### PR TITLE
fix(ci): repair release validation regressions

### DIFF
--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -154,6 +154,8 @@ vi.mock("../model-suppression.js", () => {
 vi.mock("../prepared-model-runtime.js", async () => {
   const discovery = await import("../agent-model-discovery.js");
   const discoveryContext = await import("../model-discovery-context.js");
+  const { PreparedModelRuntimeOwnerNotPublishedError } =
+    await import("../prepared-model-runtime.errors.js");
   const createSnapshot = (input: {
     agentId?: string;
     agentDir: string;
@@ -187,6 +189,7 @@ vi.mock("../prepared-model-runtime.js", async () => {
     return snapshot;
   };
   return {
+    PreparedModelRuntimeOwnerNotPublishedError,
     getPreparedModelRuntimeSnapshot: (input: Parameters<typeof createSnapshot>[0]) => {
       preparedSnapshotState.getInputs.push(input);
       return preparedSnapshotState.enabled ? createSnapshot(input) : undefined;

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -8,6 +8,7 @@ import { modelKey } from "../model-ref-shared.js";
 import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
 import { buildSuppressedBuiltInModelError } from "../model-suppression.js";
 import {
+  PreparedModelRuntimeOwnerNotPublishedError,
   getPreparedModelRuntimeSnapshot,
   loadPreparedModelRuntimeSnapshot,
   type PreparedModelRuntimeSnapshot,
@@ -135,7 +136,7 @@ export function resolveModel(
   if ((!options?.authStorage || !options?.modelRegistry) && !preparedSnapshot) {
     // Synchronous callers must enter through a lifecycle that already published discovery.
     // Falling back to an empty registry turns a stale/pending generation into a false model miss.
-    throw new Error(
+    throw new PreparedModelRuntimeOwnerNotPublishedError(
       `prepared model runtime is not published for synchronous model resolution (${resolvedAgentDir}); use resolveModelAsync before lifecycle publication`,
     );
   }

--- a/src/agents/tools-effective-inventory.runtime-model.test.ts
+++ b/src/agents/tools-effective-inventory.runtime-model.test.ts
@@ -4,6 +4,12 @@ const runtimeMocks = vi.hoisted(() => {
   class OwnerNotPublishedError extends Error {}
   return {
     OwnerNotPublishedError,
+    authStorage: {},
+    modelRegistry: {},
+    preparedSnapshot: {
+      createStores: vi.fn(),
+    },
+    release: vi.fn(),
     resolveModelAsync: vi.fn(async () => ({
       model: {
         id: "chat-latest",
@@ -16,8 +22,17 @@ const runtimeMocks = vi.hoisted(() => {
   };
 });
 
+runtimeMocks.preparedSnapshot.createStores.mockReturnValue({
+  authStorage: runtimeMocks.authStorage,
+  modelRegistry: runtimeMocks.modelRegistry,
+});
+
 vi.mock("./prepared-model-runtime.js", () => ({
   PreparedModelRuntimeOwnerNotPublishedError: runtimeMocks.OwnerNotPublishedError,
+  acquireReadOnlyPreparedModelRuntime: vi.fn(async () => ({
+    snapshot: runtimeMocks.preparedSnapshot,
+    release: runtimeMocks.release,
+  })),
 }));
 
 vi.mock("./embedded-agent-runner/model.js", () => ({
@@ -34,6 +49,7 @@ vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
 vi.mock("./agent-scope.js", () => ({
   resolveAgentDir: () => "/tmp/agents/main/agent",
   resolveAgentWorkspaceDir: () => "/tmp/workspace-main",
+  resolveDefaultAgentDir: () => "/tmp/agents/main/agent",
   resolveSessionAgentId: () => "main",
 }));
 
@@ -60,7 +76,14 @@ describe("resolveEffectiveToolInventoryRuntimeModelContextAsync", () => {
       "chat-latest",
       "/tmp/agents/main/agent",
       {},
-      { agentId: "main", workspaceDir: "/tmp/workspace-main" },
+      {
+        agentId: "main",
+        workspaceDir: "/tmp/workspace-main",
+        authStorage: runtimeMocks.authStorage,
+        modelRegistry: runtimeMocks.modelRegistry,
+        preparedModelRuntime: runtimeMocks.preparedSnapshot,
+      },
     );
+    expect(runtimeMocks.release).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/tools-effective-inventory.runtime-model.test.ts
+++ b/src/agents/tools-effective-inventory.runtime-model.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+const runtimeMocks = vi.hoisted(() => {
+  class OwnerNotPublishedError extends Error {}
+  return {
+    OwnerNotPublishedError,
+    resolveModelAsync: vi.fn(async () => ({
+      model: {
+        id: "chat-latest",
+        name: "chat-latest",
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      },
+    })),
+  };
+});
+
+vi.mock("./prepared-model-runtime.js", () => ({
+  PreparedModelRuntimeOwnerNotPublishedError: runtimeMocks.OwnerNotPublishedError,
+}));
+
+vi.mock("./embedded-agent-runner/model.js", () => ({
+  resolveModel: () => {
+    throw new runtimeMocks.OwnerNotPublishedError("owner missing");
+  },
+  resolveModelAsync: runtimeMocks.resolveModelAsync,
+}));
+
+vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
+  resolveBundledStaticCatalogModel: () => undefined,
+}));
+
+vi.mock("./agent-scope.js", () => ({
+  resolveAgentDir: () => "/tmp/agents/main/agent",
+  resolveAgentWorkspaceDir: () => "/tmp/workspace-main",
+  resolveSessionAgentId: () => "main",
+}));
+
+describe("resolveEffectiveToolInventoryRuntimeModelContextAsync", () => {
+  it("prepares dynamic model context when no lifecycle owner exists", async () => {
+    const { resolveEffectiveToolInventoryRuntimeModelContextAsync } =
+      await import("./tools-effective-inventory.js");
+
+    await expect(
+      resolveEffectiveToolInventoryRuntimeModelContextAsync({
+        cfg: {},
+        agentId: "main",
+        agentDir: "/tmp/agents/main/agent",
+        workspaceDir: "/tmp/workspace-main",
+        modelProvider: "openai",
+        modelId: "chat-latest",
+      }),
+    ).resolves.toMatchObject({
+      modelApi: "openai-responses",
+      runtimeModel: { id: "chat-latest", provider: "openai" },
+    });
+    expect(runtimeMocks.resolveModelAsync).toHaveBeenCalledWith(
+      "openai",
+      "chat-latest",
+      "/tmp/agents/main/agent",
+      {},
+      { agentId: "main", workspaceDir: "/tmp/workspace-main" },
+    );
+  });
+});

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -6,6 +6,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { createOpenClawCodingTools } from "./agent-tools.js";
+import { PreparedModelRuntimeOwnerNotPublishedError } from "./prepared-model-runtime.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 type TestPluginMeta = Record<
@@ -40,6 +41,8 @@ const effectiveInventoryState = vi.hoisted(() => ({
   normalizeToolsMock: vi.fn((options: { tools: AnyAgentTool[] }) => options.tools),
   staticCatalogModelMock: vi.fn((_options: unknown) => undefined as unknown),
   dynamicModelMock: vi.fn((_options: unknown) => undefined as unknown),
+  dynamicModelAsyncMock: vi.fn(async (_options: unknown) => undefined as unknown),
+  dynamicModelOwnerMissing: false,
   normalizeTransportMock: vi.fn((_options: unknown) => undefined as unknown),
   createToolsMock: vi.fn<typeof createOpenClawCodingTools>(
     (_options) =>
@@ -98,15 +101,34 @@ vi.mock("./embedded-agent-runner/model.js", () => ({
     cfg: unknown,
     options: unknown,
   ) =>
-    ({
-      model: effectiveInventoryState.dynamicModelMock({
-        provider,
-        modelId,
-        agentDir,
-        cfg,
-        options,
-      }),
-    }) as unknown,
+    effectiveInventoryState.dynamicModelOwnerMissing
+      ? (() => {
+          throw new PreparedModelRuntimeOwnerNotPublishedError("owner missing");
+        })()
+      : ({
+          model: effectiveInventoryState.dynamicModelMock({
+            provider,
+            modelId,
+            agentDir,
+            cfg,
+            options,
+          }),
+        } as unknown),
+  resolveModelAsync: async (
+    provider: unknown,
+    modelId: unknown,
+    agentDir: unknown,
+    cfg: unknown,
+    options: unknown,
+  ) => ({
+    model: await effectiveInventoryState.dynamicModelAsyncMock({
+      provider,
+      modelId,
+      agentDir,
+      cfg,
+      options,
+    }),
+  }),
 }));
 
 vi.mock("../plugins/provider-runtime.js", () => ({
@@ -115,6 +137,7 @@ vi.mock("../plugins/provider-runtime.js", () => ({
 }));
 
 let resolveEffectiveToolInventory: typeof import("./tools-effective-inventory.js").resolveEffectiveToolInventory;
+let resolveEffectiveToolInventoryRuntimeModelContextAsync: typeof import("./tools-effective-inventory.js").resolveEffectiveToolInventoryRuntimeModelContextAsync;
 
 async function loadHarness(options?: {
   tools?: AnyAgentTool[];
@@ -148,6 +171,8 @@ async function loadHarness(options?: {
 describe("resolveEffectiveToolInventory", () => {
   beforeAll(async () => {
     ({ resolveEffectiveToolInventory } = await import("./tools-effective-inventory.js"));
+    ({ resolveEffectiveToolInventoryRuntimeModelContextAsync } =
+      await import("./tools-effective-inventory.js"));
   });
 
   beforeEach(() => {
@@ -161,6 +186,8 @@ describe("resolveEffectiveToolInventory", () => {
     effectiveInventoryState.normalizeToolsMock = vi.fn((options) => options.tools);
     effectiveInventoryState.staticCatalogModelMock = vi.fn((_options: unknown) => undefined);
     effectiveInventoryState.dynamicModelMock = vi.fn((_options: unknown) => undefined);
+    effectiveInventoryState.dynamicModelAsyncMock = vi.fn(async (_options: unknown) => undefined);
+    effectiveInventoryState.dynamicModelOwnerMissing = false;
     effectiveInventoryState.normalizeTransportMock = vi.fn((_options: unknown) => undefined);
     effectiveInventoryState.createToolsMock = vi.fn<typeof createOpenClawCodingTools>(
       (_options) => effectiveInventoryState.tools,
@@ -846,6 +873,42 @@ describe("resolveEffectiveToolInventory", () => {
           id: "chat-latest",
           api: "openai-responses",
           provider: "openai",
+        }),
+      }),
+    );
+  });
+
+  it("publishes dynamic model context asynchronously when no lifecycle owner exists", async () => {
+    effectiveInventoryState.dynamicModelOwnerMissing = true;
+    effectiveInventoryState.dynamicModelAsyncMock.mockResolvedValue({
+      id: "chat-latest",
+      name: "chat-latest",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    });
+
+    await expect(
+      resolveEffectiveToolInventoryRuntimeModelContextAsync({
+        cfg: {},
+        agentId: "main",
+        agentDir: "/tmp/agents/main/agent",
+        workspaceDir: "/tmp/workspace-main",
+        modelProvider: "openai",
+        modelId: "chat-latest",
+      }),
+    ).resolves.toMatchObject({
+      modelApi: "openai-responses",
+      runtimeModel: { id: "chat-latest", provider: "openai" },
+    });
+    expect(effectiveInventoryState.dynamicModelAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        modelId: "chat-latest",
+        agentDir: "/tmp/agents/main/agent",
+        options: expect.objectContaining({
+          agentId: "main",
+          workspaceDir: "/tmp/workspace-main",
         }),
       }),
     );

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -6,7 +6,6 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { createOpenClawCodingTools } from "./agent-tools.js";
-import { PreparedModelRuntimeOwnerNotPublishedError } from "./prepared-model-runtime.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 type TestPluginMeta = Record<
@@ -41,8 +40,6 @@ const effectiveInventoryState = vi.hoisted(() => ({
   normalizeToolsMock: vi.fn((options: { tools: AnyAgentTool[] }) => options.tools),
   staticCatalogModelMock: vi.fn((_options: unknown) => undefined as unknown),
   dynamicModelMock: vi.fn((_options: unknown) => undefined as unknown),
-  dynamicModelAsyncMock: vi.fn(async (_options: unknown) => undefined as unknown),
-  dynamicModelOwnerMissing: false,
   normalizeTransportMock: vi.fn((_options: unknown) => undefined as unknown),
   createToolsMock: vi.fn<typeof createOpenClawCodingTools>(
     (_options) =>
@@ -100,28 +97,8 @@ vi.mock("./embedded-agent-runner/model.js", () => ({
     agentDir: unknown,
     cfg: unknown,
     options: unknown,
-  ) =>
-    effectiveInventoryState.dynamicModelOwnerMissing
-      ? (() => {
-          throw new PreparedModelRuntimeOwnerNotPublishedError("owner missing");
-        })()
-      : ({
-          model: effectiveInventoryState.dynamicModelMock({
-            provider,
-            modelId,
-            agentDir,
-            cfg,
-            options,
-          }),
-        } as unknown),
-  resolveModelAsync: async (
-    provider: unknown,
-    modelId: unknown,
-    agentDir: unknown,
-    cfg: unknown,
-    options: unknown,
   ) => ({
-    model: await effectiveInventoryState.dynamicModelAsyncMock({
+    model: effectiveInventoryState.dynamicModelMock({
       provider,
       modelId,
       agentDir,
@@ -137,7 +114,6 @@ vi.mock("../plugins/provider-runtime.js", () => ({
 }));
 
 let resolveEffectiveToolInventory: typeof import("./tools-effective-inventory.js").resolveEffectiveToolInventory;
-let resolveEffectiveToolInventoryRuntimeModelContextAsync: typeof import("./tools-effective-inventory.js").resolveEffectiveToolInventoryRuntimeModelContextAsync;
 
 async function loadHarness(options?: {
   tools?: AnyAgentTool[];
@@ -171,8 +147,6 @@ async function loadHarness(options?: {
 describe("resolveEffectiveToolInventory", () => {
   beforeAll(async () => {
     ({ resolveEffectiveToolInventory } = await import("./tools-effective-inventory.js"));
-    ({ resolveEffectiveToolInventoryRuntimeModelContextAsync } =
-      await import("./tools-effective-inventory.js"));
   });
 
   beforeEach(() => {
@@ -186,8 +160,6 @@ describe("resolveEffectiveToolInventory", () => {
     effectiveInventoryState.normalizeToolsMock = vi.fn((options) => options.tools);
     effectiveInventoryState.staticCatalogModelMock = vi.fn((_options: unknown) => undefined);
     effectiveInventoryState.dynamicModelMock = vi.fn((_options: unknown) => undefined);
-    effectiveInventoryState.dynamicModelAsyncMock = vi.fn(async (_options: unknown) => undefined);
-    effectiveInventoryState.dynamicModelOwnerMissing = false;
     effectiveInventoryState.normalizeTransportMock = vi.fn((_options: unknown) => undefined);
     effectiveInventoryState.createToolsMock = vi.fn<typeof createOpenClawCodingTools>(
       (_options) => effectiveInventoryState.tools,
@@ -873,42 +845,6 @@ describe("resolveEffectiveToolInventory", () => {
           id: "chat-latest",
           api: "openai-responses",
           provider: "openai",
-        }),
-      }),
-    );
-  });
-
-  it("publishes dynamic model context asynchronously when no lifecycle owner exists", async () => {
-    effectiveInventoryState.dynamicModelOwnerMissing = true;
-    effectiveInventoryState.dynamicModelAsyncMock.mockResolvedValue({
-      id: "chat-latest",
-      name: "chat-latest",
-      provider: "openai",
-      api: "openai-responses",
-      baseUrl: "https://api.openai.com/v1",
-    });
-
-    await expect(
-      resolveEffectiveToolInventoryRuntimeModelContextAsync({
-        cfg: {},
-        agentId: "main",
-        agentDir: "/tmp/agents/main/agent",
-        workspaceDir: "/tmp/workspace-main",
-        modelProvider: "openai",
-        modelId: "chat-latest",
-      }),
-    ).resolves.toMatchObject({
-      modelApi: "openai-responses",
-      runtimeModel: { id: "chat-latest", provider: "openai" },
-    });
-    expect(effectiveInventoryState.dynamicModelAsyncMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "openai",
-        modelId: "chat-latest",
-        agentDir: "/tmp/agents/main/agent",
-        options: expect.objectContaining({
-          agentId: "main",
-          workspaceDir: "/tmp/workspace-main",
         }),
       }),
     );

--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -15,13 +15,21 @@ import type { OpenClawConfig } from "../config/config.js";
 import { extractModelCompat } from "../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { normalizeProviderTransportWithPlugin } from "../plugins/provider-runtime.js";
-import { resolveAgentDir, resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
+import {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentDir,
+  resolveSessionAgentId,
+} from "./agent-scope.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
 import { resolveEffectiveToolPolicy } from "./agent-tools.policy.js";
 import { resolveModel, resolveModelAsync } from "./embedded-agent-runner/model.js";
 import { resolveBundledStaticCatalogModel } from "./embedded-agent-runner/model.static-catalog.js";
 import { normalizeStaticProviderModelId } from "./model-ref-shared.js";
-import { PreparedModelRuntimeOwnerNotPublishedError } from "./prepared-model-runtime.js";
+import {
+  PreparedModelRuntimeOwnerNotPublishedError,
+  acquireReadOnlyPreparedModelRuntime,
+} from "./prepared-model-runtime.js";
 import { normalizeToolName } from "./tool-policy.js";
 import { buildRuntimeCompatibleToolInventory } from "./tools-effective-inventory-build.js";
 import { buildEffectiveToolInventoryGroups } from "./tools-effective-inventory-groups.js";
@@ -279,13 +287,29 @@ export async function resolveEffectiveToolInventoryRuntimeModelContextAsync(
     return {};
   }
   const agentId = params.agentId?.trim() || resolveSessionAgentId({ config: params.cfg });
+  const agentDir = params.agentDir ?? resolveAgentDir(params.cfg, agentId);
   const workspaceDir = params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, agentId);
-  const resolved = await resolveModelAsync(provider, modelId, params.agentDir, params.cfg, {
+  const lease = await acquireReadOnlyPreparedModelRuntime({
     agentId,
+    agentDir,
+    config: params.cfg,
+    inheritedAuthDir: resolveDefaultAgentDir(params.cfg),
     workspaceDir,
   });
-  const runtimeModel = resolved.model as ProviderRuntimeModel | undefined;
-  return runtimeModel ? { modelApi: runtimeModel.api, runtimeModel } : {};
+  try {
+    const stores = lease.snapshot.createStores();
+    const resolved = await resolveModelAsync(provider, modelId, agentDir, params.cfg, {
+      agentId,
+      workspaceDir,
+      authStorage: stores.authStorage,
+      modelRegistry: stores.modelRegistry,
+      preparedModelRuntime: lease.snapshot,
+    });
+    const runtimeModel = resolved.model as ProviderRuntimeModel | undefined;
+    return runtimeModel ? { modelApi: runtimeModel.api, runtimeModel } : {};
+  } finally {
+    lease.release();
+  }
 }
 
 /** Resolves compatibility metadata explicitly configured for a provider/model pair. */

--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -351,7 +351,7 @@ export function resolveEffectiveToolInventory(
   const workspaceDir = params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, agentId);
   const agentDir = params.agentDir ?? resolveAgentDir(params.cfg, agentId);
   const runtimeModelContext =
-    params.modelApi || params.runtimeModel
+    Object.hasOwn(params, "modelApi") || Object.hasOwn(params, "runtimeModel")
       ? {
           modelApi: params.modelApi ?? params.runtimeModel?.api,
           runtimeModel: params.runtimeModel,

--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -173,7 +173,7 @@ function resolveDynamicRuntimeModelContext(params: {
 }
 
 /** Resolves the runtime model metadata needed to filter model-compatible tools. */
-export function resolveEffectiveToolInventoryRuntimeModelContext(params: {
+function resolveEffectiveToolInventoryRuntimeModelContext(params: {
   cfg: OpenClawConfig;
   agentId?: string;
   agentDir?: string;

--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -18,9 +18,10 @@ import { normalizeProviderTransportWithPlugin } from "../plugins/provider-runtim
 import { resolveAgentDir, resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
 import { resolveEffectiveToolPolicy } from "./agent-tools.policy.js";
-import { resolveModel } from "./embedded-agent-runner/model.js";
+import { resolveModel, resolveModelAsync } from "./embedded-agent-runner/model.js";
 import { resolveBundledStaticCatalogModel } from "./embedded-agent-runner/model.static-catalog.js";
 import { normalizeStaticProviderModelId } from "./model-ref-shared.js";
+import { PreparedModelRuntimeOwnerNotPublishedError } from "./prepared-model-runtime.js";
 import { normalizeToolName } from "./tool-policy.js";
 import { buildRuntimeCompatibleToolInventory } from "./tools-effective-inventory-build.js";
 import { buildEffectiveToolInventoryGroups } from "./tools-effective-inventory-groups.js";
@@ -258,6 +259,33 @@ export function resolveEffectiveToolInventoryRuntimeModelContext(params: {
     modelApi: runtimeModel.api,
     runtimeModel,
   };
+}
+
+/** Resolves dynamic model metadata after publishing a request-owned read snapshot when needed. */
+export async function resolveEffectiveToolInventoryRuntimeModelContextAsync(
+  params: Parameters<typeof resolveEffectiveToolInventoryRuntimeModelContext>[0],
+): Promise<ReturnType<typeof resolveEffectiveToolInventoryRuntimeModelContext>> {
+  try {
+    return resolveEffectiveToolInventoryRuntimeModelContext(params);
+  } catch (error) {
+    if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
+      throw error;
+    }
+  }
+
+  const provider = normalizeProviderId(params.modelProvider ?? "");
+  const modelId = params.modelId?.trim() ?? "";
+  if (!provider || !modelId) {
+    return {};
+  }
+  const agentId = params.agentId?.trim() || resolveSessionAgentId({ config: params.cfg });
+  const workspaceDir = params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, agentId);
+  const resolved = await resolveModelAsync(provider, modelId, params.agentDir, params.cfg, {
+    agentId,
+    workspaceDir,
+  });
+  const runtimeModel = resolved.model as ProviderRuntimeModel | undefined;
+  return runtimeModel ? { modelApi: runtimeModel.api, runtimeModel } : {};
 }
 
 /** Resolves compatibility metadata explicitly configured for a provider/model pair. */

--- a/src/gateway/server-methods/tools-effective.global-agent.integration.test.ts
+++ b/src/gateway/server-methods/tools-effective.global-agent.integration.test.ts
@@ -30,7 +30,7 @@ const inventoryMocks = vi.hoisted(() => ({
       modelId: params.modelId,
     }),
   ),
-  resolveEffectiveToolInventoryRuntimeModelContext: vi.fn(() => ({
+  resolveEffectiveToolInventoryRuntimeModelContext: vi.fn((_params?: unknown) => ({
     modelApi: "openai-responses",
     runtimeModel: {
       id: "work-model",

--- a/src/gateway/server-methods/tools-effective.global-agent.integration.test.ts
+++ b/src/gateway/server-methods/tools-effective.global-agent.integration.test.ts
@@ -40,6 +40,9 @@ const inventoryMocks = vi.hoisted(() => ({
       baseUrl: "https://api.openai.com/v1",
     },
   })),
+  resolveEffectiveToolInventoryRuntimeModelContextAsync: vi.fn(async (params: unknown) =>
+    inventoryMocks.resolveEffectiveToolInventoryRuntimeModelContext(params),
+  ),
 }));
 
 vi.mock("./tools-effective.runtime.js", async (importOriginal) => {
@@ -49,6 +52,8 @@ vi.mock("./tools-effective.runtime.js", async (importOriginal) => {
     resolveEffectiveToolInventory: inventoryMocks.resolveEffectiveToolInventory,
     resolveEffectiveToolInventoryRuntimeModelContext:
       inventoryMocks.resolveEffectiveToolInventoryRuntimeModelContext,
+    resolveEffectiveToolInventoryRuntimeModelContextAsync:
+      inventoryMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
     peekSessionMcpRuntime: vi.fn(() => undefined),
     resolveSessionMcpConfigSummary: vi.fn(() => ({ fingerprint: "mcp:0", serverNames: [] })),
     buildBundleMcpToolsFromCatalog: vi.fn(() => []),

--- a/src/gateway/server-methods/tools-effective.runtime.ts
+++ b/src/gateway/server-methods/tools-effective.runtime.ts
@@ -9,7 +9,6 @@ export {
 } from "../../agents/agent-scope.js";
 export {
   resolveEffectiveToolInventory,
-  resolveEffectiveToolInventoryRuntimeModelContext,
   resolveEffectiveToolInventoryRuntimeModelContextAsync,
 } from "../../agents/tools-effective-inventory.js";
 export { getRegisteredAgentHarness } from "../../agents/harness/registry.js";

--- a/src/gateway/server-methods/tools-effective.runtime.ts
+++ b/src/gateway/server-methods/tools-effective.runtime.ts
@@ -10,6 +10,7 @@ export {
 export {
   resolveEffectiveToolInventory,
   resolveEffectiveToolInventoryRuntimeModelContext,
+  resolveEffectiveToolInventoryRuntimeModelContextAsync,
 } from "../../agents/tools-effective-inventory.js";
 export { getRegisteredAgentHarness } from "../../agents/harness/registry.js";
 export {

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -544,6 +544,7 @@ describe("tools.effective handler", () => {
         name: "GPT 4.1",
         provider: "openai",
         api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
       },
     });
 

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -558,6 +558,22 @@ describe("tools.effective handler", () => {
     expect(runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext).not.toHaveBeenCalled();
   });
 
+  it("does not retry synchronous model context when async resolution has no model", async () => {
+    runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext.mockImplementation(() => {
+      throw new Error("synchronous model context should not be used");
+    });
+    runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync.mockResolvedValue({});
+
+    const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
+    await invoke();
+
+    expect(firstRespondCall(respond)?.[0]).toBe(true);
+    expect(
+      runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
+    ).toHaveBeenCalledTimes(1);
+    expect(runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext).not.toHaveBeenCalled();
+  });
+
   it("projects MCP tools from the session-owning native harness catalog", async () => {
     const loaded = runtimeMocks.loadSessionEntry();
     runtimeMocks.loadSessionEntry.mockReturnValueOnce({

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -562,7 +562,9 @@ describe("tools.effective handler", () => {
     runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext.mockImplementation(() => {
       throw new Error("synchronous model context should not be used");
     });
-    runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync.mockResolvedValue({});
+    runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync.mockResolvedValue(
+      {} as never,
+    );
 
     const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
     await invoke();

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -58,7 +58,7 @@ const runtimeMocks = vi.hoisted(() => ({
   resolveReplyToMode: vi.fn(() => "first"),
   resolveSessionAgentId: vi.fn(() => "main"),
   resolveSessionModelRef: vi.fn(() => ({ provider: "openai", model: "gpt-4.1" })),
-  resolveEffectiveToolInventoryRuntimeModelContext: vi.fn(() => ({
+  resolveEffectiveToolInventoryRuntimeModelContext: vi.fn((_params?: unknown) => ({
     modelApi: "openai-responses",
     runtimeModel: {
       id: "gpt-4.1",

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -725,6 +725,18 @@ describe("tools.effective handler", () => {
       workspaceDir: "/tmp/sandbox-copy",
       cfg: {},
     });
+    expect(
+      runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
+    ).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        workspaceDir: "/tmp/sandbox-copy",
+        modelProvider: "openai",
+        modelId: "gpt-4.1",
+      }),
+    );
   });
 
   it("does not project warm MCP tools filtered out by final policy", async () => {

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -554,7 +554,7 @@ describe("tools.effective handler", () => {
     expect(firstRespondCall(respond)?.[0]).toBe(true);
     expect(
       runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
-    ).toHaveBeenCalledTimes(2);
+    ).toHaveBeenCalledTimes(1);
     expect(runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -68,6 +68,9 @@ const runtimeMocks = vi.hoisted(() => ({
       baseUrl: "https://api.openai.com/v1",
     },
   })),
+  resolveEffectiveToolInventoryRuntimeModelContextAsync: vi.fn(async (params: unknown) =>
+    runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext(params),
+  ),
 }));
 
 vi.mock("./tools-effective.runtime.js", () => ({

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -532,6 +532,31 @@ describe("tools.effective handler", () => {
     });
   });
 
+  it("uses async model context while projecting a warm MCP catalog", async () => {
+    mockWarmMcpTool();
+    runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext.mockImplementation(() => {
+      throw new Error("synchronous model context should not be used");
+    });
+    runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync.mockResolvedValue({
+      modelApi: "openai-responses",
+      runtimeModel: {
+        id: "gpt-4.1",
+        name: "GPT 4.1",
+        provider: "openai",
+        api: "openai-responses",
+      },
+    });
+
+    const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
+    await invoke();
+
+    expect(firstRespondCall(respond)?.[0]).toBe(true);
+    expect(
+      runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
+    ).toHaveBeenCalledTimes(2);
+    expect(runtimeMocks.resolveEffectiveToolInventoryRuntimeModelContext).not.toHaveBeenCalled();
+  });
+
   it("projects MCP tools from the session-owning native harness catalog", async () => {
     const loaded = runtimeMocks.loadSessionEntry();
     runtimeMocks.loadSessionEntry.mockReturnValueOnce({

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -437,7 +437,12 @@ async function resolveReadOnlyToolsEffectiveInventory(
         toolOverrides: context.toolOverrides,
       });
       if (catalog) {
-        return projectMcpCatalog({ base, catalog, context, workspaceDir: context.workspaceDir });
+        return await projectMcpCatalog({
+          base,
+          catalog,
+          context,
+          workspaceDir: context.workspaceDir,
+        });
       }
     } catch (error) {
       logWarn(
@@ -477,15 +482,15 @@ async function resolveReadOnlyToolsEffectiveInventory(
   if (!catalog) {
     return maybeAppendMcpNotice(base, mcpConfig.serverNames, "not-listed");
   }
-  return projectMcpCatalog({ base, catalog, context, workspaceDir: runtime.workspaceDir });
+  return await projectMcpCatalog({ base, catalog, context, workspaceDir: runtime.workspaceDir });
 }
 
-function projectMcpCatalog(params: {
+async function projectMcpCatalog(params: {
   base: EffectiveToolInventoryResult;
   catalog: Parameters<typeof buildBundleMcpToolsFromCatalog>[0]["catalog"];
   context: TrustedToolsEffectiveContext;
   workspaceDir: string;
-}): EffectiveToolInventoryResult {
+}): Promise<EffectiveToolInventoryResult> {
   const projectedMcpTools = buildBundleMcpToolsFromCatalog({
     catalog: params.catalog,
     reservedToolNames: params.base.groups.flatMap((group) => group.tools.map((tool) => tool.id)),
@@ -496,7 +501,7 @@ function projectMcpCatalog(params: {
     mcpTools: projectedMcpTools,
   });
   const agentDir = resolveAgentDir(params.context.cfg, params.context.agentId);
-  const runtimeModelContext = resolveEffectiveToolInventoryRuntimeModelContext({
+  const runtimeModelContext = await resolveEffectiveToolInventoryRuntimeModelContextAsync({
     cfg: params.context.cfg,
     agentId: params.context.agentId,
     agentDir,

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -34,6 +34,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveEffectiveToolInventory,
   resolveEffectiveToolInventoryRuntimeModelContext,
+  resolveEffectiveToolInventoryRuntimeModelContextAsync,
   resolveReplyToMode,
   resolveRuntimeConfigCacheKey,
   resolveSessionAgentId,
@@ -192,9 +193,9 @@ function scheduleBaseToolsEffectiveRefresh(
   }
   const startedAt = nowForToolsEffectiveCache();
   const task = new Promise<EffectiveToolInventoryResult>((resolve, reject) => {
-    setImmediate(() => {
+    setImmediate(async () => {
       try {
-        const value = resolveBaseToolsEffectiveInventory(context);
+        const value = await resolveBaseToolsEffectiveInventory(context);
         cacheToolsEffectiveResult(key, value);
         const durationMs = nowForToolsEffectiveCache() - startedAt;
         if (durationMs >= TOOLS_EFFECTIVE_SLOW_LOG_MS) {
@@ -352,11 +353,11 @@ function maybeAppendMcpNotice(
   return notice ? appendToolInventoryNotice(base, notice) : base;
 }
 
-function resolveBaseToolsEffectiveInventory(
+async function resolveBaseToolsEffectiveInventory(
   context: TrustedToolsEffectiveContext,
-): EffectiveToolInventoryResult {
+): Promise<EffectiveToolInventoryResult> {
   const agentDir = resolveAgentDir(context.cfg, context.agentId);
-  const runtimeModelContext = resolveEffectiveToolInventoryRuntimeModelContext({
+  const runtimeModelContext = await resolveEffectiveToolInventoryRuntimeModelContextAsync({
     cfg: context.cfg,
     agentId: context.agentId,
     agentDir,

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -193,22 +193,20 @@ function scheduleBaseToolsEffectiveRefresh(
   }
   const startedAt = nowForToolsEffectiveCache();
   const task = new Promise<EffectiveToolInventoryResult>((resolve, reject) => {
-    setImmediate(async () => {
-      try {
-        const value = await resolveBaseToolsEffectiveInventory(context);
-        cacheToolsEffectiveResult(key, value);
-        const durationMs = nowForToolsEffectiveCache() - startedAt;
-        if (durationMs >= TOOLS_EFFECTIVE_SLOW_LOG_MS) {
-          logDebug(
-            `tools-effective: refresh durationMs=${durationMs} agent=${context.agentId} session=${context.sessionKey} tools=${value.groups.reduce((sum, group) => sum + group.tools.length, 0)}`,
-          );
-        }
-        resolve(value);
-      } catch (err) {
-        reject(toErrorObject(err, "Non-Error rejection"));
-      } finally {
-        toolsEffectiveInflight.delete(key);
-      }
+    setImmediate(() => {
+      void resolveBaseToolsEffectiveInventory(context)
+        .then((value) => {
+          cacheToolsEffectiveResult(key, value);
+          const durationMs = nowForToolsEffectiveCache() - startedAt;
+          if (durationMs >= TOOLS_EFFECTIVE_SLOW_LOG_MS) {
+            logDebug(
+              `tools-effective: refresh durationMs=${durationMs} agent=${context.agentId} session=${context.sessionKey} tools=${value.groups.reduce((sum, group) => sum + group.tools.length, 0)}`,
+            );
+          }
+          resolve(value);
+        })
+        .catch((err: unknown) => reject(toErrorObject(err, "Non-Error rejection")))
+        .finally(() => toolsEffectiveInflight.delete(key));
     });
   });
   toolsEffectiveInflight.set(key, task);

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -495,11 +495,22 @@ async function resolveReadOnlyToolsEffectiveInventory(
   if (!catalog) {
     return maybeAppendMcpNotice(base, mcpConfig.serverNames, "not-listed");
   }
+  const runtimeModelContext =
+    runtime.workspaceDir === context.workspaceDir
+      ? baseResolution.runtimeModelContext
+      : await resolveEffectiveToolInventoryRuntimeModelContextAsync({
+          cfg: context.cfg,
+          agentId: context.agentId,
+          agentDir: resolveAgentDir(context.cfg, context.agentId),
+          workspaceDir: runtime.workspaceDir,
+          modelProvider: context.modelProvider,
+          modelId: context.modelId,
+        });
   return await projectMcpCatalog({
     base,
     catalog,
     context,
-    runtimeModelContext: baseResolution.runtimeModelContext,
+    runtimeModelContext,
     workspaceDir: runtime.workspaceDir,
   });
 }

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -33,7 +33,6 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveEffectiveToolInventory,
-  resolveEffectiveToolInventoryRuntimeModelContext,
   resolveEffectiveToolInventoryRuntimeModelContextAsync,
   resolveReplyToMode,
   resolveRuntimeConfigCacheKey,

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -77,14 +77,23 @@ type TrustedToolsEffectiveContext = {
 };
 
 type ToolsEffectiveCacheEntry = {
-  value: EffectiveToolInventoryResult;
+  value: BaseToolsEffectiveResolution;
   createdAtMs: number;
+};
+
+type RuntimeModelContext = Awaited<
+  ReturnType<typeof resolveEffectiveToolInventoryRuntimeModelContextAsync>
+>;
+
+type BaseToolsEffectiveResolution = {
+  inventory: EffectiveToolInventoryResult;
+  runtimeModelContext: RuntimeModelContext;
 };
 
 type SessionMcpConfigSummary = ReturnType<typeof resolveSessionMcpConfigSummary>;
 
 const toolsEffectiveCache = new Map<string, ToolsEffectiveCacheEntry>();
-const toolsEffectiveInflight = new Map<string, Promise<EffectiveToolInventoryResult>>();
+const toolsEffectiveInflight = new Map<string, Promise<BaseToolsEffectiveResolution>>();
 const mcpConfigSummaryCache = new Map<string, SessionMcpConfigSummary>();
 
 function optionalCacheString(value: string | undefined | null): string {
@@ -173,7 +182,7 @@ function resolveCachedSessionMcpConfigSummary(params: {
   return summary;
 }
 
-function cacheToolsEffectiveResult(key: string, value: EffectiveToolInventoryResult): void {
+function cacheToolsEffectiveResult(key: string, value: BaseToolsEffectiveResolution): void {
   toolsEffectiveCache.delete(key);
   toolsEffectiveCache.set(key, { value, createdAtMs: nowForToolsEffectiveCache() });
   trimToolsEffectiveCache();
@@ -185,13 +194,13 @@ function cacheToolsEffectiveResult(key: string, value: EffectiveToolInventoryRes
 function scheduleBaseToolsEffectiveRefresh(
   key: string,
   context: TrustedToolsEffectiveContext,
-): Promise<EffectiveToolInventoryResult> {
+): Promise<BaseToolsEffectiveResolution> {
   const existing = toolsEffectiveInflight.get(key);
   if (existing) {
     return existing;
   }
   const startedAt = nowForToolsEffectiveCache();
-  const task = new Promise<EffectiveToolInventoryResult>((resolve, reject) => {
+  const task = new Promise<BaseToolsEffectiveResolution>((resolve, reject) => {
     setImmediate(() => {
       void resolveBaseToolsEffectiveInventory(context)
         .then((value) => {
@@ -199,7 +208,7 @@ function scheduleBaseToolsEffectiveRefresh(
           const durationMs = nowForToolsEffectiveCache() - startedAt;
           if (durationMs >= TOOLS_EFFECTIVE_SLOW_LOG_MS) {
             logDebug(
-              `tools-effective: refresh durationMs=${durationMs} agent=${context.agentId} session=${context.sessionKey} tools=${value.groups.reduce((sum, group) => sum + group.tools.length, 0)}`,
+              `tools-effective: refresh durationMs=${durationMs} agent=${context.agentId} session=${context.sessionKey} tools=${value.inventory.groups.reduce((sum, group) => sum + group.tools.length, 0)}`,
             );
           }
           resolve(value);
@@ -224,7 +233,7 @@ function refreshBaseToolsEffectiveInBackground(
 async function resolveCachedBaseToolsEffective(params: {
   sessionKey: string;
   context: TrustedToolsEffectiveContext;
-}): Promise<EffectiveToolInventoryResult> {
+}): Promise<BaseToolsEffectiveResolution> {
   const key = buildToolsEffectiveCacheKey(params);
   const now = nowForToolsEffectiveCache();
   const cached = toolsEffectiveCache.get(key);
@@ -352,7 +361,7 @@ function maybeAppendMcpNotice(
 
 async function resolveBaseToolsEffectiveInventory(
   context: TrustedToolsEffectiveContext,
-): Promise<EffectiveToolInventoryResult> {
+): Promise<BaseToolsEffectiveResolution> {
   const agentDir = resolveAgentDir(context.cfg, context.agentId);
   const runtimeModelContext = await resolveEffectiveToolInventoryRuntimeModelContextAsync({
     cfg: context.cfg,
@@ -362,25 +371,28 @@ async function resolveBaseToolsEffectiveInventory(
     modelProvider: context.modelProvider,
     modelId: context.modelId,
   });
-  return resolveEffectiveToolInventory({
-    cfg: context.cfg,
-    agentId: context.agentId,
-    agentDir,
-    sessionKey: context.sessionKey,
-    workspaceDir: context.workspaceDir,
-    messageProvider: context.messageProvider,
-    modelProvider: context.modelProvider,
-    modelId: context.modelId,
-    modelApi: runtimeModelContext.modelApi,
-    runtimeModel: runtimeModelContext.runtimeModel,
-    currentChannelId: context.currentChannelId,
-    currentThreadTs: context.currentThreadTs,
-    accountId: context.accountId,
-    groupId: context.groupId,
-    groupChannel: context.groupChannel,
-    groupSpace: context.groupSpace,
-    replyToMode: context.replyToMode,
-  });
+  return {
+    runtimeModelContext,
+    inventory: resolveEffectiveToolInventory({
+      cfg: context.cfg,
+      agentId: context.agentId,
+      agentDir,
+      sessionKey: context.sessionKey,
+      workspaceDir: context.workspaceDir,
+      messageProvider: context.messageProvider,
+      modelProvider: context.modelProvider,
+      modelId: context.modelId,
+      modelApi: runtimeModelContext.modelApi,
+      runtimeModel: runtimeModelContext.runtimeModel,
+      currentChannelId: context.currentChannelId,
+      currentThreadTs: context.currentThreadTs,
+      accountId: context.accountId,
+      groupId: context.groupId,
+      groupChannel: context.groupChannel,
+      groupSpace: context.groupSpace,
+      replyToMode: context.replyToMode,
+    }),
+  };
 }
 
 function filterMcpTools(params: {
@@ -410,10 +422,11 @@ function filterMcpTools(params: {
 async function resolveReadOnlyToolsEffectiveInventory(
   context: TrustedToolsEffectiveContext,
 ): Promise<EffectiveToolInventoryResult> {
-  const base = await resolveCachedBaseToolsEffective({
+  const baseResolution = await resolveCachedBaseToolsEffective({
     sessionKey: context.sessionKey,
     context,
   });
+  const base = baseResolution.inventory;
   const harness = context.agentHarnessId
     ? getRegisteredAgentHarness(context.agentHarnessId)?.harness
     : undefined;
@@ -440,6 +453,7 @@ async function resolveReadOnlyToolsEffectiveInventory(
           base,
           catalog,
           context,
+          runtimeModelContext: baseResolution.runtimeModelContext,
           workspaceDir: context.workspaceDir,
         });
       }
@@ -481,13 +495,20 @@ async function resolveReadOnlyToolsEffectiveInventory(
   if (!catalog) {
     return maybeAppendMcpNotice(base, mcpConfig.serverNames, "not-listed");
   }
-  return await projectMcpCatalog({ base, catalog, context, workspaceDir: runtime.workspaceDir });
+  return await projectMcpCatalog({
+    base,
+    catalog,
+    context,
+    runtimeModelContext: baseResolution.runtimeModelContext,
+    workspaceDir: runtime.workspaceDir,
+  });
 }
 
 async function projectMcpCatalog(params: {
   base: EffectiveToolInventoryResult;
   catalog: Parameters<typeof buildBundleMcpToolsFromCatalog>[0]["catalog"];
   context: TrustedToolsEffectiveContext;
+  runtimeModelContext: RuntimeModelContext;
   workspaceDir: string;
 }): Promise<EffectiveToolInventoryResult> {
   const projectedMcpTools = buildBundleMcpToolsFromCatalog({
@@ -499,23 +520,14 @@ async function projectMcpCatalog(params: {
     context: params.context,
     mcpTools: projectedMcpTools,
   });
-  const agentDir = resolveAgentDir(params.context.cfg, params.context.agentId);
-  const runtimeModelContext = await resolveEffectiveToolInventoryRuntimeModelContextAsync({
-    cfg: params.context.cfg,
-    agentId: params.context.agentId,
-    agentDir,
-    workspaceDir: params.workspaceDir,
-    modelProvider: params.context.modelProvider,
-    modelId: params.context.modelId,
-  });
   const mcpInventory = buildRuntimeCompatibleMcpToolInventory({
     tools: filteredMcpTools,
     cfg: params.context.cfg,
     workspaceDir: params.workspaceDir,
     modelProvider: params.context.modelProvider,
     modelId: params.context.modelId,
-    modelApi: runtimeModelContext.modelApi,
-    runtimeModel: runtimeModelContext.runtimeModel,
+    modelApi: params.runtimeModelContext.modelApi,
+    runtimeModel: params.runtimeModelContext.runtimeModel,
   });
   return appendMcpInventoryGroups({ base: params.base, mcpInventory });
 }

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -21,6 +21,8 @@ vi.mock("./loader.js", () => ({
   loadOpenClawPluginCliRegistry: (...args: unknown[]) =>
     mocks.loadOpenClawPluginCliRegistry(...args),
   loadOpenClawPlugins: (...args: unknown[]) => mocks.loadOpenClawPlugins(...args),
+  loadPluginRegistryHandle: (options: Record<string, unknown> = {}) =>
+    mocks.loadOpenClawPlugins({ ...options, activate: false }),
 }));
 
 vi.mock("./activation-planner.js", () => ({

--- a/src/plugins/runtime/metadata-registry-loader.test.ts
+++ b/src/plugins/runtime/metadata-registry-loader.test.ts
@@ -19,6 +19,8 @@ vi.mock("../../config/plugin-auto-enable.js", () => ({
 
 vi.mock("../loader.js", () => ({
   loadOpenClawPlugins: (...args: unknown[]) => loadOpenClawPluginsMock(...args),
+  loadPluginRegistryHandle: (options: Record<string, unknown> = {}) =>
+    loadOpenClawPluginsMock({ ...options, activate: false }),
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
@@ -170,6 +172,7 @@ describe("loadPluginMetadataRegistrySnapshot", () => {
       mode: "validate",
       loadModules: undefined,
       manifestRegistry,
+      installRecords: undefined,
     });
   });
 

--- a/src/plugins/status.dependency-health.test.ts
+++ b/src/plugins/status.dependency-health.test.ts
@@ -23,6 +23,7 @@ const loaderState = vi.hoisted(() => ({
 vi.mock("./loader.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./loader.js")>()),
   loadOpenClawPlugins: () => loaderState.registry,
+  loadPluginRegistryHandle: () => loaderState.registry,
 }));
 
 vi.mock("./runtime/metadata-registry-loader.js", async (importOriginal) => ({

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -64,6 +64,8 @@ vi.mock("../config/plugin-auto-enable.js", () => ({
 
 vi.mock("./loader.js", () => ({
   loadOpenClawPlugins: (...args: unknown[]) => loadOpenClawPluginsMock(...args),
+  loadPluginRegistryHandle: (options: Record<string, unknown> = {}) =>
+    loadOpenClawPluginsMock({ ...options, activate: false }),
   resolveCompatibleRuntimePluginRegistry: (...args: unknown[]) =>
     resolveCompatibleRuntimePluginRegistryMock(...args),
 }));


### PR DESCRIPTION
## Summary

- update plugin tests for the scoped `loadPluginRegistryHandle` facade introduced on main
- let `tools.effective` prepare dynamic model metadata asynchronously when no lifecycle-owned prepared runtime is published

## Release validation failures addressed

- plugin prerelease agentic test failures from stale loader mocks
- kitchen-sink RPC Docker failure at `tools.effective` for a freshly created session

## Validation

- `node scripts/run-vitest.mjs src/plugins/cli.test.ts src/plugins/runtime/metadata-registry-loader.test.ts src/plugins/status.dependency-health.test.ts src/plugins/status.test.ts --reporter=dot`
- `node scripts/run-vitest.mjs src/agents/tools-effective-inventory.test.ts src/gateway/server-methods/tools-effective.test.ts src/gateway/server-methods/tools-effective.global-agent.integration.test.ts --reporter=dot`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.test.ts --reporter=dot`
- autoreview: clean, patch correct (0.98)
- exact-SHA Plugin Prerelease: https://github.com/openclaw/openclaw/actions/runs/30727142356

Native locale artifacts were split into #117726 to satisfy generated-artifact isolation.
