### PR TITLE
fix(i18n): sync pinned native translations

### DIFF
--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -6459,6 +6459,11 @@
       "translated": "محدد"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "مثبّت"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "الرئيسية"

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -6459,6 +6459,11 @@
       "translated": "Ausgewählt"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Angeheftet"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Start"

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -6459,6 +6459,11 @@
       "translated": "Seleccionado"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Fijado"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Inicio"

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -6459,6 +6459,11 @@
       "translated": "انتخاب‌شده"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "سنجاق‌شده"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "خانه"

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -6459,6 +6459,11 @@
       "translated": "Sélectionné"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Épinglé"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Accueil"

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -6459,6 +6459,11 @@
       "translated": "चयनित"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "पिन किया गया"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "होम"

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -6459,6 +6459,11 @@
       "translated": "Dipilih"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Disematkan"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Beranda"

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -6459,6 +6459,11 @@
       "translated": "Selezionato"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "In evidenza"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Home"

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -6459,6 +6459,11 @@
       "translated": "選択済み"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "ピン留め済み"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "ホーム"

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -6459,6 +6459,11 @@
       "translated": "선택됨"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "고정됨"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "홈"

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -6459,6 +6459,11 @@
       "translated": "Geselecteerd"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Vastgemaakt"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Start"

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -6459,6 +6459,11 @@
       "translated": "Wybrane"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Przypięte"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Start"

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -6459,6 +6459,11 @@
       "translated": "Selecionado"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Fixado"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Início"

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -6459,6 +6459,11 @@
       "translated": "Выбрано"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Закреплено"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Главная"

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -6459,6 +6459,11 @@
       "translated": "Vald"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Fäst"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Hem"

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -6459,6 +6459,11 @@
       "translated": "เลือกแล้ว"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "ปักหมุดแล้ว"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "หน้าแรก"

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -6459,6 +6459,11 @@
       "translated": "Seçildi"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Sabitlendi"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Ana Sayfa"

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -6459,6 +6459,11 @@
       "translated": "Вибрано"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Закріплено"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Головна"

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -6459,6 +6459,11 @@
       "translated": "Đã chọn"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "Đã ghim"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "Trang chủ"

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -6459,6 +6459,11 @@
       "translated": "已选择"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "已置顶"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "主页"

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -6459,6 +6459,11 @@
       "translated": "已選取"
     },
     {
+      "id": "native.android.30aa827f48f2d6d0",
+      "source": "Pinned",
+      "translated": "已釘選"
+    },
+    {
       "id": "native.android.4e2f2b168d8402e5",
       "source": "Home",
       "translated": "首頁"

--- a/apps/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -1553,7 +1553,7 @@
     <string name="native_f1c3989a92ef10d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扫描二维码以配对"</string>
     <string name="native_f2000dce9b5d40c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已拒绝批准。"</string>
     <string name="native_f200366d0c4352cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法检查 Skill Workshop 提案。"</string>
-    <string name="native_f20c879465551f0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已固定"</string>
+    <string name="native_f20c879465551f0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已置顶"</string>
     <string name="native_f211f2bf832dda14" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"个人资料与设备"</string>
     <string name="native_f22e1435c8dfffc1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"关闭思考级别选择器"</string>
     <string name="native_f2316e644b1d2621" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法将消息加入队列以供稍后发送。"</string>


### PR DESCRIPTION
## Summary

- add the missing native `Pinned` inventory entry to all 21 locale catalogs
- regenerate the affected zh-CN Android string resource

## Validation

- `node --import tsx scripts/native-app-i18n.ts check`

This PR intentionally contains only native generated locale artifacts, per the CI isolation requirement.
