### PR TITLE
fix(release): prevent bundled plugin lock timeouts

### DIFF
--- a/scripts/generate-npm-package-lock.mjs
+++ b/scripts/generate-npm-package-lock.mjs
@@ -456,6 +456,8 @@ function readNpmLockOverrides() {
 
 function packageJsonForNpmLock(packageJson, npmLockOverrides) {
   const normalized = { ...packageJson };
+  delete normalized.bundleDependencies;
+  delete normalized.bundledDependencies;
   delete normalized.devDependencies;
   for (const field of ["dependencies", "optionalDependencies", "peerDependencies"]) {
     const dependencies = normalized[field];

--- a/test/scripts/generate-npm-package-lock.test.ts
+++ b/test/scripts/generate-npm-package-lock.test.ts
@@ -32,6 +32,8 @@ describe("generate-npm-package-lock", () => {
   it("omits workspace packages that are published beside the package", () => {
     const normalized = packageJsonForNpmLock(
       {
+        bundleDependencies: ["chalk"],
+        bundledDependencies: ["chalk"],
         dependencies: { "@openclaw/ai": "workspace:2026.6.11", chalk: "5.6.2" },
         devDependencies: { local: "workspace:*" },
         peerDependencies: { host: "workspace:^1.2.3" },
@@ -39,6 +41,8 @@ describe("generate-npm-package-lock", () => {
       {},
     );
 
+    expect(normalized).not.toHaveProperty("bundleDependencies");
+    expect(normalized).not.toHaveProperty("bundledDependencies");
     expect(normalized).not.toHaveProperty("devDependencies");
     expect(normalized.dependencies).toEqual({ chalk: "5.6.2" });
     expect(normalized.peerDependencies).toEqual({});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release operators publishing plugins with bundled dependencies could hit repeated `npm install --package-lock-only` timeouts, blocking the beta release. The failure reproduced in the frozen beta WhatsApp publish run 30726242416 after the normal source-package lock validation had passed.

## Why This Change Was Made

The augmented publish manifest contains `bundleDependencies` and `bundledDependencies`, which are packaging directives rather than dependency-resolution inputs. The lock normalizer now removes both fields while preserving the existing shallow lock strategy and dependency set.

## User Impact

Plugin packages with bundled dependencies can complete release lock generation and publish normally. There is no runtime or public API change.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/generate-npm-package-lock.test.ts`: 26 tests passed.
- Full WhatsApp bundled pack dry-run completed successfully with `baileys`, `audio-decode`, and `typebox` bundled.
- Twitch pack dry-run completed successfully as a regression check for the existing shallow lock path.
- Before the fix, the frozen beta WhatsApp preview timed out on all three bounded package-lock attempts in run 30726242416.
- No changelog entry: this is internal release tooling with no shipped runtime behavior change.
