### PR TITLE
fix: prevent lost subagent replies, stale runs, and Codex turn stalls

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-notification-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-notification-controller.ts
@@ -216,13 +216,22 @@ export function createCodexAttemptNotificationController(
   };
   const waitForActiveNativeTurnCompletion = async () => {
     const route = resourceState.turnRoute;
-    if (!route) {
+    const activeNativeTurnId =
+      resourceState.thread.lifecycle.activeTurnIds?.at(-1) ?? route?.observedNativeTurnId;
+    if (!route || !activeNativeTurnId) {
       return false;
     }
-    return await route.waitForTurnCompletion({
+    const watch = resourceState.turnRouter.watchNativeTurnCompletion({
+      threadId: route.threadId,
+      turnId: activeNativeTurnId,
       timeoutMs: Math.min(appServer.requestTimeoutMs, CODEX_APP_SERVER_NATIVE_TURN_WAIT_TIMEOUT_MS),
       signal: runAbortController.signal,
     });
+    try {
+      return await watch.completion;
+    } finally {
+      watch.cancel();
+    }
   };
   const noteNotificationReceived = (
     notification: CodexServerNotification,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3996,7 +3996,7 @@ describe("runCodexAppServerAttempt", () => {
     ]);
   });
 
-  it("waits for an already-active native turn before starting a resumed thread turn", async () => {
+  it("waits for the exact active native turn before starting a resumed thread turn", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
     const harness = createAppServerHarness(async (method) => {
@@ -4020,6 +4020,24 @@ describe("runCodexAppServerAttempt", () => {
     await harness.waitForMethod("thread/resume");
     await new Promise((resolve) => {
       setTimeout(resolve, 20);
+    });
+    expect(harness.requests.map((request) => request.method)).not.toContain("turn/start");
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-existing",
+        turn: { id: "stale-turn", status: "completed" },
+      },
+    });
+    expect(harness.requests.map((request) => request.method)).not.toContain("turn/start");
+    await harness.notify({
+      method: "error",
+      params: {
+        threadId: "thread-existing",
+        turnId: "compact-turn",
+        error: { message: "native turn has not completed" },
+        willRetry: false,
+      },
     });
     expect(harness.requests.map((request) => request.method)).not.toContain("turn/start");
     await harness.notify({

--- a/extensions/codex/src/app-server/turn-router.test.ts
+++ b/extensions/codex/src/app-server/turn-router.test.ts
@@ -650,20 +650,23 @@ describe("CodexAppServerTurnRouter", () => {
     route.release();
   });
 
-  it("consumes one native completion and clears stale completion when arming", async () => {
+  it("consumes buffered exact native completions and clears them when arming", async () => {
     const harness = createHarness();
-    const route = getCodexAppServerTurnRouter(harness.client).reserveThread({
+    const router = getCodexAppServerTurnRouter(harness.client);
+    const route = router.reserveThread({
       threadId: "thread-native",
-      onNotification: vi.fn(),
     });
     harness.send({
       method: "turn/completed",
       params: { threadId: "thread-native", turn: { id: "turn-native", items: [] } },
     });
     await settleInput();
-
-    await expect(route.waitForTurnCompletion({ timeoutMs: 10 })).resolves.toBe(true);
-    await expect(route.waitForTurnCompletion({ timeoutMs: 1 })).resolves.toBe(false);
+    await route.activate({ onNotification: vi.fn() });
+    expect(route.observedNativeTurnId).toBe("turn-native");
+    const completion = (turnId: string, timeoutMs: number) =>
+      router.watchNativeTurnCompletion({ threadId: route.threadId, turnId, timeoutMs }).completion;
+    await expect(completion("turn-native", 10)).resolves.toBe(true);
+    await expect(completion("turn-native", 1)).resolves.toBe(false);
 
     harness.send({
       method: "turn/completed",
@@ -671,32 +674,93 @@ describe("CodexAppServerTurnRouter", () => {
     });
     await settleInput();
     route.armTurn();
-    await expect(route.waitForTurnCompletion({ timeoutMs: 1 })).resolves.toBe(false);
+    expect(route.observedNativeTurnId).toBeUndefined();
+    await expect(completion("turn-stale", 1)).resolves.toBe(false);
     await route.cancelTurn();
   });
 
-  it("settles an active native-completion waiter on completion, abort, and release", async () => {
+  it("keeps an observed active native turn exact across arm and stale completion", async () => {
     const harness = createHarness();
-    const route = getCodexAppServerTurnRouter(harness.client).reserveThread({
+    const router = getCodexAppServerTurnRouter(harness.client);
+    const route = router.reserveThread({
+      threadId: "thread-native-active",
+      onNotification: vi.fn(),
+    });
+    harness.send({
+      method: "turn/started",
+      params: {
+        threadId: "thread-native-active",
+        turn: { id: "turn-compact", status: "inProgress" },
+      },
+    });
+    await settleInput();
+
+    route.armTurn();
+    expect(route.observedNativeTurnId).toBe("turn-compact");
+    harness.send({
+      method: "turn/completed",
+      params: { threadId: "thread-native-active", turn: { id: "turn-stale", items: [] } },
+    });
+    await settleInput();
+    expect(route.observedNativeTurnId).toBe("turn-compact");
+
+    const completed = router.watchNativeTurnCompletion({
+      threadId: "thread-native-active",
+      turnId: "turn-compact",
+      timeoutMs: 100,
+    });
+    harness.send({
+      method: "turn/completed",
+      params: { threadId: "thread-native-active", turn: { id: "turn-compact", items: [] } },
+    });
+    await expect(completed.completion).resolves.toBe(true);
+    await route.cancelTurn();
+  });
+
+  it("settles exact native-completion watchers on completion, abort, and route release", async () => {
+    const harness = createHarness();
+    const router = getCodexAppServerTurnRouter(harness.client);
+    const route = router.reserveThread({
       threadId: "thread-native-wait",
       onNotification: vi.fn(),
     });
 
-    const completed = route.waitForTurnCompletion({ timeoutMs: 100 });
+    const completed = router.watchNativeTurnCompletion({
+      threadId: "thread-native-wait",
+      turnId: "turn-native",
+      timeoutMs: 100,
+    });
     harness.send({
       method: "turn/completed",
       params: { threadId: "thread-native-wait", turn: { id: "turn-native", items: [] } },
     });
-    await expect(completed).resolves.toBe(true);
+    await expect(completed.completion).resolves.toBe(true);
 
     const controller = new AbortController();
-    const aborted = route.waitForTurnCompletion({ timeoutMs: 100, signal: controller.signal });
+    const aborted = router.watchNativeTurnCompletion({
+      threadId: "thread-native-wait",
+      turnId: "turn-aborted",
+      timeoutMs: 100,
+      signal: controller.signal,
+    });
     controller.abort("test");
-    await expect(aborted).resolves.toBe(false);
+    await expect(aborted.completion).resolves.toBe(false);
+    const alreadyAborted = router.watchNativeTurnCompletion({
+      threadId: "thread-native-wait",
+      turnId: "turn-aborted",
+      timeoutMs: 100,
+      signal: controller.signal,
+    });
+    await expect(alreadyAborted.completion).resolves.toBe(false);
 
-    const released = route.waitForTurnCompletion({ timeoutMs: 100 });
+    const released = router.watchNativeTurnCompletion({
+      threadId: "thread-native-wait",
+      turnId: "turn-released",
+      timeoutMs: 100,
+      signal: route.signal,
+    });
     route.release();
-    await expect(released).resolves.toBe(false);
+    await expect(released.completion).resolves.toBe(false);
   });
 
   it("watches one exact native turn without reserving its thread", async () => {

--- a/extensions/codex/src/app-server/turn-router.ts
+++ b/extensions/codex/src/app-server/turn-router.ts
@@ -46,11 +46,11 @@ type CodexThreadRouteHandlers = {
 export type CodexThreadRouteReservation = {
   readonly threadId: string;
   readonly signal: AbortSignal;
+  readonly observedNativeTurnId?: string;
   activate: (handlers: CodexThreadRouteHandlers) => Promise<void>;
   armTurn: () => void;
   bindTurn: (turnId: string) => Promise<void>;
   cancelTurn: () => Promise<void>;
-  waitForTurnCompletion: (options: { timeoutMs: number; signal?: AbortSignal }) => Promise<boolean>;
   drain: () => Promise<void>;
   release: () => void;
 };
@@ -66,6 +66,7 @@ export type CodexAppServerTurnRouter = {
     threadId: string;
     turnId: string;
     timeoutMs: number;
+    signal?: AbortSignal;
   }) => CodexNativeTurnCompletionWatch;
 };
 
@@ -92,9 +93,9 @@ type Route = {
   turnId?: string;
   pending: PendingNotification[];
   notificationTail: Promise<void>;
-  nativeTurnCompleted: boolean;
+  observedNativeTurn?: { id: string; completed: boolean };
+  completedNativeTurnIds: Set<string>;
   ignoredTurnNotificationKeys: Set<string>;
-  nativeTurnCompletion?: Deferred;
   detachReleaseOn?: () => void;
 };
 type NativeTurnCompletionWatcher = {
@@ -147,7 +148,7 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
       gate: "open",
       pending: [],
       notificationTail: Promise.resolve(),
-      nativeTurnCompleted: false,
+      completedNativeTurnIds: new Set(),
       ignoredTurnNotificationKeys: new Set(),
     };
     this.routes.set(threadId, route);
@@ -166,11 +167,13 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     return {
       threadId,
       signal: route.controller.signal,
+      get observedNativeTurnId() {
+        return route.observedNativeTurn?.id;
+      },
       activate: (handlers) => this.activate(route, handlers),
       armTurn: () => this.armTurn(route),
       bindTurn: (turnId) => this.bindTurn(route, turnId),
       cancelTurn: () => this.cancelTurn(route),
-      waitForTurnCompletion: (waitOptions) => this.waitForTurnCompletion(route, waitOptions),
       drain: () => this.drainNotifications(route),
       release: () => this.release(route),
     };
@@ -180,10 +183,19 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     threadId: string;
     turnId: string;
     timeoutMs: number;
+    signal?: AbortSignal;
   }): CodexNativeTurnCompletionWatch {
     this.assertActive();
     const threadId = requireId(options.threadId, "thread id");
     const turnId = requireId(options.turnId, "turn id");
+    if (options.signal?.aborted) {
+      return { completion: Promise.resolve(false), cancel: () => {} };
+    }
+    // Resume discovers the active turn only after its route starts buffering;
+    // preserve an exact completion that arrived before the watcher could exist.
+    if (this.routes.get(threadId)?.completedNativeTurnIds.delete(turnId)) {
+      return { completion: Promise.resolve(true), cancel: () => {} };
+    }
     let settle!: (completed: boolean) => void;
     const completion = new Promise<boolean>((resolve) => {
       settle = resolve;
@@ -202,12 +214,15 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
         this.nativeTurnCompletionWatchers.delete(threadId);
       }
       clearTimeout(timeout);
+      options.signal?.removeEventListener("abort", abort);
       settle(completed);
     };
     const watcher = { turnId, finish };
     watchers.add(watcher);
     const timeout = setTimeout(() => finish(false), Math.max(1, options.timeoutMs));
     timeout.unref?.();
+    const abort = () => finish(false);
+    options.signal?.addEventListener("abort", abort, { once: true });
     return { completion, cancel: () => finish(false) };
   }
 
@@ -260,7 +275,12 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     }
     route.gate = "armed";
     route.ignoredTurnNotificationKeys.clear();
-    route.nativeTurnCompleted = false;
+    route.completedNativeTurnIds.clear();
+    // A native turn started before our rejected turn/start remains authoritative;
+    // completed turns from an earlier attempt must not unlock the next retry.
+    if (route.observedNativeTurn?.completed) {
+      route.observedNativeTurn = undefined;
+    }
     route.binding = deferred();
   }
 
@@ -307,7 +327,6 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     if (!watchers && !route) {
       return undefined;
     }
-    const terminal = isCodexTerminalTurnNotification(notification);
     if (scope.turnId && watchers) {
       for (const watcher of watchers) {
         if (watcher.turnId === scope.turnId && notification.method === "turn/completed") {
@@ -323,11 +342,18 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
       ...(scope.turnId ? { turnId: scope.turnId } : {}),
     };
     const receivedAtMs = Date.now();
-    if (route.gate !== "bound" && terminal) {
-      if (route.nativeTurnCompletion) {
-        route.nativeTurnCompletion.resolve();
-      } else {
-        route.nativeTurnCompleted = true;
+    if (route.gate !== "bound" && scope.turnId) {
+      if (notification.method === "turn/started") {
+        route.observedNativeTurn = { id: scope.turnId, completed: false };
+      } else if (notification.method === "turn/completed") {
+        route.completedNativeTurnIds.add(scope.turnId);
+        if (
+          !route.observedNativeTurn ||
+          route.observedNativeTurn.completed ||
+          route.observedNativeTurn.id === scope.turnId
+        ) {
+          route.observedNativeTurn = { id: scope.turnId, completed: true };
+        }
       }
     }
     if (!route.handlers) {
@@ -511,55 +537,6 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     await route.notificationTail;
   }
 
-  private async waitForTurnCompletion(
-    route: Route,
-    options: { timeoutMs: number; signal?: AbortSignal },
-  ): Promise<boolean> {
-    this.assertRoute(route);
-    if (route.nativeTurnCompleted) {
-      route.nativeTurnCompleted = false;
-      return true;
-    }
-    if (route.nativeTurnCompletion) {
-      throw new Error(`codex app-server turn completion wait already active: ${route.threadId}`);
-    }
-    const completion = deferred();
-    route.nativeTurnCompletion = completion;
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    let removeAbort: (() => void) | undefined;
-    const timedOut = new Promise<boolean>((resolve) => {
-      timeout = setTimeout(() => resolve(false), Math.max(1, options.timeoutMs));
-    });
-    const aborted = new Promise<boolean>((resolve) => {
-      const signal = options.signal;
-      if (!signal) {
-        return;
-      }
-      const onAbort = () => resolve(false);
-      signal.addEventListener("abort", onAbort, { once: true });
-      removeAbort = () => signal.removeEventListener("abort", onAbort);
-      if (signal.aborted) {
-        onAbort();
-      }
-    });
-    try {
-      return await Promise.race([
-        completion.promise.then(() => true),
-        route.ended.promise.then(() => false),
-        timedOut,
-        aborted,
-      ]);
-    } finally {
-      if (route.nativeTurnCompletion === completion) {
-        route.nativeTurnCompletion = undefined;
-      }
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-      removeAbort?.();
-    }
-  }
-
   private release(route: Route, error = new Error("codex app-server thread route is released")) {
     if (route.released) {
       return;
@@ -587,18 +564,6 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
       throw route.released;
     }
   }
-}
-
-/** True after Codex will not continue the exact turn. */
-function isCodexTerminalTurnNotification(notification: CodexServerNotification): boolean {
-  if (notification.method === "turn/completed") {
-    return true;
-  }
-  return (
-    notification.method === "error" &&
-    isJsonObject(notification.params) &&
-    notification.params.willRetry === false
-  );
 }
 
 async function waitForPromiseOrAbort(

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-directives.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-directives.ts
@@ -179,33 +179,16 @@ function extractBareToolArg(text: string, name: string) {
 }
 
 export function hasDeclaredTool(body: Record<string, unknown>, name: string) {
-  const tools = Array.isArray(body.tools) ? body.tools : [];
-  const dynamicTools = Array.isArray(body.dynamicTools) ? body.dynamicTools : [];
-  if (
-    [...tools, ...dynamicTools].some((tool) => toolDefinitionMentionsName(tool, name)) ||
+  return (
+    hasToolDefinition(body, name) ||
     instructionTextMentionsToolName(extractInstructionsText(body), name)
-  ) {
-    return true;
-  }
-  return false;
+  );
 }
 
 export function hasToolDefinition(body: Record<string, unknown>, name: string) {
   const tools = Array.isArray(body.tools) ? body.tools : [];
   const dynamicTools = Array.isArray(body.dynamicTools) ? body.dynamicTools : [];
   return [...tools, ...dynamicTools].some((tool) => toolDefinitionMentionsName(tool, name));
-}
-
-export function hasDeclaredCustomTool(body: Record<string, unknown>, name: string) {
-  const tools = Array.isArray(body.tools) ? body.tools : [];
-  return tools.some(
-    (tool) =>
-      tool !== null &&
-      typeof tool === "object" &&
-      !Array.isArray(tool) &&
-      (tool as Record<string, unknown>).type === "custom" &&
-      (tool as Record<string, unknown>).name === name,
-  );
 }
 
 function toolDefinitionMentionsName(value: unknown, name: string, depth = 0): boolean {

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
@@ -133,14 +133,19 @@ export function buildToolCallEventsWithArgs(
   ];
 }
 
-export function buildCustomToolCallEventsWithInput(name: string, input: string): StreamEvent[] {
-  const call = buildMockFunctionCall(name, { input });
+export function buildCustomToolCallEventsWithInput(
+  name: string,
+  input: string,
+  namespace?: string,
+): StreamEvent[] {
+  const call = buildMockFunctionCall(name, { input }, namespace);
   const itemId = call.itemId.replace(/^fc_/, "ctc_");
   const item = {
     type: "custom_tool_call",
     id: itemId,
     call_id: call.callId,
     name,
+    ...(namespace ? { namespace } : {}),
     input,
     status: "completed",
   };

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -1,5 +1,7 @@
 // Qa Lab tests cover server plugin behavior.
+import { once } from "node:events";
 import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
 import { readQaMockRequestCursor } from "../shared/debug-request-cursor.js";
 import { readTargetFromPrompt } from "./mock-openai-tooling.js";
 import { startQaMockOpenAiServer } from "./server.js";
@@ -249,6 +251,16 @@ const CODEX_SUBAGENT_TOOL_NAMESPACE = {
   type: "namespace",
   name: "openclaw",
   tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
+} as const;
+const CODEX_CUSTOM_PATCH_TOOL = {
+  type: "custom",
+  name: "apply_patch",
+  format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+} as const;
+const CODEX_CUSTOM_PATCH_NAMESPACE = {
+  type: "namespace",
+  name: "openclaw_direct",
+  tools: [CODEX_CUSTOM_PATCH_TOOL],
 } as const;
 const READ_TOOL = { type: "function", name: "read" } as const;
 const MESSAGE_TOOL = { type: "function", name: "message" } as const;
@@ -4349,13 +4361,7 @@ describe("qa mock openai server", () => {
   ])("plans an actual $label native freeform patch", async (testCase) => {
     const server = await startMockServer();
     const response = await postNonStreamingResponses(server, {
-      tools: [
-        {
-          type: "custom",
-          name: "apply_patch",
-          format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
-        },
-      ],
+      tools: [CODEX_CUSTOM_PATCH_TOOL],
       input: [makeUserInput(testCase.prompt)],
     });
 
@@ -4380,16 +4386,62 @@ describe("qa mock openai server", () => {
     expect(debug.plannedToolArgs).toEqual({ input: item.input });
   });
 
-  it("streams native Codex patch input as custom-tool SSE", async () => {
+  it.each([
+    {
+      label: "namespaced tools",
+      declarations: { tools: [CODEX_CUSTOM_PATCH_NAMESPACE] },
+      additionalTools: undefined,
+    },
+    {
+      label: "namespaced dynamic tools",
+      declarations: { dynamicTools: [CODEX_CUSTOM_PATCH_NAMESPACE] },
+      additionalTools: undefined,
+    },
+    {
+      label: "developer additional tools",
+      declarations: {},
+      additionalTools: [CODEX_CUSTOM_PATCH_NAMESPACE],
+    },
+    {
+      label: "direct custom tools before tool search",
+      declarations: {
+        tools: [{ type: "function", name: "tool_search_code" }, CODEX_CUSTOM_PATCH_NAMESPACE],
+      },
+      additionalTools: undefined,
+    },
+  ])("preserves custom-tool identity through $label", async ({ declarations, additionalTools }) => {
+    const server = await startMockServer();
+    const input: Array<Record<string, unknown>> = [];
+    if (additionalTools) {
+      input.push({ type: "additional_tools", role: "developer", tools: additionalTools });
+    }
+    input.push(
+      makeUserInput(
+        "tool search qa check target=apply_patch. Call apply_patch exactly once and then summarize.",
+      ),
+    );
+
+    const response = await postNonStreamingResponses(server, { ...declarations, input });
+
+    expect(response.status).toBe(200);
+    expect(outputItem(await response.json())).toMatchObject({
+      type: "custom_tool_call",
+      name: "apply_patch",
+      namespace: "openclaw_direct",
+    });
+  });
+
+  it.each([
+    { label: "flat", tools: [CODEX_CUSTOM_PATCH_TOOL], namespace: undefined },
+    {
+      label: "namespaced",
+      tools: [CODEX_CUSTOM_PATCH_NAMESPACE],
+      namespace: "openclaw_direct",
+    },
+  ])("streams $label native Codex patch input as custom-tool SSE", async ({ tools, namespace }) => {
     const server = await startMockServer();
     const response = await postStreamingResponses(server, {
-      tools: [
-        {
-          type: "custom",
-          name: "apply_patch",
-          format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
-        },
-      ],
+      tools,
       input: [
         makeUserInput(
           "tool search qa check target=apply_patch. Call apply_patch exactly once and then summarize.",
@@ -4439,6 +4491,67 @@ describe("qa mock openai server", () => {
     expect(delta?.delta).toBe(done?.item?.input);
     expect(delta?.delta).toContain("runtime-tool-fixture-patch.txt");
     expect(completed?.response?.output).toEqual([done?.item]);
+    for (const item of [added?.item, done?.item, completed?.response?.output?.[0]]) {
+      if (namespace) {
+        expect(item).toMatchObject({ namespace });
+      } else {
+        expect(item).not.toHaveProperty("namespace");
+      }
+    }
+  });
+
+  it("preserves namespaced native custom-tool identity over Responses WebSocket", async () => {
+    const server = await startMockServer();
+    const socket = new WebSocket(`${server.baseUrl.replace(/^http/u, "ws")}/v1/responses`);
+    cleanups.push(async () => socket.terminate());
+    await once(socket, "open");
+
+    const completed = new Promise<Array<Record<string, unknown>>>((resolve, reject) => {
+      const events: Array<Record<string, unknown>> = [];
+      socket.on("error", reject);
+      socket.on("message", (message) => {
+        const event = JSON.parse(Buffer.from(message as Buffer).toString("utf8")) as Record<
+          string,
+          unknown
+        >;
+        events.push(event);
+        if (event.type === "response.completed") {
+          resolve(events);
+        }
+      });
+    });
+    socket.send(
+      JSON.stringify({
+        type: "response.create",
+        tools: [CODEX_CUSTOM_PATCH_NAMESPACE],
+        input: [
+          makeUserInput(
+            "tool search qa check target=apply_patch. Call apply_patch exactly once and then summarize.",
+          ),
+        ],
+      }),
+    );
+
+    const events = await completed;
+    const added = requireRecord(
+      events.find((event) => event.type === "response.output_item.added")?.item,
+      "WebSocket custom-tool added item",
+    );
+    const done = requireRecord(
+      events.find((event) => event.type === "response.output_item.done")?.item,
+      "WebSocket custom-tool completed item",
+    );
+    const response = requireRecord(
+      events.find((event) => event.type === "response.completed")?.response,
+      "WebSocket completed response",
+    );
+    for (const item of [added, done, outputItem(response)]) {
+      expect(item).toMatchObject({
+        type: "custom_tool_call",
+        name: "apply_patch",
+        namespace: "openclaw_direct",
+      });
+    }
   });
 
   it.each([

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -98,7 +98,6 @@ import {
   shouldUseWhatsAppContactMarker,
   shouldUseWhatsAppStickerMarker,
   extractBlockStreamingMarkerDirectives,
-  hasDeclaredCustomTool,
   hasDeclaredTool,
   hasToolDefinition,
   isQaToolSearchFixture,
@@ -410,8 +409,9 @@ function buildScenarioToolCallEvents(
       ...(Array.isArray(body.tools) ? body.tools : []),
       ...(Array.isArray(body.dynamicTools) ? body.dynamicTools : []),
     ].find((tool) => findNamedToolDefinition(tool, name));
-    // Codex registers namespaced tools by their complete wire identity;
-    // emitting only the nested name makes direct-only lifecycle tools unusable.
+    const definition = findNamedToolDefinition(declaration, name);
+    // Function and custom calls both retain their declared namespace; Codex
+    // dispatches the complete identity and rejects a flattened nested tool.
     const namespace =
       declaration &&
       typeof declaration === "object" &&
@@ -419,6 +419,9 @@ function buildScenarioToolCallEvents(
       typeof declaration.name === "string"
         ? declaration.name
         : undefined;
+    if (definition?.type === "custom" && typeof args.input === "string") {
+      return buildCustomToolCallEventsWithInput(name, args.input, namespace);
+    }
     return buildRawToolCallEventsWithArgs(name, args, namespace);
   }
   const encodedTarget = encodeCodeModeTarget(name, args);
@@ -574,11 +577,11 @@ async function buildResponsesPayload(
       ? buildQaToolSearchArgs(targetTool, QA_TOOL_SEARCH_FAILURE_PROMPT_RE.test(allInputText))
       : {};
     if (
-      targetTool === "apply_patch" &&
-      hasDeclaredCustomTool(body, targetTool) &&
+      targetTool &&
+      findNamedToolDefinition(toolDeclarationBody, targetTool)?.type === "custom" &&
       typeof plannedArgs.input === "string"
     ) {
-      return buildCustomToolCallEventsWithInput(targetTool, plannedArgs.input);
+      return buildToolCallEventsWithArgs(targetTool, plannedArgs);
     }
     if (targetTool && hasDeclaredTool(body, "tool_search_code")) {
       return buildToolCallEventsWithArgs("tool_search_code", {

--- a/src/agents/embedded-agent-runner/stream-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.test.ts
@@ -496,53 +496,77 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     expect(result.promptCacheKey).toBe("cron-cache-key");
   });
 
-  it("forwards the run abort signal into provider-owned stream functions", async () => {
-    const providerStreamFn = vi.fn(async (_model, _context, options) => options);
-    const signal = new AbortController().signal;
-    const streamFn = resolveEmbeddedAgentStreamFn({
-      currentStreamFn: undefined,
-      providerStreamFn,
-      sessionId: "session-1",
-      signal,
-      model: {
-        api: "openai-responses",
-        provider: "github-copilot",
-        id: "gpt-5.4",
-      } as never,
-      resolvedApiKey: "resolved-key",
-    });
+  it.each(["run", "caller"] as const)(
+    "preserves the single %s abort signal in provider-owned stream functions",
+    async (signalOwner) => {
+      const providerStreamFn = vi.fn(async (_model, _context, options) => options);
+      const signal = new AbortController().signal;
+      const streamFn = resolveEmbeddedAgentStreamFn({
+        currentStreamFn: undefined,
+        providerStreamFn,
+        sessionId: "session-1",
+        signal: signalOwner === "run" ? signal : undefined,
+        model: {
+          api: "openai-responses",
+          provider: "github-copilot",
+          id: "gpt-5.4",
+        } as never,
+        resolvedApiKey: "resolved-key",
+      });
 
-    const result = await expectStreamResultRecord(
-      streamFn({ provider: "github-copilot", id: "gpt-5.4" } as never, {} as never, {}),
-      "provider-owned signal result",
-    );
-    expect(result.signal).toBe(signal);
-  });
+      const result = await expectStreamResultRecord(
+        streamFn(
+          { provider: "github-copilot", id: "gpt-5.4" } as never,
+          {} as never,
+          signalOwner === "caller" ? { signal } : {},
+        ),
+        "provider-owned signal result",
+      );
+      expect(result.signal).toBe(signal);
+    },
+  );
 
-  it("does not overwrite an explicit provider-owned stream signal", async () => {
-    const providerStreamFn = vi.fn(async (_model, _context, options) => options);
-    const runSignal = new AbortController().signal;
-    const explicitSignal = new AbortController().signal;
-    const streamFn = resolveEmbeddedAgentStreamFn({
-      currentStreamFn: undefined,
-      providerStreamFn,
-      sessionId: "session-1",
-      signal: runSignal,
-      model: {
-        api: "openai-responses",
-        provider: "github-copilot",
-        id: "gpt-5.4",
-      } as never,
-    });
+  it.each([
+    { owner: "run", abortBeforeResolve: false },
+    { owner: "caller", abortBeforeResolve: false },
+    { owner: "run", abortBeforeResolve: true },
+    { owner: "caller", abortBeforeResolve: true },
+  ])(
+    "preserves both provider-owned cancellation sources: $owner ($abortBeforeResolve)",
+    async ({ owner, abortBeforeResolve }) => {
+      const providerStreamFn = vi.fn(async (_model, _context, options) => options);
+      const runController = new AbortController();
+      const callerController = new AbortController();
+      const abortedController = owner === "run" ? runController : callerController;
+      const abortReason = new Error(`${owner} canceled`);
+      if (abortBeforeResolve) {
+        abortedController.abort(abortReason);
+      }
+      const streamFn = resolveEmbeddedAgentStreamFn({
+        currentStreamFn: undefined,
+        providerStreamFn,
+        sessionId: "session-1",
+        signal: runController.signal,
+        model: {
+          api: "openai-responses",
+          provider: "github-copilot",
+          id: "gpt-5.4",
+        } as never,
+      });
 
-    const result = await expectStreamResultRecord(
-      streamFn({ provider: "github-copilot", id: "gpt-5.4" } as never, {} as never, {
-        signal: explicitSignal,
-      }),
-      "provider-owned explicit signal result",
-    );
-    expect(result.signal).toBe(explicitSignal);
-  });
+      const result = await expectStreamResultRecord(
+        streamFn({ provider: "github-copilot", id: "gpt-5.4" } as never, {} as never, {
+          signal: callerController.signal,
+        }),
+        "provider-owned explicit signal result",
+      );
+      if (!abortBeforeResolve) {
+        expect(result.signal).toMatchObject({ aborted: false });
+        abortedController.abort(abortReason);
+      }
+      expect(result.signal).toMatchObject({ aborted: true, reason: abortReason });
+    },
+  );
 
   it("injects the resolved run api key into the OpenClaw native Codex Responses fallback", async () => {
     const nativeStreamFn = vi.fn(async (_model, _context, options) => options);
@@ -615,31 +639,36 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     expect(result.apiKey).toBe("oauth-bearer-token");
   });
 
-  it("does not overwrite an explicit signal on the OpenClaw native fallback path", async () => {
-    const nativeStreamFn = vi.fn(async (_model, _context, options) => options);
-    const runSignal = new AbortController().signal;
-    const explicitSignal = new AbortController().signal;
-    useNativeStreamFn(nativeStreamFn as never);
-    const streamFn = resolveEmbeddedAgentStreamFn({
-      currentStreamFn: undefined,
-      sessionId: "session-1",
-      signal: runSignal,
-      model: {
-        api: "openai-chatgpt-responses",
-        provider: "openai",
-        id: "gpt-5.5",
-      } as never,
-      resolvedApiKey: "oauth-bearer-token",
-    });
+  it.each(["run", "caller"] as const)(
+    "cancels the authenticated OpenClaw native fallback when the %s signal aborts",
+    async (signalOwner) => {
+      const nativeStreamFn = vi.fn(async (_model, _context, options) => options);
+      const runController = new AbortController();
+      const callerController = new AbortController();
+      useNativeStreamFn(nativeStreamFn as never);
+      const streamFn = resolveEmbeddedAgentStreamFn({
+        currentStreamFn: undefined,
+        sessionId: "session-1",
+        signal: runController.signal,
+        model: {
+          api: "openai-chatgpt-responses",
+          provider: "openai",
+          id: "gpt-5.5",
+        } as never,
+        resolvedApiKey: "oauth-bearer-token",
+      });
 
-    const result = await expectStreamResultRecord(
-      streamFn({ provider: "openai", id: "gpt-5.5" } as never, {} as never, {
-        signal: explicitSignal,
-      }),
-      "codex explicit signal result",
-    );
-    expect(result.signal).toBe(explicitSignal);
-  });
+      const result = await expectStreamResultRecord(
+        streamFn({ provider: "openai", id: "gpt-5.5" } as never, {} as never, {
+          signal: callerController.signal,
+        }),
+        "codex explicit signal result",
+      );
+      expect(result.signal).toMatchObject({ aborted: false });
+      (signalOwner === "run" ? runController : callerController).abort();
+      expect(result.signal).toMatchObject({ aborted: true });
+    },
+  );
 
   it("forwards the run signal on the sync OpenClaw native fallback path without auth credentials", async () => {
     const nativeStreamFn = vi.fn(async (_model, _context, options) => options);

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -269,7 +269,11 @@ function wrapEmbeddedAgentStreamFn(
     params.transformContext ?? ((context: Parameters<StreamFn>[1]) => context);
   const mergeRunSignal = (options: Parameters<StreamFn>[2]) => {
     const embeddedOptions = options as EmbeddedStreamOptions | undefined;
-    const signal = embeddedOptions?.signal ?? params.runSignal;
+    const callerSignal = embeddedOptions?.signal;
+    const signal =
+      callerSignal && params.runSignal && callerSignal !== params.runSignal
+        ? AbortSignal.any([callerSignal, params.runSignal])
+        : (callerSignal ?? params.runSignal);
     let merged =
       params.sessionId && !embeddedOptions?.sessionId
         ? { ...embeddedOptions, sessionId: params.sessionId }

--- a/src/agents/subagent-registry-requester-yield.test.ts
+++ b/src/agents/subagent-registry-requester-yield.test.ts
@@ -127,30 +127,60 @@ describe("settleRequesterTurnAfterSessionSpawns", () => {
     expect(schedule).not.toHaveBeenCalled();
   });
 
-  it("ignores accepted spawns that do not produce completion messages", () => {
-    const completion = makeRun("run-completion");
-    const inline = makeRun("run-inline");
-    inline.requesterTurnRunId = undefined;
-    inline.expectsCompletionMessage = false;
-    inline.delivery = { status: "not_required" };
+  it.each([true, false])(
+    "ignores same-turn non-completion spawns during settlement (yielded: %s)",
+    (requesterYielded) => {
+      const completion = makeRun("run-completion", false);
+      const inline = makeRun("run-inline", false);
+      inline.expectsCompletionMessage = false;
+      inline.delivery = { status: "not_required" };
+      const runs = new Map([
+        [inline.runId, inline],
+        [completion.runId, completion],
+      ]);
+      const persistOrThrow = vi.fn();
+      const schedule = vi.fn();
 
-    expect(
-      settleRequesterTurnAfterSessionSpawns({
-        requesterSessionKey: REQUESTER,
-        requesterTurnRunId: REQUESTER_TURN,
-        requesterYielded: true,
-        acceptedSessionSpawns: [accepted(completion), accepted(inline)],
-        runs: new Map([
-          [completion.runId, completion],
-          [inline.runId, inline],
-        ]),
-        persistOrThrow: vi.fn(),
-        schedule: vi.fn(),
-      }),
-    ).toBe(true);
-    expect(completion.requesterSettleWake?.afterRequesterYield).toBe(true);
-    expect(inline.requesterSettleWake).toBeUndefined();
-  });
+      if (requesterYielded) {
+        expect(
+          markRequesterTurnYieldedInRuns({
+            requesterSessionKey: REQUESTER,
+            requesterTurnRunId: REQUESTER_TURN,
+            runs,
+            persistOrThrow,
+          }),
+        ).toBe(1);
+      }
+
+      expect(
+        settleRequesterTurnAfterSessionSpawns({
+          requesterSessionKey: REQUESTER,
+          requesterTurnRunId: REQUESTER_TURN,
+          requesterYielded,
+          acceptedSessionSpawns: [accepted(inline), accepted(completion)],
+          runs,
+          persistOrThrow,
+          schedule,
+        }),
+      ).toBe(true);
+      expect(persistOrThrow.mock.calls).toEqual(
+        requesterYielded ? [[completion.runId], [completion.runId]] : [[completion.runId]],
+      );
+      if (requesterYielded) {
+        expect(completion.requesterSettleWake).toMatchObject({
+          batchRunIds: [completion.runId],
+          afterRequesterYield: true,
+        });
+        expect(schedule).toHaveBeenCalledExactlyOnceWith(completion.runId, completion);
+      } else {
+        expect(completion.requesterSettleWake).toBeUndefined();
+        expect(schedule).not.toHaveBeenCalled();
+      }
+      expect(inline.requesterTurnRunId).toBe(REQUESTER_TURN);
+      expect(inline.requesterTurnYielded).toBeUndefined();
+      expect(inline.requesterSettleWake).toBeUndefined();
+    },
+  );
 
   it("re-arms a delivered delete-mode row retained through requester settlement", () => {
     const entry = makeRun("run-delete");

--- a/src/agents/subagent-registry-requester-yield.ts
+++ b/src/agents/subagent-registry-requester-yield.ts
@@ -17,7 +17,8 @@ export function markRequesterTurnYieldedInRuns(params: {
   const entries = [...params.runs.values()].filter(
     (entry) =>
       entry.requesterSessionKey === requesterSessionKey &&
-      entry.requesterTurnRunId === requesterTurnRunId,
+      entry.requesterTurnRunId === requesterTurnRunId &&
+      entry.expectsCompletionMessage === true,
   );
   if (entries.every((entry) => entry.requesterTurnYielded === true)) {
     return entries.length;
@@ -60,13 +61,13 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
   const entries = [...params.runs.values()].filter(
     (entry) =>
       entry.requesterSessionKey === requesterSessionKey &&
-      entry.requesterTurnRunId === requesterTurnRunId,
+      entry.requesterTurnRunId === requesterTurnRunId &&
+      entry.expectsCompletionMessage === true,
   );
   for (const entry of entries) {
     const spawn = spawnsByRunId.get(entry.runId);
     if (
       !spawn ||
-      entry.expectsCompletionMessage !== true ||
       entry.childSessionKey !== spawn.childSessionKey ||
       (params.requesterYielded && entry.requesterTurnYielded !== true)
     ) {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -486,6 +486,8 @@ export function createAgentEventHandler({
       !isStaleLifecycleEventForSession({
         owningSessionId: evt.sessionId,
         currentSessionId: row?.sessionId,
+        eventStartedAt: evt.data?.startedAt,
+        currentStartedAt: row?.startedAt,
       })
         ? deriveGatewaySessionLifecycleProjectionPatch({
             entry: row

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -122,6 +122,75 @@ describe("session lifecycle state", () => {
   });
 
   it.each([
+    { eventStartedAt: 100, currentStartedAt: 200, stale: true },
+    { eventStartedAt: 200, currentStartedAt: 200, stale: false },
+    { eventStartedAt: 300, currentStartedAt: 200, stale: false },
+    { eventStartedAt: undefined, currentStartedAt: 200, stale: false },
+    { eventStartedAt: Number.NaN, currentStartedAt: 200, stale: false },
+  ])(
+    "correlates explicit same-session run start times",
+    ({ eventStartedAt, currentStartedAt, stale }) => {
+      expect(
+        isStaleLifecycleEventForSession({
+          owningSessionId: "session-id",
+          currentSessionId: "session-id",
+          eventStartedAt,
+          currentStartedAt,
+        }),
+      ).toBe(stale);
+    },
+  );
+
+  it.each(["end", "error"] as const)(
+    "ignores an older overlapping run's late %s while preserving the newer owner",
+    async (phase) => {
+      const first = await persistLifecycle(
+        { sessionId: "session-id", updatedAt: 900 },
+        {
+          ts: 1_000,
+          sessionId: "session-id",
+          runId: "run-a",
+          data: { phase: "start", startedAt: 1_000 },
+        },
+      );
+      const second = await persistLifecycle(first, {
+        ts: 2_000,
+        sessionId: "session-id",
+        runId: "run-b",
+        data: { phase: "start", startedAt: 2_000 },
+      });
+      const afterOlderTerminal = await persistLifecycle(second, {
+        ts: 3_000,
+        sessionId: "session-id",
+        runId: "run-a",
+        data: {
+          phase,
+          startedAt: 1_000,
+          endedAt: 3_000,
+          ...(phase === "error" ? { error: "older run failed" } : {}),
+        },
+      });
+
+      expect(afterOlderTerminal).toMatchObject({ status: "running", startedAt: 2_000 });
+      expect(afterOlderTerminal.endedAt).toBeUndefined();
+      expect(afterOlderTerminal.lastRunError).toBeUndefined();
+
+      const completed = await persistLifecycle(afterOlderTerminal, {
+        ts: 4_000,
+        sessionId: "session-id",
+        runId: "run-b",
+        data: { phase: "end", startedAt: 2_000, endedAt: 4_000 },
+      });
+      expect(completed).toMatchObject({
+        status: "done",
+        startedAt: 2_000,
+        endedAt: 4_000,
+        runtimeMs: 2_000,
+      });
+    },
+  );
+
+  it.each([
     {
       name: "aborted",
       data: { phase: "end", endedAt: 1_800, stopReason: "aborted" },

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -250,18 +250,24 @@ export function isRestartRecoveryLifecycleEvent(params: {
 }
 
 /**
- * A pre-`sessions.reset` run's lifecycle event must not mutate a session row
- * whose sessionId was rotated by the reset. True only when both the owning
- * run's sessionId and the current row's sessionId are known and differ.
+ * Reject pre-reset runs and explicitly older runs sharing one session so late
+ * lifecycle events cannot overwrite a newer run's authoritative state.
  */
 export function isStaleLifecycleEventForSession(params: {
   owningSessionId?: string;
   currentSessionId?: string;
+  eventStartedAt?: unknown;
+  currentStartedAt?: number;
 }): boolean {
-  return Boolean(
-    params.owningSessionId &&
-    params.currentSessionId &&
-    params.owningSessionId !== params.currentSessionId,
+  return (
+    Boolean(
+      params.owningSessionId &&
+      params.currentSessionId &&
+      params.owningSessionId !== params.currentSessionId,
+    ) ||
+    (isFiniteTimestamp(params.eventStartedAt) &&
+      isFiniteTimestamp(params.currentStartedAt) &&
+      params.eventStartedAt < params.currentStartedAt)
   );
 }
 
@@ -314,10 +320,14 @@ export async function persistGatewaySessionLifecycleEvent(params: {
         // one claimed continuation. Ready or replaced claims reject late events.
         return null;
       }
-      // Reject a pre-reset run's lifecycle event: sessions.reset rotates the row
-      // to a new sessionId under the same sessionKey, so an old in-flight run's
-      // late start/end/error must not overwrite the fresh row's status (#88538).
-      if (isStaleLifecycleEventForSession({ owningSessionId, currentSessionId: entry.sessionId })) {
+      if (
+        isStaleLifecycleEventForSession({
+          owningSessionId,
+          currentSessionId: entry.sessionId,
+          eventStartedAt: params.event.data?.startedAt,
+          currentStartedAt: entry.startedAt,
+        })
+      ) {
         return null;
       }
       const patch = derivePersistedSessionLifecyclePatch({


### PR DESCRIPTION
Related: #117298

## What Problem This Solves

Fixes an issue where users running overlapping agent turns, delegated subagents, or Codex-backed sessions could lose a child completion reply, see an older run replace the current session status, continue a canceled model request, or stall when native Codex compaction or a namespaced custom tool interrupted normal inference.

## Why This Change Was Made

Record authoritative turn and run identity at their existing lifecycle owners, preserve both cancellation owners through provider streams, settle only child runs that actually produce completion messages, and retain custom-tool namespaces across the mock Responses HTTP, SSE, and WebSocket transports. Codex now uses its existing exact-turn completion watcher for native compaction instead of keeping a second, thread-wide completion mechanism.

The connected cleanup removes the duplicate Codex completion waiter and hardcoded custom-tool detection. Production changes are **100 lines added / 118 removed (net -18)**; regression tests are counted separately.

## User Impact

Yielded parent agents reliably receive delegated results, live session status stays attached to the newest run, cancellation stops provider work even when the SDK supplies its own signal, and both OpenClaw and Codex preserve approval, compaction, native workspace tools, and namespaced custom-tool behavior. No configuration, protocol, or database-schema changes are introduced.

## Evidence

Validated on Blacksmith Testbox `tbx_01kyzzjfrhyzfmbpzak7zzhmx4` before a clean, patch-identical rebase onto the newest `main` (none of the intervening main commits touched these files):

- **599 focused tests passed** across Codex turn routing/run attempts/conversation binding, mock Responses HTTP/SSE/WebSocket, gateway lifecycle/chat projections, embedded-provider cancellation, and subagent requester settlement.
- **213 affected tests passed again** after tightening the final Codex-router and WebSocket regressions.
- `CI=1 OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` passed, including all 148 public plugin-SDK exports.
- `pnpm openclaw qa suite --provider-mode mock-openai --runtime-pair openclaw,codex --fast --concurrency 3 ...` passed six scenarios under both runtimes: approval/tool follow-through, model switching, subagent handoff, child fan-out, direct completion delivery, and forked child context.
- `pnpm openclaw qa suite --provider-mode mock-openai --fast --concurrency 3 ...` passed six fault-injection scenarios: empty-response retry exhaustion, empty-response replay-safe recovery, reasoning-only replay-safe recovery, no retry after mutation, compaction after a mutating tool, and the 31-attempt global tool-loop breaker.
- `openclaw-testbox-env ... pnpm openclaw qa suite --provider-mode live-frontier --model openai/gpt-5.4 --alt-model openai/gpt-5.4 --runtime-pair openclaw,codex --fast ...` passed four **live API-key** scenarios under both runtimes: approval/tool follow-through, streaming-final integrity, legacy `Read` vocabulary, and model-switch continuity.
- `CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed` passed all formatting, dependency, plugin-boundary, dead-export, core/plugin production/test typecheck, lint, schema, storage, import-cycle, and pairing guards.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` completed cleanly with no accepted/actionable findings.
- Upstream Codex contracts were personally checked at [`codex-rs/app-server-protocol/src/protocol/v2/turn.rs:209-217,407-410`](https://github.com/openai/codex/blob/fbf666fa9875d0157816be3b7a20c63161d77ec5/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L209-L217), [`codex-rs/app-server-protocol/src/protocol/v2/shared.rs:107-111`](https://github.com/openai/codex/blob/fbf666fa9875d0157816be3b7a20c63161d77ec5/codex-rs/app-server-protocol/src/protocol/v2/shared.rs#L107-L111), [`codex-rs/protocol/src/models.rs:930-938`](https://github.com/openai/codex/blob/fbf666fa9875d0157816be3b7a20c63161d77ec5/codex-rs/protocol/src/models.rs#L930-L938), [`codex-rs/core/src/tools/router.rs:196-209`](https://github.com/openai/codex/blob/fbf666fa9875d0157816be3b7a20c63161d77ec5/codex-rs/core/src/tools/router.rs#L196-L209), and [`codex-rs/app-server/src/bespoke_event_handling.rs:156-183`](https://github.com/openai/codex/blob/fbf666fa9875d0157816be3b7a20c63161d77ec5/codex-rs/app-server/src/bespoke_event_handling.rs#L156-L183).
