### PR TITLE
fix(providers): reject provider-owned binary downloads returning JSON, HTML, or empty bodies

### DIFF
--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -285,6 +285,39 @@ describe("fal image-generation provider", () => {
     });
   });
 
+  it.each([
+    { name: "JSON error", contentType: "application/json", body: '{"error":"denied"}' },
+    { name: "problem JSON", contentType: "application/problem+json", body: '{"title":"denied"}' },
+    { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
+    { name: "empty image", contentType: "image/png", body: "" },
+  ])("rejects a successful $name response as generated image", async ({ contentType, body }) => {
+    mockFalImageProviderRuntime();
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: Response.json({
+          images: [{ url: "https://v3.fal.media/files/example/generated.png" }],
+        }),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from(body), {
+          status: 200,
+          headers: { "content-type": contentType },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "fal-ai/flux/dev",
+        prompt: "draw a cat",
+        cfg: {},
+      }),
+    ).rejects.toThrow("fal image download: malformed image response");
+  });
+
   it("shares an explicit operation deadline across generated image downloads", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-10T00:00:00Z"));

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -291,14 +291,10 @@ describe("fal image-generation provider", () => {
     { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
     { name: "empty image", contentType: "image/png", body: "" },
   ])("rejects a successful $name response as generated image", async ({ contentType, body }) => {
-    mockFalImageProviderRuntime();
     fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: Response.json({
-          images: [{ url: "https://v3.fal.media/files/example/generated.png" }],
-        }),
-        release: vi.fn(async () => {}),
-      })
+      .mockResolvedValueOnce(
+        releasedJson({ images: [{ url: "https://v3.fal.media/files/example/generated.png" }] }),
+      )
       .mockResolvedValueOnce({
         response: new Response(Buffer.from(body), {
           status: 200,
@@ -307,7 +303,6 @@ describe("fal image-generation provider", () => {
         release: vi.fn(async () => {}),
       });
 
-    const provider = buildFalImageGenerationProvider();
     await expect(
       provider.generateImage({
         provider: "fal",

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -9,7 +9,7 @@ const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
 }));
 
 import { buildFalImageGenerationProvider } from "./image-generation-provider.js";
-import { setFalFetchGuardForTesting } from "./test-support.js";
+import { releasedCapturedStream, setFalFetchGuardForTesting } from "./test-support.js";
 
 const falApiKey = { apiKey: "fal-test-key", source: "env", mode: "api-key" } as const;
 
@@ -311,6 +311,44 @@ describe("fal image-generation provider", () => {
         cfg: {},
       }),
     ).rejects.toThrow("fal image download: malformed image response");
+  });
+
+  it("rejects a captured malformed image download without waiting for its cloned stream", async () => {
+    const canceledBodies: ReadableStream<Uint8Array>[] = [];
+    let releaseCancel!: () => void;
+    const cancelGate = new Promise<void>((resolve) => {
+      releaseCancel = resolve;
+    });
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce(
+        releasedJson({ images: [{ url: "https://v3.fal.media/files/example/generated.png" }] }),
+      )
+      .mockResolvedValueOnce(
+        releasedCapturedStream({
+          contentType: "application/json",
+          cancelGate,
+          onCancel: (body) => canceledBodies.push(body),
+        }),
+      );
+
+    const generation = provider.generateImage({
+      provider: "fal",
+      model: "fal-ai/flux/dev",
+      prompt: "draw a cat",
+      cfg: {},
+    });
+    const outcome = await Promise.race([
+      generation.then(
+        () => "resolved",
+        (error: unknown) => `rejected:${error instanceof Error ? error.message : String(error)}`,
+      ),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("pending"), 100);
+      }),
+    ]);
+    releaseCancel();
+    expect(outcome).toBe("rejected:fal image download: malformed image response");
+    expect(canceledBodies).toHaveLength(1);
   });
 
   it("shares an explicit operation deadline across generated image downloads", async () => {

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -624,8 +624,9 @@ async function fetchImageBuffer(
     try {
       assertProviderBinaryResponseContent(response, "fal image download", "image");
     } catch (error) {
-      // A rejected binary response still owns a live socket until its unread body is canceled.
-      await response.body?.cancel().catch(() => undefined);
+      // A debug-capture clone can keep the tee open, so waiting for cancel
+      // would hang before the malformed-body error can be thrown.
+      void response.body?.cancel().catch(() => undefined);
       throw error;
     }
     const mimeType = response.headers.get("content-type")?.trim() || "image/png";
@@ -634,7 +635,7 @@ async function fetchImageBuffer(
         new Error(`fal generated image download exceeds ${maxBytesLocal} bytes`),
     });
     if (buffer.byteLength === 0) {
-      await response.body?.cancel().catch(() => undefined);
+      void response.body?.cancel().catch(() => undefined);
       throw new Error("fal image download: malformed image response");
     }
     return {

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -13,6 +13,7 @@ import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import {
   assertOkOrThrowHttpError,
   assertOkOrThrowProviderError,
+  assertProviderBinaryResponseContent,
   createProviderOperationDeadline,
   readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
@@ -620,12 +621,24 @@ async function fetchImageBuffer(
   });
   try {
     await assertOkOrThrowProviderError(response, "fal image download failed");
+    try {
+      assertProviderBinaryResponseContent(response, "fal image download", "image");
+    } catch (error) {
+      // A rejected binary response still owns a live socket until its unread body is canceled.
+      await response.body?.cancel().catch(() => undefined);
+      throw error;
+    }
     const mimeType = response.headers.get("content-type")?.trim() || "image/png";
+    const buffer = await readResponseWithLimit(response, maxBytes, {
+      onOverflow: ({ maxBytes: maxBytesLocal }) =>
+        new Error(`fal generated image download exceeds ${maxBytesLocal} bytes`),
+    });
+    if (buffer.byteLength === 0) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new Error("fal image download: malformed image response");
+    }
     return {
-      buffer: await readResponseWithLimit(response, maxBytes, {
-        onOverflow: ({ maxBytes: maxBytesLocal }) =>
-          new Error(`fal generated image download exceeds ${maxBytesLocal} bytes`),
-      }),
+      buffer,
       mimeType,
     };
   } finally {

--- a/extensions/fal/test-support.ts
+++ b/extensions/fal/test-support.ts
@@ -1,4 +1,5 @@
 import type { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { vi } from "vitest";
 
 type FalTestApi = {
   setImageFetchGuard: (impl: typeof fetchWithSsrFGuard | null) => void;
@@ -19,4 +20,35 @@ export function setFalFetchGuardForTesting(impl: typeof fetchWithSsrFGuard | nul
 
 export function setFalVideoFetchGuardForTesting(impl: typeof fetchWithSsrFGuard | null): void {
   getFalTestApi().setVideoFetchGuard(impl);
+}
+
+/**
+ * Builds a captured streaming response whose body cancellation stays pending
+ * until the caller resolves `cancelGate`, mirroring a debug-capture clone that
+ * keeps the response tee open. Providers must surface the malformed-body error
+ * without awaiting cancellation; callers release the gate after asserting.
+ */
+export function releasedCapturedStream(params: {
+  contentType: string;
+  cancelGate: Promise<void>;
+  onCancel?: (body: ReadableStream<Uint8Array>) => void;
+}): { response: Response; release: () => Promise<void> } {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1]));
+    },
+  });
+  const response = new Response(body, {
+    status: 200,
+    headers: { "content-type": params.contentType },
+  });
+  const responseBody = response.body;
+  if (!responseBody) {
+    throw new Error("expected a streaming response body");
+  }
+  vi.spyOn(responseBody, "cancel").mockImplementation(() => {
+    params.onCancel?.(responseBody);
+    return params.cancelGate as unknown as Promise<undefined>;
+  });
+  return { response, release: vi.fn(async () => {}) };
 }

--- a/extensions/fal/video-generation-provider.test.ts
+++ b/extensions/fal/video-generation-provider.test.ts
@@ -4,7 +4,7 @@ import * as providerAuth from "openclaw/plugin-sdk/provider-auth-runtime";
 import * as providerHttp from "openclaw/plugin-sdk/provider-http";
 import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { setFalVideoFetchGuardForTesting } from "./test-support.js";
+import { releasedCapturedStream, setFalVideoFetchGuardForTesting } from "./test-support.js";
 import { buildFalVideoGenerationProvider } from "./video-generation-provider.js";
 
 function createMockRequestConfig() {
@@ -296,6 +296,62 @@ describe("fal video generation provider", () => {
         cfg: {},
       }),
     ).rejects.toThrow("fal generated video download: malformed video response");
+  });
+
+  it("rejects a captured malformed video download without waiting for its cloned stream", async () => {
+    mockFalProviderRuntime();
+    const canceledBodies: ReadableStream<Uint8Array>[] = [];
+    let releaseCancel!: () => void;
+    const cancelGate = new Promise<void>((resolve) => {
+      releaseCancel = resolve;
+    });
+    fetchGuardMock
+      .mockResolvedValueOnce(
+        releasedJson({
+          request_id: "req-123",
+          status_url: "https://queue.fal.run/fal-ai/minimax/requests/req-123/status",
+          response_url: "https://queue.fal.run/fal-ai/minimax/requests/req-123",
+        }),
+      )
+      .mockResolvedValueOnce(releasedJson({ status: "COMPLETED" }))
+      .mockResolvedValueOnce(
+        releasedJson({
+          status: "COMPLETED",
+          response: {
+            video: { url: "https://fal.run/files/video.mp4" },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        releasedCapturedStream({
+          contentType: "application/json",
+          cancelGate,
+          onCancel: (body) => canceledBodies.push(body),
+        }),
+      );
+
+    const provider = buildFalVideoGenerationProvider();
+    const generation = provider.generateVideo({
+      provider: "fal",
+      model: "fal-ai/minimax/video-01-live",
+      prompt: "A spaceship emerges from the clouds",
+      durationSeconds: 5,
+      aspectRatio: "16:9",
+      resolution: "720P",
+      cfg: {},
+    });
+    const outcome = await Promise.race([
+      generation.then(
+        () => "resolved",
+        (error: unknown) => `rejected:${error instanceof Error ? error.message : String(error)}`,
+      ),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("pending"), 100);
+      }),
+    ]);
+    releaseCancel();
+    expect(outcome).toBe("rejected:fal generated video download: malformed video response");
+    expect(canceledBodies).toHaveLength(1);
   });
 
   it("rejects missing fal queue statuses without waiting for timeout", async () => {

--- a/extensions/fal/video-generation-provider.test.ts
+++ b/extensions/fal/video-generation-provider.test.ts
@@ -268,6 +268,36 @@ describe("fal video generation provider", () => {
     ).rejects.toThrow("fal video generation response malformed");
   });
 
+  it.each([
+    { name: "JSON error", contentType: "application/json", body: '{"error":"denied"}' },
+    { name: "problem JSON", contentType: "application/problem+json", body: '{"title":"denied"}' },
+    { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
+    { name: "empty video", contentType: "video/mp4", body: "" },
+  ])("rejects a successful $name response as generated video", async ({ contentType, body }) => {
+    mockFalProviderRuntime();
+    mockCompletedFalVideoJob({
+      requestId: "req-123",
+      statusUrl: "https://queue.fal.run/fal-ai/minimax/requests/req-123/status",
+      responseUrl: "https://queue.fal.run/fal-ai/minimax/requests/req-123",
+      videoUrl: "https://fal.run/files/video.mp4",
+      bytes: body,
+      contentType,
+    });
+
+    const provider = buildFalVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "fal",
+        model: "fal-ai/minimax/video-01-live",
+        prompt: "A spaceship emerges from the clouds",
+        durationSeconds: 5,
+        aspectRatio: "16:9",
+        resolution: "720P",
+        cfg: {},
+      }),
+    ).rejects.toThrow("fal generated video download: malformed video response");
+  });
+
   it("rejects missing fal queue statuses without waiting for timeout", async () => {
     mockFalProviderRuntime();
     fetchGuardMock

--- a/extensions/fal/video-generation-provider.ts
+++ b/extensions/fal/video-generation-provider.ts
@@ -220,8 +220,9 @@ async function downloadFalVideo(
     try {
       assertProviderBinaryResponseContent(response, "fal generated video download", "video");
     } catch (error) {
-      // A rejected binary response still owns a live socket until its unread body is canceled.
-      await response.body?.cancel().catch(() => undefined);
+      // A debug-capture clone can keep the tee open, so waiting for cancel
+      // would hang before the malformed-body error can be thrown.
+      void response.body?.cancel().catch(() => undefined);
       throw error;
     }
     const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
@@ -246,7 +247,7 @@ async function downloadFalVideo(
       throw error;
     }
     if (buffer.byteLength === 0) {
-      await response.body?.cancel().catch(() => undefined);
+      void response.body?.cancel().catch(() => undefined);
       throw new Error("fal generated video download: malformed video response");
     }
     return {

--- a/extensions/fal/video-generation-provider.ts
+++ b/extensions/fal/video-generation-provider.ts
@@ -5,6 +5,7 @@ import { resolvePositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtim
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import {
   assertOkOrThrowHttpError,
+  assertProviderBinaryResponseContent,
   createProviderOperationDeadline,
   readProviderJsonResponse,
   type ProviderOperationDeadline,
@@ -216,6 +217,13 @@ async function downloadFalVideo(
   });
   try {
     await assertOkOrThrowHttpError(response, "fal generated video download failed");
+    try {
+      assertProviderBinaryResponseContent(response, "fal generated video download", "video");
+    } catch (error) {
+      // A rejected binary response still owns a live socket until its unread body is canceled.
+      await response.body?.cancel().catch(() => undefined);
+      throw error;
+    }
     const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
     const fileName = `video-1.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`;
     let exceededMaxBytes = false;
@@ -236,6 +244,10 @@ async function downloadFalVideo(
         };
       }
       throw error;
+    }
+    if (buffer.byteLength === 0) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new Error("fal generated video download: malformed video response");
     }
     return {
       url,

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -405,6 +405,54 @@ describe("google video generation provider", () => {
     ).rejects.toThrow("Google generated video download exceeds 1 bytes");
   });
 
+  it.each([
+    { name: "JSON error", contentType: "application/json", body: '{"error":"denied"}' },
+    { name: "problem JSON", contentType: "application/problem+json", body: '{"title":"denied"}' },
+    { name: "HTML", contentType: "text/html; charset=utf-8", body: "<html>sign in</html>" },
+    { name: "empty video", contentType: "video/mp4", body: "" },
+  ])("rejects a successful $name response as generated video", async ({ contentType, body }) => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockResolvedValue({
+      done: true,
+      response: {
+        generatedVideos: [
+          {
+            video: {
+              uri: "https://generativelanguage.googleapis.com/v1beta/files/generated-video:download?alt=media",
+              mimeType: "video/mp4",
+            },
+          },
+        ],
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": contentType },
+          }),
+      ),
+    );
+
+    const provider = buildGoogleVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "google",
+        model: "veo-3.1-fast-generate-preview",
+        prompt: "A tiny robot watering a windowsill garden",
+        cfg: {},
+        durationSeconds: 3,
+      }),
+    ).rejects.toThrow("Google generated video download: malformed video response");
+  });
+
   it("cancels each captured failed video download without waiting for its cloned stream", async () => {
     vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "google-key",

--- a/extensions/google/video-generation-provider.test.ts
+++ b/extensions/google/video-generation-provider.test.ts
@@ -453,6 +453,85 @@ describe("google video generation provider", () => {
     ).rejects.toThrow("Google generated video download: malformed video response");
   });
 
+  it("rejects a captured malformed video download without waiting for its cloned stream", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "google-key",
+      source: "env",
+      mode: "api-key",
+    });
+    generateVideosMock.mockResolvedValue({
+      done: true,
+      response: {
+        generatedVideos: [
+          {
+            video: {
+              uri: "https://generativelanguage.googleapis.com/v1beta/files/generated-video:download?alt=media",
+              mimeType: "video/mp4",
+            },
+          },
+        ],
+      },
+    });
+
+    const capturedResponses: Response[] = [];
+    const canceledBodies: ReadableStream<Uint8Array>[] = [];
+    let releaseCancel!: () => void;
+    const cancelGate = new Promise<void>((resolve) => {
+      releaseCancel = resolve;
+    });
+    const fetchMock = vi.fn(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1]));
+        },
+      });
+      const response = new Response(body, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+      });
+      capturedResponses.push(response.clone());
+      const responseBody = response.body;
+      if (!responseBody) {
+        throw new Error("expected a streaming malformed video download response");
+      }
+      // A capture clone keeps the response tee open, so cancellation stays
+      // pending; the malformed-body rejection must surface without awaiting it.
+      vi.spyOn(responseBody, "cancel").mockImplementation(() => {
+        canceledBodies.push(responseBody);
+        return cancelGate as unknown as Promise<undefined>;
+      });
+      return response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generation = buildGoogleVideoGenerationProvider().generateVideo({
+      provider: "google",
+      model: "veo-3.1-fast-generate-preview",
+      prompt: "A tiny robot watering a windowsill garden",
+      cfg: {},
+      durationSeconds: 3,
+    });
+    const outcome = await Promise.race([
+      generation.then(
+        () => "resolved",
+        (error: unknown) => `rejected:${error instanceof Error ? error.message : String(error)}`,
+      ),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("pending"), 100);
+      }),
+    ]);
+    releaseCancel();
+    expect(outcome).toBe("rejected:Google generated video download: malformed video response");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(canceledBodies).toHaveLength(1);
+    // The captured clone's tee branch stays open (that is the bug we prove the
+    // provider must not wait on), so release it without awaiting.
+    for (const response of capturedResponses) {
+      void response.body?.cancel().catch(() => undefined);
+    }
+  });
+
   it("cancels each captured failed video download without waiting for its cloned stream", async () => {
     vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "google-key",

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -249,8 +249,9 @@ async function downloadGeneratedVideoFromUri(params: {
         try {
           assertProviderBinaryResponseContent(response, "Google generated video download", "video");
         } catch (error) {
-          // A rejected binary response still owns a live socket until its unread body is canceled.
-          await response.body?.cancel().catch(() => undefined);
+          // A debug-capture clone can keep the tee open, so waiting for cancel
+          // would hang before the malformed-body error can be thrown.
+          void response.body?.cancel().catch(() => undefined);
           throw error;
         }
         const buffer = await readResponseWithLimit(response, params.maxBytes, {

--- a/extensions/google/video-generation-provider.ts
+++ b/extensions/google/video-generation-provider.ts
@@ -3,6 +3,7 @@ import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generat
 import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
+  assertProviderBinaryResponseContent,
   createProviderOperationDeadline,
   executeProviderOperationWithRetry,
   resolveProviderOperationTimeoutMs,
@@ -245,6 +246,13 @@ async function downloadGeneratedVideoFromUri(params: {
             `Failed to download Google generated video: ${response.status} ${response.statusText}`,
           );
         }
+        try {
+          assertProviderBinaryResponseContent(response, "Google generated video download", "video");
+        } catch (error) {
+          // A rejected binary response still owns a live socket until its unread body is canceled.
+          await response.body?.cancel().catch(() => undefined);
+          throw error;
+        }
         const buffer = await readResponseWithLimit(response, params.maxBytes, {
           chunkTimeoutMs: params.timeoutMs,
           onOverflow: ({ maxBytes }) =>
@@ -252,6 +260,10 @@ async function downloadGeneratedVideoFromUri(params: {
           onIdleTimeout: ({ chunkTimeoutMs }) =>
             new Error(`Google generated video download stalled after ${chunkTimeoutMs}ms`),
         });
+        if (buffer.byteLength === 0) {
+          await response.body?.cancel().catch(() => undefined);
+          throw new Error("Google generated video download: malformed video response");
+        }
         return {
           buffer,
           mimeType:


### PR DESCRIPTION
## Summary

Reject provider-owned generated-media downloads that return HTTP-200 JSON, problem JSON, HTML, or empty bodies, and cancel each rejected body so the underlying socket is released. Cancellation is non-blocking so a debug-capture clone that keeps the response tee open cannot hang the malformed-body rejection.

## What Problem This Solves

`extensions/fal/video-generation-provider.ts`, `extensions/fal/image-generation-provider.ts`, and `extensions/google/video-generation-provider.ts` download generated media through `fetchWithSsrFGuard`, which hands back `{ response, release }`. The guard's `release()` cleans up the timeout and dispatcher but does **not** consume or cancel an unread response body (`src/infra/net/fetch-guard.ts:508-515`).

When the provider-owned download URL returned HTTP-200 with a JSON/HTML content-type (for example an `{"error":"authentication expired"}` payload) or zero bytes, each provider read the body as a binary buffer and reported it as **successful generated media** — the model sees a video/image result whose bytes are actually an error document. Sibling providers (BytePlus video, Runway video, MiniMax music) were already covered by #117281; these three download paths were the remaining gap.

**Code evidence**:

- `extensions/fal/video-generation-provider.ts:216-250` — `downloadFalVideo` read the body into a buffer and returned it as a video without validating content-type or emptiness.
- `extensions/fal/image-generation-provider.ts:620-642` — `fetchImageBuffer` did the same for images.
- `extensions/google/video-generation-provider.ts:244-267` — `downloadGeneratedVideoFromUri` did the same for Google generated videos.

## Root Cause

- Violated invariant: callers of `fetchWithSsrFGuard` must consume a binary body or cancel it before `release()`; and provider-owned binary downloads must be content-validated before they can be surfaced as generated media.
- The three providers only checked `assertOkOrThrowHttpError`/`assertOkOrThrowProviderError` (HTTP status), which accepts any HTTP-200 body regardless of content-type.
- Trigger condition: any provider-owned download that returns HTTP-200 with a non-media body — auth-expired JSON, a sign-in HTML page, or an empty stream.

## Why This Fix

- Option A (this PR): call the canonical `assertProviderBinaryResponseContent` helper (`src/agents/provider-http-errors.ts:406-422`) before reading each binary body — the same helper #117281 uses for BytePlus/Runway/MiniMax — and reject empty bodies with a `malformed ... response` error. Each rejected body is cancelled (`response.body?.cancel()`) before the throw so the socket is released. Empty-body handling mirrors #117281's empty-check in the Runway download path.
- Option B (rejected): teach `release()` to cancel unread bodies globally — changes the guard's semantics for every caller; the established convention is caller-side cancellation (#115873, #109442, #117665).
- Option C (rejected): validate only content-type without the empty-body check — a zero-byte `video/mp4` would still surface as an empty "successful" video.

## Captured-Stream Hang

Each rejected body is cancelled before the throw so the socket is released, but the cancellation must be **non-blocking** (`void response.body?.cancel()`). `fetchWithSsrFGuard` can route the download through debug-capture, which clones the response and keeps the response tee open until both branches close. Awaiting `cancel()` on one tee branch then hangs until the clone closes, so the malformed-body error would never reach the caller. All three malformed-download branches (Google video, fal image, fal video) therefore abandon the cancelled body without awaiting it, and the regression tests prove the error returns within 100 ms while cancellation is still pending.

## User Impact

- Affected operation: `fal` and `google` generated-media generation when the provider-owned download returns a malformed body.
- Before: the model received a "successful" video/image whose bytes were an error document or empty — a silent failure that no action or log could explain.
- After: generation fails loudly with `...: malformed video response` / `...: malformed image response`, the body is cancelled, and the provider-owned download is never surfaced as generated media.

## Evidence

- `assertProviderBinaryResponseContent` is defined in `src/agents/provider-http-errors.ts:406-422` and rejects `application/json`, `+json`, `text/*`, and `text/*`-prefixed content-types. The `text/plain` catch rejects HTML pages (served as `text/html`) as non-binary.
- `git diff --check` clean; `oxfmt` clean on all six changed files.
- Codex autoreview: clean, no accepted/actionable findings.

## Real Behavior Proof

**Real-machine production-path proof.** The proof runs the exported production `buildFalVideoGenerationProvider` against a real `node:http` server simulating the full fal queue flow (submit → status → result → download), where the provider-owned download URL returns `200` with `content-type: application/json` and body `{"error":"authentication expired"}`. The real `fetchWithSsrFGuard` is used end-to-end; `resolveProviderHttpRequestConfig` is stubbed only to point at `127.0.0.1` with `allowPrivateNetwork: true`.

### Before (on `main`)

```console
[PROOF-OUTCOME] RESOLVED mimeType=application/json bytes={"error":"authentication expired"}
```

The provider resolved the JSON error document as a **successful generated video** (`mimeType: application/json`).

### After (with fix)

```console
[PROOF-OUTCOME] REJECTED fal generated video download: malformed video response
```

The same real download is rejected with `fal generated video download: malformed video response`.

## Tests and Validation

- Added `it.each` regression tests to `extensions/fal/video-generation-provider.test.ts`, `extensions/fal/image-generation-provider.test.ts`, and `extensions/google/video-generation-provider.test.ts`: a successful (HTTP-200) download returning JSON error, problem JSON, HTML, or an empty body must reject with the matching `malformed ... response` error. Each test fails on `main` and passes with the fix.
- Added cloned-stream regression tests (`rejects a captured malformed ... download without waiting for its cloned stream`) to the Google video and fal image/video suites: a streaming response whose body cancellation is gated pending (mirroring a debug-capture clone holding the tee open) must reject with the matching `malformed ... response` error within 100 ms. The test fails on the awaited-cancellation code (`pending`) and passes with the non-blocking cleanup. The fal tests share a `releasedCapturedStream` helper in `extensions/fal/test-support.ts`.
- `node scripts/run-vitest.mjs extensions/fal/video-generation-provider.test.ts extensions/fal/image-generation-provider.test.ts extensions/google/video-generation-provider.test.ts` — 93/93 tests passed across the three files (fal 69, google 24).
- Real-machine `node:http` server proof above exercised the real `fetchWithSsrFGuard` for both `before` (resolved) and `after` (rejected) states.
