### PR TITLE
fix(cli): fail nodes push when APNs rejects delivery

### DIFF
--- a/src/cli/nodes-cli/register.push.ts
+++ b/src/cli/nodes-cli/register.push.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
+import type { PushTestResult } from "../../../packages/gateway-protocol/src/index.js";
 import { defaultRuntime } from "../../runtime.js";
 import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
 import { callGatewayCli, nodesCallOpts, resolveNodeId } from "./rpc.js";
@@ -57,19 +58,9 @@ export function registerNodesPushCommand(nodes: Command) {
           }
 
           const result = await callGatewayCli("push.test", opts, params);
-          if (opts.json) {
-            defaultRuntime.writeJson(result);
-            return;
-          }
-
           const parsed =
             typeof result === "object" && result !== null
-              ? (result as {
-                  ok?: unknown;
-                  status?: unknown;
-                  reason?: unknown;
-                  environment?: unknown;
-                })
+              ? (result as Partial<PushTestResult>)
               : {};
           const ok = parsed.ok === true;
           const status = typeof parsed.status === "number" ? parsed.status : 0;
@@ -79,11 +70,19 @@ export function registerNodesPushCommand(nodes: Command) {
             typeof parsed.environment === "string"
               ? (normalizeOptionalString(parsed.environment) ?? "unknown")
               : "unknown";
-          const { ok: okLabel, error: errorLabel } = getNodesTheme();
-          const label = ok ? okLabel : errorLabel;
-          defaultRuntime.log(label(`push.test status=${status} ok=${ok} env=${env}`));
-          if (reason) {
-            defaultRuntime.log(`reason: ${reason}`);
+          if (opts.json) {
+            defaultRuntime.writeJson(result);
+          } else {
+            const { ok: okLabel, error: errorLabel } = getNodesTheme();
+            const label = ok ? okLabel : errorLabel;
+            defaultRuntime.log(label(`push.test status=${status} ok=${ok} env=${env}`));
+            if (reason) {
+              defaultRuntime.log(`reason: ${reason}`);
+            }
+          }
+          if (!ok) {
+            // Defer termination so the complete human/JSON result reaches stdout.
+            process.exitCode = 1;
           }
         });
       }),

--- a/src/cli/program.nodes-push.e2e.test.ts
+++ b/src/cli/program.nodes-push.e2e.test.ts
@@ -1,0 +1,117 @@
+// Program nodes push tests cover APNs provider outcomes through the full CLI registration.
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PushTestResult } from "../../packages/gateway-protocol/src/index.js";
+import { createIosNodeListResponse } from "./program.nodes-test-helpers.js";
+import { callGateway, runtime } from "./program.test-mocks.js";
+
+let registerNodesCli: typeof import("./nodes-cli.js").registerNodesCli;
+
+describe("cli program (nodes push)", () => {
+  let program: Command;
+  let previousExitCode: NodeJS.Process["exitCode"];
+
+  function mockPushResult(result: PushTestResult) {
+    callGateway.mockImplementation(async (...args: unknown[]) => {
+      const opts = (args[0] ?? {}) as { method?: string };
+      if (opts.method === "node.list") {
+        return createIosNodeListResponse();
+      }
+      if (opts.method === "push.test") {
+        return result;
+      }
+      return { ok: true };
+    });
+  }
+
+  function runtimeOutput(): string {
+    return runtime.log.mock.calls
+      .map(([value]) => (typeof value === "string" ? value : (JSON.stringify(value) ?? "")))
+      .join("\n");
+  }
+
+  async function runPush(extraArgs: string[] = []) {
+    await program.parseAsync(["nodes", "push", "--node", "ios-node", ...extraArgs], {
+      from: "user",
+    });
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    ({ registerNodesCli } = await import("./nodes-cli.js"));
+    program = new Command();
+    program.exitOverride();
+    await registerNodesCli(program);
+  });
+
+  afterEach(() => {
+    process.exitCode = previousExitCode;
+  });
+
+  it("sets a failing exit code after rendering an APNs push failure", async () => {
+    mockPushResult({
+      ok: false,
+      status: 400,
+      reason: "BadDeviceToken",
+      tokenSuffix: "1234abcd",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+      transport: "direct",
+    });
+
+    await runPush();
+
+    expect(process.exitCode).toBe(1);
+    expect(runtimeOutput()).toContain("push.test status=400 ok=false env=sandbox");
+    expect(runtimeOutput()).toContain("reason: BadDeviceToken");
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("preserves parseable JSON before setting a failing APNs push exit code", async () => {
+    const result: PushTestResult = {
+      ok: false,
+      status: 410,
+      reason: "Unregistered",
+      tokenSuffix: "1234abcd",
+      topic: "ai.openclaw.ios",
+      environment: "production",
+      transport: "relay",
+    };
+    mockPushResult(result);
+
+    await runPush(["--json"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(runtimeOutput())).toEqual(result);
+    expect(runtime.writeJson).toHaveBeenCalledWith(result);
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["text", []],
+    ["JSON", ["--json"]],
+  ])("keeps successful APNs push %s output at exit zero", async (_label, extraArgs) => {
+    const result: PushTestResult = {
+      ok: true,
+      status: 200,
+      apnsId: "apns-id",
+      tokenSuffix: "1234abcd",
+      topic: "ai.openclaw.ios",
+      environment: "sandbox",
+      transport: "direct",
+    };
+    mockPushResult(result);
+
+    await runPush(extraArgs);
+
+    expect(process.exitCode).toBeUndefined();
+    if (extraArgs.length > 0) {
+      expect(JSON.parse(runtimeOutput())).toEqual(result);
+    } else {
+      expect(runtimeOutput()).toContain("push.test status=200 ok=true env=sandbox");
+    }
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #117736

## What Problem This Solves

Fixes an issue where openclaw nodes push printed an APNs rejection such as ok false or BadDeviceToken but still returned shell exit status zero in both text and JSON modes.

## Why This Change Was Made

The Gateway intentionally returns a successful RPC with a typed PushTestResult so provider status, reason, transport, and registration cleanup remain available. The CLI now treats that result ok field as the shell-success authority after rendering the complete diagnostic, using deferred process exit state so stdout can drain.

## User Impact

Operators and automation can trust the command exit status: accepted pushes remain zero, while APNs rejections return one without losing human or machine-readable detail.

## Evidence

Blacksmith Testbox run 30727207288 passed all 4 full command-registration tests and the complete changed gate. Coverage exercises node resolution, push.test, text failure status and reason, parseable JSON failure, deferred nonzero exit, and text/JSON success controls.

Fresh post-lint-fix autoreview 019fc01a-0159-7791-a96b-b6d3974ee710 and TruffleHog were clean at 0.99. Independent protocol, Gateway, process-lifecycle, history, and test review found no findings. Production is net negative: 15 additions and 16 deletions; tests add 117 lines. Gateway, protocol, registration cleanup, and APNs transport behavior are unchanged.

This PR is AI-assisted. The implementation and proof were reviewed by the maintainer orchestrator; no agent transcript is attached.