### PR TITLE
feat(google): support params.serviceTier (Flex/Priority) for direct Gemini models

### DIFF
--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -467,6 +467,35 @@ roundtrip; pass `--openai-audio-cycles 3` for a short repeated lifecycle soak.
 
   </Accordion>
 
+  <Accordion title="Gemini service tier (Flex / Priority)">
+    For direct Gemini API runs (`api: "google-generative-ai"`), OpenClaw maps a
+    configured `serviceTier` (or `service_tier`) param to the top-level
+    `serviceTier` request field.
+
+    - Accepted values: `FLEX`, `PRIORITY`, `STANDARD` (case-insensitive).
+    - Configure per-model or global params with either `serviceTier` or
+      `service_tier`; within the same scope, `serviceTier` wins.
+    - Vertex (`api: "google-vertex"`) ignores a request-body service tier, so
+      the param is only applied to direct Gemini API requests.
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          models: {
+            "google/gemini-2.5-pro": {
+              params: {
+                serviceTier: "FLEX",
+              },
+            },
+          },
+        },
+      },
+    }
+    ```
+
+  </Accordion>
+
   <Accordion title="Gemini CLI usage notes">
     The optional `google-gemini-cli` runtime uses Gemini CLI `stream-json`
     output by default and normalizes usage from the final `stats` payload.

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -472,7 +472,8 @@ roundtrip; pass `--openai-audio-cycles 3` for a short repeated lifecycle soak.
     configured `serviceTier` (or `service_tier`) param to the top-level
     `serviceTier` request field.
 
-    - Accepted values: `FLEX`, `PRIORITY`, `STANDARD` (case-insensitive).
+    - Accepted values: `flex`, `priority`, `standard` (case-insensitive input;
+      serialized to the documented lower-case wire values).
     - Configure per-model or global params with either `serviceTier` or
       `service_tier`; within the same scope, `serviceTier` wins.
     - Vertex (`api: "google-vertex"`) ignores a request-body service tier, so
@@ -485,7 +486,7 @@ roundtrip; pass `--openai-audio-cycles 3` for a short repeated lifecycle soak.
           models: {
             "google/gemini-2.5-pro": {
               params: {
-                serviceTier: "FLEX",
+                serviceTier: "flex",
               },
             },
           },

--- a/extensions/google/provider-hooks.test.ts
+++ b/extensions/google/provider-hooks.test.ts
@@ -132,7 +132,7 @@ describe("GOOGLE_GEMINI_PROVIDER_HOOKS.wrapStreamFn serviceTier", () => {
       api: "google-generative-ai",
       extraParams: { serviceTier: "flex" },
     });
-    expect(payload?.serviceTier).toBe("FLEX");
+    expect(payload?.serviceTier).toBe("flex");
   });
 
   it("does not set serviceTier on Vertex payloads", () => {
@@ -147,9 +147,9 @@ describe("GOOGLE_GEMINI_PROVIDER_HOOKS.wrapStreamFn serviceTier", () => {
     const payload = captureServiceTierCall({
       api: "google-generative-ai",
       extraParams: { serviceTier: "flex" },
-      initialPayload: { serviceTier: "PRIORITY" },
+      initialPayload: { serviceTier: "priority" },
     });
-    expect(payload?.serviceTier).toBe("PRIORITY");
+    expect(payload?.serviceTier).toBe("priority");
   });
 
   it("ignores invalid serviceTier params", () => {

--- a/extensions/google/provider-hooks.test.ts
+++ b/extensions/google/provider-hooks.test.ts
@@ -1,3 +1,4 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { createCapturedThinkingConfigStream } from "openclaw/plugin-sdk/provider-test-contracts";
 import { describe, expect, it } from "vitest";
 import { GOOGLE_GEMINI_PROVIDER_HOOKS } from "./provider-hooks.js";
@@ -91,6 +92,72 @@ describe("GOOGLE_GEMINI_PROVIDER_HOOKS.wrapStreamFn", () => {
       | { thinkingConfig?: unknown }
       | undefined;
     expect(capturedConfig?.thinkingConfig).toEqual(expected);
+  });
+});
+
+describe("GOOGLE_GEMINI_PROVIDER_HOOKS.wrapStreamFn serviceTier", () => {
+  function captureServiceTierCall(params: {
+    api: string;
+    extraParams?: Record<string, unknown>;
+    initialPayload?: Record<string, unknown>;
+  }) {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const streamFn: StreamFn = (model, _context, options) => {
+      const payload = (params.initialPayload ? { ...params.initialPayload } : {}) as Record<
+        string,
+        unknown
+      >;
+      options?.onPayload?.(payload as never, model as never);
+      capturedPayload = payload;
+      return {} as never;
+    };
+    const wrapped = GOOGLE_GEMINI_PROVIDER_HOOKS.wrapStreamFn({
+      provider: "google",
+      modelId: "gemini-3-flash-preview",
+      extraParams: params.extraParams,
+      streamFn,
+    });
+    void wrapped(
+      { api: params.api, provider: "google", id: "gemini-3-flash-preview" } as never,
+      {
+        messages: [],
+      } as never,
+      {},
+    );
+    return capturedPayload;
+  }
+
+  it("maps params.serviceTier onto the direct AI Studio payload", () => {
+    const payload = captureServiceTierCall({
+      api: "google-generative-ai",
+      extraParams: { serviceTier: "flex" },
+    });
+    expect(payload?.serviceTier).toBe("FLEX");
+  });
+
+  it("does not set serviceTier on Vertex payloads", () => {
+    const payload = captureServiceTierCall({
+      api: "google-vertex",
+      extraParams: { serviceTier: "flex" },
+    });
+    expect(payload?.serviceTier).toBeUndefined();
+  });
+
+  it("keeps an explicit payload serviceTier over params", () => {
+    const payload = captureServiceTierCall({
+      api: "google-generative-ai",
+      extraParams: { serviceTier: "flex" },
+      initialPayload: { serviceTier: "PRIORITY" },
+    });
+    expect(payload?.serviceTier).toBe("PRIORITY");
+  });
+
+  it("ignores invalid serviceTier params", () => {
+    const payload = captureServiceTierCall({
+      api: "google-generative-ai",
+      extraParams: { serviceTier: "turbo" },
+    });
+    expect(payload?.serviceTier).toBeUndefined();
   });
 });
 

--- a/extensions/google/provider-hooks.ts
+++ b/extensions/google/provider-hooks.ts
@@ -12,6 +12,7 @@ import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-st
 import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
 import { stripGoogleProviderPrefix } from "./model-id.js";
 import { resolveGoogleThinkingProfile } from "./provider-policy.js";
+import { applyGoogleServiceTierToPayload, resolveGoogleServiceTier } from "./service-tier.js";
 import { sanitizeGoogleThinkingPayload } from "./thinking-api.js";
 
 // Google-family gRPC status codes stay with the shared Gemini provider hook.
@@ -28,7 +29,8 @@ function classifyGoogleFailoverCode(code: string | undefined) {
   }
 }
 
-function wrapGoogleThinkingStream(ctx: ProviderWrapStreamFnContext) {
+function wrapGoogleStream(ctx: ProviderWrapStreamFnContext) {
+  const serviceTier = resolveGoogleServiceTier(ctx.extraParams);
   return createPayloadPatchStreamWrapper(ctx.streamFn, ({ payload, model }) => {
     if (model.api !== "google-generative-ai" && model.api !== "google-vertex") {
       return;
@@ -38,6 +40,10 @@ function wrapGoogleThinkingStream(ctx: ProviderWrapStreamFnContext) {
       modelId: stripGoogleProviderPrefix(model.id).replace(/^models\//u, ""),
       thinkingLevel: ctx.thinkingLevel,
     });
+    // Vertex ignores a request-body serviceTier; only direct AI Studio honors it.
+    if (serviceTier && model.api === "google-generative-ai") {
+      applyGoogleServiceTierToPayload(payload, serviceTier);
+    }
   });
 }
 
@@ -48,7 +54,7 @@ export const GOOGLE_GEMINI_PROVIDER_HOOKS = {
   ...buildProviderToolCompatFamilyHooks("gemini"),
   resolveThinkingProfile: (context: ProviderDefaultThinkingPolicyContext) =>
     resolveGoogleThinkingProfile(context) satisfies ProviderThinkingProfile | undefined,
-  wrapStreamFn: wrapGoogleThinkingStream,
+  wrapStreamFn: wrapGoogleStream,
   classifyFailoverReason: ({ code }: ProviderFailoverErrorContext) =>
     classifyGoogleFailoverCode(code),
 };

--- a/extensions/google/service-tier.test.ts
+++ b/extensions/google/service-tier.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { applyGoogleServiceTierToPayload, resolveGoogleServiceTier } from "./service-tier.js";
+
+describe("resolveGoogleServiceTier", () => {
+  it.each([
+    { label: "lowercase flex", params: { serviceTier: "flex" }, expected: "FLEX" },
+    { label: "uppercase FLEX", params: { serviceTier: "FLEX" }, expected: "FLEX" },
+    { label: "padded priority", params: { serviceTier: " priority " }, expected: "PRIORITY" },
+    { label: "standard", params: { serviceTier: "standard" }, expected: "STANDARD" },
+    { label: "snake_case alias", params: { service_tier: "flex" }, expected: "FLEX" },
+    {
+      label: "camelCase wins",
+      params: { serviceTier: "priority", service_tier: "flex" },
+      expected: "PRIORITY",
+    },
+    { label: "invalid value", params: { serviceTier: "turbo" }, expected: undefined },
+    { label: "empty value", params: { serviceTier: "" }, expected: undefined },
+    { label: "non-string value", params: { serviceTier: 42 }, expected: undefined },
+    { label: "missing params", params: undefined, expected: undefined },
+    { label: "unrelated params", params: { temperature: 0.2 }, expected: undefined },
+  ] as const)("resolves $label", ({ params, expected }) => {
+    expect(resolveGoogleServiceTier(params)).toBe(expected);
+  });
+});
+
+describe("applyGoogleServiceTierToPayload", () => {
+  it("sets serviceTier when the payload does not define one", () => {
+    const payload: Record<string, unknown> = {};
+    applyGoogleServiceTierToPayload(payload, "FLEX");
+    expect(payload.serviceTier).toBe("FLEX");
+  });
+
+  it("keeps an explicit payload serviceTier", () => {
+    const payload: Record<string, unknown> = { serviceTier: "PRIORITY" };
+    applyGoogleServiceTierToPayload(payload, "FLEX");
+    expect(payload.serviceTier).toBe("PRIORITY");
+  });
+});

--- a/extensions/google/service-tier.test.ts
+++ b/extensions/google/service-tier.test.ts
@@ -3,15 +3,15 @@ import { applyGoogleServiceTierToPayload, resolveGoogleServiceTier } from "./ser
 
 describe("resolveGoogleServiceTier", () => {
   it.each([
-    { label: "lowercase flex", params: { serviceTier: "flex" }, expected: "FLEX" },
-    { label: "uppercase FLEX", params: { serviceTier: "FLEX" }, expected: "FLEX" },
-    { label: "padded priority", params: { serviceTier: " priority " }, expected: "PRIORITY" },
-    { label: "standard", params: { serviceTier: "standard" }, expected: "STANDARD" },
-    { label: "snake_case alias", params: { service_tier: "flex" }, expected: "FLEX" },
+    { label: "lowercase flex", params: { serviceTier: "flex" }, expected: "flex" },
+    { label: "uppercase FLEX", params: { serviceTier: "FLEX" }, expected: "flex" },
+    { label: "padded priority", params: { serviceTier: " priority " }, expected: "priority" },
+    { label: "standard", params: { serviceTier: "standard" }, expected: "standard" },
+    { label: "snake_case alias", params: { service_tier: "flex" }, expected: "flex" },
     {
       label: "camelCase wins",
       params: { serviceTier: "priority", service_tier: "flex" },
-      expected: "PRIORITY",
+      expected: "priority",
     },
     { label: "invalid value", params: { serviceTier: "turbo" }, expected: undefined },
     { label: "empty value", params: { serviceTier: "" }, expected: undefined },
@@ -26,13 +26,13 @@ describe("resolveGoogleServiceTier", () => {
 describe("applyGoogleServiceTierToPayload", () => {
   it("sets serviceTier when the payload does not define one", () => {
     const payload: Record<string, unknown> = {};
-    applyGoogleServiceTierToPayload(payload, "FLEX");
-    expect(payload.serviceTier).toBe("FLEX");
+    applyGoogleServiceTierToPayload(payload, "flex");
+    expect(payload.serviceTier).toBe("flex");
   });
 
   it("keeps an explicit payload serviceTier", () => {
-    const payload: Record<string, unknown> = { serviceTier: "PRIORITY" };
-    applyGoogleServiceTierToPayload(payload, "FLEX");
-    expect(payload.serviceTier).toBe("PRIORITY");
+    const payload: Record<string, unknown> = { serviceTier: "priority" };
+    applyGoogleServiceTierToPayload(payload, "flex");
+    expect(payload.serviceTier).toBe("priority");
   });
 });

--- a/extensions/google/service-tier.ts
+++ b/extensions/google/service-tier.ts
@@ -1,0 +1,29 @@
+// Google AI Studio (direct Gemini API) accepts a top-level `serviceTier`
+// request field. Vertex ignores a request-body serviceTier, so this mapping
+// must only be applied to the direct `google-generative-ai` transport.
+const GOOGLE_SERVICE_TIERS = ["FLEX", "PRIORITY", "STANDARD"] as const;
+
+export type GoogleServiceTier = (typeof GOOGLE_SERVICE_TIERS)[number];
+
+export function resolveGoogleServiceTier(
+  extraParams: Record<string, unknown> | undefined,
+): GoogleServiceTier | undefined {
+  const raw = extraParams?.serviceTier ?? extraParams?.service_tier;
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const normalized = raw.trim().toUpperCase();
+  return (GOOGLE_SERVICE_TIERS as readonly string[]).includes(normalized)
+    ? (normalized as GoogleServiceTier)
+    : undefined;
+}
+
+export function applyGoogleServiceTierToPayload(
+  payload: Record<string, unknown>,
+  serviceTier: GoogleServiceTier,
+): void {
+  // An explicit payload value (e.g. set by an onPayload hook) wins over params.
+  if (payload.serviceTier === undefined) {
+    payload.serviceTier = serviceTier;
+  }
+}

--- a/extensions/google/service-tier.ts
+++ b/extensions/google/service-tier.ts
@@ -1,7 +1,10 @@
 // Google AI Studio (direct Gemini API) accepts a top-level `serviceTier`
-// request field. Vertex ignores a request-body serviceTier, so this mapping
-// must only be applied to the direct `google-generative-ai` transport.
-const GOOGLE_SERVICE_TIERS = ["FLEX", "PRIORITY", "STANDARD"] as const;
+// request field. The wire values are the documented lower-case enums
+// ("flex" | "priority" | "standard"); see the API discovery document
+// (GenerateContentRequest.serviceTier). Vertex ignores a request-body
+// serviceTier, so this mapping must only be applied to the direct
+// `google-generative-ai` transport.
+const GOOGLE_SERVICE_TIERS = ["flex", "priority", "standard"] as const;
 
 type GoogleServiceTier = (typeof GOOGLE_SERVICE_TIERS)[number];
 
@@ -12,7 +15,7 @@ export function resolveGoogleServiceTier(
   if (typeof raw !== "string") {
     return undefined;
   }
-  const normalized = raw.trim().toUpperCase();
+  const normalized = raw.trim().toLowerCase();
   return (GOOGLE_SERVICE_TIERS as readonly string[]).includes(normalized)
     ? (normalized as GoogleServiceTier)
     : undefined;

--- a/extensions/google/service-tier.ts
+++ b/extensions/google/service-tier.ts
@@ -3,7 +3,7 @@
 // must only be applied to the direct `google-generative-ai` transport.
 const GOOGLE_SERVICE_TIERS = ["FLEX", "PRIORITY", "STANDARD"] as const;
 
-export type GoogleServiceTier = (typeof GOOGLE_SERVICE_TIERS)[number];
+type GoogleServiceTier = (typeof GOOGLE_SERVICE_TIERS)[number];
 
 export function resolveGoogleServiceTier(
   extraParams: Record<string, unknown> | undefined,

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -88,6 +88,7 @@ type GoogleGenerateContentRequest = {
   cachedContent?: string;
   contents: Array<Record<string, unknown>>;
   generationConfig?: Record<string, unknown>;
+  serviceTier?: string;
   systemInstruction?: Record<string, unknown>;
   tools?: Array<Record<string, unknown>>;
   toolConfig?: Record<string, unknown>;


### PR DESCRIPTION
Closes #69102

## What Problem This Solves

Users running direct Google AI Studio (Gemini) models had no way to request the Flex service tier from OpenClaw. The Gemini API accepts a top-level `serviceTier` request field (`flex` / `priority` / `standard`), but OpenClaw never serialized it, so users who wanted Flex pricing/latency trade-offs had to route through OpenRouter workarounds instead of using their direct Google access.

## Why This Change Was Made

The per-model/global `params` config surface now accepts `serviceTier` (or `service_tier`) for Google models and the Google provider stream hook maps it onto the outbound payload's top-level `serviceTier` field. This reuses the existing `params` mechanism (same shape as `cachedContent`), so no new config keys are introduced.

The serialized values are the documented lower-case wire literals, verified against the API discovery document (`GenerateContentRequest.serviceTier` enumerates `unspecified` / `standard` / `flex` / `priority`).

Two deliberate boundaries, matching the direction flagged in the issue:

- Vertex (`google-vertex`) ignores a request-body service tier, so the mapping only applies to the direct `google-generative-ai` transport; sharing a tier contract with the Vertex alias path (#90243) is left as a separate maintainer decision.
- An explicit payload `serviceTier` (e.g. set by an `onPayload` hook) wins over the param.

## User Impact

Users can now select the Flex (or Priority) service tier for direct Gemini models:

```json5
{
  agents: {
    defaults: {
      models: {
        "google/gemini-2.5-flash": {
          params: { serviceTier: "flex" },
        },
      },
    },
  },
}
```

Values are case-insensitive on input and serialized to the documented lower-case wire values; invalid values are ignored. Documented in `docs/providers/google.md`.

**Upgrade note:** if an existing configuration already sets a generic `params.serviceTier`/`service_tier` value on a direct Google model, that value was previously inert and will become an active tier selection after upgrade. Review saved configs before upgrading if this is a concern.

## Evidence

**Live after-fix proof (real Gemini API, redacted):** OpenClaw's real transport + provider hook, `params.serviceTier: "flex"` on `gemini-2.5-flash`:

```
=== live request with params.serviceTier=flex ===
response text: "service tier ok"
stopReason: stop

=== raw API contract check (generateContent, serviceTier:"flex") ===
text: "service tier ok"
usageMetadata: {..., "serviceTier": "flex"}
```

Google accepted the tiered request and echoed `"serviceTier": "flex"` in `usageMetadata`.

**Wire-level proof (local HTTP server at the fetch boundary):**

```
=== params.serviceTier=flex (direct AI Studio) ===
request path: /v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse
top-level serviceTier: "flex"
body keys: contents, serviceTier

=== no serviceTier param (regression) ===
top-level serviceTier: undefined
```

**Tests (31 passed):** `extensions/google/service-tier.test.ts` (normalization incl. `service_tier` alias, case-insensitivity, invalid values) and `extensions/google/provider-hooks.test.ts` (direct AI Studio gets `serviceTier`, Vertex does not, explicit payload value wins, invalid ignored). Adjacent suites (`transport-stream.test.ts`, `thinking.test.ts`, 143 tests) also pass.
