### PR TITLE
fix(model-catalog): decode hosted model catalog bundles with fatal UTF-8 validation

### DIFF
--- a/src/model-catalog/remote-refresh.test.ts
+++ b/src/model-catalog/remote-refresh.test.ts
@@ -194,40 +194,33 @@ describe("remote model catalog refresh", () => {
     ).resolves.toMatchObject({ status: "error" });
   });
 
-  it("rejects a bundle whose model id contains invalid UTF-8 bytes", async () => {
-    const valid = new TextEncoder().encode(JSON.stringify(bundle));
-    const needle = new TextEncoder().encode("claude-test");
-    let index = -1;
-    for (let i = 0; i < valid.length - needle.length; i += 1) {
-      let match = true;
-      for (let j = 0; j < needle.length; j += 1) {
-        if (valid[i + j] !== needle[j]) {
-          match = false;
-          break;
-        }
-      }
-      if (match) {
-        index = i;
-        break;
-      }
-    }
-    expect(index).toBeGreaterThan(0);
-    const mid = index + 6; // inside "claude-test", between 's' and 't'
-    const corrupt = new Uint8Array(valid.length + 1);
-    corrupt.set(valid.subarray(0, mid));
-    corrupt[mid] = 0xff;
-    corrupt.set(valid.subarray(mid), mid + 1);
+  it("preserves the previous catalog when a newer bundle contains invalid UTF-8", async () => {
+    const databaseOptions = options();
+    const previous = {
+      bundle_json: JSON.stringify(bundle),
+      generated_at: bundle.generatedAt,
+      min_version: bundle.minVersion,
+      source_url: DEFAULT_REMOTE_MODEL_CATALOG_URL,
+      etag: '"previous"',
+      last_modified: "Wed, 23 Jul 2025 00:00:00 GMT",
+      checked_at: 10_000,
+    };
+    writeRemoteModelCatalog(previous, databaseOptions);
+
+    const corrupt = Buffer.from(JSON.stringify({ ...bundle, generatedAt: bundle.generatedAt + 1 }));
+    const modelIdOffset = corrupt.indexOf("claude-test");
+    expect(modelIdOffset).toBeGreaterThanOrEqual(0);
+    corrupt[modelIdOffset + "claude-".length] = 0xff;
 
     const fetchImpl = vi.fn<typeof fetch>(async () => new Response(corrupt, { status: 200 }));
     await expect(
       refreshRemoteModelCatalog({
         config: {},
         fetchImpl,
-        databaseOptions: options(),
+        databaseOptions,
         force: true,
       }),
     ).resolves.toMatchObject({ status: "error" });
-    const persisted = readRemoteModelCatalog(options())?.bundle_json;
-    expect(persisted).toBeUndefined();
+    expect(readRemoteModelCatalog(databaseOptions)).toMatchObject(previous);
   });
 });

--- a/src/model-catalog/remote-refresh.test.ts
+++ b/src/model-catalog/remote-refresh.test.ts
@@ -193,4 +193,41 @@ describe("remote model catalog refresh", () => {
       }),
     ).resolves.toMatchObject({ status: "error" });
   });
+
+  it("rejects a bundle whose model id contains invalid UTF-8 bytes", async () => {
+    const valid = new TextEncoder().encode(JSON.stringify(bundle));
+    const needle = new TextEncoder().encode("claude-test");
+    let index = -1;
+    for (let i = 0; i < valid.length - needle.length; i += 1) {
+      let match = true;
+      for (let j = 0; j < needle.length; j += 1) {
+        if (valid[i + j] !== needle[j]) {
+          match = false;
+          break;
+        }
+      }
+      if (match) {
+        index = i;
+        break;
+      }
+    }
+    expect(index).toBeGreaterThan(0);
+    const mid = index + 6; // inside "claude-test", between 's' and 't'
+    const corrupt = new Uint8Array(valid.length + 1);
+    corrupt.set(valid.subarray(0, mid));
+    corrupt[mid] = 0xff;
+    corrupt.set(valid.subarray(mid), mid + 1);
+
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response(corrupt, { status: 200 }));
+    await expect(
+      refreshRemoteModelCatalog({
+        config: {},
+        fetchImpl,
+        databaseOptions: options(),
+        force: true,
+      }),
+    ).resolves.toMatchObject({ status: "error" });
+    const persisted = readRemoteModelCatalog(options())?.bundle_json;
+    expect(persisted).toBeUndefined();
+  });
 });

--- a/src/model-catalog/remote-refresh.ts
+++ b/src/model-catalog/remote-refresh.ts
@@ -165,7 +165,7 @@ export async function refreshRemoteModelCatalog(params: {
         chunkTimeoutMs: REMOTE_MODEL_CATALOG_TIMEOUT_MS,
       });
       const bundle = validateAndSanitizeRemoteModelCatalogBundle(
-        JSON.parse(new TextDecoder().decode(body)),
+        JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(body)),
       );
       assertCompatibleMinVersion(bundle);
       const bundleJson = JSON.stringify(bundle);


### PR DESCRIPTION
## Summary

Reject malformed UTF-8 at the hosted model-catalog byte boundary before JSON parsing and SQLite persistence.

## What Problem This Solves

`refreshRemoteModelCatalog` decoded remote bytes with the forgiving `TextDecoder()` default. Invalid byte sequences inside JSON string values became U+FFFD, still parsed as valid JSON, passed structural validation, and could be persisted as corrupted model identifiers.

A corrupt stored identifier then enters model selection and fails later as an unknown model. The refresh must reject malformed bytes before the authoritative SQLite write and preserve the previous valid catalog.

## Root Cause

The hosted catalog reader used non-fatal UTF-8 decoding at the remote byte boundary. Structural validation cannot distinguish a replacement character introduced by decoding from legitimate U+FFFD content.

## Fix

Use `new TextDecoder('utf-8', { fatal: true })` immediately before `JSON.parse`. Decode failures follow the existing typed refresh-error path, so the current stored catalog remains authoritative.

This matches the sibling live provider-catalog decoder. Post-parse U+FFFD scanning is deliberately avoided because U+FFFD can be legitimate content and cannot prove byte corruption.

## Regression Coverage

The new test:

- seeds a complete prior catalog row and metadata;
- injects raw `0xFF` into a model identifier in a newer bundle;
- asserts refresh returns `status: 'error'`;
- asserts the prior SQLite row remains unchanged.

## Evidence

Exact head: `fa155bac935c6308e5c09fb170ddd7e10d4aedcf`

- Sanitized direct AWS, public networking, no instance profile, no Tailscale: `pnpm test src/model-catalog/remote-refresh.test.ts` - 7/7 passed.
- Same sanitized AWS run: `pnpm tsgo:core:test` - passed.
- Fresh branch autoreview: clean, no accepted/actionable findings.
- `git diff --check` - clean.

### Real refresh-path proof

A disposable exact-head harness started a real loopback HTTP server, seeded the canonical SQLite row, served a newer catalog containing raw invalid UTF-8, and invoked `refreshRemoteModelCatalog` without `fetchImpl`. This exercised the configured-origin SSRF guard, bounded response reader, fatal decoder, error path, and persisted-row invariant.

```text
ok=true
head=fa155bac935c6308e5c09fb170ddd7e10d4aedcf
transport=loopback-http
fetch_path=configured-origin-ssrf-guard
injected_fetch=false
refresh_status=error
malformed_utf8_rejected=true
request_count=1
conditional_refresh_headers=true
prior_row_preserved=true
metadata_preserved=true
```

Provider: sanitized direct AWS Crabbox. Run: `run_a654ea8b4e84`. The lease was stopped after the successful proof.

## Scope

Two files: one production-line replacement and one focused regression (`+31/-1`). No schema, config, migration, fallback, or gateway lifecycle changes.