### PR TITLE
fix(release): allow larger npm plugin artifacts

### DIFF
--- a/scripts/plugin-publication-artifact.mjs
+++ b/scripts/plugin-publication-artifact.mjs
@@ -39,7 +39,8 @@ const MAX_ARCHIVE_BYTES = 256 * 1024 * 1024;
 const MAX_EXPANDED_BYTES = 512 * 1024 * 1024;
 const MAX_MANIFEST_BYTES = 4 * 1024 * 1024;
 const MAX_PLUGIN_MANIFEST_BYTES = 2 * 1024 * 1024;
-const MAX_TAR_ENTRIES = 10_000;
+// Bundled SDKs can exceed 10k files; byte, path, and expansion caps remain authoritative.
+const MAX_TAR_ENTRIES = 20_000;
 const MAX_TAR_PATH_BYTES = 4 * 1024 * 1024;
 const MAX_TAR_TOTAL_FILE_BYTES = 512 * 1024 * 1024;
 export const CLAWHUB_PUBLICATION_TAR_LIMITS = Object.freeze({

--- a/test/scripts/plugin-publication-artifact.test.ts
+++ b/test/scripts/plugin-publication-artifact.test.ts
@@ -1158,14 +1158,14 @@ describe("plugin publication artifact", () => {
       createTarball([
         { path: "package/", type: "5" },
         { content: metaPackageJson(markerPath), path: "package/package.json" },
-        ...Array.from({ length: 10_000 }, (_, index) => ({
+        ...Array.from({ length: 20_000 }, (_, index) => ({
           path: `package/file-${index.toString().padStart(5, "0")}`,
         })),
       ]),
     );
 
     expect(() => createPluginPublicationArtifact(publicationParams(artifactDir))).toThrow(
-      /exceeds the 10000 entry limit/u,
+      /exceeds the 20000 entry limit/u,
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the beta publisher rejected a valid bundled npm plugin after packaging because its tarball contained more than 10,000 entries. `@openclaw/diagnostics-otel` was the only failed package in release run 30728161070.

## Why This Change Was Made

The npm publication artifact scanner now accepts up to 20,000 tar headers. The measured diagnostics-otel beta tarball contains 11,646 entries and is 4.7 MB. Existing archive-byte, expanded-byte, per-entry, total-file-byte, path-byte, and separate ClawHub limits remain unchanged.

## User Impact

Bundled plugins with large dependency trees can complete verified npm publication without weakening the scanner's byte and path safety bounds. There is no runtime or public API change.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/plugin-publication-artifact.test.ts`: 48 tests passed.
- The exact failed `@openclaw/diagnostics-otel@2026.7.2-beta.7` tarball successfully produced a canonical publication manifest with this change.
- Exact failed artifact: 11,646 entries, 4.7 MB.
- Previous failure: run 30728161070, job 91443974907, `Plugin tarball exceeds the 10000 entry limit.`
- No changelog entry: this is internal release tooling with no shipped runtime behavior change.
