### PR TITLE
fix(agents): stop flagging complete exact-limit searches as truncated

### DIFF
--- a/src/agents/sessions/tools/find.fd.test.ts
+++ b/src/agents/sessions/tools/find.fd.test.ts
@@ -43,6 +43,13 @@ function createChild(): MockChild {
   return child;
 }
 
+function textContent(
+  result: Awaited<ReturnType<ReturnType<typeof createFindToolDefinition>["execute"]>>,
+): string {
+  const first = result.content[0];
+  return first?.type === "text" ? (first.text ?? "") : "";
+}
+
 it("rejects partial fd output when fd exits with an error", async () => {
   const child = createChild();
   vi.mocked(spawnCommand).mockReturnValue(child as never);
@@ -123,4 +130,43 @@ it.each([
 
   const args = vi.mocked(spawnCommand).mock.calls[0]?.[0] as string[];
   expect(args.includes("--no-require-git")).toBe(expected);
+});
+
+it.each([
+  {
+    name: "keeps an exact-size fd result complete",
+    paths: ["/workspace/a.ts", "/workspace/b.ts"],
+    expectedText: "a.ts\nb.ts",
+    expectedLimitReached: undefined,
+  },
+  {
+    name: "uses one extra fd result as the truncation sentinel",
+    paths: ["/workspace/a.ts", "/workspace/b.ts", "/workspace/c.ts"],
+    expectedText:
+      "a.ts\nb.ts\n\n[2 results limit reached. Use limit=4 for more, or refine pattern]",
+    expectedLimitReached: 2,
+  },
+])("$name", async ({ paths, expectedText, expectedLimitReached }) => {
+  const child = createChild();
+  vi.mocked(spawnCommand).mockReturnValue(child as never);
+  vi.mocked(ensureTool).mockResolvedValue("fd");
+
+  const tool = createFindToolDefinition("/workspace");
+  const resultPromise = tool.execute(
+    "call-limit",
+    { pattern: "*.ts", limit: 2 },
+    undefined,
+    undefined,
+    {} as never,
+  );
+  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+  child.stdout.end(`${paths.join("\n")}\n`);
+  child.stderr.end();
+  child.emit("close", 0, null);
+
+  const result = await resultPromise;
+  const args = vi.mocked(spawnCommand).mock.calls[0]?.[0] as string[];
+  expect(args).toEqual(expect.arrayContaining(["--max-results", "3"]));
+  expect(textContent(result)).toBe(expectedText);
+  expect(result.details?.resultLimitReached).toBe(expectedLimitReached);
 });

--- a/src/agents/sessions/tools/find.test.ts
+++ b/src/agents/sessions/tools/find.test.ts
@@ -1,7 +1,7 @@
 // find tool tests cover custom search operation wiring and result-limit
 // normalization for session file discovery.
 import { Value } from "typebox/value";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createFindToolDefinition, type FindOperations } from "./find.js";
 
 function operations(results: string[]): FindOperations {
@@ -53,4 +53,38 @@ describe("find tool", () => {
     expect(textContent(result)).toBe("a.ts\nb.ts");
     expect(result.details).toBeUndefined();
   });
+
+  it.each([
+    {
+      name: "keeps an exact-size result complete",
+      results: ["/workspace/a.ts", "/workspace/b.ts"],
+      expectedText: "a.ts\nb.ts",
+      expectedLimitReached: undefined,
+    },
+    {
+      name: "uses one extra result as the truncation sentinel",
+      results: ["/workspace/a.ts", "/workspace/b.ts", "/workspace/c.ts"],
+      expectedText: "a.ts\nb.ts\n\n[2 results limit reached]",
+      expectedLimitReached: 2,
+    },
+  ])(
+    "$name for custom glob operations",
+    async ({ results, expectedText, expectedLimitReached }) => {
+      const glob = vi.fn((_pattern: string, _cwd: string, options: { limit: number }) =>
+        results.slice(0, options.limit),
+      );
+      const tool = createFindToolDefinition("/workspace", {
+        operations: { exists: () => true, glob },
+      });
+
+      const result = await execute(tool, 2);
+
+      expect(glob).toHaveBeenCalledWith("*.ts", "/workspace", {
+        ignore: ["**/node_modules/**", "**/.git/**"],
+        limit: 3,
+      });
+      expect(textContent(result)).toBe(expectedText);
+      expect(result.details?.resultLimitReached).toBe(expectedLimitReached);
+    },
+  );
 });

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -123,8 +123,8 @@ function buildFindResult(params: {
   content: Array<{ type: "text"; text: string }>;
   details: FindToolDetails | undefined;
 } {
-  const resultLimitReached = params.relativized.length >= params.effectiveLimit;
-  const rawOutput = params.relativized.join("\n");
+  const resultLimitReached = params.relativized.length > params.effectiveLimit;
+  const rawOutput = params.relativized.slice(0, params.effectiveLimit).join("\n");
   const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
   let resultOutput = truncation.content;
   const details: FindToolDetails = {};
@@ -198,6 +198,8 @@ export function createFindToolDefinition(
             }
             const searchPath = resolveToCwd(searchDir || ".", cwd);
             const effectiveLimit = normalizePositiveLimit(limit, DEFAULT_LIMIT);
+            // One extra candidate distinguishes an exact-size result from a truncated one.
+            const observationLimit = effectiveLimit + 1;
             const ops = customOps ?? defaultFindOperations;
 
             // If custom operations provide glob(), use that instead of fd.
@@ -212,7 +214,7 @@ export function createFindToolDefinition(
               }
               const results = await ops.glob(pattern, searchPath, {
                 ignore: ["**/node_modules/**", "**/.git/**"],
-                limit: effectiveLimit,
+                limit: observationLimit,
               });
               if (signal?.aborted) {
                 settle(() => reject(new Error("Operation aborted")));
@@ -229,7 +231,7 @@ export function createFindToolDefinition(
               }
 
               // Relativize paths against the search root for stable output.
-              const relativized = results.map((p) => {
+              const relativized = results.slice(0, observationLimit).map((p) => {
                 if (p.startsWith(searchPath)) {
                   return toPosixPath(p.slice(searchPath.length + 1));
                 }
@@ -264,7 +266,7 @@ export function createFindToolDefinition(
             if (!isInsideGitRepository(searchPath)) {
               args.push("--no-require-git");
             }
-            args.push("--max-results", String(effectiveLimit));
+            args.push("--max-results", String(observationLimit));
 
             // fd --glob matches against the basename unless --full-path is set; in --full-path
             // mode it matches against the absolute candidate path, so a path-containing

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -1,5 +1,4 @@
-// Grep tool stream error tests verify that stdout/stderr errors reject the tool
-// promise instead of crashing the agent runtime.
+// Grep tool streaming tests cover result limits, cancellation, and subprocess errors.
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
@@ -42,7 +41,73 @@ function createChild(): MockChild {
   return child;
 }
 
-describe("grep tool stream errors", () => {
+function grepMatch(lineNumber: number): string {
+  return `${JSON.stringify({
+    type: "match",
+    data: {
+      path: { text: "/tmp/match.txt" },
+      line_number: lineNumber,
+      lines: { text: "foo\n" },
+    },
+  })}\n`;
+}
+
+function textContent(
+  result: Awaited<ReturnType<ReturnType<typeof createGrepToolDefinition>["execute"]>>,
+): string {
+  const first = result.content[0];
+  return first?.type === "text" ? (first.text ?? "") : "";
+}
+
+describe("grep tool streaming", () => {
+  it.each([
+    {
+      name: "keeps an exact-size result complete",
+      matchCount: 2,
+      closeCode: 0,
+      expectedText: "match.txt:1: foo\nmatch.txt:2: foo",
+      expectedLimitReached: undefined,
+      expectedKilled: false,
+    },
+    {
+      name: "uses one extra match as the truncation sentinel",
+      matchCount: 3,
+      closeCode: null,
+      expectedText:
+        "match.txt:1: foo\nmatch.txt:2: foo\n\n[2 matches limit reached. Use limit=4 for more, or refine pattern]",
+      expectedLimitReached: 2,
+      expectedKilled: true,
+    },
+  ])(
+    "$name",
+    async ({ matchCount, closeCode, expectedText, expectedLimitReached, expectedKilled }) => {
+      const child = createChild();
+      vi.mocked(spawnCommand).mockReturnValue(child as never);
+      vi.mocked(ensureTool).mockResolvedValue("rg");
+
+      const tool = createGrepToolDefinition(process.cwd());
+      const resultPromise = tool.execute(
+        "call-limit",
+        { pattern: "foo", limit: 2 },
+        undefined,
+        undefined,
+        {} as never,
+      );
+      await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+      for (let lineNumber = 1; lineNumber <= matchCount; lineNumber += 1) {
+        child.stdout.write(grepMatch(lineNumber));
+      }
+      child.stdout.end();
+      child.stderr.end();
+      child.emit("close", closeCode);
+
+      const result = await resultPromise;
+      expect(textContent(result)).toBe(expectedText);
+      expect(result.details?.matchLimitReached).toBe(expectedLimitReached);
+      expect(child.killed).toBe(expectedKilled);
+    },
+  );
+
   it("settles promptly when aborted while resolving rg", async () => {
     let resolveEnsureTool: ((value: string) => void) | undefined;
     vi.mocked(ensureTool).mockImplementationOnce(

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -331,7 +331,7 @@ export function createGrepToolDefinition(
             // Collect matches during streaming, then format them after rg exits.
             const matches: Array<{ filePath: string; lineNumber: number; lineText?: string }> = [];
             rl.on("line", (line) => {
-              if (!line.trim() || matchCount >= effectiveLimit) {
+              if (!line.trim() || matchLimitReached) {
                 return;
               }
               let event: {
@@ -349,15 +349,17 @@ export function createGrepToolDefinition(
               }
               if (event.type === "match") {
                 matchCount++;
+                // Observe one extra match before stopping so exactly N matches stay complete.
+                if (matchCount > effectiveLimit) {
+                  matchLimitReached = true;
+                  stopChild(true);
+                  return;
+                }
                 const filePath = event.data?.path?.text;
                 const lineNumber = event.data?.line_number;
                 const lineText = event.data?.lines?.text;
                 if (filePath && typeof lineNumber === "number") {
                   matches.push({ filePath, lineNumber, lineText });
-                }
-                if (matchCount >= effectiveLimit) {
-                  matchLimitReached = true;
-                  stopChild(true);
                 }
               }
             });


### PR DESCRIPTION
Closes #117746

## What Problem This Solves

Fixes an issue where agent sessions using the built-in `find` or `grep` tools would receive a truncation warning when a search returned exactly the requested number of results. No result was actually omitted, so the warning could send the model into an unnecessary follow-up search.

## Why This Change Was Made

Each search producer now observes one additional candidate before declaring that its public limit truncated the result. Custom glob operations and `fd` receive an N+1 observation limit, while streaming ripgrep stops only after its N+1 match; both tools still return at most the requested N results. This keeps the limit contract accurate at the producer boundary and matches the existing `ls` sibling behavior.

## User Impact

Models now receive a limit warning only when more search results actually exist. Exact-size searches remain complete, while over-limit searches retain the same bounded output and actionable guidance.

## Evidence

- Added exact-limit and over-limit regression coverage for custom `find`, native `fd`, and streaming ripgrep paths.
- Blacksmith Testbox focused proof: 24/24 tests passed in https://github.com/openclaw/openclaw/actions/runs/30728068293.
- Complete `pnpm check:changed` passed on the same rebased head, including formatting, core/core-test typechecks, changed-file lint, dead-code checks, import cycles, and repository ratchets.
- Fresh Codex autoreview found no accepted/actionable findings and rated the patch correct at 0.99 confidence.
- Direct dependency checks confirmed `fd --max-results` returns at most the requested count, while ripgrep JSON emits a distinct event for each match.

Real-tool after-fix proof used the patched tool definitions with `fd 10.4.2` and `ripgrep 15.2.0` in an isolated temporary workspace:

```text
=== fd exact N ===
a.ts
b.ts
details={}
=== fd over N ===
a.ts
b.ts

[2 results limit reached. Use limit=4 for more, or refine pattern]
details={"resultLimitReached":2}
=== ripgrep exact N ===
grep-exact.txt:1: needle
grep-exact.txt:2: needle
details={}
=== ripgrep over N ===
grep-over.txt:1: needle
grep-over.txt:2: needle

[2 matches limit reached. Use limit=4 for more, or refine pattern]
details={"matchLimitReached":2}
```

AI-assisted: yes (Codex). The implementation, owner boundary, sibling behavior, dependency contracts, and proof results were reviewed directly before submission.
