### PR TITLE
fix(anthropic): preserve context-window-limited Claude responses

### DIFF
--- a/packages/ai/src/providers/anthropic-model-contract.ts
+++ b/packages/ai/src/providers/anthropic-model-contract.ts
@@ -159,6 +159,7 @@ export function mapAnthropicStopReason(reason: string | undefined): StopReason {
     case "stop_sequence":
       return "stop";
     case "max_tokens":
+    case "model_context_window_exceeded":
       return "length";
     case "tool_use":
       return "toolUse";

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1360,6 +1360,67 @@ describe("Anthropic provider", () => {
     });
   });
 
+  it("preserves completed Fable output when Anthropic reaches its context window", async () => {
+    const client = createAnthropicSseClient([
+      {
+        type: "message_start",
+        message: {
+          id: "msg_context_limit",
+          model: "claude-fable-5",
+          usage: { input_tokens: 199_997, output_tokens: 0 },
+        },
+      },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "This answer reached the context window." },
+      },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: {
+          container: null,
+          stop_details: null,
+          stop_reason: "model_context_window_exceeded",
+          stop_sequence: null,
+        },
+        usage: {
+          input_tokens: 199_997,
+          output_tokens: 3,
+          cache_creation_input_tokens: null,
+          cache_read_input_tokens: null,
+          output_tokens_details: null,
+          server_tool_use: null,
+        },
+      },
+      { type: "message_stop" },
+    ]);
+
+    const stream = streamAnthropic(
+      makeAnthropicModel({ id: "claude-fable-5", name: "Claude Fable 5" }),
+      { messages: [{ role: "user", content: "Finish the answer.", timestamp: 0 }] },
+      { apiKey: "sk-ant-provider", client: client as never },
+    );
+    const eventTypes: string[] = [];
+    for await (const event of stream) {
+      eventTypes.push(event.type);
+    }
+    const result = await stream.result();
+
+    expect(eventTypes).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
+    expect(result.stopReason).toBe("length");
+    expect(result.content).toEqual([
+      { type: "text", text: "This answer reached the context window." },
+    ]);
+    expect(result.usage).toMatchObject({ input: 199_997, output: 3 });
+    expect(result.errorMessage).toBeUndefined();
+  });
+
   it.each([
     ["claude-fable-5", "Claude Fable 5", "anthropic", "sk-ant-provider"],
     ["claude-mythos-5", "Claude Mythos 5", "anthropic", "sk-ant-provider"],

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -1503,6 +1503,72 @@ describe("anthropic transport stream", () => {
     expect(result.errorMessage).toBe("OpenClaw transport error: malformed_streaming_fragment");
   });
 
+  it("preserves completed Fable output when Anthropic reaches its context window", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: {
+            id: "msg_context_limit",
+            model: "claude-fable-5",
+            usage: { input_tokens: 199_997, output_tokens: 0 },
+          },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "This answer reached the context window." },
+        },
+        { type: "content_block_stop", index: 0 },
+        {
+          type: "message_delta",
+          delta: {
+            container: null,
+            stop_details: null,
+            stop_reason: "model_context_window_exceeded",
+            stop_sequence: null,
+          },
+          usage: {
+            input_tokens: 199_997,
+            output_tokens: 3,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+            output_tokens_details: null,
+            server_tool_use: null,
+          },
+        },
+        { type: "message_stop" },
+      ]),
+    );
+
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        makeAnthropicTransportModel({ id: "claude-fable-5", name: "Claude Fable 5" }),
+        { messages: [{ role: "user", content: "Finish the answer." }] } as AnthropicStreamContext,
+        { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+      ),
+    );
+    const eventTypes: string[] = [];
+    for await (const event of stream as AsyncIterable<{ type: string }>) {
+      eventTypes.push(event.type);
+    }
+    const result = await stream.result();
+
+    expect(eventTypes).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
+    expect(result.stopReason).toBe("length");
+    expect(result.content).toEqual([
+      { type: "text", text: "This answer reached the context window." },
+    ]);
+    expect(result.usage).toMatchObject({ input: 199_997, output: 3 });
+    expect(result.errorMessage).toBeUndefined();
+  });
+
   it.each([
     ["claude-fable-5", "Claude Fable 5", "anthropic"],
     ["claude-opus-5", "Claude Opus 5", "anthropic"],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Claude users lose an otherwise successful partial answer and its final usage when the model reaches its context window. Both the direct Anthropic provider and managed Anthropic transport treat the officially supported `model_context_window_exceeded` stop reason as an unexpected error; Claude Fable's deferred-output lifecycle then discards the answer entirely.

## Why This Change Was Made

Normalize the documented context-window stop reason in the existing shared Anthropic stop-reason owner, alongside `max_tokens`, as the canonical `length` outcome. This follows the existing Amazon Bedrock mapping for the same upstream condition, repairs both Anthropic execution paths together, and preserves the normal response, usage, billing, and follow-up compaction lifecycles without adding configuration or compatibility branches.

## User Impact

Claude users now receive the valid answer produced before the context limit, accurate positive final token usage, and the normal completed-stream events. Existing refusal, error, abort, and other provider stop-reason behavior remain unchanged.

## Evidence

- Exact reviewed head: `ad2f1305f531b51cc94a2552d2eb9272541d2bdf`; production delta is one line in the existing shared owner.
- Official Anthropic contract: [Stop reasons and fallback](https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons) documents `model_context_window_exceeded` as a successful, truncated response supplied in `message_delta`.
- Real SDK-shaped streaming regressions cover both direct-provider and managed-transport Claude Fable paths: `message_start`, text content and delta, `content_block_stop`, documented stop reason with positive output usage, and `message_stop`.
- Unmodified production **RED:** 2 failed; both routes returned only an error and discarded the partial answer.
- Final frozen head **GREEN:** 2 passed, 213 skipped across the same two focused owner suites:

  ```bash
  node scripts/run-vitest.mjs --config test/vitest/vitest.unit.config.ts \
    packages/ai/src/providers/anthropic.test.ts \
    packages/ai/src/transports/anthropic-transport-stream.test.ts \
    --testNamePattern 'Anthropic reaches its context window'
  ```

- Four fresh, independent hostile source reviews: Discord interaction/voice ownership, browser/session transport, Control UI/log diagnostics, and Telegram pairing/setup; all reported clean.
- Official structured autoreview: `gpt-5.6-sol`, high reasoning, through P3; **no findings**, patch correct, confidence **0.98**. Native TruffleHog **3.96.0** also reported clean.
