### PR TITLE
fix(agents): honor subagent completion capture deadlines

### DIFF
--- a/src/agents/subagent-announce-capture.ts
+++ b/src/agents/subagent-announce-capture.ts
@@ -13,25 +13,25 @@ export async function readLatestSubagentOutputWithRetryUsing<Outcome = unknown>(
   readSubagentOutput: (sessionKey: string, outcome?: Outcome) => Promise<string | undefined>;
 }): Promise<string | undefined> {
   const maxWaitMs = Math.max(0, Math.min(params.maxWaitMs, 15_000));
-  let waitedMs = 0;
-  let result: string | undefined;
-  while (waitedMs < maxWaitMs) {
-    result = await params.readSubagentOutput(params.sessionKey, params.outcome);
+  if (!(maxWaitMs > 0)) {
+    return undefined;
+  }
+  const deadlineAt = performance.now() + maxWaitMs;
+  for (;;) {
+    const result = await params.readSubagentOutput(params.sessionKey, params.outcome);
     if (result?.trim()) {
       return result;
     }
-    const remainingMs = maxWaitMs - waitedMs;
+    const remainingMs = deadlineAt - performance.now();
     if (remainingMs <= 0) {
-      break;
+      return result;
     }
     const sleepMs = Math.min(params.retryIntervalMs, remainingMs);
     // Use real timers here; tests provide fake timers around this small retry loop.
     await new Promise((resolve) => {
       setTimeout(resolve, sleepMs);
     });
-    waitedMs += sleepMs;
   }
-  return result;
 }
 
 /** Captures immediate output first, then optionally waits for a delayed completion reply. */

--- a/src/agents/subagent-announce.capture-completion-reply.test.ts
+++ b/src/agents/subagent-announce.capture-completion-reply.test.ts
@@ -1,7 +1,10 @@
 // Completion-reply capture tests cover the short polling window used to collect
 // final child output after an announce waits for the subagent.
 import { describe, expect, it, vi } from "vitest";
-import { captureSubagentCompletionReplyUsing } from "./subagent-announce-capture.js";
+import {
+  captureSubagentCompletionReplyUsing,
+  readLatestSubagentOutputWithRetryUsing,
+} from "./subagent-announce-capture.js";
 
 describe("captureSubagentCompletionReply", () => {
   it("returns immediate assistant output from history without polling", async () => {
@@ -44,6 +47,59 @@ describe("captureSubagentCompletionReply", () => {
     vi.useRealTimers();
   });
 
+  it("captures the final assistant reply when it becomes available at the deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const readSubagentOutput = vi
+        .fn<(sessionKey: string) => Promise<string | undefined>>()
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce("Requester-visible final result");
+
+      const pending = captureSubagentCompletionReplyUsing({
+        sessionKey: "agent:main:subagent:child",
+        maxWaitMs: 5,
+        retryIntervalMs: 5,
+        readSubagentOutput,
+      });
+      await vi.runAllTimersAsync();
+
+      await expect(pending).resolves.toBe("Requester-visible final result");
+      expect(readSubagentOutput).toHaveBeenCalledTimes(3);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("charges slow output reads against the bounded retry deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const startedAt = performance.now();
+      const readSubagentOutput = vi.fn(async () => {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 15);
+        });
+        return undefined;
+      });
+
+      const pending = readLatestSubagentOutputWithRetryUsing({
+        sessionKey: "agent:main:subagent:child",
+        maxWaitMs: 25,
+        retryIntervalMs: 10,
+        readSubagentOutput,
+      });
+      await vi.runAllTimersAsync();
+
+      await expect(pending).resolves.toBeUndefined();
+      expect(readSubagentOutput).toHaveBeenCalledTimes(2);
+      expect(performance.now() - startedAt).toBe(40);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("returns undefined when no completion output arrives before retry window closes", async () => {
     vi.useFakeTimers();
     const readSubagentOutput = vi
@@ -60,8 +116,51 @@ describe("captureSubagentCompletionReply", () => {
     const result = await pending;
 
     expect(result).toBeUndefined();
-    expect(readSubagentOutput).toHaveBeenCalledTimes(8);
+    expect(readSubagentOutput).toHaveBeenCalledTimes(9);
     vi.useRealTimers();
+  });
+
+  it.each([0, -5])("does not poll when the retry budget is %i ms", async (maxWaitMs) => {
+    vi.useFakeTimers();
+    try {
+      const readSubagentOutput = vi.fn().mockResolvedValue(undefined);
+
+      await expect(
+        captureSubagentCompletionReplyUsing({
+          sessionKey: "agent:main:subagent:child",
+          maxWaitMs,
+          retryIntervalMs: 5,
+          readSubagentOutput,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(readSubagentOutput).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not poll when waiting for a completion reply is disabled", async () => {
+    vi.useFakeTimers();
+    try {
+      const readSubagentOutput = vi.fn().mockResolvedValue(undefined);
+
+      await expect(
+        captureSubagentCompletionReplyUsing({
+          sessionKey: "agent:main:subagent:child",
+          waitForReply: false,
+          maxWaitMs: 25,
+          retryIntervalMs: 5,
+          readSubagentOutput,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(readSubagentOutput).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns partial assistant progress when the latest assistant turn is tool-only", async () => {


### PR DESCRIPTION
## What Problem This Solves

Sub-agent completion announcements can silently lose the child’s latest visible assistant reply when it arrives exactly at the capture deadline. The same retry loop can also exceed its advertised short wait substantially because time spent reading Gateway history is not counted toward the retry budget.

## Why This Change Was Made

Both failures have one canonical cause: the completion-output owner measures only its own sleeps rather than enforcing an actual deadline. Replace that brittle elapsed-sleep bookkeeping with one monotonic `performance.now()` deadline that charges output-read time, preserves the final observation at the boundary, and retains the existing non-positive-budget and explicitly disabled-wait contracts.

## User Impact

Parent agents reliably receive final child responses written at the completion boundary, and slow child-history reads no longer trigger additional out-of-budget polling. Existing immediate-output, zero/negative-budget, disabled-wait, whitespace, and bounded-retry behavior remain intact.

## Evidence

- Root cause count: **1**; the owner’s sleep-only deadline accounting produced both dropped boundary output and redundant slow-reader retries.
- Current production path traced through `src/agents/subagent-announce-output.ts` and the Gateway call timeout owner; normal capture uses a **1,500 ms** retry budget while an unqualified history read defaults to at least **10,000 ms**.
- Regression-first exact-boundary proof against untouched production failed because the completion result was `undefined` instead of `Requester-visible final result`.
- Independent slow-reader regression against untouched production failed because the owner performed **3** reads instead of the bounded **2**; the combined untouched-production run reported **2 failed / 7 passed**.
- **Actual Gateway-backed real behavior proof on the exact frozen head:** hosted [QA Smoke CI profile 2/4](https://github.com/openclaw/openclaw/actions/runs/30728904988/job/91445571952) ran `subagent-completion-direct-fallback` through a real isolated ephemeral Gateway, real native `sessions_spawn`/`sessions_yield`, real subagent completion/announcement lifecycle, real Telegram channel plugin, and a local Crabline Telegram HTTP provider; the separately mocked OpenAI provider is only the model boundary. The single-scenario [hosted evidence artifact](https://github.com/openclaw/openclaw/actions/runs/30728904988/artifacts/8827354110) reports **1 passed / 0 failed / 0 skipped**, confirms the durable subagent task reached `status=succeeded` and `deliveryStatus=delivered`, and records the parent-visible final reply `QA-SUBAGENT-DIRECT-FALLBACK-OK`. Actual redacted transport evidence: `{"at":"2026-08-02T02:32:46.366Z","method":"POST","path":"/bot<redacted>/sendMessage","body":{"chat_id":"<redacted>","text":"QA-SUBAGENT-DIRECT-FALLBACK-OK"},"accepted":true}`. No fake clock or injected history reader was used for this real Gateway/product proof.
- Exact frozen candidate focused proof: `scripts/run-vitest.mjs src/agents/subagent-announce.capture-completion-reply.test.ts`, **9/9 passed**, no skipped tests, on commit `ac7aa03b14c6ec38f04f8430bd79b54e857937ae`; coverage preserves immediate output, zero/negative budgets, explicit `waitForReply: false`, ordinary delayed output, exhausted output, and partial assistant progress.
- Exactly two existing files changed; the canonical production-owner refactor is **+8/-8 (net zero)** and replaces the stale elapsed-sleep abstraction without adding configuration, dependencies, fallbacks, wrappers, or compatibility shims.
- Four independent hostile source reviews were **CLEAN**: Google realtime owner, media/music owner, CLI parser owner, and Control UI owner.
- Official structured P0–P3 autoreview: `gpt-5.6-sol`, high reasoning, **zero findings**, correctness confidence **0.94**; native TruffleHog **3.96.0** clean on the exact immutable commit.
- Risk is confined to the existing sub-agent completion-output owner and its adjacent focused test; no security boundary, persistent state, migration, public configuration, provider contract, protocol, plugin SDK, or release behavior changed.
