### PR TITLE
fix(tlon): namespace durable ingress event ids by source and nest

### DIFF
--- a/extensions/tlon/src/monitor/ingress.test.ts
+++ b/extensions/tlon/src/monitor/ingress.test.ts
@@ -283,6 +283,78 @@ describe("Tlon durable ingress", () => {
     });
   });
 
+  it("drains a channel row persisted under the legacy bare post id", async () => {
+    await withQueue(async (queue) => {
+      const group = channelEvent({ id: "170.141.184.507", nest: "chat/~zod/general" });
+      await queue.enqueue(
+        "170.141.184.507",
+        { version: 1, receivedAt: 1, source: "channels", rawEvent: JSON.stringify(group) },
+        { receivedAt: 1, laneKey: "group:chat/~zod/general" },
+      );
+      const dispatch = vi.fn<TlonIngressDispatch>(async (_source, _event, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        await monitor.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+        expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("drains a chat row persisted under the legacy bare message id", async () => {
+    await withQueue(async (queue) => {
+      const dm = chatEvent({ id: "170.141.184.507", peer: "~nec" });
+      await queue.enqueue(
+        "170.141.184.507",
+        { version: 1, receivedAt: 1, source: "chat", rawEvent: JSON.stringify(dm) },
+        { receivedAt: 1, laneKey: "direct:~nec" },
+      );
+      const dispatch = vi.fn<TlonIngressDispatch>(async (_source, _event, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        await monitor.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+        expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("keeps a legacy row from blocking a colliding post in another channel", async () => {
+    await withQueue(async (queue) => {
+      const legacy = channelEvent({ id: "170.141.184.507", nest: "chat/~zod/general" });
+      await queue.enqueue(
+        "170.141.184.507",
+        { version: 1, receivedAt: 1, source: "channels", rawEvent: JSON.stringify(legacy) },
+        { receivedAt: 1, laneKey: "group:chat/~zod/general" },
+      );
+      const delivered: string[] = [];
+      const dispatch = vi.fn<TlonIngressDispatch>(async (_source, event, lifecycle) => {
+        delivered.push(String((event as { nest?: unknown }).nest));
+        await lifecycle.onAdopted();
+      });
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        await monitor.waitForIdle();
+        await monitor.receive({
+          source: "channels",
+          event: channelEvent({ id: "170.141.184.507", nest: "chat/~nec/other" }),
+        });
+        await monitor.waitForIdle();
+        expect(delivered).toEqual(["chat/~zod/general", "chat/~nec/other"]);
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
   it("retains completed logical ids by count rather than age", async () => {
     await withQueue(async (queue) => {
       let now = 1_700_000_000_000;

--- a/extensions/tlon/src/monitor/ingress.test.ts
+++ b/extensions/tlon/src/monitor/ingress.test.ts
@@ -212,6 +212,77 @@ describe("Tlon durable ingress", () => {
     });
   });
 
+  it("dispatches colliding post ids from different channels", async () => {
+    await withQueue(async (queue) => {
+      const delivered: string[] = [];
+      const dispatch = vi.fn<TlonIngressDispatch>(async (_source, event, lifecycle) => {
+        delivered.push(String((event as { nest?: unknown }).nest));
+        await lifecycle.onAdopted();
+      });
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        await monitor.receive({
+          source: "channels",
+          event: channelEvent({ id: "170.141.184.507", nest: "chat/~zod/general" }),
+        });
+        await monitor.waitForIdle();
+        const second = await monitor.receive({
+          source: "channels",
+          event: channelEvent({ id: "170.141.184.507", nest: "chat/~nec/other" }),
+        });
+        await monitor.waitForIdle();
+        expect(second).toEqual({ kind: "accepted" });
+        expect(delivered).toEqual(["chat/~zod/general", "chat/~nec/other"]);
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("dispatches a chat message whose id matches a completed channel post", async () => {
+    await withQueue(async (queue) => {
+      const delivered: string[] = [];
+      const dispatch = vi.fn<TlonIngressDispatch>(async (source, _event, lifecycle) => {
+        delivered.push(source);
+        await lifecycle.onAdopted();
+      });
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        await monitor.receive({
+          source: "channels",
+          event: channelEvent({ id: "170.141.184.507" }),
+        });
+        await monitor.waitForIdle();
+        await monitor.receive({ source: "chat", event: chatEvent({ id: "170.141.184.507" }) });
+        await monitor.waitForIdle();
+        expect(delivered).toEqual(["channels", "chat"]);
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("still suppresses a redelivered post id within the same channel", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn<TlonIngressDispatch>(async (_source, _event, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        for (const text of ["first delivery", "redelivery"]) {
+          await monitor.receive({
+            source: "channels",
+            event: channelEvent({ id: "170.141.184.507", nest: "chat/~zod/general", text }),
+          });
+          await monitor.waitForIdle();
+        }
+        expect(dispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
   it("retains completed logical ids by count rather than age", async () => {
     await withQueue(async (queue) => {
       let now = 1_700_000_000_000;
@@ -251,7 +322,7 @@ describe("Tlon durable ingress", () => {
         await monitor.waitForIdle();
         expect(await queue.listClaims()).toEqual([
           expect.objectContaining({
-            id: "message-raw",
+            id: "channels:chat/~zod/ops:message-raw",
             laneKey: "group:chat/~zod/ops",
             payload: expect.objectContaining({ rawEvent: JSON.stringify(group) }),
           }),
@@ -271,7 +342,10 @@ describe("Tlon durable ingress", () => {
         await monitor.receive({ source: "channels", event: reply });
         await monitor.waitForIdle();
         expect(await queue.listClaims()).toEqual([
-          expect.objectContaining({ id: "reply-stable", laneKey: "group:chat/~zod/ops" }),
+          expect.objectContaining({
+            id: "channels:chat/~zod/ops:reply-stable",
+            laneKey: "group:chat/~zod/ops",
+          }),
         ]);
       } finally {
         await monitor.stop();
@@ -301,7 +375,9 @@ describe("Tlon durable ingress", () => {
           event: chatEvent({ id: "message-auth" }),
         });
         await monitor.waitForIdle();
-        expect((await queue.enqueue("message-auth", {} as TlonIngressPayload)).kind).toBe("failed");
+        expect((await queue.enqueue("chat:message-auth", {} as TlonIngressPayload)).kind).toBe(
+          "failed",
+        );
       } finally {
         await monitor.stop();
       }
@@ -321,7 +397,7 @@ describe("Tlon durable ingress", () => {
         });
         await monitor.waitForIdle();
         expect((await queue.listPending({ limit: "all" })).map((record) => record.id)).toEqual([
-          "message-provider-auth",
+          "chat:message-provider-auth",
         ]);
       } finally {
         await monitor.stop();
@@ -367,8 +443,8 @@ describe("Tlon durable ingress", () => {
       await Promise.all([admission, queuedAdmission, stopping, stoppingAgain]);
       expect(dispatch).not.toHaveBeenCalled();
       expect((await queue.listPending({ limit: "all" })).map((record) => record.id)).toEqual([
-        "message-stop-1",
-        "message-stop-2",
+        "channels:chat/~zod/general:message-stop-1",
+        "channels:chat/~zod/general:message-stop-2",
       ]);
     });
   });

--- a/extensions/tlon/src/monitor/ingress.ts
+++ b/extensions/tlon/src/monitor/ingress.ts
@@ -64,8 +64,8 @@ function inspectChannelsEvent(event: unknown): { eventId: string; laneKey: strin
   if (!nest || (!isRecord(set?.essay) && !isRecord(replySet?.memo))) {
     return null;
   }
-  const eventId = nonEmptyString(isRecord(replySet?.memo) ? reply?.id : post?.id);
-  return eventId ? { eventId, laneKey: `group:${nest}` } : null;
+  const postId = nonEmptyString(isRecord(replySet?.memo) ? reply?.id : post?.id);
+  return postId ? { eventId: `channels:${nest}:${postId}`, laneKey: `group:${nest}` } : null;
 }
 
 function inspectChatEvent(event: unknown): { eventId: string; laneKey: string } | null {
@@ -73,13 +73,13 @@ function inspectChatEvent(event: unknown): { eventId: string; laneKey: string } 
   const response = isRecord(envelope?.response) ? envelope.response : null;
   const add = isRecord(response?.add) ? response.add : null;
   const essay = isRecord(add?.essay) ? add.essay : null;
-  const eventId = nonEmptyString(envelope?.id);
-  if (!essay || !eventId) {
+  const messageId = nonEmptyString(envelope?.id);
+  if (!essay || !messageId) {
     return null;
   }
   const whom = isRecord(envelope?.whom) ? nonEmptyString(envelope.whom.ship) : null;
   const peer = nonEmptyString(envelope?.whom) ?? whom ?? nonEmptyString(essay.author);
-  return { eventId, laneKey: peer ? `direct:${peer}` : `event:${eventId}` };
+  return { eventId: `chat:${messageId}`, laneKey: peer ? `direct:${peer}` : `event:${messageId}` };
 }
 
 function inspectTlonIngressEvent(

--- a/extensions/tlon/src/monitor/ingress.ts
+++ b/extensions/tlon/src/monitor/ingress.ts
@@ -51,7 +51,10 @@ class TlonIngressShutdownError extends Error {
   }
 }
 
-function inspectChannelsEvent(event: unknown): { eventId: string; laneKey: string } | null {
+function inspectChannelsEvent(
+  event: unknown,
+  claimedId: string | undefined,
+): { eventId: string; laneKey: string } | null {
   const envelope = isRecord(event) ? event : null;
   const nest = nonEmptyString(envelope?.nest);
   const response = isRecord(envelope?.response) ? envelope.response : null;
@@ -65,10 +68,17 @@ function inspectChannelsEvent(event: unknown): { eventId: string; laneKey: strin
     return null;
   }
   const postId = nonEmptyString(isRecord(replySet?.memo) ? reply?.id : post?.id);
-  return postId ? { eventId: `channels:${nest}:${postId}`, laneKey: `group:${nest}` } : null;
+  if (!postId) {
+    return null;
+  }
+  const eventId = claimedId === postId ? postId : `channels:${nest}:${postId}`;
+  return { eventId, laneKey: `group:${nest}` };
 }
 
-function inspectChatEvent(event: unknown): { eventId: string; laneKey: string } | null {
+function inspectChatEvent(
+  event: unknown,
+  claimedId: string | undefined,
+): { eventId: string; laneKey: string } | null {
   const envelope = isRecord(event) ? event : null;
   const response = isRecord(envelope?.response) ? envelope.response : null;
   const add = isRecord(response?.add) ? response.add : null;
@@ -79,16 +89,20 @@ function inspectChatEvent(event: unknown): { eventId: string; laneKey: string } 
   }
   const whom = isRecord(envelope?.whom) ? nonEmptyString(envelope.whom.ship) : null;
   const peer = nonEmptyString(envelope?.whom) ?? whom ?? nonEmptyString(essay.author);
-  return { eventId: `chat:${messageId}`, laneKey: peer ? `direct:${peer}` : `event:${messageId}` };
+  const eventId = claimedId === messageId ? messageId : `chat:${messageId}`;
+  return { eventId, laneKey: peer ? `direct:${peer}` : `event:${messageId}` };
 }
 
 function inspectTlonIngressEvent(
   source: TlonIngressSource,
   event: unknown,
+  claimedId: string | undefined,
 ): { eventId: string; laneKey: string } | null {
   // Urbit SSE ids belong to a disposable HTTP channel. The message id inside
   // each firehose envelope survives resubscription and preserves the retired guard key.
-  return source === "channels" ? inspectChannelsEvent(event) : inspectChatEvent(event);
+  return source === "channels"
+    ? inspectChannelsEvent(event, claimedId)
+    : inspectChatEvent(event, claimedId);
 }
 
 function decodeTlonIngressPayload(
@@ -170,7 +184,12 @@ export function createTlonIngressMonitor(options: {
         getTlonRuntime().state.openChannelIngressQueue<TlonIngressPayload>({
           accountId: options.accountId,
         })),
-    inspect: (raw) => inspectTlonIngressEvent(raw.source, raw.event),
+    inspect: (raw, context) =>
+      inspectTlonIngressEvent(
+        raw.source,
+        raw.event,
+        context.phase === "claim" ? context.claimedId : undefined,
+      ),
     payload: {
       version: TLON_INGRESS_PAYLOAD_VERSION,
       serialize: (raw, { receivedAt }) => ({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an OpenClaw bot connected to Tlon would silently lose an inbound group message when two posts in different channels happen to share the same post ID.

Tlon derives a group post ID from the send timestamp alone; the channel nest is a separate field. OpenClaw's durable ingress used that bare post ID as the queue-wide durable event ID, so two posts in different channels that land on the same timestamp-derived ID collide. The second post is acknowledged back to the Urbit firehose as accepted, SQLite treats it as a duplicate of the first, its payload is discarded, and it never reaches the Tlon message handler. Because the first row is already a completed tombstone, nothing redelivers it. The operator sees a message that was posted in their channel and simply never answered, with nothing in the logs marking it as dropped.

## Why This Change Was Made

`inspect` owns the mapping from a transport envelope to durable identity, at `extensions/tlon/src/monitor/ingress.ts:67`:

```ts
// before
const eventId = nonEmptyString(isRecord(replySet?.memo) ? reply?.id : post?.id);
return eventId ? { eventId, laneKey: `group:${nest}` } : null;
```

It records the nest only as `laneKey`, which controls drain ordering and lane blocking, not identity. Identity is enforced one level down on `(queue_name, event_id)` (`src/channels/message/ingress-queue.ts:608`), and `queue_name` is only channel plus account (`src/channels/message/ingress-queue.ts:570`). So the bare post ID was the entire identity across every channel and both firehose sources on one account.

That the ID space is flat is visible in OpenClaw's own sender: `sendGroupMessageWithStory` builds a group post ID as `scot("ud", da.fromUnix(sentAt))` with no channel component, while DM ids are ship-qualified (`extensions/tlon/src/urbit/send.ts:60`).

The duplicate was then reported as success rather than as a drop. `admitRaw` returns `kind: "durable"` for a duplicate enqueue result, and the Tlon wrapper maps that to `accepted` (`extensions/tlon/src/monitor/ingress.ts:213`), so the `/v2` firehose callback treats the lost message as delivered.

The fix namespaces the durable event ID with the surface that actually scopes the provider ID:

```ts
// after
const postId = nonEmptyString(isRecord(replySet?.memo) ? reply?.id : post?.id);
if (!postId) {
  return null;
}
const eventId = claimedId === postId ? postId : `channels:${nest}:${postId}`;
return { eventId, laneKey: `group:${nest}` };
```

`inspect` is the function that owns transport-to-durable identity for this plugin, so the namespace belongs there rather than in the shared queue, which correctly treats `event_id` as an opaque caller-owned key used by every channel.

Both firehose sources are namespaced, not just the reported one. Chat ids happen to be ship-qualified today and so cannot collide with a bare channels id, but that is an incidental format difference between two independently versioned Urbit APIs (`/v2` channels, `/v3` chat) sharing one account-scoped queue. Prefixing both makes the uniqueness invariant explicit instead of dependent on that coincidence.

Existing behavior is preserved: `laneKey` semantics are unchanged, and same-channel redelivery and edit suppression still collapse to one dispatch, since a reissued envelope derives the same namespaced ID.

Legacy rows persisted before this change: durable ingress shipped in `v2026.7.2-beta.4`, so rows can already exist keyed by the bare provider id. The drain re-derives identity from the stored envelope and dead-letters a claim whose derived id no longer matches (`src/channels/message/ingress-monitor.ts:344`), which would have failed those in-flight rows as `invalid-event` instead of dispatching them.

Identity is therefore reconciled at claim phase through the `claimedId` the ingress monitor already supplies for exactly this purpose, the same seam `imessage` and `sms` use to interpret a persisted row:

```ts
inspect: (raw, context) =>
  inspectTlonIngressEvent(
    raw.source,
    raw.event,
    context.phase === "claim" ? context.claimedId : undefined,
  ),
```

When a claimed row is keyed by the bare provider id, that id is kept for the claim so the row drains and dispatches exactly once. Admission always mints the namespaced id, so no new row can be written in the legacy form and the compat branch stops being reachable once the backlog clears. This was preferred over rewriting rows at startup, which would need a delete-and-reinsert pass racing the drain for the same outcome.

## User Impact

An inbound Tlon group message can no longer be dropped because an unrelated channel happened to produce a post with the same timestamp-derived ID. Messages in different channels are now tracked under distinct durable keys, so each one reaches the bot. Deduplication of genuine redeliveries and edits within a channel is unchanged.

## Evidence

New regression tests fail on pristine `origin/main` (`31e03bc3d1e6`) and pass with the patch: `dispatches colliding post ids from different channels` and `dispatches a chat message whose id matches a completed channel post`. Legacy-row coverage: `drains a channel row persisted under the legacy bare post id`, `drains a chat row persisted under the legacy bare message id`, and `keeps a legacy row from blocking a colliding post in another channel`. A sixth, `still suppresses a redelivered post id within the same channel`, guards the dedupe behavior that must not regress. Four existing assertions that read the durable row id were updated to the namespaced key.

- `node scripts/run-vitest.mjs extensions/tlon --run` -> 29 files, 270 tests passed
- `node scripts/run-vitest.mjs extensions/tlon/src/monitor --run` -> 7 files, 42 tests passed
- `oxlint --type-aware` clean on both changed files; `oxfmt --check` clean
- Heavy typecheck lanes and a full build were not run, by request

## Real behavior proof

Behavior addressed: two Tlon posts in different channels that share a timestamp-derived post ID collide in the durable ingress queue, and the second is acknowledged to the transport but never handed to the message handler.
Real environment tested: the production `createTlonIngressMonitor` factory driven against a real on-disk SQLite ingress queue in a temp state dir, on pristine `origin/main` `31e03bc3d1e6d7e467b56d325b8e4e928a393943` and then on the patched tree with identical inputs. The real queue, the real drain loop, the real admission path, and the real `state/openclaw.sqlite` rows all stayed live; only the Urbit SSE network transport was replaced by feeding firehose-shaped envelopes, and the rows below are read straight back out of the database file.
Exact steps or command run after this patch: feed two `channels` firehose envelopes carrying the same post ID `170.141.184.507` under nests `chat/~zod/general` and `chat/~nec/other` into `monitor.receive`, wait for the drain to idle after each, then read `channel_ingress_events` from the on-disk database.
Evidence after fix:
```
# BEFORE (pristine main 31e03bc3d1e6)
urbit post id carried by both firehose envelopes: 170.141.184.507
transport ack returned for chat/~zod/general post: accepted
transport ack returned for chat/~nec/other post: accepted

messages that reached the Tlon message handler:
  chat/~zod/general -> hello from ~zod/general
  (chat/~nec/other was never handed to the handler)

durable ingress rows persisted in state/openclaw.sqlite:
  event_id=170.141.184.507 lane_key=group:chat/~zod/general status=completed

handler_deliveries=1/2 durable_rows=1/2

# AFTER (this patch, identical inputs)
urbit post id carried by both firehose envelopes: 170.141.184.507
transport ack returned for chat/~zod/general post: accepted
transport ack returned for chat/~nec/other post: accepted

messages that reached the Tlon message handler:
  chat/~zod/general -> hello from ~zod/general
  chat/~nec/other -> hello from ~nec/other

durable ingress rows persisted in state/openclaw.sqlite:
  event_id=channels:chat/~zod/general:170.141.184.507 lane_key=group:chat/~zod/general status=completed
  event_id=channels:chat/~nec/other:170.141.184.507 lane_key=group:chat/~nec/other status=completed

handler_deliveries=2/2 durable_rows=2/2
```
Observed result after fix: on pristine main the second channel's message is acknowledged as accepted yet only one row is ever persisted and only one message reaches the handler, so the message is silently lost; with the patch both channels persist under distinct namespaced keys and both messages reach the handler.
What was not tested: no live Urbit ship or real SSE firehose connection; envelopes were fed directly into the production ingress entry point. Heavy typecheck lanes and a full build were not run, by request. The legacy-row path is driven separately below rather than in the same run as the collision case.

### Additional runtime evidence: row persisted under the legacy bare id

Same real monitor and real database, seeding one pending row keyed by the bare provider id before startup, then draining it. Behavior is identical on pristine main and on this patch, which is the point: the rename does not strand an in-flight row.

```
# BEFORE (pristine main 31e03bc3d1e6)
row written before startup, keyed by the legacy bare post id:
  event_id=170.141.184.507 lane_key=group:chat/~zod/general status=pending

messages that reached the Tlon message handler:
  chat/~zod/general -> in flight at upgrade

row state after startup drained it:
  event_id=170.141.184.507 status=completed reason=-

handler_deliveries=1/1 dead_letters=0

# AFTER (this patch, identical inputs)
row written before startup, keyed by the legacy bare post id:
  event_id=170.141.184.507 lane_key=group:chat/~zod/general status=pending

messages that reached the Tlon message handler:
  chat/~zod/general -> in flight at upgrade

row state after startup drained it:
  event_id=170.141.184.507 status=completed reason=-

handler_deliveries=1/1 dead_letters=0
```
