### PR TITLE
fix(ci): prevent sequential Vitest shards from overlapping

### DIFF
--- a/scripts/lib/vitest-batch-runner.mjs
+++ b/scripts/lib/vitest-batch-runner.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { spawnPnpmRunner } from "../pnpm-runner.mjs";
 import {
-  forceKillVitestProcessGroup,
+  createVitestProcessCompletion,
   installVitestProcessGroupCleanup,
   shouldUseDetachedVitestProcessGroup,
 } from "../vitest-process-group.mjs";
@@ -18,9 +18,10 @@ const repoRoot = path.resolve(scriptDir, "../..");
 export async function runVitestBatch(params) {
   return await new Promise((resolve, reject) => {
     let forwardedSignal;
+    const detached = shouldUseDetachedVitestProcessGroup();
     const child = spawnPnpmRunner({
       cwd: repoRoot,
-      detached: shouldUseDetachedVitestProcessGroup(),
+      detached,
       env: params.env,
       pnpmArgs: buildVitestBatchPnpmArgs(params),
       stdio: "inherit",
@@ -33,15 +34,12 @@ export async function runVitestBatch(params) {
         forwardedSignal ??= signal;
       },
     });
+    const completion = createVitestProcessCompletion({ child, detached }).finally(
+      teardownChildCleanup,
+    );
 
-    child.on("error", (error) => {
-      teardownChildCleanup();
-      reject(error);
-    });
-    child.on("exit", (code, signal) => {
-      teardownChildCleanup();
+    completion.then(({ code, signal }) => {
       if (forwardedSignal) {
-        forceKillVitestProcessGroup(child);
         process.kill(process.pid, forwardedSignal);
         return;
       }
@@ -50,7 +48,7 @@ export async function runVitestBatch(params) {
         return;
       }
       resolve(code ?? 1);
-    });
+    }, reject);
   });
 }
 

--- a/scripts/run-vitest.d.mts
+++ b/scripts/run-vitest.d.mts
@@ -30,7 +30,7 @@ export function resolveDefaultVitestNoOutputTimeoutMs(argv?: string[]): number;
 export function resolveVitestSpawnParams(
   env?: NodeJS.ProcessEnv,
   platform?: NodeJS.Platform,
-): SpawnOptions & { env: NodeJS.ProcessEnv; detached: boolean; stdio: string[] };
+): { env: NodeJS.ProcessEnv; detached: boolean; stdio: string[] };
 export function shouldSuppressVitestStderrLine(line: string): boolean;
 export function resolveDirectNodeVitestArgs(pnpmArgs: string[]): string[] | null;
 export function resolveExplicitTestFileNoPassArgs(argv: string[]): string[];
@@ -61,14 +61,18 @@ export function spawnWatchedVitestProcess(params: {
   onNoOutputTimeout?: () => void;
 }): {
   child: ChildProcess;
-  getForwardedSignal: () => NodeJS.Signals | null;
+  completion: Promise<{
+    code: number | null;
+    signal: ChildProcess["signalCode"];
+  }>;
+  getForwardedSignal: () => ChildProcess["signalCode"];
   teardown: () => void;
 };
 export function resolveTestProjectsRunnerEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv;
 export function resolveTestProjectsRunnerSpawnParams(
   env: NodeJS.ProcessEnv,
   platform?: NodeJS.Platform,
-): SpawnOptions & { env: NodeJS.ProcessEnv; detached: boolean; stdio: "inherit" };
+): { env: NodeJS.ProcessEnv; detached: boolean; stdio: "inherit" };
 export function runTestProjectsDelegation(
   argv: string[],
   env: NodeJS.ProcessEnv,

--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -1028,13 +1028,35 @@ export function spawnWatchedVitestProcess({
   forwardVitestOutput(child.stdout, process.stdout);
   forwardVitestOutput(child.stderr, process.stderr, shouldSuppressVitestStderrLine);
 
+  const teardown = () => {
+    teardownChildCleanup();
+    teardownNoOutputWatchdog();
+  };
+  const ownsDetachedGroup = spawnParams.detached === true && shouldUseDetachedVitestProcessGroup();
+  // POSIX detached groups remain addressable after the leader exits: reap any
+  // residual workers, then keep cleanup/watchdog ownership until their pipes close.
+  if (ownsDetachedGroup) {
+    child.once("exit", () => forceKillVitestProcessGroup(child));
+  }
+  // Windows has no equivalent group target after leader exit. Preserve the
+  // direct-child contract there until a Job Object owner can join the full tree.
+  const completionEvent = ownsDetachedGroup ? "close" : "exit";
+  const completion = new Promise((resolve, reject) => {
+    child.once(completionEvent, (code, signal) => {
+      teardown();
+      resolve({ code, signal });
+    });
+    child.once("error", (error) => {
+      teardown();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    });
+  });
+
   return {
     child,
+    completion,
     getForwardedSignal: () => forwardedSignal,
-    teardown: () => {
-      teardownChildCleanup();
-      teardownNoOutputWatchdog();
-    },
+    teardown,
   };
 }
 
@@ -1074,7 +1096,7 @@ function spawnTestProjectsRunner(argv, env, options = {}) {
 
 export function runTestProjectsDelegation(argv, env, options = {}) {
   const { child, getForwardedSignal, teardown } = spawnTestProjectsRunner(argv, env, options);
-  child.on("exit", (code, signal) => {
+  child.on("close", (code, signal) => {
     teardown();
     const forwardedSignal = getForwardedSignal();
     if (forwardedSignal) {
@@ -1133,33 +1155,32 @@ function main(argv = process.argv.slice(2), env = process.env) {
     throw error;
   }
 
-  const { child, getForwardedSignal, teardown } = spawnWatchedVitestProcess({
+  const { child, completion, getForwardedSignal } = spawnWatchedVitestProcess({
     pnpmArgs: ["exec", "node", ...resolveVitestNodeArgs(env), vitestCliEntry, ...guardedVitestArgs],
     spawnParams: resolveVitestSpawnParams(spawnEnv),
     env: spawnEnv,
     label: guardedVitestArgs.join(" "),
   });
 
-  child.on("exit", (code, signal) => {
-    teardown();
-    const forwardedSignal = getForwardedSignal();
-    if (forwardedSignal) {
-      forceKillVitestProcessGroup(child);
-      process.kill(process.pid, forwardedSignal);
-      return;
-    }
-    if (signal) {
-      process.kill(process.pid, signal);
-      return;
-    }
-    process.exit(code ?? 1);
-  });
-
-  child.on("error", (error) => {
-    teardown();
-    console.error(error);
-    process.exit(1);
-  });
+  completion.then(
+    ({ code, signal }) => {
+      const forwardedSignal = getForwardedSignal();
+      if (forwardedSignal) {
+        forceKillVitestProcessGroup(child);
+        process.kill(process.pid, forwardedSignal);
+        return;
+      }
+      if (signal) {
+        process.kill(process.pid, signal);
+        return;
+      }
+      process.exit(code ?? 1);
+    },
+    /** @param {unknown} error */ (error) => {
+      console.error(error);
+      process.exit(1);
+    },
+  );
 }
 
 if (import.meta.main) {

--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -12,7 +12,7 @@ import { boundaryTestFiles } from "../test/vitest/vitest.unit-paths.mjs";
 import { resolveLocalVitestEnv } from "./lib/vitest-local-scheduling.mjs";
 import { spawnPnpmRunner } from "./pnpm-runner.mjs";
 import {
-  forceKillVitestProcessGroup,
+  createVitestProcessCompletion,
   forwardSignalToVitestProcessGroup,
   installVitestProcessGroupCleanup,
   shouldUseDetachedVitestProcessGroup,
@@ -1032,25 +1032,10 @@ export function spawnWatchedVitestProcess({
     teardownChildCleanup();
     teardownNoOutputWatchdog();
   };
-  const ownsDetachedGroup = spawnParams.detached === true && shouldUseDetachedVitestProcessGroup();
-  // POSIX detached groups remain addressable after the leader exits: reap any
-  // residual workers, then keep cleanup/watchdog ownership until their pipes close.
-  if (ownsDetachedGroup) {
-    child.once("exit", () => forceKillVitestProcessGroup(child));
-  }
-  // Windows has no equivalent group target after leader exit. Preserve the
-  // direct-child contract there until a Job Object owner can join the full tree.
-  const completionEvent = ownsDetachedGroup ? "close" : "exit";
-  const completion = new Promise((resolve, reject) => {
-    child.once(completionEvent, (code, signal) => {
-      teardown();
-      resolve({ code, signal });
-    });
-    child.once("error", (error) => {
-      teardown();
-      reject(error instanceof Error ? error : new Error(String(error)));
-    });
-  });
+  const completion = createVitestProcessCompletion({
+    child,
+    detached: spawnParams.detached === true,
+  }).finally(teardown);
 
   return {
     child,
@@ -1080,8 +1065,9 @@ export function resolveTestProjectsRunnerSpawnParams(env, platform = process.pla
 
 function spawnTestProjectsRunner(argv, env, options = {}) {
   let forwardedSignal = null;
+  const spawnParams = resolveTestProjectsRunnerSpawnParams(env);
   const child = spawn(process.execPath, [options.runnerPath ?? testProjectsRunnerPath, ...argv], {
-    ...resolveTestProjectsRunnerSpawnParams(env),
+    ...spawnParams,
   });
   const teardown = installVitestProcessGroupCleanup({
     child,
@@ -1091,30 +1077,33 @@ function spawnTestProjectsRunner(argv, env, options = {}) {
       forwardedSignal ??= signal;
     },
   });
-  return { child, getForwardedSignal: () => forwardedSignal, teardown };
+  const completion = createVitestProcessCompletion({
+    child,
+    detached: spawnParams.detached,
+  }).finally(teardown);
+  return { child, completion, getForwardedSignal: () => forwardedSignal };
 }
 
 export function runTestProjectsDelegation(argv, env, options = {}) {
-  const { child, getForwardedSignal, teardown } = spawnTestProjectsRunner(argv, env, options);
-  child.on("close", (code, signal) => {
-    teardown();
-    const forwardedSignal = getForwardedSignal();
-    if (forwardedSignal) {
-      forceKillVitestProcessGroup(child);
-      process.kill(process.pid, forwardedSignal);
-      return;
-    }
-    if (signal) {
-      process.kill(process.pid, signal);
-      return;
-    }
-    process.exit(code ?? 1);
-  });
-  child.on("error", (error) => {
-    teardown();
-    console.error(error);
-    process.exit(1);
-  });
+  const { child, completion, getForwardedSignal } = spawnTestProjectsRunner(argv, env, options);
+  completion.then(
+    ({ code, signal }) => {
+      const forwardedSignal = getForwardedSignal();
+      if (forwardedSignal) {
+        process.kill(process.pid, forwardedSignal);
+        return;
+      }
+      if (signal) {
+        process.kill(process.pid, signal);
+        return;
+      }
+      process.exit(code ?? 1);
+    },
+    /** @param {unknown} error */ (error) => {
+      console.error(error);
+      process.exit(1);
+    },
+  );
   return child;
 }
 
@@ -1155,7 +1144,7 @@ function main(argv = process.argv.slice(2), env = process.env) {
     throw error;
   }
 
-  const { child, completion, getForwardedSignal } = spawnWatchedVitestProcess({
+  const { completion, getForwardedSignal } = spawnWatchedVitestProcess({
     pnpmArgs: ["exec", "node", ...resolveVitestNodeArgs(env), vitestCliEntry, ...guardedVitestArgs],
     spawnParams: resolveVitestSpawnParams(spawnEnv),
     env: spawnEnv,
@@ -1166,7 +1155,6 @@ function main(argv = process.argv.slice(2), env = process.env) {
     ({ code, signal }) => {
       const forwardedSignal = getForwardedSignal();
       if (forwardedSignal) {
-        forceKillVitestProcessGroup(child);
         process.kill(process.pid, forwardedSignal);
         return;
       }

--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnPnpmRunner } from "./pnpm-runner.mjs";
 import {
-  forwardSignalToVitestProcessGroup,
+  createVitestProcessCompletion,
   installVitestProcessGroupCleanup,
   shouldUseDetachedVitestProcessGroup,
 } from "./vitest-process-group.mjs";
@@ -719,9 +719,10 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
   const reportPath = buildLiveShardReportPath(shard, process.env);
   fs.mkdirSync(path.dirname(reportPath), { recursive: true });
   removeLiveShardReportFile(reportPath);
+  const spawnParams = buildLiveShardSpawnParams(process.env);
   const child = spawnPnpmRunner({
     pnpmArgs: buildLiveShardPnpmArgs(files, addLiveShardReportArgs(passthroughArgs, reportPath)),
-    ...buildLiveShardSpawnParams(process.env),
+    ...spawnParams,
   });
   let forwardedSignal = null;
   const teardown = installVitestProcessGroupCleanup({
@@ -732,33 +733,30 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
       forwardedSignal ??= signal;
     },
   });
-  child.on("exit", (code, signal) => {
-    teardown();
-    if (forwardedSignal) {
-      forwardSignalToVitestProcessGroup({
-        child,
-        kill: process.kill.bind(process),
-        signal: "SIGKILL",
-      });
-      process.kill(process.pid, forwardedSignal);
-      return;
-    }
-    if (signal) {
-      process.kill(process.pid, signal);
-      return;
-    }
-    if ((code ?? 1) === 0) {
-      const validation = validateLiveShardReport(reportPath, files);
-      if (!validation.ok) {
-        process.stderr.write(`[test:live:shard] ${validation.reason}\n`);
+  createVitestProcessCompletion({ child, detached: spawnParams.detached })
+    .finally(teardown)
+    .then(
+      ({ code, signal }) => {
+        if (forwardedSignal) {
+          process.kill(process.pid, forwardedSignal);
+          return;
+        }
+        if (signal) {
+          process.kill(process.pid, signal);
+          return;
+        }
+        if ((code ?? 1) === 0) {
+          const validation = validateLiveShardReport(reportPath, files);
+          if (!validation.ok) {
+            process.stderr.write(`[test:live:shard] ${validation.reason}\n`);
+            process.exit(1);
+          }
+        }
+        process.exit(code ?? 1);
+      },
+      /** @param {unknown} error */ (error) => {
+        console.error(error);
         process.exit(1);
-      }
-    }
-    process.exit(code ?? 1);
-  });
-  child.on("error", (error) => {
-    teardown();
-    console.error(error);
-    process.exit(1);
-  });
+      },
+    );
 }

--- a/scripts/test-live.mjs
+++ b/scripts/test-live.mjs
@@ -3,7 +3,7 @@ import { terminateManagedChild } from "./lib/managed-child-process.mjs";
 import { spawnPnpmRunner } from "./pnpm-runner.mjs";
 import { resolveVitestNoOutputTimeoutMs } from "./run-vitest.mjs";
 import {
-  forwardSignalToVitestProcessGroup,
+  createVitestProcessCompletion,
   installVitestProcessGroupCleanup,
   shouldUseDetachedVitestProcessGroup,
 } from "./vitest-process-group.mjs";
@@ -155,9 +155,10 @@ export function main(argv = process.argv.slice(2), baseEnv = process.env) {
   let lastHeartbeatAt = startedAt;
   let timedOut = false;
 
+  const spawnParams = buildTestLiveSpawnParams(env);
   const child = spawnPnpmRunner({
     pnpmArgs: buildTestLivePnpmArgs(args),
-    ...buildTestLiveSpawnParams(env),
+    ...spawnParams,
   });
   let forwardedSignal = null;
   const teardownChildCleanup = installVitestProcessGroupCleanup({
@@ -216,37 +217,33 @@ export function main(argv = process.argv.slice(2), baseEnv = process.env) {
   );
   heartbeat.unref?.();
 
-  child.on("exit", (code, signal) => {
-    teardown();
-    if (forwardedSignal) {
-      forwardSignalToVitestProcessGroup({
-        child,
-        kill: process.kill.bind(process),
-        signal: "SIGKILL",
-      });
-      process.kill(process.pid, forwardedSignal);
-      return;
-    }
-    if (timedOut) {
-      process.exit(1);
-      return;
-    }
-    if (signal) {
-      process.stderr.write(`[test:live] vitest exited via signal=${signal}\n`);
-      process.kill(process.pid, signal);
-      return;
-    }
-    if ((code ?? 1) !== 0) {
-      process.stderr.write(`[test:live] vitest exited code=${code ?? 1}\n`);
-    }
-    process.exit(code ?? 1);
-  });
-
-  child.on("error", (error) => {
-    teardown();
-    console.error(error);
-    process.exit(1);
-  });
+  createVitestProcessCompletion({ child, detached: spawnParams.detached })
+    .finally(teardown)
+    .then(
+      ({ code, signal }) => {
+        if (forwardedSignal) {
+          process.kill(process.pid, forwardedSignal);
+          return;
+        }
+        if (timedOut) {
+          process.exit(1);
+          return;
+        }
+        if (signal) {
+          process.stderr.write(`[test:live] vitest exited via signal=${signal}\n`);
+          process.kill(process.pid, signal);
+          return;
+        }
+        if ((code ?? 1) !== 0) {
+          process.stderr.write(`[test:live] vitest exited code=${code ?? 1}\n`);
+        }
+        process.exit(code ?? 1);
+      },
+      /** @param {unknown} error */ (error) => {
+        console.error(error);
+        process.exit(1);
+      },
+    );
 }
 
 if (import.meta.main) {

--- a/scripts/test-projects.mjs
+++ b/scripts/test-projects.mjs
@@ -91,7 +91,7 @@ function cleanupVitestRunSpec(spec) {
 function runPnpmSpecCommand(spec, pnpmArgs, label) {
   let noOutputTimedOut = false;
   return new Promise((resolve, reject) => {
-    const { child, getForwardedSignal, teardown } = spawnWatchedVitestProcess({
+    const { child, completion, getForwardedSignal } = spawnWatchedVitestProcess({
       pnpmArgs,
       env: spec.env,
       label,
@@ -104,21 +104,20 @@ function runPnpmSpecCommand(spec, pnpmArgs, label) {
       },
     });
 
-    child.on("exit", (code, signal) => {
-      teardown();
-      const forwardedSignal = getForwardedSignal();
-      if (forwardedSignal) {
-        forceKillVitestProcessGroup(child);
-        resolve({ code: 143, noOutputTimedOut, signal: forwardedSignal });
-        return;
-      }
-      resolve({ code: code ?? (signal ? 143 : 1), noOutputTimedOut, signal });
-    });
-
-    child.on("error", (error) => {
-      teardown();
-      reject(error instanceof Error ? error : new Error(String(error)));
-    });
+    completion.then(
+      ({ code, signal }) => {
+        const forwardedSignal = getForwardedSignal();
+        if (forwardedSignal) {
+          forceKillVitestProcessGroup(child);
+          resolve({ code: 143, noOutputTimedOut, signal: forwardedSignal });
+          return;
+        }
+        resolve({ code: code ?? (signal ? 143 : 1), noOutputTimedOut, signal });
+      },
+      /** @param {unknown} error */ (error) => {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
   });
 }
 

--- a/scripts/test-projects.mjs
+++ b/scripts/test-projects.mjs
@@ -43,7 +43,6 @@ import {
   withRetryNoOutputTimeout,
   writeVitestIncludeFile,
 } from "./test-projects.test-support.mjs";
-import { forceKillVitestProcessGroup } from "./vitest-process-group.mjs";
 
 // Keep this shim so `pnpm test -- src/foo.test.ts` still forwards filters
 // cleanly instead of leaking pnpm's passthrough sentinel to Vitest.
@@ -91,7 +90,7 @@ function cleanupVitestRunSpec(spec) {
 function runPnpmSpecCommand(spec, pnpmArgs, label) {
   let noOutputTimedOut = false;
   return new Promise((resolve, reject) => {
-    const { child, completion, getForwardedSignal } = spawnWatchedVitestProcess({
+    const { completion, getForwardedSignal } = spawnWatchedVitestProcess({
       pnpmArgs,
       env: spec.env,
       label,
@@ -108,7 +107,6 @@ function runPnpmSpecCommand(spec, pnpmArgs, label) {
       ({ code, signal }) => {
         const forwardedSignal = getForwardedSignal();
         if (forwardedSignal) {
-          forceKillVitestProcessGroup(child);
           resolve({ code: 143, noOutputTimedOut, signal: forwardedSignal });
           return;
         }

--- a/scripts/vitest-process-group.d.mts
+++ b/scripts/vitest-process-group.d.mts
@@ -1,3 +1,5 @@
+import type { ChildProcess } from "node:child_process";
+
 export function shouldUseDetachedVitestProcessGroup(
   platform?: NodeJS.Platform,
 ): platform is
@@ -26,6 +28,15 @@ export function forceKillVitestProcessGroup(
   child: unknown,
   kill?: (pid: number, signal?: string | number) => true,
 ): boolean;
+/**
+ * Resolves only after the child completion contract and any owned POSIX group are joined.
+ */
+export function createVitestProcessCompletion(params: {
+  child: ChildProcess;
+  detached: boolean;
+  kill?: (pid: number, signal?: string | number) => true;
+  platform?: NodeJS.Platform;
+}): Promise<{ code: number | null; signal: ChildProcess["signalCode"] }>;
 /**
  * Installs signal/exit cleanup handlers for a Vitest child process group.
  */

--- a/scripts/vitest-process-group.mjs
+++ b/scripts/vitest-process-group.mjs
@@ -52,6 +52,70 @@ export function forceKillVitestProcessGroup(child, kill = process.kill.bind(proc
   });
 }
 
+const PROCESS_GROUP_JOIN_TIMEOUT_MS = 1_000;
+
+function isVitestProcessGroupAlive(target, kill) {
+  try {
+    kill(target, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") {
+      return false;
+    }
+    if (error?.code === "EPERM") {
+      return true;
+    }
+    throw error;
+  }
+}
+
+async function joinVitestProcessGroup(child, platform, kill) {
+  const target = resolveVitestProcessGroupSignalTarget({ childPid: child.pid, platform });
+  if (target === null) {
+    return;
+  }
+  forwardSignalToVitestProcessGroup({ child, kill, platform, signal: "SIGKILL" });
+  const deadlineAt = Date.now() + PROCESS_GROUP_JOIN_TIMEOUT_MS;
+  while (isVitestProcessGroupAlive(target, kill)) {
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error(
+        `[vitest] process group ${child.pid ?? "unknown"} remained alive ${PROCESS_GROUP_JOIN_TIMEOUT_MS}ms after SIGKILL; inspect its descendants before starting another shard.`,
+      );
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, Math.min(25, remainingMs));
+    });
+  }
+}
+
+function waitForChildCompletionEvent(child, event) {
+  return new Promise((resolve, reject) => {
+    child.once(event, (code, signal) => resolve({ code, signal }));
+    child.once("error", reject);
+  });
+}
+
+/**
+ * Resolves only after the child completion contract and any owned POSIX group are joined.
+ */
+export function createVitestProcessCompletion(params) {
+  const exitCompletion = waitForChildCompletionEvent(params.child, "exit");
+  const platform = params.platform ?? process.platform;
+  if (params.detached !== true || !shouldUseDetachedVitestProcessGroup(platform)) {
+    return exitCompletion;
+  }
+
+  const closeCompletion = waitForChildCompletionEvent(params.child, "close");
+  // `close` drains inherited pipes, while the group join proves pipe-independent
+  // descendants are gone before a sequential caller advances.
+  const groupCompletion = exitCompletion.then(async (result) => {
+    await joinVitestProcessGroup(params.child, platform, params.kill ?? process.kill.bind(process));
+    return result;
+  });
+  return Promise.all([groupCompletion, closeCompletion]).then(([result]) => result);
+}
+
 function ensureProcessListenerCapacity(processObject, eventName, additionalListeners = 1) {
   if (
     typeof processObject.getMaxListeners !== "function" ||

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -806,11 +806,16 @@ describe("scripts/run-vitest", () => {
         [
           'const { spawn } = require("node:child_process");',
           'const fs = require("node:fs");',
-          'const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {',
-          '  stdio: ["ignore", "inherit", "inherit"],',
+          'const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {',
+          '  stdio: "ignore",',
           "});",
-          "fs.writeFileSync(process.env.OPENCLAW_RESIDUAL_PID_PATH, String(child.pid));",
-          "child.unref();",
+          "descendant.unref();",
+          'process.once("SIGTERM", () => process.exit(0));',
+          "const pidPath = process.env.OPENCLAW_RESIDUAL_PID_PATH;",
+          "const pendingPath = `${pidPath}.${process.pid}.tmp`;",
+          "fs.writeFileSync(pendingPath, String(descendant.pid));",
+          "fs.renameSync(pendingPath, pidPath);",
+          "setInterval(() => {}, 1000);",
         ].join("\n"),
       ],
       spawnParams: {
@@ -823,11 +828,28 @@ describe("scripts/run-vitest", () => {
     let descendantPid = 0;
 
     try {
-      await waitFor(() => fs.existsSync(descendantPidPath));
+      await waitFor(() => fs.existsSync(descendantPidPath), LOAD_SENSITIVE_PROCESS_TIMEOUT_MS);
       descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
       expect(Number.isInteger(descendantPid)).toBe(true);
-      await expect(watched.completion).resolves.toEqual({ code: 0, signal: null });
-      await waitFor(() => !isProcessAlive(descendantPid));
+      expect(isProcessAlive(descendantPid)).toBe(true);
+
+      process.kill(watched.child.pid!, "SIGTERM");
+      const snapshot = await Promise.race([
+        watched.completion.then((result) => ({
+          descendantAlive: isProcessAlive(descendantPid),
+          groupAlive: isProcessGroupAlive(watched.child.pid!),
+          result,
+        })),
+        delay(LOAD_SENSITIVE_PROCESS_TIMEOUT_MS, undefined, { ref: false }).then(() => {
+          throw new Error("timed out waiting for watched Vitest completion");
+        }),
+      ]);
+
+      expect(snapshot).toEqual({
+        descendantAlive: false,
+        groupAlive: false,
+        result: { code: 0, signal: null },
+      });
     } finally {
       watched.teardown();
       forceKillVitestProcessGroup(watched.child);
@@ -1112,5 +1134,14 @@ function isProcessAlive(pid: number) {
     return true;
   } catch {
     return false;
+  }
+}
+
+function isProcessGroupAlive(pgid: number) {
+  try {
+    process.kill(-pgid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
   }
 }

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -31,6 +31,7 @@ import {
   spawnWatchedVitestProcess,
   shouldSuppressVitestStderrLine,
 } from "../../scripts/run-vitest.mjs";
+import { forceKillVitestProcessGroup } from "../../scripts/vitest-process-group.mjs";
 
 const posixIt = process.platform === "win32" ? it.skip : it;
 // These bounds only guard broken fixtures; readiness and exit are asserted via process signals.
@@ -784,9 +785,56 @@ describe("scripts/run-vitest", () => {
       expect(await waitForClose(watched.child)).toEqual({ code: null, signal: "SIGTERM" });
     } finally {
       watched.teardown();
-      if (watched.child.pid && isProcessAlive(watched.child.pid)) {
-        process.kill(-watched.child.pid, "SIGKILL");
+      forceKillVitestProcessGroup(watched.child);
+    }
+  });
+
+  posixIt("reaps residual process-group descendants before completing", async () => {
+    const descendantPidPath = nodePath.join(
+      os.tmpdir(),
+      `openclaw-run-vitest-residual-${process.pid}-${Date.now()}.pid`,
+    );
+    const watchedEnv = {
+      OPENCLAW_RESIDUAL_PID_PATH: descendantPidPath,
+      OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "5000",
+    };
+    const watched = spawnWatchedVitestProcess({
+      pnpmArgs: [
+        "exec",
+        "node",
+        "-e",
+        [
+          'const { spawn } = require("node:child_process");',
+          'const fs = require("node:fs");',
+          'const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {',
+          '  stdio: ["ignore", "inherit", "inherit"],',
+          "});",
+          "fs.writeFileSync(process.env.OPENCLAW_RESIDUAL_PID_PATH, String(child.pid));",
+          "child.unref();",
+        ].join("\n"),
+      ],
+      spawnParams: {
+        detached: true,
+        env: watchedEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+      env: watchedEnv,
+    });
+    let descendantPid = 0;
+
+    try {
+      await waitFor(() => fs.existsSync(descendantPidPath));
+      descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
+      expect(Number.isInteger(descendantPid)).toBe(true);
+      await expect(watched.completion).resolves.toEqual({ code: 0, signal: null });
+      await waitFor(() => !isProcessAlive(descendantPid));
+    } finally {
+      watched.teardown();
+      forceKillVitestProcessGroup(watched.child);
+      if (descendantPid && isProcessAlive(descendantPid)) {
+        process.kill(descendantPid, "SIGKILL");
       }
+      fs.rmSync(descendantPidPath, { force: true });
     }
   });
 

--- a/test/scripts/vitest-process-group.test.ts
+++ b/test/scripts/vitest-process-group.test.ts
@@ -1,6 +1,8 @@
 // Vitest Process Group tests cover vitest process group script behavior.
+import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import {
+  createVitestProcessCompletion,
   forwardSignalToVitestProcessGroup,
   installVitestProcessGroupCleanup,
   resolveVitestProcessGroupSignalTarget,
@@ -79,6 +81,24 @@ describe("vitest process group helpers", () => {
         kill,
       }),
     ).toBe(false);
+  });
+
+  it.each([
+    ["Windows", { detached: true, platform: "win32" as const }],
+    ["non-detached POSIX", { detached: false, platform: "darwin" as const }],
+  ])("keeps %s completion on direct-child exit", async (_label, params) => {
+    const child = Object.assign(new EventEmitter(), { pid: 4200 });
+    const kill = vi.fn(() => true as const);
+    const completion = createVitestProcessCompletion({
+      child: child as never,
+      kill,
+      ...params,
+    });
+
+    child.emit("exit", 0, null);
+
+    await expect(completion).resolves.toEqual({ code: 0, signal: null });
+    expect(kill).not.toHaveBeenCalled();
   });
 
   it("installs and removes process cleanup listeners", () => {


### PR DESCRIPTION
Closes #117754

## What Problem This Solves

Fixes an issue where sequential Vitest owners could advance after a detached POSIX leader closed while pipe-independent members of its process group were still alive. That allows the next config or extension chunk to overlap the old group and makes cleanup timing depend on descendant stdio topology.

## Why This Change Was Made

The process-group owner now exposes one completion contract. For detached POSIX children it waits for leader exit, sends `SIGKILL` to the group, polls the negative PGID until the group is no longer addressable, and also waits for direct-child `close`. A one-second bounded failure reports the surviving group instead of silently advancing. Windows and non-detached runs preserve their existing direct-child `exit` contract because they have no POSIX group target.

Watched Vitest runs, delegated test-projects, sequential extension batches, and both live-test wrappers now use that same owner instead of carrying separate exit/cleanup policy. The regression gives the descendant ignored stdio, proves it is alive before leader exit, and requires both its PID and PGID to be gone in the exact completion reaction; it therefore proves group quiescence rather than inherited-pipe closure.

The expanded sibling sweep is one lifecycle invariant, not a general refactor. Tooling/declaration code is +219/-141 (net +78); tests are +101/-2 (net +99). No OpenClaw product runtime, config, protocol, or persistence surface changes.

AI-assisted: yes. The implementation and every accepted review finding were independently verified against the complete lifecycle path.

## User Impact

There is no OpenClaw runtime behavior change. Maintainers and contributors get deterministic process-group isolation between sequential test configs, extension chunks, delegated runs, and live-test wrapper completion.

## Evidence

Before:

- Source-matched lifecycle probe: detached leader `exit` occurred before the inherited output tree `close`; the old sequential caller advanced at leader exit.
- Review of exact head `681d25d28e9f828eb0220a0cb19793155328aa6f` found that waiting for leader `close` still did not prove pipe-independent process-group members were gone. Vitest workers use private pipes to their leader, so group disappearance must be checked directly.

After on Blacksmith Testbox `tbx_01kz096fh3qn9hkat3x8feqssw` ([run 30731158496](https://github.com/openclaw/openclaw/actions/runs/30731158496)):

- 540/540 focused assertions passed across the process-group owner, watched runner, project sequencing, extension batching, and both live wrappers.
- The stdio-independent residual-descendant regression passed with descendant PID and PGID already dead at completion.
- Complete `pnpm check:changed` passed formatting, declaration contracts, scripts/test-root typechecks, type-aware lint, Docker E2E boundaries, and raw HTTP/2 guards.
- Built-in POSIX probe observed result code 0 with descendant and group both dead; the non-detached control preserved exit code 7 without group signaling.
- `git diff --check` passed.
- Fresh pre-commit autoreview was clean (`patch is correct`, confidence 0.96).

The prior exact-head run [30730735584](https://github.com/openclaw/openclaw/actions/runs/30730735584) also reproduced a separate moving timeout inside `help-exit.process`. A retained Testbox then reproduced that timeout in a different child after startup and CLI parse completed in 232 ms. This PR does not claim to fix that distinct source-loader/one-shot child lifecycle; it is being handled independently rather than masked with retries or a larger timeout.
