### PR TITLE
improve(telegram): reduce migration discovery startup cost

### DIFF
--- a/extensions/telegram/src/bot-handlers.message-context.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.runtime.ts
@@ -16,12 +16,12 @@ import {
   isTelegramHistoryEntryAfterAmbientWatermark,
   isTelegramSelfSenderName,
 } from "./group-history-window.js";
+import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
 import {
   buildTelegramConversationContext,
   buildTelegramReplyChain,
   createTelegramMessageCache,
   isTelegramMessageFromCurrentBot,
-  resolveTelegramMessageCacheScope,
   type TelegramCachedMessageNode,
   type TelegramReplyChainEntry,
 } from "./message-cache.js";

--- a/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
@@ -25,11 +25,8 @@ import type {
   TelegramBotDeps,
   TelegramMessageContext,
 } from "./bot-message-dispatch.test-harness.js";
-import {
-  buildTelegramConversationContext,
-  createTelegramMessageCache,
-  resolveTelegramMessageCacheScope,
-} from "./message-cache.js";
+import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
+import { buildTelegramConversationContext, createTelegramMessageCache } from "./message-cache.js";
 import { recordOutboundMessageForPromptContext as recordOutboundMessageForPromptContextActual } from "./outbound-message-context.js";
 
 describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {

--- a/extensions/telegram/src/bot-message-dispatch.reply-targets.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.reply-targets.test.ts
@@ -19,7 +19,8 @@ import {
   setupDraftStreams,
 } from "./bot-message-dispatch.test-harness.js";
 import type { TelegramMessageContext } from "./bot-message-dispatch.test-harness.js";
-import { createTelegramMessageCache, resolveTelegramMessageCacheScope } from "./message-cache.js";
+import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
+import { createTelegramMessageCache } from "./message-cache.js";
 import {
   recordOutboundMessageForPromptContext as recordOutboundMessageForPromptContextActual,
   registerTelegramOutboundGroupHistoryRecorder,

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -44,7 +44,7 @@ import {
   resolveTelegramMessageCacheScope,
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
-} from "./message-cache.js";
+} from "./message-cache-persistence.js";
 import { buildTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
 import { setTelegramRuntime } from "./runtime.js";
 import { clearTelegramRuntimeForTest as clearTelegramRuntime } from "./runtime.test-support.js";

--- a/extensions/telegram/src/message-cache-persistence.ts
+++ b/extensions/telegram/src/message-cache-persistence.ts
@@ -1,0 +1,50 @@
+// Lightweight Telegram message-cache persistence contract shared with doctor migrations.
+import { createHash } from "node:crypto";
+import type { Message } from "grammy/types";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type {
+  TelegramPromptContextProjection,
+  TelegramPromptContextSource,
+} from "./prompt-context-projection.js";
+
+export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES = 3000;
+export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE = "telegram.message-cache";
+// Versioned writes preserve projection provenance. Shipped unversioned rows
+// hydrate as markerless context only; they never imply transcript projection.
+export const TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION = 1;
+
+export type TelegramMessageThreadBinding = {
+  kind: "provider-observed-v1";
+  threadId: string;
+};
+
+export type PersistedTelegramMessageCacheValue = {
+  version: typeof TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION;
+  sourceMessage: Message;
+  botUserId?: number;
+  promptContextProjection?: TelegramPromptContextProjection | TelegramPromptContextSource;
+  threadBinding?: TelegramMessageThreadBinding;
+  threadId?: string;
+};
+
+export function resolveTelegramMessageCachePath(storePath: string): string {
+  return `${storePath}.telegram-messages.json`;
+}
+
+export function resolveTelegramMessageCacheScope(storePath: string): string {
+  return resolveTelegramMessageCachePath(storePath);
+}
+
+export function resolveTelegramMessageCachePersistentScopeKey(scope: string): string {
+  return createHash("sha256").update(scope).digest("hex").slice(0, 24);
+}
+
+export function isTelegramMessageCacheSourceMessage(value: unknown): value is Message {
+  return (
+    isRecord(value) &&
+    typeof value.message_id === "number" &&
+    Number.isFinite(value.message_id) &&
+    typeof value.date === "number" &&
+    Number.isFinite(value.date)
+  );
+}

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -2,12 +2,14 @@
 import type { Message } from "grammy/types";
 import { describe, expect, it } from "vitest";
 import {
+  resolveTelegramMessageCachePersistentScopeKey,
+  TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
+} from "./message-cache-persistence.js";
+import {
   buildTelegramConversationContext,
   buildTelegramReplyChain,
   createTelegramMessageCache,
   hasProviderObservedTelegramThreadBinding,
-  resolveTelegramMessageCachePersistentScopeKey,
-  TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
 } from "./message-cache.js";
 import { resetTelegramMessageCacheForTest as resetTelegramMessageCacheBucketsForTest } from "./runtime.test-support.js";
 

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -1,5 +1,4 @@
 // Telegram plugin module implements message cache behavior.
-import { createHash } from "node:crypto";
 import type { Message } from "grammy/types";
 import { formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
@@ -17,12 +16,20 @@ import {
   getTelegramTextParts,
   normalizeForwardedContext,
 } from "./bot/helpers.js";
+import {
+  isTelegramMessageCacheSourceMessage,
+  type PersistedTelegramMessageCacheValue,
+  resolveTelegramMessageCachePersistentScopeKey,
+  TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
+  TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
+  TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION,
+  type TelegramMessageThreadBinding,
+} from "./message-cache-persistence.js";
 import { parseTelegramMessageThreadId } from "./outbound-params.js";
 import {
   parseTelegramPromptContextProjection,
   type TelegramPromptContextProjection,
   type TelegramPromptContextProjectionMarker,
-  type TelegramPromptContextSource,
 } from "./prompt-context-projection.js";
 import { getOptionalTelegramRuntime } from "./runtime.js";
 
@@ -35,13 +42,6 @@ export type TelegramCachedMessageNode = Omit<TelegramReplyChainEntry, "messageId
   sourceMessage: Message;
   promptContextProjectionMarker?: TelegramPromptContextProjectionMarker;
   threadBinding?: TelegramMessageThreadBinding;
-};
-
-// This marker is a provider fact, never an inference from invocation origin or
-// a legacy threadId. Delegated mutations may rely on it after cache hydration.
-type TelegramMessageThreadBinding = {
-  kind: "provider-observed-v1";
-  threadId: string;
 };
 
 type TelegramConversationContextNode = {
@@ -111,11 +111,6 @@ type TelegramCachedMessageObservation = {
 type TelegramEmbeddedReplyMessage = NonNullable<Message["reply_to_message"]>;
 
 const DEFAULT_MAX_MESSAGES = 5000;
-export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES = 3000;
-export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE = "telegram.message-cache";
-// Versioned writes preserve projection provenance. Shipped unversioned rows
-// hydrate as markerless context only; they never imply transcript projection.
-export const TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION = 1;
 const PERSISTENT_BUCKET_KEY = `plugin-state:${TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE}`;
 const TELEGRAM_MESSAGE_CACHE_BUCKETS_KEY = Symbol.for("openclaw.telegram.messageCacheBuckets");
 
@@ -131,15 +126,6 @@ function getPersistedMessageCacheBuckets(): Map<string, TelegramMessageCacheBuck
   globalRecord[TELEGRAM_MESSAGE_CACHE_BUCKETS_KEY] = created;
   return created;
 }
-
-export type PersistedTelegramMessageCacheValue = {
-  version: typeof TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION;
-  sourceMessage: Message;
-  botUserId?: number;
-  promptContextProjection?: TelegramPromptContextProjection | TelegramPromptContextSource;
-  threadBinding?: TelegramMessageThreadBinding;
-  threadId?: string;
-};
 
 type TelegramMessageCachePersistentStore = {
   register(key: string, value: PersistedTelegramMessageCacheValue): Promise<void>;
@@ -163,14 +149,6 @@ function telegramMessageCacheKeyPrefix(params: {
 }) {
   const prefix = `${params.accountId}:${params.chatId}:`;
   return params.scopeKey ? `${params.scopeKey}:${prefix}` : prefix;
-}
-
-export function resolveTelegramMessageCachePath(storePath: string): string {
-  return `${storePath}.telegram-messages.json`;
-}
-
-export function resolveTelegramMessageCacheScope(storePath: string): string {
-  return resolveTelegramMessageCachePath(storePath);
 }
 
 function resolveReplyMessage(msg: Message): Message | undefined {
@@ -339,16 +317,6 @@ function parseSafeMessageId(value: string | undefined): number | undefined {
   return value === undefined ? undefined : parseStrictPositiveInteger(value);
 }
 
-export function isTelegramMessageCacheSourceMessage(value: unknown): value is Message {
-  return (
-    isRecord(value) &&
-    typeof value.message_id === "number" &&
-    Number.isFinite(value.message_id) &&
-    typeof value.date === "number" &&
-    Number.isFinite(value.date)
-  );
-}
-
 function parsePersistedCacheValue(key: string, value: unknown) {
   if (
     !isRecord(value) ||
@@ -461,10 +429,6 @@ function upsertCachedMessageNode(params: {
   params.messages.delete(params.key);
   params.messages.set(params.key, node);
   return node;
-}
-
-export function resolveTelegramMessageCachePersistentScopeKey(scope: string): string {
-  return createHash("sha256").update(scope).digest("hex").slice(0, 24);
 }
 
 function resolveDefaultPersistentStore(): TelegramMessageCachePersistentStore | undefined {

--- a/extensions/telegram/src/message-topic-binding.test.ts
+++ b/extensions/telegram/src/message-topic-binding.test.ts
@@ -7,7 +7,8 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createTelegramMessageCache, resolveTelegramMessageCacheScope } from "./message-cache.js";
+import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
+import { createTelegramMessageCache } from "./message-cache.js";
 import { resolveTelegramMessageMutationChatId } from "./message-topic-binding.js";
 import { setTelegramRuntime } from "./runtime.js";
 import {

--- a/extensions/telegram/src/message-topic-binding.ts
+++ b/extensions/telegram/src/message-topic-binding.ts
@@ -9,10 +9,10 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveDefaultTelegramAccountId } from "./accounts.js";
+import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
 import {
   createTelegramMessageCache,
   hasProviderObservedTelegramThreadBinding,
-  resolveTelegramMessageCacheScope,
 } from "./message-cache.js";
 import { parseTelegramTarget } from "./targets.js";
 

--- a/extensions/telegram/src/outbound-message-context.test.ts
+++ b/extensions/telegram/src/outbound-message-context.test.ts
@@ -6,10 +6,10 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
 import {
   createTelegramMessageCache,
   hasProviderObservedTelegramThreadBinding,
-  resolveTelegramMessageCacheScope,
 } from "./message-cache.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import { setTelegramRuntime } from "./runtime.js";

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -6,7 +6,8 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { TELEGRAM_GENERAL_TOPIC_ID, type TelegramThreadSpec } from "./bot/helpers.js";
 import { buildTelegramSelfSenderName } from "./group-history-window.js";
-import { createTelegramMessageCache, resolveTelegramMessageCacheScope } from "./message-cache.js";
+import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
+import { createTelegramMessageCache } from "./message-cache.js";
 import type { TelegramPromptContextProjection } from "./prompt-context-projection.js";
 
 type TelegramOutboundPromptContextUser = {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -14,11 +14,11 @@ import {
   recordTelegramGroupHistoryEntry,
   selectTelegramGroupHistoryAfterLastSelf,
 } from "./group-history-window.js";
+import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
 import {
   buildTelegramConversationContext,
   createTelegramMessageCache,
   hasProviderObservedTelegramThreadBinding,
-  resolveTelegramMessageCacheScope,
 } from "./message-cache.js";
 import { registerTelegramOutboundGroupHistoryRecorder } from "./outbound-message-context.js";
 import { createTelegramPromptContextProjectionCursor } from "./prompt-context-projection.js";

--- a/extensions/telegram/src/state-migrations.import-boundary.test.ts
+++ b/extensions/telegram/src/state-migrations.import-boundary.test.ts
@@ -1,0 +1,11 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("telegram state migration import boundary", () => {
+  it("keeps the runtime message cache off the doctor discovery path", async () => {
+    const source = await readFile(new URL("./state-migrations.ts", import.meta.url), "utf8");
+
+    expect(source).toContain('from "./message-cache-persistence.js"');
+    expect(source).not.toContain('from "./message-cache.js"');
+  });
+});

--- a/extensions/telegram/src/state-migrations.test.ts
+++ b/extensions/telegram/src/state-migrations.test.ts
@@ -9,7 +9,7 @@ import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveTelegramBotInfoCachePath } from "./bot-info-cache.js";
-import { resolveTelegramMessageCachePath } from "./message-cache.js";
+import { resolveTelegramMessageCachePath } from "./message-cache-persistence.js";
 import { detectTelegramLegacyStateMigrations } from "./state-migrations.js";
 import {
   resolveTopicNameCacheNamespace,

--- a/extensions/telegram/src/state-migrations.ts
+++ b/extensions/telegram/src/state-migrations.ts
@@ -22,7 +22,7 @@ import {
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
   TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
   TELEGRAM_MESSAGE_CACHE_PERSISTED_VERSION,
-} from "./message-cache.js";
+} from "./message-cache-persistence.js";
 import { parseTelegramMessageThreadId } from "./outbound-params.js";
 import {
   listTelegramLegacySentMessageCacheEntries,


### PR DESCRIPTION
Related: #117743

## What Problem This Solves

Kova shows legacy state-migration discovery as the largest remaining measured doctor preflight stage, averaging about 1.08 seconds on the exact latest-main profile. Telegram migration discovery imported the full runtime message-cache graph even when no legacy Telegram cache existed.

## Why This Change Was Made

Move the Telegram message-cache persistence contract into a lightweight plugin-owned module shared by runtime code and doctor migrations. Migration eligibility, paths, namespace, ordering, validation, and persisted data remain unchanged; only the import boundary changes.

## User Impact

CLI and Gateway cold startup avoid loading unrelated Telegram runtime cache code during migration discovery. There is no channel behavior, config, storage schema, or migration result change.

## Evidence

- exact latest-main Kova baseline from #117743: legacy state migrations averaged 1,079 ms across 8 samples
- exact parent/head `state-migrations.ts` import benchmark improved from 3,007.1 ms to 2,935.6 ms warm average under the TypeScript loader: 71.5 ms / 2.38% faster across 7 samples after discarding the cold first run
- exact-head focused Telegram migration/cache proof: 5 files, 55 tests passed
- broader pre-rebase Telegram proof with the identical patch: 9 files, 412 tests passed
- import-boundary regression test verifies doctor discovery does not import `message-cache.ts`
- `oxfmt`, `oxlint`, `git diff --check`, deadcode export scans, and local autoreview passed
- exact-head GitHub CI passed on attempt 2: https://github.com/openclaw/openclaw/actions/runs/30729693793/attempts/2
- exact-head Kova and source-performance workflow passed: https://github.com/openclaw/openclaw/actions/runs/30729703759
- coarse Gateway and CLI source probes moved in both directions within noise; this PR claims the measured import-boundary improvement, not a proven end-to-end startup reduction
- remote pre-PR Testbox proof unavailable because local Blacksmith and Crabbox broker credentials are not configured; trusted-source local fallback used per repository policy

AI-assisted: implementation and review were performed with Codex.
