### PR TITLE
fix(sessions): surface archive retention cleanup failures

### DIFF
--- a/src/config/sessions/store-maintenance-operations.ts
+++ b/src/config/sessions/store-maintenance-operations.ts
@@ -177,15 +177,21 @@ async function cleanupRemovedSessionArtifacts(params: {
     archivedDirs.size > 0
       ? [...archivedDirs]
       : [path.dirname(path.resolve(params.operation.storePath))];
-  // Both retention reasons ride one cleanup call so each save enumerates the
-  // sessions dir at most once; a listing per reason would scan twice per save.
-  await params.operation.artifacts.cleanupArchivedSessionTranscripts({
-    directories: targetDirs,
-    rules: [
-      { reason: "deleted", olderThanMs: params.maintenance.resetArchiveRetentionMs },
-      { reason: "reset", olderThanMs: params.maintenance.resetArchiveRetentionMs },
-    ],
-  });
+  // Both reasons ride one advisory cleanup call: earlier artifact moves may
+  // have committed, so retention failure must not block the primary store save.
+  await params.operation.artifacts
+    .cleanupArchivedSessionTranscripts({
+      directories: targetDirs,
+      rules: [
+        { reason: "deleted", olderThanMs: params.maintenance.resetArchiveRetentionMs },
+        { reason: "reset", olderThanMs: params.maintenance.resetArchiveRetentionMs },
+      ],
+    })
+    .catch((error: unknown) => {
+      params.operation.log.warn("session transcript archive retention cleanup failed", {
+        error: String(error),
+      });
+    });
 }
 
 async function applyEnforcedMaintenance(params: {

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -2,7 +2,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
@@ -273,6 +273,48 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
       },
     ]);
     expect(trajectoryCleanupReferencedIds).toEqual(new Set(["shared-session", "active-session"]));
+  });
+
+  it("reports archive retention failure without aborting file-backed maintenance", async () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["stale", { sessionId: "stale-session", updatedAt: now - 30 * DAY_MS }],
+      ["fresh", { sessionId: "fresh-session", updatedAt: now }],
+    ]);
+    const cleanupError = new Error("archive cleanup denied");
+    const warn = vi.fn();
+    const onMaintenanceApplied = vi.fn();
+
+    const result = await applyFileBackedSessionStoreMaintenance({
+      storePath: "/tmp/openclaw-sessions/sessions.json",
+      store,
+      maintenanceConfig: {
+        mode: "enforce",
+        pruneAfterMs: 7 * DAY_MS,
+        maxEntries: 500,
+        modelRunPruneAfterMs: DAY_MS,
+        resetArchiveRetentionMs: 0,
+        maxDiskBytes: null,
+        highWaterBytes: null,
+      },
+      onMaintenanceApplied,
+      log: { warn, info: () => {} },
+      artifacts: {
+        archiveRemovedSessionTranscripts: async () => new Set(),
+        removeRemovedSessionTrajectoryArtifacts: async () => {},
+        cleanupArchivedSessionTranscripts: async () => {
+          throw cleanupError;
+        },
+      },
+    });
+
+    expect(result.changedStore).toBe(true);
+    expect(store.stale).toBeUndefined();
+    expect(store).toHaveProperty("fresh");
+    expect(onMaintenanceApplied).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith("session transcript archive retention cleanup failed", {
+      error: String(cleanupError),
+    });
   });
 
   it("forced cleanup prunes stale model-run probes before the cap evicts real sessions", async () => {

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -1,7 +1,9 @@
 // Cron session reaper tests cover cleanup of sessions created by scheduled runs.
+import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
 import { loadCombinedSessionStoreForGateway } from "../config/sessions/combined-store-gateway.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import {
@@ -106,6 +108,7 @@ describe("sweepCronRunSessions", () => {
   });
 
   afterEach(() => {
+    clearRuntimeConfigSnapshot();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     cleanupTempDirs(tempDirs);
@@ -174,6 +177,54 @@ describe("sweepCronRunSessions", () => {
       sessionId: "regular-session",
       updatedAt: now - 100 * 3_600_000,
     });
+  });
+
+  it("commits expired rows and warns when transcript archive retention cleanup fails", async () => {
+    const now = Date.now();
+    const sessionKey = "agent:main:cron:job1:run:cleanup-failure";
+    const sessionId = "cleanup-failure";
+    const staleArchive = path.join(tmpDir, "older.jsonl.deleted.2026-01-01T00-00-00.000Z");
+    const cleanupError = Object.assign(new Error("archive cleanup denied"), { code: "EACCES" });
+    const warn = vi.fn();
+    const failingLog: Logger = { ...log, warn };
+
+    await seedSessionEntries(storePath, {
+      [sessionKey]: { sessionId, updatedAt: now - 25 * 3_600_000 },
+    });
+    await sessionAccessor.appendTranscriptMessage(
+      { agentId: "main", sessionId, sessionKey, storePath },
+      { cwd: tmpDir, message: { role: "user", content: "archive me" } },
+    );
+    await fsPromises.writeFile(staleArchive, "stale archive", "utf8");
+    setRuntimeConfigSnapshot({
+      session: {
+        maintenance: {
+          maxDiskBytes: false,
+          resetArchiveRetention: "1ms",
+        },
+      },
+    });
+    const rmSpy = vi.spyOn(fsPromises, "rm").mockRejectedValueOnce(cleanupError);
+
+    try {
+      const result = await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now,
+        log: failingLog,
+        force: true,
+      });
+
+      expect(result).toEqual({ swept: true, pruned: 1 });
+      expect(readSessionEntries(storePath)[sessionKey]).toBeUndefined();
+      await expect(fsPromises.access(staleArchive)).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(
+        { err: expect.stringContaining("archive cleanup denied") },
+        "cron-reaper: transcript cleanup failed",
+      );
+    } finally {
+      rmSpy.mockRestore();
+    }
   });
 
   it("discovers, accesses, and reaps a logical owner in one shared exact store", async () => {

--- a/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
+++ b/src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
@@ -34,6 +34,10 @@ describe("cleanupArchivedSessionTranscripts", () => {
     return (await fsPromises.readdir(dir)).toSorted();
   }
 
+  function filesystemError(code: string): NodeJS.ErrnoException {
+    return Object.assign(new Error(`filesystem ${code}`), { code });
+  }
+
   it("applies every retention rule from a single directory listing", async () => {
     await seed([
       `a.jsonl.deleted.${OLD_STAMP}`,
@@ -100,5 +104,99 @@ describe("cleanupArchivedSessionTranscripts", () => {
 
     expect(result).toEqual({ removed: 0, scanned: 0 });
     expect(readdirSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores a missing archive directory", async () => {
+    const result = await cleanupArchivedSessionTranscripts({
+      directories: [path.join(dir, "missing")],
+      rules: [{ reason: "deleted", olderThanMs: 0 }],
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({ removed: 0, scanned: 0 });
+  });
+
+  it("surfaces archive directory read failures", async () => {
+    const readError = filesystemError("EACCES");
+    vi.spyOn(fsPromises, "readdir").mockRejectedValueOnce(readError);
+
+    await expect(
+      cleanupArchivedSessionTranscripts({
+        directories: [dir],
+        rules: [{ reason: "deleted", olderThanMs: 0 }],
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toBe(readError);
+  });
+
+  it("surfaces archive stat failures", async () => {
+    await seed([`a.jsonl.deleted.${OLD_STAMP}`]);
+    const statError = filesystemError("EIO");
+    vi.spyOn(fsPromises, "stat").mockRejectedValueOnce(statError);
+
+    await expect(
+      cleanupArchivedSessionTranscripts({
+        directories: [dir],
+        rules: [{ reason: "deleted", olderThanMs: 0 }],
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toBe(statError);
+  });
+
+  it("ignores an archive removed between directory listing and stat", async () => {
+    const archiveName = `a.jsonl.deleted.${OLD_STAMP}`;
+    const archivePath = path.join(dir, archiveName);
+    await seed([archiveName]);
+    const realStat = fsPromises.stat.bind(fsPromises);
+    vi.spyOn(fsPromises, "stat").mockImplementationOnce(async (target) => {
+      await fsPromises.rm(target);
+      return await realStat(target);
+    });
+
+    const result = await cleanupArchivedSessionTranscripts({
+      directories: [dir],
+      rules: [{ reason: "deleted", olderThanMs: 0 }],
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({ removed: 0, scanned: 1 });
+    await expect(fsPromises.access(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("surfaces archive removal failures without deleting the archive", async () => {
+    const archiveName = `a.jsonl.deleted.${OLD_STAMP}`;
+    await seed([archiveName]);
+    const removeError = filesystemError("EACCES");
+    vi.spyOn(fsPromises, "rm").mockRejectedValueOnce(removeError);
+
+    await expect(
+      cleanupArchivedSessionTranscripts({
+        directories: [dir],
+        rules: [{ reason: "deleted", olderThanMs: 0 }],
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toBe(removeError);
+    expect(await remaining()).toEqual([archiveName]);
+  });
+
+  it("does not count an archive removed between stat and cleanup", async () => {
+    const archiveName = `a.jsonl.deleted.${OLD_STAMP}`;
+    const archivePath = path.join(dir, archiveName);
+    await seed([archiveName]);
+    const realStat = fsPromises.stat.bind(fsPromises);
+    vi.spyOn(fsPromises, "stat").mockImplementationOnce(async (target) => {
+      const stat = await realStat(target);
+      await fsPromises.rm(target);
+      return stat;
+    });
+
+    const result = await cleanupArchivedSessionTranscripts({
+      directories: [dir],
+      rules: [{ reason: "deleted", olderThanMs: 0 }],
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({ removed: 0, scanned: 1 });
+    await expect(fsPromises.access(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 });

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -16,6 +16,7 @@ import {
   resolveSessionTranscriptPath,
   resolveSessionTranscriptPathInDir,
 } from "../config/sessions/paths.js";
+import { hasErrnoCode } from "../infra/errors.js";
 import { readFileWindowFully } from "../infra/file-read.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
@@ -443,9 +444,19 @@ type SessionArchiveCleanupRule = {
   olderThanMs: number;
 };
 
-// Store maintenance runs this on every session-store save. All retention rules
-// share one directory listing: a listing per reason would multiply READDIR
-// load on the per-save hot path, which is expensive on networked filesystems.
+async function ignoreMissingArchivePath<T>(operation: () => Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT")) {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+// Archive-retention sweeps share one directory listing across all rules. A
+// listing per reason would multiply READDIR load on networked filesystems.
 export async function cleanupArchivedSessionTranscripts(opts: {
   directories: string[];
   rules: SessionArchiveCleanupRule[];
@@ -463,7 +474,7 @@ export async function cleanupArchivedSessionTranscripts(opts: {
   let scanned = 0;
 
   for (const dir of directories) {
-    const entries = await fs.promises.readdir(dir).catch(() => []);
+    const entries = await ignoreMissingArchivePath(() => fs.promises.readdir(dir), []);
     for (const entry of entries) {
       for (const rule of rules) {
         const timestamp = parseSessionArchiveTimestamp(entry, rule.reason);
@@ -473,10 +484,15 @@ export async function cleanupArchivedSessionTranscripts(opts: {
         scanned += 1;
         if (now - timestamp > rule.olderThanMs) {
           const fullPath = path.join(dir, entry);
-          const stat = await fs.promises.stat(fullPath).catch(() => null);
+          const stat = await ignoreMissingArchivePath(() => fs.promises.stat(fullPath), null);
           if (stat?.isFile()) {
-            await fs.promises.rm(fullPath).catch(() => undefined);
-            removed += 1;
+            const removedFile = await ignoreMissingArchivePath(async () => {
+              await fs.promises.rm(fullPath);
+              return true;
+            }, false);
+            if (removedFile) {
+              removed += 1;
+            }
           }
         }
         // An archive name carries exactly one `.{reason}.{timestamp}` suffix,


### PR DESCRIPTION
Closes #117760

## What Problem This Solves

Fixes an issue where transcript archive retention could silently ignore real filesystem failures and count a failed removal as successful, leaving expired archives on disk without an operator-visible reason.

## Why This Change Was Made

The filesystem primitive now treats only `ENOENT` as a benign missing-directory or concurrent-removal race. Other read, stat, and remove errors propagate unchanged, and `removed` advances only after a successful unlink.

Lifecycle policy stays with the callers: legacy file-backed maintenance warns and continues the primary save, while SQLite cron cleanup captures the post-commit artifact error and emits its existing warning after the expired row is committed. The change does not add a config, migration, schema, or fallback path.

## User Impact

Operators now receive a clear maintenance warning when transcript retention cannot inspect or remove an archive. Ordinary missing-file races remain quiet, and primary session/cron persistence still completes at the existing owner boundary.

AI-assisted: yes. The complete filesystem and lifecycle paths were independently reviewed before opening this PR.

## Evidence

Blacksmith Testbox `tbx_01kz04h1xp0vb6sspncssxp08s` ([run 30728772686](https://github.com/openclaw/openclaw/actions/runs/30728772686)):

- Focused filesystem, store-pruning, SQLite accessor, and cron reaper suites: 166/166 tests passed.
- Real cron boundary regression: expired row commits, archive unlink failure remains visible, and `cron-reaper: transcript cleanup failed` is logged.
- Filesystem regressions cover missing directories, readdir/stat errors, readdir-to-stat and stat-to-remove `ENOENT` races, failed unlink preservation, and truthful removal counts.
- Current-main `pnpm check:changed`: green across `core` and `coreTests` in 4m56s.
- Gateway benchmark: base 1.07s / 413 ms test time; patched 0.933s / 337 ms test time.
- `git diff --check`, targeted `oxfmt`, and targeted `oxlint`: clean.
- Fresh autoreview: clean, patch correct, confidence 0.98; TruffleHog clean.

Scope: production +38/-16 (net +22); tests +192/-1 (net +191). The test growth covers the filesystem truth boundary and both advisory/committed lifecycle callers; no product API/config/schema surface changes.
