### PR TITLE
fix(tasks): keep process listener singleton

### DIFF
--- a/src/tasks/task-registry-state.ts
+++ b/src/tasks/task-registry-state.ts
@@ -29,8 +29,6 @@ export const taskIdsByOwnerKey = taskRegistryProcessState.taskIdsByOwnerKey;
 export const taskIdsByParentFlowId = taskRegistryProcessState.taskIdsByParentFlowId;
 export const taskIdsByRelatedSessionKey = taskRegistryProcessState.taskIdsByRelatedSessionKey;
 export const tasksWithPendingDelivery = taskRegistryProcessState.tasksWithPendingDelivery;
-let listenerStarted = false;
-let listenerStop: (() => void) | null = null;
 type TaskRegistryRestoreState =
   | { status: "uninitialized" }
   | { status: "restoring" }
@@ -83,21 +81,20 @@ export function setTaskRegistryListenerStarter(starter: () => void): void {
 }
 
 export function claimTaskRegistryListenerStart(): boolean {
-  if (listenerStarted) {
+  if (taskRegistryProcessState.listenerStop !== undefined) {
     return false;
   }
-  listenerStarted = true;
+  taskRegistryProcessState.listenerStop = null;
   return true;
 }
 
 export function setTaskRegistryListenerStop(stop: (() => void) | null): void {
-  listenerStop = stop;
+  taskRegistryProcessState.listenerStop = stop;
 }
 
 export function resetTaskRegistryListenerState(): void {
-  listenerStop?.();
-  listenerStop = null;
-  listenerStarted = false;
+  taskRegistryProcessState.listenerStop?.();
+  taskRegistryProcessState.listenerStop = undefined;
 }
 
 function clearTaskFlowSyncRetries(): void {

--- a/src/tasks/task-registry.process-state.test.ts
+++ b/src/tasks/task-registry.process-state.test.ts
@@ -1,6 +1,6 @@
 // Verifies process-state persistence across fresh task registry module loads.
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 describe("task registry process state", () => {
   it("shares state across duplicate module instances", async () => {
@@ -38,5 +38,60 @@ describe("task registry process state", () => {
       }),
     );
     firstState.tasks.clear();
+  });
+
+  it("does not duplicate task event listeners when modules are reset", async () => {
+    const events = await import("../infra/agent-events.js");
+    const firstStore = await import("./task-registry.store.js");
+    const store = {
+      loadSnapshot: () => ({ tasks: new Map(), deliveryStates: new Map() }),
+      saveSnapshot: () => {},
+    };
+    firstStore.configureTaskRegistryRuntime({ store });
+    const firstRegistry = await import("./task-registry.js");
+    const firstState = await import("./task-registry-state.js");
+    firstState.resetTaskRegistryListenerState();
+    events.resetAgentEventsForTest();
+    firstRegistry.ensureTaskRegistryReady();
+
+    vi.resetModules();
+
+    const secondStore = await import("./task-registry.store.js");
+    secondStore.configureTaskRegistryRuntime({ store });
+    const secondRegistry = await import("./task-registry.js");
+    const secondState = await import("./task-registry-state.js");
+
+    try {
+      secondRegistry.ensureTaskRegistryReady();
+      const task = secondRegistry.createTaskRecord({
+        runtime: "subagent",
+        requesterSessionKey: "agent:main:main",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:listener-reload",
+        runId: "run-task-listener-reload",
+        task: "Count tool events once",
+        status: "running",
+        deliveryStatus: "not_applicable",
+      });
+      expect(task).not.toBeNull();
+
+      for (const name of ["read", "exec"]) {
+        events.emitAgentEvent({
+          runId: "run-task-listener-reload",
+          stream: "tool",
+          data: { phase: "start", name },
+        });
+      }
+
+      expect(secondRegistry.getTaskById(task!.taskId)?.toolUseCount).toBe(2);
+      expect(secondRegistry.getTaskById(task!.taskId)?.lastToolName).toBe("exec");
+    } finally {
+      firstState.resetTaskRegistryListenerState();
+      secondState.resetTaskRegistryListenerState();
+      events.resetAgentEventsForTest();
+      firstStore.resetTaskRegistryRuntimeForTests();
+      secondStore.resetTaskRegistryRuntimeForTests();
+    }
   });
 });

--- a/src/tasks/task-registry.process-state.ts
+++ b/src/tasks/task-registry.process-state.ts
@@ -10,6 +10,8 @@ type TaskRegistryProcessState = {
   taskIdsByParentFlowId: Map<string, Set<string>>;
   taskIdsByRelatedSessionKey: Map<string, Set<string>>;
   tasksWithPendingDelivery: Set<string>;
+  // Listener ownership must survive module reloads alongside the task indexes it updates.
+  listenerStop?: (() => void) | null;
 };
 
 const TASK_REGISTRY_PROCESS_STATE_KEY = Symbol.for("openclaw.taskRegistry.state");


### PR DESCRIPTION
## Summary
- keep the task process-state listener singleton across repeated module evaluation
- route listener state through the canonical registry owner and remove duplicate lifecycle wiring
- add a regression for repeated tool-event listener registration

## Proof
- baseline focused regression: RED, expected 2 events and received 4
- candidate focused regression: GREEN, 2/2
- ordered gateway skills-upload + tasks pair: GREEN, 24/24
- formatter and targeted lint clean
- two independent source/security reviews plus authenticated all-priority review/scanner clean

Production code is net -1 LOC. This is a separate bugfix/refactor; it does not close an existing issue.

### Owner-boundary process-lifecycle proof

- The actual task lifecycle across `vi.resetModules` reproduces the pre-fix failure: **RED**, expected tool activity count `2`, received `4`.
- The corrected owner regression passes **2/2**; the actual non-isolated test-file order `skills-upload.test.ts` → `tasks.test.ts` passes **24/24**.
- The fix keeps the task listener canonical in the process-global singleton and reduces production code by **1 line**.
- Evidence scope: this is a real in-process task/module lifecycle defect, not a full live Gateway/service-production end-to-end claim. The repository founder accepts this calibrated owner-boundary proof; exact-head required CI must still pass before merge.