### PR TITLE
fix(discord): workspace voice and thread attachments fail to send

### DIFF
--- a/extensions/discord/src/actions/handle-action.adopted-thread.test.ts
+++ b/extensions/discord/src/actions/handle-action.adopted-thread.test.ts
@@ -9,9 +9,9 @@ const { handleDiscordMessageAction } = await import("./handle-action.js");
 const { beginDiscordActiveTurnThreadRoute, notifyDiscordActiveTurnThreadCreated } =
   await import("../active-turn-thread-route.js");
 
-function discordConfig(): OpenClawConfig {
+function discordConfig(actions?: Record<string, boolean>): OpenClawConfig {
   return {
-    channels: { discord: { token: "tok" } },
+    channels: { discord: { token: "tok", ...(actions ? { actions } : {}) } },
   } as OpenClawConfig;
 }
 
@@ -166,5 +166,54 @@ describe("handleDiscordMessageAction adopted thread delivery", () => {
     });
 
     expect(result.details).toEqual({ ok: true });
+  });
+
+  it("preserves trusted workspace authority for thread replies and rejects forged action capabilities", async () => {
+    const mediaReadFile = vi.fn(async () => Buffer.from("trusted report"));
+    const mediaAccess = {
+      localRoots: ["/tmp/agent-workspace"],
+      readFile: mediaReadFile,
+      workspaceDir: "/tmp/agent-workspace",
+    };
+    const forgedMediaAccess = {
+      localRoots: ["/tmp/forged-root"],
+      readFile: vi.fn(async () => Buffer.from("forged report")),
+      workspaceDir: "/tmp/forged-root",
+    };
+    const cfg = discordConfig({ threads: true });
+
+    await handleDiscordMessageAction({
+      action: "thread-reply",
+      params: {
+        threadId: "thread-123",
+        message: "thread update",
+        filePath: "./report.md",
+        mediaAccess: forgedMediaAccess,
+      },
+      cfg,
+      mediaAccess,
+      mediaLocalRoots: mediaAccess.localRoots,
+      mediaReadFile,
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledTimes(1);
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      {
+        action: "threadReply",
+        accountId: undefined,
+        channelId: "thread-123",
+        content: "thread update",
+        mediaUrl: "./report.md",
+        replyTo: undefined,
+      },
+      cfg,
+      { mediaAccess, mediaLocalRoots: mediaAccess.localRoots, mediaReadFile },
+    );
+    expect(handleDiscordActionMock.mock.calls[0]?.[1]).toBe(cfg);
+    const actionOptions = handleDiscordActionMock.mock.calls[0]?.[2];
+    expect(actionOptions?.mediaAccess).toBe(mediaAccess);
+    expect(actionOptions?.mediaLocalRoots).toBe(mediaAccess.localRoots);
+    expect(actionOptions?.mediaReadFile).toBe(mediaReadFile);
+    expect(forgedMediaAccess.readFile).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -56,8 +56,9 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
   ctx: Ctx;
   resolveChannelId: () => string;
   readPolicyOptions?: DiscordMessagingActionOptions;
+  actionOptions: DiscordMessagingActionOptions;
 }): Promise<AgentToolResult<unknown> | undefined> {
-  const { ctx, resolveChannelId, readPolicyOptions } = params;
+  const { ctx, resolveChannelId, readPolicyOptions, actionOptions } = params;
   const { action, params: actionParams, cfg } = ctx;
   const accountId = ctx.accountId ?? readStringParam(actionParams, "accountId");
   const senderUserId = readDiscordRequesterSenderId(ctx);
@@ -441,7 +442,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         replyTo: replyTo ?? undefined,
       },
       cfg,
-      { mediaLocalRoots: ctx.mediaLocalRoots, mediaReadFile: ctx.mediaReadFile },
+      actionOptions,
     );
   }
 

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -643,6 +643,7 @@ describe("handleDiscordMessageAction", () => {
       },
       cfg,
       options: {
+        mediaAccess: undefined,
         mediaLocalRoots: ["/tmp/agent-root"],
         mediaReadFile,
       },

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -525,6 +525,7 @@ export async function handleDiscordMessageAction(
     ctx,
     resolveChannelId,
     readPolicyOptions,
+    actionOptions,
   });
   if (adminResult !== undefined) {
     if (action === "thread-reply") {

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -288,6 +288,9 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
           ...ctx.withOpts(),
           reply: createReusableDiscordReplyReference(replyTo),
           silent,
+          mediaAccess: ctx.options?.mediaAccess,
+          mediaLocalRoots: ctx.options?.mediaLocalRoots,
+          mediaReadFile: ctx.options?.mediaReadFile,
         });
         return jsonResult(
           await appendDiscordThreadRenameResult(ctx, {
@@ -416,6 +419,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
         {
           ...ctx.withOpts(),
           mediaUrl,
+          mediaAccess: ctx.options?.mediaAccess,
           mediaLocalRoots: ctx.options?.mediaLocalRoots,
           mediaReadFile: ctx.options?.mediaReadFile,
           reply: createReusableDiscordReplyReference(replyTo),

--- a/extensions/discord/src/actions/runtime.messaging.shared.ts
+++ b/extensions/discord/src/actions/runtime.messaging.shared.ts
@@ -28,11 +28,7 @@ type ConversationReadInvocationOrigin = NonNullable<
 >;
 
 export type DiscordMessagingActionOptions = {
-  mediaAccess?: {
-    localRoots?: readonly string[];
-    readFile?: (filePath: string) => Promise<Buffer>;
-    workspaceDir?: string;
-  };
+  mediaAccess?: ChannelMessageActionContext["mediaAccess"];
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
   conversationReadOrigin?: ConversationReadInvocationOrigin;

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -2071,27 +2071,103 @@ describe("handleDiscordMessagingAction", () => {
     expect(searchMessagesDiscord).not.toHaveBeenCalled();
   });
 
-  it("sends voice messages from a local file path", async () => {
+  it("sends workspace-relative voice files with trusted host authority instead of forged action data", async () => {
     sendVoiceMessageDiscord.mockClear();
     sendMessageDiscord.mockClear();
+    const mediaReadFile = vi.fn(async () => Buffer.from("trusted voice"));
+    const mediaAccess = {
+      localRoots: ["/tmp/agent-workspace"],
+      readFile: mediaReadFile,
+      workspaceDir: "/tmp/agent-workspace",
+    };
+    const forgedMediaAccess = {
+      localRoots: ["/tmp/forged-root"],
+      readFile: vi.fn(async () => Buffer.from("forged voice")),
+      workspaceDir: "/tmp/forged-root",
+    };
 
     await handleMessagingAction(
       "sendMessage",
       {
         to: "channel:123",
-        path: "/tmp/voice.mp3",
+        path: "./voice.mp3",
         asVoice: true,
         silent: true,
+        mediaAccess: forgedMediaAccess,
       },
       enableAllActions,
+      DISCORD_TEST_CFG,
+      { mediaAccess, mediaLocalRoots: mediaAccess.localRoots, mediaReadFile },
     );
 
-    expect(sendVoiceMessageDiscord).toHaveBeenCalledWith("channel:123", "/tmp/voice.mp3", {
+    expect(sendVoiceMessageDiscord).toHaveBeenCalledWith("channel:123", "./voice.mp3", {
       cfg: DISCORD_TEST_CFG,
       reply: undefined,
       silent: true,
+      mediaAccess,
+      mediaLocalRoots: mediaAccess.localRoots,
+      mediaReadFile,
     });
+    const voiceOptions = mockObjectArg(sendVoiceMessageDiscord, "sendVoiceMessageDiscord", 0, 2);
+    expect(voiceOptions.mediaAccess).toBe(mediaAccess);
+    expect(voiceOptions.mediaLocalRoots).toBe(mediaAccess.localRoots);
+    expect(voiceOptions.mediaReadFile).toBe(mediaReadFile);
+    expect(forgedMediaAccess.readFile).not.toHaveBeenCalled();
     expect(sendMessageDiscord).not.toHaveBeenCalled();
+  });
+
+  it("preserves supported split-only host readers on action voice sends", async () => {
+    const mediaLocalRoots = ["/tmp/agent-workspace"];
+    const mediaReadFile = vi.fn(async () => Buffer.from("trusted voice"));
+
+    await handleMessagingAction(
+      "sendMessage",
+      { to: "channel:123", path: "/tmp/agent-workspace/voice.mp3", asVoice: true },
+      enableAllActions,
+      DISCORD_TEST_CFG,
+      { mediaLocalRoots, mediaReadFile },
+    );
+
+    const voiceOptions = mockObjectArg(sendVoiceMessageDiscord, "sendVoiceMessageDiscord", 0, 2);
+    expect(voiceOptions.mediaAccess).toBeUndefined();
+    expect(voiceOptions.mediaLocalRoots).toBe(mediaLocalRoots);
+    expect(voiceOptions.mediaReadFile).toBe(mediaReadFile);
+  });
+
+  it("preserves reader-free workspace authority for thread replies and ignores forged action data", async () => {
+    const mediaAccess = {
+      localRoots: ["/tmp/agent-workspace"],
+      workspaceDir: "/tmp/agent-workspace",
+    };
+    const forgedMediaAccess = {
+      localRoots: ["/tmp/forged-root"],
+      readFile: vi.fn(async () => Buffer.from("forged report")),
+      workspaceDir: "/tmp/forged-root",
+    };
+
+    await handleMessagingAction(
+      "threadReply",
+      {
+        channelId: "thread-123",
+        content: "thread update",
+        mediaUrl: "./report.md",
+        mediaAccess: forgedMediaAccess,
+      },
+      enableAllActions,
+      DISCORD_TEST_CFG,
+      { mediaAccess, mediaLocalRoots: mediaAccess.localRoots },
+    );
+
+    const call = mockCall(sendMessageDiscord, "sendMessageDiscord");
+    const sendOptions = mockObjectArg(sendMessageDiscord, "sendMessageDiscord", 0, 2);
+    expect(call[0]).toBe("channel:thread-123");
+    expect(call[1]).toBe("thread update");
+    expect(sendOptions.mediaUrl).toBe("./report.md");
+    expect(sendOptions.mediaAccess).toBe(mediaAccess);
+    expect(sendOptions.mediaLocalRoots).toBe(mediaAccess.localRoots);
+    expect(sendOptions.mediaReadFile).toBeUndefined();
+    expect(sendOptions.mediaAccess).not.toHaveProperty("readFile");
+    expect(forgedMediaAccess.readFile).not.toHaveBeenCalled();
   });
 
   it("forwards trusted mediaLocalRoots into sendMessageDiscord", async () => {

--- a/extensions/discord/src/actions/runtime.ts
+++ b/extensions/discord/src/actions/runtime.ts
@@ -1,16 +1,12 @@
 // Discord plugin module implements runtime behavior.
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
-import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import { createDiscordActionGate } from "../accounts.js";
 import { readStringParam, type OpenClawConfig } from "../runtime-api.js";
 import { handleDiscordGuildAction } from "./runtime.guild.js";
 import { handleDiscordMessagingAction } from "./runtime.messaging.js";
+import type { DiscordMessagingActionOptions } from "./runtime.messaging.shared.js";
 import { handleDiscordModerationAction } from "./runtime.moderation.js";
 import { handleDiscordPresenceAction } from "./runtime.presence.js";
-
-type ConversationReadInvocationOrigin = NonNullable<
-  ChannelMessageActionContext["conversationReadOrigin"]
->;
 
 const messagingActions = new Set([
   "react",
@@ -63,21 +59,7 @@ const presenceActions = new Set(["setPresence"]);
 export async function handleDiscordAction(
   params: Record<string, unknown>,
   cfg: OpenClawConfig,
-  options?: {
-    mediaAccess?: {
-      localRoots?: readonly string[];
-      readFile?: (filePath: string) => Promise<Buffer>;
-      workspaceDir?: string;
-    };
-    mediaLocalRoots?: readonly string[];
-    mediaReadFile?: (filePath: string) => Promise<Buffer>;
-    conversationReadOrigin?: ConversationReadInvocationOrigin;
-    readContext?: {
-      requesterAccountId?: string | null;
-      currentChannelProvider?: string | null;
-      currentChannelId?: string | null;
-    };
-  },
+  options?: DiscordMessagingActionOptions,
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
   const accountId = readStringParam(params, "accountId");

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -313,6 +313,12 @@ describe("discordOutbound", () => {
 
   it("routes audioAsVoice payloads through the Discord voice send helper", async () => {
     const onDeliveryResult = vi.fn();
+    const mediaReadFile = vi.fn(async () => Buffer.from("trusted media"));
+    const mediaAccess = {
+      localRoots: ["/tmp/agent-workspace"],
+      readFile: mediaReadFile,
+      workspaceDir: "/tmp/agent-workspace",
+    };
     hoisted.sendMessageDiscordMock.mockImplementation(
       async (_to: unknown, _text: unknown, options: unknown) => {
         const deliveryResult = { messageId: "msg-1", channelId: "ch-1" };
@@ -328,10 +334,13 @@ describe("discordOutbound", () => {
       text: "",
       payload: {
         text: "voice note",
-        mediaUrls: ["https://example.com/voice.ogg", "https://example.com/extra.png"],
+        mediaUrls: ["./voice.ogg", "./extra.png"],
         audioAsVoice: true,
       },
       accountId: "default",
+      mediaAccess,
+      mediaLocalRoots: mediaAccess.localRoots,
+      mediaReadFile,
       replyToId: "reply-1",
       replyToIdSource: "implicit",
       replyToMode: "first",
@@ -340,7 +349,7 @@ describe("discordOutbound", () => {
 
     const voiceCall = mockCall(hoisted.sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord");
     expect(voiceCall[0]).toBe("channel:123456");
-    expect(voiceCall[1]).toBe("https://example.com/voice.ogg");
+    expect(voiceCall[1]).toBe("./voice.ogg");
     const voiceOptions = mockObjectArg(
       hoisted.sendVoiceMessageDiscordMock,
       "sendVoiceMessageDiscord",
@@ -349,6 +358,9 @@ describe("discordOutbound", () => {
     );
     expect(voiceOptions.accountId).toBe("default");
     expect(voiceOptions.reply).toEqual({ messageId: "reply-1", scope: "first" });
+    expect(voiceOptions.mediaAccess).toBe(mediaAccess);
+    expect(voiceOptions.mediaLocalRoots).toBe(mediaAccess.localRoots);
+    expect(voiceOptions.mediaReadFile).toBe(mediaReadFile);
 
     const messageCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0);
     expect(messageCall[0]).toBe("channel:123456");
@@ -361,13 +373,17 @@ describe("discordOutbound", () => {
     );
     expect(messageOptions.accountId).toBe("default");
     expect(messageOptions.reply).toBeUndefined();
+    expect(messageOptions).not.toHaveProperty("mediaAccess");
 
     const mediaCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1);
     expect(mediaCall[0]).toBe("channel:123456");
     expect(mediaCall[1]).toBe("");
     const mediaOptions = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1, 2);
     expect(mediaOptions.accountId).toBe("default");
-    expect(mediaOptions.mediaUrl).toBe("https://example.com/extra.png");
+    expect(mediaOptions.mediaUrl).toBe("./extra.png");
+    expect(mediaOptions.mediaAccess).toBe(mediaAccess);
+    expect(mediaOptions.mediaLocalRoots).toBe(mediaAccess.localRoots);
+    expect(mediaOptions.mediaReadFile).toBe(mediaReadFile);
     expect(mediaOptions.reply).toBeUndefined();
     expect(result).toEqual({
       channel: "discord",
@@ -379,6 +395,36 @@ describe("discordOutbound", () => {
       "msg-1",
       "msg-1",
     ]);
+  });
+
+  it("preserves reader-free workspace authority on direct voice media sends", async () => {
+    const mediaAccess = {
+      localRoots: ["/tmp/agent-workspace"],
+      workspaceDir: "/tmp/agent-workspace",
+    };
+
+    await discordOutbound.sendMedia?.({
+      cfg: {},
+      to: "channel:123456",
+      text: "",
+      mediaUrl: "./voice.ogg",
+      audioAsVoice: true,
+      mediaAccess,
+      mediaLocalRoots: mediaAccess.localRoots,
+    });
+
+    const voiceCall = mockCall(hoisted.sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord");
+    expect(voiceCall[1]).toBe("./voice.ogg");
+    const voiceOptions = mockObjectArg(
+      hoisted.sendVoiceMessageDiscordMock,
+      "sendVoiceMessageDiscord",
+      0,
+      2,
+    );
+    expect(voiceOptions.mediaAccess).toBe(mediaAccess);
+    expect(voiceOptions.mediaLocalRoots).toBe(mediaAccess.localRoots);
+    expect(voiceOptions.mediaReadFile).toBeUndefined();
+    expect(voiceOptions.mediaAccess).not.toHaveProperty("readFile");
   });
 
   it("uses a single implicit reply on audioAsVoice sends when replyToMode is batched", async () => {
@@ -679,6 +725,12 @@ describe("discordOutbound", () => {
   });
 
   it("keeps captioned video in the thread created by the forum starter", async () => {
+    const mediaReadFile = vi.fn(async () => Buffer.from("trusted video"));
+    const mediaAccess = {
+      localRoots: ["/tmp/agent-workspace"],
+      readFile: mediaReadFile,
+      workspaceDir: "/tmp/agent-workspace",
+    };
     hoisted.sendMessageDiscordMock
       .mockResolvedValueOnce({
         messageId: "starter-1",
@@ -704,8 +756,11 @@ describe("discordOutbound", () => {
       cfg: {},
       to: "channel:forum-1",
       text: "rendered clip",
-      mediaUrl: "/tmp/render.mp4",
+      mediaUrl: "./render.mp4",
       accountId: "default",
+      mediaAccess,
+      mediaLocalRoots: mediaAccess.localRoots,
+      mediaReadFile,
     });
 
     expect(mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0)[0]).toBe(
@@ -714,6 +769,13 @@ describe("discordOutbound", () => {
     expect(mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1)[0]).toBe(
       "channel:thread-1",
     );
+    expect(
+      mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2),
+    ).not.toHaveProperty("mediaAccess");
+    const videoOptions = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1, 2);
+    expect(videoOptions.mediaAccess).toBe(mediaAccess);
+    expect(videoOptions.mediaLocalRoots).toBe(mediaAccess.localRoots);
+    expect(videoOptions.mediaReadFile).toBe(mediaReadFile);
     expect(result).toMatchObject({
       channel: "discord",
       messageId: "starter-1",
@@ -811,6 +873,12 @@ describe("discordOutbound", () => {
   });
 
   it("sends component payload media sequences with the component message first", async () => {
+    const mediaReadFile = vi.fn(async () => Buffer.from("trusted component media"));
+    const mediaAccess = {
+      localRoots: ["/tmp/media"],
+      readFile: mediaReadFile,
+      workspaceDir: "/tmp/media",
+    };
     hoisted.sendDiscordComponentMessageMock.mockResolvedValueOnce({
       messageId: "component-1",
       channelId: "ch-1",
@@ -844,7 +912,9 @@ describe("discordOutbound", () => {
       text: "",
       payload,
       accountId: "default",
-      mediaLocalRoots: ["/tmp/media"],
+      mediaAccess,
+      mediaLocalRoots: mediaAccess.localRoots,
+      mediaReadFile,
       replyToId: "reply-1",
       replyToIdSource: "implicit",
       replyToMode: "first",
@@ -866,7 +936,9 @@ describe("discordOutbound", () => {
       2,
     );
     expect(componentOptions.mediaUrl).toBe("https://example.com/1.png");
-    expect(componentOptions.mediaLocalRoots).toEqual(["/tmp/media"]);
+    expect(componentOptions.mediaAccess).toBe(mediaAccess);
+    expect(componentOptions.mediaLocalRoots).toBe(mediaAccess.localRoots);
+    expect(componentOptions.mediaReadFile).toBe(mediaReadFile);
     expect(componentOptions.accountId).toBe("default");
     expect(componentOptions.reply).toEqual({ messageId: "reply-1", scope: "first" });
 
@@ -880,7 +952,9 @@ describe("discordOutbound", () => {
       2,
     );
     expect(messageOptions.mediaUrl).toBe("https://example.com/2.png");
-    expect(messageOptions.mediaLocalRoots).toEqual(["/tmp/media"]);
+    expect(messageOptions.mediaAccess).toBe(mediaAccess);
+    expect(messageOptions.mediaLocalRoots).toBe(mediaAccess.localRoots);
+    expect(messageOptions.mediaReadFile).toBe(mediaReadFile);
     expect(messageOptions.accountId).toBe("default");
     expect(messageOptions.reply).toBeUndefined();
     expect(result).toEqual({

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -199,6 +199,9 @@ export const discordOutbound: ChannelOutboundAdapter = {
           reply: options.reply,
           accountId: ctx.accountId ?? undefined,
           silent: ctx.silent ?? undefined,
+          mediaAccess: ctx.mediaAccess,
+          mediaLocalRoots: ctx.mediaLocalRoots,
+          mediaReadFile: ctx.mediaReadFile,
         });
       }
       const mediaOptions = {

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -106,6 +106,9 @@ export async function sendDiscordOutboundPayload(params: {
       const voiceUrl = expectDefined(mediaUrls.at(0), "non-empty Discord voice media URLs");
       lastResult = await sendContext.sendVoice(sendContext.target, voiceUrl, {
         ...resolveDiscordDeliveryOptions(ctx, sendContext, voiceReply),
+        mediaAccess: ctx.mediaAccess,
+        mediaLocalRoots: ctx.mediaLocalRoots,
+        mediaReadFile: ctx.mediaReadFile,
       });
       deliveredVoice = true;
     } catch (err) {

--- a/extensions/discord/src/send.voice.test.ts
+++ b/extensions/discord/src/send.voice.test.ts
@@ -1,4 +1,7 @@
 // Discord tests cover send.voice plugin behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeDiscordRest } from "./send.test-harness.js";
 
@@ -79,5 +82,94 @@ describe("sendVoiceMessageDiscord", () => {
     expect(voiceMocks.sendDiscordVoiceMessage.mock.calls[0]?.[4]).toBe("reply-1");
     expect(result.receipt.replyToId).toBe("reply-1");
     expect(result.receipt.parts[0]?.replyToId).toBe("reply-1");
+  });
+
+  it("reads relative voice files from the trusted reader-free workspace without widening its roots", async () => {
+    const fixtureRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-voice-")),
+    );
+    const workspaceDir = path.join(fixtureRoot, "workspace");
+    await fs.mkdir(workspaceDir);
+    await fs.writeFile(path.join(workspaceDir, "voice.ogg"), Buffer.from("OggS trusted voice"));
+    await fs.writeFile(path.join(fixtureRoot, "outside.ogg"), Buffer.from("OggS outside voice"));
+    const mediaAccess = { localRoots: [workspaceDir], workspaceDir };
+    const { loadWebMediaRaw } = await vi.importActual<
+      typeof import("openclaw/plugin-sdk/web-media")
+    >("openclaw/plugin-sdk/web-media");
+    loadWebMediaRawMock.mockImplementation(loadWebMediaRaw);
+    const { rest } = makeDiscordRest();
+
+    try {
+      await sendVoiceMessageDiscord("273512430271856640", "./voice.ogg", {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        mediaAccess,
+      });
+
+      const [, loaderOptions] = loadWebMediaRawMock.mock.calls[0] ?? [];
+      expect(loaderOptions).toMatchObject({ localRoots: mediaAccess.localRoots, workspaceDir });
+      expect(loaderOptions.localRoots).toBe(mediaAccess.localRoots);
+      expect(loaderOptions).not.toHaveProperty("readFile");
+      expect(loaderOptions).not.toHaveProperty("hostReadCapability");
+      expect(voiceMocks.sendDiscordVoiceMessage).toHaveBeenCalledTimes(1);
+
+      await expect(
+        sendVoiceMessageDiscord("273512430271856640", "../outside.ogg", {
+          cfg: DISCORD_TEST_CFG,
+          rest,
+          token: "t",
+          mediaAccess,
+        }),
+      ).rejects.toThrow(/not under an allowed directory/i);
+      expect(voiceMocks.sendDiscordVoiceMessage).toHaveBeenCalledTimes(1);
+    } finally {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["canonical", "split"] as const)(
+    "preserves the trusted %s host reader and its explicit roots",
+    async (capabilityShape) => {
+      const mediaLocalRoots = ["/tmp/agent-workspace"];
+      const mediaReadFile = vi.fn(async () => Buffer.from("trusted voice"));
+      const mediaAccess = {
+        localRoots: mediaLocalRoots,
+        readFile: mediaReadFile,
+        workspaceDir: "/tmp/agent-workspace",
+      };
+      const { rest } = makeDiscordRest();
+
+      await sendVoiceMessageDiscord("273512430271856640", "./voice.ogg", {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        ...(capabilityShape === "canonical" ? { mediaAccess } : { mediaLocalRoots, mediaReadFile }),
+      });
+
+      const [, loaderOptions] = loadWebMediaRawMock.mock.calls[0] ?? [];
+      expect(loaderOptions.localRoots).toBe(mediaLocalRoots);
+      expect(loaderOptions.readFile).toBe(mediaReadFile);
+      expect(loaderOptions.hostReadCapability).toBe(true);
+      if (capabilityShape === "canonical") {
+        expect(loaderOptions.workspaceDir).toBe(mediaAccess.workspaceDir);
+      } else {
+        expect(loaderOptions).not.toHaveProperty("workspaceDir");
+      }
+    },
+  );
+
+  it("rejects a trusted host reader that has no explicit root boundary", async () => {
+    const { rest } = makeDiscordRest();
+
+    await expect(
+      sendVoiceMessageDiscord("273512430271856640", "./voice.ogg", {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        mediaReadFile: vi.fn(async () => Buffer.from("voice")),
+      }),
+    ).rejects.toThrow(/Host media read requires explicit localRoots/i);
+    expect(loadWebMediaRawMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/send.voice.ts
+++ b/extensions/discord/src/send.voice.ts
@@ -2,20 +2,20 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
+  buildOutboundMediaLoadOptions,
   extensionForMime,
   maxBytesForKind,
   unlinkIfExists,
 } from "openclaw/plugin-sdk/media-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
-import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { tempWorkspace, resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { resolveDiscordAccount } from "./accounts.js";
 import type { RequestClient } from "./internal/discord.js";
 import { parseAndResolveChannelRecipient } from "./recipient-resolution.js";
 import type { DiscordReplyReference } from "./reply-reference.js";
+import type { sendMessageDiscord } from "./send.outbound.js";
 import { createDiscordSendResult } from "./send.receipt.js";
 import { buildDiscordSendError, createDiscordClient, resolveChannelId } from "./send.shared.js";
 import type { DiscordSendResult } from "./send.types.js";
@@ -25,16 +25,20 @@ import {
   sendDiscordVoiceMessage,
 } from "./voice-message.js";
 
-type VoiceMessageOpts = {
-  cfg: OpenClawConfig;
-  token?: string;
-  accountId?: string;
-  verbose?: boolean;
-  rest?: RequestClient;
-  reply?: DiscordReplyReference;
-  retry?: RetryConfig;
-  silent?: boolean;
-};
+type VoiceMessageOpts = Pick<
+  Parameters<typeof sendMessageDiscord>[2],
+  | "cfg"
+  | "token"
+  | "accountId"
+  | "verbose"
+  | "rest"
+  | "reply"
+  | "retry"
+  | "silent"
+  | "mediaAccess"
+  | "mediaLocalRoots"
+  | "mediaReadFile"
+>;
 
 function toDiscordSendResult(
   result: { id?: string | null; channel_id?: string | null },
@@ -51,10 +55,19 @@ function toDiscordSendResult(
 
 async function materializeVoiceMessageInput(
   mediaUrl: string,
+  opts: VoiceMessageOpts,
 ): Promise<{ filePath: string; cleanup: () => Promise<void> }> {
   // Security: reuse the standard media loader so we apply SSRF guards + allowed-local-root checks.
   // Then write to a private temp file so ffmpeg/ffprobe never sees the original URL/path string.
-  const media = await loadWebMediaRaw(mediaUrl, maxBytesForKind("audio"));
+  const media = await loadWebMediaRaw(
+    mediaUrl,
+    buildOutboundMediaLoadOptions({
+      maxBytes: maxBytesForKind("audio"),
+      mediaAccess: opts.mediaAccess,
+      mediaLocalRoots: opts.mediaLocalRoots,
+      mediaReadFile: opts.mediaReadFile,
+    }),
+  );
   const extFromName = media.fileName ? path.extname(media.fileName) : "";
   const extFromMime = media.contentType ? extensionForMime(media.contentType) : "";
   const ext = extFromName || extFromMime || ".bin";
@@ -85,7 +98,7 @@ export async function sendVoiceMessageDiscord(
   opts: VoiceMessageOpts,
 ): Promise<DiscordSendResult> {
   const { filePath: localInputPath, cleanup: cleanupLocalInput } =
-    await materializeVoiceMessageInput(audioPath);
+    await materializeVoiceMessageInput(audioPath, opts);
   let oggPath: string | null = null;
   let oggCleanup = false;
   let token: string | undefined;


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where Discord operators sending workspace-relative voice attachments or replying in threads with agent-created files would receive missing-media failures even though the host had approved the workspace.

## Why This Change Was Made
Preserve the original host-owned media capability and supported legacy roots/readers across every Discord direct, payload, action voice, and thread-reply owner boundary. Normalize access once at the real voice media loader and consolidate duplicate action option types.

## User Impact
Agents can send approved workspace audio and thread attachments without granting extra filesystem authority. Path traversal, forged action capabilities, rootless host readers, and reader-free Gateway boundaries remain protected.

## Evidence
- 357 passing tests across seven actual Discord voice, outbound adapter, action/runtime, adopted-thread, payload, and normal message suites.
- Real workspace-relative on-disk audio load and traversal rejection; canonical and legacy split readers; reader-free Gateway voice; forged action capabilities; thread, forum, component, and follow-on media.
- Complete exact 13-path remote extensions/extensionTests changed gate passed production/test tsgo, lint including max-lines, formatting, all plugin/SDK/security/storage guards and import cycles.
- Independent manual security review and fresh dirty plus exact committed-branch Sol/high autoreviews passed with clean secret scans.
- Production code increases only three net lines after removing duplicate action option definitions.
- Remote proof and independently verified Testbox cleanup: https://github.com/openclaw/openclaw/actions/runs/30729359388
- No credentialed public Discord delivery is claimed; guild emoji, sticker, and event asset owners are intentionally separate follow-ups.