### PR TITLE
fix(agents): reuse prepared runtime facts for configured turns

### DIFF
--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -250,8 +250,8 @@ async function runEmbeddedAgentInternal(
         ...(params.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
         runtimePluginSelections,
       };
-      // Configless direct hosts reuse one bounded idle generation. Gateway and explicitly
-      // configured runs release dynamic workspaces so one-off paths cannot accumulate owners.
+      // Configless direct hosts reuse one idle generation. The prepared-runtime lifecycle keeps
+      // gateway run generations in its own bounded cache so one-off paths cannot accumulate.
       // Cold plugin loading and provider discovery can exceed the lane no-progress budget.
       // Active runtime acquisition is progress, not a hung lane task.
       const preparedModelRuntimeLease = await withEmbeddedRunLaneProgressHeartbeat(

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -141,7 +141,10 @@ function withRuntimePluginIdsAllowed(
   };
 }
 
-function resolveSelectedRuntime(selection: AgentHarnessPluginSelection, config?: OpenClawConfig) {
+export function resolveSelectedAgentHarnessRuntime(
+  selection: AgentHarnessPluginSelection,
+  config?: OpenClawConfig,
+) {
   const requestedRuntime = normalizeOptionalAgentRuntimeId(selection.runtime);
   return requestedRuntime && !isDefaultAgentRuntimeId(requestedRuntime)
     ? requestedRuntime
@@ -158,10 +161,14 @@ export function requiresAgentHarnessPluginSelection(
   selection: AgentHarnessPluginSelection,
   config?: OpenClawConfig,
 ): boolean {
-  const runtime = resolveSelectedRuntime(selection, config);
+  const runtime = resolveSelectedAgentHarnessRuntime(selection, config);
+  if (isDefaultAgentRuntimeId(runtime) || runtime === OPENCLAW_AGENT_RUNTIME_ID) {
+    return false;
+  }
+  // Codex is a native plugin harness, never a CLI backend alias. Keep this hot-path decision
+  // independent of setup-registry discovery for every model candidate on every turn.
   return (
-    !isDefaultAgentRuntimeId(runtime) &&
-    runtime !== OPENCLAW_AGENT_RUNTIME_ID &&
+    runtime === "codex" ||
     !isCliRuntimeAliasForProvider({ runtime, provider: selection.provider, cfg: config })
   );
 }
@@ -184,7 +191,7 @@ export function resolveAgentRuntimePluginLoadPlan(params: {
   const pluginIds = [...basePluginIds, ...memoryPluginIds];
   const forceActivatedPluginIds = [...memoryPluginIds];
   for (const selection of params.selections) {
-    const runtime = resolveSelectedRuntime(selection, config);
+    const runtime = resolveSelectedAgentHarnessRuntime(selection, config);
     if (!requiresAgentHarnessPluginSelection(selection, config)) {
       continue;
     }

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -72,6 +72,7 @@ vi.mock("../plugins/synthetic-auth.runtime.js", () => ({
 }));
 
 vi.mock("./agent-scope.js", () => ({
+  listAgentEntries: (config: { agents?: { list?: unknown[] } }) => config.agents?.list ?? [],
   listAgentIds: () => mocks.configuredAgentIds,
   resolveAgentDir: (_config: unknown, agentId: string) =>
     mocks.configuredAgentDirs.get(agentId) ??
@@ -81,6 +82,12 @@ vi.mock("./agent-scope.js", () => ({
     (agentId === "default" ? "/tmp/unused-workspace" : `/tmp/workspace-${agentId}`),
   resolveDefaultAgentDir: () => "/tmp/unused-agent",
   resolveDefaultAgentId: () => "default",
+  resolveAgentEffectiveModelPrimary: () => undefined,
+  resolveRunModelFallbacksOverride: () => undefined,
+  resolveSessionAgentIds: ({ agentId }: { agentId?: string }) => ({
+    defaultAgentId: "default",
+    sessionAgentId: agentId ?? "default",
+  }),
 }));
 
 vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
@@ -260,7 +267,7 @@ describe("prepared model runtime snapshots", () => {
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
   });
 
-  it("publishes an exact dynamic workspace owner at gateway run admission", async () => {
+  it("retains an exact dynamic workspace owner after gateway run admission", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = {};
     await refreshPreparedModelRuntimeSnapshots(config, {
@@ -286,25 +293,16 @@ describe("prepared model runtime snapshots", () => {
     expect(firstLease.snapshot.workspaceDir).toBe("/tmp/spawned-workspace");
     expect(secondLease.snapshot).toBe(firstLease.snapshot);
     firstLease.release();
-    await expect(
-      prepareModelRuntimeSnapshot({
-        agentId: "default",
-        config,
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
-        workspaceDir: "/tmp/spawned-workspace",
-      }),
-    ).resolves.toBe(firstLease.snapshot);
     secondLease.release();
-    await expect(
-      prepareModelRuntimeSnapshot({
-        agentId: "default",
-        config,
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
-        workspaceDir: "/tmp/spawned-workspace",
-      }),
-    ).rejects.toThrow("prepared model runtime owner was not published");
+    const retainedLease = await acquireAgentRunPreparedModelRuntime({
+      agentId: "default",
+      config,
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      workspaceDir: "/tmp/spawned-workspace",
+    });
+    expect(retainedLease.snapshot).toBe(firstLease.snapshot);
+    retainedLease.release();
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
   });
 

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
     find: vi.fn(() => null),
   },
   configuredAgentIds: [] as string[],
+  configuredAgentIdsError: undefined as Error | undefined,
   configuredAgentDirs: new Map<string, string>(),
   configuredWorkspaces: new Map<string, string>(),
   buildPreparedModelCatalogSnapshot: vi.fn(async (..._args: unknown[]) => ({
@@ -73,7 +74,13 @@ vi.mock("../plugins/synthetic-auth.runtime.js", () => ({
 }));
 
 vi.mock("./agent-scope.js", () => ({
-  listAgentIds: () => mocks.configuredAgentIds,
+  listAgentEntries: (config: { agents?: { list?: unknown[] } }) => config.agents?.list ?? [],
+  listAgentIds: () => {
+    if (mocks.configuredAgentIdsError) {
+      throw mocks.configuredAgentIdsError;
+    }
+    return mocks.configuredAgentIds;
+  },
   resolveAgentDir: (_config: unknown, agentId: string) =>
     mocks.configuredAgentDirs.get(agentId) ??
     (agentId === "default" ? "/tmp/unused-agent" : `/tmp/configured-${agentId}`),
@@ -82,6 +89,8 @@ vi.mock("./agent-scope.js", () => ({
     (agentId === "default" ? "/tmp/unused-workspace" : `/tmp/workspace-${agentId}`),
   resolveDefaultAgentDir: () => "/tmp/unused-agent",
   resolveDefaultAgentId: () => "default",
+  resolveAgentEffectiveModelPrimary: () => undefined,
+  resolveRunModelFallbacksOverride: () => undefined,
   resolveSessionAgentIds: ({ agentId }: { agentId?: string }) => ({
     defaultAgentId: "default",
     sessionAgentId: agentId ?? "default",
@@ -125,6 +134,7 @@ vi.mock("../logging/subsystem.js", () => ({
 }));
 
 import {
+  acquireAgentRunPreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
   prepareModelRuntimeSnapshot,
   publishPreparedModelRuntimeSnapshot,
@@ -136,12 +146,14 @@ describe("prepared model runtime owner selection", () => {
     (globalThis as Record<PropertyKey, unknown>)[
       Symbol.for("openclaw.preparedModelRuntimeTestApi")
     ] as {
+      getPreparedModelRuntimeOwnerCountForTest: () => number;
       resetPreparedModelRuntimeSnapshotsForTest: () => void;
     };
 
   beforeEach(() => {
     getTesting().resetPreparedModelRuntimeSnapshotsForTest();
     mocks.configuredAgentIds = [];
+    mocks.configuredAgentIdsError = undefined;
     mocks.configuredAgentDirs.clear();
     mocks.configuredWorkspaces.clear();
     mocks.buildPreparedModelCatalogSnapshot.mockClear();
@@ -235,7 +247,7 @@ describe("prepared model runtime owner selection", () => {
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
   });
 
-  it("reuses the configured owner for selections that need no plugin harness", async () => {
+  it("reuses the configured owner for its prepared plugin harness selections", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     await refreshPreparedModelRuntimeSnapshots(config, {
@@ -251,26 +263,115 @@ describe("prepared model runtime owner selection", () => {
       workspaceDir: "/tmp/unused-workspace",
     });
 
-    await expect(
-      prepareModelRuntimeSnapshot({
+    const runInput = {
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      allowGatewaySubagentBinding: true,
+      config,
+      runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "codex" }],
+      workspaceDir: "/tmp/unused-workspace",
+    };
+    const first = await acquireAgentRunPreparedModelRuntime(runInput);
+    first.release();
+    const second = await acquireAgentRunPreparedModelRuntime(runInput);
+    second.release();
+
+    expect(first.snapshot).toBe(configured);
+    expect(second.snapshot).toBe(first.snapshot);
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledOnce();
+    expect(mocks.prepareStaticCatalog).toHaveBeenCalledOnce();
+    expect(mocks.discoverModels).toHaveBeenCalledOnce();
+    expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
+  });
+
+  it("bounds retained gateway run owners while reusing recent selections", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      catalogMode: "static",
+      gatewayLifecycle: true,
+    });
+    const acquire = async (modelId: string) => {
+      const lease = await acquireAgentRunPreparedModelRuntime({
         agentId: "default",
         agentDir: "/tmp/unused-agent",
-        allowGatewaySubagentBinding: true,
         config,
-        runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "openclaw" }],
+        runtimePluginSelections: [{ provider: "openai", modelId, runtime: "codex" }],
         workspaceDir: "/tmp/unused-workspace",
-      }),
-    ).resolves.toBe(configured);
-    await expect(
-      prepareModelRuntimeSnapshot({
+      });
+      lease.release();
+      return lease.snapshot;
+    };
+
+    const first = await acquire("run-model-0");
+    for (let index = 1; index < 9; index += 1) {
+      await acquire(`run-model-${index}`);
+    }
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(10);
+
+    const rebuilt = await acquire("run-model-0");
+    expect(rebuilt).not.toBe(first);
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(11);
+  });
+
+  it("never evicts a configured owner acquired through the gateway run path", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      catalogMode: "static",
+      gatewayLifecycle: true,
+    });
+    const configuredInput = {
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      config,
+      runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "codex" }],
+      workspaceDir: "/tmp/unused-workspace",
+    };
+    const configured = getPreparedModelRuntimeSnapshot(configuredInput);
+    const configuredLease = await acquireAgentRunPreparedModelRuntime(configuredInput);
+    expect(configuredLease.snapshot).toBe(configured);
+    configuredLease.release();
+
+    for (let index = 0; index < 9; index += 1) {
+      const lease = await acquireAgentRunPreparedModelRuntime({
+        ...configuredInput,
+        runtimePluginSelections: [
+          { provider: "openai", modelId: `run-model-${index}`, runtime: "codex" },
+        ],
+      });
+      lease.release();
+    }
+
+    expect(getPreparedModelRuntimeSnapshot(configuredInput)).toBe(configured);
+  });
+
+  it("retires released retained run owners when gateway refresh clears the lifecycle", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      catalogMode: "static",
+      gatewayLifecycle: true,
+    });
+    for (let index = 0; index < 3; index += 1) {
+      const lease = await acquireAgentRunPreparedModelRuntime({
         agentId: "default",
         agentDir: "/tmp/unused-agent",
-        allowGatewaySubagentBinding: true,
         config,
-        runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "codex" }],
+        runtimePluginSelections: [
+          { provider: "openai", modelId: `retained-model-${index}`, runtime: "codex" },
+        ],
         workspaceDir: "/tmp/unused-workspace",
-      }),
-    ).rejects.toThrow("prepared model runtime owner was not published");
+      });
+      lease.release();
+    }
+    expect(getTesting().getPreparedModelRuntimeOwnerCountForTest()).toBe(4);
+
+    const refreshError = new Error("configured owner discovery failed");
+    mocks.configuredAgentIdsError = refreshError;
+    await expect(refreshPreparedModelRuntimeSnapshots(config)).rejects.toBe(refreshError);
+
+    expect(getTesting().getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
   });
 
   it("does not substitute a configured owner captured from another environment", async () => {

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -5,11 +5,18 @@ import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import {
   listAgentIds,
   resolveAgentDir,
+  resolveRunModelFallbacksOverride,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentDir,
   resolveDefaultAgentId,
 } from "./agent-scope.js";
-import { requiresAgentHarnessPluginSelection } from "./harness/runtime-plugin-load-plan.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
+import {
+  requiresAgentHarnessPluginSelection,
+  resolveSelectedAgentHarnessRuntime,
+} from "./harness/runtime-plugin-load-plan.js";
+import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
+import { resolveDefaultModelForAgent } from "./model-selection-config.js";
 import {
   startSerializedSnapshotBuild,
   startSerializedSnapshotBuildBatch,
@@ -53,6 +60,54 @@ export function createPreparedModelRuntimeOwner(
     generation: 0,
     needsRefresh: true,
   };
+}
+
+export class PreparedModelRuntimeOwnerRetention {
+  readonly #retained = new Map<string, PreparedModelRuntimeOwner>();
+
+  constructor(private readonly maxSize: number) {}
+
+  clear(owners: Map<string, PreparedModelRuntimeOwner>): void {
+    // Released run owners retire with this lifecycle; active leases retire on release.
+    // Configured publication owners never belong to this retention layer.
+    for (const [key, owner] of this.#retained) {
+      if (
+        owner.provenance === "run" &&
+        (owner.leaseCount ?? 0) === 0 &&
+        owners.get(key) === owner
+      ) {
+        owners.delete(key);
+      }
+    }
+    this.#retained.clear();
+  }
+
+  has(key: string, owner: PreparedModelRuntimeOwner): boolean {
+    return this.#retained.get(key) === owner;
+  }
+
+  retain(
+    key: string,
+    owner: PreparedModelRuntimeOwner,
+    owners: Map<string, PreparedModelRuntimeOwner>,
+  ): void {
+    if (owner.provenance !== "run") {
+      return;
+    }
+    this.#retained.delete(key);
+    this.#retained.set(key, owner);
+    while (this.#retained.size > this.maxSize) {
+      const oldest = this.#retained.entries().next().value;
+      if (!oldest) {
+        return;
+      }
+      const [oldestKey, oldestOwner] = oldest;
+      this.#retained.delete(oldestKey);
+      if ((oldestOwner.leaseCount ?? 0) === 0 && owners.get(oldestKey) === oldestOwner) {
+        owners.delete(oldestKey);
+      }
+    }
+  }
 }
 
 export {
@@ -123,7 +178,7 @@ export function rebindInputToCommittedConfiguredOwner(
     preserveWorkspaceDirOnRefresh: preserveWorkspaceDir,
     allowGatewaySubagentBinding:
       input.allowGatewaySubagentBinding ?? owner.input.allowGatewaySubagentBinding,
-    runtimePluginSelections: input.runtimePluginSelections,
+    runtimePluginSelections: input.runtimePluginSelections ?? owner.input.runtimePluginSelections,
   });
 }
 
@@ -166,7 +221,11 @@ export function normalizePreparedModelRuntimeInput(
     ? Object.freeze(
         [...input.runtimePluginSelections]
           .filter((selection) => requiresAgentHarnessPluginSelection(selection, input.config))
-          .map((selection) => Object.freeze({ ...selection }))
+          .map((selection) => {
+            const runtime = resolveSelectedAgentHarnessRuntime(selection, input.config);
+            const { agentId: _agentId, ...normalized } = selection;
+            return Object.freeze({ ...normalized, runtime });
+          })
           .toSorted((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right))),
       )
     : undefined;
@@ -229,8 +288,9 @@ export function resolvePublishedOwner(
       owner.input.readOnly === input.readOnly &&
       owner.input.skipCredentials === input.skipCredentials &&
       owner.input.allowGatewaySubagentBinding === input.allowGatewaySubagentBinding &&
-      JSON.stringify(owner.input.runtimePluginSelections) ===
-        JSON.stringify(input.runtimePluginSelections) &&
+      (input.runtimePluginSelections === undefined ||
+        JSON.stringify(owner.input.runtimePluginSelections) ===
+          JSON.stringify(input.runtimePluginSelections)) &&
       (input.env === undefined ||
         owner.environmentFingerprint === environmentFingerprint(input.env)) &&
       (input.workspaceDir === undefined || owner.input.workspaceDir === input.workspaceDir),
@@ -290,6 +350,7 @@ export function listConfiguredOwnerInputs(
       workspaceDir: preserveWorkspaceDirOnRefresh
         ? defaultWorkspaceDir
         : resolveAgentWorkspaceDir(config, agentId),
+      runtimePluginSelections: resolveConfiguredRuntimePluginSelections(config, agentId),
     };
     if (allowGatewaySubagentBinding === true) {
       input.allowGatewaySubagentBinding = true;
@@ -299,6 +360,25 @@ export function listConfiguredOwnerInputs(
     }
     return input;
   });
+}
+
+function resolveConfiguredRuntimePluginSelections(
+  config: OpenClawConfig,
+  agentId: string,
+): PreparedModelRuntimeInput["runtimePluginSelections"] {
+  const configured = resolveDefaultModelForAgent({ cfg: config, agentId });
+  return resolveModelCandidateChain({
+    cfg: config,
+    manifestPlugins: [],
+    provider: configured.provider || DEFAULT_PROVIDER,
+    model: configured.model || DEFAULT_MODEL,
+    requestedRouteResolution: "resolved",
+    fallbacksOverride: resolveRunModelFallbacksOverride({ cfg: config, agentId }),
+  }).map((candidate) => ({
+    provider: candidate.provider,
+    modelId: candidate.model,
+    agentId,
+  }));
 }
 
 export async function publishPreparedModelRuntimeOwnerBatch(params: {

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -120,11 +120,18 @@ vi.mock("../plugins/synthetic-auth.runtime.js", () => ({
 }));
 
 vi.mock("./agent-scope.js", () => ({
+  listAgentEntries: (config: { agents?: { list?: unknown[] } }) => config.agents?.list ?? [],
   listAgentIds: () => ["default"],
   resolveAgentDir: () => "/tmp/prepared-static-agent",
   resolveAgentWorkspaceDir: () => "/tmp/prepared-static-workspace",
   resolveDefaultAgentDir: () => "/tmp/prepared-static-agent",
   resolveDefaultAgentId: () => "default",
+  resolveAgentEffectiveModelPrimary: () => undefined,
+  resolveRunModelFallbacksOverride: () => undefined,
+  resolveSessionAgentIds: ({ agentId }: { agentId?: string }) => ({
+    defaultAgentId: "default",
+    sessionAgentId: agentId ?? "default",
+  }),
 }));
 
 vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
@@ -352,7 +359,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
     );
     expect(mocks.buildPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
     expect(mocks.loadStaticCatalog).not.toHaveBeenCalled();
-    expect(mocks.resolvePluginMetadataSnapshot).toHaveBeenCalledOnce();
+    expect(mocks.resolvePluginMetadataSnapshot).toHaveBeenCalledTimes(2);
     expect(configuredRuntimeModelCount).toBe(1);
     expect(generatedCatalogReadCount).toBe(0);
     const snapshot = getPreparedModelRuntimeSnapshot({

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -74,6 +74,7 @@ vi.mock("../plugins/synthetic-auth.runtime.js", () => ({
 }));
 
 vi.mock("./agent-scope.js", () => ({
+  listAgentEntries: (config: { agents?: { list?: unknown[] } }) => config.agents?.list ?? [],
   listAgentIds: () => mocks.configuredAgentIds,
   resolveAgentDir: (_config: unknown, agentId: string) =>
     agentId === "default" ? "/tmp/unused-agent" : `/tmp/configured-${agentId}`,
@@ -81,6 +82,12 @@ vi.mock("./agent-scope.js", () => ({
     agentId === "default" ? "/tmp/unused-workspace" : `/tmp/workspace-${agentId}`,
   resolveDefaultAgentDir: () => "/tmp/unused-agent",
   resolveDefaultAgentId: () => "default",
+  resolveAgentEffectiveModelPrimary: () => undefined,
+  resolveRunModelFallbacksOverride: () => undefined,
+  resolveSessionAgentIds: ({ agentId }: { agentId?: string }) => ({
+    defaultAgentId: "default",
+    sessionAgentId: agentId ?? "default",
+  }),
 }));
 
 vi.mock("./auth-profiles/runtime-snapshots.js", () => ({

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -5,6 +5,7 @@ import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import { registerRuntimeAuthProfileStoreMutationListener } from "./auth-profiles/runtime-snapshots.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
+  PreparedModelRuntimeOwnerRetention,
   PreparedModelRuntimePublicationSupersededError,
   createPreparedModelRuntimeOwner,
   createPreparedModelRuntimeReplacement,
@@ -54,7 +55,8 @@ let modelRuntimeBuildTimeoutMs = DEFAULT_MODEL_RUNTIME_BUILD_TIMEOUT_MS;
 const owners = new Map<string, PreparedModelRuntimeOwner>();
 const agentBuildCompletions = new Map<string, Promise<void>>();
 const standaloneActivationTails = new Map<string, Promise<void>>();
-let retainedDirectRunOwner: { key: string; owner: PreparedModelRuntimeOwner } | undefined;
+const retainedDirectRunOwners = new PreparedModelRuntimeOwnerRetention(1);
+const retainedGatewayRunOwners = new PreparedModelRuntimeOwnerRetention(8);
 let gatewayLifecycleActive = false;
 let refreshTail: Promise<void> = Promise.resolve();
 let refreshRequestEpoch = 0;
@@ -132,7 +134,9 @@ export function getPreparedModelRuntimeSnapshot(
   const input = normalizePreparedModelRuntimeInput(rawInput);
   const owner = resolvePublishedOwner(owners, input, {
     allowConfiguredWorkspaceFallback:
-      rawInput.workspaceDir === undefined || rawInput.agentId === undefined,
+      rawInput.workspaceDir === undefined ||
+      rawInput.agentId === undefined ||
+      rawInput.runtimePluginSelections === undefined,
   });
   if (!owner?.snapshot || owner.needsRefresh || owner.pending) {
     return undefined;
@@ -349,16 +353,9 @@ async function acquirePreparedModelRuntimeLease(
     return { snapshot, release: () => {} };
   }
   if (provenance === "run" && options.retainIdleRunOwner) {
-    const previous = retainedDirectRunOwner;
-    retainedDirectRunOwner = { key, owner };
-    if (
-      previous &&
-      previous.owner !== owner &&
-      (previous.owner.leaseCount ?? 0) === 0 &&
-      owners.get(previous.key) === previous.owner
-    ) {
-      owners.delete(previous.key);
-    }
+    retainedDirectRunOwners.retain(key, owner, owners);
+  } else if (provenance === "run" && gatewayLifecycleActive) {
+    retainedGatewayRunOwners.retain(key, owner, owners);
   }
   owner.leaseCount = (owner.leaseCount ?? 0) + 1;
   let released = false;
@@ -370,11 +367,10 @@ async function acquirePreparedModelRuntimeLease(
       }
       released = true;
       owner.leaseCount = Math.max(0, (owner.leaseCount ?? 1) - 1);
-      // Configless direct runs retain one bounded idle generation; dynamic gateway and metadata
-      // generations live exactly as long as their lease. The identity checks prevent an old
-      // release from deleting a replacement at the same key.
+      // Direct runs retain one idle generation; gateways retain a bounded LRU so repeated selections
+      // reuse workspace facts. Identity checks keep old releases from deleting replacements.
       if (owner.leaseCount === 0 && owners.get(key) === owner) {
-        if (retainedDirectRunOwner?.owner !== owner) {
+        if (!retainedDirectRunOwners.has(key, owner) && !retainedGatewayRunOwners.has(key, owner)) {
           owners.delete(key);
         }
       }
@@ -411,7 +407,9 @@ export async function prepareModelRuntimeSnapshot(
   const input = normalizePreparedModelRuntimeInput(rawInput);
   const existing = resolvePublishedOwner(owners, input, {
     allowConfiguredWorkspaceFallback:
-      rawInput.workspaceDir === undefined || rawInput.agentId === undefined,
+      rawInput.workspaceDir === undefined ||
+      rawInput.agentId === undefined ||
+      rawInput.runtimePluginSelections === undefined,
   });
   if (
     input.readOnly &&
@@ -494,6 +492,7 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
   options: PreparedModelRuntimeRefreshOptions,
   publicationEpoch: number,
 ): Promise<void> {
+  retainedGatewayRunOwners.clear(owners);
   const { defaultWorkspaceDir: workspace, allowGatewaySubagentBinding: bindings } = options;
   const catalogMode = options.catalogMode ?? "live";
   gatewayLifecycleActive ||= options.gatewayLifecycle === true;
@@ -628,7 +627,7 @@ export function refreshPreparedModelRuntimeSnapshots(
   markPreparedModelRuntimeSnapshotsStale(undefined, { waitForReplacement: true });
   const requestEpoch = refreshRequestEpoch;
   const replacement = pendingModelRuntimeReplacement;
-  const publication = enqueuePreparedModelRuntimePublication(async () => {
+  return enqueuePreparedModelRuntimePublication(async () => {
     if (requestEpoch !== refreshRequestEpoch) {
       return;
     }
@@ -637,8 +636,7 @@ export function refreshPreparedModelRuntimeSnapshots(
       return;
     }
     await drainPendingAuthMutations();
-  });
-  return publication.then(
+  }).then(
     () => {
       if (
         requestEpoch === refreshRequestEpoch &&
@@ -755,7 +753,7 @@ function resetPreparedModelRuntimeSnapshotsForTest(): void {
   owners.clear();
   agentBuildCompletions.clear();
   standaloneActivationTails.clear();
-  retainedDirectRunOwner = undefined;
+  retainedGatewayRunOwners.clear(owners);
   gatewayLifecycleActive = false;
   refreshTail = Promise.resolve();
   refreshRequestEpoch = 0;
@@ -767,6 +765,7 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.preparedModelRuntimeTestApi")] =
     {
       resetPreparedModelRuntimeSnapshotsForTest,
+      getPreparedModelRuntimeOwnerCountForTest: () => owners.size,
       setModelRuntimeBuildTimeoutMsForTest: (timeoutMs: number) => {
         modelRuntimeBuildTimeoutMs = timeoutMs;
       },

--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -22,6 +22,7 @@ import {
   getActivePluginRegistryWorkspaceDirFromState,
   getPluginRegistryState,
 } from "./runtime-state.js";
+import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
 import type {
   ProviderPlugin,
   ProviderExtraParamsForTransportContext,
@@ -126,6 +127,17 @@ function findProviderRuntimePluginInLoadedRegistries(params: {
   lookup: ProviderRuntimePluginLookupParams;
   apiOwnerHint?: string;
 }): ProviderPlugin | undefined {
+  const scopedRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+  const scopedPlugin = scopedRegistry
+    ? findProviderRuntimePluginInRegistry({
+        registry: scopedRegistry,
+        provider: params.lookup.provider,
+        apiOwnerHint: params.apiOwnerHint,
+      })
+    : undefined;
+  if (scopedPlugin) {
+    return scopedPlugin;
+  }
   const activeRegistry = getLoadedRuntimePluginRegistry({
     env: params.lookup.env,
     workspaceDir: params.lookup.workspaceDir,

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   expectAugmentedCodexCatalog,
   expectCodexMissingAuthHint,
 } from "./provider-runtime.test-support.js";
+import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
 import type {
   AnyAgentTool,
   ProviderExternalAuthProfile,
@@ -551,6 +552,31 @@ describe("provider-runtime", () => {
     ).toEqual({
       fromActiveRegistry: true,
     });
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the prepared run registry without repeating provider discovery", () => {
+    const provider: ProviderPlugin = {
+      id: DEMO_PROVIDER_ID,
+      label: "Prepared demo",
+      auth: [],
+    };
+    const registry = createEmptyPluginRegistry();
+    registry.providers.push({
+      pluginId: DEMO_PROVIDER_ID,
+      provider,
+      source: "test",
+    });
+
+    const resolved = withPluginRuntimeRegistryScope(registry, () =>
+      resolveProviderRuntimePlugin({
+        provider: DEMO_PROVIDER_ID,
+        workspaceDir: "/tmp/prepared-workspace",
+      }),
+    );
+
+    expect(resolved?.id).toBe(DEMO_PROVIDER_ID);
+    expect(resolved?.pluginId).toBe(DEMO_PROVIDER_ID);
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Trivial gateway-backed agent turns regressed roughly 3× overnight on production hosts. On the team Hetzner host (48 cores, ~150 plugins), a "reply with exactly this marker" turn measured 3.3–4.9 s gateway-side (`meta.durationMs`) on the 2026-08-01 dist and 14.6–18.1 s on the 2026-08-02 dist; the Molty host regressed similarly. Controls isolated the regression: a bare OpenAI Responses API call for the same model answers in ~1 s, and CLI-side overhead is a separately fixed, smaller constant.

The startup-stage trace (added in the same window) shows where the time went on a live 20 s production turn:

```
stages=workspace:11388ms@11388ms,runtime-plugins:0ms,hooks:2ms,model-resolution:2651ms@14041ms,auth:305ms,context-engine:14ms,...
```

## Why This Change Was Made

Blame: PR #117587 (`refactor(plugins): root-owned bundle installation with scoped registry handles`, commit `6c9b38862d2`).

The `workspace` label is a broad timing bucket (tracker creation through the first mark) that includes model/harness selection and `acquireAgentRunPreparedModelRuntime` — it is not a literal directory walk. #117587 added per-turn `runtimePluginSelections` to the prepared-runtime owner key, while configured gateway owners were still published **without** equivalent selections. Every configured Codex turn therefore missed the lifecycle-published owner, rebuilt workspace-scoped plugin/metadata/provider/catalog facts from scratch, and discarded that owner on release — the 11.4 s. The secondary `model-resolution: 2651ms` shares the same ownership problem: provider-hook lookup ignored the scoped prepared registry and rediscovered provider metadata.

The fix restores prepared-fact reuse at the owner boundary:

- Configured gateway owners now prepare and publish their configured model/harness selections at lifecycle publication, so turn-time keys match.
- Selection identity is normalized to the resolved runtime (per-agent identity noise removed), and an absent selections field on the acquisition side matches the published owner instead of forcing a rebuild.
- Genuinely request-specific model/harness combinations use a lifecycle-owned eight-entry LRU; reloads clear it. Review hardened this twice: configured owners can never enter or be evicted by the LRU, and clearing retention sweeps released (zero-lease) run owners out of the canonical owner map so refreshes cannot leak registries/snapshots.
- Codex native-harness selection no longer consults generic CLI-backend setup discovery (Codex is not a CLI alias).
- Provider model resolution checks the prepared run-scoped registry before global registries or provider discovery.

Sibling Codex source was inspected directly per the repo's Codex gate: `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:57-149` (ThreadStartParams accepts only optional cwd/workspace roots) and `../codex/codex-rs/app-server/src/request_processors/thread_processor.rs:972-1085,1134-1160` (processing begins asynchronously after dispatch) — Codex-side behavior does not explain the pre-dispatch delay, confirming the OpenClaw owner-key miss as the cause.

## User Impact

Configured Codex turns reuse startup-prepared facts immediately, removing ~11.4 s of per-turn reconstruction plus the ~2.6 s provider rediscovery — returning trivial-turn latency to the previous 3–5 s class. A genuinely novel request-specific combination pays one cold build, then stays cached within the bounded lifecycle owner.

## Evidence

- Prepared-runtime owner/lifecycle/startup-static/core suites: 89 passed; embedded-run settlement: 11; harness runtime: 12; provider runtime: 63. After review hardening, owner-selection suite 19/19 including two new regressions: a configured owner acquired through the run path survives LRU flooding, and refresh clears released run owners from the canonical map.
- `pnpm tsgo:core`, `pnpm tsgo:test:src`, targeted oxlint (700-line ratchet), `git diff --check`: passed.
- Autoreview (Codex `gpt-5.6-sol`, high): first round surfaced two retention defects (configured-owner evictability; clear() stranding released owners) — both fixed with regressions; final round clean, "patch is correct".
- Note on test routing: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner` (directory form) misroutes into the unit-fast config where embedded-runner mocks are absent; the exact-file form through `vitest.agents-embedded-agent-run.config.ts` passes. Reported as tooling context, not changed here.

Production delta net +98 (configured-owner identity + bounded lifecycle retention — an ownership seam, not call-site memoization). Tests net +139.
