### PR TITLE
test(mcp): make tools-list fixture logs deterministic

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -91,6 +91,7 @@ async function writeListToolsMcpServer(params: {
   await writeExecutable(
     params.filePath,
     `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
 import fs from "node:fs/promises";
 
 const logPath = ${JSON.stringify(params.logPath)};
@@ -156,7 +157,7 @@ if (hangToolCallsUntilRestartMarkerPath) {
   }
 }
 function log(line) {
-  void fs.appendFile(logPath, line + "\\n", "utf8").catch(() => {});
+  appendFileSync(logPath, line + "\\n", "utf8");
 }
 function send(message) {
   process.stdout.write(JSON.stringify(message) + "\\n");


### PR DESCRIPTION
## Summary
- make the generated MCP tools/list fixture write its log synchronously
- remove the async append race that let the parent assert before child output reached disk
- keep the change test-only and preserve all existing assertions

## Proof
- baseline race: async fixture reproduced 0/30 complete logs
- candidate fixture: synchronous write reproduced 30/30 complete logs
- focused scenario: GREEN, 2/2
- full owner file: GREEN, 90/90
- targeted formatter and lint clean
- two independent source/security reviews plus authenticated all-priority review/scanner clean

This is a standalone test-fixture reliability fix for the cross-PR large7 race. It does not close an existing issue.