### PR TITLE
fix(tui): reject oversized Gateway history requests before startup

### DIFF
--- a/packages/gateway-protocol/src/schema/chat-history-constants.ts
+++ b/packages/gateway-protocol/src/schema/chat-history-constants.ts
@@ -1,0 +1,2 @@
+/** Largest history page accepted by the Gateway wire contract. */
+export const CHAT_HISTORY_MAX_ENTRIES = 1000;

--- a/packages/gateway-protocol/src/schema/logs-chat.test.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.test.ts
@@ -1,7 +1,12 @@
 // Gateway Protocol tests cover typed chat stream events.
 import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
-import { ChatEventSchema, ChatSendParamsSchema, ChatStatusEventSchema } from "./logs-chat.js";
+import {
+  ChatEventSchema,
+  ChatHistoryParamsSchema,
+  ChatSendParamsSchema,
+  ChatStatusEventSchema,
+} from "./logs-chat.js";
 
 const statusEvent = {
   runId: "run-1",
@@ -10,6 +15,15 @@ const statusEvent = {
   state: "status",
   phase: "preparing_context",
 } as const;
+
+describe("ChatHistoryParamsSchema", () => {
+  it("accepts the history boundary and rejects larger requests", () => {
+    const request = { sessionKey: "agent:main:main" };
+
+    expect(Value.Check(ChatHistoryParamsSchema, { ...request, limit: 1000 })).toBe(true);
+    expect(Value.Check(ChatHistoryParamsSchema, { ...request, limit: 1001 })).toBe(false);
+  });
+});
 
 describe("ChatStatusEventSchema", () => {
   it("accepts closed startup phases through the chat event union", () => {

--- a/packages/gateway-protocol/src/schema/logs-chat.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol schema module defines protocol validation shapes.
 import type { Static } from "typebox";
 import { Type } from "typebox";
+import { CHAT_HISTORY_MAX_ENTRIES } from "./chat-history-constants.js";
 import { closedObject } from "./closed-object.js";
 import { ChatSendSessionKeyString, InputProvenanceSchema, NonEmptyString } from "./primitives.js";
 
@@ -25,7 +26,7 @@ export const LogsTailResultSchema = closedObject({
 export const ChatHistoryParamsSchema = closedObject({
   sessionKey: NonEmptyString,
   agentId: Type.Optional(NonEmptyString),
-  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: CHAT_HISTORY_MAX_ENTRIES })),
   offset: Type.Optional(Type.Integer({ minimum: 0 })),
   messageId: Type.Optional(NonEmptyString),
   sessionId: Type.Optional(NonEmptyString),

--- a/src/cli/program.smoke.test.ts
+++ b/src/cli/program.smoke.test.ts
@@ -58,9 +58,11 @@ describe("cli program (smoke)", () => {
     await runProgram(["tui", "--timeout-ms", "45000"]);
     const options = firstMockArg(runTui) as {
       timeoutMs?: number;
+      historyLimit?: number;
       forceProcessExitOnReturn?: boolean;
     };
     expect(options?.timeoutMs).toBe(45000);
+    expect(options?.historyLimit).toBe(200);
     expect(options?.forceProcessExitOnReturn).toBe(true);
   });
 
@@ -89,6 +91,30 @@ describe("cli program (smoke)", () => {
     expect(runtime.error).toHaveBeenCalledWith(
       "Error: --history-limit must be a positive integer.",
     );
+    expect(runTui).not.toHaveBeenCalled();
+  });
+
+  it("accepts the maximum Gateway tui history limit", async () => {
+    await runProgram(["tui", "--history-limit", "1000"]);
+
+    expect(firstMockArg(runTui)).toMatchObject({ local: false, historyLimit: 1000 });
+  });
+
+  it.each([
+    { entryPoint: "tui --local", args: ["tui", "--local"] },
+    { entryPoint: "terminal", args: ["terminal"] },
+    { entryPoint: "chat", args: ["chat"] },
+  ])("preserves oversized history limits for local $entryPoint", async ({ args }) => {
+    await runProgram([...args, "--history-limit", "1001"]);
+
+    expect(firstMockArg(runTui)).toMatchObject({ local: true, historyLimit: 1001 });
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("rejects tui history limits above the Gateway maximum", async () => {
+    await expect(runProgram(["tui", "--history-limit", "1001"])).rejects.toThrow("exit");
+
+    expect(runtime.error).toHaveBeenCalledWith("Error: --history-limit must be at most 1000.");
     expect(runTui).not.toHaveBeenCalled();
   });
 

--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -1,5 +1,6 @@
 // Registers the terminal UI subcommand and normalizes its local-vs-gateway options.
 import type { Command } from "commander";
+import { CHAT_HISTORY_MAX_ENTRIES } from "../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
@@ -50,6 +51,9 @@ export function registerTuiCli(program: Command) {
         const historyLimit = parseStrictPositiveInteger(opts.historyLimit ?? "200");
         if (historyLimit === undefined) {
           throw new Error("--history-limit must be a positive integer.");
+        }
+        if (!isLocal && historyLimit > CHAT_HISTORY_MAX_ENTRIES) {
+          throw new Error(`--history-limit must be at most ${CHAT_HISTORY_MAX_ENTRIES}.`);
         }
         const { runTui } = await import("../tui/tui.js");
         await runTui({

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -9,6 +9,7 @@ import {
   validateChatHistoryParams,
   validateChatMetadataParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { CHAT_HISTORY_MAX_ENTRIES } from "../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import {
   listAgentIds,
   resolveDefaultAgentId,
@@ -385,7 +386,7 @@ async function handleChatHistoryRequest({
     requestedSessionId && requestedSessionId !== entry?.sessionId ? undefined : entry;
   const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
   const requested = typeof limit === "number" ? limit : 200;
-  const max = Math.min(1000, requested);
+  const max = Math.min(CHAT_HISTORY_MAX_ENTRIES, requested);
   const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
   const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
   let historyPage: Awaited<ReturnType<typeof readChatHistoryPage>>;

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -1,6 +1,7 @@
 // Implements the embedded backend used by local TUI sessions.
 import { randomUUID } from "node:crypto";
 import type { SessionsPatchResult } from "../../packages/gateway-protocol/src/index.js";
+import { CHAT_HISTORY_MAX_ENTRIES } from "../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import { agentCommandFromIngress } from "../agents/agent-command.js";
 import { isAgentLifecycleYieldedWaiting } from "../agents/agent-lifecycle-parent-state.js";
 import {
@@ -621,7 +622,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
     this.runtimePluginRegistry =
       runtimePluginsPrewarm.status === "warmed" ? runtimePluginsPrewarm.registry : undefined;
     const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
-    const max = Math.min(1000, typeof opts.limit === "number" ? opts.limit : 200);
+    const max = Math.min(
+      CHAT_HISTORY_MAX_ENTRIES,
+      typeof opts.limit === "number" ? opts.limit : 200,
+    );
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
     const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg);
     const historyPage = await readChatHistoryPage({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting the Gateway-backed terminal UI with `--history-limit` above 1,000 would enter the interface and then receive a protocol-validation failure, even though the limit was already invalid before startup.

## Why This Change Was Made

Move the existing 1,000-entry boundary into one private, dependency-free Gateway-protocol owner and reuse it in the wire schema, Gateway history reader, embedded history reader, and Gateway-backed TUI argument validation. Preserve the existing `tui --local`, `terminal`, and `chat` behavior, including the embedded backend's established clamp; the wire schema, public exports, defaults, and configuration are unchanged.

## User Impact

Gateway-backed terminal users get an immediate, actionable `--history-limit must be at most 1000` error before the UI starts. Local terminal entry points continue accepting their existing arguments, and all existing history reads retain the same established maximum.

## Evidence

- Genuine unchanged-parent regression: protocol schema **4 passed**; real Commander CLI smoke **10 passed, 1 failed**, because `tui --history-limit 1001` incorrectly reached the TUI.
- Frozen candidate `2cd5bd4b4a9ebb11cd2dc90b40f113ea4ec1affe`: protocol schema **4/4 passed** and Commander CLI smoke **11/11 passed**, covering limit 1000, limit 1001, default 200, `tui --local`, `terminal`, and `chat`.
- Four independently fresh hostile source reviews verified the complete schema/Gateway/embedded/CLI ownership chain, pinned Commander alias semantics, shipped release behavior, and absence of public protocol/export changes.
- Independent official `gpt-5.6-sol` high-reasoning P0–P3 review: **zero findings**, confidence **0.96**; native TruffleHog **3.96.0** secret scan clean.
- Current `main` has no drift across any of the seven changed files; production removes duplicate boundary literals and introduces one private authoritative constant.
