### PR TITLE
fix(tasks): prevent doubled tool activity after module reload

### DIFF
--- a/src/gateway/server-methods/agent.test-harness.ts
+++ b/src/gateway/server-methods/agent.test-harness.ts
@@ -213,7 +213,7 @@ vi.mock("../../infra/agent-events.js", () => ({
     generation === mocks.lifecycleGeneration,
   registerAgentEventLifecycleRotationHandler: vi.fn(),
   registerAgentRunContext: mocks.registerAgentRunContext,
-  onAgentEvent: vi.fn(),
+  onAgentEvent: vi.fn(() => () => undefined),
 }));
 
 vi.mock("../../agents/subagent-registry-read.js", () => ({

--- a/src/tasks/task-registry-listener-reload.test.ts
+++ b/src/tasks/task-registry-listener-reload.test.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { resetTaskRegistryForTests } from "./task-runtime.test-helpers.js";
+
+const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+let stateDir = "";
+
+beforeEach(async () => {
+  stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-task-listener-reload-"));
+  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+  resetTaskRegistryForTests();
+  resetAgentEventsForTest();
+});
+
+afterEach(async () => {
+  resetTaskRegistryForTests();
+  resetAgentEventsForTest();
+  envSnapshot.restore();
+  await fs.rm(stateDir, { recursive: true, force: true });
+});
+
+function createToolActivityTask(registry: typeof import("./task-registry.js"), runId: string) {
+  return expectDefined(
+    registry.createTaskRecord({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:main:subagent:activity",
+      runId,
+      task: "Track tool activity",
+      status: "running",
+      deliveryStatus: "not_applicable",
+    }),
+    "task registry reload fixture",
+  );
+}
+
+describe("task registry listener reload", () => {
+  it("keeps one agent-event listener across module reloads", async () => {
+    const firstRegistry = await import("./task-registry.js");
+    const firstTask = createToolActivityTask(firstRegistry, "run-before-reload");
+    emitAgentEvent({
+      runId: "run-before-reload",
+      stream: "tool",
+      data: { phase: "start", name: "read", toolCallId: "call-before" },
+    });
+    expect(firstRegistry.getTaskById(firstTask.taskId)?.toolUseCount).toBe(1);
+
+    // The module cache reset intentionally abandons the first store module;
+    // close its native handle without stopping the listener under test.
+    closeOpenClawStateDatabaseForTest();
+    vi.resetModules();
+    const reloadedRegistry = await import("./task-registry.js");
+    resetTaskRegistryForTests();
+    const task = createToolActivityTask(reloadedRegistry, "run-after-reload");
+
+    emitAgentEvent({
+      runId: "run-after-reload",
+      stream: "tool",
+      data: { phase: "start", name: "exec", toolCallId: "call-after" },
+    });
+
+    expect(reloadedRegistry.getTaskById(task.taskId)?.toolUseCount).toBe(1);
+    expect(reloadedRegistry.getTaskById(task.taskId)?.lastToolName).toBe("exec");
+  });
+});

--- a/src/tasks/task-registry-state.ts
+++ b/src/tasks/task-registry-state.ts
@@ -29,8 +29,6 @@ export const taskIdsByOwnerKey = taskRegistryProcessState.taskIdsByOwnerKey;
 export const taskIdsByParentFlowId = taskRegistryProcessState.taskIdsByParentFlowId;
 export const taskIdsByRelatedSessionKey = taskRegistryProcessState.taskIdsByRelatedSessionKey;
 export const tasksWithPendingDelivery = taskRegistryProcessState.tasksWithPendingDelivery;
-let listenerStarted = false;
-let listenerStop: (() => void) | null = null;
 type TaskRegistryRestoreState =
   | { status: "uninitialized" }
   | { status: "restoring" }
@@ -83,21 +81,23 @@ export function setTaskRegistryListenerStarter(starter: () => void): void {
 }
 
 export function claimTaskRegistryListenerStart(): boolean {
-  if (listenerStarted) {
+  if (taskRegistryProcessState.agentEventListener.status !== "idle") {
     return false;
   }
-  listenerStarted = true;
+  taskRegistryProcessState.agentEventListener = { status: "starting" };
   return true;
 }
 
-export function setTaskRegistryListenerStop(stop: (() => void) | null): void {
-  listenerStop = stop;
+export function setTaskRegistryListenerStop(stop: () => void): void {
+  taskRegistryProcessState.agentEventListener = { status: "active", stop };
 }
 
 export function resetTaskRegistryListenerState(): void {
-  listenerStop?.();
-  listenerStop = null;
-  listenerStarted = false;
+  const listener = taskRegistryProcessState.agentEventListener;
+  taskRegistryProcessState.agentEventListener = { status: "idle" };
+  if (listener.status === "active") {
+    listener.stop();
+  }
 }
 
 function clearTaskFlowSyncRetries(): void {

--- a/src/tasks/task-registry.process-state.ts
+++ b/src/tasks/task-registry.process-state.ts
@@ -2,7 +2,15 @@
 import type { TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
 
 /** Process-local indexes backing task lookup, owner access, and pending delivery scans. */
+type TaskRegistryAgentEventListenerState =
+  | { status: "idle" }
+  | { status: "starting" }
+  | { status: "active"; stop: () => void };
+
 type TaskRegistryProcessState = {
+  // Listener ownership follows the global maps so module reloads cannot attach
+  // duplicate consumers that mutate the same task records twice.
+  agentEventListener: TaskRegistryAgentEventListenerState;
   tasks: Map<string, TaskRecord>;
   taskDeliveryStates: Map<string, TaskDeliveryState>;
   taskIdsByRunId: Map<string, Set<string>>;
@@ -20,6 +28,7 @@ export function getTaskRegistryProcessState(): TaskRegistryProcessState {
     [TASK_REGISTRY_PROCESS_STATE_KEY]?: TaskRegistryProcessState;
   };
   globalState[TASK_REGISTRY_PROCESS_STATE_KEY] ??= {
+    agentEventListener: { status: "idle" },
     tasks: new Map<string, TaskRecord>(),
     taskDeliveryStates: new Map<string, TaskDeliveryState>(),
     taskIdsByRunId: new Map<string, Set<string>>(),


### PR DESCRIPTION
Closes #117774

## What Problem This Solves

Fixes an issue where task summaries could report doubled tool activity after the task-registry module graph reloaded while process-global task state remained alive. The exact `expected 4 to be 2` signature failed on four unrelated CI heads and could make Gateway task activity inaccurate.

## Why This Change Was Made

Listener ownership now lives in the same process-global state as the task maps it mutates. Reloaded module instances therefore share one closed `idle | starting | active` subscription lifecycle instead of installing parallel consumers. A Gateway test harness also now honors the real `onAgentEvent` contract by returning its unsubscribe callback; production reset remains strict rather than masking invalid listener state.

The regression follows the original shared-state order: create and observe a task, reset modules without stopping the listener, reload/reset the registry, emit another tool event, and verify exactly one mutation. Sibling review found no shared abstraction to generalize: plugin runtime already co-locates global state and unsubscribe ownership, while Gateway and subagent listeners own module- or instance-local state together.

Production delta is +18/-9 lines (net +9). Tests are +74/-1 lines (net +73). No config, protocol, persistence schema, or public API changes.

AI-assisted implementation; the author reviewed the owner boundary, callers, siblings, history, and proof.

## User Impact

Gateway task summaries now count each tool-start event once after duplicate module evaluation or non-isolated module recycling. Operators and clients no longer receive inflated task activity from duplicate registry listeners, and unrelated CI changes no longer inherit this shared-state flake.

## Evidence

Before the fix, the same `toolUseCount` assertion (`expected 4 to be 2`) failed in hosted CI runs:

- https://github.com/openclaw/openclaw/actions/runs/30729051704
- https://github.com/openclaw/openclaw/actions/runs/30729154941
- https://github.com/openclaw/openclaw/actions/runs/30729222461
- https://github.com/openclaw/openclaw/actions/runs/30729253260

After the fix, Blacksmith Testbox `tbx_01kz06w7y3gwfyfjz0e5rn674c` (run https://github.com/openclaw/openclaw/actions/runs/30729981108) passed:

- Focused owner/sibling proof: 121/121 task-registry tests and 280/280 Gateway task/agent-handler tests.
- Original non-isolated environment: 142/142 files and 2,780/2,780 tests with `test/vitest/vitest.gateway-methods.config.ts`; file-order logging confirmed the shared-worker sequence.
- Complete `pnpm check:changed`: formatting, guards, production/test tsgo, lint, dead exports, database-first checks, and import cycles all passed.

The final uncommitted diff received a clean Codex autoreview with no accepted/actionable findings (`overall_correctness: patch is correct`, confidence 0.99). Rebase onto `0f7c624a3f65fed39d758649c5e7a62ebde107b8` preserved the exact patch id `0cc6c6b430ade21a0e05e6a0fdbbefdc74a1d4be`; the intervening main changes touched unrelated files.
