### PR TITLE
fix(msteams): workspace attachments fail in sends and uploads

### DIFF
--- a/extensions/msteams/src/channel.actions.test.ts
+++ b/extensions/msteams/src/channel.actions.test.ts
@@ -138,6 +138,7 @@ async function runAction(params: {
   requesterAccountId?: string;
   params?: Record<string, unknown>;
   toolContext?: Record<string, unknown>;
+  mediaAccess?: Parameters<ReturnType<typeof requireMSTeamsHandleAction>>[0]["mediaAccess"];
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
   requesterSenderId?: string | null;
@@ -152,6 +153,7 @@ async function runAction(params: {
     accountId: params.accountId,
     requesterAccountId: params.requesterAccountId,
     params: params.params ?? {},
+    mediaAccess: params.mediaAccess,
     mediaLocalRoots: params.mediaLocalRoots,
     mediaReadFile: params.mediaReadFile,
     toolContext: params.toolContext,
@@ -218,6 +220,7 @@ async function expectSuccessfulAction(params: {
   requesterAccountId?: Parameters<typeof runAction>[0]["requesterAccountId"];
   actionParams?: Parameters<typeof runAction>[0]["params"];
   toolContext?: Parameters<typeof runAction>[0]["toolContext"];
+  mediaAccess?: Parameters<typeof runAction>[0]["mediaAccess"];
   mediaLocalRoots?: Parameters<typeof runAction>[0]["mediaLocalRoots"];
   mediaReadFile?: Parameters<typeof runAction>[0]["mediaReadFile"];
   requesterSenderId?: Parameters<typeof runAction>[0]["requesterSenderId"];
@@ -234,6 +237,7 @@ async function expectSuccessfulAction(params: {
     accountId: params.accountId,
     requesterAccountId: params.requesterAccountId,
     params: params.actionParams,
+    mediaAccess: params.mediaAccess,
     mediaLocalRoots: params.mediaLocalRoots,
     mediaReadFile: params.mediaReadFile,
     toolContext: params.toolContext,
@@ -597,6 +601,16 @@ describe("msteamsPlugin message actions", () => {
 
   it("routes upload-file through sendMessageMSTeams with filename override", async () => {
     const mediaReadFile = vi.fn(async () => Buffer.from("pdf"));
+    const mediaAccess = {
+      localRoots: ["/approved/workspace"],
+      readFile: mediaReadFile,
+      workspaceDir: "/approved/workspace",
+    };
+    const forgedMediaAccess = {
+      localRoots: ["/forged/workspace"],
+      readFile: vi.fn(async () => Buffer.from("forged")),
+      workspaceDir: "/forged/workspace",
+    };
     await expectSuccessfulAction({
       mockFn: sendMessageMSTeamsMock,
       mockResult: {
@@ -609,7 +623,16 @@ describe("msteamsPlugin message actions", () => {
         path: " /tmp/report.pdf ",
         message: "Quarterly report",
         filename: "Q1-report.pdf",
+        mediaAccess: forgedMediaAccess,
+        mediaLocalRoots: ["/forged/workspace"],
+        mediaReadFile: forgedMediaAccess.readFile,
       },
+      toolContext: {
+        mediaAccess: forgedMediaAccess,
+        mediaLocalRoots: ["/forged/workspace"],
+        mediaReadFile: forgedMediaAccess.readFile,
+      },
+      mediaAccess,
       mediaLocalRoots: ["/tmp"],
       mediaReadFile,
       runtimeParams: {
@@ -617,6 +640,7 @@ describe("msteamsPlugin message actions", () => {
         text: "Quarterly report",
         mediaUrl: " /tmp/report.pdf ",
         filename: "Q1-report.pdf",
+        mediaAccess,
         mediaLocalRoots: ["/tmp"],
         mediaReadFile,
       },
@@ -632,6 +656,42 @@ describe("msteamsPlugin message actions", () => {
         messageId: "msg-upload-1",
         conversationId: "conv-upload-1",
       },
+    });
+    expect(sendMessageMSTeamsMock.mock.calls[0]?.[0]?.mediaAccess).toBe(mediaAccess);
+  });
+
+  it("does not grant forged upload-file media authority when the host grants none", async () => {
+    const forgedMediaAccess = {
+      localRoots: ["/forged/workspace"],
+      readFile: vi.fn(async () => Buffer.from("forged")),
+      workspaceDir: "/forged/workspace",
+    };
+    sendMessageMSTeamsMock.mockResolvedValue({
+      messageId: "msg-upload-1",
+      conversationId: "conv-upload-1",
+    });
+
+    await runAction({
+      action: "upload-file",
+      params: {
+        to: targetChannelId,
+        path: "report.pdf",
+        mediaAccess: forgedMediaAccess,
+        mediaLocalRoots: forgedMediaAccess.localRoots,
+        mediaReadFile: forgedMediaAccess.readFile,
+      },
+      toolContext: { mediaAccess: forgedMediaAccess },
+    });
+
+    expect(sendMessageMSTeamsMock).toHaveBeenCalledWith({
+      cfg: {},
+      to: targetChannelId,
+      text: "",
+      mediaUrl: "report.pdf",
+      filename: undefined,
+      mediaAccess: undefined,
+      mediaLocalRoots: undefined,
+      mediaReadFile: undefined,
     });
   });
 

--- a/extensions/msteams/src/channel.message-adapter.test.ts
+++ b/extensions/msteams/src/channel.message-adapter.test.ts
@@ -126,12 +126,14 @@ describe("msteams channel message adapter", () => {
     };
 
     const proveMedia = async () => {
+      const mediaAccess = { localRoots: ["/tmp"], workspaceDir: "/tmp" };
       mocks.sendMedia.mockClear();
       const result = await sendMedia({
         cfg,
         to: "conversation:abc",
         text: "photo",
         mediaUrl: "file:///tmp/photo.png",
+        mediaAccess,
         mediaLocalRoots: ["/tmp"],
         accountId: "default",
       });
@@ -140,9 +142,11 @@ describe("msteams channel message adapter", () => {
         to: "conversation:abc",
         text: "photo",
         mediaUrl: "file:///tmp/photo.png",
+        mediaAccess,
         mediaLocalRoots: ["/tmp"],
         accountId: "default",
       });
+      expect(mocks.sendMedia.mock.calls[0]?.[0]?.mediaAccess).toBe(mediaAccess);
       expect(result.receipt.platformMessageIds).toEqual(["msg-media-1"]);
       expect(result.receipt.parts[0]?.kind).toBe("media");
     };
@@ -154,11 +158,13 @@ describe("msteams channel message adapter", () => {
           blocks: [{ type: "text" as const, text: "card body" }],
         },
       };
+      const mediaAccess = { localRoots: ["/tmp"], workspaceDir: "/tmp" };
       const result = await sendPayload({
         cfg,
         to: "conversation:abc",
         text: "",
         payload,
+        mediaAccess,
         accountId: "default",
       });
       expect(mocks.sendPayload).toHaveBeenLastCalledWith({
@@ -166,8 +172,10 @@ describe("msteams channel message adapter", () => {
         to: "conversation:abc",
         text: "",
         payload,
+        mediaAccess,
         accountId: "default",
       });
+      expect(mocks.sendPayload.mock.calls[0]?.[0]?.mediaAccess).toBe(mediaAccess);
       expect(result.receipt.platformMessageIds).toEqual(["msg-payload-1"]);
       expect(result.receipt.parts[0]?.kind).toBe("card");
     };

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -786,6 +786,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
                   filename:
                     readOptionalTrimmedString(ctx.params, "filename") ??
                     readOptionalTrimmedString(ctx.params, "title"),
+                  mediaAccess: ctx.mediaAccess,
                   mediaLocalRoots: ctx.mediaLocalRoots,
                   mediaReadFile: ctx.mediaReadFile,
                 });

--- a/extensions/msteams/src/outbound.test.ts
+++ b/extensions/msteams/src/outbound.test.ts
@@ -255,6 +255,37 @@ describe("msteamsOutbound cfg threading", () => {
     });
   });
 
+  it("preserves host-owned workspace media access for direct attachments", async () => {
+    const readFile = vi.fn(async () => Buffer.from("approved attachment"));
+    const mediaAccess = {
+      localRoots: ["/approved/workspace"],
+      readFile,
+      workspaceDir: "/approved/workspace",
+    };
+    const conflictingReader = vi.fn(async () => Buffer.from("unapproved attachment"));
+
+    await requireSendMedia()({
+      cfg,
+      to: "conversation:abc",
+      text: "photo",
+      mediaUrl: "reports/photo.png",
+      mediaAccess,
+      mediaLocalRoots: ["/unapproved/workspace"],
+      mediaReadFile: conflictingReader,
+    });
+
+    expect(mocks.sendMessageMSTeams).toHaveBeenCalledWith({
+      cfg,
+      to: "conversation:abc",
+      text: "photo",
+      mediaUrl: "reports/photo.png",
+      mediaAccess,
+      mediaLocalRoots: ["/unapproved/workspace"],
+      mediaReadFile: conflictingReader,
+    });
+    expect(mocks.sendMessageMSTeams.mock.calls[0]?.[0]?.mediaAccess).toBe(mediaAccess);
+  });
+
   it("renders and sends presentation payloads as Adaptive Cards", async () => {
     const presentation = {
       title: "Deploy",
@@ -511,6 +542,39 @@ describe("msteamsOutbound cfg threading", () => {
       messageId: "msg-media-2",
       conversationId: "conv-media",
     });
+  });
+
+  it("preserves host media authority for every workspace-relative payload attachment", async () => {
+    const mediaAccess = {
+      localRoots: ["/approved/workspace"],
+      workspaceDir: "/approved/workspace",
+    };
+    mocks.sendMessageMSTeams
+      .mockResolvedValueOnce({ messageId: "msg-media-1", conversationId: "conv-media" })
+      .mockResolvedValueOnce({ messageId: "msg-media-2", conversationId: "conv-media" });
+
+    await requireSendPayload()({
+      cfg,
+      to: "conversation:abc",
+      text: "album",
+      payload: { text: "album", mediaUrls: ["one.png", "reports/two.png"] },
+      mediaAccess,
+      mediaLocalRoots: ["/unapproved/workspace"],
+    });
+
+    expect(mocks.sendMessageMSTeams).toHaveBeenCalledTimes(2);
+    for (const [index, mediaUrl] of ["one.png", "reports/two.png"].entries()) {
+      expect(mocks.sendMessageMSTeams).toHaveBeenNthCalledWith(index + 1, {
+        cfg,
+        to: "conversation:abc",
+        text: index === 0 ? "album" : "",
+        mediaUrl,
+        mediaAccess,
+        mediaLocalRoots: ["/unapproved/workspace"],
+        mediaReadFile: undefined,
+      });
+      expect(mocks.sendMessageMSTeams.mock.calls[index]?.[0]?.mediaAccess).toBe(mediaAccess);
+    }
   });
 
   it("lets media payloads use text fallback instead of card rendering", async () => {

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -32,11 +32,10 @@ function resolveMSTeamsEffectiveTextChunkLimit(configuredLimit?: number): number
 
 type MSTeamsSendConfig = Parameters<typeof sendMessageMSTeams>[0]["cfg"];
 type MSTeamsSendResult = { messageId: string; conversationId: string };
-type MSTeamsMediaSendOptions = {
-  mediaUrl?: string;
-  mediaLocalRoots?: readonly string[];
-  mediaReadFile?: (filePath: string) => Promise<Buffer>;
-};
+type MSTeamsMediaSendOptions = Pick<
+  Parameters<typeof sendMessageMSTeams>[0],
+  "mediaUrl" | "mediaAccess" | "mediaLocalRoots" | "mediaReadFile"
+>;
 type MSTeamsTextSendFn = (to: string, text: string) => Promise<MSTeamsSendResult>;
 type MSTeamsMediaSendFn = (
   to: string,
@@ -76,15 +75,7 @@ function resolveMSTeamsMediaSend(params: {
 }): MSTeamsMediaSendFn {
   return (
     resolveOutboundSendDep<MSTeamsMediaSendFn>(params.deps, "msteams") ??
-    ((to, text, opts) =>
-      sendMessageMSTeams({
-        cfg: params.cfg,
-        to,
-        text,
-        mediaUrl: opts?.mediaUrl,
-        mediaLocalRoots: opts?.mediaLocalRoots,
-        mediaReadFile: opts?.mediaReadFile,
-      }))
+    ((to, text, opts) => sendMessageMSTeams({ cfg: params.cfg, to, text, ...opts }))
   );
 }
 
@@ -130,6 +121,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
     to,
     text,
     mediaUrl,
+    mediaAccess,
     mediaLocalRoots,
     mediaReadFile,
     payload,
@@ -169,6 +161,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
         send: async ({ text: textLocal, mediaUrl: mediaUrlLocal }) =>
           await send(deliveryTarget, textLocal, {
             mediaUrl: mediaUrlLocal,
+            mediaAccess,
             mediaLocalRoots,
             mediaReadFile,
           }),
@@ -206,6 +199,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
       to,
       text,
       mediaUrl,
+      mediaAccess,
       mediaLocalRoots,
       mediaReadFile,
       deps,
@@ -214,6 +208,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
       const send = resolveMSTeamsMediaSend({ cfg, deps });
       return await send(resolveMSTeamsThreadTarget(to, threadId), text, {
         mediaUrl,
+        mediaAccess,
         mediaLocalRoots,
         mediaReadFile,
       });

--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -1,4 +1,7 @@
 // Msteams tests cover send plugin behavior.
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { deleteMessageMSTeams, editMessageMSTeams, sendMessageMSTeams } from "./send.js";
@@ -213,6 +216,14 @@ function firstObjectArg(mock: MockWithCalls): Record<string, unknown> {
   }
   return value as Record<string, unknown>;
 }
+
+async function useActualOutboundMediaLoader() {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/outbound-media")>(
+    "openclaw/plugin-sdk/outbound-media",
+  );
+  mockState.loadOutboundMediaFromUrl.mockImplementation(actual.loadOutboundMediaFromUrl);
+}
+
 describe("sendMessageMSTeams", () => {
   beforeEach(() => {
     mockState.loadOutboundMediaFromUrl.mockReset();
@@ -299,6 +310,98 @@ describe("sendMessageMSTeams", () => {
     expect(result.receipt?.parts[1]?.platformMessageId).toBe("message-media");
     expect(result.receipt?.parts[0]?.kind).toBe("text");
     expect(result.receipt?.parts[1]?.kind).toBe("media");
+  });
+
+  it.each([
+    { name: "trusted host reader", hostReader: true },
+    { name: "reader-free gateway authority", hostReader: false },
+  ])("loads workspace-relative media through $name", async ({ hostReader }) => {
+    const workspaceDir = await realpath(
+      await mkdtemp(join(tmpdir(), "openclaw-msteams-workspace-")),
+    );
+    const filePath = join(workspaceDir, "report.txt");
+    const fileContents = Buffer.from("approved Teams attachment");
+    const approvedReader = vi.fn(async (candidate: string) => await readFile(candidate));
+    const conflictingReader = vi.fn(async () => Buffer.from("forged Teams attachment"));
+    const mediaAccess = {
+      localRoots: [workspaceDir],
+      workspaceDir,
+      ...(hostReader ? { readFile: approvedReader } : {}),
+    };
+
+    try {
+      await writeFile(filePath, fileContents);
+      await useActualOutboundMediaLoader();
+
+      await sendMessageMSTeams({
+        cfg: {} as OpenClawConfig,
+        to: "conversation:19:conversation@thread.tacv2",
+        text: "approved attachment",
+        mediaUrl: "report.txt",
+        mediaAccess,
+        mediaLocalRoots: [join(workspaceDir, "unapproved")],
+        ...(hostReader ? { mediaReadFile: conflictingReader } : {}),
+      });
+
+      expect(mockState.loadOutboundMediaFromUrl.mock.calls[0]?.[1]?.mediaAccess).toBe(mediaAccess);
+      expect(conflictingReader).not.toHaveBeenCalled();
+      if (hostReader) {
+        expect(approvedReader).toHaveBeenCalledWith(filePath);
+      } else {
+        expect(approvedReader).not.toHaveBeenCalled();
+      }
+      const messages = firstObjectArg(mockState.sendMSTeamsMessages).messages as Array<{
+        mediaUrl?: string;
+      }>;
+      expect(messages[1]?.mediaUrl).toBe(
+        `data:text/plain;base64,${fileContents.toString("base64")}`,
+      );
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects workspace-relative attachments outside host-approved roots", async () => {
+    const sandbox = await realpath(await mkdtemp(join(tmpdir(), "openclaw-msteams-roots-")));
+    const workspaceDir = join(sandbox, "workspace");
+    const approvedReader = vi.fn(async (candidate: string) => await readFile(candidate));
+
+    try {
+      await mkdir(workspaceDir);
+      await writeFile(join(sandbox, "outside.txt"), "outside approved workspace");
+      await useActualOutboundMediaLoader();
+
+      await expect(
+        sendMessageMSTeams({
+          cfg: {} as OpenClawConfig,
+          to: "conversation:19:conversation@thread.tacv2",
+          text: "outside attachment",
+          mediaUrl: "../outside.txt",
+          mediaAccess: { localRoots: [workspaceDir], workspaceDir, readFile: approvedReader },
+        }),
+      ).rejects.toThrow("Local media path is not under an allowed directory");
+      expect(approvedReader).not.toHaveBeenCalled();
+      expect(mockState.sendMSTeamsMessages).not.toHaveBeenCalled();
+    } finally {
+      await rm(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a host media reader that has no approved local roots", async () => {
+    const approvedReader = vi.fn(async () => Buffer.from("private attachment"));
+    await useActualOutboundMediaLoader();
+
+    await expect(
+      sendMessageMSTeams({
+        cfg: {} as OpenClawConfig,
+        to: "conversation:19:conversation@thread.tacv2",
+        text: "private attachment",
+        mediaUrl: "report.txt",
+        mediaAccess: { workspaceDir: "/approved/workspace", readFile: approvedReader },
+      }),
+    ).rejects.toThrow("Host media read requires explicit localRoots");
+    expect(approvedReader).not.toHaveBeenCalled();
+    expect(mockState.sendMSTeamsMessages).not.toHaveBeenCalled();
   });
 
   it("sends with provided cfg even when Teams runtime text helpers are unavailable", async () => {

--- a/extensions/msteams/src/send.threaded-attachments.test.ts
+++ b/extensions/msteams/src/send.threaded-attachments.test.ts
@@ -1,6 +1,9 @@
 import { once } from "node:events";
+import { mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Client as TeamsApiClient } from "@microsoft/teams.api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
@@ -341,6 +344,78 @@ describe("Microsoft Teams SharePoint attachment thread routing", () => {
       });
     },
   );
+
+  it("delivers a workspace-relative attachment through the real Teams SDK and Bot Framework", async () => {
+    const workspaceDir = await realpath(
+      await mkdtemp(join(tmpdir(), "openclaw-msteams-sdk-media-")),
+    );
+    const filePath = join(workspaceDir, "report.pdf");
+    const fileContents = Buffer.from("%PDF-1.4\n1 0 obj\n<<>>\nendobj\n%%EOF\n");
+    const approvedReader = vi.fn(async (candidate: string) => await readFile(candidate));
+    const conflictingReader = vi.fn(async () => Buffer.from("forged Teams attachment"));
+    const mediaAccess = { localRoots: [workspaceDir], workspaceDir, readFile: approvedReader };
+
+    try {
+      await writeFile(filePath, fileContents);
+      const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/outbound-media")>(
+        "openclaw/plugin-sdk/outbound-media",
+      );
+      mockState.loadOutboundMediaFromUrl.mockImplementation(actual.loadOutboundMediaFromUrl);
+
+      await withRealTeamsSdkHttp(async ({ api, requests }) => {
+        mockState.resolveMSTeamsSendContext.mockResolvedValue({
+          app: { api },
+          appId: "app-id",
+          conversationId,
+          ref: {
+            serviceUrl,
+            agent: { id: "28:bot", name: "OpenClaw", role: "bot" },
+            user: { id: "29:user" },
+            conversation: { id: conversationId, conversationType: "channel" },
+            threadId: "workspace-thread-root",
+          },
+          conversationType: "channel",
+          replyStyle: "thread",
+          threadActivityId: "workspace-thread-root",
+          sdkCloudOptions: { cloud: "Public" },
+          tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+          sharePointSiteId: "sharepoint-site-1",
+          log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        });
+
+        await sendMessageMSTeams({
+          cfg: {} as OpenClawConfig,
+          to: conversationId,
+          text: "Workspace report",
+          mediaUrl: "report.pdf",
+          mediaAccess,
+          mediaLocalRoots: [join(workspaceDir, "unapproved")],
+          mediaReadFile: conflictingReader,
+        });
+
+        expect(approvedReader).toHaveBeenCalledWith(filePath);
+        expect(conflictingReader).not.toHaveBeenCalled();
+        expect(mockState.loadOutboundMediaFromUrl.mock.calls[0]?.[1]?.mediaAccess).toBe(
+          mediaAccess,
+        );
+        expect(mockState.uploadAndShareSharePoint).toHaveBeenCalledWith(
+          expect.objectContaining({ buffer: fileContents, filename: "report.pdf" }),
+        );
+        expect(requests).toHaveLength(1);
+        expect(requests[0]).toMatchObject({
+          path: `${new URL(serviceUrl).pathname}/v3/conversations/${conversationId};messageid=workspace-thread-root/activities`,
+          body: {
+            text: "Workspace report",
+            attachments: [
+              { contentType: "application/vnd.microsoft.teams.card.file.info", name: "report.pdf" },
+            ],
+          },
+        });
+      });
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
 
   it("keeps personal image delivery on the existing non-SharePoint path", async () => {
     await withRealTeamsSdkHttp(async ({ api, requests }) => {

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -6,6 +6,7 @@ import {
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
+import type { OutboundMediaLoadOptions } from "openclaw/plugin-sdk/outbound-media";
 import { loadOutboundMediaFromUrl, type OpenClawConfig } from "../runtime-api.js";
 import {
   classifyMSTeamsSendError,
@@ -43,6 +44,7 @@ type SendMSTeamsMessageParams = {
   mediaUrl?: string;
   /** Optional filename override for uploaded media/files */
   filename?: string;
+  mediaAccess?: OutboundMediaLoadOptions["mediaAccess"];
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
 };
@@ -175,7 +177,7 @@ type SendMSTeamsCardResult = {
 export async function sendMessageMSTeams(
   params: SendMSTeamsMessageParams,
 ): Promise<SendMSTeamsMessageResult> {
-  const { cfg, to, text, mediaUrl, filename, mediaLocalRoots, mediaReadFile } = params;
+  const { cfg, to, text, mediaUrl, filename, mediaAccess, mediaLocalRoots, mediaReadFile } = params;
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "msteams",
@@ -196,6 +198,7 @@ export async function sendMessageMSTeams(
     const mediaMaxBytes = ctx.mediaMaxBytes ?? MSTEAMS_MAX_MEDIA_BYTES;
     const media = await loadOutboundMediaFromUrl(mediaUrl, {
       maxBytes: mediaMaxBytes,
+      mediaAccess,
       mediaLocalRoots,
       mediaReadFile,
     });


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where Microsoft Teams operators sending agent-created workspace files, attachment sequences, or upload-file actions would see missing or denied attachments despite approving the agent workspace.

## Why This Change Was Made
Preserve the original host-owned media capability through Teams action, message, outbound, and upload owner boundaries while removing duplicated option projection. The existing canonical media loader enforces approved roots, trusted readers, and reader-free Gateway policy.

## User Impact
Workspace-relative Teams attachments and upload actions now reach their recipients without widening filesystem permissions or accepting model-forged capabilities.

## Evidence
- 122 passing tests across five Teams action, message-adapter, outbound, send, and threaded-attachment suites.
- Actual official Microsoft Teams SDK posts a real disk-loaded workspace PDF to an existing local Bot Framework HTTP receiver; the observed Teams activity includes the expected attachment.
- Regressions reject forged capabilities, path traversal, rootless host readers, and broader conflicting legacy roots while preserving deliberately reader-free access.
- Full exact eight-path remote changed gate passed extension production/test typechecks, lint, formatting, plugin and SDK boundary, dependency, storage, media, and cycle guards.
- Independent security review and fresh dirty plus complete committed-branch Sol/high autoreviews found zero issues; production code decreases by one line.
- Remote proof and independently verified Testbox cleanup: https://github.com/openclaw/openclaw/actions/runs/30730418486
- No public external Teams tenant or live account is claimed.