### PR TITLE
fix(feishu): approved workspace attachments fail across delivery paths

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -675,6 +675,17 @@ describe("feishuPlugin actions", () => {
       messageId: "om_fallback",
       chatId: "oc_group_1",
     });
+    const trustedReadFile = vi.fn(async () => Buffer.from("approved image"));
+    const legacyReadFile = vi.fn(async () => Buffer.from("legacy image"));
+    const mediaAccess = {
+      localRoots: ["/approved/workspace"],
+      workspaceDir: "/approved/workspace",
+      readFile: trustedReadFile,
+    };
+    const forgedMediaAccess = {
+      localRoots: ["/forged/workspace"],
+      workspaceDir: "/forged/workspace",
+    };
     const presentation = {
       blocks: [
         {
@@ -699,7 +710,10 @@ describe("feishuPlugin actions", () => {
         to: "chat:oc_group_1",
         message: `[Nexus] ${rawCardText}`,
         presentation,
-        media: "/tmp/pipeline.png",
+        media: "pipeline.png",
+        mediaAccess: forgedMediaAccess,
+        mediaLocalRoots: ["/forged/workspace"],
+        mediaReadFile: vi.fn(),
       },
       cfg: {
         ...cfg,
@@ -710,7 +724,9 @@ describe("feishuPlugin actions", () => {
       },
       accountId: undefined,
       toolContext: {},
-      mediaLocalRoots: ["/tmp"],
+      mediaAccess,
+      mediaLocalRoots: ["/legacy/workspace"],
+      mediaReadFile: legacyReadFile,
     } as never);
 
     expect(sendCardFeishuMock).not.toHaveBeenCalled();
@@ -728,9 +744,13 @@ describe("feishuPlugin actions", () => {
     const table = requireRecord(fallbackBlocks[0], "fallback table");
     const rows = requireArray(table.rows, "fallback rows");
     expect(requireArray(rows.at(-1), "last fallback row")[0]).toContain("account-399-");
-    expect(fallbackPayload.mediaUrl).toBe("/tmp/pipeline.png");
+    expect(fallbackPayload.mediaUrl).toBe("pipeline.png");
     expect(fallbackPayload.text).toBeUndefined();
     expect(fallbackArgs.text).toBe("");
+    expect(fallbackArgs.mediaAccess).toBe(mediaAccess);
+    expect(fallbackArgs.mediaAccess).not.toBe(forgedMediaAccess);
+    expect(fallbackArgs.mediaLocalRoots).toEqual(["/legacy/workspace"]);
+    expect(fallbackArgs.mediaReadFile).toBe(legacyReadFile);
   });
 
   it("prefers structured presentation over raw card JSON text", async () => {
@@ -985,37 +1005,65 @@ describe("feishuPlugin actions", () => {
     ]);
   });
 
-  it("sends media through the outbound adapter", async () => {
-    feishuOutboundSendMediaMock.mockResolvedValueOnce({
-      channel: "feishu",
-      messageId: "om_media",
-      details: { messageId: "om_media", chatId: "oc_group_1" },
-    });
+  it.each(["send", "thread-reply"] as const)(
+    "preserves only trusted workspace media access for %s actions",
+    async (action) => {
+      feishuOutboundSendMediaMock.mockResolvedValueOnce({
+        channel: "feishu",
+        messageId: "om_media",
+        details: { messageId: "om_media", chatId: "oc_group_1" },
+      });
+      const trustedReadFile = vi.fn(async () => Buffer.from("approved image"));
+      const legacyReadFile = vi.fn(async () => Buffer.from("legacy image"));
+      const mediaAccess = {
+        localRoots: ["/approved/workspace"],
+        workspaceDir: "/approved/workspace",
+        readFile: trustedReadFile,
+      };
+      const forgedMediaAccess = {
+        localRoots: ["/forged/workspace"],
+        workspaceDir: "/forged/workspace",
+      };
 
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "send",
-      params: {
+      const result = await feishuPlugin.actions?.handleAction?.({
+        action,
+        params: {
+          to: "chat:oc_group_1",
+          message: "test",
+          media: "image.png",
+          mediaAccess: forgedMediaAccess,
+          mediaLocalRoots: ["/forged/workspace"],
+          mediaReadFile: vi.fn(),
+          ...(action === "thread-reply" ? { messageId: "om_parent" } : {}),
+        },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+        mediaAccess,
+        mediaLocalRoots: ["/legacy/workspace"],
+        mediaReadFile: legacyReadFile,
+      } as never);
+
+      expect(feishuOutboundSendMediaMock).toHaveBeenCalledWith({
+        cfg,
         to: "chat:oc_group_1",
-        message: "test",
-        media: "/tmp/image.png",
-      },
-      cfg,
-      accountId: undefined,
-      toolContext: {},
-      mediaLocalRoots: ["/tmp"],
-    } as never);
-
-    expect(feishuOutboundSendMediaMock).toHaveBeenCalledWith({
-      cfg,
-      to: "chat:oc_group_1",
-      text: "test",
-      mediaUrl: "/tmp/image.png",
-      accountId: undefined,
-      mediaLocalRoots: ["/tmp"],
-      replyToId: undefined,
-    });
-    expect(resultDetails(result).messageId).toBe("om_media");
-  });
+        text: "test",
+        mediaUrl: "image.png",
+        accountId: undefined,
+        mediaAccess,
+        mediaLocalRoots: ["/legacy/workspace"],
+        mediaReadFile: legacyReadFile,
+        ...(action === "thread-reply" ? { threadId: "om_parent" } : { replyToId: undefined }),
+      });
+      const outboundArgs = requireRecord(
+        mockCallArg(feishuOutboundSendMediaMock, 0, 0, "feishuOutbound.sendMedia"),
+        "outbound args",
+      );
+      expect(outboundArgs.mediaAccess).toBe(mediaAccess);
+      expect(outboundArgs.mediaAccess).not.toBe(forgedMediaAccess);
+      expect(resultDetails(result).messageId).toBe("om_media");
+    },
+  );
 
   it("passes asVoice through media sends", async () => {
     feishuOutboundSendMediaMock.mockResolvedValueOnce({

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1095,7 +1095,9 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                   ...(audioAsVoice === undefined ? {} : { audioAsVoice }),
                 },
                 accountId: ctx.accountId ?? undefined,
+                ...(ctx.mediaAccess ? { mediaAccess: ctx.mediaAccess } : {}),
                 mediaLocalRoots: ctx.mediaLocalRoots,
+                ...(ctx.mediaReadFile ? { mediaReadFile: ctx.mediaReadFile } : {}),
                 ...(replyInThread
                   ? { threadId: replyToMessageId }
                   : { replyToId: replyToMessageId }),
@@ -1122,7 +1124,9 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 text: text ?? "",
                 mediaUrl,
                 accountId: ctx.accountId ?? undefined,
+                ...(ctx.mediaAccess ? { mediaAccess: ctx.mediaAccess } : {}),
                 mediaLocalRoots: ctx.mediaLocalRoots,
+                ...(ctx.mediaReadFile ? { mediaReadFile: ctx.mediaReadFile } : {}),
                 ...(replyInThread
                   ? { threadId: replyToMessageId }
                   : { replyToId: replyToMessageId }),

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -27,9 +27,7 @@ const validPngImage = Buffer.from(
   "hex",
 );
 
-vi.mock("./client.js", () => ({
-  createFeishuClient: createFeishuClientMock,
-}));
+vi.mock("./client.js", () => ({ createFeishuClient: createFeishuClientMock }));
 
 vi.mock("./accounts.js", () => ({
   resolveFeishuAccount: resolveFeishuAccountMock,
@@ -42,11 +40,7 @@ vi.mock("./targets.js", () => ({
 }));
 
 vi.mock("./runtime.js", () => ({
-  getFeishuRuntime: () => ({
-    media: {
-      loadWebMedia: loadWebMediaMock,
-    },
-  }),
+  getFeishuRuntime: () => ({ media: { loadWebMedia: loadWebMediaMock } }),
 }));
 
 vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => {
@@ -143,40 +137,17 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     createFeishuClientMock.mockReturnValue({
       im: {
-        file: {
-          create: fileCreateMock,
-        },
-        image: {
-          create: imageCreateMock,
-        },
-        message: {
-          create: messageCreateMock,
-          reply: messageReplyMock,
-        },
-        messageResource: {
-          get: messageResourceGetMock,
-        },
+        file: { create: fileCreateMock },
+        image: { create: imageCreateMock },
+        message: { create: messageCreateMock, reply: messageReplyMock },
+        messageResource: { get: messageResourceGetMock },
       },
     });
 
-    fileCreateMock.mockResolvedValue({
-      code: 0,
-      data: { file_key: "file_key_1" },
-    });
-    imageCreateMock.mockResolvedValue({
-      code: 0,
-      data: { image_key: "image_key_1" },
-    });
-
-    messageCreateMock.mockResolvedValue({
-      code: 0,
-      data: { message_id: "msg_1" },
-    });
-
-    messageReplyMock.mockResolvedValue({
-      code: 0,
-      data: { message_id: "reply_1" },
-    });
+    fileCreateMock.mockResolvedValue({ code: 0, data: { file_key: "file_key_1" } });
+    imageCreateMock.mockResolvedValue({ code: 0, data: { image_key: "image_key_1" } });
+    messageCreateMock.mockResolvedValue({ code: 0, data: { message_id: "msg_1" } });
+    messageReplyMock.mockResolvedValue({ code: 0, data: { message_id: "reply_1" } });
 
     loadWebMediaMock.mockResolvedValue({
       buffer: Buffer.from("remote-audio"),
@@ -650,14 +621,56 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     expect(mockCallArg(loadWebMediaMock, 0, 0)).toBe("/allowed/workspace/file.pdf");
-    const options = mockCallArg<{
-      localRoots?: string[];
-      maxBytes?: number;
-      optimizeImages?: boolean;
-    }>(loadWebMediaMock, 0, 1);
-    expect(typeof options.maxBytes).toBe("number");
-    expect(options.optimizeImages).toBe(false);
+    const options = mockCallArg<{ localRoots: readonly string[] }>(loadWebMediaMock, 0, 1);
+    expect(options).toEqual({
+      maxBytes: expect.any(Number),
+      optimizeImages: false,
+      localRoots: roots,
+    });
     expect(options.localRoots).toBe(roots);
+  });
+
+  it("keeps approved workspace access authoritative over legacy access", async () => {
+    const readFile = vi.fn(async () => Buffer.from("approved image"));
+    const legacyReadFile = vi.fn(async () => Buffer.from("legacy image"));
+    const localRoots = ["/approved/workspace"];
+    const mediaAccess = { localRoots, workspaceDir: "/approved/workspace", readFile };
+    await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaUrl: "chart.png",
+      mediaAccess,
+      mediaLocalRoots: ["/legacy/workspace"],
+      mediaReadFile: legacyReadFile,
+    });
+    expect(mockCallArg(loadWebMediaMock, 0, 0)).toBe("chart.png");
+    const options = mockCallArg<{ localRoots: readonly string[] }>(loadWebMediaMock, 0, 1);
+    expect(options).toEqual({
+      maxBytes: expect.any(Number),
+      localRoots,
+      readFile,
+      hostReadCapability: true,
+      optimizeImages: false,
+      workspaceDir: "/approved/workspace",
+    });
+    expect(options.localRoots).toBe(localRoots);
+  });
+
+  it("rejects host readers without approved roots before any media dispatch", async () => {
+    const readFile = vi.fn(async () => Buffer.from("unapproved image"));
+    await expect(
+      sendMediaFeishu({
+        cfg: emptyConfig,
+        to: "user:ou_target",
+        mediaUrl: "chart.png",
+        mediaAccess: { readFile, workspaceDir: "/unapproved/workspace" },
+      }),
+    ).rejects.toThrow("Host media read requires explicit localRoots");
+    expect(loadWebMediaMock).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(fileCreateMock).not.toHaveBeenCalled();
+    expect(imageCreateMock).not.toHaveBeenCalled();
+    expect(messageCreateMock).not.toHaveBeenCalled();
   });
 
   it("fails closed when media URL fetch is blocked", async () => {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -7,9 +7,11 @@ import type { MessageReceipt } from "openclaw/plugin-sdk/channel-outbound";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { detectMime, mediaKindFromMime } from "openclaw/plugin-sdk/media-mime";
 import {
+  buildOutboundMediaLoadOptions,
   MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS,
   runFfmpeg,
   runFfprobe,
+  type OutboundMediaAccess,
 } from "openclaw/plugin-sdk/media-runtime";
 import { saveMediaBuffer, type SavedMedia } from "openclaw/plugin-sdk/media-store";
 import type { ReplyPayloadTtsSupplement } from "openclaw/plugin-sdk/reply-payload";
@@ -949,8 +951,7 @@ async function maybeProbeUploadDurationMs(params: {
 
 /**
  * Upload and send media (image or file) from URL, local path, or buffer.
- * When mediaUrl is a local path, mediaLocalRoots (from core outbound context)
- * must be passed so loadWebMedia allows the path (post CVE-2026-26321).
+ * Local paths require host-owned mediaAccess or approved legacy roots/readers.
  */
 export async function sendMediaFeishu(params: {
   cfg: ClawdbotConfig;
@@ -962,8 +963,10 @@ export async function sendMediaFeishu(params: {
   replyInThread?: boolean;
   allowTopLevelReplyFallback?: boolean;
   accountId?: string;
+  mediaAccess?: OutboundMediaAccess;
   /** Allowed roots for local path reads; required for local filePath to work. */
   mediaLocalRoots?: readonly string[];
+  mediaReadFile?: OutboundMediaAccess["readFile"];
   /** When true, transcode compatible audio to Feishu native Ogg/Opus voice bubbles. */
   audioAsVoice?: boolean;
 }): Promise<SendMediaResult> {
@@ -1001,11 +1004,16 @@ export async function sendMediaFeishu(params: {
       return { buffer: mediaBuffer, name: fileName ?? "file", contentType: undefined };
     }
     if (mediaUrl) {
-      const media = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
-        maxBytes: mediaMaxBytes,
-        optimizeImages: false,
-        localRoots: mediaLocalRoots?.length ? mediaLocalRoots : undefined,
-      });
+      const media = await getFeishuRuntime().media.loadWebMedia(
+        mediaUrl,
+        buildOutboundMediaLoadOptions({
+          maxBytes: mediaMaxBytes,
+          mediaAccess: params.mediaAccess,
+          mediaLocalRoots,
+          mediaReadFile: params.mediaReadFile,
+          optimizeImages: false,
+        }),
+      );
       return {
         buffer: media.buffer,
         name: fileName ?? media.fileName ?? "file",

--- a/extensions/feishu/src/outbound-delivery.test.ts
+++ b/extensions/feishu/src/outbound-delivery.test.ts
@@ -60,14 +60,21 @@ describe("Feishu outbound shared delivery", () => {
   });
 
   it("routes oversized presentation media through one media send and chunked fallback text", async () => {
+    const readFile = vi.fn(async () => Buffer.from("approved image"));
+    const mediaAccess = {
+      localRoots: ["/approved/workspace"],
+      workspaceDir: "/approved/workspace",
+      readFile,
+    };
     await sendDurableMessageBatch({
       cfg: {},
       channel: "feishu",
       to: "chat_1",
       skipQueue: true,
+      mediaAccess,
       payloads: [
         {
-          mediaUrl: "https://example.com/pipeline.png",
+          mediaUrl: "pipeline.png",
           presentation: {
             blocks: [
               {
@@ -94,8 +101,19 @@ describe("Feishu outbound shared delivery", () => {
     expect(sendCardFeishuMock).not.toHaveBeenCalled();
     expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
     expect(sendMediaFeishuMock).toHaveBeenCalledWith(
-      expect.objectContaining({ mediaUrl: "https://example.com/pipeline.png", to: "chat_1" }),
+      expect.objectContaining({
+        mediaUrl: "pipeline.png",
+        mediaAccess,
+        mediaLocalRoots: mediaAccess.localRoots,
+        mediaReadFile: readFile,
+        to: "chat_1",
+      }),
     );
+    const sentMedia = sendMediaFeishuMock.mock.calls[0]?.[0] as {
+      mediaAccess?: { localRoots?: readonly string[]; readFile?: typeof readFile };
+    };
+    expect(sentMedia.mediaAccess?.localRoots).toBe(mediaAccess.localRoots);
+    expect(sentMedia.mediaAccess?.readFile).toBe(readFile);
     expect(textChunks.length).toBeGreaterThan(1);
     expect(textChunks.every((chunk) => Array.from(chunk).length <= 4000)).toBe(true);
     expect(deliveredText).toContain("account-0-");

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -328,16 +328,28 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
         },
         media: async () => {
           const onDeliveryResult = vi.fn();
+          const mediaReadFile = vi.fn(async () => Buffer.from("approved image"));
+          const mediaAccess = {
+            localRoots: ["/approved/workspace"],
+            workspaceDir: "/approved/workspace",
+            readFile: mediaReadFile,
+          };
           const result = await adapterSendMedia({
             cfg: emptyConfig,
             to: "chat:chat-1",
             text: "",
-            mediaUrl: "https://example.com/image.png",
+            mediaUrl: "image.png",
+            mediaAccess,
+            mediaLocalRoots: mediaAccess.localRoots,
+            mediaReadFile,
             accountId: "default",
             onDeliveryResult,
           });
           expect(sendMediaCall()?.to).toBe("chat:chat-1");
-          expect(sendMediaCall()?.mediaUrl).toBe("https://example.com/image.png");
+          expect(sendMediaCall()?.mediaUrl).toBe("image.png");
+          expect(sendMediaCall()?.mediaAccess).toBe(mediaAccess);
+          expect(sendMediaCall()?.mediaLocalRoots).toBe(mediaAccess.localRoots);
+          expect(sendMediaCall()?.mediaReadFile).toBe(mediaReadFile);
           expect(sendMediaCall()?.accountId).toBe("default");
           expect(result.receipt.platformMessageIds).toEqual(["feishu-media-1"]);
           expect(onDeliveryResult.mock.calls[0]?.[0]?.receipt.platformMessageIds).toEqual([
@@ -384,9 +396,15 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
   }
 
   it("sends missing TTS text before its voice supplement", async () => {
+    const mediaReadFile = vi.fn(async () => Buffer.from("approved audio"));
+    const mediaAccess = {
+      localRoots: ["/approved/workspace"],
+      workspaceDir: "/approved/workspace",
+      readFile: mediaReadFile,
+    };
     const payload = {
       text: "Readable answer",
-      mediaUrl: "https://example.com/reply.ogg",
+      mediaUrl: "reply.ogg",
       audioAsVoice: true,
       ttsSupplement: { spokenText: "Readable answer" },
     };
@@ -396,11 +414,16 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
       to: "chat_1",
       text: payload.text,
       accountId: "main",
+      mediaAccess,
+      mediaLocalRoots: mediaAccess.localRoots,
+      mediaReadFile,
       payload,
     });
 
     expect(sendMessageCall()?.text).toBe("Readable answer");
-    expect(sendMediaCall()?.mediaUrl).toBe("https://example.com/reply.ogg");
+    expect(sendMediaCall()?.mediaUrl).toBe("reply.ogg");
+    expect(sendMediaCall()?.mediaAccess).toBe(mediaAccess);
+    expect(sendMediaCall()?.mediaReadFile).toBe(mediaReadFile);
     expect(sendMediaCall()?.audioAsVoice).toBe(true);
     expect(sendMessageFeishuMock.mock.invocationCallOrder[0]).toBeLessThan(
       sendMediaFeishuMock.mock.invocationCallOrder[0] ?? 0,
@@ -463,19 +486,25 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     "sends an existing absolute %s image path as media instead of leaking it",
     async (extension) => {
       const { dir, file } = await createTmpImage(extension);
+      const mediaReadFile = vi.fn(async () => Buffer.from("approved image"));
+      const mediaAccess = { localRoots: [dir], workspaceDir: dir, readFile: mediaReadFile };
       try {
         const result = await sendText({
           cfg: emptyConfig,
           to: "chat_1",
           text: file,
           accountId: "main",
+          mediaAccess,
           mediaLocalRoots: [dir],
+          mediaReadFile,
         });
 
         expect(sendMediaCall()?.to).toBe("chat_1");
         expect(sendMediaCall()?.mediaUrl).toBe(file);
         expect(sendMediaCall()?.accountId).toBe("main");
+        expect(sendMediaCall()?.mediaAccess).toBe(mediaAccess);
         expect(sendMediaCall()?.mediaLocalRoots).toEqual([dir]);
+        expect(sendMediaCall()?.mediaReadFile).toBe(mediaReadFile);
         expect(sendMessageFeishuMock).not.toHaveBeenCalled();
         expectFeishuResult(result, "media_msg");
       } finally {
@@ -913,16 +942,22 @@ describe("feishuOutbound.sendPayload native cards", () => {
   });
 
   it("sends media once before chunking an oversized table fallback", async () => {
+    const mediaReadFile = vi.fn(async () => Buffer.from("approved image"));
+    const mediaAccess = {
+      localRoots: ["/approved/workspace"],
+      workspaceDir: "/approved/workspace",
+      readFile: mediaReadFile,
+    };
     const presentation = createOversizedTablePresentation();
     const rendered = await feishuOutbound.renderPresentation?.({
-      payload: { presentation, mediaUrl: "/tmp/pipeline.png" },
+      payload: { presentation, mediaUrl: "pipeline.png" },
       presentation,
       ctx: {
         cfg: emptyConfig,
         to: "chat_1",
         text: "",
         accountId: "main",
-        payload: { presentation, mediaUrl: "/tmp/pipeline.png" },
+        payload: { presentation, mediaUrl: "pipeline.png" },
       },
     });
     if (!rendered) {
@@ -935,7 +970,9 @@ describe("feishuOutbound.sendPayload native cards", () => {
       to: "chat_1",
       text: coreRenderedPayload.text ?? "",
       accountId: "main",
-      mediaLocalRoots: ["/tmp"],
+      mediaAccess,
+      mediaLocalRoots: mediaAccess.localRoots,
+      mediaReadFile,
       replyToId: "   ",
       threadId: "om_thread",
       payload: coreRenderedPayload,
@@ -950,10 +987,13 @@ describe("feishuOutbound.sendPayload native cards", () => {
     expect(sendMediaCall()).toEqual(
       expect.objectContaining({
         to: "chat_1",
-        mediaUrl: "/tmp/pipeline.png",
-        mediaLocalRoots: ["/tmp"],
+        mediaUrl: "pipeline.png",
+        mediaAccess,
+        mediaLocalRoots: mediaAccess.localRoots,
+        mediaReadFile,
       }),
     );
+    expect(sendMediaCall()?.mediaAccess).toBe(mediaAccess);
     expect(sendMediaCall()?.text).toBeUndefined();
     expect(sendMediaCall()?.replyToMessageId).toBe("om_thread");
     expect(sendMediaCall()?.replyInThread).toBe(true);
@@ -1768,25 +1808,39 @@ describe("feishuOutbound.sendPayload native cards", () => {
   });
 
   it("sends payload media before final native cards", async () => {
+    const mediaReadFile = vi.fn(async () => Buffer.from("approved image"));
+    const mediaAccess = {
+      localRoots: ["/approved/workspace"],
+      workspaceDir: "/approved/workspace",
+      readFile: mediaReadFile,
+    };
+    const mediaUrls = ["image.png", "summary.png"];
     const result = await feishuOutbound.sendPayload?.({
       cfg: emptyConfig,
       to: "chat_1",
       text: "See attached",
       accountId: "main",
-      mediaLocalRoots: ["/tmp"],
+      mediaAccess,
+      mediaLocalRoots: ["/legacy/workspace"],
+      mediaReadFile,
       payload: {
         text: "See attached",
-        mediaUrl: "/tmp/image.png",
+        mediaUrls,
         interactive: {
           blocks: [{ type: "buttons", buttons: [{ label: "Open", url: "https://example.com" }] }],
         },
       },
     });
 
-    expect(sendMediaCall()?.to).toBe("chat_1");
-    expect(sendMediaCall()?.mediaUrl).toBe("/tmp/image.png");
-    expect(sendMediaCall()?.mediaLocalRoots).toEqual(["/tmp"]);
-    expect(sendMediaCall()?.accountId).toBe("main");
+    expect(sendMediaFeishuMock).toHaveBeenCalledTimes(mediaUrls.length);
+    for (const [index, mediaUrl] of mediaUrls.entries()) {
+      expect(sendMediaCall(index)?.to).toBe("chat_1");
+      expect(sendMediaCall(index)?.mediaUrl).toBe(mediaUrl);
+      expect(sendMediaCall(index)?.mediaAccess).toBe(mediaAccess);
+      expect(sendMediaCall(index)?.mediaLocalRoots).toEqual(["/legacy/workspace"]);
+      expect(sendMediaCall(index)?.mediaReadFile).toBe(mediaReadFile);
+      expect(sendMediaCall(index)?.accountId).toBe("main");
+    }
     expect(sendCardCall()?.to).toBe("chat_1");
     expect(sendCardCall()?.accountId).toBe("main");
     expectFeishuResult(result, "native_card_msg");
@@ -1889,20 +1943,26 @@ describe("feishuOutbound.sendPayload native cards", () => {
 
   it("keeps text/media fallback behavior for non-card payloads, including local image text", async () => {
     const { dir, file } = await createTmpImage();
+    const mediaReadFile = vi.fn(async () => Buffer.from("approved image"));
+    const mediaAccess = { localRoots: [dir], workspaceDir: dir, readFile: mediaReadFile };
     try {
       const result = await feishuOutbound.sendPayload?.({
         cfg: emptyConfig,
         to: "chat_1",
         text: file,
         accountId: "main",
+        mediaAccess,
         mediaLocalRoots: [dir],
+        mediaReadFile,
         payload: { text: file },
       });
 
       expect(sendCardFeishuMock).not.toHaveBeenCalled();
       expect(sendMediaCall()?.to).toBe("chat_1");
       expect(sendMediaCall()?.mediaUrl).toBe(file);
+      expect(sendMediaCall()?.mediaAccess).toBe(mediaAccess);
       expect(sendMediaCall()?.mediaLocalRoots).toEqual([dir]);
+      expect(sendMediaCall()?.mediaReadFile).toBe(mediaReadFile);
       expect(sendMediaCall()?.accountId).toBe("main");
       expect(sendMessageFeishuMock).not.toHaveBeenCalled();
       expectFeishuResult(result, "media_msg");
@@ -2551,15 +2611,28 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
   });
 
   it("forwards replyToId to sendMediaFeishu", async () => {
+    const mediaReadFile = vi.fn(async () => Buffer.from("approved image"));
+    const mediaAccess = {
+      localRoots: ["/approved/workspace"],
+      workspaceDir: "/approved/workspace",
+      readFile: mediaReadFile,
+    };
     await feishuOutbound.sendMedia?.({
       cfg: emptyConfig,
       to: "chat_1",
       text: "",
-      mediaUrl: "https://example.com/image.png",
+      mediaUrl: "image.png",
+      mediaAccess,
+      mediaLocalRoots: mediaAccess.localRoots,
+      mediaReadFile,
       replyToId: "om_reply_target",
       accountId: "main",
     });
 
+    expect(sendMediaCall()?.mediaUrl).toBe("image.png");
+    expect(sendMediaCall()?.mediaAccess).toBe(mediaAccess);
+    expect(sendMediaCall()?.mediaLocalRoots).toBe(mediaAccess.localRoots);
+    expect(sendMediaCall()?.mediaReadFile).toBe(mediaReadFile);
     expect(sendMediaCall()?.replyToMessageId).toBe("om_reply_target");
     expect(sendMediaCall()?.replyInThread).toBe(false);
   });

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -749,7 +749,9 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             to: ctx.to,
             mediaUrl,
             accountId: ctx.accountId ?? undefined,
+            mediaAccess: ctx.mediaAccess,
             mediaLocalRoots: ctx.mediaLocalRoots,
+            mediaReadFile: ctx.mediaReadFile,
             replyToMessageId,
             replyInThread,
             ...(payload.audioAsVoice === true || ctx.audioAsVoice === true
@@ -782,7 +784,9 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       replyToIdSource,
       replyToMode,
       threadId,
+      mediaAccess,
       mediaLocalRoots,
+      mediaReadFile,
       identity,
       onDeliveryResult,
     }) => {
@@ -805,7 +809,9 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             accountId: accountId ?? undefined,
             replyToMessageId,
             replyInThread,
+            mediaAccess,
             mediaLocalRoots,
+            mediaReadFile,
           });
         } catch (err) {
           if (isChannelPartialDeliveryError(err)) {
@@ -894,7 +900,9 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       audioAsVoice,
       accountId,
+      mediaAccess,
       mediaLocalRoots,
+      mediaReadFile,
       replyToId,
       replyToIdSource,
       replyToMode,
@@ -974,7 +982,9 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           mediaUrl,
           accountId: accountId ?? undefined,
+          mediaAccess,
           mediaLocalRoots,
+          mediaReadFile,
           ...mediaReplyMode,
           ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
         });


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where Feishu operators sending agent-created workspace files through direct messages, thread replies, cards, fallback delivery, or attachment sequences would see media upload failures despite approving the workspace.

## Why This Change Was Made
Preserve the existing host-owned media capability and approved reader through both Feishu action paths, all outbound delivery branches, and the actual media owner. Normalize access with the existing public SDK helper instead of reconstructing roots separately.

## User Impact
Approved workspace-relative Feishu attachments now reach their recipients while forged action parameters, unapproved filesystem roots, unrooted readers, and unsafe remote media remain blocked.

## Evidence
- 320 passing tests across actual durable-core workspace-relative delivery, Feishu action/outbound/media owners, upload contracts, and shared core/SDK media policy.
- Official Lark Node SDK performs actual authenticated multipart image upload and message creation against an existing local HTTP loopback; the durable integration verifies workspace-relative bytes through oversized-card fallback.
- Exact seven-file full remote changed gate passed extension production/test typechecks, lint, formatting, SDK/plugin boundaries, security/storage/media guards, and import-cycle checks.
- Independent security review and fresh full dirty plus committed-branch Sol/high autoreviews found zero issues.
- Production increase is 22 lines across the three owner modules; no core, public SDK, config, or permission surface changed.
- Exact remote proof and independently verified Testbox cleanup: https://github.com/openclaw/openclaw/actions/runs/30730553859
- No public external Feishu tenant or live account is claimed.