### PR TITLE
refactor(auto-reply): share slow-reply timing tracker

### DIFF
--- a/src/auto-reply/reply/agent-runner-turn-timing.ts
+++ b/src/auto-reply/reply/agent-runner-turn-timing.ts
@@ -1,147 +1,47 @@
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { createReplyTimingTracker } from "./reply-timing-tracker.js";
 
-type AgentTurnTimingSpan = {
-  name: string;
-  durationMs: number;
-  elapsedMs: number;
+type AgentTurnLogContext = {
+  runId: string;
+  sessionId?: string;
+  sessionKey?: string;
 };
-
-type AgentTurnTimingSummary = {
-  totalMs: number;
-  spans: AgentTurnTimingSpan[];
+type AgentTurnTerminalLogParams = AgentTurnLogContext & {
+  outcome: "completed" | "error";
+  error?: string;
 };
-
-export type AgentTurnTimingTracker = {
-  measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
-  measureSync: <T>(name: string, run: () => T) => T;
-  logIfSlow: (params: {
-    runId: string;
-    sessionId?: string;
-    sessionKey?: string;
-    outcome: "completed" | "error";
-    error?: string;
-  }) => void;
-  logMilestoneIfSlow: (params: {
-    runId: string;
-    sessionId?: string;
-    sessionKey?: string;
-    milestone: string;
-  }) => void;
-};
+type AgentTurnMilestoneLogParams = AgentTurnLogContext & { milestone: string };
+type AgentTurnLogParams = AgentTurnTerminalLogParams | AgentTurnMilestoneLogParams;
 
 const agentTurnTimingLog = createSubsystemLogger("auto-reply/agent-turn-timing");
-const AGENT_TURN_TIMING_WARN_TOTAL_MS = 1_000;
-const AGENT_TURN_TIMING_WARN_STAGE_MS = 500;
 
-/** Creates a no-overhead pass-through unless reply profiling is enabled. */
-export function createAgentTurnTimingTracker(
-  options: {
-    profilerEnabled?: boolean;
-  } = {},
-): AgentTurnTimingTracker {
-  if (!options.profilerEnabled) {
-    // This tracker wraps the agent-turn hot path. Without an explicit profiler
-    // flag, keep every wrapper pass-through so normal turns avoid Date.now and
-    // span-array work entirely.
-    return {
-      async measure(_name, run) {
-        return await run();
-      },
-      measureSync(_name, run) {
-        return run();
-      },
-      logIfSlow() {},
-      logMilestoneIfSlow() {},
-    };
-  }
-
-  const startedAt = Date.now();
-  let didLog = false;
-  const spans: AgentTurnTimingSpan[] = [];
-  const toMs = (value: number) => Math.max(0, Math.round(value));
-  const record = (name: string, spanStartedAt: number) => {
-    spans.push({
-      name,
-      durationMs: toMs(Date.now() - spanStartedAt),
-      elapsedMs: toMs(Date.now() - startedAt),
-    });
-  };
-  const snapshot = (): AgentTurnTimingSummary => ({
-    totalMs: toMs(Date.now() - startedAt),
-    spans: spans.slice(),
+export function createAgentTurnTimingTracker(options: { profilerEnabled?: boolean } = {}) {
+  const timing = createReplyTimingTracker<AgentTurnLogParams>({
+    log: agentTurnTimingLog,
+    enabled: options.profilerEnabled === true,
+    formatMessage: (params, summary, stages) => {
+      const identity = `runId=${params.runId} sessionId=${params.sessionId ?? "unknown"} sessionKey=${params.sessionKey ?? "unknown"}`;
+      return "milestone" in params
+        ? `agent turn milestone ${identity} milestone=${params.milestone} totalMs=${summary.totalMs} stages=${stages}`
+        : `agent turn timings ${identity} outcome=${params.outcome} totalMs=${summary.totalMs} stages=${stages}${params.error ? ` error="${params.error}"` : ""}`;
+    },
+    detailKeys: (params) =>
+      "milestone" in params
+        ? ["runId", "sessionId", "sessionKey", "milestone"]
+        : ["runId", "sessionId", "sessionKey", "outcome", "error"],
   });
-  const shouldLog = (summary: AgentTurnTimingSummary) =>
-    summary.totalMs >= AGENT_TURN_TIMING_WARN_TOTAL_MS ||
-    summary.spans.some((span) => span.durationMs >= AGENT_TURN_TIMING_WARN_STAGE_MS);
-  const formatSpans = (summary: AgentTurnTimingSummary) =>
-    summary.spans.length > 0
-      ? summary.spans
-          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
-          .join(",")
-      : "none";
   return {
-    async measure(name, run) {
-      const spanStartedAt = Date.now();
-      try {
-        return await run();
-      } finally {
-        record(name, spanStartedAt);
-      }
+    measure: timing.measure,
+    measureSync: timing.measureSync,
+    logIfSlow(params: AgentTurnTerminalLogParams) {
+      const { runId, sessionId, sessionKey, outcome, error } = params;
+      timing.logIfSlow({ runId, sessionId, sessionKey, outcome, error });
     },
-    measureSync(name, run) {
-      const spanStartedAt = Date.now();
-      try {
-        return run();
-      } finally {
-        record(name, spanStartedAt);
-      }
-    },
-    logIfSlow(params) {
-      if (didLog) {
-        return;
-      }
-      const summary = snapshot();
-      if (!shouldLog(summary)) {
-        return;
-      }
-      didLog = true;
-      agentTurnTimingLog.warn(
-        `agent turn timings runId=${params.runId} sessionId=${
-          params.sessionId ?? "unknown"
-        } sessionKey=${params.sessionKey ?? "unknown"} outcome=${params.outcome} totalMs=${
-          summary.totalMs
-        } stages=${formatSpans(summary)}${params.error ? ` error="${params.error}"` : ""}`,
-        {
-          runId: params.runId,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          outcome: params.outcome,
-          error: params.error,
-          totalMs: summary.totalMs,
-          spans: summary.spans,
-        },
-      );
-    },
-    logMilestoneIfSlow(params) {
-      const summary = snapshot();
-      if (!shouldLog(summary)) {
-        return;
-      }
-      agentTurnTimingLog.warn(
-        `agent turn milestone runId=${params.runId} sessionId=${
-          params.sessionId ?? "unknown"
-        } sessionKey=${params.sessionKey ?? "unknown"} milestone=${params.milestone} totalMs=${
-          summary.totalMs
-        } stages=${formatSpans(summary)}`,
-        {
-          runId: params.runId,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          milestone: params.milestone,
-          totalMs: summary.totalMs,
-          spans: summary.spans,
-        },
-      );
+    logMilestoneIfSlow(params: AgentTurnMilestoneLogParams) {
+      const { runId, sessionId, sessionKey, milestone } = params;
+      timing.logIfSlow({ runId, sessionId, sessionKey, milestone }, { repeat: true });
     },
   };
 }
+
+export type AgentTurnTimingTracker = ReturnType<typeof createAgentTurnTimingTracker>;

--- a/src/auto-reply/reply/dispatch-from-config.timing.ts
+++ b/src/auto-reply/reply/dispatch-from-config.timing.ts
@@ -1,97 +1,28 @@
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { createReplyTimingTracker } from "./reply-timing-tracker.js";
 
-type ReplyHotPathTimingSpan = {
-  name: string;
-  durationMs: number;
-  elapsedMs: number;
-};
-
-type ReplyHotPathTimingSummary = {
-  totalMs: number;
-  spans: ReplyHotPathTimingSpan[];
+type ReplyHotPathLogParams = {
+  channel: string;
+  messageId?: number | string;
+  sessionKey?: string;
+  outcome: "completed" | "skipped" | "error";
+  reason?: string;
 };
 
 const replyHotPathTimingLog = createSubsystemLogger("auto-reply/reply-timing");
-const REPLY_HOT_PATH_TIMING_WARN_TOTAL_MS = 1_000;
-const REPLY_HOT_PATH_TIMING_WARN_STAGE_MS = 500;
 
-export function createReplyHotPathTimingTracker(options: { profilerEnabled?: boolean } = {}): {
-  measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
-  logIfSlow: (params: {
-    channel: string;
-    messageId?: number | string;
-    sessionKey?: string;
-    outcome: "completed" | "skipped" | "error";
-    reason?: string;
-  }) => void;
-} {
-  if (!options.profilerEnabled) {
-    // This slow-path splitter was added for latency investigation. Keep it
-    // inert in normal production dispatches so only explicit profiler runs pay
-    // the Date.now/span allocation cost.
-    return {
-      async measure(_name, run) {
-        return await run();
-      },
-      logIfSlow() {},
-    };
-  }
-
-  const startedAt = Date.now();
-  let didLog = false;
-  const spans: ReplyHotPathTimingSpan[] = [];
-  const toMs = (value: number) => Math.max(0, Math.round(value));
-  const snapshot = (): ReplyHotPathTimingSummary => ({
-    totalMs: toMs(Date.now() - startedAt),
-    spans: spans.slice(),
+export function createReplyHotPathTimingTracker(options: { profilerEnabled?: boolean } = {}) {
+  const timing = createReplyTimingTracker<ReplyHotPathLogParams>({
+    log: replyHotPathTimingLog,
+    enabled: options.profilerEnabled === true,
+    formatMessage: (params, summary, stages) =>
+      `reply hot path timings channel=${params.channel} messageId=${params.messageId ?? "unknown"} sessionKey=${params.sessionKey ?? "unknown"} outcome=${params.outcome} totalMs=${summary.totalMs} stages=${stages}${params.reason ? ` reason=${params.reason}` : ""}`,
+    detailKeys: () => ["channel", "messageId", "sessionKey", "outcome", "reason"],
   });
-  const shouldLog = (summary: ReplyHotPathTimingSummary) =>
-    summary.totalMs >= REPLY_HOT_PATH_TIMING_WARN_TOTAL_MS ||
-    summary.spans.some((span) => span.durationMs >= REPLY_HOT_PATH_TIMING_WARN_STAGE_MS);
-  const formatSpans = (summary: ReplyHotPathTimingSummary) =>
-    summary.spans.length > 0
-      ? summary.spans
-          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
-          .join(",")
-      : "none";
   return {
-    async measure(name, run) {
-      const spanStartedAt = Date.now();
-      try {
-        return await run();
-      } finally {
-        spans.push({
-          name,
-          durationMs: toMs(Date.now() - spanStartedAt),
-          elapsedMs: toMs(Date.now() - startedAt),
-        });
-      }
-    },
-    logIfSlow(params) {
-      if (didLog) {
-        return;
-      }
-      const summary = snapshot();
-      if (!shouldLog(summary)) {
-        return;
-      }
-      didLog = true;
-      replyHotPathTimingLog.warn(
-        `reply hot path timings channel=${params.channel} messageId=${
-          params.messageId ?? "unknown"
-        } sessionKey=${params.sessionKey ?? "unknown"} outcome=${params.outcome} totalMs=${
-          summary.totalMs
-        } stages=${formatSpans(summary)}${params.reason ? ` reason=${params.reason}` : ""}`,
-        {
-          channel: params.channel,
-          messageId: params.messageId,
-          sessionKey: params.sessionKey,
-          outcome: params.outcome,
-          reason: params.reason,
-          totalMs: summary.totalMs,
-          spans: summary.spans,
-        },
-      );
+    measure: timing.measure,
+    logIfSlow(params: ReplyHotPathLogParams) {
+      timing.logIfSlow(params);
     },
   };
 }

--- a/src/auto-reply/reply/reply-timing-tracker.test.ts
+++ b/src/auto-reply/reply/reply-timing-tracker.test.ts
@@ -1,7 +1,17 @@
 // Tests reply profiler flag detection and timing tracker output.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createAgentTurnTimingTracker } from "./agent-runner-turn-timing.js";
+import { createReplyHotPathTimingTracker } from "./dispatch-from-config.timing.js";
 import { createReplyTimingTracker, isReplyProfilerEnabled } from "./reply-timing-tracker.js";
+
+const subsystemWarn = vi.hoisted(() => vi.fn());
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ warn: subsystemWarn }),
+}));
+
+beforeEach(() => subsystemWarn.mockReset());
+afterEach(() => vi.restoreAllMocks());
 
 describe("isReplyProfilerEnabled", () => {
   it("matches global and reply profiler diagnostic flags", () => {
@@ -18,12 +28,14 @@ describe("isReplyProfilerEnabled", () => {
 describe("createReplyTimingTracker", () => {
   it("is a pass-through tracker unless the profiler flag is enabled", async () => {
     const warn = vi.fn();
-    const tracker = createReplyTimingTracker({ log: { warn } });
+    const now = vi.spyOn(Date, "now");
+    const tracker = createReplyTimingTracker({ log: { warn }, enabled: false });
 
     expect(tracker.measureSync("sync", () => 42)).toBe(42);
     await expect(tracker.measure("async", async () => "ok")).resolves.toBe("ok");
     tracker.logIfSlow({ message: "reply timings" });
 
+    expect(now).not.toHaveBeenCalled();
     expect(warn).not.toHaveBeenCalled();
   });
 
@@ -38,6 +50,7 @@ describe("createReplyTimingTracker", () => {
 
     expect(tracker.measureSync("sync", () => 7)).toBe(7);
     tracker.logIfSlow({ message: "reply timings", outcome: "completed" });
+    tracker.logIfSlow({ message: "reply timings", outcome: "completed" });
 
     expect(warn).toHaveBeenCalledOnce();
     expect(warn.mock.calls[0]?.[0]).toContain("stages=sync:");
@@ -45,5 +58,107 @@ describe("createReplyTimingTracker", () => {
       outcome: "completed",
       spans: [expect.objectContaining({ name: "sync" })],
     });
+  });
+
+  it("records sync throws and async rejections through the shared clock path", async () => {
+    const warn = vi.fn();
+    const now = vi.spyOn(Date, "now");
+    const tracker = createReplyTimingTracker({ log: { warn }, enabled: true, totalWarnMs: 0 });
+
+    expect(() =>
+      tracker.measureSync("sync_failure", () => {
+        throw new Error("sync failed");
+      }),
+    ).toThrow("sync failed");
+    await expect(
+      tracker.measure("async_failure", async () => {
+        throw new Error("async failed");
+      }),
+    ).rejects.toThrow("async failed");
+    tracker.logIfSlow({ message: "reply timings" });
+
+    expect(now).toHaveBeenCalledTimes(8);
+    expect(warn.mock.calls[0]?.[1]).toMatchObject({
+      spans: [{ name: "sync_failure" }, { name: "async_failure" }],
+    });
+  });
+
+  it("keeps total and stage warning thresholds inclusive", () => {
+    const warn = vi.fn();
+    const now = vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValue(999);
+    const totalTracker = createReplyTimingTracker({ log: { warn }, enabled: true });
+
+    totalTracker.logIfSlow({ message: "total" });
+    now.mockReturnValue(1_000);
+    totalTracker.logIfSlow({ message: "total" });
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockReset();
+    now.mockReset().mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(500);
+    const stageTracker = createReplyTimingTracker({ log: { warn }, enabled: true });
+    stageTracker.measureSync("stage", () => undefined);
+    stageTracker.logIfSlow({ message: "stage" });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("keeps agent milestones repeatable without reopening the terminal log", () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValue(1_500);
+    const tracker = createAgentTurnTimingTracker({ profilerEnabled: true });
+    const identity = { runId: "run-1", sessionId: "session-1", sessionKey: "agent:main" };
+
+    tracker.logMilestoneIfSlow({ ...identity, milestone: "model_started" });
+    tracker.logMilestoneIfSlow({ ...identity, milestone: "" });
+    const terminal = {
+      runId: "run-1",
+      outcome: "error" as const,
+      error: "failed",
+      milestone: "unexpected",
+      token: "secret",
+    };
+    tracker.logIfSlow(terminal);
+    tracker.logIfSlow({ ...identity, outcome: "completed" });
+
+    expect(subsystemWarn).toHaveBeenCalledTimes(3);
+    expect(subsystemWarn.mock.calls[0]?.[0]).toBe(
+      "agent turn milestone runId=run-1 sessionId=session-1 sessionKey=agent:main milestone=model_started totalMs=1500 stages=none",
+    );
+    expect(subsystemWarn.mock.calls[1]?.[0]).toContain(" milestone= totalMs=1500 ");
+    expect(subsystemWarn.mock.calls[2]?.[0]).toContain("agent turn timings runId=run-1");
+    expect(subsystemWarn.mock.calls[2]?.[1]).toEqual({
+      runId: "run-1",
+      sessionId: undefined,
+      sessionKey: undefined,
+      outcome: "error",
+      error: "failed",
+      totalMs: 1_500,
+      spans: [],
+    });
+  });
+
+  it("preserves dispatch timing messages and structured details", () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValue(1_500);
+    const tracker = createReplyHotPathTimingTracker({ profilerEnabled: true });
+    const details = {
+      channel: "telegram",
+      outcome: "skipped" as const,
+      token: "secret",
+    };
+
+    tracker.logIfSlow(details);
+    tracker.logIfSlow(details);
+
+    expect(subsystemWarn).toHaveBeenCalledOnce();
+    expect(subsystemWarn).toHaveBeenCalledWith(
+      "reply hot path timings channel=telegram messageId=unknown sessionKey=unknown outcome=skipped totalMs=1500 stages=none",
+      {
+        channel: "telegram",
+        messageId: undefined,
+        sessionKey: undefined,
+        outcome: "skipped",
+        reason: undefined,
+        totalMs: 1_500,
+        spans: [],
+      },
+    );
   });
 });

--- a/src/auto-reply/reply/reply-timing-tracker.ts
+++ b/src/auto-reply/reply/reply-timing-tracker.ts
@@ -2,35 +2,34 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
 
-type ReplyTimingSpan = {
-  name: string;
-  durationMs: number;
-  elapsedMs: number;
-};
-
 type ReplyTimingSummary = {
   totalMs: number;
-  spans: ReplyTimingSpan[];
+  spans: Array<{ name: string; durationMs: number; elapsedMs: number }>;
 };
 
-type ReplyTimingLogger = {
-  warn: (message: string, details?: Record<string, unknown>) => void;
+type ReplyTimingLogParams = {
+  message: string;
+  outcome?: string;
+  reason?: string;
+  error?: string;
+  details?: Record<string, unknown>;
 };
 
-type ReplyTimingTracker = {
+type ReplyTimingTracker<TLogParams extends object = ReplyTimingLogParams> = {
   measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
   measureSync: <T>(name: string, run: () => T) => T;
-  logIfSlow: (params: {
-    message: string;
-    outcome?: string;
-    reason?: string;
-    error?: string;
-    details?: Record<string, unknown>;
-  }) => void;
+  logIfSlow: (params: TLogParams, options?: { repeat?: boolean }) => void;
 };
 
-const DEFAULT_TIMING_WARN_TOTAL_MS = 1_000;
-const DEFAULT_TIMING_WARN_STAGE_MS = 500;
+const disabledTimingTracker: ReplyTimingTracker<object> = {
+  async measure(_name, run) {
+    return await run();
+  },
+  measureSync(_name, run) {
+    return run();
+  },
+  logIfSlow() {},
+};
 
 /** Checks config/env diagnostic flags for reply profiling. */
 export function isReplyProfilerEnabled(params?: {
@@ -45,36 +44,33 @@ export function isReplyProfilerEnabled(params?: {
   );
 }
 
-/** Creates a lightweight timing tracker for slow reply-stage diagnostics. */
-export function createReplyTimingTracker(params: {
-  log: ReplyTimingLogger;
+/** Creates a no-timer pass-through unless reply profiling is enabled. */
+export function createReplyTimingTracker<TLogParams extends object = ReplyTimingLogParams>(params: {
+  log: { warn: (message: string, details?: Record<string, unknown>) => void };
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   enabled?: boolean;
   totalWarnMs?: number;
   stageWarnMs?: number;
-}): ReplyTimingTracker {
+  formatMessage?: (
+    params: TLogParams,
+    summary: ReplyTimingSummary,
+    formattedSpans: string,
+  ) => string;
+  detailKeys?: (params: TLogParams) => readonly string[];
+}): ReplyTimingTracker<TLogParams> {
   const enabled =
     params.enabled ?? isReplyProfilerEnabled({ config: params.config, env: params.env });
   if (!enabled) {
-    // Normal production turns use pass-through wrappers so added profiling
-    // calls do not allocate spans or call Date.now on the hot reply path.
-    return {
-      async measure(_name, run) {
-        return await run();
-      },
-      measureSync(_name, run) {
-        return run();
-      },
-      logIfSlow() {},
-    };
+    // Normal turns share this pass-through, avoiding Date.now and span arrays.
+    return disabledTimingTracker as ReplyTimingTracker<TLogParams>;
   }
 
   const startedAt = Date.now();
-  const spans: ReplyTimingSpan[] = [];
+  const spans: ReplyTimingSummary["spans"] = [];
   let didLog = false;
-  const totalWarnMs = params.totalWarnMs ?? DEFAULT_TIMING_WARN_TOTAL_MS;
-  const stageWarnMs = params.stageWarnMs ?? DEFAULT_TIMING_WARN_STAGE_MS;
+  const totalWarnMs = params.totalWarnMs ?? 1_000;
+  const stageWarnMs = params.stageWarnMs ?? 500;
   const toMs = (value: number) => Math.max(0, Math.round(value));
   const record = (name: string, spanStartedAt: number) => {
     spans.push({
@@ -83,18 +79,6 @@ export function createReplyTimingTracker(params: {
       elapsedMs: toMs(Date.now() - startedAt),
     });
   };
-  const snapshot = (): ReplyTimingSummary => ({
-    totalMs: toMs(Date.now() - startedAt),
-    spans: spans.slice(),
-  });
-  const shouldLog = (summary: ReplyTimingSummary) =>
-    summary.totalMs >= totalWarnMs || summary.spans.some((span) => span.durationMs >= stageWarnMs);
-  const formatSpans = (summary: ReplyTimingSummary) =>
-    summary.spans.length > 0
-      ? summary.spans
-          .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
-          .join(",")
-      : "none";
 
   return {
     async measure(name, run) {
@@ -113,29 +97,53 @@ export function createReplyTimingTracker(params: {
         record(name, spanStartedAt);
       }
     },
-    logIfSlow(logParams) {
-      if (didLog) {
+    logIfSlow(logParams, options) {
+      if (didLog && !options?.repeat) {
         return;
       }
-      const summary = snapshot();
-      if (!shouldLog(summary)) {
+      const summary = { totalMs: toMs(Date.now() - startedAt), spans: spans.slice() };
+      if (
+        summary.totalMs < totalWarnMs &&
+        !summary.spans.some((span) => span.durationMs >= stageWarnMs)
+      ) {
         return;
       }
-      didLog = true;
+      if (!options?.repeat) {
+        didLog = true;
+      }
+      const formattedSpans =
+        summary.spans.length > 0
+          ? summary.spans
+              .map((span) => `${span.name}:${span.durationMs}ms@${span.elapsedMs}ms`)
+              .join(",")
+          : "none";
+      if (params.formatMessage) {
+        const detailParams = logParams as Record<string, unknown>;
+        const details = Object.fromEntries(
+          (params.detailKeys?.(logParams) ?? []).map((key) => [key, detailParams[key]]),
+        );
+        params.log.warn(params.formatMessage(logParams, summary, formattedSpans), {
+          ...details,
+          totalMs: summary.totalMs,
+          spans: summary.spans,
+        });
+        return;
+      }
+      const defaults = logParams as ReplyTimingLogParams;
       const suffix = [
         `totalMs=${summary.totalMs}`,
-        `stages=${formatSpans(summary)}`,
-        logParams.outcome ? `outcome=${logParams.outcome}` : undefined,
-        logParams.reason ? `reason=${logParams.reason}` : undefined,
-        logParams.error ? `error="${logParams.error}"` : undefined,
+        `stages=${formattedSpans}`,
+        defaults.outcome ? `outcome=${defaults.outcome}` : undefined,
+        defaults.reason ? `reason=${defaults.reason}` : undefined,
+        defaults.error ? `error="${defaults.error}"` : undefined,
       ]
         .filter(Boolean)
         .join(" ");
-      params.log.warn(`${logParams.message} ${suffix}`, {
-        ...logParams.details,
-        outcome: logParams.outcome,
-        reason: logParams.reason,
-        error: logParams.error,
+      params.log.warn(`${defaults.message} ${suffix}`, {
+        ...defaults.details,
+        outcome: defaults.outcome,
+        reason: defaults.reason,
+        error: defaults.error,
         totalMs: summary.totalMs,
         spans: summary.spans,
       });


### PR DESCRIPTION
## What Problem This Solves

Slow-reply diagnostics had three independent timing engines with the same clock, span, threshold, and log-once policy. Keeping those copies aligned made diagnostic-only changes larger and created drift risk around the disabled hot path and structured logging.

## Why This Change Was Made

The reply timing tracker is now the canonical owner for clock collection, span formatting, inclusive warning thresholds, and terminal log-once behavior. Agent-turn and dispatch wrappers retain their exact owner-specific messages, allowlisted structured details, public method shapes, and the agent milestone repeat policy.

The disabled path remains a shared pass-through with no Date.now calls or span-array allocation. No config, protocol, schema, lifecycle, delivery, or user-visible behavior changes.

## User Impact

No user-visible behavior change. Maintainers have one timing implementation instead of three, with 161 fewer production lines and deterministic regression coverage for the contracts that must remain distinct.

## Evidence

- Production delta: +122 / -283, net -161 LOC. Test delta: +117 / -2. Overall: net -46 LOC.
- Focused local timing suite: 7/7 passed.
- Blacksmith Testbox focused owner/sibling proof: 368 tests passed across the timing tracker, agent execution lifecycle and contract, dispatch/final outcomes, and get-reply fast path.
- Blacksmith Testbox full changed gate passed: formatting, dead exports, core and core-test typechecks, changed-file lint, import cycles, plugin boundaries, and repository guards.
- Exact-head GitHub CI completed without failures.
- Two independent xhigh owner/security reviews: CLEAN after restoring explicit structured-log allowlists, mode-specific agent projections, the private generic type, and dispatch's one-argument log-once surface.
- Exact behaviors covered: disabled no-clock path; sync throws and async rejections recorded in finally; inclusive 1000/500 ms thresholds; terminal log-once; repeat milestones; empty milestone; structural mode-collision and sensitive-extra-field exclusion; omitted optional detail keys; owner message/detail parity.

Direct enabled-profiler runtime capture through the actual subsystem logger, using only redacted proof identifiers and a synthetic clock to cross the existing 1000 ms threshold:

```text
[auto-reply/agent-turn-timing] agent turn milestone runId=proof-run sessionId=proof-session sessionKey=agent:proof milestone=model_started totalMs=1500 stages=none
[auto-reply/agent-turn-timing] agent turn timings runId=proof-run sessionId=proof-session sessionKey=agent:proof outcome=completed totalMs=1500 stages=none
[auto-reply/reply-timing] reply hot path timings channel=proof-channel messageId=proof-message sessionKey=agent:proof outcome=completed totalMs=1500 stages=none
```

The probe exited 0 and exercised the production wrappers and subsystem logger without mocks. The deterministic tests separately prove structured metadata allowlists, log-once/repeat state, threshold boundaries, and span recording.

Root cause: each diagnostic owner had copied the entire timing state machine instead of sharing one internal mechanism. Architectural owner: reply timing diagnostics. Canonical fix: shared tracker mechanics with thin owner projections. Removed paths: duplicate clock/span/threshold/log-once implementations only; no feature or compatibility path removed.
