### PR TITLE
fix(video): enforce one deadline across DashScope generation

### DIFF
--- a/src/video-generation/dashscope-compatible.test.ts
+++ b/src/video-generation/dashscope-compatible.test.ts
@@ -1,12 +1,16 @@
-// DashScope-compatible download regressions: body idle after headers.
+// DashScope-compatible download regressions: body lifecycle and operation deadlines.
 import { describe, expect, it, vi } from "vitest";
-import { downloadDashscopeGeneratedVideos } from "./dashscope-compatible.js";
+import {
+  downloadDashscopeGeneratedVideos,
+  runDashscopeVideoGenerationTask,
+} from "./dashscope-compatible.js";
+import type { VideoGenerationRequest } from "./types.js";
 
 function neverChunkingVideoResponse(): Response {
   return new Response(
     new ReadableStream({
       start() {
-        // Headers only — never enqueue so chunk idle must win.
+        // Headers only — never enqueue so the operation deadline must win.
       },
     }),
     {
@@ -16,8 +20,69 @@ function neverChunkingVideoResponse(): Response {
   );
 }
 
+function createVideoGenerationRequest(): VideoGenerationRequest {
+  return {
+    provider: "qwen",
+    model: "wan2.6-t2v",
+    prompt: "animate a cat",
+    cfg: {},
+  };
+}
+
+function waitForResponseDelay(delayMs: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+function createTricklingResponse(
+  params: {
+    status?: number;
+    contentType?: string;
+    intervalMs?: number;
+  } = {},
+) {
+  let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+  let nextChunk: ReturnType<typeof setTimeout> | undefined;
+  const cancel = vi.fn((_reason?: unknown): void => {
+    if (nextChunk !== undefined) {
+      clearTimeout(nextChunk);
+    }
+  });
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller = streamController;
+        const enqueue = () => {
+          streamController.enqueue(new Uint8Array([32]));
+          nextChunk = setTimeout(enqueue, params.intervalMs ?? 5);
+        };
+        enqueue();
+      },
+      cancel,
+    }),
+    {
+      status: params.status ?? 200,
+      headers: { "content-type": params.contentType ?? "application/json" },
+    },
+  );
+
+  return {
+    response,
+    cancel,
+    close() {
+      if (nextChunk !== undefined) {
+        clearTimeout(nextChunk);
+      }
+      if (controller && cancel.mock.calls.length === 0) {
+        controller.close();
+      }
+    },
+  };
+}
+
 describe("downloadDashscopeGeneratedVideos", () => {
-  it("aborts a stalled generated video body via chunk idle timeout", async () => {
+  it("aborts a stalled generated video body at its operation deadline", async () => {
     const fetchFn = vi.fn(async () => neverChunkingVideoResponse());
     const timeoutMs = 80;
     const startedAt = Date.now();
@@ -30,7 +95,7 @@ describe("downloadDashscopeGeneratedVideos", () => {
         fetchFn: fetchFn as unknown as typeof fetch,
         maxBytes: 10 * 1024 * 1024,
       }),
-    ).rejects.toThrow("Alibaba Wan generated video download stalled: no data received for 80ms");
+    ).rejects.toThrow("Alibaba Wan generated video download timed out after 80ms");
 
     const elapsedMs = Date.now() - startedAt;
     expect(elapsedMs).toBeGreaterThanOrEqual(timeoutMs - 20);
@@ -38,7 +103,7 @@ describe("downloadDashscopeGeneratedVideos", () => {
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
-  it("persists a complete generated video body before the idle deadline", async () => {
+  it("persists a complete generated video body before the operation deadline", async () => {
     const fetchFn = vi.fn(
       async () =>
         new Response(
@@ -74,6 +139,198 @@ describe("downloadDashscopeGeneratedVideos", () => {
     expect(buffer.toString("utf8")).toBe("mp4-bytes");
     expect(video?.mimeType).toBe("video/mp4");
   });
+
+  it("keeps the original operation deadline while generated video bytes keep arriving", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    let nextChunk: ReturnType<typeof setTimeout> | undefined;
+    const cancelBody = vi.fn((_reason?: unknown): void => {
+      if (nextChunk !== undefined) {
+        clearTimeout(nextChunk);
+      }
+    });
+
+    try {
+      const deadlineAt = Date.now() + 100;
+      const timeoutMs = vi.fn(() => deadlineAt - Date.now());
+      const fetchFn = vi.fn(async () => {
+        await waitForResponseDelay(30);
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(streamController) {
+              controller = streamController;
+              const enqueue = () => {
+                streamController.enqueue(new Uint8Array([1]));
+                nextChunk = setTimeout(enqueue, 20);
+              };
+              enqueue();
+            },
+            cancel: cancelBody,
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "video/mp4" },
+          },
+        );
+      });
+      let settledError: unknown;
+      const download = downloadDashscopeGeneratedVideos({
+        providerLabel: "Qwen",
+        urls: ["https://example.com/out.mp4"],
+        timeoutMs,
+        fetchFn: fetchFn as unknown as typeof fetch,
+        maxBytes: 10 * 1024 * 1024,
+      });
+      const observedDownload = download.catch((error: unknown) => {
+        settledError = error;
+      });
+
+      await vi.advanceTimersByTimeAsync(30);
+      expect(timeoutMs).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(69);
+      expect(settledError).toBeUndefined();
+      expect(cancelBody).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settledError).toBeInstanceOf(Error);
+      expect((settledError as Error).message).toBe(
+        "Qwen generated video download timed out after 70ms",
+      );
+      expect(cancelBody).toHaveBeenCalledOnce();
+      expect(cancelBody.mock.calls[0]?.[0]).toBe(settledError);
+      await observedDownload;
+    } finally {
+      if (nextChunk !== undefined) {
+        clearTimeout(nextChunk);
+      }
+      if (controller && cancelBody.mock.calls.length === 0) {
+        controller.close();
+      }
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps one numeric operation deadline across multiple video URLs and their headers", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    let trickling: ReturnType<typeof createTricklingResponse> | undefined;
+
+    try {
+      const fetchFn = vi.fn(async () => {
+        await waitForResponseDelay(30);
+        if (fetchFn.mock.calls.length === 1) {
+          return new Response("first-video", {
+            headers: { "content-type": "video/mp4" },
+          });
+        }
+        trickling = createTricklingResponse({ contentType: "video/mp4" });
+        return trickling.response;
+      });
+      let settledError: unknown;
+      const observedDownload = downloadDashscopeGeneratedVideos({
+        providerLabel: "Qwen",
+        urls: ["https://example.com/first.mp4", "https://example.com/second.mp4"],
+        timeoutMs: 100,
+        fetchFn: fetchFn as unknown as typeof fetch,
+        maxBytes: 10 * 1024 * 1024,
+      }).catch((error: unknown) => {
+        settledError = error;
+      });
+
+      await vi.advanceTimersByTimeAsync(99);
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+      expect(settledError).toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settledError).toBeInstanceOf(Error);
+      expect((settledError as Error).message).toBe(
+        "Qwen generated video download timed out after 100ms",
+      );
+      expect(trickling?.cancel).toHaveBeenCalledOnce();
+      expect(trickling?.cancel.mock.calls[0]?.[0]).toBe(settledError);
+      await observedDownload;
+    } finally {
+      trickling?.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry past the deadline when generated-video response headers stall", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    try {
+      const fetchFn = vi.fn(
+        (_url: string | URL | Request, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              "abort",
+              () => {
+                const reason = init.signal?.reason;
+                reject(reason instanceof Error ? reason : new Error("request timed out"));
+              },
+              { once: true },
+            );
+          }),
+      );
+      let settledError: unknown;
+      const observedDownload = downloadDashscopeGeneratedVideos({
+        providerLabel: "Qwen",
+        urls: ["https://example.com/stalled.mp4"],
+        timeoutMs: 100,
+        fetchFn: fetchFn as typeof fetch,
+        maxBytes: 10 * 1024 * 1024,
+      }).catch((error: unknown) => {
+        settledError = error;
+      });
+
+      await vi.advanceTimersByTimeAsync(99);
+      expect(settledError).toBeUndefined();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settledError).toBeInstanceOf(Error);
+      expect((settledError as Error).message).toContain("timed out");
+      expect(fetchFn).toHaveBeenCalledOnce();
+      await observedDownload;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([429, 503])(
+    "cancels retry backoff at the original deadline after a late HTTP %s",
+    async (status) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000);
+
+      try {
+        const fetchFn = vi.fn(async () => {
+          await waitForResponseDelay(90);
+          return new Response("provider busy", { status });
+        });
+        let settledError: unknown;
+        const observedDownload = downloadDashscopeGeneratedVideos({
+          providerLabel: "Qwen",
+          urls: ["https://example.com/busy.mp4"],
+          timeoutMs: 100,
+          fetchFn: fetchFn as unknown as typeof fetch,
+          maxBytes: 10 * 1024 * 1024,
+        }).catch((error: unknown) => {
+          settledError = error;
+        });
+
+        await vi.advanceTimersByTimeAsync(99);
+        expect(settledError).toBeUndefined();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(settledError).toBeInstanceOf(Error);
+        expect((settledError as Error).message).toContain("timed out");
+        expect(fetchFn).toHaveBeenCalledOnce();
+        await observedDownload;
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("fails closed before fetch when a function-valued remaining budget is exhausted", async () => {
     const fetchFn = vi.fn(async () => neverChunkingVideoResponse());
@@ -140,4 +397,161 @@ describe("downloadDashscopeGeneratedVideos", () => {
       vi.useRealTimers();
     }
   });
+});
+
+describe("runDashscopeVideoGenerationTask", () => {
+  it("charges submission, polling, and trickling video bytes against the default deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    let nextChunk: ReturnType<typeof setTimeout> | undefined;
+    const cancelBody = vi.fn((_reason?: unknown): void => {
+      if (nextChunk !== undefined) {
+        clearTimeout(nextChunk);
+      }
+    });
+
+    try {
+      const fetchFn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const requestUrl = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+        const delayMs = requestUrl.endsWith("/out.mp4") ? 20 : 30;
+        await waitForResponseDelay(delayMs);
+
+        if (init?.method === "POST") {
+          return Response.json({ output: { task_id: "task-1" } });
+        }
+        if (requestUrl.includes("/api/v1/tasks/")) {
+          return Response.json({
+            output: {
+              task_status: "SUCCEEDED",
+              video_url: "https://example.com/out.mp4",
+            },
+          });
+        }
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(streamController) {
+              controller = streamController;
+              const enqueue = () => {
+                streamController.enqueue(new Uint8Array([1]));
+                nextChunk = setTimeout(enqueue, 5);
+              };
+              enqueue();
+            },
+            cancel: cancelBody,
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "video/mp4" },
+          },
+        );
+      });
+      let settledError: unknown;
+      const observedGeneration = runDashscopeVideoGenerationTask({
+        providerLabel: "Qwen",
+        model: "wan2.6-t2v",
+        req: createVideoGenerationRequest(),
+        url: "https://example.com/api/v1/services/aigc/video-generation/video-synthesis",
+        headers: new Headers(),
+        baseUrl: "https://example.com",
+        defaultTimeoutMs: 100,
+        fetchFn: fetchFn as typeof fetch,
+      }).catch((error: unknown) => {
+        settledError = error;
+      });
+
+      await vi.advanceTimersByTimeAsync(80);
+      expect(fetchFn).toHaveBeenCalledTimes(3);
+      expect(cancelBody).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(19);
+      expect(settledError).toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settledError).toBeInstanceOf(Error);
+      expect((settledError as Error).message).toBe(
+        "Qwen generated video download timed out after 20ms",
+      );
+      expect(cancelBody).toHaveBeenCalledOnce();
+      expect(cancelBody.mock.calls[0]?.[0]).toBe(settledError);
+      await observedGeneration;
+    } finally {
+      if (nextChunk !== undefined) {
+        clearTimeout(nextChunk);
+      }
+      if (controller && cancelBody.mock.calls.length === 0) {
+        controller.close();
+      }
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { label: "submission JSON", stage: "submit", status: 200 },
+    { label: "poll JSON", stage: "poll", status: 200 },
+    { label: "download HTTP error", stage: "download", status: 400 },
+  ] as const)(
+    "bounds a trickling $label body by the default operation deadline",
+    async (params) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000);
+      let trickling: ReturnType<typeof createTricklingResponse> | undefined;
+
+      try {
+        const fetchFn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+          const requestUrl =
+            typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+          const stage =
+            init?.method === "POST"
+              ? "submit"
+              : requestUrl.includes("/api/v1/tasks/")
+                ? "poll"
+                : "download";
+          await waitForResponseDelay(20);
+
+          if (stage === params.stage) {
+            trickling = createTricklingResponse({ status: params.status });
+            return trickling.response;
+          }
+          if (stage === "submit") {
+            return Response.json({ output: { task_id: "task-1" } });
+          }
+          if (stage === "poll") {
+            return Response.json({
+              output: {
+                task_status: "SUCCEEDED",
+                video_url: "https://example.com/out.mp4",
+              },
+            });
+          }
+          throw new Error(`unexpected video generation stage: ${stage}`);
+        });
+        let settledError: unknown;
+        const observedGeneration = runDashscopeVideoGenerationTask({
+          providerLabel: "Qwen",
+          model: "wan2.6-t2v",
+          req: createVideoGenerationRequest(),
+          url: "https://example.com/api/v1/services/aigc/video-generation/video-synthesis",
+          headers: new Headers(),
+          baseUrl: "https://example.com",
+          defaultTimeoutMs: 100,
+          fetchFn: fetchFn as typeof fetch,
+        }).catch((error: unknown) => {
+          settledError = error;
+        });
+
+        await vi.advanceTimersByTimeAsync(99);
+        expect(trickling).toBeDefined();
+        expect(settledError).toBeUndefined();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(settledError).toBeInstanceOf(Error);
+        expect((settledError as Error).message).toContain("timed out");
+        expect(trickling?.cancel).toHaveBeenCalledOnce();
+        await observedGeneration;
+      } finally {
+        trickling?.close();
+        vi.useRealTimers();
+      }
+    },
+  );
 });

--- a/src/video-generation/dashscope-compatible.ts
+++ b/src/video-generation/dashscope-compatible.ts
@@ -15,6 +15,7 @@ import {
   waitProviderOperationPollInterval,
   type ProviderOperationTimeoutMs,
 } from "../plugin-sdk/provider-http.js";
+import { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
 import type {
   GeneratedVideoAsset,
   VideoGenerationProviderCapabilities,
@@ -186,44 +187,33 @@ export async function pollDashscopeVideoTaskUntilComplete(params: {
 }): Promise<DashscopeVideoGenerationResponse> {
   const defaultTimeoutMs = params.defaultTimeoutMs ?? DEFAULT_VIDEO_GENERATION_TIMEOUT_MS;
   const deadline = createProviderOperationDeadline({
-    timeoutMs: params.timeoutMs,
+    timeoutMs: params.timeoutMs ?? defaultTimeoutMs,
     label: `${params.providerLabel} video generation task ${params.taskId}`,
   });
+  const bodyReadOptions = createDashscopeBodyReadOptions({
+    label: deadline.label,
+    timeoutMs: createProviderOperationTimeoutResolver({ deadline, defaultTimeoutMs }),
+    totalTimeoutMs: deadline.timeoutMs,
+  });
   for (let attempt = 0; attempt < DEFAULT_VIDEO_GENERATION_MAX_POLL_ATTEMPTS; attempt += 1) {
-    const pollResult = await executeProviderOperationWithRetry({
-      provider: params.providerLabel,
+    const pollResult = await fetchDashscopeGuardedResponse({
+      providerLabel: params.providerLabel,
       stage: "poll",
-      operation: async () => {
-        const result = await fetchWithTimeoutGuarded(
-          `${params.baseUrl}/api/v1/tasks/${params.taskId}`,
-          {
-            method: "GET",
-            headers: params.headers,
-          },
-          createProviderOperationTimeoutResolver({ deadline, defaultTimeoutMs })(),
-          params.fetchFn,
-          {
-            ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
-            ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
-          },
-        );
-        try {
-          await assertOkOrThrowHttpError(
-            result.response,
-            `${params.providerLabel} video-generation task poll failed`,
-          );
-          return result;
-        } catch (error) {
-          await result.release();
-          throw error;
-        }
-      },
+      url: `${params.baseUrl}/api/v1/tasks/${params.taskId}`,
+      headers: params.headers,
+      timeoutMs: bodyReadOptions.timeoutMs,
+      bodyReadOptions,
+      failureLabel: `${params.providerLabel} video-generation task poll failed`,
+      fetchFn: params.fetchFn,
+      allowPrivateNetwork: params.allowPrivateNetwork,
+      dispatcherPolicy: params.dispatcherPolicy,
     });
     let payload: DashscopeVideoGenerationResponse;
     try {
       payload = await readProviderJsonResponse<DashscopeVideoGenerationResponse>(
         pollResult.response,
         `${params.providerLabel} video-generation task poll`,
+        bodyReadOptions,
       );
     } finally {
       await pollResult.release();
@@ -232,8 +222,6 @@ export async function pollDashscopeVideoTaskUntilComplete(params: {
     if (status === "SUCCEEDED") {
       return payload;
     }
-    // Terminal failure statuses carry provider messages; nonterminal statuses
-    // continue until the shared operation deadline or max poll attempts wins.
     if (status === "FAILED" || status === "CANCELED") {
       throw new Error(
         payload.output?.message?.trim() ||
@@ -251,6 +239,95 @@ export async function pollDashscopeVideoTaskUntilComplete(params: {
   );
 }
 
+function createDashscopeBodyReadOptions(params: {
+  label: string;
+  timeoutMs: () => number;
+  totalTimeoutMs?: number;
+}) {
+  return {
+    timeoutMs: params.timeoutMs,
+    onTimeout: ({ timeoutMs }: { timeoutMs: number }) =>
+      new Error(`${params.label} timed out after ${params.totalTimeoutMs ?? timeoutMs}ms`),
+  };
+}
+
+async function fetchDashscopeGuardedResponse(params: {
+  providerLabel: string;
+  stage: "poll" | "download";
+  url: string;
+  headers?: Headers;
+  timeoutMs: () => number;
+  bodyReadOptions: ReturnType<typeof createDashscopeBodyReadOptions>;
+  failureLabel: string;
+  fetchFn: typeof fetch;
+  allowPrivateNetwork?: boolean;
+  dispatcherPolicy?: Parameters<typeof postJsonRequest>[0]["dispatcherPolicy"];
+}) {
+  const retryController = new AbortController();
+  const initialTimeoutMs = params.timeoutMs();
+  const { signal, cleanup } = buildTimeoutAbortSignal({
+    timeoutMs: initialTimeoutMs,
+    signal: retryController.signal,
+    operation: `${params.providerLabel} ${params.stage}`,
+    url: params.url,
+  });
+  let nextTimeoutMs: number | undefined = initialTimeoutMs;
+
+  try {
+    return await executeProviderOperationWithRetry({
+      provider: params.providerLabel,
+      stage: params.stage,
+      signal,
+      operation: async () => {
+        let timeoutMs: number;
+        try {
+          timeoutMs = nextTimeoutMs ?? params.timeoutMs();
+          nextTimeoutMs = undefined;
+        } catch (error) {
+          retryController.abort(error);
+          throw error;
+        }
+        const guarded = await fetchWithTimeoutGuarded(
+          params.url,
+          {
+            method: "GET",
+            ...(params.headers ? { headers: params.headers } : {}),
+          },
+          timeoutMs,
+          params.fetchFn,
+          {
+            ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
+            ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
+          },
+        );
+        try {
+          await assertOkOrThrowHttpError(guarded.response, params.failureLabel, {
+            bodyTimeoutMs: params.bodyReadOptions.timeoutMs,
+            onBodyTimeout: (timeout) => {
+              const error = params.bodyReadOptions.onTimeout(timeout);
+              // The same deadline also owns retry backoff; never sleep after
+              // response-body timeout has exhausted the operation budget.
+              retryController.abort(error);
+              return error;
+            },
+          });
+          return guarded;
+        } catch (error) {
+          await guarded.release();
+          throw error;
+        }
+      },
+    });
+  } catch (error) {
+    if (signal?.aborted && !retryController.signal.aborted) {
+      throw params.bodyReadOptions.onTimeout({ timeoutMs: initialTimeoutMs });
+    }
+    throw error;
+  } finally {
+    cleanup();
+  }
+}
+
 export async function runDashscopeVideoGenerationTask(params: {
   providerLabel: string;
   model: string;
@@ -266,8 +343,13 @@ export async function runDashscopeVideoGenerationTask(params: {
 }): Promise<VideoGenerationResult> {
   const defaultTimeoutMs = params.defaultTimeoutMs ?? DEFAULT_VIDEO_GENERATION_TIMEOUT_MS;
   const deadline = createProviderOperationDeadline({
-    timeoutMs: params.timeoutMs,
+    timeoutMs: params.timeoutMs ?? defaultTimeoutMs,
     label: `${params.providerLabel} video generation`,
+  });
+  const bodyReadOptions = createDashscopeBodyReadOptions({
+    label: deadline.label,
+    timeoutMs: createProviderOperationTimeoutResolver({ deadline, defaultTimeoutMs }),
+    totalTimeoutMs: deadline.timeoutMs,
   });
   const { response, release } = await postJsonRequest({
     url: params.url,
@@ -293,10 +375,14 @@ export async function runDashscopeVideoGenerationTask(params: {
   });
 
   try {
-    await assertOkOrThrowHttpError(response, `${params.providerLabel} video generation failed`);
+    await assertOkOrThrowHttpError(response, `${params.providerLabel} video generation failed`, {
+      bodyTimeoutMs: bodyReadOptions.timeoutMs,
+      onBodyTimeout: bodyReadOptions.onTimeout,
+    });
     const submitted = await readProviderJsonResponse<DashscopeVideoGenerationResponse>(
       response,
       `${params.providerLabel} video generation`,
+      bodyReadOptions,
     );
     const taskId = submitted.output?.task_id?.trim();
     if (!taskId) {
@@ -373,38 +459,47 @@ export async function downloadDashscopeGeneratedVideos(params: {
   defaultTimeoutMs?: number;
   maxBytes: number;
 }): Promise<GeneratedVideoAsset[]> {
-  const videos: GeneratedVideoAsset[] = [];
-  for (const [index, url] of params.urls.entries()) {
-    const result = await executeProviderOperationWithRetry({
-      provider: params.providerLabel,
-      stage: "download",
-      operation: async () => {
-        const downloadTimeoutMs = resolveDashscopeVideoDownloadTimeoutMs(
+  if (params.urls.length === 0) {
+    return [];
+  }
+  const defaultTimeoutMs = params.defaultTimeoutMs ?? DEFAULT_VIDEO_GENERATION_TIMEOUT_MS;
+  const label = `${params.providerLabel} generated video download`;
+  const deadline =
+    typeof params.timeoutMs === "function"
+      ? undefined
+      : createProviderOperationDeadline({
+          timeoutMs: resolveDashscopeVideoDownloadTimeoutMs(
+            params.providerLabel,
+            params.timeoutMs,
+            defaultTimeoutMs,
+          ),
+          label,
+        });
+  const resolveTimeoutMs = deadline
+    ? createProviderOperationTimeoutResolver({ deadline, defaultTimeoutMs })
+    : () =>
+        resolveDashscopeVideoDownloadTimeoutMs(
           params.providerLabel,
           params.timeoutMs,
-          params.defaultTimeoutMs,
+          defaultTimeoutMs,
         );
-        const guarded = await fetchWithTimeoutGuarded(
-          url,
-          { method: "GET" },
-          downloadTimeoutMs,
-          params.fetchFn,
-          {
-            ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
-            ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
-          },
-        );
-        try {
-          await assertOkOrThrowHttpError(
-            guarded.response,
-            `${params.providerLabel} generated video download failed`,
-          );
-          return guarded;
-        } catch (error) {
-          await guarded.release();
-          throw error;
-        }
-      },
+  const bodyReadOptions = createDashscopeBodyReadOptions({
+    label,
+    timeoutMs: resolveTimeoutMs,
+    totalTimeoutMs: deadline?.timeoutMs,
+  });
+  const videos: GeneratedVideoAsset[] = [];
+  for (const [index, url] of params.urls.entries()) {
+    const result = await fetchDashscopeGuardedResponse({
+      providerLabel: params.providerLabel,
+      stage: "download",
+      url,
+      timeoutMs: resolveTimeoutMs,
+      bodyReadOptions,
+      failureLabel: `${params.providerLabel} generated video download failed`,
+      fetchFn: params.fetchFn,
+      allowPrivateNetwork: params.allowPrivateNetwork,
+      dispatcherPolicy: params.dispatcherPolicy,
     });
     let buffer: Buffer;
     let mimeType: string;
@@ -412,11 +507,7 @@ export async function downloadDashscopeGeneratedVideos(params: {
       // Re-resolve after headers so the body uses the remaining operation budget.
       let downloadTimeoutMs: number;
       try {
-        downloadTimeoutMs = resolveDashscopeVideoDownloadTimeoutMs(
-          params.providerLabel,
-          params.timeoutMs,
-          params.defaultTimeoutMs,
-        );
+        downloadTimeoutMs = resolveTimeoutMs();
       } catch (error) {
         // The body reader normally owns cancellation. If deadline resolution
         // fails first, cancel here before release clears the guarded abort.
@@ -424,13 +515,10 @@ export async function downloadDashscopeGeneratedVideos(params: {
         throw error;
       }
       buffer = await readResponseWithLimit(result.response, params.maxBytes, {
-        chunkTimeoutMs: downloadTimeoutMs,
+        ...bodyReadOptions,
+        timeoutMs: downloadTimeoutMs,
         onOverflow: ({ maxBytes }) =>
           new Error(`${params.providerLabel} generated video download exceeds ${maxBytes} bytes`),
-        onIdleTimeout: ({ chunkTimeoutMs }) =>
-          new Error(
-            `${params.providerLabel} generated video download stalled: no data received for ${chunkTimeoutMs}ms`,
-          ),
       });
       mimeType = result.response.headers.get("content-type")?.trim() || "video/mp4";
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes Alibaba and Qwen video-generation requests exceeding their timeout when response bodies keep trickling, retries consume the remaining budget, or multiple videos are downloaded.

## User Impact

Requests stop at their existing configured or default operation deadline. No configuration changes are needed.

## Why This Change Was Made

Carry one deadline through submission, polling, response bodies, retries, and sequential downloads. Use the current bounded provider readers and guarded transport, preserving MIME/byte limits, capture-aware release, and the rule that successful response bodies are never replayed.

This adapts Peter Steinberger’s original fix to current main while preserving his commit ancestry.

## Evidence

- Current-main baseline `a11a431e380`: all seven trickling-body/sequential-download regressions fail. Four additional retry/default/capture deadline regressions fail; the normal-retry control passes.
- Adapted owner suite: **46 passed**.
- Qwen caller suite: **27 passed**. Alibaba caller suite: **19 passed**.
- Source line-cap gate and diff checks pass without exceptions.
- Independent scoped review and fresh ClawSweeper review of the exact published head: no actionable correctness or security findings.
- Full changed-file checks: **PASS**, including ratchets, lint, types, dead-export and repository guards.
- [Exact-head CI35167796446](https://github.com/openclaw/openclaw/actions/runs/35167796446): **28 passed,18 skipped** at `10262bca42decb7043403c45824a09c35d86e7d3`.
- Synthetic transports only: no provider account calls or generated videos.

## Timeout Compatibility Decision

Retain the documented provider **operation** deadline, including the existing 120-second default. This intentionally ends requests that previously exceeded their budget across phases or files. Existing SDK arguments and configured/tool timeout overrides remain available for slower jobs. This accepts ClawSweeper’s recommended option for the requested timeout repair; reliance by external callers on the old overrun behavior is unmeasured. No provider-account calls or generated videos were used.
