### PR TITLE
fix(cua-computer): enable computer actions after node pairing

### DIFF
--- a/extensions/cua-computer/index.test.ts
+++ b/extensions/cua-computer/index.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
 
 describe("cua-computer plugin registration", () => {
-  it("registers the screen and dangerous computer node-host commands", () => {
+  it("registers the screen and computer node-host commands", () => {
     const commands: OpenClawPluginNodeHostCommand[] = [];
     plugin.register({
       pluginConfig: { driverPath: "cua-driver" },
@@ -15,7 +15,7 @@ describe("cua-computer plugin registration", () => {
 
     expect(commands.map(({ command, cap, dangerous }) => ({ command, cap, dangerous }))).toEqual([
       { command: "screen.snapshot", cap: "screen", dangerous: false },
-      { command: "computer.act", cap: "computer", dangerous: true },
+      { command: "computer.act", cap: "computer", dangerous: false },
     ]);
   });
 });

--- a/extensions/cua-computer/src/commands.ts
+++ b/extensions/cua-computer/src/commands.ts
@@ -447,7 +447,7 @@ export function createCuaComputerCommands(
   const act: OpenClawPluginNodeHostCommand = {
     command: "computer.act",
     cap: "computer",
-    dangerous: true,
+    dangerous: false,
     isAvailable,
     handle: async (paramsJSON) =>
       await queue.run(async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who enabled local computer control and paired a Windows or Linux node still could not use `computer.act`. The Gateway rejected the command before it reached the node, despite pairing already granting the documented capability.

## Why This Change Was Made

`computer.act` is a core-defined paired desktop capability, not a plugin-specific dangerous command that needs a second plugin approval policy. The CUA plugin retained the old `dangerous` classification after the arming flow was retired, so the Gateway removed the command from the runtime allowlist and then failed closed with `PLUGIN_POLICY_MISSING`.

This aligns the plugin metadata with the existing pairing contract and docs. Explicit operator denies in `gateway.nodes.commands.deny` still win. No config, protocol, SDK, or documentation surface changes.

Risk is low: one registration flag changes, and rollback is a one-commit revert. Production LOC delta is zero.

## User Impact

After enabling CUA computer control and pairing the node, operators can use `computer.act` on supported Windows and Linux node hosts without adding a redundant persistent allow rule. Operators can still explicitly deny the command.

## Evidence

### Real Gateway-path proof

A temporary focused Vitest harness loaded the real `cua-computer` plugin, installed its commands into the real plugin registry, and called the real Gateway allowlist and node-invoke policy functions. It did not launch `cua-driver`; the defect occurs before node transport.

Before the fix:

```json
{"registeredCommands":[{"command":"screen.snapshot","dangerous":false},{"command":"computer.act","dangerous":true}],"registeredNodeInvokePolicies":0,"allowlistContainsComputerAct":false,"commandAllowed":{"ok":false,"reason":"command not allowlisted"},"policyResult":{"ok":false,"code":"PLUGIN_POLICY_MISSING","message":"node.invoke computer.act is registered as dangerous by plugin cua-computer but has no plugin node.invoke policy","details":{"nodeCommandDispatched":false}},"reachesNodeTransport":false}
```

After the fix, using the same harness:

```json
{"registeredCommands":[{"command":"screen.snapshot","dangerous":false},{"command":"computer.act","dangerous":false}],"registeredNodeInvokePolicies":0,"allowlistContainsComputerAct":true,"commandAllowed":{"ok":true},"policyResult":null,"reachesNodeTransport":true}
```

The focused real `node.invoke` handler test also passed and asserted that `nodeRegistry.invoke` was called once for an enabled `computer.act` command.

### Focused validation

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/cua-policy-proof.test.ts extensions/cua-computer/index.test.ts` — proof harness and registration test passed (2/2); the temporary proof file is not included in the PR.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/node-command-policy.test.ts src/gateway/node-invoke-plugin-policy.test.ts` — 55/55 passed.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-methods/nodes.invoke-wake.test.ts -t "allows an enabled computer.act command for write-scoped operators"` — 1/1 passed; 50 unrelated tests skipped.
- `pnpm format extensions/cua-computer/src/commands.ts extensions/cua-computer/index.test.ts`
- `git diff --check`
- `autoreview --mode local` — TruffleHog clean; no accepted/actionable findings; patch correctness 0.94.

Docs were not changed because `docs/nodes/computer-use.md` already documents pairing as the durable grant and says `computer.act` does not require `gateway.nodes.commands.allow`.

AI-assisted: yes, with Codex. I reviewed the final diff and understand the registration, allowlist, plugin-policy, and dispatch paths described above.
