### PR TITLE
fix(cron): deliver and record primary webhook outcomes

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch-policy.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-policy.ts
@@ -299,37 +299,55 @@ function resolveDirectCronRetryDelaysMs(): readonly number[] {
 
 export async function retryTransientDirectCronDelivery<T>(params: {
   jobId: string;
+  label?: string;
   signal?: AbortSignal;
+  deadlineAtMs?: number;
   run: () => Promise<T>;
   shouldRetryError?: (err: unknown) => boolean;
 }): Promise<T> {
   const retryDelaysMs = resolveDirectCronRetryDelaysMs();
-  if (params.signal?.aborted) {
-    throw new Error("cron delivery aborted");
-  }
-  const runWithAbortCheck = async () => {
+  const assertActive = () => {
     if (params.signal?.aborted) {
       throw new Error("cron delivery aborted");
     }
-    return await params.run();
+    if (params.deadlineAtMs !== undefined && Date.now() >= params.deadlineAtMs) {
+      const error = new Error("cron delivery deadline exceeded");
+      error.name = "TimeoutError";
+      throw error;
+    }
   };
-  return await retryAsync(runWithAbortCheck, {
+  assertActive();
+  const runWithAbortCheck = async () => {
+    assertActive();
+    const result = await params.run();
+    assertActive();
+    return result;
+  };
+  const result = await retryAsync(runWithAbortCheck, {
     attempts: retryDelaysMs.length + 1,
     minDelayMs: 0,
     maxDelayMs: Math.max(...retryDelaysMs),
     delayMs: ({ attempt }) => retryDelaysMs[attempt - 1] ?? 0,
     shouldRetry: (err) =>
       params.signal?.aborted !== true &&
+      (params.deadlineAtMs === undefined || Date.now() < params.deadlineAtMs) &&
       isTransientDirectCronDeliveryError(err) &&
       (params.shouldRetryError?.(err) ?? true),
     onRetry: async ({ attempt, maxAttempts, delayMs, err }) => {
       await logCronDeliveryWarn(
-        `[cron:${params.jobId}] transient direct announce delivery failure, retrying ${attempt + 1}/${maxAttempts} in ${Math.round(delayMs / 1000)}s: ${summarizeDirectCronDeliveryError(err)}`,
+        `[cron:${params.jobId}] transient ${params.label ?? "direct announce"} delivery failure, retrying ${attempt + 1}/${maxAttempts} in ${Math.round(delayMs / 1000)}s: ${summarizeDirectCronDeliveryError(err)}`,
       );
       if (delayMs === 0) {
         await sleepWithAbort(0, params.signal);
       }
     },
-    sleep: async (delayMs) => await sleepWithAbort(delayMs, params.signal),
+    sleep: async (delayMs) => {
+      const remainingMs =
+        params.deadlineAtMs === undefined ? delayMs : Math.max(0, params.deadlineAtMs - Date.now());
+      await sleepWithAbort(Math.min(delayMs, remainingMs), params.signal);
+      assertActive();
+    },
   });
+  assertActive();
+  return result;
 }

--- a/src/cron/isolated-agent/delivery-dispatch-policy.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-policy.ts
@@ -319,9 +319,7 @@ export async function retryTransientDirectCronDelivery<T>(params: {
   assertActive();
   const runWithAbortCheck = async () => {
     assertActive();
-    const result = await params.run();
-    assertActive();
-    return result;
+    return await params.run();
   };
   const result = await retryAsync(runWithAbortCheck, {
     attempts: retryDelaysMs.length + 1,
@@ -348,6 +346,5 @@ export async function retryTransientDirectCronDelivery<T>(params: {
       assertActive();
     },
   });
-  assertActive();
   return result;
 }

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -2,6 +2,15 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { describe, expect, it, vi } from "vitest";
+const mocks = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+}));
+
+vi.mock("../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
+}));
+
+import { sendGatewayCronWebhook } from "../gateway/server-cron-notifications.js";
 import { runCronCommandJob } from "./command-runner.js";
 import { CronService } from "./service.js";
 import type { CronEvent } from "./service.js";
@@ -580,7 +589,7 @@ describe("CronService persists delivered status", () => {
     }
   });
 
-  it("preserves delivered when cancellation races after the POST settles", async () => {
+  it("preserves Gateway-delivered when cancellation races with post-2xx cleanup", async () => {
     const requests: string[] = [];
     const server = createServer((request, response) => {
       let body = "";
@@ -590,8 +599,12 @@ describe("CronService persists delivered status", () => {
       });
       request.on("end", () => {
         requests.push(body);
-        response.writeHead(204, { Connection: "close" });
-        response.end();
+        response.writeHead(200, {
+          Connection: "close",
+          "Content-Type": "text/plain",
+        });
+        response.flushHeaders();
+        response.write("accepted");
       });
     });
     await new Promise<void>((resolve) => {
@@ -599,9 +612,32 @@ describe("CronService persists delivered status", () => {
     });
     const address = server.address() as AddressInfo;
     const webhookUrl = `http://127.0.0.1:${address.port}/hook`;
-    let resolveSendStarted!: (value: { promise: Promise<void> }) => void;
-    const sendStarted = new Promise<{ promise: Promise<void> }>((resolve) => {
-      resolveSendStarted = resolve;
+    let resolveCleanupStarted!: () => void;
+    const cleanupStarted = new Promise<void>((resolve) => {
+      resolveCleanupStarted = resolve;
+    });
+    let resolveCleanup!: () => void;
+    const cleanup = new Promise<void>((resolve) => {
+      resolveCleanup = resolve;
+    });
+    mocks.fetchWithSsrFGuard.mockImplementationOnce(async (value: unknown) => {
+      const request = value as {
+        url: string;
+        init?: RequestInit;
+        signal?: AbortSignal;
+      };
+      const response = await fetch(request.url, {
+        ...request.init,
+        ...(request.signal ? { signal: request.signal } : {}),
+      });
+      return {
+        response,
+        finalUrl: request.url,
+        release: async () => {
+          resolveCleanupStarted();
+          await cleanup;
+        },
+      };
     });
     let resolveFinished!: (event: CronEvent) => void;
     const finished = new Promise<CronEvent>((resolve) => {
@@ -619,20 +655,7 @@ describe("CronService persists delivered status", () => {
         status: "ok" as const,
         summary: "HOOKSCHED_PAYLOAD",
       })),
-      sendCronWebhook: ({ event, abortSignal }) => {
-        const promise = fetch(webhookUrl, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(event),
-          signal: abortSignal,
-        }).then((response) => {
-          if (!response.ok) {
-            throw new Error(`Webhook request failed with HTTP ${response.status}`);
-          }
-        });
-        resolveSendStarted({ promise });
-        return promise;
-      },
+      sendCronWebhook: async (params) => await sendGatewayCronWebhook(params),
       onEvent: (event) => {
         if (event.action === "finished") {
           resolveFinished(event);
@@ -652,12 +675,13 @@ describe("CronService persists delivered status", () => {
         delivery: { mode: "webhook", to: webhookUrl },
       });
       const runPromise = cron.run(job.id, "force");
-      const send = await sendStarted;
-      await send.promise;
+      await cleanupStarted;
       expect(abortActiveCronTaskRuns("Cancelled after webhook acceptance.")).toBe(1);
 
       const event = await finished;
+      resolveCleanup();
       await runPromise;
+      expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledOnce();
       expect(requests).toHaveLength(1);
       expect(JSON.parse(requests[0] ?? "{}")).toMatchObject({
         jobId: job.id,
@@ -676,6 +700,7 @@ describe("CronService persists delivered status", () => {
       });
       expect(cron.getJob(job.id)?.state.lastDeliveryError).toBeUndefined();
     } finally {
+      resolveCleanup();
       cron.stop();
       await closeWebhookServer(server);
     }

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -1,6 +1,10 @@
 // Delivered status tests cover persistence of cron delivery outcomes.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { describe, expect, it, vi } from "vitest";
+import { runCronCommandJob } from "./command-runner.js";
 import { CronService } from "./service.js";
+import type { CronEvent } from "./service.js";
 import {
   createFinishedBarrier,
   createStartedCronServiceWithFinishedBarrier,
@@ -8,12 +12,51 @@ import {
   createNoopLogger,
   installCronTestHooks,
 } from "./service.test-harness.js";
+import { abortActiveCronTaskRuns } from "./service/active-run-cancellation.js";
+import type { CronServiceDeps } from "./service/state.js";
 
 const noopLogger = createNoopLogger();
 const { makeStorePath } = createCronStoreHarness();
 installCronTestHooks({ logger: noopLogger });
 
 type CronAddInput = Parameters<CronService["add"]>[0];
+
+async function createHangingWebhookServer() {
+  let resolveRequest!: (body: string) => void;
+  const requestBody = new Promise<string>((resolve) => {
+    resolveRequest = resolve;
+  });
+  const server = createServer((request) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => resolveRequest(body));
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    server,
+    requestBody,
+    webhookUrl: `http://127.0.0.1:${address.port}/hook`,
+  };
+}
+
+async function closeWebhookServer(server: ReturnType<typeof createServer>) {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
 
 function buildIsolatedAgentTurnJob(name: string): CronAddInput {
   return {
@@ -100,6 +143,7 @@ function createIsolatedCronWithFinishedBarrier(params: {
   delivered?: boolean;
   error?: string;
   deliveryError?: string;
+  sendCronWebhook?: CronServiceDeps["sendCronWebhook"];
   onFinished?: (evt: {
     jobId: string;
     error?: string;
@@ -127,6 +171,7 @@ function createIsolatedCronWithFinishedBarrier(params: {
       ...(params.deliveryError === undefined ? {} : { deliveryError: params.deliveryError }),
       ...(params.delivered === undefined ? {} : { delivered: params.delivered }),
     })),
+    sendCronWebhook: params.sendCronWebhook,
     onEvent: (evt) => {
       if (evt.action === "finished") {
         params.onFinished?.({
@@ -204,6 +249,7 @@ async function runIsolatedJobAndReadState(params: {
   delivered?: boolean;
   error?: string;
   deliveryError?: string;
+  sendCronWebhook?: CronServiceDeps["sendCronWebhook"];
   onFinished?: (evt: {
     jobId: string;
     error?: string;
@@ -225,6 +271,7 @@ async function runIsolatedJobAndReadState(params: {
     ...(params.delivered !== undefined ? { delivered: params.delivered } : {}),
     ...(params.error !== undefined ? { error: params.error } : {}),
     ...(params.deliveryError !== undefined ? { deliveryError: params.deliveryError } : {}),
+    ...(params.sendCronWebhook !== undefined ? { sendCronWebhook: params.sendCronWebhook } : {}),
     onFinished: (evt) => {
       params.onFinished?.(evt);
       finishedEvents.get(evt.jobId)?.(evt);
@@ -249,20 +296,389 @@ async function runIsolatedJobAndReadState(params: {
 }
 
 describe("CronService persists delivered status", () => {
-  it("records requested webhook delivery as unknown until its detached send is observed", async () => {
+  it("settles isolated-agent webhook delivery before recording the run", async () => {
     let finishedDeliveryStatus: string | undefined;
+    const sendCronWebhook = vi.fn(async () => {});
     const updated = await runIsolatedJobAndReadState({
-      job: buildWebhookIsolatedAgentTurnJob("webhook-pending"),
+      job: buildWebhookIsolatedAgentTurnJob("webhook-delivered"),
+      sendCronWebhook,
       onFinished: (event) => {
         finishedDeliveryStatus = event.deliveryStatus;
       },
     });
 
     expectSuccessfulCronRun(updated);
-    expect(updated?.state.lastDelivered).toBeUndefined();
-    expect(updated?.state.lastDeliveryStatus).toBe("unknown");
+    expect(sendCronWebhook).toHaveBeenCalled();
+    expect(updated?.state.lastDelivered).toBe(true);
+    expect(updated?.state.lastDeliveryStatus).toBe("delivered");
     expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("not-requested");
-    expect(finishedDeliveryStatus).toBe("unknown");
+    expect(finishedDeliveryStatus).toBe("delivered");
+  });
+
+  it.each([
+    { name: "successful endpoint", responseStatus: 204, expectedStatus: "delivered" },
+    { name: "failing endpoint", responseStatus: 503, expectedStatus: "not-delivered" },
+  ])(
+    "records command webhook delivery through a real HTTP server: $name",
+    async ({ responseStatus, expectedStatus }) => {
+      const requests: string[] = [];
+      const server = createServer((request, response) => {
+        let body = "";
+        request.setEncoding("utf8");
+        request.on("data", (chunk) => {
+          body += chunk;
+        });
+        request.on("end", () => {
+          requests.push(body);
+          response.writeHead(responseStatus, { Connection: "close" });
+          response.end();
+        });
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address() as AddressInfo;
+      const webhookUrl = `http://127.0.0.1:${address.port}/hook`;
+      const store = await makeStorePath();
+      const finished = createFinishedBarrier();
+      let finishedEvent: CronEvent | undefined;
+      const cron = new CronService({
+        storePath: store.storePath,
+        cronEnabled: true,
+        log: noopLogger,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+        runCommandJob: async ({ job, abortSignal }) =>
+          await runCronCommandJob({ job, abortSignal, nowMs: Date.now }),
+        sendCronWebhook: async ({ event, abortSignal }) => {
+          const response = await fetch(webhookUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(event),
+            signal: abortSignal,
+          });
+          if (!response.ok) {
+            throw new Error(`Webhook request failed with HTTP ${response.status}`);
+          }
+        },
+        onEvent: (event) => {
+          if (event.action === "finished") {
+            finishedEvent = event;
+          }
+          finished.onEvent(event);
+        },
+      });
+
+      await cron.start();
+      try {
+        const job = await cron.add({
+          name: `command webhook ${responseStatus}`,
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: {
+            kind: "command",
+            argv: [process.execPath, "-e", "process.stdout.write('HOOKSCHED_PAYLOAD')"],
+          },
+          delivery: { mode: "webhook", to: webhookUrl },
+        });
+        const finishedPromise = finished.waitForOk(job.id);
+        await cron.run(job.id, "force");
+        await finishedPromise;
+
+        expect(requests).toHaveLength(1);
+        expect(JSON.parse(requests[0] ?? "{}")).toMatchObject({
+          action: "finished",
+          jobId: job.id,
+          status: "ok",
+          summary: "HOOKSCHED_PAYLOAD",
+        });
+        expect(cron.getJob(job.id)?.state).toMatchObject({
+          lastRunStatus: "ok",
+          lastDeliveryStatus: expectedStatus,
+          lastDelivered: responseStatus === 204,
+        });
+        expect(finishedEvent?.deliveryStatus).toBe(expectedStatus);
+        if (responseStatus === 503) {
+          expect(cron.getJob(job.id)?.state.lastDeliveryError).toContain("HTTP 503");
+          expect(finishedEvent?.deliveryError).toContain("HTTP 503");
+        }
+      } finally {
+        cron.stop();
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          });
+        });
+      }
+    },
+  );
+
+  it("finalizes a hanging command webhook at the run deadline", async () => {
+    const { server, requestBody, webhookUrl } = await createHangingWebhookServer();
+    const store = await makeStorePath();
+    let resolveFinished!: (event: CronEvent) => void;
+    const finished = new Promise<CronEvent>((resolve) => {
+      resolveFinished = resolve;
+    });
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      runCommandJob: async ({ job, abortSignal }) =>
+        await runCronCommandJob({ job, abortSignal, nowMs: Date.now }),
+      sendCronWebhook: async ({ event, abortSignal }) => {
+        await fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(event),
+          signal: abortSignal,
+        });
+      },
+      onEvent: (event) => {
+        if (event.action === "finished") {
+          resolveFinished(event);
+        }
+      },
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add({
+        name: "command webhook deadline",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "command",
+          argv: [process.execPath, "-e", "process.stdout.write('HOOKSCHED_PAYLOAD')"],
+          timeoutSeconds: 1,
+        },
+        delivery: { mode: "webhook", to: webhookUrl },
+      });
+      const runPromise = cron.run(job.id, "force");
+      expect(JSON.parse(await requestBody)).toMatchObject({
+        jobId: job.id,
+        summary: "HOOKSCHED_PAYLOAD",
+      });
+
+      let settled = false;
+      void finished.then(() => {
+        settled = true;
+      });
+      await vi.advanceTimersByTimeAsync(999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+
+      const event = await finished;
+      await runPromise;
+      expect(event).toMatchObject({
+        status: "ok",
+        summary: "HOOKSCHED_PAYLOAD",
+        delivered: false,
+        deliveryStatus: "not-delivered",
+      });
+      expect(event.deliveryError).toContain("webhook delivery timed out");
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        lastRunStatus: "ok",
+        lastDelivered: false,
+        lastDeliveryStatus: "not-delivered",
+      });
+      expect(cron.getJob(job.id)?.state.lastDeliveryError).toContain("webhook delivery timed out");
+      expect(cron.getJob(job.id)?.state.runningAtMs).toBeUndefined();
+    } finally {
+      cron.stop();
+      await closeWebhookServer(server);
+    }
+  });
+
+  it("finalizes immediately when a command webhook is cancelled", async () => {
+    vi.useRealTimers();
+    const { server, requestBody, webhookUrl } = await createHangingWebhookServer();
+    const store = await makeStorePath();
+    let resolveFinished!: (event: CronEvent) => void;
+    const finished = new Promise<CronEvent>((resolve) => {
+      resolveFinished = resolve;
+    });
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      runCommandJob: async ({ job, abortSignal }) =>
+        await runCronCommandJob({ job, abortSignal, nowMs: Date.now }),
+      sendCronWebhook: async ({ event, abortSignal }) => {
+        await fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(event),
+          signal: abortSignal,
+        });
+      },
+      onEvent: (event) => {
+        if (event.action === "finished") {
+          resolveFinished(event);
+        }
+      },
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add({
+        name: "command webhook cancellation",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "command",
+          argv: [process.execPath, "-e", "process.stdout.write('HOOKSCHED_PAYLOAD')"],
+          timeoutSeconds: 0,
+        },
+        delivery: { mode: "webhook", to: webhookUrl },
+      });
+      const runPromise = cron.run(job.id, "force");
+      await requestBody;
+
+      const cancelledAt = performance.now();
+      expect(abortActiveCronTaskRuns("Cancelled by operator.")).toBe(1);
+      const event = await finished;
+      expect(performance.now() - cancelledAt).toBeLessThan(1_000);
+      await runPromise;
+
+      expect(event).toMatchObject({
+        status: "ok",
+        summary: "HOOKSCHED_PAYLOAD",
+        delivered: false,
+        deliveryStatus: "not-delivered",
+      });
+      expect(event.deliveryError).toContain("webhook delivery cancelled");
+      expect(event.deliveryError).toContain("Cancelled by operator.");
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        lastRunStatus: "ok",
+        lastDelivered: false,
+        lastDeliveryStatus: "not-delivered",
+      });
+      expect(cron.getJob(job.id)?.state.lastDeliveryError).toContain("webhook delivery cancelled");
+      expect(cron.getJob(job.id)?.state.runningAtMs).toBeUndefined();
+    } finally {
+      cron.stop();
+      await closeWebhookServer(server);
+    }
+  });
+
+  it("preserves delivered when cancellation races after the POST settles", async () => {
+    const requests: string[] = [];
+    const server = createServer((request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        requests.push(body);
+        response.writeHead(204, { Connection: "close" });
+        response.end();
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address() as AddressInfo;
+    const webhookUrl = `http://127.0.0.1:${address.port}/hook`;
+    let resolveSendStarted!: (value: { promise: Promise<void> }) => void;
+    const sendStarted = new Promise<{ promise: Promise<void> }>((resolve) => {
+      resolveSendStarted = resolve;
+    });
+    let resolveFinished!: (event: CronEvent) => void;
+    const finished = new Promise<CronEvent>((resolve) => {
+      resolveFinished = resolve;
+    });
+    const store = await makeStorePath();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      runCommandJob: vi.fn(async () => ({
+        status: "ok" as const,
+        summary: "HOOKSCHED_PAYLOAD",
+      })),
+      sendCronWebhook: ({ event, abortSignal }) => {
+        const promise = fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(event),
+          signal: abortSignal,
+        }).then((response) => {
+          if (!response.ok) {
+            throw new Error(`Webhook request failed with HTTP ${response.status}`);
+          }
+        });
+        resolveSendStarted({ promise });
+        return promise;
+      },
+      onEvent: (event) => {
+        if (event.action === "finished") {
+          resolveFinished(event);
+        }
+      },
+    });
+
+    await cron.start();
+    try {
+      const job = await cron.add({
+        name: "command webhook settled cancellation race",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "command", argv: ["ignored"] },
+        delivery: { mode: "webhook", to: webhookUrl },
+      });
+      const runPromise = cron.run(job.id, "force");
+      const send = await sendStarted;
+      await send.promise;
+      expect(abortActiveCronTaskRuns("Cancelled after webhook acceptance.")).toBe(1);
+
+      const event = await finished;
+      await runPromise;
+      expect(requests).toHaveLength(1);
+      expect(JSON.parse(requests[0] ?? "{}")).toMatchObject({
+        jobId: job.id,
+        summary: "HOOKSCHED_PAYLOAD",
+      });
+      expect(event).toMatchObject({
+        status: "ok",
+        delivered: true,
+        deliveryStatus: "delivered",
+      });
+      expect(event.deliveryError).toBeUndefined();
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        lastRunStatus: "ok",
+        lastDelivered: true,
+        lastDeliveryStatus: "delivered",
+      });
+      expect(cron.getJob(job.id)?.state.lastDeliveryError).toBeUndefined();
+    } finally {
+      cron.stop();
+      await closeWebhookServer(server);
+    }
   });
 
   it("persists lastDelivered=true when isolated job reports delivered", async () => {

--- a/src/cron/service.trigger-eval.test.ts
+++ b/src/cron/service.trigger-eval.test.ts
@@ -224,7 +224,7 @@ describe("cron trigger evaluation", () => {
   it("keeps webhook delivery not-requested when trigger evaluation stops before payload", async () => {
     const evaluateCronTrigger = vi.fn(async () => ({
       kind: "error" as const,
-      code: "runtime" as const,
+      code: "internal_error" as const,
       error: "trigger failed",
     }));
     const sendCronWebhook = vi.fn();

--- a/src/cron/service.trigger-eval.test.ts
+++ b/src/cron/service.trigger-eval.test.ts
@@ -32,6 +32,7 @@ async function createHarness(params: {
   evaluateCronTrigger?: Evaluator;
   runIsolatedAgentJob?: IsolatedRunner;
   runScriptJob?: ScriptRunner;
+  sendCronWebhook?: CronServiceDeps["sendCronWebhook"];
 }) {
   const { storePath } = await makeStorePath();
   const events: CronEvent[] = [];
@@ -48,6 +49,7 @@ async function createHarness(params: {
     runIsolatedAgentJob,
     ...(params.evaluateCronTrigger ? { evaluateCronTrigger: params.evaluateCronTrigger } : {}),
     ...(params.runScriptJob ? { runScriptJob: params.runScriptJob } : {}),
+    ...(params.sendCronWebhook ? { sendCronWebhook: params.sendCronWebhook } : {}),
     onEvent: (event) => events.push(structuredClone(event)),
   });
   await cron.start();
@@ -214,6 +216,45 @@ describe("cron trigger evaluation", () => {
         nextRunAtMs: persisted?.state.nextRunAtMs,
         job: { state: { nextRunAtMs: persisted?.state.nextRunAtMs } },
       });
+    } finally {
+      harness.cron.stop();
+    }
+  });
+
+  it("keeps webhook delivery not-requested when trigger evaluation stops before payload", async () => {
+    const evaluateCronTrigger = vi.fn(async () => ({
+      kind: "error" as const,
+      code: "runtime" as const,
+      error: "trigger failed",
+    }));
+    const sendCronWebhook = vi.fn();
+    const harness = await createHarness({ evaluateCronTrigger, sendCronWebhook });
+    try {
+      const job = await harness.cron.add(
+        watcher({ delivery: { mode: "webhook", to: "https://example.invalid/hook" } }),
+      );
+      await runWhenDue(harness.cron, job.id);
+
+      expect(sendCronWebhook).not.toHaveBeenCalled();
+      expect(harness.cron.getJob(job.id)?.state).toMatchObject({
+        lastDeliveryStatus: "not-requested",
+      });
+      expect(harness.cron.getJob(job.id)?.state.lastDelivered).toBeUndefined();
+      expect(harness.cron.getJob(job.id)?.state.lastDeliveryError).toBeUndefined();
+
+      const finished = harness.events.find((event) => event.action === "finished");
+      expect(finished).toMatchObject({ deliveryStatus: "not-requested" });
+      expect(finished?.delivered).toBeUndefined();
+      expect(finished?.deliveryError).toBeUndefined();
+
+      const history = readCronTaskRunHistoryPage({
+        storeKey: cronStoreKey(harness.storePath),
+        jobId: job.id,
+      }).entries;
+      expect(history).toHaveLength(1);
+      expect(history[0]).toMatchObject({ deliveryStatus: "not-requested" });
+      expect(history[0]?.delivered).toBeUndefined();
+      expect(history[0]?.deliveryError).toBeUndefined();
     } finally {
       harness.cron.stop();
     }

--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -53,6 +53,7 @@ type CronAgentWatchdog = {
   noteRunnerStarted: (info?: CronAgentExecutionStarted) => void;
   notePhase: (info: CronAgentExecutionPhaseUpdate) => void;
   activeExecution: () => CronAgentExecutionStarted | undefined;
+  deadlineAtMs: () => number | undefined;
   observedLaneWait: () => boolean;
   dispose: () => void;
 };
@@ -68,6 +69,7 @@ export function createCronAgentWatchdog(params: {
   let setupTimeoutId: NodeJS.Timeout | undefined;
   let preExecutionTimeoutId: NodeJS.Timeout | undefined;
   let activeExecution: CronAgentExecutionStarted | undefined;
+  let deadlineAtMs: number | undefined;
   let observedLaneWait = false;
   let waitingForLane = false;
 
@@ -82,6 +84,7 @@ export function createCronAgentWatchdog(params: {
     if (timeoutId || state === "disposed") {
       return;
     }
+    deadlineAtMs = Date.now() + params.jobTimeoutMs;
     timeoutId = setTimeout(() => {
       setTimedOut(timeoutErrorMessage(activeExecution));
     }, params.jobTimeoutMs);
@@ -189,6 +192,7 @@ export function createCronAgentWatchdog(params: {
       noteExecutionProgress(info);
     },
     activeExecution: () => activeExecution,
+    deadlineAtMs: () => deadlineAtMs,
     observedLaneWait: () => observedLaneWait,
     dispose: () => {
       state = "disposed";

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -206,6 +206,13 @@ export type CronServiceDeps = {
       nextCheck?: CronNextCheckProposal;
     } & CronRunOutcome
   >;
+  /** Deliver a primary cron webhook before the run outcome is finalized. */
+  sendCronWebhook?: (params: {
+    job: CronJob;
+    event: CronEvent;
+    abortSignal: AbortSignal;
+    deadlineAtMs?: number;
+  }) => Promise<void>;
   cleanupTimedOutAgentRun?: (params: {
     job: CronJob;
     timeoutMs: number;

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -212,6 +212,7 @@ export type CronServiceDeps = {
     event: CronEvent;
     abortSignal: AbortSignal;
     deadlineAtMs?: number;
+    onDeliveryAccepted: () => void;
   }) => Promise<void>;
   cleanupTimedOutAgentRun?: (params: {
     job: CronJob;

--- a/src/cron/service/timer-execution-timeout.ts
+++ b/src/cron/service/timer-execution-timeout.ts
@@ -58,6 +58,7 @@ export type CronJobRunResult = CronRunOutcome &
   Pick<CronRunTelemetry, "provider"> & {
     deliveryError?: string;
     delivered?: boolean;
+    deliveryAttempted?: boolean;
     startedAt: number;
     endedAt: number;
     nextCheck?: CronNextCheckProposal;

--- a/src/cron/service/timer-job-runner.interruption.test.ts
+++ b/src/cron/service/timer-job-runner.interruption.test.ts
@@ -1,0 +1,65 @@
+// Interruption mapping must never downgrade settled or intentionally-unrequested delivery.
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../types.js";
+import { resolveInterruptedRunProgress } from "./timer-job-runner.interruption.js";
+
+type InterruptionParams = Parameters<typeof resolveInterruptedRunProgress>[0];
+type Progress = InterruptionParams["progress"];
+type Outcome = NonNullable<Progress["completedCoreResult"]>;
+
+const webhookJob = {
+  id: "job-1",
+  name: "webhook job",
+  enabled: true,
+  schedule: { kind: "cron", expr: "* * * * *" },
+  sessionTarget: "isolated",
+  payload: { kind: "command", argv: ["sh", "-lc", "echo hi"] },
+  delivery: { mode: "webhook", to: "https://example.invalid/hook" },
+  state: {},
+} as unknown as CronJob;
+
+const outcome = (overrides: Partial<Outcome>): Outcome =>
+  ({ status: "ok", summary: "payload", ...overrides }) as Outcome;
+
+describe("resolveInterruptedRunProgress", () => {
+  it("returns the settled delivery result untouched", () => {
+    const settled = outcome({ delivered: true });
+    const resolved = resolveInterruptedRunProgress({
+      progress: { settledDeliveryResult: settled, completedCoreResult: outcome({}) },
+      job: webhookJob,
+      error: "cron webhook delivery cancelled: operator",
+    });
+    expect(resolved).toBe(settled);
+  });
+
+  it("keeps an unfired trigger's intentional non-delivery on interruption", () => {
+    const unfired = outcome({ triggerEval: { fired: false } } as Partial<Outcome>);
+    const resolved = resolveInterruptedRunProgress({
+      progress: { completedCoreResult: unfired },
+      job: webhookJob,
+      error: "cron webhook delivery cancelled: operator",
+    });
+    expect(resolved).toBe(unfired);
+    expect(resolved?.delivered).toBeUndefined();
+    expect(resolved?.deliveryError).toBeUndefined();
+  });
+
+  it("marks an interrupted fired delivery as not delivered with the interruption error", () => {
+    const resolved = resolveInterruptedRunProgress({
+      progress: { completedCoreResult: outcome({}) },
+      job: webhookJob,
+      error: "cron webhook delivery cancelled: operator",
+    });
+    expect(resolved?.delivered).toBe(false);
+    expect(resolved?.deliveryError).toBe("cron webhook delivery cancelled: operator");
+  });
+
+  it("returns undefined when no core result completed", () => {
+    const resolved = resolveInterruptedRunProgress({
+      progress: {},
+      job: webhookJob,
+      error: "cron webhook delivery cancelled: operator",
+    });
+    expect(resolved).toBeUndefined();
+  });
+});

--- a/src/cron/service/timer-job-runner.interruption.ts
+++ b/src/cron/service/timer-job-runner.interruption.ts
@@ -1,0 +1,76 @@
+// Pure interruption-outcome mapping for cron runs; kept separate so the
+// cancellation/timeout branches and their invariants are directly testable.
+import { resolveCronDeliveryPlan } from "../delivery-plan.js";
+import type { CronJob } from "../types.js";
+import type { IsolatedAgentSetupTimeoutSignal } from "./timer-execution-timeout.js";
+import type { executeJobCore } from "./timer-execution.js";
+
+type CronCoreRunOutcome = Awaited<ReturnType<typeof executeJobCore>> & {
+  isolatedAgentSetupTimeout?: IsolatedAgentSetupTimeoutSignal;
+};
+export type CronRunProgress = {
+  completedCoreResult?: CronCoreRunOutcome;
+  settledDeliveryResult?: CronCoreRunOutcome;
+};
+
+export function withPrimaryWebhookTrace(params: {
+  job: CronJob;
+  result: CronCoreRunOutcome;
+  delivered: boolean;
+  error?: string;
+}): CronCoreRunOutcome {
+  const plan = resolveCronDeliveryPlan(params.job);
+  const intended = params.result.delivery?.intended ?? {
+    to: plan.to,
+    source: "explicit" as const,
+  };
+  return {
+    ...params.result,
+    delivered: params.delivered,
+    deliveryAttempted: true,
+    ...(params.error ? { deliveryError: params.error } : { deliveryError: undefined }),
+    delivery: {
+      ...params.result.delivery,
+      intended,
+      delivered: params.delivered,
+      resolved: {
+        to: plan.to,
+        source: "explicit",
+        ok: params.delivered,
+        ...(params.error ? { error: params.error } : {}),
+      },
+    },
+  };
+}
+
+export function withPrimaryWebhookInterruption(params: {
+  job: CronJob;
+  result: CronCoreRunOutcome;
+  error: string;
+}): CronCoreRunOutcome {
+  // Mirror deliverPrimaryWebhook's unfired-trigger gate: a trigger that
+  // evaluated false never requested delivery, so an interruption must not
+  // downgrade its intentional non-outcome to a delivery failure.
+  return resolveCronDeliveryPlan(params.job).mode === "webhook" &&
+    params.result.triggerEval?.fired !== false
+    ? withPrimaryWebhookTrace({ ...params, delivered: false })
+    : params.result;
+}
+
+export function resolveInterruptedRunProgress(params: {
+  progress: CronRunProgress;
+  job: CronJob;
+  error: string;
+}): CronCoreRunOutcome | undefined {
+  if (params.progress.settledDeliveryResult) {
+    return params.progress.settledDeliveryResult;
+  }
+  if (params.progress.completedCoreResult) {
+    return withPrimaryWebhookInterruption({
+      job: params.job,
+      result: params.progress.completedCoreResult,
+      error: params.error,
+    });
+  }
+  return undefined;
+}

--- a/src/cron/service/timer-job-runner.ts
+++ b/src/cron/service/timer-job-runner.ts
@@ -27,6 +27,12 @@ import {
   runsDetachedFromMainSession,
 } from "./timer-execution-timeout.js";
 import { executeJobCore } from "./timer-execution.js";
+import {
+  resolveInterruptedRunProgress,
+  withPrimaryWebhookInterruption,
+  withPrimaryWebhookTrace,
+  type CronRunProgress,
+} from "./timer-job-runner.interruption.js";
 
 type CronCoreRunOutcome = Awaited<ReturnType<typeof executeJobCore>> & {
   isolatedAgentSetupTimeout?: IsolatedAgentSetupTimeoutSignal;
@@ -39,68 +45,6 @@ type CronCoreRunOptions = {
   streamScheduleKey?: string;
   streamSourceIdentity?: string;
 };
-type CronRunProgress = {
-  completedCoreResult?: CronCoreRunOutcome;
-  settledDeliveryResult?: CronCoreRunOutcome;
-};
-
-function withPrimaryWebhookTrace(params: {
-  job: CronJob;
-  result: CronCoreRunOutcome;
-  delivered: boolean;
-  error?: string;
-}): CronCoreRunOutcome {
-  const plan = resolveCronDeliveryPlan(params.job);
-  const intended = params.result.delivery?.intended ?? {
-    to: plan.to,
-    source: "explicit" as const,
-  };
-  return {
-    ...params.result,
-    delivered: params.delivered,
-    deliveryAttempted: true,
-    ...(params.error ? { deliveryError: params.error } : { deliveryError: undefined }),
-    delivery: {
-      ...params.result.delivery,
-      intended,
-      delivered: params.delivered,
-      resolved: {
-        to: plan.to,
-        source: "explicit",
-        ok: params.delivered,
-        ...(params.error ? { error: params.error } : {}),
-      },
-    },
-  };
-}
-
-function withPrimaryWebhookInterruption(params: {
-  job: CronJob;
-  result: CronCoreRunOutcome;
-  error: string;
-}): CronCoreRunOutcome {
-  return resolveCronDeliveryPlan(params.job).mode === "webhook"
-    ? withPrimaryWebhookTrace({ ...params, delivered: false })
-    : params.result;
-}
-
-function resolveInterruptedRunProgress(params: {
-  progress: CronRunProgress;
-  job: CronJob;
-  error: string;
-}): CronCoreRunOutcome | undefined {
-  if (params.progress.settledDeliveryResult) {
-    return params.progress.settledDeliveryResult;
-  }
-  if (params.progress.completedCoreResult) {
-    return withPrimaryWebhookInterruption({
-      job: params.job,
-      result: params.progress.completedCoreResult,
-      error: params.error,
-    });
-  }
-  return undefined;
-}
 
 async function deliverPrimaryWebhook(
   state: CronServiceState,
@@ -113,8 +57,8 @@ async function deliverPrimaryWebhook(
   const settle = (settledResult: CronCoreRunOutcome) => {
     // Publish the terminal delivery fact before this async function resolves;
     // cancellation can win the outer race during the following microtask.
-    progress.settledDeliveryResult = settledResult;
-    return settledResult;
+    progress.settledDeliveryResult ??= settledResult;
+    return progress.settledDeliveryResult;
   };
   const plan = resolveCronDeliveryPlan(job);
   if (plan.mode !== "webhook" || result.triggerEval?.fired === false) {
@@ -161,6 +105,9 @@ async function deliverPrimaryWebhook(
       job,
       abortSignal,
       ...(deadlineAtMs !== undefined ? { deadlineAtMs } : {}),
+      onDeliveryAccepted: () => {
+        settle(deliveredResult);
+      },
       event: {
         jobId: job.id,
         action: "finished",
@@ -183,6 +130,9 @@ async function deliverPrimaryWebhook(
         usage: result.usage,
       },
     });
+    if (progress.settledDeliveryResult) {
+      return progress.settledDeliveryResult;
+    }
     if (abortSignal.aborted || deadlineExceeded()) {
       return withPrimaryWebhookTrace({
         job,
@@ -193,6 +143,9 @@ async function deliverPrimaryWebhook(
     }
     return settle(deliveredResult);
   } catch (error) {
+    if (progress.settledDeliveryResult) {
+      return progress.settledDeliveryResult;
+    }
     const deliveryError = abortSignal.aborted ? interruptionError() : formatErrorMessage(error);
     state.deps.log.warn({ jobId: job.id, err: deliveryError }, "cron: webhook delivery failed");
     return settle(withPrimaryWebhookTrace({ job, result, delivered: false, error: deliveryError }));

--- a/src/cron/service/timer-job-runner.ts
+++ b/src/cron/service/timer-job-runner.ts
@@ -1,5 +1,7 @@
+import { formatErrorMessage } from "../../infra/errors.js";
 import type { CommandLaneTaskMarker } from "../../process/command-queue.js";
 import { type CronActiveJobMarker, isCronActiveJobMarkerCurrent } from "../active-jobs.js";
+import { resolveCronDeliveryPlan } from "../delivery-plan.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import type { CronAgentExecutionStarted, CronJob } from "../types.js";
 import {
@@ -29,6 +31,173 @@ import { executeJobCore } from "./timer-execution.js";
 type CronCoreRunOutcome = Awaited<ReturnType<typeof executeJobCore>> & {
   isolatedAgentSetupTimeout?: IsolatedAgentSetupTimeoutSignal;
 };
+type CronCoreRunOptions = {
+  runId?: string;
+  activeJobMarker?: CronActiveJobMarker;
+  owningCronLaneTaskMarker?: CommandLaneTaskMarker;
+  streamBatch?: string;
+  streamScheduleKey?: string;
+  streamSourceIdentity?: string;
+};
+type CronRunProgress = {
+  completedCoreResult?: CronCoreRunOutcome;
+  settledDeliveryResult?: CronCoreRunOutcome;
+};
+
+function withPrimaryWebhookTrace(params: {
+  job: CronJob;
+  result: CronCoreRunOutcome;
+  delivered: boolean;
+  error?: string;
+}): CronCoreRunOutcome {
+  const plan = resolveCronDeliveryPlan(params.job);
+  const intended = params.result.delivery?.intended ?? {
+    to: plan.to,
+    source: "explicit" as const,
+  };
+  return {
+    ...params.result,
+    delivered: params.delivered,
+    deliveryAttempted: true,
+    ...(params.error ? { deliveryError: params.error } : { deliveryError: undefined }),
+    delivery: {
+      ...params.result.delivery,
+      intended,
+      delivered: params.delivered,
+      resolved: {
+        to: plan.to,
+        source: "explicit",
+        ok: params.delivered,
+        ...(params.error ? { error: params.error } : {}),
+      },
+    },
+  };
+}
+
+function withPrimaryWebhookInterruption(params: {
+  job: CronJob;
+  result: CronCoreRunOutcome;
+  error: string;
+}): CronCoreRunOutcome {
+  return resolveCronDeliveryPlan(params.job).mode === "webhook"
+    ? withPrimaryWebhookTrace({ ...params, delivered: false })
+    : params.result;
+}
+
+function resolveInterruptedRunProgress(params: {
+  progress: CronRunProgress;
+  job: CronJob;
+  error: string;
+}): CronCoreRunOutcome | undefined {
+  if (params.progress.settledDeliveryResult) {
+    return params.progress.settledDeliveryResult;
+  }
+  if (params.progress.completedCoreResult) {
+    return withPrimaryWebhookInterruption({
+      job: params.job,
+      result: params.progress.completedCoreResult,
+      error: params.error,
+    });
+  }
+  return undefined;
+}
+
+async function deliverPrimaryWebhook(
+  state: CronServiceState,
+  job: CronJob,
+  result: CronCoreRunOutcome,
+  abortSignal: AbortSignal,
+  progress: CronRunProgress,
+  deadlineAtMs?: number,
+): Promise<CronCoreRunOutcome> {
+  const settle = (settledResult: CronCoreRunOutcome) => {
+    // Publish the terminal delivery fact before this async function resolves;
+    // cancellation can win the outer race during the following microtask.
+    progress.settledDeliveryResult = settledResult;
+    return settledResult;
+  };
+  const plan = resolveCronDeliveryPlan(job);
+  if (plan.mode !== "webhook" || result.triggerEval?.fired === false) {
+    return result;
+  }
+  if (result.status !== "error" && !(typeof result.summary === "string" && result.summary.trim())) {
+    return withPrimaryWebhookTrace({
+      job,
+      result,
+      delivered: false,
+      error: "cron webhook delivery skipped: run produced no payload",
+    });
+  }
+  if (!state.deps.sendCronWebhook) {
+    return withPrimaryWebhookTrace({
+      job,
+      result,
+      delivered: false,
+      error: "cron webhook delivery is unavailable",
+    });
+  }
+
+  const deadlineExceeded = () => deadlineAtMs !== undefined && Date.now() >= deadlineAtMs;
+  const interruptionError = () => {
+    const reason = abortErrorMessage(abortSignal);
+    return deadlineExceeded() ||
+      (abortSignal.reason instanceof Error && abortSignal.reason.name === "TimeoutError")
+      ? `cron webhook delivery timed out: ${reason}`
+      : `cron webhook delivery cancelled: ${reason}`;
+  };
+  if (abortSignal.aborted || deadlineExceeded()) {
+    return withPrimaryWebhookTrace({
+      job,
+      result,
+      delivered: false,
+      error: interruptionError(),
+    });
+  }
+
+  const startedAt = job.state.runningAtMs;
+  const deliveredResult = withPrimaryWebhookTrace({ job, result, delivered: true });
+  try {
+    await state.deps.sendCronWebhook({
+      job,
+      abortSignal,
+      ...(deadlineAtMs !== undefined ? { deadlineAtMs } : {}),
+      event: {
+        jobId: job.id,
+        action: "finished",
+        job,
+        ...(typeof startedAt === "number" ? { runAtMs: startedAt } : {}),
+        ...(typeof startedAt === "number"
+          ? { durationMs: Math.max(0, state.deps.nowMs() - startedAt) }
+          : {}),
+        status: result.status,
+        error: result.error,
+        summary: result.summary,
+        diagnostics: result.diagnostics,
+        delivered: true,
+        deliveryStatus: "delivered",
+        delivery: deliveredResult.delivery,
+        sessionId: result.sessionId,
+        sessionKey: result.sessionKey,
+        model: result.model,
+        provider: result.provider,
+        usage: result.usage,
+      },
+    });
+    if (abortSignal.aborted || deadlineExceeded()) {
+      return withPrimaryWebhookTrace({
+        job,
+        result,
+        delivered: false,
+        error: interruptionError(),
+      });
+    }
+    return settle(deliveredResult);
+  } catch (error) {
+    const deliveryError = abortSignal.aborted ? interruptionError() : formatErrorMessage(error);
+    state.deps.log.warn({ jobId: job.id, err: deliveryError }, "cron: webhook delivery failed");
+    return settle(withPrimaryWebhookTrace({ job, result, delivered: false, error: deliveryError }));
+  }
+}
 
 /**
  * Carries the already-resolved run attribution from watchdog-visible execution
@@ -59,14 +228,7 @@ function cronRunAttributionFromExecution(execution?: CronAgentExecutionStarted):
 export async function executeJobCoreWithTimeout(
   state: CronServiceState,
   job: CronJob,
-  opts?: {
-    runId?: string;
-    activeJobMarker?: CronActiveJobMarker;
-    owningCronLaneTaskMarker?: CommandLaneTaskMarker;
-    streamBatch?: string;
-    streamScheduleKey?: string;
-    streamSourceIdentity?: string;
-  },
+  opts?: CronCoreRunOptions,
 ): Promise<CronCoreRunOutcome> {
   const runAbortController = new AbortController();
   const operatorCancellationMarker = Symbol("cron-operator-cancelled");
@@ -76,7 +238,7 @@ export async function executeJobCoreWithTimeout(
   });
   const createOperatorCancellationOutcome = (execution?: CronAgentExecutionStarted) => {
     const error = abortErrorMessage(runAbortController.signal);
-    return {
+    const result: CronCoreRunOutcome = {
       status: "error" as const,
       error,
       ...cronRunAttributionFromExecution(execution),
@@ -84,6 +246,11 @@ export async function executeJobCoreWithTimeout(
         nowMs: state.deps.nowMs,
       }),
     };
+    return withPrimaryWebhookInterruption({
+      job,
+      result,
+      error: `cron webhook delivery cancelled: ${error}`,
+    });
   };
   if (!isCronActiveJobMarkerCurrent(opts?.activeJobMarker)) {
     runAbortController.abort("Gateway restarting.");
@@ -116,6 +283,7 @@ export async function executeJobCoreWithTimeout(
         accumulateExecution(info);
         recordTaskExecutionStart(info);
       };
+      const progress: CronRunProgress = {};
       const corePromise = executeJobCore(state, job, runAbortController.signal, {
         activeJobMarker: opts?.activeJobMarker,
         owningCronLaneTaskMarker: opts?.owningCronLaneTaskMarker,
@@ -125,8 +293,12 @@ export async function executeJobCoreWithTimeout(
         onExecutionStarted: noteExecutionStarted,
         onExecutionPhase: accumulateExecution,
       });
-      trackActiveCronTaskRunSettlement(corePromise);
-      void corePromise.catch((err: unknown) => {
+      const runPromise = corePromise.then(async (result) => {
+        progress.completedCoreResult = result;
+        return await deliverPrimaryWebhook(state, job, result, runAbortController.signal, progress);
+      });
+      trackActiveCronTaskRunSettlement(runPromise);
+      void runPromise.catch((err: unknown) => {
         if (runAbortController.signal.aborted) {
           state.deps.log.warn(
             { jobId: job.id, err: String(err) },
@@ -134,11 +306,19 @@ export async function executeJobCoreWithTimeout(
           );
         }
       });
-      const first = await Promise.race([corePromise, operatorCancellationPromise]);
+      const first = await Promise.race([runPromise, operatorCancellationPromise]);
       if (first !== operatorCancellationMarker) {
         return first;
       }
       startActiveCronTaskRunSettlementGrace();
+      const settled = resolveInterruptedRunProgress({
+        progress,
+        job,
+        error: `cron webhook delivery cancelled: ${abortErrorMessage(runAbortController.signal)}`,
+      });
+      if (settled) {
+        return settled;
+      }
       return createOperatorCancellationOutcome(activeExecution);
     }
 
@@ -178,6 +358,7 @@ export async function executeJobCoreWithTimeout(
       watchdog.noteRunnerStarted(info);
       recordTaskExecutionStart(info);
     };
+    const progress: CronRunProgress = {};
     const corePromise = executeJobCore(state, job, runAbortController.signal, {
       activeJobMarker: opts?.activeJobMarker,
       owningCronLaneTaskMarker: opts?.owningCronLaneTaskMarker,
@@ -188,9 +369,20 @@ export async function executeJobCoreWithTimeout(
       onExecutionPhase: deferTimeoutUntilExecutionStart ? watchdog.notePhase : undefined,
       onLaneWait: deferTimeoutUntilExecutionStart ? noteLaneState : undefined,
     });
-    trackActiveCronTaskRunSettlement(corePromise);
     watchdog.start();
-    void corePromise.catch((err: unknown) => {
+    const runPromise = corePromise.then(async (result) => {
+      progress.completedCoreResult = result;
+      return await deliverPrimaryWebhook(
+        state,
+        job,
+        result,
+        runAbortController.signal,
+        progress,
+        watchdog.deadlineAtMs(),
+      );
+    });
+    trackActiveCronTaskRunSettlement(runPromise);
+    void runPromise.catch((err: unknown) => {
       if (runAbortController.signal.aborted) {
         state.deps.log.warn(
           { jobId: job.id, err: String(err) },
@@ -199,9 +391,17 @@ export async function executeJobCoreWithTimeout(
       }
     });
     try {
-      const first = await Promise.race([corePromise, timeoutPromise, operatorCancellationPromise]);
+      const first = await Promise.race([runPromise, timeoutPromise, operatorCancellationPromise]);
       if (first === operatorCancellationMarker) {
         startActiveCronTaskRunSettlementGrace();
+        const settled = resolveInterruptedRunProgress({
+          progress,
+          job,
+          error: `cron webhook delivery cancelled: ${abortErrorMessage(runAbortController.signal)}`,
+        });
+        if (settled) {
+          return settled;
+        }
         return createOperatorCancellationOutcome(watchdog.activeExecution());
       }
       if (first !== timeoutMarker) {
@@ -209,6 +409,14 @@ export async function executeJobCoreWithTimeout(
       }
       startActiveCronTaskRunSettlementGrace();
       const activeExecution = watchdog.activeExecution();
+      const settled = resolveInterruptedRunProgress({
+        progress,
+        job,
+        error: `cron webhook delivery timed out: ${timeoutReason ?? timeoutErrorMessage(activeExecution)}`,
+      });
+      if (settled) {
+        return settled;
+      }
       await cleanupTimedOutCronAgentRun(state, job, jobTimeoutMs, activeExecution);
       const error = timeoutReason ?? timeoutErrorMessage(activeExecution);
       const observedLaneWait = watchdog.observedLaneWait();
@@ -220,7 +428,7 @@ export async function executeJobCoreWithTimeout(
               otherCronJobsActiveAtTimeout: false,
             }
           : undefined;
-      return {
+      const result: CronCoreRunOutcome = {
         status: "error",
         error,
         ...cronRunAttributionFromExecution(activeExecution),
@@ -229,6 +437,11 @@ export async function executeJobCoreWithTimeout(
         }),
         ...(isolatedAgentSetupTimeout ? { isolatedAgentSetupTimeout } : {}),
       };
+      return withPrimaryWebhookInterruption({
+        job,
+        result,
+        error: `cron webhook delivery timed out: ${error}`,
+      });
     } finally {
       watchdog.dispose();
     }

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -115,6 +115,7 @@ export function applyJobResult(
     job,
     runStatus: result.status,
     delivered: result.delivered,
+    deliveryAttempted: result.deliveryAttempted,
     // A successful run keeps `error` empty but may carry a dedicated
     // `deliveryError` when post-run delivery failed (#94058/#95419); prefer it
     // so `lastDeliveryError` is populated without conflating it with a

--- a/src/cron/service/timer-trigger.ts
+++ b/src/cron/service/timer-trigger.ts
@@ -207,6 +207,7 @@ export function resolveDeliveryState(params: {
   job: CronJob;
   runStatus: CronRunStatus;
   delivered?: boolean;
+  deliveryAttempted?: boolean;
   error?: string;
   globalFailureDestination?: CronConfig["failureAlert"];
 }): {
@@ -224,10 +225,29 @@ export function resolveDeliveryState(params: {
     params.job.delivery?.bestEffort !== true &&
     resolveFailureDestination(params.job, params.globalFailureDestination) !== null;
   if (!primaryDeliveryRequested) {
+    if (primaryDeliveryPlan.mode === "webhook") {
+      if (params.delivered === true) {
+        return {
+          delivered: true,
+          status: "delivered",
+          failureNotification: {
+            status: alternateFailureNotificationRequested ? "unknown" : "not-requested",
+          },
+        };
+      }
+      if (params.deliveryAttempted === true) {
+        return {
+          delivered: false,
+          status: "not-delivered",
+          error: params.error,
+          failureNotification: {
+            status: alternateFailureNotificationRequested ? "unknown" : "not-requested",
+          },
+        };
+      }
+    }
     return {
-      // Webhooks run outside the announce runner. Their completion is not yet
-      // known here, but an explicitly requested webhook is never "not-requested".
-      status: primaryDeliveryPlan.mode === "webhook" ? "unknown" : "not-requested",
+      status: "not-requested",
       failureNotification: {
         status: alternateFailureNotificationRequested ? "unknown" : "not-requested",
       },

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -88,6 +88,13 @@ function createWebhookJob(delivery: NonNullable<CronJob["delivery"]>): CronJob {
   };
 }
 
+function createCompletionWebhookJob(url = "https://example.invalid/cron"): CronJob {
+  return createWebhookJob({
+    mode: "announce",
+    completionDestination: { mode: "webhook", to: url },
+  });
+}
+
 describe("dispatchGatewayCronFinishedNotifications", () => {
   beforeEach(() => {
     resetGatewayWorkAdmission();
@@ -116,10 +123,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
         release: vi.fn(async () => {}),
       };
     });
-    const job = createWebhookJob({
-      mode: "webhook",
-      to: "https://example.invalid/cron",
-    });
+    const job = createCompletionWebhookJob();
     const parentAdmission = tryBeginGatewayRootWorkAdmission();
     expect(parentAdmission).not.toBeNull();
     if (!parentAdmission) {
@@ -150,10 +154,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
 
   it("keeps webhook delivery cold when its token owner is unavailable", async () => {
     const logger = { warn: vi.fn() };
-    const job = createWebhookJob({
-      mode: "webhook",
-      to: "https://example.invalid/cron",
-    });
+    const job = createCompletionWebhookJob();
     setActiveDegradedSecretOwners([
       {
         ownerKind: "capability",
@@ -196,10 +197,9 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
         release,
       });
       const logger = { warn: vi.fn() };
-      const job = createWebhookJob({
-        mode: "webhook",
-        to: "https://example.invalid/cron?token=must-not-be-logged",
-      });
+      const job = createCompletionWebhookJob(
+        "https://example.invalid/cron?token=must-not-be-logged",
+      );
 
       dispatchGatewayCronFinishedNotifications({
         evt: { jobId: job.id, action: "finished", status: "ok", summary: "done" },
@@ -213,7 +213,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
         expect(logger.warn).toHaveBeenCalledWith(
           expect.objectContaining({
             jobId: job.id,
-            source: "delivery",
+            source: "completionDestination",
             err: expect.stringContaining(String(status)),
             webhookUrl: "https://example.invalid/cron",
           }),
@@ -368,10 +368,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
 
   it("keeps immediate failure webhook messages stable and adds structured runAtMs", async () => {
     const runAtMs = Date.parse("2026-01-15T15:30:00.000Z");
-    const job = createWebhookJob({
-      mode: "webhook",
-      to: "https://example.invalid/cron",
-    });
+    const job = createCompletionWebhookJob();
 
     await sendGatewayCronFailureAlert({
       deps: {} as CliDeps,
@@ -398,10 +395,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
 
   it("delivers a failed cron webhook even when the run produced no summary", async () => {
     const logger = { warn: vi.fn() };
-    const job = createWebhookJob({
-      mode: "webhook",
-      to: "https://example.invalid/cron",
-    });
+    const job = createCompletionWebhookJob();
 
     dispatchGatewayCronFinishedNotifications({
       evt: {
@@ -427,10 +421,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
   });
 
   it("applies the webhook timeout to guarded network preflight", async () => {
-    const job = createWebhookJob({
-      mode: "webhook",
-      to: "https://example.invalid/cron",
-    });
+    const job = createCompletionWebhookJob();
 
     dispatchGatewayCronFinishedNotifications({
       evt: { jobId: job.id, action: "finished", status: "ok", summary: "done" },
@@ -571,10 +562,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
   );
 
   it("defers detached completion delivery while suspension is prepared", async () => {
-    const job = createWebhookJob({
-      mode: "webhook",
-      to: "https://example.invalid/cron",
-    });
+    const job = createCompletionWebhookJob();
     const suspensionAdmission = tryBeginGatewaySuspendAdmission(() => {});
     expect(suspensionAdmission?.commit()).toBe(true);
 
@@ -945,8 +933,11 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       wakeMode: "next-heartbeat",
       payload: { kind: "command", argv: ["echo", "ok"] },
       delivery: {
-        mode: "webhook",
-        to: "https://example.invalid/cron",
+        mode: "announce",
+        completionDestination: {
+          mode: "webhook",
+          to: "https://example.invalid/cron",
+        },
       },
       state: {
         lastDiagnosticSummary: sensitiveSummary,

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -215,6 +215,7 @@ async function postCronWebhookStrict(params: {
   payload: unknown;
   signal?: AbortSignal;
   deadlineAtMs?: number;
+  onDeliveryAccepted?: () => void;
 }): Promise<void> {
   const remainingMs =
     params.deadlineAtMs === undefined ? CRON_WEBHOOK_TIMEOUT_MS : params.deadlineAtMs - Date.now();
@@ -236,33 +237,37 @@ async function postCronWebhookStrict(params: {
       body: JSON.stringify(params.payload),
     },
   });
+  let accepted = false;
   try {
     if (!result.response.ok) {
       throw new Error(`Webhook request failed with HTTP ${result.response.status}`);
     }
+    accepted = true;
+    params.onDeliveryAccepted?.();
   } finally {
-    // Guard release closes the dispatcher, not an unread response stream.
-    // Keep response cleanup inside the request deadline; a non-settling
-    // stream cancellation must not retain the dispatcher or Gateway root.
-    if (!result.response.bodyUsed) {
-      const cancellation = result.response.body?.cancel();
-      if (cancellation) {
-        await withTimeout(
-          cancellation,
-          Math.max(1, requestDeadlineAtMs - Date.now()),
-          "cron webhook response cleanup",
-        ).catch(() => undefined);
+    const cleanup = async () => {
+      // Guard release closes the dispatcher, not an unread response stream.
+      // Keep response cleanup inside the request deadline; a non-settling
+      // stream cancellation must not retain the dispatcher or Gateway root.
+      if (!result.response.bodyUsed) {
+        const cancellation = result.response.body?.cancel();
+        if (cancellation) {
+          await withTimeout(
+            cancellation,
+            Math.max(1, requestDeadlineAtMs - Date.now()),
+            "cron webhook response cleanup",
+          ).catch(() => undefined);
+        }
       }
+      await result.release();
+    };
+    if (accepted) {
+      // A 2xx acknowledgement is the terminal delivery fact. Cleanup must not
+      // rewrite it after the receiver has accepted the webhook.
+      await cleanup().catch(() => undefined);
+    } else {
+      await cleanup();
     }
-    await result.release();
-  }
-  if (params.signal?.aborted) {
-    throw new Error("cron webhook delivery aborted");
-  }
-  if (params.deadlineAtMs !== undefined && Date.now() >= params.deadlineAtMs) {
-    const error = new Error("cron webhook delivery deadline exceeded");
-    error.name = "TimeoutError";
-    throw error;
   }
 }
 
@@ -308,6 +313,7 @@ export async function sendGatewayCronWebhook(params: {
   abortSignal?: AbortSignal;
   deadlineAtMs?: number;
   webhookToken?: unknown;
+  onDeliveryAccepted?: () => void;
 }): Promise<void> {
   const deliveryPlan = resolveCronDeliveryPlan(params.job);
   const webhookUrl = normalizeHttpWebhookUrl(deliveryPlan.to);
@@ -327,6 +333,7 @@ export async function sendGatewayCronWebhook(params: {
         payload: buildCronFinishedWebhookPayload(event),
         ...(params.abortSignal ? { signal: params.abortSignal } : {}),
         ...(params.deadlineAtMs !== undefined ? { deadlineAtMs: params.deadlineAtMs } : {}),
+        ...(params.onDeliveryAccepted ? { onDeliveryAccepted: params.onDeliveryAccepted } : {}),
       }),
     shouldRetryError: (error) => !(error instanceof SsrFBlockedError),
   });

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -15,6 +15,7 @@ import {
   sendCronAnnouncePayloadStrict,
   sendFailureNotificationAnnounce,
 } from "../cron/delivery.js";
+import { retryTransientDirectCronDelivery } from "../cron/isolated-agent/delivery-dispatch-policy.js";
 import type { CronEvent } from "../cron/service.js";
 import { resolveCronDeliverySessionKey } from "../cron/session-target.js";
 import type { CronJob, CronMessageChannel } from "../cron/types.js";
@@ -40,7 +41,7 @@ type CronAgentResolver = (requested?: string | null) => {
 
 type CronWebhookTarget = {
   url: string;
-  source: "delivery" | "completionDestination";
+  source: "completionDestination";
 };
 
 type CronFailureAlertParams = {
@@ -127,7 +128,7 @@ function redactCommandCronEventForExternalDelivery(evt: CronEvent, job?: CronJob
   return redacted;
 }
 
-/** Resolves direct webhook delivery and completion-destination webhooks. */
+/** Resolves detached completion-destination webhooks. */
 function resolveCronWebhookTargets(params: {
   delivery?: {
     mode?: string;
@@ -137,19 +138,12 @@ function resolveCronWebhookTargets(params: {
 }): CronWebhookTarget[] {
   const targets: CronWebhookTarget[] = [];
   const mode = normalizeOptionalLowercaseString(params.delivery?.mode);
-  if (mode === "webhook") {
-    const url = normalizeHttpWebhookUrl(params.delivery?.to);
-    if (url) {
-      targets.push({ url, source: "delivery" });
-    }
-  }
-
   const completionMode = normalizeOptionalLowercaseString(
     params.delivery?.completionDestination?.mode,
   );
   if (mode === "announce" && completionMode === "webhook") {
     const url = normalizeHttpWebhookUrl(params.delivery?.completionDestination?.to);
-    if (url && targets.every((target) => target.url !== url)) {
+    if (url) {
       targets.push({ url, source: "completionDestination" });
     }
   }
@@ -215,7 +209,64 @@ function buildCronFinishedWebhookPayload(evt: CronEvent) {
   return payload;
 }
 
-/** Posts a cron webhook without throwing back into scheduler completion flow. */
+async function postCronWebhookStrict(params: {
+  webhookUrl: string;
+  webhookToken?: string;
+  payload: unknown;
+  signal?: AbortSignal;
+  deadlineAtMs?: number;
+}): Promise<void> {
+  const remainingMs =
+    params.deadlineAtMs === undefined ? CRON_WEBHOOK_TIMEOUT_MS : params.deadlineAtMs - Date.now();
+  if (remainingMs <= 0) {
+    const error = new Error("cron webhook delivery deadline exceeded");
+    error.name = "TimeoutError";
+    throw error;
+  }
+  const requestTimeoutMs = Math.min(CRON_WEBHOOK_TIMEOUT_MS, remainingMs);
+  const requestDeadlineAtMs = Date.now() + requestTimeoutMs;
+  assertSecretOwnerAvailable("capability", "cron-webhook");
+  const result = await fetchWithSsrFGuard({
+    url: params.webhookUrl,
+    timeoutMs: requestTimeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
+    init: {
+      method: "POST",
+      headers: buildCronWebhookHeaders(params.webhookToken),
+      body: JSON.stringify(params.payload),
+    },
+  });
+  try {
+    if (!result.response.ok) {
+      throw new Error(`Webhook request failed with HTTP ${result.response.status}`);
+    }
+  } finally {
+    // Guard release closes the dispatcher, not an unread response stream.
+    // Keep response cleanup inside the request deadline; a non-settling
+    // stream cancellation must not retain the dispatcher or Gateway root.
+    if (!result.response.bodyUsed) {
+      const cancellation = result.response.body?.cancel();
+      if (cancellation) {
+        await withTimeout(
+          cancellation,
+          Math.max(1, requestDeadlineAtMs - Date.now()),
+          "cron webhook response cleanup",
+        ).catch(() => undefined);
+      }
+    }
+    await result.release();
+  }
+  if (params.signal?.aborted) {
+    throw new Error("cron webhook delivery aborted");
+  }
+  if (params.deadlineAtMs !== undefined && Date.now() >= params.deadlineAtMs) {
+    const error = new Error("cron webhook delivery deadline exceeded");
+    error.name = "TimeoutError";
+    throw error;
+  }
+}
+
+/** Posts a detached cron webhook without throwing back into scheduler completion flow. */
 async function postCronWebhook(params: {
   webhookUrl: string;
   webhookToken?: string;
@@ -225,40 +276,8 @@ async function postCronWebhook(params: {
   failedLog: string;
   logger: CronLogger;
 }): Promise<void> {
-  const abortController = new AbortController();
-  const deadlineAtMs = Date.now() + CRON_WEBHOOK_TIMEOUT_MS;
   try {
-    assertSecretOwnerAvailable("capability", "cron-webhook");
-    const result = await fetchWithSsrFGuard({
-      url: params.webhookUrl,
-      timeoutMs: CRON_WEBHOOK_TIMEOUT_MS,
-      init: {
-        method: "POST",
-        headers: buildCronWebhookHeaders(params.webhookToken),
-        body: JSON.stringify(params.payload),
-        signal: abortController.signal,
-      },
-    });
-    try {
-      if (!result.response.ok) {
-        throw new Error(`Webhook request failed with HTTP ${result.response.status}`);
-      }
-    } finally {
-      // Guard release closes the dispatcher, not an unread response stream.
-      // Keep response cleanup inside the request deadline; a non-settling
-      // stream cancellation must not retain the dispatcher or Gateway root.
-      if (!result.response.bodyUsed) {
-        const cancellation = result.response.body?.cancel();
-        if (cancellation) {
-          await withTimeout(
-            cancellation,
-            Math.max(1, deadlineAtMs - Date.now()),
-            "cron webhook response cleanup",
-          ).catch(() => undefined);
-        }
-      }
-      await result.release();
-    }
+    await postCronWebhookStrict(params);
   } catch (err) {
     if (err instanceof SsrFBlockedError) {
       params.logger.warn(
@@ -280,6 +299,37 @@ async function postCronWebhook(params: {
       );
     }
   }
+}
+
+/** Delivers the primary webhook while the cron run still owns its terminal outcome. */
+export async function sendGatewayCronWebhook(params: {
+  event: CronEvent;
+  job: CronJob;
+  abortSignal?: AbortSignal;
+  deadlineAtMs?: number;
+  webhookToken?: unknown;
+}): Promise<void> {
+  const deliveryPlan = resolveCronDeliveryPlan(params.job);
+  const webhookUrl = normalizeHttpWebhookUrl(deliveryPlan.to);
+  if (!webhookUrl) {
+    throw new Error("cron webhook delivery.to must be a valid http(s) URL");
+  }
+  const event = redactCommandCronEventForExternalDelivery(params.event, params.job);
+  await retryTransientDirectCronDelivery({
+    jobId: params.job.id,
+    label: "webhook",
+    ...(params.abortSignal ? { signal: params.abortSignal } : {}),
+    ...(params.deadlineAtMs !== undefined ? { deadlineAtMs: params.deadlineAtMs } : {}),
+    run: () =>
+      postCronWebhookStrict({
+        webhookUrl,
+        webhookToken: normalizeOptionalString(params.webhookToken),
+        payload: buildCronFinishedWebhookPayload(event),
+        ...(params.abortSignal ? { signal: params.abortSignal } : {}),
+        ...(params.deadlineAtMs !== undefined ? { deadlineAtMs: params.deadlineAtMs } : {}),
+      }),
+    shouldRetryError: (error) => !(error instanceof SsrFBlockedError),
+  });
 }
 
 /** Detached sends outlive cron ticks; own roots block mid-delivery suspension snapshots. */
@@ -412,19 +462,6 @@ export function dispatchGatewayCronFinishedNotifications(params: {
         deliveryTo: redactOptionalWebhookUrl(params.job.delivery.completionDestination.to),
       },
       "cron: skipped completion webhook delivery, delivery.completionDestination.to must be a valid http(s) URL",
-    );
-  }
-
-  if (
-    !webhookTargets.some((target) => target.source === "delivery") &&
-    params.job?.delivery?.mode === "webhook"
-  ) {
-    params.logger.warn(
-      {
-        jobId: params.evt.jobId,
-        deliveryTo: redactOptionalWebhookUrl(params.job.delivery.to),
-      },
-      "cron: skipped webhook delivery, delivery.to must be a valid http(s) URL",
     );
   }
 

--- a/src/gateway/server-cron-primary-webhook.test.ts
+++ b/src/gateway/server-cron-primary-webhook.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CronJob } from "../cron/types.js";
+
+const mocks = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+}));
+
+vi.mock("../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
+}));
+
+import { sendGatewayCronWebhook } from "./server-cron-notifications.js";
+
+function createWebhookJob(): CronJob {
+  return {
+    id: "primary-webhook-deadline",
+    name: "primary webhook deadline",
+    enabled: true,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "hello" },
+    delivery: { mode: "webhook", to: "https://example.invalid/cron" },
+    state: {},
+  };
+}
+
+describe("sendGatewayCronWebhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("propagates cancellation and the remaining run deadline without retrying", async () => {
+    const controller = new AbortController();
+    mocks.fetchWithSsrFGuard.mockImplementationOnce(async (value: unknown) => {
+      const request = value as { signal?: AbortSignal };
+      const signal = request.signal;
+      if (!signal) {
+        throw new Error("expected run abort signal");
+      }
+      return await new Promise<never>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => reject(new Error(String(signal.reason ?? "aborted"))),
+          { once: true },
+        );
+      });
+    });
+    const job = createWebhookJob();
+    const deadlineAtMs = Date.now() + 5_000;
+    const delivery = sendGatewayCronWebhook({
+      event: { jobId: job.id, action: "finished", status: "ok", summary: "done" },
+      job,
+      abortSignal: controller.signal,
+      deadlineAtMs,
+    });
+
+    await vi.waitFor(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledOnce());
+    const request = mocks.fetchWithSsrFGuard.mock.calls[0]?.[0] as
+      | { signal?: AbortSignal; timeoutMs?: number }
+      | undefined;
+    expect(request?.signal).toBe(controller.signal);
+    expect(request?.timeoutMs).toEqual(expect.any(Number));
+    expect(request?.timeoutMs).toBeGreaterThan(0);
+    expect(request?.timeoutMs).toBeLessThanOrEqual(5_000);
+
+    controller.abort("Cancelled by operator.");
+    await expect(delivery).rejects.toBeDefined();
+    expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledOnce();
+  });
+});

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -2655,6 +2655,7 @@ describe("buildGatewayCronService", () => {
       const job = await state.cron.add({
         name: "ssrf-webhook-blocked",
         enabled: true,
+        deleteAfterRun: false,
         schedule: { kind: "at", at: new Date(1).toISOString() },
         sessionTarget: "main",
         wakeMode: "next-heartbeat",
@@ -2677,7 +2678,13 @@ describe("buildGatewayCronService", () => {
       expect(init.method).toBe("POST");
       expect(init.headers).toEqual({ "Content-Type": "application/json" });
       expect(String(init.body)).toContain('"action":"finished"');
-      expect(init.signal).toBeInstanceOf(AbortSignal);
+      expect(request.signal).toBeInstanceOf(AbortSignal);
+      expect(state.cron.getJob(job.id)?.state).toMatchObject({
+        lastRunStatus: "ok",
+        lastDelivered: false,
+        lastDeliveryStatus: "not-delivered",
+        lastDeliveryError: "Blocked: resolves to private/internal/special-use IP address",
+      });
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -847,11 +847,12 @@ export function buildGatewayCronService(params: {
         };
       }
     },
-    sendCronWebhook: async ({ job, event, abortSignal, deadlineAtMs }) => {
+    sendCronWebhook: async ({ job, event, abortSignal, deadlineAtMs, onDeliveryAccepted }) => {
       await sendGatewayCronWebhook({
         job,
         event,
         abortSignal,
+        onDeliveryAccepted,
         ...(deadlineAtMs !== undefined ? { deadlineAtMs } : {}),
         webhookToken: params.cfg.cron?.webhookToken,
       });

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -84,6 +84,7 @@ import type { GatewayCronServiceContract } from "./server-cron-contract.js";
 import { reconcileHeartbeatMonitorJobs } from "./server-cron-heartbeat-jobs.js";
 import {
   dispatchGatewayCronFinishedNotifications,
+  sendGatewayCronWebhook,
   sendGatewayCronFailureAlert,
 } from "./server-cron-notifications.js";
 import {
@@ -845,6 +846,15 @@ export function buildGatewayCronService(params: {
           },
         };
       }
+    },
+    sendCronWebhook: async ({ job, event, abortSignal, deadlineAtMs }) => {
+      await sendGatewayCronWebhook({
+        job,
+        event,
+        abortSignal,
+        ...(deadlineAtMs !== undefined ? { deadlineAtMs } : {}),
+        webhookToken: params.cfg.cron?.webhookToken,
+      });
     },
     runScriptJob: async ({ job, streamBatch, abortSignal }) => {
       if (!scriptRuntime || job.payload.kind !== "script") {

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -417,7 +417,7 @@ async function runCronJobAndWaitForFinished(ws: WebSocket, jobId: string) {
     (payload) => payload?.jobId === jobId && payload?.action === "finished",
   );
   await runCronJobForce(ws, jobId);
-  await finished;
+  return await finished;
 }
 
 function getWebhookCall(index: number) {
@@ -1729,7 +1729,7 @@ describe("gateway server cron", () => {
         name: "webhook enabled",
         delivery: { mode: "webhook", to: "https://example.invalid/cron-finished" },
       });
-      await runCronJobAndWaitForFinished(ws, notifyJobId);
+      const notifyFinished = await runCronJobAndWaitForFinished(ws, notifyJobId);
       const notifyCall = getWebhookCall(0);
       expect(notifyCall.url).toBe("https://example.invalid/cron-finished");
       expect(notifyCall.init.method).toBe("POST");
@@ -1739,6 +1739,19 @@ describe("gateway server cron", () => {
       expect(notifyBody.action).toBe("finished");
       expect(notifyBody.jobId).toBe(notifyJobId);
       expect(notifyBody.summary).toBe("send webhook");
+      expectRecordFields(notifyFinished, {
+        status: "ok",
+        delivered: true,
+        deliveryStatus: "delivered",
+      });
+
+      const notifyRuns = await rpcReq(ws, "cron.runs", { id: notifyJobId, limit: 10 });
+      expect(notifyRuns.ok).toBe(true);
+      const notifyEntries = (notifyRuns.payload as { entries?: unknown } | null)?.entries;
+      expect(Array.isArray(notifyEntries)).toBe(true);
+      expect((notifyEntries as Array<{ deliveryStatus?: unknown }>).at(-1)?.deliveryStatus).toBe(
+        "delivered",
+      );
 
       expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## What Problem This Solves

Cron jobs configured with `--webhook` could complete successfully, produce their payload, deliver nothing, and record `deliveryStatus: "unknown"` — a silent failure indistinguishable from success in run history.

Reproduced on the production team host (dist 120fa5d): a command job with a webhook target fired twice on schedule, both runs `status: ok` with the payload in `summary`, zero POSTs observed, `deliveryStatus: "unknown"` recorded. Both command jobs and isolated agent jobs were affected. `docs/cli/cron.md` explicitly promises command jobs "route output through the same `announce`, `webhook`, or `none` delivery modes".

## Why This Change Was Made

The root cause was split ownership. Command execution only handled announce delivery (`server-cron.ts`); webhook mode returned `delivered: false` without sending. Cron then finalized state/history, converting that into terminal `"unknown"` (`timer-trigger.ts`). Only afterwards did the gateway dispatch a *detached* webhook from the finished event, whose errors were logged and swallowed — they could never repair the already-persisted history. (For loopback URLs specifically, the SSRF guard correctly rejects private addresses — that boundary is intentional and unchanged; the bug was that the rejection, like every other delivery failure, vanished into `"unknown"`.)

Provenance: not a recent regression. Command jobs plus their webhook docs arrived together in #89712 (author @mbelinky, merged by Vincent Koc) already relying on the detached path; per-job webhook delivery originated in #17901 (author Advait Paliwal, merged by Tyler Yust); #116923 later made the unobserved state explicitly `unknown` without adding reconciliation.

The fix makes primary webhook delivery a recorded part of the cron run:

- Delivery executes inside the run's tracked lifetime, sharing the run's abort controller and watchdog deadline — a hanging endpoint finalizes the run at its configured deadline as `not-delivered`/timeout, and operator cancellation interrupts an in-flight send immediately (both proven with real-HTTP regressions; review round 2 required this).
- The settled delivery result is published before the delivery promise resolves, and cancellation/timeout branches consult it first — an endpoint that already accepted the POST can never be overwritten to `not-delivered` by a late cancellation (review round 3).
- Success records `delivered`; HTTP, timeout, secret-owner, invalid-target, and SSRF failures record `not-delivered` plus a concrete `deliveryError`. `unknown` is no longer the terminal state for a configured webhook.
- A trigger that intentionally evaluates false keeps its not-requested status rather than being misrecorded as a failed delivery (review round 4).
- Transient errors retry only when provably unsent, reusing the existing 5/10/20 s policy; HTTP and SSRF failures do not retry. The detached finished-event fanout now owns only secondary `completionDestination` webhooks, preventing double POSTs.

No announce/channel behavior, Discord code, config surface, or schema changed.

## User Impact

Webhook-configured jobs now actually deliver, and every outcome is honestly recorded: `delivered` on success, `not-delivered` with the concrete error otherwise — including the previously invisible SSRF-blocked case. Runs finalize within their configured deadline even against dead endpoints, and shutdown/cancellation cannot strand a run in delivery.

## Evidence

- Real-HTTP regressions: 204 → exactly one POST containing the payload, recorded `delivered`; 503 → one POST, `not-delivered` with `HTTP 503`; hanging endpoint → finalized at the job deadline, command result preserved `ok`, delivery `not-delivered`/timeout; cancellation mid-hang → finalized in under a second with the cancellation reason; accepted-POST-then-cancel race → stays `delivered`; trigger-evaluates-false → not-requested status, no deliveryError; isolated-agent webhook sibling → `delivered`.
- `node scripts/run-vitest.mjs src/cron`: 160 files, 1,934 tests passed. Gateway webhook/cron suites: 113 passed. Timeout/watchdog regressions: 69/69.
- Changed-scope gate passed locally (Testbox backend unavailable; documented trusted-source fallback), plus formatting, oxlint, core typechecks, `git diff --check`.
- Autoreview (Codex `gpt-5.6-sol`, high): three review rounds surfaced an abort-scope escape, a settled-delivery cancellation race, and the trigger-not-fired mapping — each fixed with regressions; final round clean, "patch is correct" (0.86).

Production delta net +311 (delivery moved into the run lifecycle with signal/deadline plumbing — an ownership move, not a patch); tests net +541.
