### PR TITLE
fix(qa): make Matrix voice validation independent of staged filenames

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -3989,7 +3989,7 @@ describe("qa mock openai server", () => {
     });
   });
 
-  it("serves the Matrix voice preflight transcription contract after Matrix media staging", async () => {
+  it("serves the Matrix voice preflight transcription contract for the request prompt", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",
       port: 0,
@@ -4003,9 +4003,10 @@ describe("qa mock openai server", () => {
       headers: {
         "content-type": "multipart/form-data; boundary=qa",
       },
-      body: `--qa\r\ncontent-disposition: form-data; name="file"; filename="matrix-qa-voice-preflight---fixture-id.wav"\r\n\r\n${"voice".repeat(
-        16_000,
-      )}\r\n--qa--\r\n`,
+      body:
+        '--qa\r\ncontent-disposition: form-data; name="file"; filename="audio.wav"\r\n\r\n' +
+        `${"voice".repeat(16_000)}\r\n--qa\r\ncontent-disposition: form-data; name="prompt"\r\n\r\n` +
+        "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER\r\n--qa--\r\n",
     });
 
     expect(response.status).toBe(200);

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -191,11 +191,7 @@ const QA_AUDIO_TRANSCRIPTION_TEXT =
 const QA_GROUP_AUDIO_TRANSCRIPTION_TEXT =
   "openclawqa reply with only this exact marker after group audio preflight: WHATSAPP_QA_GROUP_AUDIO_TRANSCRIPT_OK";
 const QA_GROUP_AUDIO_MIN_MULTIPART_BODY_CHARS = 48_000;
-const QA_MATRIX_VOICE_PREFLIGHT_FILENAME = "matrix-qa-voice-preflight.wav";
-const QA_MATRIX_VOICE_PREFLIGHT_FILENAME_STEM = QA_MATRIX_VOICE_PREFLIGHT_FILENAME.replace(
-  /\.wav$/,
-  "",
-);
+const QA_MATRIX_VOICE_PREFLIGHT_TRIGGER = "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER";
 const QA_MATRIX_VOICE_PREFLIGHT_TRANSCRIPTION_TEXT =
   "MATRIX_QA_VOICE_PREFLIGHT_MENTION reply with only this exact marker: MATRIX_QA_VOICE_PREFLIGHT_OK";
 const QA_MCP_CODE_MODE_API_FILE_PROMPT_RE = /mcp code mode api file qa check/i;
@@ -259,9 +255,7 @@ function writeOpenAiMalformedJsonError(res: ServerResponse, label: string) {
 }
 
 function transcriptionTextForAudioRequest(rawBody: string) {
-  // Matrix stages inbound media as <original-stem>---<uuid>.<ext>, so the
-  // original filename is not present verbatim in the OpenAI multipart upload.
-  if (rawBody.includes(QA_MATRIX_VOICE_PREFLIGHT_FILENAME_STEM)) {
+  if (rawBody.includes(QA_MATRIX_VOICE_PREFLIGHT_TRIGGER)) {
     return QA_MATRIX_VOICE_PREFLIGHT_TRANSCRIPTION_TEXT;
   }
   if (rawBody.length >= QA_GROUP_AUDIO_MIN_MULTIPART_BODY_CHARS) {

--- a/extensions/qa-matrix/src/runners/contract/scenario-catalog.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-catalog.ts
@@ -515,6 +515,7 @@ export const MATRIX_QA_SCENARIOS: MatrixQaScenarioDefinition[] = [
       audio: {
         enabled: true,
         models: [{ model: "gpt-4o-transcribe", provider: "openai" }],
+        prompt: "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER",
       },
       groupMentionPatterns: [MATRIX_QA_VOICE_PREFLIGHT_MENTION],
     },

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -4774,9 +4774,10 @@ describe("matrix live qa scenarios", () => {
 
     const scenario = requireMatrixQaScenario("matrix-voice-preflight-mention");
     expect(scenario.configOverrides?.audio?.enabled).toBe(true);
-    expect(scenario.configOverrides?.audio?.models).toEqual([
-      { model: "gpt-4o-transcribe", provider: "openai" },
-    ]);
+    expect(scenario.configOverrides?.audio).toMatchObject({
+      models: [{ model: "gpt-4o-transcribe", provider: "openai" }],
+      prompt: "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER",
+    });
     expect(scenario.configOverrides?.groupMentionPatterns).toEqual([
       MATRIX_QA_VOICE_PREFLIGHT_MENTION,
     ]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the extended-stable Matrix voice validation could choose a generic large-audio transcription after the runtime staged the uploaded WAV under a generated filename.

## Why This Change Was Made

This replaces #117559's release-only filename matcher with main's explicit request-prompt contract: the scenario config sends a Matrix-only audio prompt marker, and the mock server selects the matching deterministic transcription before its generic audio fallback. It changes QA fixtures only, not production Matrix or media behavior.

## User Impact

Release validation reliably proves the Matrix voice mention flow for 2026.6.34, without depending on a media-store filename convention.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.test.ts extensions/qa-matrix/src/runners/contract/scenarios.test.ts` (109 mock-server tests and 88 Matrix scenario tests passed)
- Disposable local Matrix run: `qa matrix --provider-mode mock-openai --scenario matrix-voice-preflight-mention` passed (4/4 checks, 31.1s).
- `git diff --check` passed.
- Fresh `autoreview --mode uncommitted` completed with no accepted/actionable findings before committing.

AI-assisted: yes.