### PR TITLE
test(gateway): align E2E handshake timeout

### DIFF
--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -52,6 +52,7 @@ export async function connectGatewayClient(params: {
   onEvent?: (evt: { event?: string; payload?: unknown }) => void;
   onHelloOk?: (hello: HelloOk) => void;
   connectChallengeTimeoutMs?: number;
+  preauthHandshakeTimeoutMs?: number;
   requestTimeoutMs?: number;
   timeoutMs?: number;
   timeoutMessage?: string;
@@ -97,6 +98,7 @@ export async function connectGatewayClient(params: {
       ...(params.connectChallengeTimeoutMs !== undefined
         ? { connectChallengeTimeoutMs: params.connectChallengeTimeoutMs }
         : {}),
+      preauthHandshakeTimeoutMs: params.preauthHandshakeTimeoutMs ?? params.timeoutMs,
       ...(params.requestTimeoutMs !== undefined
         ? { requestTimeoutMs: params.requestTimeoutMs }
         : {}),

--- a/test/helpers/sqlite-sessions-transcripts-flip-proof.ts
+++ b/test/helpers/sqlite-sessions-transcripts-flip-proof.ts
@@ -365,7 +365,7 @@ export async function runSqliteSessionsTranscriptsFlipProof(
       token: inst.gatewayToken,
       clientDisplayName: "sqlite-sessions-transcripts-flip-proof",
       requestTimeoutMs: 20_000,
-      timeoutMs: 20_000,
+      timeoutMs: 60_000,
     });
     try {
       await waitForHistoryContains(client, context.resetSessionKey, "legacy hello");
@@ -382,7 +382,7 @@ export async function runSqliteSessionsTranscriptsFlipProof(
       token: inst.gatewayToken,
       clientDisplayName: "sqlite-sessions-transcripts-flip-proof-restart",
       requestTimeoutMs: 20_000,
-      timeoutMs: 20_000,
+      timeoutMs: 60_000,
     });
     let restartedClientConnected = true;
     try {
@@ -489,7 +489,7 @@ export async function runSqliteSessionsTranscriptsFlipProof(
         token: inst.gatewayToken,
         clientDisplayName: "sqlite-sessions-transcripts-flip-proof-post-reset-restart",
         requestTimeoutMs: 20_000,
-        timeoutMs: 20_000,
+        timeoutMs: 60_000,
       });
       try {
         secondStartupAfterReset = await runSecondStartupAfterResetProof(
@@ -1711,14 +1711,14 @@ async function runConcurrentMultiClientLifecycle(
     token: inst.gatewayToken,
     clientDisplayName: "sqlite-sessions-transcripts-flip-proof-concurrent-history",
     requestTimeoutMs: 20_000,
-    timeoutMs: 20_000,
+    timeoutMs: 60_000,
   });
   const lifecycleClient = await connectGatewayClient({
     url: inst.url,
     token: inst.gatewayToken,
     clientDisplayName: "sqlite-sessions-transcripts-flip-proof-concurrent-lifecycle",
     requestTimeoutMs: 20_000,
-    timeoutMs: 20_000,
+    timeoutMs: 60_000,
   });
   try {
     await requireHistoryContains(


### PR DESCRIPTION
## Summary

- align the shared Gateway E2E helper's WebSocket opening-handshake deadline with its configured overall connection timeout
- allow callers to override the pre-auth handshake timeout explicitly
- give the heavyweight SQLite sessions/transcripts flip proof a 60-second connection budget without changing production defaults

Fixes #117790

## Verification

- `pnpm exec oxlint --type-aware src/gateway/test-helpers.e2e.ts test/helpers/sqlite-sessions-transcripts-flip-proof.ts`
- `pnpm exec vitest run packages/gateway-client/src/client.handshake.test.ts test/helpers/openclaw-test-instance.test.ts` (6 passed)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts` (1 passed, 143.76s)
- `pnpm exec oxfmt --check src/gateway/test-helpers.e2e.ts test/helpers/sqlite-sessions-transcripts-flip-proof.ts`
- `git diff --check`