### PR TITLE
fix(gateway): preserve conversation text when large images are omitted

### DIFF
--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -97,12 +97,21 @@ export function sanitizeChatHistoryContentBlock(
     changed = true;
   }
   const type = typeof entry.type === "string" ? entry.type : "";
-  if (type === "image" && typeof entry.data === "string") {
-    const bytes = estimateBase64DecodedBytes(entry.data);
-    delete entry.data;
-    entry.omitted = true;
-    entry.bytes = bytes;
-    changed = true;
+  if (type === "image") {
+    let imageData = typeof entry.data === "string" ? entry.data : undefined;
+    const source = readRecord(entry.source);
+    if (source?.type === "base64" && typeof source.data === "string") {
+      imageData ??= source.data;
+      const projectedSource = { ...source };
+      delete projectedSource.data;
+      entry.source = projectedSource;
+    }
+    if (imageData !== undefined) {
+      delete entry.data;
+      entry.omitted = true;
+      entry.bytes = estimateBase64DecodedBytes(imageData);
+      changed = true;
+    }
   }
   if (type === "audio" && entry.source && typeof entry.source === "object") {
     const source = { ...(entry.source as Record<string, unknown>) };

--- a/src/gateway/chat-display-projection.test.ts
+++ b/src/gateway/chat-display-projection.test.ts
@@ -1,6 +1,72 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeChatHistoryMessages } from "./chat-display-projection.js";
+import { createNoisyPngBuffer } from "../../test/helpers/image-fixtures.js";
+import {
+  projectChatDisplayMessages,
+  sanitizeChatHistoryMessages,
+} from "./chat-display-projection.js";
 import { mirrorMessageToolVisibleReplies } from "./chat-display-projection.message-tool.js";
+import {
+  CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
+  replaceOversizedChatHistoryMessages,
+} from "./server-methods/chat-history-budget.js";
+import { buildSessionHistorySnapshot } from "./session-history-state.js";
+
+describe("oversized multimodal chat history", () => {
+  it.each([
+    {
+      name: "native image data",
+      image: (data: string) => ({ type: "image", mimeType: "image/png", data }),
+    },
+    {
+      name: "Anthropic image source",
+      image: (data: string) => ({
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data },
+      }),
+    },
+  ])("keeps text while omitting $name from WebSocket and SSE history", ({ image }) => {
+    const png = createNoisyPngBuffer(320, 320);
+    const encoded = png.toString("base64");
+    const message = {
+      role: "user",
+      content: [
+        { type: "text", text: "keep prefix text" },
+        image(encoded),
+        { type: "text", text: "keep suffix text" },
+      ],
+    };
+    const projected = projectChatDisplayMessages([message]);
+    const websocket = replaceOversizedChatHistoryMessages({
+      messages: projected,
+      maxSingleMessageBytes: CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
+    }).messages;
+    const sse = buildSessionHistorySnapshot({ rawMessages: [message], limit: 5 }).history.messages;
+
+    for (const messages of [websocket, sse]) {
+      expect(messages).toMatchObject([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "keep prefix text" },
+            { type: "image", omitted: true, bytes: png.length },
+            { type: "text", text: "keep suffix text" },
+          ],
+        },
+      ]);
+      expect(JSON.stringify(messages)).not.toContain(encoded);
+      expect(Buffer.byteLength(JSON.stringify(messages))).toBeLessThan(
+        CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
+      );
+    }
+  });
+
+  it("preserves URL-backed images without changing their sources", () => {
+    const source = { type: "url", url: "https://example.invalid/picture.png" };
+    expect(
+      projectChatDisplayMessages([{ role: "user", content: [{ type: "image", source }] }]),
+    ).toEqual([{ role: "user", content: [{ type: "image", source }] }]);
+  });
+});
 
 describe("chat display message-tool projection", () => {
   it("mirrors an automatic-mode send confirmed for the current source", () => {

--- a/src/gateway/control-reply-text.test.ts
+++ b/src/gateway/control-reply-text.test.ts
@@ -23,7 +23,20 @@ describe("control reply display projection", () => {
     };
 
     expect(stripSuppressedControlReplyToken("NO_REPLY")).toBe("");
-    expect(projectChatDisplayMessages([message])).toEqual([message]);
+    expect(projectChatDisplayMessages([message])).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "NO_REPLY" },
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png" },
+            omitted: true,
+            bytes: 2,
+          },
+        ],
+      },
+    ]);
   });
 
   it("strips a standalone control token beside visible text", () => {

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -5,12 +5,14 @@ import os from "node:os";
 import path from "node:path";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { createNoisyPngBuffer } from "../../test/helpers/image-fixtures.js";
 import {
   createFileBackedSessionManagerForTest,
   openFileBackedSessionManagerForTest,
 } from "../../test/helpers/session-manager-file-fixture.js";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import { estimateStringChars, estimateTokensFromChars } from "../utils/cjk-chars.js";
+import { projectChatDisplayMessages } from "./chat-display-projection.js";
 import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
 import {
   ArchivedTranscriptReader,
@@ -1600,6 +1602,382 @@ describe("oversized transcript line guards", () => {
     expect(serialized).not.toContain(oversizedContent);
     expect(serialized).toContain("[chat.history omitted: message too large]");
     expect(serialized).toContain("after oversized");
+  });
+
+  test.each([
+    {
+      name: "native image data",
+      image: (data: string) => ({ type: "image", mimeType: "image/png", data }),
+    },
+    {
+      name: "native image data before type",
+      image: (data: string) => ({ data, mimeType: "image/png", type: "image" }),
+    },
+    {
+      name: "Anthropic image source",
+      image: (data: string) => ({
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data },
+      }),
+    },
+    {
+      name: "Anthropic image source before type",
+      image: (data: string) => ({
+        source: { type: "base64", media_type: "image/png", data },
+        type: "image",
+      }),
+    },
+    {
+      name: "Anthropic image source before cache control and type",
+      image: (data: string) => ({
+        source: { type: "base64", media_type: "image/png", data },
+        cache_control: { type: "ephemeral" },
+        type: "image",
+      }),
+    },
+    {
+      name: "native and Anthropic image payloads together",
+      image: (data: string) => ({
+        type: "image",
+        data,
+        source: { type: "base64", media_type: "image/png", data },
+      }),
+    },
+  ])("preserves recoverable reset-archive text around oversized $name", async ({ name, image }) => {
+    const sessionId = `test-oversized-archive-${name.replaceAll(" ", "-")}`;
+    const png = createNoisyPngBuffer(320, 320);
+    const encoded = png.toString("base64");
+    writeResetArchive(tmpDir, sessionId, "2026-07-12T18-00-00.000Z", [
+      { type: "session", version: 3, id: sessionId },
+      createTranscriptMessage("archived-image", null, "user", [
+        { type: "text", text: "keep prefix text" },
+        image(encoded),
+        { type: "text", text: "keep suffix text" },
+      ]),
+    ]);
+
+    const messages = projectChatDisplayMessages(
+      await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+        maxMessages: 10,
+        allowResetArchiveFallback: true,
+        resetArchiveOnly: true,
+      }),
+    );
+
+    expect(messages).toMatchObject([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "keep prefix text" },
+          { type: "image", omitted: true, bytes: png.length },
+          { type: "text", text: "keep suffix text" },
+        ],
+        __openclaw: { id: "archived-image" },
+      },
+    ]);
+    expect(JSON.stringify(messages)).not.toContain(encoded);
+    if (name.includes("cache control")) {
+      expect(JSON.stringify(messages)).toContain('"cache_control":{"type":"ephemeral"}');
+    }
+
+    const singleMessage = await filesystemReader(sessionId, storePath).readById("archived-image", {
+      allowResetArchiveFallback: true,
+      resetArchiveOnly: true,
+    });
+    expect(singleMessage).toMatchObject({
+      found: true,
+      oversized: false,
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "keep prefix text" },
+          { type: "image", omitted: true, bytes: png.length },
+          { type: "text", text: "keep suffix text" },
+        ],
+      },
+    });
+  });
+
+  test("omits every image even when its data is distant from its type", async () => {
+    const sessionId = "test-oversized-distant-image";
+    const privateImage = Buffer.from("private-image-payload");
+    const privateEncoded = privateImage.toString("base64");
+    const largeImage = createNoisyPngBuffer(320, 320);
+    const largeEncoded = largeImage.toString("base64");
+    writeResetArchive(tmpDir, sessionId, "2026-07-12T18-00-00.000Z", [
+      { type: "session", version: 3, id: sessionId },
+      createTranscriptMessage("distant-image", null, "user", [
+        { type: "text", text: "keep prefix text" },
+        {
+          type: "image",
+          metadata: { caption: "x".repeat(70 * 1024) },
+          data: privateEncoded,
+        },
+        { type: "image", data: largeEncoded },
+        { type: "text", text: "keep suffix text" },
+      ]),
+    ]);
+
+    const reader = filesystemReader(sessionId, storePath);
+    const messages = await reader.read({
+      mode: "recent",
+      maxMessages: 10,
+      allowResetArchiveFallback: true,
+      resetArchiveOnly: true,
+    });
+    const singleMessage = await reader.readById("distant-image", {
+      allowResetArchiveFallback: true,
+      resetArchiveOnly: true,
+    });
+
+    for (const message of [messages.messages[0], singleMessage.message]) {
+      expect(message).toMatchObject({
+        content: [
+          { type: "text", text: "keep prefix text" },
+          { type: "image", omitted: true, bytes: privateImage.length },
+          { type: "image", omitted: true, bytes: largeImage.length },
+          { type: "text", text: "keep suffix text" },
+        ],
+      });
+      expect(JSON.stringify(message)).not.toContain(privateEncoded);
+      expect(JSON.stringify(message)).not.toContain(largeEncoded);
+    }
+    expect(singleMessage).toMatchObject({ found: true, oversized: false });
+  });
+
+  test("preserves image metadata data while omitting the actual image payload", async () => {
+    const sessionId = "test-oversized-image-metadata";
+    const image = createNoisyPngBuffer(320, 320);
+    const encoded = image.toString("base64");
+    const metadata = { data: Buffer.from("notes").toString("base64") };
+    writeResetArchive(tmpDir, sessionId, "2026-07-12T18-00-00.000Z", [
+      { type: "session", version: 3, id: sessionId },
+      createTranscriptMessage("image-metadata", null, "user", [
+        { type: "text", text: "keep prefix text" },
+        { type: "image", metadata, data: encoded },
+        { type: "text", text: "keep suffix text" },
+      ]),
+    ]);
+
+    const messages = await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+      maxMessages: 10,
+      allowResetArchiveFallback: true,
+      resetArchiveOnly: true,
+    });
+
+    expect(messages).toMatchObject([
+      {
+        content: [
+          { type: "text", text: "keep prefix text" },
+          { type: "image", metadata, omitted: true, bytes: image.length },
+          { type: "text", text: "keep suffix text" },
+        ],
+      },
+    ]);
+    expect(JSON.stringify(messages)).not.toContain(encoded);
+  });
+
+  test.each([
+    {
+      name: "text document",
+      document: { type: "document", source: { type: "text", data: "notes" } },
+    },
+    {
+      name: "base64 PDF document",
+      document: {
+        type: "document",
+        source: {
+          type: "base64",
+          media_type: "application/pdf",
+          data: Buffer.from("%PDF-1.4\nexample").toString("base64"),
+        },
+      },
+    },
+  ])("preserves a $name preceding an oversized image", async ({ name, document }) => {
+    const sessionId = `test-oversized-mixed-${name.replaceAll(" ", "-")}`;
+    const png = createNoisyPngBuffer(320, 320);
+    const encoded = png.toString("base64");
+    writeResetArchive(tmpDir, sessionId, "2026-07-12T18-00-00.000Z", [
+      { type: "session", version: 3, id: sessionId },
+      createTranscriptMessage("archived-mixed", null, "user", [
+        document,
+        { type: "text", text: "keep prefix text" },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: encoded } },
+        { type: "text", text: "keep suffix text" },
+      ]),
+    ]);
+
+    const messages = projectChatDisplayMessages(
+      await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+        maxMessages: 10,
+        allowResetArchiveFallback: true,
+        resetArchiveOnly: true,
+      }),
+    );
+
+    expect(messages).toMatchObject([
+      {
+        role: "user",
+        content: [
+          document,
+          { type: "text", text: "keep prefix text" },
+          { type: "image", omitted: true, bytes: png.length },
+          { type: "text", text: "keep suffix text" },
+        ],
+      },
+    ]);
+    expect(JSON.stringify(messages)).not.toContain(encoded);
+  });
+
+  test("keeps oversized fallback when recovered JSON numbers expand after parsing", async () => {
+    const sessionId = "test-oversized-expanded-json";
+    const encoded = createNoisyPngBuffer(320, 320).toString("base64");
+    const archivePath = writeResetArchive(tmpDir, sessionId, "2026-07-12T18-00-00.000Z", [
+      { type: "session", version: 3, id: sessionId },
+      createTranscriptMessage(
+        "expanded-json",
+        null,
+        "user",
+        [
+          { type: "text", text: "keep prefix text" },
+          { type: "image", data: encoded },
+        ],
+        { message: { compactNumbers: "__OPENCLAW_COMPACT_NUMBERS__" } },
+      ),
+    ]);
+    const compactNumbers = Array.from({ length: 13_000 }, () => "1e20").join(",");
+    const archive = fs.readFileSync(archivePath, "utf8");
+    fs.writeFileSync(
+      archivePath,
+      archive.replace('"__OPENCLAW_COMPACT_NUMBERS__"', `[${compactNumbers}]`),
+      "utf8",
+    );
+
+    const messages = await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+      maxMessages: 10,
+      allowResetArchiveFallback: true,
+      resetArchiveOnly: true,
+    });
+
+    expect(messages).toMatchObject([
+      {
+        content: [{ type: "text", text: "[chat.history omitted: message too large]" }],
+        __openclaw: { id: "expanded-json", truncated: true, reason: "oversized" },
+      },
+    ]);
+    expect(
+      await filesystemReader(sessionId, storePath).readById("expanded-json", {
+        allowResetArchiveFallback: true,
+        resetArchiveOnly: true,
+      }),
+    ).toMatchObject({ found: true, oversized: true });
+  });
+
+  test("rejects JSON-escaped transcript recovery marker collisions", async () => {
+    const sessionId = "test-oversized-escaped-marker";
+    const encoded = createNoisyPngBuffer(320, 320).toString("base64");
+    const archivePath = writeResetArchive(tmpDir, sessionId, "2026-07-12T18-00-00.000Z", [
+      { type: "session", version: 3, id: sessionId },
+      createTranscriptMessage("escaped-marker", null, "user", [
+        { type: "text", text: "__MARKER_SPOOF__" },
+        { type: "image", data: encoded },
+      ]),
+    ]);
+    const archive = fs.readFileSync(archivePath, "utf8");
+    fs.writeFileSync(
+      archivePath,
+      archive.replace('"__MARKER_SPOOF__"', '"\\u005f_openclaw_omitted_image_0__"'),
+      "utf8",
+    );
+
+    const messages = await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+      maxMessages: 10,
+      allowResetArchiveFallback: true,
+      resetArchiveOnly: true,
+    });
+
+    expect(messages).toMatchObject([
+      {
+        content: [{ type: "text", text: "[chat.history omitted: message too large]" }],
+        __openclaw: { id: "escaped-marker", truncated: true, reason: "oversized" },
+      },
+    ]);
+    expect(
+      await filesystemReader(sessionId, storePath).readById("escaped-marker", {
+        allowResetArchiveFallback: true,
+        resetArchiveOnly: true,
+      }),
+    ).toMatchObject({ found: true, oversized: true });
+  });
+
+  test.each([
+    {
+      name: "unrelated oversized data",
+      content: (data: string) => [{ type: "document", source: { type: "base64", data } }],
+    },
+    {
+      name: "unrelated oversized image metadata",
+      content: (data: string) => [{ type: "image", metadata: { data } }],
+    },
+    {
+      name: "URL image source with oversized data",
+      content: (data: string) => [
+        { type: "image", source: { type: "url", url: "https://example.invalid/image", data } },
+      ],
+    },
+    {
+      name: "malformed image base64",
+      content: (data: string) => [{ type: "image", data: `${data.slice(0, -1)}!` }],
+    },
+    {
+      name: "oversized non-image residual",
+      content: (data: string) => [
+        { type: "image", data },
+        { type: "text", text: "x".repeat(300 * 1024) },
+      ],
+    },
+    {
+      name: "oversized unrelated data after a small image",
+      content: (data: string) => [
+        { type: "image", data: "aGVsbG8=" },
+        { type: "document", data },
+      ],
+    },
+    {
+      name: "too many image candidates",
+      content: (data: string) => [
+        ...Array.from({ length: 33 }, () => ({ type: "image", data: "aGVsbG8=" })),
+        { type: "image", data },
+      ],
+    },
+  ])("keeps the existing oversized fallback for $name", async ({ name, content }) => {
+    const sessionId = `test-oversized-adversarial-${name.replaceAll(" ", "-")}`;
+    const encoded = createNoisyPngBuffer(320, 320).toString("base64");
+    writeResetArchive(tmpDir, sessionId, "2026-07-12T18-00-00.000Z", [
+      { type: "session", version: 3, id: sessionId },
+      createTranscriptMessage("adversarial-image", null, "user", content(encoded)),
+    ]);
+
+    const messages = await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+      maxMessages: 10,
+      allowResetArchiveFallback: true,
+      resetArchiveOnly: true,
+    });
+
+    expect(messages).toMatchObject([
+      {
+        role: "user",
+        content: [{ type: "text", text: "[chat.history omitted: message too large]" }],
+        __openclaw: { id: "adversarial-image", truncated: true, reason: "oversized" },
+      },
+    ]);
+    expect(JSON.stringify(messages)).not.toContain(encoded);
+    expect(
+      await filesystemReader(sessionId, storePath).readById("adversarial-image", {
+        allowResetArchiveFallback: true,
+        resetArchiveOnly: true,
+      }),
+    ).toMatchObject({ found: true, oversized: true });
   });
 
   test("readRecentSessionMessagesAsync keeps oversized active-tree leaves", async () => {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -115,6 +115,8 @@ const RECENT_SESSION_MESSAGES_DEFAULT_MAX_BYTES = 8 * 1024 * 1024;
 type TranscriptRecord = {
   byteLength: number;
   id?: string;
+  /** Private provenance; synthesized oversized placeholders must never qualify. */
+  recoveredImageData?: true;
   record: Record<string, unknown>;
 };
 
@@ -184,6 +186,7 @@ async function readRecentTranscriptTailLinesAsync(
 const MAX_TRANSCRIPT_PARSE_LINE_BYTES = 256 * 1024;
 const OVERSIZED_TRANSCRIPT_METADATA_PREFIX_CHARS = 64 * 1024;
 const OVERSIZED_TRANSCRIPT_METADATA_SUFFIX_CHARS = 64 * 1024;
+const MAX_OVERSIZED_TRANSCRIPT_RECOVERY_CANDIDATES = 32;
 const TRANSCRIPT_OVERSIZED_MESSAGE_PLACEHOLDER = "[chat.history omitted: message too large]";
 
 function isOversizedTranscriptLine(line: string): boolean {
@@ -237,10 +240,177 @@ function extractJsonStringFieldSuffix(source: string, field: string): string | u
   return extractJsonStringFieldWindow(source, field, startIndex);
 }
 
+function recoverOversizedMultimodalTranscriptRecord(
+  line: string,
+): Record<string, unknown> | undefined {
+  const markerPrefix = "__openclaw_omitted_image_";
+  if (line.includes(markerPrefix)) {
+    return undefined;
+  }
+  const payloads: Array<{ start: number; end: number; marker: string; bytes: number }> = [];
+  const dataPattern = /"data"\s*:\s*"/g;
+  let scannedCandidates = 0;
+  for (let dataMatch = dataPattern.exec(line); dataMatch; dataMatch = dataPattern.exec(line)) {
+    if (!isJsonObjectFieldToken(line, dataMatch.index)) {
+      continue;
+    }
+    if (++scannedCandidates > MAX_OVERSIZED_TRANSCRIPT_RECOVERY_CANDIDATES) {
+      return undefined;
+    }
+    const start = dataMatch.index + dataMatch[0].length;
+    let end = start;
+    let padding = 0;
+    let valid = true;
+    for (; end < line.length && line.charCodeAt(end) !== 34; end++) {
+      const code = line.charCodeAt(end);
+      if (code === 92) {
+        valid = false;
+        end++;
+        continue;
+      }
+      if (!valid) {
+        continue;
+      }
+      if (code === 61) {
+        if (++padding > 2) {
+          valid = false;
+        }
+      } else if (
+        padding > 0 ||
+        (((code | 32) < 97 || (code | 32) > 122) &&
+          (code < 48 || code > 57) &&
+          code !== 43 &&
+          code !== 47)
+      ) {
+        valid = false;
+      }
+    }
+    if (end >= line.length) {
+      return undefined;
+    }
+    dataPattern.lastIndex = end + 1;
+    if (!valid || (end - start) % 4 !== 0) {
+      continue;
+    }
+    payloads.push({
+      start,
+      end,
+      marker: `${markerPrefix}${payloads.length}__`,
+      bytes: ((end - start) * 3) / 4 - padding,
+    });
+  }
+  if (payloads.length === 0) {
+    return undefined;
+  }
+  try {
+    const parseBoundedRedaction = (
+      selected: typeof payloads,
+    ): Record<string, unknown> | undefined => {
+      const bytes = selected.reduce(
+        (remaining, payload) => remaining - (payload.end - payload.start - payload.marker.length),
+        Buffer.byteLength(line, "utf8"),
+      );
+      if (selected.length === 0 || bytes > MAX_TRANSCRIPT_PARSE_LINE_BYTES) {
+        return undefined;
+      }
+      let cursor = 0;
+      const parts: string[] = [];
+      for (const payload of selected) {
+        parts.push(line.slice(cursor, payload.start), payload.marker);
+        cursor = payload.end;
+      }
+      parts.push(line.slice(cursor));
+      const markers = new Set(selected.map((payload) => payload.marker));
+      const parsed = JSON.parse(parts.join(""), (_key: string, value: unknown) => {
+        if (typeof value === "string" && value.startsWith(markerPrefix) && !markers.delete(value)) {
+          throw new Error("invalid transcript image recovery marker");
+        }
+        return value;
+      }) as unknown;
+      if (markers.size > 0 || !parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return undefined;
+      }
+      return parsed as Record<string, unknown>;
+    };
+    const imageDataOwners = (block: Record<string, unknown>): Record<string, unknown>[] => {
+      const source = block.source as Record<string, unknown> | undefined;
+      return source && typeof source === "object" && source.type === "base64"
+        ? [block, source]
+        : [block];
+    };
+
+    // Parse all bounded candidates once, then classify image ownership from real JSON structure.
+    const preview = parseBoundedRedaction(payloads);
+    const previewContent = (preview?.message as { content?: unknown } | undefined)?.content;
+    if (!Array.isArray(previewContent)) {
+      return undefined;
+    }
+    const payloadByMarker = new Map(payloads.map((payload) => [payload.marker, payload]));
+    const imageMarkers = new Set<string>();
+    for (const candidate of previewContent) {
+      if (!candidate || typeof candidate !== "object" || candidate.type !== "image") {
+        continue;
+      }
+      for (const owner of imageDataOwners(candidate as Record<string, unknown>)) {
+        if (typeof owner.data !== "string") {
+          continue;
+        }
+        if (!payloadByMarker.has(owner.data) || imageMarkers.has(owner.data)) {
+          return undefined;
+        }
+        imageMarkers.add(owner.data);
+      }
+    }
+    if (imageMarkers.size === 0) {
+      return undefined;
+    }
+
+    // Rebuild from the original line so document and metadata bytes remain untouched.
+    const imagePayloads = payloads.filter((payload) => imageMarkers.has(payload.marker));
+    const record = parseBoundedRedaction(imagePayloads);
+    const content = (record?.message as { content?: unknown } | undefined)?.content;
+    if (!record || !Array.isArray(content)) {
+      return undefined;
+    }
+    const remaining = new Map(imagePayloads.map((payload) => [payload.marker, payload]));
+    for (const candidate of content) {
+      if (!candidate || typeof candidate !== "object" || candidate.type !== "image") {
+        continue;
+      }
+      const block = candidate as Record<string, unknown>;
+      let imageBytes: number | undefined;
+      for (const owner of imageDataOwners(block)) {
+        if (typeof owner.data !== "string") {
+          continue;
+        }
+        const payload = remaining.get(owner.data);
+        if (!payload) {
+          return undefined;
+        }
+        remaining.delete(payload.marker);
+        imageBytes ??= payload.bytes;
+        delete owner.data;
+      }
+      if (imageBytes !== undefined) {
+        block.omitted = true;
+        block.bytes = imageBytes;
+      }
+    }
+    // Parsed numeric spellings can expand, so both archive readers need the final UTF-8 bound.
+    return remaining.size === 0 && jsonUtf8Bytes(record) <= MAX_TRANSCRIPT_PARSE_LINE_BYTES
+      ? record
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function parseTranscriptRecord(line: string): TranscriptRecord | null {
-  if (!isOversizedTranscriptLine(line)) {
+  const oversized = isOversizedTranscriptLine(line);
+  const recoveredRecord = oversized ? recoverOversizedMultimodalTranscriptRecord(line) : undefined;
+  if (!oversized || recoveredRecord) {
     try {
-      const parsed = JSON.parse(line) as unknown;
+      const parsed = recoveredRecord ?? (JSON.parse(line) as unknown);
       if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
         return null;
       }
@@ -249,6 +419,7 @@ function parseTranscriptRecord(line: string): TranscriptRecord | null {
       return {
         byteLength: Buffer.byteLength(line, "utf8"),
         ...(id ? { id } : {}),
+        ...(recoveredRecord ? { recoveredImageData: true as const } : {}),
         record,
       };
     } catch {
@@ -524,7 +695,12 @@ export class ArchivedTranscriptReader {
     if (!entry) {
       return { oversized: false, found: false };
     }
-    if (entry.byteLength > MAX_TRANSCRIPT_PARSE_LINE_BYTES) {
+    // Raw-byte limits still reject placeholders; only bounded, validated image recoveries qualify.
+    if (
+      entry.byteLength > MAX_TRANSCRIPT_PARSE_LINE_BYTES &&
+      (entry.recoveredImageData !== true ||
+        jsonUtf8Bytes(entry.record) > MAX_TRANSCRIPT_PARSE_LINE_BYTES)
+    ) {
       return { oversized: true, found: true, seq: entry.seq };
     }
     return {


### PR DESCRIPTION
Fixes #78729.

## What Problem This Solves

Fixes an issue where users reviewing a conversation lose the entire visible message when ordinary text shares a transcript entry with a large inline image. Both current-session history and retained reset archives could replace useful surrounding text with a generic oversized-message placeholder.

## Why This Change Was Made

Teach the existing Gateway display owner to omit both native image data and the documented Anthropic nested base64 image shape while preserving adjacent text. For oversized retained-archive records, recover only structurally verified image payloads through two strictly bounded JSON parses; preserve non-image documents and metadata byte-for-byte, retain safe single-message lookup, and fail closed whenever ownership, marker identity, or the final UTF-8 size limit is ambiguous.

## User Impact

Conversation history and incremental snapshots continue showing the original text around oversized images instead of discarding the whole message. Archived history and single-message lookup behave consistently without leaking image bytes or weakening existing resource limits.

## Evidence

- Authentic failing-first fixtures use a valid noisy 320x320 PNG exceeding both the Gateway single-message budget and the 256 KiB archive record cap.
- Real hosted authenticated Gateway proof: https://github.com/openclaw/openclaw/actions/runs/30733641809 — **16/16 live network captures passed**, covering native and Anthropic images across active SQLite history and retained imported reset archives through WebSocket `chat.history`, HTTP JSON, actual HTTP SSE, and WebSocket `chat.message.get`. A genuine 307,678-byte PNG produced 410–411 KiB raw rows while every response preserved adjacent text/PDFs, omitted image bytes, and contained no base64 leak; missing credentials returned HTTP 401. The scenario also executed a real authenticated session reset and transparently seeded a separate retained legacy archive because modern SQLite resets intentionally do not generate legacy archive files.
- Native and Anthropic image layouts preserve surrounding text through the actual Gateway WebSocket budget/projection and SSE snapshot owners.
- Real retained reset-archive filesystem regressions cover single-message lookup; image field order; nested cache metadata; simultaneous native/nested payloads; distant image fields; preserved PDF/document/image metadata; URL-backed images; malformed base64; escaped marker collisions; candidate limits; and compact JSON numbers expanding beyond the final UTF-8 cap.
- Exact rebased head `3c78dac16c40dd5927f688b75ad82ea2e192afcb`: `node scripts/run-vitest.mjs src/gateway/chat-display-projection.test.ts src/gateway/session-utils.fs.test.ts src/gateway/control-reply-text.test.ts --project gateway-core` — **92 passed, 0 failed**, including the existing control-token visibility contract under image redaction.
- Targeted `oxfmt`, `oxlint`, and `git diff --check`: passed.
- Fresh independent owner/security review: no P0/P1/P2 findings.
- Structured `gpt-5.6-sol` xhigh autoreview with `--max-priority P2`: clean; confidence 0.94. Earlier review findings drove a bounded structural redesign rather than adding parsing heuristics.
- Exact-head official hosted CI and required merge gate: passed; one isolated 111-second runner scheduling stall was disproven by an unchanged-production prior green run, a passing exact focused test, and a successful single-job rerun.
- Existing branch/main drift does not overlap the changed history owners; repository policy treats unrelated drift as advisory, so no unnecessary rebase was introduced after exact-head proof.
- No new dependency, configuration surface, database schema, migration, or compatibility fallback.
- AI-assisted implementation and review.
