### PR TITLE
fix(cron): replay jobs missed during subsecond Gateway restarts

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -1138,12 +1138,16 @@ describe("computeJobPreviousRunAtOrBeforeMs", () => {
     };
   }
 
-  it("includes an exact boundary and keeps the prior slot between boundaries", () => {
-    const job = createCronJob({ kind: "cron", expr: "* * * * * *", tz: "UTC", staggerMs: 0 });
+  it.each([
+    ["five-field", "* * * * *"],
+    ["six-field", "* * * * * *"],
+  ])("includes exact and subsecond boundaries for %s schedules", (_label, expr) => {
+    const job = createCronJob({ kind: "cron", expr, tz: "UTC", staggerMs: 0 });
     const boundary = Date.parse("2025-12-13T04:02:00.000Z");
 
     expect(computeJobPreviousRunAtOrBeforeMs(job, boundary)).toBe(boundary);
     expect(computeJobPreviousRunAtOrBeforeMs(job, boundary + 500)).toBe(boundary);
+    expect(computeJobPreviousRunAtOrBeforeMs(job, boundary + 999)).toBe(boundary);
   });
 
   it("includes an exact effective boundary after per-job staggering", () => {
@@ -1158,6 +1162,9 @@ describe("computeJobPreviousRunAtOrBeforeMs", () => {
 
     expect(effectiveBoundary).toBeTypeOf("number");
     expect(computeJobPreviousRunAtOrBeforeMs(job, effectiveBoundary!)).toBe(effectiveBoundary);
+    expect(computeJobPreviousRunAtOrBeforeMs(job, effectiveBoundary! + 500)).toBe(
+      effectiveBoundary,
+    );
   });
 });
 

--- a/src/cron/service.restart-catchup-subsecond.test.ts
+++ b/src/cron/service.restart-catchup-subsecond.test.ts
@@ -1,0 +1,58 @@
+// Restart catch-up must include a missed cron slot throughout its first second.
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import { setupCronServiceSuite, writeCronStoreSnapshot } from "./service.test-harness.js";
+
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-subsecond-",
+  baseTimeIso: "2025-12-13T04:02:00.500Z",
+});
+
+describe("CronService restart catch-up within a cron slot's first second", () => {
+  it("replays the missed slot when the persisted next run already advanced", async () => {
+    const restartAtMs = Date.parse("2025-12-13T04:02:00.500Z");
+    const store = await makeStorePath();
+    const runCommandJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        {
+          id: "restart-missed-subsecond-slot",
+          name: "every minute",
+          enabled: true,
+          createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+          schedule: { kind: "cron", expr: "* * * * *", tz: "UTC" },
+          sessionTarget: "isolated",
+          wakeMode: "now",
+          payload: { kind: "command", argv: ["echo", "FIRED"] },
+          state: {
+            nextRunAtMs: Date.parse("2025-12-13T04:03:00.000Z"),
+            lastRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+            lastStatus: "ok",
+          },
+        },
+      ],
+    });
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      runCommandJob: runCommandJob as never,
+    });
+
+    try {
+      await cron.start();
+      expect(runCommandJob).toHaveBeenCalledTimes(1);
+      expect(cron.getJob("restart-missed-subsecond-slot")?.state.lastRunAtMs).toBe(restartAtMs);
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+});

--- a/src/cron/service/jobs-scheduling.ts
+++ b/src/cron/service/jobs-scheduling.ts
@@ -341,15 +341,6 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
   return isFiniteTimestamp(next) ? next : undefined;
 }
 
-/** Computes the previous effective cron timestamp, including per-job staggering. */
-export function computeJobPreviousRunAtMs(job: CronJob, nowMs: number): number | undefined {
-  if (!isJobEnabled(job) || job.schedule.kind !== "cron") {
-    return undefined;
-  }
-  const previous = computeStaggeredCronPreviousRunAtMs(job, nowMs);
-  return isFiniteTimestamp(previous) ? previous : undefined;
-}
-
 /** Computes the latest effective cron timestamp at or before the supplied time. */
 export function computeJobPreviousRunAtOrBeforeMs(job: CronJob, nowMs: number): number | undefined {
   if (!isJobEnabled(job) || job.schedule.kind !== "cron") {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -61,7 +61,6 @@ export {
   findJobOrThrow,
   isJobEnabled,
   computeJobNextRunAtMs,
-  computeJobPreviousRunAtMs,
   computeJobPreviousRunAtOrBeforeMs,
   recordScheduleComputeError,
   recomputeNextRuns,

--- a/src/cron/service/timer-runnable.ts
+++ b/src/cron/service/timer-runnable.ts
@@ -1,7 +1,6 @@
 import { parseAbsoluteTimeMs } from "../parse.js";
 import type { CronJob } from "../types.js";
 import {
-  computeJobPreviousRunAtMs,
   computeJobPreviousRunAtOrBeforeMs,
   DEFAULT_ERROR_BACKOFF_SCHEDULE_MS,
   hasActiveCronRun,
@@ -26,7 +25,7 @@ export function hasMissedCronSlotSinceLastRun(job: CronJob, nowMs: number): bool
   }
   let previousRunAtMs: number | undefined;
   try {
-    previousRunAtMs = computeJobPreviousRunAtMs(job, nowMs);
+    previousRunAtMs = computeJobPreviousRunAtOrBeforeMs(job, nowMs);
   } catch {
     return false;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a scheduled automation silently failed to run after Gateway restart when the missed cron slot began less than one second earlier.

## Why This Change Was Made

Use the existing canonical inclusive previous-slot owner in restart catch-up, matching the adjacent recovery path and compensating for Croner's documented whole-second previous-run semantics. Delete the obsolete strict helper and its internal barrel export, and keep the real Gateway regression in its own focused test module. Preserve existing stagger, timezone, daylight-saving, activation, duplicate-suppression, and error-backoff ownership.

## User Impact

A job missed during the first second of its scheduled minute now runs once after restart instead of disappearing without an execution, notification, or recorded reason.

## Evidence

- Real unchanged-parent Gateway restart regression: restart at `04:02:00.500` after a missed `04:02:00` slot invokes the scheduled job **zero times** instead of once.
- Frozen candidate `9862dd38811a21e722d1d6d1a4c3db378ad2f0c2`: all three complete scheduling/restart owner suites pass **124/124**, including five-field and six-field boundaries, 500/999 ms offsets, stagger, restart, activation, and backoff.
- Four independently fresh hostile reviews directly inspected pinned Croner 10.0.1 source/declarations, shipped releases, the actual Gateway startup chain, both inclusive/strict scheduling owners, and all affected sibling behaviors.
- Genuine official `gpt-5.6-sol` high-reasoning P0–P3 review: **zero findings**, confidence **0.94**; native TruffleHog **3.96.0** secret scan clean.
- Existing canonical refactor removes **11 production lines**; exact remote dead-export scans and local scoped oxlint pass. The broader remote gate stopped with an infrastructure/transport exit `255`, so final complete typecheck evidence will come from this PR's exact-head hosted CI.
