### PR TITLE
fix(ci): validate frozen releases without unsupported model config

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -754,10 +754,16 @@ jobs:
           gateway_readiness_log="$SOURCE_PERF_DIR/cli-gateway-readiness.log"
           gateway_pid=""
           mkdir -p "$gateway_state" "$gateway_readiness_state"
+          catalog_refresh_config=""
+          # Frozen release candidates can predate this config key. Inspect the
+          # target schema so the trusted harness never writes invalid config.
+          if rg -q 'catalogRefresh:' src/config/zod-schema.core.ts; then
+            catalog_refresh_config='    "models": { "catalogRefresh": { "enabled": false } },'
+          fi
           cat > "$gateway_config" <<EOF
           {
             "browser": { "enabled": false },
-            "models": { "catalogRefresh": { "enabled": false } },
+          ${catalog_refresh_config}
             "update": { "checkOnStart": false },
             "gateway": {
               "mode": "local",

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -299,7 +299,11 @@ describe("OpenClaw performance workflow", () => {
   it("keeps the source performance gateway fixture network-hermetic", () => {
     const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
 
-    expect(run).toContain('"models": { "catalogRefresh": { "enabled": false } },');
+    expect(run).toContain("catalog_refresh_config");
+    expect(run).toContain("rg -q 'catalogRefresh:' src/config/zod-schema.core.ts");
+    expect(run).toContain(
+      'catalog_refresh_config=\'    "models": { "catalogRefresh": { "enabled": false } },\'',
+    );
     expect(run).toContain('"update": { "checkOnStart": false },');
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation cannot benchmark an older frozen candidate because the trusted performance workflow writes a model-catalog setting the candidate does not support.

## Why This Change Was Made

The trusted workflow now checks the target schema before including `models.catalogRefresh`. Modern targets remain network-hermetic; older targets receive only supported configuration. This is a generic schema-capability contract, not a release-SHA allowlist.

## User Impact

Extended-stable candidates can complete performance validation without being mutated to match newer main-only config keys.

## Evidence

- Failing performance job: https://github.com/openclaw/openclaw/actions/runs/30731361193/job/91452262699
- Candidate schema accepts `models.mode`, `models.providers`, and `models.pricing`, but rejects `models.catalogRefresh`; current main supports `models.catalogRefresh`.
- `actionlint .github/workflows/openclaw-performance.yml` and `git diff --check` passed.
- Fresh `autoreview --mode uncommitted` was clean.
- Focused execution is delegated to hosted PR CI: the local worktree has no dependencies and configured remote proof credentials are unavailable.

AI-assisted: yes.