### PR TITLE
test: stabilize release CI oxlint shard cleanup

### DIFF
--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -317,12 +317,12 @@ describe("run-oxlint", () => {
           shard: { name: "timeout-group-test", args: [] },
         });
 
-        await waitFor(() => existsSync(childPidPath), 2_000);
+        await waitFor(() => existsSync(childPidPath), 15_000);
         childPid = Number(readFileSync(childPidPath, "utf8"));
         expect(isProcessAlive(childPid)).toBe(true);
 
         await expect(command).resolves.toBe(124);
-        await waitFor(() => !isProcessAlive(childPid), 2_000);
+        await waitFor(() => !isProcessAlive(childPid), 15_000);
       } finally {
         if (childPid && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where 2026.6.34 validation can fail while verifying oxlint cleanup, solely because a process-group test allows only two seconds for CI process scheduling and reaping.

## Why This Change Was Made

Backports the focused reliability hardening from #115764: retain the 250 ms timeout being tested, but give the test 15 seconds to observe its child process start and exit under loaded CI. No production lint behavior changes.

## User Impact

Release validation is less likely to fail spuriously during its tooling test shard.

## Evidence

- Failed release CI reproduction: https://github.com/openclaw/openclaw/actions/runs/30731361239/job/91452273446
- Upstream #115764 documents two earlier CI failures and bounded focused proof for this exact test.
- `git diff --check` passed.
- Fresh `autoreview --mode uncommitted` was clean.
- Focused execution is delegated to hosted PR CI: these new linked worktrees have no dependencies, and the configured Testbox/Crabbox credentials are unavailable.

AI-assisted: yes.