### PR TITLE
fix(logbook): honor canonical gateway.nodes.commands.deny kill switch

### DIFF
--- a/extensions/logbook/index.test.ts
+++ b/extensions/logbook/index.test.ts
@@ -1,0 +1,51 @@
+import type {
+  OpenClawPluginApi,
+  OpenClawPluginNodeInvokePolicy,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+type PolicyContext = Parameters<OpenClawPluginNodeInvokePolicy["handle"]>[0];
+
+function registerLogbookPolicies(): OpenClawPluginNodeInvokePolicy[] {
+  const policies: OpenClawPluginNodeInvokePolicy[] = [];
+  plugin.register({
+    pluginConfig: {},
+    session: { controls: { registerControlUiDescriptor: () => {} } },
+    registerNodeInvokePolicy: (policy: OpenClawPluginNodeInvokePolicy) => policies.push(policy),
+    registerService: () => {},
+    registerGatewayMethod: () => {},
+  } as unknown as OpenClawPluginApi);
+  return policies;
+}
+
+describe("logbook snapshot invoke policy", () => {
+  it("blocks logbook.snapshot when gateway.nodes.commands.deny lists screen.snapshot", async () => {
+    const [policy] = registerLogbookPolicies();
+    expect(policy?.commands).toEqual(["logbook.snapshot"]);
+    const invokeNode = vi.fn();
+    const result = await policy!.handle({
+      nodeId: "node-1",
+      command: "logbook.snapshot",
+      params: undefined,
+      config: { gateway: { nodes: { commands: { deny: ["screen.snapshot"] } } } },
+      invokeNode,
+    } as unknown as PolicyContext);
+    expect(result).toMatchObject({ ok: false, code: "SCREEN_CAPTURE_DENIED" });
+    expect(invokeNode).not.toHaveBeenCalled();
+  });
+
+  it("invokes the node when screen.snapshot is not denied", async () => {
+    const [policy] = registerLogbookPolicies();
+    const invokeNode = vi.fn().mockResolvedValue({ ok: true, payloadJSON: null });
+    const result = await policy!.handle({
+      nodeId: "node-1",
+      command: "logbook.snapshot",
+      params: undefined,
+      config: { gateway: { nodes: { commands: { deny: ["camera.snap"] } } } },
+      invokeNode,
+    } as unknown as PolicyContext);
+    expect(result).toMatchObject({ ok: true });
+    expect(invokeNode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/logbook/index.ts
+++ b/extensions/logbook/index.ts
@@ -113,13 +113,13 @@ export default definePluginEntry({
       handle: async (ctx) => {
         // Honor the operator's screen-capture kill switch: a screen.snapshot
         // deny must block this capture command too, not just the app node's.
-        const denied = ctx.config.gateway?.nodes?.denyCommands ?? [];
+        const denied = ctx.config.gateway?.nodes?.commands?.deny ?? [];
         if (denied.includes("screen.snapshot")) {
           return {
             ok: false,
             code: "SCREEN_CAPTURE_DENIED",
             message:
-              "screen capture is denied by gateway.nodes.denyCommands (screen.snapshot); Logbook capture stays blocked until it is removed",
+              "screen capture is denied by gateway.nodes.commands.deny (screen.snapshot); Logbook capture stays blocked until it is removed",
           };
         }
         return await ctx.invokeNode();


### PR DESCRIPTION
## What Problem This Solves

The Logbook plugin's screen-capture kill switch could never fire. `extensions/logbook/index.ts` read the retired config key `gateway.nodes.denyCommands` — the canonical Zod schema rejects that key (`src/config/dead-config-keys.test.ts`) and `openclaw doctor --fix` migrates it to `gateway.nodes.commands.deny` — so on any config that validates, the deny list was always `[]` and `logbook.snapshot` proceeded even when the operator denied `screen.snapshot`. A silent security-guard failure.

## Why This Change Was Made

Every canonical consumer (`src/security/audit-extra.sync.ts`, `src/agents/exec-defaults.ts`, computer/mobile tools) reads `gateway.nodes.commands.deny`; Logbook was the only reader left on the doctor-only legacy field. History check (`git log -S denyCommands -- extensions/logbook/index.ts`) shows the plugin shipped against the wrong key from its introduction (#99930) — drift, not intent.

## User Impact

Operators who deny `screen.snapshot` via `gateway.nodes.commands.deny` now actually block Logbook captures too, with the error message naming the canonical key. No config change needed; no behavior change for anyone not using the deny list.

## Evidence

- `node scripts/run-vitest.mjs extensions/logbook/index.test.ts` — 2 passed (new regression tests: canonical deny entry returns `SCREEN_CAPTURE_DENIED` without invoking the node; non-matching deny list invokes the node). No test previously covered this branch (`rg SCREEN_CAPTURE_DENIED` hit only the implementation).
- Codex autoreview (gpt-5.6-sol, high): clean, "patch is correct (0.98)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
