### PR TITLE
fix(qa): exercise blocked Slack lifecycle on selected account

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.slack-blocked-lifecycle.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.slack-blocked-lifecycle.test.ts
@@ -17,7 +17,10 @@ describe("Slack blocked lifecycle scenario", () => {
     });
     const flow = JSON.stringify(scenario.execution.flow);
     expect(flow).toContain("transport.accountId");
+    expect(flow).toContain("await env.gateway.call('channels.status'");
+    expect(flow).toContain("account?.lifecycle === 'blocked'");
     expect(flow).not.toContain("account.accountId === 'default'");
+    expect(flowContainsCall(scenario.execution.flow, "waitForCondition")).toBe(true);
     expect(flowContainsCall(scenario.execution.flow, "waitForTransportReady")).toBe(false);
   });
 });

--- a/extensions/qa-lab/src/scenario-catalog.slack-blocked-lifecycle.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.slack-blocked-lifecycle.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { readQaScenarioById } from "./scenario-catalog.js";
+import { flowContainsCall, requireFlowScenario } from "./scenario-catalog.test-utils.js";
+
+describe("Slack blocked lifecycle scenario", () => {
+  it("invalidates and observes the selected account without waiting for readiness", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("slack-blocked-lifecycle-no-restart"));
+
+    expect(scenario.gatewayConfigPatch).toMatchObject({
+      channels: {
+        slack: {
+          accounts: {
+            $selectedAccount: { botToken: "xoxb-intentionally-invalid-lifecycle" },
+          },
+        },
+      },
+    });
+    const flow = JSON.stringify(scenario.execution.flow);
+    expect(flow).toContain("transport.accountId");
+    expect(flow).not.toContain("account.accountId === 'default'");
+    expect(flowContainsCall(scenario.execution.flow, "waitForTransportReady")).toBe(false);
+  });
+});

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -238,6 +238,19 @@ describe("qa scenario catalog", () => {
     expect(scenario.gatewayRuntime?.forwardHostHome).toBe(true);
     expect(otelStdout.gatewayRuntime?.preserveDebugArtifacts).toBe(true);
     expect(blockedSlack.gatewayRuntime?.allowUnhealthyStartup).toBe(true);
+    expect(blockedSlack.gatewayConfigPatch).toMatchObject({
+      channels: {
+        slack: {
+          accounts: {
+            $selectedAccount: { botToken: "xoxb-intentionally-invalid-lifecycle" },
+          },
+        },
+      },
+    });
+    const blockedSlackFlow = JSON.stringify(blockedSlack.execution.flow);
+    expect(blockedSlackFlow).toContain("transport.accountId");
+    expect(blockedSlackFlow).not.toContain("account.accountId === 'default'");
+    expect(flowContainsCall(blockedSlack.execution.flow, "waitForTransportReady")).toBe(false);
   });
 
   it.each([

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -238,19 +238,6 @@ describe("qa scenario catalog", () => {
     expect(scenario.gatewayRuntime?.forwardHostHome).toBe(true);
     expect(otelStdout.gatewayRuntime?.preserveDebugArtifacts).toBe(true);
     expect(blockedSlack.gatewayRuntime?.allowUnhealthyStartup).toBe(true);
-    expect(blockedSlack.gatewayConfigPatch).toMatchObject({
-      channels: {
-        slack: {
-          accounts: {
-            $selectedAccount: { botToken: "xoxb-intentionally-invalid-lifecycle" },
-          },
-        },
-      },
-    });
-    const blockedSlackFlow = JSON.stringify(blockedSlack.execution.flow);
-    expect(blockedSlackFlow).toContain("transport.accountId");
-    expect(blockedSlackFlow).not.toContain("account.accountId === 'default'");
-    expect(flowContainsCall(blockedSlack.execution.flow, "waitForTransportReady")).toBe(false);
   });
 
   it.each([

--- a/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
+++ b/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
@@ -42,6 +42,8 @@ const mocks = vi.hoisted(() => ({
     reportPath: "/qa-output/qa-suite-report.md",
     summaryPath: "/qa-output/qa-suite-summary.json",
   })),
+  waitForGatewayHealthy: vi.fn(async () => {}),
+  waitForTransportReady: vi.fn(async () => {}),
 }));
 
 vi.mock("openclaw/plugin-sdk/agent-harness", () => ({
@@ -60,8 +62,8 @@ vi.mock("./suite-artifacts.js", () => ({
   writeQaSuiteArtifacts: mocks.writeQaSuiteArtifacts,
 }));
 vi.mock("./suite-runtime-gateway.js", () => ({
-  waitForGatewayHealthy: vi.fn(async () => {}),
-  waitForTransportReady: vi.fn(async () => {}),
+  waitForGatewayHealthy: mocks.waitForGatewayHealthy,
+  waitForTransportReady: mocks.waitForTransportReady,
 }));
 vi.mock("./suite.js", () => ({
   buildQaSuiteRuntimeMetrics: vi.fn(() => ({ wallMs: 1 })),
@@ -129,6 +131,23 @@ beforeEach(() => {
 });
 
 describe("QA runtime parity scenario retry isolation", () => {
+  it("skips connected-transport readiness for intentionally unhealthy startup", async () => {
+    const context = makeRetryTestContext();
+    context.gatewayRuntimeOptions = { allowUnhealthyStartup: true };
+    const runScenario = vi
+      .fn<QaSuiteScenarioRunner>()
+      .mockResolvedValue(makeRetryTestResult("pass"));
+
+    await runQaFlowSuiteStandard({ lab: makeRetryTestLab() }, context, runScenario);
+
+    expect(mocks.startQaGatewayChild).toHaveBeenCalledWith(
+      expect.objectContaining({ allowUnhealthyStartup: true }),
+    );
+    expect(mocks.waitForGatewayHealthy).not.toHaveBeenCalled();
+    expect(mocks.waitForTransportReady).not.toHaveBeenCalled();
+    expect(runScenario).toHaveBeenCalledOnce();
+  });
+
   it("captures one failed parity attempt without replaying its transcript or usage", async () => {
     const runScenario = vi
       .fn<QaSuiteScenarioRunner>()

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -165,16 +165,20 @@ export async function runQaFlowSuiteStandard(
     };
     env = activeEnv;
 
-    const transportReadyTimeoutMs = resolveQaSuiteTransportReadyTimeoutMs(
-      params?.transportReadyTimeoutMs,
-    );
-    // The gateway child already waits for /readyz before returning, but the
-    // selected transport can still be finishing account startup. Pay that
-    // readiness cost once here so the first scenario does not race bootstrap.
-    await waitForTransportReady(activeEnv, transportReadyTimeoutMs).catch(async () => {
-      await waitForGatewayHealthy(activeEnv, transportReadyTimeoutMs);
-      await waitForTransportReady(activeEnv, transportReadyTimeoutMs);
-    });
+    // Lifecycle scenarios deliberately start a blocked channel. Waiting for
+    // connected-channel readiness here would prevent those scenarios from running.
+    if (!gatewayRuntimeOptions?.allowUnhealthyStartup) {
+      const transportReadyTimeoutMs = resolveQaSuiteTransportReadyTimeoutMs(
+        params?.transportReadyTimeoutMs,
+      );
+      // The gateway child already waits for /readyz before returning, but the
+      // selected transport can still be finishing account startup. Pay that
+      // readiness cost once here so the first scenario does not race bootstrap.
+      await waitForTransportReady(activeEnv, transportReadyTimeoutMs).catch(async () => {
+        await waitForGatewayHealthy(activeEnv, transportReadyTimeoutMs);
+        await waitForTransportReady(activeEnv, transportReadyTimeoutMs);
+      });
+    }
     const scenarios: QaSuiteScenarioResult[] = [];
     let runtimeParityCellTiming: QaRuntimeParityCellTiming | undefined;
     const liveScenarioOutcomes: QaLabScenarioOutcome[] = selectedScenarios.map((scenario) => ({

--- a/qa/scenarios/channels/slack-blocked-lifecycle-no-restart.yaml
+++ b/qa/scenarios/channels/slack-blocked-lifecycle-no-restart.yaml
@@ -12,7 +12,9 @@ scenario:
   gatewayConfigPatch:
     channels:
       slack:
-        botToken: xoxb-intentionally-invalid-lifecycle
+        accounts:
+          $selectedAccount:
+            botToken: xoxb-intentionally-invalid-lifecycle
         healthMonitor:
           enabled: true
   gatewayRuntime:
@@ -38,8 +40,6 @@ flow:
   steps:
     - name: reports blocked without restarting
       actions:
-        - call: waitForTransportReady
-          args: [{ ref: env }, 60000]
         - call: env.gateway.call
           saveAs: initialStatus
           args:
@@ -49,7 +49,7 @@ flow:
             - timeoutMs: 15000
         - set: initialAccount
           value:
-            expr: "(initialStatus.channelAccounts?.slack ?? []).find((account) => account.accountId === 'default')"
+            expr: "(initialStatus.channelAccounts?.slack ?? []).find((account) => account.accountId === transport.accountId)"
         - assert:
             expr: "initialAccount?.lifecycle === 'blocked' && initialAccount?.healthState === 'blocked' && initialAccount?.running === true && initialAccount?.restartPending !== true && typeof initialAccount?.lastStartAt === 'number'"
             message:
@@ -66,7 +66,7 @@ flow:
             - timeoutMs: 15000
         - set: finalAccount
           value:
-            expr: "(finalStatus.channelAccounts?.slack ?? []).find((account) => account.accountId === 'default')"
+            expr: "(finalStatus.channelAccounts?.slack ?? []).find((account) => account.accountId === transport.accountId)"
         - assert:
             expr: "finalAccount?.lifecycle === 'blocked' && finalAccount?.healthState === 'blocked' && finalAccount?.running === true && finalAccount?.restartPending !== true && finalAccount?.lastStartAt === initialAccount.lastStartAt"
             message:

--- a/qa/scenarios/channels/slack-blocked-lifecycle-no-restart.yaml
+++ b/qa/scenarios/channels/slack-blocked-lifecycle-no-restart.yaml
@@ -40,16 +40,14 @@ flow:
   steps:
     - name: reports blocked without restarting
       actions:
-        - call: env.gateway.call
-          saveAs: initialStatus
+        - call: waitForCondition
+          saveAs: initialAccount
           args:
-            - channels.status
-            - probe: false
-              timeoutMs: 10000
-            - timeoutMs: 15000
-        - set: initialAccount
-          value:
-            expr: "(initialStatus.channelAccounts?.slack ?? []).find((account) => account.accountId === transport.accountId)"
+            - lambda:
+                async: true
+                expr: "((status) => { const account = (status.channelAccounts?.slack ?? []).find((candidate) => candidate.accountId === transport.accountId); return account?.lifecycle === 'blocked' && account?.healthState === 'blocked' ? account : undefined; })(await env.gateway.call('channels.status', { probe: false, timeoutMs: 10000 }, { timeoutMs: 15000 }))"
+            - 30000
+            - 250
         - assert:
             expr: "initialAccount?.lifecycle === 'blocked' && initialAccount?.healthState === 'blocked' && initialAccount?.running === true && initialAccount?.restartPending !== true && typeof initialAccount?.lastStartAt === 'number'"
             message:


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where the Slack blocked-lifecycle release scenario invalidated the default account while the live adapter ran the selected `sut` account, then waited for connected-channel readiness and searched status for `default`. The scenario therefore did not exercise the intended blocked account or its 65-second no-restart lifecycle.

## Why This Change Was Made

The scenario now patches the existing `$selectedAccount` fixture slot and resolves status through `transport.accountId`. The suite runtime also makes the existing `allowUnhealthyStartup` contract complete by skipping connected-channel readiness; lifecycle scenarios must be allowed to start with the selected channel deliberately blocked.

This removes the scenario's duplicate readiness call and hard-coded default-account assumption. It adds no config/default surface and changes no production Slack lifecycle behavior.

## User Impact

No end-user behavior changes. Release QA can now prove that the account actually selected by the Slack adapter remains visibly blocked and is not restarted by the health monitor.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.slack-blocked-lifecycle.test.ts extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts` — 4 focused tests passed on exact head `af03ffbd783e62d3709908a9208bfc134a84518d`.
- Static coverage asserts the selected-account patch, `transport.accountId` lookup, canonical `waitForCondition` blocked-state gate, and absence of the contradictory connected-readiness call.
- Runtime coverage proves `allowUnhealthyStartup` reaches gateway startup and suppresses both gateway/channel readiness waits while still executing the scenario.
- Real local Slack proof on exact head `af03ffbd783e62d3709908a9208bfc134a84518d`: `slack-blocked-lifecycle-no-restart` passed 1/1 in one run using a Convex maintainer lease and deterministic `mock-openai` provider mode. Credential values are redacted; the leased Slack payload supplied the channel identity plus distinct driver/SUT bot and SUT app credentials. Suite duration was 89.150s (96s command wall time). The scenario first observed the selected `sut` account as `lifecycle=blocked`, `healthState=blocked`, `running=true`, and `restartPending=false`, then completed the full 65-second no-restart observation with `lastStartAtUnchanged=true`.
- Local artifacts: `.artifacts/qa-e2e/pr117805-af03ffb-slack-blocked-live-20260802T094309Z/{qa-suite-report.md,qa-suite-summary.json,qa-evidence.json}`.
