### PR TITLE
fix(qa): deduplicate producer and fallback evidence by scenario id

### DIFF
--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -165,6 +165,7 @@ async function writeNativeVitestReport(
 
 async function writeScriptProducerEvidence(params: {
   outputDir: string;
+  producerId?: string;
   scenarioId?: string;
   status: "blocked" | "fail" | "pass";
   failureReason?: string;
@@ -184,7 +185,7 @@ async function writeScriptProducerEvidence(params: {
           {
             test: {
               kind: "script-producer-check",
-              id: "script-producer.web-ui.smoke",
+              id: params.producerId ?? "script-producer.web-ui.smoke",
               title: "Script producer: web-ui smoke",
               source: { path: "scripts/evidence-producer.ts" },
             },
@@ -1405,6 +1406,35 @@ describe("qa test file scenario runner", () => {
           reason: "node exited with 1",
         },
       },
+    });
+  });
+
+  it("suppresses a failed-script fallback row already owned by producer scenario evidence", async () => {
+    const repoRoot = await makeTempRepo("qa-script-duplicate-scenario-evidence-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "scenario-script-duplicate");
+    const result = await runQaTestFileScenarios({
+      repoRoot,
+      outputDir,
+      providerMode: "mock-openai",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      scenarios: [makeTestFileScenario("script", "scripts/evidence-producer.ts")],
+      runCommand: async () => {
+        await writeScriptProducerEvidence({
+          outputDir,
+          producerId: "scenario-script",
+          status: "fail",
+          failureReason: "producer recorded the script failure",
+        });
+        return { exitCode: 1, stdout: "", stderr: "script failed\n" };
+      },
+      env: { OPENCLAW_QA_REF: "scenario-ref" } as NodeJS.ProcessEnv,
+    });
+
+    expect(result.results[0]).toMatchObject({ status: "fail" });
+    expect(result.evidence.entries).toHaveLength(1);
+    expect(result.evidence.entries[0]).toMatchObject({
+      test: { id: "scenario-script" },
+      result: { failure: { reason: "producer recorded the script failure" }, status: "fail" },
     });
   });
 

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -457,6 +457,9 @@ function buildTestFileEvidence(params: {
   );
   if (producerEntries.length > 0) {
     const definition = testFileRunnerDefinitions[params.kind];
+    // Failed scripts still need generic fallback evidence unless their producer
+    // already recorded that scenario identity at the authoritative boundary.
+    const producerEntryIds = new Set(producerEntries.map((entry) => entry.test.id));
     const fallbackResults = params.results.filter(
       (result) => !result.producerEvidence || result.includeFallbackEvidence,
     );
@@ -498,7 +501,8 @@ function buildTestFileEvidence(params: {
           const { execution: _execution, ...withoutExecution } = entry;
           return withoutExecution;
         }),
-        ...(fallbackEvidence?.entries ?? []),
+        ...(fallbackEvidence?.entries.filter((entry) => !producerEntryIds.has(entry.test.id)) ??
+          []),
       ],
     });
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a script-backed QA scenario could appear twice in the final evidence summary when its producer wrote an authoritative scenario row and the generic script runner also emitted fallback evidence for the same scenario ID. This produced one duplicated Telegram evidence row in the maturity run.

## Why This Change Was Made

Merged evidence now drops a generic fallback entry only when a producer entry already owns the same `test.id`. Producer entries remain authoritative, while fallback evidence with a genuinely distinct ID is preserved for command-level failures and other separate checks.

The fix stays at the evidence merge boundary; it does not suppress all fallback evidence or deduplicate unrelated producer rows.

## User Impact

QA summaries report each producer-owned scenario once, without hiding distinct fallback failures. Product runtime behavior is unchanged.

## Evidence

- Blacksmith Testbox focused proof: [45/45 test-file scenario runner tests passed](https://github.com/openclaw/openclaw/actions/runs/30732048733).
- New regression proof covers a failed script whose producer and fallback share `scenario-script`; the summary retains only the authoritative producer row.
- Existing failed-script proof still retains both `script-producer.web-ui.smoke` and the distinct `scenario-script` fallback row.
- `git diff --check` passed after rebasing onto current `main`.
- Production delta: +5/-1 (+4 net). Tests: +31/-1 (+30 net).

AI-assisted: yes.
