### PR TITLE
fix(qa): tolerate expected Matrix sync long-poll deadlines

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/substrate/request.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/request.ts
@@ -23,6 +23,7 @@ export async function requestMatrixJson<T>(params: {
   method: "DELETE" | "GET" | "POST" | "PUT";
   okStatuses?: number[];
   query?: Record<string, string | number | undefined>;
+  signal?: AbortSignal;
   timeoutMs?: number;
 }): Promise<MatrixQaRequestResult<T>> {
   const url = new URL(params.endpoint, params.baseUrl);
@@ -39,7 +40,7 @@ export async function requestMatrixJson<T>(params: {
       ...(params.accessToken ? { authorization: `Bearer ${params.accessToken}` } : {}),
     },
     ...(params.body !== undefined ? { body: JSON.stringify(params.body) } : {}),
-    signal: AbortSignal.timeout(resolveTimerTimeoutMs(params.timeoutMs, 20_000)),
+    signal: params.signal ?? AbortSignal.timeout(resolveTimerTimeoutMs(params.timeoutMs, 20_000)),
   });
   // Read under a byte cap *before* the parse try/catch. The overflow error must
   // escape uncaught (fail-closed): swallowing it into `body = {}` would defeat

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/sync.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/sync.test.ts
@@ -514,4 +514,36 @@ describe("matrix sync helpers", () => {
       }),
     ).rejects.toThrow("invalid access token");
   });
+
+  it("preserves response-body failures raised after its long-poll deadline fires", async () => {
+    const deadline = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(deadline.signal);
+    const bodyError = new Error("late Matrix response body failure");
+    const observer = createMatrixQaRoomObserver({
+      baseUrl: "http://127.0.0.1:28008/",
+      fetchImpl: async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              deadline.abort();
+              controller.error(bodyError);
+            },
+          }),
+        ),
+      observedEvents: [],
+      since: "start-batch",
+    });
+
+    try {
+      await expect(
+        observer.waitForOptionalRoomEvent({
+          predicate: () => false,
+          roomId: "!room:matrix-qa.test",
+          timeoutMs: 1_000,
+        }),
+      ).rejects.toBe(bodyError);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
 });

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/sync.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/sync.test.ts
@@ -412,4 +412,106 @@ describe("matrix sync helpers", () => {
     });
     expect(calls).toBe(1);
   });
+
+  it("treats its own long-poll deadline as empty and recovers on the next wait", async () => {
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const expiredSignal = AbortSignal.abort(
+      new DOMException("The operation was aborted due to timeout", "TimeoutError"),
+    );
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockReturnValueOnce(expiredSignal)
+      .mockReturnValue(new AbortController().signal);
+    let calls = 0;
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      calls += 1;
+      if (calls === 1) {
+        now = 1;
+        throw init?.signal instanceof AbortSignal ? init.signal.reason : expiredSignal.reason;
+      }
+      return Response.json({
+        next_batch: "recovered-batch",
+        rooms: {
+          join: {
+            "!room:matrix-qa.test": {
+              timeline: {
+                events: [
+                  {
+                    event_id: "$recovered",
+                    sender: "@sut:matrix-qa.test",
+                    type: "m.room.message",
+                    content: { body: "recovered", msgtype: "m.text" },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+    };
+    const observer = createMatrixQaRoomObserver({
+      baseUrl: "http://127.0.0.1:28008/",
+      fetchImpl,
+      observedEvents: [],
+      since: "start-batch",
+    });
+
+    try {
+      await expect(
+        observer.waitForOptionalRoomEvent({
+          predicate: (event) => event.eventId === "$missing",
+          roomId: "!room:matrix-qa.test",
+          timeoutMs: 1,
+        }),
+      ).resolves.toEqual({ matched: false, since: "start-batch" });
+
+      now = 2;
+      await expect(
+        observer.waitForRoomEvent({
+          predicate: (event) => event.eventId === "$recovered",
+          roomId: "!room:matrix-qa.test",
+          timeoutMs: 1_000,
+        }),
+      ).resolves.toMatchObject({ event: { eventId: "$recovered" }, since: "recovered-batch" });
+    } finally {
+      nowSpy.mockRestore();
+      timeoutSpy.mockRestore();
+    }
+    expect(calls).toBe(2);
+  });
+
+  it("preserves terminal sync failures, including unrelated TimeoutErrors", async () => {
+    const timeoutError = new DOMException("upstream protocol timeout", "TimeoutError");
+    const observer = createMatrixQaRoomObserver({
+      baseUrl: "http://127.0.0.1:28008/",
+      fetchImpl: async () => {
+        throw timeoutError;
+      },
+      observedEvents: [],
+      since: "start-batch",
+    });
+
+    await expect(
+      observer.waitForOptionalRoomEvent({
+        predicate: () => false,
+        roomId: "!room:matrix-qa.test",
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toBe(timeoutError);
+
+    const authObserver = createMatrixQaRoomObserver({
+      baseUrl: "http://127.0.0.1:28008/",
+      fetchImpl: async () => Response.json({ error: "invalid access token" }, { status: 401 }),
+      observedEvents: [],
+      since: "start-batch",
+    });
+    await expect(
+      authObserver.waitForOptionalRoomEvent({
+        predicate: () => false,
+        roomId: "!room:matrix-qa.test",
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toThrow("invalid access token");
+  });
 });

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/sync.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/sync.ts
@@ -109,7 +109,7 @@ async function pollMatrixQaRoomObserver(
     } catch (error) {
       // An empty long-poll is expected at this observer-owned boundary. Other
       // request failures stay terminal so auth and protocol defects remain visible.
-      if (deadlineSignal.aborted) {
+      if (deadlineSignal.aborted && error === deadlineSignal.reason) {
         return;
       }
       throw error;

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/sync.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/sync.ts
@@ -91,18 +91,29 @@ async function pollMatrixQaRoomObserver(
   }
 
   params.roomObserver.pollPromise = (async () => {
-    const response = await requestMatrixJson<MatrixQaSyncResponse>({
-      accessToken: params.accessToken,
-      baseUrl: params.baseUrl,
-      endpoint: "/_matrix/client/v3/sync",
-      fetchImpl,
-      method: "GET",
-      query: {
-        ...(params.roomObserver.since ? { since: params.roomObserver.since } : {}),
-        timeout: Math.min(10_000, params.timeoutMs),
-      },
-      timeoutMs: Math.min(15_000, params.timeoutMs + 5_000),
-    });
+    const deadlineSignal = AbortSignal.timeout(Math.min(15_000, params.timeoutMs + 5_000));
+    let response;
+    try {
+      response = await requestMatrixJson<MatrixQaSyncResponse>({
+        accessToken: params.accessToken,
+        baseUrl: params.baseUrl,
+        endpoint: "/_matrix/client/v3/sync",
+        fetchImpl,
+        method: "GET",
+        query: {
+          ...(params.roomObserver.since ? { since: params.roomObserver.since } : {}),
+          timeout: Math.min(10_000, params.timeoutMs),
+        },
+        signal: deadlineSignal,
+      });
+    } catch (error) {
+      // An empty long-poll is expected at this observer-owned boundary. Other
+      // request failures stay terminal so auth and protocol defects remain visible.
+      if (deadlineSignal.aborted) {
+        return;
+      }
+      throw error;
+    }
     params.roomObserver.since = response.body.next_batch?.trim() || params.roomObserver.since;
     for (const [roomId, joinedRoom] of Object.entries(response.body.rooms?.join ?? {})) {
       for (const event of joinedRoom.timeline?.events ?? []) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix QA scenarios could fail after an otherwise expected empty `/sync` long poll reached the observer's HTTP deadline. The deadline error escaped as a permanent adapter failure, so the next scenario in a shared Matrix run inherited the poisoned observer state.

The failure was observed in the exact shared order `matrix-approval-exec-metadata-single-event`, `matrix-e2ee-artifact-redaction`, then `thread-follow-up` in the [failed maturity run](https://github.com/openclaw/openclaw/actions/runs/30707443777). Merged PR #117390 repaired replacement-relation observation but did not change this deadline path.

## Why This Change Was Made

The Matrix observer now owns the abort signal for each `/sync` long poll and treats only that signal's deadline as an empty poll. The shared request helper accepts the owner-provided signal; auth responses, HTTP errors, protocol/transport errors, and unrelated `TimeoutError` instances remain terminal.

This keeps timeout policy at the observer boundary instead of matching error text, adding retries, or weakening Matrix request failures globally.

## User Impact

QA operators can run Matrix scenarios in shared order without an expected idle long poll poisoning the next scenario. Product Matrix runtime behavior and timeout configuration are unchanged.

## Evidence

- Blacksmith Testbox focused proof: [15/15 Matrix request and sync tests passed](https://github.com/openclaw/openclaw/actions/runs/30732138654), including deadline recovery, same-observer reuse, terminal auth errors, and unrelated timeout errors.
- Earlier focused proof on the initial implementation shape: [15/15 passed](https://github.com/openclaw/openclaw/actions/runs/30732048801).
- Node 26.3 live contract check confirmed `AbortSignal.timeout()` aborts its own signal with a `TimeoutError`; the implementation keys on signal ownership, not the error name.
- `git diff --check` passed after rebasing onto current `main`.
- Production delta: +25/-13 (+12 net). Tests: +102/-0.

- Blacksmith Testbox exact shared-order proof: [10/10 runs passed; 30/30 scenarios](https://github.com/openclaw/openclaw/actions/runs/30732495221) in the original failing order, using the live local Tuwunel/Matrix E2EE path with the deterministic mock provider.

AI-assisted: yes.

## Exact-head local Matrix proof

- Head: `560051985562298a2344b279d30abe2d1b648b27`.
- Lane: disposable Docker-backed Tuwunel, real Matrix plugin/E2EE transport, and `mock-openai`.
- Exact shared order, repeated consecutively ten times: `matrix-approval-exec-metadata-single-event`, `matrix-e2ee-artifact-redaction`, `thread-follow-up`.
- Result: **30/30 passed** (10 × 3). Per-run elapsed times: 113.890s, 58.574s, 69.506s, 91.049s, 93.739s, 65.821s, 60.755s, 55.449s, 61.719s, and 53.863s; total proof wall time 13m56.819s.
- No scenario retries, timeout increases, or product/config changes were used.
- Redacted local summaries, reports, and evidence are preserved under `.artifacts/matrix-real-shared-order-560051985562/proof-01` through `proof-10`.
- Teardown verified: no Tuwunel/Matrix harness containers, networks, or volumes remained.
- Exact-head CI: [passed](https://github.com/openclaw/openclaw/actions/runs/30740757373).