### PR TITLE
fix(channels): tighten probe and delivery lifecycles

### DIFF
--- a/extensions/telegram/src/inbound-event-delivery.test.ts
+++ b/extensions/telegram/src/inbound-event-delivery.test.ts
@@ -21,13 +21,13 @@ describe("telegram inbound event delivery", () => {
       accountId: "a1",
     });
     expect(count).toBe(1);
-    end();
     notifyTelegramInboundEventOutboundSuccess({
       sessionKey: "sess:z",
       to: "999",
       accountId: "a1",
     });
     expect(count).toBe(1);
+    end();
   });
 
   it("ignores outbound sends to another destination", () => {
@@ -44,6 +44,26 @@ describe("telegram inbound event delivery", () => {
       accountId: undefined,
     });
     expect(count).toBe(0);
+    end();
+  });
+
+  it("releases correlation before a failing delivery marker runs", () => {
+    let count = 0;
+    const end = beginTelegramInboundEventDeliveryCorrelation("sess:throws", {
+      outboundTo: "999",
+      markInboundEventDelivered: () => {
+        count += 1;
+        throw new Error("marker failed");
+      },
+    });
+
+    expect(() =>
+      notifyTelegramInboundEventOutboundSuccess({ sessionKey: "sess:throws", to: "999" }),
+    ).toThrow("marker failed");
+    expect(() =>
+      notifyTelegramInboundEventOutboundSuccess({ sessionKey: "sess:throws", to: "999" }),
+    ).not.toThrow();
+    expect(count).toBe(1);
     end();
   });
 

--- a/extensions/telegram/src/inbound-event-delivery.ts
+++ b/extensions/telegram/src/inbound-event-delivery.ts
@@ -90,5 +90,8 @@ export function notifyTelegramInboundEventOutboundSuccess(params: {
   if (event.outboundAccountId && params.accountId && params.accountId !== event.outboundAccountId) {
     return;
   }
+  // Retire before invoking channel state: a throwing or reentrant marker must not
+  // retain the correlation or count the same outbound delivery twice.
+  registry.delete(key);
   event.markInboundEventDelivered();
 }

--- a/extensions/twitch/src/probe.test.ts
+++ b/extensions/twitch/src/probe.test.ts
@@ -122,7 +122,8 @@ describe("probeTwitch", () => {
       const result = await resultPromise;
 
       expect(result.ok).toBe(false);
-      expect(result.error).toContain("timeout");
+      expect(result.error).toBe("timeout after 100ms");
+      expect(mockQuit).toHaveBeenCalledOnce();
     } finally {
       vi.useRealTimers();
       mockConnect.mockImplementation(defaultConnectImpl);

--- a/extensions/twitch/src/probe.ts
+++ b/extensions/twitch/src/probe.ts
@@ -3,6 +3,7 @@ import { StaticAuthProvider } from "@twurple/auth";
 import { ChatClient } from "@twurple/chat";
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { TwitchAccountConfig } from "./types.js";
 import { normalizeToken } from "./utils/twitch.js";
 
@@ -26,100 +27,90 @@ export async function probeTwitch(
   account: TwitchAccountConfig,
   timeoutMs: number,
 ): Promise<ProbeTwitchResult> {
-  const started = Date.now();
-
-  if (!account.accessToken || !account.username) {
-    return {
-      ok: false,
-      error: "missing credentials (accessToken, username)",
-      username: account.username,
-      elapsedMs: Date.now() - started,
-    };
-  }
-
-  const rawToken = normalizeToken(account.accessToken.trim());
-
   let client: ChatClient | undefined;
-
   try {
-    const authProvider = new StaticAuthProvider(account.clientId ?? "", rawToken);
-
-    client = new ChatClient({
-      authProvider,
-    });
-
-    // Create a promise that resolves when connected
-    const connectionPromise = new Promise<void>((resolve, reject) => {
-      let settled = false;
-
-      const cleanup = () => {
-        if (settled) {
-          return;
+    return await runChannelProbe(
+      undefined,
+      async () => {
+        if (!account.accessToken || !account.username) {
+          return {
+            ok: false,
+            error: "missing credentials (accessToken, username)",
+            username: account.username,
+          };
         }
-        settled = true;
-        connectListener?.unbind();
-        disconnectListener?.unbind();
-        authFailListener?.unbind();
-      };
 
-      // Success: connection established
-      const connectListener: ReturnType<ChatClient["onConnect"]> | undefined = client?.onConnect(
-        () => {
-          cleanup();
-          resolve();
-        },
-      );
+        const rawToken = normalizeToken(account.accessToken.trim());
+        const authProvider = new StaticAuthProvider(account.clientId ?? "", rawToken);
 
-      // Failure: disconnected (e.g., auth failed)
-      const disconnectListener: ReturnType<ChatClient["onDisconnect"]> | undefined =
-        client?.onDisconnect((_manually, reason) => {
-          cleanup();
-          reject(reason || new Error("Disconnected"));
+        client = new ChatClient({ authProvider });
+
+        const connectionPromise = new Promise<void>((resolve, reject) => {
+          let settled = false;
+
+          const cleanup = () => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            connectListener?.unbind();
+            disconnectListener?.unbind();
+            authFailListener?.unbind();
+          };
+
+          const connectListener: ReturnType<ChatClient["onConnect"]> | undefined =
+            client?.onConnect(() => {
+              cleanup();
+              resolve();
+            });
+
+          const disconnectListener: ReturnType<ChatClient["onDisconnect"]> | undefined =
+            client?.onDisconnect((_manually, reason) => {
+              cleanup();
+              reject(reason || new Error("Disconnected"));
+            });
+
+          const authFailListener: ReturnType<ChatClient["onAuthenticationFailure"]> | undefined =
+            client?.onAuthenticationFailure(() => {
+              cleanup();
+              reject(new Error("Authentication failed"));
+            });
         });
 
-      // Failure: authentication failed
-      const authFailListener: ReturnType<ChatClient["onAuthenticationFailure"]> | undefined =
-        client?.onAuthenticationFailure(() => {
-          cleanup();
-          reject(new Error("Authentication failed"));
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+        const timeout = new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(
+            () => reject(new Error(`timeout after ${timeoutMs}ms`)),
+            timeoutMs,
+          );
         });
-    });
 
-    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<never>((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error(`timeout after ${timeoutMs}ms`)),
-        timeoutMs,
-      );
-    });
+        client.connect();
+        try {
+          await Promise.race([connectionPromise, timeout]);
+        } finally {
+          if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+          }
+        }
 
-    client.connect();
-    try {
-      await Promise.race([connectionPromise, timeout]);
-    } finally {
-      if (timeoutHandle) {
-        clearTimeout(timeoutHandle);
-      }
-    }
+        client.quit();
+        client = undefined;
 
-    client.quit();
-    client = undefined;
-
-    return {
-      ok: true,
-      connected: true,
-      username: account.username,
-      channel: account.channel,
-      elapsedMs: Date.now() - started,
-    };
-  } catch (error) {
-    return {
-      ok: false,
-      error: formatErrorMessage(error),
-      username: account.username,
-      channel: account.channel,
-      elapsedMs: Date.now() - started,
-    };
+        return {
+          ok: true,
+          connected: true,
+          username: account.username,
+          channel: account.channel,
+        };
+      },
+      (error) => ({
+        ok: false,
+        error: formatErrorMessage(error),
+        username: account.username,
+        channel: account.channel,
+      }),
+    );
   } finally {
     if (client) {
       try {

--- a/extensions/zalo/src/probe.test.ts
+++ b/extensions/zalo/src/probe.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { probeZalo } from "./probe.js";
+
+describe("probeZalo", () => {
+  it("returns the bot identity and elapsed time", async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({
+        ok: true,
+        result: { account_name: "test-bot", account_type: "BASIC", id: "bot-1" },
+      }),
+    );
+
+    await expect(probeZalo(" token ", 5000, fetcher)).resolves.toMatchObject({
+      ok: true,
+      bot: { account_name: "test-bot", id: "bot-1" },
+      elapsedMs: expect.any(Number),
+    });
+    expect(fetcher.mock.calls[0]?.[0]).toContain("/bottoken/getMe");
+  });
+
+  it("preserves provider errors", async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({ ok: false, error_code: 401, description: "invalid token" }),
+    );
+
+    await expect(probeZalo("token", 5000, fetcher)).resolves.toMatchObject({
+      ok: false,
+      error: "invalid token",
+      elapsedMs: expect.any(Number),
+    });
+  });
+
+  it("preserves timeout errors", async () => {
+    const fetcher = vi.fn(async () => {
+      throw new DOMException("aborted", "AbortError");
+    });
+
+    await expect(probeZalo("token", 1234, fetcher)).resolves.toMatchObject({
+      ok: false,
+      error: "Request timed out after 1234ms",
+      elapsedMs: expect.any(Number),
+    });
+  });
+});

--- a/extensions/zalo/src/probe.test.ts
+++ b/extensions/zalo/src/probe.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ZaloFetch } from "./api.js";
 import { probeZalo } from "./probe.js";
 
 describe("probeZalo", () => {
   it("returns the bot identity and elapsed time", async () => {
-    const fetcher = vi.fn(async () =>
+    const fetcher = vi.fn<ZaloFetch>(async () =>
       Response.json({
         ok: true,
         result: { account_name: "test-bot", account_type: "BASIC", id: "bot-1" },
@@ -19,7 +20,7 @@ describe("probeZalo", () => {
   });
 
   it("preserves provider errors", async () => {
-    const fetcher = vi.fn(async () =>
+    const fetcher = vi.fn<ZaloFetch>(async () =>
       Response.json({ ok: false, error_code: 401, description: "invalid token" }),
     );
 
@@ -31,7 +32,7 @@ describe("probeZalo", () => {
   });
 
   it("preserves timeout errors", async () => {
-    const fetcher = vi.fn(async () => {
+    const fetcher = vi.fn<ZaloFetch>(async () => {
       throw new DOMException("aborted", "AbortError");
     });
 

--- a/extensions/zalo/src/probe.ts
+++ b/extensions/zalo/src/probe.ts
@@ -1,11 +1,22 @@
 // Zalo plugin module implements probe behavior.
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
+import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { getMe, ZaloApiError, type ZaloBotInfo, type ZaloFetch } from "./api.js";
 
 export type ZaloProbeResult = BaseProbeResult<string> & {
   bot?: ZaloBotInfo;
   elapsedMs: number;
 };
+
+function formatZaloProbeError(error: unknown, timeoutMs: number): string {
+  if (error instanceof ZaloApiError) {
+    return error.description ?? error.message;
+  }
+  if (error instanceof Error) {
+    return error.name === "AbortError" ? `Request timed out after ${timeoutMs}ms` : error.message;
+  }
+  return String(error);
+}
 
 export async function probeZalo(
   token: string,
@@ -16,31 +27,17 @@ export async function probeZalo(
     return { ok: false, error: "No token provided", elapsedMs: 0 };
   }
 
-  const startTime = Date.now();
+  return await runChannelProbe(
+    undefined,
+    async ({ elapsedMs }) => {
+      const response = await getMe(token.trim(), timeoutMs, fetcher);
 
-  try {
-    const response = await getMe(token.trim(), timeoutMs, fetcher);
-    const elapsedMs = Date.now() - startTime;
-
-    if (response.ok && response.result) {
-      return { ok: true, bot: response.result, elapsedMs };
-    }
-
-    return { ok: false, error: "Invalid response from Zalo API", elapsedMs };
-  } catch (err) {
-    const elapsedMs = Date.now() - startTime;
-
-    if (err instanceof ZaloApiError) {
-      return { ok: false, error: err.description ?? err.message, elapsedMs };
-    }
-
-    if (err instanceof Error) {
-      if (err.name === "AbortError") {
-        return { ok: false, error: `Request timed out after ${timeoutMs}ms`, elapsedMs };
+      if (response.ok && response.result) {
+        return { ok: true, bot: response.result, elapsedMs: elapsedMs() };
       }
-      return { ok: false, error: err.message, elapsedMs };
-    }
 
-    return { ok: false, error: String(err), elapsedMs };
-  }
+      return { ok: false, error: "Invalid response from Zalo API", elapsedMs: elapsedMs() };
+    },
+    (error) => ({ ok: false, error: formatZaloProbeError(error, timeoutMs) }),
+  );
 }


### PR DESCRIPTION
## What Problem This Solves

Telegram retained a successful inbound-delivery correlation until turn teardown. A second matching outbound send could therefore invoke the delivery marker again, and a throwing marker left the entry live. Twitch and Zalo also duplicated elapsed-time and error-result probe scaffolding already owned by the shared channel probe runtime.

## Why This Change Was Made

Telegram now consumes the current registry entry before invoking channel state. That matches Discord's established one-shot lifecycle and protects callback failure and reentrancy without weakening the existing identity-checked teardown.

Twitch and Zalo now use `runChannelProbe` for common elapsed/error shaping. Twitch deliberately keeps its channel-specific timeout race and success cleanup order because the shared timeout does not abort the Twurple connection and emits a different error. Zalo keeps its API-owned abort timeout and provider-specific error wording.

The broader fleet candidates were intentionally stopped. The requested secret-contract descriptor cannot preserve the current owner-digest, implicit-default, nesting, and warning contracts. Shared correlation and response-release helpers would add public SDK exports, which requires updating the generated API baseline that this cleanup batch explicitly forbids.

## User Impact

Telegram inbound delivery is recorded once at the first matching successful send, including when the marker throws. Twitch and Zalo probe output and timeout wording remain unchanged. No configuration, protocol, schema, or capability surface changes.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/inbound-event-delivery.test.ts` — 9 passed
- `node scripts/run-vitest.mjs extensions/twitch/src/probe.test.ts` — 10 passed
- `node scripts/run-vitest.mjs extensions/zalo/src/probe.test.ts` — 3 passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings (0.98)
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — test-type follow-up clean (0.99)
- `git diff --check` — clean
- `node scripts/check-changed.mjs` — hosted routing unavailable; deferred heavy lanes to PR CI
- Corrected-head CI: the unrelated gateway event-loop timing shard was rerun successfully; the exact-head watcher finished green
- Production delta: 100 insertions, 109 deletions, net -9 lines
- Test delta: 68 insertions, 2 deletions, net +66 lines

Maintainer-accepted operator-visible mock-gateway evidence:

```bash
qa_state_dir="$(mktemp -d /tmp/openclaw-pr117812-state.XXXXXX)"
OPENCLAW_STATE_DIR="$qa_state_dir" OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/run-node.mjs qa suite \
  --provider-mode mock-openai \
  --scenario group-visible-reply-tool \
  --channel-driver crabline \
  --channel telegram \
  --output-dir .artifacts/qa-e2e/pr-117812-telegram-delivery-correlation
```

```json
{
  "head": "5e2699d5ab3789ce9095d3e5a6c8e3d73f514bb0",
  "scenario": "group-visible-reply-tool",
  "providerMode": "mock-openai",
  "channelDriver": "crabline",
  "channel": "telegram",
  "ephemeralGateway": true,
  "gatewayPort": 56238,
  "isolatedStateDir": true,
  "mockChannelApi": true,
  "inboundToOutboundPathObserved": true,
  "visibleDeliveries": 1,
  "duplicateVisibleDeliveries": 0,
  "operatorVisibleVerdict": "pass",
  "deliveryMarkerObserved": false,
  "oneShotRegistryConsumptionObserved": false,
  "correlationBoundaryVerdict": "not-observable"
}
```

Maintainer accepted this evidence with a structural limitation: the correlation registry is module-private and the delivery marker is an idempotent boolean, so gateway artifacts cannot observe registry membership or marker invocation count. One-shot consumption is instead proven by the focused boundary tests in `extensions/telegram/src/inbound-event-delivery.test.ts`, including second-notification suppression and release before a throwing marker. This is not claimed as an end-to-end PASS for the unobservable internal correlation boundary.
