### PR TITLE
refactor: share channel state error reporting

### DIFF
--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -5,6 +5,7 @@ import {
   resolveDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   discordComponentRegistryState,
@@ -29,16 +30,6 @@ function getComponentEntries(): Map<string, DiscordComponentEntry> {
 
 function getModalEntries(): Map<string, DiscordModalEntry> {
   return discordComponentRegistryState.modalEntries;
-}
-
-function reportPersistentComponentRegistryError(error: unknown): void {
-  try {
-    getOptionalDiscordRuntime()
-      ?.logging.getChildLogger({ plugin: "discord", feature: "component-registry-state" })
-      .warn("Discord persistent component registry state failed", formatRegistryError(error));
-  } catch {
-    // Best effort only: persistent state must never break Discord interactions.
-  }
 }
 
 function formatRegistryError(error: unknown): Record<string, unknown> {
@@ -66,6 +57,14 @@ function formatRegistryError(error: unknown): Record<string, unknown> {
   }
   return details;
 }
+
+const reportPersistentComponentRegistryError = createPluginStateErrorReporter(
+  getOptionalDiscordRuntime,
+  "discord",
+  "component-registry-state",
+  "Discord persistent component registry state failed",
+  formatRegistryError,
+);
 
 function formatRegistryErrorValue(value: unknown): string {
   if (typeof value === "string") {

--- a/extensions/imessage/src/approval-polls.ts
+++ b/extensions/imessage/src/approval-polls.ts
@@ -11,6 +11,7 @@ import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-rep
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
+import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getIMessageApprovalApprovers, imessageApprovalAuth } from "./approval-auth.js";
 import type { IMessageApprovalGatewayRuntime } from "./approval-resolver.js";
 import {
@@ -53,15 +54,12 @@ type IMessageApprovalPollTombstone = { approvalId: string };
 
 const loadApprovalResolver = createLazyRuntimeModule(() => import("./approval-resolver.js"));
 
-function reportPersistentError(error: unknown): void {
-  try {
-    getOptionalIMessageRuntime()
-      ?.logging.getChildLogger({ plugin: "imessage", feature: "approval-poll-state" })
-      .warn("iMessage persistent approval poll state failed", { error: String(error) });
-  } catch {
-    // Best effort only: persistent state must never break poll approvals.
-  }
-}
+const reportPersistentError = createPluginStateErrorReporter(
+  getOptionalIMessageRuntime,
+  "imessage",
+  "approval-poll-state",
+  "iMessage persistent approval poll state failed",
+);
 
 function readPersistedTarget(value: unknown): IMessageApprovalPollTarget | null {
   const target = value as Partial<IMessageApprovalPollTarget> | undefined;

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -25,6 +25,7 @@ import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { getIMessageApprovalApprovers, imessageApprovalAuth } from "./approval-auth.js";
 import type { IMessageApprovalGatewayRuntime } from "./approval-resolver.js";
@@ -149,15 +150,12 @@ export function listPendingIMessageApprovalReactionPollTargets(params: {
   return [...targetByApprovalAndMessage.values()];
 }
 
-function reportPersistentApprovalReactionError(error: unknown): void {
-  try {
-    getOptionalIMessageRuntime()
-      ?.logging.getChildLogger({ plugin: "imessage", feature: "approval-reaction-state" })
-      .warn("iMessage persistent approval reaction state failed", { error: String(error) });
-  } catch {
-    // Best effort only: persistent state must never break iMessage reactions.
-  }
-}
+const reportPersistentApprovalReactionError = createPluginStateErrorReporter(
+  getOptionalIMessageRuntime,
+  "imessage",
+  "approval-reaction-state",
+  "iMessage persistent approval reaction state failed",
+);
 
 function reportApprovalBindingCorrelationMismatch(binding: {
   approvalId: string;

--- a/extensions/matrix/src/approval-reactions.ts
+++ b/extensions/matrix/src/approval-reactions.ts
@@ -1,6 +1,7 @@
 // Matrix plugin module implements approval reactions behavior.
 import { createApprovalReactionTargetStore } from "openclaw/plugin-sdk/approval-reaction-runtime";
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-runtime";
+import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { normalizeAccountId, normalizeOptionalAccountId } from "openclaw/plugin-sdk/routing";
 import { getOptionalMatrixRuntime } from "./runtime.js";
 
@@ -68,15 +69,12 @@ type MatrixApprovalReactionTargetRef = {
   eventId: string;
 };
 
-function reportPersistentApprovalReactionError(error: unknown): void {
-  try {
-    getOptionalMatrixRuntime()
-      ?.logging.getChildLogger({ plugin: "matrix", feature: "approval-reaction-state" })
-      .warn("Matrix persistent approval reaction state failed", { error: String(error) });
-  } catch {
-    // Best effort only: persistent state must never break Matrix reactions.
-  }
-}
+const reportPersistentApprovalReactionError = createPluginStateErrorReporter(
+  getOptionalMatrixRuntime,
+  "matrix",
+  "approval-reaction-state",
+  "Matrix persistent approval reaction state failed",
+);
 
 function readPersistedTarget(target: unknown): MatrixApprovalReactionTarget | null {
   const value = target as Partial<MatrixApprovalReactionTarget> | null | undefined;

--- a/extensions/mattermost/src/mattermost/thread-participation.ts
+++ b/extensions/mattermost/src/mattermost/thread-participation.ts
@@ -1,5 +1,6 @@
 // Mattermost plugin module implements thread participation cache behavior.
 import { createPersistentDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
+import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getOptionalMattermostRuntime } from "../runtime.js";
 
 /**
@@ -30,17 +31,12 @@ const threadParticipation = createPersistentDedupeCache<MattermostThreadParticip
     namespace: PERSISTENT_NAMESPACE,
     maxEntries: PERSISTENT_MAX_ENTRIES,
     openStore: (options) => getOptionalMattermostRuntime()?.state.openKeyedStore(options),
-    logError: (error) => {
-      try {
-        getOptionalMattermostRuntime()
-          ?.logging.getChildLogger({ plugin: "mattermost", feature: "thread-participation-state" })
-          .warn("Mattermost persistent thread participation state failed", {
-            error: String(error),
-          });
-      } catch {
-        // Best effort only: persistent state must never break Mattermost message handling.
-      }
-    },
+    logError: createPluginStateErrorReporter(
+      getOptionalMattermostRuntime,
+      "mattermost",
+      "thread-participation-state",
+      "Mattermost persistent thread participation state failed",
+    ),
   },
 });
 

--- a/extensions/msteams/src/sent-message-cache.ts
+++ b/extensions/msteams/src/sent-message-cache.ts
@@ -1,5 +1,6 @@
 // Msteams plugin module implements sent message cache behavior.
 import { createPersistentDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
+import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getOptionalMSTeamsRuntime } from "./runtime.js";
 
 const TTL_MS = 24 * 60 * 60 * 1000;
@@ -20,15 +21,12 @@ const sentMessages = createPersistentDedupeCache<MSTeamsSentMessageRecord>({
     namespace: PERSISTENT_NAMESPACE,
     maxEntries: PERSISTENT_MAX_ENTRIES,
     openStore: (options) => getOptionalMSTeamsRuntime()?.state.openKeyedStore(options),
-    logError: (error) => {
-      try {
-        getOptionalMSTeamsRuntime()
-          ?.logging.getChildLogger({ plugin: "msteams", feature: "sent-message-state" })
-          .warn("Microsoft Teams persistent sent-message state failed", { error: String(error) });
-      } catch {
-        // Best effort only: persistent state must never break Teams routing.
-      }
-    },
+    logError: createPluginStateErrorReporter(
+      getOptionalMSTeamsRuntime,
+      "msteams",
+      "sent-message-state",
+      "Microsoft Teams persistent sent-message state failed",
+    ),
     // Re-prime with the original send time so restored entries keep their TTL window.
     readTimestamp: (record) => record.sentAt,
   },

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -18,6 +18,7 @@ import {
 } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import {
@@ -82,6 +83,13 @@ type SignalApprovalDeliveryResult = {
 };
 
 const resolverRuntimeLoader = createLazyRuntimeModule(() => import("./approval-resolver.js"));
+
+const reportPersistentApprovalReactionError = createPluginStateErrorReporter(
+  getOptionalSignalRuntime,
+  "signal",
+  "approval-reaction-state",
+  "Signal persistent approval reaction state failed",
+);
 
 const signalApprovalReactionTargets =
   createApprovalReactionTargetStore<SignalApprovalReactionTarget>({
@@ -289,16 +297,6 @@ function buildReactionTargetKey(params: {
     return null;
   }
   return `${accountId}:${conversationKey}:${messageId}`;
-}
-
-function reportPersistentApprovalReactionError(error: unknown): void {
-  try {
-    getOptionalSignalRuntime()
-      ?.logging.getChildLogger({ plugin: "signal", feature: "approval-reaction-state" })
-      .warn("Signal persistent approval reaction state failed", { error: String(error) });
-  } catch {
-    // Best effort only: persistent state must never break Signal reactions.
-  }
 }
 
 function readPersistedTarget(target: unknown): SignalApprovalReactionTarget | null {

--- a/extensions/slack/src/sent-thread-cache.ts
+++ b/extensions/slack/src/sent-thread-cache.ts
@@ -1,5 +1,6 @@
 // Slack plugin module implements sent thread cache behavior.
 import { createPersistentDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
+import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getOptionalSlackRuntime } from "./runtime.js";
 
 /**
@@ -30,15 +31,12 @@ const threadParticipation = createPersistentDedupeCache<SlackThreadParticipation
     namespace: PERSISTENT_NAMESPACE,
     maxEntries: PERSISTENT_MAX_ENTRIES,
     openStore: (options) => getOptionalSlackRuntime()?.state.openKeyedStore(options),
-    logError: (error) => {
-      try {
-        getOptionalSlackRuntime()
-          ?.logging.getChildLogger({ plugin: "slack", feature: "thread-participation-state" })
-          .warn("Slack persistent thread participation state failed", { error: String(error) });
-      } catch {
-        // Best effort only: persistent state must never break Slack message handling.
-      }
-    },
+    logError: createPluginStateErrorReporter(
+      getOptionalSlackRuntime,
+      "slack",
+      "thread-participation-state",
+      "Slack persistent thread participation state failed",
+    ),
   },
 });
 

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -17,6 +17,7 @@ import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/channel-send-re
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { createPluginStateErrorReporter } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveWhatsAppAccount } from "./accounts.js";
 import { getWhatsAppApprovalApprovers, whatsappApprovalAuth } from "./approval-auth.js";
@@ -56,6 +57,13 @@ type ResolvedWhatsAppApprovalReactionTarget = WhatsAppApprovalReactionResolution
 
 const resolverRuntimeLoader = createLazyRuntimeModule(() => import("./approval-resolver.js"));
 
+const reportPersistentApprovalReactionError = createPluginStateErrorReporter(
+  getOptionalWhatsAppRuntime,
+  "whatsapp",
+  "approval-reaction-state",
+  "WhatsApp persistent approval reaction state failed",
+);
+
 const whatsappApprovalReactionTargets =
   createApprovalReactionTargetStore<WhatsAppApprovalReactionTarget>({
     namespace: PERSISTENT_NAMESPACE,
@@ -86,16 +94,6 @@ function addCandidateRemoteJid(target: string[], value: string | null | undefine
   const remoteJid = value?.trim();
   if (remoteJid && !target.includes(remoteJid)) {
     target.push(remoteJid);
-  }
-}
-
-function reportPersistentApprovalReactionError(error: unknown): void {
-  try {
-    getOptionalWhatsAppRuntime()
-      ?.logging.getChildLogger({ plugin: "whatsapp", feature: "approval-reaction-state" })
-      .warn("WhatsApp persistent approval reaction state failed", { error: String(error) });
-  } catch {
-    // Best effort only: persistent state must never break WhatsApp reactions.
   }
 }
 

--- a/src/plugin-sdk/plugin-state-runtime.test.ts
+++ b/src/plugin-sdk/plugin-state-runtime.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPluginStateErrorReporter } from "./plugin-state-runtime.js";
+
+describe("createPluginStateErrorReporter", () => {
+  it("logs state failures with plugin bindings and default details", () => {
+    const warn = vi.fn();
+    const getChildLogger = vi.fn(() => ({ warn }));
+    const report = createPluginStateErrorReporter(
+      () => ({ logging: { getChildLogger } }) as never,
+      "test-plugin",
+      "state-cache",
+      "persistent state failed",
+    );
+
+    report(new Error("boom"));
+
+    expect(getChildLogger).toHaveBeenCalledWith({
+      plugin: "test-plugin",
+      feature: "state-cache",
+    });
+    expect(warn).toHaveBeenCalledWith("persistent state failed", { error: "Error: boom" });
+  });
+
+  it("swallows failures from runtime lookup and error formatting", () => {
+    const runtimeFailure = createPluginStateErrorReporter(
+      () => {
+        throw new Error("runtime unavailable");
+      },
+      "test-plugin",
+      "state-cache",
+      "persistent state failed",
+    );
+    const formattingFailure = createPluginStateErrorReporter(
+      () => ({ logging: { getChildLogger: () => ({ warn: vi.fn() }) } }) as never,
+      "test-plugin",
+      "state-cache",
+      "persistent state failed",
+      () => {
+        throw new Error("formatting failed");
+      },
+    );
+
+    expect(() => runtimeFailure(new Error("boom"))).not.toThrow();
+    expect(() => formattingFailure(new Error("boom"))).not.toThrow();
+  });
+});

--- a/src/plugin-sdk/plugin-state-runtime.ts
+++ b/src/plugin-sdk/plugin-state-runtime.ts
@@ -1,6 +1,24 @@
 /**
  * Runtime SDK type surface for plugin-scoped keyed state stores.
  */
+import type { PluginRuntime } from "../plugins/runtime/types.js";
+
+export function createPluginStateErrorReporter(
+  getRuntime: () => Pick<PluginRuntime, "logging"> | null | undefined,
+  plugin: string,
+  feature: string,
+  message: string,
+  formatError = (error: unknown): Record<string, unknown> => ({ error: String(error) }),
+) {
+  return (error: unknown): void => {
+    try {
+      getRuntime()?.logging.getChildLogger({ plugin, feature }).warn(message, formatError(error));
+    } catch {
+      // State fallback must remain available even when logger setup or formatting fails.
+    }
+  };
+}
+
 export { configureSqliteConnectionPragmas } from "../infra/sqlite-wal.js";
 export {
   migrateSqliteSchemaToStrict,


### PR DESCRIPTION
## What Problem This Solves

Removes repeated best-effort persistent-state logging policy from nine bundled channel plugins, where small local copies could drift in how they bind log context, format failures, or protect state fallback from logger errors.

## Why This Change Was Made

A private plugin-state runtime helper now owns the shared logger lookup and failure-isolation invariant while each plugin still supplies its exact runtime getter, plugin and feature bindings, warning text, and optional error formatter. Discord retains its richer structured error details. Signal reply-author logging is intentionally unchanged because it has distinct non-swallowing behavior.

The audio, question-reaction store, and flat group-policy clusters from the cleanup batch are intentionally excluded: their correct homes are public SDK entrypoints whose API hashes require a generated baseline edit forbidden by this batch. The audio runtime shims also preserve an intentional dynamic-import build boundary, and several group-policy implementations have history-backed lookup differences.

## User Impact

No user-visible behavior changes. Persistent-state failures keep producing the same channel-specific warnings without allowing logger setup or formatting failures to break channel handling.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/plugin-state-runtime.test.ts` — 2 passed.
- `node scripts/run-vitest.mjs extensions/discord/src/components.test.ts extensions/matrix/src/approval-reactions.test.ts extensions/mattermost/src/mattermost/thread-participation.test.ts extensions/msteams/src/sent-message-cache.test.ts extensions/slack/src/sent-thread-cache.test.ts` — 50 passed across 5 shards.
- `node scripts/run-vitest.mjs extensions/imessage/src/approval-polls.test.ts extensions/imessage/src/approval-reactions.test.ts extensions/signal/src/approval-reactions.test.ts extensions/whatsapp/src/approval-reactions.test.ts` — 70 iMessage tests passed; the initial WhatsApp load exposed a `const` initialization-order regression.
- `node scripts/run-vitest.mjs extensions/signal/src/approval-reactions.test.ts extensions/whatsapp/src/approval-reactions.test.ts` — 39 passed after moving both reporter instances above their stores.
- `/Users/steipete/Projects/openclaw/node_modules/.bin/oxfmt <11 touched files>` — clean.
- `git diff --check` — clean.
- `node scripts/check-changed.mjs` — remote delegation unavailable because no Crabbox provider was ready; hosted PR CI supplied the heavy proof.
- Fresh Codex autoreview after rebasing onto `origin/main` — no accepted or actionable findings.
- Hosted CI — 83 checks passed after rerunning one unrelated gateway event-loop timing failure; its focused test passed locally 1/1.
