### PR TITLE
fix(release): stabilize frozen live validation probes

### DIFF
--- a/src/gateway/gateway-acp-bind.live.test.ts
+++ b/src/gateway/gateway-acp-bind.live.test.ts
@@ -745,9 +745,7 @@ describeLive("gateway live (ACP bind)", () => {
             });
           } catch {
             if (attempt === 2) {
-              throw new Error(
-                `${liveAgent} ACP bind completed, but the bound session did not emit an assistant transcript`,
-              );
+              break;
             }
             logLiveStep("bound follow-up token not observed yet; retrying");
           }

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -53,6 +53,7 @@ import { clearRuntimeConfigSnapshot, getRuntimeConfig } from "../config/io.js";
 import type { ModelsConfig, ModelProviderConfig, OpenClawConfig } from "../config/types.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { ModelRegistry } from "../llm/model-registry.js";
+import { redactSecrets } from "../logging/redact.js";
 import { normalizeGoogleModelId } from "../plugin-sdk/google-model-id.js";
 import { resolveProviderThinkingProfile } from "../plugins/provider-runtime.js";
 import type { ProviderThinkingModelCompat } from "../plugins/provider-thinking.types.js";
@@ -1849,7 +1850,9 @@ async function runAnthropicRefusalProbe(params: {
     client: params.client,
     sessionKey: params.sessionKey,
     idempotencyKey: `idem-${randomUUID()}-refusal`,
-    message: `Reply with the single word ok. Test token: ${magic}`,
+    // Credential redaction masks values after "token:", including the
+    // nonce needed to correlate this probe with its persisted user turn.
+    message: `Reply with the single word ok. Test trigger: ${magic}`,
     thinkingLevel: params.thinkingLevel,
     context: `${params.label}: refusal-probe`,
     modelKey: params.modelKey,
@@ -2419,13 +2422,28 @@ describe("latestAssistantTextAfterBaseline", () => {
 
   it("correlates Anthropic refusal probes after the runtime scrubs their trigger", () => {
     const nonce = "0123456789abcdef0123456789abcdef";
-    const expected = `Reply with ok. ${ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL}_${nonce}`;
-    const scrubbed = `Reply with ok. ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_${nonce}`;
+    const expected = `Reply with the single word ok. Test trigger: ${ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL}_${nonce}`;
+    const scrubbed = `Reply with the single word ok. Test trigger: ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_${nonce}`;
+    const redacted = redactSecrets(expected);
 
     expect(matchesLiveProbeUserText(scrubbed, expected)).toBe(true);
+    expect(redacted).toContain(nonce);
+    expect(matchesLiveProbeUserText(redacted, expected)).toBe(true);
+    expect(
+      sessionMessagesAfterNextUserTurn(
+        [
+          { role: "user", content: "previous turn" },
+          { role: "assistant", content: "previous reply", stopReason: "stop" },
+          { role: "user", content: redacted },
+          { role: "assistant", content: "ok", stopReason: "stop" },
+        ],
+        2,
+        expected,
+      ),
+    ).toEqual([{ role: "assistant", content: "ok", stopReason: "stop" }]);
     expect(
       matchesLiveProbeUserText(
-        "Reply with ok. ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_ffffffffffffffffffffffffffffffff",
+        "Reply with the single word ok. Test trigger: ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_ffffffffffffffffffffffffffffffff",
         expected,
       ),
     ).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

Fixes release validation failures where an older frozen candidate uses a live Anthropic probe phrase current Haiku rejects, and where the ACP Docker lane aborts before its existing transcript fallback can assess a completed bind.

## Why This Change Was Made

Backports the two narrow, source-proven `main` test reliability fixes: `5aac6d488fd7f99c4a7e6ec5824e1da3f8ccb5d5` adapts the Anthropic refusal probe to preserve transcript correlation without the `token:` redaction behavior, and `535ab05dcd885908a062819f7140f8584614e0ed` reaches the established ACP fallback after exact-token observation retries. The unrelated SQLite-test cleanup bundled in the first source commit conflicts with this candidate and is intentionally not applied.

## User Impact

No runtime or package behavior changes. The extended-stable candidate can be validated against current provider and ACP behavior without weakening the live-proof requirements: the ACP lane still requires an assistant turn, retained memory, and the final marker.

## Evidence

- Failed Anthropic lane: https://github.com/openclaw/openclaw/actions/runs/30731539281/job/91452929583 — `claude-haiku-4-5` rejected the candidate's old `Test token:` refusal probe.
- Failed ACP Docker lane: https://github.com/openclaw/openclaw/actions/runs/30731539281/job/91454232992 — bind completed, then the candidate threw before its fallback could inspect the transcript.
- Exact source commits and surrounding fallback path reviewed; the sibling Codex checkout was inspected for ACP runtime ownership (it does not implement ACP; OpenClaw's bundled `acpx` backend owns this bridge).
- `oxfmt --check` on both changed files and `git diff --check` pass.
- Fresh structured autoreview completed with no actionable output.
- Secret-bearing Docker/live validation cannot run from this dependency-free release worktree; CI is the authoritative proof.