### PR TITLE
refactor(slack): consolidate transport test fixtures

### DIFF
--- a/extensions/slack/src/monitor/auth.test.ts
+++ b/extensions/slack/src/monitor/auth.test.ts
@@ -1,4 +1,3 @@
-// Slack tests cover auth plugin behavior.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SlackMonitorContext } from "./context.js";
 
@@ -7,6 +6,24 @@ let authorizeSlackBotRoomMessage: typeof import("./auth.js").authorizeSlackBotRo
 let authorizeSlackSystemEventSender: typeof import("./auth.js").authorizeSlackSystemEventSender;
 let resolveSlackEffectiveAllowFrom: typeof import("./auth.js").resolveSlackEffectiveAllowFrom;
 let resolveSlackCommandIngress: typeof import("./auth.js").resolveSlackCommandIngress;
+
+beforeAll(async () => {
+  ({
+    authorizeSlackBotRoomMessage,
+    authorizeSlackSystemEventSender,
+    resolveSlackCommandIngress,
+    resolveSlackEffectiveAllowFrom,
+  } = await import("./auth.js"));
+});
+
+beforeEach(() => {
+  readChannelIngressStoreAllowFromForDmPolicyMock.mockReset();
+  delete process.env.OPENCLAW_SLACK_CHANNEL_MEMBERS_CACHE_TTL_MS;
+});
+
+afterEach(() => {
+  delete process.env.OPENCLAW_SLACK_CHANNEL_MEMBERS_CACHE_TTL_MS;
+});
 
 vi.mock("openclaw/plugin-sdk/channel-ingress-runtime", async () => {
   const actual = await vi.importActual<
@@ -55,227 +72,231 @@ function makeAuthorizeCtx(params?: {
   } as unknown as SlackMonitorContext;
 }
 
+type AuthorizeContextOptions = Parameters<typeof makeAuthorizeCtx>[0];
+type AuthorizeRequest = Omit<Parameters<typeof authorizeSlackSystemEventSender>[0], "ctx">;
+type AuthorizeExpected = Awaited<ReturnType<typeof authorizeSlackSystemEventSender>>;
+type AuthorizeCase = {
+  name: string;
+  ctx?: AuthorizeContextOptions;
+  request: AuthorizeRequest;
+  expected: AuthorizeExpected;
+};
+
+const allowedChannel: AuthorizeExpected = {
+  allowed: true,
+  channelType: "channel",
+  channelName: "general",
+};
+const deniedChannel: AuthorizeExpected = {
+  allowed: false,
+  reason: "sender-not-channel-allowed",
+  channelType: "channel",
+  channelName: "general",
+};
+const channelUsers = { C1: { users: ["U_ALLOWED"] } };
+
+function interactiveRequest(
+  senderId: string,
+  request: Omit<
+    Partial<AuthorizeRequest>,
+    "senderId" | "expectedSenderId" | "interactiveEvent"
+  > = {},
+): AuthorizeRequest {
+  return { senderId, expectedSenderId: senderId, interactiveEvent: true, ...request };
+}
+
+function makeChannelMemberAuth(
+  conversationsMembers = vi.fn(async () => ({ members: ["UOWNER"], response_metadata: {} })),
+) {
+  const ctx = {
+    allowFrom: [],
+    accountId: "main",
+    allowNameMatching: false,
+    app: { client: { conversations: { members: conversationsMembers } } },
+    botToken: "xoxb-test",
+  } as unknown as SlackMonitorContext;
+  const authorize = () =>
+    authorizeSlackBotRoomMessage({
+      ctx,
+      channelId: "C1",
+      senderId: "U_BOT",
+      allowFromLower: ["uowner"],
+    });
+  return { authorize, conversationsMembers };
+}
+
 describe("resolveSlackEffectiveAllowFrom", () => {
-  beforeAll(async () => {
-    ({ authorizeSlackSystemEventSender, resolveSlackEffectiveAllowFrom } =
-      await import("./auth.js"));
-  });
+  it.each([
+    [
+      "falls back to channel config allowFrom when pairing store throws",
+      () =>
+        readChannelIngressStoreAllowFromForDmPolicyMock.mockRejectedValueOnce(new Error("boom")),
+      true,
+      ["u1"],
+      undefined,
+    ],
+    [
+      "treats malformed non-array pairing-store responses as empty",
+      () => readChannelIngressStoreAllowFromForDmPolicyMock.mockReturnValueOnce(undefined),
+      true,
+      ["u1"],
+      undefined,
+    ],
+    [
+      "reads pairing-store allowFrom when requested",
+      () => readChannelIngressStoreAllowFromForDmPolicyMock.mockResolvedValue(["u2"]),
+      true,
+      ["u1", "u2"],
+      1,
+    ],
+    [
+      "does not read pairing-store allowFrom unless requested",
+      () => readChannelIngressStoreAllowFromForDmPolicyMock.mockResolvedValue(["u2"]),
+      false,
+      ["u1"],
+      0,
+    ],
+  ] as const)("%s", async (_name, setup, includePairingStore, expected, expectedCalls) => {
+    setup();
+    const effective = await resolveSlackEffectiveAllowFrom(
+      makeSlackCtx(["u1"]),
+      includePairingStore ? { includePairingStore } : undefined,
+    );
 
-  beforeEach(() => {
-    readChannelIngressStoreAllowFromForDmPolicyMock.mockReset();
-  });
-
-  it("falls back to channel config allowFrom when pairing store throws", async () => {
-    readChannelIngressStoreAllowFromForDmPolicyMock.mockRejectedValueOnce(new Error("boom"));
-
-    const effective = await resolveSlackEffectiveAllowFrom(makeSlackCtx(["u1"]), {
-      includePairingStore: true,
-    });
-
-    expect(effective).toEqual(["u1"]);
-  });
-
-  it("treats malformed non-array pairing-store responses as empty", async () => {
-    readChannelIngressStoreAllowFromForDmPolicyMock.mockReturnValueOnce(undefined);
-
-    const effective = await resolveSlackEffectiveAllowFrom(makeSlackCtx(["u1"]), {
-      includePairingStore: true,
-    });
-
-    expect(effective).toEqual(["u1"]);
-  });
-
-  it("reads pairing-store allowFrom when requested", async () => {
-    readChannelIngressStoreAllowFromForDmPolicyMock.mockResolvedValue(["u2"]);
-    const ctx = makeSlackCtx(["u1"]);
-
-    const effective = await resolveSlackEffectiveAllowFrom(ctx, { includePairingStore: true });
-
-    expect(effective).toEqual(["u1", "u2"]);
-    expect(readChannelIngressStoreAllowFromForDmPolicyMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not read pairing-store allowFrom unless requested", async () => {
-    readChannelIngressStoreAllowFromForDmPolicyMock.mockResolvedValue(["u2"]);
-
-    const effective = await resolveSlackEffectiveAllowFrom(makeSlackCtx(["u1"]));
-
-    expect(effective).toEqual(["u1"]);
-    expect(readChannelIngressStoreAllowFromForDmPolicyMock).not.toHaveBeenCalled();
+    expect(effective).toEqual(expected);
+    if (expectedCalls !== undefined) {
+      expect(readChannelIngressStoreAllowFromForDmPolicyMock).toHaveBeenCalledTimes(expectedCalls);
+    }
   });
 });
 
 describe("authorizeSlackSystemEventSender", () => {
-  beforeAll(async () => {
-    ({ authorizeSlackBotRoomMessage, authorizeSlackSystemEventSender } = await import("./auth.js"));
-  });
+  it.each([
+    [
+      "ignores non-decimal channel member cache ttl env values",
+      () => {
+        process.env.OPENCLAW_SLACK_CHANNEL_MEMBERS_CACHE_TTL_MS = "0x0";
+      },
+      1,
+    ],
+    [
+      "drops cached channel members when the current clock is not a valid date timestamp",
+      () => {
+        vi.spyOn(Date, "now")
+          .mockReturnValueOnce(1_700_000_000_000)
+          .mockReturnValueOnce(1_700_000_000_000)
+          .mockReturnValueOnce(Number.NaN)
+          .mockReturnValue(1_700_000_000_000);
+      },
+      2,
+    ],
+    [
+      "does not cache channel members when the expiry timestamp would exceed the valid date range",
+      () => vi.spyOn(Date, "now").mockReturnValue(8_640_000_000_000_000),
+      2,
+    ],
+  ] as const)("%s", async (_name, setup, expectedCalls) => {
+    setup();
+    const { authorize, conversationsMembers } = makeChannelMemberAuth();
 
-  beforeEach(() => {
-    readChannelIngressStoreAllowFromForDmPolicyMock.mockReset();
-    delete process.env.OPENCLAW_SLACK_CHANNEL_MEMBERS_CACHE_TTL_MS;
-  });
-
-  afterEach(() => {
-    delete process.env.OPENCLAW_SLACK_CHANNEL_MEMBERS_CACHE_TTL_MS;
-  });
-
-  it("ignores non-decimal channel member cache ttl env values", async () => {
-    process.env.OPENCLAW_SLACK_CHANNEL_MEMBERS_CACHE_TTL_MS = "0x0";
-    const conversationsMembers = vi.fn(async () => ({
-      members: ["UOWNER"],
-      response_metadata: {},
-    }));
-    const ctx = {
-      allowFrom: [],
-      accountId: "main",
-      allowNameMatching: false,
-      app: { client: { conversations: { members: conversationsMembers } } },
-      botToken: "xoxb-test",
-    } as unknown as SlackMonitorContext;
-
-    await expect(
-      authorizeSlackBotRoomMessage({
-        ctx,
-        channelId: "C1",
-        senderId: "U_BOT",
-        allowFromLower: ["uowner"],
-      }),
-    ).resolves.toBe(true);
-    await expect(
-      authorizeSlackBotRoomMessage({
-        ctx,
-        channelId: "C1",
-        senderId: "U_BOT",
-        allowFromLower: ["uowner"],
-      }),
-    ).resolves.toBe(true);
-
-    expect(conversationsMembers).toHaveBeenCalledTimes(1);
-  });
-
-  it("drops cached channel members when the current clock is not a valid date timestamp", async () => {
-    vi.spyOn(Date, "now")
-      .mockReturnValueOnce(1_700_000_000_000)
-      .mockReturnValueOnce(1_700_000_000_000)
-      .mockReturnValueOnce(Number.NaN)
-      .mockReturnValue(1_700_000_000_000);
-    const conversationsMembers = vi.fn(async () => ({
-      members: ["UOWNER"],
-      response_metadata: {},
-    }));
-    const ctx = {
-      allowFrom: [],
-      accountId: "main",
-      allowNameMatching: false,
-      app: { client: { conversations: { members: conversationsMembers } } },
-      botToken: "xoxb-test",
-    } as unknown as SlackMonitorContext;
-
-    await expect(
-      authorizeSlackBotRoomMessage({
-        ctx,
-        channelId: "C1",
-        senderId: "U_BOT",
-        allowFromLower: ["uowner"],
-      }),
-    ).resolves.toBe(true);
-    await expect(
-      authorizeSlackBotRoomMessage({
-        ctx,
-        channelId: "C1",
-        senderId: "U_BOT",
-        allowFromLower: ["uowner"],
-      }),
-    ).resolves.toBe(true);
-
-    expect(conversationsMembers).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not cache channel members when the expiry timestamp would exceed the valid date range", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(8_640_000_000_000_000);
-    const conversationsMembers = vi.fn(async () => ({
-      members: ["UOWNER"],
-      response_metadata: {},
-    }));
-    const ctx = {
-      allowFrom: [],
-      accountId: "main",
-      allowNameMatching: false,
-      app: { client: { conversations: { members: conversationsMembers } } },
-      botToken: "xoxb-test",
-    } as unknown as SlackMonitorContext;
-
-    await expect(
-      authorizeSlackBotRoomMessage({
-        ctx,
-        channelId: "C1",
-        senderId: "U_BOT",
-        allowFromLower: ["uowner"],
-      }),
-    ).resolves.toBe(true);
-    await expect(
-      authorizeSlackBotRoomMessage({
-        ctx,
-        channelId: "C1",
-        senderId: "U_BOT",
-        allowFromLower: ["uowner"],
-      }),
-    ).resolves.toBe(true);
-
-    expect(conversationsMembers).toHaveBeenCalledTimes(2);
+    await expect(authorize()).resolves.toBe(true);
+    await expect(authorize()).resolves.toBe(true);
+    expect(conversationsMembers).toHaveBeenCalledTimes(expectedCalls);
   });
 
   it("still coalesces in-flight channel member lookups when durable cache expiry is invalid", async () => {
     vi.spyOn(Date, "now").mockReturnValue(8_640_000_000_000_000);
-    let resolveMembers: (value: {
-      members: string[];
-      response_metadata: Record<string, never>;
-    }) => void;
-    const membersPromise = new Promise<{
-      members: string[];
-      response_metadata: Record<string, never>;
-    }>((resolve) => {
+    type MembersResponse = { members: string[]; response_metadata: Record<string, never> };
+    let resolveMembers: (value: MembersResponse) => void;
+    const membersPromise = new Promise<MembersResponse>((resolve) => {
       resolveMembers = resolve;
     });
-    const conversationsMembers = vi.fn(() => membersPromise);
-    const ctx = {
-      allowFrom: [],
-      accountId: "main",
-      allowNameMatching: false,
-      app: { client: { conversations: { members: conversationsMembers } } },
-      botToken: "xoxb-test",
-    } as unknown as SlackMonitorContext;
+    const { authorize, conversationsMembers } = makeChannelMemberAuth(vi.fn(() => membersPromise));
 
-    const first = authorizeSlackBotRoomMessage({
-      ctx,
-      channelId: "C1",
-      senderId: "U_BOT",
-      allowFromLower: ["uowner"],
-    });
-    const second = authorizeSlackBotRoomMessage({
-      ctx,
-      channelId: "C1",
-      senderId: "U_BOT",
-      allowFromLower: ["uowner"],
-    });
+    const first = authorize();
+    const second = authorize();
     resolveMembers!({ members: ["UOWNER"], response_metadata: {} });
 
     await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
     expect(conversationsMembers).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps non-interactive channel senders open when only global allowFrom is configured", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({ allowFrom: ["U_OWNER"] }),
-      senderId: "U_ATTACKER",
-      channelId: "C1",
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: "general",
-    });
+  it.each([
+    {
+      name: "keeps non-interactive channel senders open when only global allowFrom is configured",
+      ctx: { allowFrom: ["U_OWNER"] },
+      request: { senderId: "U_ATTACKER", channelId: "C1" },
+      expected: allowedChannel,
+    },
+    {
+      name: "allows MPIM system-event senders in the configured allowFrom",
+      ctx: {
+        allowFrom: ["U_OWNER"],
+        resolveChannelName: async () => ({ name: "group-dm", type: "mpim" as const }),
+      },
+      request: { senderId: "U_OWNER", channelId: "G_MPIM" },
+      expected: {
+        allowed: true,
+        channelType: "mpim",
+        channelName: "group-dm",
+      },
+    },
+    {
+      name: "keeps channel users as the non-interactive gate even when global allowFrom is configured",
+      ctx: { allowFrom: ["U_OWNER"], channelsConfig: channelUsers },
+      request: { senderId: "U_OWNER", channelId: "C1" },
+      expected: deniedChannel,
+    },
+    {
+      name: "uses the channel denial reason for non-interactive senders who miss a channel users allowlist",
+      ctx: { allowFrom: ["U_OWNER"], channelsConfig: channelUsers },
+      request: { senderId: "U_ATTACKER", channelId: "C1" },
+      expected: deniedChannel,
+    },
+    {
+      name: "allows channel senders authorized by channel users even when not in global allowFrom",
+      ctx: { allowFrom: ["U_OWNER"], channelsConfig: channelUsers },
+      request: { senderId: "U_ALLOWED", channelId: "C1" },
+      expected: allowedChannel,
+    },
+    {
+      name: "keeps channel interactions open when no global or channel allowlists are configured",
+      request: { senderId: "U_ANYONE", channelId: "C1" },
+      expected: allowedChannel,
+    },
+    {
+      name: "does not let a wildcard global allowFrom bypass non-interactive channel users restrictions",
+      ctx: { allowFrom: ["*"], channelsConfig: channelUsers },
+      request: { senderId: "U_ATTACKER", channelId: "C1" },
+      expected: deniedChannel,
+    },
+    {
+      name: "still allows a channel user when the global allowFrom is wildcard",
+      ctx: { allowFrom: ["*"], channelsConfig: channelUsers },
+      request: { senderId: "U_ALLOWED", channelId: "C1" },
+      expected: allowedChannel,
+    },
+    {
+      name: "does not give non-interactive owner bypass when channel users are configured, even if explicit owners are also listed",
+      ctx: { allowFrom: ["U_OWNER", "*"], channelsConfig: channelUsers },
+      request: { senderId: "U_ATTACKER", channelId: "C1" },
+      expected: deniedChannel,
+    },
+    {
+      name: "keeps explicit owners behind the non-interactive channel users gate when allowFrom also contains wildcard",
+      ctx: { allowFrom: ["U_OWNER", "*"], channelsConfig: channelUsers },
+      request: { senderId: "U_OWNER", channelId: "C1" },
+      expected: deniedChannel,
+    },
+    {
+      name: "allows senders without channel context when no allowFrom is configured",
+      request: { senderId: "U_ANYONE" },
+      expected: { allowed: true, channelType: "channel", channelName: undefined },
+    },
+  ] satisfies AuthorizeCase[])("$name", async ({ ctx, request, expected }) => {
+    await expect(
+      authorizeSlackSystemEventSender({ ctx: makeAuthorizeCtx(ctx), ...request }),
+    ).resolves.toEqual(expected);
   });
 
   it("does not use pairing-store allowFrom for MPIM system events", async () => {
@@ -298,195 +319,9 @@ describe("authorizeSlackSystemEventSender", () => {
     });
     expect(readChannelIngressStoreAllowFromForDmPolicyMock).not.toHaveBeenCalled();
   });
-
-  it("allows MPIM system-event senders in the configured allowFrom", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
-        allowFrom: ["U_OWNER"],
-        resolveChannelName: async () => ({ name: "group-dm", type: "mpim" }),
-      }),
-      senderId: "U_OWNER",
-      channelId: "G_MPIM",
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "mpim",
-      channelName: "group-dm",
-    });
-  });
-
-  it("keeps channel users as the non-interactive gate even when global allowFrom is configured", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
-        allowFrom: ["U_OWNER"],
-        channelsConfig: {
-          C1: { users: ["U_ALLOWED"] },
-        },
-      }),
-      senderId: "U_OWNER",
-      channelId: "C1",
-    });
-
-    expect(result).toEqual({
-      allowed: false,
-      reason: "sender-not-channel-allowed",
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("uses the channel denial reason for non-interactive senders who miss a channel users allowlist", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
-        allowFrom: ["U_OWNER"],
-        channelsConfig: {
-          C1: { users: ["U_ALLOWED"] },
-        },
-      }),
-      senderId: "U_ATTACKER",
-      channelId: "C1",
-    });
-
-    expect(result).toEqual({
-      allowed: false,
-      reason: "sender-not-channel-allowed",
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("allows channel senders authorized by channel users even when not in global allowFrom", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
-        allowFrom: ["U_OWNER"],
-        channelsConfig: {
-          C1: { users: ["U_ALLOWED"] },
-        },
-      }),
-      senderId: "U_ALLOWED",
-      channelId: "C1",
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("keeps channel interactions open when no global or channel allowlists are configured", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx(),
-      senderId: "U_ANYONE",
-      channelId: "C1",
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("does not let a wildcard global allowFrom bypass non-interactive channel users restrictions", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
-        allowFrom: ["*"],
-        channelsConfig: {
-          C1: { users: ["U_ALLOWED"] },
-        },
-      }),
-      senderId: "U_ATTACKER",
-      channelId: "C1",
-    });
-
-    expect(result).toEqual({
-      allowed: false,
-      reason: "sender-not-channel-allowed",
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("still allows a channel user when the global allowFrom is wildcard", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
-        allowFrom: ["*"],
-        channelsConfig: {
-          C1: { users: ["U_ALLOWED"] },
-        },
-      }),
-      senderId: "U_ALLOWED",
-      channelId: "C1",
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("does not give non-interactive owner bypass when channel users are configured, even if explicit owners are also listed", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
-        allowFrom: ["U_OWNER", "*"],
-        channelsConfig: {
-          C1: { users: ["U_ALLOWED"] },
-        },
-      }),
-      senderId: "U_ATTACKER",
-      channelId: "C1",
-    });
-
-    expect(result).toEqual({
-      allowed: false,
-      reason: "sender-not-channel-allowed",
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("keeps explicit owners behind the non-interactive channel users gate when allowFrom also contains wildcard", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
-        allowFrom: ["U_OWNER", "*"],
-        channelsConfig: {
-          C1: { users: ["U_ALLOWED"] },
-        },
-      }),
-      senderId: "U_OWNER",
-      channelId: "C1",
-    });
-
-    expect(result).toEqual({
-      allowed: false,
-      reason: "sender-not-channel-allowed",
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("allows senders without channel context when no allowFrom is configured", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx(),
-      senderId: "U_ANYONE",
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: undefined,
-    });
-  });
 });
 
 describe("resolveSlackCommandIngress", () => {
-  beforeAll(async () => {
-    ({ resolveSlackCommandIngress } = await import("./auth.js"));
-  });
-
   it("does not authorize commands when sender denial stops before the command gate", async () => {
     const result = await resolveSlackCommandIngress({
       ctx: makeAuthorizeCtx(),
@@ -506,10 +341,13 @@ describe("resolveSlackCommandIngress", () => {
     expect(result.commandAccess.shouldBlockControlCommand).toBe(false);
   });
 
-  it("blocks MPIM senders outside the configured allowFrom", async () => {
+  it.each([
+    ["blocks MPIM senders outside the configured allowFrom", "U_ATTACKER", "block", false],
+    ["allows MPIM senders in the configured allowFrom", "U_OWNER", "allow", true],
+  ] as const)("%s", async (_name, senderId, decision, allowed) => {
     const result = await resolveSlackCommandIngress({
       ctx: makeAuthorizeCtx(),
-      senderId: "U_ATTACKER",
+      senderId,
       channelType: "mpim",
       channelId: "G_MPIM",
       ownerAllowFromLower: ["u_owner"],
@@ -517,254 +355,107 @@ describe("resolveSlackCommandIngress", () => {
       hasControlCommand: false,
     });
 
-    expect(result.senderAccess.decision).toBe("block");
-    expect(result.senderAccess.gate?.allowed).toBe(false);
-  });
-
-  it("allows MPIM senders in the configured allowFrom", async () => {
-    const result = await resolveSlackCommandIngress({
-      ctx: makeAuthorizeCtx(),
-      senderId: "U_OWNER",
-      channelType: "mpim",
-      channelId: "G_MPIM",
-      ownerAllowFromLower: ["u_owner"],
-      allowTextCommands: false,
-      hasControlCommand: false,
-    });
-
-    expect(result.senderAccess.decision).toBe("allow");
-    expect(result.senderAccess.gate?.allowed).toBe(true);
+    expect(result.senderAccess.decision).toBe(decision);
+    expect(result.senderAccess.gate?.allowed).toBe(allowed);
   });
 });
 
 describe("authorizeSlackSystemEventSender interactiveEvent", () => {
-  beforeAll(async () => {
-    ({ authorizeSlackSystemEventSender } = await import("./auth.js"));
-  });
-
-  it("rejects interactive events when expectedSenderId is not provided", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({ allowFrom: ["U_OWNER"] }),
-      senderId: "U_OWNER",
-      channelId: "C1",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: false,
-      reason: "missing-expected-sender",
-    });
-  });
-
-  it("allows interactive events when expectedSenderId matches senderId", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({ allowFrom: ["U_OWNER"] }),
-      senderId: "U_OWNER",
-      channelId: "C1",
-      expectedSenderId: "U_OWNER",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("allows interactive channel senders who match the global allowFrom even when channel users are configured", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
+  it.each([
+    {
+      name: "rejects interactive events when expectedSenderId is not provided",
+      ctx: { allowFrom: ["U_OWNER"] },
+      request: { senderId: "U_OWNER", channelId: "C1", interactiveEvent: true },
+      expected: { allowed: false, reason: "missing-expected-sender" },
+    },
+    {
+      name: "allows interactive events when expectedSenderId matches senderId",
+      ctx: { allowFrom: ["U_OWNER"] },
+      request: interactiveRequest("U_OWNER", { channelId: "C1" }),
+      expected: allowedChannel,
+    },
+    {
+      name: "allows interactive channel senders who match the global allowFrom even when channel users are configured",
+      ctx: { allowFrom: ["U_OWNER"], channelsConfig: channelUsers },
+      request: interactiveRequest("U_OWNER", { channelId: "C1" }),
+      expected: allowedChannel,
+    },
+    {
+      name: "uses a combined denial reason when an interactive sender matches neither global nor channel allowlists",
+      ctx: { allowFrom: ["U_OWNER"], channelsConfig: channelUsers },
+      request: interactiveRequest("U_ATTACKER", { channelId: "C1" }),
+      expected: {
+        allowed: false,
+        reason: "sender-not-authorized",
+        channelType: "channel",
+        channelName: "general",
+      },
+    },
+    {
+      name: "keeps interactive channel events open when no allowlists are configured",
+      request: interactiveRequest("U_ANYONE", { channelId: "C1" }),
+      expected: allowedChannel,
+    },
+    {
+      name: "preserves explicit owner access for interactive events when allowFrom also contains wildcard",
+      ctx: { allowFrom: ["U_OWNER", "*"], channelsConfig: channelUsers },
+      request: interactiveRequest("U_OWNER", { channelId: "C1" }),
+      expected: allowedChannel,
+    },
+    {
+      name: "keeps interactive no-channel events open when no allowFrom is configured",
+      request: interactiveRequest("U_ANYONE"),
+      expected: { allowed: true, channelType: "channel", channelName: undefined },
+    },
+    {
+      name: "denies interactive no-channel events when sender is not in allowFrom",
+      ctx: { allowFrom: ["U_OWNER"] },
+      request: interactiveRequest("U_ATTACKER"),
+      expected: { allowed: false, reason: "sender-not-allowlisted" },
+    },
+    {
+      name: "allows interactive no-channel events when sender is in allowFrom",
+      ctx: { allowFrom: ["U_OWNER"] },
+      request: interactiveRequest("U_OWNER"),
+      expected: { allowed: true, channelType: "channel", channelName: undefined },
+    },
+    {
+      name: "rejects interactive events with ambiguous channel type",
+      ctx: {
         allowFrom: ["U_OWNER"],
-        channelsConfig: {
-          C1: { users: ["U_ALLOWED"] },
-        },
-      }),
-      senderId: "U_OWNER",
-      channelId: "C1",
-      expectedSenderId: "U_OWNER",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("uses a combined denial reason when an interactive sender matches neither global nor channel allowlists", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
+        resolveChannelName: async () => ({ name: "mystery" }),
+      },
+      request: interactiveRequest("U_OWNER", { channelId: "X1" }),
+      expected: {
+        allowed: false,
+        reason: "ambiguous-channel-type",
+        channelType: "channel",
+        channelName: "mystery",
+      },
+    },
+    {
+      name: "allows interactive events when channel type is known from ID prefix",
+      ctx: { allowFrom: ["U_OWNER"] },
+      request: interactiveRequest("U_OWNER", { channelId: "C1" }),
+      expected: allowedChannel,
+    },
+    {
+      name: "allows interactive events when channel type is known from explicit type",
+      ctx: {
         allowFrom: ["U_OWNER"],
-        channelsConfig: {
-          C1: { users: ["U_ALLOWED"] },
-        },
-      }),
-      senderId: "U_ATTACKER",
-      channelId: "C1",
-      expectedSenderId: "U_ATTACKER",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: false,
-      reason: "sender-not-authorized",
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("keeps interactive channel events open when no allowlists are configured", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx(),
-      senderId: "U_ANYONE",
-      channelId: "C1",
-      expectedSenderId: "U_ANYONE",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("preserves explicit owner access for interactive events when allowFrom also contains wildcard", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
-        allowFrom: ["U_OWNER", "*"],
-        channelsConfig: {
-          C1: { users: ["U_ALLOWED"] },
-        },
-      }),
-      senderId: "U_OWNER",
-      channelId: "C1",
-      expectedSenderId: "U_OWNER",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("keeps interactive no-channel events open when no allowFrom is configured", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx(),
-      senderId: "U_ANYONE",
-      expectedSenderId: "U_ANYONE",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: undefined,
-    });
-  });
-
-  it("denies interactive no-channel events when sender is not in allowFrom", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({ allowFrom: ["U_OWNER"] }),
-      senderId: "U_ATTACKER",
-      expectedSenderId: "U_ATTACKER",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: false,
-      reason: "sender-not-allowlisted",
-    });
-  });
-
-  it("allows interactive no-channel events when sender is in allowFrom", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({ allowFrom: ["U_OWNER"] }),
-      senderId: "U_OWNER",
-      expectedSenderId: "U_OWNER",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: undefined,
-    });
-  });
-
-  it("rejects interactive events with ambiguous channel type", async () => {
-    // Channel ID "X1" has no recognized prefix (D, C, G) so the type is ambiguous
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
-        allowFrom: ["U_OWNER"],
-        resolveChannelName: () => Promise.resolve({ name: "mystery" }),
-      }),
-      senderId: "U_OWNER",
-      channelId: "X1",
-      expectedSenderId: "U_OWNER",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: false,
-      reason: "ambiguous-channel-type",
-      channelType: "channel",
-      channelName: "mystery",
-    });
-  });
-
-  it("allows interactive events when channel type is known from ID prefix", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({ allowFrom: ["U_OWNER"] }),
-      senderId: "U_OWNER",
-      channelId: "C1",
-      expectedSenderId: "U_OWNER",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: "general",
-    });
-  });
-
-  it("allows interactive events when channel type is known from explicit type", async () => {
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx({
-        allowFrom: ["U_OWNER"],
-        resolveChannelName: () => Promise.resolve({ name: "mystery", type: "group" }),
-      }),
-      senderId: "U_OWNER",
-      channelId: "X1",
-      channelType: "group",
-      expectedSenderId: "U_OWNER",
-      interactiveEvent: true,
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "group",
-      channelName: "mystery",
-    });
-  });
-
-  it("does not apply interactiveEvent restrictions to non-interactive events", async () => {
-    // Same scenario as the denying test above, but without interactiveEvent flag
-    const result = await authorizeSlackSystemEventSender({
-      ctx: makeAuthorizeCtx(),
-      senderId: "U_ANYONE",
-      channelId: "C1",
-    });
-
-    expect(result).toEqual({
-      allowed: true,
-      channelType: "channel",
-      channelName: "general",
-    });
+        resolveChannelName: async () => ({ name: "mystery", type: "group" as const }),
+      },
+      request: interactiveRequest("U_OWNER", { channelId: "X1", channelType: "group" }),
+      expected: { allowed: true, channelType: "group", channelName: "mystery" },
+    },
+    {
+      name: "does not apply interactiveEvent restrictions to non-interactive events",
+      request: { senderId: "U_ANYONE", channelId: "C1" },
+      expected: allowedChannel,
+    },
+  ] satisfies AuthorizeCase[])("$name", async ({ ctx, request, expected }) => {
+    await expect(
+      authorizeSlackSystemEventSender({ ctx: makeAuthorizeCtx(ctx), ...request }),
+    ).resolves.toEqual(expected);
   });
 });

--- a/extensions/slack/src/send.upload.test.ts
+++ b/extensions/slack/src/send.upload.test.ts
@@ -1,4 +1,3 @@
-// Slack tests cover send.upload plugin behavior.
 import type { WebClient } from "@slack/web-api";
 import {
   formatErrorMessage,
@@ -121,9 +120,7 @@ type UploadTestClient = WebClient & {
   };
 };
 
-type MockCalls = {
-  mock: { calls: unknown[][] };
-};
+type MockCalls = { mock: { calls: unknown[][] } };
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   const isObjectRecord = typeof value === "object" && value !== null && !Array.isArray(value);
@@ -212,10 +209,53 @@ function createUploadTestClient(slackApiUrl = "https://slack.com/api/"): UploadT
   } as unknown as UploadTestClient;
 }
 
+type UploadOverrides = Omit<Partial<Parameters<typeof sendMessageSlack>[2]>, "cfg" | "client">;
+type UploadParams = UploadOverrides & { mediaUrl: string; target?: string; message?: string };
+
+function sendUpload(client: UploadTestClient, params: UploadParams) {
+  const { target = "channel:C123CHAN", message = "caption", ...options } = params;
+  return sendMessageSlack(target, message, {
+    token: "xoxb-test",
+    cfg: SLACK_TEST_CFG,
+    client,
+    ...options,
+  });
+}
+
+function sendText(client: UploadTestClient, target: string, message: string) {
+  return sendMessageSlack(target, message, { token: "xoxb-test", cfg: SLACK_TEST_CFG, client });
+}
+
+function mockUploadDestination(client: UploadTestClient, uploadUrl: string) {
+  client.files.getUploadURLExternal.mockResolvedValueOnce({
+    ok: true,
+    upload_url: uploadUrl,
+    file_id: "F001",
+  });
+}
+
+async function useRealUploadGuard(networkFetch: typeof fetch, lookupAddress?: string) {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
+    "openclaw/plugin-sdk/ssrf-runtime",
+  );
+  const lookupFn = lookupAddress
+    ? ((async () => [{ address: lookupAddress, family: 4 }]) as unknown as LookupFn)
+    : undefined;
+  fetchWithSsrFGuard.mockImplementationOnce(async (params) =>
+    actual.fetchWithSsrFGuard({
+      ...params,
+      fetchImpl: networkFetch,
+      ...(lookupFn ? { lookupFn } : {}),
+    }),
+  );
+}
+
 describe("sendMessageSlack file upload with user IDs", () => {
   const originalFetch = globalThis.fetch;
+  let client: UploadTestClient;
 
   beforeEach(() => {
+    client = createUploadTestClient();
     globalThis.fetch = vi.fn(
       async () => new Response("ok", { status: 200 }),
     ) as unknown as typeof fetch;
@@ -233,59 +273,41 @@ describe("sendMessageSlack file upload with user IDs", () => {
     vi.restoreAllMocks();
   });
 
-  it("resolves bare user ID to DM channel before completing upload", async () => {
-    const client = createUploadTestClient();
-
-    // Bare user ID — parseSlackTarget classifies this as kind="channel"
-    await sendMessageSlack("U2ZH3MFSR", "screenshot", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+  it.each([
+    {
+      name: "resolves bare user ID to DM channel before completing upload",
+      target: "U2ZH3MFSR",
+      message: "screenshot",
       mediaUrl: "/tmp/screenshot.png",
-    });
-
-    // Should call conversations.open to resolve user ID → DM channel
-    expect(client.conversations.open).toHaveBeenCalledWith({
-      users: "U2ZH3MFSR",
-    });
-
-    expectCompletedUpload({
-      client,
-      expected: { channel_id: "D99RESOLVED" },
+      userId: "U2ZH3MFSR",
       file: { id: "F001", title: "screenshot.png" },
-    });
-  });
-
-  it("resolves prefixed user ID to DM channel before completing upload", async () => {
-    const client = createUploadTestClient();
-
-    await sendMessageSlack("user:UABC123", "image", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+    },
+    {
+      name: "resolves prefixed user ID to DM channel before completing upload",
+      target: "user:UABC123",
+      message: "image",
       mediaUrl: "/tmp/photo.png",
-    });
+      userId: "UABC123",
+    },
+    {
+      name: "resolves mention-style user ID before file upload",
+      target: "<@U777TEST>",
+      message: "report",
+      mediaUrl: "/tmp/report.png",
+      userId: "U777TEST",
+    },
+  ])("$name", async ({ target, message, mediaUrl, userId, file }) => {
+    await sendUpload(client, { target, message, mediaUrl });
 
-    expect(client.conversations.open).toHaveBeenCalledWith({
-      users: "UABC123",
-    });
-    expectCompletedUpload({ client, expected: { channel_id: "D99RESOLVED" } });
+    expect(client.conversations.open).toHaveBeenCalledWith({ users: userId });
+    expectCompletedUpload({ client, expected: { channel_id: "D99RESOLVED" }, file });
   });
 
   it("posts text-only user-target DMs directly without conversations.open", async () => {
-    const client = createUploadTestClient();
     client.conversations.open.mockRejectedValueOnce(new Error("missing_scope"));
 
-    await sendMessageSlack("user:UABC123", "first", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-    });
-    await sendMessageSlack("user:UABC123", "second", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-    });
+    await sendText(client, "user:UABC123", "first");
+    await sendText(client, "user:UABC123", "second");
 
     expect(client.conversations.open).not.toHaveBeenCalled();
     expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
@@ -296,7 +318,6 @@ describe("sendMessageSlack file upload with user IDs", () => {
   });
 
   it("serializes concurrent sends to the same Slack target", async () => {
-    const client = createUploadTestClient();
     let resolveFirst: (() => void) | undefined;
     client.chat.postMessage.mockImplementation(async (payload: unknown) => {
       const text =
@@ -312,18 +333,10 @@ describe("sendMessageSlack file upload with user IDs", () => {
       return { ts: "2.000" };
     });
 
-    const first = sendMessageSlack("channel:C123CHAN", "first", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-    });
+    const first = sendText(client, "channel:C123CHAN", "first");
     await vi.waitFor(() => expect(client.chat.postMessage).toHaveBeenCalledTimes(1));
 
-    const second = sendMessageSlack("channel:C123CHAN", "second", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-    });
+    const second = sendText(client, "channel:C123CHAN", "second");
     await Promise.resolve();
 
     expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
@@ -354,18 +367,16 @@ describe("sendMessageSlack file upload with user IDs", () => {
   });
 
   it("scopes DM channel resolution cache by token identity", async () => {
-    const client = createUploadTestClient();
-
-    await sendMessageSlack("user:UABC123", "first", {
+    await sendUpload(client, {
+      target: "user:UABC123",
+      message: "first",
       token: "xoxb-test-a",
-      cfg: SLACK_TEST_CFG,
-      client,
       mediaUrl: "/tmp/first.png",
     });
-    await sendMessageSlack("user:UABC123", "second", {
+    await sendUpload(client, {
+      target: "user:UABC123",
+      message: "second",
       token: "xoxb-test-b",
-      cfg: SLACK_TEST_CFG,
-      client,
       mediaUrl: "/tmp/second.png",
     });
 
@@ -373,14 +384,7 @@ describe("sendMessageSlack file upload with user IDs", () => {
   });
 
   it("sends file directly to channel without conversations.open", async () => {
-    const client = createUploadTestClient();
-
-    const result = await sendMessageSlack("channel:C123CHAN", "chart", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      mediaUrl: "/tmp/chart.png",
-    });
+    const result = await sendUpload(client, { message: "chart", mediaUrl: "/tmp/chart.png" });
 
     expect(client.conversations.open).not.toHaveBeenCalled();
     expectCompletedUpload({ client, expected: { channel_id: "C123CHAN" } });
@@ -400,24 +404,7 @@ describe("sendMessageSlack file upload with user IDs", () => {
     });
   });
 
-  it("resolves mention-style user ID before file upload", async () => {
-    const client = createUploadTestClient();
-
-    await sendMessageSlack("<@U777TEST>", "report", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      mediaUrl: "/tmp/report.png",
-    });
-
-    expect(client.conversations.open).toHaveBeenCalledWith({
-      users: "U777TEST",
-    });
-    expectCompletedUpload({ client, expected: { channel_id: "D99RESOLVED" } });
-  });
-
   it("uploads bytes to the presigned URL and completes with thread+caption", async () => {
-    const client = createUploadTestClient();
     const events: string[] = [];
     globalThis.fetch = vi.fn(async () => {
       events.push("byte-upload");
@@ -437,10 +424,7 @@ describe("sendMessageSlack file upload with user IDs", () => {
       events.push("dispatch-end");
     });
 
-    const sendPromise = sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+    const sendPromise = sendUpload(client, {
       mediaUrl: "/tmp/threaded.png",
       threadTs: "171.222",
       onPlatformSendDispatch,
@@ -494,19 +478,9 @@ describe("sendMessageSlack file upload with user IDs", () => {
   });
 
   it("keeps the presigned upload capability out of timeout logging", async () => {
-    const client = createUploadTestClient();
-    client.files.getUploadURLExternal.mockResolvedValueOnce({
-      ok: true,
-      upload_url: "https://files.slack.com/upload/v1/secret-capability",
-      file_id: "F001",
-    });
+    mockUploadDestination(client, "https://files.slack.com/upload/v1/secret-capability");
 
-    await sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      mediaUrl: "/tmp/secret.png",
-    });
+    await sendUpload(client, { mediaUrl: "/tmp/secret.png" });
 
     expectOnlyCallFirstArg(buildTimeoutAbortSignal, {
       timeoutMs: 120_000,
@@ -532,12 +506,8 @@ describe("sendMessageSlack file upload with user IDs", () => {
       async (baseUrl) => {
         vi.stubEnv("NO_PROXY", "127.0.0.1,localhost");
         vi.stubEnv("no_proxy", "127.0.0.1,localhost");
-        const client = createUploadTestClient(`${baseUrl}/api/`);
-        client.files.getUploadURLExternal.mockResolvedValueOnce({
-          ok: true,
-          upload_url: `${baseUrl}/upload/v1/capability`,
-          file_id: "F001",
-        });
+        const alternateClient = createUploadTestClient(`${baseUrl}/api/`);
+        mockUploadDestination(alternateClient, `${baseUrl}/upload/v1/capability`);
         fetchWithSsrFGuard.mockImplementationOnce(async (params) => {
           const mockedFetch = globalThis.fetch;
           globalThis.fetch = originalFetch;
@@ -548,125 +518,58 @@ describe("sendMessageSlack file upload with user IDs", () => {
           }
         });
 
-        await sendMessageSlack("channel:C123CHAN", "caption", {
-          token: "xoxb-test",
-          cfg: SLACK_TEST_CFG,
-          client,
-          mediaUrl: "/tmp/alternate-root.png",
-        });
+        await sendUpload(alternateClient, { mediaUrl: "/tmp/alternate-root.png" });
 
-        expectCompletedUpload({ client, expected: { channel_id: "C123CHAN" } });
+        expectCompletedUpload({ client: alternateClient, expected: { channel_id: "C123CHAN" } });
         expect(cleanupUploadTimeout).toHaveBeenCalledOnce();
         expect(uploadTimeoutControllers).toHaveLength(0);
       },
     );
   });
 
-  it("allows an exact Slack upload host returned by a custom API root", async () => {
-    const client = createUploadTestClient("https://slack-relay.example/api/");
-    client.files.getUploadURLExternal.mockResolvedValueOnce({
-      ok: true,
-      upload_url: "https://files.slack.com/upload/v1/relayed-capability",
-      file_id: "F001",
-    });
-    const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
-      "openclaw/plugin-sdk/ssrf-runtime",
-    );
-    const networkFetch = vi.fn(async () => new Response("ok", { status: 200 }));
-    fetchWithSsrFGuard.mockImplementationOnce(async (params) =>
-      actual.fetchWithSsrFGuard({
-        ...params,
-        fetchImpl: networkFetch,
-        lookupFn: (async () => [{ address: "93.184.216.34", family: 4 }]) as unknown as LookupFn,
-      }),
-    );
-
-    await sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+  it.each([
+    {
+      name: "allows an exact Slack upload host returned by a custom API root",
+      apiUrl: "https://slack-relay.example/api/",
+      uploadUrl: "https://files.slack.com/upload/v1/relayed-capability",
+      lookupAddress: "93.184.216.34",
       mediaUrl: "/tmp/relayed-upload.png",
-    });
-
-    expect(networkFetch).toHaveBeenCalledOnce();
-    expectCompletedUpload({ client, expected: { channel_id: "C123CHAN" } });
-  });
-
-  it("allows GovSlack upload destinations through the real hostname guard", async () => {
-    const client = createUploadTestClient("https://slack-gov.com/api/");
-    client.files.getUploadURLExternal.mockResolvedValueOnce({
-      ok: true,
-      upload_url: "https://files.slack-gov.com/upload/v1/gov-capability",
-      file_id: "F001",
-    });
-    const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
-      "openclaw/plugin-sdk/ssrf-runtime",
-    );
-    const networkFetch = vi.fn(async () => new Response("ok", { status: 200 }));
-    fetchWithSsrFGuard.mockImplementationOnce(async (params) =>
-      actual.fetchWithSsrFGuard({ ...params, fetchImpl: networkFetch }),
-    );
-
-    await sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+    },
+    {
+      name: "allows GovSlack upload destinations through the real hostname guard",
+      apiUrl: "https://slack-gov.com/api/",
+      uploadUrl: "https://files.slack-gov.com/upload/v1/gov-capability",
+      lookupAddress: undefined,
       mediaUrl: "/tmp/gov-slack.png",
-    });
-
-    expect(networkFetch).toHaveBeenCalledOnce();
-    expectCompletedUpload({ client, expected: { channel_id: "C123CHAN" } });
-  });
-
-  it("retains the shipped RFC2544 fake-IP path for an exact Slack upload host", async () => {
-    const client = createUploadTestClient();
-    const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
-      "openclaw/plugin-sdk/ssrf-runtime",
-    );
-    const networkFetch = vi.fn(async () => new Response("ok", { status: 200 }));
-    fetchWithSsrFGuard.mockImplementationOnce(async (params) =>
-      actual.fetchWithSsrFGuard({
-        ...params,
-        fetchImpl: networkFetch,
-        lookupFn: (async () => [{ address: "198.18.0.10", family: 4 }]) as unknown as LookupFn,
-      }),
-    );
-
-    await sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+    },
+    {
+      name: "retains the shipped RFC2544 fake-IP path for an exact Slack upload host",
+      apiUrl: undefined,
+      uploadUrl: undefined,
+      lookupAddress: "198.18.0.10",
       mediaUrl: "/tmp/fake-ip.png",
-    });
+    },
+  ])("$name", async ({ apiUrl, uploadUrl, lookupAddress, mediaUrl }) => {
+    const caseClient = createUploadTestClient(apiUrl);
+    if (uploadUrl) {
+      mockUploadDestination(caseClient, uploadUrl);
+    }
+    const networkFetch = vi.fn(async () => new Response("ok", { status: 200 }));
+    await useRealUploadGuard(networkFetch, lookupAddress);
+
+    await sendUpload(caseClient, { mediaUrl });
 
     expect(networkFetch).toHaveBeenCalledOnce();
-    expectCompletedUpload({ client, expected: { channel_id: "C123CHAN" } });
+    expectCompletedUpload({ client: caseClient, expected: { channel_id: "C123CHAN" } });
   });
 
   it.each(["10.0.0.1", "169.254.1.1"])(
     "rejects exact Slack upload hosts resolving to blocked address %s",
     async (address) => {
-      const client = createUploadTestClient();
-      const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
-        "openclaw/plugin-sdk/ssrf-runtime",
-      );
       const networkFetch = vi.fn(async () => new Response("unexpected"));
-      fetchWithSsrFGuard.mockImplementationOnce(async (params) =>
-        actual.fetchWithSsrFGuard({
-          ...params,
-          fetchImpl: networkFetch,
-          lookupFn: (async () => [{ address, family: 4 }]) as unknown as LookupFn,
-        }),
-      );
+      await useRealUploadGuard(networkFetch, address);
 
-      await expect(
-        sendMessageSlack("channel:C123CHAN", "caption", {
-          token: "xoxb-test",
-          cfg: SLACK_TEST_CFG,
-          client,
-          mediaUrl: "/tmp/private-address.png",
-        }),
-      ).rejects.toThrow();
+      await expect(sendUpload(client, { mediaUrl: "/tmp/private-address.png" })).rejects.toThrow();
 
       expect(networkFetch).not.toHaveBeenCalled();
       expect(client.files.completeUploadExternal).not.toHaveBeenCalled();
@@ -674,111 +577,69 @@ describe("sendMessageSlack file upload with user IDs", () => {
   );
 
   it.each([
-    [
-      "public non-Slack",
-      "https://slack.com/api/",
-      "https://example.com/upload/v1/not-slack",
-      "SsrFBlockedError",
-    ],
-    [
-      "plaintext Slack",
-      "https://slack.com/api/",
-      "http://files.slack.com/upload/v1/plaintext",
-      "Error",
-    ],
+    ["public non-Slack", "https://slack.com/api/", "https://example.com/upload/v1/not-slack"],
+    ["plaintext Slack", "https://slack.com/api/", "http://files.slack.com/upload/v1/plaintext"],
     [
       "commercial Slack to GovSlack",
       "https://slack.com/api/",
       "https://files.slack-gov.com/upload/v1/cross-plane",
-      "SsrFBlockedError",
     ],
     [
       "GovSlack to commercial Slack",
       "https://slack-gov.com/api/",
       "https://files.slack.com/upload/v1/cross-plane",
-      "SsrFBlockedError",
     ],
     [
       "trailing-dot commercial Slack to GovSlack",
       "https://slack.com./api/",
       "https://files.slack-gov.com/upload/v1/cross-plane",
-      "SsrFBlockedError",
     ],
     [
       "trailing-dot GovSlack to commercial Slack",
       "https://slack-gov.com./api/",
       "https://files.slack.com/upload/v1/cross-plane",
-      "SsrFBlockedError",
     ],
     [
       "undocumented commercial subdomain",
       "https://slack.com/api/",
       "https://future-upload.slack.com/upload/v1/capability",
-      "SsrFBlockedError",
     ],
     [
       "undocumented GovSlack subdomain",
       "https://slack-gov.com/api/",
       "https://future-upload.slack-gov.com/upload/v1/capability",
-      "SsrFBlockedError",
     ],
-  ])(
-    "rejects %s upload destinations before network access",
-    async (_label, apiUrl, uploadUrl, error) => {
-      const client = createUploadTestClient(apiUrl);
-      client.files.getUploadURLExternal.mockResolvedValueOnce({
-        ok: true,
-        upload_url: uploadUrl,
-        file_id: "F001",
-      });
-      const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
-        "openclaw/plugin-sdk/ssrf-runtime",
-      );
-      const networkFetch = vi.fn(async () => new Response("unexpected"));
-      fetchWithSsrFGuard.mockImplementationOnce(async (params) =>
-        actual.fetchWithSsrFGuard({ ...params, fetchImpl: networkFetch }),
-      );
+  ])("rejects %s upload destinations before network access", async (label, apiUrl, uploadUrl) => {
+    const rejectedClient = createUploadTestClient(apiUrl);
+    mockUploadDestination(rejectedClient, uploadUrl);
+    const networkFetch = vi.fn(async () => new Response("unexpected"));
+    const errorName = uploadUrl.startsWith("http:") ? "Error" : "SsrFBlockedError";
+    await useRealUploadGuard(networkFetch);
 
-      const rejection = await sendMessageSlack("channel:C123CHAN", "caption", {
-        token: "xoxb-test",
-        cfg: SLACK_TEST_CFG,
-        client,
-        mediaUrl: "/tmp/rejected-upload.png",
-      }).catch((cause: unknown) => cause);
+    const rejection = await sendUpload(rejectedClient, {
+      mediaUrl: "/tmp/rejected-upload.png",
+    }).catch((cause: unknown) => cause);
 
-      expect(rejection).toBeInstanceOf(PlatformMessageNotDispatchedError);
-      expect(rejection).toMatchObject({
-        cause: expect.objectContaining({ name: error }),
-      });
+    expect(rejection).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(rejection).toMatchObject({ cause: expect.objectContaining({ name: errorName }) });
 
-      expect(networkFetch).not.toHaveBeenCalled();
-      expect(client.files.completeUploadExternal).not.toHaveBeenCalled();
-    },
-  );
+    expect(networkFetch).not.toHaveBeenCalled();
+    expect(rejectedClient.files.completeUploadExternal).not.toHaveBeenCalled();
+  });
 
   it("rejects upload destinations outside an explicitly configured API origin", async () => {
-    const client = createUploadTestClient("http://slack-compatible.example/api/");
-    client.files.getUploadURLExternal.mockResolvedValueOnce({
-      ok: true,
-      upload_url: "http://other-compatible.example/upload/v1/capability",
-      file_id: "F001",
-    });
+    const originClient = createUploadTestClient("http://slack-compatible.example/api/");
+    mockUploadDestination(originClient, "http://other-compatible.example/upload/v1/capability");
 
-    await expect(
-      sendMessageSlack("channel:C123CHAN", "caption", {
-        token: "xoxb-test",
-        cfg: SLACK_TEST_CFG,
-        client,
-        mediaUrl: "/tmp/wrong-origin.png",
-      }),
-    ).rejects.toThrow("must match the configured Slack API origin");
+    await expect(sendUpload(originClient, { mediaUrl: "/tmp/wrong-origin.png" })).rejects.toThrow(
+      "must match the configured Slack API origin",
+    );
 
     expect(fetchWithSsrFGuard).not.toHaveBeenCalled();
-    expect(client.files.completeUploadExternal).not.toHaveBeenCalled();
+    expect(originClient.files.completeUploadExternal).not.toHaveBeenCalled();
   });
 
   it("times out a hanging presigned URL upload", async () => {
-    const client = createUploadTestClient();
     const closedResponses = vi.fn();
 
     await withServer(
@@ -803,17 +664,10 @@ describe("sendMessageSlack file upload with user IDs", () => {
       },
       async (baseUrl) => {
         globalThis.fetch = originalFetch;
-        client.files.getUploadURLExternal.mockResolvedValueOnce({
-          ok: true,
-          upload_url: `${baseUrl}/upload`,
-          file_id: "F001",
-        });
+        mockUploadDestination(client, `${baseUrl}/upload`);
 
         const onPlatformSendDispatch = vi.fn();
-        const error = await sendMessageSlack("channel:C123CHAN", "caption", {
-          token: "xoxb-test",
-          cfg: SLACK_TEST_CFG,
-          client,
+        const error = await sendUpload(client, {
           mediaUrl: "/tmp/hanging.png",
           onPlatformSendDispatch,
         }).catch((cause: unknown) => cause);
@@ -844,14 +698,10 @@ describe("sendMessageSlack file upload with user IDs", () => {
   });
 
   it.each([201, 204, 500])("rejects a non-200 byte-upload response (%s)", async (status) => {
-    const client = createUploadTestClient();
     const onPlatformSendDispatch = vi.fn();
     globalThis.fetch = vi.fn(async () => new Response(null, { status })) as unknown as typeof fetch;
 
-    const error = await sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+    const error = await sendUpload(client, {
       mediaUrl: "/tmp/non-200.png",
       onPlatformSendDispatch,
     }).catch((cause: unknown) => cause);
@@ -869,7 +719,6 @@ describe("sendMessageSlack file upload with user IDs", () => {
   });
 
   it("marks a non-timeout byte-upload transport failure as not dispatched", async () => {
-    const client = createUploadTestClient();
     const onPlatformSendDispatch = vi.fn();
     const transportError = Object.assign(
       new Error(
@@ -881,10 +730,7 @@ describe("sendMessageSlack file upload with user IDs", () => {
       throw transportError;
     }) as unknown as typeof fetch;
 
-    const error = await sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+    const error = await sendUpload(client, {
       mediaUrl: "/tmp/transport-failure.png",
       onPlatformSendDispatch,
     }).catch((cause: unknown) => cause);
@@ -905,7 +751,6 @@ describe("sendMessageSlack file upload with user IDs", () => {
   });
 
   it("disposes the byte-upload response and timeout before waiting for completion", async () => {
-    const client = createUploadTestClient();
     const uploadResponse = new Response("ok", { status: 200 });
     const cancelUploadBody = vi.spyOn(uploadResponse.body!, "cancel");
     cancelUploadBody.mockRejectedValueOnce(new Error("response body cleanup failed"));
@@ -923,12 +768,7 @@ describe("sendMessageSlack file upload with user IDs", () => {
       return completionResult;
     });
 
-    const sendPromise = sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      mediaUrl: "/tmp/completion-pending.png",
-    });
+    const sendPromise = sendUpload(client, { mediaUrl: "/tmp/completion-pending.png" });
 
     await completionStarted;
     expect(cancelUploadBody).toHaveBeenCalledOnce();
@@ -948,87 +788,56 @@ describe("sendMessageSlack file upload with user IDs", () => {
     await expect(sendPromise).resolves.toMatchObject({ messageId: "F001" });
   });
 
-  it("keeps completion failures unmarked because Slack may have finalized the upload", async () => {
-    const client = createUploadTestClient();
-    const onPlatformSendDispatch = vi.fn();
-    client.files.completeUploadExternal.mockRejectedValueOnce(new Error("completion unavailable"));
-
-    const error = await sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+  it.each([
+    {
+      name: "keeps completion failures unmarked because Slack may have finalized the upload",
+      completion: new Error("completion unavailable"),
       mediaUrl: "/tmp/completion-failure.png",
-      onPlatformSendDispatch,
-    }).catch((cause: unknown) => cause);
-
-    expect(error).toMatchObject({ message: "completion unavailable" });
-    expect(error).not.toBeInstanceOf(PlatformMessageNotDispatchedError);
-    expect(onPlatformSendDispatch).toHaveBeenCalledOnce();
-  });
-
-  it("keeps completion error responses unmarked because Slack may have finalized the upload", async () => {
-    const client = createUploadTestClient();
-    const onPlatformSendDispatch = vi.fn();
-    client.files.completeUploadExternal.mockResolvedValueOnce({
-      ok: false,
-      error: "completion_failed",
-    });
-
-    const error = await sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+      message: "completion unavailable",
+    },
+    {
+      name: "keeps completion error responses unmarked because Slack may have finalized the upload",
+      completion: { ok: false, error: "completion_failed" },
       mediaUrl: "/tmp/completion-error-response.png",
-      onPlatformSendDispatch,
-    }).catch((cause: unknown) => cause);
+      message: "Failed to complete upload: completion_failed",
+    },
+  ])("$name", async ({ completion, mediaUrl, message }) => {
+    const onPlatformSendDispatch = vi.fn();
+    if (completion instanceof Error) {
+      client.files.completeUploadExternal.mockRejectedValueOnce(completion);
+    } else {
+      client.files.completeUploadExternal.mockResolvedValueOnce(completion);
+    }
 
-    expect(error).toMatchObject({ message: "Failed to complete upload: completion_failed" });
+    const error = await sendUpload(client, { mediaUrl, onPlatformSendDispatch }).catch(
+      (cause: unknown) => cause,
+    );
+
+    expect(error).toMatchObject({ message });
     expect(error).not.toBeInstanceOf(PlatformMessageNotDispatchedError);
     expect(onPlatformSendDispatch).toHaveBeenCalledOnce();
   });
 
-  it("uses explicit upload filename and title overrides when provided", async () => {
-    const client = createUploadTestClient();
+  it.each([
+    ["uses explicit upload filename and title overrides when provided", "Custom Title"],
+    ["uses uploadFileName as the title fallback when uploadTitle is omitted", undefined],
+  ] as const)("%s", async (_name, uploadTitle) => {
+    const uploadFileName = "custom-name.bin";
 
-    await sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
+    await sendUpload(client, {
       mediaUrl: "/tmp/threaded.png",
-      uploadFileName: "custom-name.bin",
-      uploadTitle: "Custom Title",
+      uploadFileName,
+      ...(uploadTitle ? { uploadTitle } : {}),
     });
 
     expect(client.files.getUploadURLExternal).toHaveBeenCalledWith({
-      filename: "custom-name.bin",
+      filename: uploadFileName,
       length: Buffer.from("fake-image").length,
     });
     expectCompletedUpload({
       client,
       expected: {},
-      file: { id: "F001", title: "Custom Title" },
-    });
-  });
-
-  it("uses uploadFileName as the title fallback when uploadTitle is omitted", async () => {
-    const client = createUploadTestClient();
-
-    await sendMessageSlack("channel:C123CHAN", "caption", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      mediaUrl: "/tmp/threaded.png",
-      uploadFileName: "custom-name.bin",
-    });
-
-    expect(client.files.getUploadURLExternal).toHaveBeenCalledWith({
-      filename: "custom-name.bin",
-      length: Buffer.from("fake-image").length,
-    });
-    expectCompletedUpload({
-      client,
-      expected: {},
-      file: { id: "F001", title: "custom-name.bin" },
+      file: { id: "F001", title: uploadTitle ?? uploadFileName },
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Slack authorization and upload regression coverage had accumulated 500 lines of repeated client setup, request construction, and expected payloads. The duplication made the security, cache, dispatch, and upload-policy matrices harder to audit and maintain consistently.

## Why This Change Was Made

This consolidates the repeated fixtures into typed case tables and small owner-local helpers while retaining every existing expanded test case and test name. It changes only `monitor/auth.test.ts` and `send.upload.test.ts`; production code, configuration, documentation, package metadata, and public behavior are untouched.

The canonical test flows now make these invariants explicit:

- pairing-store and channel-member cache behavior, including invalid clocks and in-flight coalescing
- interactive and non-interactive sender authorization
- DM target resolution and token-scoped caching
- upload completion ordering, error ownership, filename/title selection, and timeout cleanup
- Slack/GovSlack upload-origin and SSRF allow/deny policy

## User Impact

No user-visible behavior changes. Maintainers get a smaller, clearer Slack regression suite with the same coverage and assertions.

## Evidence

- Diff: 502 additions, 1,002 deletions; net **-500 test LOC**, production delta **0**.
- Mechanical TypeScript AST comparison: identical expanded test-name multisets before/after — auth 36/36, upload 34/34, total 70/70.
- Focused local proof after rebasing onto current `main`: 2 files, 70/70 tests passed.
- Exact-path `oxfmt --check`, `oxlint --deny-warnings`, and `git diff --check`: passed.
- [Blacksmith Testbox proof](https://github.com/openclaw/openclaw/actions/runs/30732309347):
  - focused Slack auth/upload: 70/70 passed on the final synchronized patch
  - full Slack suite: 129 files, 2,104/2,104 tests passed
  - `pnpm check:changed`: passed, including extension-test typecheck and lint with 0 warnings/errors
- Two independent xhigh reviews: **CLEAN / BEST FIX**. Both verified async ordering, cache lifecycle, error classification, filename/title fallback, DM token identity, dispatch timing, and SSRF policy.

No build was run because this is a test-only change with no build, package, lazy-module, or published-surface impact.
