### PR TITLE
fix(telegram): reject unauthorized command media before any download

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
@@ -226,6 +226,7 @@ export function createTelegramInboundMediaGroupRuntime(
     });
     if (decision.shouldSkip) {
       if (
+        !commandGate.shouldBlockControlCommand &&
         resolveTelegramGroupIngestEnabled({
           cfg: authorization.authorizationCfg,
           chatId,

--- a/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
@@ -157,10 +157,44 @@ export function createTelegramInboundMediaGroupRuntime(
       authorization.groupConfig?.requireMention,
       resolveGroupRequireMention(chatId, authorization.authorizationCfg),
     );
+    const botUsername = ctx.me?.username?.trim().toLowerCase();
+    const hasControlCommandInMessage = hasControlCommand(
+      textParts.text,
+      authorization.authorizationCfg,
+      { botUsername },
+    );
+    if (!requireMention && !hasControlCommandInMessage) {
+      return "process";
+    }
+    const commandGate = await resolveTelegramCommandIngressAuthorization({
+      accountId,
+      cfg: authorization.authorizationCfg,
+      dmPolicy: "pairing",
+      isGroup,
+      chatId,
+      resolvedThreadId,
+      senderId,
+      effectiveDmAllow: authorization.effectiveDmAllow,
+      effectiveGroupAllow: authorization.effectiveGroupAllow,
+      ownerAccess: { ownerList: [], senderIsOwner: false },
+      eventKind: "message",
+      allowTextCommands: true,
+      hasControlCommand: hasControlCommandInMessage,
+      modeWhenAccessGroupsOff: "allow",
+      includeDmAllowForGroupCommands: false,
+    });
+    // Command authorization protects both singleton and album downloads;
+    // requiring a mention must never determine whether unauthorized media is fetched.
+    if (commandGate.shouldBlockControlCommand) {
+      logger.info(
+        { chatId, reason: "unauthorized-control-command" },
+        "skipping group command media before download",
+      );
+      return "skip";
+    }
     if (!requireMention) {
       return "process";
     }
-    const botUsername = ctx.me?.username?.trim().toLowerCase();
     const mentionRegexes = buildMentionRegexes(
       authorization.authorizationCfg,
       sessionState.agentId,
@@ -187,28 +221,6 @@ export function createTelegramInboundMediaGroupRuntime(
       "reply_to_bot",
       replyToBotMessage && !isTelegramForumServiceMessage(msg.reply_to_message),
     );
-    const hasControlCommandInMessage = hasControlCommand(
-      textParts.text,
-      authorization.authorizationCfg,
-      { botUsername },
-    );
-    const commandGate = await resolveTelegramCommandIngressAuthorization({
-      accountId,
-      cfg: authorization.authorizationCfg,
-      dmPolicy: "pairing",
-      isGroup,
-      chatId,
-      resolvedThreadId,
-      senderId,
-      effectiveDmAllow: authorization.effectiveDmAllow,
-      effectiveGroupAllow: authorization.effectiveGroupAllow,
-      ownerAccess: { ownerList: [], senderIsOwner: false },
-      eventKind: "message",
-      allowTextCommands: true,
-      hasControlCommand: hasControlCommandInMessage,
-      modeWhenAccessGroupsOff: "allow",
-      includeDmAllowForGroupCommands: false,
-    });
     const decision = resolveInboundMentionDecision({
       facts: {
         canDetectMention: Boolean(botUsername) || mentionRegexes.length > 0,
@@ -226,7 +238,6 @@ export function createTelegramInboundMediaGroupRuntime(
     });
     if (decision.shouldSkip) {
       if (
-        !commandGate.shouldBlockControlCommand &&
         resolveTelegramGroupIngestEnabled({
           cfg: authorization.authorizationCfg,
           chatId,

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -761,6 +761,40 @@ describe("createTelegramBot channel_post media", () => {
     expectTelegramIngestHook([]);
   });
 
+  it("does not download unauthorized group command media when ingestion is enabled (#92067)", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groupAllowFrom: ["999"],
+          groups: { "-100456": telegramIngestGroupForTest(true) },
+        },
+      },
+    });
+    const getFile = vi.fn(async () => ({ file_path: "photos/unauthorized-command.jpg" }));
+    const fetchSpy = createImageFetchSpy();
+
+    try {
+      createTelegramBot({ token: "tok" });
+      await dispatchTelegramGroupPhoto({
+        messageId: 92079,
+        caption: "/reset",
+        extraMessage: {
+          caption_entities: [{ type: "bot_command", offset: 0, length: 6 }],
+        },
+        getFile,
+      });
+
+      expect(getFile).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(triggerInternalHookMock).not.toHaveBeenCalled();
+      expect(sendMessageSpy).not.toHaveBeenCalled();
+      expect(replySpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it.each([
     { name: "all", messageIds: [92068, 92069], partial: false, deniedMention: false },
     { name: "partial", messageIds: [92071, 92072], partial: true, deniedMention: false },

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -6,7 +6,14 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
+import {
+  telegramBotInfoForTest,
+  telegramIngestGroupForTest,
+  waitForTelegramMockCalls,
+  type TelegramIngestGroupForTest,
+  type TelegramMentionCaseForTest,
+  type TelegramMentionPolicyForTest,
+} from "./bot.create-telegram-bot.test-support.js";
 import { resetTelegramForumFlagCacheForTest } from "./bot/helpers.js";
 import { setTelegramRuntime } from "./runtime.js";
 import type { TelegramRuntime } from "./runtime.types.js";
@@ -149,15 +156,6 @@ function createImageFetchSpy(params?: { body?: Uint8Array; contentType?: string 
   );
 }
 
-async function waitForMockCalls(mock: { mock: { calls: unknown[] } }, count: number) {
-  for (let index = 0; index < 80; index++) {
-    if (mock.mock.calls.length >= count) {
-      return;
-    }
-    await delay(25);
-  }
-}
-
 function createChannelPostContext(params: {
   messageId: number;
   date: number;
@@ -257,41 +255,10 @@ function expectTypeOnlyMediaPayload(kind: string, rawBody = "") {
   expect(media[0]?.path).toBeUndefined();
 }
 
-type TelegramMentionPolicyForTest = {
-  mode: "allow" | "deny";
-  allowIn?: string[];
-  denyIn?: string[];
-};
-
-type TelegramIngestGroupForTest = {
-  requireMention: boolean;
-  ingest?: boolean;
-  topics?: Record<string, { ingest: boolean }>;
-};
-
-function telegramIngestGroupForTest(
-  ingest?: boolean,
-  topics?: Record<string, { ingest: boolean }>,
-): TelegramIngestGroupForTest {
-  return {
-    requireMention: true,
-    ...(ingest === undefined ? {} : { ingest }),
-    ...(topics ? { topics } : {}),
-  };
-}
-
-type TelegramMentionCaseForTest = [
-  string,
-  TelegramMentionPolicyForTest,
-  TelegramMentionPolicyForTest | undefined,
-  number | undefined,
-  boolean,
-  number,
-];
-
 function setTelegramIngestGroupConfig(
   params: {
     groups?: Record<string, TelegramIngestGroupForTest>;
+    groupAllowFrom?: string[];
     providerPolicy?: TelegramMentionPolicyForTest;
     accountPolicy?: TelegramMentionPolicyForTest;
     customMentionPatterns?: boolean;
@@ -304,6 +271,7 @@ function setTelegramIngestGroupConfig(
     channels: {
       telegram: {
         groupPolicy: "open",
+        ...(params.groupAllowFrom ? { groupAllowFrom: params.groupAllowFrom } : {}),
         ...(params.providerPolicy ? { mentionPatterns: params.providerPolicy } : {}),
         groups: params.groups ?? { "-100456": { requireMention: true, ingest: true } },
         ...(params.accountPolicy
@@ -504,7 +472,7 @@ describe("createTelegramBot channel_post media", () => {
       });
       expect(replySpy).not.toHaveBeenCalled();
       await flushChannelPostMediaGroup(setTimeoutSpy);
-      await waitForMockCalls(replySpy, 1);
+      await waitForTelegramMockCalls(replySpy, 1);
 
       await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
       const payload = replyPayload() as { Body?: string };
@@ -594,7 +562,7 @@ describe("createTelegramBot channel_post media", () => {
       createTelegramBot({ token: "tok" });
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
       await handler(createTelegramPrivateMediaContext({ messageId: 411, fileId: "p1" }));
-      await waitForMockCalls(sendMessageSpy, 1);
+      await waitForTelegramMockCalls(sendMessageSpy, 1);
       expectTelegramDownloadWarning(411);
       expect(replySpy).toHaveBeenCalledOnce();
       expectTypeOnlyMediaPayload("image");
@@ -617,7 +585,7 @@ describe("createTelegramBot channel_post media", () => {
         },
       }),
     );
-    await waitForMockCalls(sendMessageSpy, 1);
+    await waitForTelegramMockCalls(sendMessageSpy, 1);
     expectTelegramDownloadWarning(100000);
     expect(replySpy).toHaveBeenCalledOnce();
     expectTypeOnlyMediaPayload("document");
@@ -644,7 +612,7 @@ describe("createTelegramBot channel_post media", () => {
           },
         }),
       );
-      await waitForMockCalls(sendMessageSpy, 1);
+      await waitForTelegramMockCalls(sendMessageSpy, 1);
       expectTelegramDownloadWarning(
         messageId,
         `⚠️ File too large. Maximum size is ${expectedLimitMb}MB.`,
@@ -711,17 +679,32 @@ describe("createTelegramBot channel_post media", () => {
     ["group disables wildcard", false, true, undefined, false],
     ["topic enables group", false, undefined, true, true],
     ["topic disables group", true, undefined, false, false],
+    ["unauthorized unmentioned command", true, undefined, undefined, false],
+    ["unauthorized mentioned command", true, undefined, undefined, false],
+    ["unauthorized mention-optional command", true, undefined, undefined, false],
+    ["unauthorized prefixed mention-optional command", true, undefined, undefined, false],
   ] as Array<[string, boolean | undefined, boolean | undefined, boolean | undefined, boolean]>)(
     "honors %s before skipping unmentioned group media (#92067)",
     async (_name, groupIngest, wildcardIngest, topicIngest, shouldIngest) => {
+      const unauthorizedCommand = _name.startsWith("unauthorized");
+      const command = `${_name.includes("prefixed") ? "[Tue 2026-06-02 12:34] " : ""}${
+        _name === "unauthorized mentioned command" ? "/reset@openclaw_bot" : "/reset"
+      }`;
+      const commandOffset = command.indexOf("/");
       const topics = topicIngest === undefined ? undefined : { "42": { ingest: topicIngest } };
       const groups = {
         ...(wildcardIngest === undefined
           ? {}
           : { "*": telegramIngestGroupForTest(wildcardIngest) }),
-        "-100456": telegramIngestGroupForTest(groupIngest, topics),
+        "-100456": {
+          ...telegramIngestGroupForTest(groupIngest, topics),
+          requireMention: !_name.includes("mention-optional"),
+        },
       };
-      setTelegramIngestGroupConfig({ groups });
+      setTelegramIngestGroupConfig({
+        groups,
+        groupAllowFrom: unauthorizedCommand ? ["999"] : undefined,
+      });
       const getFile = vi.fn(async () => ({ file_path: "photos/ingested.jpg" }));
       const fetchSpy = createImageFetchSpy();
       try {
@@ -729,6 +712,18 @@ describe("createTelegramBot channel_post media", () => {
         await dispatchTelegramGroupPhoto({
           messageId: 92067,
           topicId: topicIngest === undefined ? undefined : 42,
+          caption: unauthorizedCommand ? command : undefined,
+          extraMessage: unauthorizedCommand
+            ? {
+                caption_entities: [
+                  {
+                    type: "bot_command",
+                    offset: commandOffset,
+                    length: command.length - commandOffset,
+                  },
+                ],
+              }
+            : undefined,
           getFile,
         });
         const expectedCalls = Number(shouldIngest);
@@ -761,47 +756,16 @@ describe("createTelegramBot channel_post media", () => {
     expectTelegramIngestHook([]);
   });
 
-  it("does not download unauthorized group command media when ingestion is enabled (#92067)", async () => {
-    loadConfig.mockReturnValue({
-      channels: {
-        telegram: {
-          groupPolicy: "open",
-          groupAllowFrom: ["999"],
-          groups: { "-100456": telegramIngestGroupForTest(true) },
-        },
-      },
-    });
-    const getFile = vi.fn(async () => ({ file_path: "photos/unauthorized-command.jpg" }));
-    const fetchSpy = createImageFetchSpy();
-
-    try {
-      createTelegramBot({ token: "tok" });
-      await dispatchTelegramGroupPhoto({
-        messageId: 92079,
-        caption: "/reset",
-        extraMessage: {
-          caption_entities: [{ type: "bot_command", offset: 0, length: 6 }],
-        },
-        getFile,
-      });
-
-      expect(getFile).not.toHaveBeenCalled();
-      expect(fetchSpy).not.toHaveBeenCalled();
-      expect(triggerInternalHookMock).not.toHaveBeenCalled();
-      expect(sendMessageSpy).not.toHaveBeenCalled();
-      expect(replySpy).not.toHaveBeenCalled();
-    } finally {
-      fetchSpy.mockRestore();
-    }
-  });
-
   it.each([
     { name: "all", messageIds: [92068, 92069], partial: false, deniedMention: false },
     { name: "partial", messageIds: [92071, 92072], partial: true, deniedMention: false },
     { name: "denied mention", messageIds: [92071, 92072], partial: true, deniedMention: true },
-  ])("silently ingests group media albums with $name exactly once (#92067)", async (testCase) => {
+    { name: "unauthorized", messageIds: [92079, 92080], partial: false, deniedMention: false },
+  ])("applies group media album policy to $name (#92067)", async (testCase) => {
+    const unauthorizedCommand = testCase.name === "unauthorized";
     setTelegramIngestGroupConfig({
       customMentionPatterns: testCase.deniedMention,
+      groupAllowFrom: unauthorizedCommand ? ["999"] : undefined,
       ...(testCase.deniedMention ? { providerPolicy: { mode: "deny" } } : {}),
     });
     rejectFirstTelegramAlbumDownloadWhen(testCase.partial);
@@ -811,22 +775,29 @@ describe("createTelegramBot channel_post media", () => {
     try {
       createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
       for (const messageId of testCase.messageIds) {
+        const commandCaption = unauthorizedCommand && messageId === testCase.messageIds[1];
         await dispatchTelegramGroupPhoto({
           messageId,
           albumId: "ingested-album",
-          ...(testCase.deniedMention && messageId === testCase.messageIds[0]
-            ? { caption: "bert, see attachment" }
-            : {}),
+          caption: commandCaption
+            ? "/reset@openclaw_bot"
+            : unauthorizedCommand
+              ? "ordinary caption"
+              : testCase.deniedMention && messageId === testCase.messageIds[0]
+                ? "bert, see attachment"
+                : undefined,
+          extraMessage: commandCaption
+            ? { caption_entities: [{ type: "bot_command", offset: 0, length: 19 }] }
+            : undefined,
           getFile,
         });
       }
       expect(getFile).not.toHaveBeenCalled();
       await flushChannelPostMediaGroup(setTimeoutSpy);
-      expect(getFile).toHaveBeenCalledTimes(2);
-      expect(fetchSpy).toHaveBeenCalledTimes(testCase.partial ? 1 : 2);
-      expectTelegramIngestHook(
-        testCase.partial ? testCase.messageIds.slice(1) : testCase.messageIds,
-      );
+      expect(getFile).toHaveBeenCalledTimes(unauthorizedCommand ? 0 : 2);
+      expect(fetchSpy).toHaveBeenCalledTimes(unauthorizedCommand ? 0 : testCase.partial ? 1 : 2);
+      const ingestedIds = testCase.partial ? testCase.messageIds.slice(1) : testCase.messageIds;
+      expectTelegramIngestHook(ingestedIds, { expectedCalls: Number(!unauthorizedCommand) });
       expect(sendMessageSpy).not.toHaveBeenCalled();
       expect(replySpy).not.toHaveBeenCalled();
     } finally {
@@ -939,7 +910,7 @@ describe("createTelegramBot channel_post media", () => {
         ...("caption" in testCase ? { caption: testCase.caption } : {}),
         ...("extraMessage" in testCase ? { extraMessage: testCase.extraMessage } : {}),
       });
-      await waitForMockCalls(sendMessageSpy, 1);
+      await waitForTelegramMockCalls(sendMessageSpy, 1);
       expect(sendMessageSpy).toHaveBeenCalledWith(
         -100456,
         "⚠️ Failed to download media. Please try again.",
@@ -1038,7 +1009,7 @@ describe("createTelegramBot channel_post media", () => {
         secondMessageId: firstMessageId + 1,
       });
       await flushChannelPostMediaGroup(setTimeoutSpy);
-      await waitForMockCalls(replySpy, 1);
+      await waitForTelegramMockCalls(replySpy, 1);
 
       expect(replySpy).toHaveBeenCalledTimes(1);
       expect(replyPayload()).toMatchObject({

--- a/extensions/telegram/src/bot.create-telegram-bot.test-support.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-support.ts
@@ -1,3 +1,4 @@
+import { setTimeout as delay } from "node:timers/promises";
 import type { TelegramBotInfo } from "./bot-info.js";
 
 type DispatchReplyWithBufferedBlockDispatcher =
@@ -20,6 +21,50 @@ export const telegramBotInfoForTest = {
   has_topics_enabled: false,
   allows_users_to_create_topics: false,
 } satisfies TelegramBotInfo;
+
+export type TelegramMentionPolicyForTest = {
+  mode: "allow" | "deny";
+  allowIn?: string[];
+  denyIn?: string[];
+};
+
+export type TelegramIngestGroupForTest = {
+  requireMention: boolean;
+  ingest?: boolean;
+  topics?: Record<string, { ingest: boolean }>;
+};
+
+export function telegramIngestGroupForTest(
+  ingest?: boolean,
+  topics?: Record<string, { ingest: boolean }>,
+): TelegramIngestGroupForTest {
+  return {
+    requireMention: true,
+    ...(ingest === undefined ? {} : { ingest }),
+    ...(topics ? { topics } : {}),
+  };
+}
+
+export type TelegramMentionCaseForTest = [
+  string,
+  TelegramMentionPolicyForTest,
+  TelegramMentionPolicyForTest | undefined,
+  number | undefined,
+  boolean,
+  number,
+];
+
+export async function waitForTelegramMockCalls(
+  mock: { mock: { calls: unknown[] } },
+  count: number,
+) {
+  for (let index = 0; index < 80; index++) {
+    if (mock.mock.calls.length >= count) {
+      return;
+    }
+    await delay(25);
+  }
+}
 
 export function createTelegramNativeCommandTestDeps(
   dispatchReply: DispatchReplyWithBufferedBlockDispatcher,


### PR DESCRIPTION
Follow-up to #117537; historical context: #92067.

## What Problem This Solves

Fixes an issue where Telegram groups would download an attachment accompanying an unauthorized control command before rejecting that command, including explicitly mentioned commands, mention-optional groups, disguised timestamp-prefixed commands, and commands inside media albums.

## Why This Change Was Made

Move the existing canonical Telegram command-authorization decision to the shared pre-download owner used by both individual media messages and buffered albums. A denied control command now stops before any Telegram file lookup, network fetch, ingestion hook, or reply, regardless of mention policy or caption placement; ordinary media, allowed commands, silent ingestion, topic overrides, and canonical command-prefix normalization retain their existing behavior.

## User Impact

Unauthorized Telegram group members cannot trigger attachment downloads through rejected control commands, even when the command mentions the bot, hides behind a normalized timestamp prefix, or appears later in an album. Allowed commands, ordinary group ingestion, mention policies, and topic overrides continue working unchanged.

## Evidence

- Authentic failing-first registered Telegram bot proof covers **five unauthorized delivery shapes**: unmentioned `/reset`, explicit bot-targeted `/reset@openclaw_bot`, mention-optional groups, timestamp-disguised commands using the real canonical normalization contract, and a targeted command in the second caption of a buffered album. Every scenario performs zero Telegram `getFile` calls, network fetches, ingestion hooks, outgoing sends, or replies.
- Exact head `a7c70f2466c8ae052cb53eaf156a77638b2de7c3`: both affected Telegram runtime suites pass **66 tests, 0 failed**; all **five adversarial authorization regressions pass**.
- Full independent owner/sibling review: no P0/P1/P2 findings; existing mention/account/topic policies and hook content remain unchanged.
- Fresh structured `gpt-5.6-sol` xhigh autoreview with `--max-priority P2`: clean; confidence 0.96.
- Formatting, whitespace, and secret scan: clean.
- No new configuration, dependency, schema, compatibility layer, or change to authorization policy.
- AI-assisted implementation and review.
