### PR TITLE
fix(agents): preserve task fallback completion

### DIFF
--- a/src/agents/subagent-registry-completion.test.ts
+++ b/src/agents/subagent-registry-completion.test.ts
@@ -3,7 +3,10 @@
  * Verifies outcome comparison and exactly-once lifecycle hook emission.
  */
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { SUBAGENT_ENDED_REASON_COMPLETE } from "./subagent-lifecycle-events.js";
+import {
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_KILLED,
+} from "./subagent-lifecycle-events.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const lifecycleMocks = vi.hoisted(() => ({
@@ -52,6 +55,148 @@ describe("emitSubagentEndedHookOnce", () => {
   beforeEach(() => {
     lifecycleMocks.getGlobalHookRunner.mockClear();
     lifecycleMocks.runSubagentEnded.mockClear();
+  });
+
+  it.each([
+    {
+      name: "uses captured fallback when the primary completion is empty",
+      resultText: null,
+      fallbackResultText: "parent finished with the child results",
+      expectedResultText: "parent finished with the child results",
+      expectedTerminalOutcome: undefined,
+      expectedTerminalSummary: null,
+    },
+    {
+      name: "uses captured fallback when a resumed completion returns NO_REPLY",
+      resultText: "NO_REPLY",
+      fallbackResultText: "parent finished with the child results",
+      expectedResultText: "parent finished with the child results",
+      expectedTerminalOutcome: undefined,
+      expectedTerminalSummary: null,
+    },
+    ...["ANNOUNCE_SKIP", "REPLY_SKIP", "HEARTBEAT_OK"].map((resultText) => ({
+      name: `preserves intentional ${resultText} completion instead of using fallback`,
+      resultText,
+      fallbackResultText: "stale result that must not be delivered",
+      expectedResultText: resultText,
+      expectedTerminalOutcome: undefined,
+      expectedTerminalSummary: null,
+    })),
+    {
+      name: "keeps progress-only completion blocked despite a captured fallback",
+      resultText: "I'll inspect the repo now.",
+      fallbackResultText: "stale result that must not replace progress",
+      expectedResultText: "I'll inspect the repo now.",
+      expectedTerminalOutcome: "blocked" as const,
+      expectedTerminalSummary:
+        "Required completion ended with progress-only text, not a final deliverable.",
+    },
+    {
+      name: "keeps missing required completion blocked when no fallback exists",
+      resultText: null,
+      fallbackResultText: undefined,
+      expectedResultText: undefined,
+      expectedTerminalOutcome: "blocked" as const,
+      expectedTerminalSummary: "Required completion did not produce a final deliverable.",
+    },
+  ])(
+    "$name",
+    ({
+      resultText,
+      fallbackResultText,
+      expectedResultText,
+      expectedTerminalOutcome,
+      expectedTerminalSummary,
+    }) => {
+      const entry: SubagentRunRecord = {
+        ...createRunEntry(),
+        expectsCompletionMessage: true,
+        execution: {
+          status: "terminal",
+          endedAt: 2_000,
+          outcome: { status: "ok" },
+        },
+        completion: {
+          required: true,
+          resultText,
+          capturedAt: 2_000,
+          ...(fallbackResultText ? { fallbackResultText } : {}),
+        },
+      };
+
+      expect(mod.resolveFinalizedSubagentTaskState(entry)).toMatchObject({
+        status: "succeeded",
+        progressSummary: expectedResultText,
+        terminalSummary: expectedTerminalSummary,
+        terminalOutcome: expectedTerminalOutcome,
+      });
+    },
+  );
+
+  it("does not finalize a completion whose primary capture is still pending", () => {
+    const entry: SubagentRunRecord = {
+      ...createRunEntry(),
+      expectsCompletionMessage: true,
+      execution: {
+        status: "terminal",
+        endedAt: 2_000,
+        outcome: { status: "ok" },
+      },
+      completion: {
+        required: true,
+        fallbackResultText: "captured result from a prior generation",
+      },
+    };
+
+    expect(mod.resolveFinalizedSubagentTaskState(entry)).toBeUndefined();
+  });
+
+  it("does not promote a fallback into an errored task completion", () => {
+    const entry: SubagentRunRecord = {
+      ...createRunEntry(),
+      expectsCompletionMessage: true,
+      execution: {
+        status: "terminal",
+        endedAt: 2_000,
+        outcome: { status: "error", error: "parent failed" },
+      },
+      completion: {
+        required: true,
+        resultText: null,
+        capturedAt: 2_000,
+        fallbackResultText: "stale successful result",
+      },
+    };
+
+    expect(mod.resolveFinalizedSubagentTaskState(entry)).toMatchObject({
+      status: "failed",
+      error: "parent failed",
+      progressSummary: undefined,
+    });
+  });
+
+  it("does not promote a fallback into a cancelled task completion", () => {
+    const entry: SubagentRunRecord = {
+      ...createRunEntry(),
+      expectsCompletionMessage: true,
+      endedReason: SUBAGENT_ENDED_REASON_KILLED,
+      execution: {
+        status: "terminal",
+        endedAt: 2_000,
+        outcome: { status: "ok" },
+      },
+      completion: {
+        required: true,
+        resultText: null,
+        capturedAt: 2_000,
+        fallbackResultText: "stale successful result",
+      },
+    };
+
+    expect(mod.resolveFinalizedSubagentTaskState(entry)).toMatchObject({
+      status: "cancelled",
+      progressSummary: undefined,
+    });
   });
 
   it("records ended hook marker even when no subagent_ended hooks are registered", async () => {

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -21,6 +21,7 @@ import {
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import { selectDeliverableSessionsReply } from "./tools/sessions-send-tokens.js";
 
 const log = createSubsystemLogger("agents/subagent-registry-completion");
 
@@ -54,15 +55,20 @@ export function resolveFinalizedSubagentTaskState(
     };
   }
   if (outcome.status === "ok") {
+    const resultText =
+      entry.expectsCompletionMessage === true
+        ? (selectDeliverableSessionsReply(completion.resultText, completion.fallbackResultText) ??
+          completion.resultText)
+        : completion.resultText;
     const terminal =
       entry.expectsCompletionMessage === true
-        ? resolveRequiredCompletionTerminalResult(completion.resultText)
+        ? resolveRequiredCompletionTerminalResult(resultText)
         : {};
     return {
       status: "succeeded",
       endedAt,
       lastEventAt: endedAt,
-      progressSummary,
+      progressSummary: resultText ?? undefined,
       terminalSummary: terminal.terminalSummary ?? null,
       terminalOutcome: terminal.terminalOutcome,
     };


### PR DESCRIPTION
## Summary
- preserve the stored Task/Flow fallback only when a subagent run genuinely completes without a final message
- keep abort, error, cancel, sentinel, heartbeat, manual, skip, and progress outcomes on their existing paths
- add focused regression coverage for the fallback-completion boundary

## Proof
- baseline focused suite: RED, 2 failures / 15 passes
- candidate focused suite: GREEN, 17/17
- formatter and diff check clean
- two independent source/security reviews plus authenticated all-priority review passed
- TruffleHog 3.96.0: 0 verified, 0 unverified findings

## Codex contract checked
- `codex-rs/protocol/src/protocol.rs:1729-1738` models successful `AgentStatus::Completed(Option<String>)`
- `codex-rs/protocol/src/protocol.rs:1988-1994` keeps `TurnCompleteEvent.last_agent_message` nullable and separate from terminal errors
- `codex-rs/core/src/agent/status.rs:6-17` maps completed, interrupted, and errored outcomes distinctly
- `codex-rs/core/src/session/turn.rs:254,2341-2360` keeps the final message empty until a real agent message arrives
- `codex-rs/core/src/stream_events_utils.rs:251-275` normalizes blank assistant messages to no message
- `codex-rs/app-server-protocol/src/protocol/v2/item.rs:1195-1217` and `codex-rs/app-server/src/thread_state.rs:158-174` preserve completed-without-message as a valid state

Closes #111647
