### PR TITLE
refactor(qa): deduplicate runtime tool fixture scaffolding

### DIFF
--- a/extensions/qa-lab/src/runtime-tool-fixture.test.ts
+++ b/extensions/qa-lab/src/runtime-tool-fixture.test.ts
@@ -64,46 +64,62 @@ async function writeQaSessionTranscript(
   }
 }
 
+function transcriptToolCall(
+  toolName: string,
+  phase: "happy" | "failure",
+  input: Record<string, unknown>,
+) {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "tool_use",
+        id: `call-${toolName}-${phase}`,
+        name: toolName,
+        input,
+      },
+    ],
+  };
+}
+
+function transcriptToolResult(
+  toolName: string,
+  phase: "happy" | "failure",
+  content: string,
+  isError?: boolean,
+) {
+  return {
+    role: "tool",
+    toolName,
+    tool_call_id: `call-${toolName}-${phase}`,
+    ...(isError === undefined ? {} : { isError }),
+    content,
+  };
+}
+
+async function writeRuntimeToolTranscripts(
+  env: QaSuiteRuntimeEnv,
+  toolName: string,
+  happyMessages: Array<Record<string, unknown>>,
+  failureMessages: Array<Record<string, unknown>>,
+) {
+  await writeQaSessionTranscript(env, `agent:qa:runtime-tool:${toolName}:happy`, happyMessages);
+  await writeQaSessionTranscript(env, `agent:qa:runtime-tool:${toolName}:failure`, failureMessages);
+}
+
 async function writeLiveRuntimeToolEvidence(env: QaSuiteRuntimeEnv, toolName = "read") {
-  await writeQaSessionTranscript(env, `agent:qa:runtime-tool:${toolName}:happy`, [
-    {
-      role: "assistant",
-      content: [
-        {
-          type: "tool_use",
-          id: `call-${toolName}-happy`,
-          name: toolName,
-          input: { path: "README.md" },
-        },
-      ],
-    },
-    {
-      role: "tool",
-      toolName,
-      tool_call_id: `call-${toolName}-happy`,
-      content: "README contents",
-    },
-  ]);
-  await writeQaSessionTranscript(env, `agent:qa:runtime-tool:${toolName}:failure`, [
-    {
-      role: "assistant",
-      content: [
-        {
-          type: "tool_use",
-          id: `call-${toolName}-failure`,
-          name: toolName,
-          input: { path: "/missing" },
-        },
-      ],
-    },
-    {
-      role: "tool",
-      toolName,
-      tool_call_id: `call-${toolName}-failure`,
-      isError: true,
-      content: "outside allowed scope",
-    },
-  ]);
+  await writeRuntimeToolTranscripts(
+    env,
+    toolName,
+    [
+      transcriptToolCall(toolName, "happy", { path: "README.md" }),
+      transcriptToolResult(toolName, "happy", "README contents"),
+    ],
+    [
+      transcriptToolCall(toolName, "failure", { path: "/missing" }),
+      transcriptToolResult(toolName, "failure", "outside allowed scope", true),
+    ],
+  );
 }
 
 async function writeCodexNativePatchEvidence(
@@ -213,6 +229,194 @@ async function simulateRuntimePatchHappyTurn(
   return {};
 }
 
+type RuntimeToolFixtureConfig = Parameters<typeof runRuntimeToolFixture>[1];
+type RuntimeToolFixtureDeps = Parameters<typeof runRuntimeToolFixture>[2];
+
+const MOCK_BASE_URL = "http://127.0.0.1:9999";
+
+function runtimeToolFixtureConfig(
+  toolName: string,
+  overrides: RuntimeToolFixtureConfig = {},
+): RuntimeToolFixtureConfig {
+  return {
+    toolName,
+    toolCoverage: {
+      bucket: "openclaw-dynamic-integration",
+      expectedLayer: "openclaw-dynamic",
+    },
+    ...overrides,
+  };
+}
+
+function nativePatchFixtureConfig(): RuntimeToolFixtureConfig {
+  return runtimeToolFixtureConfig("apply_patch", {
+    toolCoverage: {
+      bucket: "codex-native-workspace",
+      expectedLayer: "codex-native-workspace",
+      required: true,
+    },
+  });
+}
+
+function runtimeToolFixtureDeps(
+  params: {
+    tools?: Iterable<string>;
+    fetchJson?: RuntimeToolFixtureDeps["fetchJson"];
+    runAgentPrompt?: RuntimeToolFixtureDeps["runAgentPrompt"];
+  } = {},
+): RuntimeToolFixtureDeps {
+  return {
+    createSession: vi.fn(async (_env, _label, key) => key!),
+    readEffectiveTools: vi.fn(async () => new Set(params.tools)),
+    runAgentPrompt: params.runAgentPrompt ?? vi.fn(async () => ({})),
+    fetchJson: params.fetchJson ?? vi.fn(),
+    ensureImageGenerationConfigured: vi.fn(),
+  };
+}
+
+function runLiveRuntimeToolFixture(
+  env: QaSuiteRuntimeEnv,
+  params: {
+    toolName?: string;
+    config?: RuntimeToolFixtureConfig;
+    tools?: Iterable<string>;
+    runAgentPrompt?: RuntimeToolFixtureDeps["runAgentPrompt"];
+  } = {},
+) {
+  const toolName = params.toolName ?? "read";
+  return runRuntimeToolFixture(
+    env,
+    params.config ?? runtimeToolFixtureConfig(toolName),
+    runtimeToolFixtureDeps({
+      tools: params.tools ?? [toolName],
+      runAgentPrompt: params.runAgentPrompt,
+    }),
+  );
+}
+
+function runNativePatchFixture(
+  env: QaSuiteRuntimeEnv,
+  params: {
+    tools?: Iterable<string>;
+    runAgentPrompt?: RuntimeToolFixtureDeps["runAgentPrompt"];
+  } = {},
+) {
+  return runLiveRuntimeToolFixture(env, {
+    toolName: "apply_patch",
+    config: nativePatchFixtureConfig(),
+    tools: params.tools ?? [],
+    runAgentPrompt: params.runAgentPrompt ?? vi.fn(simulateRuntimePatchHappyTurn),
+  });
+}
+
+function mockRequestLog(requests: Array<Record<string, unknown>>) {
+  return vi.fn().mockResolvedValueOnce({ cursor: 0 }).mockResolvedValueOnce(requests);
+}
+
+function mockToolRequests(params: {
+  toolName?: string;
+  happyArgs?: Record<string, unknown>;
+  happyOutput?: string;
+  failureArgs?: Record<string, unknown>;
+  failureOutput?: string;
+  happyCallId?: string;
+  happyOutputCallId?: string;
+  failureCallId?: string;
+  failureOutputCallId?: string;
+  omitHappyOutput?: boolean;
+  omitFailureOutput?: boolean;
+}) {
+  const toolName = params.toolName ?? "read";
+  const happyCallId = params.happyCallId ?? `call-${toolName}-happy`;
+  const failureCallId = params.failureCallId ?? `call-${toolName}-failure`;
+  return [
+    {
+      allInputText: `target=${toolName}`,
+      plannedToolCallId: happyCallId,
+      plannedToolName: toolName,
+      plannedToolArgs: params.happyArgs ?? { path: "README.md" },
+    },
+    ...(params.omitHappyOutput
+      ? []
+      : [
+          {
+            allInputText: `target=${toolName}`,
+            toolOutputCallId: params.happyOutputCallId ?? happyCallId,
+            toolOutput: params.happyOutput ?? "README contents",
+          },
+        ]),
+    {
+      allInputText: `failure target=${toolName}`,
+      plannedToolCallId: failureCallId,
+      plannedToolName: toolName,
+      plannedToolArgs: params.failureArgs ?? { path: "/missing" },
+    },
+    ...(params.omitFailureOutput
+      ? []
+      : [
+          {
+            allInputText: `failure target=${toolName}`,
+            toolOutputCallId: params.failureOutputCallId ?? failureCallId,
+            toolOutput: params.failureOutput ?? "ENOENT: no such file or directory",
+          },
+        ]),
+  ];
+}
+
+async function runMockRuntimeToolFixture(params: {
+  env?: QaSuiteRuntimeEnv;
+  toolName?: string;
+  requests: Array<Record<string, unknown>>;
+  config?: RuntimeToolFixtureConfig;
+  tools?: Iterable<string>;
+  runAgentPrompt?: RuntimeToolFixtureDeps["runAgentPrompt"];
+  forceCodex?: boolean;
+}) {
+  const toolName = params.toolName ?? "read";
+  const env = params.env ?? (await makeEnv({ mock: { baseUrl: MOCK_BASE_URL } }));
+  if (params.forceCodex) {
+    env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME = "codex";
+  }
+  return runRuntimeToolFixture(
+    env,
+    runtimeToolFixtureConfig(toolName, {
+      promptSnippet: `target=${toolName}`,
+      failurePromptSnippet: `failure target=${toolName}`,
+      ...params.config,
+    }),
+    runtimeToolFixtureDeps({
+      tools: params.tools ?? [toolName],
+      fetchJson: mockRequestLog(params.requests),
+      runAgentPrompt: params.runAgentPrompt,
+    }),
+  );
+}
+
+function asyncImageFixtureConfig(overrides: RuntimeToolFixtureConfig = {}) {
+  return runtimeToolFixtureConfig("image_generate", {
+    toolCoverage: {
+      bucket: "openclaw-dynamic-integration",
+      expectedLayer: "openclaw-dynamic",
+      required: false,
+      action: "optional runtime parity gate with async image completion coverage",
+    },
+    promptSnippet: "target=image_generate",
+    failurePromptSnippet: "failure target=image_generate",
+    ...overrides,
+  });
+}
+
+function runtimePatchAddInput(file = "runtime-tool-fixture-patch.txt") {
+  return `*** Begin Patch\n*** Add File: ${file}\n+runtime patch\n*** End Patch\n`;
+}
+
+function runtimePatchUpdateInput(
+  file = "../runtime-tool-fixture-denied.txt",
+  context = "runtime-tool-fixture-denied-original",
+) {
+  return `*** Begin Patch\n*** Update File: ${file}\n@@\n-${context}\n+runtime patch outside the workspace\n*** End Patch\n`;
+}
+
 async function runMockRuntimeToolFixtureWithOutputs(params: {
   toolName: string;
   happyArgs: Record<string, unknown>;
@@ -221,65 +425,15 @@ async function runMockRuntimeToolFixtureWithOutputs(params: {
   failureOutput: string;
   happyPatchContents?: string | null;
 }) {
-  const env = await makeEnv({
-    mock: { baseUrl: "http://127.0.0.1:9999" },
+  return runMockRuntimeToolFixture({
+    toolName: params.toolName,
+    requests: mockToolRequests(params),
+    runAgentPrompt: vi.fn(async (runEnv, promptParams) =>
+      params.toolName === "apply_patch"
+        ? simulateRuntimePatchHappyTurn(runEnv, promptParams, params.happyPatchContents)
+        : {},
+    ),
   });
-  const promptSnippet = `target=${params.toolName}`;
-  const failurePromptSnippet = `failure target=${params.toolName}`;
-  const happyCallId = `call-${params.toolName}-happy`;
-  const failureCallId = `call-${params.toolName}-failure`;
-  const fetchJson = vi
-    .fn()
-    .mockResolvedValueOnce({ cursor: 0 })
-    .mockResolvedValueOnce([
-      {
-        allInputText: promptSnippet,
-        plannedToolCallId: happyCallId,
-        plannedToolName: params.toolName,
-        plannedToolArgs: params.happyArgs,
-      },
-      {
-        allInputText: promptSnippet,
-        toolOutputCallId: happyCallId,
-        toolOutput: params.happyOutput,
-      },
-      {
-        allInputText: failurePromptSnippet,
-        plannedToolCallId: failureCallId,
-        plannedToolName: params.toolName,
-        plannedToolArgs: params.failureArgs,
-      },
-      {
-        allInputText: failurePromptSnippet,
-        toolOutputCallId: failureCallId,
-        toolOutput: params.failureOutput,
-      },
-    ]);
-
-  return runRuntimeToolFixture(
-    env,
-    {
-      toolName: params.toolName,
-      toolCoverage: {
-        bucket: "openclaw-dynamic-integration",
-        expectedLayer: "openclaw-dynamic",
-      },
-      promptSnippet,
-      failurePromptSnippet,
-    },
-    {
-      createSession: vi.fn(async (_env, _label, key) => key!),
-      readEffectiveTools: vi.fn(async () => new Set([params.toolName])),
-      runAgentPrompt: vi.fn(async (runEnv, promptParams) => {
-        if (params.toolName === "apply_patch") {
-          return simulateRuntimePatchHappyTurn(runEnv, promptParams, params.happyPatchContents);
-        }
-        return {};
-      }),
-      fetchJson,
-      ensureImageGenerationConfigured: vi.fn(),
-    },
-  );
 }
 
 afterEach(async () => {
@@ -355,23 +509,7 @@ describe("runtime tool fixture", () => {
     const infraError = new QaSuiteInfraError("agent_wait_failed", "failure prompt did not settle");
     const runAgentPrompt = vi.fn().mockResolvedValueOnce({}).mockRejectedValueOnce(infraError);
 
-    const result = runRuntimeToolFixture(
-      env,
-      {
-        toolName: "read",
-        toolCoverage: {
-          bucket: "openclaw-dynamic-integration",
-          expectedLayer: "openclaw-dynamic",
-        },
-      },
-      {
-        createSession: vi.fn(async (_env, _label, key) => key),
-        readEffectiveTools: vi.fn(async () => new Set(["read"])),
-        runAgentPrompt,
-        fetchJson: vi.fn(),
-        ensureImageGenerationConfigured: vi.fn(),
-      },
-    );
+    const result = runLiveRuntimeToolFixture(env, { runAgentPrompt });
     await expect(result).rejects.toBeInstanceOf(QaSuiteInfraError);
     await expect(result).rejects.toMatchObject({ code: "agent_wait_failed", cause: infraError });
     await expect(result).rejects.toThrow(
@@ -385,55 +523,23 @@ describe("runtime tool fixture", () => {
 
   it("requires live runtime tool fixtures to produce transcript tool output", async () => {
     const env = await makeEnv();
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:read:happy", [
-      { role: "assistant", content: "I checked README.md and it looks good." },
-    ]);
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:read:failure", [
-      { role: "assistant", content: "The denied-input path looks good." },
-    ]);
+    await writeRuntimeToolTranscripts(
+      env,
+      "read",
+      [{ role: "assistant", content: "I checked README.md and it looks good." }],
+      [{ role: "assistant", content: "The denied-input path looks good." }],
+    );
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "read",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["read"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).rejects.toThrow("expected live happy-path tool call for read");
+    await expect(runLiveRuntimeToolFixture(env)).rejects.toThrow(
+      "expected live happy-path tool call for read",
+    );
   });
 
   it("accepts live runtime tool fixtures only after transcript tool output", async () => {
     const env = await makeEnv();
     await writeLiveRuntimeToolEvidence(env);
 
-    const details = await runRuntimeToolFixture(
-      env,
-      {
-        toolName: "read",
-        toolCoverage: {
-          bucket: "openclaw-dynamic-integration",
-          expectedLayer: "openclaw-dynamic",
-        },
-      },
-      {
-        createSession: vi.fn(async (_env, _label, key) => key!),
-        readEffectiveTools: vi.fn(async () => new Set(["read"])),
-        runAgentPrompt: vi.fn(async () => ({})),
-        fetchJson: vi.fn(),
-        ensureImageGenerationConfigured: vi.fn(),
-      },
-    );
+    const details = await runLiveRuntimeToolFixture(env);
 
     expect(details).toContain("read live provider happy planned args");
     expect(details).toContain("read live provider failure planned args");
@@ -441,234 +547,94 @@ describe("runtime tool fixture", () => {
 
   it("skips async live runtime tool fixtures when the happy path has no result", async () => {
     const env = await makeEnv();
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:image_generate:happy", [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "call-image-happy",
-            name: "image_generate",
-            input: { prompt: "QA lighthouse runtime parity fixture" },
-          },
-        ],
-      },
-    ]);
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:image_generate:failure", [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "call-image-failure",
-            name: "image_generate",
-            input: { __qaFailureMode: "denied-input" },
-          },
-        ],
-      },
-      {
-        role: "tool",
-        toolName: "image_generate",
-        tool_call_id: "call-image-failure",
-        isError: true,
-        content: "denied-input",
-      },
-    ]);
+    await writeRuntimeToolTranscripts(
+      env,
+      "image_generate",
+      [
+        transcriptToolCall("image_generate", "happy", {
+          prompt: "QA lighthouse runtime parity fixture",
+        }),
+      ],
+      [
+        transcriptToolCall("image_generate", "failure", {
+          __qaFailureMode: "denied-input",
+        }),
+        transcriptToolResult("image_generate", "failure", "denied-input", true),
+      ],
+    );
 
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "image_generate",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-          happyPathOutputRequired: false,
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+      runLiveRuntimeToolFixture(env, {
+        toolName: "image_generate",
+        config: runtimeToolFixtureConfig("image_generate", { happyPathOutputRequired: false }),
+      }),
     ).rejects.toThrow("planned call without a linked successful result");
   });
 
   it("still requires async live runtime tool fixtures to call the happy-path tool", async () => {
     const env = await makeEnv();
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:image_generate:happy", [
-      { role: "assistant", content: "I can start image generation later." },
-    ]);
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:image_generate:failure", [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "call-image-failure",
-            name: "image_generate",
-            input: { __qaFailureMode: "denied-input" },
-          },
-        ],
-      },
-      {
-        role: "tool",
-        toolName: "image_generate",
-        tool_call_id: "call-image-failure",
-        isError: true,
-        content: "denied-input",
-      },
-    ]);
+    await writeRuntimeToolTranscripts(
+      env,
+      "image_generate",
+      [{ role: "assistant", content: "I can start image generation later." }],
+      [
+        transcriptToolCall("image_generate", "failure", {
+          __qaFailureMode: "denied-input",
+        }),
+        transcriptToolResult("image_generate", "failure", "denied-input", true),
+      ],
+    );
 
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "image_generate",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-          happyPathOutputRequired: false,
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+      runLiveRuntimeToolFixture(env, {
+        toolName: "image_generate",
+        config: runtimeToolFixtureConfig("image_generate", { happyPathOutputRequired: false }),
+      }),
     ).rejects.toThrow("expected live happy-path tool call for image_generate");
   });
 
   it("requires live failure fixtures to produce failure-shaped tool output", async () => {
     const env = await makeEnv();
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:read:happy", [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "call-read-happy",
-            name: "read",
-            input: { path: "README.md" },
-          },
-        ],
-      },
-      {
-        role: "tool",
-        toolName: "read",
-        tool_call_id: "call-read-happy",
-        content: "README documents invalid requests, errors, and denied inputs.",
-      },
-    ]);
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:read:failure", [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "call-read-failure",
-            name: "read",
-            input: { path: "/missing" },
-          },
-        ],
-      },
-      {
-        role: "tool",
-        toolName: "read",
-        tool_call_id: "call-read-failure",
-        content: "README contents",
-      },
-    ]);
+    await writeRuntimeToolTranscripts(
+      env,
+      "read",
+      [
+        transcriptToolCall("read", "happy", { path: "README.md" }),
+        transcriptToolResult(
+          "read",
+          "happy",
+          "README documents invalid requests, errors, and denied inputs.",
+        ),
+      ],
+      [
+        transcriptToolCall("read", "failure", { path: "/missing" }),
+        transcriptToolResult("read", "failure", "README contents"),
+      ],
+    );
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "read",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["read"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).rejects.toThrow("expected live failure-path tool failure output for read");
+    await expect(runLiveRuntimeToolFixture(env)).rejects.toThrow(
+      "expected live failure-path tool failure output for read",
+    );
   });
 
   it("rejects failure-shaped live happy-path tool output", async () => {
     const env = await makeEnv();
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:read:happy", [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "call-read-happy",
-            name: "read",
-            input: { path: "README.md" },
-          },
-        ],
-      },
-      {
-        role: "tool",
-        toolName: "read",
-        tool_call_id: "call-read-happy",
-        isError: true,
-        content: "ENOENT: no such file or directory",
-      },
-    ]);
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:read:failure", [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "call-read-failure",
-            name: "read",
-            input: { path: "/missing" },
-          },
-        ],
-      },
-      {
-        role: "tool",
-        toolName: "read",
-        tool_call_id: "call-read-failure",
-        isError: true,
-        content: "ENOENT: no such file or directory",
-      },
-    ]);
+    await writeRuntimeToolTranscripts(
+      env,
+      "read",
+      [
+        transcriptToolCall("read", "happy", { path: "README.md" }),
+        transcriptToolResult("read", "happy", "ENOENT: no such file or directory", true),
+      ],
+      [
+        transcriptToolCall("read", "failure", { path: "/missing" }),
+        transcriptToolResult("read", "failure", "ENOENT: no such file or directory", true),
+      ],
+    );
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "read",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["read"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).rejects.toThrow("expected live happy-path successful tool output for read");
+    await expect(runLiveRuntimeToolFixture(env)).rejects.toThrow(
+      "expected live happy-path successful tool output for read",
+    );
   });
 
   it("skips Codex-native fixtures when only OpenClaw dynamic exposure evidence is absent", async () => {
@@ -745,30 +711,15 @@ describe("runtime tool fixture", () => {
       transcriptToolName?: string;
     }> = [];
 
-    const details = await runRuntimeToolFixture(
-      env,
-      {
-        toolName: "apply_patch",
-        toolCoverage: {
-          bucket: "codex-native-workspace",
-          expectedLayer: "codex-native-workspace",
-          required: true,
-        },
-      },
-      {
-        createSession: vi.fn(async (_env, _label, key) => key!),
-        readEffectiveTools: vi.fn(async () => new Set<string>()),
-        runAgentPrompt: vi.fn(async (_env, params) => {
-          promptEvidence.push({
-            transcriptToolName: params.transcriptToolName,
-            requireSuccessfulTranscriptToolResult: params.requireSuccessfulTranscriptToolResult,
-          });
-          return simulateRuntimePatchHappyTurn(_env, params);
-        }),
-        fetchJson: vi.fn(),
-        ensureImageGenerationConfigured: vi.fn(),
-      },
-    );
+    const details = await runNativePatchFixture(env, {
+      runAgentPrompt: vi.fn(async (_env, params) => {
+        promptEvidence.push({
+          transcriptToolName: params.transcriptToolName,
+          requireSuccessfulTranscriptToolResult: params.requireSuccessfulTranscriptToolResult,
+        });
+        return simulateRuntimePatchHappyTurn(_env, params);
+      }),
+    });
 
     expect(promptEvidence).toEqual([
       { transcriptToolName: undefined, requireSuccessfulTranscriptToolResult: undefined },
@@ -798,30 +749,16 @@ describe("runtime tool fixture", () => {
     }> = [];
 
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["apply_patch"])),
-          runAgentPrompt: vi.fn(async (_env, params) => {
-            promptEvidence.push({
-              transcriptToolName: params.transcriptToolName,
-              requireSuccessfulTranscriptToolResult: params.requireSuccessfulTranscriptToolResult,
-            });
-            return simulateRuntimePatchHappyTurn(_env, params);
-          }),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+      runNativePatchFixture(env, {
+        tools: ["apply_patch"],
+        runAgentPrompt: vi.fn(async (_env, params) => {
+          promptEvidence.push({
+            transcriptToolName: params.transcriptToolName,
+            requireSuccessfulTranscriptToolResult: params.requireSuccessfulTranscriptToolResult,
+          });
+          return simulateRuntimePatchHappyTurn(_env, params);
+        }),
+      }),
     ).resolves.toContain("apply_patch live provider happy planned args");
 
     expect(promptEvidence).toEqual([
@@ -841,26 +778,9 @@ describe("runtime tool fixture", () => {
       },
     });
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(simulateRuntimePatchHappyTurn),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).rejects.toThrow("expected linked live apply_patch to add runtime-tool-fixture-patch.txt");
+    await expect(runNativePatchFixture(env)).rejects.toThrow(
+      "expected linked live apply_patch to add runtime-tool-fixture-patch.txt",
+    );
   });
 
   it.each([
@@ -895,26 +815,9 @@ describe("runtime tool fixture", () => {
       ...("shadowInput" in testCase ? { happyInput: {}, failureInput: {} } : {}),
     });
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(simulateRuntimePatchHappyTurn),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).resolves.toContain("apply_patch live provider happy planned args");
+    await expect(runNativePatchFixture(env)).resolves.toContain(
+      "apply_patch live provider happy planned args",
+    );
 
     await expect(
       fs.access(path.resolve(env.gateway.workspaceDir, "../runtime-tool-fixture-denied.txt")),
@@ -934,26 +837,9 @@ describe("runtime tool fixture", () => {
       happyPath: path.join(workspaceAlias, "runtime-tool-fixture-patch.txt"),
     });
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(simulateRuntimePatchHappyTurn),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).resolves.toContain("apply_patch live provider happy planned args");
+    await expect(runNativePatchFixture(env)).resolves.toContain(
+      "apply_patch live provider happy planned args",
+    );
   });
 
   it("does not accept assistant text as evidence of a native Codex workspace rejection", async () => {
@@ -972,26 +858,9 @@ describe("runtime tool fixture", () => {
       },
     ]);
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(simulateRuntimePatchHappyTurn),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).rejects.toThrow("expected live failure-path tool call for apply_patch");
+    await expect(runNativePatchFixture(env)).rejects.toThrow(
+      "expected live failure-path tool call for apply_patch",
+    );
 
     await expect(
       fs.access(path.resolve(env.gateway.workspaceDir, "../runtime-tool-fixture-denied.txt")),
@@ -1016,26 +885,9 @@ describe("runtime tool fixture", () => {
       },
     });
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(simulateRuntimePatchHappyTurn),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).resolves.toContain("apply_patch live provider happy planned args");
+    await expect(runNativePatchFixture(env)).resolves.toContain(
+      "apply_patch live provider happy planned args",
+    );
   });
 
   it("rejects native patch transcripts that claim success without creating the workspace file", async () => {
@@ -1044,24 +896,7 @@ describe("runtime tool fixture", () => {
     await writeCodexNativePatchEvidence(env);
 
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+      runNativePatchFixture(env, { runAgentPrompt: vi.fn(async () => ({})) }),
     ).rejects.toThrow(
       "expected apply_patch to create runtime-tool-fixture-patch.txt with exact contents",
     );
@@ -1075,26 +910,7 @@ describe("runtime tool fixture", () => {
       "apply_patch failed: failed to find expected lines in runtime-tool-fixture-denied.txt",
     );
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(simulateRuntimePatchHappyTurn),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).rejects.toThrow(
+    await expect(runNativePatchFixture(env)).rejects.toThrow(
       "expected live apply_patch failure to explicitly reject the workspace boundary",
     );
   });
@@ -1106,26 +922,9 @@ describe("runtime tool fixture", () => {
       failureStructuredError: false,
     });
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(simulateRuntimePatchHappyTurn),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).rejects.toThrow("expected live failure-path tool failure output for apply_patch");
+    await expect(runNativePatchFixture(env)).rejects.toThrow(
+      "expected live failure-path tool failure output for apply_patch",
+    );
   });
 
   it.each([
@@ -1155,26 +954,7 @@ describe("runtime tool fixture", () => {
       testCase.options,
     );
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(simulateRuntimePatchHappyTurn),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).rejects.toThrow(testCase.expectedError);
+    await expect(runNativePatchFixture(env)).rejects.toThrow(testCase.expectedError);
   });
 
   it("validates the native patch call linked to its result instead of the first plan", async () => {
@@ -1197,26 +977,9 @@ describe("runtime tool fixture", () => {
     ]);
     await writeCodexNativePatchEvidence(env);
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(simulateRuntimePatchHappyTurn),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).resolves.toContain("apply_patch live provider happy planned args");
+    await expect(runNativePatchFixture(env)).resolves.toContain(
+      "apply_patch live provider happy planned args",
+    );
   });
 
   it("fails closed and cleans up when a patch changes the outside-workspace sentinel", async () => {
@@ -1227,31 +990,18 @@ describe("runtime tool fixture", () => {
     );
 
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["apply_patch"])),
-          runAgentPrompt: vi.fn(async (_env, params) => {
-            if (params.sessionKey.endsWith(":failure")) {
-              expect(await fs.readFile(sentinelPath, "utf8")).toBe(
-                "runtime-tool-fixture-denied-original\n",
-              );
-              await fs.writeFile(sentinelPath, "runtime patch outside the workspace\n", "utf8");
-            }
-            return simulateRuntimePatchHappyTurn(_env, params);
-          }),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+      runLiveRuntimeToolFixture(env, {
+        toolName: "apply_patch",
+        runAgentPrompt: vi.fn(async (_env, params) => {
+          if (params.sessionKey.endsWith(":failure")) {
+            expect(await fs.readFile(sentinelPath, "utf8")).toBe(
+              "runtime-tool-fixture-denied-original\n",
+            );
+            await fs.writeFile(sentinelPath, "runtime patch outside the workspace\n", "utf8");
+          }
+          return simulateRuntimePatchHappyTurn(_env, params);
+        }),
+      }),
     ).rejects.toThrow("apply_patch modified or removed the outside-workspace sentinel");
 
     await expect(fs.access(sentinelPath)).rejects.toThrow();
@@ -1260,111 +1010,50 @@ describe("runtime tool fixture", () => {
   it("fails closed when required native Codex patch execution has no linked transcript", async () => {
     const env = await makeEnv();
     env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME = "codex";
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:apply_patch:happy", [
-      { role: "assistant", content: "The patch was applied." },
-    ]);
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:apply_patch:failure", [
-      { role: "assistant", content: "The unsafe patch was rejected." },
-    ]);
+    await writeRuntimeToolTranscripts(
+      env,
+      "apply_patch",
+      [{ role: "assistant", content: "The patch was applied." }],
+      [{ role: "assistant", content: "The unsafe patch was rejected." }],
+    );
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(simulateRuntimePatchHappyTurn),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).rejects.toThrow("expected live happy-path tool call for apply_patch");
+    await expect(runNativePatchFixture(env)).rejects.toThrow(
+      "expected live happy-path tool call for apply_patch",
+    );
   });
 
   it.each([
     { label: "dynamically exposed", dynamicPatchExposed: true },
     { label: "native-only", dynamicPatchExposed: false },
   ])("verifies $label private-QA Codex patch calls without skipping them", async (testCase) => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME = "codex";
+    const env = await makeEnv({ mock: { baseUrl: MOCK_BASE_URL } });
     const promptEvidence: Array<{
       requireSuccessfulTranscriptToolResult?: boolean;
       transcriptToolName?: string;
     }> = [];
-    const happyCallId = "private-qa-patch-happy";
-    const failureCallId = "private-qa-patch-failure";
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=apply_patch",
-          plannedToolCallId: happyCallId,
-          plannedToolName: "apply_patch",
-          plannedToolArgs: {
-            input:
-              "*** Begin Patch\n*** Add File: runtime-tool-fixture-patch.txt\n+runtime patch\n*** End Patch\n",
-          },
-        },
-        {
-          allInputText: "target=apply_patch",
-          toolOutputCallId: happyCallId,
-          toolOutput: "Successfully applied patch",
-        },
-        {
-          allInputText: "failure target=apply_patch",
-          plannedToolCallId: failureCallId,
-          plannedToolName: "apply_patch",
-          plannedToolArgs: {
-            input:
-              "*** Begin Patch\n*** Update File: ../runtime-tool-fixture-denied.txt\n@@\n-runtime-tool-fixture-denied-original\n+runtime patch outside the workspace\n*** End Patch\n",
-          },
-        },
-        {
-          allInputText: "failure target=apply_patch",
-          toolOutputCallId: failureCallId,
-          toolOutput: "Error: Path escapes sandbox root",
-        },
-      ]);
-
-    const details = await runRuntimeToolFixture(
+    const details = await runMockRuntimeToolFixture({
       env,
-      {
+      toolName: "apply_patch",
+      requests: mockToolRequests({
         toolName: "apply_patch",
-        toolCoverage: {
-          bucket: "codex-native-workspace",
-          expectedLayer: "codex-native-workspace",
-          required: true,
-        },
-        promptSnippet: "target=apply_patch",
-        failurePromptSnippet: "failure target=apply_patch",
-      },
-      {
-        createSession: vi.fn(async (_env, _label, key) => key!),
-        readEffectiveTools: vi.fn(
-          async () => new Set(testCase.dynamicPatchExposed ? ["apply_patch"] : []),
-        ),
-        runAgentPrompt: vi.fn(async (_env, params) => {
-          promptEvidence.push({
-            transcriptToolName: params.transcriptToolName,
-            requireSuccessfulTranscriptToolResult: params.requireSuccessfulTranscriptToolResult,
-          });
-          return simulateRuntimePatchHappyTurn(_env, params);
-        }),
-        fetchJson,
-        ensureImageGenerationConfigured: vi.fn(),
-      },
-    );
+        happyArgs: { input: runtimePatchAddInput() },
+        failureArgs: { input: runtimePatchUpdateInput() },
+        happyOutput: "Successfully applied patch",
+        failureOutput: "Error: Path escapes sandbox root",
+        happyCallId: "private-qa-patch-happy",
+        failureCallId: "private-qa-patch-failure",
+      }),
+      config: nativePatchFixtureConfig(),
+      tools: testCase.dynamicPatchExposed ? ["apply_patch"] : [],
+      forceCodex: true,
+      runAgentPrompt: vi.fn(async (_env, params) => {
+        promptEvidence.push({
+          transcriptToolName: params.transcriptToolName,
+          requireSuccessfulTranscriptToolResult: params.requireSuccessfulTranscriptToolResult,
+        });
+        return simulateRuntimePatchHappyTurn(_env, params);
+      }),
+    });
 
     expect(promptEvidence).toEqual([
       { transcriptToolName: undefined, requireSuccessfulTranscriptToolResult: undefined },
@@ -1489,61 +1178,39 @@ describe("runtime tool fixture", () => {
   });
 
   it("rejects unlinked private-QA Codex patch results without waiting for a transcript", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME = "codex";
     const promptEvidence: Array<{
       requireSuccessfulTranscriptToolResult?: boolean;
       transcriptToolName?: string;
     }> = [];
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=apply_patch",
-          plannedToolCallId: "private-qa-patch-happy",
-          plannedToolName: "apply_patch",
-          plannedToolArgs: {
-            input:
-              "*** Begin Patch\n*** Add File: runtime-tool-fixture-patch.txt\n+runtime patch\n*** End Patch\n",
-          },
-        },
-        {
-          allInputText: "target=apply_patch",
-          toolOutputCallId: "unrelated-patch-call",
-          toolOutput: "Successfully applied patch",
-        },
-      ]);
+    const requests = [
+      {
+        allInputText: "target=apply_patch",
+        plannedToolCallId: "private-qa-patch-happy",
+        plannedToolName: "apply_patch",
+        plannedToolArgs: { input: runtimePatchAddInput() },
+      },
+      {
+        allInputText: "target=apply_patch",
+        toolOutputCallId: "unrelated-patch-call",
+        toolOutput: "Successfully applied patch",
+      },
+    ];
 
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "apply_patch",
-          toolCoverage: {
-            bucket: "codex-native-workspace",
-            expectedLayer: "codex-native-workspace",
-            required: true,
-          },
-          promptSnippet: "target=apply_patch",
-          failurePromptSnippet: "failure target=apply_patch",
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["apply_patch"])),
-          runAgentPrompt: vi.fn(async (_env, params) => {
-            promptEvidence.push({
-              transcriptToolName: params.transcriptToolName,
-              requireSuccessfulTranscriptToolResult: params.requireSuccessfulTranscriptToolResult,
-            });
-            return simulateRuntimePatchHappyTurn(_env, params);
-          }),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+      runMockRuntimeToolFixture({
+        toolName: "apply_patch",
+        requests,
+        config: nativePatchFixtureConfig(),
+        tools: ["apply_patch"],
+        forceCodex: true,
+        runAgentPrompt: vi.fn(async (_env, params) => {
+          promptEvidence.push({
+            transcriptToolName: params.transcriptToolName,
+            requireSuccessfulTranscriptToolResult: params.requireSuccessfulTranscriptToolResult,
+          });
+          return simulateRuntimePatchHappyTurn(_env, params);
+        }),
+      }),
     ).rejects.toThrow("expected mock happy-path tool output for apply_patch");
 
     expect(promptEvidence).toEqual([
@@ -1553,518 +1220,163 @@ describe("runtime tool fixture", () => {
   });
 
   it("skips Codex-native async planned-only fixtures without treating the plan as proof", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-      gateway: {
-        baseUrl: "http://127.0.0.1:1",
-        tempRoot: "",
-        workspaceDir: "",
-        runtimeEnv: { OPENCLAW_QA_FORCE_RUNTIME: "codex" },
-        call: vi.fn(),
-      },
-    });
-    env.gateway.tempRoot = env.repoRoot;
-    env.gateway.workspaceDir = env.repoRoot;
-
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=image_generate",
-          plannedToolCallId: "call-image-happy",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { prompt: "QA lighthouse runtime parity fixture" },
-        },
-        {
-          allInputText: "failure target=image_generate",
-          plannedToolCallId: "call-image-failure",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { __qaFailureMode: "denied-input" },
-        },
-        {
-          allInputText: "failure target=image_generate",
-          toolOutputCallId: "call-image-failure",
-          toolOutput: "Error: denied-input",
-        },
-      ]);
-
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
+      runMockRuntimeToolFixture({
+        toolName: "image_generate",
+        requests: mockToolRequests({
           toolName: "image_generate",
+          happyArgs: { prompt: "QA lighthouse runtime parity fixture" },
+          failureArgs: { __qaFailureMode: "denied-input" },
+          omitHappyOutput: true,
+          failureOutput: "Error: denied-input",
+        }),
+        config: runtimeToolFixtureConfig("image_generate", {
           toolCoverage: {
             bucket: "codex-native-workspace",
             expectedLayer: "codex-native-workspace",
             reason: "Codex owns image generation natively in this fixture.",
           },
-          promptSnippet: "target=image_generate",
-          failurePromptSnippet: "failure target=image_generate",
           happyPathOutputRequired: false,
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+        }),
+        tools: [],
+        forceCodex: true,
+      }),
     ).rejects.toThrow("image_generate mock provider report-only");
   });
 
   it("requires mock runtime tool fixtures to produce tool output", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=read",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "README.md" },
-        },
-        {
-          allInputText: "failure target=read",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "/missing" },
-        },
-        {
-          allInputText: "failure target=read",
-          toolOutput: "ENOENT: no such file or directory",
-        },
-      ]);
+    const requests = [
+      {
+        allInputText: "target=read",
+        plannedToolName: "read",
+        plannedToolArgs: { path: "README.md" },
+      },
+      {
+        allInputText: "failure target=read",
+        plannedToolName: "read",
+        plannedToolArgs: { path: "/missing" },
+      },
+      {
+        allInputText: "failure target=read",
+        toolOutput: "ENOENT: no such file or directory",
+      },
+    ];
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "read",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-          promptSnippet: "target=read",
-          failurePromptSnippet: "failure target=read",
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["read"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).rejects.toThrow("expected mock happy-path tool output for read");
+    await expect(runMockRuntimeToolFixture({ requests })).rejects.toThrow(
+      "expected mock happy-path tool output for read",
+    );
   });
 
   it("skips async mock runtime tool fixtures when the happy path has no result", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=image_generate",
-          plannedToolCallId: "call-image-happy",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { prompt: "QA lighthouse runtime parity fixture" },
-        },
-        {
-          allInputText: "failure target=image_generate",
-          plannedToolCallId: "call-image-failure",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { __qaFailureMode: "denied-input" },
-        },
-        {
-          allInputText: "failure target=image_generate",
-          toolOutputCallId: "call-image-failure",
-          toolOutput: "Error: denied-input",
-        },
-      ]);
-
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
+      runMockRuntimeToolFixture({
+        toolName: "image_generate",
+        requests: mockToolRequests({
           toolName: "image_generate",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-          promptSnippet: "target=image_generate",
-          failurePromptSnippet: "failure target=image_generate",
+          happyArgs: { prompt: "QA lighthouse runtime parity fixture" },
+          failureArgs: { __qaFailureMode: "denied-input" },
+          omitHappyOutput: true,
+          failureOutput: "Error: denied-input",
+        }),
+        config: runtimeToolFixtureConfig("image_generate", {
           happyPathOutputRequired: false,
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+        }),
+      }),
     ).rejects.toThrow("planned call without a linked successful result");
   });
 
   it("accepts mock runtime tool fixtures only after planned calls return output", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=read",
-          plannedToolCallId: "call-read-happy",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "README.md" },
-        },
-        {
-          allInputText: "target=read",
-          toolOutputCallId: "call-read-happy",
-          toolOutput: "README contents",
-        },
-        {
-          allInputText: "failure target=read",
-          plannedToolCallId: "call-read-failure",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "/missing" },
-        },
-        {
-          allInputText: "failure target=read",
-          toolOutputCallId: "call-read-failure",
-          toolOutput: "ENOENT: no such file or directory",
-        },
-      ]);
-
-    const details = await runRuntimeToolFixture(
-      env,
-      {
-        toolName: "read",
-        toolCoverage: {
-          bucket: "openclaw-dynamic-integration",
-          expectedLayer: "openclaw-dynamic",
-        },
-        promptSnippet: "target=read",
-        failurePromptSnippet: "failure target=read",
-      },
-      {
-        createSession: vi.fn(async (_env, _label, key) => key!),
-        readEffectiveTools: vi.fn(async () => new Set(["read"])),
-        runAgentPrompt: vi.fn(async () => ({})),
-        fetchJson,
-        ensureImageGenerationConfigured: vi.fn(),
-      },
-    );
+    const details = await runMockRuntimeToolFixture({ requests: mockToolRequests({}) });
 
     expect(details).toContain("read mock provider happy planned args");
     expect(details).toContain("read mock provider failure planned args");
   });
 
   it("skips non-required mock fixtures when both paths are only planned", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=image_generate",
-          plannedToolCallId: "call-image-happy",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { prompt: "QA lighthouse", filename: "runtime-tool-fixture" },
-        },
-        {
-          allInputText: "failure target=image_generate",
-          plannedToolCallId: "call-image-failure",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { __qaFailureMode: "denied-input" },
-        },
-      ]);
-
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
+      runMockRuntimeToolFixture({
+        toolName: "image_generate",
+        requests: mockToolRequests({
           toolName: "image_generate",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-            required: false,
-            action: "optional runtime parity gate with async image completion coverage",
-          },
-          promptSnippet: "target=image_generate",
-          failurePromptSnippet: "failure target=image_generate",
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+          happyArgs: { prompt: "QA lighthouse", filename: "runtime-tool-fixture" },
+          failureArgs: { __qaFailureMode: "denied-input" },
+          omitHappyOutput: true,
+          omitFailureOutput: true,
+        }),
+        config: asyncImageFixtureConfig(),
+      }),
     ).rejects.toThrow("image_generate mock provider report-only");
   });
 
   it("still rejects failed happy output for non-required mock fixtures", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=image_generate",
-          plannedToolCallId: "call-image-happy",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { prompt: "QA lighthouse" },
-        },
-        {
-          allInputText: "target=image_generate",
-          toolOutputCallId: "call-image-happy",
-          toolOutput: "Failed: provider rejected image request",
-        },
-        {
-          allInputText: "failure target=image_generate",
-          plannedToolCallId: "call-image-failure",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { __qaFailureMode: "denied-input" },
-        },
-      ]);
-
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
+      runMockRuntimeToolFixture({
+        toolName: "image_generate",
+        requests: mockToolRequests({
           toolName: "image_generate",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-            required: false,
-            action: "optional runtime parity gate with async image completion coverage",
-          },
-          promptSnippet: "target=image_generate",
-          failurePromptSnippet: "failure target=image_generate",
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+          happyArgs: { prompt: "QA lighthouse" },
+          happyOutput: "Failed: provider rejected image request",
+          failureArgs: { __qaFailureMode: "denied-input" },
+          omitFailureOutput: true,
+        }),
+        config: asyncImageFixtureConfig(),
+      }),
     ).rejects.toThrow("expected mock happy-path successful tool output for image_generate");
   });
 
   it("still rejects successful failure output for non-required mock fixtures", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=image_generate",
-          plannedToolCallId: "call-image-happy",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { prompt: "QA lighthouse" },
-        },
-        {
-          allInputText: "failure target=image_generate",
-          plannedToolCallId: "call-image-failure",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { __qaFailureMode: "denied-input" },
-        },
-        {
-          allInputText: "failure target=image_generate",
-          toolOutputCallId: "call-image-failure",
-          toolOutput: "Task queued for async image delivery",
-        },
-      ]);
-
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
+      runMockRuntimeToolFixture({
+        toolName: "image_generate",
+        requests: mockToolRequests({
           toolName: "image_generate",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-            required: false,
-            action: "optional runtime parity gate with async image completion coverage",
-          },
-          promptSnippet: "target=image_generate",
-          failurePromptSnippet: "failure target=image_generate",
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+          happyArgs: { prompt: "QA lighthouse" },
+          omitHappyOutput: true,
+          failureArgs: { __qaFailureMode: "denied-input" },
+          failureOutput: "Task queued for async image delivery",
+        }),
+        config: asyncImageFixtureConfig(),
+      }),
     ).rejects.toThrow("expected mock failure-path tool failure output for image_generate");
   });
 
   it("rejects malformed report-only failure plans for non-required mock fixtures", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=image_generate",
-          plannedToolCallId: "call-image-happy",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { prompt: "QA lighthouse" },
-        },
-        {
-          allInputText: "failure target=image_generate",
-          plannedToolCallId: "call-image-failure",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { prompt: "not a denied-input failure" },
-        },
-      ]);
-
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
+      runMockRuntimeToolFixture({
+        toolName: "image_generate",
+        requests: mockToolRequests({
           toolName: "image_generate",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-            required: false,
-            action: "optional runtime parity gate with async image completion coverage",
-          },
-          promptSnippet: "target=image_generate",
-          failurePromptSnippet: "failure target=image_generate",
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+          happyArgs: { prompt: "QA lighthouse" },
+          failureArgs: { prompt: "not a denied-input failure" },
+          omitHappyOutput: true,
+          omitFailureOutput: true,
+        }),
+        config: asyncImageFixtureConfig(),
+      }),
     ).rejects.toThrow("expected mock failure-path denied-input args for image_generate");
   });
 
   it("rejects malformed report-only happy plans for non-required mock fixtures", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=image_generate",
-          plannedToolCallId: "call-image-happy",
-          plannedToolName: "image_generate",
-          plannedToolArgs: {},
-        },
-        {
-          allInputText: "failure target=image_generate",
-          plannedToolCallId: "call-image-failure",
-          plannedToolName: "image_generate",
-          plannedToolArgs: { __qaFailureMode: "denied-input" },
-        },
-      ]);
-
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
+      runMockRuntimeToolFixture({
+        toolName: "image_generate",
+        requests: mockToolRequests({
           toolName: "image_generate",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-            required: false,
-            action: "optional runtime parity gate with async image completion coverage",
-          },
-          promptSnippet: "target=image_generate",
-          failurePromptSnippet: "failure target=image_generate",
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+          happyArgs: {},
+          failureArgs: { __qaFailureMode: "denied-input" },
+          omitHappyOutput: true,
+          omitFailureOutput: true,
+        }),
+        config: asyncImageFixtureConfig(),
+      }),
     ).rejects.toThrow("expected mock happy-path prompt args for image_generate");
   });
 
   it("rejects failure-shaped mock happy-path tool output", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=read",
-          plannedToolCallId: "call-read-happy",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "README.md" },
-        },
-        {
-          allInputText: "target=read",
-          toolOutputCallId: "call-read-happy",
-          toolOutput: "ENOENT: no such file or directory",
-        },
-        {
-          allInputText: "failure target=read",
-          plannedToolCallId: "call-read-failure",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "/missing" },
-        },
-        {
-          allInputText: "failure target=read",
-          toolOutputCallId: "call-read-failure",
-          toolOutput: "ENOENT: no such file or directory",
-        },
-      ]);
-
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "read",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-          promptSnippet: "target=read",
-          failurePromptSnippet: "failure target=read",
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["read"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+      runMockRuntimeToolFixture({
+        requests: mockToolRequests({ happyOutput: "ENOENT: no such file or directory" }),
+      }),
     ).rejects.toThrow(
       [
         "RUNTIME_PARITY_SESSION_KEY=agent:qa:runtime-tool:read:happy",
@@ -2075,57 +1387,10 @@ describe("runtime tool fixture", () => {
   });
 
   it("requires mock failure fixtures to produce failure-shaped tool output", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=read",
-          plannedToolCallId: "call-read-happy",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "README.md" },
-        },
-        {
-          allInputText: "target=read",
-          toolOutputCallId: "call-read-happy",
-          toolOutput: "README contents",
-        },
-        {
-          allInputText: "failure target=read",
-          plannedToolCallId: "call-read-failure",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "/missing" },
-        },
-        {
-          allInputText: "failure target=read",
-          toolOutputCallId: "call-read-failure",
-          toolOutput: "README contents",
-        },
-      ]);
-
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "read",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-          promptSnippet: "target=read",
-          failurePromptSnippet: "failure target=read",
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["read"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+      runMockRuntimeToolFixture({
+        requests: mockToolRequests({ failureOutput: "README contents" }),
+      }),
     ).rejects.toThrow("expected mock failure-path tool failure output for read");
   });
 
@@ -2183,188 +1448,59 @@ describe("runtime tool fixture", () => {
   });
 
   it("allows successful happy-path tool output to mention errors", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
+    const details = await runMockRuntimeToolFixture({
+      requests: mockToolRequests({
+        happyOutput: "README documents error handling and missing-file behavior.",
+      }),
     });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=read",
-          plannedToolCallId: "call-read-happy",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "README.md" },
-        },
-        {
-          allInputText: "target=read",
-          toolOutputCallId: "call-read-happy",
-          toolOutput: "README documents error handling and missing-file behavior.",
-        },
-        {
-          allInputText: "failure target=read",
-          plannedToolCallId: "call-read-failure",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "/missing" },
-        },
-        {
-          allInputText: "failure target=read",
-          toolOutputCallId: "call-read-failure",
-          toolOutput: "ENOENT: no such file or directory",
-        },
-      ]);
-
-    const details = await runRuntimeToolFixture(
-      env,
-      {
-        toolName: "read",
-        toolCoverage: {
-          bucket: "openclaw-dynamic-integration",
-          expectedLayer: "openclaw-dynamic",
-        },
-        promptSnippet: "target=read",
-        failurePromptSnippet: "failure target=read",
-      },
-      {
-        createSession: vi.fn(async (_env, _label, key) => key!),
-        readEffectiveTools: vi.fn(async () => new Set(["read"])),
-        runAgentPrompt: vi.fn(async () => ({})),
-        fetchJson,
-        ensureImageGenerationConfigured: vi.fn(),
-      },
-    );
 
     expect(details).toContain("read mock provider happy planned args");
   });
 
   it("rejects unrelated tool output after a planned mock runtime tool call", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=read",
-          plannedToolCallId: "call-read-happy",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "README.md" },
-        },
-        {
-          allInputText: "target=read",
-          toolOutputCallId: "call-write-happy",
-          toolOutput: "README contents from some other tool",
-        },
-        {
-          allInputText: "failure target=read",
-          plannedToolCallId: "call-read-failure",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "/missing" },
-        },
-        {
-          allInputText: "failure target=read",
-          toolOutputCallId: "call-read-failure",
-          toolOutput: "ENOENT: no such file or directory",
-        },
-      ]);
-
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "read",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-          promptSnippet: "target=read",
-          failurePromptSnippet: "failure target=read",
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["read"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+      runMockRuntimeToolFixture({
+        requests: mockToolRequests({
+          happyOutputCallId: "call-write-happy",
+          happyOutput: "README contents from some other tool",
+        }),
+      }),
     ).rejects.toThrow("expected mock happy-path tool output for read");
   });
 
   it("rejects mismatched planned and output call ids on the same mock request", async () => {
-    const env = await makeEnv({
-      mock: { baseUrl: "http://127.0.0.1:9999" },
-    });
-    const fetchJson = vi
-      .fn()
-      .mockResolvedValueOnce({ cursor: 0 })
-      .mockResolvedValueOnce([
-        {
-          allInputText: "target=read",
-          plannedToolCallId: "call-read-happy",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "README.md" },
-          toolOutputCallId: "call-write-previous",
-          toolOutput: "previous write output",
-        },
-        {
-          allInputText: "failure target=read",
-          plannedToolCallId: "call-read-failure",
-          plannedToolName: "read",
-          plannedToolArgs: { path: "/missing" },
-        },
-        {
-          allInputText: "failure target=read",
-          toolOutputCallId: "call-read-failure",
-          toolOutput: "ENOENT: no such file or directory",
-        },
-      ]);
+    const requests = [
+      {
+        allInputText: "target=read",
+        plannedToolCallId: "call-read-happy",
+        plannedToolName: "read",
+        plannedToolArgs: { path: "README.md" },
+        toolOutputCallId: "call-write-previous",
+        toolOutput: "previous write output",
+      },
+      {
+        allInputText: "failure target=read",
+        plannedToolCallId: "call-read-failure",
+        plannedToolName: "read",
+        plannedToolArgs: { path: "/missing" },
+      },
+      {
+        allInputText: "failure target=read",
+        toolOutputCallId: "call-read-failure",
+        toolOutput: "ENOENT: no such file or directory",
+      },
+    ];
 
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "read",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-          promptSnippet: "target=read",
-          failurePromptSnippet: "failure target=read",
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["read"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson,
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).rejects.toThrow("expected mock happy-path tool output for read");
+    await expect(runMockRuntimeToolFixture({ requests })).rejects.toThrow(
+      "expected mock happy-path tool output for read",
+    );
   });
 
   it("still fails required OpenClaw dynamic fixtures when the tool is absent", async () => {
     const env = await makeEnv();
 
     await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "web_search",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set<string>()),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
+      runLiveRuntimeToolFixture(env, { toolName: "web_search", tools: [] }),
     ).rejects.toThrow("web_search not present in effective tools");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The QA Lab runtime-tool fixture tests repeated the same environment, dependency, transcript, request-log, and patch-input setup across dozens of cases. That duplication made security-sensitive Codex/native patch coverage harder to compare and maintain.

## Why This Change Was Made

This introduces canonical test-only builders for live transcripts, runtime dependencies, mock request logs, and patch inputs, then routes the existing cases through them. All production code, test registrations, expanded cases, matcher calls, call-linking semantics, workspace-containment checks, and cleanup behavior remain unchanged.

This PR is AI-assisted. I reviewed the resulting code and understand the helper/config precedence and the native/dynamic runtime coverage it preserves.

## User Impact

No user-visible behavior changes. Maintainers get the same QA Lab coverage with 864 fewer test lines and one canonical fixture construction path.

## Evidence

- Diff: production `0`; tests `+578/-1,442`; total net `-864` LOC.
- Structural audit before/after: `46` registrations, `62` expanded cases, `75` static `expect()` calls, `110` expanded matcher executions, `0` timers.
- Focused current-state proof: `node scripts/run-vitest.mjs extensions/qa-lab/src/runtime-tool-fixture.test.ts` — 62/62 passed.
- Full Blacksmith Testbox QA Lab proof: `OPENCLAW_BUILD_PRIVATE_QA=1 ... pnpm test extensions/qa-lab` — 169 files and 2,181 tests passed on lease `tbx_01kz0bghejer6m9mx0tnwg2ey8` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/30732350361)).
- Blacksmith Testbox changed gate: formatting, extension-test typecheck, lint, plugin boundaries, duplicate scan, and dead-export scans all passed on the same lease.
- Mandatory autoreview: `gpt-5.6-sol`, xhigh — CLEAN, no accepted/actionable findings, 0.99 confidence.
- Independent xhigh reviews: `qa_runtime_fixture_review_a` CLEAN; `qa_runtime_fixture_review_b` CLEAN.
- Codex contract checked against `openai/codex@ee0247f95a6f`: custom-tool call IDs/freeform inputs, apply-patch parsing, cwd/sandbox verification, explicit rejection output, and patch begin/end call-ID linkage remain covered.
