### PR TITLE
fix(test): prevent source CLI loader hangs

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -215,6 +215,10 @@ type CliProcessFailure = Error & {
   stdout?: string;
 };
 describe("CLI help process exit", () => {
+  it("disables esbuild worker IPC for source CLI children", () => {
+    expect(process.env.ESBUILD_WORKER_THREADS).toBe("0");
+  });
+
   it("exits promptly after root --help", async () => {
     // Keep this precomputed-help case off plugin discovery; plugin-sensitive root help is covered
     // separately, so the shared child timeout remains a deadlock guard rather than a startup SLO.

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -623,6 +623,9 @@ describe("scoped vitest configs", () => {
     );
     expect(requireTestConfig(defaultCliProcessConfig).include).toEqual(cliProcessTestFiles);
     expect(requireTestConfig(defaultCliProcessConfig).fileParallelism).toBe(false);
+    expect(requireTestConfig(defaultCliProcessConfig).env).toMatchObject({
+      ESBUILD_WORKER_THREADS: "0",
+    });
   });
 
   it("keeps native SQLite runtime config tests in forked workers", () => {

--- a/test/vitest/vitest.cli-process.config.ts
+++ b/test/vitest/vitest.cli-process.config.ts
@@ -4,7 +4,7 @@ import { cliProcessTestFiles } from "./vitest.cli-process-paths.mjs";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
 export function createCliProcessVitestConfig(env?: Record<string, string | undefined>) {
-  return createScopedVitestConfig(cliProcessTestFiles, {
+  const config = createScopedVitestConfig(cliProcessTestFiles, {
     env,
     fileParallelism: false,
     isolate: true,
@@ -13,6 +13,17 @@ export function createCliProcessVitestConfig(env?: Record<string, string | undef
     pool: "forks",
     useNonIsolatedRunner: false,
   });
+  return {
+    ...config,
+    test: {
+      ...config.test,
+      env: {
+        ...config.test?.env,
+        // Avoid TSX's unbounded wait on esbuild's synchronous worker IPC in source-child tests.
+        ESBUILD_WORKER_THREADS: "0",
+      },
+    },
+  };
 }
 
 export default createCliProcessVitestConfig();


### PR DESCRIPTION
Closes #117829

## What Problem This Solves

Fixes an issue where the source CLI-process suite could stall a different real CLI child inside TSX/esbuild loader IPC until the unchanged 100-second product deadlock guard killed it. These moving false-red failures blocked unrelated PRs even though neighboring children completed normally.

## Why This Change Was Made

The CLI-process Vitest project now sets esbuild's supported `ESBUILD_WORKER_THREADS=0` mode in `test.env`. That project is the owner because all four of its files launch Node source children through `node --import tsx`; the setting reaches the Vitest fork and every child without changing packaged/dev CLI execution, Bun, or unrelated source-process suites.

Pinned `tsx@4.23.1` uses synchronous transforms. Pinned `esbuild@0.28.1` routes those through an unref'd worker whose synchronous call waits indefinitely in `Atomics.wait`; the exact `"0"` setting selects esbuild's per-call synchronous service path instead. Config-shape and runtime assertions prevent the setting from becoming another inert config field.

This is test-loader ownership, not a product parser, cleanup, timeout, or retry workaround. Production LOC is unchanged. The test/config diff is +19/-1.

AI-assisted: yes. The dependency contract, config propagation, runtime inheritance, affected suite, sibling coverage, and proof were independently reviewed.

## User Impact

There is no shipped OpenClaw behavior change. Maintainers and contributors get a stable CLI-process proof lane while the real 100-second deadlock guard continues to detect actual product hangs.

## Evidence

Before:

- [CI run 30730735584](https://github.com/openclaw/openclaw/actions/runs/30730735584) timed out `uses named-profile logging style when container parsing fails` at 100,034 ms.
- Retained Testbox [run 30731158496](https://github.com/openclaw/openclaw/actions/runs/30731158496) timed out a different case, `flushes explicitly requested entry traces on precomputed help`, at 100,089 ms. Startup and CLI parse had completed in 232 ms, excluding a cold import or parser failure.

After on Blacksmith Testbox `tbx_01kz0aj136frv7pm25fr16pegr` ([run 30731861522](https://github.com/openclaw/openclaw/actions/runs/30731861522)):

- Full CLI-process project: 65/65 passed, including the runtime inheritance assertion.
- Moving-failure stress: 20 rounds, 40/40 passed; affected cases completed in roughly 0.38-0.54 seconds.
- Exact predecessor order: 4,028/4,028 broad CLI tests, then 65/65 CLI-process tests.
- Complete `pnpm check:changed`: formatting, config/declaration guards, core/test-root typechecks, full lint, plugin boundaries, and dead exports passed.
- Fresh autoreview: clean, `patch is correct`, confidence 0.99.
- Independent dependency/owner review: no actionable finding; land-ready as a source-test loader fix.

The final lane completed without increasing the child timeout, adding retries, weakening assertions, or changing product cleanup.
