### PR TITLE
refactor(status): collapse overview surface adapters

### DIFF
--- a/src/commands/status-all/format.ts
+++ b/src/commands/status-all/format.ts
@@ -16,7 +16,7 @@ import { formatUpdateOneLiner, resolveUpdateAvailability } from "../status.updat
 
 export { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
 
-export type StatusOverviewRow = {
+type StatusOverviewRow = {
   Item: string;
   Value: string;
 };

--- a/src/commands/status-overview-surface.ts
+++ b/src/commands/status-overview-surface.ts
@@ -1,98 +1,55 @@
 // Normalized status overview surface shared by text and JSON status outputs.
 // It collects gateway/update/service fields into one shape before row or payload builders run.
 
-import type { OpenClawConfig } from "../config/types.js";
-import type { UpdateCheckResult } from "../infra/update-check.js";
 import {
   buildGatewayStatusJsonPayload,
   buildStatusOverviewSurfaceRows,
-  type StatusOverviewRow,
 } from "./status-all/format.js";
 import type { NodeOnlyGatewayInfo } from "./status.node-mode.js";
 import type { StatusScanOverviewResult } from "./status.scan-overview.ts";
 import type { StatusScanResult } from "./status.scan-result.ts";
 
-type StatusGatewayConnection = {
-  url: string;
-  urlSource?: string;
-};
+type StatusOverviewRowInput = Parameters<typeof buildStatusOverviewSurfaceRows>[0];
+type StatusOverviewFormatOptions = Pick<
+  StatusOverviewRowInput,
+  | "tailscaleBackendState"
+  | "includeBackendStateWhenOff"
+  | "includeBackendStateWhenOn"
+  | "includeDnsNameWhenOff"
+  | "decorateTailscaleOff"
+  | "decorateTailscaleWarn"
+  | "decorateOk"
+  | "decorateWarn"
+  | "prefixRows"
+  | "middleRows"
+  | "suffixRows"
+  | "agentsValue"
+  | "updateValue"
+  | "gatewayAuthWarningValue"
+  | "gatewaySelfFallbackValue"
+>;
 
-type StatusGatewayProbe = {
-  connectLatencyMs?: number | null;
-  error?: string | null;
-  health?: unknown;
-} | null;
-
-type StatusGatewayAuth = {
-  token?: string;
-  password?: string;
-} | null;
-
-type StatusGatewaySelf =
-  | {
-      host?: string | null;
-      ip?: string | null;
-      version?: string | null;
-      platform?: string | null;
-    }
-  | null
-  | undefined;
-
-type StatusServiceSummary = {
-  label: string;
-  installed: boolean | null;
-  managedByOpenClaw?: boolean;
-  loadedText: string;
-  runtimeShort?: string | null;
-  runtime?: {
-    status?: string | null;
-    pid?: number | null;
-  } | null;
-};
-
-export type StatusOverviewSurface = {
-  cfg: Pick<OpenClawConfig, "update" | "gateway">;
-  update: UpdateCheckResult;
-  tailscaleMode: string;
-  tailscaleDns?: string | null;
-  tailscaleHttpsUrl?: string | null;
-  advertisedControlUiLinks?: { httpUrl: string; wsUrl: string };
-  gatewayMode: "local" | "remote";
-  remoteUrlMissing: boolean;
-  gatewayConnection: StatusGatewayConnection;
-  gatewayReachable: boolean;
-  gatewayProbe: StatusGatewayProbe;
-  gatewayProbeAuth: StatusGatewayAuth;
-  gatewayProbeAuthWarning?: string | null;
-  gatewaySelf: StatusGatewaySelf;
-  gatewayService: StatusServiceSummary;
-  nodeService: StatusServiceSummary;
+export type StatusOverviewSurface = Omit<
+  StatusOverviewRowInput,
+  keyof StatusOverviewFormatOptions | "nodeOnlyGateway"
+> & {
   nodeOnlyGateway?: NodeOnlyGatewayInfo | null;
 };
+
+type StatusOverviewServices = Pick<
+  StatusOverviewSurface,
+  "gatewayService" | "nodeService" | "nodeOnlyGateway"
+>;
+type StatusOverviewSourceKeys = Exclude<keyof StatusOverviewSurface, keyof StatusOverviewServices>;
+type StatusSource<T> = Pick<T, Extract<keyof T, StatusOverviewSourceKeys>>;
+type StatusScanInput = StatusSource<StatusScanResult>;
+type StatusOverviewInput = StatusSource<StatusScanOverviewResult> &
+  Pick<StatusScanOverviewResult, "gatewaySnapshot">;
 
 /** Converts the full status scan result into the shared overview surface. */
-export function buildStatusOverviewSurfaceFromScan(params: {
-  scan: Pick<
-    StatusScanResult,
-    | "cfg"
-    | "update"
-    | "tailscaleMode"
-    | "tailscaleDns"
-    | "tailscaleHttpsUrl"
-    | "advertisedControlUiLinks"
-    | "gatewayMode"
-    | "remoteUrlMissing"
-    | "gatewayConnection"
-    | "gatewayReachable"
-    | "gatewayProbe"
-    | "gatewayProbeAuth"
-    | "gatewayProbeAuthWarning"
-    | "gatewaySelf"
-  >;
-  gatewayService: StatusServiceSummary;
-  nodeService: StatusServiceSummary;
-  nodeOnlyGateway?: NodeOnlyGatewayInfo | null;
-}): StatusOverviewSurface {
+export function buildStatusOverviewSurfaceFromScan(
+  params: { scan: StatusScanInput } & StatusOverviewServices,
+): StatusOverviewSurface {
   return {
     cfg: params.scan.cfg,
     update: params.scan.update,
@@ -117,21 +74,9 @@ export function buildStatusOverviewSurfaceFromScan(params: {
 }
 
 /** Converts the lighter status-all overview scan into the shared overview surface. */
-export function buildStatusOverviewSurfaceFromOverview(params: {
-  overview: Pick<
-    StatusScanOverviewResult,
-    | "cfg"
-    | "update"
-    | "tailscaleMode"
-    | "tailscaleDns"
-    | "tailscaleHttpsUrl"
-    | "advertisedControlUiLinks"
-    | "gatewaySnapshot"
-  >;
-  gatewayService: StatusServiceSummary;
-  nodeService: StatusServiceSummary;
-  nodeOnlyGateway?: NodeOnlyGatewayInfo | null;
-}): StatusOverviewSurface {
+export function buildStatusOverviewSurfaceFromOverview(
+  params: { overview: StatusOverviewInput } & StatusOverviewServices,
+): StatusOverviewSurface {
   return {
     cfg: params.overview.cfg,
     update: params.overview.update,
@@ -156,82 +101,16 @@ export function buildStatusOverviewSurfaceFromOverview(params: {
 }
 
 /** Builds overview rows from an already-normalized surface. */
-export function buildStatusOverviewRowsFromSurface(params: {
-  surface: StatusOverviewSurface;
-  prefixRows?: StatusOverviewRow[];
-  middleRows?: StatusOverviewRow[];
-  suffixRows?: StatusOverviewRow[];
-  agentsValue: string;
-  updateValue?: string;
-  gatewayAuthWarningValue?: string | null;
-  gatewaySelfFallbackValue?: string | null;
-  tailscaleBackendState?: string | null;
-  includeBackendStateWhenOff?: boolean;
-  includeBackendStateWhenOn?: boolean;
-  includeDnsNameWhenOff?: boolean;
-  decorateOk?: (value: string) => string;
-  decorateWarn?: (value: string) => string;
-  decorateTailscaleOff?: (value: string) => string;
-  decorateTailscaleWarn?: (value: string) => string;
-}) {
-  return buildStatusOverviewSurfaceRows({
-    cfg: params.surface.cfg,
-    update: params.surface.update,
-    tailscaleMode: params.surface.tailscaleMode,
-    tailscaleDns: params.surface.tailscaleDns,
-    tailscaleHttpsUrl: params.surface.tailscaleHttpsUrl,
-    ...(params.surface.advertisedControlUiLinks
-      ? { advertisedControlUiLinks: params.surface.advertisedControlUiLinks }
-      : {}),
-    tailscaleBackendState: params.tailscaleBackendState,
-    includeBackendStateWhenOff: params.includeBackendStateWhenOff,
-    includeBackendStateWhenOn: params.includeBackendStateWhenOn,
-    includeDnsNameWhenOff: params.includeDnsNameWhenOff,
-    decorateTailscaleOff: params.decorateTailscaleOff,
-    decorateTailscaleWarn: params.decorateTailscaleWarn,
-    gatewayMode: params.surface.gatewayMode,
-    remoteUrlMissing: params.surface.remoteUrlMissing,
-    gatewayConnection: params.surface.gatewayConnection,
-    gatewayReachable: params.surface.gatewayReachable,
-    gatewayProbe: params.surface.gatewayProbe,
-    gatewayProbeAuth: params.surface.gatewayProbeAuth,
-    gatewayProbeAuthWarning: params.surface.gatewayProbeAuthWarning,
-    gatewaySelf: params.surface.gatewaySelf,
-    gatewayService: params.surface.gatewayService,
-    nodeService: params.surface.nodeService,
-    nodeOnlyGateway: params.surface.nodeOnlyGateway,
-    decorateOk: params.decorateOk,
-    decorateWarn: params.decorateWarn,
-    prefixRows: params.prefixRows,
-    middleRows: params.middleRows,
-    suffixRows: params.suffixRows,
-    agentsValue: params.agentsValue,
-    updateValue: params.updateValue,
-    gatewayAuthWarningValue: params.gatewayAuthWarningValue,
-    gatewaySelfFallbackValue: params.gatewaySelfFallbackValue,
-  });
+export function buildStatusOverviewRowsFromSurface(
+  params: { surface: StatusOverviewSurface } & StatusOverviewFormatOptions,
+) {
+  const { surface, ...options } = params;
+  return buildStatusOverviewSurfaceRows({ ...surface, ...options });
 }
 
 /** Builds the gateway JSON payload from the gateway portion of an overview surface. */
 export function buildStatusGatewayJsonPayloadFromSurface(params: {
-  surface: Pick<
-    StatusOverviewSurface,
-    | "gatewayMode"
-    | "gatewayConnection"
-    | "remoteUrlMissing"
-    | "gatewayReachable"
-    | "gatewayProbe"
-    | "gatewaySelf"
-    | "gatewayProbeAuthWarning"
-  >;
+  surface: Pick<StatusOverviewSurface, keyof Parameters<typeof buildGatewayStatusJsonPayload>[0]>;
 }) {
-  return buildGatewayStatusJsonPayload({
-    gatewayMode: params.surface.gatewayMode,
-    gatewayConnection: params.surface.gatewayConnection,
-    remoteUrlMissing: params.surface.remoteUrlMissing,
-    gatewayReachable: params.surface.gatewayReachable,
-    gatewayProbe: params.surface.gatewayProbe,
-    gatewaySelf: params.surface.gatewaySelf,
-    gatewayProbeAuthWarning: params.surface.gatewayProbeAuthWarning,
-  });
+  return buildGatewayStatusJsonPayload(params.surface);
 }


### PR DESCRIPTION
## What Problem This Solves

The status overview normalization layer duplicated the canonical formatter's input types and copied every field through two forwarding adapters. That made text and JSON status contracts harder to keep aligned and left 121 lines of redundant production code.

## Why This Change Was Made

Derive the normalized surface and formatting options from the canonical status formatter, while retaining the two explicit field-by-field normalization boundaries for flat scans and nested `gatewaySnapshot` scans. The normalized surface still carries the full `NodeOnlyGatewayInfo`; only already-normalized data is spread into the formatter, and the JSON builder still constructs its stable output key-by-key. The row type export exposed as dead by this cleanup is now private to its owner module.

Production delta: +47/-168, net **-121 LOC**.

## User Impact

No user-visible behavior changes. `openclaw status`, `openclaw status --all`, and `openclaw status --json` retain the same rows, ordering, options, values, and JSON gateway keys.

## Evidence

- Focused status coverage: **38/38 tests passed** across 9 files and all 3 command-test shards.
- Full changed-path gate: **passed**, including production/full-tree dead-export scans, core and test typechecks, lint, formatting, import cycles, and repository guards. [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/30732411501)
- Full packaged build: **passed**. [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/30732675204)
- Real isolated CLI proof on Testbox `tbx_01kz0c56cnhd49yaeh0mcp373t` after the build:
  - `openclaw status`: exit 0; overview rows present and ordered.
  - `openclaw status --all`: exit 0; overview rows present and ordered.
  - `openclaw status --json`: exit 0; update/gateway/service fields present; gateway keys exactly `mode,url,urlSource,misconfigured,reachable,connectLatencyMs,self,error,authWarning`.
  - Disposable `HOME` and `OPENCLAW_STATE_DIR` removed after proof; Testbox stopped.
- Structured Codex Sol xhigh autoreview: **clean**, no findings.
- Two independent Codex Sol xhigh reviews: **CLEAN / CLEAN**; both judged this the best owner-boundary fix.
- `git diff --check`: passed.

Exact reviewed head: `6986cc1191c637ad8acd3f0ba15bd0469c304cac`.
