### PR TITLE
refactor(whatsapp): consolidate QA message extraction

### DIFF
--- a/extensions/whatsapp/src/inbound.test.ts
+++ b/extensions/whatsapp/src/inbound.test.ts
@@ -1,268 +1,125 @@
 // Whatsapp tests cover inbound plugin behavior.
+import type { proto } from "baileys";
 import { describe, expect, it } from "vitest";
 import { extractContactContext, extractLocationData, extractText } from "./inbound.js";
 import { extractExternalAdReplyContext, extractMediaKind } from "./inbound/extract.js";
 
+const message = (value: proto.IMessage) => value;
+const vcard = (name: string, phones: string[] = []) =>
+  [
+    "BEGIN:VCARD",
+    "VERSION:3.0",
+    `FN:${name}`,
+    ...phones.map((phone) => `TEL;TYPE=CELL:${phone}`),
+    "END:VCARD",
+  ].join("\n");
+
 describe("web inbound helpers", () => {
-  it("prefers the main conversation body", () => {
-    const body = extractText({
-      conversation: " hello ",
-    } as unknown as import("baileys").proto.IMessage);
-    expect(body).toBe("hello");
-  });
-
-  it("falls back to captions when conversation text is missing", () => {
-    const body = extractText({
-      imageMessage: { caption: " caption " },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(body).toBe("caption");
-  });
-
-  it("handles document captions", () => {
-    const body = extractText({
-      documentMessage: { caption: " doc " },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(body).toBe("doc");
+  it.each([
+    ["the main conversation body", { conversation: " hello " }, "hello"],
+    ["image captions", { imageMessage: { caption: " caption " } }, "caption"],
+    ["document captions", { documentMessage: { caption: " doc " } }, "doc"],
+    [
+      "view-once v2 extension messages",
+      { viewOnceMessageV2Extension: { message: { conversation: " hello " } } },
+      "hello",
+    ],
+  ])("extracts %s", (_name, input, expected) => {
+    expect(extractText(message(input))).toBe(expected);
   });
 
   it("extracts WhatsApp contact cards", () => {
-    const body = extractText({
+    const input = message({
       contactMessage: {
         displayName: "Ada Lovelace",
-        vcard: [
-          "BEGIN:VCARD",
-          "VERSION:3.0",
-          "FN:Ada Lovelace",
-          "TEL;TYPE=CELL:+15555550123",
-          "END:VCARD",
-        ].join("\n"),
+        vcard: vcard("Ada Lovelace", ["+15555550123"]),
       },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(body).toBe("<contact>");
-    expect(
-      extractContactContext({
-        contactMessage: {
-          displayName: "Ada Lovelace",
-          vcard: [
-            "BEGIN:VCARD",
-            "VERSION:3.0",
-            "FN:Ada Lovelace",
-            "TEL;TYPE=CELL:+15555550123",
-            "END:VCARD",
-          ].join("\n"),
-        },
-      } as unknown as import("baileys").proto.IMessage),
-    ).toEqual({
+    });
+    expect(extractText(input)).toBe("<contact>");
+    expect(extractContactContext(input)).toEqual({
       kind: "contact",
       total: 1,
       contacts: [{ name: "Ada Lovelace", phones: ["+15555550123"] }],
     });
   });
 
-  it("prefers FN over N in WhatsApp vcards", () => {
-    const body = extractText({
-      contactMessage: {
-        vcard: [
-          "BEGIN:VCARD",
-          "VERSION:3.0",
-          "N:Lovelace;Ada;;;",
-          "FN:Ada Lovelace",
-          "TEL;TYPE=CELL:+15555550123",
-          "END:VCARD",
-        ].join("\n"),
-      },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(body).toBe("<contact>");
+  it.each([
+    [
+      "prefers FN over N",
+      [
+        "BEGIN:VCARD",
+        "VERSION:3.0",
+        "N:Lovelace;Ada;;;",
+        "FN:Ada Lovelace",
+        "TEL;TYPE=CELL:+15555550123",
+        "END:VCARD",
+      ].join("\n"),
+    ],
+    ["normalizes tel: prefixes", vcard("Ada Lovelace", ["tel:+15555550123"])],
+    [
+      "trims and skips empty phones",
+      [
+        "BEGIN:VCARD",
+        "VERSION:3.0",
+        "FN:Ada Lovelace",
+        "TEL;TYPE=CELL:  +15555550123  ",
+        "TEL;TYPE=HOME:   ",
+        "TEL;TYPE=WORK:+15555550124",
+        "END:VCARD",
+      ].join("\n"),
+    ],
+  ])("%s in WhatsApp vcards", (_name, card) => {
+    expect(extractText(message({ contactMessage: { vcard: card } }))).toBe("<contact>");
   });
 
-  it("normalizes tel: prefixes in WhatsApp vcards", () => {
-    const body = extractText({
-      contactMessage: {
-        vcard: [
-          "BEGIN:VCARD",
-          "VERSION:3.0",
-          "FN:Ada Lovelace",
-          "TEL;TYPE=CELL:tel:+15555550123",
-          "END:VCARD",
-        ].join("\n"),
-      },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(body).toBe("<contact>");
+  it.each([
+    [
+      "multiple contact cards",
+      [
+        { displayName: "Alice", vcard: vcard("Alice", ["+15555550101"]) },
+        { displayName: "Bob", vcard: vcard("Bob", ["+15555550102"]) },
+        {
+          displayName: "Charlie",
+          vcard: vcard("Charlie", ["+15555550103", "+15555550104"]),
+        },
+        { displayName: "Dana", vcard: vcard("Dana", ["+15555550105"]) },
+      ],
+      "<contacts: 4 contacts>",
+    ],
+    [
+      "empty contact cards alongside populated cards",
+      [{ displayName: "Alice", vcard: vcard("Alice", ["+15555550101"]) }, {}, {}],
+      "<contacts: 3 contacts>",
+    ],
+    ["only empty contact cards", [{}, {}], "<contacts: 2 contacts>"],
+  ])("summarizes %s", (_name, contacts, expected) => {
+    expect(extractText(message({ contactsArrayMessage: { contacts } }))).toBe(expected);
   });
 
-  it("trims and skips empty WhatsApp vcard phones", () => {
-    const body = extractText({
-      contactMessage: {
-        vcard: [
-          "BEGIN:VCARD",
-          "VERSION:3.0",
-          "FN:Ada Lovelace",
-          "TEL;TYPE=CELL:  +15555550123  ",
-          "TEL;TYPE=HOME:   ",
-          "TEL;TYPE=WORK:+15555550124",
-          "END:VCARD",
-        ].join("\n"),
-      },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(body).toBe("<contact>");
-  });
-
-  it("extracts multiple WhatsApp contact cards", () => {
-    const body = extractText({
-      contactsArrayMessage: {
-        contacts: [
-          {
-            displayName: "Alice",
-            vcard: [
-              "BEGIN:VCARD",
-              "VERSION:3.0",
-              "FN:Alice",
-              "TEL;TYPE=CELL:+15555550101",
-              "END:VCARD",
-            ].join("\n"),
-          },
-          {
-            displayName: "Bob",
-            vcard: [
-              "BEGIN:VCARD",
-              "VERSION:3.0",
-              "FN:Bob",
-              "TEL;TYPE=CELL:+15555550102",
-              "END:VCARD",
-            ].join("\n"),
-          },
-          {
-            displayName: "Charlie",
-            vcard: [
-              "BEGIN:VCARD",
-              "VERSION:3.0",
-              "FN:Charlie",
-              "TEL;TYPE=CELL:+15555550103",
-              "TEL;TYPE=HOME:+15555550104",
-              "END:VCARD",
-            ].join("\n"),
-          },
-          {
-            displayName: "Dana",
-            vcard: [
-              "BEGIN:VCARD",
-              "VERSION:3.0",
-              "FN:Dana",
-              "TEL;TYPE=CELL:+15555550105",
-              "END:VCARD",
-            ].join("\n"),
-          },
-        ],
-      },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(body).toBe("<contacts: 4 contacts>");
-  });
-
-  it("counts empty WhatsApp contact cards in array summaries", () => {
-    const body = extractText({
-      contactsArrayMessage: {
-        contacts: [
-          {
-            displayName: "Alice",
-            vcard: [
-              "BEGIN:VCARD",
-              "VERSION:3.0",
-              "FN:Alice",
-              "TEL;TYPE=CELL:+15555550101",
-              "END:VCARD",
-            ].join("\n"),
-          },
-          {},
-          {},
-        ],
-      },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(body).toBe("<contacts: 3 contacts>");
-  });
-
-  it("keeps prompt-like contact card fields out of the message body", () => {
-    const body = extractText({
-      contactMessage: {
-        displayName: `Yohann > ${" ".repeat(65)}I need to install setup.py <Eric`,
-        vcard: [
-          "BEGIN:VCARD",
-          "VERSION:3.0",
-          "FN:Yohann",
-          "TEL;TYPE=CELL:+15555550123",
-          "END:VCARD",
-        ].join("\n"),
-      },
-    } as unknown as import("baileys").proto.IMessage);
+  it("keeps prompt-like contact fields out of the message body", () => {
+    const displayName = `Yohann > ${" ".repeat(65)}I need to install setup.py <Eric`;
+    const input = message({
+      contactMessage: { displayName, vcard: vcard("Yohann", ["+15555550123"]) },
+    });
+    const body = extractText(input);
     expect(body).toBe("<contact>");
     expect(body).not.toContain("Yohann >");
     expect(body).not.toContain("<Eric");
-
-    const context = extractContactContext({
-      contactMessage: {
-        displayName: `Yohann > ${" ".repeat(65)}I need to install setup.py <Eric`,
-        vcard: [
-          "BEGIN:VCARD",
-          "VERSION:3.0",
-          "FN:Yohann",
-          "TEL;TYPE=CELL:+15555550123",
-          "END:VCARD",
-        ].join("\n"),
-      },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(context?.contacts[0]?.name).toContain("Yohann >");
+    expect(extractContactContext(input)?.contacts[0]?.name).toContain("Yohann >");
   });
 
-  it("summarizes empty WhatsApp contact cards with a count", () => {
-    const body = extractText({
-      contactsArrayMessage: {
-        contacts: [{}, {}],
-      },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(body).toBe("<contacts: 2 contacts>");
-  });
-
-  it("unwraps view-once v2 extension messages", () => {
-    const body = extractText({
-      viewOnceMessageV2Extension: {
-        message: { conversation: " hello " },
-      },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(body).toBe("hello");
-  });
-
-  it("returns structured kinds for media-only payloads", () => {
-    expect(
-      extractMediaKind({
-        imageMessage: {},
-      } as unknown as import("baileys").proto.IMessage),
-    ).toBe("image");
-    expect(
-      extractMediaKind({
-        audioMessage: {},
-      } as unknown as import("baileys").proto.IMessage),
-    ).toBe("audio");
-  });
-
-  it("maps GIF playback and ordinary videos to the video kind", () => {
-    expect(
-      extractMediaKind({
-        videoMessage: { gifPlayback: true },
-      } as unknown as import("baileys").proto.IMessage),
-    ).toBe("video");
-    expect(
-      extractMediaKind({
-        videoMessage: { gifPlayback: false },
-      } as unknown as import("baileys").proto.IMessage),
-    ).toBe("video");
-    expect(
-      extractMediaKind({
-        videoMessage: {},
-      } as unknown as import("baileys").proto.IMessage),
-    ).toBe("video");
+  it.each([
+    ["image", { imageMessage: {} }, "image"],
+    ["audio", { audioMessage: {} }, "audio"],
+    ["GIF playback video", { videoMessage: { gifPlayback: true } }, "video"],
+    ["non-GIF video", { videoMessage: { gifPlayback: false } }, "video"],
+    ["ordinary video", { videoMessage: {} }, "video"],
+  ])("returns the %s media kind", (_name, input, expected) => {
+    expect(extractMediaKind(message(input))).toBe(expected);
   });
 
   it("keeps externalAdReply metadata out of the media kind", () => {
-    const message = {
+    const input = message({
       videoMessage: {
         gifPlayback: true,
         contextInfo: {
@@ -273,55 +130,59 @@ describe("web inbound helpers", () => {
           },
         },
       },
-    } as unknown as import("baileys").proto.IMessage;
-
-    expect(extractMediaKind(message)).toBe("video");
-    expect(extractExternalAdReplyContext(message)).toEqual({
+    });
+    expect(extractMediaKind(input)).toBe("video");
+    expect(extractExternalAdReplyContext(input)).toEqual({
       title: "This Is Fine",
       sourceUrl: "https://giphy.com/gifs/this-is-fine-3o7TK",
       body: "A dog in a burning room",
     });
   });
 
-  it("extracts WhatsApp location messages", () => {
-    const location = extractLocationData({
-      locationMessage: {
-        degreesLatitude: 48.858844,
-        degreesLongitude: 2.294351,
+  it.each([
+    [
+      "place",
+      {
+        locationMessage: {
+          degreesLatitude: 48.858844,
+          degreesLongitude: 2.294351,
+          name: "Eiffel Tower",
+          address: "Champ de Mars, Paris",
+          accuracyInMeters: 12,
+          comment: "Meet here",
+        },
+      },
+      {
+        latitude: 48.858844,
+        longitude: 2.294351,
+        accuracy: 12,
         name: "Eiffel Tower",
         address: "Champ de Mars, Paris",
-        accuracyInMeters: 12,
-        comment: "Meet here",
+        caption: "Meet here",
+        source: "place",
+        isLive: false,
       },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(location).toEqual({
-      latitude: 48.858844,
-      longitude: 2.294351,
-      accuracy: 12,
-      name: "Eiffel Tower",
-      address: "Champ de Mars, Paris",
-      caption: "Meet here",
-      source: "place",
-      isLive: false,
-    });
-  });
-
-  it("extracts WhatsApp live location messages", () => {
-    const location = extractLocationData({
-      liveLocationMessage: {
-        degreesLatitude: 37.819929,
-        degreesLongitude: -122.478255,
-        accuracyInMeters: 20,
+    ],
+    [
+      "live",
+      {
+        liveLocationMessage: {
+          degreesLatitude: 37.819929,
+          degreesLongitude: -122.478255,
+          accuracyInMeters: 20,
+          caption: "On the move",
+        },
+      },
+      {
+        latitude: 37.819929,
+        longitude: -122.478255,
+        accuracy: 20,
         caption: "On the move",
+        source: "live",
+        isLive: true,
       },
-    } as unknown as import("baileys").proto.IMessage);
-    expect(location).toEqual({
-      latitude: 37.819929,
-      longitude: -122.478255,
-      accuracy: 20,
-      caption: "On the move",
-      source: "live",
-      isLive: true,
-    });
+    ],
+  ])("extracts WhatsApp %s locations", (_name, input, expected) => {
+    expect(extractLocationData(message(input))).toEqual(expected);
   });
 });

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -45,6 +45,22 @@ function buildMessageChain(message: proto.IMessage | undefined): proto.IMessage[
   return chain;
 }
 
+export function findMessageSection<K extends keyof proto.IMessage>(
+  rawMessage: proto.IMessage | undefined,
+  sectionNames: readonly K[],
+): { name: K; value: Record<string, unknown> } | undefined {
+  const chain = buildMessageChain(rawMessage);
+  for (const name of sectionNames) {
+    for (const message of chain) {
+      const value = message[name];
+      if (isRecord(value)) {
+        return { name, value };
+      }
+    }
+  }
+  return undefined;
+}
+
 function unwrapMessage(message: proto.IMessage | undefined): proto.IMessage | undefined {
   const chain = buildMessageChain(message);
   return chain.at(-1);

--- a/extensions/whatsapp/src/qa-driver.runtime.test.ts
+++ b/extensions/whatsapp/src/qa-driver.runtime.test.ts
@@ -1,10 +1,11 @@
 // Whatsapp tests cover qa driver plugin behavior.
 import { EventEmitter } from "node:events";
-import type { WAMessage } from "baileys";
+import type { proto, WAMessage } from "baileys";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { startWhatsAppQaDriverSession } from "./qa-driver.runtime.js";
+import { startWhatsAppQaDriverSession, type WhatsAppQaDriverSession } from "./qa-driver.runtime.js";
 import { DEFAULT_WHATSAPP_SOCKET_TIMING } from "./socket-timing.js";
 
+const AUTH_DIR = "/tmp/openclaw-whatsapp-auth";
 const mocks = vi.hoisted(() => ({
   createWebSendApi: vi.fn(),
   createWaSocket: vi.fn(),
@@ -26,219 +27,123 @@ vi.mock("./session.js", () => ({
     (error as { output?: { statusCode?: number } } | undefined)?.output?.statusCode,
   waitForWaConnection: mocks.waitForWaConnection,
 }));
-
-vi.mock("./text-runtime.js", () => ({
-  jidToE164: mocks.jidToE164,
-}));
-
-vi.mock("./inbound/send-api.js", () => ({
-  createWebSendApi: mocks.createWebSendApi,
-}));
+vi.mock("./text-runtime.js", () => ({ jidToE164: mocks.jidToE164 }));
+vi.mock("./inbound/send-api.js", () => ({ createWebSendApi: mocks.createWebSendApi }));
 
 function createMockSocket() {
   return {
     end: vi.fn(),
     ev: new EventEmitter(),
     sendMessage: mocks.socketSendMessage,
-    ws: {
-      close: vi.fn(),
-    },
   };
 }
 
-function incomingMessage(remoteJid: string, text: string, id = "message-1"): WAMessage {
-  return {
-    key: {
-      fromMe: false,
-      id,
-      remoteJid,
-    },
-    message: {
-      conversation: text,
-    },
-  } as WAMessage;
-}
-
-function incomingGroupMessage(params: {
+type MockSocket = ReturnType<typeof createMockSocket>;
+type MessageKey = {
+  fromMe?: boolean;
   id?: string;
-  participant: string;
-  remoteJid: string;
-  text: string;
-}): WAMessage {
+  participant?: string;
+  remoteJid?: string;
+};
+
+let sock: MockSocket;
+const sessions = new Set<WhatsAppQaDriverSession>();
+
+function incoming(message: proto.IMessage, key: MessageKey = {}): WAMessage {
   return {
     key: {
       fromMe: false,
-      id: params.id ?? "group-message-1",
-      participant: params.participant,
-      remoteJid: params.remoteJid,
+      id: "message-1",
+      remoteJid: "12345@lid",
+      ...key,
     },
-    message: {
-      conversation: params.text,
-    },
+    message,
   } as WAMessage;
 }
 
-function incomingImageMessage(remoteJid: string, text: string): WAMessage {
-  return {
-    key: {
-      fromMe: false,
-      id: "image-1",
-      remoteJid,
-    },
-    message: {
-      imageMessage: {
-        caption: text,
-        mimetype: "image/png",
+function emitMessages(...messages: WAMessage[]) {
+  sock.ev.emit("messages.upsert", { messages });
+}
+
+function expectCalled(mock: ReturnType<typeof vi.fn>, ...args: unknown[]) {
+  expect(mock).toHaveBeenCalledWith(...args);
+}
+
+async function startSession(
+  options: { connectionTimeoutMs?: number; waitForPendingNotifications?: boolean } = {},
+) {
+  const session = await startWhatsAppQaDriverSession({ authDir: AUTH_DIR, ...options });
+  sessions.add(session);
+  return session;
+}
+
+async function observe(message: proto.IMessage, key?: MessageKey) {
+  const session = await startSession();
+  emitMessages(incoming(message, key));
+  return session.getObservedMessages()[0];
+}
+
+const pollExpected = {
+  kind: "poll",
+  poll: { question: "Choose a time", options: ["Morning", "Afternoon"] },
+};
+const pollMessage = (pollKey: string) => ({
+  [pollKey]: {
+    name: "Choose a time",
+    options: [{ optionName: "Morning" }, { optionName: "Afternoon" }],
+  },
+});
+const ingressCases = [
+  ...[
+    ["captionless video note", { ptvMessage: {} }],
+    ["ephemeral captionless video note", { ephemeralMessage: { message: { ptvMessage: {} } } }],
+    ["edited captionless video note", { editedMessage: { message: { ptvMessage: {} } } }],
+  ].map(([name, message]) => ({
+    name,
+    message,
+    expected: { kind: "media", mediaType: "video/mp4", text: "" },
+  })),
+  ...[
+    "pollCreationMessage",
+    "pollCreationMessageV2",
+    "pollCreationMessageV3",
+    "pollCreationMessageV5",
+  ].flatMap((pollKey) => {
+    const message = pollMessage(pollKey);
+    return [
+      { name: pollKey, message, expected: pollExpected },
+      {
+        name: `ephemeral ${pollKey}`,
+        message: { ephemeralMessage: { message } },
+        expected: pollExpected,
       },
-    },
-  } as WAMessage;
-}
-
-function incomingImageMessageWithoutMime(remoteJid: string): WAMessage {
-  return {
-    key: {
-      fromMe: false,
-      id: "image-no-mime-1",
-      remoteJid,
-    },
-    message: {
-      imageMessage: {},
-    },
-  } as WAMessage;
-}
-
-function incomingStickerMessageWithoutMime(remoteJid: string): WAMessage {
-  return {
-    key: {
-      fromMe: false,
-      id: "sticker-no-mime-1",
-      remoteJid,
-    },
-    message: {
-      stickerMessage: {},
-    },
-  } as WAMessage;
-}
-
-function incomingAudioMessage(remoteJid: string): WAMessage {
-  return {
-    key: {
-      fromMe: false,
-      id: "audio-1",
-      remoteJid,
-    },
-    message: {
-      audioMessage: {
-        mimetype: "audio/ogg; codecs=opus",
+    ];
+  }),
+  ...["pollCreationMessageV3", "pollCreationMessageV5"].flatMap((pollKey) => {
+    const message = pollMessage(pollKey);
+    const wrapped = { pollCreationMessageV4: { message } };
+    return [
+      { name: `future-proof version-4 ${pollKey}`, message: wrapped, expected: pollExpected },
+      {
+        name: `ephemeral future-proof version-4 ${pollKey}`,
+        message: { ephemeralMessage: { message: wrapped } },
+        expected: pollExpected,
       },
-    },
-  } as WAMessage;
-}
-
-function incomingEditedImageMessage(remoteJid: string): WAMessage {
-  return {
-    key: {
-      fromMe: false,
-      id: "edited-image-1",
-      remoteJid,
-    },
-    message: {
-      editedMessage: {
-        message: {
-          imageMessage: {
-            caption: "edited image caption",
-          },
-        },
+      {
+        name: `edited ${pollKey}`,
+        message: { editedMessage: { message } },
+        expected: pollExpected,
       },
-    },
-  } as WAMessage;
-}
-
-function incomingLocationMessage(remoteJid: string): WAMessage {
-  return {
-    key: {
-      fromMe: false,
-      id: "location-1",
-      remoteJid,
-    },
-    message: {
-      locationMessage: {
-        degreesLatitude: 37.7749,
-        degreesLongitude: -122.4194,
-      },
-    },
-  } as WAMessage;
-}
-
-function incomingReactionMessage(remoteJid: string): WAMessage {
-  return {
-    key: {
-      fromMe: false,
-      id: "reaction-1",
-      remoteJid,
-    },
-    message: {
-      reactionMessage: {
-        text: "👍",
-        key: {
-          fromMe: true,
-          id: "driver-message-1",
-          participant: "15551234567@s.whatsapp.net",
-        },
-      },
-    },
-  } as WAMessage;
-}
-
-function incomingQuotedMessage(remoteJid: string): WAMessage {
-  return {
-    key: {
-      fromMe: false,
-      id: "quoted-reply-1",
-      remoteJid,
-    },
-    message: {
-      extendedTextMessage: {
-        text: "reply body",
-        contextInfo: {
-          participant: "15551234567@s.whatsapp.net",
-          quotedMessage: {
-            conversation: "original body",
-          },
-          stanzaId: "driver-message-1",
-        },
-      },
-    },
-  } as WAMessage;
-}
-
-function incomingQuotedLocationMessage(remoteJid: string): WAMessage {
-  return {
-    key: {
-      fromMe: false,
-      id: "quoted-location-reply-1",
-      remoteJid,
-    },
-    message: {
-      extendedTextMessage: {
-        text: "reply body",
-        contextInfo: {
-          participant: "15551234567@s.whatsapp.net",
-          quotedMessage: {
-            locationMessage: {
-              degreesLatitude: 37.7749,
-              degreesLongitude: -122.4194,
-            },
-          },
-          stanzaId: "driver-location-1",
-        },
-      },
-    },
-  } as WAMessage;
-}
+    ];
+  }),
+];
 
 describe("startWhatsAppQaDriverSession", () => {
   beforeEach(() => {
+    sock = createMockSocket();
+    mocks.createWaSocket.mockResolvedValue(sock);
+    mocks.waitForWaConnection.mockResolvedValue(undefined);
+    mocks.jidToE164.mockReturnValue("+15551234567");
     mocks.createWebSendApi.mockImplementation(() => ({
       sendContact: mocks.sendContact,
       sendLocation: mocks.sendLocation,
@@ -249,149 +154,63 @@ describe("startWhatsAppQaDriverSession", () => {
     }));
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await Promise.all([...sessions].map((session) => session.close()));
+    sessions.clear();
     vi.useRealTimers();
     vi.clearAllMocks();
   });
 
-  it("normalizes LID-backed senders using the QA auth directory", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [incomingMessage("12345@lid", "hello")],
-    });
-
-    expect(mocks.jidToE164).toHaveBeenCalledWith("12345@lid", {
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-    const observedMessages = session.getObservedMessages();
-    const observedAt = observedMessages[0]?.observedAt;
-    expect(observedAt).toBe(new Date(observedAt ?? "").toISOString());
-    expect(observedMessages).toEqual([
-      {
-        fromJid: "12345@lid",
-        fromPhoneE164: "+15551234567",
-        kind: "text",
-        messageId: "message-1",
-        observedAt,
-        text: "hello",
+  it.each([
+    {
+      name: "LID-backed senders",
+      key: { remoteJid: "12345@lid" },
+      normalizedJid: "12345@lid",
+    },
+    {
+      name: "group participants separately from the conversation JID",
+      key: {
+        id: "group-message-1",
+        participant: "15551234567@s.whatsapp.net",
+        remoteJid: "120363000000000000@g.us",
       },
-    ]);
-
-    await session.close();
-  });
-
-  it("normalizes group participants separately from the group conversation JID", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [
-        incomingGroupMessage({
-          participant: "15551234567@s.whatsapp.net",
-          remoteJid: "120363000000000000@g.us",
-          text: "hello group",
-        }),
-      ],
-    });
-
-    expect(mocks.jidToE164).toHaveBeenCalledWith("15551234567@s.whatsapp.net", {
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-    const observedMessages = session.getObservedMessages();
-    const observedAt = observedMessages[0]?.observedAt;
-    expect(observedAt).toBe(new Date(observedAt ?? "").toISOString());
-    expect(observedMessages).toEqual([
-      {
-        fromJid: "120363000000000000@g.us",
-        fromPhoneE164: "+15551234567",
-        kind: "text",
-        messageId: "group-message-1",
-        observedAt,
-        participantJid: "15551234567@s.whatsapp.net",
-        text: "hello group",
+      normalizedJid: "15551234567@s.whatsapp.net",
+    },
+    {
+      name: "DM senders from the conversation JID when a participant is present",
+      key: {
+        id: "dm-message-1",
+        participant: "99999@lid",
+        remoteJid: "15551234567@s.whatsapp.net",
       },
-    ]);
-
-    await session.close();
-  });
-
-  it("normalizes DM senders from the conversation JID when Baileys includes a participant", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
+      normalizedJid: "15551234567@s.whatsapp.net",
+    },
+  ])("normalizes $name", async ({ key, normalizedJid }) => {
     mocks.jidToE164.mockImplementation((jid: string) =>
-      jid === "15551234567@s.whatsapp.net" ? "+15551234567" : null,
+      jid === normalizedJid ? "+15551234567" : null,
     );
+    const session = await startSession();
+    emitMessages(incoming({ conversation: "hello" }, key));
 
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
+    expect(mocks.jidToE164).toHaveBeenCalledWith(normalizedJid, { authDir: AUTH_DIR });
+    const observed = session.getObservedMessages()[0];
+    expect(observed?.observedAt).toBe(new Date(observed?.observedAt ?? "").toISOString());
+    expect(observed).toEqual({
+      fromJid: key.remoteJid,
+      fromPhoneE164: "+15551234567",
+      kind: "text",
+      messageId: key.id ?? "message-1",
+      observedAt: observed?.observedAt,
+      ...(key.participant ? { participantJid: key.participant } : {}),
+      text: "hello",
     });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [
-        {
-          key: {
-            fromMe: false,
-            id: "dm-message-1",
-            participant: "99999@lid",
-            remoteJid: "15551234567@s.whatsapp.net",
-          },
-          message: {
-            conversation: "hello dm",
-          },
-        } as WAMessage,
-      ],
-    });
-
-    expect(mocks.jidToE164).toHaveBeenCalledWith("15551234567@s.whatsapp.net", {
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-    const observedMessages = session.getObservedMessages();
-    const observedAt = observedMessages[0]?.observedAt;
-    expect(observedMessages).toEqual([
-      {
-        fromJid: "15551234567@s.whatsapp.net",
-        fromPhoneE164: "+15551234567",
-        kind: "text",
-        messageId: "dm-message-1",
-        observedAt,
-        participantJid: "99999@lid",
-        text: "hello dm",
-      },
-    ]);
-
-    await session.close();
   });
 
   it("does not satisfy a wait with messages observed before the lower bound", async () => {
     vi.useFakeTimers();
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
-
     vi.setSystemTime(new Date("2026-06-04T23:42:32.036Z"));
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [incomingMessage("12345@lid", "OpenClaw status stale", "stale-message")],
-    });
+    const session = await startSession();
+    emitMessages(incoming({ conversation: "OpenClaw status stale" }, { id: "stale-message" }));
 
     const observedAfter = new Date("2026-06-04T23:46:59.166Z");
     vi.setSystemTime(observedAfter);
@@ -400,520 +219,265 @@ describe("startWhatsAppQaDriverSession", () => {
       timeoutMs: 1_000,
       match: (message) => message.text.includes("OpenClaw status"),
     });
-
     vi.setSystemTime(new Date("2026-06-04T23:47:00.000Z"));
-    sock.ev.emit("messages.upsert", {
-      messages: [incomingMessage("12345@lid", "OpenClaw status fresh", "fresh-message")],
-    });
+    emitMessages(incoming({ conversation: "OpenClaw status fresh" }, { id: "fresh-message" }));
 
     await expect(waited).resolves.toMatchObject({
       messageId: "fresh-message",
       text: "OpenClaw status fresh",
     });
-
-    await session.close();
-  });
-
-  it("observes media messages without dropping their caption text", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [incomingImageMessage("12345@lid", "image caption")],
-    });
-
-    expect(session.getObservedMessages()[0]).toMatchObject({
-      hasMedia: true,
-      kind: "media",
-      mediaType: "image/png",
-      text: "image caption",
-    });
-
-    await session.close();
-  });
-
-  it("observes audio media messages without requiring a text body", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [incomingAudioMessage("12345@lid")],
-    });
-
-    expect(session.getObservedMessages()[0]).toMatchObject({
-      hasMedia: true,
-      kind: "media",
-      mediaType: "audio/ogg; codecs=opus",
-      text: "",
-    });
-
-    await session.close();
   });
 
   it.each([
-    ...[
-      { name: "captionless video note", message: { ptvMessage: {} } },
-      {
-        name: "ephemeral captionless video note",
-        message: { ephemeralMessage: { message: { ptvMessage: {} } } },
+    {
+      name: "captioned media",
+      message: { imageMessage: { caption: "image caption", mimetype: "image/png" } },
+      expected: { hasMedia: true, kind: "media", mediaType: "image/png", text: "image caption" },
+    },
+    {
+      name: "bodyless audio",
+      message: { audioMessage: { mimetype: "audio/ogg; codecs=opus" } },
+      expected: { hasMedia: true, kind: "media", mediaType: "audio/ogg; codecs=opus", text: "" },
+    },
+    {
+      name: "future-proof wrapped media",
+      message: {
+        editedMessage: { message: { imageMessage: { caption: "edited image caption" } } },
       },
-      {
-        name: "edited captionless video note",
-        message: { editedMessage: { message: { ptvMessage: {} } } },
+      expected: {
+        hasMedia: true,
+        kind: "media",
+        mediaType: "image/jpeg",
+        text: "edited image caption",
       },
-    ].map(({ name, message }) => ({
-      name,
-      message,
-      expected: { kind: "media", mediaType: "video/mp4", text: "" },
-    })),
-    ...[
-      "pollCreationMessage",
-      "pollCreationMessageV2",
-      "pollCreationMessageV3",
-      "pollCreationMessageV5",
-    ].flatMap((pollKey) => {
-      const poll = {
-        [pollKey]: {
-          name: "Choose a time",
-          options: [{ optionName: "Morning" }, { optionName: "Afternoon" }],
+    },
+    {
+      name: "top-level locations",
+      message: {
+        locationMessage: { degreesLatitude: 37.7749, degreesLongitude: -122.4194 },
+      },
+      expected: { kind: "location", text: "📍 37.774900, -122.419400" },
+    },
+    {
+      name: "bodyless reactions",
+      message: {
+        reactionMessage: {
+          text: "👍",
+          key: {
+            fromMe: true,
+            id: "driver-message-1",
+            participant: "15551234567@s.whatsapp.net",
+          },
         },
-      };
-      const expected = {
-        kind: "poll",
-        poll: { question: "Choose a time", options: ["Morning", "Afternoon"] },
-      };
-      return [
-        { name: pollKey, message: poll, expected },
-        {
-          name: `ephemeral ${pollKey}`,
-          message: { ephemeralMessage: { message: poll } },
-          expected,
+      },
+      expected: {
+        kind: "reaction",
+        reaction: {
+          emoji: "👍",
+          fromMe: true,
+          messageId: "driver-message-1",
+          participant: "15551234567@s.whatsapp.net",
         },
-      ];
-    }),
-    ...["pollCreationMessageV3", "pollCreationMessageV5"].flatMap((pollKey) => {
-      const poll = {
-        [pollKey]: {
-          name: "Choose a time",
-          options: [{ optionName: "Morning" }, { optionName: "Afternoon" }],
+        text: "",
+      },
+    },
+    {
+      name: "quoted replies",
+      message: {
+        extendedTextMessage: {
+          text: "reply body",
+          contextInfo: {
+            participant: "15551234567@s.whatsapp.net",
+            quotedMessage: { conversation: "original body" },
+            stanzaId: "driver-message-1",
+          },
         },
-      };
-      const wrappedPoll = { pollCreationMessageV4: { message: poll } };
-      const expected = {
-        kind: "poll",
-        poll: { question: "Choose a time", options: ["Morning", "Afternoon"] },
-      };
-      return [
-        { name: `future-proof version-4 ${pollKey}`, message: wrappedPoll, expected },
-        {
-          name: `ephemeral future-proof version-4 ${pollKey}`,
-          message: { ephemeralMessage: { message: wrappedPoll } },
-          expected,
+      },
+      expected: {
+        kind: "text",
+        quoted: {
+          messageId: "driver-message-1",
+          participant: "15551234567@s.whatsapp.net",
+          text: "original body",
         },
-        { name: `edited ${pollKey}`, message: { editedMessage: { message: poll } }, expected },
-      ];
-    }),
-  ])("resolves live ingress waiters for $name", async ({ message, expected }) => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
+        text: "reply body",
+      },
+    },
+    {
+      name: "quoted locations",
+      message: {
+        extendedTextMessage: {
+          text: "reply body",
+          contextInfo: {
+            participant: "15551234567@s.whatsapp.net",
+            quotedMessage: {
+              locationMessage: { degreesLatitude: 37.7749, degreesLongitude: -122.4194 },
+            },
+            stanzaId: "driver-location-1",
+          },
+        },
+      },
+      expected: {
+        kind: "text",
+        quoted: {
+          messageId: "driver-location-1",
+          participant: "15551234567@s.whatsapp.net",
+          text: "📍 37.774900, -122.419400",
+        },
+        text: "reply body",
+      },
+    },
+  ])("observes $name", async ({ message, expected }) => {
+    expect(await observe(message as proto.IMessage)).toMatchObject(expected);
+  });
 
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
+  it("uses canonical media MIME defaults", async () => {
+    const session = await startSession();
+    emitMessages(
+      incoming({ imageMessage: {} }, { id: "image-no-mime-1" }),
+      incoming({ stickerMessage: {} }, { id: "sticker-no-mime-1" }),
+    );
+    expect(session.getObservedMessages()).toMatchObject([
+      { hasMedia: true, kind: "media", mediaType: "image/jpeg" },
+      { hasMedia: true, kind: "media", mediaType: "image/webp" },
+    ]);
+  });
 
-    try {
+  it.each(ingressCases)(
+    "resolves live ingress waiters for $name",
+    async ({ message, expected }) => {
+      const session = await startSession();
       const observed = session.waitForMessage({
         timeoutMs: 150,
         match: (candidate) => candidate.kind === expected.kind,
       });
-      sock.ev.emit("messages.upsert", {
-        messages: [
-          {
-            key: { fromMe: false, id: "observed-message", remoteJid: "12345@lid" },
-            message,
-          } as WAMessage,
-        ],
-      });
+      emitMessages(incoming(message as proto.IMessage, { id: "observed-message" }));
 
       await expect(observed).resolves.toMatchObject(expected);
       expect(session.getObservedMessages()).toHaveLength(1);
-    } finally {
-      await session.close();
-    }
-  });
+    },
+  );
 
-  it("uses canonical WhatsApp media MIME defaults when Baileys omits MIME", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [
-        incomingImageMessageWithoutMime("12345@lid"),
-        incomingStickerMessageWithoutMime("12345@lid"),
-      ],
-    });
-
-    expect(session.getObservedMessages()).toMatchObject([
-      {
-        hasMedia: true,
-        kind: "media",
-        mediaType: "image/jpeg",
-      },
-      {
-        hasMedia: true,
-        kind: "media",
-        mediaType: "image/webp",
-      },
-    ]);
-
-    await session.close();
-  });
-
-  it("observes media through Baileys future-proof wrappers", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [incomingEditedImageMessage("12345@lid")],
-    });
-
-    expect(session.getObservedMessages()[0]).toMatchObject({
-      hasMedia: true,
-      kind: "media",
-      mediaType: "image/jpeg",
-      text: "edited image caption",
-    });
-
-    await session.close();
-  });
-
-  it("observes top-level location messages with canonical location text", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [incomingLocationMessage("12345@lid")],
-    });
-
-    expect(session.getObservedMessages()[0]).toMatchObject({
-      kind: "location",
-      text: "📍 37.774900, -122.419400",
-    });
-
-    await session.close();
-  });
-
-  it("observes reaction messages that have no text body", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [incomingReactionMessage("12345@lid")],
-    });
-
-    expect(session.getObservedMessages()[0]).toMatchObject({
-      kind: "reaction",
-      reaction: {
-        emoji: "👍",
-        fromMe: true,
-        messageId: "driver-message-1",
-        participant: "15551234567@s.whatsapp.net",
-      },
-      text: "",
-    });
-
-    await session.close();
-  });
-
-  it("observes quoted reply context", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [incomingQuotedMessage("12345@lid")],
-    });
-
-    expect(session.getObservedMessages()[0]).toMatchObject({
-      kind: "text",
-      quoted: {
-        messageId: "driver-message-1",
-        participant: "15551234567@s.whatsapp.net",
-        text: "original body",
-      },
-      text: "reply body",
-    });
-
-    await session.close();
-  });
-
-  it("observes quoted location context with canonical reply body text", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.jidToE164.mockReturnValue("+15551234567");
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    sock.ev.emit("messages.upsert", {
-      messages: [incomingQuotedLocationMessage("12345@lid")],
-    });
-
-    expect(session.getObservedMessages()[0]).toMatchObject({
-      kind: "text",
-      quoted: {
-        messageId: "driver-location-1",
-        participant: "15551234567@s.whatsapp.net",
-        text: "📍 37.774900, -122.419400",
-      },
-      text: "reply body",
-    });
-
-    await session.close();
-  });
-
-  it("uses the web send API for existing outbound helpers", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
+  it("adapts all QA sends to the web send API", async () => {
     mocks.sendMessage.mockResolvedValue({ messageId: "send-1" });
     mocks.sendPoll.mockResolvedValue({ messageId: "poll-1" });
     mocks.sendReaction.mockResolvedValue({ messageId: "reaction-send-1" });
+    mocks.sendContact.mockResolvedValue({ messageId: "contact-1" });
+    mocks.sendLocation.mockResolvedValue({ messageId: "location-1" });
+    mocks.sendSticker.mockResolvedValue({ messageId: "sticker-1" });
+    const session = await startSession();
+    const media = Buffer.from("png");
+    const sticker = Buffer.from("webp");
 
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
+    await expect(
+      Promise.all([
+        session.sendMedia("15551234567", "caption", media, "image/png", {
+          fileName: "qa.png",
+        }),
+        session.sendPoll("15551234567", { question: "Pick one", options: ["A", "B"] }),
+        session.sendReaction("15551234567@s.whatsapp.net", "driver-message-1", "👍", {
+          fromMe: true,
+        }),
+        session.sendContact("15551234567", {
+          displayName: "QA Contact",
+          vcard: "BEGIN:VCARD\nFN:QA Contact\nEND:VCARD",
+        }),
+        session.sendLocation("15551234567", {
+          degreesLatitude: 37.7749,
+          degreesLongitude: -122.4194,
+          name: "QA Location",
+        }),
+        session.sendSticker("15551234567", sticker, { mimetype: "image/webp" }),
+      ]),
+    ).resolves.toEqual([
+      { messageId: "send-1" },
+      { messageId: "poll-1" },
+      { messageId: "reaction-send-1" },
+      { messageId: "contact-1" },
+      { messageId: "location-1" },
+      { messageId: "sticker-1" },
+    ]);
+    expectCalled(mocks.sendMessage, "15551234567", "caption", media, "image/png", {
+      fileName: "qa.png",
     });
-
-    await expect(
-      session.sendMedia("15551234567", "caption", Buffer.from("png"), "image/png", {
-        fileName: "qa.png",
-      }),
-    ).resolves.toEqual({ messageId: "send-1" });
-    await expect(
-      session.sendPoll("15551234567", {
-        question: "Pick one",
-        options: ["A", "B"],
-      }),
-    ).resolves.toEqual({ messageId: "poll-1" });
-    await expect(
-      session.sendReaction("15551234567@s.whatsapp.net", "driver-message-1", "👍", {
-        fromMe: true,
-      }),
-    ).resolves.toEqual({ messageId: "reaction-send-1" });
-
-    expect(mocks.sendMessage).toHaveBeenCalledWith(
-      "15551234567",
-      "caption",
-      Buffer.from("png"),
-      "image/png",
-      { fileName: "qa.png" },
-    );
-    expect(mocks.sendPoll).toHaveBeenCalledWith("15551234567", {
+    expectCalled(mocks.sendPoll, "15551234567", {
       question: "Pick one",
       options: ["A", "B"],
     });
-    expect(mocks.sendReaction).toHaveBeenCalledWith(
+    expectCalled(
+      mocks.sendReaction,
       "15551234567@s.whatsapp.net",
       "driver-message-1",
       "👍",
       true,
       undefined,
     );
-
-    await session.close();
-  });
-
-  it("sends structured QA stimuli through the web send API", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-    mocks.sendContact.mockResolvedValue({ messageId: "contact-1" });
-    mocks.sendLocation.mockResolvedValue({ messageId: "location-1" });
-    mocks.sendSticker.mockResolvedValue({ messageId: "sticker-1" });
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
-
-    await expect(
-      session.sendContact("15551234567", {
-        displayName: "QA Contact",
-        vcard: "BEGIN:VCARD\nFN:QA Contact\nEND:VCARD",
-      }),
-    ).resolves.toEqual({ messageId: "contact-1" });
-    await expect(
-      session.sendLocation("15551234567", {
-        degreesLatitude: 37.7749,
-        degreesLongitude: -122.4194,
-        name: "QA Location",
-      }),
-    ).resolves.toEqual({ messageId: "location-1" });
-    await expect(
-      session.sendSticker("15551234567", Buffer.from("webp"), { mimetype: "image/webp" }),
-    ).resolves.toEqual({ messageId: "sticker-1" });
-
-    expect(mocks.sendContact).toHaveBeenCalledWith("15551234567", {
+    expectCalled(mocks.sendContact, "15551234567", {
       displayName: "QA Contact",
       vcard: "BEGIN:VCARD\nFN:QA Contact\nEND:VCARD",
     });
-    expect(mocks.sendLocation).toHaveBeenCalledWith("15551234567", {
+    expectCalled(mocks.sendLocation, "15551234567", {
       degreesLatitude: 37.7749,
       degreesLongitude: -122.4194,
       name: "QA Location",
     });
-    expect(mocks.sendSticker).toHaveBeenCalledWith("15551234567", Buffer.from("webp"), {
+    expectCalled(mocks.sendSticker, "15551234567", sticker, {
       mimetype: "image/webp",
     });
     expect(mocks.socketSendMessage).not.toHaveBeenCalled();
-
-    await session.close();
   });
 
   it("passes the connection timeout to the shared connection waiter", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-      connectionTimeoutMs: 45_000,
-    });
-
+    await startSession({ connectionTimeoutMs: 45_000 });
     expect(mocks.waitForWaConnection).toHaveBeenCalledWith(sock, { timeoutMs: 45_000 });
-
-    await session.close();
   });
 
   it("passes a bounded socket adapter to the send API", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
+    await startSession();
     const sendApiParams = mocks.createWebSendApi.mock.calls[0]?.[0] as {
-      sock: {
-        sendMessage: (jid: string, content: { text: string }) => Promise<unknown>;
-      };
+      sock: { sendMessage: (jid: string, content: { text: string }) => Promise<unknown> };
     };
-
     vi.useFakeTimers();
-    try {
-      sock.sendMessage.mockImplementationOnce(async () => await new Promise(() => {}));
-
-      const sendPromise = sendApiParams.sock.sendMessage("1555@s.whatsapp.net", { text: "hi" });
-      const rejection = expect(sendPromise).rejects.toMatchObject({
-        name: "WhatsAppSocketOperationTimeoutError",
-        operation: "sendMessage",
-        timeoutMs: DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs,
-      });
-      await vi.advanceTimersByTimeAsync(DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs);
-
-      await rejection;
-    } finally {
-      vi.useRealTimers();
-      await session.close();
-    }
+    sock.sendMessage.mockImplementationOnce(async () => await new Promise(() => {}));
+    const sendPromise = sendApiParams.sock.sendMessage("1555@s.whatsapp.net", { text: "hi" });
+    const rejection = expect(sendPromise).rejects.toMatchObject({
+      name: "WhatsAppSocketOperationTimeoutError",
+      operation: "sendMessage",
+      timeoutMs: DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs,
+    });
+    await vi.advanceTimersByTimeAsync(DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs);
+    await rejection;
+    vi.useRealTimers();
   });
 
-  it("can wait for pending notifications before returning the driver session", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-
-    const pending = startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
+  it("can wait for pending notifications before returning", async () => {
+    const pending = startSession({
       connectionTimeoutMs: 10_000,
       waitForPendingNotifications: true,
     });
     let settled = false;
-    pending.then(
-      () => {
-        settled = true;
-      },
-      () => {
-        settled = true;
-      },
-    );
-
+    void pending.finally(() => {
+      settled = true;
+    });
     await Promise.resolve();
     expect(settled).toBe(false);
 
     sock.ev.emit("connection.update", { receivedPendingNotifications: true });
-
-    const session = await pending;
+    await pending;
     expect(settled).toBe(true);
-    await session.close();
   });
 
-  it("rejects pending and future waits when the connected driver session closes", async () => {
-    const sock = createMockSocket();
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockResolvedValue(undefined);
-
-    const session = await startWhatsAppQaDriverSession({
-      authDir: "/tmp/openclaw-whatsapp-auth",
-    });
+  it("rejects pending and future waits when the connection closes", async () => {
+    const session = await startSession();
     const pending = session.waitForMessage({
       match: (message) => message.text.includes("approval required"),
       timeoutMs: 60_000,
     });
-
     sock.ev.emit("connection.update", {
       connection: "close",
       lastDisconnect: {
         date: new Date("2026-06-05T17:54:52.000Z"),
-        error: {
-          output: {
-            statusCode: 428,
-          },
-        },
+        error: { output: { statusCode: 428 } },
       },
     });
 
@@ -929,19 +493,13 @@ describe("startWhatsAppQaDriverSession", () => {
     expect(sock.end).toHaveBeenCalledOnce();
   });
 
-  it("closes the socket and removes listeners when connection setup times out", async () => {
-    const sock = createMockSocket();
-    const timeoutError = new Error("timed out waiting for WhatsApp QA driver session");
-    mocks.createWaSocket.mockResolvedValue(sock);
-    mocks.waitForWaConnection.mockRejectedValue(timeoutError);
-
-    await expect(
-      startWhatsAppQaDriverSession({
-        authDir: "/tmp/openclaw-whatsapp-auth",
-        connectionTimeoutMs: 10,
-      }),
-    ).rejects.toThrow("timed out waiting for WhatsApp QA driver session");
-
+  it("closes resources when connection setup times out", async () => {
+    mocks.waitForWaConnection.mockRejectedValue(
+      new Error("timed out waiting for WhatsApp QA driver session"),
+    );
+    await expect(startSession({ connectionTimeoutMs: 10 })).rejects.toThrow(
+      "timed out waiting for WhatsApp QA driver session",
+    );
     expect(mocks.waitForWaConnection).toHaveBeenCalledWith(sock, { timeoutMs: 10 });
     expect(sock.ev.listenerCount("messages.upsert")).toBe(0);
     expect(sock.ev.listenerCount("connection.update")).toBe(0);

--- a/extensions/whatsapp/src/qa-driver.runtime.ts
+++ b/extensions/whatsapp/src/qa-driver.runtime.ts
@@ -1,14 +1,19 @@
 // Whatsapp plugin module implements qa driver behavior.
-import { getContentType, type ConnectionState, type proto, type WAMessage } from "baileys";
+import type { ConnectionState, proto, WAMessage } from "baileys";
 import { formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  asBoolean,
+  isRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   describeReplyContext,
   extractContextInfo,
   extractLocationData,
   extractText,
+  findMessageSection,
 } from "./inbound/extract.js";
 import { resolveInboundMediaMimetype } from "./inbound/media-mimetype.js";
-import { normalizeMessageContent } from "./inbound/runtime-api.js";
 import { createWebSendApi } from "./inbound/send-api.js";
 import type { ActiveWebSendOptions } from "./inbound/types.js";
 import { isWhatsAppGroupJid } from "./normalize-target.js";
@@ -73,14 +78,16 @@ type WhatsAppQaDriverSendReactionOptions = {
   participant?: string;
 };
 
+type WhatsAppQaDriverSendResult = Promise<{ messageId?: string }>;
+
 export type WhatsAppQaDriverSession = {
-  close: () => Promise<void>;
-  getObservedMessages: () => WhatsAppQaDriverObservedMessage[];
-  sendContact: (
+  close(): Promise<void>;
+  getObservedMessages(): WhatsAppQaDriverObservedMessage[];
+  sendContact(
     to: string,
     contact: { displayName: string; vcard: string },
-  ) => Promise<{ messageId?: string }>;
-  sendLocation: (
+  ): WhatsAppQaDriverSendResult;
+  sendLocation(
     to: string,
     location: {
       address?: string;
@@ -88,39 +95,39 @@ export type WhatsAppQaDriverSession = {
       degreesLongitude: number;
       name?: string;
     },
-  ) => Promise<{ messageId?: string }>;
-  sendMedia: (
+  ): WhatsAppQaDriverSendResult;
+  sendMedia(
     to: string,
     text: string,
     mediaBuffer: Buffer,
     mediaType: string,
     options?: WhatsAppQaDriverSendMediaOptions,
-  ) => Promise<{ messageId?: string }>;
-  sendPoll: (
+  ): WhatsAppQaDriverSendResult;
+  sendPoll(
     to: string,
     poll: { maxSelections?: number; options: string[]; question: string },
-  ) => Promise<{ messageId?: string }>;
-  sendReaction: (
+  ): WhatsAppQaDriverSendResult;
+  sendReaction(
     chatJid: string,
     messageId: string,
     emoji: string,
     options: WhatsAppQaDriverSendReactionOptions,
-  ) => Promise<{ messageId?: string }>;
-  sendSticker: (
+  ): WhatsAppQaDriverSendResult;
+  sendSticker(
     to: string,
     stickerBuffer: Buffer,
     options?: { mimetype?: string },
-  ) => Promise<{ messageId?: string }>;
-  sendText: (
+  ): WhatsAppQaDriverSendResult;
+  sendText(
     to: string,
     text: string,
     options?: WhatsAppQaDriverSendTextOptions,
-  ) => Promise<{ messageId?: string }>;
-  waitForMessage: (params: {
+  ): WhatsAppQaDriverSendResult;
+  waitForMessage(params: {
     match: (message: WhatsAppQaDriverObservedMessage) => boolean;
     observedAfter?: Date;
     timeoutMs: number;
-  }) => Promise<WhatsAppQaDriverObservedMessage>;
+  }): Promise<WhatsAppQaDriverObservedMessage>;
 };
 
 type MessageUpsertEvent = {
@@ -136,128 +143,76 @@ type Waiter = {
   timeout: NodeJS.Timeout;
 };
 
-type PendingNotificationsWaiter = {
+type VoidWaiter = {
   reject: (error: Error) => void;
   resolve: () => void;
   timeout: NodeJS.Timeout;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object");
-}
-
-function readString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function readBoolean(value: unknown): boolean | undefined {
-  return typeof value === "boolean" ? value : undefined;
-}
-
-function findMessageSection(
-  message: unknown,
-  sectionNames: readonly string[],
-): Record<string, unknown> | undefined {
-  if (!isRecord(message)) {
-    return undefined;
-  }
-  const queue: Array<{ depth: number; value: Record<string, unknown> }> = [
-    { depth: 0, value: message },
-  ];
-  const seen = new Set<Record<string, unknown>>();
-  while (queue.length > 0) {
-    const current = queue.shift();
-    if (!current || seen.has(current.value)) {
-      continue;
-    }
-    seen.add(current.value);
-    for (const sectionName of sectionNames) {
-      const section = current.value[sectionName];
-      if (isRecord(section)) {
-        return section;
-      }
-    }
-    if (current.depth >= 4) {
-      continue;
-    }
-    const contentType = getContentType(current.value as proto.IMessage);
-    const wrapper = contentType ? current.value[contentType] : undefined;
-    if (isRecord(wrapper) && isRecord(wrapper.message)) {
-      queue.push({ depth: current.depth + 1, value: wrapper.message });
-    }
-  }
-  return undefined;
-}
-
-function readReaction(message: unknown): WhatsAppQaDriverObservedReaction | undefined {
-  const reaction = findMessageSection(message, ["reactionMessage"]);
+function readReaction(
+  message: proto.IMessage | null | undefined,
+): WhatsAppQaDriverObservedReaction | undefined {
+  const reaction = findMessageSection(message ?? undefined, ["reactionMessage"])?.value;
   if (!reaction) {
     return undefined;
   }
-  const emoji = readString(reaction.text) ?? "";
+  const emoji = normalizeOptionalString(reaction.text) ?? "";
   const key = isRecord(reaction.key) ? reaction.key : undefined;
   return {
     emoji,
-    fromMe: readBoolean(key?.fromMe),
-    messageId: readString(key?.id),
-    participant: readString(key?.participant),
+    fromMe: asBoolean(key?.fromMe),
+    messageId: normalizeOptionalString(key?.id),
+    participant: normalizeOptionalString(key?.participant),
   };
 }
 
-function readPoll(message: unknown): WhatsAppQaDriverObservedPoll | undefined {
-  const poll = findMessageSection(message, [
+function readPoll(
+  message: proto.IMessage | null | undefined,
+): WhatsAppQaDriverObservedPoll | undefined {
+  const poll = findMessageSection(message ?? undefined, [
     "pollCreationMessage",
     "pollCreationMessageV2",
     "pollCreationMessageV3",
     "pollCreationMessageV5",
-  ]);
+  ])?.value;
   if (!poll) {
     return undefined;
   }
   const rawOptions = Array.isArray(poll.options) ? poll.options : [];
   const options = rawOptions
-    .map((option) => (isRecord(option) ? readString(option.optionName) : undefined))
+    .map((option) => (isRecord(option) ? normalizeOptionalString(option.optionName) : undefined))
     .filter((option): option is string => Boolean(option));
   return {
     options,
-    question: readString(poll.name),
+    question: normalizeOptionalString(poll.name),
   };
 }
 
-function readMedia(message: unknown):
+function readMedia(message: proto.IMessage | null | undefined):
   | {
       fileName?: string;
       mediaType?: string;
     }
   | undefined {
-  const normalizedMessage = isRecord(message)
-    ? normalizeMessageContent(message as proto.IMessage)
-    : undefined;
-  const mediaSections = [
+  const media = findMessageSection(message ?? undefined, [
     "imageMessage",
     "videoMessage",
     "ptvMessage",
     "audioMessage",
     "documentMessage",
     "stickerMessage",
-  ];
-  for (const sectionName of mediaSections) {
-    const section = findMessageSection(normalizedMessage ?? message, [sectionName]);
-    if (!section) {
-      continue;
-    }
-    const mediaMessage = { [sectionName]: section } as proto.IMessage;
-    return {
-      fileName: readString(section.fileName),
-      mediaType: resolveInboundMediaMimetype(mediaMessage),
-    };
-  }
-  return undefined;
+  ]);
+  return media
+    ? {
+        fileName: normalizeOptionalString(media.value.fileName),
+        mediaType: resolveInboundMediaMimetype({ [media.name]: media.value } as proto.IMessage),
+      }
+    : undefined;
 }
 
 function readQuotedMessage(message: WAMessage): WhatsAppQaDriverQuotedMessage | undefined {
   const contextInfo = extractContextInfo(message.message ?? undefined);
-  const replyContext = describeReplyContext(message.message as proto.IMessage | undefined);
+  const replyContext = describeReplyContext(message.message ?? undefined);
   if (!contextInfo && !replyContext) {
     return undefined;
   }
@@ -279,7 +234,7 @@ function normalizeObservedMessage(
     return null;
   }
   const extractedText = extractText(message.message ?? undefined);
-  const location = extractLocationData(message.message as proto.IMessage | undefined);
+  const location = extractLocationData(message.message ?? undefined);
   const locationText = location ? formatLocationText(location) : undefined;
   const text = [extractedText, locationText].filter(Boolean).join("\n").trim() || undefined;
   const reaction = readReaction(message.message);
@@ -321,18 +276,6 @@ function normalizeObservedMessage(
   };
 }
 
-function closeSocket(sock: Awaited<ReturnType<typeof createWaSocket>>) {
-  const maybeEnd = (sock as unknown as { end?: (error?: Error) => void }).end;
-  if (typeof maybeEnd === "function") {
-    maybeEnd.call(sock);
-    return;
-  }
-  const maybeClose = (sock.ws as unknown as { close?: () => void } | undefined)?.close;
-  if (typeof maybeClose === "function") {
-    maybeClose.call(sock.ws);
-  }
-}
-
 function createConnectionClosedError(update: ConnectionUpdateEvent) {
   const reason = update.lastDisconnect?.error;
   const status = getStatusCode(reason);
@@ -348,42 +291,34 @@ export async function startWhatsAppQaDriverSession(params: {
 }): Promise<WhatsAppQaDriverSession> {
   const sock = await createWaSocket(false, false, { authDir: params.authDir });
   const observedMessages: WhatsAppQaDriverObservedMessage[] = [];
-  const pendingNotificationsWaiters: PendingNotificationsWaiter[] = [];
-  const waiters: Waiter[] = [];
+  const waiters = new Set<Waiter>();
+  let pendingNotificationsWaiter: VoidWaiter | undefined;
   let closed = false;
   let closedError: Error | undefined;
   let receivedPendingNotifications = false;
 
   const removeWaiter = (waiter: Waiter) => {
-    const index = waiters.indexOf(waiter);
-    if (index >= 0) {
-      waiters.splice(index, 1);
-    }
+    waiters.delete(waiter);
     clearTimeout(waiter.timeout);
   };
 
-  const removePendingNotificationsWaiter = (waiter: PendingNotificationsWaiter) => {
-    const index = pendingNotificationsWaiters.indexOf(waiter);
-    if (index >= 0) {
-      pendingNotificationsWaiters.splice(index, 1);
-    }
-    clearTimeout(waiter.timeout);
-  };
-
-  const markPendingNotificationsReceived = () => {
-    if (receivedPendingNotifications) {
+  const settlePendingNotifications = (error?: Error) => {
+    const waiter = pendingNotificationsWaiter;
+    if (!waiter) {
       return;
     }
-    receivedPendingNotifications = true;
-    for (const waiter of pendingNotificationsWaiters.slice()) {
-      removePendingNotificationsWaiter(waiter);
+    pendingNotificationsWaiter = undefined;
+    clearTimeout(waiter.timeout);
+    if (error) {
+      waiter.reject(error);
+    } else {
       waiter.resolve();
     }
   };
 
   const observe = (message: WhatsAppQaDriverObservedMessage) => {
     observedMessages.push(message);
-    for (const waiter of waiters.slice()) {
+    for (const waiter of waiters) {
       if (!waiter.predicate(message)) {
         continue;
       }
@@ -403,7 +338,8 @@ export async function startWhatsAppQaDriverSession(params: {
 
   const onConnectionUpdate = (event: ConnectionUpdateEvent) => {
     if (event.receivedPendingNotifications === true) {
-      markPendingNotificationsReceived();
+      receivedPendingNotifications = true;
+      settlePendingNotifications();
     }
     if (event.connection === "close") {
       closeSessionResources(createConnectionClosedError(event));
@@ -411,14 +347,8 @@ export async function startWhatsAppQaDriverSession(params: {
   };
 
   const removeMessageListener = () => {
-    const evWithOff = sock.ev as unknown as {
-      off?: (
-        event: string,
-        listener: ((event: ConnectionUpdateEvent) => void) | ((event: MessageUpsertEvent) => void),
-      ) => void;
-    };
-    evWithOff.off?.("messages.upsert", onMessagesUpsert);
-    evWithOff.off?.("connection.update", onConnectionUpdate);
+    sock.ev.off("messages.upsert", onMessagesUpsert);
+    sock.ev.off("connection.update", onConnectionUpdate);
   };
 
   const closeSessionResources = (waiterError?: Error) => {
@@ -427,20 +357,15 @@ export async function startWhatsAppQaDriverSession(params: {
     }
     closed = true;
     closedError = waiterError;
-    for (const waiter of pendingNotificationsWaiters.slice()) {
-      removePendingNotificationsWaiter(waiter);
-      if (waiterError) {
-        waiter.reject(waiterError);
-      }
-    }
-    for (const waiter of waiters.slice()) {
+    settlePendingNotifications(waiterError);
+    for (const waiter of waiters) {
       removeWaiter(waiter);
       if (waiterError) {
         waiter.reject(waiterError);
       }
     }
     removeMessageListener();
-    closeSocket(sock);
+    void sock.end(undefined);
   };
 
   sock.ev.on("messages.upsert", onMessagesUpsert);
@@ -458,11 +383,11 @@ export async function startWhatsAppQaDriverSession(params: {
           return;
         }
         const timeoutMs = params.connectionTimeoutMs ?? 45_000;
-        const waiter: PendingNotificationsWaiter = {
+        const waiter: VoidWaiter = {
           resolve,
           reject,
           timeout: setTimeout(() => {
-            removePendingNotificationsWaiter(waiter);
+            pendingNotificationsWaiter = undefined;
             reject(
               new Error(
                 `timed out after ${timeoutMs}ms waiting for WhatsApp QA driver pending notifications`,
@@ -470,7 +395,7 @@ export async function startWhatsAppQaDriverSession(params: {
             );
           }, timeoutMs),
         };
-        pendingNotificationsWaiters.push(waiter);
+        pendingNotificationsWaiter = waiter;
       });
     }
   } catch (error) {
@@ -496,53 +421,28 @@ export async function startWhatsAppQaDriverSession(params: {
     getObservedMessages() {
       return [...observedMessages];
     },
-    async sendContact(to, contact) {
-      const result = await sendApi.sendContact(to, contact);
-      return {
-        messageId: result.messageId,
-      };
+    sendContact(to, contact) {
+      return toMessageIdResult(sendApi.sendContact(to, contact));
     },
-    async sendLocation(to, location) {
-      const result = await sendApi.sendLocation(to, location);
-      return {
-        messageId: result.messageId,
-      };
+    sendLocation(to, location) {
+      return toMessageIdResult(sendApi.sendLocation(to, location));
     },
-    async sendMedia(to, text, mediaBuffer, mediaType, options) {
-      const result = await sendApi.sendMessage(to, text, mediaBuffer, mediaType, options);
-      return {
-        messageId: result.messageId,
-      };
+    sendMedia(to, text, mediaBuffer, mediaType, options) {
+      return toMessageIdResult(sendApi.sendMessage(to, text, mediaBuffer, mediaType, options));
     },
-    async sendPoll(to, poll) {
-      const result = await sendApi.sendPoll(to, poll);
-      return {
-        messageId: result.messageId,
-      };
+    sendPoll(to, poll) {
+      return toMessageIdResult(sendApi.sendPoll(to, poll));
     },
-    async sendReaction(chatJid, messageId, emoji, options) {
-      const result = await sendApi.sendReaction(
-        chatJid,
-        messageId,
-        emoji,
-        options.fromMe,
-        options.participant,
+    sendReaction(chatJid, messageId, emoji, options) {
+      return toMessageIdResult(
+        sendApi.sendReaction(chatJid, messageId, emoji, options.fromMe, options.participant),
       );
-      return {
-        messageId: result.messageId,
-      };
     },
-    async sendSticker(to, stickerBuffer, options) {
-      const result = await sendApi.sendSticker(to, stickerBuffer, options);
-      return {
-        messageId: result.messageId,
-      };
+    sendSticker(to, stickerBuffer, options) {
+      return toMessageIdResult(sendApi.sendSticker(to, stickerBuffer, options));
     },
-    async sendText(to, text, options) {
-      const result = await sendApi.sendMessage(to, text, undefined, undefined, options);
-      return {
-        messageId: result.messageId,
-      };
+    sendText(to, text, options) {
+      return toMessageIdResult(sendApi.sendMessage(to, text, undefined, undefined, options));
     },
     async waitForMessage(paramsLocal) {
       const predicate = (message: WhatsAppQaDriverObservedMessage) =>
@@ -566,8 +466,15 @@ export async function startWhatsAppQaDriverSession(params: {
             reject(new Error("timed out waiting for WhatsApp QA driver message"));
           }, paramsLocal.timeoutMs),
         };
-        waiters.push(waiter);
+        waiters.add(waiter);
       });
     },
   };
+}
+
+async function toMessageIdResult(
+  pending: Promise<{ messageId?: string }>,
+): Promise<{ messageId?: string }> {
+  const { messageId } = await pending;
+  return { messageId };
 }


### PR DESCRIPTION
## What Problem This Solves

The WhatsApp QA transport independently reimplemented Baileys message-envelope traversal, scalar coercion, socket shutdown fallback, waiter bookkeeping, and outbound result wrapping. Its test fixtures repeated substantial setup, which made behavior coverage harder to audit and left two envelope owners that could drift.

## Why This Change Was Made

The WhatsApp inbound extractor now owns canonical message-section traversal through its existing normalized message chain, and the QA driver reuses shared coercion plus the pinned typed Baileys event and socket contracts. Repetitive tests are table-driven while preserving the shipped ingress, outbound, and lifecycle assertions.

Architectural owner: `extensions/whatsapp`. Canonical fix: one envelope traversal owner in `extensions/whatsapp/src/inbound/extract.ts`. Removed paths include the QA-local traversal and scalar readers, close fallback stack, array waiter mutation, and repeated outbound result adapters.

## User Impact

No user-visible behavior change. Maintainers get one canonical Baileys envelope path and a smaller regression suite with the same behavioral coverage.

Production delta: +115/-192, net -77 lines. Test delta: +455/-1,036, net -581 lines. Total: +570/-1,228, net -658 lines.

## Evidence

- Blacksmith Testbox `tbx_01kz0bh8k6agwp468m8mg0txaq`: `pnpm test extensions/whatsapp` passed 101 files and 1,294 tests, including 35 QA-driver and 20 inbound tests.
- Full remote `pnpm check:changed` passed production/test tsgo, formatting, lint, dead-export/Knip, plugin-boundary, SDK API, deprecated-usage, storage, and import-cycle gates.
- Full remote `pnpm build` passed, including plugin SDK declarations and Control UI build/performance checks.
- Run: https://github.com/openclaw/openclaw/actions/runs/30732360892
- Directly inspected pinned Baileys 7.0.0-rc13 source/types for content normalization, wrapper selection, poll V2/V3/V5 and V4 future-proof envelopes, PTV, reactions, typed emitter `.off`, and async socket `end(undefined)`.
- Two independent `gpt-5.6-sol` xhigh reviewers returned CLEAN: `/root/wave10_whatsapp_transport_owner_cleanup/whatsapp_wave10_review_a` and `/root/wave10_whatsapp_transport_owner_cleanup/whatsapp_wave10_review_b`.
- Fresh exhaustive audit of 2,188 open PRs, including paginated tails for every PR above 100 files, found no exact-path collision.
- Current `main` has no intervening changes on the four paths; committed head `53dfd77fdb72c2b752c7cf70c3c36454cf3017f9` merges synthetically without conflict.

Changelog: none; internal refactor and assertion-preserving test consolidation only.