### PR TITLE
refactor(gateway): centralize HTTP route staging

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -73,16 +73,18 @@ import {
 import { isTerminalConfigEnabled } from "./terminal/enabled.js";
 import { matchUserProfileAvatarPath } from "./user-profiles-http-path.js";
 
+type PluginGatewayDispatchContext = {
+  gatewayAuthSatisfied?: boolean;
+  gatewayRequestAuth?: AuthorizedGatewayHttpRequest;
+  gatewayRequestOperatorScopes?: readonly string[];
+  gatewayRequestClientIp?: string;
+};
+
 type PluginHttpRequestHandler = (
   req: IncomingMessage,
   res: ServerResponse,
   pathContext?: PluginRoutePathContext,
-  dispatchContext?: {
-    gatewayAuthSatisfied?: boolean;
-    gatewayRequestAuth?: AuthorizedGatewayHttpRequest;
-    gatewayRequestOperatorScopes?: readonly string[];
-    gatewayRequestClientIp?: string;
-  },
+  dispatchContext?: PluginGatewayDispatchContext,
 ) => Promise<boolean>;
 
 type WatchNodeHttpRequestHandler = (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
@@ -92,12 +94,7 @@ type PluginHttpUpgradeHandler = (
   socket: import("node:stream").Duplex,
   head: Buffer,
   pathContext?: PluginRoutePathContext,
-  dispatchContext?: {
-    gatewayAuthSatisfied?: boolean;
-    gatewayRequestAuth?: AuthorizedGatewayHttpRequest;
-    gatewayRequestOperatorScopes?: readonly string[];
-    gatewayRequestClientIp?: string;
-  },
+  dispatchContext?: PluginGatewayDispatchContext,
 ) => Promise<boolean>;
 
 type ResolvePluginNodeCapabilityRoute = (
@@ -105,54 +102,30 @@ type ResolvePluginNodeCapabilityRoute = (
 ) => PluginNodeCapabilitySurface | undefined;
 
 const getControlUiModule = createLazyRuntimeModule(() => import("./control-ui.js"));
-
 const getCanvasServeModule = createLazyRuntimeModule(() => import("../canvas/serve.runtime.js"));
-
 const getBoardHttpModule = createLazyRuntimeModule(() => import("./board-http.js"));
-
 const getEmbeddingsHttpModule = createLazyRuntimeModule(() => import("./embeddings-http.js"));
-
 const getManagedMediaAttachmentsModule = createLazyRuntimeModule(
   () => import("./managed-image-attachments.js"),
 );
-
 const getMcpAppStandaloneModule = createLazyRuntimeModule(() => import("./mcp-app-standalone.js"));
-
 const getPluginIconHttpModule = createLazyRuntimeModule(() => import("./plugin-icon-http.js"));
-
 const getModelsHttpModule = createLazyRuntimeModule(() => import("./models-http.js"));
-
 const getOpenAiHttpModule = createLazyRuntimeModule(() => import("./openai-http.js"));
-
 const getOpenResponsesHttpModule = createLazyRuntimeModule(() => import("./openresponses-http.js"));
-
 const getSessionHistoryHttpModule = createLazyRuntimeModule(
   () => import("./sessions-history-http.js"),
 );
-
 const getSessionKillHttpModule = createLazyRuntimeModule(() => import("./session-kill-http.js"));
-
 const getToolsInvokeHttpModule = createLazyRuntimeModule(() => import("./tools-invoke-http.js"));
-
 const getUserProfilesHttpModule = createLazyRuntimeModule(() => import("./user-profiles-http.js"));
-
 const getPluginNodeCapabilityAuthModule = createLazyRuntimeModule(
   () => import("./server/plugin-node-capability-auth.js"),
 );
-
 const getHttpAuthUtilsModule = createLazyRuntimeModule(() => import("./http-auth-utils.js"));
-
 const getPluginRouteRuntimeScopesModule = createLazyRuntimeModule(
   () => import("./server/plugin-route-runtime-scopes.js"),
 );
-
-function isControlUiCatalogIconRequest(pathname: string, basePath: string): boolean {
-  const normalizedBasePath =
-    basePath && basePath !== "/" ? (basePath.endsWith("/") ? basePath.slice(0, -1) : basePath) : "";
-  return [CONTROL_UI_PLUGIN_ICON_PATH_PREFIX, CONTROL_UI_CATALOG_ICON_PATH_PREFIX].some((prefix) =>
-    pathname.startsWith(`${normalizedBasePath}${prefix}/`),
-  );
-}
 
 const pluginGatewayAuthBypassPathsCache = new WeakMap<
   OpenClawConfig,
@@ -193,76 +166,12 @@ function getCachedPluginGatewayAuthBypassPaths(
   return resolved;
 }
 
-function isOpenAiModelsPath(pathname: string): boolean {
-  return pathname === "/v1/models" || pathname.startsWith("/v1/models/");
-}
-
-function isBoardWidgetPath(pathname: string): boolean {
-  return pathname.startsWith("/__openclaw__/board/");
-}
-
-function isEmbeddingsPath(pathname: string): boolean {
-  return pathname === "/v1/embeddings";
-}
-
-function isOpenAiChatCompletionsPath(pathname: string): boolean {
-  return pathname === "/v1/chat/completions";
-}
-
-function isOpenResponsesPath(pathname: string): boolean {
-  return pathname === "/v1/responses";
-}
-
-function isToolsInvokePath(pathname: string): boolean {
-  return pathname === "/tools/invoke";
-}
-
-function isManagedOutgoingImagePath(pathname: string): boolean {
-  return pathname.startsWith("/api/chat/media/outgoing/");
-}
-
-function isSessionKillPath(pathname: string): boolean {
-  return /^\/sessions\/[^/]+\/kill$/.test(pathname);
-}
-
-function isSessionHistoryPath(pathname: string): boolean {
-  return /^\/sessions\/[^/]+\/history$/.test(pathname);
-}
-
 function shouldEnforceDefaultPluginGatewayAuth(pathContext: PluginRoutePathContext): boolean {
   return (
     pathContext.malformedEncoding ||
     pathContext.decodePassLimitReached ||
     isProtectedPluginRoutePathFromContext(pathContext)
   );
-}
-
-async function canRevealReadinessDetails(params: {
-  req: IncomingMessage;
-  resolvedAuth: ResolvedGatewayAuth;
-  trustedProxies: string[];
-  allowRealIpFallback: boolean;
-}): Promise<boolean> {
-  // Readiness details expose subsystem names; show them only to local direct callers or
-  // requests that prove gateway auth, while unauthenticated remote probes get a boolean.
-  if (isLocalDirectRequest(params.req, params.trustedProxies, params.allowRealIpFallback)) {
-    return true;
-  }
-  if (params.resolvedAuth.mode === "none") {
-    return false;
-  }
-
-  const { getBearerToken, resolveHttpBrowserOriginPolicy } = await getHttpAuthUtilsModule();
-  const bearerToken = getBearerToken(params.req);
-  const authResult = await authorizeHttpGatewayConnect({
-    auth: params.resolvedAuth,
-    connectAuth: bearerToken ? { token: bearerToken, password: bearerToken } : null,
-    req: params.req,
-    trustedProxies: params.trustedProxies,
-    allowRealIpFallback: params.allowRealIpFallback,
-    browserOriginPolicy: resolveHttpBrowserOriginPolicy(params.req),
-  });
-  return authResult.ok;
 }
 
 /** Handles live/ready probe endpoints before normal gateway routing. */
@@ -295,12 +204,23 @@ async function handleGatewayProbeRequest(
   let statusCode: number;
   let body: string;
   if (status === "ready" && getReadiness) {
-    const includeDetails = await canRevealReadinessDetails({
-      req,
-      resolvedAuth,
-      trustedProxies,
-      allowRealIpFallback,
-    });
+    // Readiness details expose subsystem names, so only local direct or authenticated
+    // callers receive them; unauthenticated remote probes get the aggregate boolean.
+    let includeDetails = isLocalDirectRequest(req, trustedProxies, allowRealIpFallback);
+    if (!includeDetails && resolvedAuth.mode !== "none") {
+      const { getBearerToken, resolveHttpBrowserOriginPolicy } = await getHttpAuthUtilsModule();
+      const bearerToken = getBearerToken(req);
+      includeDetails = (
+        await authorizeHttpGatewayConnect({
+          auth: resolvedAuth,
+          connectAuth: bearerToken ? { token: bearerToken, password: bearerToken } : null,
+          req,
+          trustedProxies,
+          allowRealIpFallback,
+          browserOriginPolicy: resolveHttpBrowserOriginPolicy(req),
+        })
+      ).ok;
+    }
     try {
       const result = getReadiness();
       statusCode = result.ready ? 200 : 503;
@@ -349,35 +269,17 @@ function writeUpgradeAuthFailure(
   socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
 }
 
-function parseGatewayRequestPath(rawUrl: string | undefined): string | undefined {
-  try {
-    return new URL(rawUrl ?? "/", "http://localhost").pathname;
-  } catch {
-    return undefined;
-  }
-}
-
-function headerValueContainsToken(
-  value: string | readonly string[] | undefined,
-  token: string,
-): boolean {
-  if (value === undefined) {
-    return false;
-  }
-  const expected = token.toLowerCase();
-  const values: readonly string[] = typeof value === "string" ? [value] : value;
-  return values.some((entry) =>
-    entry
-      .toLowerCase()
-      .split(",")
-      .some((part) => part.trim() === expected),
-  );
-}
-
 function isWebSocketUpgradeRequest(req: IncomingMessage): boolean {
+  const headerContains = (value: string | readonly string[] | undefined, token: string) =>
+    (typeof value === "string" ? [value] : (value ?? [])).some((entry) =>
+      entry
+        .toLowerCase()
+        .split(",")
+        .some((part) => part.trim() === token),
+    );
   return (
-    headerValueContainsToken(req.headers.upgrade, "websocket") &&
-    headerValueContainsToken(req.headers.connection, "upgrade")
+    headerContains(req.headers.upgrade, "websocket") &&
+    headerContains(req.headers.connection, "upgrade")
   );
 }
 
@@ -408,92 +310,6 @@ async function runGatewayHttpRequestStages(
   return false;
 }
 
-function buildPluginRequestStages(params: {
-  req: IncomingMessage;
-  res: ServerResponse;
-  requestPath: string;
-  getGatewayAuthBypassPaths: () => Promise<ReadonlySet<string>>;
-  pluginPathContext: PluginRoutePathContext | null;
-  handlePluginRequest?: PluginHttpRequestHandler;
-  shouldEnforcePluginGatewayAuth?: (pathContext: PluginRoutePathContext) => boolean;
-  resolvedAuth: ResolvedGatewayAuth;
-  trustedProxies: string[];
-  allowRealIpFallback: boolean;
-  rateLimiter?: AuthRateLimiter;
-}): GatewayHttpRequestStage[] {
-  if (!params.handlePluginRequest) {
-    return [];
-  }
-  const requestClientIp = resolveRequestClientIp(
-    params.req,
-    params.trustedProxies,
-    params.allowRealIpFallback,
-  );
-  let pluginGatewayAuthSatisfied = false;
-  let pluginGatewayRequestAuth: AuthorizedGatewayHttpRequest | undefined;
-  let pluginRequestOperatorScopes: string[] | undefined;
-  // Plugin auth and plugin dispatch are separate stages so route handlers receive the
-  // gateway-auth context while plugin failures can still fall through to core/Control UI routes.
-  return [
-    {
-      name: "plugin-auth",
-      run: async () => {
-        const pathContext =
-          params.pluginPathContext ?? resolvePluginRoutePathContext(params.requestPath);
-        if (
-          !(params.shouldEnforcePluginGatewayAuth ?? shouldEnforceDefaultPluginGatewayAuth)(
-            pathContext,
-          )
-        ) {
-          return false;
-        }
-        if ((await params.getGatewayAuthBypassPaths()).has(params.requestPath)) {
-          return false;
-        }
-        // Bypass paths come only from activated channel plugins' gateway-auth
-        // artifacts (bundled or installed); all other protected plugin routes must
-        // produce an AuthorizedGatewayHttpRequest before runtime scopes are derived.
-        const { authorizePluginGatewayHttpRequestOrReply } = await getHttpAuthUtilsModule();
-        const { resolvePluginRouteRuntimeOperatorScopes } =
-          await getPluginRouteRuntimeScopesModule();
-        const authResult = await authorizePluginGatewayHttpRequestOrReply({
-          req: params.req,
-          res: params.res,
-          auth: params.resolvedAuth,
-          trustedProxies: params.trustedProxies,
-          allowRealIpFallback: params.allowRealIpFallback,
-          rateLimiter: params.rateLimiter,
-          requestPath: params.requestPath,
-          resolveOperatorScopes: resolvePluginRouteRuntimeOperatorScopes,
-        });
-        if (!authResult) {
-          return true;
-        }
-        pluginGatewayAuthSatisfied = true;
-        pluginGatewayRequestAuth = authResult.requestAuth;
-        pluginRequestOperatorScopes = authResult.operatorScopes;
-        return false;
-      },
-    },
-    {
-      name: "plugin-http",
-      continueOnError: true,
-      run: () => {
-        const pathContext =
-          params.pluginPathContext ?? resolvePluginRoutePathContext(params.requestPath);
-        return (
-          params.handlePluginRequest?.(params.req, params.res, pathContext, {
-            gatewayAuthSatisfied: pluginGatewayAuthSatisfied,
-            gatewayRequestAuth: pluginGatewayRequestAuth,
-            gatewayRequestOperatorScopes: pluginRequestOperatorScopes,
-            gatewayRequestClientIp: requestClientIp,
-          }) ?? false
-        );
-      },
-    },
-  ];
-}
-
 /** Creates the gateway HTTP/HTTPS server and ordered request-stage router. */
 export function createGatewayHttpServer(opts: {
   clients: Set<GatewayWsClient>;
@@ -508,7 +324,6 @@ export function createGatewayHttpServer(opts: {
   handleHooksRequest: HooksRequestHandler;
   handleWatchNodeRequest?: WatchNodeHttpRequestHandler;
   handlePluginRequest?: PluginHttpRequestHandler;
-  handlePluginUpgrade?: PluginHttpUpgradeHandler;
   shouldEnforcePluginGatewayAuth?: (pathContext: PluginRoutePathContext) => boolean;
   resolvePluginNodeCapabilityRoute?: ResolvePluginNodeCapabilityRoute;
   resolvedAuth: ResolvedGatewayAuth;
@@ -541,8 +356,12 @@ export function createGatewayHttpServer(opts: {
   const getResolvedAuth = opts.getResolvedAuth ?? (() => resolvedAuth);
   const loadGatewayConfig = opts.getRuntimeConfig ?? getRuntimeConfig;
   const openAiCompatEnabled = openAiChatCompletionsEnabled || openResponsesEnabled;
+  const controlUiRouteBasePath =
+    controlUiBasePath && controlUiBasePath !== "/" ? controlUiBasePath.replace(/\/$/, "") : "";
   const handleServerRequest = (req: IncomingMessage, res: ServerResponse) => {
-    void handleRequestWithTrace(req, res).catch((error: unknown) => {
+    void runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () =>
+      handleRequest(req, res),
+    ).catch((error: unknown) => {
       console.error("[gateway-http] failed to finalize request:", error);
       if (!res.destroyed) {
         res.destroy(error instanceof Error ? error : undefined);
@@ -552,12 +371,6 @@ export function createGatewayHttpServer(opts: {
   const httpServer: HttpServer = opts.tlsOptions
     ? createHttpsServer(opts.tlsOptions, handleServerRequest)
     : createHttpServer(handleServerRequest);
-
-  function handleRequestWithTrace(req: IncomingMessage, res: ServerResponse) {
-    return runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () =>
-      handleRequest(req, res),
-    );
-  }
 
   async function handleRequest(req: IncomingMessage, res: ServerResponse) {
     setDefaultSecurityHeaders(res, {
@@ -577,7 +390,7 @@ export function createGatewayHttpServer(opts: {
     }
 
     try {
-      const requestPath = parseGatewayRequestPath(req.url);
+      const requestPath = URL.parse(req.url ?? "/", "http://localhost")?.pathname;
       if (requestPath === undefined) {
         sendGatewayAuthFailure(res, { ok: false, reason: "unauthorized" });
         return;
@@ -612,17 +425,23 @@ export function createGatewayHttpServer(opts: {
       const pluginPathContext = resolvePluginRoutePathContext(scopedRequestPath);
       const nodeCapability = resolvePluginNodeCapabilityRoute?.(pluginPathContext);
       const resolvedAuthValue = getResolvedAuth();
+      const routeAuth = {
+        auth: resolvedAuthValue,
+        trustedProxies,
+        allowRealIpFallback,
+        rateLimiter,
+      };
+      const controlUiRouteOptions = {
+        basePath: controlUiBasePath,
+        config: configSnapshot,
+        ...routeAuth,
+      };
       const handleControlUiRequest = async () =>
         (await getControlUiModule()).handleControlUiHttpRequest(req, res, {
-          basePath: controlUiBasePath,
-          config: configSnapshot,
+          ...controlUiRouteOptions,
           terminalEnabled: opts.isTerminalEnabled?.() ?? isTerminalConfigEnabled(configSnapshot),
           agentId: resolveAssistantIdentity({ cfg: configSnapshot }).agentId,
           root: controlUiRoot,
-          auth: resolvedAuthValue,
-          trustedProxies,
-          allowRealIpFallback,
-          rateLimiter,
         });
       const requestStages: GatewayHttpRequestStage[] = [
         {
@@ -643,237 +462,156 @@ export function createGatewayHttpServer(opts: {
           run: () => handleHooksRequest(req, res),
         },
       ];
-      if (opts.handleWatchNodeRequest && scopedRequestPath.startsWith("/api/nodes/watch/")) {
-        requestStages.push({
-          name: "watch-node",
-          run: () =>
-            runWithGatewayHttpWorkAdmission(
-              res,
-              () => opts.handleWatchNodeRequest?.(req, res) ?? false,
-            ),
-        });
-      }
-      if (openAiCompatEnabled && isOpenAiModelsPath(scopedRequestPath)) {
-        requestStages.push({
-          name: "models",
-          run: async () =>
-            await runWithGatewayHttpWorkAdmission(res, async () =>
-              (await getModelsHttpModule()).handleOpenAiModelsHttpRequest(req, res, {
-                auth: resolvedAuthValue,
-                trustedProxies,
-                allowRealIpFallback,
-                rateLimiter,
-              }),
-            ),
-        });
-      }
-      if (openAiCompatEnabled && isEmbeddingsPath(scopedRequestPath)) {
-        requestStages.push({
-          name: "embeddings",
-          run: async () =>
-            await runWithGatewayHttpWorkAdmission(res, async () =>
-              (await getEmbeddingsHttpModule()).handleOpenAiEmbeddingsHttpRequest(req, res, {
-                auth: resolvedAuthValue,
-                trustedProxies,
-                allowRealIpFallback,
-                rateLimiter,
-              }),
-            ),
-        });
-      }
-      if (isToolsInvokePath(scopedRequestPath)) {
-        requestStages.push({
-          name: "tools-invoke",
-          run: async () =>
-            await runWithGatewayHttpWorkAdmission(res, async () =>
-              (await getToolsInvokeHttpModule()).handleToolsInvokeHttpRequest(req, res, {
-                auth: resolvedAuthValue,
-                trustedProxies,
-                allowRealIpFallback,
-                rateLimiter,
-              }),
-            ),
-        });
-      }
-      if (isSessionKillPath(scopedRequestPath)) {
-        requestStages.push({
-          name: "sessions-kill",
-          run: async () =>
-            await runWithGatewayHttpWorkAdmission(res, async () =>
-              (await getSessionKillHttpModule()).handleSessionKillHttpRequest(req, res, {
-                auth: resolvedAuthValue,
-                trustedProxies,
-                allowRealIpFallback,
-                rateLimiter,
-              }),
-            ),
-        });
-      }
-      if (isSessionHistoryPath(scopedRequestPath)) {
-        requestStages.push({
-          name: "sessions-history",
-          run: async () =>
-            await runWithGatewayHttpWorkAdmission(res, async () =>
-              (await getSessionHistoryHttpModule()).handleSessionHistoryHttpRequest(req, res, {
-                auth: resolvedAuthValue,
-                getResolvedAuth,
-                trustedProxies,
-                allowRealIpFallback,
-                rateLimiter,
-              }),
-            ),
-        });
-      }
-      if (isBoardWidgetPath(scopedRequestPath)) {
-        requestStages.push({
-          name: "board-widget",
-          run: async () =>
-            await runWithGatewayHttpWorkAdmission(res, async () =>
-              (await getBoardHttpModule()).handleBoardHttpRequest(req, res),
-            ),
-        });
-      }
-      if (matchUserProfileAvatarPath(scopedRequestPath) !== undefined) {
-        requestStages.push({
-          name: "user-profile-avatar",
-          run: async () =>
-            await runWithGatewayHttpWorkAdmission(res, async () =>
-              (await getUserProfilesHttpModule()).handleUserProfileAvatarHttpRequest(
-                req,
-                res,
-                scopedRequestPath,
-                {
-                  auth: resolvedAuthValue,
-                  trustedProxies,
-                  allowRealIpFallback,
-                  rateLimiter,
-                },
-              ),
-            ),
-        });
-      }
-      if (openResponsesEnabled && isOpenResponsesPath(scopedRequestPath)) {
-        requestStages.push({
-          name: "openresponses",
-          run: async () =>
-            await runWithGatewayHttpWorkAdmission(res, async () =>
-              (await getOpenResponsesHttpModule()).handleOpenResponsesHttpRequest(req, res, {
-                auth: resolvedAuthValue,
-                config: openResponsesConfig,
-                trustedProxies,
-                allowRealIpFallback,
-                rateLimiter,
-              }),
-            ),
-        });
-      }
-      if (openAiChatCompletionsEnabled && isOpenAiChatCompletionsPath(scopedRequestPath)) {
-        requestStages.push({
-          name: "openai",
-          run: async () =>
-            await runWithGatewayHttpWorkAdmission(res, async () =>
-              (await getOpenAiHttpModule()).handleOpenAiHttpRequest(req, res, {
-                auth: resolvedAuthValue,
-                config: openAiChatCompletionsConfig,
-                trustedProxies,
-                allowRealIpFallback,
-                rateLimiter,
-              }),
-            ),
-        });
-      }
-      if (
+      const addRequestStage = (
+        name: string,
+        enabled: boolean,
+        run: GatewayHttpRequestStage["run"],
+        admitted = false,
+      ) => {
+        if (enabled) {
+          requestStages.push({
+            name,
+            run: admitted ? () => runWithGatewayHttpWorkAdmission(res, run) : run,
+          });
+        }
+      };
+      const addAdmittedStage = (
+        name: string,
+        enabled: boolean,
+        run: GatewayHttpRequestStage["run"],
+      ) => addRequestStage(name, enabled, run, true);
+
+      addAdmittedStage(
+        "watch-node",
+        Boolean(opts.handleWatchNodeRequest) && scopedRequestPath.startsWith("/api/nodes/watch/"),
+        () => opts.handleWatchNodeRequest?.(req, res) ?? false,
+      );
+      addAdmittedStage(
+        "models",
+        openAiCompatEnabled &&
+          (scopedRequestPath === "/v1/models" || scopedRequestPath.startsWith("/v1/models/")),
+        async () =>
+          (await getModelsHttpModule()).handleOpenAiModelsHttpRequest(req, res, routeAuth),
+      );
+      addAdmittedStage(
+        "embeddings",
+        openAiCompatEnabled && scopedRequestPath === "/v1/embeddings",
+        async () =>
+          (await getEmbeddingsHttpModule()).handleOpenAiEmbeddingsHttpRequest(req, res, routeAuth),
+      );
+      addAdmittedStage("tools-invoke", scopedRequestPath === "/tools/invoke", async () =>
+        (await getToolsInvokeHttpModule()).handleToolsInvokeHttpRequest(req, res, routeAuth),
+      );
+      addAdmittedStage(
+        "sessions-kill",
+        /^\/sessions\/[^/]+\/kill$/.test(scopedRequestPath),
+        async () =>
+          (await getSessionKillHttpModule()).handleSessionKillHttpRequest(req, res, routeAuth),
+      );
+      addAdmittedStage(
+        "sessions-history",
+        /^\/sessions\/[^/]+\/history$/.test(scopedRequestPath),
+        async () =>
+          (await getSessionHistoryHttpModule()).handleSessionHistoryHttpRequest(req, res, {
+            ...routeAuth,
+            getResolvedAuth,
+          }),
+      );
+      addAdmittedStage(
+        "board-widget",
+        scopedRequestPath.startsWith("/__openclaw__/board/"),
+        async () => (await getBoardHttpModule()).handleBoardHttpRequest(req, res),
+      );
+      addAdmittedStage(
+        "user-profile-avatar",
+        matchUserProfileAvatarPath(scopedRequestPath) !== undefined,
+        async () =>
+          (await getUserProfilesHttpModule()).handleUserProfileAvatarHttpRequest(
+            req,
+            res,
+            scopedRequestPath,
+            routeAuth,
+          ),
+      );
+      addAdmittedStage(
+        "openresponses",
+        openResponsesEnabled && scopedRequestPath === "/v1/responses",
+        async () =>
+          (await getOpenResponsesHttpModule()).handleOpenResponsesHttpRequest(req, res, {
+            ...routeAuth,
+            config: openResponsesConfig,
+          }),
+      );
+      addAdmittedStage(
+        "openai",
+        openAiChatCompletionsEnabled && scopedRequestPath === "/v1/chat/completions",
+        async () =>
+          (await getOpenAiHttpModule()).handleOpenAiHttpRequest(req, res, {
+            ...routeAuth,
+            config: openAiChatCompletionsConfig,
+          }),
+      );
+      addRequestStage(
+        "control-ui-approval-document",
         isControlUiApprovalDocumentPath({
           basePath: controlUiBasePath,
           pathname: scopedRequestPath,
-        })
-      ) {
-        requestStages.push({
-          name: "control-ui-approval-document",
-          run: async () => {
-            if (!controlUiEnabled) {
-              res.statusCode = 404;
-              res.setHeader("Content-Type", "text/plain; charset=utf-8");
-              res.end("Not Found");
-              return true;
-            }
-            const handled = await handleControlUiRequest();
-            if (handled) {
-              return true;
-            }
+        }),
+        async () => {
+          if (!controlUiEnabled) {
             res.statusCode = 404;
             res.setHeader("Content-Type", "text/plain; charset=utf-8");
             res.end("Not Found");
             return true;
-          },
+          }
+          const handled = await handleControlUiRequest();
+          if (handled) {
+            return true;
+          }
+          res.statusCode = 404;
+          res.setHeader("Content-Type", "text/plain; charset=utf-8");
+          res.end("Not Found");
+          return true;
+        },
+      );
+      addRequestStage("node-capability-auth", Boolean(nodeCapability), async () => {
+        const { authorizePluginNodeCapabilityRequest } = await getPluginNodeCapabilityAuthModule();
+        const ok = await authorizePluginNodeCapabilityRequest({
+          req,
+          auth: resolvedAuthValue,
+          trustedProxies,
+          allowRealIpFallback,
+          clients,
+          nodeCapability: nodeCapability!,
+          capability: scopedNodeCapability.capability,
+          malformedScopedPath: scopedNodeCapability.malformedScopedPath,
+          rateLimiter,
         });
-      }
-      if (nodeCapability) {
-        requestStages.push({
-          name: "node-capability-auth",
-          run: async () => {
-            if (!nodeCapability) {
-              return false;
-            }
-            const { authorizePluginNodeCapabilityRequest } =
-              await getPluginNodeCapabilityAuthModule();
-            const ok = await authorizePluginNodeCapabilityRequest({
-              req,
-              auth: resolvedAuthValue,
-              trustedProxies,
-              allowRealIpFallback,
-              clients,
-              nodeCapability,
-              capability: scopedNodeCapability.capability,
-              malformedScopedPath: scopedNodeCapability.malformedScopedPath,
-              rateLimiter,
-            });
-            if (!ok.ok) {
-              sendGatewayAuthFailure(res, ok);
-              return true;
-            }
-            return false;
-          },
-        });
-      }
-      if (
-        nodeCapability &&
-        isCoreCanvasHostEnabled(configSnapshot) &&
-        isCanvasDocumentHttpPath(scopedRequestPath)
-      ) {
-        requestStages.push({
-          name: "canvas-documents",
-          run: async () =>
-            await (await getCanvasServeModule()).handleCanvasDocumentHttpRequest(req, res),
-        });
-      }
-      if (
+        if (!ok.ok) {
+          sendGatewayAuthFailure(res, ok);
+          return true;
+        }
+        return false;
+      });
+      addRequestStage(
+        "canvas-documents",
+        Boolean(nodeCapability) &&
+          isCoreCanvasHostEnabled(configSnapshot) &&
+          isCanvasDocumentHttpPath(scopedRequestPath),
+        async () => (await getCanvasServeModule()).handleCanvasDocumentHttpRequest(req, res),
+      );
+      // This page must remain reachable when a plugin route is broken so the
+      // operator can disable it. Other explicit plugin routes retain precedence.
+      addRequestStage(
+        "control-ui-plugin-manager",
         controlUiEnabled &&
-        isControlUiPluginManagerRequest({
-          basePath: controlUiBasePath,
-          pathname: scopedRequestPath,
-          method: req.method,
-        })
-      ) {
-        // This page must remain reachable when a plugin route is broken so the
-        // operator can disable it. Other explicit plugin routes retain precedence.
-        requestStages.push({
-          name: "control-ui-plugin-manager",
-          run: async () =>
-            (await getControlUiModule()).handleControlUiHttpRequest(req, res, {
-              basePath: controlUiBasePath,
-              config: configSnapshot,
-              terminalEnabled:
-                opts.isTerminalEnabled?.() ?? isTerminalConfigEnabled(configSnapshot),
-              agentId: resolveAssistantIdentity({ cfg: configSnapshot }).agentId,
-              root: controlUiRoot,
-              auth: resolvedAuthValue,
-              trustedProxies,
-              allowRealIpFallback,
-              rateLimiter,
-            }),
-        });
-      }
+          isControlUiPluginManagerRequest({
+            basePath: controlUiBasePath,
+            pathname: scopedRequestPath,
+            method: req.method,
+          }),
+        handleControlUiRequest,
+      );
       const mcpAppRoute = classifyMcpAppStandalonePath(scopedRequestPath);
       if (
         configSnapshot.mcp?.apps?.enabled === true &&
@@ -894,86 +632,93 @@ export function createGatewayHttpServer(opts: {
       // Plugin routes run before the general Control UI SPA catch-all so
       // explicitly registered endpoints stay reachable. Core routes and the
       // plugin recovery surface staged above keep precedence.
-      requestStages.push(
-        ...buildPluginRequestStages({
-          req,
-          res,
-          requestPath: scopedRequestPath,
-          getGatewayAuthBypassPaths: () => getCachedPluginGatewayAuthBypassPaths(configSnapshot),
-          pluginPathContext,
-          handlePluginRequest,
-          shouldEnforcePluginGatewayAuth,
-          resolvedAuth: resolvedAuthValue,
-          trustedProxies,
-          allowRealIpFallback,
-          rateLimiter,
+      if (handlePluginRequest) {
+        const requestClientIp = resolveRequestClientIp(req, trustedProxies, allowRealIpFallback);
+        let pluginGatewayAuthSatisfied = false;
+        let pluginGatewayRequestAuth: AuthorizedGatewayHttpRequest | undefined;
+        let pluginRequestOperatorScopes: string[] | undefined;
+        // Auth and dispatch stay separate so authorized context reaches the handler while
+        // plugin failures can still fall through to core and Control UI routes.
+        requestStages.push(
+          {
+            name: "plugin-auth",
+            run: async () => {
+              if (
+                !(shouldEnforcePluginGatewayAuth ?? shouldEnforceDefaultPluginGatewayAuth)(
+                  pluginPathContext,
+                ) ||
+                (await getCachedPluginGatewayAuthBypassPaths(configSnapshot)).has(scopedRequestPath)
+              ) {
+                return false;
+              }
+              // Bypass paths come only from activated channel plugins; every other protected
+              // route must authorize before runtime scopes are derived.
+              const { authorizePluginGatewayHttpRequestOrReply } = await getHttpAuthUtilsModule();
+              const { resolvePluginRouteRuntimeOperatorScopes } =
+                await getPluginRouteRuntimeScopesModule();
+              const authResult = await authorizePluginGatewayHttpRequestOrReply({
+                req,
+                res,
+                ...routeAuth,
+                requestPath: scopedRequestPath,
+                resolveOperatorScopes: resolvePluginRouteRuntimeOperatorScopes,
+              });
+              if (!authResult) {
+                return true;
+              }
+              pluginGatewayAuthSatisfied = true;
+              pluginGatewayRequestAuth = authResult.requestAuth;
+              pluginRequestOperatorScopes = authResult.operatorScopes;
+              return false;
+            },
+          },
+          {
+            name: "plugin-http",
+            continueOnError: true,
+            run: () =>
+              handlePluginRequest(req, res, pluginPathContext, {
+                gatewayAuthSatisfied: pluginGatewayAuthSatisfied,
+                gatewayRequestAuth: pluginGatewayRequestAuth,
+                gatewayRequestOperatorScopes: pluginRequestOperatorScopes,
+                gatewayRequestClientIp: requestClientIp,
+              }),
+          },
+        );
+      }
+
+      addRequestStage(
+        "chat-managed-media",
+        scopedRequestPath.startsWith("/api/chat/media/outgoing/"),
+        async () =>
+          (await getManagedMediaAttachmentsModule()).handleManagedOutgoingMediaHttpRequest(
+            req,
+            res,
+            routeAuth,
+          ),
+      );
+      addRequestStage(
+        "control-ui-catalog-icon",
+        controlUiEnabled &&
+          [CONTROL_UI_PLUGIN_ICON_PATH_PREFIX, CONTROL_UI_CATALOG_ICON_PATH_PREFIX].some((prefix) =>
+            scopedRequestPath.startsWith(`${controlUiRouteBasePath}${prefix}/`),
+          ),
+        async () =>
+          (await getPluginIconHttpModule()).handlePluginIconHttpRequest(
+            req,
+            res,
+            controlUiRouteOptions,
+          ),
+      );
+      addRequestStage("control-ui-assistant-media", controlUiEnabled, async () =>
+        (await getControlUiModule()).handleControlUiAssistantMediaRequest(req, res, {
+          ...controlUiRouteOptions,
+          agentId: resolveAssistantIdentity({ cfg: configSnapshot }).agentId,
         }),
       );
-
-      if (isManagedOutgoingImagePath(scopedRequestPath)) {
-        requestStages.push({
-          name: "chat-managed-media",
-          run: async () =>
-            (await getManagedMediaAttachmentsModule()).handleManagedOutgoingMediaHttpRequest(
-              req,
-              res,
-              {
-                auth: resolvedAuthValue,
-                trustedProxies,
-                allowRealIpFallback,
-                rateLimiter,
-              },
-            ),
-        });
-      }
-
-      if (controlUiEnabled && isControlUiCatalogIconRequest(scopedRequestPath, controlUiBasePath)) {
-        requestStages.push({
-          name: "control-ui-catalog-icon",
-          run: async () =>
-            (await getPluginIconHttpModule()).handlePluginIconHttpRequest(req, res, {
-              basePath: controlUiBasePath,
-              config: configSnapshot,
-              auth: resolvedAuthValue,
-              trustedProxies,
-              allowRealIpFallback,
-              rateLimiter,
-            }),
-        });
-      }
-      if (controlUiEnabled) {
-        requestStages.push({
-          name: "control-ui-assistant-media",
-          run: async () =>
-            (await getControlUiModule()).handleControlUiAssistantMediaRequest(req, res, {
-              basePath: controlUiBasePath,
-              config: configSnapshot,
-              agentId: resolveAssistantIdentity({ cfg: configSnapshot }).agentId,
-              auth: resolvedAuthValue,
-              trustedProxies,
-              allowRealIpFallback,
-              rateLimiter,
-            }),
-        });
-        requestStages.push({
-          name: "control-ui-avatar",
-          run: async () => {
-            const { handleControlUiAvatarRequest } = await getControlUiModule();
-            return handleControlUiAvatarRequest(req, res, {
-              basePath: controlUiBasePath,
-              config: configSnapshot,
-              auth: resolvedAuthValue,
-              trustedProxies,
-              allowRealIpFallback,
-              rateLimiter,
-            });
-          },
-        });
-        requestStages.push({
-          name: "control-ui-http",
-          run: handleControlUiRequest,
-        });
-      }
+      addRequestStage("control-ui-avatar", controlUiEnabled, async () =>
+        (await getControlUiModule()).handleControlUiAvatarRequest(req, res, controlUiRouteOptions),
+      );
+      addRequestStage("control-ui-http", controlUiEnabled, handleControlUiRequest);
 
       if (await runGatewayHttpRequestStages(requestStages)) {
         return;


### PR DESCRIPTION
## What Problem This Solves

The gateway HTTP router expressed one canonical ordered routing policy through repeated conditional stage pushes, route-auth option objects, one-use predicates, and a one-use plugin stage builder. That duplication made security-sensitive route ordering, admission, and auth ownership harder to audit.

## Why This Change Was Made

Centralizes stage registration and per-request route options inside the gateway HTTP owner, while inlining one-use route and plugin scaffolding. The canonical order remains:

1. probes and hooks;
2. admitted watch/models/embeddings/tools/session/board/avatar/OpenAI-compatible routes;
3. Control UI approval recovery, node-capability auth, canvas, and plugin-manager recovery;
4. admitted MCP app handling;
5. plugin auth and plugin HTTP dispatch;
6. managed media, catalog icons, assistant media, avatar, and the Control UI catch-all.

The change preserves every route predicate, lazy import, work-admission label, auth decision, plugin bypass/scope/client-IP context, fallthrough rule, and final 404 behavior. The MCP app route block is byte-identical before and after (SHA-256 `8d74e32e59ced1c7863265979819f504d9531f141f4506b1c6cfd72beaa661df`). There are no config, protocol, schema, persistence, compatibility, docs, or public behavior changes.

## User Impact

No user-visible behavior changes. The gateway routing owner is smaller and easier to audit: one production file changes by +279/-534, net -255 handwritten production lines. Tests are unchanged.

## Evidence

- Exact reviewed head: `de266e648988389cdb522823b6b361a726b75ba7`.
- Focused Blacksmith proof: 10 gateway HTTP/auth/admission/upgrade files, 103/103 tests passed.
- Full `src/gateway` suite: 647 files, 10,478/10,478 tests passed with two workers. The first four-worker attempt completed reported tests but ended with a Vitest worker-exit infrastructure failure; the bounded retry passed.
- Full `src/security` suite: 35 files, 237/237 tests passed.
- Remote `pnpm check:changed`: passed, including core/core-test tsgo, oxfmt, oxlint, Knip, import-cycle, schema, persistence, webhook, pairing, and boundary guards.
- Remote full `pnpm build`: passed on a fresh Testbox lease. The preceding lease terminated after visibly completing compilation, SDK, and Control UI gates, so it was not counted as proof.
- `git diff --check`: clean.
- Live open-PR collision audit: zero PRs touch `src/gateway/server-http.ts`.
- Two independent xhigh final reviews reconstructed the full before/after route-stage matrix and returned CLEAN at the exact head.

Architectural owner: `src/gateway/server-http.ts`. Removed paths: duplicate one-use route predicates, readiness and trace wrappers, repeated auth/UI option construction, and the duplicate plugin-stage builder. Sibling coverage includes gateway probes, hooks, MCP admission, plugin HTTP/frame/node-capability auth, request tracing, upgrades, and security tests.
