### PR TITLE
fix(media): preserve attachment intent across image and history paths

### DIFF
--- a/src/agents/embedded-agent-runner/run/images.media-refs.test.ts
+++ b/src/agents/embedded-agent-runner/run/images.media-refs.test.ts
@@ -5,12 +5,16 @@ import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { normalizeMediaFacts, resolveMediaFacts } from "../../../media/media-facts.js";
 import { captureEnv, setTestEnvValue } from "../../../test-utils/env.js";
+import type { AgentMessage } from "../../runtime/index.js";
 import { createHostSandboxFsBridge } from "../../test-helpers/host-sandbox-fs-bridge.js";
-import { detectAndLoadPromptImages, hasHydratableMediaImages } from "./images.js";
+import {
+  detectAndLoadPromptImages,
+  hasHydratableMediaImages,
+  hydratePromptMediaMessages,
+} from "./images.js";
 
 const TINY_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADUlEQVR4nGP4////KwAJ5gPoxLp9owAAAABJRU5ErkJggg==";
-
 describe("fact-carried image references", () => {
   it("counts only facts that will hydrate an image attachment", () => {
     expect(hasHydratableMediaImages([{ path: "/tmp/photo.png", kind: "image" }])).toBe(true);
@@ -30,6 +34,98 @@ describe("fact-carried image references", () => {
     expect(hasHydratableMediaImages(undefined)).toBe(false);
     for (const contentType of ["audio", "video", "document"]) {
       expect(hasHydratableMediaImages([{ path: "/tmp/photo.png", contentType }])).toBe(false);
+    }
+  });
+
+  it("shares canonical SVG, TIFF, and document classification with embedded image refs", () => {
+    expect(hasHydratableMediaImages([{ path: "/tmp/diagram.svg" }])).toBe(false);
+    expect(hasHydratableMediaImages([{ path: "/tmp/diagram.svg", kind: "unknown" }])).toBe(false);
+    expect(hasHydratableMediaImages([{ path: "/tmp/diagram.svg", kind: "image" }])).toBe(true);
+    expect(hasHydratableMediaImages([{ path: "/tmp/scan.tiff" }])).toBe(true);
+    expect(
+      hasHydratableMediaImages([
+        { path: "/tmp/scan.tif", contentType: "application/octet-stream" },
+      ]),
+    ).toBe(true);
+    expect(
+      hasHydratableMediaImages([
+        { path: "/tmp/report.png", kind: "unknown", contentType: "application/pdf" },
+      ]),
+    ).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "filename-only SVG",
+      fileName: "diagram.svg",
+      contentType: undefined,
+      kind: undefined,
+      bytes: Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"/>'),
+      expectedImages: 0,
+    },
+    {
+      name: "unknown-kind PDF metadata over valid PNG bytes",
+      fileName: "report.png",
+      contentType: "application/pdf",
+      kind: "unknown" as const,
+      bytes: Buffer.from(TINY_PNG_BASE64, "base64"),
+      expectedImages: 0,
+    },
+    {
+      name: "filename-only authentic PNG",
+      fileName: "scan.png",
+      contentType: undefined,
+      kind: undefined,
+      bytes: Buffer.from(TINY_PNG_BASE64, "base64"),
+      expectedImages: 1,
+    },
+    {
+      name: "generic-binary authentic PNG",
+      fileName: "scan.png",
+      contentType: "application/octet-stream",
+      kind: undefined,
+      bytes: Buffer.from(TINY_PNG_BASE64, "base64"),
+      expectedImages: 1,
+    },
+  ])("applies canonical $name rules to actual persisted embedded replay", async (testCase) => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-canonical-media-ref-"));
+    const imagePath = path.join(workspaceDir, testCase.fileName);
+    await fs.writeFile(imagePath, testCase.bytes);
+    const media = [{ path: imagePath, contentType: testCase.contentType, kind: testCase.kind }];
+
+    try {
+      const loaded = await detectAndLoadPromptImages({
+        prompt: "",
+        media,
+        workspaceDir,
+        model: { input: ["text", "image"] },
+        workspaceOnly: true,
+      });
+      expect(loaded.images).toHaveLength(testCase.expectedImages);
+      expect(loaded.failedMediaCount).toBe(0);
+      if (testCase.expectedImages > 0) {
+        expect(loaded.images[0]?.mimeType).toBe("image/png");
+      }
+
+      const persisted = {
+        role: "user",
+        content: "inspect",
+        __openclaw: { media },
+      } as unknown as AgentMessage;
+      const replayed = await hydratePromptMediaMessages([persisted], {
+        workspaceDir,
+        model: { input: ["text", "image"] },
+        workspaceOnly: true,
+      });
+      const replayedMessage = replayed[0];
+      const content = replayedMessage?.role === "user" ? replayedMessage.content : undefined;
+      const images = Array.isArray(content) ? content.filter((item) => item.type === "image") : [];
+      expect(images).toHaveLength(testCase.expectedImages);
+      if (testCase.expectedImages > 0) {
+        expect(images[0]?.mimeType).toBe("image/png");
+      }
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
     }
   });
 

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
@@ -10,7 +10,6 @@ import { preparePluginHarnessPromptImages } from "./plugin-harness-prompt-images
 
 const TINY_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADUlEQVR4nGP4////KwAJ5gPoxLp9owAAAABJRU5ErkJggg==";
-
 describe("plugin harness prompt media", () => {
   it("does not hydrate marker or bare paths from recalled memory context", async () => {
     const recalledMemory = [
@@ -35,6 +34,82 @@ describe("plugin harness prompt media", () => {
         pluginHarnessOwnsTransport: true,
       } as unknown as Parameters<typeof preparePluginHarnessPromptImages>[0]),
     ).resolves.toEqual({ images: undefined, imageOrder: undefined, media: undefined });
+  });
+
+  it.each([
+    {
+      name: "filename-only SVG",
+      fileName: "diagram.svg",
+      contentType: undefined,
+      kind: undefined,
+      bytes: Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"/>'),
+      expectedImages: 0,
+    },
+    {
+      name: "unknown-kind PDF metadata over valid PNG bytes",
+      fileName: "report.png",
+      contentType: "application/pdf",
+      kind: "unknown" as const,
+      bytes: Buffer.from(TINY_PNG_BASE64, "base64"),
+      expectedImages: 0,
+    },
+    {
+      name: "filename-only authentic PNG",
+      fileName: "scan.png",
+      contentType: undefined,
+      kind: undefined,
+      bytes: Buffer.from(TINY_PNG_BASE64, "base64"),
+      expectedImages: 1,
+    },
+    {
+      name: "generic-binary authentic PNG",
+      fileName: "scan.png",
+      contentType: "application/octet-stream",
+      kind: undefined,
+      bytes: Buffer.from(TINY_PNG_BASE64, "base64"),
+      expectedImages: 1,
+    },
+  ])("applies canonical $name rules at the actual plugin-harness boundary", async (testCase) => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-harness-canonical-"));
+    const workspaceDir = path.join(stateDir, "workspace");
+    const inboundDir = path.join(stateDir, "media", "inbound");
+    const imagePath = path.join(inboundDir, testCase.fileName);
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(inboundDir, { recursive: true });
+    await fs.writeFile(imagePath, testCase.bytes);
+    const media = [{ path: imagePath, contentType: testCase.contentType, kind: testCase.kind }];
+    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+
+    try {
+      const result = await preparePluginHarnessPromptImages({
+        runParams: {
+          agentId: "main",
+          config: { agents: { defaults: { sandbox: { mode: "off" } } } },
+          media,
+          sessionId: "session-canonical-media",
+          userTurnTranscriptRecorder: {
+            message: { role: "user", content: "inspect", __openclaw: { media } },
+          },
+        },
+        runtime: {
+          model: { input: ["text", "image"] },
+          sessionId: "session-canonical-media",
+          workspaceDir,
+        },
+        pluginHarnessOwnsTransport: true,
+      } as unknown as Parameters<typeof preparePluginHarnessPromptImages>[0]);
+
+      expect(result.images ?? []).toHaveLength(testCase.expectedImages);
+      if (testCase.expectedImages > 0) {
+        expect(result.images?.[0]?.mimeType).toBe("image/png");
+      } else {
+        expect(result.media).toEqual(media);
+      }
+    } finally {
+      envSnapshot.restore();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("hydrates plugin images and preserves serialized replay order with non-image facts", async () => {

--- a/src/auto-reply/reply/agent-turn-attachments.ts
+++ b/src/auto-reply/reply/agent-turn-attachments.ts
@@ -25,6 +25,7 @@ export function loadAgentTurnMediaRuntime() {
 type AgentTurnAttachmentRuntime = Pick<
   Awaited<ReturnType<typeof loadAgentTurnMediaRuntime>>,
   | "MediaAttachmentCache"
+  | "isImageAttachment"
   | "isMediaUnderstandingSkipError"
   | "normalizeAttachments"
   | "resolveMediaAttachmentLocalRoots"
@@ -32,10 +33,6 @@ type AgentTurnAttachmentRuntime = Pick<
 
 const AGENT_TURN_ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
 const AGENT_TURN_ATTACHMENT_TIMEOUT_MS = 1_000;
-
-function isImageAgentTurnAttachment(attachment: MediaAttachment): boolean {
-  return attachment.mime?.startsWith("image/") === true;
-}
 
 function hasInboundHistoryMedia(ctx: MsgContext): boolean {
   return (
@@ -72,7 +69,10 @@ export async function resolveAgentTurnAttachments(params: {
         : attachment,
     );
   const recentHistoryImages = includeRecentHistoryImages
-    ? resolveRecentInboundHistoryImages({ ctx: params.ctx })
+    ? resolveRecentInboundHistoryImages({
+        ctx: params.ctx,
+        isImageAttachment: runtime.isImageAttachment,
+      })
     : [];
   const firstHistoryAttachmentIndex =
     currentAttachments.reduce(
@@ -83,6 +83,7 @@ export async function resolveAgentTurnAttachments(params: {
   const historyAttachments: MediaAttachment[] = recentHistoryImages.map((image, index) => ({
     path: image.path,
     mime: image.contentType,
+    kind: image.kind,
     index: firstHistoryAttachmentIndex + index,
   }));
   const historyAttachmentByIndex = new Map(
@@ -99,19 +100,22 @@ export async function resolveAgentTurnAttachments(params: {
   const resultIndexes: number[] = [];
   const resolvedHistoryImages: RecentInboundHistoryImage[] = [];
   const resolveImageAttachment = async (attachment: MediaAttachment): Promise<boolean> => {
-    const mediaType = attachment.mime ?? "application/octet-stream";
-    if (!isImageAgentTurnAttachment(attachment)) {
+    if (!runtime.isImageAttachment(attachment)) {
       return false;
     }
     if (!normalizeOptionalString(attachment.path)) {
       return false;
     }
     try {
-      const { buffer } = await cache.getBuffer({
+      const { buffer, mime: mediaType } = await cache.getBuffer({
         attachmentIndex: attachment.index,
         maxBytes: AGENT_TURN_ATTACHMENT_MAX_BYTES,
         timeoutMs: AGENT_TURN_ATTACHMENT_TIMEOUT_MS,
       });
+      // Declared image kind selects the candidate; byte-aware cache detection owns the provider MIME.
+      if (!mediaType?.startsWith("image/")) {
+        return false;
+      }
       results.push({
         mediaType,
         data: buffer.toString("base64"),
@@ -139,7 +143,7 @@ export async function resolveAgentTurnAttachments(params: {
 
   let currentImageResolved = false;
   const hasCurrentMedia = currentAttachments.length > 0;
-  const hasCurrentImageCandidate = currentAttachments.some(isImageAgentTurnAttachment);
+  const hasCurrentImageCandidate = currentAttachments.some(runtime.isImageAttachment);
   for (const attachment of currentAttachments) {
     currentImageResolved = (await resolveImageAttachment(attachment)) || currentImageResolved;
   }

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -9,6 +9,13 @@ import type { MsgContext } from "../templating.js";
 import { resolveCurrentTurnImages } from "./current-turn-images.js";
 
 const originalStateDirEnv = process.env.OPENCLAW_STATE_DIR;
+const PNG_IMAGE_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=",
+  "base64",
+);
+const JPEG_IMAGE_BYTES = Buffer.from("ffd8ffe000104a46494600010100000100010000ffd9", "hex");
+const PDF_BYTES = Buffer.from("%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n");
+const ZIP_BYTES = Buffer.from("504b0506000000000000000000000000000000000000", "hex");
 
 function restoreProcessState() {
   if (originalStateDirEnv === undefined) {
@@ -55,6 +62,157 @@ describe("resolveCurrentTurnImages", () => {
         ],
         imageOrder: ["inline"],
       });
+    });
+  });
+
+  it.each([
+    {
+      name: "generic Telegram image bytes under a .bin path",
+      fileName: "upload.bin",
+      contentType: "application/octet-stream",
+      kind: "image" as const,
+      imageBytes: PNG_IMAGE_BYTES,
+      expectedMime: "image/png",
+    },
+    {
+      name: "an extensionless image without transport MIME",
+      fileName: "upload",
+      contentType: undefined,
+      kind: "image" as const,
+      imageBytes: JPEG_IMAGE_BYTES,
+      expectedMime: "image/jpeg",
+    },
+    {
+      name: "a sticker with generic transport MIME",
+      fileName: "sticker.bin",
+      contentType: "application/octet-stream",
+      kind: "sticker" as const,
+      imageBytes: PNG_IMAGE_BYTES,
+      expectedMime: "image/png",
+    },
+  ])("hydrates $name using the verified byte MIME", async (testCase) => {
+    await withTempDir({ prefix: "openclaw-current-turn-canonical-kind-" }, async (base) => {
+      const imagePath = path.join(base, testCase.fileName);
+      await fs.writeFile(imagePath, testCase.imageBytes);
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          Body: "describe this image",
+          media: [
+            {
+              path: imagePath,
+              contentType: testCase.contentType,
+              kind: testCase.kind,
+              workspaceDir: base,
+            },
+          ],
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+      });
+
+      expect(result).toEqual({
+        images: [
+          {
+            type: "image",
+            data: testCase.imageBytes.toString("base64"),
+            mimeType: testCase.expectedMime,
+          },
+        ],
+        imageOrder: ["inline"],
+      });
+    });
+  });
+
+  it.each([undefined, "application/pdf", "application/octet-stream", "image/png"] as const)(
+    "never hydrates valid image bytes when the authoritative document MIME is %s",
+    async (contentType) => {
+      await withTempDir({ prefix: "openclaw-current-turn-document-image-" }, async (base) => {
+        const documentPath = path.join(base, "report.png");
+        await fs.writeFile(documentPath, PNG_IMAGE_BYTES);
+
+        const result = await resolveCurrentTurnImages({
+          ctx: {
+            Body: "summarize this document",
+            media: [{ path: documentPath, contentType, kind: "document", workspaceDir: base }],
+          } satisfies MsgContext,
+          cfg: {} as OpenClawConfig,
+        });
+
+        expect(result.images).toBeUndefined();
+      });
+    },
+  );
+
+  it.each([undefined, "application/octet-stream", "binary/octet-stream"] as const)(
+    "hydrates unknown-kind filename images when MIME %s has no concrete category",
+    async (contentType) => {
+      await withTempDir({ prefix: "openclaw-current-turn-unknown-image-" }, async (base) => {
+        const imagePath = path.join(base, "upload.png");
+        await fs.writeFile(imagePath, PNG_IMAGE_BYTES);
+
+        const result = await resolveCurrentTurnImages({
+          ctx: {
+            Body: "describe this upload",
+            media: [{ path: imagePath, contentType, kind: "unknown", workspaceDir: base }],
+          } satisfies MsgContext,
+          cfg: {} as OpenClawConfig,
+        });
+
+        expect(result.images).toEqual([
+          {
+            type: "image",
+            data: PNG_IMAGE_BYTES.toString("base64"),
+            mimeType: "image/png",
+          },
+        ]);
+      });
+    },
+  );
+
+  it.each(["application/pdf", "application/zip", "text/plain"] as const)(
+    "never hydrates valid PNG bytes when unknown-kind MIME %s declares a document",
+    async (contentType) => {
+      await withTempDir({ prefix: "openclaw-current-turn-unknown-document-" }, async (base) => {
+        const documentPath = path.join(base, "report.png");
+        await fs.writeFile(documentPath, PNG_IMAGE_BYTES);
+
+        const result = await resolveCurrentTurnImages({
+          ctx: {
+            Body: "summarize this upload",
+            media: [{ path: documentPath, contentType, kind: "unknown", workspaceDir: base }],
+          } satisfies MsgContext,
+          cfg: {} as OpenClawConfig,
+        });
+
+        expect(result.images).toBeUndefined();
+      });
+    },
+  );
+
+  it.each([
+    { name: "PDF", bytes: PDF_BYTES },
+    { name: "ZIP", bytes: ZIP_BYTES },
+  ])("rejects $name bytes despite a spoofed image kind, MIME, and filename", async (testCase) => {
+    await withTempDir({ prefix: "openclaw-current-turn-spoofed-image-" }, async (base) => {
+      const imagePath = path.join(base, "spoofed.png");
+      await fs.writeFile(imagePath, testCase.bytes);
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          Body: "describe this image",
+          media: [
+            {
+              path: imagePath,
+              contentType: "image/png",
+              kind: "image",
+              workspaceDir: base,
+            },
+          ],
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+      });
+
+      expect(result.images).toBeUndefined();
     });
   });
 

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -1,25 +1,23 @@
 // Tracks image attachments that belong to the current reply turn.
-import { mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { ImageContent } from "../../llm/types.js";
-import { normalizeAttachments } from "../../media-understanding/attachments.normalize.js";
+import {
+  isImageAttachment,
+  normalizeAttachments,
+} from "../../media-understanding/attachments.normalize.js";
 import {
   stripExtractedFileImageMetadata,
   type ExtractedFileImage,
 } from "../../media-understanding/extracted-file-images.js";
+import type { MediaAttachment } from "../../media-understanding/types.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { RuntimeMsgContext as MsgContext } from "../templating.js";
 import { resolveAgentTurnAttachments } from "./agent-turn-attachments.js";
 
-type CurrentImageAttachment = {
-  index: number;
-  path: string;
-  mediaType: string;
-  workspaceDir?: string;
-};
+type CurrentImageAttachment = MediaAttachment & { path: string };
 
 type OrderedTurnImage = {
   image?: ImageContent;
@@ -28,46 +26,10 @@ type OrderedTurnImage = {
   sequence: number;
 };
 
-function isGenericMediaType(mediaType: string | undefined): boolean {
-  if (!mediaType) {
-    return true;
-  }
-  const normalized = mediaType.split(";")[0]?.trim().toLowerCase();
-  return normalized === "application/octet-stream" || normalized === "binary/octet-stream";
-}
-
-/** Resolves image media types from current-turn attachment metadata or filenames. */
-function resolveCurrentImageMediaType(pathValue: unknown, mediaType?: unknown): string | undefined {
-  const mediaPath = normalizeOptionalString(pathValue);
-  if (!mediaPath) {
-    return undefined;
-  }
-  const normalizedMediaType = normalizeOptionalString(mediaType);
-  if (normalizedMediaType?.startsWith("image/")) {
-    return normalizedMediaType;
-  }
-  if (!isGenericMediaType(normalizedMediaType)) {
-    return undefined;
-  }
-  const inferredType = mimeTypeFromFilePath(mediaPath);
-  return inferredType?.startsWith("image/") ? inferredType : undefined;
-}
-
 function collectCurrentImageAttachments(ctx: MsgContext): CurrentImageAttachment[] {
   return normalizeAttachments(ctx).flatMap((attachment) => {
     const mediaPath = normalizeOptionalString(attachment.path);
-    const mediaType = resolveCurrentImageMediaType(attachment.path, attachment.mime);
-    if (mediaPath && mediaType) {
-      return [
-        {
-          index: attachment.index,
-          path: mediaPath,
-          mediaType,
-          workspaceDir: attachment.workspaceDir,
-        },
-      ];
-    }
-    return [];
+    return mediaPath && isImageAttachment(attachment) ? [{ ...attachment, path: mediaPath }] : [];
   });
 }
 
@@ -85,7 +47,8 @@ function createUndescribedImageContext(
 ): MsgContext {
   const media = undescribedAttachments.map((attachment) => ({
     path: attachment.path,
-    contentType: attachment.mediaType,
+    contentType: attachment.mime,
+    kind: attachment.kind,
     workspaceDir: attachment.workspaceDir,
   }));
   return {

--- a/src/auto-reply/reply/dispatch-acp-media.runtime.ts
+++ b/src/auto-reply/reply/dispatch-acp-media.runtime.ts
@@ -1,6 +1,9 @@
 /** Runtime media-understanding dependencies used by ACP reply dispatch. */
 export { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 export { MediaAttachmentCache } from "../../media-understanding/attachments.js";
-export { normalizeAttachments } from "../../media-understanding/attachments.normalize.js";
+export {
+  isImageAttachment,
+  normalizeAttachments,
+} from "../../media-understanding/attachments.normalize.js";
 export { isMediaUnderstandingSkipError } from "../../../packages/media-understanding-common/src/errors.js";
 export { resolveMediaAttachmentLocalRoots } from "../../media-understanding/runner.js";

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { detectMime } from "@openclaw/media-core/mime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MediaUnderstandingSkipError } from "../../../packages/media-understanding-common/src/errors.js";
 import { AcpRuntimeError } from "../../acp/runtime/errors.js";
@@ -9,6 +10,7 @@ import type { AcpSessionStoreEntry } from "../../acp/runtime/session-meta.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
 import type { ApplyMediaUnderstandingResult } from "../../media-understanding/apply.js";
+import { isImageAttachment } from "../../media-understanding/attachments.normalize.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import {
   resolveAgentTurnAttachments,
@@ -101,6 +103,13 @@ const mediaUnderstandingMocks = vi.hoisted(() => ({
 }));
 
 const acpAttachmentBuffers = vi.hoisted(() => new Map<string, Buffer>());
+const ACP_PNG_IMAGE_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=",
+  "base64",
+);
+const ACP_JPEG_IMAGE_BYTES = Buffer.from("ffd8ffe000104a46494600010100000100010000ffd9", "hex");
+const ACP_PDF_BYTES = Buffer.from("%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n");
+const ACP_ZIP_BYTES = Buffer.from("504b0506000000000000000000000000000000000000", "hex");
 
 const diagnosticMocks = vi.hoisted(() => ({
   markDiagnosticSessionProgress: vi.fn(),
@@ -176,48 +185,51 @@ vi.mock("../../tts/status-config.js", () => ({
   }),
 }));
 
-vi.mock("./dispatch-acp-media.runtime.js", () => ({
-  applyMediaUnderstanding: (params: unknown) =>
-    mediaUnderstandingMocks.applyMediaUnderstanding(params),
-  isMediaUnderstandingSkipError: (error: unknown): error is MediaUnderstandingSkipError =>
-    error instanceof Error && error.name === "MediaUnderstandingSkipError",
-  normalizeAttachments: (ctx: { media?: Array<{ path?: string; contentType?: string }> }) =>
-    ctx.media?.[0]?.path
-      ? [
-          {
-            path: ctx.media[0].path,
-            mime: ctx.media[0].contentType,
-            index: 0,
-          },
-        ]
-      : [],
-  resolveMediaAttachmentLocalRoots: (params: {
-    cfg: { channels?: Record<string, { attachmentRoots?: string[] } | undefined> };
-    ctx: { Provider?: string; Surface?: string };
-  }) => {
-    const channel = params.ctx.Provider ?? params.ctx.Surface ?? "";
-    return params.cfg.channels?.[channel]?.attachmentRoots ?? [];
-  },
-  MediaAttachmentCache: class {
-    constructor(private readonly attachments: Array<{ path?: string; index: number }>) {}
-    async getBuffer({ attachmentIndex }: { attachmentIndex: number }) {
-      const attachment = this.attachments.find((item) => item.index === attachmentIndex);
-      const pathLocal = attachment?.path;
-      const buffer = pathLocal ? acpAttachmentBuffers.get(pathLocal) : undefined;
-      if (buffer) {
-        return {
-          buffer,
-          mime: "image/png",
-          fileName: pathLocal,
-          size: buffer.length,
-        };
+vi.mock("./dispatch-acp-media.runtime.js", async () => {
+  const attachmentNormalization = await vi.importActual<
+    typeof import("../../media-understanding/attachments.normalize.js")
+  >("../../media-understanding/attachments.normalize.js");
+  return {
+    applyMediaUnderstanding: (params: unknown) =>
+      mediaUnderstandingMocks.applyMediaUnderstanding(params),
+    isImageAttachment: attachmentNormalization.isImageAttachment,
+    isMediaUnderstandingSkipError: (error: unknown): error is MediaUnderstandingSkipError =>
+      error instanceof Error && error.name === "MediaUnderstandingSkipError",
+    normalizeAttachments: attachmentNormalization.normalizeAttachments,
+    resolveMediaAttachmentLocalRoots: (params: {
+      cfg: { channels?: Record<string, { attachmentRoots?: string[] } | undefined> };
+      ctx: { Provider?: string; Surface?: string };
+    }) => {
+      const channel = params.ctx.Provider ?? params.ctx.Surface ?? "";
+      return params.cfg.channels?.[channel]?.attachmentRoots ?? [];
+    },
+    MediaAttachmentCache: class {
+      constructor(
+        private readonly attachments: Array<{ path?: string; mime?: string; index: number }>,
+      ) {}
+      async getBuffer({ attachmentIndex }: { attachmentIndex: number }) {
+        const attachment = this.attachments.find((item) => item.index === attachmentIndex);
+        const pathLocal = attachment?.path;
+        const buffer = pathLocal ? acpAttachmentBuffers.get(pathLocal) : undefined;
+        if (buffer) {
+          return {
+            buffer,
+            mime: await detectMime({
+              buffer,
+              filePath: pathLocal,
+              headerMime: attachment?.mime,
+            }),
+            fileName: pathLocal,
+            size: buffer.length,
+          };
+        }
+        const error = new Error("outside allowed roots");
+        error.name = "MediaUnderstandingSkipError";
+        throw error;
       }
-      const error = new Error("outside allowed roots");
-      error.name = "MediaUnderstandingSkipError";
-      throw error;
-    }
-  },
-}));
+    },
+  };
+});
 
 vi.mock("./dispatch-acp-session.runtime.js", () => ({
   readAcpSessionEntry: (params: { sessionKey: string; cfg?: OpenClawConfig }) =>
@@ -1211,10 +1223,11 @@ describe("tryDispatchAcpReply", () => {
       ],
     });
 
-    expect(resolveRecentInboundHistoryImages({ ctx })).toEqual([
+    expect(resolveRecentInboundHistoryImages({ ctx, isImageAttachment })).toEqual([
       {
         path: "/tmp/recent-2.png",
         contentType: "image/png",
+        kind: "image",
         sender: "Recent 2",
         sentAtMs: 1_699_999_997_000,
         messagePosition: 6,
@@ -1224,6 +1237,7 @@ describe("tryDispatchAcpReply", () => {
       {
         path: "/tmp/recent-3.png",
         contentType: "image/png",
+        kind: "image",
         sender: "Recent 3",
         sentAtMs: 1_699_999_998_000,
         messagePosition: 7,
@@ -1233,6 +1247,7 @@ describe("tryDispatchAcpReply", () => {
       {
         path: "/tmp/recent-4.png",
         contentType: "image/png",
+        kind: "image",
         sender: "Recent 4",
         sentAtMs: 1_699_999_999_000,
         messagePosition: 8,
@@ -1242,6 +1257,7 @@ describe("tryDispatchAcpReply", () => {
       {
         path: "C:\\Users\\Alice\\Pictures\\recent.png",
         contentType: "image/png",
+        kind: "image",
         sender: "Windows",
         sentAtMs: 1_699_999_999_500,
         messagePosition: 9,
@@ -1250,6 +1266,120 @@ describe("tryDispatchAcpReply", () => {
       },
     ]);
   });
+
+  it("preserves authoritative history image kinds, order, and per-message deduplication", () => {
+    const now = 1_700_000_000_000;
+    const imagePath = "/tmp/openclaw-history-upload.bin";
+    const stickerPath = "/tmp/openclaw-history-sticker";
+    const ctx = buildTestCtx({
+      Timestamp: now,
+      InboundHistory: [
+        {
+          sender: "@alice",
+          body: "<media:image>",
+          timestamp: now - 2_000,
+          messageId: "image-message",
+          media: [
+            { path: imagePath, contentType: "application/octet-stream", kind: "image" },
+            { path: imagePath, contentType: "application/octet-stream", kind: "image" },
+          ],
+        },
+        {
+          sender: "@bob",
+          body: "<media:sticker>",
+          timestamp: now - 1_000,
+          messageId: "sticker-message",
+          media: [{ path: stickerPath, kind: "sticker" }],
+        },
+        {
+          sender: "@eve",
+          body: "<media:document>",
+          timestamp: now,
+          messageId: "document-message",
+          media: [{ path: "/tmp/openclaw-history-document.bin", kind: "document" }],
+        },
+      ],
+    });
+
+    expect(resolveRecentInboundHistoryImages({ ctx, isImageAttachment })).toEqual([
+      {
+        path: imagePath,
+        contentType: "application/octet-stream",
+        kind: "image",
+        sender: "@alice",
+        sentAtMs: now - 2_000,
+        messagePosition: 1,
+        messageCount: 3,
+        messageId: "image-message",
+      },
+      {
+        path: stickerPath,
+        kind: "sticker",
+        sender: "@bob",
+        sentAtMs: now - 1_000,
+        messagePosition: 2,
+        messageCount: 3,
+        messageId: "sticker-message",
+      },
+    ]);
+  });
+
+  it.each([undefined, "application/pdf", "image/png"] as const)(
+    "never reuses a historical document with an image-looking path and MIME %s",
+    (contentType) => {
+      const now = 1_700_000_000_000;
+      const ctx = buildTestCtx({
+        Timestamp: now,
+        InboundHistory: [
+          {
+            sender: "@alice",
+            body: "<media:document>",
+            timestamp: now,
+            media: [{ path: "/tmp/openclaw-history-document.png", contentType, kind: "document" }],
+          },
+        ],
+      });
+
+      expect(resolveRecentInboundHistoryImages({ ctx, isImageAttachment })).toEqual([]);
+    },
+  );
+
+  it("never reuses filename-only SVG history as a raster image", () => {
+    const now = 1_700_000_000_000;
+    const ctx = buildTestCtx({
+      Timestamp: now,
+      InboundHistory: [
+        {
+          sender: "@alice",
+          body: "<media:document>",
+          timestamp: now,
+          media: [{ path: "/tmp/openclaw-history-diagram.svg" }],
+        },
+      ],
+    });
+
+    expect(resolveRecentInboundHistoryImages({ ctx, isImageAttachment })).toEqual([]);
+  });
+
+  it.each(["application/pdf", "application/zip", "text/plain"] as const)(
+    "never reuses unknown-kind image-looking history with concrete MIME %s",
+    (contentType) => {
+      const now = 1_700_000_000_000;
+      const ctx = buildTestCtx({
+        Timestamp: now,
+        InboundHistory: [
+          {
+            sender: "@alice",
+            body: "<media:document>",
+            timestamp: now,
+            media: [{ path: "/tmp/openclaw-history-report.png", contentType, kind: "unknown" }],
+          },
+        ],
+      });
+
+      expect(resolveRecentInboundHistoryImages({ ctx, isImageAttachment })).toEqual([]);
+    },
+  );
 
   it("adds recent history image context without exposing paths", () => {
     const text = appendRecentHistoryImageContext({
@@ -1310,6 +1440,7 @@ describe("tryDispatchAcpReply", () => {
           } as unknown as typeof import("./dispatch-acp-media.runtime.js").MediaAttachmentCache,
           isMediaUnderstandingSkipError: (_error: unknown): _error is MediaUnderstandingSkipError =>
             false,
+          isImageAttachment,
           normalizeAttachments: () => [],
           resolveMediaAttachmentLocalRoots: () => [tempDir],
         },
@@ -1325,6 +1456,7 @@ describe("tryDispatchAcpReply", () => {
         {
           path: imagePath,
           contentType: "image/png",
+          kind: "image",
           sender: "@alice",
           sentAtMs: 1_700_000_000_000,
           messagePosition: 1,
@@ -1355,6 +1487,7 @@ describe("tryDispatchAcpReply", () => {
         } as unknown as typeof import("./dispatch-acp-media.runtime.js").MediaAttachmentCache,
         isMediaUnderstandingSkipError: (_error: unknown): _error is MediaUnderstandingSkipError =>
           false,
+        isImageAttachment,
         normalizeAttachments,
         resolveMediaAttachmentLocalRoots: () => [],
       },
@@ -1400,6 +1533,7 @@ describe("tryDispatchAcpReply", () => {
           } as unknown as typeof import("./dispatch-acp-media.runtime.js").MediaAttachmentCache,
           isMediaUnderstandingSkipError: (_error: unknown): _error is MediaUnderstandingSkipError =>
             false,
+          isImageAttachment,
           normalizeAttachments: (ctx) => [
             { path: ctx.media?.[0]?.path, mime: ctx.media?.[0]?.contentType, index: 0 },
           ],
@@ -1455,6 +1589,7 @@ describe("tryDispatchAcpReply", () => {
           } as unknown as typeof import("./dispatch-acp-media.runtime.js").MediaAttachmentCache,
           isMediaUnderstandingSkipError: (_error: unknown): _error is MediaUnderstandingSkipError =>
             false,
+          isImageAttachment,
           normalizeAttachments: (ctx) => [
             { path: ctx.media?.[0]?.path, mime: ctx.media?.[0]?.contentType, index: 1 },
           ],
@@ -1508,6 +1643,7 @@ describe("tryDispatchAcpReply", () => {
           } as unknown as typeof import("./dispatch-acp-media.runtime.js").MediaAttachmentCache,
           isMediaUnderstandingSkipError: (_error: unknown): _error is MediaUnderstandingSkipError =>
             false,
+          isImageAttachment,
           normalizeAttachments: (ctx) => [
             { path: ctx.media?.[0]?.path, mime: ctx.media?.[0]?.contentType, index: 0 },
           ],
@@ -1559,6 +1695,7 @@ describe("tryDispatchAcpReply", () => {
           } as unknown as typeof import("./dispatch-acp-media.runtime.js").MediaAttachmentCache,
           isMediaUnderstandingSkipError: (_error: unknown): _error is MediaUnderstandingSkipError =>
             false,
+          isImageAttachment,
           normalizeAttachments: (ctx) => [
             { url: ctx.media?.[0]?.url, mime: ctx.media?.[0]?.contentType, index: 0 },
           ],
@@ -1576,6 +1713,7 @@ describe("tryDispatchAcpReply", () => {
         {
           path: historyPath,
           contentType: "image/png",
+          kind: "image",
           sender: "@alice",
           sentAtMs: 1_700_000_000_000,
           messagePosition: 1,
@@ -1614,6 +1752,322 @@ describe("tryDispatchAcpReply", () => {
         data: image.data,
       },
     ]);
+  });
+
+  it.each([
+    {
+      name: "generic Telegram image bytes under a .bin path",
+      imagePath: "/tmp/openclaw-acp-image-upload.bin",
+      contentType: "application/octet-stream",
+      kind: "image" as const,
+      imageBytes: ACP_PNG_IMAGE_BYTES,
+      expectedMime: "image/png",
+    },
+    {
+      name: "an extensionless image without transport MIME",
+      imagePath: "/tmp/openclaw-acp-image-upload",
+      contentType: undefined,
+      kind: "image" as const,
+      imageBytes: ACP_JPEG_IMAGE_BYTES,
+      expectedMime: "image/jpeg",
+    },
+    {
+      name: "a sticker with generic transport MIME",
+      imagePath: "/tmp/openclaw-acp-sticker.bin",
+      contentType: "application/octet-stream",
+      kind: "sticker" as const,
+      imageBytes: ACP_PNG_IMAGE_BYTES,
+      expectedMime: "image/png",
+    },
+  ])("forwards $name into the ACP runtime using the verified byte MIME", async (testCase) => {
+    setReadyAcpResolution();
+    acpAttachmentBuffers.set(testCase.imagePath, testCase.imageBytes);
+
+    await runDispatch({
+      bodyForAgent: "describe image",
+      ctxOverrides: {
+        media: [
+          {
+            path: testCase.imagePath,
+            contentType: testCase.contentType,
+            kind: testCase.kind,
+          },
+        ],
+      },
+    });
+
+    expect(runTurnCall().attachments).toEqual([
+      {
+        mediaType: testCase.expectedMime,
+        data: testCase.imageBytes.toString("base64"),
+      },
+    ]);
+  });
+
+  it.each([
+    { name: "valid PNG bytes without MIME", contentType: undefined, bytes: ACP_PNG_IMAGE_BYTES },
+    {
+      name: "valid PNG bytes with PDF MIME",
+      contentType: "application/pdf",
+      bytes: ACP_PNG_IMAGE_BYTES,
+    },
+    {
+      name: "valid PNG bytes with contradictory image MIME",
+      contentType: "image/png",
+      bytes: ACP_PNG_IMAGE_BYTES,
+    },
+    {
+      name: "PDF bytes with an image-looking filename",
+      contentType: undefined,
+      bytes: ACP_PDF_BYTES,
+    },
+    {
+      name: "ZIP bytes with an image-looking filename",
+      contentType: "application/pdf",
+      bytes: ACP_ZIP_BYTES,
+    },
+  ])("never forwards $name or substitutes unrelated history for a document", async (testCase) => {
+    setReadyAcpResolution();
+    const documentPath = "/tmp/openclaw-acp-authoritative-document.png";
+    const historyPath = "/tmp/openclaw-acp-unrelated-history.png";
+    acpAttachmentBuffers.set(documentPath, testCase.bytes);
+    acpAttachmentBuffers.set(historyPath, ACP_PNG_IMAGE_BYTES);
+
+    await runDispatch({
+      bodyForAgent: "summarize this document",
+      ctxOverrides: {
+        Timestamp: 1_700_000_000_000,
+        media: [{ path: documentPath, contentType: testCase.contentType, kind: "document" }],
+        InboundHistory: [
+          {
+            sender: "@alice",
+            body: "<media:image>",
+            timestamp: 1_700_000_000_000,
+            media: [{ path: historyPath, contentType: "image/png", kind: "image" }],
+          },
+        ],
+      },
+    });
+
+    expect(runTurnCall().attachments).toBeUndefined();
+    expect(runTurnCall().text).not.toContain("Recent image");
+  });
+
+  it.each(["application/pdf", "application/zip", "text/plain"] as const)(
+    "never forwards unknown-kind PNG bytes with MIME %s or substitutes history",
+    async (contentType) => {
+      setReadyAcpResolution();
+      const documentPath = "/tmp/openclaw-acp-unknown-document.png";
+      const historyPath = "/tmp/openclaw-acp-unrelated-history.png";
+      acpAttachmentBuffers.set(documentPath, ACP_PNG_IMAGE_BYTES);
+      acpAttachmentBuffers.set(historyPath, ACP_PNG_IMAGE_BYTES);
+
+      await runDispatch({
+        bodyForAgent: "summarize this upload",
+        ctxOverrides: {
+          Timestamp: 1_700_000_000_000,
+          media: [{ path: documentPath, contentType, kind: "unknown" }],
+          InboundHistory: [
+            {
+              sender: "@alice",
+              body: "<media:image>",
+              timestamp: 1_700_000_000_000,
+              media: [{ path: historyPath, contentType: "image/png", kind: "image" }],
+            },
+          ],
+        },
+      });
+
+      expect(runTurnCall().attachments).toBeUndefined();
+      expect(runTurnCall().text).not.toContain("Recent image");
+    },
+  );
+
+  it("never forwards filename-only SVG history into an ACP runtime turn", async () => {
+    setReadyAcpResolution();
+    const svgPath = "/tmp/openclaw-acp-history-diagram.svg";
+    acpAttachmentBuffers.set(svgPath, Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"/>'));
+
+    await runDispatch({
+      bodyForAgent: "describe the recent attachment",
+      ctxOverrides: {
+        Timestamp: 1_700_000_000_000,
+        InboundHistory: [
+          {
+            sender: "@alice",
+            body: "<media:document>",
+            timestamp: 1_700_000_000_000,
+            media: [{ path: svgPath }],
+          },
+        ],
+      },
+    });
+
+    expect(runTurnCall().attachments).toBeUndefined();
+    expect(runTurnCall().text).not.toContain("Recent image");
+  });
+
+  it.each([
+    { name: "PDF", bytes: ACP_PDF_BYTES },
+    { name: "ZIP", bytes: ACP_ZIP_BYTES },
+  ])(
+    "never forwards $name bytes with a spoofed image kind, MIME, and filename",
+    async (testCase) => {
+      setReadyAcpResolution();
+      const imagePath = `/tmp/openclaw-acp-spoofed-${testCase.name.toLowerCase()}.png`;
+      acpAttachmentBuffers.set(imagePath, testCase.bytes);
+
+      await runDispatch({
+        bodyForAgent: "describe attachment",
+        ctxOverrides: {
+          media: [{ path: imagePath, contentType: "image/png", kind: "image" }],
+        },
+      });
+
+      expect(runTurnCall().attachments).toBeUndefined();
+    },
+  );
+
+  it("falls back to history when an authoritative current image contains document bytes", async () => {
+    setReadyAcpResolution();
+    const currentPath = "/tmp/openclaw-acp-current-spoofed.bin";
+    const historyPath = "/tmp/openclaw-acp-history-valid.bin";
+    acpAttachmentBuffers.set(currentPath, ACP_PDF_BYTES);
+    acpAttachmentBuffers.set(historyPath, ACP_PNG_IMAGE_BYTES);
+
+    await runDispatch({
+      bodyForAgent: "describe the recent image",
+      ctxOverrides: {
+        Timestamp: 1_700_000_000_000,
+        media: [{ path: currentPath, contentType: "image/png", kind: "image" }],
+        InboundHistory: [
+          {
+            sender: "@alice",
+            body: "<media:image>",
+            timestamp: 1_700_000_000_000,
+            media: [{ path: historyPath, contentType: "image/png", kind: "image" }],
+          },
+        ],
+      },
+    });
+
+    expect(runTurnCall().attachments).toEqual([
+      {
+        mediaType: "image/png",
+        data: ACP_PNG_IMAGE_BYTES.toString("base64"),
+      },
+    ]);
+  });
+
+  it("does not substitute history for an authoritative current document", async () => {
+    setReadyAcpResolution();
+    const documentPath = "/tmp/openclaw-acp-current-document.bin";
+    const historyPath = "/tmp/openclaw-acp-history-image.png";
+    acpAttachmentBuffers.set(documentPath, ACP_PDF_BYTES);
+    acpAttachmentBuffers.set(historyPath, ACP_PNG_IMAGE_BYTES);
+
+    await runDispatch({
+      bodyForAgent: "describe this document",
+      ctxOverrides: {
+        Timestamp: 1_700_000_000_000,
+        media: [{ path: documentPath, contentType: "application/pdf", kind: "document" }],
+        InboundHistory: [
+          {
+            sender: "@alice",
+            body: "<media:image>",
+            timestamp: 1_700_000_000_000,
+            media: [{ path: historyPath, contentType: "image/png", kind: "image" }],
+          },
+        ],
+      },
+    });
+
+    expect(runTurnCall().attachments).toBeUndefined();
+  });
+
+  it.each([
+    {
+      name: "a historical Telegram .bin image with generic MIME",
+      imagePath: "/tmp/openclaw-acp-history-upload.bin",
+      contentType: "application/octet-stream",
+      kind: "image" as const,
+      imageBytes: ACP_PNG_IMAGE_BYTES,
+      expectedMime: "image/png",
+    },
+    {
+      name: "an extensionless historical image without MIME",
+      imagePath: "/tmp/openclaw-acp-history-upload",
+      contentType: undefined,
+      kind: "image" as const,
+      imageBytes: ACP_JPEG_IMAGE_BYTES,
+      expectedMime: "image/jpeg",
+    },
+    {
+      name: "a historical sticker with generic MIME",
+      imagePath: "/tmp/openclaw-acp-history-sticker.bin",
+      contentType: "application/octet-stream",
+      kind: "sticker" as const,
+      imageBytes: ACP_PNG_IMAGE_BYTES,
+      expectedMime: "image/png",
+    },
+  ])("forwards $name into the ACP runtime using the verified byte MIME", async (testCase) => {
+    setReadyAcpResolution();
+    acpAttachmentBuffers.set(testCase.imagePath, testCase.imageBytes);
+
+    await runDispatch({
+      bodyForAgent: "describe the recent attachment",
+      ctxOverrides: {
+        Timestamp: 1_700_000_000_000,
+        InboundHistory: [
+          {
+            sender: "@alice",
+            body: "<media:image>",
+            timestamp: 1_700_000_000_000,
+            messageId: "history-message",
+            media: [
+              {
+                path: testCase.imagePath,
+                contentType: testCase.contentType,
+                kind: testCase.kind,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(runTurnCall().attachments).toEqual([
+      {
+        mediaType: testCase.expectedMime,
+        data: testCase.imageBytes.toString("base64"),
+      },
+    ]);
+  });
+
+  it.each([
+    { name: "PDF", bytes: ACP_PDF_BYTES },
+    { name: "ZIP", bytes: ACP_ZIP_BYTES },
+  ])("does not forward historical $name bytes disguised as image media", async (testCase) => {
+    setReadyAcpResolution();
+    const imagePath = `/tmp/openclaw-acp-history-spoofed-${testCase.name.toLowerCase()}.png`;
+    acpAttachmentBuffers.set(imagePath, testCase.bytes);
+
+    await runDispatch({
+      bodyForAgent: "describe the recent attachment",
+      ctxOverrides: {
+        Timestamp: 1_700_000_000_000,
+        InboundHistory: [
+          {
+            sender: "@alice",
+            body: "<media:image>",
+            timestamp: 1_700_000_000_000,
+            media: [{ path: imagePath, contentType: "image/png", kind: "image" }],
+          },
+        ],
+      },
+    });
+
+    expect(runTurnCall().attachments).toBeUndefined();
   });
 
   it("annotates recent history images with sent time and available history position", async () => {

--- a/src/auto-reply/reply/get-reply-run-helpers.media-facts.test.ts
+++ b/src/auto-reply/reply/get-reply-run-helpers.media-facts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMediaFacts } from "../../media/media-facts.js";
+import { buildPersistedMediaImageLayout } from "./get-reply-run-helpers.js";
+
+describe("persisted media image layout", () => {
+  it.each([
+    { name: "filename-only SVG", media: { path: "/tmp/diagram.svg" }, image: false },
+    {
+      name: "unknown-kind filename-only SVG",
+      media: { path: "/tmp/diagram.svg", kind: "unknown" as const },
+      image: false,
+    },
+    {
+      name: "explicit image-kind SVG",
+      media: { path: "/tmp/diagram.svg", kind: "image" as const },
+      image: true,
+    },
+    {
+      name: "explicit image MIME SVG",
+      media: { path: "/tmp/diagram.svg", contentType: "image/svg+xml" },
+      image: true,
+    },
+    { name: "filename-only TIFF", media: { path: "/tmp/scan.tiff" }, image: true },
+    {
+      name: "generic-binary TIFF",
+      media: { path: "/tmp/scan.tif", contentType: "application/octet-stream" },
+      image: true,
+    },
+    {
+      name: "unknown-kind PDF with an image-looking filename",
+      media: { path: "/tmp/report.png", kind: "unknown" as const, contentType: "application/pdf" },
+      image: false,
+    },
+    {
+      name: "explicit document with conflicting image MIME",
+      media: { path: "/tmp/report.png", kind: "document" as const, contentType: "image/png" },
+      image: false,
+    },
+    {
+      name: "generic-binary sticker",
+      media: { path: "/tmp/sticker.bin", kind: "sticker" as const },
+      image: true,
+    },
+  ])("classifies $name through the real persisted-layout owner", ({ media, image }) => {
+    const normalized = normalizeMediaFacts([media]);
+    const layout = buildPersistedMediaImageLayout({
+      ctx: {},
+      media: normalized,
+      ctxMediaCount: normalized.length,
+    });
+
+    expect(layout).toEqual(image ? { slots: [{ kind: "offloaded", factIndex: 0 }] } : undefined);
+  });
+});

--- a/src/auto-reply/reply/history-media.ts
+++ b/src/auto-reply/reply/history-media.ts
@@ -3,15 +3,17 @@ import { mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { MediaAttachment } from "../../media-understanding/types.js";
 import type { MsgContext } from "../templating.js";
-import type { HistoryEntry, HistoryMediaEntry } from "./history.types.js";
+import type { HistoryEntry } from "./history.types.js";
 
 const RECENT_HISTORY_IMAGE_TTL_MS = 30 * 60_000;
 const RECENT_HISTORY_IMAGE_LIMIT = 4;
 
 export type RecentInboundHistoryImage = {
   path: string;
-  contentType: string;
+  contentType?: string;
+  kind?: MediaAttachment["kind"];
   sender: string;
   sentAtMs: number;
   messagePosition: number;
@@ -30,22 +32,6 @@ function isRemotePath(value: string): boolean {
   }
 }
 
-function resolveHistoryImageContentType(media: HistoryMediaEntry): string | undefined {
-  const contentType = normalizeOptionalString(media.contentType);
-  if (contentType?.startsWith("image/")) {
-    return contentType;
-  }
-  const path = normalizeOptionalString(media.path);
-  return mimeTypeFromFilePath(path);
-}
-
-function isHistoryImageMedia(media: HistoryMediaEntry): boolean {
-  if (media.kind === "image") {
-    return true;
-  }
-  return Boolean(resolveHistoryImageContentType(media)?.startsWith("image/"));
-}
-
 function resolveTimestamp(value: unknown): number | undefined {
   return asFiniteNumber(value);
 }
@@ -56,6 +42,8 @@ function resolveHistoryEntries(ctx: MsgContext): HistoryEntry[] {
 
 export function resolveRecentInboundHistoryImages(params: {
   ctx: MsgContext;
+  // Inject the canonical classifier so text-only ACP turns never eagerly load media runtime.
+  isImageAttachment: (attachment: MediaAttachment) => boolean;
   nowMs?: number;
   ttlMs?: number;
   limit?: number;
@@ -83,17 +71,24 @@ export function resolveRecentInboundHistoryImages(params: {
       mediaIndex -= 1
     ) {
       const media = mediaEntries[mediaIndex];
-      if (!media || !isHistoryImageMedia(media)) {
+      if (
+        !media ||
+        !params.isImageAttachment({
+          path: media.path,
+          url: media.url,
+          mime: media.contentType,
+          kind: media.kind,
+          index: mediaIndex,
+        })
+      ) {
         continue;
       }
       const mediaPath = normalizeOptionalString(media.path);
       if (!mediaPath || isRemotePath(mediaPath)) {
         continue;
       }
-      const contentType = resolveHistoryImageContentType(media);
-      if (!contentType?.startsWith("image/")) {
-        continue;
-      }
+      const contentType =
+        normalizeOptionalString(media.contentType) ?? mimeTypeFromFilePath(mediaPath);
       const messageId = normalizeOptionalString(media.messageId) ?? entry.messageId;
       const key = [messageId ?? "", mediaPath].join("\0");
       if (seen.has(key)) {
@@ -102,7 +97,8 @@ export function resolveRecentInboundHistoryImages(params: {
       seen.add(key);
       out.push({
         path: mediaPath,
-        contentType,
+        ...(contentType ? { contentType } : {}),
+        ...(media.kind ? { kind: media.kind } : {}),
         sender: entry.sender,
         sentAtMs: timestamp,
         messagePosition: index + 1,

--- a/src/auto-reply/reply/history.test.ts
+++ b/src/auto-reply/reply/history.test.ts
@@ -39,6 +39,130 @@ describe("history media recording", () => {
     ]);
   });
 
+  it.each([
+    {
+      name: "an image with generic MIME and a .bin path",
+      path: "/tmp/telegram-upload.bin",
+      contentType: "application/octet-stream",
+      kind: "image" as const,
+    },
+    {
+      name: "a sticker with generic MIME and a .bin path",
+      path: "/tmp/telegram-sticker.bin",
+      contentType: "application/octet-stream",
+      kind: "sticker" as const,
+    },
+    {
+      name: "an extensionless sticker without transport MIME",
+      path: "/tmp/telegram-sticker",
+      contentType: undefined,
+      kind: "sticker" as const,
+    },
+  ])("records $name at the actual channel history boundary", async (testCase) => {
+    const historyMap = new Map<string, HistoryEntry[]>();
+
+    await recordPendingHistoryEntryWithMedia({
+      historyMap,
+      historyKey: "telegram-chat",
+      limit: 5,
+      entry: {
+        sender: "Alice",
+        body: "<media:image>",
+        messageId: "telegram-message",
+      },
+      media: async () => [
+        {
+          path: testCase.path,
+          contentType: testCase.contentType,
+          kind: testCase.kind,
+        },
+      ],
+    });
+
+    expect(historyMap.get("telegram-chat")).toEqual([
+      {
+        sender: "Alice",
+        body: "<media:image>",
+        messageId: "telegram-message",
+        media: [
+          {
+            path: testCase.path,
+            contentType: testCase.contentType,
+            kind: testCase.kind,
+            messageId: "telegram-message",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it.each([
+    { path: "/tmp/telegram-document.bin", contentType: "application/octet-stream" },
+    { path: "/tmp/telegram-document.png", contentType: undefined },
+    { path: "/tmp/telegram-document.png", contentType: "application/pdf" },
+    { path: "/tmp/telegram-document.png", contentType: "image/png" },
+  ])("never records authoritative documents with MIME $contentType as history images", (media) => {
+    expect(
+      normalizeHistoryMediaEntries({
+        media: [
+          {
+            ...media,
+            kind: "document",
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it.each(["application/pdf", "application/zip", "text/plain"] as const)(
+    "never records unknown-kind image-looking documents with MIME %s",
+    (contentType) => {
+      expect(
+        normalizeHistoryMediaEntries({
+          media: [{ path: "/tmp/report.png", contentType, kind: "unknown" }],
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it.each([
+    { path: "/tmp/diagram.svg", kind: undefined },
+    { path: "/tmp/diagram.svg", kind: "unknown" as const },
+    { path: "/tmp/photo.png", kind: undefined },
+    { path: "/tmp/photo.png", kind: "unknown" as const },
+  ])("never manufactures image history from filename-only $path", (media) => {
+    expect(normalizeHistoryMediaEntries({ media: [media] })).toEqual([]);
+  });
+
+  it.each([
+    { path: "/tmp/diagram.svg", kind: "image" as const, contentType: undefined },
+    { path: "/tmp/diagram.svg", kind: undefined, contentType: "image/svg+xml" },
+  ])("preserves explicitly identified SVG history media", (media) => {
+    expect(normalizeHistoryMediaEntries({ media: [media] })).toEqual([
+      {
+        ...media,
+        kind: "image",
+        messageId: undefined,
+      },
+    ]);
+  });
+
+  it("records filename-only SVG turns without manufacturing reusable image history", async () => {
+    const historyMap = new Map<string, HistoryEntry[]>();
+
+    await recordPendingHistoryEntryWithMedia({
+      historyMap,
+      historyKey: "telegram-chat",
+      limit: 5,
+      entry: { sender: "Alice", body: "<media:document>", messageId: "diagram-message" },
+      media: async () => [{ path: "/tmp/diagram.svg" }],
+    });
+
+    expect(historyMap.get("telegram-chat")).toEqual([
+      { sender: "Alice", body: "<media:document>", messageId: "diagram-message" },
+    ]);
+  });
+
   it("records text history unchanged when media resolver has no usable media", async () => {
     const historyMap = new Map<string, HistoryEntry[]>();
 

--- a/src/auto-reply/reply/history.ts
+++ b/src/auto-reply/reply/history.ts
@@ -109,8 +109,11 @@ function isLocalHistoryMediaPath(path: string): boolean {
 }
 
 function isImageHistoryMediaEntry(entry: HistoryMediaEntry): boolean {
-  const contentType = entry.contentType?.split(";")[0]?.trim().toLowerCase();
-  return entry.kind === "image" || contentType?.startsWith("image/") === true;
+  if (entry.kind && entry.kind !== "unknown") {
+    return entry.kind === "image" || entry.kind === "sticker";
+  }
+  // History may manufacture image kind; filename-only inference would turn SVG documents into images.
+  return entry.contentType?.split(";")[0]?.trim().toLowerCase().startsWith("image/") === true;
 }
 
 /** Filters history media to local image entries safe to re-attach to prompt context. */

--- a/src/media-understanding/attachments.normalize.test.ts
+++ b/src/media-understanding/attachments.normalize.test.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
-import { normalizeAttachmentPath, normalizeAttachments } from "./attachments.normalize.js";
+import {
+  normalizeAttachmentPath,
+  normalizeAttachments,
+  resolveAttachmentKind,
+} from "./attachments.normalize.js";
 
 describe("normalizeAttachmentPath", () => {
   it("allows localhost file URLs", () => {
@@ -53,13 +57,15 @@ describe("normalizeAttachments", () => {
         path: "/tmp/voice.ogg",
         url: undefined,
         mime: "audio/ogg",
+        kind: "audio",
         index: 0,
         alreadyTranscribed: true,
       },
       {
         path: undefined,
         url: "https://example.test/photo.jpg",
-        mime: "image",
+        mime: undefined,
+        kind: "image",
         index: 1,
         alreadyTranscribed: false,
       },
@@ -85,5 +91,180 @@ describe("normalizeAttachments", () => {
         workspaceDir: "/tmp/staged",
       }),
     ]);
+  });
+
+  it("preserves authoritative media kinds without inventing MIME metadata", () => {
+    expect(
+      normalizeAttachments({
+        media: [{ url: "https://cdn.example.test/download?token=fixture", kind: "image" }],
+      }),
+    ).toEqual([
+      {
+        path: undefined,
+        url: "https://cdn.example.test/download?token=fixture",
+        mime: undefined,
+        kind: "image",
+        index: 0,
+        alreadyTranscribed: false,
+      },
+    ]);
+  });
+
+  it("distinguishes an explicit document from generic binary MIME inference", () => {
+    const attachments = normalizeAttachments({
+      media: [
+        { path: "/tmp/upload.avif", contentType: "application/octet-stream" },
+        {
+          path: "/tmp/report.png",
+          contentType: "application/octet-stream",
+          kind: "document",
+        },
+      ],
+    });
+
+    expect(attachments.map(({ kind }) => kind)).toEqual([undefined, "document"]);
+    expect(attachments.map(resolveAttachmentKind)).toEqual(["image", "unknown"]);
+  });
+
+  it("omits optional attachment fields when canonical facts do not declare them", () => {
+    const [attachment] = normalizeAttachments({
+      media: [{ path: "/tmp/photo.png", contentType: "application/octet-stream" }],
+    });
+
+    expect(attachment).toEqual({
+      path: "/tmp/photo.png",
+      url: undefined,
+      mime: "application/octet-stream",
+      index: 0,
+      alreadyTranscribed: false,
+    });
+  });
+});
+
+describe("resolveAttachmentKind", () => {
+  it.each([
+    { source: "/tmp/photo.avif", expected: "image" },
+    { source: "/tmp/photo.HEIC", expected: "image" },
+    { source: "/tmp/photo.heif", expected: "image" },
+    { source: "/tmp/scan.tif", expected: "image" },
+    { source: "/tmp/scan.TIFF", expected: "image" },
+    { source: "/tmp/clip.flv", expected: "video" },
+    { source: "/tmp/clip.m4v", expected: "video" },
+    { source: "/tmp/clip.wmv", expected: "video" },
+    { source: "/tmp/voice.aiff", expected: "audio" },
+    { source: "https://cdn.example.test/photo%2EHEIC?download=1", expected: "image" },
+  ] as const)(
+    "classifies $source as $expected from canonical media metadata",
+    ({ source, expected }) => {
+      expect(resolveAttachmentKind({ path: source, index: 0 })).toBe(expected);
+    },
+  );
+
+  it.each(["image", "audio", "video"] as const)(
+    "preserves an authoritative %s kind for an extensionless URL",
+    (kind) => {
+      expect(
+        resolveAttachmentKind({ url: "https://cdn.example.test/download", kind, index: 0 }),
+      ).toBe(kind);
+    },
+  );
+
+  it.each([
+    { mime: undefined, expected: "image" },
+    { mime: "image/webp", expected: "image" },
+    { mime: "audio/ogg", expected: "image" },
+  ] as const)(
+    "treats sticker facts as authoritative image media with MIME $mime",
+    ({ mime, expected }) => {
+      expect(
+        resolveAttachmentKind({
+          url: "https://cdn.example.test/sticker",
+          kind: "sticker",
+          mime,
+          index: 0,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it("does not let the unknown category mask a concrete audio MIME", () => {
+    expect(
+      resolveAttachmentKind({
+        url: "https://cdn.example.test/download",
+        kind: "unknown",
+        mime: "audio/ogg",
+        index: 0,
+      }),
+    ).toBe("audio");
+  });
+
+  it.each([
+    { source: "/tmp/report.png", mime: undefined },
+    { source: "/tmp/report.png", mime: "application/pdf" },
+    { source: "/tmp/report.png", mime: "application/octet-stream" },
+    { source: "/tmp/report.png", mime: "image/png" },
+    { source: "/tmp/report.ogg", mime: "audio/ogg" },
+    { source: "/tmp/report.mp4", mime: "video/mp4" },
+    { source: "/tmp/report.tiff", mime: undefined },
+  ])("keeps explicit documents authoritative for $source and MIME $mime", ({ source, mime }) => {
+    expect(resolveAttachmentKind({ path: source, kind: "document", mime, index: 0 })).toBe(
+      "unknown",
+    );
+  });
+
+  it.each([undefined, "application/octet-stream"] as const)(
+    "infers an unknown-kind image from its canonical filename with MIME %s",
+    (mime) => {
+      expect(
+        resolveAttachmentKind({ path: "/tmp/upload.png", kind: "unknown", mime, index: 0 }),
+      ).toBe("image");
+    },
+  );
+
+  it.each(["application/pdf", "application/zip", "text/plain", "application/json"] as const)(
+    "never infers an image over authoritative non-image MIME %s",
+    (mime) => {
+      expect(
+        resolveAttachmentKind({ path: "/tmp/report.png", kind: "unknown", mime, index: 0 }),
+      ).toBe("unknown");
+      expect(resolveAttachmentKind({ path: "/tmp/report.png", mime, index: 0 })).toBe("unknown");
+    },
+  );
+
+  it("prefers the authoritative kind over conflicting MIME and filename hints", () => {
+    expect(
+      resolveAttachmentKind({
+        path: "/tmp/video.mp4",
+        mime: "video/mp4",
+        kind: "image",
+        index: 0,
+      }),
+    ).toBe("image");
+  });
+
+  it("preserves explicit MIME precedence over a conflicting filename", () => {
+    expect(resolveAttachmentKind({ path: "/tmp/video.mp4", mime: "image/heic", index: 0 })).toBe(
+      "image",
+    );
+  });
+
+  it("keeps filename-only SVG out of raster image understanding", () => {
+    expect(resolveAttachmentKind({ path: "/tmp/diagram.svg", index: 0 })).toBe("unknown");
+  });
+
+  it("preserves explicitly identified SVG images", () => {
+    expect(
+      resolveAttachmentKind({ path: "/tmp/diagram.svg", mime: "image/svg+xml", index: 0 }),
+    ).toBe("image");
+  });
+
+  it("falls back to canonical filename metadata when the declared MIME is not media", () => {
+    expect(
+      resolveAttachmentKind({
+        path: "/tmp/photo.avif",
+        mime: "application/octet-stream",
+        index: 0,
+      }),
+    ).toBe("image");
   });
 });

--- a/src/media-understanding/attachments.normalize.ts
+++ b/src/media-understanding/attachments.normalize.ts
@@ -1,11 +1,15 @@
 // Attachment normalization converts message context media fields into typed
 // attachment records and classifies media kind from MIME or filename.
 import type { MediaKind } from "@openclaw/media-core/constants";
-import { getFileExtension, isAudioFileName, kindFromMime } from "@openclaw/media-core/mime";
+import { kindFromMime, mimeTypeFromFilePath, normalizeMimeType } from "@openclaw/media-core/mime";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { RuntimeMsgContext as MsgContext } from "../auto-reply/templating.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../infra/local-file-access.js";
-import { normalizeMediaFacts } from "../media/media-facts.js";
+import {
+  isGenericBinaryMediaContentType,
+  isImageMediaFact,
+  normalizeMediaFacts,
+} from "../media/media-facts.js";
 import type { MediaAttachment } from "./types.js";
 
 /** Normalizes a local attachment path while rejecting remote file URLs and Windows UNC paths. */
@@ -32,38 +36,54 @@ export function normalizeAttachmentPath(raw?: string | null): string | undefined
 /** Converts ordered media facts into indexed attachment records. */
 export function normalizeAttachments(ctx: MsgContext): MediaAttachment[] {
   return normalizeMediaFacts(ctx.media)
-    .map((fact, index) => ({
-      path: normalizeOptionalString(fact.path),
-      url: normalizeOptionalString(fact.url),
-      mime: normalizeOptionalString(fact.contentType) ?? fact.kind,
-      workspaceDir: normalizeOptionalString(fact.workspaceDir),
-      index,
-      alreadyTranscribed: fact.transcribed === true,
-    }))
+    .map((fact, index) => {
+      const attachment: MediaAttachment = {
+        path: normalizeOptionalString(fact.path),
+        url: normalizeOptionalString(fact.url),
+        mime: normalizeOptionalString(fact.contentType),
+        index,
+        alreadyTranscribed: fact.transcribed === true,
+      };
+      if (fact.kind) {
+        attachment.kind = fact.kind;
+      }
+      if (fact.workspaceDir) {
+        attachment.workspaceDir = fact.workspaceDir;
+      }
+      return attachment;
+    })
     .filter((entry) => Boolean(entry.path ?? entry.url));
 }
 
-/** Classifies an attachment by MIME first, then by filename/URL extension fallback. */
+/** Classifies an attachment by authoritative kind, MIME, then canonical filename metadata. */
 export function resolveAttachmentKind(attachment: MediaAttachment): Exclude<MediaKind, "sticker"> {
-  const kind = kindFromMime(attachment.mime);
-  if (kind === "image" || kind === "audio" || kind === "video") {
-    return kind;
-  }
-
-  const ext = getFileExtension(attachment.path ?? attachment.url);
-  if (!ext) {
-    return "unknown";
-  }
-  if ([".mp4", ".mov", ".mkv", ".webm", ".avi", ".m4v"].includes(ext)) {
-    return "video";
-  }
-  if (isAudioFileName(attachment.path ?? attachment.url)) {
-    return "audio";
-  }
-  if ([".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp", ".tiff", ".tif"].includes(ext)) {
+  if (
+    isImageMediaFact({
+      path: attachment.path,
+      url: attachment.url,
+      contentType: attachment.mime,
+      kind: attachment.kind,
+    })
+  ) {
     return "image";
   }
-  return "unknown";
+  if (attachment.kind === "audio" || attachment.kind === "video") {
+    return attachment.kind;
+  }
+  if (attachment.kind === "document") {
+    return "unknown";
+  }
+  const mime = normalizeMimeType(attachment.mime);
+  const kind = kindFromMime(mime);
+  if (kind === "audio" || kind === "video") {
+    return kind;
+  }
+  if (mime && !isGenericBinaryMediaContentType(mime)) {
+    return "unknown";
+  }
+
+  const inferredKind = kindFromMime(mimeTypeFromFilePath(attachment.path ?? attachment.url));
+  return inferredKind === "audio" || inferredKind === "video" ? inferredKind : "unknown";
 }
 
 /** Returns true when the attachment is classified as video media. */

--- a/src/media-understanding/runner.attachments.test.ts
+++ b/src/media-understanding/runner.attachments.test.ts
@@ -19,7 +19,41 @@ describe("normalizeMediaAttachments", () => {
         path: "/tmp/replied-audio.ogg",
         url: undefined,
         mime: "audio/ogg",
+        kind: "audio",
         index: 1,
+        alreadyTranscribed: false,
+      },
+    ]);
+  });
+
+  it.each(["image", "sticker", "document"] as const)(
+    "preserves the authoritative %s kind at the private runner facade",
+    (kind) => {
+      expect(normalizeMediaAttachments({ media: [{ path: "/tmp/upload.bin", kind }] })).toEqual([
+        {
+          path: "/tmp/upload.bin",
+          url: undefined,
+          mime: undefined,
+          kind,
+          index: 0,
+          alreadyTranscribed: false,
+        },
+      ]);
+    },
+  );
+
+  it("preserves an explicitly declared staging root without inventing empty optional fields", () => {
+    expect(
+      normalizeMediaAttachments({
+        media: [{ path: "/tmp/staged/photo.png", workspaceDir: "/tmp/staged" }],
+      }),
+    ).toEqual([
+      {
+        path: "/tmp/staged/photo.png",
+        url: undefined,
+        mime: undefined,
+        workspaceDir: "/tmp/staged",
+        index: 0,
         alreadyTranscribed: false,
       },
     ]);

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -1,5 +1,6 @@
 // Shared media-understanding types for attachments, provider hooks, request
 // auth, decisions, and structured extraction inputs.
+import type { MediaKind } from "@openclaw/media-core/constants";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -27,6 +28,7 @@ export type MediaAttachment = {
   path?: string;
   url?: string;
   mime?: string;
+  kind?: MediaKind;
   workspaceDir?: string;
   index: number;
   alreadyTranscribed?: boolean;

--- a/src/media/media-facts.persisted.test.ts
+++ b/src/media/media-facts.persisted.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   canonicalizePersistedUserMessageMedia,
+  isImageMediaFact,
+  normalizeMediaFacts,
   PERSISTED_LEGACY_MEDIA_KEYS,
   readPersistedMediaFacts,
 } from "./media-facts.js";
@@ -197,5 +199,95 @@ describe("canonical persisted media", () => {
 
     expect(result.message).not.toHaveProperty("media");
     expect(readPersistedMediaFacts(result.message)?.[0]).toMatchObject(canonicalFact);
+  });
+});
+
+describe("canonical image media facts", () => {
+  it.each([
+    { name: "filename-only SVG", fact: { path: "/tmp/diagram.svg" }, expected: false },
+    {
+      name: "unknown-kind SVG with generic MIME",
+      fact: {
+        path: "/tmp/diagram.svg",
+        kind: "unknown" as const,
+        contentType: "application/octet-stream",
+      },
+      expected: false,
+    },
+    {
+      name: "explicit image-kind SVG",
+      fact: { path: "/tmp/diagram.svg", kind: "image" as const },
+      expected: true,
+    },
+    {
+      name: "explicit SVG image MIME",
+      fact: { path: "/tmp/diagram.svg", contentType: "image/svg+xml" },
+      expected: true,
+    },
+    { name: "filename-only TIFF", fact: { path: "/tmp/scan.tiff" }, expected: true },
+    {
+      name: "generic MIME TIFF",
+      fact: { path: "/tmp/scan.TIF", contentType: "binary/octet-stream" },
+      expected: true,
+    },
+    {
+      name: "authoritative document TIFF",
+      fact: { path: "/tmp/scan.tiff", contentType: "image/png", kind: "document" as const },
+      expected: false,
+    },
+    {
+      name: "unknown-kind PDF with image filename",
+      fact: { path: "/tmp/report.png", contentType: "application/pdf", kind: "unknown" as const },
+      expected: false,
+    },
+    {
+      name: "unknown-kind ZIP with image filename",
+      fact: { path: "/tmp/report.png", contentType: "application/zip", kind: "unknown" as const },
+      expected: false,
+    },
+    {
+      name: "unknown-kind text with image filename",
+      fact: { path: "/tmp/report.png", contentType: "text/plain", kind: "unknown" as const },
+      expected: false,
+    },
+    {
+      name: "legacy bare image kind",
+      fact: { path: "/tmp/photo.png", contentType: "image" },
+      expected: true,
+    },
+    {
+      name: "legacy bare sticker kind",
+      fact: { path: "/tmp/sticker.bin", contentType: "sticker" },
+      expected: true,
+    },
+  ])("classifies $name at the shared image-fact owner", ({ fact, expected }) => {
+    expect(isImageMediaFact(fact)).toBe(expected);
+  });
+
+  it("preserves generic binary provenance without inventing authoritative documents", () => {
+    const [inferredImage, explicitDocument] = normalizeMediaFacts([
+      { path: "/tmp/scan.tiff", contentType: "application/octet-stream" },
+      { path: "/tmp/report.png", contentType: "application/octet-stream", kind: "document" },
+    ]);
+
+    expect(inferredImage?.kind).toBeUndefined();
+    expect(inferredImage && isImageMediaFact(inferredImage)).toBe(true);
+    expect(explicitDocument?.kind).toBe("document");
+    expect(explicitDocument && isImageMediaFact(explicitDocument)).toBe(false);
+  });
+
+  it("keeps persisted filename SVG and TIFF aligned with the canonical image owner", () => {
+    const media = readPersistedMediaFacts({
+      __openclaw: {
+        media: [
+          { path: "/tmp/diagram.svg" },
+          { path: "/tmp/scan.tiff", contentType: "application/octet-stream" },
+          { path: "/tmp/explicit.svg", kind: "image" },
+        ],
+      },
+    });
+
+    expect(media?.map(isImageMediaFact)).toEqual([false, true, true]);
+    expect(media?.[1]?.kind).toBeUndefined();
   });
 });

--- a/src/media/media-facts.ts
+++ b/src/media/media-facts.ts
@@ -1,5 +1,10 @@
 import type { MediaKind } from "@openclaw/media-core/constants";
-import { kindFromMime, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
+import {
+  getFileExtension,
+  kindFromMime,
+  mimeTypeFromFilePath,
+  normalizeMimeType,
+} from "@openclaw/media-core/mime";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { PromptImageOrderEntry } from "./prompt-image-order.js";
 
@@ -274,37 +279,39 @@ export function readRuntimePromptImageOrder(message: object): PromptImageOrderEn
   return Array.isArray(imageOrder) ? (imageOrder as PromptImageOrderEntry[]) : undefined;
 }
 
+/** Returns whether a declared MIME only describes otherwise unclassified binary bytes. */
+export function isGenericBinaryMediaContentType(contentType?: string | null): boolean {
+  const normalizedContentType = normalizeMimeType(contentType);
+  return (
+    normalizedContentType === "application/octet-stream" ||
+    normalizedContentType === "binary/octet-stream"
+  );
+}
+
 /** Returns whether a fact can produce native image input. */
 export function isImageMediaFact(fact: MediaFactInput): boolean {
   if (fact.kind && fact.kind !== "unknown") {
     return fact.kind === "image" || fact.kind === "sticker";
   }
-  const contentType = normalizeOptionalString(fact.contentType);
-  const normalizedContentType = contentType?.split(";")[0]?.trim().toLowerCase();
-  if (
-    normalizedContentType &&
-    normalizedContentType !== "application/octet-stream" &&
-    normalizedContentType !== "binary/octet-stream"
-  ) {
+  const normalizedContentType = normalizeMimeType(fact.contentType);
+  if (normalizedContentType && !isGenericBinaryMediaContentType(normalizedContentType)) {
     const mimeKind = kindFromMime(normalizedContentType);
     if (mimeKind) {
       return mimeKind === "image";
     }
-    // Legacy channel-mode projections persist bare kinds as MediaType; honor
-    // them, and fall through to filename inference for other unknown strings.
-    if (normalizedContentType === "image" || normalizedContentType === "sticker") {
-      return true;
-    }
-    if (
-      normalizedContentType === "audio" ||
-      normalizedContentType === "video" ||
-      normalizedContentType === "document"
-    ) {
-      return false;
-    }
+    // Legacy channel-mode projections persist bare image or sticker kind as MediaType.
+    return normalizedContentType === "image" || normalizedContentType === "sticker";
   }
   const pathValue = normalizeOptionalString(fact.path) ?? normalizeOptionalString(fact.url);
-  return kindFromMime(mimeTypeFromFilePath(pathValue)) === "image";
+  const inferredMime = mimeTypeFromFilePath(pathValue);
+  if (inferredMime === "image/svg+xml") {
+    return false;
+  }
+  if (kindFromMime(inferredMime) === "image") {
+    return true;
+  }
+  const extension = getFileExtension(pathValue);
+  return extension === ".tif" || extension === ".tiff";
 }
 
 type MediaFactDefaults<TInput extends MediaFactInput = MediaFactInput> = {
@@ -355,7 +362,10 @@ function normalizeMediaFact<TInput extends MediaFactInput>(
     path: normalizeOptionalString(media.path),
     url: normalizeOptionalString(media.url),
     contentType,
-    kind: media.kind ?? defaults.kind ?? kindFromMime(contentType),
+    kind:
+      media.kind ??
+      defaults.kind ??
+      (isGenericBinaryMediaContentType(contentType) ? undefined : kindFromMime(contentType)),
     fileName: normalizeOptionalString(media.fileName),
     sizeBytes: normalizeNonNegativeNumber(media.sizeBytes),
     ...(durationMs ? { durationMs } : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where valid user images, stickers, audio, or videos silently disappeared from channel history, media understanding, native model turns, ACP turns, persisted replay, or the plugin harness when their attachment category and MIME diverged, filenames lacked recognized extensions, or sibling owners disagreed about the attachment type.

## Why This Change Was Made

Make the existing media-fact owner authoritative at every actual attachment boundary; preserve explicit document/image/sticker intent, classify generic or absent MIME consistently, delete drifting duplicate private classifiers, and retain the existing guarded byte-aware image loader, lazy runtime loading, history ownership, and strict private facade shape.

## User Impact

Valid extensionless or generic-MIME images and stickers consistently reach their intended user-visible workflow. Documents and filename-only SVG stay out of native image paths, forged PDF/ZIP image payloads remain rejected by actual byte detection, supported audio/video formats are classified consistently, and existing TIFF metadata classification is preserved without claiming unsupported Linux TIFF decoding.

## Evidence

- Authentic untouched-parent owner regressions reproduce **79 genuine failures** across attachment normalization, channel-history recording, native/ACP current-turn and history dispatch, persisted image layout, embedded replay, and the actual plugin harness; a private facade additionally reproduces one strict optional-property regression.
- Exact immutable head `99e8afc8eecd6f47718a0a6c8f42204360da7b01` passes all **259 focused tests across nine real owner/sibling suites and four Vitest shards**. Real filename-only and generic-binary PNG bytes are persisted, replayed, byte-sniffed, and delivered to the actual embedded and plugin-harness image paths.
- Four independently fresh hostile source reviewers inspected all 17 changed owner/test files, actual downstream consumers, pinned MIME detection contracts, trusted local roots, SSRF policy, lazy loading, document/sticker/SVG semantics, and the extensible `AgentMessage` union.
- Genuine `gpt-5.6-sol` high-effort P0–P3 official autoreview found **zero issues** (confidence **0.97**); native TruffleHog 3.96 was clean.
- Eight existing production owners total **130 additions and 129 deletions (net +1 line)**. No image processor, Photon runtime, dependency, public SDK, configuration, gateway protocol, persistent schema, authentication, or security policy changes are included.

Actual post-fix source-product execution; no mocked owner, provider, or Gateway:

```text
$ node --import tsx /private/tmp/openclaw-media-99e8-real-runtime-proof.mjs
{"scenario":"generic-binary PNG filename","declaredMime":"application/octet-stream","authoritativeKind":null,"canonicalIsImage":true,"inputBytes":91,"direct":{"images":1,"failedMediaCount":0,"mime":"image/png","imageBytes":91},"persistedReplay":{"images":1,"mime":"image/png","imageBytes":91},"pluginHarness":{"images":1,"mime":"image/png","imageBytes":91}}
{"scenario":"generic-binary extensionless authoritative image","declaredMime":"application/octet-stream","authoritativeKind":"image","canonicalIsImage":true,"inputBytes":91,"direct":{"images":1,"failedMediaCount":0,"mime":"image/png","imageBytes":91},"persistedReplay":{"images":1,"mime":"image/png","imageBytes":91},"pluginHarness":{"images":1,"mime":"image/png","imageBytes":91}}
$ echo $?
0
```

This invokes the actual canonical media classifier, `detectAndLoadPromptImages`, `hydratePromptMediaMessages`, and `preparePluginHarnessPromptImages` with genuine PNG bytes under fresh trusted media/workspace roots. The `example.test` domains visible elsewhere are intentional unit-test fixture literals, not linked proof artifacts or runtime network endpoints. The reviewed branch has no overlapping source drift against current `main`; rebasing solely for unrelated commits would invalidate its exact-head reviews without changing the repaired owner.

**Maintainer media-owner decision:** confirmed and accepted: an explicitly recorded image, sticker, document, audio, or video `MediaFact.kind` is the authoritative product fact; generic binary MIME and filename inference apply only when that owner fact is absent or unknown. This restores consistent producer-to-replay ownership, preserves explicit documents, and is verified across channel history, native turns, ACP, persisted replay, and the actual plugin harness.
