### PR TITLE
fix(gateway): isolate startup event-loop responsiveness guard

### DIFF
--- a/src/gateway/server-startup-model-runtime.event-loop.test.ts
+++ b/src/gateway/server-startup-model-runtime.event-loop.test.ts
@@ -87,12 +87,13 @@ async function listenHealthz(): Promise<{ port: number; close: () => Promise<voi
 }
 
 async function requestHealthzAfter(port: number, delayMs: number) {
-  const startedAt = performance.now();
+  const cpuStartedAt = process.threadCpuUsage();
   await new Promise<void>((resolve) => {
     setTimeout(resolve, delayMs);
   });
   const response = await fetch(`http://127.0.0.1:${port}/healthz`);
-  return { elapsedMs: performance.now() - startedAt, response };
+  const cpuUsage = process.threadCpuUsage(cpuStartedAt);
+  return { cpuMs: (cpuUsage.user + cpuUsage.system) / 1_000, response };
 }
 
 afterEach(() => {
@@ -163,11 +164,11 @@ describe("Gateway prepared model runtime startup", () => {
             logChannels: { info: vi.fn(), error: vi.fn() },
           });
 
-          const [{ elapsedMs, response }] = await Promise.all([probe, sidecars]);
+          const [{ cpuMs, response }] = await Promise.all([probe, sidecars]);
           expect(response.status).toBe(200);
-          // The configured model is already resolved from manifest facts. Either provider hook
-          // would deliberately block the event loop well beyond this responsiveness guard.
-          expect(elapsedMs).toBeLessThan(1_000);
+          // Current-thread CPU isolates startup work from runner descheduling. Either provider
+          // hook would consume well beyond this budget while starving health-probe handling.
+          expect(cpuMs).toBeLessThan(1_000);
           expect(providerMocks.staticCatalog).not.toHaveBeenCalled();
           expect(providerMocks.liveCatalog).not.toHaveBeenCalled();
         },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the gateway startup responsiveness guard failed repeatedly on saturated hosted CI runners even though the startup path remained responsive. The guard measured loopback health-probe wall time, so operating-system descheduling was reported as gateway event-loop blockage and burned reruns across unrelated PRs.

## Why This Change Was Made

The probe now measures current-thread CPU consumed while startup and the health request run, using Node's documented [`process.threadCpuUsage()`](https://nodejs.org/api/process.html#processthreadcpuusagepreviousvalue) API. This preserves the original 1,000 ms regression budget and the real HTTP health check, while excluding time when a hosted runner is not scheduled. Either forbidden provider-catalog hook still deliberately consumes 1,500 ms of the same thread CPU and therefore fails the guard.

The production startup path is unchanged. The existing assertions still prove that prepared model-runtime facts prevent both static and live provider discovery during sidecar startup.

## User Impact

There is no runtime behavior change. Maintainers should stop seeing false gateway startup failures caused by hosted-runner starvation, while genuine synchronous startup work remains covered.

## Evidence

- CI-history audit found 26 failures in `checks-node-compact-large-2` during the 03:37–04:59 UTC saturation wave: 11 measured 105.5–109.6 seconds and 15 hit the 120-second Vitest timeout. The compact shard uses `planConcurrency: 1`, the gateway project disables file parallelism, and neighboring startup files completed normally. Representative failures: [108.1 seconds](https://github.com/openclaw/openclaw/actions/runs/30731757908/job/91453279212), [105.5 seconds](https://github.com/openclaw/openclaw/actions/runs/30732982881/job/91456555935), [109.6 seconds](https://github.com/openclaw/openclaw/actions/runs/30732883634/job/91456259897).
- `for run_index in {1..20}; do node scripts/run-vitest.mjs src/gateway/server-startup-model-runtime.event-loop.test.ts || exit $?; done` — 20/20 passed sequentially. Two runs waited 102 and 238 seconds for cross-worktree contention before executing, then passed.
- Post-rebase focused run: `node scripts/run-vitest.mjs src/gateway/server-startup-model-runtime.event-loop.test.ts` — passed.
- A direct 1.5-second busy-loop contract probe reported 1,495.9 ms of current-thread CPU, above the unchanged 1,000 ms guard.
- Touched-file `oxfmt` and `git diff --check` — clean.
- `node scripts/check-changed.mjs` classified the change for hosted proof but could not acquire a ready Crabbox provider on this machine; PR CI supplies the changed-surface checks.
- Required autoreview completed twice, including after rebasing onto current `origin/main`, with no accepted or actionable findings.
