### PR TITLE
fix(gateway): resume terminal output when slow viewers disconnect

### DIFF
--- a/src/gateway/terminal/output-flow-control.ts
+++ b/src/gateway/terminal/output-flow-control.ts
@@ -66,6 +66,11 @@ export class TerminalOutputController {
     this.lastInputAtMs = this.now();
   }
 
+  /** Reassesses flow control immediately when the live recipient set changes. */
+  reconcileRecipients(): void {
+    this.reconcile(this.getConnIds());
+  }
+
   /** Flushes existing viewers, then aligns live frames after the attach snapshot. */
   prepareViewerAttach(): void {
     this.coalescer.flush();

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -704,6 +704,96 @@ describe("TerminalSessionManager agent ownership", () => {
     }
   });
 
+  it.each(["disconnect", "close"] as const)(
+    "immediately resumes a shared terminal when its slow viewer leaves via %s",
+    async (removal) => {
+      vi.useFakeTimers();
+      const fake = makeFakePty();
+      const emit = vi.fn();
+      const bufferedAmounts = new Map([
+        ["viewer-slow", Number.MAX_SAFE_INTEGER],
+        ["viewer-healthy", 0],
+      ]);
+      const manager = new TerminalSessionManager({
+        emit,
+        getBufferedAmount: (connId) => bufferedAmounts.get(connId),
+        spawn: async () => fake,
+      });
+
+      try {
+        const outcome = await manager.open(baseRequest({ owner: agentOwner }));
+        if (!outcome.ok) {
+          throw new Error("expected open");
+        }
+        manager.attach("viewer-slow", outcome.sessionId);
+        manager.attach("viewer-healthy", outcome.sessionId);
+
+        fake.emitData("pressure");
+        await vi.advanceTimersByTimeAsync(4);
+        expect(fake.paused).toBe(true);
+
+        if (removal === "disconnect") {
+          manager.handleDisconnect("viewer-slow");
+        } else {
+          expect(manager.close("viewer-slow", outcome.sessionId)).toBe(true);
+        }
+
+        expect(fake.paused).toBe(false);
+        emit.mockClear();
+        fake.emitData("resumed");
+        await vi.advanceTimersByTimeAsync(4);
+        expect(emit).toHaveBeenCalledWith(
+          "viewer-healthy",
+          TERMINAL_EVENT_DATA,
+          expect.objectContaining({ data: "resumed" }),
+        );
+        expect(emit).not.toHaveBeenCalledWith(
+          "viewer-slow",
+          TERMINAL_EVENT_DATA,
+          expect.anything(),
+        );
+      } finally {
+        manager.disposeAll();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("keeps a shared terminal paused when its remaining viewer is still slow", async () => {
+    vi.useFakeTimers();
+    const fake = makeFakePty();
+    const bufferedAmounts = new Map([
+      ["viewer-slow", Number.MAX_SAFE_INTEGER],
+      ["viewer-healthy", 0],
+    ]);
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      getBufferedAmount: (connId) => bufferedAmounts.get(connId),
+      spawn: async () => fake,
+    });
+
+    try {
+      const outcome = await manager.open(baseRequest({ owner: agentOwner }));
+      if (!outcome.ok) {
+        throw new Error("expected open");
+      }
+      manager.attach("viewer-slow", outcome.sessionId);
+      manager.attach("viewer-healthy", outcome.sessionId);
+
+      fake.emitData("pressure");
+      await vi.advanceTimersByTimeAsync(4);
+      expect(fake.paused).toBe(true);
+
+      manager.handleDisconnect("viewer-healthy");
+
+      expect(fake.paused).toBe(true);
+      expect(fake.resumeCalls).toBe(0);
+    } finally {
+      manager.disposeAll();
+      vi.useRealTimers();
+    }
+  });
+
   it("resumes a pressured PTY immediately when its last viewer disconnects", async () => {
     const fake = makeFakePty();
     const manager = new TerminalSessionManager({

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -662,6 +662,9 @@ export class TerminalSessionManager {
       // With no socket pressure left, resume immediately. Buffered bytes stay
       // in the replay ring and the next viewer starts at its high-water mark.
       session.output.resetOwnership();
+    } else {
+      // A departed slow viewer must not leave healthy co-viewers stalled.
+      session.output.reconcileRecipients();
     }
     return true;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a healthy browser viewing a shared agent terminal would silently stop receiving live output after a different slow browser disconnected or closed its terminal view.

## Why This Change Was Made

Let the existing terminal output-flow owner immediately reconcile its actual remaining recipients whenever a viewer leaves. This preserves the canonical high/low-watermark policy and last-viewer reset while removing the stale paused state shared by healthy co-viewers.

## User Impact

Live agent-terminal output immediately resumes for a healthy remaining browser when a backpressured co-viewer closes or disconnects. A genuinely slow remaining browser still pauses its terminal, and existing ownership, replay, cancellation, and authorization behavior do not change.

## Exact-Head Verification

- Reviewed commit: `9556d626317c0215c6f3cd2f49590e23613fb8c6`; clean latest-main parent: `0a4ce1bb168f82b92c5b841aa247ffb9fc1365f4`.
- A dedicated trusted Blacksmith Testbox first synced **only** the new regression tests onto untouched latest main: the actual manager suite failed on both browser-disconnect and explicit terminal-close routes (**2 failed / 40 passed**, exit 1).
- The same lease then synced the exact reviewed canonical owner refactor: the same suite passed **42/42**, exit 0, including immediate PTY resumption, departed-viewer exclusion, and a remaining-slow-viewer negative control. The lease was explicitly stopped.
- Remote proof: https://github.com/openclaw/openclaw/actions/runs/30737043385
- The original reviewed patch and the refreshed latest-main patch have identical stable patch ID `b07ebeac385820dc92414b6a8b47b089aac0fcfb`.
- **Five genuinely fresh independent hostile reviewers** inspected complete owner/caller/sibling modules, real node-pty pause/resume behavior, the durable exact-parent RED/GREEN logs, and authorization/backpressure/replay invariants; all reported zero P0-P3 findings.
- Actual official `gpt-5.6-sol` high-reasoning autoreview of this exact commit found **zero P0-P3 issues**, confidence **0.99**; native TruffleHog **3.96.0** found no secrets.
- One private lifecycle-owner refactor; three files, **+8 production lines**. No public protocol, configuration, plugin SDK, security policy, or terminal ownership contract changes.

## Real Shared-Browser Terminal Proof

Actual Chromium 144 + actual Gateway + actual built-in agent terminal tool + actual `@lydell/node-pty` were exercised on the exact reviewed commit (no mocked Gateway, provider, WebSocket, PTY, or production property):

1. Create one real **agent-owned** terminal using the built-in agent tool, then connect **two separately authenticated real Control UI Chromium browser contexts** to that same terminal.
2. Pause only the slow viewer loopback transport until the real Gateway socket reports **4,194,733 bytes buffered**, exceeding the real **4,194,304-byte** high-water mark; the healthy viewer remains at **0 buffered bytes** and the actual PTY pauses.
3. Close the actual slow browser context. The surviving real browser receives and visibly renders the actual PTY marker `LIVE_SHARED_TERMINAL_RECOVERED_9556_4cc91e18` after **3,137 ms**, before the unrelated **5,000 ms** periodic failsafe. One healthy viewer remains.
4. Four real browser screenshots, recordings from both Chromium contexts, and a redacted machine-readable proof record were captured; authentication tokens are redacted. The single trusted Blacksmith lease was stopped and verified completed.

Real user-path Actions run: https://github.com/openclaw/openclaw/actions/runs/30737720835

All current exact-head substantive hosted CI checks, including the required `openclaw/ci-gate`, build, all QA profiles, production/test type checks, security checks, and Gateway/Node shards, have passed.
