### PR TITLE
docs(cli): document nodes push exit status

### DIFF
--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -73,7 +73,7 @@ openclaw nodes screen record --node <id> --duration 10s --fps 10 --out ./clip.mp
 ```
 
 - `notify` sends a local notification on a node that declares `system.notify`, including macOS, iOS, Android, and direct watchOS nodes. Direct watchOS delivery requires OpenClaw to be active. Requires `--title` or `--body`. Options: `--sound <name>`, `--priority <passive|active|timeSensitive>`, `--delivery <system|overlay|auto>` (default `system`), `--invoke-timeout <ms>` (default `15000`).
-- `push` sends an APNs test push to an iOS node. Options: `--title <text>` (default `OpenClaw`), `--body <text>`, `--environment <sandbox|production>` to override the detected APNs environment.
+- `push` sends an APNs test push to an iOS node. Options: `--title <text>` (default `OpenClaw`), `--body <text>`, `--environment <sandbox|production>` to override the detected APNs environment. Accepted delivery exits `0`; a typed APNs rejection preserves the complete text or JSON diagnostic and exits non-zero.
 - `location get` fetches the node's current location. Options: `--max-age <ms>` (reuse a cached fix), `--accuracy <coarse|balanced|precise>`, `--location-timeout <ms>` (default `10000`), `--invoke-timeout <ms>` (default `20000`).
 - `screen record` captures a short clip and prints the saved path (or writes JSON with `--json`). Options: `--screen <index>` (default `0`), `--duration <ms|10s>` (default `10000`), `--fps <fps>` (default `10`), `--no-audio`, `--out <path>`, `--invoke-timeout <ms>` (default `120000`).
 


### PR DESCRIPTION
Related: #117736
Related: #117737

## What Problem This Solves

Resolves a documentation gap where the `openclaw nodes push` reference did not state the shell exit-status contract added by the landed APNs rejection fix.

## Why This Change Was Made

The existing `push` option paragraph now states the complete observable contract: accepted delivery exits zero, while a typed APNs rejection preserves its text or JSON diagnostic and exits non-zero. No command, transport, Gateway, or protocol behavior changes.

## User Impact

Operators and automation authors can tell from the CLI reference that shell status is authoritative without losing provider diagnostics.

## Evidence

- `node scripts/docs-list.js`: `cli/nodes.md` parsed and remained present in the public docs map.
- `git diff --check`: passed.
- Fresh autoreview `019fc0ef-ced1-7200-aab3-97c68434251b`: clean, documentation accurate, confidence 0.99.
- The documented behavior is already shipped on `main` by #117737 / `fa1123a53093089ebfc76e09ec877ab1b817788f`.

AI-assisted: yes. No agent transcript is attached per the campaign-wide decision.
