### PR TITLE
fix(google): reject malformed embeddings before memory indexing

### DIFF
--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -323,7 +323,10 @@ describe("Google embedding-batch bounded JSON reads", () => {
     );
   });
 
-  it("runs the complete batch lifecycle over loopback HTTP", async () => {
+  it.each([
+    { label: "a valid vector", values: [1, 0, 0], expectedError: undefined },
+    { label: "a corrupt vector", values: [1, null], expectedError: "r0: invalid embedding" },
+  ])("runs loopback HTTP with $label", async ({ values, expectedError }) => {
     let createBody: unknown;
     const authHeaders: Array<string | undefined> = [];
     const server = createServer((request, response) => {
@@ -370,7 +373,7 @@ describe("Google embedding-batch bounded JSON reads", () => {
           response.writeHead(200, { "content-type": "application/jsonl" });
           const line = JSON.stringify({
             key: "r0",
-            response: { embedding: { values: [1, 0, 0] } },
+            response: { embedding: { values } },
           });
           response.write(line.slice(0, 17));
           response.end(line.slice(17));
@@ -384,17 +387,38 @@ describe("Google embedding-batch bounded JSON reads", () => {
     const port = await listenLoopbackServer(server);
 
     try {
-      const result = await runBatch(
-        singleRequest(),
-        makeGeminiClient(`http://127.0.0.1:${port}/v1beta`),
-      );
+      const result = runBatch(singleRequest(), makeGeminiClient(`http://127.0.0.1:${port}/v1beta`));
 
-      expect(result).toEqual(new Map([["r0", [1, 0, 0]]]));
-      expect(createBody).toMatchObject({ batch: { inputConfig: { file_name: "files/input-0" } } });
+      if (expectedError) {
+        await expect(result).rejects.toThrow(expectedError);
+      } else {
+        await expect(result).resolves.toEqual(new Map([["r0", [1, 0, 0]]]));
+      }
+      expect(createBody).toMatchObject({
+        batch: { inputConfig: { file_name: "files/input-0" } },
+      });
       expect(authHeaders).toEqual(["test-key", "test-key", "test-key", "test-key"]);
     } finally {
       await closeServer(server);
     }
+  });
+
+  it.each([
+    { label: "a missing vector", values: undefined, message: "r0: empty embedding" },
+    { label: "an empty vector", values: [], message: "r0: empty embedding" },
+    { label: "a non-array vector", values: "bad", message: "r0: invalid embedding" },
+    { label: "an array-like vector", values: { length: 1 }, message: "r0: invalid embedding" },
+    { label: "a null coordinate", values: [null], message: "r0: invalid embedding" },
+    { label: "a string coordinate", values: ["bad"], message: "r0: invalid embedding" },
+    { label: "a mixed coordinate", values: [1, null], message: "r0: invalid embedding" },
+  ])("rejects downloaded Gemini batch output with $label", async ({ values, message }) => {
+    stubBatchFetch((stage) =>
+      stage === "download"
+        ? new Response(JSON.stringify({ key: "r0", response: { embedding: { values } } }))
+        : undefined,
+    );
+
+    await expect(runBatch()).rejects.toThrow(message);
   });
 
   it("honors terminal LRO fields when metadata is stale", async () => {

--- a/extensions/google/embedding-batch.ts
+++ b/extensions/google/embedding-batch.ts
@@ -21,7 +21,11 @@ import {
   resolveProviderOperationTimeoutMs,
   waitProviderOperationPollInterval,
 } from "openclaw/plugin-sdk/provider-http";
-import type { GeminiEmbeddingClient, GeminiTextEmbeddingRequest } from "./embedding-provider.js";
+import {
+  isValidGeminiEmbeddingValues,
+  type GeminiEmbeddingClient,
+  type GeminiTextEmbeddingRequest,
+} from "./embedding-provider.js";
 import { parseGeminiAuth } from "./gemini-auth.js";
 
 type GeminiBatchRequest = {
@@ -45,13 +49,13 @@ type GeminiBatchOperation = {
 type GeminiBatchState = "pending" | "succeeded" | "failed" | "cancelled" | "expired" | "unknown";
 
 type GeminiBatchOutputLine = {
-  // Alternate ids and direct embeddings are shipped compatible-endpoint shapes.
+  // Preserve shipped output aliases; provider JSON remains unknown until validated.
   key?: string;
   custom_id?: string;
   request_id?: string;
-  embedding?: { values?: number[] };
+  embedding?: { values?: unknown };
   response?: {
-    embedding?: { values?: number[] };
+    embedding?: { values?: unknown };
     error?: { message?: string };
   };
   error?: { message?: string };
@@ -301,14 +305,14 @@ function applyGeminiBatchOutputLine(params: {
     params.errors.push(`${customId}: ${error}`);
     return;
   }
-  const embedding = sanitizeAndNormalizeEmbedding(
-    params.line.embedding?.values ?? params.line.response?.embedding?.values ?? [],
-  );
-  if (embedding.length === 0) {
-    params.errors.push(`${customId}: empty embedding`);
+  const values = params.line.embedding?.values ?? params.line.response?.embedding?.values;
+  if (!isValidGeminiEmbeddingValues(values)) {
+    const reason =
+      values == null || (Array.isArray(values) && values.length === 0) ? "empty" : "invalid";
+    params.errors.push(`${customId}: ${reason} embedding`);
     return;
   }
-  params.byCustomId.set(customId, embedding);
+  params.byCustomId.set(customId, sanitizeAndNormalizeEmbedding(values));
 }
 
 async function fetchGeminiBatchOutput(params: {

--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -1,4 +1,5 @@
 // Google tests cover embedding provider plugin behavior.
+import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importOriginal) => {
@@ -202,6 +203,62 @@ describe("Gemini embedding provider", () => {
       "gemini embeddings failed: malformed JSON response",
     );
   });
+
+  it.each([
+    { operation: "query", response: { embedding: { values: [] } } },
+    { operation: "batch", response: { embeddings: [{ values: [] }] } },
+    { operation: "structured batch", response: { embeddings: [{ values: [] }] } },
+  ])(
+    "rejects empty provider vectors from a non-empty $operation",
+    async ({ operation, response }) => {
+      const server = createServer((_request, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(response));
+      });
+      const port = await new Promise<number>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+          server.off("error", reject);
+          const address = server.address();
+          if (!address || typeof address === "string") {
+            reject(new Error("expected loopback TCP address"));
+            return;
+          }
+          resolve(address.port);
+        });
+      });
+
+      try {
+        const { provider } = await createGeminiEmbeddingProvider({
+          config: {} as never,
+          provider: "gemini",
+          remote: { apiKey: "test-key", baseUrl: `http://127.0.0.1:${port}/v1beta` },
+          model: "gemini-embedding-001",
+          fallback: "none",
+        });
+
+        const embedding =
+          operation === "query"
+            ? provider.embedQuery("test query")
+            : operation === "batch"
+              ? provider.embedBatch(["one"])
+              : (provider.embedBatchInputs?.([
+                  {
+                    text: "Image file: diagram.png",
+                    parts: [{ type: "text", text: "Image file: diagram.png" }],
+                  },
+                ]) ?? Promise.reject(new Error("expected structured embedding support")));
+
+        await expect(embedding).rejects.toThrow(
+          "gemini embeddings failed: malformed JSON response",
+        );
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
 
   it("rejects batch embedding count mismatches", async () => {
     installFetchMock(() => ({ embeddings: [{ values: [1, 2] }] }));

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -75,14 +75,18 @@ function malformedGeminiEmbeddingResponse(): Error {
   return new Error("gemini embeddings failed: malformed JSON response");
 }
 
+/** Keep direct and downloaded Gemini vectors valid before normalization or indexing. */
+export function isValidGeminiEmbeddingValues(value: unknown): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((entry) => typeof entry === "number" && Number.isFinite(entry))
+  );
+}
+
 function readGeminiEmbeddingValues(value: unknown): number[] {
-  if (!Array.isArray(value)) {
+  if (!isValidGeminiEmbeddingValues(value)) {
     throw malformedGeminiEmbeddingResponse();
-  }
-  for (const entry of value) {
-    if (typeof entry !== "number" || !Number.isFinite(entry)) {
-      throw malformedGeminiEmbeddingResponse();
-    }
   }
   return value;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes Google memory embedding responses that silently accept empty vectors or normalize corrupt downloaded coordinates into plausible search vectors.

## User Impact

Malformed responses from Google or compatible endpoints now fail at the provider boundary. Valid vectors, configured dimensions, empty input lists, and existing fallback handling remain unchanged. Existing stored data and cache identities are untouched; this does not repair previously stored vectors.

## Why This Change Was Made

Direct, synchronous, and downloaded batch responses share one Google-owned nonempty, numeric, finite-vector invariant before normalization. The repair retains current main's unified embedding API, dimension checks, response aliases, first-response ownership, scoped credentials, guarded body reads, deadlines, and retry handling.

Adapted Peter Steinberger's (@steipete) original repair to current main, preserving the original commit in the branch ancestry.

## Evidence

- Current-main regression run: **11 failures / 9 passes** before the repair. Corrupt downloaded coordinates were silently normalized, string/array-like values threw `vec.map` errors, and empty direct vectors were accepted.
- After repair: **95/95 tests pass** across `extensions/google/embedding-batch.test.ts` and `extensions/google/embedding-provider.test.ts`.
- The public adapter's real loopback HTTP flow covers upload → create → poll → streamed JSONL download, valid responses, null coordinates, JSON numeric overflow, query-prefix preservation, and synthetic auth headers. Synthetic lifecycle cases also cover missing/empty/string/array-like/mixed values, first-response ownership, and dimension mismatch.
- Existing tests cover synchronous cardinality, structured inputs, model/task requests, credential scoping, bounded bodies, cooldowns, and cancellation. Installed `@google/genai` types define embedding values as numeric floats.
- Fresh independent autoreview: no actionable P0–P2 findings. Production change: +19/−15 lines; no public SDK, configuration, storage schema, or transport change.
- No live Google/provider calls or memory indexing writes were performed. Loopback/synthetic proof is not live-provider or durable-index verification.

Local changed checks passed, including production/test types, plugin boundaries, dead exports, lint, formatting and static safety guards. The nested-worktree declaration guard was preserved by running checks in a separate physical checkout. A test-only URL narrowing correction passed lint and all six affected malformed-vector cases. [Exact-head hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/35167440234) for `f01c6d6e4e99e6b068b9714df742369a86e623c5`.

## Upgrade compatibility

No stored schema, cache identity, persistence, or valid-vector representation changes. The adapter, API barrel, persistence/fallback owner and dimension-aware sanitizer match integrated main. Two focused existing cache-identity tests pass on the final head: version-only metadata remains stable, while semantic header changes still invalidate identity. No migration or existing-data repair is introduced or executed.
