### PR TITLE
fix: keep rendered message media counts consistent

### DIFF
--- a/src/channels/message/rendered-batch.test.ts
+++ b/src/channels/message/rendered-batch.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { createRenderedMessageBatchPlan } from "./rendered-batch.js";
+
+describe("createRenderedMessageBatchPlan", () => {
+  it("keeps aggregate media counts aligned with normalized media items", () => {
+    const plan = createRenderedMessageBatchPlan([
+      {
+        text: "caption",
+        mediaUrls: ["  ", "/tmp/image.png", "\t"],
+        audioAsVoice: true,
+      },
+    ]);
+
+    expect(plan.mediaCount).toBe(1);
+    expect(plan.voiceCount).toBe(1);
+    expect(plan.items[0]).toMatchObject({
+      kinds: ["text", "voice"],
+      mediaUrls: ["/tmp/image.png"],
+      audioAsVoice: true,
+    });
+  });
+});

--- a/src/channels/message/rendered-batch.ts
+++ b/src/channels/message/rendered-batch.ts
@@ -12,7 +12,7 @@ import type {
 } from "./types.js";
 
 function countMedia(payload: ReplyPayload): number {
-  return (payload.mediaUrls?.filter(Boolean).length ?? 0) + (payload.mediaUrl ? 1 : 0);
+  return collectMediaUrls(payload).length;
 }
 
 function collectMediaUrls(payload: ReplyPayload): string[] {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where channel delivery planning could report more media items than the normalized rendered payload actually contains when a reply includes blank or whitespace-only media URLs.

## Why This Change Was Made

The aggregate media count now reuses the same trimming and filtering path as the rendered media items. This keeps planning metadata aligned with the payloads that adapters will actually deliver.

## User Impact

Channel delivery decisions and recovery metadata now see accurate media counts for replies containing empty media entries, while valid media URLs remain unchanged.

## Evidence

- Regression test: `node scripts/run-vitest.mjs src/channels/message/rendered-batch.test.ts` — 1 file and 1 test passed.
- Formatting: `oxfmt --check src/channels/message/rendered-batch.ts src/channels/message/rendered-batch.test.ts` — passed.
- Lint: `node scripts/run-oxlint.mjs src/channels/message/rendered-batch.ts src/channels/message/rendered-batch.test.ts` — passed.
- Diff hygiene: `git diff --check` — passed.
- TruffleHog filesystem scan of the final changed files — 0 verified and 0 unknown secrets.
- Autoreview status: the helper stopped before model review because its TruffleHog Git preflight could not complete on this Windows worktree; no reviewer findings were produced.
- Final head: `c033e645be89d6a61566f9f9c9c8ce68b9be889b`.

This PR was created with AI assistance; the author understands and has verified the change.

## Real behavior proof

Validated the exact PR head `c033e645be89d6a61566f9f9c9c8ce68b9be889b` in a fresh, sanitized direct AWS Crabbox checkout.

- Isolation: public network, no Tailscale, no instance profile, IMDSv2 IAM credentials endpoint returned `404`, `--no-hydrate`, and only `CI` was eligible for environment forwarding.
- Toolchain: Node `24.15.0`, pnpm `11.15.1`; the trusted bootstrap verified the exact Git head and repository package-manager pin before installation.
- Runtime path: an ephemeral, uncommitted harness called `withDurableMessageSendContext`, rendered the reply, and captured the plan handed to the mocked durable outbound sender.
- Input media: `["  ", " /tmp/image.png ", "\\t"]` with `audioAsVoice: true`.
- Observed outbound plan: `mediaCount: 1`, `voiceCount: 1`, `items[0].mediaUrls: ["/tmp/image.png"]`, `items[0].kinds: ["text", "voice"]`; send result was `sent`.
- Tests: the committed regression test and the outbound runtime harness each passed (`2/2` tests across two Vitest shards).
- Crabbox: provider `aws`, lease `cbx_764d378bbd79`, run [`run_bcf3870ab21d`](https://crabbox.openclaw.ai/portal/runs/run_bcf3870ab21d).

Autoreview: the first task-owned run exceeded the documented 30-minute window without a heartbeat or output and was stopped. One controlled retry used the same Codex engine (`gpt-5.6-sol`) and `high` effort with streaming enabled; it completed clean with no accepted/actionable findings, judged the patch correct at `0.99` confidence, and made no code changes.