### PR TITLE
fix(tui): retire run ownership when switching sessions

### DIFF
--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { ChatLog } from "./components/chat-log.js";
 import type { TuiBackend } from "./tui-backend.js";
+import { createEventHandlers } from "./tui-event-handlers.js";
 import { createSessionActions } from "./tui-session-actions.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
 import {
@@ -1199,6 +1200,111 @@ describe("tui session actions", () => {
     expect(updateAssistant).toHaveBeenCalledWith("still working in the background", "run-bg");
     expect(state.activeChatRunId).toBe("run-bg");
     expect(setActivityStatus).toHaveBeenLastCalledWith("streaming");
+  });
+
+  it("retires the previous session run before adopting and finalizing a restored run", async () => {
+    vi.useFakeTimers();
+    try {
+      const previousSessionKey = "agent:main:previous";
+      const nextSessionKey = "agent:main:next";
+      const previousRunId = "run-previous";
+      const nextRunId = "run-next";
+      const state = createBaseState({
+        currentSessionKey: previousSessionKey,
+        currentSessionId: "session-previous",
+        historyLoaded: true,
+      });
+      const chatLog = new ChatLog();
+      const addPendingSystem = vi.spyOn(chatLog, "addPendingSystem");
+      const tui = { requestRender: vi.fn() } as unknown as import("@earendil-works/pi-tui").TUI;
+      const setActivityStatus = vi.fn((status: string) => {
+        state.activityStatus = status;
+      });
+      let loadSelectedHistory: () => Promise<{
+        loaded: boolean;
+        inFlightRunId?: string | null;
+      }> = async () => ({ loaded: false });
+      const handlers = createEventHandlers({
+        chatLog,
+        btw: createBtwPresenter(),
+        tui,
+        state,
+        setActivityStatus,
+        loadHistory: () => loadSelectedHistory(),
+        streamingWatchdogMs: 100,
+      });
+      handlers.handleChatEvent({
+        runId: previousRunId,
+        sessionKey: previousSessionKey,
+        seq: 1,
+        state: "delta",
+        message: { role: "assistant", content: [{ type: "text", text: "old partial" }] },
+      });
+      expect(state.activeChatRunId).toBe(previousRunId);
+
+      const actions = createTestSessionActions({
+        client: {
+          listSessions: vi.fn(),
+          loadHistory: vi.fn().mockResolvedValue({
+            sessionId: "session-next",
+            sessionInfo: {
+              key: nextSessionKey,
+              sessionId: "session-next",
+              updatedAt: 1,
+            },
+            messages: [],
+            inFlightRun: { runId: nextRunId, text: "new partial" },
+          }),
+        } as unknown as TuiBackend,
+        chatLog,
+        state,
+        tui,
+        setActivityStatus,
+        invalidateRunOwnership: handlers.dispose,
+      });
+      loadSelectedHistory = actions.loadHistory;
+
+      await actions.setSession(nextSessionKey);
+      expect(state.activeChatRunId).toBe(nextRunId);
+
+      handlers.handleChatEvent({
+        runId: nextRunId,
+        sessionKey: nextSessionKey,
+        seq: 2,
+        state: "final",
+        message: { role: "assistant", content: [{ type: "text", text: "new final" }] },
+      });
+
+      expect(state.activeChatRunId).toBeNull();
+      expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
+      vi.advanceTimersByTime(101);
+      expect(addPendingSystem).not.toHaveBeenCalled();
+      handlers.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves run ownership when reloading the same session selection", async () => {
+    const sessionKey = "agent:main:main";
+    const invalidateRunOwnership = vi.fn();
+    const state = createBaseState({ currentSessionKey: sessionKey });
+    const { setSession } = createTestSessionActions({
+      client: {
+        listSessions: vi.fn(),
+        loadHistory: vi.fn().mockResolvedValue({
+          sessionId: "session-main",
+          sessionInfo: { key: sessionKey, sessionId: "session-main" },
+          messages: [],
+        }),
+      } as unknown as TuiBackend,
+      state,
+      invalidateRunOwnership,
+    });
+
+    await setSession(sessionKey);
+
+    expect(invalidateRunOwnership).not.toHaveBeenCalled();
   });
 
   it("adopts an in-flight run with no buffered text (Codex) and shows streaming", async () => {

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -14,7 +14,7 @@ import {
   getPendingSubmitDraft,
   type TuiPendingSubmit,
 } from "./tui-submit-state.js";
-import type { TuiStateAccess } from "./tui-types.js";
+import type { TuiHistoryLoadResult, TuiStateAccess } from "./tui-types.js";
 
 describe("tui session actions", () => {
   const sendingSubmit = (runId: string, draftText = "pending"): TuiPendingSubmit => ({
@@ -1220,10 +1220,9 @@ describe("tui session actions", () => {
       const setActivityStatus = vi.fn((status: string) => {
         state.activityStatus = status;
       });
-      let loadSelectedHistory: () => Promise<{
-        loaded: boolean;
-        inFlightRunId?: string | null;
-      }> = async () => ({ loaded: false });
+      let loadSelectedHistory: () => Promise<TuiHistoryLoadResult> = async () => ({
+        loaded: false,
+      });
       const handlers = createEventHandlers({
         chatLog,
         btw: createBtwPresenter(),

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -53,6 +53,7 @@ type SessionActionContext = {
   updateFooter: () => void;
   updateAutocompleteProvider: () => void;
   setActivityStatus: (text: string) => void;
+  invalidateRunOwnership?: () => void;
   clearLocalRunIds?: () => void;
   rememberSessionKey?: (sessionKey: string) => void | Promise<void>;
 };
@@ -73,6 +74,7 @@ export function createSessionActions(context: SessionActionContext) {
     updateFooter,
     updateAutocompleteProvider,
     setActivityStatus,
+    invalidateRunOwnership,
     clearLocalRunIds,
     rememberSessionKey,
   } = context;
@@ -614,6 +616,9 @@ export function createSessionActions(context: SessionActionContext) {
       agentSessionKeysMatchByRequestKey(nextKey, previousSelection.sessionKey)
     );
     if (selectionChanged) {
+      // Retire the previous session's runs before history can adopt a new
+      // in-flight owner; otherwise its completion can promote an old run.
+      invalidateRunOwnership?.();
       reduceTuiSessionProjection(state, {
         type: "sessionReset",
         scope: readTuiSessionProjectionScope(state),

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1280,6 +1280,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     updateFooter,
     updateAutocompleteProvider,
     setActivityStatus,
+    invalidateRunOwnership: () => invalidateSessionRunOwnership(),
     clearLocalRunIds: localRunIds.clear,
     rememberSessionKey: rememberCurrentSessionKey,
   });


### PR DESCRIPTION
Closes #117851

## What Problem This Solves

Fixes an issue where selecting a different TUI session could leave the previous session's run coordinator, watchdog, and terminal state alive while history restored another in-flight run. A delayed event from the old session could then reactivate stale ownership or interfere with the new session's final/follow-up state.

## Why This Change Was Made

The semantic `setSession` transition now invokes the existing run-lifecycle invalidation owner before projection reset and history loading, but only when the selection actually changes. That retires coordinator, watchdog, pending-submit/terminal, local-run, BTW, and stream ownership before the target history can adopt a run. Same-session reloads preserve active ownership.

The regression exercises the original order through real event handlers: A delta, switch to B, B history adoption, B final, watchdog advance. A separate control locks same-session behavior.

Production is +6/-0 lines; tests are +106/-1. No protocol, config, persistence, Gateway, provider, or public API changes.

AI-assisted: yes. The owner boundary, sibling state, history adoption, and PTY behavior were independently reviewed.

## User Impact

TUI users can switch sessions during active/restored runs without stale streaming state or watchdog activity leaking from the previous selection. The selected session finalizes to idle and accepts a real follow-up under the correct owner.

## Evidence

Blacksmith Testbox `tbx_01kz05eawk7xr3acp1e50kh1ng`, [run 30729243036](https://github.com/openclaw/openclaw/actions/runs/30729243036):

- Focused TUI session actions: 72/72 passed.
- Existing real-PTY suite: 52/52 passed.
- Complete `pnpm check:changed`: formatting, guards, production/test tsgo, lint, dead exports, boundaries, database-first checks, and import cycles passed.
- Source-blind real-PTY contract passed in 32.65 seconds: A visibly streamed; selecting B restored/finalized run B; terminal returned idle; no A reactivation or watchdog appeared after 30 seconds; a real B follow-up was accepted and visibly completed.

Additional proof:

- Rebase onto current main preserved exact patch id `3e03fa707bee0b2180857c73dc13f8e2e98269d3`; intervening main changes did not touch the three files.
- Fresh integrated autoreview `019fc0f5-1381-73c0-a5bd-247b29c0717e`: clean, patch correct, confidence 0.99.
- `git diff --check`: passed.
