### PR TITLE
fix(zalouser): surface delivery failures and preserve partial receipts

### DIFF
--- a/extensions/zalouser/src/monitor.group-gating.test.ts
+++ b/extensions/zalouser/src/monitor.group-gating.test.ts
@@ -18,6 +18,8 @@ import {
   sendTypingZalouserMock,
 } from "./monitor.send.test-mocks.js";
 import { setZalouserRuntime } from "./runtime.js";
+import { createZalouserSendReceipt } from "./send-receipt.js";
+import { sendMessageZalouser } from "./send.js";
 import { createZalouserRuntimeEnv } from "./test-helpers.js";
 import type { ResolvedZalouserAccount, ZaloInboundMessage } from "./types.js";
 import {
@@ -92,15 +94,23 @@ function dispatchReplyCall(mock: unknown, index = 0): DispatchReplyCallArg {
 function installRuntime(params: {
   commandAuthorized?: boolean;
   replyPayload?: { text?: string; mediaUrl?: string; mediaUrls?: string[] };
+  replyKind?: "block" | "tool";
   resolveCommandAuthorizedFromAuthorizers?: (params: {
     useAccessGroups: boolean;
     authorizers: Array<{ configured: boolean; allowed: boolean }>;
   }) => boolean;
 }) {
+  const deliveryErrors: unknown[] = [];
   const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async ({ dispatcherOptions, ctx }) => {
     await dispatcherOptions.typingCallbacks?.onReplyStart?.();
     if (params.replyPayload) {
-      await dispatcherOptions.deliver(params.replyPayload);
+      const info = { kind: params.replyKind ?? "block" };
+      try {
+        await dispatcherOptions.deliver(params.replyPayload, info);
+      } catch (error) {
+        deliveryErrors.push(error);
+        dispatcherOptions.onError(error, info);
+      }
     }
     return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 }, ctx };
   });
@@ -165,7 +175,9 @@ function installRuntime(params: {
         ...replyPipeline,
         ...turn.dispatcherOptions,
         deliver: async (...args: Parameters<typeof turn.delivery.deliver>) => {
-          await turn.delivery.deliver(...args);
+          const result = await turn.delivery.deliver(...args);
+          await turn.delivery.onDelivered?.(args[0], args[1], result);
+          return result;
         },
         onError: turn.delivery.onError,
       },
@@ -276,6 +288,7 @@ function installRuntime(params: {
   } as unknown as PluginRuntime);
 
   return {
+    deliveryErrors,
     dispatchReplyWithBufferedBlockDispatcher,
     resolveAgentRoute,
     resolveCommandAuthorizedFromAuthorizers,
@@ -476,16 +489,9 @@ describe("zalouser monitor group mention gating", () => {
     const runtime = installRuntime({
       commandAuthorized: false,
     });
-    const account = createAccount();
     await processMessageWithDefaults({
       message: createDmMessage(params?.message),
-      account: {
-        ...account,
-        config: {
-          ...account.config,
-          dmPolicy: "open",
-        },
-      },
+      account: createAccount(),
     });
     return runtime;
   }
@@ -612,24 +618,18 @@ describe("zalouser monitor group mention gating", () => {
 
   it("passes long markdown replies through once so formatting happens before chunking", async () => {
     const replyText = `**${"a".repeat(2501)}**`;
+    const statusSink = vi.fn();
     installRuntime({
       commandAuthorized: false,
       replyPayload: { text: replyText },
     });
 
     await processMessageThroughMonitor({
-      message: createDmMessage({
-        content: "hello",
-      }),
-      account: {
-        ...createAccount(),
-        config: {
-          ...createAccount().config,
-          dmPolicy: "open",
-        },
-      },
+      message: createDmMessage(),
+      account: createAccount(),
       config: createConfig(),
       runtime: createRuntimeEnv(),
+      statusSink,
     });
 
     expect(sendMessageZalouserMock).toHaveBeenCalledTimes(1);
@@ -639,7 +639,103 @@ describe("zalouser monitor group mention gating", () => {
       textMode: "markdown",
       textChunkMode: "length",
       textChunkLimit: 1200,
+      onDeliveryResult: expect.any(Function),
     });
+    expect(statusSink).toHaveBeenCalledWith({ lastOutboundAt: expect.any(Number) });
+  });
+
+  it.each([
+    {
+      name: "text block",
+      kind: "block" as const,
+      payload: { text: "reply" },
+    },
+    {
+      name: "first attachment tool",
+      kind: "tool" as const,
+      payload: { text: "caption", mediaUrls: ["https://a/1"] },
+    },
+    {
+      name: "later attachment block",
+      kind: "block" as const,
+      payload: {
+        text: "caption",
+        mediaUrls: ["https://a/1", "https://a/2", "https://a/3"],
+      },
+      partial: true,
+      successfulSends: 1,
+    },
+    {
+      name: "later text chunk block",
+      kind: "block" as const,
+      payload: { text: "reply" },
+      partial: true,
+    },
+  ])("reports $name delivery failures through the canonical dispatcher", async (testCase) => {
+    const failure = new Error(`${testCase.name} unavailable`);
+    if (testCase.partial) {
+      vi.mocked(sendMessageZalouser).mockImplementationOnce(async (_threadId, _text, options) => {
+        const result = {
+          ok: true,
+          messageId: "accepted-1",
+          receipt: createZalouserSendReceipt({ messageId: "accepted-1", threadId: "u-1" }),
+        };
+        await options?.onDeliveryResult?.(result);
+        if (!testCase.successfulSends) {
+          throw failure;
+        }
+        return result;
+      });
+    }
+    if (!testCase.partial || testCase.successfulSends) {
+      sendMessageZalouserMock.mockRejectedValueOnce(failure);
+    }
+    const runtime = { ...createRuntimeEnv(), error: vi.fn() };
+    const statusSink = vi.fn();
+    const { deliveryErrors } = installRuntime({
+      replyPayload: testCase.payload,
+      replyKind: testCase.kind,
+    });
+
+    await processMessageThroughMonitor({
+      message: createDmMessage(),
+      account: createAccount(),
+      config: createConfig(),
+      runtime,
+      statusSink,
+    });
+
+    expect(sendMessageZalouserMock).toHaveBeenCalledTimes((testCase.successfulSends ?? 0) + 1);
+    expect(runtime.error).toHaveBeenCalledTimes(1);
+    expect(runtime.error).toHaveBeenCalledWith(
+      `[default] Zalouser ${testCase.kind} reply failed: Error: ${testCase.name} unavailable`,
+    );
+    expect(deliveryErrors).toHaveLength(1);
+    if (testCase.partial) {
+      expect(deliveryErrors[0]).toMatchObject({
+        cause: failure,
+        sentBeforeError: true,
+        deliveryResult: { messageIds: ["accepted-1"], visibleReplySent: true },
+      });
+      expect(statusSink).toHaveBeenCalledWith({ lastOutboundAt: expect.any(Number) });
+    } else {
+      expect(deliveryErrors[0]).toBe(failure);
+      expect(statusSink).not.toHaveBeenCalledWith({ lastOutboundAt: expect.any(Number) });
+    }
+    if (testCase.successfulSends) {
+      expect(sendMessageZalouserMock).toHaveBeenNthCalledWith(
+        1,
+        "u-1",
+        "caption",
+        expect.objectContaining({ mediaUrl: "https://a/1" }),
+      );
+      expect(sendMessageZalouserMock).toHaveBeenNthCalledWith(
+        2,
+        "u-1",
+        "",
+        expect.objectContaining({ mediaUrl: "https://a/2" }),
+      );
+    }
   });
 
   it("allows DM senders from static access groups", async () => {
@@ -878,16 +974,9 @@ describe("zalouser monitor group mention gating", () => {
     const { readAllowFromStore } = installRuntime({
       commandAuthorized: false,
     });
-    const account = createAccount();
     await processMessageThroughMonitor({
       message: createDmMessage({ content: "/new", commandContent: "/new" }),
-      account: {
-        ...account,
-        config: {
-          ...account.config,
-          dmPolicy: "open",
-        },
-      },
+      account: createAccount(),
       config: createConfig(),
       runtime: createRuntimeEnv(),
     });
@@ -899,16 +988,9 @@ describe("zalouser monitor group mention gating", () => {
     const { readAllowFromStore } = installRuntime({
       commandAuthorized: false,
     });
-    const account = createAccount();
     await processMessageThroughMonitor({
       message: createDmMessage({ content: "hello there" }),
-      account: {
-        ...account,
-        config: {
-          ...account.config,
-          dmPolicy: "open",
-        },
-      },
+      account: createAccount(),
       config: createConfig(),
       runtime: createRuntimeEnv(),
     });
@@ -961,7 +1043,6 @@ describe("zalouser monitor group mention gating", () => {
     ]);
     expect(firstDispatch?.ctx?.Body ?? "").toContain("first unmentioned line");
 
-    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(2);
     const secondDispatch = dispatchReplyCall(dispatchReplyWithBufferedBlockDispatcher, 1);
     expect(secondDispatch?.ctx?.InboundHistory).toStrictEqual([]);
   });

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -1,10 +1,16 @@
 import { mergeAllowlist, summarizeMapping } from "openclaw/plugin-sdk/allow-from";
 import {
   createChannelInboundEnvelopeBuilder,
+  createChannelPartialDeliveryError,
   implicitMentionKindWhen,
+  isChannelPartialDeliveryError,
   resolveInboundMentionDecision,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
+import {
+  createMessageReceiptFromOutboundResults,
+  listMessageReceiptPlatformIds,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
@@ -662,6 +668,9 @@ async function processMessage(
         }
       },
       onError: (err, info) => {
+        if (isChannelPartialDeliveryError(err)) {
+          statusSink?.({ lastOutboundAt: Date.now() });
+        }
         runtime.error(`[${account.accountId}] Zalouser ${info.kind} reply failed: ${String(err)}`);
       },
     },
@@ -702,43 +711,46 @@ async function deliverZalouserReply(params: {
   const textChunkLimit = core.channel.text.resolveTextChunkLimit(config, "zalouser", accountId, {
     fallbackLimit: ZALOUSER_TEXT_LIMIT,
   });
-  await deliverTextOrMediaReply({
-    payload,
-    text: reply.text,
-    sendText: async (chunk) => {
-      try {
-        await sendMessageZalouser(chatId, chunk, {
-          profile,
-          isGroup,
-          textMode: "markdown",
-          textChunkMode: chunkMode,
-          textChunkLimit,
-        });
+  const accepted: Awaited<ReturnType<typeof sendMessageZalouser>>[] = [];
+  const sendReplyPart = async (text: string, mediaUrl?: string) => {
+    await sendMessageZalouser(chatId, text, {
+      profile,
+      ...(mediaUrl ? { mediaUrl } : {}),
+      isGroup,
+      textMode: "markdown",
+      textChunkMode: chunkMode,
+      textChunkLimit,
+      onDeliveryResult: (result) => {
+        accepted.push(result);
         visibleReplySent = true;
-      } catch (err) {
-        runtime.error(`Zalouser message send failed: ${String(err)}`);
-      }
-    },
-    sendMedia: async ({ mediaUrl, caption }) => {
-      logVerbose(core, runtime, `Sending media to ${chatId}`);
-      await sendMessageZalouser(chatId, caption ?? "", {
-        profile,
-        mediaUrl,
-        isGroup,
-        textMode: "markdown",
-        textChunkMode: chunkMode,
-        textChunkLimit,
-      });
-      visibleReplySent = true;
-    },
-    onMediaError: (error) => {
-      runtime.error(
-        `Zalouser media send failed: ${
-          error instanceof Error ? error.message : JSON.stringify(error)
-        }`,
-      );
-    },
-  });
+      },
+    });
+    visibleReplySent = true;
+  };
+  try {
+    await deliverTextOrMediaReply({
+      payload,
+      text: reply.text,
+      sendText: sendReplyPart,
+      sendMedia: async ({ mediaUrl, caption }) => {
+        logVerbose(core, runtime, `Sending media to ${chatId}`);
+        await sendReplyPart(caption ?? "", mediaUrl);
+      },
+    });
+  } catch (error) {
+    if (!visibleReplySent) {
+      throw error;
+    }
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: accepted.map((result) => ({ receipt: result.receipt })),
+      kind: reply.hasMedia ? "media" : "text",
+    });
+    throw createChannelPartialDeliveryError(error, {
+      messageIds: listMessageReceiptPlatformIds(receipt),
+      receipt,
+      visibleReplySent: true,
+    });
+  }
   return { visibleReplySent };
 }
 


### PR DESCRIPTION
## Summary

- Stop swallowing ZaloUser block/tool text and attachment delivery failures at the channel owner; let the actual reply dispatcher report authoritative errors.
- Preserve already-accepted platform message IDs, ordered receipts, visible-send facts, and accurate outbound status when a later chunk/attachment fails.
- Keep existing host-owned media policy, durable routing, retry boundaries, and original provider failure causes unchanged.

## Root cause and scope

The existing monitor catches text send failures and passes a logging-only media-error callback to the shared reply helper, making failed block/tool/media sends appear successful. The ZaloUser monitor now records accepted results at the actual send boundary and emits the existing canonical partial-delivery error when later work fails. Exactly two owner files change; production delta is +12 lines for authoritative partial receipt ownership.

## Validation

- 275/275 tests across all 27 ZaloUser plugin test files.
- Complete exact-two-path extensions + extensionTests changed gate, including production/test tsgo, lint, formatting, SDK/plugin/security guards, and max-lines ratchet.
- Trusted Blacksmith runner attested the entire reviewed source tree, selected main parent, exactly two changed paths, and both file SHA-256 hashes before running.
- Remote validation: https://github.com/openclaw/openclaw/actions/runs/30734358547.
- Independent provider/dispatcher/partial-delivery security review and fresh committed-branch Codex Sol/high P0/P1 autoreview: zero findings; fresh TruffleHog clean.
- Owned Testbox independently verified completed. No public Zalo delivery is claimed.