### PR TITLE
fix(zalo): surface swallowed delivery failures and retain partial receipts

### DIFF
--- a/extensions/zalo/src/monitor.polling.media-reply.test-support.ts
+++ b/extensions/zalo/src/monitor.polling.media-reply.test-support.ts
@@ -11,6 +11,7 @@ import {
   createRuntimeEnv,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { createReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime } from "../runtime-api.js";
 import { setZaloRuntime } from "./runtime.js";
@@ -21,8 +22,10 @@ import {
 } from "./test-support/lifecycle-test-support.js";
 import {
   getUpdatesMock,
+  getZaloRuntimeMock,
   loadCachedLifecycleMonitorModule,
   resetLifecycleTestState,
+  sendMessageMock,
   sendPhotoMock,
   setLifecycleRuntimeCore,
 } from "./test-support/monitor-mocks-test-support.js";
@@ -102,6 +105,16 @@ function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean):
   }
   return count;
 }
+
+type ZaloReplyFailureCase = {
+  name: string;
+  kind: "block" | "tool" | "final";
+  payload: { text?: string; mediaUrl?: string; mediaUrls?: string[] };
+  partial?: "text" | "media";
+  missingMessageId?: boolean;
+  hosted?: boolean;
+  blocked?: boolean;
+};
 
 describe("Zalo polling media replies", () => {
   const finalizeInboundContextMock = vi.fn((ctx: Record<string, unknown>) => ctx);
@@ -268,6 +281,208 @@ describe("Zalo polling media replies", () => {
         },
         undefined,
       );
+    } finally {
+      abort.abort();
+      await run;
+    }
+  });
+
+  it.each<ZaloReplyFailureCase>([
+    { name: "block text", kind: "block", payload: { text: "block reply" } },
+    { name: "tool text", kind: "tool", payload: { text: "tool reply" } },
+    {
+      name: "first block attachment",
+      kind: "block",
+      payload: { text: "caption", mediaUrl: "https://example.com/first.png" },
+    },
+    {
+      name: "first tool attachment",
+      kind: "tool",
+      payload: { text: "caption", mediaUrl: "https://example.com/first.png" },
+    },
+    {
+      name: "final attachment",
+      kind: "final",
+      payload: { text: "caption", mediaUrl: "https://example.com/final.png" },
+    },
+    {
+      name: "blocked hosted attachment",
+      kind: "tool",
+      payload: { text: "caption", mediaUrl: "file:///etc/passwd" },
+      hosted: true,
+      blocked: true,
+    },
+    {
+      name: "later block attachment",
+      kind: "block",
+      payload: {
+        text: "caption",
+        mediaUrls: [
+          "https://example.com/first.png",
+          "https://example.com/second.png",
+          "https://example.com/third.png",
+        ],
+      },
+      partial: "media",
+    },
+    {
+      name: "later tool text chunk",
+      kind: "tool",
+      payload: { text: "first chunk second chunk third chunk" },
+      partial: "text",
+    },
+    {
+      name: "later attachment without a provider id",
+      kind: "tool",
+      payload: {
+        text: "caption",
+        mediaUrls: ["https://example.com/first.png", "https://example.com/second.png"],
+      },
+      partial: "media",
+      missingMessageId: true,
+    },
+    {
+      name: "later text chunk without a provider id",
+      kind: "block",
+      payload: { text: "first chunk second chunk" },
+      partial: "text",
+      missingMessageId: true,
+    },
+  ])("reports $name failures through the real reply dispatcher", async (testCase) => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    const failure = new Error(`${testCase.name} rejected`);
+    const acceptedMessageId = `zalo-accepted-${testCase.partial ?? "none"}`;
+    const acceptedResponse = {
+      ok: true,
+      ...(testCase.missingMessageId ? {} : { result: { message_id: acceptedMessageId } }),
+    };
+    const isMedia = Boolean(testCase.payload.mediaUrl || testCase.payload.mediaUrls?.length);
+    if (testCase.blocked) {
+      prepareHostedZaloMediaUrlMock.mockRejectedValueOnce(failure);
+    } else if (testCase.partial === "media") {
+      sendPhotoMock.mockResolvedValueOnce(acceptedResponse).mockRejectedValueOnce(failure);
+    } else if (testCase.partial === "text") {
+      const core = getZaloRuntimeMock() as PluginRuntime;
+      vi.mocked(core.channel.text.chunkMarkdownTextWithMode).mockReturnValueOnce([
+        "first chunk",
+        "second chunk",
+        "third chunk",
+      ]);
+      sendMessageMock.mockResolvedValueOnce(acceptedResponse).mockRejectedValueOnce(failure);
+    } else if (isMedia) {
+      sendPhotoMock.mockRejectedValueOnce(failure);
+    } else {
+      sendMessageMock.mockRejectedValueOnce(failure);
+    }
+
+    const deliveryErrors: unknown[] = [];
+    let failedCounts: Record<"tool" | "block" | "final", number> | undefined;
+    dispatchReplyWithBufferedBlockDispatcherMock.mockImplementation(
+      async ({
+        dispatcherOptions,
+      }: {
+        dispatcherOptions: Parameters<typeof createReplyDispatcher>[0];
+      }) => {
+        const dispatcher = createReplyDispatcher({
+          ...dispatcherOptions,
+          onError: async (error, info) => {
+            deliveryErrors.push(error);
+            await dispatcherOptions.onError?.(error, info);
+          },
+        });
+        if (testCase.kind === "tool") {
+          dispatcher.sendToolResult(testCase.payload);
+        } else if (testCase.kind === "final") {
+          dispatcher.sendFinalReply(testCase.payload);
+        } else {
+          dispatcher.sendBlockReply(testCase.payload);
+        }
+        dispatcher.markComplete();
+        await dispatcher.waitForIdle();
+        failedCounts = dispatcher.getFailedCounts();
+        return {
+          queuedFinal: testCase.kind === "final",
+          counts: dispatcher.getQueuedCounts(),
+        };
+      },
+    );
+
+    getUpdatesMock
+      .mockResolvedValueOnce({
+        ok: true,
+        result: createTextUpdate({
+          messageId: `polling-delivery-${testCase.name.replaceAll(" ", "-")}`,
+          userId: "user-1",
+          userName: "User One",
+          chatId: "dm-chat-1",
+        }),
+      })
+      .mockImplementation(() => new Promise(() => {}));
+    const { monitorZaloProvider } = await loadCachedLifecycleMonitorModule(
+      "zalo-polling-media-reply",
+    );
+    const abort = new AbortController();
+    const runtime = createRuntimeEnv();
+    const statusSink =
+      vi.fn<(patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void>();
+    const { account, config } = createLifecycleMonitorSetup({
+      accountId: "acct-zalo-delivery",
+      dmPolicy: "open",
+      webhookUrl: testCase.hosted ? "https://example.com/hooks/zalo" : "",
+    });
+    const run = monitorZaloProvider({
+      token: "zalo-token",
+      account,
+      config,
+      runtime,
+      statusSink,
+      abortSignal: abort.signal,
+    });
+
+    try {
+      await settleAsyncWork();
+      expect(failedCounts).toEqual({
+        block: testCase.kind === "block" ? 1 : 0,
+        tool: testCase.kind === "tool" ? 1 : 0,
+        final: testCase.kind === "final" ? 1 : 0,
+      });
+      expect(deliveryErrors).toHaveLength(1);
+      if (testCase.partial) {
+        const acceptedMessageIds = testCase.missingMessageId ? [] : [acceptedMessageId];
+        expect(deliveryErrors[0]).toMatchObject({
+          cause: failure,
+          sentBeforeError: true,
+          visibleReplySent: true,
+          deliveryResult: {
+            messageIds: acceptedMessageIds,
+            receipt: { platformMessageIds: acceptedMessageIds },
+            visibleReplySent: true,
+          },
+        });
+      } else {
+        expect(deliveryErrors[0]).toBe(failure);
+      }
+      expect(runtime.error).toHaveBeenCalledTimes(1);
+      expect(runtime.error).toHaveBeenCalledWith(
+        `[acct-zalo-delivery] Zalo ${testCase.kind} reply failed: Error: ${testCase.name} rejected`,
+      );
+      const outboundUpdates = statusSink.mock.calls.filter(
+        ([patch]) => patch.lastOutboundAt !== undefined,
+      );
+      expect(outboundUpdates).toHaveLength(testCase.partial ? 1 : 0);
+      expect(sendMessageMock).toHaveBeenCalledTimes(isMedia ? 0 : testCase.partial ? 2 : 1);
+      expect(sendPhotoMock).toHaveBeenCalledTimes(
+        !isMedia || testCase.blocked ? 0 : testCase.partial ? 2 : 1,
+      );
+      if (testCase.hosted) {
+        expect(prepareHostedZaloMediaUrlMock).toHaveBeenCalledWith({
+          mediaUrl: "file:///etc/passwd",
+          webhookUrl: "https://example.com/hooks/zalo",
+          webhookPath: "/hooks/zalo",
+          maxBytes: 5 * 1024 * 1024,
+          proxyUrl: undefined,
+        });
+      }
     } finally {
       abort.abort();
       await run;

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -2,11 +2,13 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
 import {
+  createChannelPartialDeliveryError,
   formatInboundMediaUnavailableText,
   resolveChannelInboundRouteEnvelope,
   type ChannelInboundMediaInput,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -704,7 +706,6 @@ async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Pr
           payload,
           token,
           chatId,
-          runtime,
           core,
           config,
           webhookUrl: params.webhookUrl,
@@ -718,8 +719,10 @@ async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Pr
           tableMode: "off",
         });
       },
-      onDelivered: () => {
-        statusSink?.({ lastOutboundAt: Date.now() });
+      onDelivered: (_payload, _info, result) => {
+        if (result?.visibleReplySent !== false) {
+          statusSink?.({ lastOutboundAt: Date.now() });
+        }
       },
       onError: (err, info) => {
         runtime.error?.(`[${account.accountId}] Zalo ${info.kind} reply failed: ${String(err)}`);
@@ -741,7 +744,6 @@ async function deliverZaloReply(params: {
   payload: OutboundReplyPayload;
   token: string;
   chatId: string;
-  runtime: ZaloRuntimeEnv;
   core: ZaloCoreRuntime;
   config: OpenClawConfig;
   webhookUrl?: string;
@@ -758,7 +760,6 @@ async function deliverZaloReply(params: {
     payload,
     token,
     chatId,
-    runtime,
     core,
     config,
     webhookUrl,
@@ -775,39 +776,56 @@ async function deliverZaloReply(params: {
     text: core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode),
   });
   const chunkMode = core.channel.text.resolveChunkMode(config, "zalo", accountId);
-  await deliverTextOrMediaReply({
-    payload,
-    text: reply.text,
-    chunkText: (value) =>
-      core.channel.text.chunkMarkdownTextWithMode(value, ZALO_TEXT_LIMIT, chunkMode),
-    sendText: async (chunk) => {
-      try {
-        await sendMessage(token, { chat_id: chatId, text: chunk }, fetcher);
-        statusSink?.({ lastOutboundAt: Date.now() });
-      } catch (err) {
-        runtime.error?.(`Zalo message send failed: ${String(err)}`);
-      }
-    },
-    sendMedia: async ({ mediaUrl, caption }) => {
-      const sendableMediaUrl =
-        canHostMedia && webhookUrl && webhookPath
-          ? await prepareHostedZaloMediaUrl({
-              mediaUrl,
-              webhookUrl,
-              webhookPath,
-              maxBytes: mediaMaxBytes,
-              proxyUrl,
-            })
-          : mediaUrl;
-      await sendPhoto(token, { chat_id: chatId, photo: sendableMediaUrl, caption }, fetcher);
-      statusSink?.({ lastOutboundAt: Date.now() });
-    },
-    onMediaError: (error) => {
-      runtime.error?.(
-        `Zalo photo send failed: ${error instanceof Error ? error.message : JSON.stringify(error)}`,
-      );
-    },
-  });
+  const acceptedMessageIds: string[] = [];
+  let visibleReplySent = false;
+  const recordAcceptedSend = (result: Awaited<ReturnType<typeof sendMessage>>) => {
+    const messageId = result.result?.message_id;
+    if (messageId) {
+      acceptedMessageIds.push(messageId);
+    }
+    visibleReplySent = true;
+    statusSink?.({ lastOutboundAt: Date.now() });
+  };
+  try {
+    await deliverTextOrMediaReply({
+      payload,
+      text: reply.text,
+      chunkText: (value) =>
+        core.channel.text.chunkMarkdownTextWithMode(value, ZALO_TEXT_LIMIT, chunkMode),
+      sendText: async (chunk) => {
+        recordAcceptedSend(await sendMessage(token, { chat_id: chatId, text: chunk }, fetcher));
+      },
+      sendMedia: async ({ mediaUrl, caption }) => {
+        const sendableMediaUrl =
+          canHostMedia && webhookUrl && webhookPath
+            ? await prepareHostedZaloMediaUrl({
+                mediaUrl,
+                webhookUrl,
+                webhookPath,
+                maxBytes: mediaMaxBytes,
+                proxyUrl,
+              })
+            : mediaUrl;
+        recordAcceptedSend(
+          await sendPhoto(token, { chat_id: chatId, photo: sendableMediaUrl, caption }, fetcher),
+        );
+      },
+    });
+  } catch (error) {
+    if (!visibleReplySent) {
+      throw error;
+    }
+    // Preserve accepted provider identities so recovery never duplicates a visible partial send.
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: acceptedMessageIds.map((messageId) => ({ channel: "zalo", messageId })),
+      kind: reply.hasMedia ? "media" : "text",
+    });
+    throw createChannelPartialDeliveryError(error, {
+      messageIds: acceptedMessageIds,
+      receipt,
+      visibleReplySent: true,
+    });
+  }
 }
 
 export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<void> {


### PR DESCRIPTION
## Summary

- Stop the official Zalo plugin from swallowing block/tool text-send failures and attachment-send failures.
- Preserve accepted provider message IDs, ordered partial-delivery receipts, original failures, visible-send facts, and accurate outbound status.
- Keep text-only final-reply durability, hosted-media access, signed URLs, SSRF restrictions, and provider privacy unchanged.

## Root cause and scope

The official Zalo monitor catches text send exceptions and provides a logging-only media-error callback to the shared reply helper. That callback intentionally converts media failures into apparent success, so the dispatcher never sees the real error and can record a false successful outbound action. This shipped defect is present in v2026.7.1. The Zalo monitor now records authoritative accepted sends at their actual owner and propagates failures through the existing dispatcher. Partial successes use the existing canonical partial-delivery error and preserve true provider IDs, including Bot API successes that legitimately omit a message ID. Exactly two official-Zalo owner/test-support files change; production +18 lines are needed for accurate accepted-send and partial-receipt ownership.

## Validation

- Complete official Zalo plugin suite: 159/159 passing tests across 25 files.
- Focused actual reply dispatcher plus real local Zalo Bot API HTTP loopback: 32/32 passing tests across three files.
- Ten dispatcher regressions cover block/tool text failures, first/final media failures, denied hosted-media preparation, accepted-prefix text/media failures, missing optional provider IDs, original error identity, status correctness, and duplicate prevention.
- Complete exact-two-path extension + extensionTests changed gate: production/test typecheck, lint, formatting, max-lines ratchet, SDK/plugin/security guards, exit zero.
- Reviewed main base, exactly two changed files, complete binary patch digest, and both file hashes independently attested before and after validation.
- Actual dispatcher/Bot API HTTP proof: https://github.com/openclaw/openclaw/actions/runs/30734442372.
- Independent official Bot API/dependency/SSRF/durable security review and fresh rebased full committed-branch Codex Sol/high P0/P1 autoreview: zero findings; fresh TruffleHog clean.
- Owned trusted Testbox independently verified completed. HTTP proof uses a real local Bot API server; no public Zalo account delivery is claimed.