### PR TITLE
fix(release): block core publish when plugin artifacts are missing

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -885,6 +885,21 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
 
+      - name: Verify matching plugin releases are published
+        run: |
+          set -euo pipefail
+          PLAN_FILE="$RUNNER_TEMP/plugin-npm-release-plan.json"
+          node --import tsx scripts/plugin-npm-release-plan.ts \
+            --selection-mode all-publishable > "$PLAN_FILE"
+          MISSING_PLUGINS="$(
+            jq -r '.candidates[]? | "- \(.packageName)@\(.version)"' "$PLAN_FILE"
+          )"
+          if [[ -n "$MISSING_PLUGINS" ]]; then
+            echo "OpenClaw npm publish is blocked because matching plugin releases are missing:" >&2
+            printf '%s\n' "$MISSING_PLUGINS" >&2
+            exit 1
+          fi
+
       - name: Ensure version is not already published
         run: |
           set -euo pipefail

--- a/scripts/lib/plugin-npm-release.ts
+++ b/scripts/lib/plugin-npm-release.ts
@@ -645,6 +645,23 @@ function isNpmViewTimeoutError(error: unknown): error is Error & { code: "ETIMED
   return error instanceof Error && "code" in error && error.code === "ETIMEDOUT";
 }
 
+function isNpmViewNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const processError = error as Error & { stderr?: unknown; stdout?: unknown };
+  const output = [processError.message, processError.stderr, processError.stdout]
+    .map((value) => {
+      if (typeof value === "string") {
+        return value;
+      }
+      return Buffer.isBuffer(value) ? value.toString("utf8") : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+  return /\bE404\b|404 not found|is not in this registry/iu.test(output);
+}
+
 function runNpmView(args: string[]): string {
   const tempDir = mkdtempSync(join(tmpdir(), "openclaw-plugin-npm-view-"));
   const userconfigPath = join(tempDir, "npmrc");
@@ -738,10 +755,10 @@ function isPluginVersionPublished(packageName: string, version: string): boolean
     runNpmView([`${packageName}@${version}`, "version"]);
     return true;
   } catch (error) {
-    if (isNpmViewTimeoutError(error)) {
-      throw error;
+    if (isNpmViewNotFoundError(error)) {
+      return false;
     }
-    return false;
+    throw error;
   }
 }
 

--- a/test/plugin-npm-release.test.ts
+++ b/test/plugin-npm-release.test.ts
@@ -498,7 +498,7 @@ describe("collectPluginReleaseDependencyFreshnessErrors", () => {
 });
 
 describe("collectPluginReleasePlan", () => {
-  it("fails closed when the published-version lookup times out", () => {
+  function createPublishablePluginRepo(): string {
     const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-release-");
     mkdirSync(join(repoDir, "extensions", "demo-plugin"), { recursive: true });
     writePluginReadme(repoDir, "demo-plugin");
@@ -521,6 +521,61 @@ describe("collectPluginReleasePlan", () => {
         },
       },
     });
+    return repoDir;
+  }
+
+  it("reports a confirmed npm 404 as an unpublished candidate", () => {
+    const repoDir = createPublishablePluginRepo();
+    childProcessMock.execFileSyncOverride = (() => {
+      throw Object.assign(new Error("Command failed: npm view"), {
+        stderr: "npm error code E404\nnpm error 404 No match found for version 2026.4.10",
+      });
+    }) as unknown as ExecFileSync;
+
+    const plan = collectPluginReleasePlan({ rootDir: repoDir });
+
+    expect(plan.candidates).toEqual([
+      expect.objectContaining({
+        packageName: "@openclaw/demo-plugin",
+        version: "2026.4.10",
+        alreadyPublished: false,
+      }),
+    ]);
+    expect(plan.skippedPublished).toEqual([]);
+  });
+
+  it("skips a plugin version that npm confirms is already published", () => {
+    const repoDir = createPublishablePluginRepo();
+    childProcessMock.execFileSyncOverride = (() => "2026.4.10\n") as unknown as ExecFileSync;
+
+    const plan = collectPluginReleasePlan({ rootDir: repoDir });
+
+    expect(plan.candidates).toEqual([]);
+    expect(plan.skippedPublished).toEqual([
+      expect.objectContaining({
+        packageName: "@openclaw/demo-plugin",
+        version: "2026.4.10",
+        alreadyPublished: true,
+      }),
+    ]);
+  });
+
+  it("propagates non-404 npm registry failures", () => {
+    const repoDir = createPublishablePluginRepo();
+    childProcessMock.execFileSyncOverride = (() => {
+      throw Object.assign(new Error("getaddrinfo EAI_AGAIN registry.npmjs.org"), {
+        code: "EAI_AGAIN",
+        stderr: "npm error code EAI_AGAIN",
+      });
+    }) as unknown as ExecFileSync;
+
+    expect(() => collectPluginReleasePlan({ rootDir: repoDir })).toThrow(
+      "getaddrinfo EAI_AGAIN registry.npmjs.org",
+    );
+  });
+
+  it("fails closed when the published-version lookup times out", () => {
+    const repoDir = createPublishablePluginRepo();
     childProcessMock.execFileSyncOverride = ((command: string, args?: readonly string[]) => {
       expect(command).toBe("npm");
       expect(args).toEqual([

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -94,6 +94,24 @@ describe("minimal npm extended-stable workflow", () => {
     ).not.toContain("Setup Node environment");
   });
 
+  it("blocks standalone core publication until matching plugin versions exist", () => {
+    const publish = workflow().jobs?.publish_openclaw_npm;
+    const steps = publish?.steps ?? [];
+    const gate = step(publish, "Verify matching plugin releases are published");
+    const gateIndex = steps.indexOf(gate);
+    const coreVersionIndex = steps.indexOf(
+      step(publish, "Ensure version is not already published"),
+    );
+
+    expect(gate.run).toContain("scripts/plugin-npm-release-plan.ts");
+    expect(gate.run).toContain("--selection-mode all-publishable");
+    expect(gate.run).toContain(".candidates[]?");
+    expect(gate.run).toContain('if [[ -n "$MISSING_PLUGINS" ]]');
+    expect(gate.run).toContain("exit 1");
+    expect(gateIndex).toBeGreaterThan(-1);
+    expect(gateIndex).toBeLessThan(coreVersionIndex);
+  });
+
   it("threads an explicit, default-off extended-stable bypass through every policy gate", () => {
     const parsed = workflow();
     const input = parsed.on?.workflow_dispatch?.inputs?.bypass_extended_stable_guard;


### PR DESCRIPTION
## Summary

- block the standalone OpenClaw npm publish job when any publishable plugin's matching version is absent from npm
- reuse the existing plugin release planner so the gate follows the same publishable-package inventory as `plugin-npm-release.yml`
- classify only confirmed npm 404 responses as absent artifacts; propagate DNS, authentication, timeout, and registry-service failures with their original diagnostics
- print every confirmed missing package/version to make release recovery actionable

## What Problem This Solves

`openclaw@2026.7.2-beta.6` was published without the matching plugin artifacts. The beta.6 source tag contains the updated inbound-debounce contract and the compatible WhatsApp implementation, but `@openclaw/whatsapp@2026.7.2-beta.6` is absent from npm. Updating a beta.5 installation therefore left the beta.5 WhatsApp plugin beside beta.6 core.

That version skew caused every inbound WhatsApp message to fail in `runFlush` with `Cannot read properties of undefined (reading 'catch')`: beta.6 core expects the new `{ admission, completion }` flush handle while the beta.5 plugin returns the old Promise shape.

The coordinated release workflow already waits for plugin npm publication. This adds the same fail-closed invariant to the independently dispatchable core publish workflow, including direct recovery runs.

## Evidence

- `git diff --check`
- `pnpm tsgo:test`
- `node scripts/run-vitest.mjs test/plugin-npm-release.test.ts test/scripts/openclaw-npm-extended-stable-workflow.test.ts --reporter=verbose` — 54 tests passed
- after-fix block path: `collectPluginReleasePlan > reports a confirmed npm 404 as an unpublished candidate` passed
- after-fix pass path: `collectPluginReleasePlan > skips a plugin version that npm confirms is already published` passed
- registry failure path: `collectPluginReleasePlan > propagates non-404 npm registry failures` passed with an `EAI_AGAIN` fixture
- workflow placement: `minimal npm extended-stable workflow > blocks standalone core publication until matching plugin versions exist` passed and verifies the gate runs before the core publish checks
- registry audit on 2026-08-02: `npm view @openclaw/whatsapp@2026.7.2-beta.6 version` returns `E404`, while the release tag declares that exact plugin version
- the successful standalone core publish run for beta.6 is https://github.com/openclaw/openclaw/actions/runs/30685198638
- live reproduction with beta.6 core and beta.5 WhatsApp: inbound messages repeatedly failed in `runFlush` with `TypeError: Cannot read properties of undefined (reading 'catch')`
- live recovery after adapting the plugin callback to the beta.6 contract: gateway health `OK`, WhatsApp linked, 593 ingress events completed, and 0 pending or claimed
