### PR TITLE
refactor: remove OAuth pass-through wrappers

### DIFF
--- a/extensions/google-meet/src/cli.ts
+++ b/extensions/google-meet/src/cli.ts
@@ -1,5 +1,7 @@
 import type { Command } from "commander";
 import { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
+import { generateHexPkceVerifierChallenge } from "openclaw/plugin-sdk/provider-auth";
+import { generateOAuthState } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   buildGoogleMeetCalendarDayWindow,
   findGoogleMeetCalendarEvent,
@@ -33,8 +35,6 @@ import {
 import { resolveGoogleMeetGatewayOperationTimeoutMs, type GoogleMeetConfig } from "./config.js";
 import {
   buildGoogleMeetAuthUrl,
-  createGoogleMeetOAuthState,
-  createGoogleMeetPkce,
   exchangeGoogleMeetAuthCode,
   waitForGoogleMeetAuthCode,
 } from "./oauth.js";
@@ -220,8 +220,8 @@ export function registerGoogleMeetCli(params: {
           "Missing Google Meet OAuth client id. Configure oauth.clientId or pass --client-id.",
         );
       }
-      const { verifier, challenge } = createGoogleMeetPkce();
-      const state = createGoogleMeetOAuthState();
+      const { verifier, challenge } = generateHexPkceVerifierChallenge();
+      const state = generateOAuthState();
       const authUrl = buildGoogleMeetAuthUrl({
         clientId,
         challenge,

--- a/extensions/google-meet/src/oauth.ts
+++ b/extensions/google-meet/src/oauth.ts
@@ -4,9 +4,7 @@ import {
   resolveDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
-import { generateHexPkceVerifierChallenge } from "openclaw/plugin-sdk/provider-auth";
 import {
-  generateOAuthState,
   parseOAuthCallbackInput,
   waitForLocalOAuthCallback,
 } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -206,15 +204,6 @@ export async function resolveGoogleMeetAccessToken(params: {
     expiresAt: refreshed.expiresAt,
     refreshed: true,
   };
-}
-
-export function createGoogleMeetPkce() {
-  const { verifier, challenge } = generateHexPkceVerifierChallenge();
-  return { verifier, challenge };
-}
-
-export function createGoogleMeetOAuthState(): string {
-  return generateOAuthState();
 }
 
 function isLocalCallbackListenerError(error: unknown): boolean {

--- a/extensions/msteams/src/oauth.flow.ts
+++ b/extensions/msteams/src/oauth.flow.ts
@@ -1,15 +1,7 @@
 // Msteams plugin module implements oauth.flow behavior.
-import { generateHexPkceVerifierChallenge } from "openclaw/plugin-sdk/provider-auth";
-import {
-  generateOAuthState,
-  parseOAuthCallbackInput,
-  waitForLocalOAuthCallback,
-} from "openclaw/plugin-sdk/provider-auth-runtime";
 import { isWSL2Sync } from "openclaw/plugin-sdk/runtime-env";
 import {
   MSTEAMS_DEFAULT_DELEGATED_SCOPES,
-  MSTEAMS_OAUTH_CALLBACK_PATH,
-  MSTEAMS_OAUTH_CALLBACK_PORT,
   MSTEAMS_OAUTH_REDIRECT_URI,
   buildMSTeamsAuthEndpoint,
 } from "./oauth.shared.js";
@@ -17,12 +9,6 @@ import {
 export function shouldUseManualOAuthFlow(isRemote: boolean): boolean {
   return isRemote || isWSL2Sync();
 }
-
-export function generatePkce(): { verifier: string; challenge: string } {
-  return generateHexPkceVerifierChallenge();
-}
-
-export { generateOAuthState };
 
 export function buildMSTeamsAuthUrl(params: {
   tenantId: string;
@@ -45,34 +31,4 @@ export function buildMSTeamsAuthUrl(params: {
     prompt: "consent",
   });
   return `${endpoint}?${query.toString()}`;
-}
-
-export function parseCallbackInput(
-  input: string,
-  // Kept in the signature for API symmetry with the caller's CSRF verify step.
-  // The caller compares the parsed `state` against the expected value.
-  _expectedState: string,
-): { code: string; state: string } | { error: string } {
-  return parseOAuthCallbackInput(input, {
-    missingState: "Missing 'state' parameter in URL. Paste the full redirect URL.",
-    invalidInput:
-      "Paste the full redirect URL (including code and state parameters), not just the authorization code.",
-  });
-}
-
-export async function waitForLocalCallback(params: {
-  expectedState: string;
-  timeoutMs: number;
-  onProgress?: (message: string) => void;
-}): Promise<{ code: string; state: string }> {
-  return await waitForLocalOAuthCallback({
-    expectedState: params.expectedState,
-    timeoutMs: params.timeoutMs,
-    port: MSTEAMS_OAUTH_CALLBACK_PORT,
-    callbackPath: MSTEAMS_OAUTH_CALLBACK_PATH,
-    redirectUri: MSTEAMS_OAUTH_REDIRECT_URI,
-    successTitle: "MSTeams Delegated OAuth complete",
-    progressMessage: `Waiting for OAuth callback on ${MSTEAMS_OAUTH_REDIRECT_URI}...`,
-    onProgress: params.onProgress,
-  });
 }

--- a/extensions/msteams/src/oauth.test.ts
+++ b/extensions/msteams/src/oauth.test.ts
@@ -1,5 +1,4 @@
 // Msteams tests cover oauth plugin behavior.
-import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() =>
@@ -24,12 +23,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
-import {
-  generatePkce,
-  generateOAuthState,
-  buildMSTeamsAuthUrl,
-  parseCallbackInput,
-} from "./oauth.flow.js";
+import { buildMSTeamsAuthUrl } from "./oauth.flow.js";
 import {
   MSTEAMS_DEFAULT_DELEGATED_SCOPES,
   MSTEAMS_OAUTH_REDIRECT_URI,
@@ -53,28 +47,10 @@ function firstFetchCall(fetchSpy: ReturnType<typeof vi.fn>): [string, RequestIni
   return call as [string, RequestInit];
 }
 
-describe("generatePkce", () => {
-  it("produces a 64-char hex verifier and a base64url SHA-256 challenge", () => {
-    const { verifier, challenge } = generatePkce();
-    expect(verifier).toMatch(/^[0-9a-f]{64}$/);
-    const expected = createHash("sha256").update(verifier).digest("base64url");
-    expect(challenge).toBe(expected);
-  });
-});
-
-describe("generateOAuthState", () => {
-  it("produces a 64-char hex string separate from the PKCE verifier", () => {
-    const state = generateOAuthState();
-    expect(state).toMatch(/^[0-9a-f]{64}$/);
-    const { verifier } = generatePkce();
-    expect(state).not.toBe(verifier);
-  });
-});
-
 describe("buildMSTeamsAuthUrl", () => {
   it("includes correct tenant, client_id, scopes, PKCE params, and redirect_uri", () => {
-    const { challenge } = generatePkce();
-    const state = generateOAuthState();
+    const challenge = "challenge-value";
+    const state = "state-value";
     const url = buildMSTeamsAuthUrl({
       tenantId: "my-tenant-id",
       clientId: "my-client-id",
@@ -94,19 +70,6 @@ describe("buildMSTeamsAuthUrl", () => {
     expect(parsed.searchParams.get("prompt")).toBe("consent");
   });
 
-  it("does not expose the PKCE verifier in the URL", () => {
-    const { verifier, challenge } = generatePkce();
-    const state = generateOAuthState();
-    const url = buildMSTeamsAuthUrl({
-      tenantId: "t",
-      clientId: "c",
-      challenge,
-      state,
-    });
-    expect(url).not.toContain(verifier);
-    expect(url).toContain(`state=${state}`);
-  });
-
   it("uses custom scopes when provided", () => {
     const url = buildMSTeamsAuthUrl({
       tenantId: "t",
@@ -117,51 +80,6 @@ describe("buildMSTeamsAuthUrl", () => {
     });
     const parsed = new URL(url);
     expect(parsed.searchParams.get("scope")).toBe("User.Read offline_access");
-  });
-});
-
-describe("parseCallbackInput", () => {
-  const expectedState = "expected-state-value";
-
-  it("extracts code and state from a valid callback URL", () => {
-    const input = `${MSTEAMS_OAUTH_REDIRECT_URI}?code=abc123&state=${expectedState}`;
-    const result = parseCallbackInput(input, expectedState);
-    expect(result).toEqual({ code: "abc123", state: expectedState });
-  });
-
-  it("returns error when code is missing from URL", () => {
-    const input = `${MSTEAMS_OAUTH_REDIRECT_URI}?state=${expectedState}`;
-    const result = parseCallbackInput(input, expectedState);
-    expect(result).toEqual({ error: "Missing 'code' parameter in URL" });
-  });
-
-  it("rejects bare authorization codes to prevent CSRF bypass", () => {
-    const result = parseCallbackInput("bare-code-value", expectedState);
-    expect(result).toEqual({
-      error:
-        "Paste the full redirect URL (including code and state parameters), not just the authorization code.",
-    });
-  });
-
-  it("returns error on empty input", () => {
-    const result = parseCallbackInput("", expectedState);
-    expect(result).toEqual({ error: "No input provided" });
-  });
-
-  it("returns error when state is missing from a valid URL (CSRF protection)", () => {
-    const input = `${MSTEAMS_OAUTH_REDIRECT_URI}?code=abc123`;
-    const result = parseCallbackInput(input, expectedState);
-    expect(result).toEqual({
-      error: "Missing 'state' parameter in URL. Paste the full redirect URL.",
-    });
-  });
-
-  it("rejects bare codes even when expectedState is empty", () => {
-    const result = parseCallbackInput("bare-code", "");
-    expect(result).toEqual({
-      error:
-        "Paste the full redirect URL (including code and state parameters), not just the authorization code.",
-    });
   });
 });
 

--- a/extensions/msteams/src/oauth.ts
+++ b/extensions/msteams/src/oauth.ts
@@ -1,15 +1,16 @@
 // Msteams plugin module implements oauth behavior.
+import { generateHexPkceVerifierChallenge } from "openclaw/plugin-sdk/provider-auth";
 import {
-  buildMSTeamsAuthUrl,
   generateOAuthState,
-  generatePkce,
-  parseCallbackInput,
-  shouldUseManualOAuthFlow,
-  waitForLocalCallback,
-} from "./oauth.flow.js";
+  parseOAuthCallbackInput,
+  waitForLocalOAuthCallback,
+} from "openclaw/plugin-sdk/provider-auth-runtime";
+import { buildMSTeamsAuthUrl, shouldUseManualOAuthFlow } from "./oauth.flow.js";
 import {
   MSTEAMS_DEFAULT_DELEGATED_SCOPES,
+  MSTEAMS_OAUTH_CALLBACK_PATH,
   MSTEAMS_OAUTH_CALLBACK_PORT,
+  MSTEAMS_OAUTH_REDIRECT_URI,
   type MSTeamsDelegatedOAuthContext,
   type MSTeamsDelegatedTokens,
 } from "./oauth.shared.js";
@@ -44,7 +45,7 @@ export async function loginMSTeamsDelegated(
     "MSTeams Delegated OAuth",
   );
 
-  const { verifier, challenge } = generatePkce();
+  const { verifier, challenge } = generateHexPkceVerifierChallenge();
   const state = generateOAuthState();
   const authUrl = buildMSTeamsAuthUrl({
     tenantId: params.tenantId,
@@ -66,9 +67,14 @@ export async function loginMSTeamsDelegated(
   }
 
   try {
-    const { code } = await waitForLocalCallback({
+    const { code } = await waitForLocalOAuthCallback({
       expectedState: state,
       timeoutMs: 5 * 60 * 1000,
+      port: MSTEAMS_OAUTH_CALLBACK_PORT,
+      callbackPath: MSTEAMS_OAUTH_CALLBACK_PATH,
+      redirectUri: MSTEAMS_OAUTH_REDIRECT_URI,
+      successTitle: "MSTeams Delegated OAuth complete",
+      progressMessage: `Waiting for OAuth callback on ${MSTEAMS_OAUTH_REDIRECT_URI}...`,
       onProgress: (msg) => ctx.progress.update(msg),
     });
     ctx.progress.update("Exchanging authorization code for tokens...");
@@ -112,7 +118,11 @@ async function manualFlow(
   ctx.log(`\nOpen this URL in your LOCAL browser:\n\n${authUrl}\n`);
   ctx.progress.update("Waiting for you to paste the callback URL...");
   const callbackInput = await ctx.prompt("Paste the redirect URL here: ");
-  const parsed = parseCallbackInput(callbackInput, state);
+  const parsed = parseOAuthCallbackInput(callbackInput, {
+    missingState: "Missing 'state' parameter in URL. Paste the full redirect URL.",
+    invalidInput:
+      "Paste the full redirect URL (including code and state parameters), not just the authorization code.",
+  });
   if ("error" in parsed) {
     throw new Error(parsed.error, cause ? { cause } : undefined);
   }

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -14,6 +14,7 @@ import {
 } from "openclaw/plugin-sdk/provider-auth";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { applyXaiOAuthConfig, XAI_OAUTH_DEFAULT_MODEL_REF } from "./onboard.js";
 import { xaiUserAgent } from "./src/xai-user-agent.js";
 
@@ -113,12 +114,6 @@ function requireTrustedXaiOAuthEndpoint(endpoint: string, label: string): string
   return endpoint;
 }
 
-function readStringRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
-}
-
 async function readResponseBody(response: Response): Promise<XaiOAuthResponseBody> {
   const buffer = await readResponseWithLimit(response, XAI_OAUTH_RESPONSE_MAX_BYTES, {
     onOverflow: ({ maxBytes }) => new Error(`xAI OAuth response exceeds ${maxBytes} bytes`),
@@ -136,8 +131,8 @@ async function readResponseBody(response: Response): Promise<XaiOAuthResponseBod
 async function readJsonResponse(response: Response, context: string): Promise<unknown> {
   const body = await readResponseBody(response);
   if (!response.ok) {
-    const errorText =
-      readStringRecord(body.json).error_description ?? readStringRecord(body.json).error;
+    const json = asOptionalRecord(body.json);
+    const errorText = json?.error_description ?? json?.error;
     throw new Error(
       `${context} failed (${response.status})${typeof errorText === "string" ? `: ${errorText}` : ""}`,
     );
@@ -155,7 +150,7 @@ async function fetchXaiOAuthDiscoveryDocument(
     },
     signal: xaiOAuthFetchSignal(options.signal),
   });
-  return readStringRecord(await readJsonResponse(response, "xAI OAuth discovery"));
+  return asOptionalRecord(await readJsonResponse(response, "xAI OAuth discovery")) ?? {};
 }
 
 async function fetchXaiOAuthDiscovery(
@@ -198,7 +193,7 @@ function parseXaiOAuthTokenResponse(
   now: () => number,
   options: { requireRefreshToken?: boolean } = {},
 ): XaiOAuthTokenResponse {
-  const json = readStringRecord(value);
+  const json = asOptionalRecord(value) ?? {};
   const accessToken = json.access_token;
   if (typeof accessToken !== "string" || accessToken.trim().length === 0) {
     throw new Error("xAI OAuth token response is missing access_token");
@@ -238,7 +233,7 @@ function deriveExpiresFromJwt(token: string | undefined): number | undefined {
 }
 
 function parseXaiOAuthErrorResponse(value: unknown): XaiOAuthErrorResponse {
-  const json = readStringRecord(value);
+  const json = asOptionalRecord(value) ?? {};
   const error = typeof json.error === "string" ? json.error : undefined;
   const errorDescription =
     typeof json.error_description === "string" ? json.error_description : undefined;
@@ -380,7 +375,7 @@ async function requestXaiDeviceCode(
       signal: xaiOAuthFetchSignal(params.signal),
     },
   );
-  const json = readStringRecord(await readJsonResponse(response, "xAI device code request"));
+  const json = asOptionalRecord(await readJsonResponse(response, "xAI device code request")) ?? {};
   const deviceCode = json.device_code;
   const userCode = json.user_code;
   const verificationUri = json.verification_uri;
@@ -536,7 +531,7 @@ function decodeJwtPayload(token: string | undefined): Record<string, unknown> {
     return {};
   }
   try {
-    return readStringRecord(JSON.parse(Buffer.from(part, "base64url").toString("utf8")));
+    return asOptionalRecord(JSON.parse(Buffer.from(part, "base64url").toString("utf8"))) ?? {};
   } catch {
     return {};
   }


### PR DESCRIPTION
## What Problem This Solves

Several plugin OAuth paths carried owner-local functions that only forwarded to existing SDK helpers. The extra indirection duplicated tests and made the canonical OAuth utility ownership harder to follow.

## Why This Change Was Made

MSTeams and Google Meet now call the same SDK PKCE, state, callback parsing, and localhost callback helpers directly, preserving every existing option and provider-specific message. xAI now uses `asOptionalRecord` from the SDK string-coercion surface, which preserves the local guard's non-array record semantics. The maintainer-directed scope deliberately excludes a shared device-flow runner, core Copilot ownership relocation, and the window-gated Chutes cleanup.

## User Impact

No user-visible behavior changes. OAuth URLs, state validation, callback handling, messages, and xAI response coercion remain unchanged, with fewer local code paths to maintain.

## Evidence

- `node scripts/run-vitest.mjs extensions/msteams` — 89 files, 1,365 tests passed.
- `node scripts/run-vitest.mjs extensions/google-meet` — 22 files, 309 tests passed.
- `node scripts/run-vitest.mjs extensions/xai` — 27 files, 402 tests passed.
- `node scripts/run-vitest.mjs packages/normalization-core/src/record-coerce.test.ts` — 1 file, 2 tests passed; covers the canonical null/array rejection contract.
- `oxfmt <six touched files>` using the canonical checkout binary — passed.
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings; patch correctness 0.99.
- `node scripts/check-changed.mjs` could not start its delegated checks because no Crabbox/Testbox provider was ready. A forced local fallback began dependency hydration and was interrupted to preserve the no-install worktree policy.
- Hosted CI — green; `openclaw/ci-gate` and all required type, lint, guard, build, boundary, changed-node, contract, baseline, security, and CodeQL checks passed.

AI-assisted: yes. The implementation and full diff were independently reviewed before push.
