### PR TITLE
refactor: centralize agent session settings state

### DIFF
--- a/src/agents/sessions/settings-manager.test.ts
+++ b/src/agents/sessions/settings-manager.test.ts
@@ -1,6 +1,95 @@
-/** Tests session settings manager runtime overrides. */
+/** Tests session settings loading, persistence, and runtime overrides. */
 import { describe, expect, it } from "vitest";
-import { SettingsManager } from "./settings-manager.js";
+import { SettingsManager, type SettingsScope, type SettingsStorage } from "./settings-manager.js";
+
+class InspectableSettingsStorage implements SettingsStorage {
+  private values: Record<SettingsScope, string | undefined> = {
+    global: undefined,
+    project: undefined,
+  };
+
+  withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void {
+    const next = fn(this.values[scope]);
+    if (next !== undefined) {
+      this.values[scope] = next;
+    }
+  }
+
+  set(scope: SettingsScope, value: unknown): void {
+    this.values[scope] = typeof value === "string" ? value : JSON.stringify(value);
+  }
+
+  get(scope: SettingsScope): unknown {
+    const value = this.values[scope];
+    return value === undefined ? undefined : JSON.parse(value);
+  }
+}
+
+describe("SettingsManager scoped persistence", () => {
+  it("preserves external sibling changes while writing global and project scopes", async () => {
+    const storage = new InspectableSettingsStorage();
+    storage.set("global", {
+      terminal: { showImages: true, imageWidthCells: 60 },
+      packages: ["npm:@openclaw/global"],
+    });
+    storage.set("project", {
+      packages: ["npm:@openclaw/project"],
+      skills: ["old-skill"],
+    });
+    const settingsManager = SettingsManager.fromStorage(storage);
+
+    const updatedSkills = ["new-skill"];
+    settingsManager.setShowImages(false);
+    settingsManager.setProjectSkillPaths(updatedSkills);
+    updatedSkills.push("caller-mutation");
+    storage.set("global", {
+      terminal: { showImages: true, imageWidthCells: 120, clearOnShrink: true },
+      packages: ["npm:@openclaw/global"],
+    });
+    storage.set("project", {
+      packages: ["npm:@openclaw/external"],
+      skills: ["old-skill"],
+      themes: ["external-theme"],
+    });
+
+    await settingsManager.flush();
+
+    expect(storage.get("global")).toEqual({
+      terminal: { showImages: false, imageWidthCells: 120, clearOnShrink: true },
+      packages: ["npm:@openclaw/global"],
+    });
+    expect(storage.get("project")).toEqual({
+      packages: ["npm:@openclaw/external"],
+      skills: ["new-skill"],
+      themes: ["external-theme"],
+    });
+
+    await settingsManager.reload();
+    expect(settingsManager.getShowImages()).toBe(false);
+    expect(settingsManager.getImageWidthCells()).toBe(120);
+    expect(settingsManager.getClearOnShrink()).toBe(true);
+    expect(settingsManager.getPackages()).toEqual(["npm:@openclaw/external"]);
+    expect(settingsManager.getSkillPaths()).toEqual(["new-skill"]);
+    expect(settingsManager.getThemePaths()).toEqual(["external-theme"]);
+  });
+
+  it("isolates parse failures to the affected scope", async () => {
+    const storage = new InspectableSettingsStorage();
+    storage.set("global", "{");
+    storage.set("project", { skills: ["old-skill"] });
+    const settingsManager = SettingsManager.fromStorage(storage);
+
+    expect(settingsManager.drainErrors()).toEqual([
+      expect.objectContaining({ scope: "global", error: expect.any(SyntaxError) }),
+    ]);
+    settingsManager.setTheme("blocked-global-write");
+    settingsManager.setProjectSkillPaths(["new-skill"]);
+    await settingsManager.flush();
+
+    expect(() => storage.get("global")).toThrow(SyntaxError);
+    expect(storage.get("project")).toEqual({ skills: ["new-skill"] });
+  });
+});
 
 describe("SettingsManager runtime overrides", () => {
   it("preserves compaction overrides after global setting writes", async () => {

--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalObjectRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
 import { mergeDeep } from "../../infra/deep-merge.js";
 import { acquireFileLockSyncWithRetry } from "../../infra/file-lock-sync.js";
 import type { Transport } from "../../llm/types.js";
@@ -129,6 +130,8 @@ function deepMergeSettings(base: Settings, overrides: Settings): Settings {
 
 export type SettingsScope = "global" | "project";
 
+const SETTINGS_SCOPES: SettingsScope[] = ["global", "project"];
+
 export interface SettingsStorage {
   withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void;
 }
@@ -139,16 +142,17 @@ export interface SettingsError {
 }
 
 export class FileSettingsStorage implements SettingsStorage {
-  private globalSettingsPath: string;
-  private projectSettingsPath: string;
+  private paths: Record<SettingsScope, string>;
 
   constructor(cwd: string, agentDir: string) {
-    this.globalSettingsPath = join(agentDir, "settings.json");
-    this.projectSettingsPath = join(cwd, CONFIG_DIR_NAME, "settings.json");
+    this.paths = {
+      global: join(agentDir, "settings.json"),
+      project: join(cwd, CONFIG_DIR_NAME, "settings.json"),
+    };
   }
 
   withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void {
-    const path = scope === "global" ? this.globalSettingsPath : this.projectSettingsPath;
+    const path = this.paths[scope];
     const dir = dirname(path);
 
     let release: (() => void) | undefined;
@@ -171,60 +175,46 @@ export class FileSettingsStorage implements SettingsStorage {
         writeFileSync(path, next, "utf-8");
       }
     } finally {
-      if (release) {
-        release();
-      }
+      release?.();
     }
   }
 }
 
 export class InMemorySettingsStorage implements SettingsStorage {
-  private global: string | undefined;
-  private project: string | undefined;
+  private values: Record<SettingsScope, string | undefined> = {
+    global: undefined,
+    project: undefined,
+  };
 
   withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void {
-    const current = scope === "global" ? this.global : this.project;
-    const next = fn(current);
+    const next = fn(this.values[scope]);
     if (next !== undefined) {
-      if (scope === "global") {
-        this.global = next;
-      } else {
-        this.project = next;
-      }
+      this.values[scope] = next;
     }
   }
 }
 
+interface SettingsScopeState {
+  settings: Settings;
+  modified: Map<keyof Settings, Set<string> | null>;
+  loadError: Error | null;
+}
+
 export class SettingsManager {
-  private storage: SettingsStorage;
-  private globalSettings: Settings;
-  private projectSettings: Settings;
   private settings: Settings = {};
   // Non-persisted overrides layered above global/project settings for this manager.
   private runtimeOverrides: Settings = {};
-  private modifiedFields = new Set<keyof Settings>(); // Track global fields modified during session
-  private modifiedNestedFields = new Map<keyof Settings, Set<string>>(); // Track global nested field modifications
-  private modifiedProjectFields = new Set<keyof Settings>(); // Track project fields modified during session
-  private modifiedProjectNestedFields = new Map<keyof Settings, Set<string>>(); // Track project nested field modifications
-  private globalSettingsLoadError: Error | null = null; // Track if global settings file had parse errors
-  private projectSettingsLoadError: Error | null = null; // Track if project settings file had parse errors
   private writeQueue: Promise<void> = Promise.resolve();
   private errors: SettingsError[];
 
   private constructor(
-    storage: SettingsStorage,
-    initialGlobal: Settings,
-    initialProject: Settings,
-    globalLoadError: Error | null = null,
-    projectLoadError: Error | null = null,
-    initialErrors: SettingsError[] = [],
+    private storage: SettingsStorage,
+    private scopes: Record<SettingsScope, SettingsScopeState>,
   ) {
-    this.storage = storage;
-    this.globalSettings = initialGlobal;
-    this.projectSettings = initialProject;
-    this.globalSettingsLoadError = globalLoadError;
-    this.projectSettingsLoadError = projectLoadError;
-    this.errors = [...initialErrors];
+    this.errors = SETTINGS_SCOPES.flatMap((scope) => {
+      const error = scopes[scope].loadError;
+      return error ? [{ scope, error }] : [];
+    });
     this.recomputeSettings();
   }
 
@@ -236,24 +226,10 @@ export class SettingsManager {
 
   /** Create a SettingsManager from an arbitrary storage backend */
   static fromStorage(storage: SettingsStorage): SettingsManager {
-    const globalLoad = SettingsManager.tryLoadFromStorage(storage, "global");
-    const projectLoad = SettingsManager.tryLoadFromStorage(storage, "project");
-    const initialErrors: SettingsError[] = [];
-    if (globalLoad.error) {
-      initialErrors.push({ scope: "global", error: globalLoad.error });
-    }
-    if (projectLoad.error) {
-      initialErrors.push({ scope: "project", error: projectLoad.error });
-    }
-
-    return new SettingsManager(
-      storage,
-      globalLoad.settings,
-      projectLoad.settings,
-      globalLoad.error,
-      projectLoad.error,
-      initialErrors,
-    );
+    return new SettingsManager(storage, {
+      global: SettingsManager.loadScope(storage, "global"),
+      project: SettingsManager.loadScope(storage, "project"),
+    });
   }
 
   /** Create an in-memory SettingsManager (no file I/O) */
@@ -266,29 +242,31 @@ export class SettingsManager {
     return SettingsManager.fromStorage(storage);
   }
 
-  private static loadFromStorage(storage: SettingsStorage, scope: SettingsScope): Settings {
+  private static loadScope(storage: SettingsStorage, scope: SettingsScope): SettingsScopeState {
     let content: string | undefined;
-    storage.withLock(scope, (current) => {
-      content = current;
-      return undefined;
-    });
-
-    if (!content) {
-      return {};
+    try {
+      storage.withLock(scope, (current) => {
+        content = current;
+        return undefined;
+      });
+      const settings = content
+        ? SettingsManager.migrateSettings(JSON.parse(content) as Record<string, unknown>)
+        : {};
+      return SettingsManager.createScopeState(settings);
+    } catch (error) {
+      return SettingsManager.createScopeState({}, error as Error);
     }
-    const settings = JSON.parse(content);
-    return SettingsManager.migrateSettings(settings);
   }
 
-  private static tryLoadFromStorage(
-    storage: SettingsStorage,
-    scope: SettingsScope,
-  ): { settings: Settings; error: Error | null } {
-    try {
-      return { settings: SettingsManager.loadFromStorage(storage, scope), error: null };
-    } catch (error) {
-      return { settings: {}, error: error as Error };
-    }
+  private static createScopeState(
+    settings: Settings,
+    loadError: Error | null = null,
+  ): SettingsScopeState {
+    return {
+      settings,
+      modified: new Map(),
+      loadError,
+    };
   }
 
   /** Migrate old settings format to new format */
@@ -306,16 +284,8 @@ export class SettingsManager {
     }
 
     // Migrate old skills object format to new array format
-    if (
-      "skills" in settings &&
-      typeof settings.skills === "object" &&
-      settings.skills !== null &&
-      !Array.isArray(settings.skills)
-    ) {
-      const skillsSettings = settings.skills as {
-        enableSkillCommands?: boolean;
-        customDirectories?: unknown;
-      };
+    if (isRecord(settings.skills)) {
+      const skillsSettings = settings.skills;
       if (
         skillsSettings.enableSkillCommands !== undefined &&
         settings.enableSkillCommands === undefined
@@ -333,21 +303,12 @@ export class SettingsManager {
     }
 
     // Migrate retry.maxDelayMs -> retry.provider.maxRetryDelayMs
-    if (
-      "retry" in settings &&
-      typeof settings.retry === "object" &&
-      settings.retry !== null &&
-      !Array.isArray(settings.retry)
-    ) {
-      const retrySettings = settings.retry as Record<string, unknown>;
-      const providerSettings =
-        typeof retrySettings.provider === "object" && retrySettings.provider !== null
-          ? (retrySettings.provider as Record<string, unknown>)
-          : undefined;
+    if (isRecord(settings.retry)) {
+      const retrySettings = settings.retry;
+      const providerSettings = asOptionalObjectRecord(retrySettings.provider);
       if (
         typeof retrySettings.maxDelayMs === "number" &&
-        (providerSettings?.maxRetryDelayMs === undefined ||
-          providerSettings?.maxRetryDelayMs === null)
+        providerSettings?.maxRetryDelayMs == null
       ) {
         retrySettings.provider = {
           ...providerSettings,
@@ -361,43 +322,33 @@ export class SettingsManager {
   }
 
   getGlobalSettings(): Settings {
-    return structuredClone(this.globalSettings);
+    return structuredClone(this.scopes.global.settings);
   }
 
   getProjectSettings(): Settings {
-    return structuredClone(this.projectSettings);
+    return structuredClone(this.scopes.project.settings);
   }
 
   private recomputeSettings(): void {
     this.settings = deepMergeSettings(
-      deepMergeSettings(this.globalSettings, this.projectSettings),
+      deepMergeSettings(this.scopes.global.settings, this.scopes.project.settings),
       this.runtimeOverrides,
     );
   }
 
   async reload(): Promise<void> {
     await this.writeQueue;
-    const globalLoad = SettingsManager.tryLoadFromStorage(this.storage, "global");
-    if (!globalLoad.error) {
-      this.globalSettings = globalLoad.settings;
-      this.globalSettingsLoadError = null;
-    } else {
-      this.globalSettingsLoadError = globalLoad.error;
-      this.recordError("global", globalLoad.error);
-    }
-
-    this.modifiedFields.clear();
-    this.modifiedNestedFields.clear();
-    this.modifiedProjectFields.clear();
-    this.modifiedProjectNestedFields.clear();
-
-    const projectLoad = SettingsManager.tryLoadFromStorage(this.storage, "project");
-    if (!projectLoad.error) {
-      this.projectSettings = projectLoad.settings;
-      this.projectSettingsLoadError = null;
-    } else {
-      this.projectSettingsLoadError = projectLoad.error;
-      this.recordError("project", projectLoad.error);
+    for (const scope of SETTINGS_SCOPES) {
+      const state = this.scopes[scope];
+      const loaded = SettingsManager.loadScope(this.storage, scope);
+      if (loaded.loadError) {
+        state.loadError = loaded.loadError;
+        this.recordError(scope, loaded.loadError);
+      } else {
+        state.settings = loaded.settings;
+        state.loadError = null;
+      }
+      state.modified.clear();
     }
 
     this.recomputeSettings();
@@ -409,26 +360,16 @@ export class SettingsManager {
     this.recomputeSettings();
   }
 
-  /** Mark a global field as modified during this session */
-  private markModified(field: keyof Settings, nestedKey?: string): void {
-    this.modifiedFields.add(field);
-    if (nestedKey) {
-      if (!this.modifiedNestedFields.has(field)) {
-        this.modifiedNestedFields.set(field, new Set());
-      }
-      this.modifiedNestedFields.get(field)!.add(nestedKey);
+  private markModified(scope: SettingsScope, field: keyof Settings, nestedKey?: string): void {
+    const state = this.scopes[scope];
+    const existing = state.modified.get(field);
+    if (!nestedKey || existing === null) {
+      state.modified.set(field, null);
+      return;
     }
-  }
-
-  /** Mark a project field as modified during this session */
-  private markProjectModified(field: keyof Settings, nestedKey?: string): void {
-    this.modifiedProjectFields.add(field);
-    if (nestedKey) {
-      if (!this.modifiedProjectNestedFields.has(field)) {
-        this.modifiedProjectNestedFields.set(field, new Set());
-      }
-      this.modifiedProjectNestedFields.get(field)!.add(nestedKey);
-    }
+    const nestedFields = existing ?? new Set<string>();
+    nestedFields.add(nestedKey);
+    state.modified.set(field, nestedFields);
   }
 
   private recordError(scope: SettingsScope, error: unknown): void {
@@ -436,53 +377,30 @@ export class SettingsManager {
     this.errors.push({ scope, error: normalizedError });
   }
 
-  private clearModifiedScope(scope: SettingsScope): void {
-    if (scope === "global") {
-      this.modifiedFields.clear();
-      this.modifiedNestedFields.clear();
-      return;
-    }
-
-    this.modifiedProjectFields.clear();
-    this.modifiedProjectNestedFields.clear();
-  }
-
   private enqueueWrite(scope: SettingsScope, task: () => void): void {
     this.writeQueue = this.writeQueue
       .then(() => {
         task();
-        this.clearModifiedScope(scope);
+        this.scopes[scope].modified.clear();
       })
       .catch((error: unknown) => {
         this.recordError(scope, error);
       });
   }
 
-  private cloneModifiedNestedFields(
-    source: Map<keyof Settings, Set<string>>,
-  ): Map<keyof Settings, Set<string>> {
-    const snapshot = new Map<keyof Settings, Set<string>>();
-    for (const [key, value] of source.entries()) {
-      snapshot.set(key, new Set(value));
-    }
-    return snapshot;
-  }
-
   private persistScopedSettings(
     scope: SettingsScope,
     snapshotSettings: Settings,
-    modifiedFields: Set<keyof Settings>,
-    modifiedNestedFields: Map<keyof Settings, Set<string>>,
+    modified: Map<keyof Settings, Set<string> | null>,
   ): void {
     this.storage.withLock(scope, (current) => {
       const currentFileSettings = current
         ? SettingsManager.migrateSettings(JSON.parse(current) as Record<string, unknown>)
         : {};
       const mergedSettings: Settings = { ...currentFileSettings };
-      for (const field of modifiedFields) {
+      for (const [field, nestedModified] of modified) {
         const value = snapshotSettings[field];
-        if (modifiedNestedFields.has(field) && typeof value === "object" && value !== null) {
-          const nestedModified = modifiedNestedFields.get(field)!;
+        if (nestedModified && typeof value === "object" && value !== null) {
           const baseNested = (currentFileSettings[field] as Record<string, unknown>) ?? {};
           const inMemoryNested = value as Record<string, unknown>;
           const mergedNested = { ...baseNested };
@@ -499,46 +417,42 @@ export class SettingsManager {
     });
   }
 
-  private save(): void {
+  private save(scope: SettingsScope): void {
     this.recomputeSettings();
-
-    if (this.globalSettingsLoadError) {
+    const state = this.scopes[scope];
+    if (state.loadError) {
       return;
     }
-
-    const snapshotGlobalSettings = structuredClone(this.globalSettings);
-    const modifiedFields = new Set(this.modifiedFields);
-    const modifiedNestedFields = this.cloneModifiedNestedFields(this.modifiedNestedFields);
-
-    this.enqueueWrite("global", () => {
-      this.persistScopedSettings(
-        "global",
-        snapshotGlobalSettings,
-        modifiedFields,
-        modifiedNestedFields,
-      );
+    const snapshotSettings = structuredClone(state.settings);
+    const modified = new Map(
+      [...state.modified].map(([field, nested]) => [field, nested && new Set(nested)]),
+    );
+    this.enqueueWrite(scope, () => {
+      this.persistScopedSettings(scope, snapshotSettings, modified);
     });
   }
 
-  private saveProjectSettings(settings: Settings): void {
-    this.projectSettings = structuredClone(settings);
-    this.recomputeSettings();
+  private setScopedSetting<K extends keyof Settings>(
+    scope: SettingsScope,
+    field: K,
+    value: Settings[K],
+  ): void {
+    this.scopes[scope].settings[field] = scope === "project" ? structuredClone(value) : value;
+    this.markModified(scope, field);
+    this.save(scope);
+  }
 
-    if (this.projectSettingsLoadError) {
-      return;
-    }
-
-    const snapshotProjectSettings = structuredClone(this.projectSettings);
-    const modifiedFields = new Set(this.modifiedProjectFields);
-    const modifiedNestedFields = this.cloneModifiedNestedFields(this.modifiedProjectNestedFields);
-    this.enqueueWrite("project", () => {
-      this.persistScopedSettings(
-        "project",
-        snapshotProjectSettings,
-        modifiedFields,
-        modifiedNestedFields,
-      );
-    });
+  private setGlobalNestedSetting(
+    field: "compaction" | "images" | "retry" | "terminal",
+    nestedField: string,
+    value: unknown,
+  ): void {
+    const current = this.scopes.global.settings[field];
+    const nested = isRecord(current) ? { ...current } : {};
+    nested[nestedField] = value;
+    (this.scopes.global.settings as Record<string, unknown>)[field] = nested;
+    this.markModified("global", field, nestedField);
+    this.save("global");
   }
 
   async flush(): Promise<void> {
@@ -556,9 +470,7 @@ export class SettingsManager {
   }
 
   setLastChangelogVersion(version: string): void {
-    this.globalSettings.lastChangelogVersion = version;
-    this.markModified("lastChangelogVersion");
-    this.save();
+    this.setScopedSetting("global", "lastChangelogVersion", version);
   }
 
   getSessionDir(): string | undefined {
@@ -566,13 +478,11 @@ export class SettingsManager {
     if (!sessionDir) {
       return sessionDir;
     }
-    if (sessionDir === "~") {
-      return homedir();
-    }
-    if (sessionDir.startsWith("~/")) {
-      return join(homedir(), sessionDir.slice(2));
-    }
-    return sessionDir;
+    return sessionDir === "~"
+      ? homedir()
+      : sessionDir.startsWith("~/")
+        ? join(homedir(), sessionDir.slice(2))
+        : sessionDir;
   }
 
   getDefaultProvider(): string | undefined {
@@ -584,23 +494,19 @@ export class SettingsManager {
   }
 
   setDefaultProvider(provider: string): void {
-    this.globalSettings.defaultProvider = provider;
-    this.markModified("defaultProvider");
-    this.save();
+    this.setScopedSetting("global", "defaultProvider", provider);
   }
 
   setDefaultModel(modelId: string): void {
-    this.globalSettings.defaultModel = modelId;
-    this.markModified("defaultModel");
-    this.save();
+    this.setScopedSetting("global", "defaultModel", modelId);
   }
 
   setDefaultModelAndProvider(provider: string, modelId: string): void {
-    this.globalSettings.defaultProvider = provider;
-    this.globalSettings.defaultModel = modelId;
-    this.markModified("defaultProvider");
-    this.markModified("defaultModel");
-    this.save();
+    this.scopes.global.settings.defaultProvider = provider;
+    this.scopes.global.settings.defaultModel = modelId;
+    this.markModified("global", "defaultProvider");
+    this.markModified("global", "defaultModel");
+    this.save("global");
   }
 
   getSteeringMode(): "all" | "one-at-a-time" {
@@ -608,9 +514,7 @@ export class SettingsManager {
   }
 
   setSteeringMode(mode: "all" | "one-at-a-time"): void {
-    this.globalSettings.steeringMode = mode;
-    this.markModified("steeringMode");
-    this.save();
+    this.setScopedSetting("global", "steeringMode", mode);
   }
 
   getFollowUpMode(): "all" | "one-at-a-time" {
@@ -618,9 +522,7 @@ export class SettingsManager {
   }
 
   setFollowUpMode(mode: "all" | "one-at-a-time"): void {
-    this.globalSettings.followUpMode = mode;
-    this.markModified("followUpMode");
-    this.save();
+    this.setScopedSetting("global", "followUpMode", mode);
   }
 
   getTheme(): string | undefined {
@@ -628,29 +530,15 @@ export class SettingsManager {
   }
 
   setTheme(theme: string): void {
-    this.globalSettings.theme = theme;
-    this.markModified("theme");
-    this.save();
+    this.setScopedSetting("global", "theme", theme);
   }
 
-  getDefaultThinkingLevel():
-    | "off"
-    | "minimal"
-    | "low"
-    | "medium"
-    | "high"
-    | "xhigh"
-    | "max"
-    | undefined {
+  getDefaultThinkingLevel(): Settings["defaultThinkingLevel"] {
     return this.settings.defaultThinkingLevel;
   }
 
-  setDefaultThinkingLevel(
-    level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max",
-  ): void {
-    this.globalSettings.defaultThinkingLevel = level;
-    this.markModified("defaultThinkingLevel");
-    this.save();
+  setDefaultThinkingLevel(level: NonNullable<Settings["defaultThinkingLevel"]>): void {
+    this.setScopedSetting("global", "defaultThinkingLevel", level);
   }
 
   getTransport(): TransportSetting {
@@ -658,9 +546,7 @@ export class SettingsManager {
   }
 
   setTransport(transport: TransportSetting): void {
-    this.globalSettings.transport = transport;
-    this.markModified("transport");
-    this.save();
+    this.setScopedSetting("global", "transport", transport);
   }
 
   getCompactionEnabled(): boolean {
@@ -668,12 +554,7 @@ export class SettingsManager {
   }
 
   setCompactionEnabled(enabled: boolean): void {
-    if (!this.globalSettings.compaction) {
-      this.globalSettings.compaction = {};
-    }
-    this.globalSettings.compaction.enabled = enabled;
-    this.markModified("compaction", "enabled");
-    this.save();
+    this.setGlobalNestedSetting("compaction", "enabled", enabled);
   }
 
   getCompactionReserveTokens(): number {
@@ -708,12 +589,7 @@ export class SettingsManager {
   }
 
   setRetryEnabled(enabled: boolean): void {
-    if (!this.globalSettings.retry) {
-      this.globalSettings.retry = {};
-    }
-    this.globalSettings.retry.enabled = enabled;
-    this.markModified("retry", "enabled");
-    this.save();
+    this.setGlobalNestedSetting("retry", "enabled", enabled);
   }
 
   getRetrySettings(): { enabled: boolean; maxRetries: number; baseDelayMs: number } {
@@ -740,9 +616,7 @@ export class SettingsManager {
     if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
       throw new Error(`Invalid httpIdleTimeoutMs setting: ${String(timeoutMs)}`);
     }
-    this.globalSettings.httpIdleTimeoutMs = Math.floor(timeoutMs);
-    this.markModified("httpIdleTimeoutMs");
-    this.save();
+    this.setScopedSetting("global", "httpIdleTimeoutMs", Math.floor(timeoutMs));
   }
 
   getProviderRetrySettings(): { timeoutMs?: number; maxRetries?: number; maxRetryDelayMs: number } {
@@ -758,9 +632,7 @@ export class SettingsManager {
   }
 
   setHideThinkingBlock(hide: boolean): void {
-    this.globalSettings.hideThinkingBlock = hide;
-    this.markModified("hideThinkingBlock");
-    this.save();
+    this.setScopedSetting("global", "hideThinkingBlock", hide);
   }
 
   getShellPath(): string | undefined {
@@ -768,9 +640,7 @@ export class SettingsManager {
   }
 
   setShellPath(path: string | undefined): void {
-    this.globalSettings.shellPath = path;
-    this.markModified("shellPath");
-    this.save();
+    this.setScopedSetting("global", "shellPath", path);
   }
 
   getQuietStartup(): boolean {
@@ -778,9 +648,7 @@ export class SettingsManager {
   }
 
   setQuietStartup(quiet: boolean): void {
-    this.globalSettings.quietStartup = quiet;
-    this.markModified("quietStartup");
-    this.save();
+    this.setScopedSetting("global", "quietStartup", quiet);
   }
 
   getShellCommandPrefix(): string | undefined {
@@ -788,9 +656,7 @@ export class SettingsManager {
   }
 
   setShellCommandPrefix(prefix: string | undefined): void {
-    this.globalSettings.shellCommandPrefix = prefix;
-    this.markModified("shellCommandPrefix");
-    this.save();
+    this.setScopedSetting("global", "shellCommandPrefix", prefix);
   }
 
   getNpmCommand(): string[] | undefined {
@@ -798,9 +664,7 @@ export class SettingsManager {
   }
 
   setNpmCommand(command: string[] | undefined): void {
-    this.globalSettings.npmCommand = command ? [...command] : undefined;
-    this.markModified("npmCommand");
-    this.save();
+    this.setScopedSetting("global", "npmCommand", command ? [...command] : undefined);
   }
 
   getCollapseChangelog(): boolean {
@@ -808,9 +672,7 @@ export class SettingsManager {
   }
 
   setCollapseChangelog(collapse: boolean): void {
-    this.globalSettings.collapseChangelog = collapse;
-    this.markModified("collapseChangelog");
-    this.save();
+    this.setScopedSetting("global", "collapseChangelog", collapse);
   }
 
   getEnableInstallTelemetry(): boolean {
@@ -818,9 +680,7 @@ export class SettingsManager {
   }
 
   setEnableInstallTelemetry(enabled: boolean): void {
-    this.globalSettings.enableInstallTelemetry = enabled;
-    this.markModified("enableInstallTelemetry");
-    this.save();
+    this.setScopedSetting("global", "enableInstallTelemetry", enabled);
   }
 
   getPackages(): PackageSource[] {
@@ -828,16 +688,11 @@ export class SettingsManager {
   }
 
   setPackages(packages: PackageSource[]): void {
-    this.globalSettings.packages = packages;
-    this.markModified("packages");
-    this.save();
+    this.setScopedSetting("global", "packages", packages);
   }
 
   setProjectPackages(packages: PackageSource[]): void {
-    const projectSettings = structuredClone(this.projectSettings);
-    projectSettings.packages = packages;
-    this.markProjectModified("packages");
-    this.saveProjectSettings(projectSettings);
+    this.setScopedSetting("project", "packages", packages);
   }
 
   getExtensionPaths(): string[] {
@@ -845,16 +700,11 @@ export class SettingsManager {
   }
 
   setExtensionPaths(paths: string[]): void {
-    this.globalSettings.extensions = paths;
-    this.markModified("extensions");
-    this.save();
+    this.setScopedSetting("global", "extensions", paths);
   }
 
   setProjectExtensionPaths(paths: string[]): void {
-    const projectSettings = structuredClone(this.projectSettings);
-    projectSettings.extensions = paths;
-    this.markProjectModified("extensions");
-    this.saveProjectSettings(projectSettings);
+    this.setScopedSetting("project", "extensions", paths);
   }
 
   getSkillPaths(): string[] {
@@ -862,16 +712,11 @@ export class SettingsManager {
   }
 
   setSkillPaths(paths: string[]): void {
-    this.globalSettings.skills = paths;
-    this.markModified("skills");
-    this.save();
+    this.setScopedSetting("global", "skills", paths);
   }
 
   setProjectSkillPaths(paths: string[]): void {
-    const projectSettings = structuredClone(this.projectSettings);
-    projectSettings.skills = paths;
-    this.markProjectModified("skills");
-    this.saveProjectSettings(projectSettings);
+    this.setScopedSetting("project", "skills", paths);
   }
 
   getPromptTemplatePaths(): string[] {
@@ -879,16 +724,11 @@ export class SettingsManager {
   }
 
   setPromptTemplatePaths(paths: string[]): void {
-    this.globalSettings.prompts = paths;
-    this.markModified("prompts");
-    this.save();
+    this.setScopedSetting("global", "prompts", paths);
   }
 
   setProjectPromptTemplatePaths(paths: string[]): void {
-    const projectSettings = structuredClone(this.projectSettings);
-    projectSettings.prompts = paths;
-    this.markProjectModified("prompts");
-    this.saveProjectSettings(projectSettings);
+    this.setScopedSetting("project", "prompts", paths);
   }
 
   getThemePaths(): string[] {
@@ -896,16 +736,11 @@ export class SettingsManager {
   }
 
   setThemePaths(paths: string[]): void {
-    this.globalSettings.themes = paths;
-    this.markModified("themes");
-    this.save();
+    this.setScopedSetting("global", "themes", paths);
   }
 
   setProjectThemePaths(paths: string[]): void {
-    const projectSettings = structuredClone(this.projectSettings);
-    projectSettings.themes = paths;
-    this.markProjectModified("themes");
-    this.saveProjectSettings(projectSettings);
+    this.setScopedSetting("project", "themes", paths);
   }
 
   getEnableSkillCommands(): boolean {
@@ -913,9 +748,7 @@ export class SettingsManager {
   }
 
   setEnableSkillCommands(enabled: boolean): void {
-    this.globalSettings.enableSkillCommands = enabled;
-    this.markModified("enableSkillCommands");
-    this.save();
+    this.setScopedSetting("global", "enableSkillCommands", enabled);
   }
 
   getThinkingBudgets(): ThinkingBudgetsSettings | undefined {
@@ -927,12 +760,7 @@ export class SettingsManager {
   }
 
   setShowImages(show: boolean): void {
-    if (!this.globalSettings.terminal) {
-      this.globalSettings.terminal = {};
-    }
-    this.globalSettings.terminal.showImages = show;
-    this.markModified("terminal", "showImages");
-    this.save();
+    this.setGlobalNestedSetting("terminal", "showImages", show);
   }
 
   getImageWidthCells(): number {
@@ -940,12 +768,7 @@ export class SettingsManager {
   }
 
   setImageWidthCells(width: number): void {
-    if (!this.globalSettings.terminal) {
-      this.globalSettings.terminal = {};
-    }
-    this.globalSettings.terminal.imageWidthCells = Math.max(1, Math.floor(width));
-    this.markModified("terminal", "imageWidthCells");
-    this.save();
+    this.setGlobalNestedSetting("terminal", "imageWidthCells", Math.max(1, Math.floor(width)));
   }
 
   getClearOnShrink(): boolean {
@@ -953,12 +776,7 @@ export class SettingsManager {
   }
 
   setClearOnShrink(enabled: boolean): void {
-    if (!this.globalSettings.terminal) {
-      this.globalSettings.terminal = {};
-    }
-    this.globalSettings.terminal.clearOnShrink = enabled;
-    this.markModified("terminal", "clearOnShrink");
-    this.save();
+    this.setGlobalNestedSetting("terminal", "clearOnShrink", enabled);
   }
 
   getShowTerminalProgress(): boolean {
@@ -966,12 +784,7 @@ export class SettingsManager {
   }
 
   setShowTerminalProgress(enabled: boolean): void {
-    if (!this.globalSettings.terminal) {
-      this.globalSettings.terminal = {};
-    }
-    this.globalSettings.terminal.showTerminalProgress = enabled;
-    this.markModified("terminal", "showTerminalProgress");
-    this.save();
+    this.setGlobalNestedSetting("terminal", "showTerminalProgress", enabled);
   }
 
   getImageAutoResize(): boolean {
@@ -979,12 +792,7 @@ export class SettingsManager {
   }
 
   setImageAutoResize(enabled: boolean): void {
-    if (!this.globalSettings.images) {
-      this.globalSettings.images = {};
-    }
-    this.globalSettings.images.autoResize = enabled;
-    this.markModified("images", "autoResize");
-    this.save();
+    this.setGlobalNestedSetting("images", "autoResize", enabled);
   }
 
   getBlockImages(): boolean {
@@ -992,12 +800,7 @@ export class SettingsManager {
   }
 
   setBlockImages(blocked: boolean): void {
-    if (!this.globalSettings.images) {
-      this.globalSettings.images = {};
-    }
-    this.globalSettings.images.blockImages = blocked;
-    this.markModified("images", "blockImages");
-    this.save();
+    this.setGlobalNestedSetting("images", "blockImages", blocked);
   }
 
   getEnabledModels(): string[] | undefined {
@@ -1005,9 +808,7 @@ export class SettingsManager {
   }
 
   setEnabledModels(patterns: string[] | undefined): void {
-    this.globalSettings.enabledModels = patterns;
-    this.markModified("enabledModels");
-    this.save();
+    this.setScopedSetting("global", "enabledModels", patterns);
   }
 
   getDoubleEscapeAction(): "fork" | "tree" | "none" {
@@ -1015,9 +816,7 @@ export class SettingsManager {
   }
 
   setDoubleEscapeAction(action: "fork" | "tree" | "none"): void {
-    this.globalSettings.doubleEscapeAction = action;
-    this.markModified("doubleEscapeAction");
-    this.save();
+    this.setScopedSetting("global", "doubleEscapeAction", action);
   }
 
   getTreeFilterMode(): "default" | "no-tools" | "user-only" | "labeled-only" | "all" {
@@ -1027,9 +826,7 @@ export class SettingsManager {
   }
 
   setTreeFilterMode(mode: "default" | "no-tools" | "user-only" | "labeled-only" | "all"): void {
-    this.globalSettings.treeFilterMode = mode;
-    this.markModified("treeFilterMode");
-    this.save();
+    this.setScopedSetting("global", "treeFilterMode", mode);
   }
 
   getShowHardwareCursor(): boolean {
@@ -1037,9 +834,7 @@ export class SettingsManager {
   }
 
   setShowHardwareCursor(enabled: boolean): void {
-    this.globalSettings.showHardwareCursor = enabled;
-    this.markModified("showHardwareCursor");
-    this.save();
+    this.setScopedSetting("global", "showHardwareCursor", enabled);
   }
 
   getEditorPaddingX(): number {
@@ -1047,9 +842,11 @@ export class SettingsManager {
   }
 
   setEditorPaddingX(padding: number): void {
-    this.globalSettings.editorPaddingX = Math.max(0, Math.min(3, Math.floor(padding)));
-    this.markModified("editorPaddingX");
-    this.save();
+    this.setScopedSetting(
+      "global",
+      "editorPaddingX",
+      Math.max(0, Math.min(3, Math.floor(padding))),
+    );
   }
 
   getAutocompleteMaxVisible(): number {
@@ -1057,9 +854,11 @@ export class SettingsManager {
   }
 
   setAutocompleteMaxVisible(maxVisible: number): void {
-    this.globalSettings.autocompleteMaxVisible = Math.max(3, Math.min(20, Math.floor(maxVisible)));
-    this.markModified("autocompleteMaxVisible");
-    this.save();
+    this.setScopedSetting(
+      "global",
+      "autocompleteMaxVisible",
+      Math.max(3, Math.min(20, Math.floor(maxVisible))),
+    );
   }
 
   getCodeBlockIndent(): string {
@@ -1071,9 +870,7 @@ export class SettingsManager {
   }
 
   setWarnings(warnings: WarningSettings): void {
-    this.globalSettings.warnings = { ...warnings };
-    this.markModified("warnings");
-    this.save();
+    this.setScopedSetting("global", "warnings", { ...warnings });
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The agent session settings owner maintained parallel global and project implementations for loading, dirty tracking, persistence, and error state. That duplication made it easy for scope behavior to drift when adding or repairing a setting.

## Why This Change Was Made

SettingsManager now represents both scopes through one canonical scope-state and persistence flow. A single modification map distinguishes whole-field writes from nested-field writes, preserving lock-time merge behavior, runtime override ordering, parse-error isolation, and project input cloning without changing the exported classes, types, or method set.

Removed paths: the separate global/project dirty sets, nested dirty maps, load-error fields, project save implementation, and repeated setter mutation/persistence sequences.

Production delta: +179 / -382, net -203 lines. Test delta: +91 / -2. Total delta: net -114 lines.

## User Impact

No intended user-visible behavior change. Developers get one settings lifecycle path instead of parallel scope-specific implementations, reducing future drift while keeping existing global/project precedence and persistence behavior.

## Evidence

- Focused remote Testbox: `settings-manager.test.ts` — 5/5 passed.
- Remote sibling lifecycle proof: `agent-settings`, `agent-project-settings`, session SDK, and package manager — 77/77 passed; 82/82 including the focused suite.
- Added regression proof for concurrent external sibling-field preservation, global/project isolation, parse-error isolation, and project setter input cloning.
- Remote `pnpm check:changed` passed, including formatting, public plugin SDK API baseline, production/full-tree dead-export scans, core/core-test typechecks, lint (0 warnings/errors), storage guards, and import-cycle checks.
- Remote packaged `pnpm build` passed, including all 148 public plugin SDK subpath checks and Control UI build/performance checks.
- Public SettingsManager method-name comparison against the base is unchanged.
- Two independent xhigh final reviewers returned `CLEAN` (`settings_contract_review_a`, `settings_contract_review_b`).
