### PR TITLE
fix(media): fall back from zero-byte generated assets

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -953,7 +953,15 @@ catalog, API-key auth, and dynamic model resolution.
             generate: { maxCount: 4, supportsSize: true },
             edit: { enabled: false },
           },
-          generateImage: async (req) => ({ images: [] }),
+          generateImage: async (req) => ({
+            images: [
+              {
+                buffer: await generateAcmeImageBytes(req),
+                mimeType: "image/png",
+                fileName: "acme-image.png",
+              },
+            ],
+          }),
         });
 
         api.registerVideoGenerationProvider({
@@ -987,9 +995,23 @@ catalog, API-key auth, and dynamic model resolution.
               },
             },
           },
-          generateVideo: async (req) => ({ videos: [] }),
+          generateVideo: async (req) => ({
+            videos: [
+              {
+                url: await generateAcmeVideoUrl(req),
+                mimeType: "video/mp4",
+              },
+            ],
+          }),
         });
         ```
+
+        The illustrative helpers stand in for provider calls: the image helper
+        returns non-empty encoded bytes, while the video helper returns a hosted
+        media URL. Video providers may return non-empty encoded bytes instead,
+        or both when the URL is a delivery fallback. Empty result arrays and
+        empty buffers are candidate failures, except that a video asset with a
+        usable URL ignores an empty buffer and continues with the URL.
 
         `capabilities` is required on both provider types; `edit` and the
         video transform blocks (`imageToVideo`, `videoToVideo`) always need an

--- a/src/image-generation/runtime.test.ts
+++ b/src/image-generation/runtime.test.ts
@@ -51,6 +51,16 @@ function runGenerateImage(params: GenerateImageParams) {
   return generateImage({ ...params, cfg }, runtimeDeps);
 }
 
+function createBufferedImageProvider(id: string, buffers: Buffer[]): ImageGenerationProvider {
+  return {
+    id,
+    capabilities: { generate: {}, edit: { enabled: false } },
+    generateImage: async () => ({
+      images: buffers.map((buffer) => ({ buffer, mimeType: "image/png" })),
+    }),
+  };
+}
+
 describe("image-generation runtime", () => {
   beforeEach(() => {
     providers = [];
@@ -286,6 +296,63 @@ describe("image-generation runtime", () => {
     ]);
     expect(warnings).toContain(
       "image-generation candidate failed: openai/gpt-image-1: OpenAI API key missing",
+    );
+  });
+
+  it("falls through when an image provider returns an empty buffer", async () => {
+    providers = [
+      createBufferedImageProvider("empty", [Buffer.from("partial"), Buffer.alloc(0)]),
+      createBufferedImageProvider("valid", [Buffer.from("png-bytes")]),
+    ];
+
+    const result = await runGenerateImage({
+      cfg: {
+        agents: {
+          defaults: {
+            mediaModels: {
+              image: { primary: "empty/img-v1", fallbacks: ["valid/img-v2"] },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "draw a cat",
+    });
+
+    expect(result.provider).toBe("valid");
+    expect(result.images[0]?.buffer).toEqual(Buffer.from("png-bytes"));
+    expect(result.attempts).toEqual([
+      {
+        provider: "empty",
+        model: "img-v1",
+        error: "Image generation provider returned an empty image buffer at index 1.",
+      },
+    ]);
+  });
+
+  it("fails visibly when every image provider returns an empty buffer", async () => {
+    providers = [
+      createBufferedImageProvider("empty-primary", [Buffer.alloc(0)]),
+      createBufferedImageProvider("empty-fallback", [Buffer.alloc(0)]),
+    ];
+
+    await expect(
+      runGenerateImage({
+        cfg: {
+          agents: {
+            defaults: {
+              mediaModels: {
+                image: {
+                  primary: "empty-primary/img-v1",
+                  fallbacks: ["empty-fallback/img-v2"],
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        prompt: "draw a cat",
+      }),
+    ).rejects.toThrow(
+      "All image generation models failed (2): empty-primary/img-v1: Image generation provider returned an empty image buffer at index 0. | empty-fallback/img-v2: Image generation provider returned an empty image buffer at index 0.",
     );
   });
 

--- a/src/image-generation/runtime.ts
+++ b/src/image-generation/runtime.ts
@@ -81,8 +81,8 @@ export async function generateImage(
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
 
-  // Try configured/fallback models in order and return the first provider that
-  // yields at least one image; failed attempts are preserved for diagnostics.
+  // Try configured/fallback models in order and return the first provider whose
+  // entire image batch is present and non-empty; preserve failed attempts for diagnostics.
   for (const candidate of candidates) {
     const provider = getProvider(candidate.provider, params.cfg);
     if (!provider) {
@@ -164,6 +164,12 @@ export async function generateImage(
       });
       if (!Array.isArray(result.images) || result.images.length === 0) {
         throw new Error("Image generation provider returned no images.");
+      }
+      const emptyImageIndex = result.images.findIndex((image) => image.buffer.byteLength === 0);
+      if (emptyImageIndex >= 0) {
+        throw new Error(
+          `Image generation provider returned an empty image buffer at index ${emptyImageIndex}.`,
+        );
       }
       return {
         images: result.images,

--- a/src/image-generation/types.ts
+++ b/src/image-generation/types.ts
@@ -4,7 +4,7 @@ import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 
-/** Binary image asset returned by an image-generation provider. */
+/** Non-empty binary image asset returned by an image-generation provider. */
 export type GeneratedImageAsset = {
   buffer: Buffer;
   mimeType: string;

--- a/src/music-generation/runtime.test.ts
+++ b/src/music-generation/runtime.test.ts
@@ -43,6 +43,16 @@ function runGenerateMusic(params: GenerateMusicParams) {
   return generateMusic({ ...params, cfg }, runtimeDeps);
 }
 
+function createBufferedMusicProvider(id: string, buffers: Buffer[]): MusicGenerationProvider {
+  return {
+    id,
+    capabilities: {},
+    generateMusic: async () => ({
+      tracks: buffers.map((buffer) => ({ buffer, mimeType: "audio/mpeg" })),
+    }),
+  };
+}
+
 describe("music-generation runtime", () => {
   beforeEach(() => {
     providers = [];
@@ -208,6 +218,63 @@ describe("music-generation runtime", () => {
         error: "Google music generation response missing audio data",
       },
     ]);
+  });
+
+  it("falls through when a music provider returns an empty buffer", async () => {
+    providers = [
+      createBufferedMusicProvider("empty", [Buffer.from("partial"), Buffer.alloc(0)]),
+      createBufferedMusicProvider("valid", [Buffer.from("mp3-bytes")]),
+    ];
+
+    const result = await runGenerateMusic({
+      cfg: {
+        agents: {
+          defaults: {
+            mediaModels: {
+              music: { primary: "empty/track-v1", fallbacks: ["valid/track-v2"] },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "play a synth line",
+    });
+
+    expect(result.provider).toBe("valid");
+    expect(result.tracks[0]?.buffer).toEqual(Buffer.from("mp3-bytes"));
+    expect(result.attempts).toEqual([
+      {
+        provider: "empty",
+        model: "track-v1",
+        error: "Music generation provider returned an empty track buffer at index 1.",
+      },
+    ]);
+  });
+
+  it("fails visibly when every music provider returns an empty buffer", async () => {
+    providers = [
+      createBufferedMusicProvider("empty-primary", [Buffer.alloc(0)]),
+      createBufferedMusicProvider("empty-fallback", [Buffer.alloc(0)]),
+    ];
+
+    await expect(
+      runGenerateMusic({
+        cfg: {
+          agents: {
+            defaults: {
+              mediaModels: {
+                music: {
+                  primary: "empty-primary/track-v1",
+                  fallbacks: ["empty-fallback/track-v2"],
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        prompt: "play a synth line",
+      }),
+    ).rejects.toThrow(
+      "All music generation models failed (2): empty-primary/track-v1: Music generation provider returned an empty track buffer at index 0. | empty-fallback/track-v2: Music generation provider returned an empty track buffer at index 0.",
+    );
   });
 
   it("lists runtime music-generation providers through the provider registry", () => {

--- a/src/music-generation/runtime.ts
+++ b/src/music-generation/runtime.ts
@@ -118,6 +118,12 @@ export async function generateMusic(
       if (!Array.isArray(result.tracks) || result.tracks.length === 0) {
         throw new Error("Music generation provider returned no tracks.");
       }
+      const emptyTrackIndex = result.tracks.findIndex((track) => track.buffer.byteLength === 0);
+      if (emptyTrackIndex >= 0) {
+        throw new Error(
+          `Music generation provider returned an empty track buffer at index ${emptyTrackIndex}.`,
+        );
+      }
       return {
         tracks: result.tracks,
         provider: candidate.provider,

--- a/src/music-generation/types.ts
+++ b/src/music-generation/types.ts
@@ -12,7 +12,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 /** Audio output formats currently understood by music generation providers. */
 export type MusicGenerationOutputFormat = "mp3" | "wav";
 
-/** In-memory audio asset returned from a music generation provider. */
+/** Non-empty in-memory audio asset returned from a music generation provider. */
 export type GeneratedMusicAsset = {
   buffer: Buffer;
   mimeType: string;

--- a/src/plugin-sdk/video-generation.ts
+++ b/src/plugin-sdk/video-generation.ts
@@ -38,11 +38,10 @@ import {
 
 /** Video asset returned by a provider after generation or transformation. */
 export type GeneratedVideoAsset = {
-  /** Raw video bytes. Either buffer or url must be present. */
+  /** Non-empty raw video bytes; may accompany url as a delivery fallback. */
   buffer?: Buffer;
-  /** Pre-signed or provider-hosted URL for the video. When set and buffer is
-   * absent, callers can deliver or download the asset without requiring the
-   * provider to materialize the full file in memory first. */
+  /** Provider-hosted URL returned instead of bytes or alongside them as a delivery fallback.
+   * When buffer is absent, callers can forward or download without materializing the video. */
   url?: string;
   mimeType: string;
   fileName?: string;

--- a/src/video-generation/runtime.test.ts
+++ b/src/video-generation/runtime.test.ts
@@ -47,6 +47,16 @@ function runGenerateVideo(params: GenerateVideoParams) {
   return generateVideo({ ...params, cfg }, runtimeDeps);
 }
 
+function createBufferedVideoProvider(id: string, buffers: Buffer[]): VideoGenerationProvider {
+  return {
+    id,
+    capabilities: {},
+    generateVideo: async () => ({
+      videos: buffers.map((buffer) => ({ buffer, mimeType: "video/mp4" })),
+    }),
+  };
+}
+
 function requireAttempt(
   result: Awaited<ReturnType<typeof runGenerateVideo>>,
   index: number,
@@ -272,6 +282,96 @@ describe("video-generation runtime", () => {
         error: "Your request was blocked by our moderation system.",
       },
     ]);
+  });
+
+  it("falls through when a video provider returns an empty buffer", async () => {
+    providers = [
+      createBufferedVideoProvider("empty", [Buffer.from("partial"), Buffer.alloc(0)]),
+      createBufferedVideoProvider("valid", [Buffer.from("mp4-bytes")]),
+    ];
+
+    const result = await runGenerateVideo({
+      cfg: {
+        agents: {
+          defaults: {
+            mediaModels: {
+              video: { primary: "empty/vid-v1", fallbacks: ["valid/vid-v2"] },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "animate a cat",
+    });
+
+    expect(result.provider).toBe("valid");
+    expect(result.videos[0]?.buffer).toEqual(Buffer.from("mp4-bytes"));
+    expect(result.attempts).toEqual([
+      {
+        provider: "empty",
+        model: "vid-v1",
+        error: "Video generation provider returned an empty video buffer at index 1.",
+      },
+    ]);
+  });
+
+  it("fails visibly when every video provider returns an empty buffer", async () => {
+    providers = [
+      createBufferedVideoProvider("empty-primary", [Buffer.alloc(0)]),
+      createBufferedVideoProvider("empty-fallback", [Buffer.alloc(0)]),
+    ];
+
+    await expect(
+      runGenerateVideo({
+        cfg: {
+          agents: {
+            defaults: {
+              mediaModels: {
+                video: {
+                  primary: "empty-primary/vid-v1",
+                  fallbacks: ["empty-fallback/vid-v2"],
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        prompt: "animate a cat",
+      }),
+    ).rejects.toThrow(
+      "All video generation models failed (2): empty-primary/vid-v1: Video generation provider returned an empty video buffer at index 0. | empty-fallback/vid-v2: Video generation provider returned an empty video buffer at index 0.",
+    );
+  });
+
+  it("uses a provider URL when the same video asset has an empty buffer", async () => {
+    providers = [
+      {
+        id: "url-provider",
+        capabilities: {},
+        generateVideo: async () => ({
+          videos: [
+            {
+              buffer: Buffer.alloc(0),
+              url: "https://example.com/generated.mp4",
+              mimeType: "video/mp4",
+            },
+          ],
+        }),
+      },
+    ];
+
+    const result = await runGenerateVideo({
+      cfg: {
+        agents: {
+          defaults: { mediaModels: { video: { primary: "url-provider/vid-v1" } } },
+        },
+      } as OpenClawConfig,
+      prompt: "animate a cat",
+    });
+
+    expect(result.attempts).toEqual([]);
+    expect(result.videos[0]).toEqual({
+      url: "https://example.com/generated.mp4",
+      mimeType: "video/mp4",
+    });
   });
 
   it("forwards providerOptions to providers that declare the matching schema", async () => {

--- a/src/video-generation/runtime.ts
+++ b/src/video-generation/runtime.ts
@@ -321,15 +321,27 @@ export async function generateVideo(
       if (!Array.isArray(result.videos) || result.videos.length === 0) {
         throw new Error("Video generation provider returned no videos.");
       }
-      for (const [index, video] of result.videos.entries()) {
+      const videos = result.videos.map((video, index) => {
+        if (video.buffer?.byteLength === 0) {
+          if (video.url) {
+            // URL-only video is valid; remove the unusable buffer so callers do not
+            // prefer it and persist zero bytes instead of delivering the URL.
+            const { buffer: _emptyBuffer, ...urlOnlyVideo } = video;
+            return urlOnlyVideo;
+          }
+          throw new Error(
+            `Video generation provider returned an empty video buffer at index ${index}.`,
+          );
+        }
         if (!video.buffer && !video.url) {
           throw new Error(
             `Video generation provider returned an undeliverable asset at index ${index}: neither buffer nor url is set.`,
           );
         }
-      }
+        return video;
+      });
       return {
-        videos: result.videos,
+        videos,
         provider: candidate.provider,
         model: result.model ?? candidate.model,
         attempts,

--- a/src/video-generation/types.ts
+++ b/src/video-generation/types.ts
@@ -4,11 +4,10 @@ import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 export type GeneratedVideoAsset = {
-  /** Raw video bytes. Required for local delivery; omit when url is provided instead. */
+  /** Non-empty raw video bytes for local delivery; may accompany url as a fallback. */
   buffer?: Buffer;
-  /** External URL for the video (for example a pre-signed cloud storage URL).
-   * When set and buffer is absent, delivery surfaces can forward the URL
-   * without downloading the full video into memory first. */
+  /** Provider-hosted URL returned instead of bytes or alongside them as a delivery fallback.
+   * When buffer is absent, surfaces can forward the URL without materializing the video. */
   url?: string;
   mimeType: string;
   fileName?: string;


### PR DESCRIPTION
Closes #117874

## What Problem This Solves

Fixes an issue where image, music, and video generation could report success with a zero-byte provider asset, suppressing configured fallback and leaving callers with unusable media.

## Why This Change Was Made

The shared media runtimes now enforce the provider-output invariant at the candidate boundary: image and music batches must contain only non-empty buffers, and video assets must contain non-empty bytes or a usable hosted URL. A video URL remains valid when its accompanying buffer is empty, but the runtime removes that buffer so downstream consumers cannot prefer and persist zero bytes.

This keeps the policy in the one owner traversed by every provider instead of duplicating checks across plugins. The batch is rejected atomically so a partially valid primary cannot silently replace the complete configured fallback.

## User Impact

Operators now receive a valid fallback result when a media provider returns empty bytes. If every configured candidate is empty, generation fails visibly with per-provider diagnostics rather than claiming success. Plugin authors also have an explicit non-empty output contract in the SDK types and provider documentation.

## Evidence

- Built-main before proof at `8ae21a6ae5b18c921afa56648fdc8be91e767069` on Blacksmith Testbox `tbx_01kz0hge7r2cqybcgzhskgq3bh`: image, music, and video each selected the empty primary, returned byte lengths `[13, 0]`, and recorded no failed attempt; URL-backed video retained its zero-byte buffer.
- Exact pushed head `9148de7ec2902cded49c4657a8b329ae4516940a` on Blacksmith Testbox `tbx_01kz0jzvc7jqmx6adnkrg5x08j` / run `30736215093`: 58/58 focused assertions passed across the image, music, and video runtimes.
- Exact-head changed gate: passed formatting, core and extension production/test typechecks, SDK API/export/surface checks, plugin boundaries, lint, dependency guards, dead-code scans, import cycles, and media guards.
- Exact-head full build: passed, including all 148 public Plugin SDK declaration subpaths and the Control UI production build.
- Source-blind built-artifact contract: 5/5 clauses passed. Image, music, and video selected unique non-empty fallback bytes after an empty primary; URL-backed video removed the empty buffer; all three two-provider all-empty chains failed with explicit per-candidate diagnostics.
- Final branch autoreview `019fc13e-8523-7df0-adaf-10ca1a94725a`: clean, no accepted/actionable findings, correctness confidence 0.99.

The Testbox workflow is a retained provisioner and may record cancellation after the completed command proof when the lease is stopped; the wrapper command summaries above all exited 0.

Production delta: +37/-15. Tests: +234/-0. Docs: +24/-2. No config, protocol, storage, dependency, or migration changes.

AI-assisted: yes.
