### PR TITLE
test(outbound): consolidate recovery fixtures

### DIFF
--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -1,5 +1,3 @@
-// Covers startup delivery recovery, backoff, permanent failures, unknown-send
-// reconciliation, commit hooks, and retry budget deferral.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
@@ -45,30 +43,91 @@ import {
   readQueuedEntry,
   setQueuedEntryState,
 } from "./delivery-queue.test-helpers.js";
-
 const RECOVERY_REPLAY_SPACING_MS = 250;
 const MAX_RETRIES = 5;
+const BLIND_REPLAY_LOG = "refusing blind replay without adapter reconciliation";
+const BOUNDED_COMPLETION_RETENTION = {
+  idPrefix: "cron-direct-delivery:v1:",
+  maxAgeMs: 24 * 60 * 60_000,
+  maxEntries: 2_000,
+} as const;
+const RECOVERY_SUMMARY = {
+  deferred: { recovered: 0, failed: 0, skippedMaxRetries: 0, deferredBackoff: 1 },
+  empty: { recovered: 0, failed: 0, skippedMaxRetries: 0, deferredBackoff: 0 },
+  failed: { recovered: 0, failed: 1, skippedMaxRetries: 0, deferredBackoff: 0 },
+  recovered: { recovered: 1, failed: 0, skippedMaxRetries: 0, deferredBackoff: 0 },
+  recoveredWithDeferred: { recovered: 1, failed: 0, skippedMaxRetries: 0, deferredBackoff: 1 },
+  twoRecovered: { recovered: 2, failed: 0, skippedMaxRetries: 0, deferredBackoff: 0 },
+} as const;
 const resolveOutboundChannelMessageAdapterMock = vi.hoisted(() => vi.fn());
 const sleepMock = vi.hoisted(() => vi.fn<(ms: number) => Promise<void>>());
-
 vi.mock("./channel-resolution.js", () => ({
   resolveOutboundChannelMessageAdapter: resolveOutboundChannelMessageAdapterMock,
 }));
 vi.mock("../../utils/sleep.js", () => ({ sleep: sleepMock }));
-
-function mockCallArg(mock: { mock: { calls: unknown[][] } }, index = 0): unknown {
-  const call = mock.mock.calls[index];
-  if (!call) {
-    throw new Error(`Expected mock call ${index}`);
+function mockCallRecord(mock: { mock: { calls: unknown[][] } }, index = 0) {
+  const value = mock.mock.calls[index]?.[0];
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Expected mock call ${index} argument to be a record`);
   }
-  return call[0];
+  return value as Record<string, unknown>;
 }
-
 function expectMockMessageContaining(mock: { mock: { calls: unknown[][] } }, expected: string) {
   const messages = mock.mock.calls.map((call) => (typeof call[0] === "string" ? call[0] : ""));
   expect(messages.join("\n")).toContain(expected);
 }
-
+function captureAuditEvents() {
+  const auditEvents: TrustedMessageAuditEvent[] = [];
+  return {
+    auditEvents,
+    unsubscribe: onTrustedMessageAuditEvent((event) => auditEvents.push(event)),
+  };
+}
+function expectPayloadAudits(
+  auditEvents: TrustedMessageAuditEvent[],
+  queueId: string,
+  expected: Array<Record<string, unknown>>,
+) {
+  expect(auditEvents).toHaveLength(expected.length);
+  expected.forEach((event, index) =>
+    expect(auditEvents[index]).toMatchObject({
+      sourceId: `message:outbound:queue:${queueId}:payload:${index}`,
+      ...event,
+    }),
+  );
+}
+type PayloadOutcomeSink = Pick<Parameters<DeliverFn>[0], "onPayloadDeliveryOutcome">;
+function reportPayloadFailure(
+  params: PayloadOutcomeSink,
+  error: Error,
+  overrides: Partial<OutboundPayloadDeliveryOutcome> = {},
+) {
+  params.onPayloadDeliveryOutcome?.({
+    index: 0,
+    status: "failed",
+    error,
+    sentBeforeError: false,
+    stage: "platform_send",
+    ...overrides,
+  } as OutboundPayloadDeliveryOutcome);
+}
+function reconciledSent(messageId: string, sentAt = Date.now()) {
+  return {
+    status: "sent",
+    messageId,
+    receipt: {
+      primaryPlatformMessageId: messageId,
+      platformMessageIds: [messageId],
+      parts: [{ platformMessageId: messageId, kind: "text", index: 0 }],
+      sentAt,
+    },
+  };
+}
+async function runIf(condition: unknown, action: () => unknown) {
+  if (condition) {
+    await action();
+  }
+}
 function readOutboundQueueStatus(tmpDir: string, id: string): string | undefined {
   const { db } = openOpenClawStateDatabase({
     env: { ...process.env, OPENCLAW_STATE_DIR: tmpDir },
@@ -78,11 +137,9 @@ function readOutboundQueueStatus(tmpDir: string, id: string): string | undefined
     .get(OUTBOUND_DELIVERY_QUEUE_NAME, id) as { status?: string } | undefined;
   return row?.status;
 }
-
 describe("delivery-queue recovery", () => {
   const { tmpDir } = installDeliveryQueueTmpDirHooks();
   const baseCfg = {};
-
   function enqueueRecoveryDelivery(params: Partial<Parameters<typeof enqueueDelivery>[0]> = {}) {
     return enqueueDelivery(
       {
@@ -94,13 +151,98 @@ describe("delivery-queue recovery", () => {
       tmpDir(),
     );
   }
-
+  function enqueueDemoRecoveryDelivery(
+    texts: string[] = ["x"],
+    params: Partial<Parameters<typeof enqueueDelivery>[0]> = {},
+  ) {
+    return enqueueRecoveryDelivery({
+      channel: "demo-channel-c",
+      to: "#ch",
+      payloads: texts.map((text) => ({ text })),
+      ...params,
+    });
+  }
+  function installUnknownSendAdapter(
+    reconcileUnknownSend: ReturnType<typeof vi.fn>,
+    durableFinal: Record<string, unknown> = {},
+    adapter: Record<string, unknown> = {},
+  ) {
+    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
+      ...adapter,
+      durableFinal: {
+        capabilities: { reconcileUnknownSend: true },
+        reconcileUnknownSend,
+        ...durableFinal,
+      },
+    });
+  }
+  function installUnknownSendResult(
+    result: Record<string, unknown>,
+    durableFinal: Record<string, unknown> = {},
+  ) {
+    const reconcileUnknownSend = vi.fn().mockResolvedValue(result);
+    installUnknownSendAdapter(reconcileUnknownSend, durableFinal);
+    return reconcileUnknownSend;
+  }
+  async function enqueueUnknownRecovery(params: {
+    text: string;
+    state?: "send_attempt_started" | "unknown_after_send";
+    delivery?: Partial<Parameters<typeof enqueueDelivery>[0]>;
+    queue?: Record<string, unknown>;
+  }) {
+    const id = await enqueueRecoveryDelivery({
+      payloads: [{ text: params.text }],
+      ...params.delivery,
+    });
+    setQueuedEntryState(tmpDir(), id, {
+      retryCount: 0,
+      platformSendStartedAt: Date.now(),
+      recoveryState: params.state ?? "unknown_after_send",
+      ...params.queue,
+    });
+    return id;
+  }
+  async function expectFailedQueue(id: string) {
+    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
+  }
+  async function expectPendingEntry(expected: Record<string, unknown>) {
+    const entries = await loadPendingDeliveries(tmpDir());
+    expect(entries).toHaveLength(1);
+    const entry = entries[0] as unknown as Record<string, unknown>;
+    for (const [key, value] of Object.entries(expected)) {
+      expect(entry[key]).toEqual(value);
+    }
+    return entries[0];
+  }
+  async function enqueueClaimedRecoveryDelivery(
+    id: string,
+    delivery: Partial<Parameters<typeof enqueueDeliveryOnce>[0]>,
+    route?: { replyToId: string | null },
+  ) {
+    await enqueueDeliveryOnce(
+      {
+        channel: "demo-channel-a",
+        to: "+1",
+        payloads: [{ text: "stable delivery" }],
+        queuePolicy: "required",
+        ...delivery,
+      },
+      id,
+      tmpDir(),
+    );
+    const claimId = await claimDeliveryPlatformSendAttempt(id, tmpDir());
+    if (!claimId) {
+      throw new Error("test invariant: stable delivery must own its platform attempt");
+    }
+    await markDeliveryPlatformSendAttemptStarted(id, tmpDir(), route, claimId);
+    return claimId;
+  }
   beforeEach(() => {
     resolveOutboundChannelMessageAdapterMock.mockReset();
     sleepMock.mockReset();
     sleepMock.mockResolvedValue(undefined);
   });
-
   const enqueueCrashRecoveryEntries = async () => {
     await enqueueRecoveryDelivery({
       preparedMessageId: "prepared-message-a",
@@ -113,7 +255,6 @@ describe("delivery-queue recovery", () => {
       requireUnknownSendReconciliation: true,
     });
   };
-
   const runRecovery = async ({
     deliver,
     log = createRecoveryLog(),
@@ -132,7 +273,37 @@ describe("delivery-queue recovery", () => {
     });
     return { result, log };
   };
-
+  type StorageModule = typeof import("./delivery-queue-storage.js");
+  async function runRecoveryWithStorageOverrides(params: {
+    overrides: (actual: StorageModule) => Partial<StorageModule>;
+    deliver?: ReturnType<typeof vi.fn>;
+    createDeliver?: () => Promise<ReturnType<typeof vi.fn>>;
+  }) {
+    vi.resetModules();
+    vi.doMock("./delivery-queue-storage.js", async () => {
+      const actual = await vi.importActual<StorageModule>("./delivery-queue-storage.js");
+      return { ...actual, ...params.overrides(actual) };
+    });
+    try {
+      const { recoverPendingDeliveries: recoverWithFailures } =
+        await import("./delivery-queue-recovery.js");
+      const log = createRecoveryLog();
+      const deliver = params.deliver ?? (await params.createDeliver?.());
+      if (!deliver) {
+        throw new Error("Storage override recovery requires a delivery function");
+      }
+      const summary = await recoverWithFailures({
+        deliver: asDeliverFn(deliver),
+        log,
+        cfg: baseCfg,
+        stateDir: tmpDir(),
+      });
+      return { summary, log };
+    } finally {
+      vi.doUnmock("./delivery-queue-storage.js");
+      vi.resetModules();
+    }
+  }
   async function createConversationRecoveryFixture(operationId: string) {
     const storePath = path.join(tmpDir(), "agent-sessions.json");
     const scope = { agentId: "main", storePath };
@@ -183,35 +354,24 @@ describe("delivery-queue recovery", () => {
     );
     return scope;
   }
-
   it("recovers entries from a simulated crash", async () => {
     await enqueueCrashRecoveryEntries();
     const deliver = vi.fn().mockResolvedValue([]);
     const { result } = await runRecovery({ deliver });
-
     expect(deliver).toHaveBeenCalledTimes(2);
-    expect(deliver.mock.calls.map(([params]) => params.queuePolicy)).toEqual([
-      undefined,
-      "required",
+    expect(
+      deliver.mock.calls.map(([params]) => [
+        params.queuePolicy,
+        params.requireUnknownSendReconciliation,
+        params.preparedMessageId,
+      ]),
+    ).toEqual([
+      [undefined, undefined, "prepared-message-a"],
+      ["required", true, undefined],
     ]);
-    expect(deliver.mock.calls.map(([params]) => params.requireUnknownSendReconciliation)).toEqual([
-      undefined,
-      true,
-    ]);
-    expect(deliver.mock.calls.map(([params]) => params.preparedMessageId)).toEqual([
-      "prepared-message-a",
-      undefined,
-    ]);
-    expect(result).toEqual({
-      recovered: 2,
-      failed: 0,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
-
+    expect(result).toEqual(RECOVERY_SUMMARY.twoRecovered);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
   });
-
   it("finalizes a persisted conversation operation during queue recovery", async () => {
     const scope = await createConversationRecoveryFixture("operation-recovery");
     const deliveryResult = { channel: "reef" as const, messageId: "reef-platform" };
@@ -219,10 +379,8 @@ describe("delivery-queue recovery", () => {
       await params.onDeliveryResult?.(deliveryResult);
       return [deliveryResult];
     });
-
     try {
       const { result } = await runRecovery({ deliver });
-
       expect(result.recovered).toBe(1);
       expect(getConversationDeliveryOperation(scope, "operation-recovery")).toMatchObject({
         status: "sent",
@@ -234,289 +392,183 @@ describe("delivery-queue recovery", () => {
       closeOpenClawAgentDatabasesForTest();
     }
   });
-
-  it("acks a persisted suppressed conversation operation without replaying it", async () => {
-    const scope = await createConversationRecoveryFixture("operation-suppressed");
-    markConversationDeliverySuppressed(scope, "operation-suppressed");
+  it.each([
+    "acks a persisted suppressed conversation operation without replaying it",
+    "acks a persisted rejected conversation operation without replaying it",
+  ])("%s", async (name) => {
+    const rejected = name.includes("rejected");
+    const operationId = rejected ? "operation-rejected" : "operation-suppressed";
+    const scope = await createConversationRecoveryFixture(operationId);
+    await runIf(rejected, () =>
+      markConversationDeliveryRejected(scope, operationId, "atomic message limit"),
+    );
+    await runIf(!rejected, () => markConversationDeliverySuppressed(scope, operationId));
     const deliver = vi.fn();
-
     try {
       const { result } = await runRecovery({ deliver });
-
-      expect(result.recovered).toBe(1);
+      expect(result).toMatchObject(rejected ? { failed: 1 } : { recovered: 1 });
       expect(deliver).not.toHaveBeenCalled();
-      expect(getConversationDeliveryOperation(scope, "operation-suppressed")?.status).toBe(
-        "suppressed",
+      expect(getConversationDeliveryOperation(scope, operationId)).toMatchObject(
+        rejected
+          ? { status: "rejected", rejectionError: "atomic message limit" }
+          : { status: "suppressed" },
       );
       expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
     } finally {
       closeOpenClawAgentDatabasesForTest();
     }
   });
-
-  it("acks a persisted rejected conversation operation without replaying it", async () => {
-    const scope = await createConversationRecoveryFixture("operation-rejected");
-    markConversationDeliveryRejected(scope, "operation-rejected", "atomic message limit");
-    const deliver = vi.fn();
-
-    try {
-      const { result } = await runRecovery({ deliver });
-
-      expect(result.failed).toBe(1);
-      expect(deliver).not.toHaveBeenCalled();
-      expect(getConversationDeliveryOperation(scope, "operation-rejected")).toMatchObject({
-        status: "rejected",
-        rejectionError: "atomic message limit",
+  it.each([
+    ["permanently rejects provider-blocked rows before backoff or reconciliation", false],
+    ["checks bounded provider admission before replaying a reconciliable platform attempt", true],
+  ])("%s", async (_, stableAttempt) => {
+    const capture = stableAttempt ? undefined : captureAuditEvents();
+    const id = stableAttempt
+      ? "cron-direct-delivery:v1:blocked-reconciled-admission"
+      : await enqueueRecoveryDelivery({
+          channel: "slack",
+          to: "C123",
+          accountId: "enterprise",
+          payloads: [{ text: "blocked" }],
+        });
+    const producerClaimId = stableAttempt
+      ? await enqueueClaimedRecoveryDelivery(id, {
+          channel: "slack",
+          to: "C123",
+          accountId: "enterprise",
+          payloads: [{ text: "disabled account must never be replayed" }],
+          completionRetention: BOUNDED_COMPLETION_RETENTION,
+        })
+      : undefined;
+    if (!stableAttempt) {
+      setQueuedEntryState(tmpDir(), id, {
+        retryCount: MAX_RETRIES,
+        lastAttemptAt: Date.now(),
+        recoveryState: "unknown_after_send",
+        platformSendStartedAt: Date.now(),
       });
-      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
     }
-  });
-
-  it("permanently rejects provider-blocked rows before backoff or reconciliation", async () => {
-    const auditEvents: TrustedMessageAuditEvent[] = [];
-    const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
-    const id = await enqueueRecoveryDelivery({
-      channel: "slack",
-      to: "C123",
-      accountId: "enterprise",
-      payloads: [{ text: "blocked" }],
-    });
-    setQueuedEntryState(tmpDir(), id, {
-      retryCount: MAX_RETRIES,
-      lastAttemptAt: Date.now(),
-      recoveryState: "unknown_after_send",
-      platformSendStartedAt: Date.now(),
-    });
     const admitDeferredDelivery = vi.fn(() => ({
       status: "permanent_rejection" as const,
       reason: "unsupported_enterprise_slack_delivery",
     }));
-    const reconcileUnknownSend = vi.fn();
-    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
-      durableFinal: { admitDeferredDelivery, reconcileUnknownSend },
-    });
-    const deliver = vi.fn();
-
-    const { result } = await runRecovery({ deliver });
-    unsubscribe();
-
-    expect(admitDeferredDelivery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accountId: "enterprise",
-        channel: "slack",
-        phase: "recovery",
-        to: "C123",
-      }),
-    );
-    expect(reconcileUnknownSend).not.toHaveBeenCalled();
-    expect(deliver).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      recovered: 0,
-      failed: 1,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-    expect(readQueuedEntry(tmpDir(), id).lastError).toBe("unsupported_enterprise_slack_delivery");
-    expect(auditEvents).toHaveLength(1);
-    expect(auditEvents[0]).toMatchObject({
-      sourceId: `message:outbound:queue:${id}:payload:0`,
-      status: "unknown",
-      outcome: "unknown",
-      failureStage: "queue",
-    });
-
-    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
-      durableFinal: { admitDeferredDelivery: () => ({ status: "allowed" }) },
-    });
-    await runRecovery({ deliver });
-    expect(deliver).not.toHaveBeenCalled();
-  });
-
-  it("checks bounded provider admission before replaying a reconciliable platform attempt", async () => {
-    const id = "cron-direct-delivery:v1:blocked-reconciled-admission";
-    await enqueueDeliveryOnce(
-      {
-        channel: "slack",
-        to: "C123",
-        accountId: "enterprise",
-        payloads: [{ text: "disabled account must never be replayed" }],
-        queuePolicy: "required",
-        completionRetention: {
-          idPrefix: "cron-direct-delivery:v1:",
-          maxAgeMs: 24 * 60 * 60_000,
-          maxEntries: 2_000,
-        },
-      },
-      id,
-      tmpDir(),
-    );
-    const producerClaimId = await claimDeliveryPlatformSendAttempt(id, tmpDir());
-    if (!producerClaimId) {
-      throw new Error("test invariant: bounded platform attempt must be owned");
-    }
-    await markDeliveryPlatformSendAttemptStarted(id, tmpDir(), undefined, producerClaimId);
-    const admitDeferredDelivery = vi.fn(() => ({
-      status: "permanent_rejection" as const,
-      reason: "unsupported_enterprise_slack_delivery",
-    }));
-    const reconcileUnknownSend = vi.fn().mockResolvedValue({ status: "not_sent" });
+    const reconcileUnknownSend = stableAttempt
+      ? vi.fn().mockResolvedValue({ status: "not_sent" })
+      : vi.fn();
     resolveOutboundChannelMessageAdapterMock.mockReturnValue({
       durableFinal: {
-        capabilities: { reconcileUnknownSend: true },
+        ...(stableAttempt ? { capabilities: { reconcileUnknownSend: true } } : {}),
         admitDeferredDelivery,
         reconcileUnknownSend,
       },
     });
     const deliver = vi.fn();
-
-    await runRecovery({ deliver });
-
+    const { result } = await runRecovery({ deliver });
+    capture?.unsubscribe();
     expect(admitDeferredDelivery).toHaveBeenCalledWith(
       expect.objectContaining({
         accountId: "enterprise",
         channel: "slack",
         phase: "recovery",
+        ...(stableAttempt ? {} : { to: "C123" }),
       }),
     );
     expect(reconcileUnknownSend).not.toHaveBeenCalled();
     expect(deliver).not.toHaveBeenCalled();
-    expect((await loadPendingDeliveries(tmpDir()))[0]).toMatchObject({
-      id,
-      recoveryState: "send_attempt_started",
-      platformSendAttemptId: producerClaimId,
-    });
+    if (stableAttempt) {
+      expect((await loadPendingDeliveries(tmpDir()))[0]).toMatchObject({
+        id,
+        recoveryState: "send_attempt_started",
+        platformSendAttemptId: producerClaimId,
+      });
+    } else {
+      expect(result).toEqual(RECOVERY_SUMMARY.failed);
+      expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
+      expect(readQueuedEntry(tmpDir(), id).lastError).toBe("unsupported_enterprise_slack_delivery");
+      expectPayloadAudits(capture?.auditEvents ?? [], id, [
+        { status: "unknown", outcome: "unknown", failureStage: "queue" },
+      ]);
+      resolveOutboundChannelMessageAdapterMock.mockReturnValue({
+        durableFinal: { admitDeferredDelivery: () => ({ status: "allowed" }) },
+      });
+      await runRecovery({ deliver });
+      expect(deliver).not.toHaveBeenCalled();
+    }
   });
-
-  it("paces startup replay instead of draining eligible entries back-to-back", async () => {
+  it.each([
+    ["paces startup replay instead of draining eligible entries back-to-back", 60_000],
+    ["counts replay pacing against the recovery budget and defers the backlog tail", 1],
+  ])("%s", async (_, maxRecoveryMs) => {
+    const addBacklogTail = maxRecoveryMs === 1;
+    const expectedCalls = addBacklogTail ? 1 : 2;
+    const expectedSleep = addBacklogTail ? 1 : RECOVERY_REPLAY_SPACING_MS;
     vi.useFakeTimers();
     const startedAt = new Date("2026-04-23T00:00:00.000Z");
     vi.setSystemTime(startedAt);
     try {
       const controlledSleep = controlNextRecoverySleep(sleepMock);
       await enqueueCrashRecoveryEntries();
+      await runIf(addBacklogTail, () => enqueueDemoRecoveryDelivery(["c"], { to: "#c" }));
       const deliveryTimes: number[] = [];
       const deliver = vi.fn(async () => {
         deliveryTimes.push(Date.now());
         return [];
       });
-
-      const recovery = runRecovery({ deliver, maxRecoveryMs: 60_000 });
-
-      await expect(controlledSleep.started).resolves.toBe(RECOVERY_REPLAY_SPACING_MS);
+      const recovery = runRecovery({ deliver, maxRecoveryMs });
+      await expect(controlledSleep.started).resolves.toBe(expectedSleep);
       expect(deliver).toHaveBeenCalledTimes(1);
       controlledSleep.release();
       const { result } = await recovery;
-
-      expect(deliver).toHaveBeenCalledTimes(2);
-      expect(deliveryTimes[1]).toBe(startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS);
-      expect(result).toMatchObject({ recovered: 2, deferredBackoff: 0 });
+      expect(deliver).toHaveBeenCalledTimes(expectedCalls);
+      const observedTimes = expectedCalls === 1 ? deliveryTimes : deliveryTimes.slice(1);
+      const expectedTimes = [
+        startedAt.getTime() + (expectedCalls === 1 ? 0 : RECOVERY_REPLAY_SPACING_MS),
+      ];
+      expect(observedTimes).toEqual(expectedTimes);
+      expect(result).toMatchObject({ recovered: expectedCalls, deferredBackoff: 0 });
+      await runIf(addBacklogTail, async () =>
+        expect(await loadPendingDeliveries(tmpDir())).toHaveLength(2),
+      );
     } finally {
       vi.useRealTimers();
     }
   });
-
-  it("counts replay pacing against the recovery budget and defers the backlog tail", async () => {
-    vi.useFakeTimers();
-    const startedAt = new Date("2026-04-23T00:00:00.000Z");
-    vi.setSystemTime(startedAt);
-    try {
-      const controlledSleep = controlNextRecoverySleep(sleepMock);
-      await enqueueCrashRecoveryEntries();
-      await enqueueRecoveryDelivery({
-        channel: "demo-channel-c",
-        to: "#c",
-        payloads: [{ text: "c" }],
-      });
-      const deliveryTimes: number[] = [];
-      const deliver = vi.fn(async () => {
-        deliveryTimes.push(Date.now());
-        return [];
-      });
-
-      const recovery = runRecovery({ deliver, maxRecoveryMs: 1 });
-
-      await expect(controlledSleep.started).resolves.toBe(1);
-      expect(deliver).toHaveBeenCalledTimes(1);
-      controlledSleep.release();
-      const { result } = await recovery;
-
-      expect(deliver).toHaveBeenCalledTimes(1);
-      expect(deliveryTimes).toEqual([startedAt.getTime()]);
-      expect(result).toMatchObject({ recovered: 1, deferredBackoff: 0 });
-      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(2);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it("moves entries that exceeded max retries to failed/", async () => {
-    const auditEvents: TrustedMessageAuditEvent[] = [];
-    const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
+    const { auditEvents, unsubscribe } = captureAuditEvents();
     const id = await enqueueRecoveryDelivery();
     setQueuedEntryState(tmpDir(), id, { retryCount: MAX_RETRIES });
-
     const deliver = vi.fn();
     const { result } = await runRecovery({ deliver });
     unsubscribe();
-
     expect(deliver).not.toHaveBeenCalled();
     expect(result.skippedMaxRetries).toBe(1);
     expect(result.deferredBackoff).toBe(0);
     expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-    expect(auditEvents).toHaveLength(1);
-    expect(auditEvents[0]).toMatchObject({
-      sourceId: `message:outbound:queue:${id}:payload:0`,
-      outcome: "failed",
-      failureStage: "queue",
-    });
+    expectPayloadAudits(auditEvents, id, [{ outcome: "failed", failureStage: "queue" }]);
   });
-
-  it("honors a producer-specific retry budget", async () => {
-    const id = await enqueueRecoveryDelivery({
-      maxRetries: 45,
-    });
-    setQueuedEntryState(tmpDir(), id, {
-      retryCount: MAX_RETRIES,
-      lastAttemptAt: Date.now() - 10_000_000,
-    });
-    const deliver = vi.fn().mockResolvedValue([]);
-
+  it.each([
+    ["honors a producer-specific retry budget", 45, MAX_RETRIES, false, true, true],
+    ["dead-letters an atomically exhausted attempt budget before replay", 1, 0, true, false, true],
+    ["ignores an invalid producer retry budget", 0.5, 0, false, true, false],
+  ])("%s", async (_, maxRetries, retryCount, reserve, shouldDeliver, checkStatus) => {
+    const id = await enqueueRecoveryDelivery({ maxRetries });
+    if (retryCount) {
+      setQueuedEntryState(tmpDir(), id, {
+        retryCount,
+        lastAttemptAt: Date.now() - 10_000_000,
+      });
+    }
+    await runIf(reserve, () => reserveDeliveryAttempt(id, 1, tmpDir()));
+    const deliver = shouldDeliver ? vi.fn().mockResolvedValue([]) : vi.fn();
     const { result } = await runRecovery({ deliver });
-
-    expect(deliver).toHaveBeenCalledOnce();
-    expect(result).toMatchObject({ recovered: 1, skippedMaxRetries: 0 });
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
+    expect(deliver).toHaveBeenCalledTimes(shouldDeliver ? 1 : 0);
+    expect(result).toMatchObject(
+      shouldDeliver ? { recovered: 1, skippedMaxRetries: 0 } : { skippedMaxRetries: 1 },
+    );
+    if (checkStatus) {
+      expect(readOutboundQueueStatus(tmpDir(), id)).toBe(shouldDeliver ? undefined : "failed");
+    }
   });
-
-  it("dead-letters an atomically exhausted attempt budget before replay", async () => {
-    const id = await enqueueRecoveryDelivery({
-      maxRetries: 1,
-    });
-    await reserveDeliveryAttempt(id, 1, tmpDir());
-    const deliver = vi.fn();
-
-    const { result } = await runRecovery({ deliver });
-
-    expect(deliver).not.toHaveBeenCalled();
-    expect(result.skippedMaxRetries).toBe(1);
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-  });
-
-  it("ignores an invalid producer retry budget", async () => {
-    await enqueueRecoveryDelivery({
-      maxRetries: 0.5,
-    });
-    const deliver = vi.fn().mockResolvedValue([]);
-
-    const { result } = await runRecovery({ deliver });
-
-    expect(deliver).toHaveBeenCalledOnce();
-    expect(result).toMatchObject({ recovered: 1, skippedMaxRetries: 0 });
-  });
-
   it("dead-letters max-retry entries even when conversation owner state is missing", async () => {
     const storePath = path.join(tmpDir(), "missing-owner-sessions.json");
     const id = await enqueueRecoveryDelivery({
@@ -529,10 +581,8 @@ describe("delivery-queue recovery", () => {
     });
     setQueuedEntryState(tmpDir(), id, { retryCount: MAX_RETRIES });
     const log = createRecoveryLog();
-
     try {
       const { result } = await runRecovery({ deliver: vi.fn(), log });
-
       expect(result.skippedMaxRetries).toBe(1);
       expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
       expectMockMessageContaining(log.warn, "owner state could not be marked unknown");
@@ -540,10 +590,8 @@ describe("delivery-queue recovery", () => {
       closeOpenClawAgentDatabasesForTest();
     }
   });
-
   it("audits max-retry deadletters as unknown when platform send may have started", async () => {
-    const auditEvents: TrustedMessageAuditEvent[] = [];
-    const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
+    const { auditEvents, unsubscribe } = captureAuditEvents();
     const id = await enqueueRecoveryDelivery();
     setQueuedEntryState(tmpDir(), id, {
       retryCount: MAX_RETRIES,
@@ -551,346 +599,197 @@ describe("delivery-queue recovery", () => {
       platformSendStartedAt: Date.now(),
       recoveryState: "send_attempt_started",
     });
-
     const { result } = await runRecovery({ deliver: vi.fn() });
     unsubscribe();
-
     expect(result).toMatchObject({ failed: 1, skippedMaxRetries: 0 });
-    expect(auditEvents).toHaveLength(1);
-    expect(auditEvents[0]).toMatchObject({
-      sourceId: `message:outbound:queue:${id}:payload:0`,
-      outcome: "unknown",
-      failureStage: "queue",
-    });
+    expectPayloadAudits(auditEvents, id, [{ outcome: "unknown", failureStage: "queue" }]);
   });
-
   it("increments retryCount on failed recovery attempt", async () => {
-    const auditEvents: TrustedMessageAuditEvent[] = [];
-    const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
-    await enqueueRecoveryDelivery({
-      channel: "demo-channel-c",
-      to: "#ch",
-      payloads: [{ text: "x" }],
-    });
-
+    const { auditEvents, unsubscribe } = captureAuditEvents();
+    await enqueueDemoRecoveryDelivery();
     const deliver = vi.fn().mockRejectedValue(new Error("network down"));
     const { result } = await runRecovery({ deliver });
     unsubscribe();
-
     expect(result.failed).toBe(1);
     expect(result.recovered).toBe(0);
-
-    const entries = await loadPendingDeliveries(tmpDir());
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.retryCount).toBe(1);
-    expect(entries[0]?.attemptCount).toBe(1);
-    expect(entries[0]?.lastError).toBe("network down");
+    await expectPendingEntry({ retryCount: 1, attemptCount: 1, lastError: "network down" });
     expect(auditEvents).toEqual([]);
   });
-
-  it("keeps a repeated pre-connect recovery failure replayable", async () => {
-    const id = await enqueueRecoveryDelivery({
-      channel: "demo-channel-c",
-      to: "#ch",
-      payloads: [{ text: "x" }],
-    });
-    const connectError = Object.assign(new Error("connect ECONNREFUSED"), {
-      code: "ECONNREFUSED",
-      syscall: "connect",
-    });
-    const deliver = vi.fn(async () => {
-      await markDeliveryPlatformSendAttemptStarted(id, tmpDir());
-      throw connectError;
-    });
-
-    const { result } = await runRecovery({ deliver });
-
-    expect(result).toMatchObject({ recovered: 0, failed: 1 });
-    const entries = await loadPendingDeliveries(tmpDir());
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.retryCount).toBe(1);
-    expect(entries[0]?.recoveryState).toBeUndefined();
-    expect(entries[0]?.platformSendStartedAt).toBeUndefined();
-  });
-
-  it("keeps a repeated provider-not-dispatched recovery failure replayable", async () => {
-    const id = await enqueueRecoveryDelivery({
-      channel: "demo-channel-c",
-      to: "#ch",
-      payloads: [{ text: "x" }],
-    });
-    const deliver = vi.fn(async () => {
-      await markDeliveryPlatformSendAttemptStarted(id, tmpDir());
-      throw new PlatformMessageNotDispatchedError("upload stopped before finalization", {
+  it.each([
+    {
+      name: "keeps a repeated pre-connect recovery failure replayable",
+      error: Object.assign(new Error("connect ECONNREFUSED"), {
+        code: "ECONNREFUSED",
+        syscall: "connect",
+      }),
+    },
+    {
+      name: "keeps a repeated provider-not-dispatched recovery failure replayable",
+      error: new PlatformMessageNotDispatchedError("upload stopped before finalization", {
         cause: new Error("request timed out"),
-      });
+      }),
+    },
+  ])("$name", async ({ error }) => {
+    const id = await enqueueDemoRecoveryDelivery();
+    const deliver = vi.fn(async () => {
+      await markDeliveryPlatformSendAttemptStarted(id, tmpDir());
+      throw error;
     });
-
     const { result } = await runRecovery({ deliver });
-
     expect(result).toMatchObject({ recovered: 0, failed: 1 });
-    const entries = await loadPendingDeliveries(tmpDir());
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.retryCount).toBe(1);
-    expect(entries[0]?.recoveryState).toBeUndefined();
-    expect(entries[0]?.platformSendStartedAt).toBeUndefined();
-  });
-
-  it("does not replay a recovery batch that rejected after an earlier send succeeded", async () => {
-    const id = await enqueueRecoveryDelivery({
-      channel: "demo-channel-c",
-      to: "#ch",
-      payloads: [{ text: "first" }, { text: "second" }],
+    await expectPendingEntry({
+      retryCount: 1,
+      recoveryState: undefined,
+      platformSendStartedAt: undefined,
     });
+  });
+  it("does not replay a recovery batch that rejected after an earlier send succeeded", async () => {
+    const id = await enqueueDemoRecoveryDelivery(["first", "second"]);
     const partialFailure = new OutboundDeliveryError("second send failed", {
       cause: new Error("network down"),
       results: [{ channel: "demo-channel-c", messageId: "m1" }],
     });
-
     const { result } = await runRecovery({
       deliver: vi.fn().mockRejectedValue(partialFailure),
     });
-
     expect(result).toMatchObject({ recovered: 0, failed: 1 });
-    const entries = await loadPendingDeliveries(tmpDir());
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.id).toBe(id);
-    expect(entries[0]?.recoveryState).toBe("unknown_after_send");
-    expect(entries[0]?.retryCount).toBe(0);
-
+    await expectPendingEntry({ id, recoveryState: "unknown_after_send", retryCount: 0 });
     const replay = vi.fn();
     await runRecovery({ deliver: replay });
     expect(replay).not.toHaveBeenCalled();
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
     expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
   });
-
   it("keeps a best-effort recovery failure retryable when no payload was sent", async () => {
-    await enqueueRecoveryDelivery({
-      channel: "demo-channel-c",
-      to: "#ch",
-      payloads: [{ text: "first" }],
-      bestEffort: true,
+    await enqueueDemoRecoveryDelivery(["first"], { bestEffort: true });
+    const deliver = vi.fn(async (params: PayloadOutcomeSink) => {
+      reportPayloadFailure(params, new Error("network down"));
+      return [];
     });
-    const deliver = vi.fn(
-      async (params: {
-        onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
-      }) => {
-        params.onPayloadDeliveryOutcome?.({
-          index: 0,
-          status: "failed",
-          error: new Error("network down"),
-          sentBeforeError: false,
-          stage: "platform_send",
-        });
-        return [];
-      },
-    );
-
     const { result } = await runRecovery({ deliver });
-
     expect(result).toMatchObject({ recovered: 0, failed: 1 });
-    const entries = await loadPendingDeliveries(tmpDir());
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.recoveryState).toBeUndefined();
-    expect(entries[0]?.retryCount).toBe(1);
-    expect(entries[0]?.lastError).toBe("network down");
-  });
-
-  it("clears send evidence for an all-pre-connect best-effort recovery failure", async () => {
-    const id = await enqueueRecoveryDelivery({
-      channel: "demo-channel-c",
-      to: "#ch",
-      payloads: [{ text: "first" }],
-      bestEffort: true,
+    await expectPendingEntry({
+      recoveryState: undefined,
+      retryCount: 1,
+      lastError: "network down",
     });
-    const deliver = vi.fn(
-      async (params: {
-        onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
-      }) => {
-        await markDeliveryPlatformSendAttemptStarted(id, tmpDir());
-        params.onPayloadDeliveryOutcome?.({
-          index: 0,
-          status: "failed",
-          error: Object.assign(new Error("getaddrinfo EAI_AGAIN"), {
-            code: "EAI_AGAIN",
-            syscall: "getaddrinfo",
-          }),
-          sentBeforeError: false,
-          stage: "platform_send",
-        });
-        return [];
-      },
-    );
-
-    const { result } = await runRecovery({ deliver });
-
-    expect(result).toMatchObject({ recovered: 0, failed: 1 });
-    const entries = await loadPendingDeliveries(tmpDir());
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.retryCount).toBe(1);
-    expect(entries[0]?.recoveryState).toBeUndefined();
-    expect(entries[0]?.platformSendStartedAt).toBeUndefined();
   });
-
-  it("clears send evidence for an all-not-dispatched best-effort recovery failure", async () => {
-    const id = await enqueueRecoveryDelivery({
-      channel: "demo-channel-c",
-      to: "#ch",
-      payloads: [{ text: "first" }],
-      bestEffort: true,
+  it.each([
+    {
+      name: "clears send evidence for an all-pre-connect best-effort recovery failure",
+      error: Object.assign(new Error("getaddrinfo EAI_AGAIN"), {
+        code: "EAI_AGAIN",
+        syscall: "getaddrinfo",
+      }),
+    },
+    {
+      name: "clears send evidence for an all-not-dispatched best-effort recovery failure",
+      error: new PlatformMessageNotDispatchedError("upload timed out before completion dispatch", {
+        cause: new Error("request timed out"),
+      }),
+    },
+  ])("$name", async ({ error }) => {
+    const id = await enqueueDemoRecoveryDelivery(["first"], { bestEffort: true });
+    const deliver = vi.fn(async (params: PayloadOutcomeSink) => {
+      await markDeliveryPlatformSendAttemptStarted(id, tmpDir());
+      reportPayloadFailure(params, error);
+      return [];
     });
-    const deliver = vi.fn(
-      async (params: {
-        onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
-      }) => {
-        await markDeliveryPlatformSendAttemptStarted(id, tmpDir());
-        params.onPayloadDeliveryOutcome?.({
-          index: 0,
-          status: "failed",
-          error: new PlatformMessageNotDispatchedError(
-            "upload timed out before completion dispatch",
-            { cause: new Error("request timed out") },
-          ),
-          sentBeforeError: false,
-          stage: "platform_send",
-        });
-        return [];
-      },
-    );
-
     const { result } = await runRecovery({ deliver });
-
     expect(result).toMatchObject({ recovered: 0, failed: 1 });
-    const entries = await loadPendingDeliveries(tmpDir());
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.retryCount).toBe(1);
-    expect(entries[0]?.recoveryState).toBeUndefined();
-    expect(entries[0]?.platformSendStartedAt).toBeUndefined();
+    await expectPendingEntry({
+      retryCount: 1,
+      recoveryState: undefined,
+      platformSendStartedAt: undefined,
+    });
   });
-
   it("preserves send evidence when a marked recovery batch has an ambiguous failure", async () => {
-    const id = await enqueueRecoveryDelivery({
-      channel: "demo-channel-c",
-      to: "#ch",
-      payloads: [{ text: "first" }, { text: "second" }],
-      bestEffort: true,
+    const id = await enqueueDemoRecoveryDelivery(["first", "second"], { bestEffort: true });
+    const deliver = vi.fn(async (params: PayloadOutcomeSink) => {
+      await markDeliveryPlatformSendAttemptStarted(id, tmpDir());
+      reportPayloadFailure(
+        params,
+        new PlatformMessageNotDispatchedError("upload timed out before completion dispatch", {
+          cause: new Error("request timed out"),
+        }),
+      );
+      reportPayloadFailure(
+        params,
+        Object.assign(new Error("read ECONNRESET"), {
+          code: "ECONNRESET",
+          syscall: "read",
+        }),
+        { index: 1 },
+      );
+      return [];
     });
-    const deliver = vi.fn(
-      async (params: {
-        onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
-      }) => {
-        await markDeliveryPlatformSendAttemptStarted(id, tmpDir());
-        params.onPayloadDeliveryOutcome?.({
-          index: 0,
-          status: "failed",
-          error: new PlatformMessageNotDispatchedError(
-            "upload timed out before completion dispatch",
-            { cause: new Error("request timed out") },
-          ),
-          sentBeforeError: false,
-          stage: "platform_send",
-        });
-        params.onPayloadDeliveryOutcome?.({
-          index: 1,
-          status: "failed",
-          error: Object.assign(new Error("read ECONNRESET"), {
-            code: "ECONNRESET",
-            syscall: "read",
-          }),
-          sentBeforeError: false,
-          stage: "platform_send",
-        });
-        return [];
-      },
-    );
-
     const { result } = await runRecovery({ deliver });
-
     expect(result).toMatchObject({ recovered: 0, failed: 1 });
-    const entries = await loadPendingDeliveries(tmpDir());
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.retryCount).toBe(1);
-    expect(entries[0]?.recoveryState).toBe("send_attempt_started");
-    expect(typeof entries[0]?.platformSendStartedAt).toBe("number");
+    const entry = await expectPendingEntry({
+      retryCount: 1,
+      recoveryState: "send_attempt_started",
+    });
+    expect(typeof entry?.platformSendStartedAt).toBe("number");
   });
-
   it("does not ack a partially sent best-effort recovery batch", async () => {
-    const id = await enqueueRecoveryDelivery({
-      channel: "demo-channel-c",
-      to: "#ch",
-      payloads: [{ text: "first" }, { text: "second" }],
-      bestEffort: true,
+    const id = await enqueueDemoRecoveryDelivery(["first", "second"], { bestEffort: true });
+    const deliver = vi.fn(async (params: PayloadOutcomeSink) => {
+      reportPayloadFailure(params, new Error("second send failed"), {
+        index: 1,
+        sentBeforeError: true,
+      });
+      return [{ channel: "demo-channel-c", messageId: "m1" }];
     });
-    const deliver = vi.fn(
-      async (params: {
-        onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
-      }) => {
-        params.onPayloadDeliveryOutcome?.({
-          index: 1,
-          status: "failed",
-          error: new Error("second send failed"),
-          sentBeforeError: true,
-          stage: "platform_send",
-        });
-        return [{ channel: "demo-channel-c", messageId: "m1" }];
-      },
-    );
-
     const { result } = await runRecovery({ deliver });
-
     expect(result).toMatchObject({ recovered: 0, failed: 1 });
-    const entries = await loadPendingDeliveries(tmpDir());
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.id).toBe(id);
-    expect(entries[0]?.recoveryState).toBe("unknown_after_send");
-    expect(entries[0]?.retryCount).toBe(0);
-
+    await expectPendingEntry({ id, recoveryState: "unknown_after_send", retryCount: 0 });
     const replay = vi.fn();
     await runRecovery({ deliver: replay });
     expect(replay).not.toHaveBeenCalled();
     expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
   });
-
-  it("moves entries abandoned after platform send may have started to failed without reconciliation", async () => {
-    const auditEvents: TrustedMessageAuditEvent[] = [];
-    const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
-    const id = await enqueueRecoveryDelivery({
-      payloads: [{ text: "maybe sent" }],
-    });
-    setQueuedEntryState(tmpDir(), id, {
-      retryCount: 0,
-      platformSendStartedAt: Date.now(),
-      recoveryState: "unknown_after_send",
-    });
-
+  it.each([
+    [
+      "moves entries abandoned after platform send may have started to failed without reconciliation",
+      0,
+    ],
+    ["moves started entries without reconciliation to failed instead of blindly replaying", 1],
+    ["moves unknown-after-send entries to failed without replaying", 2],
+    ["does not reconcile unknown-after-send entries unless the adapter declares the capability", 3],
+  ])("%s", async (_, mode) => {
+    const text = ["maybe sent", "not yet sent", "a", "hidden method"][mode] ?? "a";
+    const state = mode === 1 ? "send_attempt_started" : "unknown_after_send";
+    const markUnknown = mode === 2;
+    const hiddenReconciler = mode === 3;
+    const logText = mode === 0 ? "unknown_after_send" : BLIND_REPLAY_LOG;
+    const audit = mode === 0;
+    const capture = audit ? captureAuditEvents() : undefined;
+    const id = markUnknown
+      ? await enqueueRecoveryDelivery({ payloads: [{ text }] })
+      : await enqueueUnknownRecovery({ text, state });
+    await runIf(markUnknown, () => markDeliveryPlatformOutcomeUnknown(id, tmpDir()));
+    const reconcileUnknownSend = vi.fn().mockResolvedValue({ status: "not_sent" });
+    if (hiddenReconciler) {
+      resolveOutboundChannelMessageAdapterMock.mockReturnValue({
+        durableFinal: { reconcileUnknownSend },
+      });
+    }
     const deliver = vi.fn().mockResolvedValue([]);
-    const log = createRecoveryLog();
-    const { result } = await runRecovery({ deliver, log });
-    unsubscribe();
-
+    const { result, log } = await runRecovery({ deliver });
+    capture?.unsubscribe();
+    await runIf(hiddenReconciler, () => expect(reconcileUnknownSend).not.toHaveBeenCalled());
     expect(deliver).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      recovered: 0,
-      failed: 1,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
-    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-    expectMockMessageContaining(log.warn, "unknown_after_send");
-    expect(auditEvents).toHaveLength(1);
-    expect(auditEvents[0]).toMatchObject({
-      sourceId: `message:outbound:queue:${id}:payload:0`,
-      status: "unknown",
-      outcome: "unknown",
-      failureStage: "queue",
-    });
+    expect(result).toEqual(RECOVERY_SUMMARY.failed);
+    await expectFailedQueue(id);
+    expectMockMessageContaining(log.warn, logText);
+    if (capture) {
+      expectPayloadAudits(capture.auditEvents, id, [
+        { status: "unknown", outcome: "unknown", failureStage: "queue" },
+      ]);
+    }
   });
-
   it("reports every payload unknown when a multi-payload send is crash-ambiguous", async () => {
-    const auditEvents: TrustedMessageAuditEvent[] = [];
-    const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
+    const { auditEvents, unsubscribe } = captureAuditEvents();
     const id = await enqueueRecoveryDelivery({
       payloads: [{ text: "sent" }, { text: "hidden" }],
     });
@@ -899,127 +798,45 @@ describe("delivery-queue recovery", () => {
       platformSendStartedAt: Date.now(),
       recoveryState: "unknown_after_send",
     });
-
     await runRecovery({ deliver: vi.fn() });
     unsubscribe();
-
-    expect(auditEvents).toHaveLength(2);
-    expect(auditEvents[0]).toMatchObject({
-      sourceId: `message:outbound:queue:${id}:payload:0`,
-      status: "unknown",
-      outcome: "unknown",
-      resultCount: 0,
-    });
-    expect(auditEvents[1]).toMatchObject({
-      sourceId: `message:outbound:queue:${id}:payload:1`,
-      status: "unknown",
-      outcome: "unknown",
-      resultCount: 0,
-    });
+    expectPayloadAudits(auditEvents, id, [
+      { status: "unknown", outcome: "unknown", resultCount: 0 },
+      { status: "unknown", outcome: "unknown", resultCount: 0 },
+    ]);
   });
-
-  it("moves started entries without reconciliation to failed instead of blindly replaying", async () => {
-    const id = await enqueueRecoveryDelivery({
-      payloads: [{ text: "not yet sent" }],
-    });
-    setQueuedEntryState(tmpDir(), id, {
-      retryCount: 0,
-      platformSendStartedAt: Date.now(),
-      recoveryState: "send_attempt_started",
-    });
-
-    const deliver = vi.fn().mockResolvedValue([]);
-    const log = createRecoveryLog();
-    const { result } = await runRecovery({ deliver, log });
-
-    expect(deliver).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      recovered: 0,
-      failed: 1,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
-    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-    expectMockMessageContaining(log.warn, "refusing blind replay without adapter reconciliation");
-  });
-
   it("replays started entries only after adapter proves they were not sent", async () => {
-    const id = await enqueueRecoveryDelivery({
-      payloads: [{ text: "not yet sent" }],
+    await enqueueUnknownRecovery({
+      text: "not yet sent",
+      state: "send_attempt_started",
     });
-    setQueuedEntryState(tmpDir(), id, {
-      retryCount: 0,
-      platformSendStartedAt: Date.now(),
-      recoveryState: "send_attempt_started",
-    });
-    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
-      durableFinal: {
-        capabilities: { reconcileUnknownSend: true },
-        reconcileUnknownSend: vi.fn().mockResolvedValue({ status: "not_sent" }),
-      },
-    });
-
+    installUnknownSendResult({ status: "not_sent" });
     const deliver = vi.fn().mockResolvedValue([]);
     const { result } = await runRecovery({ deliver });
-
     expect(resolveOutboundChannelMessageAdapterMock).toHaveBeenCalledWith({
       channel: "demo-channel-a",
       cfg: baseCfg,
       allowBootstrap: true,
     });
-    const deliverInput = mockCallArg(deliver) as {
-      channel?: string;
-      to?: string;
-      skipQueue?: boolean;
-    };
+    const deliverInput = mockCallRecord(deliver);
     expect(deliverInput.channel).toBe("demo-channel-a");
     expect(deliverInput.to).toBe("+1");
     expect(deliverInput.skipQueue).toBe(true);
-    expect(result).toEqual({
-      recovered: 1,
-      failed: 0,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
+    expect(result).toEqual(RECOVERY_SUMMARY.recovered);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
   });
-
   it("keeps an in-flight stable platform send fenced across recovery", async () => {
     const id = "cron-direct-delivery:v1:in-flight-producer-lease";
-    await enqueueDeliveryOnce(
-      {
-        channel: "demo-channel-a",
-        to: "+1",
-        payloads: [{ text: "the original platform send is still in flight" }],
-        queuePolicy: "required",
-        completionRetention: {
-          idPrefix: "cron-direct-delivery:v1:",
-          maxAgeMs: 24 * 60 * 60_000,
-          maxEntries: 2_000,
-        },
-        requiresProducerClaim: true,
-      },
-      id,
-      tmpDir(),
-    );
-    const producerClaimId = await claimDeliveryPlatformSendAttempt(id, tmpDir());
-    if (!producerClaimId) {
-      throw new Error("test invariant: the live platform sender must own its producer lease");
-    }
-    await markDeliveryPlatformSendAttemptStarted(id, tmpDir(), undefined, producerClaimId);
+    const producerClaimId = await enqueueClaimedRecoveryDelivery(id, {
+      payloads: [{ text: "the original platform send is still in flight" }],
+      completionRetention: BOUNDED_COMPLETION_RETENTION,
+      requiresProducerClaim: true,
+    });
     await markDeliveryPlatformSendDispatched(id, tmpDir(), undefined, producerClaimId);
     const reconcileUnknownSend = vi.fn().mockResolvedValue({ status: "not_sent" });
-    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
-      durableFinal: {
-        capabilities: { reconcileUnknownSend: true },
-        reconcileUnknownSend,
-      },
-    });
+    installUnknownSendAdapter(reconcileUnknownSend);
     const deliver = vi.fn();
-
     const { result } = await runRecovery({ deliver });
-
     expect(result).toMatchObject({ recovered: 0, failed: 0 });
     expect(reconcileUnknownSend).not.toHaveBeenCalled();
     expect(deliver).not.toHaveBeenCalled();
@@ -1030,40 +847,17 @@ describe("delivery-queue recovery", () => {
       availableAt: expect.any(Number),
     });
   });
-
   it("atomically fences stable recovery after an adapter proves an ambiguous send was not sent", async () => {
     const id = "cron-direct-delivery:v1:reconciled-stable-recovery";
-    await enqueueDeliveryOnce(
+    await enqueueClaimedRecoveryDelivery(
+      id,
       {
-        channel: "demo-channel-a",
-        to: "+1",
         payloads: [{ text: "recover exactly once after reconciliation" }],
-        queuePolicy: "required",
-        completionRetention: {
-          idPrefix: "cron-direct-delivery:v1:",
-          maxAgeMs: 24 * 60 * 60_000,
-          maxEntries: 2_000,
-        },
+        completionRetention: BOUNDED_COMPLETION_RETENTION,
       },
-      id,
-      tmpDir(),
-    );
-    const originalAttemptId = await claimDeliveryPlatformSendAttempt(id, tmpDir());
-    if (!originalAttemptId) {
-      throw new Error("test invariant: the original stable send must own a producer claim");
-    }
-    await markDeliveryPlatformSendAttemptStarted(
-      id,
-      tmpDir(),
       { replyToId: null },
-      originalAttemptId,
     );
-    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
-      durableFinal: {
-        capabilities: { reconcileUnknownSend: true },
-        reconcileUnknownSend: vi.fn().mockResolvedValue({ status: "not_sent" }),
-      },
-    });
+    installUnknownSendResult({ status: "not_sent" });
     const deliver = vi.fn(async (params: Parameters<DeliverFn>[0]) => {
       if (!params.deliveryProducerClaimId) {
         throw new Error("recovered provider send must own a fenced producer lease");
@@ -1076,68 +870,37 @@ describe("delivery-queue recovery", () => {
       );
       return [{ channel: "demo-channel-a", messageId: "fenced-reconciled-message" }];
     });
-
     const { result } = await runRecovery({ deliver });
-
     expect(result).toMatchObject({ recovered: 1, failed: 0 });
     expect(deliver).toHaveBeenCalledOnce();
-    expect(mockCallArg(deliver)).toMatchObject({
+    expect(mockCallRecord(deliver)).toMatchObject({
       deliveryQueueId: id,
       deliveryProducerClaimId: expect.any(String),
     });
     expect(readOutboundQueueStatus(tmpDir(), id)).toBe("completed");
   });
-
   it("acknowledges a permanently fenced send reconciled as already sent", async () => {
     const id = "permanent-reconciled-platform-delivery";
-    await enqueueDeliveryOnce(
-      {
-        channel: "demo-channel-a",
-        to: "+1",
-        payloads: [{ text: "the platform already delivered this permanent intent" }],
-        queuePolicy: "required",
-        completionRetention: "permanent",
-        requiresProducerClaim: true,
-      },
-      id,
-      tmpDir(),
-    );
-    const platformSendAttemptId = await claimDeliveryPlatformSendAttempt(id, tmpDir());
-    if (!platformSendAttemptId) {
-      throw new Error("test invariant: the permanent platform send must own its attempt");
-    }
-    await markDeliveryPlatformSendAttemptStarted(id, tmpDir(), undefined, platformSendAttemptId);
+    const platformSendAttemptId = await enqueueClaimedRecoveryDelivery(id, {
+      payloads: [{ text: "the platform already delivered this permanent intent" }],
+      completionRetention: "permanent",
+      requiresProducerClaim: true,
+    });
     await markDeliveryPlatformOutcomeUnknown(id, tmpDir(), platformSendAttemptId);
-    const reconcileUnknownSend = vi.fn().mockResolvedValue({
-      status: "sent",
-      messageId: "reconciled-permanent-message",
-      receipt: {
-        primaryPlatformMessageId: "reconciled-permanent-message",
-        platformMessageIds: ["reconciled-permanent-message"],
-        parts: [{ platformMessageId: "reconciled-permanent-message", kind: "text", index: 0 }],
-        sentAt: Date.now(),
-      },
-    });
-    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
-      durableFinal: {
-        capabilities: { reconcileUnknownSend: true },
-        reconcileUnknownSend,
-      },
-    });
+    const reconcileUnknownSend = vi
+      .fn()
+      .mockResolvedValue(reconciledSent("reconciled-permanent-message"));
+    installUnknownSendAdapter(reconcileUnknownSend);
     const deliver = vi.fn();
-
     const { result } = await runRecovery({ deliver });
-
     expect(result).toMatchObject({ recovered: 1, failed: 0 });
     expect(reconcileUnknownSend).toHaveBeenCalledOnce();
     expect(deliver).not.toHaveBeenCalled();
     expect(readOutboundQueueStatus(tmpDir(), id)).toBe("completed");
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
   });
-
   it("acks unknown-after-send entries reconciled as already sent before commit hooks", async () => {
-    const auditEvents: TrustedMessageAuditEvent[] = [];
-    const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
+    const { auditEvents, unsubscribe } = captureAuditEvents();
     const id = await enqueueRecoveryDelivery({
       accountId: "acct-1",
       payloads: [{ text: "maybe sent" }],
@@ -1155,52 +918,24 @@ describe("delivery-queue recovery", () => {
     const afterCommit = vi.fn(() => {
       order.push("afterCommit");
     });
-    const reconcileUnknownSend = vi.fn().mockResolvedValue({
-      status: "sent",
-      messageId: "platform-1",
-      receipt: {
-        primaryPlatformMessageId: "platform-1",
-        platformMessageIds: ["platform-1"],
-        parts: [{ platformMessageId: "platform-1", kind: "text", index: 0 }],
-        sentAt: 1,
-      },
-    });
-    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
-      durableFinal: {
-        capabilities: { reconcileUnknownSend: true },
-        reconcileUnknownSend,
-      },
-      send: {
-        lifecycle: {
-          afterCommit,
+    const reconcileUnknownSend = vi.fn().mockResolvedValue(reconciledSent("platform-1", 1));
+    installUnknownSendAdapter(
+      reconcileUnknownSend,
+      {},
+      {
+        send: {
+          lifecycle: {
+            afterCommit,
+          },
         },
       },
-    });
-
+    );
     const deliver = vi.fn().mockResolvedValue([]);
     const { result } = await runRecovery({ deliver });
     unsubscribe();
-
     expect(deliver).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      recovered: 1,
-      failed: 0,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
-    const reconcileInput = mockCallArg(reconcileUnknownSend) as {
-      cfg?: unknown;
-      queueId?: string;
-      channel?: string;
-      to?: string;
-      accountId?: string;
-      payloads?: unknown;
-      replyToId?: string;
-      effectiveReplyToId?: string;
-      threadId?: string;
-      silent?: boolean;
-      retryCount?: number;
-    };
+    expect(result).toEqual(RECOVERY_SUMMARY.recovered);
+    const reconcileInput = mockCallRecord(reconcileUnknownSend);
     expect(reconcileInput.cfg).toBe(baseCfg);
     expect(reconcileInput.queueId).toBe(id);
     expect(reconcileInput.channel).toBe("demo-channel-a");
@@ -1212,17 +947,7 @@ describe("delivery-queue recovery", () => {
     expect(reconcileInput.threadId).toBe("thread-1");
     expect(reconcileInput.silent).toBe(true);
     expect(reconcileInput.retryCount).toBe(0);
-
-    const afterCommitInput = mockCallArg(afterCommit) as {
-      deliveryQueueId?: string;
-      kind?: string;
-      to?: string;
-      accountId?: string;
-      replyToId?: string;
-      threadId?: string;
-      silent?: boolean;
-      result?: { messageId?: string };
-    };
+    const afterCommitInput = mockCallRecord(afterCommit);
     expect(afterCommitInput.deliveryQueueId).toBe(id);
     expect(afterCommitInput.kind).toBe("text");
     expect(afterCommitInput.to).toBe("+1");
@@ -1230,96 +955,49 @@ describe("delivery-queue recovery", () => {
     expect(afterCommitInput.replyToId).toBe("hooked-root-message");
     expect(afterCommitInput.threadId).toBe("thread-1");
     expect(afterCommitInput.silent).toBe(true);
-    expect(afterCommitInput.result?.messageId).toBe("platform-1");
+    expect((afterCommitInput.result as { messageId?: string })?.messageId).toBe("platform-1");
     expect(order).toEqual(["afterCommit"]);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(auditEvents).toHaveLength(1);
-    expect(auditEvents[0]).toMatchObject({
-      sourceId: `message:outbound:queue:${id}:payload:0`,
-      status: "succeeded",
-      outcome: "sent",
-      messageId: "platform-1",
-      resultCount: 1,
-    });
+    expectPayloadAudits(auditEvents, id, [
+      { status: "succeeded", outcome: "sent", messageId: "platform-1", resultCount: 1 },
+    ]);
   });
-
   it("moves unknown-after-send entries to failed when adapter reports not sent", async () => {
-    const id = await enqueueRecoveryDelivery({
-      payloads: [{ text: "not sent" }],
-    });
-    setQueuedEntryState(tmpDir(), id, {
-      retryCount: 0,
-      platformSendStartedAt: Date.now(),
-      recoveryState: "unknown_after_send",
-    });
-    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
-      durableFinal: {
-        capabilities: { reconcileUnknownSend: true },
-        reconcileUnknownSend: vi.fn().mockResolvedValue({ status: "not_sent" }),
-      },
-    });
-
+    const id = await enqueueUnknownRecovery({ text: "not sent" });
+    installUnknownSendResult({ status: "not_sent" });
     const deliver = vi.fn().mockResolvedValue([]);
     const log = createRecoveryLog();
     const { result } = await runRecovery({ deliver, log });
-
     expect(deliver).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      recovered: 0,
-      failed: 1,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
-    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
+    expect(result).toEqual(RECOVERY_SUMMARY.failed);
+    await expectFailedQueue(id);
     expectMockMessageContaining(log.warn, "refusing full replay after post-send evidence");
   });
-
   it("keeps retryable unresolved unknown-after-send entries on the queue without replaying", async () => {
-    const id = await enqueueRecoveryDelivery({
-      payloads: [{ text: "unknown" }],
+    const id = await enqueueUnknownRecovery({ text: "unknown" });
+    installUnknownSendResult({
+      status: "unresolved",
+      error: "provider lookup timed out",
+      retryable: true,
     });
-    setQueuedEntryState(tmpDir(), id, {
-      retryCount: 0,
-      platformSendStartedAt: Date.now(),
-      recoveryState: "unknown_after_send",
-    });
-    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
-      durableFinal: {
-        capabilities: { reconcileUnknownSend: true },
-        reconcileUnknownSend: vi.fn().mockResolvedValue({
-          status: "unresolved",
-          error: "provider lookup timed out",
-          retryable: true,
-        }),
-      },
-    });
-
     const deliver = vi.fn().mockResolvedValue([]);
     const { result } = await runRecovery({ deliver });
-
     expect(deliver).not.toHaveBeenCalled();
     expect(result.failed).toBe(1);
-    const entries = await loadPendingDeliveries(tmpDir());
-    expect(entries).toHaveLength(1);
-    expect(entries[0]?.id).toBe(id);
-    expect(entries[0]?.retryCount).toBe(1);
-    expect(entries[0]?.recoveryState).toBe("unknown_after_send");
-    expect(entries[0]?.lastError).toContain("provider lookup timed out");
-  });
-
-  it("dead-letters an exhausted unknown send after retryable reconciliation fails", async () => {
-    const id = await enqueueRecoveryDelivery({
-      payloads: [{ text: "unknown final attempt" }],
-      maxRetries: 1,
-    });
-    await reserveDeliveryAttempt(id, 1, tmpDir());
-    setQueuedEntryState(tmpDir(), id, {
-      retryCount: 0,
-      lastAttemptAt: Date.now() - 10_000_000,
-      platformSendStartedAt: Date.now(),
+    const entry = await expectPendingEntry({
+      id,
+      retryCount: 1,
       recoveryState: "unknown_after_send",
     });
+    expect(entry?.lastError).toContain("provider lookup timed out");
+  });
+  it("dead-letters an exhausted unknown send after retryable reconciliation fails", async () => {
+    const id = await enqueueUnknownRecovery({
+      text: "unknown final attempt",
+      delivery: { maxRetries: 1 },
+      queue: { lastAttemptAt: Date.now() - 10_000_000 },
+    });
+    await reserveDeliveryAttempt(id, 1, tmpDir());
     const reconcileUnknownSend = vi.fn().mockResolvedValue({
       status: "unresolved",
       error: "provider lookup timed out",
@@ -1329,144 +1007,57 @@ describe("delivery-queue recovery", () => {
       expect(ctx.queueId).toBe(id);
       expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
     });
-    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
-      durableFinal: {
-        capabilities: { reconcileUnknownSend: true },
-        reconcileUnknownSend,
-        afterUnknownSendTerminal,
-      },
-    });
+    installUnknownSendAdapter(reconcileUnknownSend, { afterUnknownSendTerminal });
     const deliver = vi.fn().mockResolvedValue([]);
-
     const { result } = await runRecovery({ deliver });
-
     expect(reconcileUnknownSend).toHaveBeenCalledOnce();
     expect(deliver).not.toHaveBeenCalled();
     expect(result).toMatchObject({ failed: 1, skippedMaxRetries: 0 });
-    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
+    await expectFailedQueue(id);
     expect(afterUnknownSendTerminal).toHaveBeenCalledOnce();
   });
-
-  it("does not reconcile unknown-after-send entries unless the adapter declares the capability", async () => {
-    const id = await enqueueRecoveryDelivery({
-      payloads: [{ text: "hidden method" }],
-    });
-    setQueuedEntryState(tmpDir(), id, {
-      retryCount: 0,
-      platformSendStartedAt: Date.now(),
-      recoveryState: "unknown_after_send",
-    });
-    const reconcileUnknownSend = vi.fn().mockResolvedValue({ status: "not_sent" });
-    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
-      durableFinal: {
-        reconcileUnknownSend,
-      },
-    });
-
-    const deliver = vi.fn().mockResolvedValue([]);
-    const log = createRecoveryLog();
-    const { result } = await runRecovery({ deliver, log });
-
-    expect(reconcileUnknownSend).not.toHaveBeenCalled();
-    expect(deliver).not.toHaveBeenCalled();
-    expect(result.failed).toBe(1);
-    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-    expectMockMessageContaining(log.warn, "refusing blind replay without adapter reconciliation");
-  });
-
-  it("moves entries to failed/ immediately on permanent delivery errors", async () => {
-    const id = await enqueueRecoveryDelivery({
-      channel: "demo-channel",
-      to: "user:abc",
-      payloads: [{ text: "hi" }],
-    });
-    const deliver = vi
-      .fn()
-      .mockRejectedValue(new Error("No conversation reference found for user:abc"));
-    const log = createRecoveryLog();
-    const { result } = await runRecovery({ deliver, log });
-
-    expect(result.failed).toBe(1);
-    expect(result.recovered).toBe(0);
-    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-    expectMockMessageContaining(log.warn, "permanent error");
-  });
-
-  it("moves typed permanent platform rejections to failed without retry backoff", async () => {
-    const id = await enqueueRecoveryDelivery({
-      channel: "demo-channel",
-      to: "user:abc",
-      payloads: [{ text: "hi" }],
-    });
-    const deliver = vi.fn().mockRejectedValue(
+  it.each([
+    [
+      "moves entries to failed/ immediately on permanent delivery errors",
+      "demo-channel",
+      "user:abc",
+      new Error("No conversation reference found for user:abc"),
+    ],
+    [
+      "moves typed permanent platform rejections to failed without retry backoff",
+      "demo-channel",
+      "user:abc",
       new PlatformMessageNotDispatchedError("atomic message limit", {
         cause: new Error("rendered text is too large"),
         retryable: false,
       }),
-    );
-    const { result } = await runRecovery({ deliver });
-
-    expect(result).toMatchObject({ failed: 1, recovered: 0 });
-    expect(deliver).toHaveBeenCalledOnce();
-    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-  });
-
-  it("treats Matrix 'User not in room' as a permanent error", async () => {
-    const id = await enqueueRecoveryDelivery({
-      channel: "matrix",
-      to: "!lowercased:matrix.example.com",
-      payloads: [{ text: "hi" }],
-    });
-    const deliver = vi
-      .fn()
-      .mockRejectedValue(
-        new Error(
-          "MatrixError: [403] User @bot:matrix.example.com not in room !lowercased:matrix.example.com",
-        ),
-      );
-    const log = createRecoveryLog();
-    const { result } = await runRecovery({ deliver, log });
-
+    ],
+    [
+      "treats Matrix 'User not in room' as a permanent error",
+      "matrix",
+      "!lowercased:matrix.example.com",
+      new Error(
+        "MatrixError: [403] User @bot:matrix.example.com not in room !lowercased:matrix.example.com",
+      ),
+    ],
+  ])("%s", async (_, channel, to, error) => {
+    const id = await enqueueRecoveryDelivery({ channel, to, payloads: [{ text: "hi" }] });
+    const deliver = vi.fn().mockRejectedValue(error);
+    const { result, log } = await runRecovery({ deliver });
     expect(result.failed).toBe(1);
     expect(result.recovered).toBe(0);
-    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-    expectMockMessageContaining(log.warn, "permanent error");
+    await expectFailedQueue(id);
+    const typedRejection = error instanceof PlatformMessageNotDispatchedError;
+    await runIf(typedRejection, () => expect(deliver).toHaveBeenCalledOnce());
+    await runIf(!typedRejection, () => expectMockMessageContaining(log.warn, "permanent error"));
   });
-
   it("passes skipQueue: true to prevent re-enqueueing during recovery", async () => {
     await enqueueRecoveryDelivery();
-
     const deliver = vi.fn().mockResolvedValue([]);
     await runRecovery({ deliver });
-
-    const deliverInput = mockCallArg(deliver) as { skipQueue?: boolean };
+    const deliverInput = mockCallRecord(deliver);
     expect(deliverInput.skipQueue).toBe(true);
   });
-
-  it("moves unknown-after-send entries to failed without replaying", async () => {
-    const id = await enqueueRecoveryDelivery();
-    await markDeliveryPlatformOutcomeUnknown(id, tmpDir());
-
-    const deliver = vi.fn().mockResolvedValue([]);
-    const { result, log } = await runRecovery({ deliver });
-
-    expect(deliver).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      recovered: 0,
-      failed: 1,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
-    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(readOutboundQueueStatus(tmpDir(), id)).toBe("failed");
-    expectMockMessageContaining(log.warn, "refusing blind replay without adapter reconciliation");
-  });
-
   it("runs recovered send commit hooks only after the queue entry is acked", async () => {
     const id = await enqueueRecoveryDelivery();
     const order: string[] = [];
@@ -1483,14 +1074,11 @@ describe("delivery-queue recovery", () => {
       order.push("deliver");
       return [result];
     });
-
     await runRecovery({ deliver });
-
     expect(order).toEqual(["deliver", "commit-after-ack"]);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
     expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
   });
-
   it("does not restore an acked entry when a recovered send commit hook fails", async () => {
     const id = await enqueueRecoveryDelivery();
     const result = attachOutboundDeliveryCommitHook(
@@ -1500,147 +1088,73 @@ describe("delivery-queue recovery", () => {
       },
     );
     const deliver = vi.fn().mockResolvedValue([result]);
-
     const { result: summary } = await runRecovery({ deliver });
-
-    expect(summary).toEqual({
-      recovered: 1,
-      failed: 0,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
+    expect(summary).toEqual(RECOVERY_SUMMARY.recovered);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
     expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
   });
-
-  it("marks a recovered send unknown before ack so ack failure cannot make it replayable", async () => {
+  it.each([
+    ["marks a recovered send unknown before ack so ack failure cannot make it replayable", "ack"],
+    ["keeps a recovered zero-result delivery retryable when ack fails", "zero-result-ack"],
+    ["directly acks a recovered send when its post-send marker fails", "marker"],
+    ["retains unknown-after-send when recovered-send marking and ack both fail", "marker-and-ack"],
+  ])("%s", async (_, mode) => {
     const id = await enqueueRecoveryDelivery();
+    const markerFails = mode === "marker" || mode === "marker-and-ack";
+    const ackFails = mode === "ack" || mode === "zero-result-ack" || mode === "marker-and-ack";
     let recoveryStateAtAck: string | undefined;
-    vi.resetModules();
-    vi.doMock("./delivery-queue-storage.js", async () => {
-      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
-        "./delivery-queue-storage.js",
-      );
-      return {
-        ...actual,
-        ackDelivery: vi.fn(async (entryId: string, stateDir?: string) => {
-          recoveryStateAtAck = (await actual.loadPendingDelivery(entryId, stateDir))?.recoveryState;
-          throw new Error("ack state db locked");
-        }),
-      };
-    });
-
-    try {
-      const { recoverPendingDeliveries: recoverWithAckFailure } =
-        await import("./delivery-queue-recovery.js");
-      const summary = await recoverWithAckFailure({
-        deliver: asDeliverFn(
-          vi.fn().mockResolvedValue([{ channel: "demo-channel-a", messageId: "m1" }]),
+    const { summary, log } = await runRecoveryWithStorageOverrides({
+      overrides: (actual) => ({
+        ...(markerFails
+          ? {
+              markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
+                throw new Error("post-send state db locked");
+              }),
+            }
+          : {}),
+        ...(ackFails
+          ? {
+              ackDelivery: vi.fn(async (entryId: string, stateDir?: string) => {
+                if (mode === "ack") {
+                  recoveryStateAtAck = (await actual.loadPendingDelivery(entryId, stateDir))
+                    ?.recoveryState;
+                }
+                throw new Error("ack state db locked");
+              }),
+            }
+          : {}),
+      }),
+      deliver: vi
+        .fn()
+        .mockResolvedValue(
+          mode === "zero-result-ack" ? [] : [{ channel: "demo-channel-a", messageId: "m1" }],
         ),
-        log: createRecoveryLog(),
-        cfg: baseCfg,
-        stateDir: tmpDir(),
-      });
-
-      expect(summary).toEqual({
-        recovered: 0,
-        failed: 1,
-        skippedMaxRetries: 0,
-        deferredBackoff: 0,
-      });
-      expect(recoveryStateAtAck).toBe("unknown_after_send");
-      const pending = await loadPendingDeliveries(tmpDir());
-      expect(pending).toHaveLength(1);
-      expect(pending[0]?.id).toBe(id);
-      expect(pending[0]?.recoveryState).toBe("unknown_after_send");
-      expect(pending[0]?.lastError).toContain("ack state db locked");
-    } finally {
-      vi.doUnmock("./delivery-queue-storage.js");
-      vi.resetModules();
-    }
-  });
-
-  it("keeps a recovered zero-result delivery retryable when ack fails", async () => {
-    const id = await enqueueRecoveryDelivery();
-    vi.resetModules();
-    vi.doMock("./delivery-queue-storage.js", async () => {
-      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
-        "./delivery-queue-storage.js",
-      );
-      return {
-        ...actual,
-        ackDelivery: vi.fn(async () => {
-          throw new Error("ack state db locked");
-        }),
-      };
     });
-
-    try {
-      const { recoverPendingDeliveries: recoverWithAckFailure } =
-        await import("./delivery-queue-recovery.js");
-      const summary = await recoverWithAckFailure({
-        deliver: asDeliverFn(vi.fn().mockResolvedValue([])),
-        log: createRecoveryLog(),
-        cfg: baseCfg,
-        stateDir: tmpDir(),
-      });
-
-      expect(summary).toMatchObject({ recovered: 0, failed: 1 });
-      const pending = await loadPendingDeliveries(tmpDir());
-      expect(pending).toHaveLength(1);
-      expect(pending[0]?.id).toBe(id);
-      expect(pending[0]?.recoveryState).toBeUndefined();
-      expect(pending[0]?.retryCount).toBe(1);
-      expect(pending[0]?.lastError).toContain("ack state db locked");
-    } finally {
-      vi.doUnmock("./delivery-queue-storage.js");
-      vi.resetModules();
-    }
-  });
-
-  it("directly acks a recovered send when its post-send marker fails", async () => {
-    const id = await enqueueRecoveryDelivery();
-    vi.resetModules();
-    vi.doMock("./delivery-queue-storage.js", async () => {
-      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
-        "./delivery-queue-storage.js",
-      );
-      return {
-        ...actual,
-        markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
-          throw new Error("post-send state db locked");
-        }),
-      };
-    });
-
-    try {
-      const { recoverPendingDeliveries: recoverWithMarkFailure } =
-        await import("./delivery-queue-recovery.js");
-      const log = createRecoveryLog();
-      const summary = await recoverWithMarkFailure({
-        deliver: asDeliverFn(
-          vi.fn().mockResolvedValue([{ channel: "demo-channel-a", messageId: "m1" }]),
-        ),
-        cfg: baseCfg,
-        stateDir: tmpDir(),
-        log,
-      });
-
-      expect(summary).toEqual({
-        recovered: 1,
-        failed: 0,
-        skippedMaxRetries: 0,
-        deferredBackoff: 0,
-      });
+    if (mode === "marker") {
+      expect(summary).toEqual(RECOVERY_SUMMARY.recovered);
       expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
       expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
       expectMockMessageContaining(log.warn, "falling back to direct ack");
-    } finally {
-      vi.doUnmock("./delivery-queue-storage.js");
-      vi.resetModules();
+      return;
     }
+    if (mode === "ack") {
+      expect(summary).toEqual(RECOVERY_SUMMARY.failed);
+      expect(recoveryStateAtAck).toBe("unknown_after_send");
+    } else {
+      expect(summary).toMatchObject({ recovered: 0, failed: 1 });
+    }
+    const pending = await expectPendingEntry({
+      id,
+      recoveryState: mode === "zero-result-ack" ? undefined : "unknown_after_send",
+      ...(mode === "ack" ? {} : { retryCount: 1 }),
+    });
+    await runIf(markerFails, () =>
+      expect(pending?.lastError).toContain("marker=post-send state db locked"),
+    );
+    expect(pending?.lastError).toContain(
+      mode === "marker-and-ack" ? "ack=ack state db locked" : "ack state db locked",
+    );
   });
-
   it("retains later media until an early recovery ack finishes the batch", async () => {
     const spoolDir = path.join(tmpDir(), "delivery-queue-media");
     const firstArtifact = path.join(spoolDir, "00000000-0000-4000-8000-000000000001.ogg");
@@ -1654,193 +1168,89 @@ describe("delivery-queue recovery", () => {
     await enqueueRecoveryDelivery({
       payloads: [{ mediaUrl: firstArtifact }, { mediaUrl: secondArtifact }],
     });
-    vi.resetModules();
-    vi.doMock("./delivery-queue-storage.js", async () => {
-      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
-        "./delivery-queue-storage.js",
-      );
-      return {
-        ...actual,
+    const firstResult = { channel: "demo-channel-a", messageId: "m1" };
+    const secondResult = { channel: "demo-channel-a", messageId: "m2" };
+    const deliver = vi.fn(async (params: Parameters<DeliverFn>[0]) => {
+      await params.onDeliveryResult?.(firstResult);
+      await pruneOrphanedDeliveryQueueMedia({ stateDir: tmpDir() });
+      expect(await fs.readFile(secondArtifact, "utf8")).toBe("second-audio");
+      await params.onDeliveryResult?.(secondResult);
+      return [firstResult, secondResult];
+    });
+    const { summary } = await runRecoveryWithStorageOverrides({
+      overrides: () => ({
         markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
           throw new Error("post-send state db locked");
         }),
-      };
+      }),
+      deliver,
     });
-
-    try {
-      const { recoverPendingDeliveries: recoverWithMarkFailure } =
-        await import("./delivery-queue-recovery.js");
-      const firstResult = { channel: "demo-channel-a", messageId: "m1" };
-      const secondResult = { channel: "demo-channel-a", messageId: "m2" };
-      const deliver = vi.fn(async (params: Parameters<DeliverFn>[0]) => {
-        await params.onDeliveryResult?.(firstResult);
-        await pruneOrphanedDeliveryQueueMedia({ stateDir: tmpDir() });
-        expect(await fs.readFile(secondArtifact, "utf8")).toBe("second-audio");
-        await params.onDeliveryResult?.(secondResult);
-        return [firstResult, secondResult];
-      });
-
-      const summary = await recoverWithMarkFailure({
-        deliver,
-        cfg: baseCfg,
-        stateDir: tmpDir(),
-        log: createRecoveryLog(),
-      });
-
-      expect(summary).toMatchObject({ recovered: 1, failed: 0 });
-      await expect(fs.stat(firstArtifact)).rejects.toThrow();
-      await expect(fs.stat(secondArtifact)).rejects.toThrow();
-    } finally {
-      vi.doUnmock("./delivery-queue-storage.js");
-      vi.resetModules();
-    }
+    expect(summary).toMatchObject({ recovered: 1, failed: 0 });
+    await expect(fs.stat(firstArtifact)).rejects.toThrow();
+    await expect(fs.stat(secondArtifact)).rejects.toThrow();
   });
-
   it("owns the stable terminal when recovery fallback ack precedes provider rejection", async () => {
-    const auditEvents: TrustedMessageAuditEvent[] = [];
-    const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
+    const { auditEvents, unsubscribe } = captureAuditEvents();
     const id = await enqueueRecoveryDelivery({
       queuePolicy: "best_effort",
       payloads: [{ text: "secret" }],
     });
-    const deliver = vi.fn(
-      async (params: {
-        onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
-      }) => {
-        await ackDelivery(id, tmpDir());
-        params.onPayloadDeliveryOutcome?.({
-          index: 0,
-          status: "failed",
-          error: new Error("provider rejected send"),
-          sentBeforeError: false,
-          stage: "platform_send",
-        });
-        throw new Error("provider rejected send");
-      },
-    );
-
+    const deliver = vi.fn(async (params: PayloadOutcomeSink) => {
+      await ackDelivery(id, tmpDir());
+      reportPayloadFailure(params, new Error("provider rejected send"));
+      throw new Error("provider rejected send");
+    });
     const { result } = await runRecovery({ deliver });
     unsubscribe();
-
     expect(result).toMatchObject({ recovered: 0, failed: 1 });
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    expect(auditEvents).toHaveLength(1);
-    expect(auditEvents[0]).toMatchObject({
-      sourceId: `message:outbound:queue:${id}:payload:0`,
-      outcome: "failed",
-      failureStage: "platform_send",
-    });
+    expectPayloadAudits(auditEvents, id, [{ outcome: "failed", failureStage: "platform_send" }]);
     expect(JSON.stringify(auditEvents)).not.toContain("secret");
     expect(JSON.stringify(auditEvents)).not.toContain("provider rejected send");
   });
-
   it("runs recovered commit hooks when marker fallback ack precedes a partial failure", async () => {
     await enqueueRecoveryDelivery({
       payloads: [{ text: "first" }, { text: "second" }],
       bestEffort: true,
     });
     const afterCommit = vi.fn();
-    vi.resetModules();
-    vi.doMock("./delivery-queue-storage.js", async () => {
-      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
-        "./delivery-queue-storage.js",
-      );
-      return {
-        ...actual,
+    const { summary } = await runRecoveryWithStorageOverrides({
+      overrides: () => ({
         markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
           throw new Error("post-send state db locked");
         }),
-      };
+      }),
+      createDeliver: async () => {
+        const { attachOutboundDeliveryCommitHook: attachHookAfterReset } =
+          await import("./delivery-commit-hooks.js");
+        const result = attachHookAfterReset(
+          { channel: "demo-channel-a", messageId: "m1" },
+          afterCommit,
+        );
+        return vi.fn(
+          async (params: {
+            onDeliveryResult?: (deliveryResult: typeof result) => Promise<void> | void;
+            onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
+          }) => {
+            await params.onDeliveryResult?.(result);
+            params.onPayloadDeliveryOutcome?.({
+              index: 1,
+              status: "failed",
+              error: new Error("second send failed"),
+              sentBeforeError: false,
+              stage: "platform_send",
+            });
+            return [result];
+          },
+        );
+      },
     });
-
-    try {
-      const { recoverPendingDeliveries: recoverWithMarkFailure } =
-        await import("./delivery-queue-recovery.js");
-      const { attachOutboundDeliveryCommitHook: attachHookAfterReset } =
-        await import("./delivery-commit-hooks.js");
-      const result = attachHookAfterReset(
-        { channel: "demo-channel-a", messageId: "m1" },
-        afterCommit,
-      );
-      const summary = await recoverWithMarkFailure({
-        deliver: asDeliverFn(
-          vi.fn(
-            async (params: {
-              onDeliveryResult?: (deliveryResult: typeof result) => Promise<void> | void;
-              onPayloadDeliveryOutcome?: (outcome: OutboundPayloadDeliveryOutcome) => void;
-            }) => {
-              await params.onDeliveryResult?.(result);
-              params.onPayloadDeliveryOutcome?.({
-                index: 1,
-                status: "failed",
-                error: new Error("second send failed"),
-                sentBeforeError: false,
-                stage: "platform_send",
-              });
-              return [result];
-            },
-          ),
-        ),
-        cfg: baseCfg,
-        stateDir: tmpDir(),
-        log: createRecoveryLog(),
-      });
-
-      expect(summary).toMatchObject({ recovered: 0, failed: 1 });
-      expect(afterCommit).toHaveBeenCalledTimes(1);
-      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-    } finally {
-      vi.doUnmock("./delivery-queue-storage.js");
-      vi.resetModules();
-    }
+    expect(summary).toMatchObject({ recovered: 0, failed: 1 });
+    expect(afterCommit).toHaveBeenCalledTimes(1);
+    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
   });
-
-  it("retains unknown-after-send when recovered-send marking and ack both fail", async () => {
-    const id = await enqueueRecoveryDelivery();
-    vi.resetModules();
-    vi.doMock("./delivery-queue-storage.js", async () => {
-      const actual = await vi.importActual<typeof import("./delivery-queue-storage.js")>(
-        "./delivery-queue-storage.js",
-      );
-      return {
-        ...actual,
-        markDeliveryPlatformOutcomeUnknown: vi.fn(async () => {
-          throw new Error("post-send state db locked");
-        }),
-        ackDelivery: vi.fn(async () => {
-          throw new Error("ack state db locked");
-        }),
-      };
-    });
-
-    try {
-      const { recoverPendingDeliveries: recoverWithStateFailures } =
-        await import("./delivery-queue-recovery.js");
-      const summary = await recoverWithStateFailures({
-        deliver: asDeliverFn(
-          vi.fn().mockResolvedValue([{ channel: "demo-channel-a", messageId: "m1" }]),
-        ),
-        cfg: baseCfg,
-        stateDir: tmpDir(),
-        log: createRecoveryLog(),
-      });
-
-      expect(summary).toMatchObject({ recovered: 0, failed: 1 });
-      const entries = await loadPendingDeliveries(tmpDir());
-      expect(entries).toHaveLength(1);
-      expect(entries[0]?.id).toBe(id);
-      expect(entries[0]?.recoveryState).toBe("unknown_after_send");
-      expect(entries[0]?.retryCount).toBe(1);
-      expect(entries[0]?.lastError).toContain("marker=post-send state db locked");
-      expect(entries[0]?.lastError).toContain("ack=ack state db locked");
-    } finally {
-      vi.doUnmock("./delivery-queue-storage.js");
-      vi.resetModules();
-    }
-  });
-
   it("replays stored delivery options during recovery", async () => {
-    await enqueueRecoveryDelivery({
+    const storedOptions = {
       replyToId: "root-message",
       replyToMode: "first",
       formatting: {
@@ -1873,217 +1283,103 @@ describe("delivery-queue recovery", () => {
         requesterSenderUsername: "sender.one",
         requesterSenderE164: "+15551234567",
       },
-    });
-
+    } satisfies Partial<Parameters<typeof enqueueDelivery>[0]>;
+    await enqueueRecoveryDelivery(storedOptions);
     const deliver = vi.fn().mockResolvedValue([]);
     await runRecovery({ deliver });
-
-    const deliverInput = mockCallArg(deliver) as {
-      bestEffort?: boolean;
-      gifPlayback?: boolean;
-      silent?: boolean;
-      replyToId?: string;
-      replyToMode?: string;
-      formatting?: unknown;
-      gatewayClientScopes?: string[];
-      mirror?: unknown;
-      session?: unknown;
-    };
-    expect(deliverInput.bestEffort).toBe(true);
-    expect(deliverInput.gifPlayback).toBe(true);
-    expect(deliverInput.silent).toBe(true);
-    expect(deliverInput.replyToId).toBe("root-message");
-    expect(deliverInput.replyToMode).toBe("first");
-    expect(deliverInput.formatting).toEqual({
-      textLimit: 1234,
-      maxLinesPerMessage: 7,
-      tableMode: "off",
-      chunkMode: "newline",
-    });
-    expect(deliverInput.gatewayClientScopes).toEqual(["operator.write"]);
-    expect(deliverInput.mirror).toEqual({
-      sessionKey: "agent:main:main",
-      expectedSessionId: "session-main",
-      text: "a",
-      mediaUrls: ["https://example.com/a.png"],
-      idempotencyKey: "channel-final:message-1",
-      deliveryMirror: {
-        kind: "channel-final",
-        sourceMessageId: "message-1",
-      },
-    });
-    expect(deliverInput.session).toEqual({
-      key: "agent:main:main",
-      agentId: "agent-main",
-      requesterAccountId: "acct-1",
-      requesterSenderId: "sender-1",
-      requesterSenderName: "Sender One",
-      requesterSenderUsername: "sender.one",
-      requesterSenderE164: "+15551234567",
-    });
+    const deliverInput = mockCallRecord(deliver);
+    expect(deliverInput).toEqual(expect.objectContaining(storedOptions));
   });
-
-  it("respects maxRecoveryMs time budget without bumping deferred retries", async () => {
-    await enqueueCrashRecoveryEntries();
-    await enqueueRecoveryDelivery({
-      channel: "demo-channel-c",
-      to: "#c",
-      payloads: [{ text: "c" }],
-    });
-
-    const deliver = vi.fn().mockResolvedValue([]);
-    const { result, log } = await runRecovery({
-      deliver,
-      maxRecoveryMs: 0,
-    });
-
-    expect(deliver).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      recovered: 0,
-      failed: 0,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
-
-    const remaining = await loadPendingDeliveries(tmpDir());
-    expect(remaining).toHaveLength(3);
-    expect(remaining.map((entry) => entry.retryCount)).toStrictEqual([0, 0, 0]);
-    expectMockMessageContaining(log.warn, "deferred to next startup");
-  });
-
-  it("defers recovery when the recovery deadline would exceed the Date timestamp range", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(MAX_DATE_TIMESTAMP_MS));
+  it.each([
+    ["respects maxRecoveryMs time budget without bumping deferred retries", 0, true, 3, false],
+    [
+      "defers recovery when the recovery deadline would exceed the Date timestamp range",
+      1,
+      false,
+      2,
+      true,
+    ],
+  ])("%s", async (_, maxRecoveryMs, addBacklogTail, remainingCount, useMaxDate) => {
+    if (useMaxDate) {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(MAX_DATE_TIMESTAMP_MS));
+    }
     try {
       await enqueueCrashRecoveryEntries();
+      await runIf(addBacklogTail, () => enqueueDemoRecoveryDelivery(["c"], { to: "#c" }));
       const deliver = vi.fn().mockResolvedValue([]);
-      const { result, log } = await runRecovery({
-        deliver,
-        maxRecoveryMs: 1,
-      });
-
+      const { result, log } = await runRecovery({ deliver, maxRecoveryMs });
       expect(deliver).not.toHaveBeenCalled();
-      expect(result).toEqual({
-        recovered: 0,
-        failed: 0,
-        skippedMaxRetries: 0,
-        deferredBackoff: 0,
-      });
-      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(2);
+      expect(result).toEqual(RECOVERY_SUMMARY.empty);
+      const remaining = await loadPendingDeliveries(tmpDir());
+      expect(remaining).toHaveLength(remainingCount);
+      if (addBacklogTail) {
+        expect(remaining.map((entry) => entry.retryCount)).toStrictEqual([0, 0, 0]);
+      }
       expectMockMessageContaining(log.warn, "deferred to next startup");
     } finally {
-      vi.useRealTimers();
+      await runIf(useMaxDate, () => vi.useRealTimers());
     }
   });
-
   it("defers entries until backoff becomes eligible", async () => {
     const id = await enqueueRecoveryDelivery();
     setQueuedEntryState(tmpDir(), id, { retryCount: 3, lastAttemptAt: Date.now() });
-
     const deliver = vi.fn().mockResolvedValue([]);
     const { result, log } = await runRecovery({
       deliver,
       maxRecoveryMs: 60_000,
     });
-
     expect(deliver).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      recovered: 0,
-      failed: 0,
-      skippedMaxRetries: 0,
-      deferredBackoff: 1,
-    });
+    expect(result).toEqual(RECOVERY_SUMMARY.deferred);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(1);
     expectMockMessageContaining(log.info, "not ready for retry yet");
   });
-
   it("continues past high-backoff entries and recovers ready entries behind them", async () => {
     const now = Date.now();
-    const blockedId = await enqueueRecoveryDelivery({
-      payloads: [{ text: "blocked" }],
-    });
+    const blockedId = await enqueueRecoveryDelivery({ payloads: [{ text: "blocked" }] });
     const readyId = await enqueueRecoveryDelivery({
       channel: "demo-channel-b",
       to: "2",
       payloads: [{ text: "ready" }],
     });
-
     setQueuedEntryState(tmpDir(), blockedId, {
       retryCount: 3,
       lastAttemptAt: now,
       enqueuedAt: now - 30_000,
     });
     setQueuedEntryState(tmpDir(), readyId, { retryCount: 0, enqueuedAt: now - 10_000 });
-
     const deliver = vi.fn().mockResolvedValue([]);
     const { result } = await runRecovery({ deliver, maxRecoveryMs: 60_000 });
-
-    expect(result).toEqual({
-      recovered: 1,
-      failed: 0,
-      skippedMaxRetries: 0,
-      deferredBackoff: 1,
-    });
+    expect(result).toEqual(RECOVERY_SUMMARY.recoveredWithDeferred);
     expect(deliver).toHaveBeenCalledTimes(1);
-    const deliverInput = mockCallArg(deliver) as {
-      channel?: string;
-      to?: string;
-      skipQueue?: boolean;
-    };
-    expect(deliverInput.channel).toBe("demo-channel-b");
-    expect(deliverInput.to).toBe("2");
-    expect(deliverInput.skipQueue).toBe(true);
-
+    const deliverInput = mockCallRecord(deliver);
+    expect(deliverInput).toMatchObject({ channel: "demo-channel-b", to: "2", skipQueue: true });
     const remaining = await loadPendingDeliveries(tmpDir());
     expect(remaining).toHaveLength(1);
     expect(remaining[0]?.id).toBe(blockedId);
   });
-
   it("recovers deferred entries on a later restart once backoff elapsed", async () => {
     vi.useFakeTimers();
     const start = new Date("2026-01-01T00:00:00.000Z");
     vi.setSystemTime(start);
-
-    const id = await enqueueRecoveryDelivery({
-      payloads: [{ text: "later" }],
-    });
+    const id = await enqueueRecoveryDelivery({ payloads: [{ text: "later" }] });
     setQueuedEntryState(tmpDir(), id, { retryCount: 3, lastAttemptAt: start.getTime() });
-
     const firstDeliver = vi.fn().mockResolvedValue([]);
     const firstRun = await runRecovery({ deliver: firstDeliver, maxRecoveryMs: 60_000 });
-    expect(firstRun.result).toEqual({
-      recovered: 0,
-      failed: 0,
-      skippedMaxRetries: 0,
-      deferredBackoff: 1,
-    });
+    expect(firstRun.result).toEqual(RECOVERY_SUMMARY.deferred);
     expect(firstDeliver).not.toHaveBeenCalled();
-
     vi.setSystemTime(new Date(start.getTime() + 120_000 + 1));
     const secondDeliver = vi.fn().mockResolvedValue([]);
     const secondRun = await runRecovery({ deliver: secondDeliver, maxRecoveryMs: 60_000 });
-    expect(secondRun.result).toEqual({
-      recovered: 1,
-      failed: 0,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
+    expect(secondRun.result).toEqual(RECOVERY_SUMMARY.recovered);
     expect(secondDeliver).toHaveBeenCalledTimes(1);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
-
     vi.useRealTimers();
   });
-
   it("returns zeros when queue is empty", async () => {
     const deliver = vi.fn();
     const { result } = await runRecovery({ deliver });
-
-    expect(result).toEqual({
-      recovered: 0,
-      failed: 0,
-      skippedMaxRetries: 0,
-      deferredBackoff: 0,
-    });
+    expect(result).toEqual(RECOVERY_SUMMARY.empty);
     expect(deliver).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The outbound recovery suite repeated queue creation, reconciliation adapters, audit capture, terminal-state assertions, and storage-failure wiring across 56 cases, making lifecycle coverage costly to review and change.

## Why This Change Was Made

Consolidates repeated test-only setup and assertions into typed helpers and focused scenario matrices. All 56 existing test names, queue/SQLite transitions, audit fields, commit-hook ordering, ambiguous-send reconciliation outcomes, retry/backoff/deadline behavior, payload isolation, exact stored options, and failure visibility remain covered. No production, config, schema, package, or user-visible behavior changes.

## User Impact

No user-visible behavior change. Test maintenance is smaller by 704 net LOC while preserving the outbound recovery contract.

## Evidence

- Blacksmith Testbox `tbx_01kz0ghn6fty7xth2nz136963q` (`crimson-prawn-4b2d`): focused recovery test 56/56 passed on the final diff
- Remote `pnpm check:changed`: passed (format, deadcode, core-test tsgo, changed-file oxlint)
- Exact test-name parity: 56/56, zero mismatches
- Same-box baseline/current benchmark: 5.26s vs 5.44s test time
- Delta: +683/-1387, net -704; production delta 0
- Independent xhigh reviews:
  - `/root/wave11_outbound_owner_cleanup/outbound_recovery_review_a`: CLEAN
  - `/root/wave11_outbound_owner_cleanup/outbound_recovery_review_b`: CLEAN
- Fresh open-PR exact-path collision audit: zero
- Current `origin/main` exact-path drift from the audited base: zero

## Changelog

No changelog: test-only refactor with no user-visible behavior change.

## Maintainer exact-head proof

- Prepared head `6233eb296e57f798d8ae6b22799315e580f6ceea`: [Blacksmith Testbox focused recovery run](https://github.com/openclaw/openclaw/actions/runs/30778367697) passed 56/56 tests.
- [Ready-for-review exact-head CI](https://github.com/openclaw/openclaw/actions/runs/30779714115) completed green.
- Native prepare fetched current main; touched-path drift remained zero and the current-main merge-tree check was clean.
