### PR TITLE
fix(ui): prevent channel setup from stalling on gateway progress

### DIFF
--- a/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
+++ b/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
@@ -228,22 +228,21 @@ describeControlUiE2e("Control UI WhatsApp logout mocked Gateway E2E", () => {
       await expect.poll(() => beta.getAttribute("aria-pressed")).toBe("true");
       await wizard.getByRole("button", { name: "Continue" }).click();
       await wizard.getByRole("button", { name: "Yes" }).click();
-      await wizard.getByRole("button", { name: "Continue" }).click();
       await wizard.getByRole("button", { name: "Finish" }).waitFor();
 
-      const answers = [
+      const userAnswers = [
         ["account", "work"],
         ["token", "123456:proof-secret"],
         ["features", ["alpha", "beta"]],
         ["confirm", true],
-        ["progress", null],
       ] as const;
-      expect((await gateway.getRequests("wizard.next")).map(({ params }) => params)).toEqual(
-        answers.map(([stepId, value]) => ({
+      expect((await gateway.getRequests("wizard.next")).map(({ params }) => params)).toEqual([
+        ...userAnswers.map(([stepId, value]) => ({
           sessionId: "channel-standard-proof",
           answer: { stepId, value },
         })),
-      );
+        { sessionId: "channel-standard-proof" },
+      ]);
     } finally {
       await context.close();
     }

--- a/ui/src/pages/channels/wizard-controller.test.ts
+++ b/ui/src/pages/channels/wizard-controller.test.ts
@@ -4,7 +4,11 @@ import { describe, expect, it, vi } from "vitest";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import { ChannelWizardController } from "./wizard-controller.ts";
 
-type RequestHandler = (method: string, params?: unknown) => Promise<unknown>;
+type RequestHandler = (
+  method: string,
+  params?: unknown,
+  options?: { timeoutMs?: number | null; signal?: AbortSignal },
+) => Promise<unknown>;
 
 function createController(handler: RequestHandler) {
   const request = vi.fn(handler);
@@ -72,6 +76,218 @@ describe("ChannelWizardController", () => {
       sessionId: "s1",
       answer: { stepId: "step-select", value: "telegram" },
     });
+  });
+
+  it("advances gateway-owned progress without inventing user answers", async () => {
+    let resolveProgress: ((value: unknown) => void) | undefined;
+    let nextCount = 0;
+    const { controller, request } = createController(async (method) => {
+      if (method === "wizard.start") {
+        return {
+          sessionId: "s-progress",
+          done: false,
+          status: "running",
+          step: { id: "progress-1", type: "progress", executor: "gateway", message: "Starting" },
+        };
+      }
+      if (method !== "wizard.next") {
+        throw new Error(`unexpected ${method}`);
+      }
+      nextCount += 1;
+      if (nextCount === 1) {
+        return await new Promise((resolve) => {
+          resolveProgress = resolve;
+        });
+      }
+      if (nextCount === 2) {
+        return { done: false, status: "running", step: tokenStep };
+      }
+      if (nextCount === 3) {
+        return {
+          done: false,
+          status: "running",
+          step: { id: "progress-3", type: "progress", executor: "gateway", message: "Finishing" },
+        };
+      }
+      return { done: true, status: "done", channels: ["telegram"], accounts: [] };
+    });
+
+    await controller.start("telegram");
+    expect(controller.state).toMatchObject({
+      phase: "step",
+      step: { id: "progress-1", executor: "gateway" },
+      busy: true,
+    });
+    expect(request).toHaveBeenLastCalledWith(
+      "wizard.next",
+      { sessionId: "s-progress" },
+      { timeoutMs: null, signal: expect.any(AbortSignal) },
+    );
+
+    await controller.answer(null);
+    expect(nextCount).toBe(1);
+
+    resolveProgress?.({
+      done: false,
+      status: "running",
+      step: { id: "progress-2", type: "progress", executor: "gateway", message: "Downloading" },
+    });
+    await vi.waitFor(() => {
+      expect(controller.state).toMatchObject({ phase: "step", step: { id: "step-token" } });
+    });
+
+    await controller.answer("secret-token");
+    await vi.waitFor(() => {
+      expect(controller.state).toMatchObject({ phase: "done", channels: ["telegram"] });
+    });
+
+    expect(request.mock.calls.filter(([method]) => method === "wizard.next")).toEqual([
+      [
+        "wizard.next",
+        { sessionId: "s-progress" },
+        { timeoutMs: null, signal: expect.any(AbortSignal) },
+      ],
+      [
+        "wizard.next",
+        { sessionId: "s-progress" },
+        { timeoutMs: null, signal: expect.any(AbortSignal) },
+      ],
+      [
+        "wizard.next",
+        { sessionId: "s-progress", answer: { stepId: "step-token", value: "secret-token" } },
+      ],
+      [
+        "wizard.next",
+        { sessionId: "s-progress" },
+        { timeoutMs: null, signal: expect.any(AbortSignal) },
+      ],
+    ]);
+  });
+
+  it("keeps a gateway-owned progress poll alive beyond the bounded request ceiling", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveProgress: ((value: unknown) => void) | undefined;
+      let progressSignal: AbortSignal | undefined;
+      const { controller, request } = createController(async (method, _params, options) => {
+        if (method === "wizard.start") {
+          return {
+            sessionId: "s-long-progress",
+            done: false,
+            status: "running",
+            step: { id: "long-progress", type: "progress", executor: "gateway" },
+          };
+        }
+        if (method === "wizard.next") {
+          progressSignal = options?.signal;
+          return await new Promise((resolve) => {
+            resolveProgress = resolve;
+          });
+        }
+        throw new Error(`unexpected ${method}`);
+      });
+
+      await controller.start("telegram");
+      await vi.advanceTimersByTimeAsync(120_001);
+
+      expect(controller.state).toMatchObject({
+        phase: "step",
+        step: { id: "long-progress", executor: "gateway" },
+        busy: true,
+      });
+      expect(progressSignal?.aborted).toBe(false);
+      expect(request.mock.calls.filter(([method]) => method === "wizard.next")).toEqual([
+        [
+          "wizard.next",
+          { sessionId: "s-long-progress" },
+          { timeoutMs: null, signal: expect.any(AbortSignal) },
+        ],
+      ]);
+
+      resolveProgress?.({
+        done: true,
+        status: "done",
+        channels: ["telegram"],
+        accounts: [{ channel: "telegram", accountId: "work" }],
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(controller.state).toEqual({
+        phase: "done",
+        channel: "telegram",
+        channels: ["telegram"],
+        accounts: [{ channel: "telegram", accountId: "work" }],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores a gateway progress response after the wizard is cancelled", async () => {
+    let resolveProgress: ((value: unknown) => void) | undefined;
+    let progressSignal: AbortSignal | undefined;
+    const { controller, request, onChange } = createController(async (method, _params, options) => {
+      if (method === "wizard.start") {
+        return {
+          sessionId: "s-progress-cancel",
+          done: false,
+          status: "running",
+          step: { id: "progress", type: "progress", executor: "gateway" },
+        };
+      }
+      if (method === "wizard.next") {
+        progressSignal = options?.signal;
+        return await new Promise((resolve) => {
+          resolveProgress = resolve;
+        });
+      }
+      return { status: "cancelled" };
+    });
+
+    await controller.start("telegram");
+    await controller.cancel();
+    const changeCountAfterCancel = onChange.mock.calls.length;
+    resolveProgress?.({ done: false, status: "running", step: tokenStep });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(controller.state).toEqual({ phase: "idle" });
+    expect(progressSignal?.aborted).toBe(true);
+    expect(onChange).toHaveBeenCalledTimes(changeCountAfterCancel);
+    expect(request.mock.calls.filter(([method]) => method === "wizard.next")).toHaveLength(1);
+    expect(request).toHaveBeenCalledWith("wizard.cancel", { sessionId: "s-progress-cancel" });
+  });
+
+  it("reports an expired gateway progress session without fabricating an answer", async () => {
+    const { controller, request } = createController(async (method) => {
+      if (method === "wizard.start") {
+        return {
+          sessionId: "s-progress-expired",
+          done: false,
+          status: "running",
+          step: { id: "progress", type: "progress", executor: "gateway" },
+        };
+      }
+      throw new GatewayRequestError({
+        code: "INVALID_REQUEST",
+        message: "wizard not found",
+        details: { code: "WIZARD_NOT_FOUND" },
+      });
+    });
+
+    await controller.start("telegram");
+    await vi.waitFor(() => {
+      expect(controller.state).toEqual({
+        phase: "error",
+        channel: "telegram",
+        message: "Setup expired. Close and restart setup.",
+      });
+    });
+    expect(request).toHaveBeenLastCalledWith(
+      "wizard.next",
+      { sessionId: "s-progress-expired" },
+      { timeoutMs: null, signal: expect.any(AbortSignal) },
+    );
   });
 
   it("surfaces validation errors on the re-emitted step", async () => {

--- a/ui/src/pages/channels/wizard-controller.ts
+++ b/ui/src/pages/channels/wizard-controller.ts
@@ -1,11 +1,10 @@
 // Drives a gateway channel-setup wizard session (wizard.start flow "channels")
 // as a step/answer state machine for the Control UI wizard modal.
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { WizardStep } from "../../api/types.ts";
 import { isWizardNotFoundError } from "../../lib/gateway-errors.ts";
 
-type WizardGatewayClient = {
-  request<T = unknown>(method: string, params?: unknown): Promise<T>;
-};
+type WizardGatewayClient = Pick<GatewayBrowserClient, "request">;
 
 // Keep the wire request alive behind a local ceiling: protocol-level timeouts
 // discard late responses, but wizard.start carries the session id needed for cleanup.
@@ -89,6 +88,7 @@ export class ChannelWizardController {
   private channel: string | null = null;
   private stepIndex = 0;
   private generation = 0;
+  private abortController: AbortController | null = null;
 
   constructor(
     private readonly getClient: () => WizardGatewayClient | null,
@@ -110,6 +110,8 @@ export class ChannelWizardController {
       return;
     }
     const generation = ++this.generation;
+    this.abortController?.abort();
+    this.abortController = new AbortController();
     this.sessionId = null;
     this.channel = channel;
     this.stepIndex = 0;
@@ -141,9 +143,8 @@ export class ChannelWizardController {
   }
 
   async answer(value: unknown): Promise<void> {
-    const client = this.getClient();
     const current = this.currentState;
-    if (!client || !this.sessionId || current.phase !== "step" || current.busy) {
+    if (!this.getClient() || !this.sessionId || current.phase !== "step" || current.busy) {
       return;
     }
     const generation = this.generation;
@@ -151,11 +152,33 @@ export class ChannelWizardController {
       this.channel ??= value;
     }
     this.setState({ ...current, busy: true, validationError: null });
+    await this.advance(generation, { stepId: current.step.id, value });
+  }
+
+  private async advance(
+    generation: number,
+    answer?: { stepId: string; value: unknown },
+  ): Promise<void> {
+    const client = this.getClient();
+    const sessionId = this.sessionId;
+    if (!client || !sessionId || this.generation !== generation) {
+      return;
+    }
+    const signal = this.abortController?.signal;
+    if (!answer && !signal) {
+      return;
+    }
     try {
-      const result = await requestWithTimeout<WizardNextResult>(client, "wizard.next", {
-        sessionId: this.sessionId,
-        answer: { stepId: current.step.id, value },
-      });
+      const params = {
+        sessionId,
+        ...(answer ? { answer } : {}),
+      };
+      const result = answer
+        ? await requestWithTimeout<WizardNextResult>(client, "wizard.next", params)
+        : await client.request<WizardNextResult>("wizard.next", params, {
+            timeoutMs: null,
+            ...(signal ? { signal } : {}),
+          });
       if (this.generation !== generation) {
         return;
       }
@@ -166,6 +189,8 @@ export class ChannelWizardController {
       }
       if (isWizardNotFoundError(err)) {
         this.sessionId = null;
+        this.abortController?.abort();
+        this.abortController = null;
         this.setState({
           phase: "error",
           channel: this.channel,
@@ -182,6 +207,8 @@ export class ChannelWizardController {
     const sessionId = this.sessionId;
     this.generation += 1;
     this.sessionId = null;
+    this.abortController?.abort();
+    this.abortController = null;
     this.channel = null;
     this.setState({ phase: "idle" });
     if (client && sessionId) {
@@ -196,18 +223,25 @@ export class ChannelWizardController {
   private applyResult(result: WizardNextResult): void {
     if (!result.done && result.step) {
       this.stepIndex += 1;
+      const gatewayOwned = result.step.executor === "gateway";
       this.setState({
         phase: "step",
         channel: this.channel,
         step: result.step,
         stepIndex: this.stepIndex,
-        busy: false,
+        busy: gatewayOwned,
         validationError: result.error ?? null,
       });
+      if (gatewayOwned) {
+        // Gateway-owned steps cannot consume an answer; next long-polls for
+        // progress or completion while keeping this generation cancellable.
+        void this.advance(this.generation);
+      }
       return;
     }
     if (result.status === "done") {
       this.sessionId = null;
+      this.abortController = null;
       // The gateway reports what the flow actually configured; the initially
       // requested channel is only a preselection and may have been skipped.
       const channels = result.channels ?? [];
@@ -221,11 +255,13 @@ export class ChannelWizardController {
     }
     if (result.status === "cancelled") {
       this.sessionId = null;
+      this.abortController = null;
       this.channel = null;
       this.setState({ phase: "idle" });
       return;
     }
     this.sessionId = null;
+    this.abortController = null;
     this.setState({
       phase: "error",
       channel: this.channel,

--- a/ui/src/pages/channels/wizard-view.busy.test.ts
+++ b/ui/src/pages/channels/wizard-view.busy.test.ts
@@ -9,6 +9,7 @@ import { renderChannelWizard } from "./wizard-view.ts";
 function renderStep(step: ChannelWizardStep, busy = true) {
   const container = document.createElement("div");
   const onAnswer = vi.fn();
+  const onClose = vi.fn();
   const onToggleMultiselect = vi.fn();
   document.body.append(container);
   render(
@@ -25,7 +26,7 @@ function renderStep(step: ChannelWizardStep, busy = true) {
       multiselectValues: ["alpha"],
       onToggleMultiselect,
       onAnswer,
-      onClose: vi.fn(),
+      onClose,
       whatsappQrDataUrl: null,
       whatsappMessage: null,
       whatsappConnected: null,
@@ -35,7 +36,7 @@ function renderStep(step: ChannelWizardStep, busy = true) {
     }),
     container,
   );
-  return { container, onAnswer, onToggleMultiselect };
+  return { container, onAnswer, onClose, onToggleMultiselect };
 }
 
 describe("renderChannelWizard busy controls", () => {
@@ -68,6 +69,35 @@ describe("renderChannelWizard busy controls", () => {
     confirmButtons.forEach((button) => button.click());
     expect(confirm.onAnswer).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { message: "Installing channel plugin", expectedStatus: "Installing channel plugin" },
+    { message: undefined, expectedStatus: "Working…" },
+  ])(
+    "announces gateway-owned progress and keeps cancellation available",
+    ({ message, expectedStatus }) => {
+      const progress = renderStep({
+        id: "install-progress",
+        type: "progress",
+        executor: "gateway",
+        ...(message ? { message } : {}),
+      });
+
+      const status = progress.container.querySelector<HTMLElement>('[role="status"]');
+      expect(status?.textContent?.trim()).toBe(expectedStatus);
+      expect(status?.getAttribute("aria-live")).toBe("polite");
+      expect(progress.container.querySelectorAll('[role="status"]')).toHaveLength(1);
+
+      const cancel = progress.container.querySelector<HTMLButtonElement>(
+        ".channels-wizard__footer button",
+      );
+      expect(cancel?.textContent?.trim()).toBe("Cancel");
+      expect(progress.container.querySelector(".channels-wizard__footer .primary")).toBeNull();
+      cancel?.click();
+      expect(progress.onClose).toHaveBeenCalledOnce();
+      expect(progress.onAnswer).not.toHaveBeenCalled();
+    },
+  );
 
   it("disables select choices while a step is running", () => {
     const select = renderStep({

--- a/ui/src/pages/channels/wizard-view.ts
+++ b/ui/src/pages/channels/wizard-view.ts
@@ -33,6 +33,19 @@ function stepIsBusy(props: ChannelWizardViewProps): boolean {
 
 function renderNoteStep(step: ChannelWizardStep, props: ChannelWizardViewProps) {
   const message = step.message?.trim() ?? "";
+  if (step.executor === "gateway") {
+    return html`
+      ${step.title ? html`<div class="channels-wizard__message">${step.title}</div>` : nothing}
+      <div class="channels-wizard__spinner" role="status" aria-live="polite">
+        ${message || t("channels.setup.working")}
+      </div>
+      <div class="channels-wizard__footer">
+        <button type="button" class="btn" @click=${() => props.onClose()}>
+          ${t("common.cancel")}
+        </button>
+      </div>
+    `;
+  }
   const looksLikeCode = message.includes("{") || message.includes("  ");
   return html`
     ${step.title ? html`<div class="channels-wizard__message">${step.title}</div>` : nothing}
@@ -218,7 +231,7 @@ export function renderChannelWizard(
         ? html`<div class="channels-wizard__error">${wizard.validationError}</div>`
         : nothing}
       ${renderStepBody(step, props)}
-      ${wizard.phase === "step" && wizard.busy
+      ${wizard.phase === "step" && wizard.busy && step.executor !== "gateway"
         ? html`<div class="channels-wizard__spinner">${t("channels.setup.working")}</div>`
         : nothing}
     `;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users adding a channel in Control UI could become stuck on Gateway-owned installation progress, see a bogus Continue action, lose successful setup after 120 seconds, or receive no accessible progress announcement.

## Why This Change Was Made

Give the existing Channels wizard one canonical session-owned progression lifecycle: Gateway-owned progress advances through an answerless, cancellable long poll; ordinary user answers remain bounded; cancellation and stale responses are fenced; and progress is announced through one accessible live status with a real Cancel action.

## User Impact

Channel setup automatically completes real Gateway installation steps, remains reliable for legitimately slow operations, exposes clear screen-reader progress, and allows operators to cancel. User answers are never fabricated and ordinary prompt behavior remains unchanged.

## Evidence

- Genuine unchanged-parent owner regressions reproduce **five failures**; rejected intermediate versions additionally reproduce a >120-second premature timeout and two missing accessibility/status failures. The exact final owner suites pass **23/23**.
- Real remote **Chromium 144** executed the existing Playwright Channel setup scenario: **2/2 browser tests passed**, including four genuine user answers followed by exactly one answerless Gateway progress poll, one `role="status" aria-live="polite"` region, an enabled Cancel action, and zero fabricated Continue/progress answers.
- Exact immutable remote source was verified by Git-bundle identity and all five changed-file hashes. Remote `pnpm tsgo:ui` and `pnpm ui:build` also passed. Trusted remote execution: https://github.com/openclaw/openclaw/actions/runs/30736040108.
- Four genuinely fresh independent hostile reviewers checked actual Gateway wizard sessions, browser transport, cancellation, timeout, accessibility, sibling model/macOS flows, and existing Playwright behavior. Genuine `gpt-5.6-sol` high-effort P0–P3 official autoreview found **zero issues** (confidence **0.98**); native TruffleHog 3.96 was clean.

```json
{
  "candidate": "fd326f72c3865529051c22ae8cd57407d8fc21de",
  "chromiumVersion": "144.0.7559.0",
  "userAnswers": 4,
  "automaticGatewayPolls": 1,
  "progressRole": "status",
  "ariaLive": "polite",
  "cancelEnabled": true,
  "fabricatedProgressAnswers": 0
}
```
