### PR TITLE
test(sqlite): align flip-proof request budgets

### DIFF
--- a/test/helpers/sqlite-sessions-transcripts-flip-proof.ts
+++ b/test/helpers/sqlite-sessions-transcripts-flip-proof.ts
@@ -42,6 +42,8 @@ import { createOpenClawTestInstance } from "./openclaw-test-instance.js";
 type DoctorMode = "import" | "inspect" | "validate" | "restore";
 type ProofChildProcess = ChildProcessByStdio<null, Readable, Readable>;
 
+const SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS = 60_000;
+
 type DoctorMigrationRunEvidence = {
   failureReportJsonPath?: string;
   failureReportMarkdownPath?: string;
@@ -364,8 +366,8 @@ export async function runSqliteSessionsTranscriptsFlipProof(
       url: inst.url,
       token: inst.gatewayToken,
       clientDisplayName: "sqlite-sessions-transcripts-flip-proof",
-      requestTimeoutMs: 20_000,
-      timeoutMs: 60_000,
+      requestTimeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS,
+      timeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS,
     });
     try {
       await waitForHistoryContains(client, context.resetSessionKey, "legacy hello");
@@ -381,8 +383,8 @@ export async function runSqliteSessionsTranscriptsFlipProof(
       url: inst.url,
       token: inst.gatewayToken,
       clientDisplayName: "sqlite-sessions-transcripts-flip-proof-restart",
-      requestTimeoutMs: 20_000,
-      timeoutMs: 60_000,
+      requestTimeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS,
+      timeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS,
     });
     let restartedClientConnected = true;
     try {
@@ -488,8 +490,8 @@ export async function runSqliteSessionsTranscriptsFlipProof(
         url: inst.url,
         token: inst.gatewayToken,
         clientDisplayName: "sqlite-sessions-transcripts-flip-proof-post-reset-restart",
-        requestTimeoutMs: 20_000,
-        timeoutMs: 60_000,
+        requestTimeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS,
+        timeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS,
       });
       try {
         secondStartupAfterReset = await runSecondStartupAfterResetProof(
@@ -710,7 +712,7 @@ async function startMockOpenAiServer(params: {
   child.stderr.on("data", (chunk) => {
     output += String(chunk);
   });
-  const deadline = Date.now() + 10_000;
+  const deadline = Date.now() + SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS;
   while (Date.now() < deadline) {
     if (child.exitCode !== null || child.signalCode !== null) {
       throw new Error(
@@ -1407,7 +1409,7 @@ async function runGatewayCleanupPruningProof(
   const result: { afterCount?: number; applied?: boolean; pruned?: number } = await client.request(
     "sessions.cleanup",
     { enforce: true },
-    { timeoutMs: 20_000 },
+    { timeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS },
   );
   if (result?.applied !== true || (result.pruned ?? 0) < 1) {
     throw new Error(`sessions.cleanup did not prune stale SQLite rows: ${JSON.stringify(result)}`);
@@ -1623,7 +1625,7 @@ async function runSqliteBusyContentionProof(
     childOutput += String(chunk);
   });
 
-  await waitForFile(readyPath, 10_000, () => {
+  await waitForFile(readyPath, SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS, () => {
     if (child.exitCode !== null || child.signalCode !== null) {
       throw new Error(
         `SQLite busy child exited before acquiring lock code=${String(
@@ -1649,7 +1651,7 @@ async function runSqliteBusyContentionProof(
     storePath: context.storePath,
   });
   const elapsedMs = Date.now() - startedAt;
-  const exit = await waitForChildExit(child, 10_000);
+  const exit = await waitForChildExit(child, SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS);
   if (exit.code !== 0) {
     throw new Error(
       `SQLite busy child exited non-zero code=${String(exit.code)} signal=${String(
@@ -1710,15 +1712,15 @@ async function runConcurrentMultiClientLifecycle(
     url: inst.url,
     token: inst.gatewayToken,
     clientDisplayName: "sqlite-sessions-transcripts-flip-proof-concurrent-history",
-    requestTimeoutMs: 20_000,
-    timeoutMs: 60_000,
+    requestTimeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS,
+    timeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS,
   });
   const lifecycleClient = await connectGatewayClient({
     url: inst.url,
     token: inst.gatewayToken,
     clientDisplayName: "sqlite-sessions-transcripts-flip-proof-concurrent-lifecycle",
-    requestTimeoutMs: 20_000,
-    timeoutMs: 60_000,
+    requestTimeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS,
+    timeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS,
   });
   try {
     await requireHistoryContains(
@@ -1734,7 +1736,7 @@ async function runConcurrentMultiClientLifecycle(
     const historyPromise = historyClient.request(
       "chat.history",
       { sessionKey: context.concurrentResetSessionKey, limit: 50 },
-      { timeoutMs: 20_000 },
+      { timeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS },
     );
     const resetPromise = resetSession(lifecycleClient, context.concurrentResetSessionKey);
 
@@ -1774,7 +1776,7 @@ async function runConcurrentMultiClientLifecycle(
     const deleteHistoryPromise = lifecycleClient.request(
       "chat.history",
       { sessionKey: context.concurrentDeleteSessionKey, limit: 50 },
-      { timeoutMs: 20_000 },
+      { timeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS },
     );
     await Promise.all([
       deleteHistoryPromise,
@@ -1816,7 +1818,7 @@ async function sendGatewayUserMessage(
       message,
       idempotencyKey: `sqlite-send-${randomUUID()}`,
     },
-    { timeoutMs: 20_000 },
+    { timeoutMs: SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS },
   );
   if (result?.status !== "started" || typeof result.runId !== "string") {
     throw new Error(`chat.send did not start correctly: ${JSON.stringify(result)}`);
@@ -1975,7 +1977,7 @@ async function waitForSqliteEvents(
   sessionId: string,
   minEvents: number,
 ): Promise<void> {
-  const deadline = Date.now() + 10_000;
+  const deadline = Date.now() + SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS;
   while (Date.now() < deadline) {
     const sqlite = readSqliteEvidence(dbPath, []);
     const row = sqlite.trackedEntries.find((entry) => entry.sessionId === sessionId);
@@ -1988,7 +1990,7 @@ async function waitForSqliteEvents(
 }
 
 async function waitForSqliteSessionId(dbPath: string, sessionKey: string): Promise<string> {
-  const deadline = Date.now() + 20_000;
+  const deadline = Date.now() + SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS;
   while (Date.now() < deadline) {
     const row = readSqliteEvidence(dbPath, [sessionKey]).trackedEntries.find(
       (entry) => entry.sessionKey === sessionKey && entry.sessionId,
@@ -2006,7 +2008,7 @@ async function waitForTrackedSessionId(
   sessionKey: string,
   expectedSessionId: string,
 ): Promise<void> {
-  const deadline = Date.now() + 20_000;
+  const deadline = Date.now() + SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS;
   while (Date.now() < deadline) {
     const row = readSqliteEvidence(dbPath, [sessionKey]).trackedEntries.find(
       (entry) => entry.sessionKey === sessionKey,
@@ -2022,7 +2024,7 @@ async function waitForTrackedSessionId(
 }
 
 async function waitForSessionEntryAbsent(dbPath: string, sessionKey: string): Promise<void> {
-  const deadline = Date.now() + 20_000;
+  const deadline = Date.now() + SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS;
   let absentSince: number | undefined;
   while (Date.now() < deadline) {
     const row = readSqliteEvidence(dbPath, [sessionKey]).trackedEntries.find(
@@ -2043,7 +2045,7 @@ async function waitForSessionEntryAbsent(dbPath: string, sessionKey: string): Pr
 }
 
 async function waitForSqliteEventsAbsent(dbPath: string, sessionId: string): Promise<void> {
-  const deadline = Date.now() + 20_000;
+  const deadline = Date.now() + SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS;
   let absentSince: number | undefined;
   while (Date.now() < deadline) {
     const count = countSqliteTranscriptEvents(dbPath, sessionId);
@@ -2067,7 +2069,7 @@ async function waitForSqliteMessageContains(
   role: "assistant" | "user",
   expected: string,
 ): Promise<void> {
-  const deadline = Date.now() + 20_000;
+  const deadline = Date.now() + SQLITE_FLIP_PROOF_OPERATION_TIMEOUT_MS;
   while (Date.now() < deadline) {
     const messages = readSqliteTranscriptMessages(dbPath, sessionId);
     if (

--- a/test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts
+++ b/test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts
@@ -11,5 +11,5 @@ describe("SQLite sessions/transcripts flip built CLI proof", () => {
       expect.arrayContaining([expect.stringMatching(/^dist\/index\.(?:js|mjs)$/u)]),
     );
     assertSqliteFlipProofCore(report);
-  }, 180_000);
+  }, 420_000);
 });

--- a/test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts
+++ b/test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts
@@ -230,5 +230,5 @@ describe("SQLite sessions/transcripts flip proof harness", () => {
           checkpoint.archiveArtifacts.length > 0,
       ),
     ).toBe(true);
-  }, 180_000);
+  }, 420_000);
 });


### PR DESCRIPTION
## Summary

- align ordinary SQLite flip-proof gateway requests and readiness/state waits to one bounded 60-second operation budget
- retain the intentional 65-second `agent.wait` budget
- raise the source and built-CLI outer proof ceilings from 180 to 420 seconds

## Root cause

The hosted SQLite flip proof now survives its repaired WebSocket handshake, but under runner starvation legitimate gateway operations exceed the old 10–20-second helper budgets and the complete proof exceeds the 180-second Vitest ceiling. This causes the proof to fail at exactly 180 seconds while the isolated gateway remains active.

## Evidence

- PR #117727 exact-head hosted run 30736090584 fails this lane at exactly `180052ms` with `Test timed out in 180000ms`.
- The same widening previously passed the exact hosted SQLite lane on run 30735331831.
- All changes are test-only; production behavior is unchanged.
