### PR TITLE
fix(agents): report truthful embedded startup stages

### DIFF
--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -202,6 +202,7 @@ async function runEmbeddedAgentInternal(
         agentId: params.agentId,
         config: params.config,
       });
+      startupStages.mark("workspace");
       const config = params.config ?? EMPTY_EMBEDDED_AGENT_CONFIG;
       const requestedAgentDir =
         params.agentDir ?? resolveAgentDir(config, requestedWorkspaceResolution.agentId);
@@ -250,6 +251,7 @@ async function runEmbeddedAgentInternal(
         ...(params.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
         runtimePluginSelections,
       };
+      startupStages.mark("harness-selection");
       // Configless direct hosts reuse one idle generation. The prepared-runtime lifecycle keeps
       // gateway run generations in its own bounded cache so one-off paths cannot accumulate.
       // Cold plugin loading and provider discovery can exceed the lane no-progress budget.
@@ -261,6 +263,7 @@ async function runEmbeddedAgentInternal(
             ? acquireReadOnlyPreparedModelRuntime(preparedInput)
             : acquireAgentRunPreparedModelRuntime(preparedInput, { retainIdleRunOwner }),
       );
+      startupStages.mark("prepared-runtime");
       const preparedModelRuntimeOwnerSnapshot = preparedModelRuntimeLease.snapshot;
       try {
         // A reload may complete while admission waits. The committed generation owns config,
@@ -320,7 +323,7 @@ async function runEmbeddedAgentInternal(
               `[workspace-fallback] caller=runEmbeddedAgent reason=${requestedWorkspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${preparedAgentId} workspace=${redactedWorkspace}`,
             );
           }
-          startupStages.mark("workspace");
+          startupStages.mark("runtime-context");
           notifyExecutionPhase("workspace");
           startupStages.mark("runtime-plugins");
           notifyExecutionPhase("runtime_plugins");

--- a/src/agents/embedded-agent-runner/run/attempt-stage-timing.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stage-timing.test.ts
@@ -71,6 +71,25 @@ describe("embedded run stage timing", () => {
     );
   });
 
+  it("keeps orchestration startup stages ordered and cumulative", () => {
+    let clock = 0;
+    const tracker = createEmbeddedRunStageTracker({ now: () => clock });
+
+    clock = 2;
+    tracker.mark("workspace");
+    clock = 7;
+    tracker.mark("harness-selection");
+    clock = 18;
+    tracker.mark("prepared-runtime");
+    clock = 21;
+    tracker.mark("runtime-context");
+    tracker.mark("runtime-plugins");
+
+    expect(formatEmbeddedRunStageSummary("startup", tracker.snapshot())).toBe(
+      "startup totalMs=21 stages=workspace:2ms@2ms,harness-selection:5ms@7ms,prepared-runtime:11ms@18ms,runtime-context:3ms@21ms,runtime-plugins:0ms@21ms",
+    );
+  });
+
   it("names first-attempt dispatch subspans for slow startup summaries", () => {
     // First-attempt dispatch stages use stable names because logs are compared
     // across provider/runtime startup regressions.


### PR DESCRIPTION
## What Problem This Solves

The embedded-run startup trace reported everything between tracker creation and the first mark as a single `workspace` stage. During the 2026-08-02 production turn-latency regression (fixed in #117768), a live trace read `workspace:11388ms` while the actual cost was prepared-model-runtime acquisition and model/harness selection — the label sent the investigation toward filesystem scans of a 7.5 GB agent workspace before code reading corrected it. A trace whose label misnames its contents is worse than no trace.

## Why This Change Was Made

The former `workspace` bucket covered workspace resolution, model/harness selection, prepared-runtime acquisition, snapshot rebinding, and runtime-context setup. Three added marks and one rename split it truthfully:

`workspace → harness-selection → prepared-runtime → runtime-context → runtime-plugins → hooks → model-resolution → …`

`workspace` now ends where workspace resolution actually ends; the old mark at the former bucket boundary becomes `runtime-context`. The `name:Nms@Nms` emission format and all existing truthful stage names are unchanged, so log parsing is unaffected.

## User Impact

Operators diagnosing slow turns from journal traces see where startup time actually goes. Had these stages existed on 2026-08-02, the #117768 regression would have read `prepared-runtime:~11000ms` on first glance.

## Evidence

- Stage-timing suite extended with ordering/cumulative assertions for the new stages: 6/6 passed; embedded orchestration 13/13.
- `pnpm tsgo:core`, `git diff --check`: passed.
- Autoreview (Codex `gpt-5.6-sol`, high): clean, "patch is correct" (0.93).
- Production LOC net +3; tests +19. No behavior change to the run itself.
