### PR TITLE
fix(onboard): honor explicit provider auth choice

### DIFF
--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -38,6 +38,9 @@ not install or modify anything on the remote host.
     - With a configured default model, **Keep existing model config** appears
       first and becomes the default, followed by **QuickStart (recommended)**
       and **Manual setup**.
+      An explicit non-`skip` `--auth-choice` still configures that provider
+      without changing the existing default model, unless the provider requires
+      you to select a model.
     - When a migration provider is available, **Import from another agent**
       appears after those setup choices. Selecting it opens a provider list
       with entries such as **Import from Claude**, **Import from Codex**, and

--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -187,6 +187,32 @@ it("uses expanded max_tokens for anthropic verification probes", () => {
 
 describe("applyCustomApiConfig", () => {
   it.each([
+    { setAsPrimary: undefined, expectedPrimary: "custom/foo-large" },
+    { setAsPrimary: false, expectedPrimary: "anthropic/sonnet-4.6" },
+  ])(
+    "respects custom-provider primary selection ($setAsPrimary)",
+    ({ setAsPrimary, expectedPrimary }) => {
+      const result = applyCustomApiConfig({
+        config: {
+          agents: {
+            defaults: { model: { primary: "anthropic/sonnet-4.6" } },
+          },
+        },
+        baseUrl: "https://llm.example.com/v1",
+        modelId: "foo-large",
+        compatibility: "openai",
+        providerId: "custom",
+        setAsPrimary,
+      });
+
+      expect(result.config.agents?.defaults?.model).toEqual({ primary: expectedPrimary });
+      expect(result.config.models?.providers?.custom?.models?.map((model) => model.id)).toEqual([
+        "foo-large",
+      ]);
+    },
+  );
+
+  it.each([
     {
       name: "uses stable default context window for newly added custom models",
       existingContextWindow: undefined,

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -195,6 +195,7 @@ type ApplyCustomApiConfigParams = {
   alias?: string;
   supportsImageInput?: boolean;
   target?: OnboardingAgentTarget;
+  setAsPrimary?: boolean;
 };
 
 /** Raw CLI flag values for non-interactive custom API setup. */
@@ -557,7 +558,7 @@ export function parseNonInteractiveCustomApiFlags(
   };
 }
 
-/** Applies custom provider config and makes the custom model the primary model. */
+/** Applies custom provider config and optionally makes its model the primary model. */
 export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): CustomApiResult {
   const baseUrl = normalizeOptionalString(params.baseUrl) ?? "";
   if (!URL.canParse(baseUrl)) {
@@ -689,7 +690,9 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
     },
   };
 
-  config = applyPrimaryModel(config, modelRef);
+  if (params.setAsPrimary !== false) {
+    config = applyPrimaryModel(config, modelRef);
+  }
   if (isAzure && isLikelyReasoningModel) {
     const existingPerModelThinking = config.agents?.defaults?.models?.[modelRef]?.params?.thinking;
     if (!existingPerModelThinking) {

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -241,6 +241,7 @@ export async function promptCustomApiConfig(params: {
   config: OpenClawConfig;
   target?: OnboardingAgentTarget;
   secretInputMode?: SecretInputMode;
+  setAsPrimary?: boolean;
 }): Promise<CustomApiResult> {
   const { prompter, runtime, config } = params;
 
@@ -415,6 +416,7 @@ export async function promptCustomApiConfig(params: {
     alias: aliasInput,
     supportsImageInput,
     ...(params.target ? { target: params.target } : {}),
+    ...(params.setAsPrimary === false ? { setAsPrimary: false } : {}),
   });
 
   if (result.providerIdRenamedFrom && result.providerId) {

--- a/src/wizard/setup.model-auth.ts
+++ b/src/wizard/setup.model-auth.ts
@@ -126,6 +126,7 @@ export async function runSetupModelAuthStep(params: {
   runtime: RuntimeEnv;
   agentDir?: string;
   stateDir?: string;
+  preserveExistingModelSelection?: boolean;
 }): Promise<SetupModelAuthCandidate> {
   const { opts, prompter, runtime } = params;
   const env = params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : undefined;
@@ -202,6 +203,7 @@ export async function runSetupModelAuthStep(params: {
         runtime,
         config: nextConfig,
         secretInputMode: opts.secretInputMode,
+        setAsPrimary: !params.preserveExistingModelSelection,
       });
       nextConfig = customResult.config;
       prompter.disableBackNavigation?.();
@@ -306,7 +308,10 @@ export async function runSetupModelAuthStep(params: {
       resolvePreferredProviderForAuthChoice,
     });
     const shouldPromptModelSelection =
-      authChoiceFromPrompt || authChoiceModelSelectionPolicy?.promptWhenAuthChoiceProvided;
+      authChoiceFromPrompt ||
+      (authChoiceModelSelectionPolicy.promptWhenAuthChoiceProvided &&
+        (!params.preserveExistingModelSelection ||
+          !authChoiceModelSelectionPolicy.allowKeepCurrent));
     if (shouldPromptModelSelection) {
       const modelSelection = await promptDefaultModel({
         config: nextConfig,

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -2466,6 +2466,78 @@ describe("runSetupWizard", () => {
     );
   });
 
+  it.each([
+    { name: "authenticates a provider", authChoice: "google-api-key" },
+    { name: "skips an optional provider model picker", authChoice: "github-copilot" },
+    { name: "honors a provider-required model picker", authChoice: "ollama" },
+    { name: "configures a custom provider", authChoice: "custom-api-key" },
+    { name: "keeps an explicit skip cold", authChoice: "skip" },
+  ] as const)("$name while keeping the existing model config", async ({ authChoice }) => {
+    const modelSelection = {
+      promptWhenAuthChoiceProvided: true,
+      allowKeepCurrent: authChoice !== "ollama",
+    };
+    if (authChoice === "ollama" || authChoice === "github-copilot") {
+      if (authChoice === "ollama") {
+        promptDefaultModel.mockResolvedValueOnce({ model: "ollama/llama3" });
+      }
+      resolveProviderPluginChoice.mockReturnValue({
+        provider: providerPluginStub({
+          id: authChoice,
+          wizard: { setup: { modelSelection } },
+        }),
+        method: {
+          id: authChoice === "ollama" ? "local" : "device",
+          label: authChoice,
+          kind: "custom",
+          run: vi.fn(async () => ({ profiles: [] })),
+        },
+        wizard: { modelSelection },
+      });
+    }
+    const existingConfig: OpenClawConfig = {
+      agents: {
+        defaults: { model: { primary: "anthropic/sonnet-4.6" } },
+        entries: { main: { default: true } },
+      },
+    };
+    readConfigFileSnapshot.mockResolvedValueOnce(configSnapshot(existingConfig));
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        authChoice,
+        installDaemon: false,
+        skipChannels: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      createRuntime(),
+      buildWizardPrompter({}, { defaultSelect: "keep-model" }),
+    );
+
+    if (authChoice === "ollama") {
+      expect(promptDefaultModel).toHaveBeenCalledWith(
+        expect.objectContaining({ allowKeep: false }),
+      );
+    } else {
+      expect(promptDefaultModel).not.toHaveBeenCalled();
+    }
+    if (authChoice === "custom-api-key") {
+      expect(promptCustomApiConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ setAsPrimary: false }),
+      );
+    } else {
+      expect(prepareAuthChoice).toHaveBeenCalledTimes(authChoice === "skip" ? 0 : 1);
+    }
+    const persistedConfig = replaceConfigFile.mock.calls.at(-1)?.[0].nextConfig;
+    expect(persistedConfig?.agents?.defaults?.model).toEqual({
+      primary: authChoice === "ollama" ? "ollama/llama3" : "anthropic/sonnet-4.6",
+    });
+  });
+
   it("prompts for a model during explicit interactive Ollama setup", async () => {
     promptDefaultModel.mockClear();
     warnIfModelConfigLooksOff.mockClear();

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -2501,7 +2501,9 @@ describe("runSetupWizard", () => {
         entries: { main: { default: true } },
       },
     };
-    readConfigFileSnapshot.mockResolvedValueOnce(configSnapshot(existingConfig));
+    readConfigFileSnapshot.mockImplementation(async () =>
+      configSnapshot(persistedWizardConfigs().at(-1) ?? existingConfig),
+    );
 
     await runSetupWizard(
       {
@@ -2532,7 +2534,7 @@ describe("runSetupWizard", () => {
     } else {
       expect(prepareAuthChoice).toHaveBeenCalledTimes(authChoice === "skip" ? 0 : 1);
     }
-    const persistedConfig = replaceConfigFile.mock.calls.at(-1)?.[0].nextConfig;
+    const persistedConfig = persistedWizardConfigs().at(-1);
     expect(persistedConfig?.agents?.defaults?.model).toEqual({
       primary: authChoice === "ollama" ? "ollama/llama3" : "anthropic/sonnet-4.6",
     });

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -507,12 +507,14 @@ async function runSetupWizardOnce(
   }
   const preModelAuthConfig = nextConfig;
   let stagedModelAuth: SetupModelAuthCandidate | undefined;
-  if (!keepExistingModelConfig) {
+  const hasExplicitAuthSetup = opts.authChoice !== undefined && opts.authChoice !== "skip";
+  if (!keepExistingModelConfig || hasExplicitAuthSetup) {
     stagedModelAuth = await runSetupModelAuthStep({
       config: nextConfig,
       opts,
       prompter,
       runtime,
+      preserveExistingModelSelection: keepExistingModelConfig,
     });
     nextConfig = stagedModelAuth.config;
   }


### PR DESCRIPTION
Closes #88373

## What Problem This Solves

On an already-configured installation, the default **Keep existing model config** setup mode skipped the entire model/auth step even when the operator supplied an explicit non-skip `--auth-choice`. The requested provider authentication silently never happened.

## Why This Change Was Made

Route explicit non-skip auth choices through the existing canonical wizard model/auth owner while carrying the operator's keep-model intent into provider selection. Ordinary provider authentication and custom-provider setup preserve the existing primary model. A provider-owned model-selection policy with `allowKeepCurrent: false`, such as NVIDIA or Ollama, still runs its required picker and may replace the primary; optional provider pickers remain suppressed. An explicit `skip` remains cold.

The current-main semantic port preserves staged/pending auth profiles, target handling, existing custom-provider aliases and metadata, and current onboarding/documentation behavior. There is no parallel auth flow or new public config surface.

Original contributor: @zyz619963502zyz (Jony); maintainer semantic port preserves contributor attribution in the commit.

## Evidence

### Real interactive CLI: before, positive control, and after

Used the actual installed OpenClaw launcher with isolated temporary HOME/state/config, an existing configured primary model, and explicit `--auth-choice nvidia-api-key`. No credential was submitted, no provider request ran, and no daemon/service was started.

- **Before:** select the default **Keep existing model config**, answer the first-agent prompt, and onboarding immediately asks **Test AI access now with a live completion?** without ever showing the NVIDIA credential prompt.
- **Positive control:** change only the setup selection to **QuickStart**; the same installed launcher correctly reaches **Enter NVIDIA API key**, proving the provider and credential prompt are available.
- **After:** project the exact current-source wizard decision into the real installed launcher through an in-memory Node module hook; the same **Keep existing model config** scenario now reaches **Enter NVIDIA API key**. Cancel before entering credentials; the existing primary remains unchanged and no auth profile or Gateway config is created.

```json
{
  "setupMode": "keep-model",
  "explicitAuthChoice": "nvidia-api-key",
  "before": "credential prompt missing",
  "after": "Enter NVIDIA API key",
  "existingModelPreserved": true,
  "authProfileCountAfterCancel": 0
}
```

The after proof executes the real installed CLI with the exact new wizard owner decision projected in memory; it is not described as a full current-source rebuilt distribution. Hosted exact-head CI runs the complete current-source test suites.

### Owner-boundary regressions and static verification

- Existing wizard regression table covers an ordinary provider preserving the primary, a GitHub Copilot-shaped optional picker remaining suppressed, an Ollama-required picker running with `allowKeep: false` and persisting the newly selected primary, a custom provider preserving the primary, and explicit `skip` avoiding auth entirely.
- Existing custom-provider owner regression proves the historical default still promotes its model while explicit `setAsPrimary: false` retains the existing primary and still registers the provider model.
- Executing the actual current custom-provider owner in an isolated in-memory module independently proved both provider metadata/alias registration and primary preservation/promotion.
- Executing the exact current wizard gate and provider-policy predicate covered omitted auth, explicit skip, explicit provider, optional picker, mandatory picker, and ordinary prompted selection.
- Targeted formatter and TypeScript lint checks pass for every changed file; `git diff --check` passes. Mandatory isolated Codex autoreview is performed before committing.

Production delta: +16/-4 (net +12), justified by the missing explicit-auth capability, preservation intent at the canonical wizard owner, and custom-provider primary-selection ownership. Tests: +98; documentation: +3.
