### PR TITLE
fix(acp): kill spawned ACP server when the handshake fails

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -1,5 +1,5 @@
 /** Tests ACP client permission handling, env sanitization, and spawn invocation resolution. */
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -47,6 +47,7 @@ import {
   resolvePermissionRequest,
   shouldStripProviderAuthEnvVarsForAcpServer,
 } from "./client-helpers.js";
+import { runAcpClientInteractive } from "./client.js";
 import {
   extractAttachmentsFromPrompt,
   extractTextFromPrompt,
@@ -1021,4 +1022,51 @@ describe("acp event mapper", () => {
       'exec: command: \\x1b[2K\\x1b[1A\\x1b[2K[permission] Allow "safe"? (y/N) \\nnext',
     );
   });
+});
+
+describe("runAcpClientInteractive", () => {
+  it("kills the spawned ACP server when the handshake fails", async () => {
+    const dir = await createTempDir();
+    const pidFile = path.join(dir, "server.pid");
+    // The client always prepends "acp" to the server args, so with
+    // serverCommand=node the spawned invocation is `node acp`: provide a fake
+    // entry that records its pid, breaks the handshake by closing stdout,
+    // then stays alive on a timer.
+    await writeFile(
+      path.join(dir, "acp"),
+      `require("fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));\n` +
+        `process.stdout.end("garbage-not-json\\n");\n` +
+        `setTimeout(() => {}, 300_000);\n`,
+    );
+
+    let serverPid: number | undefined;
+    try {
+      await expect(
+        runAcpClientInteractive({ serverCommand: process.execPath, cwd: dir }),
+      ).rejects.toThrow(/ACP connection closed/);
+
+      serverPid = Number(await readFile(pidFile, "utf8"));
+      const deadline = Date.now() + 5_000;
+      let alive = true;
+      while (Date.now() < deadline && alive) {
+        try {
+          process.kill(serverPid, 0);
+        } catch {
+          alive = false;
+        }
+        if (alive) {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+      }
+      expect(alive).toBe(false);
+    } finally {
+      if (serverPid !== undefined) {
+        try {
+          process.kill(serverPid, "SIGKILL");
+        } catch {
+          // already reaped
+        }
+      }
+    }
+  }, 20_000);
 });

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -168,26 +168,33 @@ async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpClientHa
   );
 
   log("initializing");
-  await client.initialize({
-    protocolVersion: PROTOCOL_VERSION,
-    clientCapabilities: {
-      fs: { readTextFile: true, writeTextFile: true },
-      terminal: true,
-    },
-    clientInfo: { name: "openclaw-acp-client", version: "1.0.0" },
-  });
+  try {
+    await client.initialize({
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+        terminal: true,
+      },
+      clientInfo: { name: "openclaw-acp-client", version: "1.0.0" },
+    });
 
-  log("creating session");
-  const session = await client.newSession({
-    cwd,
-    mcpServers: [],
-  });
+    log("creating session");
+    const session = await client.newSession({
+      cwd,
+      mcpServers: [],
+    });
 
-  return {
-    client,
-    agent,
-    sessionId: session.sessionId,
-  };
+    return {
+      client,
+      agent,
+      sessionId: session.sessionId,
+    };
+  } catch (error) {
+    // Handshake failed: kill the spawned server so a hung or non-ACP
+    // process is not leaked when this function throws.
+    agent.kill();
+    throw error;
+  }
 }
 
 /** Starts the terminal prompt loop for a local ACP client session. */


### PR DESCRIPTION
## Summary

`createAcpClient` now kills the spawned ACP server process when the handshake (`initialize` / `newSession`) rejects, instead of throwing while leaving the server running.

## What Problem This Solves

`createAcpClient` (`src/acp/client.ts`) spawns the ACP server at :138 and then awaits `client.initialize()` (:171) and `client.newSession()` (:181). If either rejects — for example the server closes its stdout mid-handshake (crash, protocol violation) or answers with a protocol error while staying alive — the function throws immediately. The only `agent.kill()` in the file is in the interactive prompt loop's `exit` branch (:215), which is never reached on a handshake failure.

The result: the CLI surfaces the handshake error, but the spawned server process keeps running. For a one-shot CLI invocation the parent exit usually lets a *cooperative* server notice its stdin EOF and quit — but a server that is hung, not reading stdin, or parked on its own timers stays behind as an orphan. The same repo already hardens sibling spawn lifecycles (#109529 attached an error listener to this very `agent` process; #115859 reaps timed-out process groups); the handshake-failure exit was simply missed.

## Root Cause

Present since the client harness was introduced in `9809b47d454` (2026-01-18, "feat(acp): add interactive client harness"). The violated invariant: "once `agent` is spawned, every exit path from `createAcpClient` either returns the live handle to the caller or kills the process." The success path returns `{ client, agent, sessionId }`; the interactive loop kills on `exit`; but the two awaited handshake calls sit between spawn and return with no failure handling, so their rejection path leaks the process.

Trigger: `initialize`/`newSession` rejects while the spawned server is still alive — e.g. a non-conforming or crashing server that emits garbage and closes its stdout but does not exit (repro below), or a server that replies with a handshake error and keeps running.

## Why This Fix

Wrap the `initialize`/`newSession` block in try/catch; on rejection, `agent.kill()` and rethrow.

- **Kill in the handshake catch, not in a global finally**: the success path must hand the live `agent` to the caller, so only the failure path kills.
- **Plain `agent.kill()` (SIGTERM)**, matching the existing teardown in the interactive loop (:215) — consistent behavior, no new signal semantics. Process-group escalation (#115859-style) is deliberately out of scope for this minimal fix.
- **Rethrow the original error** unchanged so callers keep the exact handshake failure.
- The pre-spawn `throw` paths (missing stdio pipes) are untouched — nothing to kill there.

## User Impact

- Affected operation: `openclaw acp` client sessions against a misbehaving or crashing ACP server.
- Before: handshake failure prints an error and exits, but the spawned server (pid still alive) is left behind until it happens to die on its own.
- After: the server is killed as the error propagates — no orphaned ACP server processes.

## Evidence

- **Before**: the real client pointed at a fake server (a temp `acp` entry run via the client's own `node acp` invocation) that records its pid, breaks the handshake by ending stdout with garbage, then hangs on a timer. The client rejects with `ACP connection closed`, yet the server pid is **still alive** afterwards — `FAIL: spawned ACP server leaked after handshake failure`.
- **After**: identical setup; the client rejects with the same error and the server pid is **gone** — `PASS: handshake failure killed the spawned ACP server`.

## Real Behavior Proof

### Before (on main)

```bash
$ node --import tsx proof.mjs
Failed to parse JSON message: garbage-not-json SyntaxError: Unexpected token 'g', "garbage-not-json" is not valid JSON
    at JSON.parse (<anonymous>)
    at enqueueLine (.../@agentclientprotocol/sdk/src/stream.ts:57:43)
client handshake result: rejected with: Error: ACP connection closed
spawned ACP server pid=1349927: still alive = true
FAIL: spawned ACP server leaked after handshake failure
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
Failed to parse JSON message: garbage-not-json SyntaxError: Unexpected token 'g', "garbage-not-json" is not valid JSON
    at JSON.parse (<anonymous>)
    at enqueueLine (.../@agentclientprotocol/sdk/src/stream.ts:57:43)
client handshake result: rejected with: Error: ACP connection closed
spawned ACP server pid=1350084: still alive = false
PASS: handshake failure killed the spawned ACP server
```

Proof harness: a temp directory contains an `acp` entry file (what the client spawns with `serverCommand=node`, since the client prepends `acp` to the server args) that writes its pid to a file, ends stdout with a non-JSON line, then hangs on `setTimeout`. The real `runAcpClientInteractive()` is awaited; after it rejects, the recorded pid is probed with `kill(pid, 0)` and SIGKILLed during cleanup.

## Tests and Validation

- Added regression test `runAcpClientInteractive > kills the spawned ACP server when the handshake fails` in `src/acp/client.test.ts` (real spawned fake server; asserts the client rejects and the server pid is reaped); verified it fails without the fix.
- `npx vitest run src/acp/client.test.ts` — all 58 tests pass.
- `pnpm check` — all checks pass except a pre-existing local `npm package-lock guard` integrity mismatch on `node_modules/set-blocking` (stale sha1 in the local install vs sha512 in the lockfile; reproduces without this change and is unrelated to it — no manifest or lockfile was touched).
