### PR TITLE
fix: remove duplicate plugin CLI registry mock

### DIFF
--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -20,7 +20,6 @@ const mocks = vi.hoisted(() => ({
 vi.mock("./loader.js", () => ({
   loadOpenClawPluginCliRegistry: (...args: unknown[]) =>
     mocks.loadOpenClawPluginCliRegistry(...args),
-  loadPluginRegistryHandle: (...args: unknown[]) => mocks.loadOpenClawPlugins(...args),
   loadOpenClawPlugins: (...args: unknown[]) => mocks.loadOpenClawPlugins(...args),
   loadPluginRegistryHandle: (options: Record<string, unknown> = {}) =>
     mocks.loadOpenClawPlugins({ ...options, activate: false }),


### PR DESCRIPTION
## Summary
- Remove the stale duplicate `loadPluginRegistryHandle` key from the plugin CLI loader mock.
- Keep the canonical non-activating `activate: false` mock behavior.

## Verification
- Current `main` reproduced TS1117 from duplicate keys in `src/plugins/cli.test.ts`.
- Focused owner suite: 22/22 passing.
- Exact-path formatting: passing.
- Independent FIRST and SECOND reviews: no findings.
- Authenticated final review: no findings.
- TruffleHog exact diff scan: zero findings.
