### PR TITLE
fix(acp): kill spawned ACP server when the handshake fails

### DIFF
--- a/src/acp/client.process.test.ts
+++ b/src/acp/client.process.test.ts
@@ -1,0 +1,83 @@
+/** Real-process lifecycle tests for the interactive ACP client. */
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+import { runAcpClientInteractive } from "./client.js";
+
+const tempDirs = createTrackedTempDirs();
+
+afterEach(async () => {
+  await tempDirs.cleanup();
+});
+
+describe("runAcpClientInteractive process lifecycle", () => {
+  it("force-kills the spawned ACP server when the handshake fails", async () => {
+    const dir = await tempDirs.make("openclaw-acp-client-process-test-");
+    const pidFile = path.join(dir, "server.pid");
+    const termFile = path.join(dir, "server.term");
+    // The client prepends "acp" to server args, so this becomes `node acp`.
+    await writeFile(
+      path.join(dir, "acp"),
+      `
+const fs = require("node:fs");
+const readline = require("node:readline");
+fs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
+process.on("SIGTERM", () => {
+  fs.writeFileSync(${JSON.stringify(termFile)}, "SIGTERM");
+});
+const lines = readline.createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+  const request = JSON.parse(line);
+  if (request.method === "initialize") {
+    process.stdout.write(JSON.stringify({
+      jsonrpc: "2.0",
+      id: request.id,
+      result: {
+        protocolVersion: request.params.protocolVersion,
+        agentCapabilities: { loadSession: false },
+      },
+    }) + "\\n");
+  } else if (request.method === "session/new") {
+    process.stdout.write(JSON.stringify({
+      jsonrpc: "2.0",
+      id: request.id,
+      error: {
+        code: -32000,
+        message: "fixture newSession failure",
+        data: { stage: "newSession" },
+      },
+    }) + "\\n");
+  }
+});
+setInterval(() => {}, 60_000);
+`,
+    );
+
+    let serverPid: number | undefined;
+    try {
+      const error = await runAcpClientInteractive({
+        serverCommand: process.execPath,
+        cwd: dir,
+      }).catch((caught: unknown) => caught);
+      serverPid = Number(await readFile(pidFile, "utf8"));
+
+      expect(error).toMatchObject({
+        name: "RequestError",
+        code: -32000,
+        message: "fixture newSession failure",
+        data: { stage: "newSession" },
+      });
+      expect(await readFile(termFile, "utf8")).toBe("SIGTERM");
+      expect(() => process.kill(serverPid as number, 0)).toThrow();
+    } finally {
+      if (serverPid !== undefined) {
+        try {
+          process.kill(serverPid, "SIGKILL");
+        } catch {
+          // Already reaped.
+        }
+      }
+    }
+  }, 20_000);
+});

--- a/src/acp/client.process.test.ts
+++ b/src/acp/client.process.test.ts
@@ -68,7 +68,9 @@ setInterval(() => {}, 60_000);
         message: "fixture newSession failure",
         data: { stage: "newSession" },
       });
-      expect(await readFile(termFile, "utf8")).toBe("SIGTERM");
+      if (process.platform !== "win32") {
+        expect(await readFile(termFile, "utf8")).toBe("SIGTERM");
+      }
       expect(() => process.kill(serverPid as number, 0)).toThrow();
     } finally {
       if (serverPid !== undefined) {

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -1,5 +1,5 @@
 /** Tests ACP client permission handling, env sanitization, and spawn invocation resolution. */
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -47,7 +47,6 @@ import {
   resolvePermissionRequest,
   shouldStripProviderAuthEnvVarsForAcpServer,
 } from "./client-helpers.js";
-import { runAcpClientInteractive } from "./client.js";
 import {
   extractAttachmentsFromPrompt,
   extractTextFromPrompt,
@@ -1022,51 +1021,4 @@ describe("acp event mapper", () => {
       'exec: command: \\x1b[2K\\x1b[1A\\x1b[2K[permission] Allow "safe"? (y/N) \\nnext',
     );
   });
-});
-
-describe("runAcpClientInteractive", () => {
-  it("kills the spawned ACP server when the handshake fails", async () => {
-    const dir = await createTempDir();
-    const pidFile = path.join(dir, "server.pid");
-    // The client always prepends "acp" to the server args, so with
-    // serverCommand=node the spawned invocation is `node acp`: provide a fake
-    // entry that records its pid, breaks the handshake by closing stdout,
-    // then stays alive on a timer.
-    await writeFile(
-      path.join(dir, "acp"),
-      `require("fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));\n` +
-        `process.stdout.end("garbage-not-json\\n");\n` +
-        `setTimeout(() => {}, 300_000);\n`,
-    );
-
-    let serverPid: number | undefined;
-    try {
-      await expect(
-        runAcpClientInteractive({ serverCommand: process.execPath, cwd: dir }),
-      ).rejects.toThrow(/ACP connection closed/);
-
-      serverPid = Number(await readFile(pidFile, "utf8"));
-      const deadline = Date.now() + 5_000;
-      let alive = true;
-      while (Date.now() < deadline && alive) {
-        try {
-          process.kill(serverPid, 0);
-        } catch {
-          alive = false;
-        }
-        if (alive) {
-          await new Promise((resolve) => setTimeout(resolve, 50));
-        }
-      }
-      expect(alive).toBe(false);
-    } finally {
-      if (serverPid !== undefined) {
-        try {
-          process.kill(serverPid, "SIGKILL");
-        } catch {
-          // already reaped
-        }
-      }
-    }
-  }, 20_000);
 });

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -1,5 +1,5 @@
 /** Tests ACP client permission handling, env sanitization, and spawn invocation resolution. */
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -47,6 +47,7 @@ import {
   resolvePermissionRequest,
   shouldStripProviderAuthEnvVarsForAcpServer,
 } from "./client-helpers.js";
+import { runAcpClientInteractive } from "./client.js";
 import {
   extractAttachmentsFromPrompt,
   extractTextFromPrompt,
@@ -1021,4 +1022,51 @@ describe("acp event mapper", () => {
       'exec: command: \\x1b[2K\\x1b[1A\\x1b[2K[permission] Allow "safe"? (y/N) \\nnext',
     );
   });
+});
+
+describe("runAcpClientInteractive", () => {
+  it("kills the spawned ACP server when the handshake fails", async () => {
+    const dir = await createTempDir();
+    const pidFile = path.join(dir, "server.pid");
+    // The client always prepends "acp" to the server args, so with
+    // serverCommand=node the spawned invocation is `node acp`: provide a fake
+    // entry that records its pid, breaks the handshake by closing stdout,
+    // then stays alive on a timer.
+    await writeFile(
+      path.join(dir, "acp"),
+      `require("fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));\n` +
+        `process.stdout.end("garbage-not-json\\n");\n` +
+        `setTimeout(() => {}, 300_000);\n`,
+    );
+
+    let serverPid: number | undefined;
+    try {
+      await expect(
+        runAcpClientInteractive({ serverCommand: process.execPath, cwd: dir }),
+      ).rejects.toThrow(/ACP connection closed/);
+
+      serverPid = Number(await readFile(pidFile, "utf8"));
+      const deadline = Date.now() + 5_000;
+      let alive = true;
+      while (Date.now() < deadline && alive) {
+        try {
+          process.kill(serverPid, 0);
+        } catch {
+          alive = false;
+        }
+        if (alive) {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+      }
+      expect(alive).toBe(false);
+    } finally {
+      if (serverPid !== undefined) {
+        try {
+          process.kill(serverPid, "SIGKILL");
+        } catch {
+          // already reaped
+        }
+      }
+    }
+  }, 20_000);
 });

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import * as readline from "node:readline";
 import { Readable, Writable } from "node:stream";
+import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import {
   ClientSideConnection,
@@ -14,6 +15,7 @@ import {
 } from "@agentclientprotocol/sdk";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
+import { killProcessTree, signalProcessTree } from "../process/kill-tree.js";
 import {
   buildAcpClientStripKeys,
   resolveAcpClientSpawnEnv,
@@ -35,6 +37,50 @@ type AcpClientHandle = {
   agent: ChildProcess;
   sessionId: string;
 };
+
+const ACP_SERVER_KILL_GRACE_MS = 1000;
+const ACP_SERVER_FORCE_KILL_TIMEOUT_MS = 1000;
+const ACP_SERVER_EXIT_POLL_MS = 25;
+
+function hasChildExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+async function waitForChildExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (!hasChildExited(child) && Date.now() < deadline) {
+    await delay(ACP_SERVER_EXIT_POLL_MS);
+  }
+  return hasChildExited(child);
+}
+
+async function terminateAcpServer(child: ChildProcess): Promise<void> {
+  if (hasChildExited(child)) {
+    return;
+  }
+
+  if (child.pid) {
+    // This child is not detached, so Unix cleanup must stay on its direct PID.
+    // Windows still reaps descendants; both paths escalate if SIGTERM is ignored.
+    killProcessTree(child.pid, {
+      detached: false,
+      graceMs: ACP_SERVER_KILL_GRACE_MS,
+    });
+  } else {
+    child.kill("SIGTERM");
+  }
+
+  if (await waitForChildExit(child, ACP_SERVER_KILL_GRACE_MS + ACP_SERVER_FORCE_KILL_TIMEOUT_MS)) {
+    return;
+  }
+
+  if (child.pid) {
+    signalProcessTree(child.pid, "SIGKILL", { detached: false });
+  } else {
+    child.kill("SIGKILL");
+  }
+  await waitForChildExit(child, ACP_SERVER_FORCE_KILL_TIMEOUT_MS);
+}
 
 function toArgs(value: string[] | string | undefined): string[] {
   if (!value) {
@@ -143,32 +189,32 @@ async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpClientHa
     windowsHide: spawnInvocation.windowsHide,
   });
 
-  if (!agent.stdin || !agent.stdout) {
-    throw new Error("Failed to create ACP stdio pipes");
-  }
-
   agent.on("error", (err) => {
     log(`agent error: ${String(err)}`);
   });
 
-  const input = Writable.toWeb(agent.stdin);
-  const output = Readable.toWeb(agent.stdout) as unknown as ReadableStream<Uint8Array>;
-  const stream = ndJsonStream(input, output);
-
-  const client = new ClientSideConnection(
-    () => ({
-      sessionUpdate: async (params: SessionNotification) => {
-        printSessionUpdate(params);
-      },
-      requestPermission: async (params: RequestPermissionRequest) => {
-        return resolvePermissionRequest(params, { cwd });
-      },
-    }),
-    stream,
-  );
-
-  log("initializing");
   try {
+    if (!agent.stdin || !agent.stdout) {
+      throw new Error("Failed to create ACP stdio pipes");
+    }
+
+    const input = Writable.toWeb(agent.stdin);
+    const output = Readable.toWeb(agent.stdout) as unknown as ReadableStream<Uint8Array>;
+    const stream = ndJsonStream(input, output);
+
+    const client = new ClientSideConnection(
+      () => ({
+        sessionUpdate: async (params: SessionNotification) => {
+          printSessionUpdate(params);
+        },
+        requestPermission: async (params: RequestPermissionRequest) => {
+          return resolvePermissionRequest(params, { cwd });
+        },
+      }),
+      stream,
+    );
+
+    log("initializing");
     await client.initialize({
       protocolVersion: PROTOCOL_VERSION,
       clientCapabilities: {
@@ -190,9 +236,7 @@ async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpClientHa
       sessionId: session.sessionId,
     };
   } catch (error) {
-    // Handshake failed: kill the spawned server so a hung or non-ACP
-    // process is not leaked when this function throws.
-    agent.kill();
+    await terminateAcpServer(agent);
     throw error;
   }
 }
@@ -219,7 +263,7 @@ export async function runAcpClientInteractive(opts: AcpClientOptions = {}): Prom
           return;
         }
         if (text === "exit" || text === "quit") {
-          agent.kill();
+          await terminateAcpServer(agent);
           rl.close();
           process.exit(0);
         }

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -168,26 +168,33 @@ async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpClientHa
   );
 
   log("initializing");
-  await client.initialize({
-    protocolVersion: PROTOCOL_VERSION,
-    clientCapabilities: {
-      fs: { readTextFile: true, writeTextFile: true },
-      terminal: true,
-    },
-    clientInfo: { name: "openclaw-acp-client", version: "1.0.0" },
-  });
+  try {
+    await client.initialize({
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+        terminal: true,
+      },
+      clientInfo: { name: "openclaw-acp-client", version: "1.0.0" },
+    });
 
-  log("creating session");
-  const session = await client.newSession({
-    cwd,
-    mcpServers: [],
-  });
+    log("creating session");
+    const session = await client.newSession({
+      cwd,
+      mcpServers: [],
+    });
 
-  return {
-    client,
-    agent,
-    sessionId: session.sessionId,
-  };
+    return {
+      client,
+      agent,
+      sessionId: session.sessionId,
+    };
+  } catch (error) {
+    // Handshake failed: kill the spawned server so a hung or non-ACP
+    // process is not leaked when this function throws.
+    agent.kill();
+    throw error;
+  }
 }
 
 /** Starts the terminal prompt loop for a local ACP client session. */


### PR DESCRIPTION
## Summary

`createAcpClient` now owns teardown of the ACP server from spawn until the live
handle is returned. If stdio setup, `initialize`, or `newSession` fails, the
client awaits bounded process cleanup and then rethrows the original error.

## What Problem This Solves

The ACP client spawned its server before building the stdio connection and
performing the protocol handshake, but only the later interactive prompt loop
owned process teardown. A rejection between spawn and successful handoff
therefore returned the handshake error while leaving a still-running server
behind.

The violated invariant is:

> Once the ACP server is spawned, every exit from `createAcpClient` must either
> return the live process handle or finish tearing that process down.

## Root Cause

The spawn-to-handoff lifecycle had no cleanup owner until the interactive
prompt loop started. Handshake rejection therefore escaped before any teardown
path became active.

## Canonical Repair

- Wrap the complete post-spawn setup and handshake in the lifecycle owner's
  `try`/`catch`.
- Await shared process-tree cleanup before rethrowing the original failure.
- Use the direct PID on Unix because the ACP child is not detached; use the
  shared Windows tree-kill path.
- Give cooperative servers a one-second TERM grace period, then escalate to
  KILL and wait for exit.
- Reuse the same awaited teardown for interactive `exit` and `quit`.

This replaces the previous one-shot `agent.kill()` policy. It does not add or
change config, protocol, SDK, storage, or public product surfaces.

## Dependency Contract

OpenClaw pins `@agentclientprotocol/sdk` 1.3.0. Its
`ClientSideConnection.initialize()` and `.newSession()` return JSON-RPC request
promises; error responses reject those promises with `RequestError`. The SDK
owns the protocol connection, not the spawned OS process, so cleanup belongs in
the OpenClaw spawn-to-handoff lifecycle.

## Evidence

`src/acp/client.process.test.ts` launches a real fake ACP server that:

1. completes `initialize`,
2. rejects `session/new` with a structured JSON-RPC error,
3. ignores TERM by remaining alive,
4. records TERM receipt on non-Windows platforms.

The test asserts that the original `RequestError` is preserved and the server
PID is already gone before the client rejection is observed. The TERM-file
assertion is Unix-only because Windows uses `taskkill`; PID reaping is the
portable contract.

## Validation

Exact head: `ec3907fcecb93c57fceefaafc451535de0036e71`

- Sanitized AWS proof: 57 ACP client unit tests passed.
- Sanitized AWS proof: the real resistant-process regression passed.
- Sanitized AWS proof: full `core, coreTests` changed gate passed, including
  formatting, max-lines, typechecks, lint, dependency and boundary guards,
  dead-code scans, database guards, and import-cycle checks.
- Exact-head GitHub CI: 79 successful, 0 failing, 0 pending:
  https://github.com/openclaw/openclaw/actions/runs/30742377564
- Exact-head autoreview: clean, patch correct with 0.98 confidence.
- Exact-head ClawSweeper: 4/6, sufficient proof, no actionable findings:
  https://github.com/openclaw/openclaw/pull/117901#issuecomment-5156479849

## Scope

- Production: +89 / -38 (`+51` net)
- Tests: +85 / -0

The positive production delta is the bounded, awaited cross-platform lifecycle
helper required to guarantee that failure paths do not outlive the CLI.
