### PR TITLE
fix: stop lost cancellations, false success, and stuck Codex compaction

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-cleanup.ts
+++ b/extensions/codex/src/app-server/run-attempt-cleanup.ts
@@ -89,7 +89,7 @@ export async function cleanupCodexAttempt(
     terminalState.turnSucceeded &&
     !isIncognitoSessionKey(params.sessionKey) &&
     params.cleanupBundleMcpOnRunEnd !== true &&
-    !params.contextEngine &&
+    !connection.activeContextEngine &&
     resourceState.thread.liveThreadConfigFingerprint !== undefined &&
     resourceState.thread.clientId === resolveCodexAppServerClientInstanceId(resourceState.client) &&
     resourceState.thread.preserveNativeModel !== true &&

--- a/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
@@ -198,7 +198,15 @@ describe("Codex app-server main thread cleanup", () => {
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
-  it("retains a subscribed persistent Codex thread after a completed turn", async () => {
+  it.each([
+    { label: "without a context engine", contextEngine: undefined },
+    {
+      label: "with the default legacy context engine",
+      contextEngine: {
+        info: { id: "legacy", name: "Legacy", version: "1.0.0" },
+      } as EmbeddedRunAttemptParams["contextEngine"],
+    },
+  ])("retains a subscribed persistent Codex thread $label", async ({ contextEngine }) => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const requests: Array<{ method: string; params: unknown }> = [];
@@ -227,10 +235,10 @@ describe("Codex app-server main thread cleanup", () => {
       } as never;
     });
 
-    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
-      bindingStore: testCodexAppServerBindingStore,
-      clientFactory,
-    });
+    const run = runCodexAppServerAttempt(
+      { ...createParams(sessionFile, workspaceDir), contextEngine },
+      { bindingStore: testCodexAppServerBindingStore, clientFactory },
+    );
     await vi.waitFor(() => expect(requests.map((entry) => entry.method)).toContain("turn/start"), {
       interval: 1,
       timeout: 5_000,

--- a/extensions/codex/src/app-server/turn-router.test.ts
+++ b/extensions/codex/src/app-server/turn-router.test.ts
@@ -935,16 +935,21 @@ describe("CodexAppServerTurnRouter", () => {
     expect(notificationHandler).not.toHaveBeenCalled();
     expect(requestHandler).not.toHaveBeenCalled();
 
-    let finishActiveRequest!: (result: { decision: string }) => void;
-    const activeResult = new Promise<{ decision: string }>((resolve) => {
-      finishActiveRequest = resolve;
-    });
-    let failActiveRequest!: (error: Error) => void;
-    const rejectedActiveResult = new Promise<{ decision: string }>((_resolve, reject) => {
-      failActiveRequest = reject;
-    });
-    const activeHandler = vi.fn((request: { id: number | string }) =>
-      request.id === "request-active-reject" ? rejectedActiveResult : activeResult,
+    const activeHandler = vi.fn(
+      (request: { id: number | string }, _scope: unknown, signal: AbortSignal) =>
+        new Promise<{ decision: string }>((resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              if (request.id === "request-active-reject") {
+                reject(new Error("stale request failure"));
+                return;
+              }
+              resolve({ decision: "accept" });
+            },
+            { once: true },
+          );
+        }),
     );
     const activeRoute = router.reserveThread({
       threadId: "thread-active",
@@ -952,29 +957,22 @@ describe("CodexAppServerTurnRouter", () => {
     });
     activeRoute.armTurn();
     await activeRoute.bindTurn("turn-active");
-    harness.send({
-      id: "request-active",
-      method: "item/commandExecution/requestApproval",
-      params: {
-        threadId: "thread-active",
-        turnId: "turn-active",
-        itemId: "item-2",
-      },
-    });
-    harness.send({
-      id: "request-active-reject",
-      method: "item/commandExecution/requestApproval",
-      params: {
-        threadId: "thread-active",
-        turnId: "turn-active",
-        itemId: "item-3",
-      },
-    });
+    for (const [id, itemId] of [
+      ["request-active", "item-2"],
+      ["request-active-reject", "item-3"],
+    ]) {
+      harness.send({
+        id,
+        method: "item/commandExecution/requestApproval",
+        params: { threadId: "thread-active", turnId: "turn-active", itemId },
+      });
+    }
     await vi.waitFor(() => expect(activeHandler).toHaveBeenCalledTimes(2));
+    const activeSignals = () => activeHandler.mock.calls.map((call) => call[2].aborted);
+    expect(activeSignals()).toEqual([false, false]);
 
     activeRoute.release();
-    finishActiveRequest({ decision: "accept" });
-    failActiveRequest(new Error("stale request failure"));
+    expect(activeSignals()).toEqual([true, true]);
 
     expect(await waitForResponse(harness, "request-active")).toEqual({
       id: "request-active",
@@ -987,12 +985,21 @@ describe("CodexAppServerTurnRouter", () => {
 
     const closingRoute = router.reserveThread({
       threadId: "thread-close",
-      onRequest: requestHandler,
+      onRequest: activeHandler,
     });
+    closingRoute.armTurn();
+    await closingRoute.bindTurn("turn-close");
+    harness.send({
+      id: "request-close",
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: "thread-close", turnId: "turn-close", itemId: "item-4" },
+    });
+    await vi.waitFor(() => expect(activeHandler).toHaveBeenCalledTimes(3));
     harness.process.stderr.write("fatal transport detail\n");
     harness.process.emit("exit", 17, "SIGTERM");
 
     await expect(closingRoute.bindTurn("turn-close")).rejects.toThrow("turn router closed");
+    expect(activeHandler.mock.calls[2]?.[2].aborted).toBe(true);
     expect(closingRoute.signal.aborted).toBe(true);
     expect(closingRoute.signal.reason).toEqual(
       new Error("codex app-server turn router closed", {

--- a/extensions/codex/src/app-server/turn-router.ts
+++ b/extensions/codex/src/app-server/turn-router.ts
@@ -389,13 +389,16 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
       return undefined;
     }
     const route = this.routes.get(scope.threadId);
-    if (!route || route.released) {
+    if (!route) {
       return undefined;
     }
-    if (!route.handlers && !(await waitForPromiseOrAbort(route.activated.promise, signal))) {
+    // A retired route owns its in-flight tools and approvals; upstream can
+    // cancel their callbacks before sending the terminal turn notification.
+    const requestSignal = AbortSignal.any([signal, route.controller.signal]);
+    if (!route.handlers && !(await waitForPromiseOrAbort(route.activated.promise, requestSignal))) {
       return undefined;
     }
-    if (signal.aborted || route.released || !route.handlers) {
+    if (requestSignal.aborted || !route.handlers) {
       return undefined;
     }
     const handler = route.handlers.onRequest;
@@ -406,25 +409,20 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     // new OpenClaw turn, whose requests must wait for its accepted turn id.
     while (route.gate === "armed") {
       const binding = route.binding?.promise;
-      if (!binding || !(await waitForPromiseOrAbort(binding, signal))) {
+      if (!binding || !(await waitForPromiseOrAbort(binding, requestSignal))) {
         return undefined;
       }
-      if (signal.aborted || route.released) {
-        return undefined;
-      }
-    }
-    if (route.gate === "bound") {
-      if (scope.turnId && scope.turnId !== route.turnId) {
-        return undefined;
-      }
-      if (route.released) {
+      if (requestSignal.aborted) {
         return undefined;
       }
     }
-    if (!(await waitForPromiseOrAbort(this.waitForNotifications(route), signal))) {
+    if (route.gate === "bound" && scope.turnId && scope.turnId !== route.turnId) {
       return undefined;
     }
-    if (signal.aborted || route.released) {
+    if (!(await waitForPromiseOrAbort(this.waitForNotifications(route), requestSignal))) {
+      return undefined;
+    }
+    if (requestSignal.aborted) {
       return undefined;
     }
     try {
@@ -434,11 +432,11 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
           threadId: scope.threadId,
           ...(scope.turnId ? { turnId: scope.turnId } : {}),
         },
-        signal,
+        requestSignal,
       );
-      return signal.aborted || route.released ? undefined : result;
+      return requestSignal.aborted ? undefined : result;
     } catch (error) {
-      if (signal.aborted || route.released) {
+      if (requestSignal.aborted) {
         return undefined;
       }
       throw error;

--- a/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts
@@ -102,15 +102,12 @@ export function convertAnthropicMessagesToResponsesInput(params: {
         continue;
       }
       if (block.type === "tool_result") {
-        const output = stringifyToolResultContent(block.content);
-        if (output.trim()) {
-          toolResultItems.push({
-            type: "function_call_output",
-            call_id: block.tool_use_id,
-            output,
-            ...(block.is_error === true ? { is_error: true } : {}),
-          });
-        }
+        toolResultItems.push({
+          type: "function_call_output",
+          call_id: block.tool_use_id,
+          output: stringifyToolResultContent(block.content),
+          ...(block.is_error === true ? { is_error: true } : {}),
+        });
         continue;
       }
       if (block.type === "tool_use") {

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts
@@ -126,116 +126,56 @@ function extractFunctionCallOutputText(item: ResponsesInputItem) {
   return stringifyFunctionCallOutput(item.output);
 }
 
-function extractFunctionCallOutputCallId(item: ResponsesInputItem) {
-  if (!isResponsesToolCallOutput(item)) {
-    return "";
+function findCurrentToolOutput(input: ResponsesInputItem[]): ResponsesInputItem | undefined {
+  const lastUserIndex = findLastUserIndex(input);
+  for (const item of input.slice(lastUserIndex + 1).toReversed()) {
+    if (isResponsesToolCallOutput(item)) {
+      return item;
+    }
   }
-  const record = item as {
-    call_id?: unknown;
-    tool_call_id?: unknown;
-    tool_use_id?: unknown;
-  };
+  for (const [candidateIndex, candidateItem] of Array.from(input.entries()).toReversed()) {
+    if (!isResponsesToolCallOutput(candidateItem)) {
+      continue;
+    }
+    const laterUserTexts = input
+      .slice(candidateIndex + 1)
+      .filter((laterItem) => laterItem.role === "user" && Array.isArray(laterItem.content))
+      .map((laterItem) => extractInputText(laterItem.content as unknown[]))
+      .filter(Boolean);
+    if (laterUserTexts.length > 0 && laterUserTexts.every(isContinuationUserText)) {
+      return candidateItem;
+    }
+  }
+  return undefined;
+}
+
+export function hasToolOutput(input: ResponsesInputItem[]) {
+  return findCurrentToolOutput(input) !== undefined;
+}
+
+export function extractToolOutput(input: ResponsesInputItem[]) {
+  const item = findCurrentToolOutput(input);
+  return item ? stringifyFunctionCallOutput(item.output) : "";
+}
+
+export function extractToolOutputStructuredError(input: ResponsesInputItem[]) {
+  const item = findCurrentToolOutput(input);
+  return item?.is_error === true || item?.isError === true;
+}
+
+export function extractToolOutputCallId(input: ResponsesInputItem[]) {
+  const item = findCurrentToolOutput(input);
   return (
-    [record.call_id, record.tool_call_id, record.tool_use_id].find(
+    [item?.call_id, item?.tool_call_id, item?.tool_use_id].find(
       (value): value is string => typeof value === "string" && value.trim().length > 0,
     ) ?? ""
   );
 }
 
-function functionCallOutputIsStructuredError(item: ResponsesInputItem) {
-  if (!isResponsesToolCallOutput(item)) {
-    return false;
-  }
-  return item.is_error === true || item.isError === true;
-}
-
-export function extractToolOutput(input: ResponsesInputItem[]) {
-  const lastUserIndex = findLastUserIndex(input);
-  for (const item of input.slice(lastUserIndex + 1).toReversed()) {
-    const output = extractFunctionCallOutputText(item);
-    if (output) {
-      return output;
-    }
-  }
-  for (const [candidateIndex, candidateItem] of Array.from(input.entries()).toReversed()) {
-    const output = extractFunctionCallOutputText(candidateItem);
-    if (output) {
-      const laterUserTexts = input
-        .slice(candidateIndex + 1)
-        .filter((laterItem) => laterItem.role === "user" && Array.isArray(laterItem.content))
-        .map((laterItem) => extractInputText(laterItem.content as unknown[]))
-        .filter(Boolean);
-      if (
-        laterUserTexts.length > 0 &&
-        laterUserTexts.every((text) => isContinuationUserText(text))
-      ) {
-        return output;
-      }
-      continue;
-    }
-  }
-  return "";
-}
-
-export function extractToolOutputStructuredError(input: ResponsesInputItem[]) {
-  const lastUserIndex = findLastUserIndex(input);
-  for (const item of input.slice(lastUserIndex + 1).toReversed()) {
-    const output = extractFunctionCallOutputText(item);
-    if (output) {
-      return functionCallOutputIsStructuredError(item);
-    }
-  }
-  for (const [candidateIndex, candidateItem] of Array.from(input.entries()).toReversed()) {
-    const output = extractFunctionCallOutputText(candidateItem);
-    if (output) {
-      const laterUserTexts = input
-        .slice(candidateIndex + 1)
-        .filter((laterItem) => laterItem.role === "user" && Array.isArray(laterItem.content))
-        .map((laterItem) => extractInputText(laterItem.content as unknown[]))
-        .filter(Boolean);
-      if (
-        laterUserTexts.length > 0 &&
-        laterUserTexts.every((text) => isContinuationUserText(text))
-      ) {
-        return functionCallOutputIsStructuredError(candidateItem);
-      }
-    }
-  }
-  return false;
-}
-
-export function extractToolOutputCallId(input: ResponsesInputItem[]) {
-  const lastUserIndex = findLastUserIndex(input);
-  for (const item of input.slice(lastUserIndex + 1).toReversed()) {
-    const output = extractFunctionCallOutputText(item);
-    if (output) {
-      return extractFunctionCallOutputCallId(item);
-    }
-  }
-  for (const [candidateIndex, candidateItem] of Array.from(input.entries()).toReversed()) {
-    const output = extractFunctionCallOutputText(candidateItem);
-    if (output) {
-      const laterUserTexts = input
-        .slice(candidateIndex + 1)
-        .filter((laterItem) => laterItem.role === "user" && Array.isArray(laterItem.content))
-        .map((laterItem) => extractInputText(laterItem.content as unknown[]))
-        .filter(Boolean);
-      if (
-        laterUserTexts.length > 0 &&
-        laterUserTexts.every((text) => isContinuationUserText(text))
-      ) {
-        return extractFunctionCallOutputCallId(candidateItem);
-      }
-    }
-  }
-  return "";
-}
-
 export function extractLatestToolOutput(input: ResponsesInputItem[]) {
   for (const item of input.toReversed()) {
-    const output = extractFunctionCallOutputText(item);
-    if (output) {
-      return output;
+    if (isResponsesToolCallOutput(item)) {
+      return stringifyFunctionCallOutput(item.output);
     }
   }
   return "";
@@ -249,9 +189,7 @@ export function extractAllToolOutputText(input: ResponsesInputItem[]) {
 }
 
 export function extractUserTextAfterLatestToolOutput(input: ResponsesInputItem[]) {
-  const latestToolOutputIndex = input.findLastIndex((item) =>
-    Boolean(extractFunctionCallOutputText(item)),
-  );
+  const latestToolOutputIndex = input.findLastIndex(isResponsesToolCallOutput);
   if (latestToolOutputIndex < 0) {
     return "";
   }

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.test.ts
@@ -157,6 +157,37 @@ describe("QA mock OpenAI Responses WebSocket", () => {
     });
   });
 
+  it("preserves empty tool-result identity without replaying a native patch", async () => {
+    const server = await startServer();
+    const socket = await connectResponsesWebSocket(server.baseUrl);
+    const prompt =
+      "tool search qa check target=apply_patch. Call apply_patch exactly once and then summarize.";
+    const initial = readCompletedResponse(
+      await collectResponseEvents(socket, {
+        type: "response.create",
+        tools: [{ type: "custom", name: "apply_patch" }],
+        input: [{ role: "user", content: [{ type: "input_text", text: prompt }] }],
+      }),
+    );
+    const call = (initial.output as Array<Record<string, unknown>>)[0];
+    expect(call).toMatchObject({ type: "custom_tool_call", name: "apply_patch" });
+
+    const completed = readCompletedResponse(
+      await collectResponseEvents(socket, {
+        type: "response.create",
+        previous_response_id: initial.id,
+        input: [{ type: "custom_tool_call_output", call_id: call?.call_id, output: "" }],
+      }),
+    );
+
+    expect(completed.output).toEqual([expect.objectContaining({ type: "message" })]);
+    const debug = (await fetch(`${server.baseUrl}/debug/last-request`).then((response) =>
+      response.json(),
+    )) as Record<string, unknown>;
+    expect(debug).toMatchObject({ toolOutput: "", toolOutputCallId: call?.call_id });
+    expect(debug).not.toHaveProperty("plannedToolName");
+  });
+
   it("rejects a response ID after a newer response replaces the connection cache", async () => {
     const server = await startServer();
     const socket = await connectResponsesWebSocket(server.baseUrl);

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -4588,6 +4588,38 @@ describe("qa mock openai server", () => {
       expectedOutput: "Successfully applied structured patch",
       structuredError: false,
     },
+    {
+      label: "empty native patch output",
+      prompt:
+        "tool search qa check target=apply_patch. Call apply_patch exactly once and then summarize.",
+      output: "",
+      expectedOutput: "",
+      structuredError: false,
+    },
+    {
+      label: "empty structured native patch output",
+      prompt:
+        "tool search qa check target=apply_patch. Call apply_patch exactly once and then summarize.",
+      output: [],
+      expectedOutput: "",
+      structuredError: false,
+    },
+    {
+      label: "non-text native patch output",
+      prompt:
+        "tool search qa check target=apply_patch. Call apply_patch exactly once and then summarize.",
+      output: [{ type: "input_image", image_url: "data:image/png;base64,AA==" }],
+      expectedOutput: "",
+      structuredError: false,
+    },
+    {
+      label: "empty failed native patch output",
+      prompt:
+        "tool search qa failure target=apply_patch. Exercise the denied-input path once and then summarize.",
+      output: "",
+      expectedOutput: "",
+      structuredError: true,
+    },
   ])("links and completes $label custom-tool outputs", async (testCase) => {
     const server = await startMockServer();
     const planResponse = await postNonStreamingResponses(server, {
@@ -4624,6 +4656,33 @@ describe("qa mock openai server", () => {
     }
     expect(debug).not.toHaveProperty("plannedToolName");
   });
+
+  it.each([false, true])(
+    "does not replay an empty function-tool result when stream=%s",
+    async (stream) => {
+      const server = await startMockServer();
+      const response = await postResponses(server, {
+        stream,
+        input: [
+          makeUserInput(
+            "tool search qa check target=apply_patch. Call apply_patch exactly once and then summarize.",
+          ),
+          makeToolOutputWithCallId("call_empty_patch", ""),
+        ],
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      expect(body).toContain('"type":"message"');
+      expect(body).not.toContain('"type":"function_call"');
+      const debug = requireRecord(
+        await fetch(`${server.baseUrl}/debug/last-request`).then((result) => result.json()),
+        "empty function-tool debug request",
+      );
+      expect(debug).toMatchObject({ toolOutput: "", toolOutputCallId: "call_empty_patch" });
+      expect(debug).not.toHaveProperty("plannedToolName");
+    },
+  );
 
   it("plans Codex Responses Lite handoff from declared developer additional tools", async () => {
     const server = await startMockServer();
@@ -5883,6 +5942,54 @@ describe("qa mock openai server", () => {
     };
     expect(debug.toolOutputCallId).toBe("toolu_mock_read_error");
     expect(debug.toolOutputStructuredError).toBe(true);
+  });
+
+  it.each([
+    { label: "empty", content: "", isError: false },
+    { label: "whitespace", content: "  ", isError: false },
+    { label: "empty failed", content: [], isError: true },
+  ])("preserves $label Anthropic tool results without replay", async ({ content, isError }) => {
+    const server = await startMockServer();
+    const callId = "toolu_empty_patch";
+    const response = await postJson(server, "/v1/messages", {
+      model: "claude-opus-4-8",
+      max_tokens: 256,
+      tools: [{ name: "apply_patch", input_schema: { type: "object", properties: {} } }],
+      messages: [
+        makeAnthropicUserText(
+          "tool search qa check target=apply_patch. Call apply_patch exactly once and then summarize.",
+        ),
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: callId, name: "apply_patch", input: {} }],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: callId,
+              content,
+              ...(isError ? { is_error: true } : {}),
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    const body = requireRecord(await response.json(), "Anthropic empty tool completion");
+    expect(body.stop_reason).toBe("end_turn");
+    expect(requireArray(body.content, "Anthropic response content")).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "tool_use" })]),
+    );
+    const debug = requireRecord(
+      await fetch(`${server.baseUrl}/debug/last-request`).then((result) => result.json()),
+      "Anthropic empty tool debug request",
+    );
+    expect(debug.toolOutputCallId).toBe(callId);
+    expect(debug.toolOutputStructuredError ?? false).toBe(isError);
+    expect(debug).not.toHaveProperty("plannedToolName");
   });
 
   it("replays one signed Anthropic thinking error for each independent scenario", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -124,6 +124,7 @@ import {
 import {
   extractLastUserText,
   extractLastMatchingUserTurn,
+  hasToolOutput,
   extractToolOutput,
   extractToolOutputStructuredError,
   extractToolOutputCallId,
@@ -464,6 +465,7 @@ async function buildResponsesPayload(
   const input = Array.isArray(body.input) ? (body.input as ResponsesInputItem[]) : [];
   const toolDeclarationBody = resolveCurrentToolDeclarationSurface(body, input);
   const prompt = extractLastUserText(input);
+  const hasCompletedToolOutput = hasToolOutput(input);
   const rawToolOutput = extractToolOutput(input);
   const codeModeControlJson = isCodeModeControlToolOutput(toolDeclarationBody, input)
     ? parseToolOutputJson(rawToolOutput)
@@ -555,7 +557,7 @@ async function buildResponsesPayload(
     return command ? buildToolCallEventsWithArgs("exec", { command }) : null;
   };
   if (QA_TOOL_LOOP_GLOBAL_BREAKER_PROMPT_RE.test(allInputText)) {
-    if (!toolOutput) {
+    if (!hasCompletedToolOutput) {
       scenarioState.toolLoopReadAttempts = 0;
     }
     if (/global circuit breaker/i.test(toolOutput)) {
@@ -570,7 +572,7 @@ async function buildResponsesPayload(
   if (
     (QA_TOOL_SEARCH_PROMPT_RE.test(allInputText) ||
       QA_TOOL_SEARCH_FAILURE_PROMPT_RE.test(allInputText)) &&
-    !toolOutput
+    !hasCompletedToolOutput
   ) {
     const targetTool = extractToolSearchTarget(allInputText);
     const plannedArgs = targetTool
@@ -617,7 +619,7 @@ async function buildResponsesPayload(
     ) {
       return buildToolCallEventsWithArgs("wait", { runId: toolJson.runId });
     }
-    if (!toolOutput && hasDeclaredTool(body, "exec")) {
+    if (!hasCompletedToolOutput && hasDeclaredTool(body, "exec")) {
       return buildToolCallEventsWithArgs("exec", {
         language: "javascript",
         restartSafe: true,
@@ -634,7 +636,7 @@ async function buildResponsesPayload(
     QA_MCP_CODE_MODE_API_FILE_PROMPT_RE.test(allInputText) ||
     QA_MCP_CODE_MODE_PROMPT_RE.test(allInputText)
   ) {
-    if (!toolOutput && hasDeclaredTool(body, "exec")) {
+    if (!hasCompletedToolOutput && hasDeclaredTool(body, "exec")) {
       const useApiFiles = QA_MCP_CODE_MODE_API_FILE_PROMPT_RE.test(allInputText);
       return buildToolCallEventsWithArgs("exec", {
         language: "javascript",
@@ -706,7 +708,7 @@ async function buildResponsesPayload(
     return buildAssistantEvents("");
   }
   if (QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE.test(allInputText)) {
-    if (!toolOutput && canCallSessionsSpawn) {
+    if (!hasCompletedToolOutput && canCallSessionsSpawn) {
       return buildToolCallEventsWithArgs("sessions_spawn", {
         task: `Subagent direct fallback worker: finish with exactly ${QA_SUBAGENT_DIRECT_FALLBACK_MARKER}.`,
         label: "qa-direct-fallback-worker",
@@ -714,7 +716,7 @@ async function buildResponsesPayload(
         mode: "run",
       });
     }
-    if (toolOutput && canCallSessionsYield && !/\byielded\b/i.test(toolOutput)) {
+    if (hasCompletedToolOutput && canCallSessionsYield && !/\byielded\b/i.test(toolOutput)) {
       return buildToolCallEventsWithArgs("sessions_yield", {
         message: `Waiting for ${QA_SUBAGENT_DIRECT_FALLBACK_MARKER}.`,
       });
@@ -729,7 +731,7 @@ async function buildResponsesPayload(
         exactMarkerDirective ?? exactReplyDirective ?? "TELEGRAM-EMPTY-WRITE-RECOVERED-OK",
       );
     }
-    if (!toolOutput) {
+    if (!hasCompletedToolOutput) {
       return buildToolCallEventsWithArgs("write", {
         path: "qa-empty-response-side-effect.txt",
         content: "side effect completed once\n",
@@ -799,7 +801,7 @@ async function buildResponsesPayload(
     return buildAssistantEvents("THINKING-OFF-OK");
   }
   if (QA_EMPTY_RESPONSE_RECOVERY_PROMPT_RE.test(allInputText)) {
-    if (!toolOutput) {
+    if (!hasCompletedToolOutput) {
       return buildToolCallEventsWithArgs("read", { path: "QA_KICKOFF_TASK.md" });
     }
     if (!hasEmptyResponseRetryInstruction) {
@@ -808,7 +810,7 @@ async function buildResponsesPayload(
     return buildAssistantEvents("EMPTY-RECOVERED-OK");
   }
   if (QA_EMPTY_RESPONSE_EXHAUSTION_PROMPT_RE.test(allInputText)) {
-    if (!toolOutput) {
+    if (!hasCompletedToolOutput) {
       return buildToolCallEventsWithArgs("read", { path: "QA_KICKOFF_TASK.md" });
     }
     return buildAssistantEvents("");
@@ -873,7 +875,7 @@ async function buildResponsesPayload(
   }
   const slackChartMatch = QA_SLACK_CHART_PRESENTATION_PROMPT_RE.exec(allInputText);
   if (slackChartMatch?.[1] && slackChartMatch[2]) {
-    if (!toolOutput && hasDeclaredTool(body, "message")) {
+    if (!hasCompletedToolOutput && hasDeclaredTool(body, "message")) {
       return buildToolCallEventsWithArgs("message", {
         action: "send",
         message: slackChartMatch[1],
@@ -892,24 +894,24 @@ async function buildResponsesPayload(
         },
       });
     }
-    if (toolOutput) {
+    if (hasCompletedToolOutput) {
       return buildAssistantEvents(slackChartMatch[2]);
     }
   }
   if (QA_WHATSAPP_AGENT_MESSAGE_ACTION_REACT_PROMPT_RE.test(allInputText)) {
-    if (!toolOutput && hasDeclaredTool(body, "message")) {
+    if (!hasCompletedToolOutput && hasDeclaredTool(body, "message")) {
       return buildToolCallEventsWithArgs("message", {
         action: "react",
         emoji: "👍",
       });
     }
-    if (toolOutput) {
+    if (hasCompletedToolOutput) {
       return buildAssistantEvents("");
     }
   }
   const whatsAppUploadMatch = QA_WHATSAPP_AGENT_MESSAGE_ACTION_UPLOAD_PROMPT_RE.exec(allInputText);
   if (whatsAppUploadMatch?.[1]) {
-    if (!toolOutput && hasDeclaredTool(body, "message")) {
+    if (!hasCompletedToolOutput && hasDeclaredTool(body, "message")) {
       return buildToolCallEventsWithArgs("message", {
         action: "upload-file",
         buffer: TINY_PNG_BASE64,
@@ -918,7 +920,7 @@ async function buildResponsesPayload(
         filename: "whatsapp-qa-agent-upload.png",
       });
     }
-    if (toolOutput) {
+    if (hasCompletedToolOutput) {
       return buildAssistantEvents("");
     }
   }
@@ -983,7 +985,7 @@ async function buildResponsesPayload(
     }
   }
   if (QA_BLOCK_STREAMING_PROMPT_RE.test(scenarioFamilyPrompt) && blockStreamingMarkers) {
-    if (!toolOutput) {
+    if (!hasCompletedToolOutput) {
       return buildAssistantThenToolCallEvents(
         {
           id: "msg_mock_block_1",
@@ -1011,7 +1013,7 @@ async function buildResponsesPayload(
   }
   if (QA_STRANDED_FINAL_RECOVERY_PROMPT_RE.test(allInputText)) {
     if (QA_STRANDED_FINAL_RETRY_PROMPT_RE.test(allInputText)) {
-      if (!toolOutput && hasDeclaredTool(body, "message")) {
+      if (!hasCompletedToolOutput && hasDeclaredTool(body, "message")) {
         return buildToolCallEventsWithArgs("message", {
           action: "send",
           message: buildStrandedFinalRecoveryText(),
@@ -1022,7 +1024,7 @@ async function buildResponsesPayload(
     return buildAssistantEvents(buildStrandedFinalRecoveryText());
   }
   if (QA_A2A_MESSAGE_TOOL_MIRROR_PROMPT_RE.test(prompt)) {
-    if (toolOutput) {
+    if (hasCompletedToolOutput) {
       return buildAssistantEvents("");
     }
     const sessionsSendArgs = buildQaA2aMessageToolMirrorSessionsSendArgs(prompt);
@@ -1032,7 +1034,7 @@ async function buildResponsesPayload(
   }
   if (QA_GROUP_VISIBLE_REPLY_TOOL_PROMPT_RE.test(allInputText)) {
     const marker = exactMarkerDirective ?? exactReplyDirective ?? "QA-GROUP-TOOL-OK";
-    if (!toolOutput && hasDeclaredTool(body, "message")) {
+    if (!hasCompletedToolOutput && hasDeclaredTool(body, "message")) {
       return buildToolCallEventsWithArgs("message", {
         action: "send",
         message: marker,
@@ -1043,7 +1045,7 @@ async function buildResponsesPayload(
   if (QA_MSTEAMS_THREAD_DEDUPE_PROMPT_RE.test(allInputText)) {
     const marker = exactMarkerDirective ?? exactReplyDirective ?? "QA-MSTEAMS-THREAD-DEDUPE-OK";
     const target = /msteams message target:\s*`([^`]+)`/iu.exec(prompt)?.[1]?.trim();
-    if (!toolOutput && hasDeclaredTool(body, "message")) {
+    if (!hasCompletedToolOutput && hasDeclaredTool(body, "message")) {
       return buildToolCallEventsWithArgs("message", {
         action: "send",
         message: marker,
@@ -1088,9 +1090,9 @@ async function buildResponsesPayload(
   }
   const isTelegramCurrentSessionStatusTurn =
     QA_TELEGRAM_CURRENT_SESSION_STATUS_PROMPT_RE.test(prompt) ||
-    (Boolean(toolOutput) && QA_TELEGRAM_CURRENT_SESSION_STATUS_PROMPT_RE.test(allInputText));
+    (hasCompletedToolOutput && QA_TELEGRAM_CURRENT_SESSION_STATUS_PROMPT_RE.test(allInputText));
   if (isTelegramCurrentSessionStatusTurn) {
-    if (!toolOutput && hasDeclaredTool(body, "session_status")) {
+    if (!hasCompletedToolOutput && hasDeclaredTool(body, "session_status")) {
       return buildToolCallEventsWithArgs("session_status", { sessionKey: "current" });
     }
     const sessionKey = extractSessionStatusSessionKey(toolJson, toolOutput);
@@ -1127,7 +1129,7 @@ async function buildResponsesPayload(
       }),
     );
   }
-  if (QA_SKILL_WORKSHOP_GIF_PROMPT_RE.test(prompt) && !toolOutput) {
+  if (QA_SKILL_WORKSHOP_GIF_PROMPT_RE.test(prompt) && !hasCompletedToolOutput) {
     return buildToolCallEventsWithArgs("write", {
       path: "animated-gif-qa-checklist.md",
       content: [
@@ -1142,7 +1144,7 @@ async function buildResponsesPayload(
     });
   }
   if (QA_RELEASE_AUDIT_PROMPT_RE.test(prompt)) {
-    if (!toolOutput) {
+    if (!hasCompletedToolOutput) {
       return buildToolCallEventsWithArgs("read", { path: "audit-fixture/README.md" });
     }
     if (/Release readiness task|current checklist/i.test(toolOutput)) {
@@ -1289,7 +1291,7 @@ async function buildResponsesPayload(
     }
   }
   if (/lobster invaders/i.test(prompt)) {
-    if (!toolOutput) {
+    if (!hasCompletedToolOutput) {
       return buildToolCallEventsWithArgs("read", { path: "QA_KICKOFF_TASK.md" });
     }
     if (toolOutput.includes("QA mission") || toolOutput.includes("Testing")) {
@@ -1308,7 +1310,7 @@ async function buildResponsesPayload(
     /compaction retry evidence/i.test(toolOutput) ||
     /compaction-retry-summary\.txt/i.test(toolOutput)
   ) {
-    if (!toolOutput) {
+    if (!hasCompletedToolOutput) {
       return buildToolCallEventsWithArgs("read", { path: "COMPACTION_RETRY_CONTEXT.md" });
     }
     if (toolOutput.includes("compaction retry evidence")) {
@@ -1344,7 +1346,7 @@ async function buildResponsesPayload(
     }
   }
   if (isActiveMemorySubagentPrompt(allInputText) && isSnackRecallPrompt(allInputText)) {
-    if (!toolOutput) {
+    if (!hasCompletedToolOutput) {
       if (!hasDeclaredTool(body, "memory_recall")) {
         return buildToolCallEventsWithArgs("memory_search", {
           query: "QA movie night snack lemon pepper wings blue cheese",
@@ -1506,7 +1508,7 @@ async function buildResponsesPayload(
   }
   if (
     QA_IMAGE_GENERATION_PROMPT_RE.test(allInputText) &&
-    !toolOutput &&
+    !hasCompletedToolOutput &&
     (hasToolDefinition(body, "image_generate") || hasCodeModeExecSurface(body))
   ) {
     return buildToolCallEventsWithArgs("image_generate", {
@@ -1535,7 +1537,11 @@ async function buildResponsesPayload(
   const fanoutRequiresMessageTool =
     fanoutHasPrivateSourceReply &&
     (hasToolDefinition(toolDeclarationBody, "message") || hasCallableCodeMode);
-  if (scenarioState.subagentFanoutPhase === 3 && fanoutRequiresMessageTool && toolOutput) {
+  if (
+    scenarioState.subagentFanoutPhase === 3 &&
+    fanoutRequiresMessageTool &&
+    hasCompletedToolOutput
+  ) {
     return buildAssistantEvents("");
   }
   const completeSubagentFanout = () => {
@@ -1550,7 +1556,7 @@ async function buildResponsesPayload(
       : buildAssistantEvents(message);
   };
   if (
-    !toolOutput &&
+    !hasCompletedToolOutput &&
     /subagent fanout synthesis check/i.test(prompt) &&
     scenarioState.subagentFanoutPhase !== 0
   ) {
@@ -1562,7 +1568,7 @@ async function buildResponsesPayload(
     return buildAssistantEvents("subagent-1: ok\nsubagent-2: ok");
   }
   if (canCallSessionsSpawn && isSubagentFanoutPrompt) {
-    if (!toolOutput && scenarioState.subagentFanoutPhase === 0) {
+    if (!hasCompletedToolOutput && scenarioState.subagentFanoutPhase === 0) {
       scenarioState.subagentFanoutPhase = 1;
       return buildToolCallEventsWithArgs("sessions_spawn", {
         task: subagentFanoutTaskForProvider(providerVariant, "alpha"),
@@ -1570,7 +1576,7 @@ async function buildResponsesPayload(
         thread: false,
       });
     }
-    if (toolOutput && scenarioState.subagentFanoutPhase === 1) {
+    if (hasCompletedToolOutput && scenarioState.subagentFanoutPhase === 1) {
       scenarioState.subagentFanoutPhase = 2;
       return buildToolCallEventsWithArgs("sessions_spawn", {
         task: subagentFanoutTaskForProvider(providerVariant, "beta"),
@@ -1604,15 +1610,19 @@ async function buildResponsesPayload(
       // workers settle instead of advancing past the sole visible reply.
       return buildAssistantEvents("");
     }
-    if (toolOutput) {
+    if (hasCompletedToolOutput) {
       return completeSubagentFanout();
     }
   }
   const explicitSessionsSpawnArgs = buildExplicitSessionsSpawnArgs(prompt);
-  if (explicitSessionsSpawnArgs && canCallSessionsSpawn && !toolOutput) {
+  if (explicitSessionsSpawnArgs && canCallSessionsSpawn && !hasCompletedToolOutput) {
     return buildToolCallEventsWithArgs("sessions_spawn", explicitSessionsSpawnArgs);
   }
-  if (canCallSessionsSpawn && /forked subagent context qa check/i.test(prompt) && !toolOutput) {
+  if (
+    canCallSessionsSpawn &&
+    /forked subagent context qa check/i.test(prompt) &&
+    !hasCompletedToolOutput
+  ) {
     return buildToolCallEventsWithArgs("sessions_spawn", {
       task: "Report the visible code from the requester transcript.",
       label: "qa-fork-context",
@@ -1620,7 +1630,7 @@ async function buildResponsesPayload(
       context: "fork",
     });
   }
-  if (/tool continuity check/i.test(prompt) && !toolOutput) {
+  if (/tool continuity check/i.test(prompt) && !hasCompletedToolOutput) {
     return buildToolCallEventsWithArgs("read", { path: "QA_KICKOFF_TASK.md" });
   }
   if (/repo contract followthrough check/i.test(allInputText)) {
@@ -1710,7 +1720,7 @@ async function buildResponsesPayload(
     canCallSessionsSpawn &&
     (/delegate (?:one |a )bounded qa task/i.test(allInputText) ||
       /subagent handoff/i.test(allInputText)) &&
-    !toolOutput &&
+    !hasCompletedToolOutput &&
     !scenarioState.subagentHandoffSpawned
   ) {
     scenarioState.subagentHandoffSpawned = true;
@@ -1722,22 +1732,22 @@ async function buildResponsesPayload(
   }
   if (
     /(worked, failed, blocked|worked\/failed\/blocked|source and docs)/i.test(prompt) &&
-    !toolOutput
+    !hasCompletedToolOutput
   ) {
     return buildToolCallEventsWithArgs("read", {
       path: sourceDiscoveryReadPathForProvider(providerVariant),
     });
   }
-  if (!toolOutput && /\b(read|inspect|repo|docs|scenario|kickoff)\b/i.test(prompt)) {
+  if (!hasCompletedToolOutput && /\b(read|inspect|repo|docs|scenario|kickoff)\b/i.test(prompt)) {
     return buildToolCallEvents(prompt);
   }
-  if (/visible skill marker/i.test(prompt) && !toolOutput) {
+  if (/visible skill marker/i.test(prompt) && !hasCompletedToolOutput) {
     return buildAssistantEvents("VISIBLE-SKILL-OK");
   }
-  if (/hot install marker/i.test(prompt) && !toolOutput) {
+  if (/hot install marker/i.test(prompt) && !hasCompletedToolOutput) {
     return buildAssistantEvents("HOT-INSTALL-OK");
   }
-  if (isGroupChat && isBaselineUnmentionedChannelChatter && !toolOutput) {
+  if (isGroupChat && isBaselineUnmentionedChannelChatter && !hasCompletedToolOutput) {
     return buildAssistantEvents("NO_REPLY");
   }
   if (QA_NATIVE_STOP_DELAY_PROMPT_RE.test(prompt)) {
@@ -1819,7 +1829,7 @@ export async function startQaMockOpenAiServer(params?: {
     });
     return {
       events,
-      ...(QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE.test(allInputText) && extractToolOutput(input)
+      ...(QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE.test(allInputText) && hasToolOutput(input)
         ? {
             failure: {
               status: 503,

--- a/qa/scenarios/channels/group-visible-reply-tool.yaml
+++ b/qa/scenarios/channels/group-visible-reply-tool.yaml
@@ -48,9 +48,12 @@ flow:
             - ref: env
             - 60000
         - call: reset
+        - set: delivery
+          value:
+            expr: "transport.buildAgentDelivery({ target: `group:${config.conversationId}` })"
         - set: sessionKey
           value:
-            expr: "buildAgentSessionKey({ agentId: 'qa', channel: 'qa-channel', accountId: 'default', peer: { kind: 'group', id: `group:${config.conversationId}` }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
+            expr: "buildAgentSessionKey({ agentId: 'qa', channel: delivery.channel, accountId: transport.accountId, peer: { kind: 'group', id: delivery.replyTo }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
         - set: requestCursorBefore
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"

--- a/qa/scenarios/channels/group-visible-reply-tool.yaml
+++ b/qa/scenarios/channels/group-visible-reply-tool.yaml
@@ -18,6 +18,7 @@ scenario:
     - Agent receives a synthetic shared-room turn.
     - Mock provider calls the shared message tool instead of relying on final-answer delivery.
     - The visible reply lands once in the same group transcript.
+    - The source turn settles with a durably recorded successful message-tool result.
   docsRefs:
     - docs/channels/groups.md
     - docs/channels/qa-channel.md
@@ -47,6 +48,9 @@ flow:
             - ref: env
             - 60000
         - call: reset
+        - set: sessionKey
+          value:
+            expr: "buildAgentSessionKey({ agentId: 'qa', channel: 'qa-channel', accountId: 'default', peer: { kind: 'group', id: `group:${config.conversationId}` }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
         - set: requestCursorBefore
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
@@ -82,6 +86,21 @@ flow:
                 params: [candidate]
                 expr: "candidate.conversation.id === config.conversationId && candidate.conversation.kind === 'group' && !candidate.threadId && candidate.text.includes(config.expectedMarker)"
             - expr: liveTurnTimeoutMs(env, 180000)
+        - call: waitForCondition
+          args:
+            - lambda:
+                async: true
+                expr: "env.gateway.call('sessions.list', {}, { timeoutMs: 30000 }).then((result) => result.sessions?.find((session) => session.key === sessionKey && session.hasActiveRun === false))"
+            - expr: liveTurnTimeoutMs(env, 180000)
+            - 100
+        - call: readSessionTranscriptSummary
+          saveAs: transcriptSummary
+          args:
+            - ref: env
+            - ref: sessionKey
+        - assert:
+            expr: "transcriptSummary.successfulToolCallCounts.message === 1"
+            message: visible group reply did not persist exactly one successful message-tool result
         - set: matchingOutbound
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && message.conversation.kind === 'group' && String(message.text ?? '').includes(config.expectedMarker))"

--- a/src/agents/embedded-agent-runner/stream-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.test.ts
@@ -19,6 +19,11 @@ import {
 const streamMocks = vi.hoisted(() => ({
   delegate: undefined as StreamFn | undefined,
   streamSimple: vi.fn(),
+  anthropicVertex: vi.fn(),
+}));
+
+vi.mock("../anthropic-vertex-stream.js", () => ({
+  createAnthropicVertexStreamFnForModel: streamMocks.anthropicVertex,
 }));
 
 vi.mock("../../llm/stream.js", async (importOriginal) => {
@@ -89,6 +94,7 @@ async function expectStreamResultRecord(
 
 afterEach(() => {
   streamMocks.streamSimple.mockReset();
+  streamMocks.anthropicVertex.mockReset();
   if (streamMocks.delegate) {
     streamMocks.streamSimple.mockImplementation(streamMocks.delegate);
   }
@@ -646,6 +652,64 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     );
     expect(result.sessionId).toBe("run-session");
     expect(result.promptCacheKey).toBe("cron-cache-key");
+  });
+
+  it.each(["custom", "anthropic-vertex"] as const)(
+    "preserves %s stream identity without cache or run cancellation",
+    (provider) => {
+      const currentStreamFn = vi.fn(async (_model, _context, options) => options);
+      if (provider === "anthropic-vertex") {
+        streamMocks.anthropicVertex.mockReturnValueOnce(currentStreamFn);
+      }
+      const streamFn = resolveEmbeddedAgentStreamFn({
+        currentStreamFn: currentStreamFn as never,
+        sessionId: "session-1",
+        model: {
+          api: provider === "anthropic-vertex" ? "anthropic-messages" : "custom-api",
+          provider,
+          id: "custom-model",
+        } as never,
+      });
+
+      expect(streamFn).toBe(currentStreamFn);
+    },
+  );
+
+  it.each([
+    ["custom", "run"],
+    ["custom", "caller"],
+    ["anthropic-vertex", "run"],
+    ["anthropic-vertex", "caller"],
+  ] as const)("cancels %s streams when their %s owner aborts", async (provider, signalOwner) => {
+    // Attempt transport and compaction both resolve streams through this owner.
+    const currentStreamFn = vi.fn(async (_model, _context, options) => options);
+    if (provider === "anthropic-vertex") {
+      streamMocks.anthropicVertex.mockReturnValueOnce(currentStreamFn);
+    }
+    const runController = new AbortController();
+    const callerController = new AbortController();
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: currentStreamFn as never,
+      sessionId: "session-1",
+      signal: runController.signal,
+      model: {
+        api: provider === "anthropic-vertex" ? "anthropic-messages" : "custom-api",
+        provider,
+        id: "custom-model",
+      } as never,
+    });
+
+    const result = await expectStreamResultRecord(
+      streamFn({ provider, id: "custom-model" } as never, {} as never, {
+        signal: callerController.signal,
+      }),
+      `${provider} composed signal`,
+    );
+    expect(result.signal).toMatchObject({ aborted: false });
+
+    const abortReason = new Error(`${signalOwner} canceled`);
+    (signalOwner === "run" ? runController : callerController).abort(abortReason);
+    expect(result.signal).toMatchObject({ aborted: true, reason: abortReason });
   });
 
   it.each(["run", "caller"] as const)(

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -179,7 +179,13 @@ export function resolveEmbeddedAgentStreamFn(
 
   const currentStreamFn = params.currentStreamFn ?? llmRuntime.streamSimple;
   if (params.model.provider === "anthropic-vertex") {
-    return createAnthropicVertexStreamFnForModel(params.model);
+    const vertexStreamFn = createAnthropicVertexStreamFnForModel(params.model);
+    return params.signal
+      ? wrapEmbeddedAgentStreamFn(vertexStreamFn, {
+          runSignal: params.signal,
+          providerId: params.model.provider,
+        })
+      : vertexStreamFn;
   }
 
   const openClawNativeCodexResponsesStreamFn = resolveOpenClawNativeCodexResponsesStreamFn({
@@ -244,14 +250,11 @@ export function resolveEmbeddedAgentStreamFn(
   }
 
   const promptCacheKey = params.promptCacheKey?.trim();
-  if (!promptCacheKey) {
+  if (!promptCacheKey && !params.signal) {
     return currentStreamFn;
   }
   return wrapEmbeddedAgentStreamFn(currentStreamFn, {
     runSignal: params.signal,
-    resolvedApiKey: undefined,
-    authProfileId: undefined,
-    authStorage: undefined,
     providerId: params.model.provider,
     promptCacheKey,
   });
@@ -261,9 +264,9 @@ function wrapEmbeddedAgentStreamFn(
   inner: StreamFn,
   params: {
     runSignal: AbortSignal | undefined;
-    resolvedApiKey: string | undefined;
-    authProfileId: string | undefined;
-    authStorage: { getApiKey(provider: string): Promise<string | undefined> } | undefined;
+    resolvedApiKey?: string;
+    authProfileId?: string;
+    authStorage?: { getApiKey(provider: string): Promise<string | undefined> };
     providerId: string;
     sessionId?: string;
     promptCacheKey?: string;

--- a/src/agents/subagent-announce-handoff.ts
+++ b/src/agents/subagent-announce-handoff.ts
@@ -20,7 +20,7 @@ export type SubagentCompletionToolHandoffRegistration = {
   idempotencyKey: string;
 };
 
-function resolveExactSubagentCompletionEvent(params: {
+export function resolveExactSubagentCompletionEvent(params: {
   inputProvenance?: InputProvenance;
   internalEvents?: AgentInternalEvent[];
 }) {

--- a/src/agents/subagent-registry-requester-yield.test.ts
+++ b/src/agents/subagent-registry-requester-yield.test.ts
@@ -79,6 +79,48 @@ describe("settleRequesterTurnAfterSessionSpawns", () => {
     expect(schedule).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    ["matches", "agent:main:subagent:worker", true],
+    ["rejects", "agent:main:subagent:other", false],
+  ] as const)("%s the exact child session after same-turn steer", (_, sessionKey, expected) => {
+    const originalRunId = "run-original";
+    const entry = makeRun("run-steered", false);
+    entry.taskRunId = originalRunId;
+    entry.childSessionKey = "agent:main:subagent:worker";
+    const runs = new Map([[entry.runId, entry]]);
+    const persistOrThrow = vi.fn();
+    const schedule = vi.fn();
+
+    expect(
+      markRequesterTurnYieldedInRuns({
+        requesterSessionKey: REQUESTER,
+        requesterTurnRunId: REQUESTER_TURN,
+        runs,
+        persistOrThrow,
+      }),
+    ).toBe(1);
+    expect(
+      settleRequesterTurnAfterSessionSpawns({
+        requesterSessionKey: REQUESTER,
+        requesterTurnRunId: REQUESTER_TURN,
+        requesterYielded: true,
+        acceptedSessionSpawns: [{ runId: originalRunId, childSessionKey: sessionKey }],
+        runs,
+        persistOrThrow,
+        schedule,
+      }),
+    ).toBe(expected);
+    expect(persistOrThrow).toHaveBeenCalledTimes(expected ? 2 : 1);
+    if (expected) {
+      expect(entry.requesterSettleWake?.batchRunIds).toEqual([entry.runId]);
+      expect(schedule).toHaveBeenCalledExactlyOnceWith(entry.runId, entry);
+    } else {
+      expect(entry.requesterSettleWake).toBeUndefined();
+      expect(entry.requesterTurnRunId).toBe(REQUESTER_TURN);
+      expect(schedule).not.toHaveBeenCalled();
+    }
+  });
+
   it("freezes active yielded children without scheduling before terminal delivery", () => {
     const entry = makeRun("run-child");
     entry.execution = { ...entry.execution, status: "running", endedAt: undefined };

--- a/src/agents/subagent-registry-requester-yield.ts
+++ b/src/agents/subagent-registry-requester-yield.ts
@@ -56,8 +56,8 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
     return false;
   }
 
-  // Registry markers select completion-producing children. Accepted inline or
-  // otherwise non-completion spawns are intentionally outside this batch.
+  // Completion rows keep their original task owner across steer; inline or
+  // non-completion spawns are intentionally outside this batch.
   const entries = [...params.runs.values()].filter(
     (entry) =>
       entry.requesterSessionKey === requesterSessionKey &&
@@ -65,7 +65,7 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
       entry.expectsCompletionMessage === true,
   );
   for (const entry of entries) {
-    const spawn = spawnsByRunId.get(entry.runId);
+    const spawn = spawnsByRunId.get(entry.taskRunId ?? entry.runId);
     if (
       !spawn ||
       entry.childSessionKey !== spawn.childSessionKey ||

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -2,10 +2,15 @@
 // abort fanout, history snapshots, and cleanup of buffered streaming state.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
-import { onAgentEvent } from "../infra/agent-events.js";
+import {
+  clearAgentRunContext,
+  onAgentEvent,
+  registerAgentRunContext,
+} from "../infra/agent-events.js";
 import {
   abortChatRunById,
   abortChatRunsForProvider,
+  abortTrackedChatRunById,
   boundInFlightRunSnapshotForChatHistory,
   isChatStopCommandText,
   registerChatAbortController,
@@ -335,6 +340,30 @@ describe("abortChatRunById", () => {
     }
   });
 
+  it("preserves the owning session identity when synchronous abort cleanup clears run context", () => {
+    const { runId, sessionKey, entry, ops } = createAbortRunFixture({
+      runId: "run-pre-reset-abort",
+    });
+    registerAgentRunContext(runId, { sessionKey, sessionId: entry.sessionId });
+    entry.controller.signal.addEventListener("abort", () => clearAgentRunContext(runId));
+    const events: Array<{ sessionId?: string }> = [];
+    const unsubscribe = onAgentEvent((event) => {
+      if (event.runId === runId && event.stream === "lifecycle") {
+        events.push({ sessionId: event.sessionId });
+      }
+    });
+
+    try {
+      expect(abortChatRunById(ops, { runId, sessionKey, stopReason: "rpc" })).toEqual({
+        aborted: true,
+      });
+      expect(events).toEqual([{ sessionId: entry.sessionId }]);
+    } finally {
+      unsubscribe();
+      clearAgentRunContext(runId);
+    }
+  });
+
   it("broadcasts aborted payload with partial message when buffered text exists", () => {
     const now = new Date("2026-01-02T03:04:05.000Z");
     const { runId, sessionKey, entry, ops } = createAbortRunFixture({
@@ -447,18 +476,26 @@ describe("abortChatRunById", () => {
       name: "fans out default-agent global aborts to scoped and legacy global subscribers",
       runId: "run-main-global",
       createEntry: () => ({ ...createActiveEntry("global"), agentId: "main" }),
+      abort: abortChatRunById,
     },
     {
       name: "resolves unscoped global aborts to the default agent subscribers",
       runId: "run-unscoped-global",
       createEntry: () => createActiveEntry("global"),
+      abort: abortChatRunById,
+    },
+    {
+      name: "preserves default-agent global delivery through tracked maintenance aborts",
+      runId: "run-tracked-global",
+      createEntry: () => ({ ...createActiveEntry("global"), agentId: "main" }),
+      abort: abortTrackedChatRunById,
     },
   ]) {
     it(testCase.name, () => {
       const ops = createOps({ runId: testCase.runId, entry: testCase.createEntry() });
       ops.getRuntimeConfig = () => ({ agents: { list: [{ id: "main", default: true }] } });
 
-      const result = abortChatRunById(ops, { runId: testCase.runId, sessionKey: "global" });
+      const result = testCase.abort(ops, { runId: testCase.runId, sessionKey: "global" });
 
       expect(result).toEqual({ aborted: true });
       const payload = firstBroadcastPayload(ops) as ChatAbortPayload;

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -413,17 +413,7 @@ export function abortTrackedChatRunById(
   ops: TrackedChatRunAbortOps,
   params: Parameters<typeof abortChatRunById>[1],
 ) {
-  return abortChatRunById(
-    {
-      chatAbortControllers: ops.chatAbortControllers,
-      chatRunState: ops.chatRunState,
-      removeChatRun: ops.removeChatRun,
-      agentRunSeq: ops.agentRunSeq,
-      broadcast: ops.broadcast,
-      nodeSendToSession: ops.nodeSendToSession,
-    },
-    params,
-  );
+  return abortChatRunById(ops, params);
 }
 
 function resolveChatAbortDeliverySessionKeys(
@@ -579,6 +569,7 @@ export function abortChatRunById(
     runId,
     ...(active.lifecycleGeneration ? { lifecycleGeneration: active.lifecycleGeneration } : {}),
     sessionKey,
+    sessionId: active.sessionId,
     agentId: active.agentId,
     stream: "lifecycle",
     data: {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2167,11 +2167,33 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
   });
 
   it.each([
-    { name: "successful completion", fail: false, expected: "hello" },
-    { name: "internal agent error", fail: true, expected: "Error: internal error" },
+    {
+      name: "successful completion without a provider terminal",
+      fail: false,
+      providerTerminal: false,
+      expected: "hello",
+    },
+    {
+      name: "successful completion with a provider terminal",
+      fail: false,
+      providerTerminal: true,
+      expected: "hello",
+    },
+    {
+      name: "internal agent error without a provider terminal",
+      fail: true,
+      providerTerminal: false,
+      expected: "Error: internal error",
+    },
+    {
+      name: "internal agent error with a provider terminal",
+      fail: true,
+      providerTerminal: true,
+      expected: "Error: internal error",
+    },
   ])(
     "separates streamed content from the terminal finish for an official SDK $name",
-    async ({ fail, expected }) => {
+    async ({ fail, providerTerminal, expected }) => {
       const idleRootCount = getActiveGatewayRootWorkCount();
       const terminalAdmission = createDeferred<{
         active: number;
@@ -2179,15 +2201,17 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }>();
       const wireResponse = createDeferred<string>();
       const continueAgent = createDeferred();
+      const lifecycleTerminals: string[] = [];
       let activeRunId: string | undefined;
       const unsubscribe = onAgentEvent((event) => {
-        if (
-          event.runId !== activeRunId ||
-          event.stream !== "lifecycle" ||
-          event.data?.phase !== "end"
-        ) {
+        const phase = event.data?.phase;
+        if (event.runId !== activeRunId || event.stream !== "lifecycle") {
           return;
         }
+        if (phase !== "end" && phase !== "error") {
+          return;
+        }
+        lifecycleTerminals.push(phase);
         // Agent settlement schedules the terminal in a later microtask. The
         // request must remain admitted until Node finishes the actual stream.
         const active = getActiveGatewayRootWorkCount();
@@ -2203,14 +2227,21 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         }
         await continueAgent.promise;
         if (fail) {
+          if (providerTerminal) {
+            emitAgentEvent({ runId: activeRunId, stream: "lifecycle", data: { phase: "error" } });
+          }
           throw new Error("private upstream failure");
         }
-        return buildAssistantDeltaResult({
+        const result = buildAssistantDeltaResult({
           opts,
           emit: emitAgentEvent,
           deltas: ["he", "llo"],
           text: expected,
         });
+        if (providerTerminal) {
+          emitAgentEvent({ runId: activeRunId, stream: "lifecycle", data: { phase: "end" } });
+        }
+        return result;
       }) as never);
 
       try {
@@ -2251,6 +2282,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(admission.active).toBe(idleRootCount + 1);
         expect(admission.drained).toEqual({ drained: false, active: idleRootCount + 1 });
         expect(parseSseDataLines(wire).at(-1)).toBe("[DONE]");
+        expect(lifecycleTerminals).toEqual([fail ? "error" : "end"]);
 
         const contentChoices = choices.filter((choice) => typeof choice.delta.content === "string");
         expect(contentChoices.map((choice) => choice.delta.content).join("")).toBe(expected);

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1199,6 +1199,8 @@ export async function handleOpenAiHttpRequest(
   let finalizeFinishReason: "stop" | "tool_calls" = "stop";
   let resultResolved = false;
   let closed = false;
+  let observedTerminalLifecycle = false;
+  let terminalLifecyclePhase: "end" | "error" = "end";
   let stopWatchingDisconnect = () => {};
 
   const maybeFinalize = () => {
@@ -1299,7 +1301,11 @@ export async function handleOpenAiHttpRequest(
 
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
+      if (phase === "start") {
+        observedTerminalLifecycle = false;
+      }
       if (phase === "end" || phase === "error") {
+        observedTerminalLifecycle = true;
         requestFinalize();
       }
     }
@@ -1416,6 +1422,7 @@ export async function handleOpenAiHttpRequest(
       if (closed || abortController.signal.aborted) {
         return;
       }
+      terminalLifecyclePhase = "error";
       logWarn(`openai-compat: streaming chat completion failed: ${String(err)}`);
       if (isClientToolNameConflictError(err)) {
         closed = true;
@@ -1449,19 +1456,15 @@ export async function handleOpenAiHttpRequest(
         completion_tokens: 0,
         total_tokens: 0,
       };
-      emitAgentEvent({
-        runId,
-        stream: "lifecycle",
-        data: { phase: "error" },
-      });
       requestFinalize();
     } finally {
       releaseAgentRootWork?.();
-      if (!closed) {
+      // The provider owns observed terminals; a second end would erase a failed session.
+      if (!observedTerminalLifecycle && (terminalLifecyclePhase === "error" || !closed)) {
         emitAgentEvent({
           runId,
           stream: "lifecycle",
-          data: { phase: "end" },
+          data: { phase: terminalLifecyclePhase },
         });
       }
     }

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1549,11 +1549,44 @@ describe("OpenResponses HTTP API (e2e)", () => {
   });
 
   it.each([
-    { name: "completed", failed: false },
-    { name: "failed", failed: true },
+    {
+      name: "completed",
+      label: "completed response without a provider terminal",
+      failed: false,
+      providerTerminal: false,
+      reject: false,
+    },
+    {
+      name: "completed",
+      label: "completed response with a provider terminal",
+      failed: false,
+      providerTerminal: true,
+      reject: false,
+    },
+    {
+      name: "failed",
+      label: "provider-failed response with a resolved run",
+      failed: true,
+      providerTerminal: true,
+      reject: false,
+    },
+    {
+      name: "failed",
+      label: "rejected response with a provider terminal",
+      failed: true,
+      providerTerminal: true,
+      reject: true,
+    },
+    {
+      name: "failed",
+      label: "rejected response without a provider terminal",
+      failed: true,
+      providerTerminal: false,
+      reject: true,
+    },
   ])(
-    "keeps the $name response admitted until its deferred SSE terminal is written",
-    async ({ name, failed }) => {
+    "keeps the $label admitted until its deferred SSE terminal is written",
+    async ({ name, failed, providerTerminal, reject }) => {
       const idleRootCount = getActiveGatewayRootWorkCount();
       const terminalAdmission = createDeferred<{
         active: number;
@@ -1561,15 +1594,17 @@ describe("OpenResponses HTTP API (e2e)", () => {
       }>();
       const wireResponse = createDeferred<string>();
       const continueAgent = createDeferred();
+      const lifecycleTerminals: string[] = [];
       let activeRunId: string | undefined;
       const unsubscribe = onAgentEvent((event) => {
-        if (
-          event.runId !== activeRunId ||
-          event.stream !== "lifecycle" ||
-          event.data?.phase !== "end"
-        ) {
+        const phase = event.data?.phase;
+        if (event.runId !== activeRunId || event.stream !== "lifecycle") {
           return;
         }
+        if (phase !== "end" && phase !== "error") {
+          return;
+        }
+        lifecycleTerminals.push(phase);
         // Restart drains run before the next-turn SSE finalizer, so inspect the real
         // root owner at that boundary instead of observing eventual client delivery.
         queueMicrotask(() => {
@@ -1588,12 +1623,15 @@ describe("OpenResponses HTTP API (e2e)", () => {
         }
         await continueAgent.promise;
         emitAgentEvent({ runId: activeRunId, stream: "assistant", data: { delta: "answer" } });
-        if (failed) {
+        if (providerTerminal) {
           emitAgentEvent({
             runId: activeRunId,
             stream: "lifecycle",
-            data: { phase: "error", error: "provider request failed" },
+            data: failed ? { phase: "error", error: "provider request failed" } : { phase: "end" },
           });
+        }
+        if (reject) {
+          throw new Error("provider request failed");
         }
         return {
           payloads: [{ text: "answer" }],
@@ -1637,6 +1675,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
         expect(admission.drained).toEqual({ drained: false, active: idleRootCount + 1 });
         expect(response.status).toBe(name);
         expect(terminalEvents).toEqual([`response.${name}`]);
+        expect(lifecycleTerminals).toEqual([failed ? "error" : "end"]);
         expect(parseSseEvents(wire).at(-1)?.data).toBe("[DONE]");
         await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(idleRootCount));
       } finally {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -902,6 +902,7 @@ export async function handleOpenResponsesHttpRequest(
   let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
   let finalizeScheduled = false;
   let finalizeErrorMessage: string | undefined;
+  let terminalLifecyclePhase: "end" | "error" = "end";
 
   const maybeFinalize = () => {
     if (closed || finalizeScheduled) {
@@ -1368,6 +1369,7 @@ export async function handleOpenResponsesHttpRequest(
       if (closed || abortController.signal.aborted) {
         return;
       }
+      terminalLifecyclePhase = "error";
       logWarn(`openresponses: streaming response failed: ${String(err)}`);
 
       finalUsage = finalUsage ?? createEmptyUsage();
@@ -1382,11 +1384,6 @@ export async function handleOpenResponsesHttpRequest(
         });
 
         finalizeFailedResponse(errorResponse);
-        emitAgentEvent({
-          runId: responseId,
-          stream: "lifecycle",
-          data: { phase: "error" },
-        });
         return;
       }
       const errorResponse = createResponseResource({
@@ -1413,28 +1410,18 @@ export async function handleOpenResponsesHttpRequest(
         });
         rememberResponseSession();
         finalizeFailedResponse(mappedResponse);
-        emitAgentEvent({
-          runId: responseId,
-          stream: "lifecycle",
-          data: { phase: "error" },
-        });
         return;
       }
       rememberResponseSession();
       finalizeFailedResponse(errorResponse);
-      emitAgentEvent({
-        runId: responseId,
-        stream: "lifecycle",
-        data: { phase: "error" },
-      });
     } finally {
       releaseAgentRootWork?.();
-      if (!closed) {
-        // Emit lifecycle end to trigger completion
+      // Existing provider terminals must not be replaced or emitted twice.
+      if (finalizeStatus === null && (terminalLifecyclePhase === "error" || !closed)) {
         emitAgentEvent({
           runId: responseId,
           stream: "lifecycle",
-          data: { phase: "end" },
+          data: { phase: terminalLifecyclePhase },
         });
       }
     }

--- a/src/gateway/server-methods/agent-run-admission-phase.ts
+++ b/src/gateway/server-methods/agent-run-admission-phase.ts
@@ -5,14 +5,16 @@ import {
   isEmbeddedAgentRunAbortableForRunId,
   retainEmbeddedAgentRunAbortabilityForRunId,
 } from "../../agents/embedded-agent-runner/runs.js";
-import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "../../agents/internal-event-contract.js";
 import {
   commitMainSessionRecovery,
   type MainSessionRecoveryPendingTarget,
 } from "../../agents/main-session-recovery-store.js";
 import { resolvePersistedOverrideModelRef } from "../../agents/model-selection.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
-import type { TrustedSubagentCompletionHandoff } from "../../agents/subagent-announce-handoff.js";
+import {
+  resolveExactSubagentCompletionEvent,
+  type TrustedSubagentCompletionHandoff,
+} from "../../agents/subagent-announce-handoff.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -275,20 +277,10 @@ export async function prepareAgentRunDispatch(params: {
 
   const resolvedThreadId =
     params.delivery.explicitThreadId ?? params.delivery.deliveryPlan.resolvedThreadId;
-  const completionSourceSessionKey =
-    params.inputProvenance?.kind === "inter_session" &&
-    params.inputProvenance.sourceTool === "subagent_announce"
-      ? params.inputProvenance.sourceSessionKey
-      : undefined;
-  const completionEvents = params.request.internalEvents?.filter(
-    (event) =>
-      event.type === AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION && event.source === "subagent",
-  );
-  const completionEvent =
-    completionEvents?.length === 1 &&
-    completionEvents[0]?.childSessionKey === completionSourceSessionKey
-      ? completionEvents[0]
-      : undefined;
+  const completionEvent = resolveExactSubagentCompletionEvent({
+    inputProvenance: params.inputProvenance,
+    internalEvents: params.request.internalEvents,
+  });
   const trustedInternalHandoff =
     params.providerOverride === undefined &&
     params.modelOverride === undefined &&

--- a/src/gateway/server-methods/agent-run-execution-phase.ts
+++ b/src/gateway/server-methods/agent-run-execution-phase.ts
@@ -441,6 +441,7 @@ export function startAgentRunExecution(params: {
             resolvedSessionKey: params.resolvedSessionKey,
             lifecycleStorePath: prepared.lifecycleStorePath,
             activeSessionAgentId: params.activeSessionAgentId,
+            trustedInternalHandoff: prepared.trustedInternalHandoff,
           }),
           onSessionIdChanged: (sessionId) => {
             if (prepared.activeRunAbort.entry) {

--- a/src/gateway/server-methods/agent-run-model-selection.ts
+++ b/src/gateway/server-methods/agent-run-model-selection.ts
@@ -15,8 +15,14 @@ export function createAgentRunModelSelectionHandler(params: {
   resolvedSessionKey?: string;
   lifecycleStorePath: string;
   activeSessionAgentId: string;
+  trustedInternalHandoff?: { provider: string; model: string };
 }): (selection: { provider: string; model: string }) => Promise<void> {
   return async ({ provider, model }) => {
+    if (params.trustedInternalHandoff) {
+      // The one-use grant remains tied to this run while its active model falls back.
+      params.trustedInternalHandoff.provider = provider.trim().toLowerCase();
+      params.trustedInternalHandoff.model = model.trim();
+    }
     updateChatRunProvider(params.context.chatAbortControllers, {
       runId: params.runId,
       providerId: provider,

--- a/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
+++ b/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
@@ -465,20 +465,37 @@ describe("gateway agent handler", () => {
     );
 
     const call = await waitForAgentCommandCall<{
+      onActiveModelSelected?: (selection: { provider: string; model: string }) => Promise<void>;
       trustedInternalHandoff?: {
         kind: string;
         sourceSessionKey: string;
         sourceSessionId?: string;
         targetSessionKey: string;
         targetSessionId: string;
+        provider: string;
+        model: string;
       };
     }>();
+    const trustedInternalHandoff = expectDefined(
+      call.trustedInternalHandoff,
+      "trusted completion handoff test invariant",
+    );
+    await expectDefined(
+      call.onActiveModelSelected,
+      "model-selection callback test invariant",
+    )({
+      provider: "anthropic",
+      model: "sonnet-4.6",
+    });
+    expect(call.trustedInternalHandoff).toBe(trustedInternalHandoff);
     expect(call.trustedInternalHandoff).toMatchObject({
       kind: "subagent-completion",
       sourceSessionKey: "agent:main:subagent:child",
       sourceSessionId: "child-session-id",
       targetSessionKey: "agent:main:main",
       targetSessionId: "existing-session-id",
+      provider: "anthropic",
+      model: "sonnet-4.6",
     });
   });
 

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -532,6 +532,68 @@ describe("agent-events sequencing", () => {
     });
   });
 
+  test.each(["end", "error"] as const)(
+    "stamps the owning start onto an older overlapping run's %s event",
+    (phase) => {
+      registerAgentRunContext("older-run", { sessionKey: "shared-session" });
+      registerAgentRunContext("newer-run", { sessionKey: "shared-session" });
+      const seen: AgentEventPayload[] = [];
+      const stop = onAgentEvent((event) => seen.push(event));
+
+      emitAgentEvent({
+        runId: "older-run",
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      });
+      emitAgentEvent({
+        runId: "newer-run",
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 2_000 },
+      });
+      emitAgentEvent({
+        runId: "older-run",
+        stream: "lifecycle",
+        data: { phase, endedAt: 3_000 },
+      });
+      emitAgentEvent({
+        runId: "newer-run",
+        stream: "lifecycle",
+        data: { phase: "end", endedAt: 4_000 },
+      });
+      stop();
+
+      expect(seen.map((event) => [event.runId, event.data.phase, event.data.startedAt])).toEqual([
+        ["older-run", "start", 1_000],
+        ["newer-run", "start", 2_000],
+        ["older-run", phase, 1_000],
+        ["newer-run", "end", 2_000],
+      ]);
+    },
+  );
+
+  test("does not invent or replace producer-owned lifecycle start timestamps", () => {
+    registerAgentRunContext("unstarted-run", { sessionKey: "shared-session" });
+    registerAgentRunContext("started-run", { sessionKey: "shared-session" });
+    const seen: AgentEventPayload[] = [];
+    const stop = onAgentEvent((event) => seen.push(event));
+
+    emitAgentEvent({ runId: "unstarted-run", stream: "lifecycle", data: { phase: "end" } });
+    emitAgentEvent({
+      runId: "started-run",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    emitAgentEvent({
+      runId: "started-run",
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 1_500 },
+    });
+    stop();
+
+    expect(seen[0]?.data).toEqual({ phase: "end" });
+    expect(seen[2]?.data.startedAt).toBe(1_500);
+  });
+
   test("rejects old runs after restart and stamps the new generation", () => {
     const oldGeneration = getAgentEventLifecycleGeneration();
     registerAgentRunContext("old-run", { sessionKey: "main" });

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -84,6 +84,8 @@ type AgentRunContext = {
   sessionId?: string;
   /** Gateway lifecycle generation captured when the run was registered. */
   lifecycleGeneration?: string;
+  /** Producer-owned start captured from this run's accepted lifecycle event. */
+  lifecycleStartedAt?: number;
   verboseLevel?: VerboseLevel;
   isHeartbeat?: boolean;
   /** Whether control UI clients should receive chat/agent updates for this run. */
@@ -617,6 +619,19 @@ function enrichAgentEvent(
   if (hasInvalidLifecycleStartTimestamp(event.stream, event.data)) {
     return undefined;
   }
+  let data = event.data;
+  if (context && event.stream === "lifecycle") {
+    if (data.phase === "start") {
+      context.lifecycleStartedAt = data.startedAt as number;
+    } else if (
+      (data.phase === "end" || data.phase === "error") &&
+      data.startedAt === undefined &&
+      context.lifecycleStartedAt !== undefined
+    ) {
+      // Preserve this run's identity after a newer run takes over its session.
+      data = { ...data, startedAt: context.lifecycleStartedAt };
+    }
+  }
   const nextSeq = (state.seqByRun.get(event.runId) ?? 0) + 1;
   state.seqByRun.set(event.runId, nextSeq);
   if (context) {
@@ -645,6 +660,7 @@ function enrichAgentEvent(
   const agentId = event.agentId ?? context?.agentId;
   const enriched: AgentEventRuntimePayload = {
     ...event,
+    data,
     sessionKey,
     ...(sessionId ? { sessionId } : {}),
     ...(agentId ? { agentId } : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where users running inference, switching models, cancelling chats, delegating work, or manually compacting Codex sessions could see orphaned tools, stale or falsely successful run status, missing timeout notifications, lost delegated replies, duplicate mutating calls, permanently sleeping requesters, or a `/compact` command that never answers.

Related: #117731

## Why This Change Was Made

Record and consume each authoritative fact at its existing owner: route and provider cancellation, run/session lifecycle identity, exact fallback handoff, stable child-task identity, native Codex thread subscriptions, and tool-result presence. Consolidate duplicate mock-provider completion scans and remove redundant abort/terminal adapters; preserve fail-closed handoff checks and existing config, protocol, provider, and storage contracts.

## User Impact

- Cancelled tools and approval handlers stop immediately, including custom streams and Anthropic Vertex.
- Global timeout subscribers receive their terminal events, and old aborts or completions cannot overwrite a reset/newer session.
- Streaming OpenAI Chat Completions and Responses report provider failures once instead of silently marking failed runs successful.
- Delegated source replies retain their exact session-bound authority during model fallback, and spawn → steer → yield reliably wakes the requester.
- Empty or image-only tool results count as completed across OpenAI, Anthropic, and Codex/WebSocket transports rather than replaying a mutating tool.
- Ordinary Codex sessions retain their native thread subscription, so manual `/compact` completes and goal context remains available afterward.
- Runtime-pair QA waits for durable message-tool completion before collecting parity evidence.
- Production delta: **171 added / 229 deleted = 58 fewer production lines**; regression/harness coverage is counted separately.

## Evidence

- Seven remote focused Vitest shards across Codex, mock providers, agent streams, lifecycle/session ownership, HTTP streaming, fallback handoffs, and requester wakeups; the gateway shard passed **572 tests**, the Codex shard **271 tests**.
- Additional focused native-compaction/thread-cleanup proof: **170 Codex tests passed**, including the new default-legacy-engine subscription regression.
- Mock runtime-pair stress: **12 scenarios × OpenClaw/Codex = 24 passing cells**, including the formerly failing native `/compact` and durable group-message parity cases.
- Fault injection: **10/10 passed** across empty/reasoning-only responses, replay-safe reads versus mutating writes, Anthropic thinking failures, tool-loop circuit breakers, in-flight gateway restart, memory-flush recovery, tool search, and stranded message finals.
- Real provider verification: **6 scenarios × OpenClaw/Codex = 12 passing cells** against live `openai/gpt-5.4`, covering streaming, tool vocabulary, approvals, goal follow-through, delegated work, and model-switch continuity.
- Full remote `pnpm check:changed` passed: whole-project typecheck, zero-warning core/plugin/script lint across roughly 24,000 files, dependency/plugin/storage/architecture guards, and zero runtime import cycles. Full private-QA production build passed. Independent structured autoreview: **clean; no accepted/actionable findings**.
- Exact formerly failing CI transport reproduced and repaired: `pnpm openclaw qa run --repo-root . --qa-profile smoke-ci --scenario group-visible-reply-tool` passes through the real **Telegram plugin + Crabline local Telegram provider**; the same scenario also passes OpenClaw/Codex parity over QA-channel. Session identity is derived from the actual active transport, not a hardcoded channel.
- Upstream Codex contracts inspected directly at source revision `fbf666fa9875d0157816be3b7a20c63161d77ec5`: native turn and callback cancellation (`codex-rs/app-server/src/bespoke_event_handling.rs:156-203`, `codex-rs/app-server/src/outgoing_message.rs:469-496`), empty tool outputs (`codex-rs/protocol/src/models.rs:1925-1970`), subscribed-only compaction notifications (`codex-rs/app-server/src/request_processors/thread_processor.rs:876-900,1867-1878`, `codex-rs/app-server/src/request_processors/thread_lifecycle.rs:320-332`), and dynamic-tool completion ordering (`codex-rs/core/src/tools/handlers/dynamic.rs:196-245`).
