### PR TITLE
fix(comfy): honor request deadlines across complete media workflows

### DIFF
--- a/extensions/comfy/image-generation-provider.test.ts
+++ b/extensions/comfy/image-generation-provider.test.ts
@@ -729,11 +729,7 @@ describe("comfy image-generation provider", () => {
 
   it("caps oversized local workflow timeouts", async () => {
     setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
-    const nowSpy = vi.spyOn(Date, "now");
-    nowSpy
-      .mockReturnValueOnce(0)
-      .mockReturnValueOnce(0)
-      .mockReturnValueOnce(MAX_TIMER_TIMEOUT_MS + 1);
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(0);
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
         response: new Response(JSON.stringify({ prompt_id: "local-prompt-1" }), {
@@ -742,12 +738,15 @@ describe("comfy image-generation provider", () => {
         }),
         release: vi.fn(async () => {}),
       })
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ "local-prompt-1": { outputs: {} } }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
+      .mockImplementationOnce(async () => {
+        nowSpy.mockReturnValue(MAX_TIMER_TIMEOUT_MS + 1);
+        return {
+          response: new Response(JSON.stringify({ "local-prompt-1": { outputs: {} } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+          release: vi.fn(async () => {}),
+        };
       });
 
     try {

--- a/extensions/comfy/music-generation-provider.test.ts
+++ b/extensions/comfy/music-generation-provider.test.ts
@@ -12,6 +12,7 @@ describe("comfy music-generation provider", () => {
   afterEach(() => {
     setComfyFetchGuardForTesting(null);
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it("registers the workflow model", () => {
@@ -163,5 +164,92 @@ describe("comfy music-generation provider", () => {
         } as never,
       }),
     ).rejects.toThrow("Comfy music output download exceeds 1 bytes");
+  });
+
+  it.each([
+    {
+      label: "forwards the explicit caller budget when the plugin has no timeout",
+      requestTimeoutMs: 1_250,
+      configuredTimeoutMs: undefined,
+      expectedTimeoutMs: 1_250,
+    },
+    {
+      label: "prefers the explicit caller budget over the plugin timeout",
+      requestTimeoutMs: 1_250,
+      configuredTimeoutMs: 9_000,
+      expectedTimeoutMs: 1_250,
+    },
+    {
+      label: "uses the plugin timeout when the caller does not supply a budget",
+      requestTimeoutMs: undefined,
+      configuredTimeoutMs: 4_200,
+      expectedTimeoutMs: 4_200,
+    },
+  ])("$label", async ({ requestTimeoutMs, configuredTimeoutMs, expectedTimeoutMs }) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ prompt_id: "music-timeout-1" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            "music-timeout-1": {
+              outputs: {
+                "9": {
+                  audio: [{ filename: "song.mp3", subfolder: "", type: "output" }],
+                },
+              },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("music-bytes"), {
+          status: 200,
+          headers: { "content-type": "audio/mpeg" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    await buildComfyMusicGenerationProvider().generateMusic({
+      provider: "comfy",
+      model: "workflow",
+      prompt: "bounded music workflow",
+      ...(requestTimeoutMs === undefined ? {} : { timeoutMs: requestTimeoutMs }),
+      cfg: {
+        plugins: {
+          entries: {
+            comfy: {
+              config: {
+                music: {
+                  workflow: {
+                    "6": { inputs: { text: "" } },
+                    "9": { inputs: {} },
+                  },
+                  promptNodeId: "6",
+                  outputNodeId: "9",
+                  ...(configuredTimeoutMs === undefined ? {} : { timeoutMs: configuredTimeoutMs }),
+                },
+              },
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(fetchWithSsrFGuardMock.mock.calls.map(([request]) => request.timeoutMs)).toEqual([
+      expectedTimeoutMs,
+      expectedTimeoutMs,
+      expectedTimeoutMs,
+    ]);
   });
 });

--- a/extensions/comfy/music-generation-provider.ts
+++ b/extensions/comfy/music-generation-provider.ts
@@ -70,6 +70,7 @@ export function buildComfyMusicGenerationProvider(): MusicGenerationProvider {
         authStore: req.authStore,
         prompt: req.prompt,
         model: req.model,
+        timeoutMs: req.timeoutMs,
         capability: "music",
         outputKinds: ["audio"],
         inputImage: resolveInputImage(req.inputImages?.[0]),

--- a/extensions/comfy/video-generation-provider.test.ts
+++ b/extensions/comfy/video-generation-provider.test.ts
@@ -18,12 +18,16 @@ function parseJsonBody(call: number): Record<string, unknown> {
   return parseComfyJsonBody(fetchWithSsrFGuardMock, call);
 }
 
-function fetchGuardParams(call: number): { url?: unknown; auditContext?: unknown } {
+function fetchGuardParams(call: number): {
+  url?: unknown;
+  auditContext?: unknown;
+  timeoutMs?: unknown;
+} {
   const params = fetchWithSsrFGuardMock.mock.calls[call]?.[0];
   if (!params || typeof params !== "object") {
     throw new Error(`expected Comfy fetch guard call ${call}`);
   }
-  return params as { url?: unknown; auditContext?: unknown };
+  return params as { url?: unknown; auditContext?: unknown; timeoutMs?: unknown };
 }
 
 describe("comfy video-generation provider", () => {
@@ -238,5 +242,46 @@ describe("comfy video-generation provider", () => {
       promptId: "cloud-video-1",
       outputNodeIds: ["9"],
     });
+  });
+
+  it("prefers explicit cloud video request budgets over capability configuration", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    try {
+      mockComfyProviderApiKey();
+      setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
+      mockComfyCloudJobResponses(fetchWithSsrFGuardMock, {
+        body: Buffer.from("cloud-video-data"),
+        contentType: "video/mp4",
+        filename: "cloud.mp4",
+        outputKind: "gifs",
+        promptId: "cloud-video-budget-1",
+      });
+
+      await buildComfyVideoGenerationProvider().generateVideo({
+        provider: "comfy",
+        model: "workflow",
+        prompt: "cloud video with an explicit deadline",
+        timeoutMs: 1_250,
+        cfg: buildComfyConfig({
+          mode: "cloud",
+          video: {
+            workflow: {
+              "6": { inputs: { text: "" } },
+              "9": { inputs: {} },
+            },
+            promptNodeId: "6",
+            outputNodeId: "9",
+            timeoutMs: 9_000,
+          },
+        }),
+      });
+
+      expect(
+        fetchWithSsrFGuardMock.mock.calls.map((_, index) => fetchGuardParams(index).timeoutMs),
+      ).toEqual([1_250, 1_250, 1_250, 1_250]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/comfy/workflow-runtime.test.ts
+++ b/extensions/comfy/workflow-runtime.test.ts
@@ -1,6 +1,10 @@
 // Comfy tests cover workflow-runtime bounded-read delegation.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildComfyImageGenerationProvider } from "./image-generation-provider.js";
+import { buildComfyMusicGenerationProvider } from "./music-generation-provider.js";
+import { buildComfyConfig } from "./test-helpers.js";
 import { setComfyFetchGuardForTesting } from "./test-support.js";
+import { buildComfyVideoGenerationProvider } from "./video-generation-provider.js";
 import { readJsonResponseForTest } from "./workflow-runtime.js";
 
 describe("readJsonResponse bounded read (readProviderJsonResponse delegation)", () => {
@@ -168,5 +172,340 @@ describe("readJsonResponse bounded read (readProviderJsonResponse delegation)", 
     ).rejects.toThrow(/Comfy test failed/);
 
     expect(release).toHaveBeenCalledOnce();
+  });
+});
+
+type ComfyDeadlineCapability = "image" | "music" | "video";
+type ComfyDeadlineMode = "local" | "cloud";
+type TimedComfyResponse = {
+  elapsedMs: number;
+  response: Response;
+};
+
+function comfyJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function comfyOutputKind(capability: ComfyDeadlineCapability): "images" | "audio" | "gifs" {
+  if (capability === "music") {
+    return "audio";
+  }
+  return capability === "video" ? "gifs" : "images";
+}
+
+function comfyOutputResponse(
+  capability: ComfyDeadlineCapability,
+  contents = "generated",
+): Response {
+  const contentType =
+    capability === "music" ? "audio/mpeg" : capability === "video" ? "video/mp4" : "image/png";
+  return new Response(Buffer.from(contents), {
+    status: 200,
+    headers: { "content-type": contentType },
+  });
+}
+
+function comfyCompletedHistory(
+  capability: ComfyDeadlineCapability,
+  promptId: string,
+  filenames: string[],
+): Record<string, unknown> {
+  return {
+    [promptId]: {
+      outputs: {
+        "9": {
+          [comfyOutputKind(capability)]: filenames.map((filename) => ({
+            filename,
+            subfolder: "",
+            type: "output",
+          })),
+        },
+      },
+    },
+  };
+}
+
+function comfyDeadlineConfig(params: {
+  capability: ComfyDeadlineCapability;
+  mode?: ComfyDeadlineMode;
+  configuredTimeoutMs?: number;
+  referenceImage?: boolean;
+}) {
+  return buildComfyConfig({
+    ...(params.mode === "cloud" ? { mode: "cloud", apiKey: "comfy-deadline-test-key" } : {}),
+    [params.capability]: {
+      workflow: {
+        "6": { inputs: { text: "" } },
+        ...(params.referenceImage ? { "7": { inputs: { image: "" } } } : {}),
+        "9": { inputs: {} },
+      },
+      promptNodeId: "6",
+      outputNodeId: "9",
+      ...(params.referenceImage ? { inputImageNodeId: "7" } : {}),
+      ...(params.configuredTimeoutMs === undefined
+        ? {}
+        : { timeoutMs: params.configuredTimeoutMs }),
+    },
+  });
+}
+
+async function runComfyDeadlineFixture(params: {
+  capability: ComfyDeadlineCapability;
+  cfg: ReturnType<typeof buildComfyConfig>;
+  timeoutMs: number;
+  referenceImage?: boolean;
+}): Promise<unknown> {
+  const request = {
+    provider: "comfy",
+    model: "workflow",
+    prompt: "enforce one Comfy operation budget",
+    cfg: params.cfg,
+    timeoutMs: params.timeoutMs,
+    ...(params.referenceImage
+      ? {
+          inputImages: [
+            { buffer: Buffer.from("reference"), mimeType: "image/png", fileName: "reference.png" },
+          ],
+        }
+      : {}),
+  };
+  switch (params.capability) {
+    case "image":
+      return await buildComfyImageGenerationProvider().generateImage(request);
+    case "music":
+      return await buildComfyMusicGenerationProvider().generateMusic(request);
+    case "video":
+      return await buildComfyVideoGenerationProvider().generateVideo(request);
+  }
+}
+
+describe("Comfy canonical workflow operation deadline", () => {
+  const fetchGuard = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    setComfyFetchGuardForTesting(fetchGuard);
+  });
+
+  afterEach(() => {
+    setComfyFetchGuardForTesting(null);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it.each<ComfyDeadlineCapability>(["image", "music", "video"])(
+    "lets explicit %s request budgets override capability plugin configuration",
+    async (capability) => {
+      const promptId = `${capability}-deadline-1`;
+      fetchGuard
+        .mockResolvedValueOnce({
+          response: comfyJsonResponse({ prompt_id: promptId }),
+          release: vi.fn(async () => {}),
+        })
+        .mockResolvedValueOnce({
+          response: comfyJsonResponse(comfyCompletedHistory(capability, promptId, ["result.bin"])),
+          release: vi.fn(async () => {}),
+        })
+        .mockResolvedValueOnce({
+          response: comfyOutputResponse(capability),
+          release: vi.fn(async () => {}),
+        });
+
+      await runComfyDeadlineFixture({
+        capability,
+        cfg: comfyDeadlineConfig({ capability, configuredTimeoutMs: 9_000 }),
+        timeoutMs: 1_250,
+      });
+
+      expect(fetchGuard.mock.calls.map(([request]) => request.timeoutMs)).toEqual([
+        1_250, 1_250, 1_250,
+      ]);
+    },
+  );
+
+  it.each([
+    {
+      label: "local upload, submit, history, and every output download",
+      capability: "image" as const,
+      mode: "local" as const,
+      referenceImage: true,
+      expectedTimeouts: [600, 400, 250, 150, 50],
+      stages: () => [
+        { elapsedMs: 200, response: comfyJsonResponse({ name: "reference.png" }) },
+        { elapsedMs: 150, response: comfyJsonResponse({ prompt_id: "local-budget-1" }) },
+        {
+          elapsedMs: 100,
+          response: comfyJsonResponse(
+            comfyCompletedHistory("image", "local-budget-1", ["first.png", "second.png"]),
+          ),
+        },
+        { elapsedMs: 100, response: comfyOutputResponse("image", "first") },
+        { elapsedMs: 60, response: comfyOutputResponse("image", "second") },
+      ],
+    },
+    {
+      label: "cloud submit, status poll, history, and output download",
+      capability: "video" as const,
+      mode: "cloud" as const,
+      referenceImage: false,
+      expectedTimeouts: [600, 400, 200, 50],
+      stages: () => [
+        { elapsedMs: 200, response: comfyJsonResponse({ prompt_id: "cloud-budget-1" }) },
+        { elapsedMs: 200, response: comfyJsonResponse({ status: "completed" }) },
+        {
+          elapsedMs: 150,
+          response: comfyJsonResponse(
+            comfyCompletedHistory("video", "cloud-budget-1", ["generated.mp4"]),
+          ),
+        },
+        { elapsedMs: 100, response: comfyOutputResponse("video") },
+      ],
+    },
+  ])("keeps $label inside one absolute budget", async (scenario) => {
+    const stages: TimedComfyResponse[] = scenario.stages();
+    const releases: ReturnType<typeof vi.fn>[] = [];
+    fetchGuard.mockImplementation(async () => {
+      const stage = stages.shift();
+      if (!stage) {
+        throw new Error("Comfy workflow unexpectedly retried a guarded request");
+      }
+      vi.setSystemTime(Date.now() + stage.elapsedMs);
+      const release = vi.fn(async () => {});
+      releases.push(release);
+      return { response: stage.response, release };
+    });
+
+    await expect(
+      runComfyDeadlineFixture({
+        capability: scenario.capability,
+        cfg: comfyDeadlineConfig({
+          capability: scenario.capability,
+          mode: scenario.mode,
+          referenceImage: scenario.referenceImage,
+        }),
+        timeoutMs: 600,
+        referenceImage: scenario.referenceImage,
+      }),
+    ).rejects.toThrow("Comfy workflow did not finish within 1s");
+
+    expect(fetchGuard.mock.calls.map(([request]) => request.timeoutMs)).toEqual(
+      scenario.expectedTimeouts,
+    );
+    expect(releases).toHaveLength(scenario.expectedTimeouts.length);
+    for (const release of releases) {
+      expect(release).toHaveBeenCalledOnce();
+    }
+  });
+
+  it("bounds a successful JSON body with the same operation budget", async () => {
+    let interval: ReturnType<typeof setInterval> | undefined;
+    let canceled = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          let chunkCount = 0;
+          interval = setInterval(() => {
+            chunkCount += 1;
+            if (chunkCount === 12) {
+              controller.enqueue(new TextEncoder().encode("{}"));
+              controller.close();
+              clearInterval(interval);
+              return;
+            }
+            controller.enqueue(new TextEncoder().encode(" "));
+          }, 20);
+        },
+        cancel() {
+          canceled = true;
+          clearInterval(interval);
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+    const release = vi.fn(async () => {});
+    fetchGuard.mockResolvedValueOnce({ response, release });
+
+    const read = readJsonResponseForTest({
+      url: "http://127.0.0.1:8188/prompt",
+      timeoutMs: 100,
+      auditContext: "comfy-image-generate",
+      errorPrefix: "Comfy workflow submit failed",
+    });
+    const outcome = read.then(
+      (value) => ({ status: "fulfilled" as const, value }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    );
+    await vi.advanceTimersByTimeAsync(240);
+
+    await expect(outcome).resolves.toMatchObject({
+      status: "rejected",
+      error: { message: "Comfy workflow did not finish within 1s" },
+    });
+    expect(canceled).toBe(true);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("prioritizes an expired workflow over a guarded timeout while draining HTTP 503", async () => {
+    const guardTimeout = Object.assign(new Error("request timed out"), { name: "TimeoutError" });
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          timeoutId = setTimeout(() => controller.error(guardTimeout), 100);
+        },
+        cancel() {
+          clearTimeout(timeoutId);
+        },
+      }),
+      { status: 503, headers: { "content-type": "application/json" } },
+    );
+    const release = vi.fn(async () => {});
+    fetchGuard.mockResolvedValueOnce({ response, release });
+
+    const read = readJsonResponseForTest({
+      url: "http://127.0.0.1:8188/prompt",
+      timeoutMs: 100,
+      auditContext: "comfy-image-generate",
+      errorPrefix: "Comfy workflow submit failed",
+    });
+    const outcome = read.then(
+      (value) => ({ status: "fulfilled" as const, value }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    );
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(outcome).resolves.toMatchObject({
+      status: "rejected",
+      error: { message: "Comfy workflow did not finish within 1s" },
+    });
+    expect(release).toHaveBeenCalledOnce();
+    expect(fetchGuard).toHaveBeenCalledOnce();
+  });
+
+  it("normalizes a real-clock guarded connection timeout to the shipped workflow error", async () => {
+    vi.useRealTimers();
+    const timeoutMs = 25;
+    fetchGuard.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, timeoutMs + 10));
+      const error = new Error("request timed out");
+      error.name = "TimeoutError";
+      throw error;
+    });
+
+    await expect(
+      readJsonResponseForTest({
+        url: "http://127.0.0.1:8188/prompt",
+        timeoutMs,
+        auditContext: "comfy-image-generate",
+        errorPrefix: "Comfy workflow submit failed",
+      }),
+    ).rejects.toThrow("Comfy workflow did not finish within 1s");
+
+    expect(fetchGuard).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -12,9 +12,13 @@ import {
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   assertOkOrThrowHttpError,
+  createProviderOperationDeadline,
+  createProviderOperationTimeoutResolver,
   normalizeBaseUrl,
   readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
+  waitProviderOperationPollInterval,
+  type ProviderOperationDeadline,
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
@@ -322,29 +326,87 @@ function isSingleLabelServiceHostname(hostname: string): boolean {
   return /^[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?$/u.test(hostname);
 }
 
-async function readJsonResponse<T>(params: {
+type ComfyGuardedRequest = {
   url: string;
   init?: RequestInit;
   timeoutMs?: number;
+  deadline?: ProviderOperationDeadline;
   policy?: SsrFPolicy;
   dispatcherPolicy?: ComfyDispatcherPolicy;
   auditContext: string;
   errorPrefix: string;
-}): Promise<T> {
-  const { response, release } = await comfyFetchGuard({
-    url: params.url,
-    init: params.init,
-    timeoutMs: params.timeoutMs,
-    policy: params.policy,
-    dispatcherPolicy: params.dispatcherPolicy,
-    auditContext: params.auditContext,
-  });
-  try {
-    await assertOkOrThrowHttpError(response, params.errorPrefix);
-    return (await readProviderJsonResponse(response, params.errorPrefix)) as T;
-  } finally {
-    await release();
+};
+
+function createComfyWorkflowTimeoutError(
+  deadline: ProviderOperationDeadline,
+  cause?: unknown,
+): Error {
+  return new Error(
+    `Comfy workflow did not finish within ${Math.ceil((deadline.timeoutMs ?? DEFAULT_TIMEOUT_MS) / 1000)}s`,
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+function normalizeComfyWorkflowError(error: unknown, deadline: ProviderOperationDeadline): unknown {
+  if (typeof deadline.deadlineAtMs === "number" && Date.now() >= deadline.deadlineAtMs) {
+    return createComfyWorkflowTimeoutError(deadline, error);
   }
+  return error;
+}
+
+async function withComfyGuardedResponse<T>(
+  params: ComfyGuardedRequest,
+  read: (
+    response: Response,
+    resolveTimeoutMs: () => number,
+    deadline: ProviderOperationDeadline,
+  ) => Promise<T>,
+): Promise<T> {
+  const deadline =
+    params.deadline ??
+    createProviderOperationDeadline({
+      timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      label: "Comfy workflow",
+    });
+  const resolveTimeoutMs = createProviderOperationTimeoutResolver({
+    deadline,
+    defaultTimeoutMs: deadline.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  });
+  let release: (() => Promise<void>) | undefined;
+
+  // Keep guarded acquisition, body consumption, timeout normalization, and
+  // dispatcher release under one owner so connection failures cannot bypass it.
+  try {
+    const guarded = await comfyFetchGuard({
+      url: params.url,
+      init: params.init,
+      timeoutMs: resolveTimeoutMs(),
+      policy: params.policy,
+      dispatcherPolicy: params.dispatcherPolicy,
+      auditContext: params.auditContext,
+    });
+    release = guarded.release;
+    await assertOkOrThrowHttpError(guarded.response, params.errorPrefix, {
+      bodyTimeoutMs: resolveTimeoutMs,
+      onBodyTimeout: () => createComfyWorkflowTimeoutError(deadline),
+    });
+    return await read(guarded.response, resolveTimeoutMs, deadline);
+  } catch (error) {
+    throw normalizeComfyWorkflowError(error, deadline);
+  } finally {
+    await release?.();
+  }
+}
+
+async function readJsonResponse<T>(params: ComfyGuardedRequest): Promise<T> {
+  return await withComfyGuardedResponse(
+    params,
+    async (response, resolveTimeoutMs, deadline) =>
+      await readProviderJsonResponse<T>(response, params.errorPrefix, {
+        timeoutMs: resolveTimeoutMs,
+        onTimeout: () => createComfyWorkflowTimeoutError(deadline),
+      }),
+  );
 }
 
 /** @internal Test-only export. */
@@ -375,7 +437,7 @@ function toBlobBytes(buffer: Buffer): ArrayBuffer {
 async function uploadInputImage(params: {
   baseUrl: string;
   headers: Headers;
-  timeoutMs: number;
+  deadline: ProviderOperationDeadline;
   policy?: SsrFPolicy;
   dispatcherPolicy?: ComfyDispatcherPolicy;
   image: ComfySourceImage;
@@ -402,7 +464,7 @@ async function uploadInputImage(params: {
       headers,
       body: form,
     },
-    timeoutMs: params.timeoutMs,
+    deadline: params.deadline,
     policy: params.policy,
     dispatcherPolicy: params.dispatcherPolicy,
     auditContext: `comfy-${params.capability}-upload`,
@@ -436,21 +498,19 @@ async function waitForLocalHistory(params: {
   baseUrl: string;
   promptId: string;
   headers: Headers;
-  timeoutMs: number;
+  deadline: ProviderOperationDeadline;
   pollIntervalMs: number;
   policy?: SsrFPolicy;
   dispatcherPolicy?: ComfyDispatcherPolicy;
 }): Promise<ComfyHistoryEntry> {
-  const deadline = Date.now() + params.timeoutMs;
   for (;;) {
-    const requestTimeoutMs = resolveComfyRemainingMs(deadline, params.timeoutMs);
     const history = await readJsonResponse<unknown>({
       url: `${params.baseUrl}/history/${params.promptId}`,
       init: {
         method: "GET",
         headers: params.headers,
       },
-      timeoutMs: requestTimeoutMs,
+      deadline: params.deadline,
       policy: params.policy,
       dispatcherPolicy: params.dispatcherPolicy,
       auditContext: "comfy-history",
@@ -462,10 +522,7 @@ async function waitForLocalHistory(params: {
       return entry;
     }
 
-    const pollDelayMs = resolveComfyRemainingMs(deadline, params.timeoutMs, params.pollIntervalMs);
-    await new Promise((resolve) => {
-      setTimeout(resolve, pollDelayMs);
-    });
+    await waitForComfyPollInterval(params.deadline, params.pollIntervalMs);
   }
 }
 
@@ -473,21 +530,19 @@ async function waitForCloudCompletion(params: {
   baseUrl: string;
   promptId: string;
   headers: Headers;
-  timeoutMs: number;
+  deadline: ProviderOperationDeadline;
   pollIntervalMs: number;
   policy?: SsrFPolicy;
   dispatcherPolicy?: ComfyDispatcherPolicy;
 }): Promise<void> {
-  const deadline = Date.now() + params.timeoutMs;
   for (;;) {
-    const requestTimeoutMs = resolveComfyRemainingMs(deadline, params.timeoutMs);
     const status = await readJsonResponse<ComfyStatusResponse>({
       url: `${params.baseUrl}/api/job/${params.promptId}/status`,
       init: {
         method: "GET",
         headers: params.headers,
       },
-      timeoutMs: requestTimeoutMs,
+      deadline: params.deadline,
       policy: params.policy,
       dispatcherPolicy: params.dispatcherPolicy,
       auditContext: "comfy-status",
@@ -503,24 +558,19 @@ async function waitForCloudCompletion(params: {
       );
     }
 
-    const pollDelayMs = resolveComfyRemainingMs(deadline, params.timeoutMs, params.pollIntervalMs);
-    await new Promise((resolve) => {
-      setTimeout(resolve, pollDelayMs);
-    });
+    await waitForComfyPollInterval(params.deadline, params.pollIntervalMs);
   }
 }
 
-function resolveComfyRemainingMs(
-  deadline: number,
-  timeoutMs: number,
-  defaultTimeoutMs = timeoutMs,
-) {
-  const defaultMs = resolvePositiveTimerTimeoutMs(defaultTimeoutMs, 1);
-  const remainingMs = deadline - Date.now();
-  if (remainingMs <= 0) {
-    throw new Error(`Comfy workflow did not finish within ${Math.ceil(timeoutMs / 1000)}s`);
+async function waitForComfyPollInterval(
+  deadline: ProviderOperationDeadline,
+  pollIntervalMs: number,
+): Promise<void> {
+  try {
+    await waitProviderOperationPollInterval({ deadline, pollIntervalMs });
+  } catch (error) {
+    throw normalizeComfyWorkflowError(error, deadline);
   }
-  return Math.max(1, Math.min(defaultMs, remainingMs));
 }
 
 function collectOutputFiles(params: {
@@ -556,7 +606,7 @@ function collectOutputFiles(params: {
 async function downloadOutputFile(params: {
   baseUrl: string;
   headers: Headers;
-  timeoutMs: number;
+  deadline: ProviderOperationDeadline;
   policy?: SsrFPolicy;
   dispatcherPolicy?: ComfyDispatcherPolicy;
   file: ComfyOutputFile;
@@ -578,36 +628,33 @@ async function downloadOutputFile(params: {
   const viewPath = params.mode === "cloud" ? "/api/view" : "/view";
   const auditContext = `comfy-${params.capability}-download`;
 
-  const firstResponse = await comfyFetchGuard({
-    url: `${params.baseUrl}${viewPath}?${query.toString()}`,
-    init: {
-      method: "GET",
-      headers: params.headers,
+  return await withComfyGuardedResponse(
+    {
+      url: `${params.baseUrl}${viewPath}?${query.toString()}`,
+      init: {
+        method: "GET",
+        headers: params.headers,
+      },
+      deadline: params.deadline,
+      policy: params.policy,
+      dispatcherPolicy: params.dispatcherPolicy,
+      auditContext,
+      errorPrefix: "Comfy output download failed",
     },
-    timeoutMs: params.timeoutMs,
-    policy: params.policy,
-    dispatcherPolicy: params.dispatcherPolicy,
-    auditContext,
-  });
-
-  try {
-    await assertOkOrThrowHttpError(firstResponse.response, "Comfy output download failed");
-    const mimeType =
-      normalizeOptionalString(firstResponse.response.headers.get("content-type")) ||
-      "application/octet-stream";
-    return {
-      buffer: await readResponseWithLimit(firstResponse.response, params.maxBytes, {
-        chunkTimeoutMs: params.timeoutMs,
+    async (response, resolveTimeoutMs, deadline) => ({
+      buffer: await readResponseWithLimit(response, params.maxBytes, {
+        chunkTimeoutMs: resolveTimeoutMs(),
+        timeoutMs: resolveTimeoutMs,
+        onTimeout: () => createComfyWorkflowTimeoutError(deadline),
         onOverflow: ({ maxBytes }) =>
           new Error(`Comfy ${params.capability} output download exceeds ${maxBytes} bytes`),
         onIdleTimeout: ({ chunkTimeoutMs }) =>
           new Error(`Comfy ${params.capability} output download stalled after ${chunkTimeoutMs}ms`),
       }),
-      mimeType,
-    };
-  } finally {
-    await firstResponse.release();
-  }
+      mimeType:
+        normalizeOptionalString(response.headers.get("content-type")) || "application/octet-stream",
+    }),
+  );
 }
 
 export function isComfyCapabilityConfigured(params: {
@@ -668,7 +715,7 @@ export async function runComfyWorkflow(params: {
     DEFAULT_POLL_INTERVAL_MS,
   );
   const timeoutMs = resolvePositiveTimerTimeoutMs(
-    readConfigInteger(capabilityConfig, "timeoutMs") ?? params.timeoutMs,
+    params.timeoutMs ?? readConfigInteger(capabilityConfig, "timeoutMs"),
     DEFAULT_TIMEOUT_MS,
   );
   const providerModel = normalizeOptionalString(params.model) || DEFAULT_COMFY_MODEL;
@@ -733,16 +780,24 @@ export async function runComfyWorkflow(params: {
     mode,
   });
 
+  if (params.inputImage && !inputImageNodeId) {
+    throw new Error(
+      "Comfy edit requests require plugins.entries.comfy.config.<capability>.inputImageNodeId to be configured",
+    );
+  }
+
+  // Configuration, workflow filesystem access, and auth resolution are setup;
+  // one absolute budget starts immediately before the first guarded network call.
+  const deadline = createProviderOperationDeadline({
+    timeoutMs,
+    label: "Comfy workflow",
+  });
+
   if (params.inputImage) {
-    if (!inputImageNodeId) {
-      throw new Error(
-        "Comfy edit requests require plugins.entries.comfy.config.<capability>.inputImageNodeId to be configured",
-      );
-    }
     const uploadedName = await uploadInputImage({
       baseUrl: normalizedBaseUrl,
       headers: new Headers(headers),
-      timeoutMs,
+      deadline,
       policy: networkPolicy.apiPolicy,
       dispatcherPolicy,
       image: params.inputImage,
@@ -771,7 +826,7 @@ export async function runComfyWorkflow(params: {
       headers,
       body: JSON.stringify(submitPayload),
     },
-    timeoutMs,
+    deadline,
     policy: networkPolicy.apiPolicy,
     dispatcherPolicy,
     auditContext: `comfy-${params.capability}-generate`,
@@ -790,7 +845,7 @@ export async function runComfyWorkflow(params: {
             baseUrl: normalizedBaseUrl,
             promptId,
             headers: new Headers(headers),
-            timeoutMs,
+            deadline,
             pollIntervalMs,
             policy: networkPolicy.apiPolicy,
             dispatcherPolicy,
@@ -801,7 +856,7 @@ export async function runComfyWorkflow(params: {
               method: "GET",
               headers: new Headers(headers),
             },
-            timeoutMs,
+            deadline,
             policy: networkPolicy.apiPolicy,
             dispatcherPolicy,
             auditContext: "comfy-history",
@@ -812,7 +867,7 @@ export async function runComfyWorkflow(params: {
           baseUrl: normalizedBaseUrl,
           promptId,
           headers: new Headers(headers),
-          timeoutMs,
+          deadline,
           pollIntervalMs,
           policy: networkPolicy.apiPolicy,
           dispatcherPolicy,
@@ -840,7 +895,7 @@ export async function runComfyWorkflow(params: {
     const downloaded = await downloadOutputFile({
       baseUrl: normalizedBaseUrl,
       headers: new Headers(headers),
-      timeoutMs,
+      deadline,
       policy: networkPolicy.apiPolicy,
       dispatcherPolicy,
       file: output.file,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators generating music, images, or video through ComfyUI could silently ignore explicit caller deadlines, let plugin settings override per-request deadlines, or repeatedly restart the full timeout for upload, submission, polling, history, output downloads, and response bodies.

## Why This Change Was Made

Move workflow timing into one existing provider-operation deadline owned by the Comfy plugin, forward music request deadlines, and consistently prioritize explicit request deadlines. Keep guarded network access, dispatcher cleanup, response-size limits, existing retry behavior, and the exact timeout wording/timer cap already shipped in stable `v2026.7.1`.

## User Impact

Comfy image, music, and video requests now reliably obey the requested deadline across the complete network workflow, including slow successful/error response bodies and multiple downloads. Existing plugin-config defaults, security protections, timer limits, and operator-visible timeout messages remain compatible.

## Evidence

- Frozen reviewed head: `9ecc0dac75bbc9ccb894864e67bc088c24787677`; direct reviewed parent: `9fd56e6d6529610ac1a341f7eafe195c8a936869`. All six changed-file baselines remain byte-identical on newer main.
- Authentic unchanged-production RED across **all four** Comfy workflow/image/music/video owner suites: **11 failed / 42 passed**, including missing music deadline propagation, caller-versus-config precedence, repeated operation-budget resets, and unbounded guarded acquisition/success/error response bodies.
- Exact immutable candidate GREEN across the same four complete suites: **53 / 53 passed**, with the unchanged **28-test image suite** proving the real shipped `Comfy workflow did not finish within Ns` contract, the safe maximum-timer cap, local/cloud behavior, upload/download limits, origin restrictions, and error cleanup.
- Existing stable release `v2026.7.1` was inspected directly to prove timeout wording and timer-limit compatibility rather than inferring a contract from test expectations.
- **Five genuinely fresh independent hostile full-source reviews** inspected the complete Comfy owner, all sibling capability providers, direct SDK deadline and guarded-fetch implementations, HTTP-body handling, SSRF/redirect protections, and durable RED/GREEN artifacts; no P0-P3 findings remain.
- Actual official `gpt-5.6-sol` high-reasoning P0-P3 autoreview found **zero actionable findings**, confidence **0.89**; native TruffleHog **3.96.0** found no secrets.
- Scope is two existing Comfy plugin production modules plus their existing regression suites. No public configuration/schema change, plugin SDK change, authentication change, new retry, dependency update, migration, or core security-policy change.

## Root Causes

1. Music requests dropped the existing caller-provided timeout.
2. Plugin configuration incorrectly overrode explicit per-request deadlines.
3. Individual guarded requests, polling steps, response bodies, and downloads repeatedly escaped the one intended workflow deadline.
