### PR TITLE
refactor: consolidate Teams and error helpers

### DIFF
--- a/extensions/matrix/src/matrix/delivery-plan.test.ts
+++ b/extensions/matrix/src/matrix/delivery-plan.test.ts
@@ -202,6 +202,17 @@ describe("Matrix durable delivery plans", () => {
     );
   });
 
+  it("preserves the unknown-error fallback for non-error send failures", async () => {
+    await persist();
+    client.sendMessage.mockRejectedValueOnce({ code: "M_UNKNOWN" });
+
+    await expect(reconcileMatrixUnknownSend(reconciliationContext())).resolves.toMatchObject({
+      status: "unresolved",
+      error: "unknown error",
+      retryable: true,
+    });
+  });
+
   it("preserves ordered typed receipt parts and the final event identity", async () => {
     const deliveryIdentity = identity("queue-multi-event");
     const plannedEvents = createMatrixPlannedEvents({

--- a/extensions/matrix/src/matrix/delivery-plan.ts
+++ b/extensions/matrix/src/matrix/delivery-plan.ts
@@ -6,6 +6,7 @@ import type {
   MessageReceipt,
   MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { getMatrixRuntime } from "../runtime.js";
 import type { MatrixClient } from "./sdk.js";
 import type { MatrixMessageWireDispatch } from "./sdk/client-base.js";
@@ -383,13 +384,6 @@ function createReconciledMatrixReceipt(params: {
   };
 }
 
-function describeError(value: unknown): string {
-  if (value instanceof Error) {
-    return value.message;
-  }
-  return typeof value === "string" ? value : "unknown error";
-}
-
 async function requireTransactionScope(client: MatrixClient): Promise<string> {
   const scope = (await client.getTransactionScopeId()).trim();
   if (!scope) {
@@ -488,13 +482,19 @@ export async function reconcileMatrixUnknownSend(
         cleanupError = cleanupFailure;
       }
     }
-    const errorMessage = describeError(error);
+    const errorMessage = formatErrorMessage(
+      error instanceof Error || typeof error === "string" ? error : "unknown error",
+    );
     return {
       status: "unresolved",
       error:
         cleanupError === undefined
           ? errorMessage
-          : `${errorMessage}; Matrix delivery-plan cleanup failed: ${describeError(cleanupError)}`,
+          : `${errorMessage}; Matrix delivery-plan cleanup failed: ${formatErrorMessage(
+              cleanupError instanceof Error || typeof cleanupError === "string"
+                ? cleanupError
+                : "unknown error",
+            )}`,
       retryable,
     };
   }

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -18,6 +18,7 @@ import {
   isDownloadableAttachment,
   isRecord,
   isUrlAllowed,
+  isRedirectStatus,
   type MSTeamsAttachmentDownloadLogger,
   type MSTeamsAttachmentFetchPolicy,
   type MSTeamsAttachmentResolveFn,
@@ -128,10 +129,6 @@ function scopeCandidatesForUrl(url: string): string[] {
   } catch {
     return ["https://api.botframework.com", "https://graph.microsoft.com"];
   }
-}
-
-function isRedirectStatus(status: number): boolean {
-  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
 }
 
 async function resolveInlineDataImageMime(inline: {

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -626,6 +626,10 @@ async function resolveAndValidateIP(
 
 /** Maximum number of redirects to follow in safeFetch. */
 const MAX_SAFE_REDIRECTS = 5;
+export function isRedirectStatus(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
 /**
  * Fetch a URL with redirect: "manual", validating each redirect target
  * against the hostname allowlist and optional DNS-resolved IP (anti-SSRF).
@@ -711,7 +715,7 @@ async function safeFetch(params: {
       redirect: "manual",
     });
 
-    if (![301, 302, 303, 307, 308].includes(res.status)) {
+    if (!isRedirectStatus(res.status)) {
       return res;
     }
 

--- a/extensions/msteams/src/graph-group-management.test.ts
+++ b/extensions/msteams/src/graph-group-management.test.ts
@@ -10,9 +10,8 @@ import {
 const mockState = vi.hoisted(() => ({
   resolveGraphToken: vi.fn(),
   fetchGraphJson: vi.fn(),
-  postGraphJson: vi.fn(),
+  mutateGraphJson: vi.fn(),
   deleteGraphRequest: vi.fn(),
-  patchGraphJson: vi.fn(),
   findPreferredDmByUserId: vi.fn(),
 }));
 
@@ -22,9 +21,8 @@ vi.mock("./graph.js", async (importOriginal) => {
     ...actual,
     resolveGraphToken: mockState.resolveGraphToken,
     fetchGraphJson: mockState.fetchGraphJson,
-    postGraphJson: mockState.postGraphJson,
+    mutateGraphJson: mockState.mutateGraphJson,
     deleteGraphRequest: mockState.deleteGraphRequest,
-    patchGraphJson: mockState.patchGraphJson,
   };
 });
 
@@ -39,7 +37,7 @@ const CHAT_ID = "19:abc@thread.tacv2";
 const CHANNEL_TO = "team-id-1/channel-id-1";
 
 function postGraphBodyAt(index: number): Record<string, unknown> {
-  const call = mockState.postGraphJson.mock.calls[index];
+  const call = mockState.mutateGraphJson.mock.calls[index];
   if (!call) {
     throw new Error(`expected Graph post call ${index}`);
   }
@@ -57,7 +55,7 @@ describe("addParticipantMSTeams", () => {
   });
 
   it("maps the default chat member role to Graph owner", async () => {
-    mockState.postGraphJson.mockResolvedValue({});
+    mockState.mutateGraphJson.mockResolvedValue({});
 
     const result = await addParticipantMSTeams({
       cfg: {} as OpenClawConfig,
@@ -66,9 +64,10 @@ describe("addParticipantMSTeams", () => {
     });
 
     expect(result).toEqual({ added: { userId: "user-aad-id-1", chatId: CHAT_ID } });
-    expect(mockState.postGraphJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: `/chats/${encodeURIComponent(CHAT_ID)}/members`,
+      method: "POST",
       body: {
         "@odata.type": "#microsoft.graph.aadUserConversationMember",
         roles: ["owner"],
@@ -78,7 +77,7 @@ describe("addParticipantMSTeams", () => {
   });
 
   it("adds member to a chat with owner role", async () => {
-    mockState.postGraphJson.mockResolvedValue({});
+    mockState.mutateGraphJson.mockResolvedValue({});
 
     const result = await addParticipantMSTeams({
       cfg: {} as OpenClawConfig,
@@ -88,9 +87,10 @@ describe("addParticipantMSTeams", () => {
     });
 
     expect(result).toEqual({ added: { userId: "user-aad-id-2", chatId: CHAT_ID } });
-    expect(mockState.postGraphJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: `/chats/${encodeURIComponent(CHAT_ID)}/members`,
+      method: "POST",
       body: {
         "@odata.type": "#microsoft.graph.aadUserConversationMember",
         roles: ["owner"],
@@ -100,7 +100,7 @@ describe("addParticipantMSTeams", () => {
   });
 
   it("normalizes role casing and whitespace", async () => {
-    mockState.postGraphJson.mockResolvedValue({});
+    mockState.mutateGraphJson.mockResolvedValue({});
 
     await addParticipantMSTeams({
       cfg: {} as OpenClawConfig,
@@ -109,9 +109,10 @@ describe("addParticipantMSTeams", () => {
       role: " OWNER ",
     });
 
-    expect(mockState.postGraphJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: `/chats/${encodeURIComponent(CHAT_ID)}/members`,
+      method: "POST",
       body: {
         "@odata.type": "#microsoft.graph.aadUserConversationMember",
         roles: ["owner"],
@@ -130,11 +131,11 @@ describe("addParticipantMSTeams", () => {
       }),
     ).rejects.toThrow('role must be "member" or "owner"');
 
-    expect(mockState.postGraphJson).not.toHaveBeenCalled();
+    expect(mockState.mutateGraphJson).not.toHaveBeenCalled();
   });
 
   it("constructs correct user@odata.bind URL", async () => {
-    mockState.postGraphJson.mockResolvedValue({});
+    mockState.mutateGraphJson.mockResolvedValue({});
 
     await addParticipantMSTeams({
       cfg: {} as OpenClawConfig,
@@ -149,7 +150,7 @@ describe("addParticipantMSTeams", () => {
   });
 
   it("escapes user ids before building the OData bind URL", async () => {
-    mockState.postGraphJson.mockResolvedValue({});
+    mockState.mutateGraphJson.mockResolvedValue({});
 
     await addParticipantMSTeams({
       cfg: {} as OpenClawConfig,
@@ -164,7 +165,7 @@ describe("addParticipantMSTeams", () => {
   });
 
   it("maps the default channel member role to an empty Graph role list", async () => {
-    mockState.postGraphJson.mockResolvedValue({});
+    mockState.mutateGraphJson.mockResolvedValue({});
 
     const result = await addParticipantMSTeams({
       cfg: {} as OpenClawConfig,
@@ -173,9 +174,10 @@ describe("addParticipantMSTeams", () => {
     });
 
     expect(result).toEqual({ added: { userId: "user-aad-id-3", chatId: CHANNEL_TO } });
-    expect(mockState.postGraphJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: "/teams/team-id-1/channels/channel-id-1/members",
+      method: "POST",
       body: {
         "@odata.type": "#microsoft.graph.aadUserConversationMember",
         roles: [],
@@ -185,7 +187,7 @@ describe("addParticipantMSTeams", () => {
   });
 
   it("preserves the owner role for a channel", async () => {
-    mockState.postGraphJson.mockResolvedValue({});
+    mockState.mutateGraphJson.mockResolvedValue({});
 
     await addParticipantMSTeams({
       cfg: {} as OpenClawConfig,
@@ -194,9 +196,10 @@ describe("addParticipantMSTeams", () => {
       role: "owner",
     });
 
-    expect(mockState.postGraphJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: "/teams/team-id-1/channels/channel-id-1/members",
+      method: "POST",
       body: {
         "@odata.type": "#microsoft.graph.aadUserConversationMember",
         roles: ["owner"],
@@ -319,7 +322,7 @@ describe("renameGroupMSTeams", () => {
   });
 
   it("renames a chat with topic", async () => {
-    mockState.patchGraphJson.mockResolvedValue(undefined);
+    mockState.mutateGraphJson.mockResolvedValue(undefined);
 
     const result = await renameGroupMSTeams({
       cfg: {} as OpenClawConfig,
@@ -328,15 +331,16 @@ describe("renameGroupMSTeams", () => {
     });
 
     expect(result).toEqual({ renamed: { chatId: CHAT_ID, newName: "New Chat Name" } });
-    expect(mockState.patchGraphJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: `/chats/${encodeURIComponent(CHAT_ID)}`,
+      method: "PATCH",
       body: { topic: "New Chat Name" },
     });
   });
 
   it("renames a channel with displayName", async () => {
-    mockState.patchGraphJson.mockResolvedValue(undefined);
+    mockState.mutateGraphJson.mockResolvedValue(undefined);
 
     const result = await renameGroupMSTeams({
       cfg: {} as OpenClawConfig,
@@ -345,9 +349,10 @@ describe("renameGroupMSTeams", () => {
     });
 
     expect(result).toEqual({ renamed: { chatId: CHANNEL_TO, newName: "New Channel Name" } });
-    expect(mockState.patchGraphJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: "/teams/team-id-1/channels/channel-id-1",
+      method: "PATCH",
       body: { displayName: "New Channel Name" },
     });
   });

--- a/extensions/msteams/src/graph-group-management.ts
+++ b/extensions/msteams/src/graph-group-management.ts
@@ -2,13 +2,7 @@
 import type { OpenClawConfig } from "../runtime-api.js";
 import { findMSTeamsConversationMember } from "./graph-conversation-members.js";
 import { resolveConversationPath, resolveGraphConversationId } from "./graph-messages.js";
-import {
-  deleteGraphRequest,
-  escapeOData,
-  patchGraphJson,
-  postGraphJson,
-  resolveGraphToken,
-} from "./graph.js";
+import { deleteGraphRequest, escapeOData, mutateGraphJson, resolveGraphToken } from "./graph.js";
 
 // ---------------------------------------------------------------------------
 // Add Participant
@@ -67,9 +61,10 @@ export async function addParticipantMSTeams(
     "user@odata.bind": `https://graph.microsoft.com/v1.0/users('${escapeOData(params.userId)}')`,
   };
 
-  await postGraphJson<unknown>({
+  await mutateGraphJson<unknown>({
     token,
     path: `${conv.basePath}/members`,
+    method: "POST",
     body,
   });
 
@@ -142,9 +137,10 @@ export async function renameGroupMSTeams(
 
   const body = conv.kind === "chat" ? { topic: params.name } : { displayName: params.name };
 
-  await patchGraphJson<unknown>({
+  await mutateGraphJson<unknown>({
     token,
     path: conv.basePath,
+    method: "PATCH",
     body,
   });
 

--- a/extensions/msteams/src/graph-messages.actions.test.ts
+++ b/extensions/msteams/src/graph-messages.actions.test.ts
@@ -57,7 +57,7 @@ describe("MSTeams reaction validation", () => {
 
 describe("pinMessageMSTeams", () => {
   it("pins a message in a chat via message@odata.bind body", async () => {
-    mockState.postGraphJson.mockResolvedValue({ id: "pinned-1" });
+    mockState.mutateGraphJson.mockResolvedValue({ id: "pinned-1" });
 
     const result = await pinMessageMSTeams({
       cfg: {} as OpenClawConfig,
@@ -66,9 +66,10 @@ describe("pinMessageMSTeams", () => {
     });
 
     expect(result).toEqual({ ok: true, pinnedMessageId: "pinned-1" });
-    expect(mockState.postGraphJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: `/chats/${encodeURIComponent(CHAT_ID)}/pinnedMessages`,
+      method: "POST",
       body: {
         "message@odata.bind": `https://graph.microsoft.com/v1.0/chats/${encodeURIComponent(
           CHAT_ID,
@@ -85,7 +86,7 @@ describe("pinMessageMSTeams", () => {
         messageId: "msg-2",
       }),
     ).rejects.toThrow(/Pin\/unpin is not supported for channel messages/);
-    expect(mockState.postGraphJson).not.toHaveBeenCalled();
+    expect(mockState.mutateGraphJson).not.toHaveBeenCalled();
   });
 });
 
@@ -120,7 +121,7 @@ describe("unpinMessageMSTeams", () => {
 
 describe("reactMessageMSTeams", () => {
   it("sets a like reaction on a chat message", async () => {
-    mockState.postGraphBetaJson.mockResolvedValue(undefined);
+    mockState.mutateGraphJson.mockResolvedValue(undefined);
 
     const result = await reactMessageMSTeams({
       cfg: {} as OpenClawConfig,
@@ -130,15 +131,17 @@ describe("reactMessageMSTeams", () => {
     });
 
     expect(result).toEqual({ ok: true });
-    expect(mockState.postGraphBetaJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: `/chats/${encodeURIComponent(CHAT_ID)}/messages/msg-1/setReaction`,
+      method: "POST",
       body: { reactionType: "👍" },
+      beta: true,
     });
   });
 
   it("sets a reaction on a channel message", async () => {
-    mockState.postGraphBetaJson.mockResolvedValue(undefined);
+    mockState.mutateGraphJson.mockResolvedValue(undefined);
 
     const result = await reactMessageMSTeams({
       cfg: {} as OpenClawConfig,
@@ -148,15 +151,17 @@ describe("reactMessageMSTeams", () => {
     });
 
     expect(result).toEqual({ ok: true });
-    expect(mockState.postGraphBetaJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: "/teams/team-id-1/channels/channel-id-1/messages/msg-2/setReaction",
+      method: "POST",
       body: { reactionType: "❤️" },
+      beta: true,
     });
   });
 
   it("normalizes a case-insensitive reaction name to Unicode", async () => {
-    mockState.postGraphBetaJson.mockResolvedValue(undefined);
+    mockState.mutateGraphJson.mockResolvedValue(undefined);
 
     await reactMessageMSTeams({
       cfg: {} as OpenClawConfig,
@@ -165,16 +170,18 @@ describe("reactMessageMSTeams", () => {
       reactionType: "LAUGH",
     });
 
-    expect(mockState.postGraphBetaJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: `/chats/${encodeURIComponent(CHAT_ID)}/messages/msg-1/setReaction`,
+      method: "POST",
       body: { reactionType: "😆" },
+      beta: true,
     });
   });
 
   it("passes through non-well-known reaction types (e.g. Unicode emoji)", async () => {
     // Graph setReaction accepts Unicode values outside the named convenience set.
-    mockState.postGraphBetaJson.mockResolvedValue(undefined);
+    mockState.mutateGraphJson.mockResolvedValue(undefined);
 
     await reactMessageMSTeams({
       cfg: {} as OpenClawConfig,
@@ -183,10 +190,12 @@ describe("reactMessageMSTeams", () => {
       reactionType: "🎉",
     });
 
-    expect(mockState.postGraphBetaJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: `/chats/${encodeURIComponent(CHAT_ID)}/messages/msg-1/setReaction`,
+      method: "POST",
       body: { reactionType: "🎉" },
+      beta: true,
     });
   });
 
@@ -195,7 +204,7 @@ describe("reactMessageMSTeams", () => {
       conversationId: "19:dm-chat@thread.tacv2",
       reference: {},
     });
-    mockState.postGraphBetaJson.mockResolvedValue(undefined);
+    mockState.mutateGraphJson.mockResolvedValue(undefined);
 
     await reactMessageMSTeams({
       cfg: {} as OpenClawConfig,
@@ -205,17 +214,19 @@ describe("reactMessageMSTeams", () => {
     });
 
     expect(mockState.findPreferredDmByUserId).toHaveBeenCalledWith("aad-user-1");
-    expect(mockState.postGraphBetaJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: `/chats/${encodeURIComponent("19:dm-chat@thread.tacv2")}/messages/msg-1/setReaction`,
+      method: "POST",
       body: { reactionType: "👍" },
+      beta: true,
     });
   });
 });
 
 describe("unreactMessageMSTeams", () => {
   it("removes a reaction from a chat message", async () => {
-    mockState.postGraphBetaJson.mockResolvedValue(undefined);
+    mockState.mutateGraphJson.mockResolvedValue(undefined);
 
     const result = await unreactMessageMSTeams({
       cfg: {} as OpenClawConfig,
@@ -225,15 +236,17 @@ describe("unreactMessageMSTeams", () => {
     });
 
     expect(result).toEqual({ ok: true });
-    expect(mockState.postGraphBetaJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: `/chats/${encodeURIComponent(CHAT_ID)}/messages/msg-1/unsetReaction`,
+      method: "POST",
       body: { reactionType: "😢" },
+      beta: true,
     });
   });
 
   it("removes a reaction from a channel message", async () => {
-    mockState.postGraphBetaJson.mockResolvedValue(undefined);
+    mockState.mutateGraphJson.mockResolvedValue(undefined);
 
     const result = await unreactMessageMSTeams({
       cfg: {} as OpenClawConfig,
@@ -243,10 +256,12 @@ describe("unreactMessageMSTeams", () => {
     });
 
     expect(result).toEqual({ ok: true });
-    expect(mockState.postGraphBetaJson).toHaveBeenCalledWith({
+    expect(mockState.mutateGraphJson).toHaveBeenCalledWith({
       token: TOKEN,
       path: "/teams/team-id-1/channels/channel-id-1/messages/msg-2/unsetReaction",
+      method: "POST",
       body: { reactionType: "😡" },
+      beta: true,
     });
   });
 });

--- a/extensions/msteams/src/graph-messages.test-helpers.ts
+++ b/extensions/msteams/src/graph-messages.test-helpers.ts
@@ -5,8 +5,7 @@ const graphMessagesMockState = vi.hoisted(() => ({
   resolveGraphToken: vi.fn(),
   fetchGraphJson: vi.fn(),
   fetchGraphAbsoluteUrl: vi.fn(),
-  postGraphJson: vi.fn(),
-  postGraphBetaJson: vi.fn(),
+  mutateGraphJson: vi.fn(),
   deleteGraphRequest: vi.fn(),
   findPreferredDmByUserId: vi.fn(),
 }));
@@ -16,8 +15,7 @@ vi.mock("./graph.js", () => {
     resolveGraphToken: graphMessagesMockState.resolveGraphToken,
     fetchGraphJson: graphMessagesMockState.fetchGraphJson,
     fetchGraphAbsoluteUrl: graphMessagesMockState.fetchGraphAbsoluteUrl,
-    postGraphJson: graphMessagesMockState.postGraphJson,
-    postGraphBetaJson: graphMessagesMockState.postGraphBetaJson,
+    mutateGraphJson: graphMessagesMockState.mutateGraphJson,
     deleteGraphRequest: graphMessagesMockState.deleteGraphRequest,
     escapeOData: vi.fn((value: string) => value.replaceAll("'", "''")),
   };

--- a/extensions/msteams/src/graph-messages.ts
+++ b/extensions/msteams/src/graph-messages.ts
@@ -6,8 +6,7 @@ import {
   deleteGraphRequest,
   fetchGraphAbsoluteUrl,
   fetchGraphJson,
-  postGraphBetaJson,
-  postGraphJson,
+  mutateGraphJson,
   resolveGraphToken,
 } from "./graph.js";
 import { getMSTeamsReactionEmoji, resolveMSTeamsReactionEmoji } from "./reaction-types.js";
@@ -194,9 +193,10 @@ export async function pinMessageMSTeams(
   const body = {
     "message@odata.bind": `https://graph.microsoft.com/v1.0/chats/${encodeURIComponent(conversationId)}/messages/${encodeURIComponent(params.messageId)}`,
   };
-  const result = await postGraphJson<{ id?: string }>({
+  const result = await mutateGraphJson<{ id?: string }>({
     token,
     path: `${conv.basePath}/pinnedMessages`,
+    method: "POST",
     body,
   });
   return { ok: true, pinnedMessageId: result.id };
@@ -353,7 +353,13 @@ export async function reactMessageMSTeams(
   const conversationId = await resolveGraphConversationId(params.to);
   const { basePath } = resolveConversationPath(conversationId);
   const path = `${basePath}/messages/${encodeURIComponent(params.messageId)}/setReaction`;
-  await postGraphBetaJson<unknown>({ token, path, body: { reactionType } });
+  await mutateGraphJson<unknown>({
+    token,
+    path,
+    method: "POST",
+    body: { reactionType },
+    beta: true,
+  });
   return { ok: true };
 }
 
@@ -371,7 +377,13 @@ export async function unreactMessageMSTeams(
   const conversationId = await resolveGraphConversationId(params.to);
   const { basePath } = resolveConversationPath(conversationId);
   const path = `${basePath}/messages/${encodeURIComponent(params.messageId)}/unsetReaction`;
-  await postGraphBetaJson<unknown>({ token, path, body: { reactionType } });
+  await mutateGraphJson<unknown>({
+    token,
+    path,
+    method: "POST",
+    body: { reactionType },
+    beta: true,
+  });
   return { ok: true };
 }
 

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -55,9 +55,8 @@ import {
   listChannelsForTeamWithPageInfo,
   listTeamsByName,
   listTeamsByNameWithPageInfo,
+  mutateGraphJson,
   normalizeQuery,
-  postGraphBetaJson,
-  postGraphJson,
   resolveGraphToken,
 } from "./graph.js";
 
@@ -110,20 +109,13 @@ function graphStreamResponse(body: unknown): {
       controller.close();
     },
   });
-  const arrayBuffer = vi.fn(async () => {
+  const response = new Response(stream, {
+    headers: { "content-type": "application/json" },
+  });
+  const arrayBuffer = vi.spyOn(response, "arrayBuffer").mockImplementation(async () => {
     throw new Error("Graph response must stay streaming");
   });
-  return {
-    response: {
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: new Headers({ "content-type": "application/json" }),
-      body: stream,
-      arrayBuffer,
-    } as unknown as Response,
-    arrayBuffer,
-  };
+  return { response, arrayBuffer };
 }
 
 function graphCollection<T>(...items: T[]) {
@@ -324,27 +316,42 @@ describe("msteams graph helpers", () => {
     );
   });
 
-  it("posts Graph JSON to v1 and beta roots and treats empty mutation responses as undefined", async () => {
-    mockFetch(async (input) => {
+  it("mutates Graph JSON at v1 and beta roots and treats empty responses as undefined", async () => {
+    mockFetch(async (input, init) => {
       if (requestUrl(input).startsWith("https://graph.microsoft.com/beta")) {
         return new Response(null, { status: 204 });
+      }
+      if (init?.method === "PATCH") {
+        return new Response(null, { headers: { "content-length": "0" } });
       }
       return jsonResponse({ id: "created-1" });
     });
 
     await expect(
-      postGraphJson<{ id: string }>({
+      mutateGraphJson<{ id: string }>({
         token: graphToken,
         path: "/chats/chat-1/pinnedMessages",
+        method: "POST",
         body: { messageId: "msg-1" },
       }),
     ).resolves.toEqual({ id: "created-1" });
 
     await expect(
-      postGraphBetaJson<undefined>({
+      mutateGraphJson<undefined>({
         token: graphToken,
         path: "/chats/chat-1/messages/msg-1/setReaction",
+        method: "POST",
         body: { reactionType: "like" },
+        beta: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      mutateGraphJson<undefined>({
+        token: graphToken,
+        path: "/chats/chat-1",
+        method: "PATCH",
+        body: { topic: "New topic" },
       }),
     ).resolves.toBeUndefined();
 
@@ -358,6 +365,9 @@ describe("msteams graph helpers", () => {
     );
     expect(fetchCallInit(1)?.method).toBe("POST");
     expect(fetchCallInit(1)?.body).toBe(JSON.stringify({ reactionType: "like" }));
+    expect(fetchCallUrl(2)).toBe("https://graph.microsoft.com/v1.0/chats/chat-1");
+    expect(fetchCallInit(2)?.method).toBe("PATCH");
+    expect(fetchCallInit(2)?.body).toBe(JSON.stringify({ topic: "New topic" }));
   });
 
   it("surfaces POST and DELETE graph failures with method-specific labels", async () => {
@@ -370,9 +380,10 @@ describe("msteams graph helpers", () => {
     });
 
     await expectRejectsToThrow(
-      postGraphJson({
+      mutateGraphJson({
         token: graphToken,
         path: "/teams/team-1/channels",
+        method: "POST",
         body: { displayName: "Deployments" },
       }),
       "Graph POST /teams/team-1/channels failed (403): denied",

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -90,30 +90,41 @@ async function requestGraph(params: {
 }
 
 async function readOptionalGraphJson<T>(res: Response, label: string): Promise<T> {
-  // Use optional chaining to stay resilient to partial test mocks that do not
-  // provide a status or Headers instance (they only shim `ok` + `json()`).
-  if (res.status === 204 || res.headers?.get?.("content-length") === "0") {
+  if (res.status === 204 || res.headers.get("content-length") === "0") {
     return undefined as T;
   }
   return await readProviderJsonResponse<T>(res, label);
+}
+
+export async function mutateGraphJson<T>(params: {
+  token: string;
+  path: string;
+  method: "POST" | "PATCH";
+  body?: unknown;
+  beta?: boolean;
+}): Promise<T> {
+  const errorPrefix = `Graph${params.beta ? " beta" : ""} ${params.method}`;
+  const response = await requestGraph({
+    token: params.token,
+    path: params.path,
+    method: params.method,
+    body: params.body,
+    root: params.beta ? GRAPH_BETA : undefined,
+    errorPrefix,
+  });
+  return readOptionalGraphJson<T>(response, `${errorPrefix} ${params.path} failed`);
 }
 
 export async function fetchGraphJson<T>(params: {
   token: string;
   path: string;
   headers?: Record<string, string>;
-  /** HTTP method; defaults to "GET" */
-  method?: string;
-  /** Request body (serialized as JSON). Only used for non-GET methods. */
-  body?: unknown;
   /** Optional shared operation deadline; actively aborts the guarded fetch when spent. */
   deadline?: MSTeamsRequestDeadline;
 }): Promise<T> {
   const res = await requestGraph({
     token: params.token,
     path: params.path,
-    method: params.method as "GET" | "POST" | "DELETE" | undefined,
-    body: params.body,
     headers: params.headers,
     deadline: params.deadline,
   });
@@ -269,37 +280,6 @@ export async function listTeamsByNameWithPageInfo(
   return await fetchAllGraphPages<GraphGroup>({ token, path });
 }
 
-export async function postGraphJson<T>(params: {
-  token: string;
-  path: string;
-  body?: unknown;
-}): Promise<T> {
-  const res = await requestGraph({
-    token: params.token,
-    path: params.path,
-    method: "POST",
-    body: params.body,
-    errorPrefix: "Graph POST",
-  });
-  return readOptionalGraphJson<T>(res, `Graph POST ${params.path} failed`);
-}
-
-export async function postGraphBetaJson<T>(params: {
-  token: string;
-  path: string;
-  body?: unknown;
-}): Promise<T> {
-  const res = await requestGraph({
-    token: params.token,
-    path: params.path,
-    method: "POST",
-    root: GRAPH_BETA,
-    body: params.body,
-    errorPrefix: "Graph beta POST",
-  });
-  return readOptionalGraphJson<T>(res, `Graph beta POST ${params.path} failed`);
-}
-
 export async function deleteGraphRequest(params: { token: string; path: string }): Promise<void> {
   const response = await requestGraph({
     token: params.token,
@@ -308,21 +288,6 @@ export async function deleteGraphRequest(params: { token: string; path: string }
     errorPrefix: "Graph DELETE",
   });
   await response.body?.cancel().catch(() => undefined);
-}
-
-export async function patchGraphJson<T>(params: {
-  token: string;
-  path: string;
-  body?: unknown;
-}): Promise<T> {
-  const res = await requestGraph({
-    token: params.token,
-    path: params.path,
-    method: "PATCH",
-    body: params.body,
-    errorPrefix: "Graph PATCH",
-  });
-  return readOptionalGraphJson<T>(res, `Graph PATCH ${params.path} failed`);
 }
 
 export async function listChannelsForTeam(token: string, teamId: string): Promise<GraphChannel[]> {

--- a/extensions/qwen/video-generation-provider.ts
+++ b/extensions/qwen/video-generation-provider.ts
@@ -1,6 +1,5 @@
 // Qwen provider module implements model/runtime integration.
 import { buildDashscopeVideoGenerationProvider } from "openclaw/plugin-sdk/video-generation";
-import { QWEN_STANDARD_CN_BASE_URL, QWEN_STANDARD_GLOBAL_BASE_URL } from "./models.js";
 
 const DEFAULT_QWEN_VIDEO_BASE_URL = "https://dashscope-intl.aliyuncs.com";
 function resolveQwenVideoBaseUrl(configuredBaseUrl: string | undefined): string {
@@ -16,24 +15,14 @@ function resolveQwenVideoBaseUrl(configuredBaseUrl: string | undefined): string 
 }
 
 function resolveDashscopeAigcApiBaseUrl(baseUrl: string): string {
-  try {
-    const url = new URL(baseUrl);
-    if (
-      url.hostname === "coding-intl.dashscope.aliyuncs.com" ||
-      url.hostname === "coding.dashscope.aliyuncs.com" ||
-      url.hostname === "dashscope-intl.aliyuncs.com" ||
-      url.hostname === "dashscope.aliyuncs.com"
-    ) {
-      return url.origin;
-    }
-  } catch {
-    // Fall through to legacy prefix handling for non-URL strings.
-  }
-  if (baseUrl.startsWith(QWEN_STANDARD_CN_BASE_URL)) {
-    return "https://dashscope.aliyuncs.com";
-  }
-  if (baseUrl.startsWith(QWEN_STANDARD_GLOBAL_BASE_URL)) {
-    return DEFAULT_QWEN_VIDEO_BASE_URL;
+  const url = new URL(baseUrl);
+  if (
+    url.hostname === "coding-intl.dashscope.aliyuncs.com" ||
+    url.hostname === "coding.dashscope.aliyuncs.com" ||
+    url.hostname === "dashscope-intl.aliyuncs.com" ||
+    url.hostname === "dashscope.aliyuncs.com"
+  ) {
+    return url.origin;
   }
   return baseUrl.replace(/\/+$/u, "");
 }

--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -1,17 +1,14 @@
 import { createHash, randomUUID } from "node:crypto";
 import { stableStringify } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { formatErrorMessage } from "../infra/errors.js";
 import { NODE_FS_LIST_DIR_COMMAND } from "../infra/node-commands.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { parseNodeList } from "../shared/node-list-parse.js";
 import type { NodeListNode } from "../shared/node-list-types.js";
 import { toCodeModeJsonSafe } from "./code-mode-json.js";
 import type { CodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
-import {
-  errorMessage,
-  type PendingBridgeRequest,
-  type SettledBridgeRequest,
-} from "./code-mode-runtime.js";
+import type { PendingBridgeRequest, SettledBridgeRequest } from "./code-mode-runtime.js";
 import { readCodeModeSkill } from "./code-mode-skills.js";
 import type { AgentToolUpdateCallback } from "./runtime/index.js";
 import { getSwarmRunByLaunchReplayKey, initSubagentRegistry } from "./subagent-registry.js";
@@ -538,7 +535,7 @@ export async function runBridgeRequest(params: {
     }
     return { id: params.request.id, ok: true, value: toCodeModeJsonSafe(value) };
   } catch (error) {
-    return { id: params.request.id, ok: false, error: errorMessage(error) };
+    return { id: params.request.id, ok: false, error: formatErrorMessage(error) };
   }
 }
 

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -2,6 +2,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
 import { parse, tokenizer } from "acorn";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
 import { clampNumber } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
@@ -280,7 +281,7 @@ class CodeModeLimitError extends ToolInputError {
 }
 
 function isRuntimeInterruptedError(error: unknown): boolean {
-  return errorMessage(error) === "interrupted";
+  return (error instanceof Error ? error.message : error) === "interrupted";
 }
 
 export function codeModeFailureCode(error: unknown): CodeModeFailureCode {
@@ -294,7 +295,9 @@ export function codeModeFailureCode(error: unknown): CodeModeFailureCode {
 }
 
 export function codeModeFailureMessage(error: unknown): string {
-  return isRuntimeInterruptedError(error) ? "code mode timeout exceeded" : errorMessage(error);
+  return isRuntimeInterruptedError(error)
+    ? "code mode timeout exceeded"
+    : formatErrorMessage(error);
 }
 
 export function enforceOutputLimit(output: unknown[], config: CodeModeConfig): void {
@@ -621,13 +624,6 @@ export async function prepareSource(input: {
     throw new ToolInputError(CODE_MODE_SHELL_SOURCE_ERROR);
   }
   return transformed.outputText;
-}
-
-export function errorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message || String(error);
-  }
-  return String(error);
 }
 
 export function createCodeModeApiFilesForRun(

--- a/src/agents/code-mode-worker.ts
+++ b/src/agents/code-mode-worker.ts
@@ -4,11 +4,8 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import {
-  errorMessage,
-  type CodeModeFailureCode,
-  type CodeModeWorkerResult,
-} from "./code-mode-runtime.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import type { CodeModeFailureCode, CodeModeWorkerResult } from "./code-mode-runtime.js";
 
 let quickJsWasmModulePromise: Promise<WebAssembly.Module> | undefined;
 
@@ -48,7 +45,7 @@ function failedCodeModeWorkerResult(
 ): Extract<CodeModeWorkerResult, { status: "failed" }> {
   return {
     status: "failed",
-    error: errorMessage(error),
+    error: formatErrorMessage(error),
     code,
     failurePhase: "host",
     bridgeDispatchStarted: false,

--- a/src/agents/code-mode.limits.test.ts
+++ b/src/agents/code-mode.limits.test.ts
@@ -2,6 +2,7 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { codeModeFailureCode } from "./code-mode-runtime.js";
 import { applyCodeModeCatalog, createCodeModeTools, resolveCodeModeConfig } from "./code-mode.js";
 import {
   resetCodeModeTestState,
@@ -302,6 +303,9 @@ describe("Code Mode runtime and output limits", () => {
   });
 
   it("normalizes QuickJS interrupt timeout errors", () => {
+    expect(
+      codeModeFailureCode(new Error("interrupted", { cause: new Error("worker stopped") })),
+    ).toBe("timeout");
     expect(
       testing.normalizeCodeModeWorkerResult({
         status: "failed",

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -18,6 +18,7 @@ import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import type { GatewayHttpChatCompletionsConfig } from "../config/types.gateway.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
 import {
   DEFAULT_INPUT_IMAGE_MAX_BYTES,
@@ -861,16 +862,6 @@ function resolveChatCompletionTokenCap(value: unknown, field: string): number | 
   return maxTokens;
 }
 
-function resolveErrorMessage(err: unknown): string {
-  if (err instanceof Error) {
-    const message = err.message.trim();
-    if (message) {
-      return message;
-    }
-  }
-  return String(err);
-}
-
 export async function handleOpenAiHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -916,7 +907,7 @@ export async function handleOpenAiHttpRequest(
     maxTokens = maxCompletionTokens ?? legacyMaxTokens;
   } catch (err) {
     sendJson(res, 400, {
-      error: { message: resolveErrorMessage(err), type: "invalid_request_error" },
+      error: { message: formatErrorMessage(err).trim(), type: "invalid_request_error" },
     });
     return true;
   }
@@ -933,7 +924,7 @@ export async function handleOpenAiHttpRequest(
   } catch (err) {
     sendJson(res, 400, {
       error: {
-        message: `Invalid response_format: ${resolveErrorMessage(err)}`,
+        message: `Invalid response_format: ${formatErrorMessage(err).trim()}`,
         type: "invalid_request_error",
       },
     });
@@ -945,7 +936,7 @@ export async function handleOpenAiHttpRequest(
   } catch (err) {
     sendJson(res, 400, {
       error: {
-        message: `Invalid stop: ${resolveErrorMessage(err)}`,
+        message: `Invalid stop: ${formatErrorMessage(err).trim()}`,
         type: "invalid_request_error",
       },
     });
@@ -1034,7 +1025,7 @@ export async function handleOpenAiHttpRequest(
   } catch (err) {
     sendJson(res, 400, {
       error: {
-        message: `Invalid tools/tool_choice: ${resolveErrorMessage(err)}`,
+        message: `Invalid tools/tool_choice: ${formatErrorMessage(err).trim()}`,
         type: "invalid_request_error",
       },
     });


### PR DESCRIPTION
## What Problem This Solves

Several small request and error-formatting paths still duplicated canonical behavior. Teams carried three Graph mutation wrappers plus a second unused mutation-capable read API, two attachment redirect predicates, and test-only response defensiveness. OpenAI HTTP, Matrix delivery reconciliation, and Code Mode each retained local generic error helpers. Qwen video generation also kept URL-prefix fallbacks that its validated request-config producer cannot reach.

## Why This Change Was Made

This change consolidates Teams POST/PATCH requests into one mutation function while retaining DELETE as the distinct response-release owner. It moves both attachment paths onto one redirect predicate, uses the canonical core/plugin error formatter at each valid boundary, keeps Code Mode's raw interruption sentinel check ahead of formatting, and preserves Matrix's explicit unknown-error fallback. Qwen now relies on its validated absolute URL producer while retaining custom-host trailing-slash normalization.

The workboard error helper was audited and intentionally left unchanged because its shipped record and fallback semantics are not equivalent to the canonical formatter and current callers do not prove those inputs impossible.

## User Impact

No intended behavior change. Graph request methods, beta routing, error labels, bounded response parsing, DELETE body release, redirect handling, OpenAI validation text trimming, Matrix fallback text, Code Mode timeout classification, and Qwen custom URL normalization are preserved. Production code shrinks by 58 lines.

## Evidence

- `node scripts/run-vitest.mjs extensions/msteams/src/graph.test.ts extensions/msteams/src/graph-group-management.test.ts extensions/msteams/src/graph-messages.actions.test.ts extensions/msteams/src/graph-messages.read.test.ts extensions/msteams/src/graph-messages.search.test.ts` — 75 passed
- `node scripts/run-vitest.mjs extensions/msteams/src/attachments.test.ts extensions/msteams/src/attachments/shared.test.ts extensions/msteams/src/attachments.graph.test.ts` — 82 passed
- `node scripts/run-vitest.mjs src/gateway/openai-http.test.ts` — 33 passed
- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/delivery-plan.test.ts extensions/qwen/video-generation-provider.test.ts` — 14 passed
- `node scripts/run-vitest.mjs src/agents/code-mode.limits.test.ts src/agents/code-mode-worker-lifecycle.test.ts` — 24 passed
- Canonical `oxfmt` completed on all 17 changed files.
- `git diff --check` passed.
- Two post-rebase autoreview passes were clean; the final pass rated the patch correct at 0.98.
- `node scripts/check-changed.mjs` attempted hosted proof, but no configured Crabbox/Testbox provider was ready; heavy proof is left to this PR's CI as required for this worktree.
