### PR TITLE
fix(doctor): stop stale builds before repair guidance

### DIFF
--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -66,7 +66,7 @@ export const confirm = vi.fn().mockResolvedValue(true) as unknown as MockFn;
 const select = vi.fn().mockResolvedValue("node") as unknown as MockFn;
 const note = vi.fn() as unknown as MockFn;
 export const writeConfigFile = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
-const resolveOpenClawPackageRoot = vi.fn().mockResolvedValue(null) as unknown as MockFn;
+export const resolveOpenClawPackageRoot = vi.fn().mockResolvedValue(null) as unknown as MockFn;
 export const runGatewayUpdate = vi
   .fn()
   .mockResolvedValue(createGatewayUpdateResult()) as unknown as MockFn;
@@ -87,7 +87,7 @@ const runExec = vi.fn().mockResolvedValue({
   stdout: "",
   stderr: "",
 }) as unknown as MockFn;
-const runCommandWithTimeout = vi
+export const runCommandWithTimeout = vi
   .fn()
   .mockResolvedValue(createCommandWithTimeoutResult()) as unknown as MockFn;
 

--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -61,13 +61,13 @@ function createLegacyConfigSnapshot() {
   } as const;
 }
 
-const readConfigFileSnapshot = vi.fn() as unknown as MockFn;
+export const readConfigFileSnapshot = vi.fn() as unknown as MockFn;
 export const confirm = vi.fn().mockResolvedValue(true) as unknown as MockFn;
 const select = vi.fn().mockResolvedValue("node") as unknown as MockFn;
 const note = vi.fn() as unknown as MockFn;
 export const writeConfigFile = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
 const resolveOpenClawPackageRoot = vi.fn().mockResolvedValue(null) as unknown as MockFn;
-const runGatewayUpdate = vi
+export const runGatewayUpdate = vi
   .fn()
   .mockResolvedValue(createGatewayUpdateResult()) as unknown as MockFn;
 const collectRelevantDoctorPluginIds = vi.fn(() => []) as unknown as MockFn;
@@ -133,7 +133,7 @@ export const callGateway = vi
   .fn()
   .mockRejectedValue(new Error("gateway closed")) as unknown as MockFn;
 
-const autoMigrateLegacyStateDir = vi.fn().mockResolvedValue({
+export const autoMigrateLegacyStateDir = vi.fn().mockResolvedValue({
   migrated: false,
   skipped: false,
   changes: [],

--- a/src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts
+++ b/src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts
@@ -9,6 +9,8 @@ import {
   createDoctorRuntime,
   mockDoctorConfigSnapshot,
   readConfigFileSnapshot,
+  resolveOpenClawPackageRoot,
+  runCommandWithTimeout,
   runGatewayUpdate,
 } from "./doctor.e2e-harness.js";
 
@@ -21,7 +23,33 @@ describe("doctor database schema preflight", () => {
     vi.clearAllMocks();
   });
 
-  it("refuses a newer state schema before update and config repair flows", async () => {
+  it("lets a successful interactive update replace the stale doctor", async () => {
+    writeStateSchemaVersion(OPENCLAW_STATE_SCHEMA_VERSION + 1);
+    mockDoctorConfigSnapshot();
+    mockInteractiveGitUpdate("ok");
+
+    await expect(doctorCommand(createDoctorRuntime())).resolves.toBeUndefined();
+
+    expect(runGatewayUpdate).toHaveBeenCalledOnce();
+    expect(autoMigrateLegacyStateDir).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("refuses after an interactive update does not handle doctor", async () => {
+    writeStateSchemaVersion(OPENCLAW_STATE_SCHEMA_VERSION + 1);
+    mockDoctorConfigSnapshot();
+    mockInteractiveGitUpdate("skipped");
+
+    await expect(doctorCommand(createDoctorRuntime())).rejects.toThrow(
+      /Doctor refused to continue.*database schema.*newer than this build/iu,
+    );
+
+    expect(runGatewayUpdate).toHaveBeenCalledOnce();
+    expect(autoMigrateLegacyStateDir).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("refuses before config repair flows when updates are disabled", async () => {
     writeStateSchemaVersion(OPENCLAW_STATE_SCHEMA_VERSION + 1);
     mockDoctorConfigSnapshot();
 
@@ -34,6 +62,25 @@ describe("doctor database schema preflight", () => {
     expect(readConfigFileSnapshot).not.toHaveBeenCalled();
   });
 });
+
+function mockInteractiveGitUpdate(status: "ok" | "skipped"): void {
+  delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
+  resolveOpenClawPackageRoot.mockResolvedValue("/repo");
+  runCommandWithTimeout.mockResolvedValue({
+    stdout: "/repo\n",
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+  });
+  runGatewayUpdate.mockResolvedValue({
+    status,
+    mode: "git",
+    root: "/repo",
+    steps: [],
+    durationMs: 0,
+  });
+}
 
 function writeStateSchemaVersion(version: number): void {
   const statePath = resolveOpenClawStateSqlitePath(process.env);

--- a/src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts
+++ b/src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import {
+  autoMigrateLegacyStateDir,
+  createDoctorRuntime,
+  mockDoctorConfigSnapshot,
+  readConfigFileSnapshot,
+  runGatewayUpdate,
+} from "./doctor.e2e-harness.js";
+
+let doctorCommand: typeof import("./doctor.js").doctorCommand;
+
+describe("doctor database schema preflight", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ doctorCommand } = await import("./doctor.js"));
+    vi.clearAllMocks();
+  });
+
+  it("refuses a newer state schema before update and config repair flows", async () => {
+    writeStateSchemaVersion(OPENCLAW_STATE_SCHEMA_VERSION + 1);
+    mockDoctorConfigSnapshot();
+
+    await expect(doctorCommand(createDoctorRuntime(), { nonInteractive: true })).rejects.toThrow(
+      /Doctor refused to continue.*database schema.*newer than this build/iu,
+    );
+
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyStateDir).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshot).not.toHaveBeenCalled();
+  });
+});
+
+function writeStateSchemaVersion(version: number): void {
+  const statePath = resolveOpenClawStateSqlitePath(process.env);
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(statePath);
+  try {
+    database.exec(`PRAGMA user_version = ${version};`);
+  } finally {
+    database.close();
+  }
+}

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -49,11 +49,6 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
   // Preserve the entry fact so doctor can report that automatic initialization.
   const stateDirExistedAtStart = stateDirectoryExistsAtDoctorStart();
   intro("OpenClaw doctor");
-  await assertDoctorDatabaseSchemasCompatible();
-  if (options.repair === true || options.yes === true || options.generateGatewayToken === true) {
-    const { assertConfigWriteAllowedInCurrentMode } = await loadConfigModule();
-    assertConfigWriteAllowedInCurrentMode();
-  }
 
   const { createDoctorPrompter } = await import("../commands/doctor-prompter.js");
   const prompter = createDoctorPrompter({ runtime: effectiveRuntime, options });
@@ -75,6 +70,14 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
   });
   if (updateResult.handled) {
     return;
+  }
+
+  // A stale source checkout may update itself, but no diagnostic or repair may
+  // touch state until the surviving build proves it understands every database.
+  await assertDoctorDatabaseSchemasCompatible();
+  if (options.repair === true || options.yes === true || options.generateGatewayToken === true) {
+    const { assertConfigWriteAllowedInCurrentMode } = await loadConfigModule();
+    assertConfigWriteAllowedInCurrentMode();
   }
 
   // Keep side-effect-heavy legacy checks before structured contributions until fully migrated.

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -14,6 +14,26 @@ const outro = (message: string) => clackOutro(stylePromptTitle(message) ?? messa
 
 const loadConfigModule = createLazyRuntimeModule(() => import("../config/config.js"));
 
+async function assertDoctorDatabaseSchemasCompatible(): Promise<void> {
+  const [databasePreflight, agentDatabase, stateDatabase] = await Promise.all([
+    import("../state/openclaw-database-preflight.js"),
+    import("../state/openclaw-agent-db.js"),
+    import("../state/openclaw-state-db.js"),
+  ]);
+  const databaseSchemas = databasePreflight.preflightOpenClawDatabaseSchemas({
+    env: process.env,
+    supportedVersions: {
+      state: stateDatabase.OPENCLAW_STATE_SCHEMA_VERSION,
+      agent: agentDatabase.OPENCLAW_AGENT_SCHEMA_VERSION,
+    },
+  });
+  if (databaseSchemas.incompatible.length > 0) {
+    throw new databasePreflight.OpenClawDatabaseSchemaPreflightError(databaseSchemas.incompatible, {
+      operation: "doctor",
+    });
+  }
+}
+
 function stateDirectoryExistsAtDoctorStart(): boolean {
   try {
     return fs.statSync(resolveStateDir()).isDirectory();
@@ -28,6 +48,8 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
   // Config loading can initialize SQLite-backed state before integrity runs.
   // Preserve the entry fact so doctor can report that automatic initialization.
   const stateDirExistedAtStart = stateDirectoryExistsAtDoctorStart();
+  intro("OpenClaw doctor");
+  await assertDoctorDatabaseSchemasCompatible();
   if (options.repair === true || options.yes === true || options.generateGatewayToken === true) {
     const { assertConfigWriteAllowedInCurrentMode } = await loadConfigModule();
     assertConfigWriteAllowedInCurrentMode();
@@ -35,7 +57,6 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
 
   const { createDoctorPrompter } = await import("../commands/doctor-prompter.js");
   const prompter = createDoctorPrompter({ runtime: effectiveRuntime, options });
-  intro("OpenClaw doctor");
 
   const { resolveOpenClawPackageRoot } = await import("../infra/openclaw-root.js");
   const root = await resolveOpenClawPackageRoot({

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -31,6 +31,23 @@ describe("OpenClaw database schema preflight", () => {
     });
   });
 
+  it("accepts a supported state schema", () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-database-preflight-supported-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    openOpenClawStateDatabase({ env });
+    closeOpenClawStateDatabaseForTest();
+
+    expect(
+      preflightOpenClawDatabaseSchemas({
+        env,
+        supportedVersions: {
+          state: OPENCLAW_STATE_SCHEMA_VERSION,
+          agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+        },
+      }),
+    ).toEqual({ incompatible: [], indeterminate: [] });
+  });
+
   it("collects newer state and registered agent schemas with writer builds", () => {
     const stateDir = makeTempDir(tempDirs, "openclaw-database-preflight-");
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -44,12 +44,30 @@ export type OpenClawDatabaseSchemaPreflight = {
 
 type AgentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "agent_databases">;
 
-/** Fatal Gateway refusal when persisted schemas were written by a newer build. */
+type OpenClawDatabaseSchemaPreflightOperation = "doctor" | "gateway-startup";
+
+function formatDoctorIncompatibleDatabase(database: IncompatibleOpenClawDatabase): string {
+  const agent = database.agentId ? ` for agent ${database.agentId}` : "";
+  const writer = database.writerAppVersion ? `; writer build ${database.writerAppVersion}` : "";
+  return `${database.kind} database${agent} ${database.path} uses schema ${database.foundVersion}; this build supports ${database.supportedVersion}${writer}.`;
+}
+
+/** Fatal refusal when persisted schemas were written by a newer build. */
 export class OpenClawDatabaseSchemaPreflightError extends Error {
-  constructor(readonly incompatibleDatabases: readonly IncompatibleOpenClawDatabase[]) {
+  constructor(
+    readonly incompatibleDatabases: readonly IncompatibleOpenClawDatabase[],
+    options: { operation?: OpenClawDatabaseSchemaPreflightOperation } = {},
+  ) {
+    const operation = options.operation ?? "gateway-startup";
+    const prefix =
+      operation === "doctor" ? "Doctor refused to continue" : "Gateway refused startup";
+    const doctorGuidance =
+      operation === "doctor"
+        ? ` ${incompatibleDatabases.map(formatDoctorIncompatibleDatabase).join(" ")} Run Doctor with the OpenClaw install that wrote this state (typically the active Gateway install), or another build that supports these schemas.`
+        : "";
     super(
-      `Gateway refused startup because ${incompatibleDatabases.length} OpenClaw database schema(s) are newer than this build. ` +
-        `Refused by ${describeRunningOpenClawBuild()}. See ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
+      `${prefix} because ${incompatibleDatabases.length} OpenClaw database schema(s) are newer than this build. ` +
+        `Refused by ${describeRunningOpenClawBuild()}.${doctorGuidance} See ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
     );
     this.name = "OpenClawDatabaseSchemaPreflightError";
   }


### PR DESCRIPTION
Related: #115008

AI-assisted: yes. I understand the change and validated the observable CLI behavior against isolated fixtures.

## What Problem This Solves

Fixes an issue where users running Doctor from a stale OpenClaw installation could receive `doctor --fix` guidance and a successful exit even though the selected state database used a schema newer than that installation supported.

That guidance is unsafe and unactionable: the stale Doctor cannot reliably interpret the newer persisted state, so it must not enter config or migration planning first.

## Why This Change Was Made

Interactive Doctor now reuses the existing read-only database schema preflight already owned by Gateway startup and update safety. A plain interactive git checkout retains Doctor's existing update-first recovery: a successful update replaces the stale process, while a declined or non-handled update reaches the schema preflight. Every surviving Doctor path runs the preflight before config loading, UI/install checks, state migrations, or repairs.

Incompatible state or registered agent schemas fail closed with the refusing build/install, found and supported schema versions, and matching-runtime guidance. Supported schemas and indeterminate/unreadable databases continue into normal Doctor diagnostics. The Gateway startup refusal keeps its existing default wording.

## User Impact

Operators can still accept Doctor's documented fetch/rebase/build recovery from an interactive source checkout. If the running build remains incompatible, Doctor exits non-zero and tells the operator to use the state-writing/active Gateway installation or another compatible build; it does not suggest repairs it cannot safely perform.

Release-note context: stale Doctor invocations may update first, then fail before repair guidance when persisted database schemas remain newer than the executing build.

## Evidence

- **Red reproduction:** `OpenClaw 2026.7.1-beta.5 (b6387af)` against a synthetic schema-6 fixture exited `0`, printed both `Repair with openclaw doctor --fix` and `Run "openclaw doctor --fix"`, then printed `Doctor complete`. Before/after SHA-256 checksums matched.
- **Green built CLI:** Blacksmith Testbox `tbx_01kz0rvw14wwrphrty18dn6dfx` ([run](https://github.com/openclaw/openclaw/actions/runs/30739532290)) built the changed surface and ran a schema-7 fixture against a schema-6 build. Doctor exited `1`, emitted `Doctor refused to continue`, contained no `doctor --fix` or `Doctor changes preview`, and preserved both fixture checksums.
- **Ordering regressions:** Blacksmith Testbox `tbx_01kz1qvn4j5618sw148yz0rzda` ([run](https://github.com/openclaw/openclaw/actions/runs/30758655293)) passed the successful interactive update, non-handled interactive update, and update-disabled refusal cases on the final patch content.
- **Negative control:** malformed config without an incompatible database still emitted `Config invalid; doctor will run with best-effort config` and no schema refusal.
- **Focused tests:** shared database preflight `6/6`, Doctor updater `11/11`, and Doctor ordering E2E `3/3` passed on Testbox.
- **Build:** `pnpm build` passed in the built-CLI Testbox proof.
- **Autoreview:** clean; no accepted/actionable findings (Codex, 0.98 confidence).
