### PR TITLE
feat(browser): relay CDP compat for Puppeteer clients (chrome-devtools-mcp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Browser extension relay CDP compat:** answer `Target.getBrowserContexts` so Puppeteer-based clients (chrome-devtools-mcp) can drive the paired Chrome without the remote-debugging permission prompt, serve DevTools-style `/json/list` target descriptors, and add `openclaw browser extension cdp` to print the relay endpoint plus auth header for external CDP clients.
 - **Local model setup:** advertise provider-owned Ollama, llama.cpp, and LM Studio setup choices to Control UI and macOS, retry unavailable LM Studio services in place, and verify the exact prepared model before showing success.
 - **Control UI first-run setup:** continue verified model setup into Custodian, explain that the web app is ready without a channel, and offer an optional dismissible path to Channels.
 - **Fish Audio speech:** add hosted S2.1 synthesis with streaming, voice notes, voice discovery, and telephony, plus local Fish S2 Pro reference-voice streaming in native macOS Talk. Thanks @Conan-Scott for the earlier community-plugin implementation.

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -91,6 +91,30 @@ openclaw config set browser.defaultProfile chrome
 - Revoke: click the button again, drag the tab out of the group, or dismiss
   Chrome's debugging banner. The agent loses access to that tab immediately.
 
+### External CDP clients (chrome-devtools-mcp, Puppeteer)
+
+The relay is a standard CDP browser endpoint, so tools other than OpenClaw can
+drive the paired Chrome through it — same consent model (shared tabs only),
+same host-local token, and still no "Allow remote debugging?" prompt. Print the
+endpoint and auth header:
+
+```bash
+openclaw browser extension cdp
+```
+
+For example, Google's [chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp)
+connects with:
+
+```bash
+npx chrome-devtools-mcp --wsEndpoint ws://127.0.0.1:18799/cdp \
+  --wsHeaders '{"Authorization":"Bearer <token>"}'
+```
+
+`openclaw browser extension cdp --json` emits `{ browserUrl, wsEndpoint,
+headers }` for scripting. The token is the same host-local relay secret the
+pairing string carries: treat it as private, and rotate it by deleting
+`credentials/browser-extension-relay.secret` and pairing again.
+
 ### Tab copilot side panel
 
 After pairing the extension, click **Open tab copilot** in its toolbar popup.

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -573,4 +573,66 @@ describe("ExtensionRelayBridge", () => {
     expect(socket.closed).toBe(true);
     expect(bridge.extensionConnected).toBe(false);
   });
+
+  it("answers the Puppeteer connect bootstrap without protocol errors", async () => {
+    // The exact browser-scoped sequence puppeteer.connect() issues before any
+    // page work (chrome-devtools-mcp --browserUrl/--wsEndpoint rides this).
+    const bridge = new ExtensionRelayBridge();
+    const { handlers } = wireExtension(bridge);
+    sendHello(handlers);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    const bootstrap: Array<{ id: number; method: string; params?: Record<string, unknown> }> = [
+      { id: 1, method: "Browser.getVersion" },
+      { id: 2, method: "Target.setDiscoverTargets", params: { discover: true } },
+      {
+        id: 3,
+        method: "Target.setAutoAttach",
+        params: { autoAttach: true, waitForDebuggerOnStart: false, flatten: true },
+      },
+      { id: 4, method: "Target.getBrowserContexts" },
+    ];
+    for (const message of bootstrap) {
+      cdp.onMessage(JSON.stringify(message));
+    }
+    await flush();
+
+    for (const message of bootstrap) {
+      const response = client.frames().find((frame) => frame.id === message.id);
+      expect(response, `response for ${message.method}`).toBeTruthy();
+      expect(response?.error, `error for ${message.method}`).toBeUndefined();
+    }
+    const contexts = client.frames().find((frame) => frame.id === 4);
+    // Only createBrowserContext-made contexts belong here; the relay drives the
+    // real profile's default context, so the list is always empty (as in Chrome).
+    expect(contexts?.result).toEqual({ browserContextIds: [] });
+  });
+
+  it("lists shared tabs as DevTools-style target descriptors", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const { handlers } = wireExtension(bridge);
+    sendHello(handlers);
+
+    expect(bridge.devtoolsTargetDescriptors()).toEqual([
+      {
+        tabId: 1,
+        url: "https://example.com",
+        title: "Example",
+        active: true,
+        id: "tab-1",
+        type: "page",
+      },
+    ]);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+
+    // Once the debugger attaches, descriptors carry the live targetId.
+    expect(bridge.devtoolsTargetDescriptors()[0]).toMatchObject({ id: "target-1", type: "page" });
+  });
 });

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -148,7 +148,10 @@ export class ExtensionRelayBridge {
    */
   devtoolsTargetDescriptors(): Array<RelayTabInfo & { id: string; type: string }> {
     return [...this.tabs.values()].map((tab) => ({
-      ...tab.info,
+      tabId: tab.info.tabId,
+      url: tab.info.url,
+      title: tab.info.title,
+      active: tab.info.active,
       id: tab.attached?.targetId ?? `tab-${tab.info.tabId}`,
       type: "page",
     }));

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -138,6 +138,22 @@ export class ExtensionRelayBridge {
     return [...this.tabs.values()].map((tab) => tab.info);
   }
 
+  /**
+   * DevTools-style descriptors for `/json/list`: RelayTabInfo plus the `id`
+   * and `type` fields CDP discovery clients expect. `id` is the live debugger
+   * targetId once a tab is attached; before that it is the same `tab-<tabId>`
+   * fallback ensureTabAttached mints, so unattached tabs still list stably.
+   * No per-target webSocketDebuggerUrl: all CDP traffic multiplexes over the
+   * single browser endpoint (`/cdp`).
+   */
+  devtoolsTargetDescriptors(): Array<RelayTabInfo & { id: string; type: string }> {
+    return [...this.tabs.values()].map((tab) => ({
+      ...tab.info,
+      id: tab.attached?.targetId ?? `tab-${tab.info.tabId}`,
+      type: "page",
+    }));
+  }
+
   /** Number of connected CDP clients (diagnostics). */
   get cdpClientCount(): number {
     return this.clients.size;
@@ -927,6 +943,13 @@ export class ExtensionRelayBridge {
         }
         await this.callExtension({ type: "activateTab", tabId: found.tabId });
         this.respond(client, request, {});
+        return;
+      }
+      case "Target.getBrowserContexts": {
+        // Real Chrome reports only contexts made via Target.createBrowserContext
+        // here — never the default one — so the relay's answer is always empty.
+        // Puppeteer's connect bootstrap (chrome-devtools-mcp) requires this.
+        this.respond(client, request, { browserContextIds: [] });
         return;
       }
       case "Target.createBrowserContext": {

--- a/extensions/browser/src/browser/extension-relay/relay-server.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.ts
@@ -168,7 +168,7 @@ export async function startExtensionRelayServer(params: {
     }
     if (req.method === "GET" && (path === "/json" || path === "/json/list")) {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(bridge.sharedTabs()));
+      res.end(JSON.stringify(bridge.devtoolsTargetDescriptors()));
       return;
     }
     res.writeHead(404).end("Not found");

--- a/extensions/browser/src/cli/browser-cli-extension.test.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.test.ts
@@ -83,4 +83,25 @@ describe("browser extension pairing Gateway URL", () => {
       remote: false,
     });
   });
+
+  it("prints the relay CDP endpoint for external clients via cdp --json", async () => {
+    vi.spyOn(cliCoreApiModule, "getRuntimeConfig").mockReturnValue({});
+    const logSpy = vi.spyOn(cliCoreApiModule.defaultRuntime, "log").mockImplementation(runtime.log);
+    const writeJsonSpy = vi
+      .spyOn(cliCoreApiModule.defaultRuntime, "writeJson")
+      .mockImplementation(runtime.writeJson);
+    const { registerBrowserExtensionCommands } = await import("./browser-cli-extension.js");
+    const program = new Command();
+    const browser = program.command("browser");
+    registerBrowserExtensionCommands(browser, () => ({}));
+
+    await program.parseAsync(["browser", "extension", "cdp", "--json"], { from: "user" });
+
+    expect(writeJsonSpy).toHaveBeenCalledWith({
+      browserUrl: "http://127.0.0.1:18799",
+      wsEndpoint: "ws://127.0.0.1:18799/cdp",
+      headers: { Authorization: "Bearer pair-token" },
+    });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/browser/src/cli/browser-cli-extension.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.ts
@@ -113,7 +113,29 @@ async function buildPairingString(gatewayUrl?: string): Promise<{
   };
 }
 
-/** Register `openclaw browser extension {path,pair}`. */
+/**
+ * Resolve the local relay CDP endpoint for third-party CDP clients
+ * (Puppeteer, chrome-devtools-mcp, raw WebSocket). Creates the host-local
+ * relay secret on first use, mirroring `pair`.
+ */
+async function buildCdpEndpoint(): Promise<{
+  browserUrl: string;
+  wsEndpoint: string;
+  headers: { Authorization: string };
+}> {
+  const cfg = getRuntimeConfig();
+  const resolved = resolveBrowserConfig(cfg.browser, cfg);
+  const token = await ensureExtensionRelayToken();
+  const profile = firstExtensionProfile(resolved);
+  const relayPort = profile?.relayPort ?? resolved.extensionRelayDefaultPort;
+  return {
+    browserUrl: `http://127.0.0.1:${relayPort}`,
+    wsEndpoint: `ws://127.0.0.1:${relayPort}/cdp`,
+    headers: { Authorization: `Bearer ${token}` },
+  };
+}
+
+/** Register `openclaw browser extension {path,pair,cdp}`. */
 export function registerBrowserExtensionCommands(
   browser: Command,
   _parentOpts: (cmd: Command) => BrowserParentOpts,
@@ -166,6 +188,41 @@ export function registerBrowserExtensionCommands(
               info("2. Open the OpenClaw popup and paste this pairing string:"),
               "",
               theme.heading(result.pairing),
+              "",
+              info("The token is a host-local secret; keep it private."),
+            ].join("\n"),
+          );
+        },
+        (err: unknown) => {
+          defaultRuntime.error(danger(String(err)));
+          defaultRuntime.exit(1);
+        },
+      );
+    });
+
+  extension
+    .command("cdp")
+    .description("Print the relay CDP endpoint and auth header for external CDP clients")
+    .option("--json", "Print the endpoint as JSON")
+    .action(async (opts) => {
+      await runCommandWithRuntime(
+        defaultRuntime,
+        async () => {
+          const endpoint = await buildCdpEndpoint();
+          if (opts.json === true) {
+            defaultRuntime.writeJson(endpoint);
+            return;
+          }
+          defaultRuntime.log(
+            [
+              info("Relay CDP endpoint (pair the extension first):"),
+              `browserUrl: ${endpoint.browserUrl}`,
+              `wsEndpoint: ${endpoint.wsEndpoint}`,
+              `header:     Authorization: ${endpoint.headers.Authorization}`,
+              "",
+              info("Example (chrome-devtools-mcp):"),
+              `  npx chrome-devtools-mcp --wsEndpoint ${endpoint.wsEndpoint} \\`,
+              `    --wsHeaders '${JSON.stringify(endpoint.headers)}'`,
               "",
               info("The token is a host-local secret; keep it private."),
             ].join("\n"),


### PR DESCRIPTION
## Summary

The extension relay's CDP surface was built against Playwright's `connectOverCDP`, and Puppeteer-based clients — notably Google's [chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp) — failed on connect with `Protocol error (Target.getBrowserContexts): 'Target.getBrowserContexts' wasn't found`. This closes that gap so any Puppeteer client can drive the paired Chrome through the relay: same shared-tab consent model, same host-local token, and still no "Allow remote debugging?" prompt.

- **relay-bridge**: answer `Target.getBrowserContexts` with the always-empty context list (real Chrome only reports contexts made via `Target.createBrowserContext` here, never the default one).
- **relay-server**: serve DevTools-style `/json/list` descriptors (`id`, `type: "page"` on top of RelayTabInfo). Bonus fix: the HTTP tab-list fallback in `server-context.tab-ops` skips entries without `id`, so extension-profile tabs were invisible to it before.
- **CLI**: `openclaw browser extension cdp [--json]` prints `{ browserUrl, wsEndpoint, headers }` so external CDP clients can be pointed at the relay without scraping the pairing string.
- Docs section in `docs/tools/chrome-extension.md` + changelog.

## Testing

- `node scripts/run-vitest.mjs run extensions/browser/src/cli/browser-cli-extension.test.ts extensions/browser/src/browser/extension-relay/` — 47 passed, including a new Puppeteer connect-bootstrap sequence test and descriptor-shape test.
- Live end-to-end on macOS: extension paired to a real signed-in Chrome, then `chrome-devtools-mcp --wsEndpoint ws://127.0.0.1:18799/cdp --wsHeaders '{"Authorization":"Bearer …"}'` — `list_pages`, `navigate_page`, `take_snapshot`, `take_screenshot`, `evaluate_script`, network/console listing, and performance tracing all pass with zero permission dialogs.
- `oxfmt --check` clean; Codex autoreview clean (5 chunks, 0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
