### PR TITLE
fix: preserve queued messages during session compaction

### DIFF
--- a/src/gateway/server-methods/sessions-compact.ts
+++ b/src/gateway/server-methods/sessions-compact.ts
@@ -6,6 +6,7 @@ import {
   validateSessionsCompactParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { getFollowupQueueDepth } from "../../auto-reply/reply/queue.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import {
   resolveSessionWorkStartError,
@@ -224,7 +225,12 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
           }
           // Drop work queued against the pre-compaction transcript before its
           // lifecycle fence commits and no longer exposes queue cleanup.
-          clearSessionQueues([key, target.canonicalKey, compactTarget.primaryKey, sessionId]);
+          const queueKeys = [key, target.canonicalKey, compactTarget.primaryKey, sessionId];
+          if (queueKeys.some((k) => typeof k === "string" && getFollowupQueueDepth(k) > 0)) {
+            blockedByActiveRun = true;
+            return;
+          }
+          clearSessionQueues(queueKeys);
         },
         run: async () => {
           if (!sessionStillCurrent) {

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -1692,4 +1692,50 @@ test("sessions.patch preserves nested model ids under provider overrides", async
     expect(mainSession?.model).toBe("moonshotai/kimi-k2.5");
   });
 });
+
+test("sessions.compact refuses when pending follow-up queue items would be silently dropped", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionId = "sess-compact-pending-queue";
+  await seedSessionEntry({
+    entry: sessionStoreEntry(sessionId),
+    sessionKey: "agent:main:main",
+    storePath,
+  });
+  await seedTranscriptRows({
+    sessionId,
+    sessionKey: "agent:main:main",
+    storePath,
+    totalLines: 3,
+  });
+
+  // Simulate pending items in the follow-up queue by spying on getFollowupQueueDepth.
+  // The queue is keyed by sessionKey (agent:main:main) during enqueue, so the check
+  // in the prepare step will see a non-zero depth and refuse compaction.
+  const queueModule = await import("../auto-reply/reply/queue.js");
+  const depthSpy = vi.spyOn(queueModule, "getFollowupQueueDepth");
+  try {
+    depthSpy.mockReturnValue(3);
+
+    const compacted = await directSessionReq(
+      "sessions.compact",
+      { key: "main" },
+      {
+        context: {
+          getRuntimeConfig: () => ({
+            agents: { list: [{ id: "main", default: true }] },
+            session: { store: storePath },
+          }),
+        },
+      },
+    );
+
+    expect(compacted.ok).toBe(false);
+    expect(compacted.error?.code).toBe("INVALID_REQUEST");
+    expect(compacted.error?.message).toContain("has an active run");
+    // The queue cleanup should never have been reached.
+    expectNoSessionQueueCleanup();
+  } finally {
+    depthSpy.mockRestore();
+  }
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Closes #117810

## What Problem This Solves

Fixes an issue where users who request manual session compaction while accepted follow-up messages are queued can have those queued messages silently discarded.

## Why This Change Was Made

Manual compaction now refuses to proceed while any queue key associated with the session has pending follow-up items. This keeps the change at the gateway compaction boundary and preserves the existing cleanup behavior when no queued work is present.

## User Impact

Queued user messages are preserved instead of being silently lost. Users may retry manual compaction after the pending follow-up queue has drained.

## Evidence

- Added regression coverage: `sessions.compact refuses when pending follow-up queue items would be silently dropped`.
- Focused test command:

```text
COREPACK_HOME=/workspace/.corepack OPENCLAW_VITEST_MAX_WORKERS=1 pnpm vitest run src/gateway/server.sessions.compaction.test.ts --reporter=verbose --maxWorkers=1
```

- Result: 21 passed, 0 failed.
- `oxfmt --check` passed for both changed files.
- `oxlint` reported 0 warnings and 0 errors for both changed files.
- Repository `$autoreview` passed: TruffleHog clean; no accepted/actionable P0 findings; patch correctness 0.98.

## AI-assisted development

This change was implemented with an OpenClaw coding agent and published through a human-approved workflow. The exact diff and focused validation evidence were verified before publication.

Artifact SHA-256: `949276fbec8c51208328fba6b1dd94ef26745ce87c321e27a8843d397c32b3c9`
