### PR TITLE
fix(lmstudio): avoid loading downloaded models during setup

### DIFF
--- a/extensions/lmstudio/index.test.ts
+++ b/extensions/lmstudio/index.test.ts
@@ -89,7 +89,13 @@ describe("lmstudio plugin", () => {
     fetchLmstudioModelsMock.mockResolvedValue({
       reachable: true,
       status: 200,
-      models: [{ type: "llm", key: "qwen/qwen3.5-9b" }],
+      models: [
+        {
+          type: "llm",
+          key: "qwen/qwen3.5-9b",
+          loaded_instances: [{ id: "qwen", config: { context_length: 32_768 } }],
+        },
+      ],
     });
     const ctx = createLmstudioResetValidationContext({
       customBaseUrl: "http://lmstudio.internal:1234/api/v1/",
@@ -112,7 +118,13 @@ describe("lmstudio plugin", () => {
     fetchLmstudioModelsMock.mockResolvedValue({
       reachable: true,
       status: 200,
-      models: [{ type: "llm", key: "qwen/qwen3.5-9b" }],
+      models: [
+        {
+          type: "llm",
+          key: "qwen/qwen3.5-9b",
+          loaded_instances: [{ id: "qwen", config: { context_length: 32_768 } }],
+        },
+      ],
     });
     const ctx = createLmstudioResetValidationContext(
       {
@@ -173,7 +185,13 @@ describe("lmstudio plugin", () => {
     fetchLmstudioModelsMock.mockResolvedValue({
       reachable: true,
       status: 200,
-      models: [{ type: "llm", key: "phi-4" }],
+      models: [
+        {
+          type: "llm",
+          key: "phi-4",
+          loaded_instances: [{ id: "phi", config: { context_length: 32_768 } }],
+        },
+      ],
     });
     const ctx = createLmstudioResetValidationContext({
       customBaseUrl: "http://lmstudio.internal:1234/v1",
@@ -192,7 +210,13 @@ describe("lmstudio plugin", () => {
     fetchLmstudioModelsMock.mockResolvedValue({
       reachable: true,
       status: 200,
-      models: [{ type: "llm", key: "qwen/qwen3.5-9b" }],
+      models: [
+        {
+          type: "llm",
+          key: "qwen/qwen3.5-9b",
+          loaded_instances: [{ id: "qwen", config: { context_length: 32_768 } }],
+        },
+      ],
     });
     const ctx = createLmstudioResetValidationContext({
       customBaseUrl: "http://lmstudio.internal:1234/v1",
@@ -220,7 +244,26 @@ describe("lmstudio plugin", () => {
     await expect(requireLmstudioResetValidator()(ctx)).resolves.toBe(false);
 
     expect(ctx.runtime.error).toHaveBeenCalledWith(
-      "No LM Studio LLM models were found at http://lmstudio.internal:1234/v1.\nLoad at least one model in LM Studio (or run lms load), then re-run setup.",
+      "No loaded LM Studio LLM models were found at http://lmstudio.internal:1234/v1.\nLoad a model in LM Studio (or run lms load <model>), then re-run setup.",
+    );
+    expect(ctx.runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects an installed but unloaded LM Studio model before destructive reset", async () => {
+    fetchLmstudioModelsMock.mockResolvedValue({
+      reachable: true,
+      status: 200,
+      models: [{ type: "llm", key: "qwen/qwen3.5-9b", loaded_instances: [] }],
+    });
+    const ctx = createLmstudioResetValidationContext({
+      customBaseUrl: "http://lmstudio.internal:1234/v1",
+      customModelId: "qwen/qwen3.5-9b",
+    });
+
+    await expect(requireLmstudioResetValidator()(ctx)).resolves.toBe(false);
+
+    expect(ctx.runtime.error).toHaveBeenCalledWith(
+      "LM Studio model qwen/qwen3.5-9b is installed but not loaded at http://lmstudio.internal:1234/v1.\nLoad that model in LM Studio, then re-run setup.",
     );
     expect(ctx.runtime.exit).toHaveBeenCalledWith(1);
   });

--- a/extensions/lmstudio/index.ts
+++ b/extensions/lmstudio/index.ts
@@ -25,6 +25,7 @@ import {
 import {
   normalizeLmstudioConfiguredCatalogEntries,
   normalizeLmstudioProviderConfig,
+  resolveLoadedContextWindow,
   resolveLmstudioInferenceBase,
 } from "./src/models.js";
 import { shouldUseLmstudioSyntheticAuth } from "./src/provider-auth.js";
@@ -82,23 +83,39 @@ async function validateLmstudioNonInteractive(
     return false;
   }
 
-  const availableModels = discovery.models
+  const installedModels = discovery.models
     .filter((model) => model.type === "llm")
+    .map((model) => model.key?.trim())
+    .filter((model): model is string => Boolean(model));
+  const loadedModels = discovery.models
+    .filter(
+      (model) =>
+        model.type === "llm" &&
+        Boolean(model.key?.trim()) &&
+        resolveLoadedContextWindow(model) !== null,
+    )
     .map((model) => model.key?.trim())
     .filter((model): model is string => Boolean(model));
   // Setup matches the requested wire key unchanged. Accepting provider-
   // qualified refs here would permit reset before setup rejects the model.
   const requestedModel = normalizeOptionalSecretInput(ctx.opts.customModelId);
-  if (requestedModel && !availableModels.includes(requestedModel)) {
+  if (requestedModel && !installedModels.includes(requestedModel)) {
     ctx.runtime.error(
-      `LM Studio model ${requestedModel} was not found at ${baseUrl}.\nAvailable models: ${availableModels.join(", ")}`,
+      `LM Studio model ${requestedModel} was not found at ${baseUrl}.\nAvailable models: ${installedModels.join(", ")}`,
     );
     ctx.runtime.exit(1);
     return false;
   }
-  if (availableModels.length === 0) {
+  if (requestedModel && !loadedModels.includes(requestedModel)) {
     ctx.runtime.error(
-      `No LM Studio LLM models were found at ${baseUrl}.\nLoad at least one model in LM Studio (or run lms load), then re-run setup.`,
+      `LM Studio model ${requestedModel} is installed but not loaded at ${baseUrl}.\nLoad that model in LM Studio, then re-run setup.`,
+    );
+    ctx.runtime.exit(1);
+    return false;
+  }
+  if (loadedModels.length === 0) {
+    ctx.runtime.error(
+      `No loaded LM Studio LLM models were found at ${baseUrl}.\nLoad a model in LM Studio (or run lms load <model>), then re-run setup.`,
     );
     ctx.runtime.exit(1);
     return false;

--- a/extensions/lmstudio/src/models.ts
+++ b/extensions/lmstudio/src/models.ts
@@ -252,15 +252,6 @@ export function resolveLoadedContextWindow(
   return contextWindow;
 }
 
-/** Uses the loaded context when present, otherwise the model's advertised maximum. */
-export function resolveLmstudioEffectiveContextWindow(
-  entry: Pick<LmstudioModelWire, "loaded_instances" | "max_context_length">,
-): number | null {
-  return (
-    resolveLoadedContextWindow(entry) ?? asPositiveSafeInteger(entry.max_context_length) ?? null
-  );
-}
-
 function normalizeLmstudioVariantIds(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];

--- a/extensions/lmstudio/src/setup.test.ts
+++ b/extensions/lmstudio/src/setup.test.ts
@@ -106,7 +106,12 @@ function createWireModel(
   key: string,
   overrides: Omit<LmstudioModelWire, "key"> = {},
 ): LmstudioModelWire {
-  return { type: "llm", key, ...overrides };
+  return {
+    type: "llm",
+    key,
+    loaded_instances: [{ id: `${key}-loaded`, config: { context_length: 32_768 } }],
+    ...overrides,
+  };
 }
 
 function mockFetchedModels(models: LmstudioModelWire[]): void {
@@ -411,13 +416,41 @@ describe("lmstudio setup", () => {
 
   it.each([
     {
-      name: "prefers the strongest tool-calling family among installed models",
+      name: "prefers the strongest tool-calling family among loaded models",
       models: [
-        { key: "llama3.3-70b-instruct", max_context_length: 65_536 },
-        { key: "qwen3.5-4b-instruct", max_context_length: 65_536 },
-        { key: "nomic-embed-text", max_context_length: 65_536 },
+        {
+          key: "llama3.3-70b-instruct",
+          max_context_length: 65_536,
+          loaded_instances: [{ id: "llama", config: { context_length: 32_768 } }],
+        },
+        {
+          key: "qwen3.5-4b-instruct",
+          max_context_length: 65_536,
+          loaded_instances: [{ id: "qwen", config: { context_length: 32_768 } }],
+        },
+        {
+          key: "nomic-embed-text",
+          max_context_length: 65_536,
+          loaded_instances: [{ id: "nomic", config: { context_length: 32_768 } }],
+        },
       ],
       expectedModel: "lmstudio/qwen3.5-4b-instruct",
+    },
+    {
+      name: "ignores a preferred downloaded model when another model is loaded",
+      models: [
+        {
+          key: "qwen3.5-4b-instruct",
+          max_context_length: 65_536,
+          loaded_instances: [],
+        },
+        {
+          key: "llama3.3-70b-instruct",
+          max_context_length: 65_536,
+          loaded_instances: [{ id: "llama", config: { context_length: 32_768 } }],
+        },
+      ],
+      expectedModel: "lmstudio/llama3.3-70b-instruct",
     },
     {
       name: "skips a preferred model loaded with less than 16k context",
@@ -677,6 +710,24 @@ describe("lmstudio setup", () => {
 
     expect(ctx.runtime.error).toHaveBeenCalledWith(
       `LM Studio model missing-model was not found at ${expectedBaseUrl}.\nAvailable models: qwen3-8b-instruct`,
+    );
+    expect(ctx.runtime.exit).toHaveBeenCalledWith(1);
+    expect(configureSelfHostedNonInteractiveMock).not.toHaveBeenCalled();
+  });
+
+  it("non-interactive setup rejects an installed model that is not loaded", async () => {
+    mockFetchedModelsOnce([
+      createWireModel("qwen3-8b-instruct", { loaded_instances: [] }),
+      createWireModel("phi-4"),
+    ]);
+    const ctx = buildNonInteractiveContext({
+      customModelId: "qwen3-8b-instruct",
+    });
+
+    await expect(configureLmstudioNonInteractive(ctx)).resolves.toBeNull();
+
+    expect(ctx.runtime.error).toHaveBeenCalledWith(
+      "LM Studio model qwen3-8b-instruct is installed but not loaded at http://localhost:1234/v1.\nLoad that model in LM Studio, then re-run setup.",
     );
     expect(ctx.runtime.exit).toHaveBeenCalledWith(1);
     expect(configureSelfHostedNonInteractiveMock).not.toHaveBeenCalled();
@@ -1007,7 +1058,16 @@ describe("lmstudio setup", () => {
           status: 200,
           models: [{ type: "embedding", key: "text-embedding-nomic-embed-text-v1.5" }],
         },
-        expectedError: "No LM Studio models found",
+        expectedError: "No loaded LM Studio models found",
+      },
+      {
+        name: "only unloaded llm models",
+        discovery: {
+          reachable: true,
+          status: 200,
+          models: [createWireModel("qwen3-8b-instruct", { loaded_instances: [] })],
+        },
+        expectedError: "No loaded LM Studio models found",
       },
     ];
 

--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -45,7 +45,7 @@ import { discoverLmstudioModels, fetchLmstudioModels } from "./models.fetch.js";
 import {
   mapLmstudioWireModelsToConfig,
   type LmstudioModelWire,
-  resolveLmstudioEffectiveContextWindow,
+  resolveLoadedContextWindow,
   resolveLmstudioInferenceBase,
 } from "./models.js";
 import {
@@ -73,6 +73,7 @@ const LMSTUDIO_APP_GUIDED_MIN_CONTEXT_TOKENS = 16_384;
 type LmstudioSetupDiscovery = {
   discovery: LmstudioDiscoveryResult;
   models: ModelDefinitionConfig[];
+  loadedModelIds: Set<string>;
   defaultModel: string | undefined;
   defaultModelId: string | undefined;
 };
@@ -206,6 +207,15 @@ function applyRequestedContextWindowToAllModels(params: {
   );
 }
 
+function collectLoadedLmstudioModelIds(discovery: LmstudioDiscoveryResult): Set<string> {
+  return new Set(
+    discovery.models.flatMap((entry) => {
+      const id = entry.key?.trim();
+      return entry.type === "llm" && id && resolveLoadedContextWindow(entry) !== null ? [id] : [];
+    }),
+  );
+}
+
 function resolveLmstudioDiscoveryFailure(params: {
   baseUrl: string;
   discovery: LmstudioDiscoveryResult;
@@ -238,17 +248,14 @@ function resolveLmstudioDiscoveryFailure(params: {
       reason: `LM Studio discovery failed (${discovery.status})`,
     };
   }
-  const hasUsableModel = discovery.models.some(
-    (model) => model.type === "llm" && Boolean(model.key?.trim()),
-  );
-  if (!hasUsableModel) {
+  if (collectLoadedLmstudioModelIds(discovery).size === 0) {
     return {
       noteLines: [
-        `No LM Studio LLM models were found at ${baseUrl}.`,
-        "Load at least one model in LM Studio (or run lms load), then re-run setup.",
+        `No loaded LM Studio LLM models were found at ${baseUrl}.`,
+        "Load a model in LM Studio (or run lms load <model>), then re-run setup.",
       ],
-      retryLine: "Load at least one model in LM Studio (or run lms load), then continue to retry.",
-      reason: "No LM Studio models found",
+      retryLine: "Load a model in LM Studio (or run lms load <model>), then continue to retry.",
+      reason: "No loaded LM Studio models found",
     };
   }
   return null;
@@ -367,9 +374,9 @@ function collectAppGuidedLmstudioModelIds(discovery: LmstudioDiscoveryResult): S
       if (entry.type !== "llm" || entry.capabilities?.trained_for_tool_use !== true || !id) {
         return [];
       }
-      const effectiveContextWindow = resolveLmstudioEffectiveContextWindow(entry);
-      return effectiveContextWindow !== null &&
-        effectiveContextWindow >= LMSTUDIO_APP_GUIDED_MIN_CONTEXT_TOKENS
+      const loadedContextWindow = resolveLoadedContextWindow(entry);
+      return loadedContextWindow !== null &&
+        loadedContextWindow >= LMSTUDIO_APP_GUIDED_MIN_CONTEXT_TOKENS
         ? [id]
         : [];
     }),
@@ -399,11 +406,15 @@ async function discoverLmstudioSetupModels(params: {
     return { failure };
   }
   const models = mapLmstudioWireModelsToConfig(discovery.models);
-  const defaultModelId = selectDefaultLmstudioModelId(models);
+  const loadedModelIds = collectLoadedLmstudioModelIds(discovery);
+  const defaultModelId = selectDefaultLmstudioModelId(
+    models.filter((model) => loadedModelIds.has(model.id)),
+  );
   return {
     value: {
       discovery,
       models,
+      loadedModelIds,
       defaultModel: defaultModelId ? `${PROVIDER_ID}/${defaultModelId}` : undefined,
       defaultModelId,
     },
@@ -787,18 +798,25 @@ export async function configureLmstudioNonInteractive(
   const selectedModel = selectedModelId
     ? discoveredModels.find((model) => model.id === selectedModelId)
     : undefined;
-  if (!selectedModelId || !selectedModel) {
+  const selectedModelLoaded =
+    selectedModelId !== undefined && setupDiscovery.value.loadedModelIds.has(selectedModelId);
+  if (!selectedModelId || !selectedModel || !selectedModelLoaded) {
     const availableModels = discoveredModels.map((model) => model.id).join(", ");
     normalizedCtx.runtime.error(
-      requestedModelId
+      requestedModelId && selectedModel && !selectedModelLoaded
         ? [
-            `LM Studio model ${requestedModelId} was not found at ${baseUrl}.`,
-            `Available models: ${availableModels}`,
+            `LM Studio model ${requestedModelId} is installed but not loaded at ${baseUrl}.`,
+            "Load that model in LM Studio, then re-run setup.",
           ].join("\n")
-        : [
-            `LM Studio did not expose a usable default model at ${baseUrl}.`,
-            `Available models: ${availableModels || "(none)"}`,
-          ].join("\n"),
+        : requestedModelId
+          ? [
+              `LM Studio model ${requestedModelId} was not found at ${baseUrl}.`,
+              `Available models: ${availableModels}`,
+            ].join("\n")
+          : [
+              `LM Studio did not expose a usable default model at ${baseUrl}.`,
+              `Available models: ${availableModels || "(none)"}`,
+            ].join("\n"),
     );
     normalizedCtx.runtime.exit(1);
     return null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where LM Studio setup could select any downloaded model instead of the model already loaded by the operator. LM Studio would then JIT-load that unrelated model during verification, which could consume several additional gigabytes and exhaust local memory.

## Why This Change Was Made

LM Studio setup now treats the server's loaded instances as the setup-ready set across guided, interactive, and non-interactive flows. Downloaded models remain in the runtime catalog, but setup never silently loads one; when nothing is loaded, it tells the operator to load a model and retry.

Maintainer product decision: require an already loaded model during setup. Model loading stays an explicit operator action in LM Studio.

## User Impact

Operators can load one model in LM Studio and trust OpenClaw setup to verify that exact model. Explicitly requested but unloaded models fail with a clear next step instead of triggering a hidden model load.

## Evidence

- Rebased signed head: `4fa7c243c647b6192bd90f8983adad3e492045fa`, current with `main`.
- Live Control UI setup selected `lmstudio/qwen3-0.6b` while downloaded `google/gemma-4-e4b` remained unloaded.
- Verification completed in 2,894 ms and the first chat returned `LM_STUDIO_READY` in 12 seconds.
- Residency check during the flow: Qwen had one loaded 32,768-token instance; Gemma had zero loaded instances; Ollama had zero resident models.
- Fresh one-model probe returned exactly `LM_STUDIO_READY`; Qwen remained the only loaded LM Studio model before and after, and Ollama remained at zero resident models.
- Focused Blacksmith Testbox run: 3 files passed, 109 tests total (`models`: 47, `setup`: 47, plugin entrypoint: 15).
- Exact-head autoreview: clean, patch correct, confidence 0.98.

### Screenshots

**Loaded-model detection**

![LM Studio setup detects the loaded Qwen model](https://gist.githubusercontent.com/vincentkoc/0c340948da5874682e33914ec88a3904/raw/9e971b3051570e6b57e7fc6ebace34d9eb7edea2/lmstudio-detection.svg)

**Verified connection**

![LM Studio connection verified with the loaded Qwen model](https://gist.githubusercontent.com/vincentkoc/0c340948da5874682e33914ec88a3904/raw/cd3a0b6d7e0ebab89bd90a79f9b789a311a1f3a9/lmstudio-success.svg)

**First chat**

![LM Studio first chat returns LM_STUDIO_READY](https://gist.githubusercontent.com/vincentkoc/0c340948da5874682e33914ec88a3904/raw/c6d5a447d5e5802cce62665d3397a9d29a362182/lmstudio-first-chat.svg)
