### PR TITLE
test(gateway): mock orphan recovery in startup proof

### DIFF
--- a/src/gateway/server-startup-model-runtime.event-loop.test.ts
+++ b/src/gateway/server-startup-model-runtime.event-loop.test.ts
@@ -51,6 +51,12 @@ vi.mock("../plugins/provider-discovery.js", async (importOriginal) => {
   };
 });
 
+// Session orphan recovery has separate owner coverage; avoid loading its broad
+// cold startup graph inside this timed model-runtime responsiveness proof.
+vi.mock("../agents/main-session-restart-recovery-marking.js", () => ({
+  markStartupOrphanedMainSessionsForRecovery: vi.fn(async () => ({ marked: 0, skipped: 0 })),
+}));
+
 const { resetPreparedModelRuntimeSnapshotsForTest } =
   await import("../agents/prepared-model-runtime.test-support.js");
 const { writePersistedAuthProfileStoreRaw } = await import("../agents/auth-profiles/sqlite.js");


### PR DESCRIPTION
## Summary
- Mock the unrelated orphan-recovery marker in the Gateway startup event-loop proof, matching the canonical sibling seam.
- Keep the real startup runtime, auth, SQLite, HTTP, ordering, and catalog assertions intact.

## Verification
- Hosted symptom: four required large2 runs timed out at the event-loop test after roughly 222–226s.
- Focused predecessor + target suite: 12/12 before and after; observed duration improved from 26.23s to 12.38s, with the caveat that the after run benefits from a warm module/cache state.
- Exact-path formatting and diff check: passing.
- Independent FIRST and SECOND reviews: no findings.
- Authenticated final review: no findings.
- TruffleHog exact diff scan: zero findings.
