### PR TITLE
fix(ci): keep frozen CLI probes compatible

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -683,7 +683,7 @@ jobs:
           fi
 
           mkdir -p "$SOURCE_PERF_DIR/mock-hello"
-          if ! node -e "const fs=require('node:fs'); const scripts=require('./package.json').scripts||{}; process.exit(scripts['test:gateway:cpu-scenarios'] && scripts['test:extensions:memory'] && scripts.openclaw && fs.existsSync('scripts/bench-cli-startup.ts') && fs.existsSync('scripts/profile-extension-memory.mjs') ? 0 : 1)"; then
+          if ! node -e "const fs=require('node:fs'); const scripts=require('./package.json').scripts||{}; process.exit(scripts['test:gateway:cpu-scenarios'] && scripts['test:extensions:memory'] && scripts.openclaw && fs.existsSync('openclaw.mjs') && fs.existsSync('scripts/profile-extension-memory.mjs') ? 0 : 1)"; then
             cat > "$SOURCE_PERF_DIR/index.md" <<EOF
           # OpenClaw Source Performance
 
@@ -695,7 +695,7 @@ jobs:
 
           - Tested ref: ${TESTED_REF}
           - Tested SHA: ${TESTED_SHA}
-          - Required scripts: test:gateway:cpu-scenarios, test:extensions:memory, openclaw, scripts/bench-cli-startup.ts, scripts/profile-extension-memory.mjs
+          - Required scripts: test:gateway:cpu-scenarios, test:extensions:memory, openclaw, openclaw.mjs, scripts/profile-extension-memory.mjs
           EOF
             cat "$SOURCE_PERF_DIR/index.md" >> "$GITHUB_STEP_SUMMARY"
             exit 0
@@ -849,7 +849,8 @@ jobs:
           done
 
           OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" \
-            node --import tsx scripts/bench-cli-startup.ts \
+            node --import tsx "$PERFORMANCE_HELPER_DIR/scripts/bench-cli-startup.ts" \
+            --entry "$GITHUB_WORKSPACE/openclaw.mjs" \
             --case gatewayHealthJsonConnected \
             --case gatewayHealthJsonFirstDevice \
             --case configGetGatewayPort \

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -5,7 +5,6 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
-import { parseStrictIntegerOption } from "./lib/dev-tooling-safety.ts";
 
 type CommandCase = {
   id: string;
@@ -529,11 +528,28 @@ function validateCliArgs(argv: readonly string[] = process.argv.slice(2)): void 
 }
 
 function parsePositiveInt(raw: string | undefined, fallback: number, label = "value"): number {
-  return parseStrictIntegerOption({ fallback, label, min: 1, raw });
+  return parseIntegerOption(raw, fallback, label, 1);
 }
 
 function parseNonNegativeInt(raw: string | undefined, fallback: number, label = "value"): number {
-  return parseStrictIntegerOption({ fallback, label, min: 0, raw });
+  return parseIntegerOption(raw, fallback, label, 0);
+}
+
+// This runner is checked out from trusted main beside frozen candidates, whose
+// root dependencies need not include current workspace packages.
+function parseIntegerOption(raw: string | undefined, fallback: number, label: string, min: number): number {
+  const value = raw?.trim();
+  if (!value) {
+    return fallback;
+  }
+  if (!/^\d+$/u.test(value)) {
+    throw new Error(`${label} must be an integer >= ${min}; got ${JSON.stringify(raw)}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < min) {
+    throw new Error(`${label} must be an integer >= ${min}; got ${JSON.stringify(raw)}`);
+  }
+  return parsed;
 }
 
 function parseGatewayPortEnv(raw: string | undefined): number {

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -537,7 +537,12 @@ function parseNonNegativeInt(raw: string | undefined, fallback: number, label = 
 
 // This runner is checked out from trusted main beside frozen candidates, whose
 // root dependencies need not include current workspace packages.
-function parseIntegerOption(raw: string | undefined, fallback: number, label: string, min: number): number {
+function parseIntegerOption(
+  raw: string | undefined,
+  fallback: number,
+  label: string,
+  min: number,
+): number {
   const value = raw?.trim();
   if (!value) {
     return fallback;

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -247,7 +247,7 @@ describe("OpenClaw performance workflow", () => {
       "    sleep 1",
       "  fi",
     ].join("\n");
-    const benchmark = "node --import tsx scripts/bench-cli-startup.ts \\";
+    const benchmark = 'node --import tsx "$PERFORMANCE_HELPER_DIR/scripts/bench-cli-startup.ts" \\';
 
     expect(run).toContain("gateway_ready_timeout_seconds=120");
     expect(run).toContain("gateway_probe_timeout_seconds=5");
@@ -289,9 +289,11 @@ describe("OpenClaw performance workflow", () => {
     expect(run).toContain('rm -rf "$gateway_home" "$gateway_readiness_home"');
   });
 
-  it("measures warmed and first-device gateway health separately", () => {
+  it("runs trusted CLI performance cases against the frozen candidate entrypoint", () => {
     const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
 
+    expect(run).toContain('"$PERFORMANCE_HELPER_DIR/scripts/bench-cli-startup.ts"');
+    expect(run).toContain('--entry "$GITHUB_WORKSPACE/openclaw.mjs"');
     expect(run).toContain("--case gatewayHealthJsonConnected \\");
     expect(run).toContain("--case gatewayHealthJsonFirstDevice \\");
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full release validation of an older frozen candidate would fail after its source-performance probes passed, because the trusted workflow invoked a candidate-owned benchmark script with newer harness-only case IDs. Reproduced in [run 30740699769](https://github.com/openclaw/openclaw/actions/runs/30740699769/job/91477515873).

## Why This Change Was Made

The trusted performance checkout now owns the benchmark implementation and runs it against the frozen candidate’s built `openclaw.mjs` entrypoint. Candidate code remains the program under measurement, while benchmark case IDs no longer form an evolving cross-version API.

## User Impact

Release managers can validate supported extended-stable candidates even as trusted performance probes evolve, without requiring old candidate source to implement newer harness-only case IDs.

## Evidence

- `actionlint .github/workflows/openclaw-performance.yml`
- Ruby YAML parse of `.github/workflows/openclaw-performance.yml`
- Focused workflow contract test updated in `test/scripts/openclaw-performance-workflow.test.ts`
- `autoreview --mode local`: clean, no accepted/actionable findings

The isolated PR worktree has no `node_modules`; the focused Vitest test will run in CI.