### PR TITLE
fix(agents): keep cumulative token totals consistent

### DIFF
--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -283,8 +283,6 @@ export async function runPreparedEmbeddedLoop(
     let authRetryPending = false;
     let accumulatedReplayState = createEmbeddedRunReplayState();
     let latestMcpAppChannelView: McpAppChannelView | undefined;
-    // Hoisted so the retry-limit error path can use the most recent API total.
-    let lastTurnTotal: number | undefined;
     while (true) {
       refreshPreparedRuntimeSnapshot();
       if (runLoopIterations >= MAX_RUN_LOOP_ITERATIONS) {
@@ -316,7 +314,6 @@ export async function runPreparedEmbeddedLoop(
             ...outerContextTokenMeta,
             usageAccumulator,
             lastRunPromptUsage,
-            lastTurnTotal,
           }),
           replayInvalid: accumulatedReplayState.replayInvalid ? true : undefined,
           livenessState: "blocked",
@@ -368,7 +365,6 @@ export async function runPreparedEmbeddedLoop(
         bootstrapPromptWarningSignaturesSeen,
         usageAccumulator,
         lastRunPromptUsage,
-        lastTurnTotal,
         idleTimeoutBreakerState,
         contextRecoveryState,
         replayState: accumulatedReplayState,
@@ -381,13 +377,11 @@ export async function runPreparedEmbeddedLoop(
         bootstrapPromptWarningSignaturesSeen =
           normalizedAttempt.bootstrapPromptWarningSignaturesSeen;
         lastRunPromptUsage = normalizedAttempt.lastRunPromptUsage;
-        lastTurnTotal = normalizedAttempt.lastTurnTotal;
         accumulatedReplayState = normalizedAttempt.replayState;
         continue;
       }
       bootstrapPromptWarningSignaturesSeen = normalizedAttempt.bootstrapPromptWarningSignaturesSeen;
       lastRunPromptUsage = normalizedAttempt.lastRunPromptUsage;
-      lastTurnTotal = normalizedAttempt.lastTurnTotal;
       accumulatedReplayState = normalizedAttempt.replayState;
       const {
         attempt,
@@ -421,7 +415,6 @@ export async function runPreparedEmbeddedLoop(
         armPostCompactionGuard: () => postCompactionGuard.armPostCompaction(),
         usageAccumulator,
         lastRunPromptUsage,
-        lastTurnTotal,
         runtimeAuthRetry,
         codexAppServerRecoveryRetryAvailable,
         codexAppServerRecoveryRetries,
@@ -520,7 +513,6 @@ export async function runPreparedEmbeddedLoop(
           resolvedToolResultFormat,
         },
         lastRunPromptUsage,
-        lastTurnTotal,
         finalization: {
           preparedAttempt: dispatchedAttempt.preparedAttempt,
           harness: agentHarness,
@@ -539,7 +531,6 @@ export async function runPreparedEmbeddedLoop(
         finalizationAttempted: settledTurnFinalizationAttempted,
       } = finalizedTerminal;
       lastRunPromptUsage = finalizedTerminal.lastRunPromptUsage;
-      lastTurnTotal = finalizedTerminal.lastTurnTotal;
       if (finalizedTerminal.finalizationSucceeded) {
         assistantProfileFailureReason = null;
       }

--- a/src/agents/embedded-agent-runner/run/attempt-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-normalization.ts
@@ -57,7 +57,6 @@ export async function normalizeEmbeddedRunAttempt(input: {
   bootstrapPromptWarningSignaturesSeen: string[];
   usageAccumulator: ReturnType<typeof createUsageAccumulator>;
   lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
-  lastTurnTotal: number | undefined;
   idleTimeoutBreakerState: ReturnType<typeof createIdleTimeoutBreakerState>;
   contextRecoveryState: ReturnType<typeof createEmbeddedRunContextRecoveryState>;
   replayState: ReplayState;
@@ -68,14 +67,12 @@ export async function normalizeEmbeddedRunAttempt(input: {
       action: "retry";
       bootstrapPromptWarningSignaturesSeen: string[];
       lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
-      lastTurnTotal: number | undefined;
       replayState: ReplayState;
     }
   | {
       action: "proceed";
       bootstrapPromptWarningSignaturesSeen: string[];
       lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
-      lastTurnTotal: number | undefined;
       replayState: ReplayState;
       attempt: ReturnType<typeof normalizeEmbeddedRunAttemptResult>;
       sessionIdUsed: string;
@@ -170,7 +167,6 @@ export async function normalizeEmbeddedRunAttempt(input: {
   mergeUsageIntoAccumulator(input.usageAccumulator, attemptUsage);
   mergeAttemptRunStatsIntoAccumulator(input.usageAccumulator, attempt);
   const lastRunPromptUsage = callUsage.latest;
-  const lastTurnTotal = callUsage.latest?.total;
   const breakerStep = stepIdleTimeoutBreaker(input.idleTimeoutBreakerState, {
     idleTimedOut: terminalTimedOut && idleTimedOut,
     completedModelProgress: hasCompletedModelProgressForIdleBreaker(attempt),
@@ -207,7 +203,6 @@ export async function normalizeEmbeddedRunAttempt(input: {
           ...runtime.outerContextTokenMeta,
           usageAccumulator: input.usageAccumulator,
           lastRunPromptUsage,
-          lastTurnTotal,
         }),
         replayInvalid: input.replayState.replayInvalid ? true : undefined,
         livenessState: "blocked",
@@ -268,7 +263,6 @@ export async function normalizeEmbeddedRunAttempt(input: {
       action: "retry",
       bootstrapPromptWarningSignaturesSeen,
       lastRunPromptUsage,
-      lastTurnTotal,
       replayState,
     };
   }
@@ -276,7 +270,6 @@ export async function normalizeEmbeddedRunAttempt(input: {
     action: "proceed",
     bootstrapPromptWarningSignaturesSeen,
     lastRunPromptUsage,
-    lastTurnTotal,
     replayState,
     attempt,
     sessionIdUsed,

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -53,7 +53,6 @@ export async function recoverEmbeddedRunAttempt(input: {
   armPostCompactionGuard: () => void;
   usageAccumulator: ReturnType<typeof createUsageAccumulator>;
   lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
-  lastTurnTotal: number | undefined;
   runtimeAuthRetry: boolean;
   codexAppServerRecoveryRetryAvailable: boolean;
   codexAppServerRecoveryRetries: number;
@@ -245,7 +244,6 @@ export async function recoverEmbeddedRunAttempt(input: {
           usageAccumulator: input.usageAccumulator,
           lastRunPromptUsage: input.lastRunPromptUsage,
           lastAssistant: attemptAssistant,
-          lastTurnTotal: input.lastTurnTotal,
         }),
         attempt,
         replayInvalid,
@@ -273,7 +271,6 @@ export async function recoverEmbeddedRunAttempt(input: {
           usageAccumulator: input.usageAccumulator,
           lastRunPromptUsage: input.lastRunPromptUsage,
           lastAssistant: attemptAssistant,
-          lastTurnTotal: input.lastTurnTotal,
         }),
         attempt,
         replayInvalid,
@@ -345,7 +342,6 @@ export async function recoverEmbeddedRunAttempt(input: {
           usageAccumulator: input.usageAccumulator,
           lastRunPromptUsage: input.lastRunPromptUsage,
           lastAssistant: attemptAssistant,
-          lastTurnTotal: input.lastTurnTotal,
         }),
       startedAtMs: runInput.startedAtMs,
       fallbackConfigured: runInput.fallbackConfigured,

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -253,6 +253,34 @@ describe("buildUsageAgentMetaFields", () => {
     expect(fields.promptTokens).toBe(180);
   });
 
+  it("keeps cumulative usage and the latest call distinct across a zero-usage retry", () => {
+    const usageAccumulator = createUsageAccumulator();
+    mergeUsageIntoAccumulator(usageAccumulator, {
+      input: 100,
+      output: 50,
+      total: 150,
+    });
+    const latestCallUsage = {
+      input: 150,
+      output: 50,
+      total: 200,
+    } satisfies NormalizedUsage;
+    mergeUsageIntoAccumulator(usageAccumulator, latestCallUsage);
+
+    const fields = buildUsageAgentMetaFields({
+      usageAccumulator,
+      lastAssistantUsage: { input: 0, output: 0, total: 0 },
+      lastRunPromptUsage: latestCallUsage,
+    });
+
+    expect(fields.usage).toMatchObject({
+      input: 250,
+      output: 100,
+      total: 350,
+    });
+    expect(fields.lastCallUsage).toEqual(latestCallUsage);
+  });
+
   it("does not derive a prompt override from unavailable context usage", () => {
     const usageAccumulator = createUsageAccumulator();
     const latestCallUsage = {
@@ -297,6 +325,38 @@ describe("buildUsageAgentMetaFields", () => {
 });
 
 describe("buildErrorAgentMeta", () => {
+  it("keeps cumulative usage separate from the latest call on error exits", () => {
+    const usageAccumulator = createUsageAccumulator();
+    mergeUsageIntoAccumulator(usageAccumulator, {
+      input: 100,
+      output: 50,
+      total: 150,
+    });
+    const latestCallUsage = {
+      input: 150,
+      output: 50,
+      total: 200,
+    } satisfies NormalizedUsage;
+    mergeUsageIntoAccumulator(usageAccumulator, latestCallUsage);
+
+    const fields = buildErrorAgentMeta({
+      sessionId: "session-error",
+      sessionFile: "/tmp/session-error.jsonl",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      usageAccumulator,
+      lastRunPromptUsage: latestCallUsage,
+      lastAssistant: { usage: latestCallUsage },
+    });
+
+    expect(fields.usage).toMatchObject({
+      input: 250,
+      output: 100,
+      total: 350,
+    });
+    expect(fields.lastCallUsage).toEqual(latestCallUsage);
+  });
+
   it("preserves active session file for error exits after transcript rotation", () => {
     // Error metadata follows the active session after transcript rotation so
     // diagnostics and resume links point at the file that contains the failure.

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -217,19 +217,23 @@ describe("resolveLatestCallUsage", () => {
 });
 
 describe("buildUsageAgentMetaFields", () => {
-  it("keeps aggregate billing buckets out of the latest context snapshot", () => {
+  it("keeps cumulative usage separate from the latest context snapshot", () => {
     const usageAccumulator = createUsageAccumulator();
+    mergeUsageIntoAccumulator(usageAccumulator, {
+      input: 100,
+      output: 50,
+      total: 150,
+    });
     const latestCallUsage = {
-      input: 12,
-      output: 15_104,
-      cacheRead: 819_661,
-      cacheWrite: 93_130,
+      input: 80,
+      output: 20,
+      cacheRead: 100,
       contextUsage: {
         state: "available",
-        promptTokens: 148_874,
-        totalTokens: 163_978,
+        promptTokens: 180,
+        totalTokens: 200,
       },
-      total: 927_907,
+      total: 200,
     } satisfies NormalizedUsage;
     mergeUsageIntoAccumulator(usageAccumulator, latestCallUsage);
 
@@ -237,18 +241,16 @@ describe("buildUsageAgentMetaFields", () => {
       usageAccumulator,
       lastAssistantUsage: undefined,
       lastRunPromptUsage: latestCallUsage,
-      lastTurnTotal: latestCallUsage.total,
     });
 
     expect(fields.usage).toMatchObject({
-      input: 12,
-      output: 15_104,
-      cacheRead: 819_661,
-      cacheWrite: 93_130,
-      total: 927_907,
+      input: 180,
+      output: 70,
+      cacheRead: 100,
+      total: 350,
     });
     expect(fields.lastCallUsage).toEqual(latestCallUsage);
-    expect(fields.promptTokens).toBe(148_874);
+    expect(fields.promptTokens).toBe(180);
   });
 
   it("does not derive a prompt override from unavailable context usage", () => {
@@ -267,7 +269,6 @@ describe("buildUsageAgentMetaFields", () => {
       usageAccumulator,
       lastAssistantUsage: latestCallUsage,
       lastRunPromptUsage: latestCallUsage,
-      lastTurnTotal: latestCallUsage.total,
     });
 
     expect(fields.lastCallUsage).toEqual(latestCallUsage);

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -205,12 +205,8 @@ export function buildUsageAgentMetaFields(params: {
   usageAccumulator: UsageAccumulator;
   lastAssistantUsage?: UsageSnapshot | null;
   lastRunPromptUsage: UsageSnapshot | undefined;
-  lastTurnTotal?: number;
 }): Pick<EmbeddedAgentMeta, "usage" | "lastCallUsage" | "promptTokens"> {
   const usage = toNormalizedUsage(params.usageAccumulator);
-  if (usage && params.lastTurnTotal && params.lastTurnTotal > 0) {
-    usage.total = params.lastTurnTotal;
-  }
   const lastAssistantUsage = normalizeUsage(params.lastAssistantUsage as never);
   const lastCallUsage = hasNonzeroUsage(lastAssistantUsage)
     ? lastAssistantUsage
@@ -242,13 +238,11 @@ export function buildErrorAgentMeta(params: {
   usageAccumulator: UsageAccumulator;
   lastRunPromptUsage: UsageSnapshot | undefined;
   lastAssistant?: { usage?: unknown } | null;
-  lastTurnTotal?: number;
 }): EmbeddedAgentMeta {
   const usageMeta = buildUsageAgentMetaFields({
     usageAccumulator: params.usageAccumulator,
     lastAssistantUsage: params.lastAssistant?.usage as UsageSnapshot | undefined,
     lastRunPromptUsage: params.lastRunPromptUsage,
-    lastTurnTotal: params.lastTurnTotal,
   });
   return {
     sessionId: params.sessionId,

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -27,7 +27,6 @@ type TerminalPreparationBase = Omit<
   | "sessionIdUsed"
   | "sessionFileUsed"
   | "lastRunPromptUsage"
-  | "lastTurnTotal"
   | "terminalState"
 >;
 
@@ -43,7 +42,6 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
   };
   terminalBase: TerminalPreparationBase;
   lastRunPromptUsage: TerminalPreparationInput["lastRunPromptUsage"];
-  lastTurnTotal: TerminalPreparationInput["lastTurnTotal"];
   finalization: {
     preparedAttempt: EmbeddedRunAttemptParams;
     harness: AgentHarness;
@@ -58,7 +56,6 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
   const initial = input.initial;
   let attempt = initial.attempt;
   let lastRunPromptUsage = input.lastRunPromptUsage;
-  let lastTurnTotal = input.lastTurnTotal;
   let prepared = prepareEmbeddedRunTerminal({
     ...input.terminalBase,
     attempt,
@@ -66,7 +63,6 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
     sessionIdUsed: initial.sessionIdUsed,
     sessionFileUsed: initial.sessionFileUsed,
     lastRunPromptUsage,
-    lastTurnTotal,
     terminalState: initial.terminalState,
   });
   const prompt = resolveSettledTurnFinalizationRequest({
@@ -88,7 +84,6 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       ...initial,
       prepared,
       lastRunPromptUsage,
-      lastTurnTotal,
       finalizationAttempted: false,
       finalizationSucceeded: false,
     };
@@ -111,7 +106,6 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
     mergeUsageIntoAccumulator(input.terminalBase.usageAccumulator, attempt.attemptUsage);
     mergeAttemptRunStatsIntoAccumulator(input.terminalBase.usageAccumulator, attempt);
     lastRunPromptUsage = attempt.attemptUsage ?? lastRunPromptUsage;
-    lastTurnTotal = attempt.attemptUsage?.total ?? lastTurnTotal;
     // Successful isolated finalization owns a fresh terminal, never the original abort signal.
     const terminalState: EmbeddedRunTerminalState = {
       outcome: resolveEmbeddedRunAttemptTerminalOutcome({
@@ -127,7 +121,6 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       sessionIdUsed: attempt.sessionIdUsed,
       sessionFileUsed: attempt.sessionFileUsed,
       lastRunPromptUsage,
-      lastTurnTotal,
       terminalState,
     });
     return {
@@ -140,7 +133,6 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       sessionFileUsed: attempt.sessionFileUsed,
       prepared,
       lastRunPromptUsage,
-      lastTurnTotal,
       finalizationAttempted: true,
       finalizationSucceeded: true,
     };
@@ -153,7 +145,6 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       ...initial,
       prepared,
       lastRunPromptUsage,
-      lastTurnTotal,
       finalizationAttempted: true,
       finalizationSucceeded: false,
     };

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -39,7 +39,6 @@ export function prepareEmbeddedRunTerminal(input: {
   outerContextTokenMeta: { contextTokens?: number };
   usageAccumulator: UsageAccumulator;
   lastRunPromptUsage?: NormalizedUsage;
-  lastTurnTotal?: number;
   contextRecoveryState: EmbeddedRunContextRecoveryState;
   resolvedToolResultFormat: NonNullable<RunEmbeddedAgentParams["toolResultFormat"]>;
   terminalState: EmbeddedRunTerminalState;
@@ -72,7 +71,6 @@ export function prepareEmbeddedRunTerminal(input: {
     usageAccumulator: input.usageAccumulator,
     lastAssistantUsage: terminalAssistant?.usage as UsageLike | undefined,
     lastRunPromptUsage: input.lastRunPromptUsage,
-    lastTurnTotal: input.lastTurnTotal,
   });
   const reportedModelRef = resolveReportedModelRef({
     provider: input.provider,
@@ -82,8 +80,6 @@ export function prepareEmbeddedRunTerminal(input: {
   const finalAssistantStopReason = (terminalAssistant?.stopReason ?? "").trim().toLowerCase();
   const terminalAssistantCanOwnFinalText =
     finalAssistantStopReason !== "error" && finalAssistantStopReason !== "aborted";
-  // Total-only usage (lastTurnTotal override) carries no token split, so cost
-  // math uses the accumulated input/output/cache fields untouched by it.
   const costUsd = estimateUsageCost({
     usage: usageMeta.usage,
     cost: resolveModelCostConfig({

--- a/src/agents/embedded-agent-runner/usage-reporting.test.ts
+++ b/src/agents/embedded-agent-runner/usage-reporting.test.ts
@@ -275,24 +275,7 @@ describe("runEmbeddedAgent usage reporting", () => {
     expect(attemptInput.memoryFlushWritePath).toBe("memory/2026-03-10.md");
   });
 
-  it("reports total usage from the last turn instead of accumulated total", async () => {
-    // Billing metadata uses accumulated input/output but the reported total
-    // remains the final provider call total, matching last-turn usage contracts.
-    // Simulate a multi-turn run result.
-    // Turn 1: Input 100, Output 50. Total 150.
-    // Turn 2: Input 150, Output 50. Total 200.
-
-    // The accumulated usage (attemptUsage) will be the sum:
-    // Input: 100 + 150 = 250 (Note: runEmbeddedAttempt actually returns accumulated usage)
-    // Output: 50 + 50 = 100
-    // Total: 150 + 200 = 350
-
-    // The last assistant usage (lastAssistant.usage) will be Turn 2:
-    // Input: 150, Output 50, Total 200.
-
-    // We expect result.meta.agentMeta.usage.total to be 200 (last turn total).
-    // The bug causes it to be 350 (accumulated total).
-
+  it("reports cumulative usage separately from the last call", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Response 1", "Response 2"],
@@ -313,15 +296,16 @@ describe("runEmbeddedAgent usage reporting", () => {
       runId: "run-1",
     });
 
-    // Check usage in meta
-    const usage = result.meta.agentMeta?.usage;
-    expect(usage?.input).toBe(250);
-    expect(usage?.output).toBe(100);
-    expect(usage?.total).toBe(200);
-
-    // Check if total matches the last turn's total (200)
-    // If the bug exists, it will likely be 350
-    expect(usage?.total).toBe(200);
+    expect(result.meta.agentMeta?.usage).toMatchObject({
+      input: 250,
+      output: 100,
+      total: 350,
+    });
+    expect(result.meta.agentMeta?.lastCallUsage).toMatchObject({
+      input: 150,
+      output: 50,
+      total: 200,
+    });
   });
 
   it("uses current-attempt usage when the persisted assistant snapshot is zeroed", async () => {
@@ -357,7 +341,7 @@ describe("runEmbeddedAgent usage reporting", () => {
     expect(result.meta.agentMeta?.usage).toMatchObject({
       input: 250,
       output: 100,
-      total: 200,
+      total: 350,
     });
     expect(result.meta.agentMeta?.lastCallUsage).toMatchObject({
       input: 150,

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -159,8 +159,8 @@ export async function finalizeCronRun(params: {
       output_tokens: output,
     };
     const bucketTotalTokens = input + output + cacheRead + cacheWrite;
-    // Embedded runs accumulate billing buckets across calls, while usage.total
-    // may be replaced with the final provider-call total for context tracking.
+    // Keep telemetry totals consistent when a provider reports only a partial
+    // aggregate alongside the normalized billing buckets.
     const aggregateTotalTokens =
       typeof usage.total === "number" && Number.isFinite(usage.total)
         ? Math.max(bucketTotalTokens, usage.total)

--- a/src/gateway/worker-environments/worker-turn-launcher.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test.ts
@@ -1046,7 +1046,7 @@ describe("worker turn launcher", () => {
         output: 40,
         cacheRead: 60,
         cacheWrite: 5,
-        total: 270,
+        total: 405,
       },
       lastCallUsage: {
         input: 200,

--- a/src/gateway/worker-environments/worker-turn-payload.ts
+++ b/src/gateway/worker-environments/worker-turn-payload.ts
@@ -135,7 +135,6 @@ export function buildWorkerAgentMeta(params: {
     usageAccumulator,
     lastAssistantUsage: lastAssistant?.usage,
     lastRunPromptUsage,
-    lastTurnTotal: lastRunPromptUsage?.total,
   });
   const reportedModelRef = resolveReportedModelRef({
     ...params.modelRef,


### PR DESCRIPTION
Closes #117586

## What Problem This Solves

Fixes an issue where multi-call agent runs exposed token metadata whose input/output/cache buckets were cumulative but whose `total` was replaced with the latest provider-call total. Consumers of agent-exec JSON, diagnostics, cron telemetry, and billing metadata could therefore receive an internally inconsistent aggregate.

## Why This Change Was Made

`usage` now remains the canonical cumulative run aggregate. Latest-call context stays in the existing `lastCallUsage` and `promptTokens` fields. The obsolete `lastTurnTotal` override and its cross-loop plumbing were removed instead of adding another reconciliation rule.

Architectural owner: embedded agent usage normalization/reporting. No config, protocol, SDK, provider, or persistence contract changes.

## User Impact

Multi-call runs now report internally consistent cumulative token totals. Current-context behavior is unchanged because it already reads `lastCallUsage` / `promptTokens`.

## Evidence

- Regression reproduced before the fix: cumulative buckets expected `350`, but metadata returned the latest-call total `200`.
- Post-fix local focused proof: 41/41 tests passed across helper, terminal preparation, attempt normalization, and worker payload coverage.
- Blacksmith Testbox: full `usage-reporting.test.ts` passed 10/10; `pnpm check:changed` passed. Run: https://github.com/openclaw/openclaw/actions/runs/30739656157
- Post-rebase formatting, `git diff --check`, and the 41-test focused suite passed on current `origin/main`.
- Production change is net-negative: the fix deletes the override and dead propagation paths.

Codex dependency contract checked directly at `openai/codex@2b5bdcf67547860f2e5c5a605009a70026796b2b`:

- [`TokenUsageInfo` separates cumulative `total_token_usage` from `last_token_usage`, and appends the latter into the former](https://github.com/openai/codex/blob/2b5bdcf67547860f2e5c5a605009a70026796b2b/codex-rs/protocol/src/protocol.rs#L2081-L2119).
- [Session replay requires the complete snapshot because notifications carry both totals](https://github.com/openai/codex/blob/2b5bdcf67547860f2e5c5a605009a70026796b2b/codex-rs/core/src/session/mod.rs#L1231-L1244).
- [Reading only the cumulative total loses latest-turn usage](https://github.com/openai/codex/blob/2b5bdcf67547860f2e5c5a605009a70026796b2b/codex-rs/core/src/codex_thread.rs#L496-L504).

Regression provenance: the mixed-basis reporting policy originated in `a62ff19a6638` (2026-02-16, @artale; committed by @steipete), and PR https://github.com/openclaw/openclaw/pull/34275 propagated it into error metadata (authored by @RealKai42, merged by @jalehman on 2026-03-04).

AI assistance: Codex assisted with investigation, implementation, tests, and structured review. The maintainer directly verified the source contracts, diff, and proof above.