### PR TITLE
test(gateway): widen aggregate event-loop budget

### DIFF
--- a/src/gateway/server-startup-model-runtime.event-loop.test.ts
+++ b/src/gateway/server-startup-model-runtime.event-loop.test.ts
@@ -249,5 +249,5 @@ describe("Gateway prepared model runtime startup", () => {
       closeOpenClawAgentDatabasesForTest();
       await rm(root, { recursive: true, force: true });
     }
-  });
+  }, 300_000);
 });


### PR DESCRIPTION
## Summary

- widen the outer timeout for the gateway startup event-loop proof from the repository default (120 seconds) to 300 seconds
- keep the behavioral assertions and implementation unchanged

## Why

The test passes in about 5 seconds when run alone, but the hosted aggregate `gateway-server` shard has twice delayed the test beyond the 120-second per-test ceiling while still logging the expected successful sequence afterward. This blocks unrelated PRs despite the behavior proof succeeding.

## Verification

- `pnpm exec vitest run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-startup-model-runtime.event-loop.test.ts` — 1/1 passed in 5.06s
- targeted `oxfmt --check` — passed
- `git diff --check` — passed

AI-assisted: Codex implementation and verification. I reviewed and understand the change.
