### PR TITLE
perf(cli): keep read-only commands on cold paths

### DIFF
--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -27,6 +27,7 @@ import {
 import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "../../plugins/plugin-metadata-lifecycle.js";
 import { resolvePluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import {
   getCachedPluginModuleLoader,
   type PluginModuleLoaderCache,
@@ -59,6 +60,7 @@ type ReadOnlyChannelPluginOptions = {
   activationSourceConfig?: OpenClawConfig;
   includePersistedAuthState?: boolean;
   includeSetupFallbackPlugins?: boolean;
+  metadataSnapshot?: PluginMetadataSnapshot;
 };
 
 type ReadOnlyChannelPluginResolution = {
@@ -717,13 +719,15 @@ export function resolveReadOnlyChannelPluginsForConfig(
   if (cached) {
     return cloneReadOnlyChannelPluginResolution(cached);
   }
-  const manifestRecords = resolvePluginMetadataSnapshot({
-    config: cfg,
-    stateDir: options.stateDir,
-    workspaceDir,
-    env,
-    allowWorkspaceScopedCurrent: true,
-  }).plugins;
+  const manifestRecords =
+    options.metadataSnapshot?.plugins ??
+    resolvePluginMetadataSnapshot({
+      config: cfg,
+      stateDir: options.stateDir,
+      workspaceDir,
+      env,
+      allowWorkspaceScopedCurrent: true,
+    }).plugins;
   const bundledManifestRecords = listBundledChannelManifestRecords(manifestRecords);
   const externalManifestRecords = listExternalChannelManifestRecords(manifestRecords);
   const activationSourceConfig = options.activationSourceConfig ?? cfg;

--- a/src/cli/channels-list-route-cold-imports.test.ts
+++ b/src/cli/channels-list-route-cold-imports.test.ts
@@ -1,0 +1,107 @@
+// The real channels-list route must project manifest facts without executing setup modules.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  createColdPluginFixture,
+  isColdPluginRuntimeLoaded,
+} from "../plugins/test-helpers/cold-plugin-fixtures.js";
+
+const testState = vi.hoisted(() => ({
+  config: {} as OpenClawConfig,
+  json: [] as unknown[],
+}));
+
+vi.mock("./command-execution-startup.js", () => ({
+  applyCliExecutionStartupPresentation: vi.fn(async () => {}),
+  ensureCliExecutionBootstrap: vi.fn(async () => {}),
+  resolveCliExecutionStartupContext: vi.fn(() => ({
+    startupPolicy: { loadPlugins: false, suppressDoctorStdout: true },
+  })),
+}));
+
+vi.mock("../commands/channels/shared.js", () => ({
+  formatChannelAccountLabel: vi.fn(),
+  requireValidConfig: vi.fn(async () => testState.config),
+}));
+
+vi.mock("../commands/channel-setup/trusted-catalog.js", () => ({
+  listTrustedChannelPluginCatalogEntries: vi.fn(() => []),
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: vi.fn(() => undefined),
+  resolveDefaultAgentId: vi.fn(() => "main"),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    error: vi.fn(),
+    exit: vi.fn(),
+    log: vi.fn(),
+    writeJson: (value: unknown) => testState.json.push(value),
+    writeStdout: vi.fn(),
+  },
+  writeRuntimeJson: vi.fn((runtime: { writeJson: (value: unknown) => void }, value: unknown) =>
+    runtime.writeJson(value),
+  ),
+}));
+
+import { tryRouteCli } from "./route.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channels-list-route-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+it("renders configured channel metadata without loading the plugin runtime", async () => {
+  const pluginRoot = path.join(tempRoot, "cold-channel-plugin");
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  const fixture = createColdPluginFixture({
+    rootDir: pluginRoot,
+    pluginId: "cold-channel-plugin",
+    channelId: "cold-channel",
+    manifest: {
+      channelConfigs: {
+        "cold-channel": {
+          schema: {
+            type: "object",
+            additionalProperties: false,
+            properties: { token: { type: "string" } },
+          },
+          label: "Cold Channel",
+          description: "Prepared cold channel metadata",
+        },
+      },
+    },
+  });
+  vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  vi.stubEnv("OPENCLAW_HOME", path.join(tempRoot, "home"));
+  vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tempRoot, "state"));
+  testState.config = {
+    channels: { "cold-channel": { token: "configured" } },
+    plugins: {
+      load: { paths: [pluginRoot] },
+      entries: { "cold-channel-plugin": { enabled: true } },
+    },
+  };
+
+  await expect(tryRouteCli(["node", "openclaw", "channels", "list", "--json"])).resolves.toBe(true);
+
+  expect(testState.json).toEqual([
+    {
+      chat: {
+        "cold-channel": {
+          accounts: ["default"],
+          installed: true,
+          origin: "configured",
+        },
+      },
+    },
+  ]);
+  expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+});

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -127,7 +127,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   {
     commandPath: ["agents", "bindings"],
     exact: true,
-    policy: { loadPlugins: "never" },
+    policy: { configGuard: "skip", loadPlugins: "never" },
   },
   {
     commandPath: ["agents", "unbind"],
@@ -213,11 +213,19 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   { commandPath: ["gateway", "install"], exact: true, policy: { networkProxy: "bypass" } },
   { commandPath: ["gateway", "probe"], exact: true, policy: { networkProxy: "bypass" } },
   { commandPath: ["gateway", "restart"], exact: true, policy: { networkProxy: "bypass" } },
-  { commandPath: ["gateway", "stability"], exact: true, policy: { networkProxy: "bypass" } },
+  {
+    commandPath: ["gateway", "stability"],
+    exact: true,
+    policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
+  },
   { commandPath: ["gateway", "start"], exact: true, policy: { networkProxy: "bypass" } },
   { commandPath: ["gateway", "stop"], exact: true, policy: { networkProxy: "bypass" } },
   { commandPath: ["gateway", "uninstall"], exact: true, policy: { networkProxy: "bypass" } },
-  { commandPath: ["gateway", "usage-cost"], exact: true, policy: { networkProxy: "bypass" } },
+  {
+    commandPath: ["gateway", "usage-cost"],
+    exact: true,
+    policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
+  },
   {
     commandPath: ["sessions"],
     exact: true,
@@ -232,6 +240,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   {
     commandPath: ["commitments"],
     policy: {
+      configGuard: "skip",
       ensureCliPath: false,
       loadPlugins: "never",
       networkProxy: "bypass",
@@ -284,6 +293,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: {
       ensureCliPath: false,
       configGuard: "skip",
+      loadPlugins: "never",
       networkProxy: ({ argv }) => (hasFlag(argv, "--probe") ? "default" : "bypass"),
     },
     route: { id: "models-status" },
@@ -335,6 +345,11 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { ownsProtocolStdout: true },
   },
   { commandPath: ["approvals"], policy: { networkProxy: "bypass" } },
+  {
+    commandPath: ["approvals", "pending"],
+    exact: true,
+    policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
+  },
   // automations is a commander alias for cron; argv-derived command paths keep the typed token.
   {
     commandPath: ["automations"],
@@ -513,11 +528,23 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
     route: { id: "channels-list" },
   },
-  { commandPath: ["skills"], exact: true, policy: { networkProxy: "bypass" } },
-  { commandPath: ["skills", "check"], exact: true, policy: { networkProxy: "bypass" } },
+  {
+    commandPath: ["skills"],
+    exact: true,
+    policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
+  },
+  {
+    commandPath: ["skills", "check"],
+    exact: true,
+    policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
+  },
   { commandPath: ["skills", "info"], exact: true, policy: { networkProxy: "bypass" } },
   { commandPath: ["skills", "install"], exact: true },
-  { commandPath: ["skills", "list"], exact: true, policy: { networkProxy: "bypass" } },
+  {
+    commandPath: ["skills", "list"],
+    exact: true,
+    policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
+  },
   { commandPath: ["skills", "search"], exact: true },
   { commandPath: ["skills", "update"], exact: true },
   { commandPath: ["skills", "verify"], exact: true },

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -212,7 +212,6 @@ describe("command-path-policy", () => {
     }
     for (const commandPath of [
       ["agents", "bind"],
-      ["agents", "bindings"],
       ["agents", "unbind"],
       ["agents", "set-identity"],
       ["agents", "delete"],
@@ -222,6 +221,28 @@ describe("command-path-policy", () => {
         networkProxy: "bypass",
       });
     }
+    expectResolvedPolicy(["agents", "bindings"], {
+      configGuard: "skip",
+      loadPlugins: "never",
+      networkProxy: "bypass",
+    });
+  });
+
+  it.each([
+    ["approvals", "pending"],
+    ["commitments"],
+    ["skills"],
+    ["skills", "list"],
+    ["skills", "check"],
+    ["gateway", "stability"],
+    ["gateway", "usage-cost"],
+  ])("keeps read-only cold path %s out of startup config and plugins", (...commandPath) => {
+    expectResolvedPolicy(commandPath, {
+      configGuard: "skip",
+      loadPlugins: "never",
+      ...(commandPath[0] === "commitments" ? { ensureCliPath: false } : {}),
+      networkProxy: "bypass",
+    });
   });
 
   it("resolves mixed startup-only rules", () => {

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -33,6 +33,14 @@ describe("command-startup-policy", () => {
       ["docs"],
       ["agent", "exec"],
       ["status"],
+      ["agents", "bindings"],
+      ["approvals", "pending"],
+      ["commitments"],
+      ["skills"],
+      ["skills", "list"],
+      ["skills", "check"],
+      ["gateway", "stability"],
+      ["gateway", "usage-cost"],
     ]) {
       expect(resolvePolicy({ commandPath }).skipConfigGuard, commandPath.join(" ")).toBe(true);
     }

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -298,76 +298,24 @@ describe("gateway-cli coverage", () => {
     );
   });
 
-  it("waits for refreshing all-agent usage caches before printing totals", async () => {
-    const settleSleep = vi.fn(async (_ms: number) => {});
-    gatewayProgram = createGatewayProgram({
-      usageCostSettle: {
-        now: () => 0,
-        sleep: settleSleep,
-      },
-    });
-    callGateway
-      .mockResolvedValueOnce({
-        cacheStatus: { status: "refreshing", cachedFiles: 0, pendingFiles: 2 },
-      })
-      .mockResolvedValueOnce({
-        totals: { totalTokens: 100, totalCost: 0.1 },
-        cacheStatus: { status: "fresh", cachedFiles: 2, pendingFiles: 0 },
-      });
-
-    await runGatewayCommand(["gateway", "usage-cost", "--all-agents", "--days", "7", "--json"]);
-
-    expect(callGateway).toHaveBeenCalledTimes(2);
-    expect(settleSleep).toHaveBeenCalledOnce();
-    expect(settleSleep).toHaveBeenCalledWith(250);
-    const costCalls = callGateway.mock.calls.map(
-      ([raw]) => raw as { method?: string; timeoutMs?: number },
-    );
-    expect(costCalls.every((call) => call.method === "usage.cost")).toBe(true);
-    expect(costCalls.every((call) => call.timeoutMs === 10_000)).toBe(true);
-    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
-      expect.objectContaining({
-        totals: expect.objectContaining({ totalTokens: 100, totalCost: 0.1 }),
-        cacheStatus: expect.objectContaining({ status: "fresh" }),
-      }),
-    );
-  });
-
   it.each(["refreshing", "partial", "stale"] as const)(
-    "uses --timeout as the command-wide usage-cost settle budget for %s caches",
+    "returns the first usage-cost RPC result when the cache is %s",
     async (status) => {
-      let now = 0;
-      gatewayProgram = createGatewayProgram({
-        usageCostSettle: {
-          now: () => now,
-          sleep: async (ms) => {
-            now += ms;
-          },
-        },
-      });
-      callGateway.mockResolvedValue({
-        cacheStatus: { status, cachedFiles: 0, pendingFiles: 1 },
-      });
+      const summary = {
+        totals: { totalTokens: 100, totalCost: 0.1 },
+        cacheStatus: { status, cachedFiles: 0, pendingFiles: 2 },
+      };
+      callGateway.mockResolvedValue(summary);
 
-      await expectGatewayExit([
-        "gateway",
-        "usage-cost",
-        "--all-agents",
-        "--timeout",
-        "50",
-        "--json",
-      ]);
+      await runGatewayCommand(["gateway", "usage-cost", "--all-agents", "--days", "7", "--json"]);
 
-      // A fast host can fit a second poll inside the 50ms budget; the contract
-      // is the budget bound on every call, not the poll count.
-      expect(callGateway.mock.calls.length).toBeGreaterThanOrEqual(1);
-      const costCalls = callGateway.mock.calls.map(
-        ([raw]) => raw as { method?: string; timeoutMs?: number },
-      );
-      expect(costCalls.every((call) => call.method === "usage.cost")).toBe(true);
-      expect(costCalls.every((call) => (call.timeoutMs ?? 0) > 0)).toBe(true);
-      expect(costCalls.every((call) => (call.timeoutMs ?? 0) <= 50)).toBe(true);
-      expect(runtimeErrors.join("\n")).toContain("Timed out waiting for usage cost cache refresh");
+      expect(callGateway).toHaveBeenCalledOnce();
+      expect(firstMockArg(callGateway)).toMatchObject({
+        method: "usage.cost",
+        params: { days: 7, agentScope: "all" },
+        timeoutMs: 10_000,
+      });
+      expect(defaultRuntime.writeJson).toHaveBeenCalledWith(summary);
     },
   );
 

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -17,13 +17,11 @@ import type {
 import type { WriteDiagnosticSupportExportResult } from "../../logging/diagnostic-support-export.js";
 import { defaultRuntime } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
-import { sleep } from "../../utils/sleep.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayServiceCommands } from "../daemon-cli/register-service-commands.js";
 import { parseGatewayPortOption } from "../gateway-port-option.js";
 import { callGatewayFromCliWithTransport } from "../gateway-rpc.js";
 import { formatHelpExamples } from "../help-format.js";
-import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
 import { setCommandJsonMode } from "../program/json-mode.js";
 import type { GatewayDiscoverOpts } from "./discover.js";
 import { isGatewayMachineOutput } from "./output-mode.js";
@@ -58,15 +56,7 @@ const daemonStatusGatherModuleLoader = createLazyImportLoader(
 );
 
 const DEFAULT_GATEWAY_RPC_TIMEOUT_MS = 10_000;
-const DEFAULT_USAGE_COST_TIMEOUT_MS = 5 * 60_000;
-const USAGE_COST_SETTLE_INITIAL_POLL_MS = 250;
-const USAGE_COST_SETTLE_MAX_POLL_MS = 5_000;
-
 type GatewayCliDependencies = {
-  usageCostSettle?: {
-    now: () => number;
-    sleep: (ms: number) => Promise<void>;
-  };
   loadGatewayHealthModule?: typeof loadGatewayHealthModule;
   loadHealthStyleModule?: typeof loadHealthStyleModule;
 };
@@ -133,55 +123,6 @@ function parseGatewayCallParams(value = "{}"): unknown {
   } catch {
     throw new Error("--params must be valid JSON.");
   }
-}
-
-async function loadSettledCostUsageSummary(
-  rpcOpts: GatewayRpcOpts,
-  params: { days: number; agentId?: string; agentScope?: "all" },
-  deps: NonNullable<GatewayCliDependencies["usageCostSettle"]> = {
-    now: Date.now,
-    sleep,
-  },
-): Promise<CostUsageSummary> {
-  const timeoutMs = parseTimeoutMsWithFallback(rpcOpts.timeout, DEFAULT_USAGE_COST_TIMEOUT_MS, {
-    invalidType: "error",
-  });
-  const deadline = deps.now() + timeoutMs;
-  let lastSummary: CostUsageSummary | undefined;
-  let pollMs = USAGE_COST_SETTLE_INITIAL_POLL_MS;
-  for (;;) {
-    const remainingBeforeCallMs = deadline - deps.now();
-    if (remainingBeforeCallMs <= 0) {
-      throw createUsageCostSettleTimeoutError(lastSummary);
-    }
-    const callOpts = {
-      ...rpcOpts,
-      timeout: String(Math.min(DEFAULT_GATEWAY_RPC_TIMEOUT_MS, remainingBeforeCallMs)),
-    };
-    const summary = (await callGatewayCli("usage.cost", callOpts, params)) as CostUsageSummary;
-    lastSummary = summary;
-    const status = summary.cacheStatus?.status;
-    if (!status || status === "fresh") {
-      return summary;
-    }
-
-    const remainingMs = deadline - deps.now();
-    if (remainingMs <= 0) {
-      throw createUsageCostSettleTimeoutError(summary);
-    }
-    // The usage-cost timeout is the whole command budget. Each transport call
-    // remains capped separately so one unresponsive RPC cannot consume it all.
-    await deps.sleep(Math.min(pollMs, remainingMs));
-    pollMs = Math.min(pollMs * 2, USAGE_COST_SETTLE_MAX_POLL_MS);
-  }
-}
-
-function createUsageCostSettleTimeoutError(summary?: CostUsageSummary): Error {
-  const cachedFiles = summary?.cacheStatus?.cachedFiles ?? 0;
-  const pendingFiles = summary?.cacheStatus?.pendingFiles ?? 0;
-  return new Error(
-    `Timed out waiting for usage cost cache refresh (${cachedFiles} cached, ${pendingFiles} pending)`,
-  );
 }
 
 async function runGatewayCommand(
@@ -654,15 +595,11 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
             if (agentId && opts.allAgents) {
               throw new Error("Use --agent or --all-agents, not both");
             }
-            const summary = await loadSettledCostUsageSummary(
-              rpcOpts,
-              {
-                days,
-                ...(agentId ? { agentId } : {}),
-                ...(opts.allAgents ? { agentScope: "all" } : {}),
-              },
-              deps.usageCostSettle,
-            );
+            const summary = (await callGatewayCli("usage.cost", rpcOpts, {
+              days,
+              ...(agentId ? { agentId } : {}),
+              ...(opts.allAgents ? { agentScope: "all" } : {}),
+            })) as CostUsageSummary;
             if (rpcOpts.json) {
               defaultRuntime.writeJson(summary);
               return;
@@ -676,7 +613,6 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
           { json: Boolean(opts.json) },
         );
       }),
-    DEFAULT_USAGE_COST_TIMEOUT_MS,
   );
 
   gatewayCallOpts(

--- a/src/cli/models-status-route-cold-imports.test.ts
+++ b/src/cli/models-status-route-cold-imports.test.ts
@@ -1,0 +1,80 @@
+// The real non-probe models-status route must scope discovery to providers already in use.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  createColdPluginFixture,
+  isColdPluginRuntimeLoaded,
+} from "../plugins/test-helpers/cold-plugin-fixtures.js";
+
+const testState = vi.hoisted(() => ({
+  config: {} as OpenClawConfig,
+  logs: [] as string[],
+}));
+
+vi.mock("./command-execution-startup.js", () => ({
+  applyCliExecutionStartupPresentation: vi.fn(async () => {}),
+  ensureCliExecutionBootstrap: vi.fn(async () => {}),
+  resolveCliExecutionStartupContext: vi.fn(() => ({
+    startupPolicy: { loadPlugins: false, suppressDoctorStdout: true },
+  })),
+}));
+
+vi.mock("../commands/models/load-config.js", () => ({
+  loadModelsConfig: vi.fn(async () => testState.config),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    error: vi.fn(),
+    exit: vi.fn(),
+    log: (value: unknown) => testState.logs.push(String(value)),
+    writeJson: (value: unknown) => testState.logs.push(JSON.stringify(value)),
+    writeStdout: vi.fn(),
+  },
+  writeRuntimeJson: vi.fn((runtime: { writeJson: (value: unknown) => void }, value: unknown) =>
+    runtime.writeJson(value),
+  ),
+}));
+
+import { tryRouteCli } from "./route.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-models-status-route-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+it("does not execute an unrelated provider plugin", async () => {
+  const pluginRoot = path.join(tempRoot, "unrelated-provider");
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  const fixture = createColdPluginFixture({
+    rootDir: pluginRoot,
+    pluginId: "unrelated-provider",
+    providerId: "unrelated-provider",
+  });
+  vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  vi.stubEnv("OPENCLAW_HOME", path.join(tempRoot, "home"));
+  vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tempRoot, "state"));
+  testState.config = {
+    agents: {
+      defaults: {
+        model: { primary: "openai/gpt-5.6-sol" },
+        models: { "openai/gpt-5.6-sol": {} },
+      },
+    },
+    plugins: {
+      load: { paths: [pluginRoot] },
+      entries: { "unrelated-provider": { enabled: true } },
+    },
+  };
+
+  await expect(tryRouteCli(["node", "openclaw", "models", "status", "--json"])).resolves.toBe(true);
+
+  const payload = JSON.parse(testState.logs.at(-1) ?? "{}") as { defaultModel?: string };
+  expect(payload.defaultModel).toBe("openai/gpt-5.6-sol");
+  expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+});

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -203,6 +203,12 @@ describe("registerPreActionHooks", () => {
       .command("health")
       .option("--json")
       .action(() => {});
+    for (const gatewayCommand of ["stability", "usage-cost"]) {
+      gateway
+        .command(gatewayCommand)
+        .option("--json")
+        .action(() => {});
+    }
     programLocal
       .command("backup")
       .command("create")
@@ -215,6 +221,13 @@ describe("registerPreActionHooks", () => {
     programLocal.command("completion").action(() => {});
     programLocal.command("secrets").action(() => {});
     const skills = programLocal.command("skills");
+    skills.option("--json").action(() => {});
+    for (const skillCommand of ["list", "check"]) {
+      skills
+        .command(skillCommand)
+        .option("--json")
+        .action(() => {});
+    }
     for (const skillCommand of ["install", "verify"]) {
       skills
         .command(skillCommand)
@@ -226,9 +239,22 @@ describe("registerPreActionHooks", () => {
       .command("qa")
       .command("suite")
       .action(() => {});
-    programLocal
-      .command("agents")
+    const agents = programLocal.command("agents");
+    agents
       .command("list")
+      .option("--json")
+      .action(() => {});
+    agents
+      .command("bindings")
+      .option("--json")
+      .action(() => {});
+    programLocal
+      .command("approvals")
+      .command("pending")
+      .option("--json")
+      .action(() => {});
+    programLocal
+      .command("commitments")
       .option("--json")
       .action(() => {});
     programLocal.command("configure").action(() => {});
@@ -328,6 +354,25 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
     processTitleSetSpy.mockRestore();
+  });
+
+  it.each([
+    ["approvals", "pending"],
+    ["commitments"],
+    ["skills"],
+    ["skills", "list"],
+    ["skills", "check"],
+    ["agents", "bindings"],
+    ["gateway", "stability"],
+    ["gateway", "usage-cost"],
+  ])("keeps the real Commander preAction cold for %s", async (...commandPath) => {
+    await runPreAction({
+      parseArgv: commandPath,
+      processArgv: ["node", "openclaw", ...commandPath, "--json"],
+    });
+
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
   });
 
   it("runs gateway pre-bootstrap before full-CLI gateway bootstrap", async () => {

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -73,7 +73,7 @@ const mocks = vi.hoisted(() => {
   });
   return {
     callGatewayMock: vi.fn(),
-    loadConfigMock: vi.fn(() => ({})),
+    loadConfigMock: vi.fn((_options?: unknown) => ({})),
     resolveDefaultAgentIdMock: vi.fn((_configForTest: unknown) => "main"),
     resolveAgentIdByWorkspacePathMock: vi.fn(
       (_configForTest: unknown, _workspacePath: string): string | undefined => undefined,
@@ -204,7 +204,7 @@ vi.mock("../utils.js", async (importOriginal) => ({
 }));
 
 vi.mock("../config/config.js", () => ({
-  getRuntimeConfig: () => mocks.loadConfigMock(),
+  getRuntimeConfig: (...args: unknown[]) => mocks.loadConfigMock(...args),
   loadConfig: () => mocks.loadConfigMock(),
 }));
 
@@ -1442,6 +1442,7 @@ describe("skills cli commands", () => {
   it("keeps non-JSON skills list output on stdout with human-readable formatting", async () => {
     await runCommand(["skills", "list"]);
 
+    expect(loadConfigMock).toHaveBeenCalledWith({ skipPluginValidation: true });
     expect(defaultRuntime.writeStdout).toHaveBeenCalledTimes(1);
     expect(defaultRuntime.log).not.toHaveBeenCalled();
     expect(runtimeErrors).toStrictEqual([]);

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -119,6 +119,7 @@ function isClawHubSkillBlockedCliFailure(result: { code?: string; warning?: stri
 type ResolveSkillsWorkspaceOptions = {
   agentId?: string;
   cwd?: string;
+  skipPluginValidation?: boolean;
 };
 
 type ResolvedSkillsWorkspace = ReturnType<typeof resolveSkillsWorkspace>;
@@ -135,7 +136,9 @@ function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
   agentId: string;
 } {
   // Prefer explicit --agent, then infer from cwd, then fall back to configured default agent.
-  const config = getRuntimeConfig();
+  const config = getRuntimeConfig(
+    options?.skipPluginValidation ? { skipPluginValidation: true } : undefined,
+  );
   const explicitAgentId = normalizeOptionalString(options?.agentId);
   const inferredAgentId = explicitAgentId
     ? undefined
@@ -176,7 +179,7 @@ async function loadGatewaySkillsStatusReport(
 async function loadSkillsStatusReport(
   options?: ResolveSkillsWorkspaceOptions,
 ): Promise<SkillStatusReport> {
-  const resolved = resolveSkillsWorkspace(options);
+  const resolved = resolveSkillsWorkspace({ ...options, skipPluginValidation: true });
   const gatewayReport = await loadGatewaySkillsStatusReport(resolved);
   if (gatewayReport) {
     return gatewayReport;

--- a/src/commands/agents.bind.commands.test.ts
+++ b/src/commands/agents.bind.commands.test.ts
@@ -181,6 +181,7 @@ describe("agents bind/unbind commands", () => {
 
     await agentsBindingsCommand({}, runtime);
 
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ skipPluginValidation: true });
     expect(runtime.log).toHaveBeenCalledWith(
       ["Routing bindings:", "- main <- matrix", "- ops <- telegram accountId=work"].join("\n"),
     );

--- a/src/commands/agents.bind.test-support.ts
+++ b/src/commands/agents.bind.test-support.ts
@@ -36,8 +36,8 @@ vi.mock("../config/config.js", () => ({
 
 vi.mock("./agents.command-shared.js", () => ({
   createQuietRuntime: <T>(runtime: T) => runtime,
-  requireValidConfig: async () => {
-    const snapshot = (await readConfigFileSnapshotMock()) as
+  requireValidConfig: async (_runtime: unknown, opts?: unknown) => {
+    const snapshot = (await readConfigFileSnapshotMock(opts)) as
       | { config?: OpenClawConfig; sourceConfig?: OpenClawConfig }
       | undefined;
     return snapshot?.sourceConfig ?? snapshot?.config ?? null;

--- a/src/commands/agents.command-shared.ts
+++ b/src/commands/agents.command-shared.ts
@@ -17,6 +17,9 @@ export async function requireValidConfigFileSnapshot(runtime: RuntimeEnv) {
 }
 
 /** Load the current runtime config and return null after reporting validation failures. */
-export async function requireValidConfig(runtime: RuntimeEnv): Promise<OpenClawConfig | null> {
-  return await requireValidConfigSnapshot(runtime);
+export async function requireValidConfig(
+  runtime: RuntimeEnv,
+  opts?: { skipPluginValidation?: boolean },
+): Promise<OpenClawConfig | null> {
+  return await requireValidConfigSnapshot(runtime, opts);
 }

--- a/src/commands/agents.commands.bind.ts
+++ b/src/commands/agents.commands.bind.ts
@@ -179,7 +179,7 @@ export async function agentsBindingsCommand(
   opts: AgentsBindingsListOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
-  const cfg = await requireValidConfig(runtime);
+  const cfg = await requireValidConfig(runtime, { skipPluginValidation: true });
   if (!cfg) {
     return;
   }

--- a/src/commands/channel-setup/discovery.ts
+++ b/src/commands/channel-setup/discovery.ts
@@ -9,6 +9,7 @@ import type { ChannelMeta } from "../../channels/plugins/types.public.js";
 import { isStaticallyChannelConfigured } from "../../config/channel-configured-shared.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { InstalledPluginIndex } from "../../plugins/installed-plugin-index.js";
 import { listManifestChannelContributionIds } from "../../plugins/manifest-contribution-ids.js";
 import type { ChannelChoice } from "../onboard-types.js";
 import {
@@ -43,6 +44,7 @@ export function listManifestInstalledChannelIds(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  index?: InstalledPluginIndex;
 }): Set<ChannelChoice> {
   const resolvedConfig = applyPluginAutoEnable({
     config: params.cfg,
@@ -54,6 +56,7 @@ export function listManifestInstalledChannelIds(params: {
       config: resolvedConfig,
       workspaceDir,
       env: params.env ?? process.env,
+      ...(params.index ? { index: params.index } : {}),
     }).map((channelId) => channelId as ChannelChoice),
   );
 }

--- a/src/commands/channel-setup/trusted-catalog.ts
+++ b/src/commands/channel-setup/trusted-catalog.ts
@@ -10,6 +10,7 @@ import {
   normalizePluginsConfig,
   resolveEffectivePluginActivationState,
 } from "../../plugins/config-state.js";
+import type { PluginDiscoveryResult } from "../../plugins/discovery.js";
 import {
   hasExplicitManifestOwnerTrust,
   resolveManifestOwnerBasePolicyBlock,
@@ -124,6 +125,7 @@ function resolveTrustedCatalogEntry(
     cfg: OpenClawConfig;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
+    discovery?: PluginDiscoveryResult;
   },
   rejected: ChannelPluginCatalogEntry[] = [],
 ): ChannelPluginCatalogEntry | undefined {
@@ -141,6 +143,7 @@ function resolveTrustedCatalogEntry(
       workspaceDir: params.workspaceDir,
       env: params.env,
       ...(extraPaths ? { extraPaths } : {}),
+      ...(params.discovery ? { discovery: params.discovery } : {}),
       ...resolveRejectedCatalogLookup(rejectedEntries),
     });
     if (!candidate) {
@@ -171,6 +174,7 @@ export function getTrustedChannelPluginCatalogEntry(
     cfg: OpenClawConfig;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
+    discovery?: PluginDiscoveryResult;
   },
 ): ChannelPluginCatalogEntry | undefined {
   return resolveTrustedCatalogEntry(channelId, params);
@@ -181,6 +185,7 @@ function listChannelPluginCatalogEntriesWithTrustedFallback(
     cfg: OpenClawConfig;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
+    discovery?: PluginDiscoveryResult;
   },
   onMissingFallback: (entry: ChannelPluginCatalogEntry) => ChannelPluginCatalogEntry[],
 ): ChannelPluginCatalogEntry[] {
@@ -189,6 +194,7 @@ function listChannelPluginCatalogEntriesWithTrustedFallback(
     workspaceDir: params.workspaceDir,
     env: params.env,
     ...(extraPaths ? { extraPaths } : {}),
+    ...(params.discovery ? { discovery: params.discovery } : {}),
   });
   return unfiltered.flatMap((entry) => {
     if (isTrustedLocalChannelCatalogEntry(entry, params.cfg, params.env)) {
@@ -204,6 +210,7 @@ export function listTrustedChannelPluginCatalogEntries(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  discovery?: PluginDiscoveryResult;
 }): ChannelPluginCatalogEntry[] {
   return listChannelPluginCatalogEntriesWithTrustedFallback(params, () => []);
 }
@@ -213,6 +220,7 @@ export function listSetupDiscoveryChannelPluginCatalogEntries(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  discovery?: PluginDiscoveryResult;
 }): ChannelPluginCatalogEntry[] {
   return listChannelPluginCatalogEntriesWithTrustedFallback(params, (entry) => [entry]);
 }

--- a/src/commands/channels.list.test.ts
+++ b/src/commands/channels.list.test.ts
@@ -15,9 +15,7 @@ const mocks = vi.hoisted(() => ({
   listReadOnlyChannelPluginsForConfig: vi.fn<() => ChannelPlugin[]>(() => []),
   buildChannelAccountSnapshot: vi.fn(),
   listTrustedChannelPluginCatalogEntries: vi.fn<() => ChannelPluginCatalogEntry[]>(() => []),
-  isCatalogChannelInstalled: vi.fn<(params: { entry: ChannelPluginCatalogEntry }) => boolean>(
-    () => true,
-  ),
+  listManifestInstalledChannelIds: vi.fn<() => Set<string>>(() => new Set()),
   resolveMissingOfficialExternalChannelPluginRepairHint: vi.fn(),
   callGateway: vi.fn(),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
@@ -53,7 +51,7 @@ vi.mock("./channel-setup/trusted-catalog.js", () => ({
 }));
 
 vi.mock("./channel-setup/discovery.js", () => ({
-  isCatalogChannelInstalled: mocks.isCatalogChannelInstalled,
+  listManifestInstalledChannelIds: mocks.listManifestInstalledChannelIds,
 }));
 
 vi.mock("../plugins/official-external-plugin-repair-hints.js", () => ({
@@ -125,8 +123,8 @@ describe("channels list", () => {
     mocks.buildChannelAccountSnapshot.mockReset();
     mocks.listTrustedChannelPluginCatalogEntries.mockReset();
     mocks.listTrustedChannelPluginCatalogEntries.mockReturnValue([]);
-    mocks.isCatalogChannelInstalled.mockReset();
-    mocks.isCatalogChannelInstalled.mockReturnValue(true);
+    mocks.listManifestInstalledChannelIds.mockReset();
+    mocks.listManifestInstalledChannelIds.mockReturnValue(new Set());
     mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReset();
     mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue(null);
     mocks.callGateway.mockReset();
@@ -169,9 +167,8 @@ describe("channels list", () => {
 
     await channelsListCommand({ json: true }, runtime);
 
-    expect(mocks.listReadOnlyChannelPluginsForConfig).toHaveBeenCalledWith(config, {
-      includeSetupFallbackPlugins: true,
-    });
+    expect(mocks.listReadOnlyChannelPluginsForConfig).toHaveBeenCalledWith(config);
+    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledWith({ skipPluginValidation: true });
     const payload = JSON.parse(loggedText(runtime)) as {
       chat?: Record<string, { accounts: string[]; installed: boolean; origin: string }>;
     };
@@ -349,7 +346,7 @@ describe("channels list", () => {
     mocks.listTrustedChannelPluginCatalogEntries.mockReturnValue([
       createCatalogEntry("qqbot", "QQ Bot"),
     ]);
-    mocks.isCatalogChannelInstalled.mockReturnValue(false);
+    mocks.listManifestInstalledChannelIds.mockReturnValue(new Set());
     mocks.readConfigFileSnapshot.mockResolvedValue({
       ...baseConfigSnapshot,
       config: {},
@@ -370,7 +367,7 @@ describe("channels list", () => {
     mocks.listTrustedChannelPluginCatalogEntries.mockReturnValue([
       createCatalogEntry("discord", "Discord"),
     ]);
-    mocks.isCatalogChannelInstalled.mockReturnValue(false);
+    mocks.listManifestInstalledChannelIds.mockReturnValue(new Set());
     mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue({
       pluginId: "discord",
       channelId: "discord",
@@ -418,7 +415,7 @@ describe("channels list", () => {
     mocks.listTrustedChannelPluginCatalogEntries.mockReturnValue([
       createCatalogEntry("discord", "Discord"),
     ]);
-    mocks.isCatalogChannelInstalled.mockReturnValue(false);
+    mocks.listManifestInstalledChannelIds.mockReturnValue(new Set());
     mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue({
       pluginId: "discord",
       channelId: "discord",
@@ -456,7 +453,7 @@ describe("channels list", () => {
     mocks.listTrustedChannelPluginCatalogEntries.mockReturnValue([
       createCatalogEntry("qqbot", "QQ Bot"),
     ]);
-    mocks.isCatalogChannelInstalled.mockReturnValue(false);
+    mocks.listManifestInstalledChannelIds.mockReturnValue(new Set());
     mocks.readConfigFileSnapshot.mockResolvedValue({
       ...baseConfigSnapshot,
       config: {},
@@ -515,7 +512,7 @@ describe("channels list", () => {
     mocks.listTrustedChannelPluginCatalogEntries.mockReturnValue([
       createCatalogEntry("qqbot", "QQ Bot"),
     ]);
-    mocks.isCatalogChannelInstalled.mockImplementation(({ entry }) => entry.id !== "qqbot");
+    mocks.listManifestInstalledChannelIds.mockReturnValue(new Set());
     mocks.readConfigFileSnapshot.mockResolvedValue({
       ...baseConfigSnapshot,
       config: {
@@ -538,6 +535,32 @@ describe("channels list", () => {
     expect(payload.chat.qqbot?.installed).toBe(false);
   });
 
+  it("resolves installed manifest channels once for the whole catalog", async () => {
+    const runtime = createTestRuntime();
+    mocks.listTrustedChannelPluginCatalogEntries.mockReturnValue([
+      createCatalogEntry("wecom", "WeCom"),
+      createCatalogEntry("qqbot", "QQ Bot"),
+    ]);
+    mocks.listManifestInstalledChannelIds.mockReturnValue(new Set(["wecom"]));
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {},
+    });
+
+    await channelsListCommand({ all: true, json: true }, runtime);
+
+    expect(mocks.listManifestInstalledChannelIds).toHaveBeenCalledOnce();
+    expect(mocks.listManifestInstalledChannelIds).toHaveBeenCalledWith({
+      cfg: {},
+      workspaceDir: "/tmp/workspace",
+    });
+    const payload = JSON.parse(loggedText(runtime)) as {
+      chat: Record<string, { installed: boolean }>;
+    };
+    expect(payload.chat.wecom?.installed).toBe(true);
+    expect(payload.chat.qqbot?.installed).toBe(false);
+  });
+
   it(
     "--all still surfaces catalog channels that are installed on disk but have no " +
       "plugin object loaded and no config entry (regression: WeCom-like channels " +
@@ -547,12 +570,12 @@ describe("channels list", () => {
       // Read-only loader returns nothing for wecom because the user has no
       // configured wecom channel, so the loader never activates it.
       mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([]);
-      // But catalog knows about wecom, and isCatalogChannelInstalled sees
+      // But catalog knows about wecom, and manifest discovery sees
       // the wecom npm package on disk.
       mocks.listTrustedChannelPluginCatalogEntries.mockReturnValue([
         createCatalogEntry("wecom", "WeCom"),
       ]);
-      mocks.isCatalogChannelInstalled.mockReturnValue(true);
+      mocks.listManifestInstalledChannelIds.mockReturnValue(new Set(["wecom"]));
       mocks.readConfigFileSnapshot.mockResolvedValue({
         ...baseConfigSnapshot,
         config: {},

--- a/src/commands/channels.list.test.ts
+++ b/src/commands/channels.list.test.ts
@@ -6,6 +6,11 @@ import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => ({
+  metadataSnapshot: {
+    plugins: [],
+    index: { plugins: [] },
+    discovery: { candidates: [], diagnostics: [] },
+  },
   readConfigFileSnapshot: vi.fn(),
   resolveCommandConfigWithSecrets: vi.fn(async ({ config }: { config: unknown }) => ({
     resolvedConfig: config,
@@ -20,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
   resolveDefaultAgentId: vi.fn(() => "main"),
+  resolvePluginMetadataSnapshot: vi.fn(),
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -32,6 +38,10 @@ vi.mock("../cli/command-config-resolution.js", () => ({
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,
+}));
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  resolvePluginMetadataSnapshot: mocks.resolvePluginMetadataSnapshot,
 }));
 
 vi.mock("../cli/command-secret-targets.js", () => ({
@@ -129,6 +139,7 @@ describe("channels list", () => {
     mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue(null);
     mocks.callGateway.mockReset();
     mocks.callGateway.mockRejectedValue(new Error("gateway unavailable"));
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue(mocks.metadataSnapshot);
   });
 
   it("does not include auth providers in JSON output (auth section was removed)", async () => {
@@ -167,7 +178,9 @@ describe("channels list", () => {
 
     await channelsListCommand({ json: true }, runtime);
 
-    expect(mocks.listReadOnlyChannelPluginsForConfig).toHaveBeenCalledWith(config);
+    expect(mocks.listReadOnlyChannelPluginsForConfig).toHaveBeenCalledWith(config, {
+      metadataSnapshot: mocks.metadataSnapshot,
+    });
     expect(mocks.readConfigFileSnapshot).toHaveBeenCalledWith({ skipPluginValidation: true });
     const payload = JSON.parse(loggedText(runtime)) as {
       chat?: Record<string, { accounts: string[]; installed: boolean; origin: string }>;
@@ -224,6 +237,7 @@ describe("channels list", () => {
 
     expect(mocks.listReadOnlyChannelPluginsForConfig).toHaveBeenCalledWith(config, {
       includeSetupFallbackPlugins: true,
+      metadataSnapshot: mocks.metadataSnapshot,
     });
     const output = stripAnsi(loggedText(runtime));
     expect(output).toContain("Chat channels:");
@@ -550,9 +564,15 @@ describe("channels list", () => {
     await channelsListCommand({ all: true, json: true }, runtime);
 
     expect(mocks.listManifestInstalledChannelIds).toHaveBeenCalledOnce();
+    expect(mocks.listTrustedChannelPluginCatalogEntries).toHaveBeenCalledWith({
+      cfg: {},
+      workspaceDir: "/tmp/workspace",
+      discovery: mocks.metadataSnapshot.discovery,
+    });
     expect(mocks.listManifestInstalledChannelIds).toHaveBeenCalledWith({
       cfg: {},
       workspaceDir: "/tmp/workspace",
+      index: mocks.metadataSnapshot.index,
     });
     const payload = JSON.parse(loggedText(runtime)) as {
       chat: Record<string, { installed: boolean }>;

--- a/src/commands/channels/list.ts
+++ b/src/commands/channels/list.ts
@@ -16,7 +16,7 @@ import {
 import { callGateway } from "../../gateway/call.js";
 import { resolveMissingOfficialExternalChannelPluginRepairHint } from "../../plugins/official-external-plugin-repair-hints.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
-import { isCatalogChannelInstalled } from "../channel-setup/discovery.js";
+import { listManifestInstalledChannelIds } from "../channel-setup/discovery.js";
 import { listTrustedChannelPluginCatalogEntries } from "../channel-setup/trusted-catalog.js";
 import { formatChannelAccountLabel, requireValidConfig } from "./shared.js";
 
@@ -147,15 +147,17 @@ export async function channelsListCommand(
   opts: ChannelsListOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
-  const cfg = await requireValidConfig(runtime);
+  const cfg = await requireValidConfig(runtime, { skipPluginValidation: true });
   if (!cfg) {
     return;
   }
   const showAll = opts.all === true;
 
-  const plugins = listReadOnlyChannelPluginsForConfig(cfg, {
-    includeSetupFallbackPlugins: true,
-  });
+  // JSON needs only manifest-backed account ids. Text keeps setup-backed snapshots
+  // because its credential/status details are part of the human output contract.
+  const plugins = opts.json
+    ? listReadOnlyChannelPluginsForConfig(cfg)
+    : listReadOnlyChannelPluginsForConfig(cfg, { includeSetupFallbackPlugins: true });
   const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
   const catalogEntries = listTrustedChannelPluginCatalogEntries({
     cfg,
@@ -165,21 +167,19 @@ export async function channelsListCommand(
     opts.json === true
       ? new Map<string, ChannelAccountSnapshot[]>()
       : normalizeRuntimeChannelAccountSnapshots(await readGatewayChannelStatus());
-  const installedByChannelId = new Map<string, boolean>();
-  for (const entry of catalogEntries) {
-    installedByChannelId.set(
-      entry.id,
-      isCatalogChannelInstalled({
-        cfg,
-        entry,
-        ...(workspaceDir ? { workspaceDir } : {}),
-      }),
-    );
-  }
-  // A plugin loaded into the runtime registry is, by definition, installed.
-  // Catalog-tracked channels may still be flagged as not installed when the
-  // plugin object only came in via setup fallback metadata; in that case the
-  // explicit catalog check above wins.
+  // Installed ids are one prepared manifest fact set for the invocation. Rebuilding
+  // discovery for each catalog row turns this read into a full filesystem walk per row.
+  const manifestInstalledChannelIds = new Set<string>(
+    listManifestInstalledChannelIds({
+      cfg,
+      ...(workspaceDir ? { workspaceDir } : {}),
+    }),
+  );
+  const installedByChannelId = new Map(
+    catalogEntries.map((entry) => [entry.id, manifestInstalledChannelIds.has(entry.id)]),
+  );
+  // Metadata-backed plugins are installed by definition; catalog-only rows use
+  // the manifest snapshot above because no plugin projection exists for them.
   const isInstalled = (channelId: string): boolean => installedByChannelId.get(channelId) ?? true;
 
   type AccountLineSource = {
@@ -188,12 +188,22 @@ export async function channelsListCommand(
     installed: boolean;
   };
   const accountLines: AccountLineSource[] = [];
-  const renderedChannelIds = new Set<string>();
+  const accountIdsByPlugin = new Map(
+    plugins.map((plugin) => [plugin.id, plugin.config.listAccountIds(cfg) ?? []]),
+  );
+  const renderedChannelIds = new Set(
+    plugins
+      .filter(
+        (plugin) =>
+          (accountIdsByPlugin.get(plugin.id)?.length ?? 0) > 0 ||
+          (showAll && shouldShowConfigured(plugin)),
+      )
+      .map((plugin) => plugin.id),
+  );
 
-  for (const plugin of plugins) {
-    const accountIds = plugin.config.listAccountIds(cfg);
+  for (const plugin of opts.json ? [] : plugins) {
+    const accountIds = accountIdsByPlugin.get(plugin.id) ?? [];
     if (accountIds && accountIds.length > 0) {
-      renderedChannelIds.add(plugin.id);
       const runtimeAccounts = runtimeAccountsByChannel.get(plugin.id) ?? [];
       const rows = await resolveChannelAccountStatusRows({
         localAccountIds: accountIds,
@@ -229,7 +239,6 @@ export async function channelsListCommand(
     const runtimeSnapshot = runtimeAccountsByChannel
       .get(plugin.id)
       ?.find((account) => account.accountId === "default");
-    renderedChannelIds.add(plugin.id);
     accountLines.push({
       plugin,
       snapshot: runtimeSnapshot ?? snapshot,
@@ -276,7 +285,7 @@ export async function channelsListCommand(
     };
     const chat: Record<string, JsonChannelEntry> = {};
     for (const plugin of plugins) {
-      const accountIds = plugin.config.listAccountIds(cfg);
+      const accountIds = accountIdsByPlugin.get(plugin.id) ?? [];
       const installed = isInstalled(plugin.id);
       if (accountIds && accountIds.length > 0) {
         chat[plugin.id] = {

--- a/src/commands/channels/list.ts
+++ b/src/commands/channels/list.ts
@@ -15,6 +15,7 @@ import {
 } from "../../channels/status/read-model.js";
 import { callGateway } from "../../gateway/call.js";
 import { resolveMissingOfficialExternalChannelPluginRepairHint } from "../../plugins/official-external-plugin-repair-hints.js";
+import { resolvePluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { listManifestInstalledChannelIds } from "../channel-setup/discovery.js";
 import { listTrustedChannelPluginCatalogEntries } from "../channel-setup/trusted-catalog.js";
@@ -152,16 +153,28 @@ export async function channelsListCommand(
     return;
   }
   const showAll = opts.all === true;
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+  // Plugin metadata is process-stable. Resolve it once and carry its manifest,
+  // discovery, and installed-index facts through every list projection.
+  const metadataSnapshot = resolvePluginMetadataSnapshot({
+    config: cfg,
+    ...(workspaceDir ? { workspaceDir } : {}),
+    env: process.env,
+    allowWorkspaceScopedCurrent: true,
+  });
 
   // JSON needs only manifest-backed account ids. Text keeps setup-backed snapshots
   // because its credential/status details are part of the human output contract.
   const plugins = opts.json
-    ? listReadOnlyChannelPluginsForConfig(cfg)
-    : listReadOnlyChannelPluginsForConfig(cfg, { includeSetupFallbackPlugins: true });
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+    ? listReadOnlyChannelPluginsForConfig(cfg, { metadataSnapshot })
+    : listReadOnlyChannelPluginsForConfig(cfg, {
+        includeSetupFallbackPlugins: true,
+        metadataSnapshot,
+      });
   const catalogEntries = listTrustedChannelPluginCatalogEntries({
     cfg,
     ...(workspaceDir ? { workspaceDir } : {}),
+    ...(metadataSnapshot.discovery ? { discovery: metadataSnapshot.discovery } : {}),
   });
   const runtimeAccountsByChannel =
     opts.json === true
@@ -173,6 +186,7 @@ export async function channelsListCommand(
     listManifestInstalledChannelIds({
       cfg,
       ...(workspaceDir ? { workspaceDir } : {}),
+      index: metadataSnapshot.index,
     }),
   );
   const installedByChannelId = new Map(

--- a/src/commands/channels/shared.ts
+++ b/src/commands/channels/shared.ts
@@ -23,9 +23,13 @@ export async function requireValidConfig(
   secretResolution?: {
     commandName?: string;
     mode?: CommandSecretResolutionMode;
+    skipPluginValidation?: boolean;
   },
 ): Promise<OpenClawConfig | null> {
-  const cfg = await requireValidConfigSnapshot(runtime);
+  const cfg = await requireValidConfigSnapshot(
+    runtime,
+    secretResolution?.skipPluginValidation ? { skipPluginValidation: true } : undefined,
+  );
   if (!cfg) {
     return null;
   }

--- a/src/commands/commitments.test.ts
+++ b/src/commands/commitments.test.ts
@@ -9,17 +9,12 @@ const mocks = vi.hoisted(() => ({
   listCommitments: vi.fn(),
   markCommitmentsStatus: vi.fn(),
   resolveCommitmentDatabasePath: vi.fn(() => "/tmp/openclaw.sqlite"),
-  getRuntimeConfig: vi.fn(() => ({})),
 }));
 
 vi.mock("../commitments/store.js", () => ({
   listCommitments: mocks.listCommitments,
   markCommitmentsStatus: mocks.markCommitmentsStatus,
   resolveCommitmentDatabasePath: mocks.resolveCommitmentDatabasePath,
-}));
-
-vi.mock("../config/config.js", () => ({
-  getRuntimeConfig: mocks.getRuntimeConfig,
 }));
 
 function createRuntime(): { runtime: OutputRuntimeEnv; logs: string[]; stdout: string[] } {
@@ -267,7 +262,6 @@ describe("commitments command", () => {
     expect(logs).toEqual([]);
     expect(stdout).toEqual([JSON.stringify({ dismissed: ["cm_escape"] }, null, 2)]);
     expect(mocks.markCommitmentsStatus).toHaveBeenCalledWith({
-      cfg: {},
       ids: ["cm_escape"],
       status: "dismissed",
       nowMs: expect.any(Number),
@@ -284,7 +278,6 @@ describe("commitments command", () => {
     );
 
     expect(mocks.markCommitmentsStatus).toHaveBeenCalledWith({
-      cfg: {},
       ids: ["cm_valid", "cm_missing", "cm_terminal"],
       status: "dismissed",
       nowMs: expect.any(Number),

--- a/src/commands/commitments.ts
+++ b/src/commands/commitments.ts
@@ -12,7 +12,6 @@ import {
   resolveCommitmentDatabasePath,
 } from "../commitments/store.js";
 import type { CommitmentRecord, CommitmentStatus } from "../commitments/types.js";
-import { getRuntimeConfig } from "../config/config.js";
 import { info } from "../globals.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 
@@ -95,14 +94,12 @@ export async function commitmentsListCommand(
   opts: { json?: boolean; status?: string; all?: boolean; agent?: string },
   runtime: RuntimeEnv,
 ): Promise<void> {
-  const cfg = getRuntimeConfig();
   const status = opts.all ? undefined : parseStatus(opts.status ?? "pending", runtime);
   if (!opts.all && opts.status && !status) {
     return;
   }
   const commitments = (
     await listCommitments({
-      cfg,
       status,
       agentId: normalizeOptionalString(opts.agent),
     })
@@ -151,9 +148,7 @@ export async function commitmentsDismissCommand(
     runtime.exit(1);
     return;
   }
-  const cfg = getRuntimeConfig();
   const dismissed = await markCommitmentsStatus({
-    cfg,
     ids,
     status: "dismissed",
     nowMs: Date.now(),

--- a/src/commands/config-validation.test.ts
+++ b/src/commands/config-validation.test.ts
@@ -71,6 +71,17 @@ describe("requireValidConfigSnapshot", () => {
     expect(runtime.log).not.toHaveBeenCalled();
   });
 
+  it("can validate core config without loading plugin schemas", async () => {
+    createValidSnapshot();
+    const runtime = createRuntime();
+
+    await expect(
+      requireValidConfigSnapshot(runtime, { skipPluginValidation: true }),
+    ).resolves.toEqual({ plugins: {} });
+
+    expect(readConfigFileSnapshot).toHaveBeenCalledWith({ skipPluginValidation: true });
+  });
+
   it("emits a non-blocking compatibility advisory when explicitly requested", async () => {
     createValidSnapshot();
     const runtime = createRuntime();

--- a/src/commands/config-validation.ts
+++ b/src/commands/config-validation.ts
@@ -17,9 +17,11 @@ import type { RuntimeEnv } from "../runtime.js";
 /** Read the config file and exit through the runtime when validation fails. */
 export async function requireValidConfigFileSnapshot(
   runtime: RuntimeEnv,
-  opts?: { includeCompatibilityAdvisory?: boolean },
+  opts?: { includeCompatibilityAdvisory?: boolean; skipPluginValidation?: boolean },
 ): Promise<ConfigFileSnapshot | null> {
-  const snapshot = await readConfigFileSnapshot();
+  const snapshot = await readConfigFileSnapshot(
+    opts?.skipPluginValidation ? { skipPluginValidation: true } : undefined,
+  );
   if (snapshot.exists && !snapshot.valid) {
     const issues =
       snapshot.issues.length > 0
@@ -57,7 +59,7 @@ export async function requireValidConfigFileSnapshot(
 /** Read and return a valid OpenClaw config, or null after reporting validation errors. */
 export async function requireValidConfigSnapshot(
   runtime: RuntimeEnv,
-  opts?: { includeCompatibilityAdvisory?: boolean },
+  opts?: { includeCompatibilityAdvisory?: boolean; skipPluginValidation?: boolean },
 ): Promise<OpenClawConfig | null> {
   return (await requireValidConfigFileSnapshot(runtime, opts))?.config ?? null;
 }

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -363,7 +363,11 @@ export async function modelsStatusCommand(
     throw new Error("--probe cannot be used with --plain output.");
   }
   const configPath = createConfigIO().configPath;
-  const cfg = await loadModelsConfig({ commandName: "models status", runtime });
+  const cfg = await loadModelsConfig({
+    commandName: "models status",
+    runtime,
+    skipPluginValidation: opts.probe !== true,
+  });
   const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent });
   const workspaceAgentId = agentId ?? resolveDefaultAgentId(cfg);
   const agentDir = agentId
@@ -401,8 +405,6 @@ export async function modelsStatusCommand(
   const selectedPluginRootDirs = new Map(
     [...metadataSnapshot.byPluginId].map(([pluginId, plugin]) => [pluginId, plugin.rootDir]),
   );
-  const { runPluginPayloadSmokeCheckForManifestRecords } =
-    await import("../../cli/update-cli/plugin-payload-validation.js");
   const codexRuntimeAvailabilityByProvider = new Map<
     string,
     Promise<AgentHarnessRuntimeAvailability>
@@ -415,6 +417,8 @@ export async function modelsStatusCommand(
       return cached;
     }
     const pending = (async () => {
+      const { runPluginPayloadSmokeCheckForManifestRecords } =
+        await import("../../cli/update-cli/plugin-payload-validation.js");
       const ownerPluginIds = resolveAgentHarnessOwnerPluginIds({
         runtime: "codex",
         provider,
@@ -617,9 +621,38 @@ export async function modelsStatusCommand(
         registryDiagnostics: metadataSnapshot.registryDiagnostics,
       }).map((provider) => normalizeProviderId(provider)),
     );
+    const createStatusAuthResolver = (
+      authStore: Parameters<typeof createModelAuthAvailabilityResolver>[0]["authStore"],
+    ) =>
+      createModelAuthAvailabilityResolver({
+        cfg,
+        authStore,
+        agentDir,
+        workspaceDir,
+        env: process.env,
+        // A generic Codex runtime marker proves only that the harness can be
+        // contacted. It is not an OpenAI model credential.
+        syntheticAuthProviderRefs: [...syntheticAuthProviderRefs].filter(
+          (provider) => provider !== "codex",
+        ),
+        metadataSnapshot,
+      });
+    let authResolver = createStatusAuthResolver(store);
+    // Status already owns the complete provider/auth use set. Carry it into the
+    // catalog owner so a read-only status does not discover every provider plugin.
+    const probedProvider = normalizeOptionalString(opts.probeProvider);
+    const providerDiscoveryProviderIds = [
+      ...new Set([
+        ...authResolver.providerDiscoveryProviderIds,
+        ...providersFromConfig,
+        ...providersFromModels,
+        ...(probedProvider ? [normalizeProviderId(probedProvider)] : []),
+      ]),
+    ].toSorted((left, right) => left.localeCompare(right));
     const catalog = await loadPreparedModelCatalogSnapshot({
       config: cfg,
       ...(agentId ? { agentId } : {}),
+      providerDiscoveryProviderIds,
       readOnly: true,
     });
     const visibilityPolicy = createModelVisibilityPolicy({
@@ -661,23 +694,6 @@ export async function modelsStatusCommand(
       sources.push({ api: entry.api, baseUrl: entry.baseUrl });
       routeSourcesByModel.set(key, sources);
     }
-    const createStatusAuthResolver = (
-      authStore: Parameters<typeof createModelAuthAvailabilityResolver>[0]["authStore"],
-    ) =>
-      createModelAuthAvailabilityResolver({
-        cfg,
-        authStore,
-        agentDir,
-        workspaceDir,
-        env: process.env,
-        // A generic Codex runtime marker proves only that the harness can be
-        // contacted. It is not an OpenAI model credential.
-        syntheticAuthProviderRefs: [...syntheticAuthProviderRefs].filter(
-          (provider) => provider !== "codex",
-        ),
-        metadataSnapshot,
-      });
-    let authResolver = createStatusAuthResolver(store);
     const resolveProviderUses = async (
       resolver: ModelAuthAvailabilityResolver,
     ): Promise<StatusProviderUse[]> =>

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -151,6 +151,7 @@ const mocks = vi.hoisted(() => {
       models: { providers: {} },
       env: { shellEnv: { enabled: true } },
     }),
+    loadModelsConfigArgs: vi.fn(),
     loadProviderUsageSummary: vi.fn().mockResolvedValue(undefined),
     resolveRuntimeSyntheticAuthProviderRefs: vi.fn().mockReturnValue([]),
     resolveProviderSyntheticAuthWithPlugin: vi.fn().mockReturnValue(undefined),
@@ -268,7 +269,10 @@ vi.mock("../../config/config.js", async (importOriginal) => ({
   createConfigIO: mocks.createConfigIO,
 }));
 vi.mock("./load-config.js", () => ({
-  loadModelsConfig: vi.fn(async () => mocks.loadConfig()),
+  loadModelsConfig: vi.fn(async (...args: unknown[]) => {
+    mocks.loadModelsConfigArgs(...args);
+    return mocks.loadConfig();
+  }),
 }));
 vi.mock("../../infra/provider-usage.js", () => ({
   formatUsageWindowSummary: vi.fn().mockReturnValue("-"),
@@ -556,6 +560,17 @@ describe("modelsStatusCommand auth overview", () => {
   it("includes masked auth sources in JSON output", async () => {
     await modelsStatusCommand({ json: true }, runtime as never);
     const payload = parseFirstJsonLog(runtime);
+
+    expect(mocks.loadModelsConfigArgs.mock.calls.at(-1)?.[0]).toMatchObject({
+      commandName: "models status",
+      skipPluginValidation: true,
+    });
+    expect(mocks.loadModelCatalog.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({
+        providerDiscoveryProviderIds: expect.arrayContaining(["anthropic", "openai"]),
+        readOnly: true,
+      }),
+    );
 
     expectResolveAgentDirCalledFor("main");
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalled();

--- a/src/commands/models/load-config.test.ts
+++ b/src/commands/models/load-config.test.ts
@@ -88,6 +88,15 @@ describe("models load-config", () => {
     expect(mocks.setRuntimeConfigSnapshot).toHaveBeenCalledWith(resolvedConfig, sourceConfig);
   });
 
+  it("can read core model config without loading plugin schemas", async () => {
+    const sourceConfig = { models: { providers: {} } };
+    mockResolvedConfigFlow({ sourceConfig, diagnostics: [] });
+
+    await loadModelsConfig({ commandName: "models status", skipPluginValidation: true });
+
+    expect(mocks.getRuntimeConfig).toHaveBeenCalledWith({ skipPluginValidation: true });
+  });
+
   it("does not reread config when no source snapshot is pinned", async () => {
     mocks.getRuntimeConfig.mockReturnValue(runtimeConfig);
     mocks.getRuntimeConfigSourceSnapshot.mockReturnValue(null);

--- a/src/commands/models/load-config.ts
+++ b/src/commands/models/load-config.ts
@@ -20,8 +20,11 @@ type LoadedModelsConfig = {
 export async function loadModelsConfigWithSource(params: {
   commandName: string;
   runtime?: RuntimeEnv;
+  skipPluginValidation?: boolean;
 }): Promise<LoadedModelsConfig> {
-  const runtimeConfig = getRuntimeConfig();
+  const runtimeConfig = getRuntimeConfig(
+    params.skipPluginValidation ? { skipPluginValidation: true } : undefined,
+  );
   const pinnedSourceConfig = getRuntimeConfigSourceSnapshot();
   const sourceConfig = pinnedSourceConfig ?? runtimeConfig;
   const { resolvedConfig, diagnostics } = await resolveCommandConfigWithSecrets({
@@ -44,6 +47,7 @@ export async function loadModelsConfigWithSource(params: {
 export async function loadModelsConfig(params: {
   commandName: string;
   runtime?: RuntimeEnv;
+  skipPluginValidation?: boolean;
 }): Promise<OpenClawConfig> {
   return (await loadModelsConfigWithSource(params)).resolvedConfig;
 }

--- a/src/commitments/store.ts
+++ b/src/commitments/store.ts
@@ -401,7 +401,6 @@ export async function markCommitmentsAttempted(params: {
 }
 
 export async function markCommitmentsStatus(params: {
-  cfg?: OpenClawConfig;
   ids: string[];
   status: Extract<CommitmentStatus, "sent" | "dismissed" | "expired">;
   nowMs?: number;
@@ -445,7 +444,6 @@ export async function markCommitmentsStatus(params: {
 }
 
 export async function listCommitments(params?: {
-  cfg?: OpenClawConfig;
   status?: CommitmentStatus;
   agentId?: string;
   nowMs?: number;

--- a/src/infra/heartbeat-runner-delivery.ts
+++ b/src/infra/heartbeat-runner-delivery.ts
@@ -169,7 +169,7 @@ export async function finalizeHeartbeatOutcome(params: {
   const { delivery, dueCommitmentIds, entry, previousUpdatedAt } = params.prepared;
   const { runSessionKey, sessionKey, storePath, visibility } = params.prepared;
   const markDueCommitments = (status: "dismissed" | "sent") =>
-    markCommitmentsStatus({ cfg, ids: dueCommitmentIds, status, nowMs: startedAt });
+    markCommitmentsStatus({ ids: dueCommitmentIds, status, nowMs: startedAt });
   const outcome = params.outcome;
   if (outcome.kind === "terminal-failure") {
     const failureChannel = delivery.channel;


### PR DESCRIPTION
## What Problem This Solves

A full read-only CLI sweep on a production host (48 cores, ~150 installed plugins, warm jiti cache) found nine commands taking 9.7–48 s that should take about a second:

| command | production wall |
| --- | ---: |
| `gateway usage-cost --days 1 --json` | 48.2 s |
| `channels list --json` | 17.2 s |
| `models status --json` | 15.3 s |
| `approvals pending --json` | 10.1 s |
| `skills list --json` | 9.9 s |
| `agents bindings --json` | 9.8 s |
| `skills check --json` | 9.8 s |
| `gateway stability --json` | 9.8 s |
| `commitments --json` | 9.7 s |

Baselines on the same host: `openclaw --version` 43 ms, `gateway call health` 1.83 s, `sessions --json` 2.06 s, `channels status --json` 1.16 s.

CPU profiles showed the familiar plugin-module load storm (jiti ~2.5 s, `package_json_reader` ~0.9 s, compile/vm ~1 s) — plus, for `channels list`, an *additional* ~5.7 s of filesystem walking (lstat 3.8 s). And a decisive measurement for `usage-cost`: the underlying RPC `gateway call usage.cost --params '{"days":1}'` returned in **1.77 s** while the CLI command took **48.2 s**.

This continues the cold-path work in #117705 / #117751 / #117880 / #117900.

## Why This Change Was Made

Each command was audited rather than blanket-patched, and two of them turned out **not** to be another catalog-declaration bug:

**Startup declarations (6 commands).** `approvals pending` and `gateway stability` are gateway RPC reads → skip config validation and plugin loading. `agents bindings` is a local config projection → still reads config, skips plugin validation (route bindings do not consume plugin runtime). `commitments` reads the shared SQLite store → its unnecessary config load was removed outright. `skills list`/`check` genuinely need skill/manifest metadata → they skip plugin *config validation* while keeping the gateway-first, manifest fallback; no plugin module execution.

**`channels list` (17.2 s) — declaration was already effective.** The real costs were command-local: `requireValidConfig` performed plugin validation; JSON listing entered setup-backed fallback logic meant for human credential/status output; and manifest projection, trusted-catalog construction, and installed-ID calculation each rediscovered the same plugin filesystem graph. JSON now stays on manifest-backed projections and one immutable metadata snapshot is carried into the read-only channel plugin reader, trusted catalog, and discovery. Human text output keeps setup-backed snapshots, because removing them would change credential/status output.

Notably, the cross-dispatch parity guard added in #117880 could not have caught this: it proves both resolvers interpret the catalog identically, not that a command-local path is cold. The new fixtures close that gap by executing the real route.

**`models status` (15.3 s) — also command-local.** `loadModelsConfig` re-ran plugin validation inside the command; status eagerly imported payload-validation support; and catalog ownership rediscovered providers broadly. The non-probe path now skips plugin validation, imports payload smoke validation only inside actual Codex runtime-availability evaluation, and carries the complete provider/auth use set into the prepared catalog owner. `--probe` deliberately keeps full validation and live provider probing.

**`gateway usage-cost` (48.2 s) — not startup at all.** The CLI was *polling* `usage.cost`, waiting for `cacheStatus` to become fresh, with reconnect and exponential delay. The gateway intentionally serves cached/in-flight summaries and owns background refresh, and cross-agent aggregation is server-side. The CLI now performs exactly one `usage.cost` RPC and renders the response.

Per the repository's Codex gate, the sibling Codex contract was inspected directly for the `models status` change: `account/read` in `../codex/codex-rs/app-server-protocol/src/protocol/common.rs:1192`, dispatch at `../codex/codex-rs/app-server/src/message_processor.rs:1372`, and account state ownership at `../codex/codex-rs/app-server/src/request_processors/account_processor.rs:121,1010`. The lazy payload check and provider scoping do not alter it.

## User Impact

| Command | Before (prod) | After (local dist) |
| --- | ---: | ---: |
| `gateway usage-cost` | 48.2 s | 0.62 s* |
| `channels list` | 17.2 s | 3.12 s |
| `models status` | 15.3 s | 3.92 s |
| `approvals pending` | 10.1 s | 0.96 s* |
| `skills list` / `check` | ~9.9 s | ~1.15 s |
| `agents bindings` | 9.8 s | 0.86 s |
| `gateway stability` | 9.8 s | 0.67 s* |
| `commitments` | 9.7 s | 0.59 s |

`*` no local gateway service was available, so these measure full cold startup plus the failure path rather than live RPC latency; the one-RPC assertions are the behavioral proof for `usage-cost`. On a comparable local bundled-catalog repro, `channels list` went 9.71 s → 3.12 s and `models status` 10.91 s → 3.92 s (1.04 s / 1.46 s with bundled plugins disabled). This checkout cannot reproduce the host's ~150-plugin topology, so the real-route module markers are the scale-independent proof.

No output shapes changed; `--probe` and human rendering paths are preserved.

## Evidence

- 17 focused test files, 329 tests, run individually (the `src/cli` directory composition has known order-dependent contamination).
- Two new real-route cold-import fixtures install a generated plugin whose runtime **marks or throws if imported**, invoke the actual `channels list --json` / `models status --json` routes, verify output, and prove the runtime never executed.
- Usage RPC-count tests assert exactly one `usage.cost` call across fresh, refreshing, and stale cache-status responses.
- `pnpm tsgo:core`, `pnpm build` (2m50s, CLI bootstrap guard, no `[INEFFECTIVE_DYNAMIC_IMPORT]`), `git diff --check`: passed.
- Autoreview (Codex `gpt-5.6-sol`, high): clean, correctness 0.99, no actionable findings.
- Production LOC `+173/-147` (net **+26** — a prepared-metadata ownership seam replacing repeated filesystem discovery); tests net +282.
