### PR TITLE
fix(cli): preserve buffered media output on write failure

### DIFF
--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -106,6 +106,7 @@ A good infer-based skill maps common user intents to the right subcommand, inclu
 - For `image describe`, `--file` accepts local paths and HTTP(S) URLs; remote URLs go through the normal media-fetch SSRF policy.
 - Stateless execution commands (`model run`, `image *`, `audio *`, `video *`, `web *`, `embedding *`) default to local. Gateway-managed state commands (`tts status`) default to gateway.
 - The local path never requires the gateway to be running.
+- Generated image and video `--output` files are staged beside the destination and replace it only after the complete buffer is written; a failed write leaves an existing destination unchanged.
 - Local `model run` is a lean one-shot provider completion: it resolves the configured agent model and auth but does not start a chat-agent turn, load tools, or open bundled MCP servers.
 - `model run --file` attaches image files (auto-detected MIME type) to the prompt; repeat `--file` for multiple images. Non-image files are rejected — use `infer audio transcribe` or `infer video describe` instead.
 - `model run --gateway` exercises Gateway routing, saved auth, provider selection, and the embedded runtime, but stays a raw model probe: no prior session transcript, bootstrap/AGENTS context, tools, or bundled MCP servers.

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2028,6 +2028,76 @@ describe("capability cli", () => {
     }
   });
 
+  it.each([
+    { kind: "image", extension: ".png", original: "existing-image", byte: 0x49 },
+    { kind: "video", extension: ".mp4", original: "existing-video", byte: 0x56 },
+  ])(
+    "preserves an existing buffered $kind --output when publication fails",
+    async ({ kind, extension, original, byte }) => {
+      const buffer = Buffer.alloc(2_048, byte);
+      if (kind === "image") {
+        mocks.generateImage.mockResolvedValue({
+          provider: "openai",
+          model: "gpt-image-2",
+          attempts: [],
+          images: [{ buffer, mimeType: "image/png", fileName: "generated.png" }],
+        });
+      } else {
+        mocks.generateVideo.mockResolvedValue({
+          provider: "openai",
+          model: "sora-2",
+          attempts: [],
+          videos: [{ buffer, mimeType: "video/mp4", fileName: "generated.mp4" }],
+        });
+      }
+
+      const tempDir = tempDirs.make(`openclaw-buffered-${kind}-fail-`);
+      const outputBase = path.join(tempDir, "result");
+      const outputPath = `${outputBase}${extension}`;
+      await fs.writeFile(outputPath, original);
+      await fs.chmod(outputPath, 0o640);
+
+      const writeFile = fs.writeFile.bind(fs);
+      const writeFileSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+        const [filePath, data, options] = args;
+        if (
+          typeof filePath === "string" &&
+          Buffer.isBuffer(data) &&
+          data.byteLength === buffer.byteLength &&
+          path.dirname(filePath) === tempDir
+        ) {
+          await writeFile(filePath, data.subarray(0, 17), options);
+          throw new Error("injected buffered media write failure");
+        }
+        await writeFile(...args);
+      });
+
+      try {
+        await expect(
+          runCapability(
+            kind,
+            "generate",
+            "--prompt",
+            "friendly lobster",
+            "--output",
+            outputBase,
+            "--json",
+          ),
+        ).rejects.toThrow("exit 1");
+
+        expectRuntimeErrorContains("injected buffered media write failure");
+        expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+        expect(await fs.readFile(outputPath, "utf8")).toBe(original);
+        if (process.platform !== "win32") {
+          expect((await fs.stat(outputPath)).mode & 0o777).toBe(0o640);
+        }
+        expect(await fs.readdir(tempDir)).toEqual([`result${extension}`]);
+      } finally {
+        writeFileSpy.mockRestore();
+      }
+    },
+  );
+
   it("blocks private-network url-only generated video downloads by default", async () => {
     mocks.loadConfig.mockReturnValue({});
     primeGeneratedVideoUrl("http://127.0.0.2:40123/private-video.mp4?sig=secret-presigned-token");

--- a/src/cli/capability-cli/media-output.ts
+++ b/src/cli/capability-cli/media-output.ts
@@ -1,7 +1,40 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { detectMime, extensionForMime, normalizeMimeType } from "@openclaw/media-core/mime";
+import { writeSiblingTempFile } from "../../infra/sibling-temp-file.js";
 import { saveMediaBuffer } from "../../media/store.js";
+
+const GENERATED_MEDIA_OUTPUT_TEMP_PREFIX = ".openclaw-media-output";
+
+async function resolveExistingOutputMode(filePath: string): Promise<number | undefined> {
+  try {
+    return (await fs.stat(filePath)).mode & 0o7777;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+export async function publishOutputFileAtomically<T>(params: {
+  filePath: string;
+  writeTemp: (tempPath: string) => Promise<T>;
+}): Promise<T> {
+  const dir = path.dirname(params.filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const mode = await resolveExistingOutputMode(params.filePath);
+  // Stage beside the destination so producer failures never destroy prior user bytes.
+  const { result } = await writeSiblingTempFile({
+    dir,
+    chmodDir: false,
+    tempPrefix: GENERATED_MEDIA_OUTPUT_TEMP_PREFIX,
+    ...(mode === undefined ? {} : { mode }),
+    writeTemp: params.writeTemp,
+    resolveFinalPath: () => params.filePath,
+  });
+  return result;
+}
 
 export async function writeOutputAsset(params: {
   buffer: Buffer;
@@ -42,8 +75,12 @@ export async function writeOutputAsset(params: {
     params.outputCount <= 1
       ? path.join(parsed.dir, `${parsed.name}${ext}`)
       : path.join(parsed.dir, `${parsed.name}-${String(params.outputIndex + 1)}${ext}`);
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, params.buffer);
+  await publishOutputFileAtomically({
+    filePath,
+    writeTemp: async (tempPath) => {
+      await fs.writeFile(tempPath, params.buffer, { flag: "wx" });
+    },
+  });
   return {
     path: filePath,
     mimeType: detectedNormalized ?? params.mimeType,

--- a/src/cli/capability-cli/video.ts
+++ b/src/cli/capability-cli/video.ts
@@ -14,7 +14,6 @@ import { getRuntimeConfig } from "../../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readResponseWithLimit } from "../../infra/http-body.js";
-import { writeSiblingTempFile } from "../../infra/sibling-temp-file.js";
 import { buildMediaUnderstandingRegistry } from "../../media-understanding/provider-registry.js";
 import { describeVideoFile } from "../../media-understanding/runtime.js";
 import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
@@ -31,7 +30,7 @@ import {
 import type { VideoGenerationResolution } from "../../video-generation/types.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
-import { writeOutputAsset } from "./media-output.js";
+import { publishOutputFileAtomically, writeOutputAsset } from "./media-output.js";
 import type { CapabilityEnvelope } from "./metadata.js";
 import {
   emitJsonOrText,
@@ -45,18 +44,6 @@ import {
 } from "./shared.js";
 
 const GENERATED_VIDEO_DOWNLOAD_TIMEOUT_MS = 120_000;
-const GENERATED_VIDEO_OUTPUT_TEMP_PREFIX = ".openclaw-video-output";
-
-async function resolveExistingVideoOutputMode(filePath: string): Promise<number | undefined> {
-  try {
-    return (await fs.stat(filePath)).mode & 0o7777;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return undefined;
-    }
-    throw error;
-  }
-}
 
 function normalizeVideoResolution(raw: string | undefined): VideoGenerationResolution | undefined {
   const normalized = raw?.trim().toUpperCase();
@@ -176,14 +163,8 @@ async function runVideoGenerate(params: {
               result.videos.length <= 1
                 ? path.join(parsed.dir, `${parsed.name}${ext}`)
                 : path.join(parsed.dir, `${parsed.name}-${String(index + 1)}${ext}`);
-            const dir = path.dirname(filePath);
-            await fs.mkdir(dir, { recursive: true });
-            const mode = await resolveExistingVideoOutputMode(filePath);
-            const { result: size } = await writeSiblingTempFile({
-              dir,
-              chmodDir: false,
-              tempPrefix: GENERATED_VIDEO_OUTPUT_TEMP_PREFIX,
-              ...(mode === undefined ? {} : { mode }),
+            const size = await publishOutputFileAtomically({
+              filePath,
               writeTemp: async (tempPath) => {
                 await pipeline(
                   Readable.fromWeb(
@@ -197,7 +178,6 @@ async function runVideoGenerate(params: {
                 }
                 return writtenSize;
               },
-              resolveFinalPath: () => filePath,
             });
             return { path: filePath, mimeType: video.mimeType, size };
           }


### PR DESCRIPTION
Closes #117926

## What Problem This Solves

Fixes an issue where users replacing an existing buffered image or video `--output` could lose the original file when the filesystem write failed after truncation. The command exited nonzero, but partial generated bytes had already replaced the destination.

## Why This Change Was Made

Buffered image and video publication now share the same sibling-temp atomic owner already used by streamed video output. A producer writes beside the destination, and OpenClaw renames that complete file into place only after success. The shared helper also centralizes existing-mode preservation and removes the duplicated streamed-video temp/mode path.

This stays at the CLI output publication boundary. Provider-specific guards would not protect every buffered media provider, and changing provider runtimes is unnecessary because they correctly return complete in-memory assets.

## User Impact

Failed buffered image and video writes no longer destroy an existing output file. Successful generation keeps the same command, JSON result, output naming, complete bytes, and destination mode.

## Evidence

- Built current-main baseline `a0d4aa34661f55804b5cc68f9b04e69081069574` on Blacksmith Testbox `tbx_01kz0vqh64cm8zjr9sazmgfxtf` / run `30741184034`: deterministic fault injection made both real built-CLI commands exit 1 after replacing the existing destination with 17 generated bytes.
- Exact head `826052eb9421511db690c27daf4c86d80271e0b0` on Blacksmith Testbox `tbx_01kz0y0kmsr5wfrmvfy29ehhzn` / run `30742503532`: 136/136 focused capability-CLI assertions passed.
- The exact-head complete unscoped `check:changed` gate passed, including formatting, production/test typechecks, lint, boundaries, dead-code scans, database/state guards, and import-cycle checks.
- Exact-head full build passed and verified all 149 public Plugin SDK subpaths.
- Exact-head source-blind built-CLI contract passed 4/4 cases through a temporary local provider plugin: image and video controls each published the complete 2,048-byte buffer with mode `0640`; injected partial-write failures exited 1 while preserving the original image/video bytes and mode; no sibling temp remained.

<details>
<summary>Redacted exact-head built-CLI output</summary>

```json
{
  "head": "826052eb9421511db690c27daf4c86d80271e0b0",
  "summary": { "pass": 4, "fail": 0, "blocked": 0 },
  "imageValid": { "exit": 0, "size": 2048, "mode": "0640", "tempFiles": 0 },
  "imageFault": { "exit": 1, "preserved": "existing-image-fault", "mode": "0640", "tempFiles": 0 },
  "videoValid": { "exit": 0, "size": 2048, "mode": "0640", "tempFiles": 0 },
  "videoFault": { "exit": 1, "preserved": "existing-video-fault", "mode": "0640", "tempFiles": 0 }
}
```

</details>

- Final exact-head autoreview: clean, no accepted/actionable findings, correctness confidence 0.99.
- Public model identifier gate: PASS. Test-only `gpt-image-2` and `sora-2` identifiers are publicly documented at https://developers.openai.com/api/docs/models/gpt-image-2 and https://developers.openai.com/api/docs/models/sora-2.
- Hosted exact-head CI run `30742473876` is green on attempt 2. Attempt 1 had one unrelated TUI PTY timeout (`model did not repeat the malformed edit call`); the unchanged `build-artifacts` job and aggregate `openclaw/ci-gate` passed on rerun.

Production delta: +42/-25 (net +17, primarily the shared atomic owner). Tests: +70/-0. Docs: +1/-0. No config, protocol, storage, migration, dependency, provider-runtime, or Gateway change.

AI-assisted: yes.
