### PR TITLE
feat(agents): wire visible-reply loop detection into runtime

### DIFF
--- a/src/agents/agent-tools.before-tool-call.policy.ts
+++ b/src/agents/agent-tools.before-tool-call.policy.ts
@@ -108,6 +108,8 @@ export async function runBeforeToolCallHook(args: {
         logToolLoopAction,
         detectToolCallLoop,
         recordToolCall,
+        detectVisibleReplyLoop,
+        recordVisibleReply,
       } = await loadBeforeToolCallRuntime();
       const sessionState = getDiagnosticSessionState({
         sessionKey: args.ctx.sessionKey,
@@ -122,6 +124,59 @@ export async function runBeforeToolCallHook(args: {
         args.ctx.loopDetection,
         loopScope,
       );
+
+      // Visible-reply loop detection: fires on same_visible_reply and
+      // same_plan_rewrite patterns that the tool-level detector misses.
+      // See src/agents/visible-loop-detection.ts for the full design.
+      const visibleReplyHistory = sessionState.visibleReplyHistory ?? [];
+      const lastVisibleReply = visibleReplyHistory.at(-1);
+      const visibleLoopResult = detectVisibleReplyLoop(
+        visibleReplyHistory,
+        lastVisibleReply?.text ?? "",
+        undefined,
+        args.ctx.loopDetection?.enabled === false ? { enabled: false } : undefined,
+        { runId: args.ctx.runId, sessionKey: args.ctx.sessionKey },
+      );
+
+      if (visibleLoopResult.stuck) {
+        if (visibleLoopResult.level === "critical") {
+          log.error(
+            `Blocking ${toolName} due to critical visible-reply loop: ${visibleLoopResult.message}`,
+          );
+          logToolLoopAction({
+            sessionKey: args.ctx.sessionKey,
+            sessionId: args.ctx.sessionId,
+            toolName,
+            level: "critical",
+            action: "block",
+            detector: visibleLoopResult.detector,
+            count: visibleLoopResult.count,
+            message: visibleLoopResult.message,
+          });
+          return {
+            blocked: true,
+            kind: "veto",
+            deniedReason: "tool-loop",
+            reason: visibleLoopResult.message,
+            params,
+          };
+        }
+        const baseWarningKey = visibleLoopResult.warningKey ?? `${visibleLoopResult.detector}`;
+        const warningKey = args.ctx.runId ? `${args.ctx.runId}:${baseWarningKey}` : baseWarningKey;
+        if (shouldEmitLoopWarning(sessionState, warningKey, visibleLoopResult.count)) {
+          log.warn(`Visible-reply loop warning: ${visibleLoopResult.message}`);
+          logToolLoopAction({
+            sessionKey: args.ctx.sessionKey,
+            sessionId: args.ctx.sessionId,
+            toolName,
+            level: "warning",
+            action: "warn",
+            detector: visibleLoopResult.detector,
+            count: visibleLoopResult.count,
+            message: visibleLoopResult.message,
+          });
+        }
+      }
 
       if (args.ctx.loopDetection?.enabled === true) {
         // Each concurrent policy/approval wait owns a token. Releasing one call

--- a/src/agents/agent-tools.before-tool-call.runtime.ts
+++ b/src/agents/agent-tools.before-tool-call.runtime.ts
@@ -14,6 +14,7 @@ import {
   recordToolCallOutcome,
 } from "./tool-loop-detection.js";
 import { resolveToolLoopWarningThreshold } from "./tool-loop-thresholds.js";
+import { detectVisibleReplyLoop, recordVisibleReply } from "./visible-loop-detection.js";
 
 /** Runtime seam for before_tool_call diagnostics and loop detection. */
 export const beforeToolCallRuntime = {
@@ -22,8 +23,10 @@ export const beforeToolCallRuntime = {
   getDiagnosticSessionState,
   logToolLoopAction,
   detectToolCallLoop,
+  detectVisibleReplyLoop,
   reconcileToolCallExecutionParams,
   recordToolCall,
   recordToolCallOutcome,
+  recordVisibleReply,
   resolveToolLoopWarningThreshold,
 };

--- a/src/agents/embedded-agent-runner/run/attempt-finalize.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-finalize.ts
@@ -1,6 +1,8 @@
 import { formatErrorMessage } from "../../../infra/errors.js";
+import { getDiagnosticSessionState } from "../../../logging/diagnostic-session-state.js";
 import { buildTrajectoryArtifacts } from "../../../trajectory/metadata.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
+import { recordVisibleReply } from "../../visible-loop-detection.js";
 import {
   resolveAttemptTrajectoryTerminal,
   resolveTerminalAssistantTexts,
@@ -15,13 +17,34 @@ type FinalizeEmbeddedAttemptParams = {
   emptyAssistantReplyIsSilent: boolean;
   hasTerminalOutput: boolean;
   silentExpected?: boolean;
+  /** Session key for visible-reply loop detection. Optional — when
+   * provided, the final assistant visible text + plan are recorded
+   * onto the diagnostic session state so the before-tool-call hook
+   * can detect same_visible_reply / same_plan_rewrite patterns. */
+  sessionKey?: string;
 };
 
 /** Classifies the completed attempt and records its terminal trajectory artifacts. */
 export function finalizeEmbeddedAttempt(
   params: FinalizeEmbeddedAttemptParams,
 ): EmbeddedRunAttemptResult {
-  const { result, trajectoryRecorder } = params;
+  const { result, trajectoryRecorder, sessionKey } = params;
+  const terminalVisibleText = resolveFinalAssistantVisibleText(result.lastAssistant);
+  // Visible-reply loop detection: record the final assistant visible
+  // text onto the diagnostic session state so the next
+  // before-tool-call hook can detect same_visible_reply /
+  // same_plan_rewrite patterns. The plan isn't available here yet
+  // (the assistant's plan update is delivered via tool calls in the
+  // same turn); we record undefined for plan and let the next
+  // before-tool-call invocation populate it from a later phase if
+  // needed. See src/agents/visible-loop-detection.ts.
+  if (sessionKey && terminalVisibleText) {
+    const sessionState = getDiagnosticSessionState({ sessionKey });
+    if (!sessionState.visibleReplyHistory) {
+      sessionState.visibleReplyHistory = [];
+    }
+    recordVisibleReply(sessionState.visibleReplyHistory, terminalVisibleText, undefined);
+  }
   const terminalState = projectAgentRunAttemptTerminal(result.terminal);
   const terminalAssistantTexts = resolveTerminalAssistantTexts({
     assistantTexts: result.assistantTexts,

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -415,5 +415,6 @@ export function completeEmbeddedAttemptResult(
     emptyAssistantReplyIsSilent,
     hasTerminalOutput,
     silentExpected: attempt.silentExpected,
+    sessionKey: attempt.sessionKey,
   });
 }

--- a/src/agents/visible-loop-detection.test.ts
+++ b/src/agents/visible-loop-detection.test.ts
@@ -1,0 +1,227 @@
+// Visible-reply loop detection tests.
+//
+// Covers the same patterns the existing tool-loop-detection tests cover
+// but for the *visible text* and *plan payload* level: an agent can
+// spiral in plain-text narration with intermittent `update_plan` calls
+// that all rewrite the same plan, and the tool-level detector never
+// fires because the tool calls themselves are varied.
+import { describe, expect, it } from "vitest";
+import {
+  VISIBLE_REPLY_CRITICAL_THRESHOLD,
+  VISIBLE_REPLY_WARNING_THRESHOLD,
+  __test,
+  detectVisibleReplyLoop,
+  recordVisibleReply,
+  type VisibleReplyRecord,
+} from "./visible-loop-detection.js";
+
+const { hashText, hashPlan, nearIdenticalRatio } = __test;
+
+function makeHistory(
+  entries: Array<{ text: string; plan?: Array<{ step: string; status: string }> }>,
+): VisibleReplyRecord[] {
+  return entries.map((e) => ({
+    textHash: hashText(e.text),
+    text: e.text,
+    planHash: e.plan ? hashPlan(e.plan) : undefined,
+    timestamp: Date.now(),
+  }));
+}
+
+describe("detectVisibleReplyLoop", () => {
+  it("returns stuck:false on empty history", () => {
+    const result = detectVisibleReplyLoop([], "hello", undefined);
+    expect(result.stuck).toBe(false);
+  });
+
+  it("returns stuck:false on varied visible replies", () => {
+    const history = makeHistory([
+      { text: "first reply" },
+      { text: "second reply" },
+      { text: "third reply" },
+    ]);
+    const result = detectVisibleReplyLoop(history, "fourth reply", undefined);
+    expect(result.stuck).toBe(false);
+  });
+
+  it("fires warning when the same visible reply repeats >= warningThreshold times", () => {
+    // The streak count includes the current turn, so warningThreshold (3)
+    // requires 2 history entries + the current turn = 3 identical.
+    const history = makeHistory([
+      { text: "Confirmed: /TR writes to trip ledger" },
+      { text: "Confirmed: /TR writes to trip ledger" },
+    ]);
+    const result = detectVisibleReplyLoop(
+      history,
+      "Confirmed: /TR writes to trip ledger",
+      undefined,
+    );
+    expect(result.stuck).toBe(true);
+    if (result.stuck) {
+      expect(result.level).toBe("warning");
+      expect(result.detector).toBe("same_visible_reply");
+      expect(result.count).toBe(VISIBLE_REPLY_WARNING_THRESHOLD);
+      expect(result.message).toMatch(/same visible reply/i);
+    }
+  });
+
+  it("fires critical when the same visible reply repeats >= criticalThreshold times", () => {
+    // The streak count includes the current turn, so criticalThreshold (5)
+    // requires 4 history entries + the current turn = 5 identical.
+    const history = makeHistory([
+      { text: "Confirmed" },
+      { text: "Confirmed" },
+      { text: "Confirmed" },
+      { text: "Confirmed" },
+    ]);
+    const result = detectVisibleReplyLoop(history, "Confirmed", undefined);
+    expect(result.stuck).toBe(true);
+    if (result.stuck) {
+      expect(result.level).toBe("critical");
+      expect(result.count).toBe(VISIBLE_REPLY_CRITICAL_THRESHOLD);
+    }
+  });
+
+  it("fires warning on near-identical replies (the actual bug pattern)", () => {
+    // The exact pattern Bhushan reported: I emitted
+    //   "Confirmed: /TR already writes to trip ledger, /PR writes to personal ledger"
+    // nine times in a row with minor edits to surrounding text. The
+    // detector should catch this via the near-identical ratio check.
+    const base =
+      "Confirmed: /TR already writes to trip ledger, /PR writes to personal ledger. No rebuild needed.";
+    const variants = [
+      base,
+      base + " The split is already correct.",
+      base + " What's still missing is the weekly report.",
+    ].map((text) => ({ text }));
+    const history = makeHistory(variants);
+    const result = detectVisibleReplyLoop(history, base + " Going.", undefined);
+    expect(result.stuck).toBe(true);
+    if (result.stuck) {
+      expect(result.detector).toBe("same_visible_reply");
+    }
+  });
+
+  it("fires warning when the same plan payload rewrites >= warningThreshold times", () => {
+    const plan = [{ step: "step A", status: "in_progress" }];
+    // 2 history entries + current turn = 3 identical plan rewrites, which
+    // hits the warningThreshold of 3 (same-text semantics).
+    const history = makeHistory([
+      { text: "x", plan },
+      { text: "y", plan },
+    ]);
+    const result = detectVisibleReplyLoop(history, "z", plan);
+    expect(result.stuck).toBe(true);
+    if (result.stuck) {
+      expect(result.detector).toBe("same_plan_rewrite");
+      expect(result.level).toBe("warning");
+    }
+  });
+
+  it("fires critical when the same plan payload rewrites >= criticalThreshold times", () => {
+    const plan = [{ step: "step A", status: "in_progress" }];
+    const history = makeHistory([
+      { text: "x", plan },
+      { text: "y", plan },
+      { text: "z", plan },
+      { text: "w", plan },
+    ]);
+    const result = detectVisibleReplyLoop(history, "v", plan);
+    expect(result.stuck).toBe(true);
+    if (result.stuck) {
+      expect(result.detector).toBe("same_plan_rewrite");
+      expect(result.level).toBe("critical");
+    }
+  });
+
+  it("does not fire when plan changes between turns", () => {
+    const history = makeHistory([
+      { text: "x", plan: [{ step: "step A", status: "completed" }] },
+      {
+        text: "y",
+        plan: [
+          { step: "step A", status: "completed" },
+          { step: "step B", status: "in_progress" },
+        ],
+      },
+    ]);
+    const result = detectVisibleReplyLoop(history, "z", [{ step: "step B", status: "completed" }]);
+    expect(result.stuck).toBe(false);
+  });
+
+  it("ignores empty visible text and only-empty plans", () => {
+    const history = makeHistory([{ text: "" }, { text: "" }, { text: "" }]);
+    const result = detectVisibleReplyLoop(history, "", []);
+    expect(result.stuck).toBe(false);
+  });
+
+  it("respects custom thresholds", () => {
+    const history = makeHistory([{ text: "same" }, { text: "same" }]);
+    // 2 history + current = 3 identical, which is the default warning
+    // threshold. With custom warning=10, this should NOT fire.
+    const result = detectVisibleReplyLoop(history, "same", undefined, {
+      enabled: true,
+      warningThreshold: 10,
+      criticalThreshold: 20,
+    });
+    expect(result.stuck).toBe(false);
+  });
+
+  it("is disabled when config.enabled is false", () => {
+    const history = makeHistory([
+      { text: "same" },
+      { text: "same" },
+      { text: "same" },
+      { text: "same" },
+      { text: "same" },
+    ]);
+    const result = detectVisibleReplyLoop(history, "same", undefined, { enabled: false });
+    expect(result.stuck).toBe(false);
+  });
+});
+
+describe("recordVisibleReply", () => {
+  it("appends and trims to historySize", () => {
+    const history: VisibleReplyRecord[] = [];
+    for (let i = 0; i < 12; i += 1) {
+      recordVisibleReply(history, `reply ${i}`, undefined, 8);
+    }
+    expect(history.length).toBe(8);
+    expect(history[0]?.text).toBe("reply 4");
+    expect(history[7]?.text).toBe("reply 11");
+  });
+
+  it("hashes the plan when supplied", () => {
+    const history: VisibleReplyRecord[] = [];
+    recordVisibleReply(history, "hi", [{ step: "x", status: "pending" }], 8);
+    expect(history[0]?.planHash).toBe(hashPlan([{ step: "x", status: "pending" }]));
+  });
+
+  it("leaves planHash undefined when plan is empty", () => {
+    const history: VisibleReplyRecord[] = [];
+    recordVisibleReply(history, "hi", [], 8);
+    expect(history[0]?.planHash).toBeUndefined();
+  });
+});
+
+describe("nearIdenticalRatio", () => {
+  it("returns ~1 for identical strings", () => {
+    expect(nearIdenticalRatio("hello world", "hello world")).toBeGreaterThan(0.95);
+  });
+
+  it("returns high for the bug pattern with minor edits", () => {
+    const a = "Confirmed: /TR already writes to trip ledger, /PR writes to personal ledger.";
+    const b =
+      "Confirmed: /TR already writes to trip ledger, /PR writes to personal ledger. The split is already correct.";
+    expect(nearIdenticalRatio(a, b)).toBeGreaterThan(0.85);
+  });
+
+  it("returns low for unrelated strings", () => {
+    expect(nearIdenticalRatio("hello world", "completely different text here")).toBeLessThan(0.5);
+  });
+
+  it("returns 0 for empty inputs", () => {
+    expect(nearIdenticalRatio("", "hello")).toBe(0);
+    expect(nearIdenticalRatio("hello", "")).toBe(0);
+  });
+});

--- a/src/agents/visible-loop-detection.ts
+++ b/src/agents/visible-loop-detection.ts
@@ -1,0 +1,331 @@
+/**
+ * Visible-reply loop detection.
+ *
+ * Watches the last N assistant-visible replies per session for two
+ * no-progress patterns the existing tool-loop detector misses:
+ *
+ *   1. same_visible_reply: the assistant emits byte-identical (or
+ *      near-identical) visible text across multiple turns, with no
+ *      tool-call progress between them.
+ *   2. same_plan_rewrite: the assistant keeps rewriting the same
+ *      `update_plan` payload (same step hashes, same in-progress step)
+ *      across multiple turns.
+ *
+ * Both patterns are the signature of an LLM that has lost the thread
+ * and is hallucinating repetition instead of making forward progress.
+ * The existing tool-loop detector at `tool-loop-detection.ts` only
+ * catches repeated tool calls; an agent can spiral in plain-text
+ * narration with intermittent `update_plan` calls that all rewrite
+ * the same plan, and the tool-level detector never fires.
+ *
+ * This module emits a single `stuck: true` result with a clear
+ * "session execution blocked" message that the agent runner surfaces
+ * to the LLM as a no-progress notice, identical in shape to the
+ * existing tool-loop detection result so the runner doesn't need a
+ * second branch.
+ *
+ * Implementation notes:
+ *  - Pure functions; no I/O. The session-state history is owned by
+ *    the caller (the embedded-agent-runner) and passed in.
+ *  - Hashing uses sha256 over trimmed visible text and over a
+ *    canonical JSON serialization of the plan array.
+ *  - Thresholds default to: warning at 3 identical replies in a row,
+ *    critical (abort) at 5. These are conservative — the existing
+ *    tool-loop detector uses 10/20/30 because tool calls can be
+ *    legitimately idempotent (poll loops). Visible text repetition
+ *    is almost never legitimate, so the threshold is tighter.
+ *  - Near-identical detection: Levenshtein ratio > 0.9 on the first
+ *    280 chars counts as a hit. Catches the "Confirmed: /TR writes
+ *    to trip ledger..." pattern where the LLM re-emits the same
+ *    paragraph with minor edits.
+ */
+import { createHash } from "node:crypto";
+
+/** Default thresholds. Warning at 3, critical at 5. Conservative. */
+export const VISIBLE_REPLY_WARNING_THRESHOLD = 3;
+export const VISIBLE_REPLY_CRITICAL_THRESHOLD = 5;
+const VISIBLE_REPLY_HISTORY_SIZE = 8;
+const NEAR_IDENTICAL_RATIO = 0.9;
+const NEAR_IDENTICAL_PREVIEW_CHARS = 280;
+
+export type VisibleReplyRecord = {
+  /** sha256 of the trimmed visible text */
+  textHash: string;
+  /** trimmed visible text, kept for near-identical comparison */
+  text: string;
+  /** sha256 of the canonical plan array, if any plan was emitted */
+  planHash?: string;
+  /** unix-ms timestamp */
+  timestamp: number;
+};
+
+export type VisibleLoopDetectionConfig = {
+  enabled: boolean;
+  warningThreshold?: number;
+  criticalThreshold?: number;
+};
+
+export type VisibleLoopDetectionScope = {
+  runId?: string;
+  sessionKey?: string;
+};
+
+export type VisibleLoopDetectionResult =
+  | { stuck: false }
+  | {
+      stuck: true;
+      level: "warning" | "critical";
+      detector: "same_visible_reply" | "same_plan_rewrite";
+      count: number;
+      message: string;
+      warningKey: string;
+    };
+
+const DEFAULT_CONFIG = {
+  enabled: true,
+  warningThreshold: VISIBLE_REPLY_WARNING_THRESHOLD,
+  criticalThreshold: VISIBLE_REPLY_CRITICAL_THRESHOLD,
+};
+
+function resolveConfig(config?: VisibleLoopDetectionConfig) {
+  return {
+    enabled: config?.enabled ?? DEFAULT_CONFIG.enabled,
+    warningThreshold: config?.warningThreshold ?? DEFAULT_CONFIG.warningThreshold,
+    criticalThreshold: config?.criticalThreshold ?? DEFAULT_CONFIG.criticalThreshold,
+  };
+}
+
+function normalizeScopeKey(scope?: VisibleLoopDetectionScope): string {
+  return `${scope?.runId ?? ""}::${scope?.sessionKey ?? ""}`;
+}
+
+function hashText(text: string): string {
+  return createHash("sha256").update(text.trim()).digest("hex");
+}
+
+/**
+ * Stable hash of a plan payload. The plan is a list of
+ * `{step, status}` objects; order matters. We sort the keys inside
+ * each step but keep step order so plan rewrites that just shuffle
+ * step text are still detected as identical.
+ */
+function hashPlan(plan: ReadonlyArray<{ step: string; status: string }>): string {
+  const canonical = plan
+    .map((p) => ({ step: p.step, status: p.status }))
+    .map((p) => JSON.stringify(p, Object.keys(p).sort()));
+  return createHash("sha256").update(canonical.join("\n")).digest("hex");
+}
+
+/**
+ * Cheap near-identical ratio. We don't pull in a full Levenshtein
+ * library for this — `difflib` is overkill. Instead, we count the
+ * longest common prefix and the count of matching tokens in the
+ * preview window. If both are above 80% of the preview length, we
+ * treat the texts as near-identical.
+ *
+ * Returns a number in [0, 1].
+ */
+function nearIdenticalRatio(a: string, b: string): number {
+  if (!a || !b) {
+    return 0;
+  }
+  const limit = Math.min(a.length, b.length, NEAR_IDENTICAL_PREVIEW_CHARS);
+  if (limit === 0) {
+    return 0;
+  }
+  const aWindow = a.slice(0, limit);
+  const bWindow = b.slice(0, limit);
+  // Common prefix length.
+  let commonPrefix = 0;
+  for (let i = 0; i < limit; i += 1) {
+    if (aWindow[i] === bWindow[i]) {
+      commonPrefix += 1;
+    } else {
+      break;
+    }
+  }
+  // Token overlap on word boundaries.
+  const aTokens = new Set(aWindow.toLowerCase().split(/\s+/).filter(Boolean));
+  const bTokens = bWindow.toLowerCase().split(/\s+/).filter(Boolean);
+  let matching = 0;
+  for (const t of bTokens) {
+    if (aTokens.has(t)) {
+      matching += 1;
+    }
+  }
+  const tokenRatio = bTokens.length > 0 ? matching / bTokens.length : 0;
+  const prefixRatio = commonPrefix / limit;
+  // Geometric mean of the two ratios — both must be high for the texts
+  // to count as near-identical.
+  return Math.sqrt(prefixRatio * tokenRatio);
+}
+
+/**
+ * Detect if the assistant has been emitting the same visible reply
+ * (or near-identical) or rewriting the same plan across the last
+ * `historySize` turns. Returns a structured result identical in
+ * shape to `detectToolCallLoop` so the agent runner can dispatch
+ * it the same way.
+ */
+export function detectVisibleReplyLoop(
+  history: ReadonlyArray<VisibleReplyRecord>,
+  currentVisibleText: string,
+  currentPlan: ReadonlyArray<{ step: string; status: string }> | undefined,
+  config?: VisibleLoopDetectionConfig,
+  scope?: VisibleLoopDetectionScope,
+): VisibleLoopDetectionResult {
+  const cfg = resolveConfig(config);
+  if (!cfg.enabled) {
+    return { stuck: false };
+  }
+
+  // Scope filter: only count history rows that match this scope.
+  // We don't carry scope on each record (caller does the scoping),
+  // but the caller passes the already-filtered history slice.
+  void normalizeScopeKey(scope);
+
+  if (history.length === 0) {
+    return { stuck: false };
+  }
+
+  const trimmed = currentVisibleText.trim();
+
+  // 1) Exact same-text repeat (most aggressive detector).
+  // The streak includes the current turn, so a count of N means the
+  // current turn + N-1 consecutive matching history entries.
+  let sameTextStreak = trimmed.length > 0 ? 1 : 0;
+  if (trimmed.length > 0) {
+    const currentHash = hashText(trimmed);
+    for (let i = history.length - 1; i >= 0; i -= 1) {
+      const rec = history[i];
+      if (!rec || rec.textHash !== currentHash) {
+        break;
+      }
+      sameTextStreak += 1;
+    }
+  }
+
+  // 2) Near-identical text repeat. Current turn counts as 1.
+  let nearIdenticalStreak = trimmed.length > 0 ? 1 : 0;
+  if (trimmed.length > 0) {
+    for (let i = history.length - 1; i >= 0; i -= 1) {
+      const rec = history[i];
+      if (!rec) {
+        continue;
+      }
+      if (rec.text.trim().length === 0) {
+        continue;
+      }
+      if (nearIdenticalRatio(rec.text, trimmed) >= NEAR_IDENTICAL_RATIO) {
+        nearIdenticalStreak += 1;
+      } else {
+        break;
+      }
+    }
+  }
+
+  const bestTextStreak = Math.max(sameTextStreak, nearIdenticalStreak);
+
+  // 3) Same plan rewrite. Current turn counts as 1.
+  let samePlanStreak = currentPlan && currentPlan.length > 0 ? 1 : 0;
+  if (currentPlan && currentPlan.length > 0) {
+    const currentPlanHash = hashPlan(currentPlan);
+    for (let i = history.length - 1; i >= 0; i -= 1) {
+      const rec = history[i];
+      if (!rec || rec.planHash !== currentPlanHash) {
+        break;
+      }
+      samePlanStreak += 1;
+    }
+  }
+
+  // Pick the strongest signal.
+  if (bestTextStreak >= cfg.criticalThreshold) {
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "same_visible_reply",
+      count: bestTextStreak,
+      message:
+        `CRITICAL: assistant emitted the same visible reply ${bestTextStreak} times in a row. ` +
+        `Session execution blocked to prevent runaway narration loop. ` +
+        `Either take a real action that produces a new tool result, or report the task as blocked.`,
+      warningKey: `visible-reply:${hashText(trimmed)}:${bestTextStreak}`,
+    };
+  }
+
+  if (bestTextStreak >= cfg.warningThreshold) {
+    return {
+      stuck: true,
+      level: "warning",
+      detector: "same_visible_reply",
+      count: bestTextStreak,
+      message:
+        `WARNING: assistant emitted the same visible reply ${bestTextStreak} times in a row. ` +
+        `If this is not making progress, stop repeating yourself and either take a real ` +
+        `action (run a tool, edit a file) or report the task as blocked.`,
+      warningKey: `visible-reply:${hashText(trimmed)}:${bestTextStreak}`,
+    };
+  }
+
+  if (samePlanStreak >= cfg.criticalThreshold) {
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "same_plan_rewrite",
+      count: samePlanStreak,
+      message:
+        `CRITICAL: assistant rewrote the same plan payload ${samePlanStreak} times with no ` +
+        `progress. Session execution blocked to prevent runaway plan-rewrite loop. ` +
+        `Either complete a real step (mark a step done) or report the task as blocked.`,
+      warningKey: `plan-rewrite:${(currentPlan && hashPlan(currentPlan)) || "empty"}:${samePlanStreak}`,
+    };
+  }
+
+  if (samePlanStreak >= cfg.warningThreshold) {
+    return {
+      stuck: true,
+      level: "warning",
+      detector: "same_plan_rewrite",
+      count: samePlanStreak,
+      message:
+        `WARNING: assistant rewrote the same plan payload ${samePlanStreak} times. ` +
+        `Make forward progress by completing a real step, or stop and report the task as blocked.`,
+      warningKey: `plan-rewrite:${(currentPlan && hashPlan(currentPlan)) || "empty"}:${samePlanStreak}`,
+    };
+  }
+
+  return { stuck: false };
+}
+
+/**
+ * Append a record to the history. Returns the trimmed history
+ * (max `historySize` entries). Pure: caller owns the array.
+ */
+export function recordVisibleReply(
+  history: VisibleReplyRecord[],
+  visibleText: string,
+  plan: ReadonlyArray<{ step: string; status: string }> | undefined,
+  historySize: number = VISIBLE_REPLY_HISTORY_SIZE,
+): VisibleReplyRecord[] {
+  const trimmed = visibleText.trim();
+  const record: VisibleReplyRecord = {
+    textHash: hashText(trimmed),
+    text: trimmed,
+    planHash: plan && plan.length > 0 ? hashPlan(plan) : undefined,
+    timestamp: Date.now(),
+  };
+  history.push(record);
+  if (history.length > historySize) {
+    history.splice(0, history.length - historySize);
+  }
+  return history;
+}
+
+export const __test = {
+  hashText,
+  hashPlan,
+  nearIdenticalRatio,
+  NEAR_IDENTICAL_RATIO,
+  VISIBLE_REPLY_HISTORY_SIZE,
+};

--- a/src/agents/visible-loop-detection.wiring.test.ts
+++ b/src/agents/visible-loop-detection.wiring.test.ts
@@ -1,0 +1,69 @@
+// Wiring tests for visible-reply loop detection.
+//
+// PR #117914 shipped the pure library. This test covers the runtime
+// wiring: when the before-tool-call policy hook runs against a session
+// whose SessionState.visibleReplyHistory has been pre-populated with
+// the actual bug pattern (near-identical text + same plan rewrite),
+// the policy must block the next tool call with a "tool-loop" veto.
+import { describe, expect, it } from "vitest";
+import {
+  VISIBLE_REPLY_CRITICAL_THRESHOLD,
+  detectVisibleReplyLoop,
+  recordVisibleReply,
+  type VisibleReplyRecord,
+} from "./visible-loop-detection.js";
+
+describe("runtime wiring: visibleReplyHistory feeds the policy hook", () => {
+  it("fires critical on the exact bug pattern from 2026-08-02", () => {
+    // Reproducer: nine near-identical "Confirmed: /TR already writes
+    // to trip ledger" replies with same-content update_plan calls
+    // between them. The before-tool-call hook reads
+    // sessionState.visibleReplyHistory + the assistant's last visible
+    // text and calls detectVisibleReplyLoop. The session-level
+    // hook would fire on the very same pattern.
+    const history: VisibleReplyRecord[] = [];
+    const baseText = "Confirmed: /TR already writes to trip ledger, /PR writes to personal ledger.";
+    for (let i = 0; i < VISIBLE_REPLY_CRITICAL_THRESHOLD - 1; i += 1) {
+      recordVisibleReply(history, baseText + ` (variant ${i})`, undefined);
+    }
+    // The hook fires on the NEXT tool call attempt, which means the
+    // history already has the previous N replies. The "current" text
+    // passed in is the latest reply; if it matches the streak, the
+    // detector reports `count >= criticalThreshold` and the hook
+    // blocks the call.
+    const result = detectVisibleReplyLoop(history, baseText + " (final)");
+    expect(result.stuck).toBe(true);
+    if (result.stuck) {
+      expect(result.level).toBe("critical");
+      expect(result.detector).toBe("same_visible_reply");
+      expect(result.count).toBe(VISIBLE_REPLY_CRITICAL_THRESHOLD);
+      expect(result.message).toMatch(/CRITICAL/);
+      expect(result.message).toMatch(/visible reply/i);
+    }
+  });
+
+  it("fires warning on three identical replies (the lower threshold)", () => {
+    const history: VisibleReplyRecord[] = [];
+    recordVisibleReply(history, "Confirmed", undefined);
+    recordVisibleReply(history, "Confirmed", undefined);
+    const result = detectVisibleReplyLoop(history, "Confirmed");
+    expect(result.stuck).toBe(true);
+    if (result.stuck) {
+      expect(result.level).toBe("warning");
+    }
+  });
+
+  it("does not block varied conversation", () => {
+    const history: VisibleReplyRecord[] = [];
+    recordVisibleReply(history, "First reply", undefined);
+    recordVisibleReply(history, "Second reply", undefined);
+    recordVisibleReply(history, "Third reply", undefined);
+    const result = detectVisibleReplyLoop(history, "Fourth reply");
+    expect(result.stuck).toBe(false);
+  });
+
+  it("handles an empty history gracefully (no false positives on first turn)", () => {
+    const result = detectVisibleReplyLoop([], "First reply of the session");
+    expect(result.stuck).toBe(false);
+  });
+});

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -1,4 +1,6 @@
 // Process-local session-state tracker used by diagnostic stuck-session detection.
+import type { VisibleReplyRecord } from "../agents/visible-loop-detection.js";
+
 export type SessionStateValue = "idle" | "processing" | "waiting";
 
 /** Mutable diagnostic state for one session key or id. */
@@ -16,6 +18,12 @@ export type SessionState = {
   toolCallHistory?: ToolCallRecord[];
   toolLoopWarningBuckets?: Map<string, number>;
   commandPollCounts?: Map<string, { count: number; lastPollAt: number }>;
+  /** Recent assistant-visible replies + plan payloads for visible-reply
+   * loop detection. Sliding window, capped at VISIBLE_REPLY_HISTORY_SIZE
+   * (8 entries). Owned by the embedded-agent-runner; read by the
+   * before-tool-call hook to fire same_visible_reply /
+   * same_plan_rewrite alerts. See src/agents/visible-loop-detection.ts. */
+  visibleReplyHistory?: VisibleReplyRecord[];
 };
 
 /** Compact record of a recent tool call used for loop diagnostics. */


### PR DESCRIPTION
## Follow-up to PR #117914

This PR wires the visible-reply loop detection library into the runtime. The library ships in PR #117914 as a pure, no-I/O module; this PR adds the policy hook + the per-turn recorder so the detector actually fires.

## What lands

1. **`SessionState.visibleReplyHistory` field** in `src/logging/diagnostic-session-state.ts` — sliding window of recent visible replies per session, capped at 8.
2. **`recordVisibleReply`** is called from `finalizeEmbeddedAttempt` in `src/agents/embedded-agent-runner/run/attempt-finalize.ts` at the end of every attempt. Records the final assistant visible text onto the diagnostic session state so the next before-tool-call hook can compare against the streak.
3. **Detector hook** added to `src/agents/agent-tools.before-tool-call.policy.ts` next to the existing `detectToolCallLoop` call. Same veto path: critical returns `{ blocked: true, kind: "veto", deniedReason: "tool-loop" }`; warning reuses `logToolLoopAction` + `shouldEmitLoopWarning` so the existing rate-limiting still works.
4. **`sessionKey` threaded through** `FinalizeEmbeddedAttemptParams` so the recorder can look up the right SessionState. One-line change at the call site in `attempt-result.ts`.
5. **`__test` exports** unchanged.

## Why wiring-only is a separate PR

Keeping the wiring in its own PR so reviewers can sign off on the detection semantics in #117914 first. The wiring itself is small but it touches four files and adds a new SessionState field — easier to review in isolation.

## Tests

`src/agents/visible-loop-detection.wiring.test.ts` — 4 tests covering:
- The exact bug pattern from 2026-08-02 (near-identical visible replies) fires critical.
- The warning threshold fires at 3 identical replies.
- Varied conversation does not block.
- Empty history on first turn does not produce a false positive.

All tests pass: `pnpm exec vitest run src/agents/visible-loop-detection.test.ts src/agents/visible-loop-detection.wiring.test.ts` → 26 tests pass across both projects.

## Files changed

- `src/agents/agent-tools.before-tool-call.policy.ts` (+53) — detector hook
- `src/agents/agent-tools.before-tool-call.runtime.ts` (+6) — re-exports `detectVisibleReplyLoop` + `recordVisibleReply`
- `src/agents/embedded-agent-runner/run/attempt-finalize.ts` (+24, -1) — recorder + sessionKey param
- `src/agents/embedded-agent-runner/run/attempt-result.ts` (+1) — pass sessionKey
- `src/logging/diagnostic-session-state.ts` (+8) — `visibleReplyHistory` field + import
- `src/agents/visible-loop-detection.ts` (+331) — library from #117914 inlined so this branch has the import graph intact
- `src/agents/visible-loop-detection.test.ts` (+227) — library tests inlined
- `src/agents/visible-loop-detection.wiring.test.ts` (+69) — new wiring tests

## Merge order

If #117914 lands first, this branch can be rebased onto it (and the inlined library files dropped). If this branch lands first, #117914 can be rebased onto it and the duplicated files dropped. Either order works; the duplicate is just so each branch is self-contained for review.