### PR TITLE
fix(whatsapp): keep inbound media diagnostics safely redacted

### DIFF
--- a/extensions/whatsapp/src/inbound.media.test.ts
+++ b/extensions/whatsapp/src/inbound.media.test.ts
@@ -258,6 +258,9 @@ let resetLogger: typeof import("openclaw/plugin-sdk/runtime-env").resetLogger;
 let setLoggerOverride: typeof import("openclaw/plugin-sdk/runtime-env").setLoggerOverride;
 
 const LOG_PATH = path.join(os.tmpdir(), `openclaw-inbound-media-${crypto.randomUUID()}.log`);
+const DIRECT_SYNTHETIC_BEARER = "synthetic-direct-bearer-never-real";
+const QUOTED_SYNTHETIC_API_KEY = "synthetic-quoted-api-key-never-real";
+const DEPLOYMENT_REDACTION_SENTINEL = "deployment-secret-never-real";
 
 async function waitForMessage(onMessage: ReturnType<typeof vi.fn>) {
   await vi.waitFor(() => expect(onMessage).toHaveBeenCalledTimes(1), {
@@ -339,6 +342,12 @@ describe("web inbound media saves with extension", () => {
 
   beforeAll(async () => {
     await fs.rm(HOME, { recursive: true, force: true });
+    const configDir = path.join(HOME, ".openclaw");
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(
+      path.join(configDir, "openclaw.json"),
+      JSON.stringify({ logging: { redactPatterns: ["deployment-secret-[a-z-]+"] } }),
+    );
     ({ resetLogger, setLoggerOverride } = await import("openclaw/plugin-sdk/runtime-env"));
     setLoggerOverride({ level: "trace", consoleLevel: "info", file: LOG_PATH });
     ({ monitorWebInbox, resetWebInboundDedupe } = await import("./inbound.js"));
@@ -637,7 +646,7 @@ describe("web inbound media saves with extension", () => {
     downloadMediaMessageMock.mockRejectedValueOnce(
       await createBaileysMediaHttpError(
         410,
-        "expired media reference +15551234567 111@s.whatsapp.net 789@hosted.lid 42@c.us",
+        `expired media reference +15551234567 111@s.whatsapp.net 789@hosted.lid 42@c.us Authorization: Bearer ${DIRECT_SYNTHETIC_BEARER} ${DEPLOYMENT_REDACTION_SENTINEL}`,
       ),
     );
     const onMessage = vi.fn();
@@ -694,6 +703,8 @@ describe("web inbound media saves with extension", () => {
     expect(diagnostic).not.toContain("111@s.whatsapp.net");
     expect(diagnostic).not.toContain("789@hosted.lid");
     expect(diagnostic).not.toContain("42@c.us");
+    expect(diagnostic).not.toContain(DIRECT_SYNTHETIC_BEARER);
+    expect(diagnostic).not.toContain(DEPLOYMENT_REDACTION_SENTINEL);
     const terminalDiagnostic = observedConsoleWarnings.mock.calls.find(
       ([message]) => message === "WhatsApp inbound media materialization failed",
     )?.[1]?.consoleMessage;
@@ -703,6 +714,8 @@ describe("web inbound media saves with extension", () => {
     expect(terminalDiagnostic).not.toContain("media.example/private");
     expect(terminalDiagnostic).not.toContain("789@hosted.lid");
     expect(terminalDiagnostic).not.toContain("42@c.us");
+    expect(terminalDiagnostic).not.toContain(DIRECT_SYNTHETIC_BEARER);
+    expect(terminalDiagnostic).not.toContain(DEPLOYMENT_REDACTION_SENTINEL);
 
     await listener.close();
   });
@@ -711,7 +724,7 @@ describe("web inbound media saves with extension", () => {
     downloadMediaMessageMock.mockRejectedValueOnce(
       await createBaileysMediaHttpError(
         410,
-        "quoted media reference expired 7@hosted 88@newsletter",
+        `quoted media reference expired 7@hosted 88@newsletter api_key=${QUOTED_SYNTHETIC_API_KEY} ${DEPLOYMENT_REDACTION_SENTINEL}`,
       ),
     );
     const onMessage = vi.fn();
@@ -759,6 +772,8 @@ describe("web inbound media saves with extension", () => {
     expect(diagnostic).toContain("quoted media reference expired");
     expect(diagnostic).not.toContain("7@hosted");
     expect(diagnostic).not.toContain("88@newsletter");
+    expect(diagnostic).not.toContain(QUOTED_SYNTHETIC_API_KEY);
+    expect(diagnostic).not.toContain(DEPLOYMENT_REDACTION_SENTINEL);
     const terminalDiagnostic = observedConsoleWarnings.mock.calls.find(
       ([message]) => message === "WhatsApp inbound media materialization failed",
     )?.[1]?.consoleMessage;
@@ -766,6 +781,8 @@ describe("web inbound media saves with extension", () => {
     expect(terminalDiagnostic).toContain("status=410");
     expect(terminalDiagnostic).not.toContain("7@hosted");
     expect(terminalDiagnostic).not.toContain("88@newsletter");
+    expect(terminalDiagnostic).not.toContain(QUOTED_SYNTHETIC_API_KEY);
+    expect(terminalDiagnostic).not.toContain(DEPLOYMENT_REDACTION_SENTINEL);
 
     await listener.close();
   });

--- a/extensions/whatsapp/src/inbound/message-enrichment.ts
+++ b/extensions/whatsapp/src/inbound/message-enrichment.ts
@@ -5,7 +5,7 @@ import {
   formatLocationText,
   type MediaPlaceholderTextFact,
 } from "openclaw/plugin-sdk/channel-inbound";
-import { createSubsystemLogger, redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
+import { createSubsystemLogger, redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { getStatusCode } from "../session-errors.js";
 import {
@@ -24,7 +24,7 @@ const MAX_MEDIA_ERROR_MESSAGE_CHARS = 256;
 
 function sanitizeMediaErrorMessage(error: unknown): string {
   const rawMessage = error instanceof Error ? error.message : String(error);
-  const redacted = redactSensitiveText(rawMessage)
+  const redacted = redactToolPayloadText(rawMessage)
     .replace(/https?:\/\/\S+/giu, "[redacted-url]")
     .replace(/\b[^@\s]+@[a-z][a-z\d.-]*\b/giu, "[redacted-jid]")
     .replace(/\+?\d[\d ().-]{6,}\d/gu, "[redacted-phone]");


### PR DESCRIPTION
Related: #117709, #117717

## What Problem This Solves

Fixes an issue where users with custom logging redaction patterns could see sensitive credential-like text in normal WhatsApp inbound attachment failure diagnostics.

## Why This Change Was Made

Reuse the existing public Plugin SDK sanitizer that always combines baseline credential protections with deployment-specific redaction rules. Keep sanitization in the WhatsApp inbound-media owner and preserve existing URL, phone, account-identifier, status, and structured-file logging behavior.

## User Impact

Failed direct and quoted WhatsApp attachment downloads remain visible and actionable without exposing credentials or dropping custom deployment redactions.

## Evidence

- Added failing-first direct and quoted WhatsApp inbound regressions using real configured custom patterns, the existing Baileys HTTP failure path, real message ingress, and harmless synthetic credential markers.
- Before the fix, both actual console-redaction assertions failed; after the two-line production change, both pass and existing URL/account redaction remains intact.
- Rebased onto current main and reran `node scripts/run-vitest.mjs extensions/whatsapp/src/inbound.media.test.ts`: **8 tests passed**.
- Existing targeted formatter and `git diff --check` clean.
- Independent fresh review: no P0–P2 findings.
- Mandatory fresh autoreview: `--mode uncommitted --thinking xhigh --max-priority P2`, clean.

### Real operator-visible production-runtime proof

Executed the exact pull-request production WhatsApp owner with the packaged public Plugin SDK, a real isolated custom logging configuration, real unmocked installed Baileys, and **two actual localhost HTTP 410 attachment requests**. No Vitest mocks, live user credentials, or real account data were involved.

```text
PROOF: exact-head production WhatsApp source + packaged public SDK + actual custom logging configuration
TRANSPORT: real Baileys localhost HTTP 410; requests=2
DIRECT OPERATOR WARNING: 03:13:04 [whatsapp] inbound media materialization failed (stage=direct kind=image status=410): Failed to fetch stream from [redacted-url]  Authorization: Bearer synthe…real deploy…real
QUOTED OPERATOR WARNING: 03:13:04 [whatsapp] inbound media materialization failed (stage=quoted kind=image status=410): Failed to fetch stream from [redacted-url]  api_key= synthe…real deploy…real
RESULT: bearer=false api_key=false deployment_marker=false unavailable_markers_preserved=true no_vitest_mocks=true
```

Both complete harmless credential markers and the configured deployment-specific marker are absent from real operator-visible warnings, while attachment failure notices remain present. This directly completes both requested ClawSweeper rank-up moves.