### PR TITLE
fix(gateway): preserve trusted CA certificates when reinstalling services

### DIFF
--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -271,6 +271,61 @@ describe("mergeInstallInvocationEnv", () => {
     expect(env.openai_api_key).toBeUndefined();
     expect(env.NODE_OPTIONS).toBeUndefined();
   });
+
+  it.each([
+    { platform: "darwin" as const, caKey: "NODE_EXTRA_CA_CERTS" },
+    { platform: "linux" as const, caKey: "NODE_EXTRA_CA_CERTS" },
+    { platform: "win32" as const, caKey: "node_extra_ca_certs" },
+  ])(
+    "preserves installed additive Node CA trust without unsafe overrides on $platform",
+    ({ platform, caKey }) => {
+      const env = mergeInstallInvocationEnv({
+        env: { PATH: "/usr/bin" },
+        existingServiceEnv: {
+          [caKey]: " /opt/openclaw/corporate-ca.pem ",
+          NODE_TLS_REJECT_UNAUTHORIZED: "0",
+          HTTPS_PROXY: "https://attacker.invalid",
+          NODE_OPTIONS: "--require /tmp/untrusted.js",
+          BASH_ENV: "/tmp/untrusted.sh",
+          LD_PRELOAD: "/tmp/untrusted.so",
+          OPENAI_API_KEY: "existing-service-key",
+        },
+        platform,
+      });
+
+      expectFields(env, {
+        NODE_EXTRA_CA_CERTS: "/opt/openclaw/corporate-ca.pem",
+        OPENAI_API_KEY: "existing-service-key",
+        PATH: "/usr/bin",
+      });
+      expect(env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+      expect(env.HTTPS_PROXY).toBeUndefined();
+      expect(env.NODE_OPTIONS).toBeUndefined();
+      expect(env.BASH_ENV).toBeUndefined();
+      expect(env.LD_PRELOAD).toBeUndefined();
+      if (platform === "win32") {
+        expect(env.node_extra_ca_certs).toBeUndefined();
+      }
+    },
+  );
+
+  it.each([
+    { platform: "darwin" as const, shellKey: "NODE_EXTRA_CA_CERTS" },
+    { platform: "win32" as const, shellKey: "node_extra_ca_certs" },
+  ])(
+    "lets the current shell override installed Node CA trust on $platform",
+    ({ platform, shellKey }) => {
+      const env = mergeInstallInvocationEnv({
+        env: { [shellKey]: "/opt/openclaw/current-shell-ca.pem" },
+        existingServiceEnv: {
+          NODE_EXTRA_CA_CERTS: "/opt/openclaw/previous-service-ca.pem",
+        },
+        platform,
+      });
+
+      expect(env.NODE_EXTRA_CA_CERTS).toBe("/opt/openclaw/current-shell-ca.pem");
+    },
+  );
 });
 
 describe("runDaemonInstall", () => {
@@ -803,6 +858,66 @@ describe("runDaemonInstall", () => {
       OPENCLAW_WRAPPER: "/usr/local/bin/openclaw-doppler",
     });
     expect(installDaemonServiceAndEmitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves generated-service CA trust without unsafe overrides during forced reinstall", async () => {
+    const extraCaCerts = "/opt/openclaw/corporate-ca.pem";
+    for (const key of [
+      "NODE_EXTRA_CA_CERTS",
+      "NODE_TLS_REJECT_UNAUTHORIZED",
+      "HTTPS_PROXY",
+      "NODE_OPTIONS",
+      "BASH_ENV",
+      "LD_PRELOAD",
+    ]) {
+      delete process.env[key];
+    }
+    service.isLoaded.mockResolvedValue(true);
+    service.readCommand.mockResolvedValue({
+      programArguments: ["openclaw", "gateway", "run"],
+      environment: {
+        NODE_EXTRA_CA_CERTS: extraCaCerts,
+        NODE_TLS_REJECT_UNAUTHORIZED: "0",
+        HTTPS_PROXY: "https://attacker.invalid",
+        NODE_OPTIONS: "--require /tmp/untrusted.js",
+        BASH_ENV: "/tmp/untrusted.sh",
+        LD_PRELOAD: "/tmp/untrusted.so",
+      },
+      environmentValueSources: {
+        NODE_EXTRA_CA_CERTS: "file",
+      },
+    } as never);
+    buildGatewayInstallPlanMock.mockImplementationOnce(async (params) => {
+      const plan = await createInstallPlanFixture(params);
+      return {
+        ...plan,
+        environment: {
+          ...plan.environment,
+          NODE_EXTRA_CA_CERTS: params?.env?.NODE_EXTRA_CA_CERTS ?? "/etc/ssl/cert.pem",
+        },
+      };
+    });
+    installDaemonServiceAndEmitMock.mockImplementationOnce(async (params?: unknown) => {
+      await (params as { install: () => Promise<void> }).install();
+    });
+
+    await runDaemonInstall({ json: true, force: true });
+
+    const installPlanArg = readFirstInstallPlanArg();
+    const installEnv = installPlanArg.env as Record<string, string | undefined>;
+    expect(installEnv.NODE_EXTRA_CA_CERTS).toBe(extraCaCerts);
+    expect(installEnv.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+    expect(installEnv.HTTPS_PROXY).toBeUndefined();
+    expect(installEnv.NODE_OPTIONS).toBeUndefined();
+    expect(installEnv.BASH_ENV).toBeUndefined();
+    expect(installEnv.LD_PRELOAD).toBeUndefined();
+    expectFields(installPlanArg.existingEnvironmentValueSources, {
+      NODE_EXTRA_CA_CERTS: "file",
+    });
+    const installCalls = service.install.mock.calls as unknown as Array<
+      [{ environment?: Record<string, string | undefined> }]
+    >;
+    expect(installCalls[0]?.[0].environment?.NODE_EXTRA_CA_CERTS).toBe(extraCaCerts);
   });
 
   it("reinstalls when wrapper command matches but wrapper env is missing", async () => {

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -123,9 +123,12 @@ export function mergeInstallInvocationEnv(params: {
     ) {
       continue;
     }
-    // Existing service env may contain host-specific secrets or loader overrides; keep only
-    // portable, non-dangerous values and let the current shell override them.
-    if (isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key)) {
+    // An installed CA file is additive, operator-owned Node startup trust; retain it on reinstall.
+    // Never replay service-owned TLS-disable, proxy, or loader overrides from the old environment.
+    if (
+      isDangerousHostEnvVarName(key) ||
+      (isDangerousHostEnvOverrideVarName(key) && upper !== "NODE_EXTRA_CA_CERTS")
+    ) {
       continue;
     }
     const value = rawValue.trim();

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1571,6 +1571,44 @@ describe("launchd install", () => {
     expect(command?.environmentValueSources?.OPENAI_API_KEY).toBe("file");
   });
 
+  it("retains custom Node CA trust when reinstalling a generated owner-only LaunchAgent", async () => {
+    const env = createDefaultLaunchdEnv();
+    const extraCaCerts = "/Users/test/certs/corporate-ca.pem";
+    const envFilePath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway.env";
+    const wrapperPath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
+
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+      environment: { NODE_EXTRA_CA_CERTS: extraCaCerts },
+    });
+
+    const installedCommand = await readLaunchAgentProgramArguments(env);
+    expect(installedCommand?.environment?.NODE_EXTRA_CA_CERTS).toBe(extraCaCerts);
+    expect(installedCommand?.environmentValueSources?.NODE_EXTRA_CA_CERTS).toBe("file");
+    const initialEnvWrites = countMatching(state.fileWrites, ({ path }) => path === envFilePath);
+
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+      environment: installedCommand?.environment,
+    });
+
+    const refreshedCommand = await readLaunchAgentProgramArguments(env);
+    expect(refreshedCommand?.environment?.NODE_EXTRA_CA_CERTS).toBe(extraCaCerts);
+    expect(refreshedCommand?.environmentValueSources?.NODE_EXTRA_CA_CERTS).toBe("file");
+    expect(countMatching(state.fileWrites, ({ path }) => path === envFilePath)).toBeGreaterThan(
+      initialEnvWrites,
+    );
+    expect(state.files.get(envFilePath)).toContain(`export NODE_EXTRA_CA_CERTS='${extraCaCerts}'`);
+    expect(state.files.get(resolveLaunchAgentPlistPath(env))).not.toContain(extraCaCerts);
+    expect(state.fileModes.get(envFilePath)).toBe(0o600);
+    expect(state.fileModes.get(wrapperPath)).toBe(0o700);
+    expect(state.dirModes.get("/Users/test/.openclaw/service-env")).toBe(0o700);
+  });
+
   it("warns before overwriting a customized generated LaunchAgent env wrapper", async () => {
     const env = createDefaultLaunchdEnv();
     const wrapperPath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";


### PR DESCRIPTION
Closes #86579

## What Problem This Solves

Fixes an issue where users reinstalling or upgrading an existing Gateway service lost their configured custom certificate-authority bundle, causing secure connections to fail after `openclaw gateway install --force`.

## Why This Change Was Made

Preserve only the existing installed service's additive `NODE_EXTRA_CA_CERTS` setting at the canonical service-installation owner. Continue rejecting inherited TLS-disable flags, proxy overrides, preload/injection settings, and other unsafe environment overrides; explicit settings from the current shell retain precedence.

## User Impact

Gateway upgrades and forced reinstalls preserve operator-configured private/company certificate trust without weakening TLS verification. The same owner-level behavior applies consistently to macOS, Linux, and Windows.

## Evidence

- Failing-first regressions reproduced four existing certificate-preservation failures before the production repair.
- Rebased onto current main and ran `node scripts/run-vitest.mjs src/cli/daemon-cli/install.test.ts src/daemon/launchd.test.ts`: **169 tests passed**.
- Exercises macOS, Linux, Windows variable casing, current-shell precedence, and the complete forced-install callback.
- Real generated macOS LaunchAgent install → read → reinstall proof preserves the custom CA in its owner-only `0600` environment file; wrapper/directory remain `0700`, and the CA path is absent from the plist.
- Explicit hostile-environment cases continue rejecting `NODE_TLS_REJECT_UNAUTHORIZED=0`, proxy overrides, `NODE_OPTIONS`, `BASH_ENV`, and `LD_PRELOAD`.
- Independent security review and fresh `autoreview --thinking xhigh --max-priority P2`: no actionable findings.