### PR TITLE
fix(diagnostics): read active assistant context from canonical SQLite sessions

### DIFF
--- a/src/logging/diagnostic-session-context.test.ts
+++ b/src/logging/diagnostic-session-context.test.ts
@@ -1,7 +1,11 @@
 // Diagnostic session context tests cover session context capture for diagnostics.
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendTranscriptMessageSync,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { saveCronStore } from "../cron/store.js";
 import {
   createOpenClawTestState,
@@ -16,9 +20,17 @@ import {
 let tempDir: string | undefined;
 let testState: OpenClawTestState | undefined;
 
-function writeJsonl(filePath: string, rows: unknown[]) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, rows.map((row) => JSON.stringify(row)).join("\n") + "\n");
+async function seedSessionTranscript(params: {
+  agentId: string;
+  sessionId: string;
+  sessionKey: string;
+  messages: unknown[];
+}) {
+  const { agentId, sessionId, sessionKey, messages } = params;
+  await replaceSessionEntry({ agentId, sessionKey }, { sessionId, updatedAt: 1 });
+  for (const message of messages) {
+    appendTranscriptMessageSync({ agentId, sessionId, sessionKey }, { message });
+  }
 }
 
 describe("diagnostic session context", () => {
@@ -63,18 +75,23 @@ describe("diagnostic session context", () => {
         },
       ],
     });
-    writeJsonl(path.join(stateDir, "agents", "clawblocker", "sessions", "run-456.jsonl"), [
-      { message: { role: "user", content: "run" } },
-      {
-        message: {
+    const sessionKey = "agent:clawblocker:cron:job-123:run:run-456";
+    await seedSessionTranscript({
+      agentId: "clawblocker",
+      sessionId: "run-456",
+      sessionKey,
+      messages: [
+        { role: "user", content: "run" },
+        {
           role: "assistant",
           content: [{ type: "text", text: "There are 40\ncached mentions ready." }],
         },
-      },
-    ]);
+      ],
+    });
 
     const context = resolveCronSessionDiagnosticContext({
-      sessionKey: "agent:clawblocker:cron:job-123:run:run-456",
+      sessionKey,
+      activeSessionId: "run-456",
     });
 
     expect(formatCronSessionDiagnosticFields(context)).toContain("cronJobId=job-123");
@@ -90,37 +107,115 @@ describe("diagnostic session context", () => {
     );
   });
 
-  it("reads the latest assistant message from a transcript tail", () => {
-    const filePath = path.join(tempDir!, "agents", "clawblocker", "sessions", "run-456.jsonl");
-    writeJsonl(filePath, [
-      { message: { role: "assistant", content: "older" } },
-      { message: { role: "user", content: "later user" } },
-      { message: { role: "assistant", content: "newer" } },
-    ]);
+  it("reads the latest visible app-agent assistant text from its SQLite transcript", async () => {
+    const sessionKey = "agent:oauth-agent:main";
+    await seedSessionTranscript({
+      agentId: "oauth-agent",
+      sessionId: "oauth-session",
+      sessionKey,
+      messages: [
+        { role: "assistant", content: "older reply" },
+        { role: "user", content: "later user" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "internal reasoning",
+              textSignature: JSON.stringify({ v: 1, id: "reasoning", phase: "commentary" }),
+            },
+            {
+              type: "text",
+              text: "latest visible reply",
+              textSignature: JSON.stringify({ v: 1, id: "reply", phase: "final_answer" }),
+            },
+          ],
+        },
+      ],
+    });
 
-    const realReadSync = fs.readSync.bind(fs);
-    let shortReadCalls = 0;
-    const readSpy = vi.spyOn(fs, "readSync").mockImplementation(((
-      fd: number,
-      buffer: NodeJS.ArrayBufferView,
-      offset: number,
-      length: number,
-      position: fs.ReadPosition | null,
-    ) => {
-      shortReadCalls += 1;
-      return realReadSync(fd, buffer, offset, Math.min(length, 16), position);
-    }) as typeof fs.readSync);
+    const context = resolveCronSessionDiagnosticContext({
+      sessionKey,
+      activeSessionId: "oauth-session",
+    });
 
-    try {
-      expect(
-        resolveCronSessionDiagnosticContext({
-          sessionKey: "agent:clawblocker:cron:job-123:run:run-456",
-        }).lastAssistant,
-      ).toBe("newer");
-      expect(shortReadCalls).toBeGreaterThan(1);
-    } finally {
-      readSpy.mockRestore();
-    }
+    expect(context.lastAssistant).toBe("latest visible reply");
+    expect(formatCronSessionDiagnosticFields(context)).toBe('lastAssistant="latest visible reply"');
+  });
+
+  it("requires the authoritative current session id before reading transcript text", async () => {
+    const sessionKey = "agent:oauth-agent:main";
+    await seedSessionTranscript({
+      agentId: "oauth-agent",
+      sessionId: "current-session",
+      sessionKey,
+      messages: [{ role: "assistant", content: "current private reply" }],
+    });
+
+    expect(
+      resolveCronSessionDiagnosticContext({
+        sessionKey,
+        activeSessionId: "rotated-session",
+      }).lastAssistant,
+    ).toBeUndefined();
+    expect(resolveCronSessionDiagnosticContext({ sessionKey }).lastAssistant).toBeUndefined();
+  });
+
+  it("keeps identical session ids isolated to their owning agents", async () => {
+    await seedSessionTranscript({
+      agentId: "main",
+      sessionId: "shared-session-id",
+      sessionKey: "agent:main:main",
+      messages: [{ role: "assistant", content: "main private reply" }],
+    });
+    await seedSessionTranscript({
+      agentId: "oauth-agent",
+      sessionId: "shared-session-id",
+      sessionKey: "agent:oauth-agent:main",
+      messages: [{ role: "assistant", content: "oauth private reply" }],
+    });
+
+    expect(
+      resolveCronSessionDiagnosticContext({
+        sessionKey: "agent:oauth-agent:main",
+        activeSessionId: "shared-session-id",
+      }).lastAssistant,
+    ).toBe("oauth private reply");
+  });
+
+  it("rejects malformed agent ids before resolving a default agent transcript", async () => {
+    await seedSessionTranscript({
+      agentId: "main",
+      sessionId: "main-session",
+      sessionKey: "agent:main:main",
+      messages: [{ role: "assistant", content: "main private reply" }],
+    });
+
+    expect(
+      resolveCronSessionDiagnosticContext({
+        sessionKey: "agent:../main:main",
+        activeSessionId: "main-session",
+      }),
+    ).toEqual({});
+  });
+
+  it("does not treat channel-owned cron segments as cron metadata", async () => {
+    const sessionKey = "agent:oauth-agent:slack:cron:job-123:run:run-456";
+    await seedSessionTranscript({
+      agentId: "oauth-agent",
+      sessionId: "slack-session",
+      sessionKey,
+      messages: [{ role: "assistant", content: "channel reply" }],
+    });
+
+    const context = resolveCronSessionDiagnosticContext({
+      sessionKey,
+      activeSessionId: "slack-session",
+    });
+
+    expect(context.lastAssistant).toBe("channel reply");
+    expect(context.cronJobId).toBeUndefined();
+    expect(context.cronRunId).toBeUndefined();
   });
 
   it("keeps bounded quoted fields UTF-16 safe", () => {
@@ -131,12 +226,22 @@ describe("diagnostic session context", () => {
     ).toBe(`cronJob="${prefix}..."`);
   });
 
-  it("ignores missing transcript tail files", () => {
+  it("does not create an agent database when its session store is missing", () => {
+    const databasePath = path.join(
+      tempDir!,
+      "agents",
+      "missing-agent",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    expect(fs.existsSync(databasePath)).toBe(false);
+
     expect(
       resolveCronSessionDiagnosticContext({
-        sessionKey: "agent:clawblocker:cron:job-123:run:run-456",
+        sessionKey: "agent:missing-agent:main",
         activeSessionId: "missing",
       }).lastAssistant,
     ).toBeUndefined();
+    expect(fs.existsSync(databasePath)).toBe(false);
   });
 });

--- a/src/logging/diagnostic-session-context.test.ts
+++ b/src/logging/diagnostic-session-context.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   appendTranscriptMessageSync,
+  readLatestTranscriptAssistantText,
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { saveCronStore } from "../cron/store.js";
@@ -25,9 +26,13 @@ async function seedSessionTranscript(params: {
   sessionId: string;
   sessionKey: string;
   messages: unknown[];
+  incognito?: boolean;
 }) {
-  const { agentId, sessionId, sessionKey, messages } = params;
-  await replaceSessionEntry({ agentId, sessionKey }, { sessionId, updatedAt: 1 });
+  const { agentId, sessionId, sessionKey, messages, incognito } = params;
+  await replaceSessionEntry(
+    { agentId, sessionKey },
+    { sessionId, updatedAt: 1, ...(incognito ? { incognito: true } : {}) },
+  );
   for (const message of messages) {
     appendTranscriptMessageSync({ agentId, sessionId, sessionKey }, { message });
   }
@@ -142,6 +147,32 @@ describe("diagnostic session context", () => {
     expect(context.lastAssistant).toBe("latest visible reply");
     expect(formatCronSessionDiagnosticFields(context)).toBe('lastAssistant="latest visible reply"');
   });
+
+  it.each(["dashboard", "subagent", "internal-session-effects"])(
+    "never exposes a %s incognito assistant reply to durable diagnostics",
+    async (sessionSurface) => {
+      const sessionKey = `agent:main:${sessionSurface}:incognito-private`;
+      const sessionId = `incognito-${sessionSurface}`;
+      const privateReply = `memory-only ${sessionSurface} reply`;
+      await seedSessionTranscript({
+        agentId: "main",
+        incognito: true,
+        sessionId,
+        sessionKey,
+        messages: [{ role: "assistant", content: privateReply }],
+      });
+
+      expect(
+        readLatestTranscriptAssistantText({ agentId: "main", sessionId, sessionKey })?.text,
+      ).toBe(privateReply);
+      expect(
+        resolveCronSessionDiagnosticContext({ sessionKey, activeSessionId: sessionId }),
+      ).toEqual({});
+      expect(
+        fs.existsSync(path.join(tempDir!, "agents", "main", "agent", "openclaw-agent.sqlite")),
+      ).toBe(false);
+    },
+  );
 
   it("requires the authoritative current session id before reading transcript text", async () => {
     const sessionKey = "agent:oauth-agent:main";

--- a/src/logging/diagnostic-session-context.ts
+++ b/src/logging/diagnostic-session-context.ts
@@ -1,16 +1,19 @@
 // Diagnostic session context helpers capture session metadata for support bundles.
-import fs from "node:fs";
-import path from "node:path";
-import { expectDefined } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { resolveStateDir } from "../config/paths.js";
+import {
+  loadSessionEntryReadOnly,
+  readLatestTranscriptAssistantText,
+} from "../config/sessions/session-accessor.js";
 import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
-import { readFileWindowFullySync } from "../infra/file-read.js";
+import {
+  isValidAgentId,
+  parseAgentSessionKey,
+  type ParsedAgentSessionKey,
+} from "../routing/session-key.js";
 
-const SESSION_TAIL_BYTES = 64 * 1024;
 const MAX_QUOTED_FIELD_CHARS = 140;
 
-type CronSessionContext = {
+type SessionDiagnosticContext = {
   agentId?: string;
   cronJobId?: string;
   cronRunId?: string;
@@ -27,114 +30,19 @@ function quoteLogField(value: string): string {
   return `"${truncated.replace(/["\\]/g, "\\$&")}"`;
 }
 
-function parseCronRunSessionKey(sessionKey?: string): {
-  agentId?: string;
+function parseCronRunSessionKey(parsed: ParsedAgentSessionKey): {
   cronJobId?: string;
   cronRunId?: string;
 } {
-  const parts = sessionKey?.trim().split(":") ?? [];
-  if (parts[0] !== "agent") {
+  const parts = parsed.rest.split(":");
+  if (parts[0] !== "cron" || !parts[1]) {
     return {};
   }
-  const cronIndex = parts.indexOf("cron");
-  if (cronIndex < 2) {
-    return {};
-  }
-  const runIndex = parts.indexOf("run", cronIndex + 2);
+  const runIndex = parts.indexOf("run", 2);
   return {
-    agentId: parts[1],
-    cronJobId: parts[cronIndex + 1],
+    cronJobId: parts[1],
     cronRunId: runIndex >= 0 ? parts[runIndex + 1] : undefined,
   };
-}
-
-function resolveSessionFile(params: {
-  agentId?: string;
-  cronRunId?: string;
-  activeSessionId?: string;
-}): string | undefined {
-  const agentId = params.agentId?.trim();
-  const runId = params.activeSessionId?.trim() || params.cronRunId?.trim();
-  if (!agentId || !runId) {
-    return undefined;
-  }
-  return path.join(resolveStateDir(), "agents", agentId, "sessions", `${runId}.jsonl`);
-}
-
-function readTailText(filePath: string): { text: string; truncated: boolean } | undefined {
-  let fd: number | undefined;
-  try {
-    const stat = fs.statSync(filePath);
-    if (!stat.isFile() || stat.size <= 0) {
-      return undefined;
-    }
-    const length = Math.min(stat.size, SESSION_TAIL_BYTES);
-    const start = Math.max(0, stat.size - length);
-    const buffer = Buffer.alloc(length);
-    fd = fs.openSync(filePath, "r");
-    const read = readFileWindowFullySync(fd, buffer, start);
-    return { text: buffer.subarray(0, read).toString("utf8"), truncated: start > 0 };
-  } catch {
-    return undefined;
-  } finally {
-    if (fd !== undefined) {
-      try {
-        fs.closeSync(fd);
-      } catch {
-        // best-effort diagnostic context only
-      }
-    }
-  }
-}
-
-function textFromContent(content: unknown): string | undefined {
-  if (typeof content === "string") {
-    return content;
-  }
-  if (!Array.isArray(content)) {
-    return undefined;
-  }
-  const texts = content
-    .map((part) => {
-      if (!part || typeof part !== "object") {
-        return undefined;
-      }
-      const text = (part as { text?: unknown }).text;
-      return typeof text === "string" ? text : undefined;
-    })
-    .filter((text): text is string => Boolean(text?.trim()));
-  return texts.length ? texts.join(" ") : undefined;
-}
-
-function readLastAssistantFromSessionFile(filePath: string | undefined): string | undefined {
-  if (!filePath) {
-    return undefined;
-  }
-  const tail = readTailText(filePath);
-  if (!tail?.text) {
-    return undefined;
-  }
-  const lines = tail.text.split(/\r?\n/).filter(Boolean);
-  if (tail.truncated && lines.length > 0) {
-    lines.shift();
-  }
-  for (let index = lines.length - 1; index >= 0; index -= 1) {
-    try {
-      const parsed = JSON.parse(expectDefined(lines[index], "lines entry at index")) as {
-        message?: { role?: unknown; content?: unknown };
-      };
-      if (parsed.message?.role !== "assistant") {
-        continue;
-      }
-      const text = textFromContent(parsed.message.content)?.trim();
-      if (text) {
-        return text;
-      }
-    } catch {
-      // Ignore partial or non-JSON diagnostic transcript lines.
-    }
-  }
-  return undefined;
 }
 
 function readCronJobName(cronJobId: string | undefined): string | undefined {
@@ -153,21 +61,40 @@ function readCronJobName(cronJobId: string | undefined): string | undefined {
 export function resolveCronSessionDiagnosticContext(params: {
   sessionKey?: string;
   activeSessionId?: string;
-}): CronSessionContext {
-  const parsed = parseCronRunSessionKey(params.sessionKey);
-  if (!parsed.cronJobId && !parsed.cronRunId) {
+}): SessionDiagnosticContext {
+  const sessionKey = params.sessionKey?.trim();
+  const parsedAgent = parseAgentSessionKey(sessionKey);
+  if (!sessionKey || !parsedAgent || !isValidAgentId(parsedAgent.agentId)) {
     return {};
   }
-  return {
-    ...parsed,
-    cronJobName: readCronJobName(parsed.cronJobId),
-    lastAssistant: readLastAssistantFromSessionFile(
-      resolveSessionFile({ ...parsed, activeSessionId: params.activeSessionId }),
-    ),
+  const cron = parseCronRunSessionKey(parsedAgent);
+  const context: SessionDiagnosticContext = {
+    agentId: parsedAgent.agentId,
+    ...cron,
+    ...(cron.cronJobId ? { cronJobName: readCronJobName(cron.cronJobId) } : {}),
   };
+  const activeSessionId = params.activeSessionId?.trim();
+  if (!activeSessionId) {
+    return context;
+  }
+
+  try {
+    const sessionScope = { agentId: parsedAgent.agentId, sessionKey };
+    // The read-only owner proves both identity and existence before transcript
+    // access, preventing rotated-session leaks and phantom agent databases.
+    if (loadSessionEntryReadOnly(sessionScope)?.sessionId === activeSessionId) {
+      context.lastAssistant = readLatestTranscriptAssistantText({
+        ...sessionScope,
+        sessionId: activeSessionId,
+      })?.text;
+    }
+  } catch {
+    // Session context is best-effort and must not interrupt diagnostics.
+  }
+  return context;
 }
 
-export function formatCronSessionDiagnosticFields(context: CronSessionContext): string {
+export function formatCronSessionDiagnosticFields(context: SessionDiagnosticContext): string {
   const fields: string[] = [];
   if (context.cronJobId) {
     fields.push(`cronJobId=${context.cronJobId}`);
@@ -184,7 +111,9 @@ export function formatCronSessionDiagnosticFields(context: CronSessionContext): 
   return fields.join(" ");
 }
 
-export function formatStoppedCronSessionDiagnosticFields(context: CronSessionContext): string {
+export function formatStoppedCronSessionDiagnosticFields(
+  context: SessionDiagnosticContext,
+): string {
   const fields: string[] = [];
   if (context.cronJobName) {
     fields.push(`stopped=${quoteLogField(context.cronJobName)}`);

--- a/src/logging/diagnostic-session-context.ts
+++ b/src/logging/diagnostic-session-context.ts
@@ -6,6 +6,7 @@ import {
 } from "../config/sessions/session-accessor.js";
 import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
 import {
+  isIncognitoSessionKey,
   isValidAgentId,
   parseAgentSessionKey,
   type ParsedAgentSessionKey,
@@ -63,6 +64,11 @@ export function resolveCronSessionDiagnosticContext(params: {
   activeSessionId?: string;
 }): SessionDiagnosticContext {
   const sessionKey = params.sessionKey?.trim();
+  // Incognito transcripts live only in memory; copying their replies into
+  // durable operator logs would bypass both persistence and sharing boundaries.
+  if (isIncognitoSessionKey(sessionKey)) {
+    return {};
+  }
   const parsedAgent = parseAgentSessionKey(sessionKey);
   if (!sessionKey || !parsedAgent || !isValidAgentId(parsedAgent.agentId)) {
     return {};

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -1,7 +1,10 @@
 // Stuck session recovery runtime tests cover recovery inspection and event output.
-import fs from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  appendTranscriptMessageSync,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { saveCronStore } from "../cron/store.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 
@@ -333,14 +336,14 @@ describe("stuck session recovery", () => {
           },
         ],
       });
-      fs.mkdirSync(path.join(tempDir, "agents", "clawblocker", "sessions"), {
-        recursive: true,
-      });
-      fs.writeFileSync(
-        path.join(tempDir, "agents", "clawblocker", "sessions", "run-456.jsonl"),
-        JSON.stringify({
-          message: { role: "assistant", content: "There are 40 cached mentions." },
-        }) + "\n",
+      const sessionKey = "agent:clawblocker:cron:job-123:run:run-456";
+      await replaceSessionEntry(
+        { agentId: "clawblocker", sessionKey },
+        { sessionId: "run-456", updatedAt: 1 },
+      );
+      appendTranscriptMessageSync(
+        { agentId: "clawblocker", sessionId: "run-456", sessionKey },
+        { message: { role: "assistant", content: "There are 40 cached mentions." } },
       );
       mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("run-456");
       mocks.abortEmbeddedAgentRun.mockReturnValue(true);
@@ -348,7 +351,7 @@ describe("stuck session recovery", () => {
 
       await recoverStuckDiagnosticSession({
         sessionId: "run-456",
-        sessionKey: "agent:clawblocker:cron:job-123:run:run-456",
+        sessionKey,
         ageMs: 629_000,
         allowActiveAbort: true,
       });

--- a/src/logging/diagnostic-support-export.test.ts
+++ b/src/logging/diagnostic-support-export.test.ts
@@ -93,6 +93,8 @@ describe("diagnostic support export", () => {
       "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
     ].join(".");
     const privateChat = "private user said diagnose my bank transfer";
+    const privateAssistantReply = "the reimbursement is approved for 420 credits";
+    const privateLogTapeAssistantReply = "the wire transfer clears on Thursday";
     const webhookBody = "raw webhook body with message contents";
     const requestAuthValue = "support-request-auth-value";
     const requestTlsPassphrase = "support-request-tls-passphrase";
@@ -224,6 +226,17 @@ describe("diagnostic support export", () => {
           msg: "user said structured secret payload",
         }),
         JSON.stringify({
+          time: "2026-04-22T12:00:00.250Z",
+          level: "warn",
+          subsystem: "diagnostic",
+          msg: `stuck session: lastAssistant="${privateAssistantReply}"`,
+        }),
+        JSON.stringify({
+          "0": `stalled session: lastAssistant="${privateLogTapeAssistantReply}"`,
+          _meta: { logLevelName: "warn", name: "diagnostic" },
+          time: "2026-04-22T12:00:00.275Z",
+        }),
+        JSON.stringify({
           "0": JSON.stringify({ subsystem: "gateway/channels/matrix" }),
           "1": privateChat,
           _meta: {
@@ -312,6 +325,8 @@ describe("diagnostic support export", () => {
     const combined = Object.values(entries).join("\n");
     expect(combined).not.toContain(fakeToken);
     expect(combined).not.toContain(privateChat);
+    expect(combined).not.toContain(privateAssistantReply);
+    expect(combined).not.toContain(privateLogTapeAssistantReply);
     expect(combined).not.toContain(webhookBody);
     expect(combined).not.toContain("15555551212");
     expect(combined).not.toContain("4444555566");
@@ -363,6 +378,8 @@ describe("diagnostic support export", () => {
     expect(sanitizedLogs).toContain('"omittedLogMessageBytes"');
     expect(sanitizedLogs).toContain('"omittedLogMessageCount"');
     expect(sanitizedLogs).not.toContain("private user said");
+    expect(sanitizedLogs).not.toContain(privateAssistantReply);
+    expect(sanitizedLogs).not.toContain(privateLogTapeAssistantReply);
     expect(sanitizedLogs).not.toContain("@support-user:matrix.example.com");
     expect(sanitizedLogs).not.toContain("support-host");
     expect(sanitizedLogs).toContain('"omitted":"unparsed"');

--- a/src/logging/diagnostic-support-log-redaction.ts
+++ b/src/logging/diagnostic-support-log-redaction.ts
@@ -14,7 +14,7 @@ const LOG_SCALAR_FIELD_RE =
 const OMITTED_LOG_FIELD_RE =
   /(?:authorization|body|chat|content|cookie|credential|detail|error|header|instruction|message|password|payload|prompt|result|secret|session[-_]?id|session[-_]?key|text|token|tool|transcript|url)/iu;
 const UNSAFE_LOG_MESSAGE_RE =
-  /(?:\b(?:ai response|assistant said|chat text|message contents|prompt|raw webhook body|tool output|tool result|transcript|user said|webhook body)\b|auto-responding\b.*:\s*["']|partial for\b.*:)/iu;
+  /(?:\blastAssistant\s*=|\b(?:ai response|assistant said|chat text|message contents|prompt|raw webhook body|tool output|tool result|transcript|user said|webhook body)\b|auto-responding\b.*:\s*["']|partial for\b.*:)/iu;
 const MAX_LOG_STRING_LENGTH = 240;
 const LOGTAPE_META_FIELD = "_meta";
 const LOGTAPE_ARG_FIELD_RE = /^\d+$/u;

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -3,12 +3,17 @@ import fs from "node:fs";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  appendTranscriptMessageSync,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import {
   emitDiagnosticEvent,
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
   setDiagnosticsEnabledForProcess,
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { withDiagnosticPhase } from "./diagnostic-phase.js";
 import {
   getDiagnosticSessionActivitySnapshot,
@@ -404,6 +409,38 @@ describe("stuck session diagnostics threshold", () => {
       { sessionId: "s1", sessionKey: "main", queueDepth: 0 },
       ["ageMs", "stateGeneration"],
     );
+  });
+
+  it("includes the current app-agent SQLite assistant reply in heartbeat diagnostics", async () => {
+    const openClawState = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-heartbeat-app-agent-",
+    });
+    const sessionKey = "agent:oauth-agent:main";
+    const sessionId = "oauth-session";
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+
+    try {
+      await replaceSessionEntry(
+        { agentId: "oauth-agent", sessionKey },
+        { sessionId, updatedAt: 1 },
+      );
+      appendTranscriptMessageSync(
+        { agentId: "oauth-agent", sessionId, sessionKey },
+        { message: { role: "assistant", content: "the reimbursement was approved" } },
+      );
+
+      startDiagnosticHeartbeat(
+        { diagnostics: { enabled: true } },
+        { recoverStuckSession: vi.fn() },
+      );
+      logSessionStateChange({ sessionId, sessionKey, state: "processing" });
+      vi.advanceTimersByTime(61_000);
+
+      expectLoggerMessageContaining(warnSpy, 'lastAssistant="the reimbursement was approved"');
+    } finally {
+      await openClawState.cleanup();
+    }
   });
 
   it("threads session files from heartbeat state into stuck-session recovery", () => {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -443,6 +443,41 @@ describe("stuck session diagnostics threshold", () => {
     }
   });
 
+  it("never copies an incognito assistant reply into durable heartbeat diagnostics", async () => {
+    const openClawState = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-heartbeat-incognito-",
+    });
+    const sessionKey = "agent:main:dashboard:incognito-private";
+    const sessionId = "incognito-private-session";
+    const privateReply = "memory-only personal reimbursement details";
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+
+    try {
+      await replaceSessionEntry(
+        { agentId: "main", sessionKey },
+        { sessionId, updatedAt: 1, incognito: true },
+      );
+      appendTranscriptMessageSync(
+        { agentId: "main", sessionId, sessionKey },
+        { message: { role: "assistant", content: privateReply } },
+      );
+
+      startDiagnosticHeartbeat(
+        { diagnostics: { enabled: true } },
+        { recoverStuckSession: vi.fn() },
+      );
+      logSessionStateChange({ sessionId, sessionKey, state: "processing" });
+      vi.advanceTimersByTime(61_000);
+
+      expectLoggerMessageContaining(warnSpy, `sessionKey=${sessionKey}`);
+      expectNoLoggerMessageContaining(warnSpy, privateReply);
+      expectNoLoggerMessageContaining(warnSpy, "lastAssistant=");
+    } finally {
+      await openClawState.cleanup();
+    }
+  });
+
   it("threads session files from heartbeat state into stuck-session recovery", () => {
     const recoverStuckSession = vi.fn();
     const sessionFile = "/tmp/openclaw-heartbeat-session.jsonl";

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1049,10 +1049,13 @@ export function logSessionAttention(
         ? "stalled session"
         : "long-running session";
   const activityFields = formatSessionActivityLogFields(activity);
-  const cronFields = formatCronSessionDiagnosticFields(
-    resolveCronSessionDiagnosticContext({ sessionKey: state.sessionKey }),
+  const sessionFields = formatCronSessionDiagnosticFields(
+    resolveCronSessionDiagnosticContext({
+      sessionKey: state.sessionKey,
+      activeSessionId: state.sessionId,
+    }),
   );
-  const detailFields = [activityFields, cronFields].filter(Boolean).join(" ");
+  const detailFields = [activityFields, sessionFields].filter(Boolean).join(" ");
   const message = `${label}: sessionId=${state.sessionId ?? "unknown"} sessionKey=${
     state.sessionKey ?? "unknown"
   } state=${params.state} age=${Math.round(params.ageMs / 1000)}s queueDepth=${


### PR DESCRIPTION
Closes #91505

## What Problem This Solves

Fixes an issue where operators diagnosing stuck app-agent or cron sessions could not see the latest legitimate assistant response because diagnostics rejected ordinary agent session keys and attempted to read retired JSONL transcript files instead of current SQLite-backed sessions.

The issue was incorrectly auto-closed after checking only a separate recovery-classification improvement; the actual missing transcript context remained reproducible.

## Why This Change Was Made

Route diagnostic transcript lookups through the existing canonical SQLite session accessor. Validate agent identity and the currently active session before reading, preserve cron metadata and recovery behavior, thread authoritative session IDs through heartbeat diagnostics, and ensure support exports omit private assistant text.

## User Impact

Stuck-session diagnostics again show the correct current assistant context for both app-agent and cron sessions without exposing another agent/session, creating phantom databases, or leaking conversation content into exported support bundles.

## Evidence

- Failing-first real SQLite regressions reproduced missing app-agent diagnostics, broken cron diagnostics/recovery, missing heartbeat context, and private assistant text in actual exported support ZIPs.
- After repair and the incognito privacy regression fix, `node scripts/run-vitest.mjs src/logging/diagnostic-session-context.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic.test.ts src/logging/diagnostic-support-export.test.ts src/config/sessions/incognito-session-transcript.test.ts src/state/openclaw-agent-db.incognito.test.ts --maxWorkers 1`: **134 tests passed across six suites**.
- Covers rotated session IDs, malformed agent IDs, identical IDs across distinct agents, missing database noncreation, canonical cron routing, final-answer visibility, and both named/LogTape support-log formats.
- Removes the obsolete JSONL runtime reader; no legacy fallback or SQLite schema changes.
- Targeted formatting/lint and `git diff --check` passed.
- Independent fresh owner/privacy review and explicit `autoreview --thinking xhigh --max-priority P2` both clean.


## Maintainer privacy decision and existing shipped contract

Keep the established, bounded `lastAssistant` field in local operator diagnostics for ordinary app-agent and cron sessions only. This is not a new operator authorization boundary: shipped `v2026.6.1` already emits the same quoted, 140-character `lastAssistant` field, and the existing `operator.read` scope already permits `chat.history`, `sessions.get`, and `sessions.preview` for ordinary sessions. Do not expose any incognito transcript: the canonical incognito-key classifier rejects dashboard, subagent, and internal-session-effects keys before any transcript or cron-store read. Their sessions remain administrator-only and in memory as documented in `docs/concepts/session.md`. Exported support bundles omit conversation text as required by `docs/gateway/diagnostics.md`; OpenTelemetry content capture remains opt-in.

## Real operator behavior and support export: exact head 9751c8b1c611

Executed the actual 30-second production diagnostics heartbeat against a real ordinary per-agent SQLite database, a real incognito `:memory:` database, the configured durable operator logger, and the actual default support ZIP exporter. No Vitest, mocks, fake timers, mocked storage, or substituted export path.

Actual ordinary-session operator log:

```text
stuck session: sessionId=synthetic-ordinary-session sessionKey=agent:oauth-agent:main state=processing age=210s queueDepth=0 reason=stale_session_state classification=stale_session_state lastAssistant="synthetic ordinary reimbursement 420" recovery=checking
```

Actual incognito-session operator log:

```text
stuck session: sessionId=synthetic-incognito-session sessionKey=agent:oauth-agent:dashboard:incognito-synthetic state=processing age=210s queueDepth=0 reason=stale_session_state classification=stale_session_state recovery=checking
```

- Ordinary assistant reply appears only in the intended local operator log.
- Incognito assistant reply never appears in the local operator log; the incognito warning contains no `lastAssistant` field.
- The generated support ZIP contains neither ordinary nor incognito assistant text; its sanitized diagnostics record is `{"omitted":"log-message","bytes":257,"count":1}`.
- Ordinary SQLite state exists on disk; incognito SQLite uses its live `:memory:` handle and creates no agent database.
- A recursive scan of every isolated state artifact, including the shared SQLite database and write-ahead log, finds zero occurrences of the dynamically generated incognito assistant reply.
- Failing-first regressions prove all three canonical incognito key families plus the actual heartbeat warning; final result: **134 passing tests** and a clean fresh `autoreview --thinking xhigh --max-priority P2`.
