### PR TITLE
fix(llama-cpp): clarify local model setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Docs: https://docs.openclaw.ai
 
 - **Browser extension relay CDP compat:** answer `Target.getBrowserContexts` so Puppeteer-based clients (chrome-devtools-mcp) can drive the paired Chrome without the remote-debugging permission prompt, serve DevTools-style `/json/list` target descriptors, and add `openclaw browser extension cdp` to print the relay endpoint plus auth header for external CDP clients.
 - **Local model setup:** advertise provider-owned Ollama, llama.cpp, and LM Studio setup choices to Control UI and macOS, retry unavailable LM Studio services in place, and verify the exact prepared model before showing success.
-- **llama.cpp setup:** present llama.cpp as an in-Gateway GGUF runtime, use one clear setup action, and state the recommended model download at the confirmation step instead of making it look like a remote connection.
 - **Control UI first-run setup:** continue verified model setup into Custodian, explain that the web app is ready without a channel, and offer an optional dismissible path to Channels.
 - **Fish Audio speech:** add hosted S2.1 synthesis with streaming, voice notes, voice discovery, and telephony, plus local Fish S2 Pro reference-voice streaming in native macOS Talk. Thanks @Conan-Scott for the earlier community-plugin implementation.
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - **Browser extension relay CDP compat:** answer `Target.getBrowserContexts` so Puppeteer-based clients (chrome-devtools-mcp) can drive the paired Chrome without the remote-debugging permission prompt, serve DevTools-style `/json/list` target descriptors, and add `openclaw browser extension cdp` to print the relay endpoint plus auth header for external CDP clients.
 - **Local model setup:** advertise provider-owned Ollama, llama.cpp, and LM Studio setup choices to Control UI and macOS, retry unavailable LM Studio services in place, and verify the exact prepared model before showing success.
+- **llama.cpp setup:** present llama.cpp as an in-Gateway GGUF runtime, use one clear setup action, and state the recommended model download at the confirmation step instead of making it look like a remote connection.
 - **Control UI first-run setup:** continue verified model setup into Custodian, explain that the web app is ready without a channel, and offer an optional dismissible path to Channels.
 - **Fish Audio speech:** add hosted S2.1 synthesis with streaming, voice notes, voice discovery, and telephony, plus local Fish S2 Pro reference-voice streaming in native macOS Talk. Thanks @Conan-Scott for the earlier community-plugin implementation.
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.

--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -75,7 +75,7 @@ describe("llama.cpp provider plugin", () => {
     expect(registerProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "llama-cpp",
-        label: "Local model (llama.cpp)",
+        label: "llama.cpp",
         createStreamFn: expect.any(Function),
         normalizeToolSchemas: expect.any(Function),
         inspectToolSchemas: expect.any(Function),

--- a/extensions/llama-cpp/index.ts
+++ b/extensions/llama-cpp/index.ts
@@ -24,7 +24,7 @@ export default definePluginEntry({
         {
           id: "local",
           label: LLAMA_CPP_PROVIDER_LABEL,
-          hint: "In-process local GGUF model (about 5.0 GB download; requires 16 GB RAM)",
+          hint: "Run one private GGUF model directly inside this Gateway",
           kind: "custom",
           appGuidedSetup: {
             detect: detectLlamaCppSetup,
@@ -59,15 +59,15 @@ export default definePluginEntry({
         setup: {
           choiceId: LLAMA_CPP_PROVIDER_ID,
           choiceLabel: LLAMA_CPP_PROVIDER_LABEL,
-          choiceHint: "In-process local model (about 5.0 GB download; requires 16 GB RAM)",
+          choiceHint: "Run one private GGUF model directly inside this Gateway",
           groupId: LLAMA_CPP_PROVIDER_ID,
           groupLabel: "Local llama.cpp",
           groupHint: "No API key required",
           methodId: "local",
         },
         modelPicker: {
-          label: "llama.cpp (local GGUF)",
-          hint: "Run a GGUF model in the OpenClaw process",
+          label: "llama.cpp",
+          hint: "Run a GGUF model directly inside OpenClaw",
           methodId: "local",
         },
       },

--- a/extensions/llama-cpp/openclaw.plugin.json
+++ b/extensions/llama-cpp/openclaw.plugin.json
@@ -29,9 +29,9 @@
       "method": "local",
       "choiceId": "llama-cpp",
       "appGuidedDiscovery": true,
-      "appGuidedActionLabel": "Review download",
-      "choiceLabel": "Local model (llama.cpp)",
-      "choiceHint": "Downloads an approximately 5.0 GB local model; requires 16 GB RAM",
+      "appGuidedActionLabel": "Set up model",
+      "choiceLabel": "llama.cpp",
+      "choiceHint": "Run one private GGUF model directly inside this Gateway",
       "groupId": "llama-cpp",
       "groupLabel": "Local llama.cpp",
       "groupHint": "No API key required"

--- a/extensions/llama-cpp/src/defaults.ts
+++ b/extensions/llama-cpp/src/defaults.ts
@@ -6,7 +6,7 @@ import type {
 } from "openclaw/plugin-sdk/provider-model-shared";
 
 export const LLAMA_CPP_PROVIDER_ID = "llama-cpp";
-export const LLAMA_CPP_PROVIDER_LABEL = "Local model (llama.cpp)";
+export const LLAMA_CPP_PROVIDER_LABEL = "llama.cpp";
 const LLAMA_CPP_LOCAL_AUTH_MARKER = "llama-cpp-local";
 const LLAMA_CPP_LOCAL_BASE_URL = "local://llama-cpp";
 

--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -125,7 +125,7 @@ describe("llama.cpp setup", () => {
 
     await expect(detectLlamaCppSetup({ config: configWithCache(), env: {} })).resolves.toEqual({
       modelRef: DEFAULT_LLAMA_CPP_MODEL_REF,
-      detail: "gemma-4-e4b-it-q4_k_m (downloaded)",
+      detail: "Ready locally",
     });
     expect(nodeLlamaMocks.createModelDownloader).not.toHaveBeenCalled();
     expect(nodeLlamaMocks.resolveModelFile).toHaveBeenCalledWith(
@@ -157,7 +157,7 @@ describe("llama.cpp setup", () => {
 
     await expect(detectLlamaCppSetup({ config, env: {} })).resolves.toEqual({
       modelRef: "llama-cpp/custom",
-      detail: "custom (downloaded)",
+      detail: "Ready locally",
     });
     expect(nodeLlamaMocks.resolveModelFile).toHaveBeenCalledWith(
       "hf:org/repo/model.gguf#release",
@@ -215,7 +215,7 @@ describe("llama.cpp setup", () => {
 
     expect(ctx.prompter.confirm).not.toHaveBeenCalled();
     expect(ctx.prompter.note).toHaveBeenCalledWith(
-      "This machine has 8 GB RAM; the bundled local model needs 16 GB+. Use Ollama/LM Studio with a smaller model, or a cloud provider.",
+      "This Gateway has 8 GB RAM; the recommended model needs 16 GB+. Use Ollama or LM Studio with a smaller model, configure an existing GGUF, or choose a cloud provider.",
       "Setup skipped",
     );
     expect(nodeLlamaMocks.createModelDownloader).not.toHaveBeenCalled();
@@ -240,7 +240,9 @@ describe("llama.cpp setup", () => {
     await expect(runLlamaCppSetup(ctx)).resolves.toEqual({ profiles: [] });
 
     expect(ctx.prompter.confirm).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining("about 5.0 GB") }),
+      expect.objectContaining({
+        message: expect.stringContaining("run it directly inside this Gateway"),
+      }),
     );
     expect(nodeLlamaMocks.createModelDownloader).not.toHaveBeenCalled();
   });

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -98,7 +98,7 @@ export async function detectLlamaCppSetup(ctx: ProviderAppGuidedSetupContext) {
       }
       return {
         modelRef: `${LLAMA_CPP_PROVIDER_ID}/${candidate.model.id}`,
-        detail: `${candidate.model.id} (downloaded)`,
+        detail: "Ready locally",
       };
     } catch {
       // Discovery is read-only: a missing model or native module is not a setup error.
@@ -148,13 +148,14 @@ export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<Provid
     const totalmemBytes = os.totalmem();
     if (!meetsLlamaCppDefaultModelRamFloor(totalmemBytes)) {
       await ctx.prompter.note(
-        `This machine has ${formatRamGb(totalmemBytes)} GB RAM; the bundled local model needs 16 GB+. Use Ollama/LM Studio with a smaller model, or a cloud provider.`,
+        `This Gateway has ${formatRamGb(totalmemBytes)} GB RAM; the recommended model needs 16 GB+. Use Ollama or LM Studio with a smaller model, configure an existing GGUF, or choose a cloud provider.`,
         "Setup skipped",
       );
       return { profiles: [] };
     }
     const consent = await ctx.prompter.confirm({
-      message: "Download Gemma 4 E4B IT Q4_K_M (about 5.0 GB) for local llama.cpp inference?",
+      message:
+        "OpenClaw will download Gemma 4 E4B IT Q4_K_M (about 5.0 GB) and run it directly inside this Gateway. Continue?",
       initialValue: false,
     });
     if (!consent) {

--- a/ui/src/components/wizard-step-controls.ts
+++ b/ui/src/components/wizard-step-controls.ts
@@ -19,6 +19,7 @@ type WizardStepControlsProps = {
   onAnswer: (value: unknown, includeValue?: boolean) => void;
   presentation?: "channels";
   answerLabel?: string;
+  confirmAffirmativeLabel?: string;
 };
 
 function stepClass(props: WizardStepControlsProps, name: string): string {
@@ -263,7 +264,7 @@ function renderConfirmStep(props: WizardStepControlsProps) {
           ?disabled=${props.busy}
           @click=${() => props.onAnswer(answer)}
         >
-          ${answer ? (props.answerLabel ?? t("common.yes")) : t("common.no")}
+          ${answer ? (props.confirmAffirmativeLabel ?? t("common.yes")) : t("common.no")}
         </button>`,
       )}
     </div>

--- a/ui/src/components/wizard-step-controls.ts
+++ b/ui/src/components/wizard-step-controls.ts
@@ -263,7 +263,7 @@ function renderConfirmStep(props: WizardStepControlsProps) {
           ?disabled=${props.busy}
           @click=${() => props.onAnswer(answer)}
         >
-          ${t(answer ? "common.yes" : "common.no")}
+          ${answer ? (props.answerLabel ?? t("common.yes")) : t("common.no")}
         </button>`,
       )}
     </div>

--- a/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
+++ b/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
@@ -27,9 +27,9 @@ const prepareOptions = [
   {
     id: "llama-cpp",
     brandId: "llama-cpp",
-    label: "Local model (llama.cpp)",
-    hint: "Download and run a private GGUF model",
-    actionLabel: "Review download",
+    label: "llama.cpp",
+    hint: "Run one private GGUF model directly inside this Gateway",
+    actionLabel: "Set up model",
   },
   {
     id: "lmstudio",
@@ -106,7 +106,7 @@ describeControlUiE2e("Control UI llama.cpp setup mocked Gateway E2E", () => {
                 id: "llama-cpp-consent",
                 type: "confirm",
                 message:
-                  "Download Gemma 4 E4B IT Q4_K_M (about 5.0 GB) for local llama.cpp inference?",
+                  "OpenClaw will download Gemma 4 E4B IT Q4_K_M (about 5.0 GB) and run it directly inside this Gateway. Continue?",
                 initialValue: false,
               },
             },
@@ -140,7 +140,7 @@ describeControlUiE2e("Control UI llama.cpp setup mocked Gateway E2E", () => {
       const response = await page.goto(`${server.baseUrl}settings/model-setup`);
       expect(response?.status()).toBe(200);
       const llamaCppRow = page.locator('[data-prepare-choice="llama-cpp"]');
-      await llamaCppRow.getByRole("button", { name: "Review download" }).waitFor();
+      await llamaCppRow.getByRole("button", { name: "Set up model" }).waitFor();
       await expect
         .poll(() => llamaCppRow.locator('[data-provider-icon="llamacpp"]').count())
         .toBe(1);
@@ -157,11 +157,11 @@ describeControlUiE2e("Control UI llama.cpp setup mocked Gateway E2E", () => {
         });
       }
 
-      await llamaCppRow.getByRole("button", { name: "Review download" }).click();
+      await llamaCppRow.getByRole("button", { name: "Set up model" }).click();
       const start = await gateway.waitForRequest("openclaw.setup.prepare.start");
       expect(start.params).toMatchObject({ authChoice: "llama-cpp" });
       await page.getByRole("heading", { name: "Set up a local model" }).waitFor();
-      await page.getByText("Download Gemma 4 E4B IT Q4_K_M").waitFor();
+      await page.getByText("OpenClaw will download Gemma 4 E4B IT Q4_K_M").waitFor();
 
       if (artifactDir) {
         await page.screenshot({
@@ -185,7 +185,7 @@ describeControlUiE2e("Control UI llama.cpp setup mocked Gateway E2E", () => {
           },
         ],
       });
-      await page.getByRole("button", { name: "Yes" }).click();
+      await page.getByRole("button", { name: "Continue" }).click();
       await page.getByRole("heading", { name: "Connection verified" }).waitFor();
       await expect
         .poll(() => page.locator(".model-setup-success").textContent())

--- a/ui/src/e2e/model-setup-lmstudio.e2e.test.ts
+++ b/ui/src/e2e/model-setup-lmstudio.e2e.test.ts
@@ -188,7 +188,7 @@ describeControlUiE2e("Control UI LM Studio setup mocked Gateway E2E", () => {
           },
         ],
       });
-      await page.getByRole("button", { name: "Yes" }).click();
+      await page.getByRole("button", { name: "Continue" }).click();
       await page.getByRole("heading", { name: "Connection verified" }).waitFor();
       await expect
         .poll(() => page.locator(".model-setup-success").textContent())

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -27,9 +27,9 @@ const localPrepareOptions = [
   {
     id: "llama-cpp",
     brandId: "llama-cpp",
-    label: "Local model (llama.cpp)",
-    hint: "Download and run a private GGUF model",
-    actionLabel: "Review download",
+    label: "llama.cpp",
+    hint: "Run one private GGUF model directly inside this Gateway",
+    actionLabel: "Set up model",
   },
   {
     id: "lmstudio",
@@ -447,7 +447,7 @@ describeControlUiE2e("Control UI Model Setup mocked Gateway E2E", () => {
         ],
         recommendedInstalls: [],
       });
-      await page.getByRole("button", { name: "Yes" }).click();
+      await page.getByRole("button", { name: "Continue" }).click();
       await page.getByRole("heading", { name: "Connection verified" }).waitFor();
       await expect
         .poll(() => page.locator(".model-setup-success").textContent())

--- a/ui/src/pages/channels/wizard-view.busy.test.ts
+++ b/ui/src/pages/channels/wizard-view.busy.test.ts
@@ -65,6 +65,7 @@ describe("renderChannelWizard busy controls", () => {
       confirm.container.querySelectorAll<HTMLButtonElement>(".channels-wizard__footer button"),
     );
     expect(confirmButtons).toHaveLength(2);
+    expect(confirmButtons.map((button) => button.textContent?.trim())).toEqual(["No", "Yes"]);
     expect(confirmButtons.every((button) => button.disabled)).toBe(true);
     confirmButtons.forEach((button) => button.click());
     expect(confirm.onAnswer).not.toHaveBeenCalled();

--- a/ui/src/pages/model-setup/configured-model.test.ts
+++ b/ui/src/pages/model-setup/configured-model.test.ts
@@ -53,7 +53,7 @@ describe("renderConfiguredModel", () => {
     },
     {
       brandId: "llama-cpp",
-      detail: "gemma-4-e4b-it-q4_k_m (downloaded)",
+      detail: "Ready locally",
       kind: "provider-auto:llama-cpp",
       label: "llama.cpp",
       modelRef: "llama-cpp/gemma-4-e4b-it-q4_k_m",
@@ -86,7 +86,8 @@ describe("renderConfiguredModel", () => {
     };
     const { container, onVerify } = mount(result);
 
-    expect(text(container)).toContain(`Selected model ${fixture.label} ${fixture.detail}`);
+    expect(text(container)).toContain(`Selected model ${fixture.label}`);
+    expect(text(container)).toContain(fixture.detail);
     expect(text(container)).toContain(`${fixture.label} isn’t responding.`);
     expect(text(container)).not.toContain("Change connection");
     const button = container.querySelector<HTMLButtonElement>("button");

--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -36,8 +36,8 @@ const detection: SystemAgentSetupDetectResult = {
     {
       id: "llama-cpp",
       brandId: "llama-cpp",
-      label: "Local model (llama.cpp)",
-      hint: "Download and run a private GGUF model",
+      label: "llama.cpp",
+      hint: "Run one private GGUF model directly inside this Gateway",
     },
     {
       id: "lmstudio",
@@ -400,7 +400,7 @@ describe("ModelSetupPage catalog icons", () => {
 
     await vi.waitFor(() => {
       expect(page.textContent).toContain(
-        "Local model (llama.cpp) did not expose a usable local model. Review the setup result, then retry.",
+        "llama.cpp did not expose a usable local model. Review the setup result, then retry.",
       );
     });
     expect(page.textContent).not.toContain("llama-cpp/persisted-before-verification");

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -1027,6 +1027,22 @@ describe("renderModelSetup", () => {
     const confirm = wizardStep({ id: "confirm", type: "confirm", message: "Continue?" });
     expect(text(confirm)).toContain("Yes");
     expect(text(confirm)).toContain("No");
+
+    const prepareConfirm = mount(
+      props({
+        wizard: {
+          phase: "step",
+          authChoice: "llama-cpp",
+          step: { id: "confirm", type: "confirm", message: "Set up this model?" },
+          busy: false,
+          validationError: null,
+        },
+        wizardMode: "prepare",
+      }),
+    );
+    expect(text(prepareConfirm)).toContain("Continue");
+    expect(text(prepareConfirm)).toContain("No");
+    expect(text(prepareConfirm)).not.toContain("Yes");
   });
 
   it.each(["multiselect", "action"] as const)("renders the %s wizard step", (type) => {

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -85,9 +85,9 @@ const detected: SystemAgentSetupDetectResult = {
     {
       id: "llama-cpp",
       brandId: "llama-cpp",
-      label: "Local model (llama.cpp)",
-      hint: "Download and run a private GGUF model",
-      actionLabel: "Review download",
+      label: "llama.cpp",
+      hint: "Run one private GGUF model directly inside this Gateway",
+      actionLabel: "Set up model",
     },
   ],
   recommendedInstalls: [
@@ -502,7 +502,7 @@ describe("renderModelSetup", () => {
       '[data-prepare-choice="llama-cpp"] button',
     );
     expect(ollama?.textContent).toContain("Choose connection");
-    expect(llamaCpp?.textContent).toContain("Review download");
+    expect(llamaCpp?.textContent).toContain("Set up model");
     expect(
       container.querySelector<HTMLButtonElement>('[data-prepare-choice="lmstudio"] button')
         ?.textContent,

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -159,7 +159,11 @@ function text(container: Element): string {
   return container.textContent?.replace(/\s+/gu, " ").trim() ?? "";
 }
 
-function wizardStep(step: WizardStep, value: unknown = step.initialValue): HTMLDivElement {
+function wizardStep(
+  step: WizardStep,
+  value: unknown = step.initialValue,
+  wizardMode: ModelSetupViewProps["wizardMode"] = "auth",
+): HTMLDivElement {
   return mount(
     props({
       wizard: {
@@ -169,6 +173,7 @@ function wizardStep(step: WizardStep, value: unknown = step.initialValue): HTMLD
         busy: false,
         validationError: null,
       },
+      wizardMode,
       wizardValue: value,
     }),
   );
@@ -1028,17 +1033,10 @@ describe("renderModelSetup", () => {
     expect(text(confirm)).toContain("Yes");
     expect(text(confirm)).toContain("No");
 
-    const prepareConfirm = mount(
-      props({
-        wizard: {
-          phase: "step",
-          authChoice: "llama-cpp",
-          step: { id: "confirm", type: "confirm", message: "Set up this model?" },
-          busy: false,
-          validationError: null,
-        },
-        wizardMode: "prepare",
-      }),
+    const prepareConfirm = wizardStep(
+      { id: "confirm", type: "confirm", message: "Set up this model?" },
+      undefined,
+      "prepare",
     );
     expect(text(prepareConfirm)).toContain("Continue");
     expect(text(prepareConfirm)).toContain("No");

--- a/ui/src/pages/model-setup/wizard-view.ts
+++ b/ui/src/pages/model-setup/wizard-view.ts
@@ -69,7 +69,7 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
                       value: props.value,
                       busy: props.state.busy,
                       inputId: WIZARD_TEXT_INPUT_ID,
-                      answerLabel:
+                      confirmAffirmativeLabel:
                         props.mode === "prepare" && props.state.step.type === "confirm"
                           ? t("modelSetup.wizard.continue")
                           : undefined,

--- a/ui/src/pages/model-setup/wizard-view.ts
+++ b/ui/src/pages/model-setup/wizard-view.ts
@@ -69,6 +69,10 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
                       value: props.value,
                       busy: props.state.busy,
                       inputId: WIZARD_TEXT_INPUT_ID,
+                      answerLabel:
+                        props.mode === "prepare" && props.state.step.type === "confirm"
+                          ? t("modelSetup.wizard.continue")
+                          : undefined,
                       onValueChange: props.onValueChange,
                       onAnswer: props.onAnswer,
                     })}
@@ -77,11 +81,21 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
                       : nothing}
                   `}
         </div>
-        <div class="model-setup-wizard__footer">
-          <button type="button" class="btn" @click=${canCancel ? props.onCancel : props.onClose}>
-            ${canCancel ? t("common.cancel") : t("common.close")}
-          </button>
-        </div>
+        ${props.mode === "prepare" &&
+        props.state.phase === "step" &&
+        props.state.step.type === "confirm"
+          ? nothing
+          : html`
+              <div class="model-setup-wizard__footer">
+                <button
+                  type="button"
+                  class="btn"
+                  @click=${canCancel ? props.onCancel : props.onClose}
+                >
+                  ${canCancel ? t("common.cancel") : t("common.close")}
+                </button>
+              </div>
+            `}
       </div>
     </openclaw-modal-dialog>
   `;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users setting up llama.cpp in Model Setup would see a generic "Local model" provider, a vague "Review download" action, and a confirmation dialog with overlapping Yes/No/Cancel semantics. The flow looked like another remote connection even though llama.cpp runs a GGUF model directly inside the Gateway.

## Why This Change Was Made

Present llama.cpp as its own local runtime, explain the in-Gateway execution boundary before setup, and state the recommended 5.0 GB model download at the consent step. Prepare-mode confirmations now use one clear No/Continue decision without a duplicate footer action. Existing configured-GGUF detection and model verification behavior remain unchanged.

## User Impact

Users can distinguish llama.cpp from Ollama and LM Studio immediately, understand what OpenClaw will download and where it runs, and move from consent to the standard verified/start-chat success state without ambiguous controls.

## Evidence

### Before

![Before: llama.cpp appears as a generic local model with a Review download action](https://gist.githubusercontent.com/vincentkoc/6eedcd518931d9de7cc0246f979371d0/raw/39e0b041f63d2766ff90ae877fe78db0cfa71ccc/llama-cpp-before.svg)

### After

![After: distinct Ollama, llama.cpp, and LM Studio choices with provider-specific actions](https://gist.githubusercontent.com/vincentkoc/6eedcd518931d9de7cc0246f979371d0/raw/0c0f0ff6429fcc77efba6a611558c6fea959c651/llama-cpp-provider-choice.svg)

![Explicit llama.cpp download and in-Gateway execution confirmation](https://gist.githubusercontent.com/vincentkoc/6eedcd518931d9de7cc0246f979371d0/raw/bf52d9c039b62626ba467ddb1960e5783b4f264c/llama-cpp-download-confirmation.svg)

![Verified llama.cpp model with Start chatting action](https://gist.githubusercontent.com/vincentkoc/6eedcd518931d9de7cc0246f979371d0/raw/602f9337db3711dab26f70c415e6ed1e025f34cc/llama-cpp-verified.svg)

### Live runtime proof

- Exercised the plugin's real `createLlamaCppStreamFn` through `node-llama-cpp` on Blacksmith Testbox with one 491 MB Qwen 2.5 0.5B Q4_K_M GGUF.
- Real reply: `LLAMA_CPP_READY`.
- Stream events: `start,text_start,text_delta,text_delta,text_delta,text_delta,text_end,done`.
- No model was loaded on the local operator machine. The remote model process exited after proof and the Testbox lease was stopped.

### Validation

- `node scripts/run-vitest.mjs extensions/llama-cpp/src/setup.test.ts extensions/llama-cpp/index.test.ts` — 24 passed.
- Model Setup unit coverage — 3 files, 52 passed.
- llama.cpp Model Setup mocked-Gateway E2E — 1 passed.
- LM Studio plus generic Model Setup E2E after shared confirmation-control change — 2 files, 6 passed.
- `OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30741007291
- Autoreview: clean, no accepted/actionable findings, patch correctness 0.99.
- Rebased cleanly onto `origin/main` at `0bc32f0f5cf5b2202ae0918a26b0a252c1b59495`; the intervening main changes overlapped only `CHANGELOG.md`.

- [x] AI-assisted
- [x] I understand the implementation and validation evidence
