### PR TITLE
refactor(google-meet): consolidate CLI resolution

### DIFF
--- a/extensions/google-meet/src/cli-artifact-commands.ts
+++ b/extensions/google-meet/src/cli-artifact-commands.ts
@@ -1,5 +1,7 @@
-import type { GoogleMeetCalendarLookupResult } from "./calendar.js";
-import type { GoogleMeetCliCommandContext } from "./cli-command-context.js";
+import {
+  addGoogleMeetArtifactOptions,
+  type GoogleMeetCliCommandContext,
+} from "./cli-command-context.js";
 import {
   buildGoogleMeetExportManifest,
   googleMeetExportFileNames,
@@ -18,48 +20,40 @@ import {
   writeStdoutLine,
 } from "./cli-shared.js";
 import { fetchGoogleMeetArtifacts, fetchGoogleMeetAttendance } from "./meet.js";
-import { resolveGoogleMeetAccessToken } from "./oauth.js";
+import { resolveArtifactQueryFromParams } from "./plugin-helpers.js";
+
+async function resolveCliArtifactQuery(
+  context: GoogleMeetCliCommandContext,
+  options: MeetArtifactOptions,
+) {
+  const { lateAfterMinutes, earlyBeforeMinutes, ...raw } =
+    context.resolveCliArtifactParams(options);
+  return {
+    ...(await resolveArtifactQueryFromParams(context.config, raw)),
+    lateAfterMinutes,
+    earlyBeforeMinutes,
+  };
+}
 
 export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommandContext): void {
   const params = context;
-  const { root, resolveArtifactTokenOptions, resolveMeetingForToken } = context;
+  const { root } = context;
 
-  root
-    .command("artifacts")
-    .description("List Meet conference records and available participant/artifact metadata")
-    .option("--meeting <value>", "Meet URL, meeting code, or spaces/{id}")
-    .option("--conference-record <name>", "Conference record name or id")
-    .option("--today", "Find a Meet link on today's calendar")
-    .option("--event <query>", "Find a matching calendar event with a Meet link")
-    .option("--calendar <id>", "Calendar id for --today or --event", "primary")
-    .option("--access-token <token>", "Access token override")
-    .option("--refresh-token <token>", "Refresh token override")
-    .option("--client-id <id>", "OAuth client id override")
-    .option("--client-secret <secret>", "OAuth client secret override")
-    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
-    .option("--page-size <n>", "Max resources per Meet API page")
-    .option("--all-conference-records", "Fetch every conference record for --meeting")
+  addGoogleMeetArtifactOptions(
+    root
+      .command("artifacts")
+      .description("List Meet conference records and available participant/artifact metadata"),
+  )
     .option("--no-transcript-entries", "Skip structured transcript entry lookup")
     .option("--include-doc-bodies", "Export linked transcript and smart-note Google Docs text")
     .option("--format <format>", "Output format: summary or markdown", "summary")
     .option("--output <path>", "Write output to a file instead of stdout")
     .option("--json", "Print JSON output", false)
     .action(async (options: MeetArtifactOptions) => {
-      const resolved = resolveArtifactTokenOptions(params.config, options);
-      const token = await resolveGoogleMeetAccessToken(resolved);
-      const meeting = resolved.conferenceRecord
-        ? resolved.meeting
-        : (
-            await resolveMeetingForToken({
-              config: params.config,
-              options,
-              accessToken: token.accessToken,
-              configuredMeeting: resolved.meeting,
-            })
-          ).meeting;
+      const resolved = await resolveCliArtifactQuery(params, options);
       const result = await fetchGoogleMeetArtifacts({
-        accessToken: token.accessToken,
-        meeting,
+        accessToken: resolved.token.accessToken,
+        meeting: resolved.meeting,
         conferenceRecord: resolved.conferenceRecord,
         pageSize: resolved.pageSize,
         includeTranscriptEntries: resolved.includeTranscriptEntries,
@@ -72,7 +66,7 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
           JSON.stringify(
             {
               ...result,
-              tokenSource: token.refreshed ? "refresh-token" : "cached-access-token",
+              tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
             },
             null,
             2,
@@ -90,25 +84,13 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
       writeArtifactsSummary(result);
       writeStdoutLine(
         "token source: %s",
-        token.refreshed ? "refresh-token" : "cached-access-token",
+        resolved.token.refreshed ? "refresh-token" : "cached-access-token",
       );
     });
 
-  root
-    .command("attendance")
-    .description("List Meet participants and participant sessions")
-    .option("--meeting <value>", "Meet URL, meeting code, or spaces/{id}")
-    .option("--conference-record <name>", "Conference record name or id")
-    .option("--today", "Find a Meet link on today's calendar")
-    .option("--event <query>", "Find a matching calendar event with a Meet link")
-    .option("--calendar <id>", "Calendar id for --today or --event", "primary")
-    .option("--access-token <token>", "Access token override")
-    .option("--refresh-token <token>", "Refresh token override")
-    .option("--client-id <id>", "OAuth client id override")
-    .option("--client-secret <secret>", "OAuth client secret override")
-    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
-    .option("--page-size <n>", "Max resources per Meet API page")
-    .option("--all-conference-records", "Fetch every conference record for --meeting")
+  addGoogleMeetArtifactOptions(
+    root.command("attendance").description("List Meet participants and participant sessions"),
+  )
     .option("--no-merge-duplicates", "Keep duplicate participant resources as separate rows")
     .option("--late-after-minutes <n>", "Mark participants late after this many minutes", "5")
     .option("--early-before-minutes <n>", "Mark early leavers before this many minutes", "5")
@@ -116,21 +98,10 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
     .option("--output <path>", "Write output to a file instead of stdout")
     .option("--json", "Print JSON output", false)
     .action(async (options: MeetArtifactOptions) => {
-      const resolved = resolveArtifactTokenOptions(params.config, options);
-      const token = await resolveGoogleMeetAccessToken(resolved);
-      const meeting = resolved.conferenceRecord
-        ? resolved.meeting
-        : (
-            await resolveMeetingForToken({
-              config: params.config,
-              options,
-              accessToken: token.accessToken,
-              configuredMeeting: resolved.meeting,
-            })
-          ).meeting;
+      const resolved = await resolveCliArtifactQuery(params, options);
       const result = await fetchGoogleMeetAttendance({
-        accessToken: token.accessToken,
-        meeting,
+        accessToken: resolved.token.accessToken,
+        meeting: resolved.meeting,
         conferenceRecord: resolved.conferenceRecord,
         pageSize: resolved.pageSize,
         allConferenceRecords: resolved.allConferenceRecords,
@@ -144,7 +115,7 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
           JSON.stringify(
             {
               ...result,
-              tokenSource: token.refreshed ? "refresh-token" : "cached-access-token",
+              tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
             },
             null,
             2,
@@ -166,25 +137,15 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
       writeAttendanceSummary(result);
       writeStdoutLine(
         "token source: %s",
-        token.refreshed ? "refresh-token" : "cached-access-token",
+        resolved.token.refreshed ? "refresh-token" : "cached-access-token",
       );
     });
 
-  root
-    .command("export")
-    .description("Write Meet artifacts, attendance, transcript, and raw JSON into a folder")
-    .option("--meeting <value>", "Meet URL, meeting code, or spaces/{id}")
-    .option("--conference-record <name>", "Conference record name or id")
-    .option("--today", "Find a Meet link on today's calendar")
-    .option("--event <query>", "Find a matching calendar event with a Meet link")
-    .option("--calendar <id>", "Calendar id for --today or --event", "primary")
-    .option("--access-token <token>", "Access token override")
-    .option("--refresh-token <token>", "Refresh token override")
-    .option("--client-id <id>", "OAuth client id override")
-    .option("--client-secret <secret>", "OAuth client secret override")
-    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
-    .option("--page-size <n>", "Max resources per Meet API page")
-    .option("--all-conference-records", "Fetch every conference record for --meeting")
+  addGoogleMeetArtifactOptions(
+    root
+      .command("export")
+      .description("Write Meet artifacts, attendance, transcript, and raw JSON into a folder"),
+  )
     .option("--no-transcript-entries", "Skip structured transcript entry lookup")
     .option("--include-doc-bodies", "Export linked transcript and smart-note Google Docs text")
     .option("--no-merge-duplicates", "Keep duplicate participant resources as separate rows")
@@ -195,20 +156,10 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
     .option("--dry-run", "Fetch export data and print the manifest without writing files", false)
     .option("--json", "Print JSON output", false)
     .action(async (options: MeetArtifactOptions) => {
-      const resolved = resolveArtifactTokenOptions(params.config, options);
-      const token = await resolveGoogleMeetAccessToken(resolved);
-      const meetingResult: { meeting?: string; calendarEvent?: GoogleMeetCalendarLookupResult } =
-        resolved.conferenceRecord
-          ? { meeting: resolved.meeting }
-          : await resolveMeetingForToken({
-              config: params.config,
-              options,
-              accessToken: token.accessToken,
-              configuredMeeting: resolved.meeting,
-            });
+      const resolved = await resolveCliArtifactQuery(params, options);
       const artifacts = await fetchGoogleMeetArtifacts({
-        accessToken: token.accessToken,
-        meeting: meetingResult.meeting,
+        accessToken: resolved.token.accessToken,
+        meeting: resolved.meeting,
         conferenceRecord: resolved.conferenceRecord,
         pageSize: resolved.pageSize,
         includeTranscriptEntries: resolved.includeTranscriptEntries,
@@ -216,8 +167,8 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
         includeDocumentBodies: resolved.includeDocumentBodies,
       });
       const attendance = await fetchGoogleMeetAttendance({
-        accessToken: token.accessToken,
-        meeting: meetingResult.meeting,
+        accessToken: resolved.token.accessToken,
+        meeting: resolved.meeting,
         conferenceRecord: resolved.conferenceRecord,
         pageSize: resolved.pageSize,
         allConferenceRecords: resolved.allConferenceRecords,
@@ -225,15 +176,14 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
         lateAfterMinutes: resolved.lateAfterMinutes,
         earlyBeforeMinutes: resolved.earlyBeforeMinutes,
       });
-      const resolvedMeeting = meetingResult.meeting ?? resolved.meeting;
       const request: GoogleMeetExportRequest = {
-        ...(resolvedMeeting ? { meeting: resolvedMeeting } : {}),
+        ...(resolved.meeting ? { meeting: resolved.meeting } : {}),
         ...(resolved.conferenceRecord ? { conferenceRecord: resolved.conferenceRecord } : {}),
-        ...(meetingResult.calendarEvent?.event.id
-          ? { calendarEventId: meetingResult.calendarEvent.event.id }
+        ...(resolved.calendarEvent?.event.id
+          ? { calendarEventId: resolved.calendarEvent.event.id }
           : {}),
-        ...(meetingResult.calendarEvent?.event.summary
-          ? { calendarEventSummary: meetingResult.calendarEvent.event.summary }
+        ...(resolved.calendarEvent?.event.summary
+          ? { calendarEventSummary: resolved.calendarEvent.event.summary }
           : {}),
         ...(options.calendar ? { calendarId: options.calendar } : {}),
         ...(resolved.pageSize !== undefined ? { pageSize: resolved.pageSize } : {}),
@@ -256,11 +206,11 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
             attendance,
             files: googleMeetExportFileNames(),
             request,
-            tokenSource: token.refreshed ? "refresh-token" : "cached-access-token",
-            ...(meetingResult.calendarEvent ? { calendarEvent: meetingResult.calendarEvent } : {}),
+            tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
+            ...(resolved.calendarEvent ? { calendarEvent: resolved.calendarEvent } : {}),
           }),
-          ...(meetingResult.calendarEvent ? { calendarEvent: meetingResult.calendarEvent } : {}),
-          tokenSource: token.refreshed ? "refresh-token" : "cached-access-token",
+          ...(resolved.calendarEvent ? { calendarEvent: resolved.calendarEvent } : {}),
+          tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
         });
         return;
       }
@@ -270,13 +220,13 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
         attendance,
         zip: Boolean(options.zip),
         request,
-        tokenSource: token.refreshed ? "refresh-token" : "cached-access-token",
-        ...(meetingResult.calendarEvent ? { calendarEvent: meetingResult.calendarEvent } : {}),
+        tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
+        ...(resolved.calendarEvent ? { calendarEvent: resolved.calendarEvent } : {}),
       });
       const payload = {
         ...bundle,
-        ...(meetingResult.calendarEvent ? { calendarEvent: meetingResult.calendarEvent } : {}),
-        tokenSource: token.refreshed ? "refresh-token" : "cached-access-token",
+        ...(resolved.calendarEvent ? { calendarEvent: resolved.calendarEvent } : {}),
+        tokenSource: resolved.token.refreshed ? "refresh-token" : "cached-access-token",
       };
       if (options.json) {
         writeStdoutJson(payload);

--- a/extensions/google-meet/src/cli-command-context.ts
+++ b/extensions/google-meet/src/cli-command-context.ts
@@ -1,26 +1,40 @@
 import type { Command } from "commander";
 import type { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
-import type { GoogleMeetCalendarLookupResult } from "./calendar.js";
 import type { CreateOptions, MeetArtifactOptions, ResolveSpaceOptions } from "./cli-shared.js";
 import type { GoogleMeetConfig } from "./config.js";
 import type { GoogleMeetRuntime } from "./runtime.js";
 
-type GoogleMeetOAuthTokenOptions = {
-  clientId?: string;
-  clientSecret?: string;
-  refreshToken?: string;
-  accessToken?: string;
-  expiresAt?: number;
-};
+export function addGoogleMeetOAuthOptions(command: Command): Command {
+  return command
+    .option("--access-token <token>", "Access token override")
+    .option("--refresh-token <token>", "Refresh token override")
+    .option("--client-id <id>", "OAuth client id override")
+    .option("--client-secret <secret>", "OAuth client secret override")
+    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds");
+}
 
-type GoogleMeetArtifactTokenOptions = GoogleMeetOAuthTokenOptions & {
-  meeting?: string;
-  conferenceRecord?: string;
-  pageSize?: number;
-  includeTranscriptEntries?: boolean;
-  allConferenceRecords?: boolean;
-  includeDocumentBodies?: boolean;
-  mergeDuplicateParticipants?: boolean;
+export function addGoogleMeetMeetingOption(command: Command): Command {
+  return command.option("--meeting <value>", "Meet URL, meeting code, or spaces/{id}");
+}
+
+export function addGoogleMeetCalendarOptions(command: Command): Command {
+  return command
+    .option("--today", "Find a Meet link on today's calendar")
+    .option("--event <query>", "Find a matching calendar event with a Meet link")
+    .option("--calendar <id>", "Calendar id for --today or --event", "primary");
+}
+
+export function addGoogleMeetArtifactOptions(command: Command): Command {
+  const withMeeting = addGoogleMeetMeetingOption(command).option(
+    "--conference-record <name>",
+    "Conference record name or id",
+  );
+  return addGoogleMeetOAuthOptions(addGoogleMeetCalendarOptions(withMeeting))
+    .option("--page-size <n>", "Max resources per Meet API page")
+    .option("--all-conference-records", "Fetch every conference record for --meeting");
+}
+
+type GoogleMeetCliArtifactParams = Record<string, unknown> & {
   lateAfterMinutes?: number;
   earlyBeforeMinutes?: number;
 };
@@ -32,23 +46,7 @@ export type GoogleMeetCliCommandContext = {
   callGateway: typeof callGatewayFromCli;
   operationTimeoutMs: number;
   resolveMeetingInput: (config: GoogleMeetConfig, value?: string) => string;
-  resolveOAuthTokenOptions: (
-    config: GoogleMeetConfig,
-    options: ResolveSpaceOptions,
-  ) => GoogleMeetOAuthTokenOptions;
-  resolveTokenOptions: (
-    config: GoogleMeetConfig,
-    options: ResolveSpaceOptions,
-  ) => GoogleMeetOAuthTokenOptions & { meeting: string };
-  resolveMeetingForToken: (params: {
-    config: GoogleMeetConfig;
-    options: ResolveSpaceOptions;
-    accessToken: string;
-    configuredMeeting?: string;
-  }) => Promise<{ meeting: string; calendarEvent?: GoogleMeetCalendarLookupResult }>;
-  resolveArtifactTokenOptions: (
-    config: GoogleMeetConfig,
-    options: MeetArtifactOptions,
-  ) => GoogleMeetArtifactTokenOptions;
+  resolveCliParams: (options: ResolveSpaceOptions) => Record<string, unknown>;
+  resolveCliArtifactParams: (options: MeetArtifactOptions) => GoogleMeetCliArtifactParams;
   hasCreateOAuth: (config: GoogleMeetConfig, options: CreateOptions) => boolean;
 };

--- a/extensions/google-meet/src/cli-space-commands.ts
+++ b/extensions/google-meet/src/cli-space-commands.ts
@@ -1,5 +1,10 @@
 import { buildGoogleMeetCalendarDayWindow, listGoogleMeetCalendarEvents } from "./calendar.js";
-import type { GoogleMeetCliCommandContext } from "./cli-command-context.js";
+import {
+  addGoogleMeetCalendarOptions,
+  addGoogleMeetMeetingOption,
+  addGoogleMeetOAuthOptions,
+  type GoogleMeetCliCommandContext,
+} from "./cli-command-context.js";
 import { writeCalendarEventsSummary, writeLatestConferenceRecordSummary } from "./cli-export.js";
 import {
   callGoogleMeetGateway,
@@ -14,10 +19,59 @@ import {
   buildGoogleMeetPreflightReport,
   createGoogleMeetSpace,
   endGoogleMeetActiveConference,
-  fetchGoogleMeetSpace,
   fetchLatestGoogleMeetConferenceRecord,
 } from "./meet.js";
-import { resolveGoogleMeetAccessToken } from "./oauth.js";
+import {
+  resolveGoogleMeetTokenFromParams,
+  resolveMeetingFromParams,
+  resolveSpaceFromParams,
+} from "./plugin-helpers.js";
+
+type GoogleMeetCreateOutput = {
+  browser?: {
+    nodeId?: string;
+    targetId?: string;
+    browserUrl?: string;
+    browserTitle?: string;
+  };
+  joined?: boolean;
+  join?: { session?: { id?: string } };
+  meetingUri?: string;
+  source?: string;
+  space?: { name?: string; meetingCode?: string };
+  tokenSource?: string;
+};
+
+function writeGoogleMeetCreateOutput(
+  payload: GoogleMeetCreateOutput,
+  json: boolean | undefined,
+): void {
+  if (json) {
+    writeStdoutJson(payload);
+    return;
+  }
+  writeStdoutLine("meeting uri: %s", payload.meetingUri);
+  if (payload.space?.name) {
+    writeStdoutLine("space: %s", payload.space.name);
+  }
+  if (payload.space?.meetingCode) {
+    writeStdoutLine("meeting code: %s", payload.space.meetingCode);
+  }
+  if (payload.source) {
+    writeStdoutLine("source: %s", payload.source);
+  }
+  if (payload.browser?.nodeId) {
+    writeStdoutLine("node: %s", payload.browser.nodeId);
+  }
+  if (payload.tokenSource) {
+    writeStdoutLine("token source: %s", payload.tokenSource);
+  }
+  const joinedSessionId = payload.joined ? payload.join?.session?.id : undefined;
+  writeStdoutLine(
+    joinedSessionId ? "joined: %s" : "joined: no (run `openclaw googlemeet join %s`)",
+    joinedSessionId ?? payload.meetingUri,
+  );
+}
 
 export function registerGoogleMeetCreateCommands(context: GoogleMeetCliCommandContext): void {
   const params = context;
@@ -27,17 +81,12 @@ export function registerGoogleMeetCreateCommands(context: GoogleMeetCliCommandCo
     operationTimeoutMs,
     hasCreateOAuth,
     resolveMeetingInput,
-    resolveOAuthTokenOptions,
+    resolveCliParams,
   } = context;
 
-  root
-    .command("create")
-    .description("Create a new Google Meet space and print its meeting URL")
-    .option("--access-token <token>", "Access token override")
-    .option("--refresh-token <token>", "Refresh token override")
-    .option("--client-id <id>", "OAuth client id override")
-    .option("--client-secret <secret>", "OAuth client secret override")
-    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
+  addGoogleMeetOAuthOptions(
+    root.command("create").description("Create a new Google Meet space and print its meeting URL"),
+  )
     .option(
       "--access-type <type>",
       "Google Meet SpaceConfig accessType for API create: OPEN, TRUSTED, or RESTRICTED",
@@ -72,31 +121,7 @@ export function registerGoogleMeetCreateCommands(context: GoogleMeetCliCommandCo
             space?: { name?: string; meetingCode?: string };
             tokenSource?: string;
           };
-          if (options.json) {
-            writeStdoutJson(payload);
-            return;
-          }
-          writeStdoutLine("meeting uri: %s", payload.meetingUri);
-          if (payload.space?.name) {
-            writeStdoutLine("space: %s", payload.space.name);
-          }
-          if (payload.space?.meetingCode) {
-            writeStdoutLine("meeting code: %s", payload.space.meetingCode);
-          }
-          if (payload.source) {
-            writeStdoutLine("source: %s", payload.source);
-          }
-          if (payload.browser?.nodeId) {
-            writeStdoutLine("node: %s", payload.browser.nodeId);
-          }
-          if (payload.tokenSource) {
-            writeStdoutLine("token source: %s", payload.tokenSource);
-          }
-          if (payload.joined && payload.join?.session?.id) {
-            writeStdoutLine("joined: %s", payload.join.session.id);
-          } else {
-            writeStdoutLine("joined: no (run `openclaw googlemeet join %s`)", payload.meetingUri);
-          }
+          writeGoogleMeetCreateOutput(payload, options.json);
           return;
         }
       }
@@ -120,34 +145,26 @@ export function registerGoogleMeetCreateCommands(context: GoogleMeetCliCommandCo
                 dtmfSequence: options.dtmfSequence,
               })
             : undefined;
-        const payload = {
-          source: result.source,
-          meetingUri: result.meetingUri,
-          joined: Boolean(join),
-          ...(join ? { join } : {}),
-          browser: {
-            nodeId: result.nodeId,
-            targetId: result.targetId,
-            browserUrl: result.browserUrl,
-            browserTitle: result.browserTitle,
+        writeGoogleMeetCreateOutput(
+          {
+            source: result.source,
+            meetingUri: result.meetingUri,
+            joined: Boolean(join),
+            ...(join ? { join } : {}),
+            browser: {
+              nodeId: result.nodeId,
+              targetId: result.targetId,
+              browserUrl: result.browserUrl,
+              browserTitle: result.browserTitle,
+            },
           },
-        };
-        if (options.json) {
-          writeStdoutJson(payload);
-          return;
-        }
-        writeStdoutLine("meeting uri: %s", result.meetingUri);
-        writeStdoutLine("source: browser");
-        writeStdoutLine("node: %s", result.nodeId);
-        if (join) {
-          writeStdoutLine("joined: %s", join.session.id);
-        } else {
-          writeStdoutLine("joined: no (run `openclaw googlemeet join %s`)", result.meetingUri);
-        }
+          options.json,
+        );
         return;
       }
-      const token = await resolveGoogleMeetAccessToken(
-        resolveOAuthTokenOptions(params.config, options),
+      const token = await resolveGoogleMeetTokenFromParams(
+        params.config,
+        resolveCliParams(options),
       );
       const result = await createGoogleMeetSpace({
         accessToken: token.accessToken,
@@ -167,44 +184,28 @@ export function registerGoogleMeetCreateCommands(context: GoogleMeetCliCommandCo
               dtmfSequence: options.dtmfSequence,
             })
           : undefined;
-      if (options.json) {
-        writeStdoutJson({
+      writeGoogleMeetCreateOutput(
+        {
           ...result,
           tokenSource: token.refreshed ? "refresh-token" : "cached-access-token",
           joined: Boolean(join),
           ...(join ? { join } : {}),
-        });
-        return;
-      }
-      writeStdoutLine("meeting uri: %s", result.meetingUri);
-      writeStdoutLine("space: %s", result.space.name);
-      if (result.space.meetingCode) {
-        writeStdoutLine("meeting code: %s", result.space.meetingCode);
-      }
-      writeStdoutLine(
-        "token source: %s",
-        token.refreshed ? "refresh-token" : "cached-access-token",
+        },
+        options.json,
       );
-      if (join) {
-        writeStdoutLine("joined: %s", join.session.id);
-      } else {
-        writeStdoutLine("joined: no (run `openclaw googlemeet join %s`)", result.meetingUri);
-      }
     });
 
-  root
-    .command("end-active-conference")
-    .description("End the active conference for a Google Meet space")
-    .argument("[meeting]", "Meet URL, meeting code, or spaces/{id}")
-    .option("--access-token <token>", "Access token override")
-    .option("--refresh-token <token>", "Refresh token override")
-    .option("--client-id <id>", "OAuth client id override")
-    .option("--client-secret <secret>", "OAuth client secret override")
-    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
+  addGoogleMeetOAuthOptions(
+    root
+      .command("end-active-conference")
+      .description("End the active conference for a Google Meet space")
+      .argument("[meeting]", "Meet URL, meeting code, or spaces/{id}"),
+  )
     .option("--json", "Print JSON output", false)
     .action(async (meeting: string | undefined, options: ResolveSpaceOptions & JsonOptions) => {
-      const token = await resolveGoogleMeetAccessToken(
-        resolveOAuthTokenOptions(params.config, options),
+      const token = await resolveGoogleMeetTokenFromParams(
+        params.config,
+        resolveCliParams(options),
       );
       const result = await endGoogleMeetActiveConference({
         accessToken: token.accessToken,
@@ -228,30 +229,27 @@ export function registerGoogleMeetCreateCommands(context: GoogleMeetCliCommandCo
 
 export function registerGoogleMeetApiCommands(context: GoogleMeetCliCommandContext): void {
   const params = context;
-  const { root, resolveMeetingForToken, resolveOAuthTokenOptions, resolveTokenOptions } = context;
+  const { root, resolveCliParams, resolveMeetingInput } = context;
 
-  root
-    .command("resolve-space")
-    .description("Resolve a Meet URL, meeting code, or spaces/{id} to its canonical space")
-    .option("--meeting <value>", "Meet URL, meeting code, or spaces/{id}")
-    .option("--access-token <token>", "Access token override")
-    .option("--refresh-token <token>", "Refresh token override")
-    .option("--client-id <id>", "OAuth client id override")
-    .option("--client-secret <secret>", "OAuth client secret override")
-    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
+  addGoogleMeetOAuthOptions(
+    addGoogleMeetMeetingOption(
+      root
+        .command("resolve-space")
+        .description("Resolve a Meet URL, meeting code, or spaces/{id} to its canonical space"),
+    ),
+  )
     .option("--json", "Print JSON output", false)
     .action(async (options: ResolveSpaceOptions) => {
-      const resolved = resolveTokenOptions(params.config, options);
-      const token = await resolveGoogleMeetAccessToken(resolved);
-      const space = await fetchGoogleMeetSpace({
-        accessToken: token.accessToken,
-        meeting: resolved.meeting,
+      const meeting = resolveMeetingInput(params.config, options.meeting);
+      const { space, token } = await resolveSpaceFromParams(params.config, {
+        ...resolveCliParams(options),
+        meeting,
       });
       if (options.json) {
         writeStdoutJson(space);
         return;
       }
-      writeStdoutLine("input: %s", resolved.meeting);
+      writeStdoutLine("input: %s", meeting);
       writeStdoutLine("space: %s", space.name);
       if (space.meetingCode) {
         writeStdoutLine("meeting code: %s", space.meetingCode);
@@ -266,25 +264,22 @@ export function registerGoogleMeetApiCommands(context: GoogleMeetCliCommandConte
       );
     });
 
-  root
-    .command("preflight")
-    .description("Validate OAuth + meeting resolution prerequisites for Meet media work")
-    .option("--meeting <value>", "Meet URL, meeting code, or spaces/{id}")
-    .option("--access-token <token>", "Access token override")
-    .option("--refresh-token <token>", "Refresh token override")
-    .option("--client-id <id>", "OAuth client id override")
-    .option("--client-secret <secret>", "OAuth client secret override")
-    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
+  addGoogleMeetOAuthOptions(
+    addGoogleMeetMeetingOption(
+      root
+        .command("preflight")
+        .description("Validate OAuth + meeting resolution prerequisites for Meet media work"),
+    ),
+  )
     .option("--json", "Print JSON output", false)
     .action(async (options: ResolveSpaceOptions) => {
-      const resolved = resolveTokenOptions(params.config, options);
-      const token = await resolveGoogleMeetAccessToken(resolved);
-      const space = await fetchGoogleMeetSpace({
-        accessToken: token.accessToken,
-        meeting: resolved.meeting,
+      const meeting = resolveMeetingInput(params.config, options.meeting);
+      const { space, token } = await resolveSpaceFromParams(params.config, {
+        ...resolveCliParams(options),
+        meeting,
       });
       const report = buildGoogleMeetPreflightReport({
-        input: resolved.meeting,
+        input: meeting,
         space,
         previewAcknowledged: params.config.preview.enrollmentAcknowledged,
         tokenSource: token.refreshed ? "refresh-token" : "cached-access-token",
@@ -314,28 +309,30 @@ export function registerGoogleMeetApiCommands(context: GoogleMeetCliCommandConte
       }
     });
 
-  root
-    .command("latest")
-    .description("Find the latest Meet conference record for a meeting")
-    .option("--meeting <value>", "Meet URL, meeting code, or spaces/{id}")
-    .option("--today", "Find a Meet link on today's calendar")
-    .option("--event <query>", "Find a matching calendar event with a Meet link")
-    .option("--calendar <id>", "Calendar id for --today or --event", "primary")
-    .option("--access-token <token>", "Access token override")
-    .option("--refresh-token <token>", "Refresh token override")
-    .option("--client-id <id>", "OAuth client id override")
-    .option("--client-secret <secret>", "OAuth client secret override")
-    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
+  addGoogleMeetOAuthOptions(
+    addGoogleMeetCalendarOptions(
+      addGoogleMeetMeetingOption(
+        root.command("latest").description("Find the latest Meet conference record for a meeting"),
+      ),
+    ),
+  )
     .option("--json", "Print JSON output", false)
     .action(async (options: ResolveSpaceOptions) => {
-      const token = await resolveGoogleMeetAccessToken(
-        resolveOAuthTokenOptions(params.config, options),
-      );
-      const resolved = await resolveMeetingForToken({
+      const raw = resolveCliParams(options);
+      const token = await resolveGoogleMeetTokenFromParams(params.config, raw);
+      if (!options.today && !options.event?.trim()) {
+        const meeting = options.meeting?.trim() || params.config.defaults.meeting;
+        if (!meeting) {
+          throw new Error(
+            "Meeting input is required. Pass --meeting, --today, --event, or configure defaults.meeting.",
+          );
+        }
+        raw.meeting = meeting;
+      }
+      const resolved = await resolveMeetingFromParams({
         config: params.config,
-        options,
+        raw,
         accessToken: token.accessToken,
-        configuredMeeting: options.meeting?.trim(),
       });
       const result = await fetchLatestGoogleMeetConferenceRecord({
         accessToken: token.accessToken,
@@ -373,8 +370,9 @@ export function registerGoogleMeetApiCommands(context: GoogleMeetCliCommandConte
     .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
     .option("--json", "Print JSON output", false)
     .action(async (options: ResolveSpaceOptions) => {
-      const token = await resolveGoogleMeetAccessToken(
-        resolveOAuthTokenOptions(params.config, options),
+      const token = await resolveGoogleMeetTokenFromParams(
+        params.config,
+        resolveCliParams(options),
       );
       const window = options.today ? buildGoogleMeetCalendarDayWindow() : {};
       const result = await listGoogleMeetCalendarEvents({

--- a/extensions/google-meet/src/cli.ts
+++ b/extensions/google-meet/src/cli.ts
@@ -2,11 +2,6 @@ import type { Command } from "commander";
 import { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
 import { generateHexPkceVerifierChallenge } from "openclaw/plugin-sdk/provider-auth";
 import { generateOAuthState } from "openclaw/plugin-sdk/provider-auth-runtime";
-import {
-  buildGoogleMeetCalendarDayWindow,
-  findGoogleMeetCalendarEvent,
-  type GoogleMeetCalendarLookupResult,
-} from "./calendar.js";
 import { registerGoogleMeetArtifactCommands } from "./cli-artifact-commands.js";
 import type { GoogleMeetCliCommandContext } from "./cli-command-context.js";
 import { registerGoogleMeetDoctorCommand } from "./cli-doctor.js";
@@ -57,104 +52,23 @@ function resolveMeetingInput(config: GoogleMeetConfig, value?: string): string {
   return meeting;
 }
 
-function resolveOAuthTokenOptions(
-  config: GoogleMeetConfig,
-  options: ResolveSpaceOptions,
-): {
-  clientId?: string;
-  clientSecret?: string;
-  refreshToken?: string;
-  accessToken?: string;
-  expiresAt?: number;
-} {
-  return {
-    clientId: options.clientId?.trim() || config.oauth.clientId,
-    clientSecret: options.clientSecret?.trim() || config.oauth.clientSecret,
-    refreshToken: options.refreshToken?.trim() || config.oauth.refreshToken,
-    accessToken: options.accessToken?.trim() || config.oauth.accessToken,
-    expiresAt: parseOptionalNumber(options.expiresAt) ?? config.oauth.expiresAt,
-  };
-}
-
-function resolveTokenOptions(
-  config: GoogleMeetConfig,
-  options: ResolveSpaceOptions,
-): {
-  meeting: string;
-  clientId?: string;
-  clientSecret?: string;
-  refreshToken?: string;
-  accessToken?: string;
-  expiresAt?: number;
-} {
-  return {
-    meeting: resolveMeetingInput(config, options.meeting),
-    ...resolveOAuthTokenOptions(config, options),
-  };
-}
-
 function hasCalendarLookupOptions(options: ResolveSpaceOptions): boolean {
   return Boolean(options.today || options.event?.trim());
 }
 
-async function resolveCalendarMeetingInput(params: {
-  accessToken: string;
-  options: ResolveSpaceOptions;
-}): Promise<{ meeting?: string; calendarEvent?: GoogleMeetCalendarLookupResult }> {
-  if (!hasCalendarLookupOptions(params.options)) {
-    return {};
-  }
-  const window = params.options.today ? buildGoogleMeetCalendarDayWindow() : {};
-  const calendarEvent = await findGoogleMeetCalendarEvent({
-    accessToken: params.accessToken,
-    calendarId: params.options.calendar,
-    eventQuery: params.options.event,
-    ...window,
-  });
-  return { meeting: calendarEvent.meetingUri, calendarEvent };
+function resolveCliParams(options: ResolveSpaceOptions): Record<string, unknown> {
+  const { calendar, expiresAt, ...raw } = options;
+  return {
+    ...raw,
+    calendarId: calendar,
+    expiresAt: parseOptionalNumber(expiresAt),
+  };
 }
 
-async function resolveMeetingForToken(params: {
-  config: GoogleMeetConfig;
-  options: ResolveSpaceOptions;
-  accessToken: string;
-  configuredMeeting?: string;
-}): Promise<{ meeting: string; calendarEvent?: GoogleMeetCalendarLookupResult }> {
-  const calendarMeeting = await resolveCalendarMeetingInput({
-    accessToken: params.accessToken,
-    options: params.options,
-  });
-  const meeting =
-    calendarMeeting.meeting ?? params.configuredMeeting ?? params.config.defaults.meeting;
-  if (!meeting) {
-    throw new Error(
-      "Meeting input is required. Pass --meeting, --today, --event, or configure defaults.meeting.",
-    );
-  }
-  return calendarMeeting.calendarEvent
-    ? { meeting, calendarEvent: calendarMeeting.calendarEvent }
-    : { meeting };
-}
-
-function resolveArtifactTokenOptions(
+function resolveCliArtifactParams(
   config: GoogleMeetConfig,
   options: MeetArtifactOptions,
-): {
-  meeting?: string;
-  conferenceRecord?: string;
-  clientId?: string;
-  clientSecret?: string;
-  refreshToken?: string;
-  accessToken?: string;
-  expiresAt?: number;
-  pageSize?: number;
-  includeTranscriptEntries?: boolean;
-  allConferenceRecords?: boolean;
-  includeDocumentBodies?: boolean;
-  mergeDuplicateParticipants?: boolean;
-  lateAfterMinutes?: number;
-  earlyBeforeMinutes?: number;
-} {
+): Record<string, unknown> {
   const meeting = options.meeting?.trim() || config.defaults.meeting;
   const conferenceRecord = options.conferenceRecord?.trim();
   if (!meeting && !conferenceRecord && !hasCalendarLookupOptions(options)) {
@@ -163,18 +77,14 @@ function resolveArtifactTokenOptions(
     );
   }
   return {
+    ...resolveCliParams(options),
     meeting,
     conferenceRecord,
-    clientId: options.clientId?.trim() || config.oauth.clientId,
-    clientSecret: options.clientSecret?.trim() || config.oauth.clientSecret,
-    refreshToken: options.refreshToken?.trim() || config.oauth.refreshToken,
-    accessToken: options.accessToken?.trim() || config.oauth.accessToken,
-    expiresAt: parseOptionalNumber(options.expiresAt) ?? config.oauth.expiresAt,
     pageSize: parsePositiveIntegerOption(options.pageSize, "page-size"),
-    includeTranscriptEntries: options.transcriptEntries !== false,
-    allConferenceRecords: Boolean(options.allConferenceRecords),
-    includeDocumentBodies: Boolean(options.includeDocBodies),
-    mergeDuplicateParticipants: options.mergeDuplicates !== false,
+    includeTranscriptEntries: options.transcriptEntries,
+    includeAllConferenceRecords: options.allConferenceRecords,
+    includeDocumentBodies: options.includeDocBodies,
+    mergeDuplicateParticipants: options.mergeDuplicates,
     lateAfterMinutes: parseOptionalNumber(options.lateAfterMinutes),
     earlyBeforeMinutes: parseOptionalNumber(options.earlyBeforeMinutes),
   };
@@ -269,10 +179,8 @@ export function registerGoogleMeetCli(params: {
     callGateway,
     operationTimeoutMs,
     resolveMeetingInput,
-    resolveOAuthTokenOptions,
-    resolveTokenOptions,
-    resolveMeetingForToken,
-    resolveArtifactTokenOptions,
+    resolveCliParams,
+    resolveCliArtifactParams: (options) => resolveCliArtifactParams(params.config, options),
     hasCreateOAuth,
   };
 


### PR DESCRIPTION
## What Problem This Solves

The Google Meet CLI independently declared repeated option groups and reimplemented OAuth, meeting/calendar, and artifact-query resolution already owned by the plugin helpers. That duplication made the command surface harder to audit and easier for tool and CLI behavior to drift.

## Why This Change Was Made

Use exact Commander option-group helpers and the canonical Google Meet token, meeting, space, and artifact resolvers while preserving command-specific validation and output behavior. Attendance thresholds remain parsed by the CLI and are removed before the shared positive-integer reader, preserving the existing zero, decimal, and negative-number contract.

The four production files shrink by 146 lines (`+248/-394`). Google API request functions, arguments, and export fetch ordering are unchanged.

## User Impact

No intended user-visible behavior change. Command names, flags, help text, registration order, defaults, stdout/JSON ordering, auth fallbacks, validation timing, meeting/calendar precedence, and API calls remain unchanged.

## Evidence

- Blacksmith Testbox: `pnpm test extensions/google-meet` — 22 files, 309 tests passed.
- Blacksmith Testbox: changed gate passed, including formatting, dead-export scans, extension production/test typechecks, lint, storage guards, sidecar loading, and import-cycle checks.
- Blacksmith Testbox: full `pnpm build` passed.
- Real isolated CLI before/after proof against the base commit: byte-identical help from each stable `Usage:` boundary for `googlemeet`, `create`, `end-active-conference`, `resolve-space`, `preflight`, `latest`, `calendar-events`, `artifacts`, `attendance`, and `export`.
- Two independent xhigh security/lifecycle reviews: CLEAN.
- Commander 15.0.0 source/types verified that `option()`/`addOption()` append options and return the same command, preserving helper-chain scope and order.
- Live all-open collision audit: 2,160 PRs, all first-100 paths plus 53 tail pages for 32 large PRs; zero exact-path collisions.

Live Google API calls were not run because the external request functions and their arguments are unchanged.
