### PR TITLE
refactor: consolidate verified inference test fixtures

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -934,7 +934,6 @@ src/status/status-message.ts
 src/system-agent/chat-engine.test.ts
 src/system-agent/chat-engine.ts
 src/system-agent/setup-inference.test.ts
-src/system-agent/verified-inference.test.ts
 src/system-agent/verified-inference.ts
 src/tasks/task-executor.test.ts
 src/tasks/task-flow-registry.ts

--- a/src/system-agent/verified-inference.test.ts
+++ b/src/system-agent/verified-inference.test.ts
@@ -120,17 +120,10 @@ beforeEach(() => {
 });
 
 function authDeps(apiKey = "verified-key") {
+  const resolvedAuth = profileAuth("openai:verified", apiKey);
   return {
-    ensureAuthProfileStore: vi.fn(() => ({
-      version: 1,
-      profiles: { "openai:verified": { ...profile, key: apiKey } },
-    })) as never,
-    resolveApiKeyForProvider: vi.fn(async () => ({
-      apiKey,
-      profileId: "openai:verified",
-      source: "profile:openai:verified",
-      mode: "api-key" as const,
-    })),
+    ensureAuthProfileStore: profileStore("openai:verified", { ...profile, key: apiKey }),
+    resolveApiKeyForProvider: vi.fn(async () => resolvedAuth),
     resolveAgentHarnessAuthBindingFingerprint: vi.fn(
       async (
         params: Parameters<
@@ -142,12 +135,7 @@ function authDeps(apiKey = "verified-key") {
           ? fingerprintResolvedAuthProfileCredential({
               profileId: params.authProfileId,
               credential,
-              resolvedAuth: {
-                apiKey,
-                profileId: params.authProfileId,
-                source: `profile:${params.authProfileId}`,
-                mode: "api-key",
-              },
+              resolvedAuth: profileAuth(params.authProfileId, apiKey),
             })
           : undefined;
       },
@@ -189,31 +177,38 @@ function config(model = "openai/gpt-5.5@openai:verified"): OpenClawConfig {
   };
 }
 
+function profileAuth(profileId: string, apiKey: string) {
+  return { apiKey, profileId, source: `profile:${profileId}`, mode: "api-key" as const };
+}
+
+function profileStore(profileId: string, credential: object) {
+  return vi.fn(() => ({ version: 1, profiles: { [profileId]: credential } })) as never;
+}
+
+function requireFingerprint(value: string | undefined): string {
+  if (!value) {
+    throw new Error("missing test auth fingerprint");
+  }
+  return value;
+}
+
 async function bindingFor(
   baseConfig: OpenClawConfig,
   deps: SystemAgentVerifiedInferenceDeps = { ...authDeps(), ...pluginArtifactDeps() },
 ) {
-  const route = await resolveSystemAgentConfiguredRouteFromConfig(baseConfig);
-  if (!route) {
-    throw new Error("missing test route");
-  }
-  const authFingerprint = fingerprintAuthProfileCredential({
-    profileId: "openai:verified",
-    credential: profile,
-  });
-  if (!authFingerprint) {
-    throw new Error("missing test auth fingerprint");
-  }
+  const route = await requireRoute(baseConfig);
+  const authFingerprint = requireFingerprint(
+    fingerprintAuthProfileCredential({ profileId: "openai:verified", credential: profile }),
+  );
   const agentHarnessId =
     route.runner === "embedded"
       ? route.agentHarnessRuntimeOverride === "auto"
         ? "openclaw"
         : route.agentHarnessRuntimeOverride
       : undefined;
-  return await createSystemAgentVerifiedInferenceBinding({
-    configuredRoute: route,
-    executionRoute: route,
-    auth: {
+  return createBinding(
+    route,
+    {
       authProfileId: "openai:verified",
       authFingerprint,
       modelId: route.model,
@@ -232,7 +227,132 @@ async function bindingFor(
         : {}),
     },
     deps,
+  );
+}
+
+type ConfiguredRoute = NonNullable<
+  Awaited<ReturnType<typeof resolveSystemAgentConfiguredRouteFromConfig>>
+>;
+type EmbeddedRoute = Extract<ConfiguredRoute, { runner: "embedded" }>;
+type CliRoute = Extract<ConfiguredRoute, { runner: "cli" }>;
+
+async function requireRoute(baseConfig: OpenClawConfig): Promise<ConfiguredRoute>;
+async function requireRoute(baseConfig: OpenClawConfig, runner: "embedded"): Promise<EmbeddedRoute>;
+async function requireRoute(baseConfig: OpenClawConfig, runner: "cli"): Promise<CliRoute>;
+async function requireRoute(baseConfig: OpenClawConfig, runner?: ConfiguredRoute["runner"]) {
+  const route = await resolveSystemAgentConfiguredRouteFromConfig(baseConfig);
+  if (!route || (runner && route.runner !== runner)) {
+    throw new Error("missing test route");
+  }
+  return route;
+}
+
+function createBinding(
+  route: ConfiguredRoute,
+  auth: Parameters<typeof createSystemAgentVerifiedInferenceBinding>[0]["auth"],
+  deps: SystemAgentVerifiedInferenceDeps = {},
+) {
+  return createSystemAgentVerifiedInferenceBinding({
+    configuredRoute: route,
+    executionRoute: route,
+    auth,
+    deps,
   });
+}
+
+function configSnapshot(baseConfig: OpenClawConfig) {
+  const snapshot = { exists: true, valid: true, config: baseConfig };
+  return { readConfigFileSnapshot: vi.fn(async () => snapshot) as never };
+}
+
+function codexHarnessConfig(
+  profileId?: string,
+  plugins?: OpenClawConfig["plugins"],
+): OpenClawConfig {
+  return {
+    agents: {
+      list: [
+        {
+          id: "ops",
+          default: true,
+          model: `openai/gpt-5.5${profileId ? `@${profileId}` : ""}`,
+          models: { "openai/gpt-5.5": { agentRuntime: { id: "codex" } } },
+        },
+      ],
+    },
+    ...(profileId
+      ? { auth: { profiles: { [profileId]: { provider: "openai", mode: "api_key" } } } }
+      : {}),
+    ...(plugins ? { plugins } : {}),
+  };
+}
+
+function opaqueHarnessAuth(route: ConfiguredRoute, backendId = "codex") {
+  const runtimeOwnerFingerprint = requireFingerprint(
+    fingerprintOpaqueRuntimeOwner({
+      kind: "plugin-harness",
+      runner: "embedded",
+      provider: route.provider,
+      backendId,
+      runtimeArtifactFingerprint: codexRuntimeArtifactAuth.runtimeArtifactFingerprint,
+    }),
+  );
+  return {
+    agentHarnessId: backendId,
+    runtimeOwnerFingerprint,
+    runtimeOwnerKind: "plugin-harness" as const,
+    runtimeOwnerId: backendId,
+    ...codexRuntimeArtifactAuth,
+  };
+}
+
+async function opaqueHarnessBinding(
+  baseConfig: OpenClawConfig,
+  options: { configuredAuto?: boolean; backendId?: string } = {},
+) {
+  const route = await requireRoute(baseConfig, "embedded");
+  const configuredRoute = options.configuredAuto
+    ? ({ ...route, agentHarnessRuntimeOverride: "auto" } satisfies ConfiguredRoute)
+    : route;
+  const binding = await createBinding(
+    configuredRoute,
+    opaqueHarnessAuth(configuredRoute, options.backendId),
+    pluginArtifactDeps(),
+  );
+  return { binding };
+}
+
+async function revalidate(
+  binding: Awaited<ReturnType<typeof bindingFor>>,
+  baseConfig: OpenClawConfig,
+  deps: SystemAgentVerifiedInferenceDeps = {},
+) {
+  return resolveSystemAgentVerifiedInferenceRoute(binding, {
+    ...configSnapshot(baseConfig),
+    ...deps,
+  });
+}
+
+async function envAuthFixture() {
+  const baseConfig = {
+    agents: {
+      defaults: {
+        model: "openai/gpt-5.6",
+        models: { "openai/gpt-5.6": { agentRuntime: { id: "openclaw" } } },
+      },
+    },
+  } satisfies OpenClawConfig;
+  const route = await requireRoute(baseConfig);
+  const resolvedAuth = {
+    apiKey: "env-key",
+    source: "env: OPENAI_API_KEY",
+    mode: "api-key" as const,
+  };
+  return {
+    route,
+    authFingerprint: requireFingerprint(fingerprintResolvedProviderAuth(resolvedAuth)),
+    resolveAuth: vi.fn(async () => resolvedAuth),
+  };
 }
 
 describe("verified OpenClaw inference binding", () => {
@@ -241,10 +361,7 @@ describe("verified OpenClaw inference binding", () => {
       agents: { defaults: { model: "anthropic/claude-opus-4-8@anthropic:oauth" } },
       auth: { profiles: { "anthropic:oauth": { provider: "anthropic", mode: "oauth" } } },
     } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(oauthConfig);
-    if (!route) {
-      throw new Error("missing test OAuth route");
-    }
+    const route = await requireRoute(oauthConfig);
     const credential = {
       type: "oauth" as const,
       provider: "anthropic",
@@ -252,62 +369,40 @@ describe("verified OpenClaw inference binding", () => {
       refresh: "refresh-a",
       expires: 1,
     };
-    const authFingerprint = fingerprintAuthProfileCredential({
-      profileId: "anthropic:oauth",
-      credential,
-    });
-    if (!authFingerprint) {
-      throw new Error("missing test OAuth fingerprint");
-    }
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute: route,
-      executionRoute: route,
-      auth: {
+    const authFingerprint = requireFingerprint(
+      fingerprintAuthProfileCredential({ profileId: "anthropic:oauth", credential }),
+    );
+    const binding = await createBinding(
+      route,
+      {
         authProfileId: "anthropic:oauth",
         authFingerprint,
         agentHarnessId: "openclaw",
       },
-      deps: {
+      {
         ...pluginArtifactDeps(),
-        ensureAuthProfileStore: vi.fn(() => ({
-          version: 1,
-          profiles: { "anthropic:oauth": credential },
-        })) as never,
+        ensureAuthProfileStore: profileStore("anthropic:oauth", credential),
       },
-    });
+    );
 
-    const current = await resolveSystemAgentVerifiedInferenceRoute(binding, {
-      readConfigFileSnapshot: vi.fn(async () => ({
-        exists: true,
-        valid: true,
-        config: oauthConfig,
-      })) as never,
-      ensureAuthProfileStore: vi.fn(() => ({
-        version: 1,
-        profiles: {
-          "anthropic:oauth": {
-            ...credential,
-            access: "access-b",
-            refresh: "refresh-b",
-          },
-        },
-      })) as never,
+    const current = await revalidate(binding, oauthConfig, {
+      ensureAuthProfileStore: profileStore("anthropic:oauth", {
+        ...credential,
+        access: "access-b",
+        refresh: "refresh-b",
+      }),
     });
 
     expect(current).toBeNull();
   });
 
   it("rejects a binding when no credential fingerprint can be observed", async () => {
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(config());
-    if (!route) {
-      throw new Error("missing test route");
-    }
+    const route = await requireRoute(config());
 
     await expect(
-      createSystemAgentVerifiedInferenceBinding({
-        configuredRoute: route,
-        executionRoute: route,
-        auth: {
+      createBinding(
+        route,
+        {
           authProfileId: "openai:verified",
           authFingerprint: "reported-owner",
           agentHarnessId: "codex",
@@ -315,23 +410,18 @@ describe("verified OpenClaw inference binding", () => {
           runtimeOwnerId: "codex",
           ...codexRuntimeArtifactAuth,
         },
-        deps: {
+        {
           ...pluginArtifactDeps(),
-          ensureAuthProfileStore: vi.fn(() => ({
-            version: 1,
-            profiles: {
-              "openai:verified": {
-                type: "api_key",
-                provider: "openai",
-                keyRef: { source: "file", provider: "vault", id: "/openai/key" },
-              },
-            },
-          })) as never,
+          ensureAuthProfileStore: profileStore("openai:verified", {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "file", provider: "vault", id: "/openai/key" },
+          }),
           resolveAgentHarnessAuthBindingFingerprint: vi.fn(async () => {
             throw new Error("active secret unavailable");
           }),
         },
-      }),
+      ),
     ).rejects.toThrow("active secret unavailable");
   });
 
@@ -339,42 +429,20 @@ describe("verified OpenClaw inference binding", () => {
     // The successful run already resolved the model under its selected auth
     // plan. Revalidation must carry that exact tuple forward instead of
     // repeating catalog and provider discovery in the authority hot path.
-    const envConfig = {
-      agents: {
-        defaults: {
-          model: "openai/gpt-5.6",
-          models: { "openai/gpt-5.6": { agentRuntime: { id: "openclaw" } } },
-        },
-      },
-    } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(envConfig);
-    if (!route) {
-      throw new Error("missing test route");
-    }
-    const envAuth = {
-      apiKey: "env-key",
-      source: "env: OPENAI_API_KEY",
-      mode: "api-key" as const,
-    };
-    const authFingerprint = fingerprintResolvedProviderAuth(envAuth);
-    if (!authFingerprint) {
-      throw new Error("missing test env fingerprint");
-    }
-    const resolveAuth = vi.fn(async () => envAuth);
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute: route,
-      executionRoute: route,
-      auth: {
+    const { route, authFingerprint, resolveAuth } = await envAuthFixture();
+    const binding = await createBinding(
+      route,
+      {
         authFingerprint,
         agentHarnessId: "openclaw",
         modelId: "gpt-5.6",
         modelApi: "openai-responses",
       },
-      deps: {
+      {
         ...pluginArtifactDeps(),
         resolveApiKeyForProvider: resolveAuth as never,
       },
-    });
+    );
 
     expect(binding.auth.authFingerprint).toBe(authFingerprint);
     expect(resolveAuth).toHaveBeenCalledWith(
@@ -383,39 +451,17 @@ describe("verified OpenClaw inference binding", () => {
   });
 
   it("fails closed when a credential-backed run omits its model transport facts", async () => {
-    const envConfig = {
-      agents: {
-        defaults: {
-          model: "openai/gpt-5.6",
-          models: { "openai/gpt-5.6": { agentRuntime: { id: "openclaw" } } },
-        },
-      },
-    } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(envConfig);
-    if (!route) {
-      throw new Error("missing test route");
-    }
-    const envAuth = {
-      apiKey: "env-key",
-      source: "env: OPENAI_API_KEY",
-      mode: "api-key" as const,
-    };
-    const authFingerprint = fingerprintResolvedProviderAuth(envAuth);
-    if (!authFingerprint) {
-      throw new Error("missing test env fingerprint");
-    }
-    const resolveAuth = vi.fn(async () => envAuth);
+    const { route, authFingerprint, resolveAuth } = await envAuthFixture();
 
     await expect(
-      createSystemAgentVerifiedInferenceBinding({
-        configuredRoute: route,
-        executionRoute: route,
-        auth: { authFingerprint, agentHarnessId: "openclaw" },
-        deps: {
+      createBinding(
+        route,
+        { authFingerprint, agentHarnessId: "openclaw" },
+        {
           ...pluginArtifactDeps(),
           resolveApiKeyForProvider: resolveAuth as never,
         },
-      }),
+      ),
     ).rejects.toThrow("no longer the active route owner");
     expect(resolveAuth).not.toHaveBeenCalled();
   });
@@ -426,90 +472,57 @@ describe("verified OpenClaw inference binding", () => {
         entries: { ops: { default: true, model: "claude-cli/claude-opus-5" } },
       },
     } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(cliConfig);
-    if (!route || route.runner !== "cli") {
-      throw new Error("missing test CLI route");
-    }
+    const route = await requireRoute(cliConfig, "cli");
     const resolveOwner = vi.fn(async () => "opaque-cli-owner");
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute: route,
-      executionRoute: route,
-      auth: {
+    const deps = {
+      ...cliRuntimeArtifactDeps(),
+      resolveCliRuntimeOwnerFingerprint: resolveOwner,
+    };
+    const binding = await createBinding(
+      route,
+      {
         runtimeOwnerFingerprint: "opaque-cli-owner",
         runtimeOwnerKind: "cli-runtime",
         runtimeOwnerId: "claude-cli",
         ...cliRuntimeArtifactAuth,
       },
-      deps: {
-        ...pluginArtifactDeps(),
-        ...cliRuntimeArtifactDeps(),
-        resolveCliRuntimeOwnerFingerprint: resolveOwner,
-      },
-    });
+      { ...pluginArtifactDeps(), ...deps },
+    );
 
     expect(binding.auth).toMatchObject({
       authFingerprint: "opaque-cli-owner",
       proofKind: "runtime-owner",
     });
     expect(resolveOwner).toHaveBeenCalledWith(expect.objectContaining({ agentId: "ops" }));
-    await expect(
-      resolveSystemAgentVerifiedInferenceRoute(binding, {
-        readConfigFileSnapshot: vi.fn(async () => ({
-          exists: true,
-          valid: true,
-          config: cliConfig,
-        })) as never,
-        ...cliRuntimeArtifactDeps(),
-        resolveCliRuntimeOwnerFingerprint: resolveOwner,
-      }),
-    ).resolves.toBe(binding.execution);
+    await expect(revalidate(binding, cliConfig, deps)).resolves.toBe(binding.execution);
 
     resolveOwner.mockResolvedValue("replacement-owner");
-    await expect(
-      resolveSystemAgentVerifiedInferenceRoute(binding, {
-        readConfigFileSnapshot: vi.fn(async () => ({
-          exists: true,
-          valid: true,
-          config: cliConfig,
-        })) as never,
-        ...cliRuntimeArtifactDeps(),
-        resolveCliRuntimeOwnerFingerprint: resolveOwner,
-      }),
-    ).resolves.toBeNull();
+    await expect(revalidate(binding, cliConfig, deps)).resolves.toBeNull();
   });
 
   it("invalidates a strict CLI credential when its package artifact changes", async () => {
     const cliConfig = {
       agents: { defaults: { model: "claude-cli/claude-opus-4-8" } },
     } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(cliConfig);
-    if (!route || route.runner !== "cli") {
-      throw new Error("missing test CLI route");
-    }
+    const route = await requireRoute(cliConfig, "cli");
     const resolveAuth = vi.fn(() => "strict-cli-credential");
     const resolveArtifact = vi.fn(async () => "claude-cli-artifact-v1");
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute: route,
-      executionRoute: route,
-      auth: {
+    const binding = await createBinding(
+      route,
+      {
         authFingerprint: "strict-cli-credential",
         ...cliRuntimeArtifactAuth,
       },
-      deps: {
+      {
         ...pluginArtifactDeps(),
         resolveCliAuthBindingFingerprint: resolveAuth,
         resolveCliRuntimeArtifactFingerprint: resolveArtifact,
       },
-    });
+    );
 
     resolveArtifact.mockResolvedValue("claude-cli-artifact-v2");
     await expect(
-      resolveSystemAgentVerifiedInferenceRoute(binding, {
-        readConfigFileSnapshot: vi.fn(async () => ({
-          exists: true,
-          valid: true,
-          config: cliConfig,
-        })) as never,
+      revalidate(binding, cliConfig, {
         resolveCliAuthBindingFingerprint: resolveAuth,
         resolveCliRuntimeArtifactFingerprint: resolveArtifact,
       }),
@@ -535,10 +548,7 @@ describe("verified OpenClaw inference binding", () => {
       provider: "claude-cli",
       keyRef: { source: "file" as const, provider: "vault", id: "/claude/work" },
     };
-    const ensureStore = vi.fn(() => ({
-      version: 1,
-      profiles: { [profileId]: credential },
-    })) as never;
+    const ensureStore = profileStore(profileId, credential);
     const route = await resolveSystemAgentConfiguredRouteFromConfig(cliConfig, undefined, {
       loadAuthProfileStoreForRuntime: ensureStore,
     });
@@ -546,25 +556,19 @@ describe("verified OpenClaw inference binding", () => {
       throw new Error("missing test CLI SecretRef route");
     }
     let activeKey = "materialized-a";
-    const resolveAuth = vi.fn(async () => ({
-      apiKey: activeKey,
-      profileId,
-      source: `profile:${profileId}`,
-      mode: "api-key" as const,
-    }));
+    const resolveAuth = vi.fn(async () => profileAuth(profileId, activeKey));
     const resolveBinding = vi.fn(
       (params: { resolvedAuth?: { apiKey?: string } }) =>
         params.resolvedAuth?.apiKey && `strict:${params.resolvedAuth.apiKey}`,
     );
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute: route,
-      executionRoute: route,
-      auth: {
+    const binding = await createBinding(
+      route,
+      {
         authProfileId: profileId,
         authFingerprint: "strict:materialized-a",
         ...cliRuntimeArtifactAuth,
       },
-      deps: {
+      {
         ...pluginArtifactDeps(),
         ...cliRuntimeArtifactDeps(),
         loadAuthProfileStoreForRuntime: ensureStore,
@@ -572,7 +576,7 @@ describe("verified OpenClaw inference binding", () => {
         resolveApiKeyForProvider: resolveAuth,
         resolveCliAuthBindingFingerprint: resolveBinding as never,
       },
-    });
+    );
 
     expect(resolveBinding).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -584,12 +588,7 @@ describe("verified OpenClaw inference binding", () => {
     );
     activeKey = "materialized-b";
     await expect(
-      resolveSystemAgentVerifiedInferenceRoute(binding, {
-        readConfigFileSnapshot: vi.fn(async () => ({
-          exists: true,
-          valid: true,
-          config: cliConfig,
-        })) as never,
+      revalidate(binding, cliConfig, {
         ...cliRuntimeArtifactDeps(),
         loadAuthProfileStoreForRuntime: ensureStore,
         ensureAuthProfileStore: ensureStore,
@@ -608,179 +607,46 @@ describe("verified OpenClaw inference binding", () => {
   });
 
   it("revalidates a plugin-harness owner without binding rotating token material", async () => {
-    const harnessConfig = {
-      agents: {
-        list: [
-          {
-            id: "ops",
-            default: true,
-            model: "openai/gpt-5.5",
-            models: { "openai/gpt-5.5": { agentRuntime: { id: "codex" } } },
-          },
-        ],
-      },
-    } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(harnessConfig);
-    if (!route || route.runner !== "embedded" || route.agentHarnessRuntimeOverride !== "codex") {
-      throw new Error("missing test plugin harness route");
-    }
-    const runtimeOwnerFingerprint = fingerprintOpaqueRuntimeOwner({
-      kind: "plugin-harness",
-      runner: "embedded",
-      provider: route.provider,
-      backendId: route.agentHarnessRuntimeOverride,
-      runtimeArtifactFingerprint: codexRuntimeArtifactAuth.runtimeArtifactFingerprint,
-    });
-    if (!runtimeOwnerFingerprint) {
-      throw new Error("missing test harness owner");
-    }
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute: route,
-      executionRoute: route,
-      auth: {
-        agentHarnessId: route.agentHarnessRuntimeOverride,
-        runtimeOwnerFingerprint,
-        runtimeOwnerKind: "plugin-harness",
-        runtimeOwnerId: route.agentHarnessRuntimeOverride,
-        ...codexRuntimeArtifactAuth,
-      },
-      deps: pluginArtifactDeps(),
-    });
+    const harnessConfig = codexHarnessConfig();
+    const { binding } = await opaqueHarnessBinding(harnessConfig);
 
     expect(binding.ownerPluginIds).toEqual(["codex", "provider-owner"]);
-
-    await expect(
-      resolveSystemAgentVerifiedInferenceRoute(binding, {
-        readConfigFileSnapshot: vi.fn(async () => ({
-          exists: true,
-          valid: true,
-          config: harnessConfig,
-        })) as never,
-      }),
-    ).resolves.toBe(binding.execution);
+    await expect(revalidate(binding, harnessConfig)).resolves.toBe(binding.execution);
   });
 
   it("invalidates a plugin-harness binding when its child runtime artifact changes", async () => {
-    const harnessConfig = {
-      agents: {
-        list: [
-          {
-            id: "ops",
-            default: true,
-            model: "openai/gpt-5.5",
-            models: { "openai/gpt-5.5": { agentRuntime: { id: "codex" } } },
-          },
-        ],
-      },
-    } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(harnessConfig);
-    if (!route || route.runner !== "embedded") {
-      throw new Error("missing test plugin harness route");
-    }
-    const runtimeOwnerFingerprint = fingerprintOpaqueRuntimeOwner({
-      kind: "plugin-harness",
-      runner: "embedded",
-      provider: route.provider,
-      backendId: "codex",
-      runtimeArtifactFingerprint: codexRuntimeArtifactAuth.runtimeArtifactFingerprint,
-    });
-    if (!runtimeOwnerFingerprint) {
-      throw new Error("missing test harness owner");
-    }
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute: route,
-      executionRoute: route,
-      auth: {
-        agentHarnessId: "codex",
-        runtimeOwnerFingerprint,
-        runtimeOwnerKind: "plugin-harness",
-        runtimeOwnerId: "codex",
-        ...codexRuntimeArtifactAuth,
-      },
-      deps: pluginArtifactDeps(),
-    });
+    const harnessConfig = codexHarnessConfig();
+    const { binding } = await opaqueHarnessBinding(harnessConfig);
 
     harnessRuntimeArtifactState.fingerprint = "codex-runtime-v2";
-    await expect(
-      resolveSystemAgentVerifiedInferenceRoute(binding, {
-        readConfigFileSnapshot: vi.fn(async () => ({
-          exists: true,
-          valid: true,
-          config: harnessConfig,
-        })) as never,
-      }),
-    ).resolves.toBeNull();
+    await expect(revalidate(binding, harnessConfig)).resolves.toBeNull();
   });
 
   it("requires a child runtime artifact for credential-backed plugin harness inference", async () => {
-    const harnessConfig = {
-      agents: {
-        list: [
-          {
-            id: "ops",
-            default: true,
-            model: "openai/gpt-5.5@openai:verified",
-            models: { "openai/gpt-5.5": { agentRuntime: { id: "codex" } } },
-          },
-        ],
-      },
-      auth: {
-        profiles: { "openai:verified": { provider: "openai", mode: "api_key" } },
-      },
-    } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(harnessConfig);
-    if (!route || route.runner !== "embedded") {
-      throw new Error("missing test plugin harness route");
-    }
-    const authFingerprint = fingerprintAuthProfileCredential({
-      profileId: "openai:verified",
-      credential: profile,
-    });
-    if (!authFingerprint) {
-      throw new Error("missing test auth fingerprint");
-    }
+    const harnessConfig = codexHarnessConfig("openai:verified");
+    const route = await requireRoute(harnessConfig, "embedded");
+    const authFingerprint = requireFingerprint(
+      fingerprintAuthProfileCredential({ profileId: "openai:verified", credential: profile }),
+    );
+    const deps = { ...authDeps(), ...pluginArtifactDeps() };
+    const harnessAuth = {
+      authProfileId: "openai:verified",
+      authFingerprint,
+      agentHarnessId: "codex",
+      runtimeOwnerKind: "plugin-harness" as const,
+      runtimeOwnerId: "codex",
+    };
 
     await expect(
-      createSystemAgentVerifiedInferenceBinding({
-        configuredRoute: route,
-        executionRoute: route,
-        auth: {
-          authProfileId: "openai:verified",
-          authFingerprint,
-        },
-        deps: { ...authDeps(), ...pluginArtifactDeps() },
-      }),
+      createBinding(route, { authProfileId: "openai:verified", authFingerprint }, deps),
     ).rejects.toThrow("did not report its exact runtime artifact");
 
-    await expect(
-      createSystemAgentVerifiedInferenceBinding({
-        configuredRoute: route,
-        executionRoute: route,
-        auth: {
-          authProfileId: "openai:verified",
-          authFingerprint,
-          agentHarnessId: "codex",
-          runtimeOwnerKind: "plugin-harness",
-          runtimeOwnerId: "codex",
-        },
-        deps: { ...authDeps(), ...pluginArtifactDeps() },
-      }),
-    ).rejects.toThrow("did not report its exact runtime artifact");
+    await expect(createBinding(route, harnessAuth, deps)).rejects.toThrow(
+      "did not report its exact runtime artifact",
+    );
 
     await expect(
-      createSystemAgentVerifiedInferenceBinding({
-        configuredRoute: route,
-        executionRoute: route,
-        auth: {
-          authProfileId: "openai:verified",
-          authFingerprint,
-          agentHarnessId: "codex",
-          runtimeOwnerKind: "plugin-harness",
-          runtimeOwnerId: "codex",
-          ...codexRuntimeArtifactAuth,
-        },
-        deps: { ...authDeps(), ...pluginArtifactDeps() },
-      }),
+      createBinding(route, { ...harnessAuth, ...codexRuntimeArtifactAuth }, deps),
     ).resolves.toMatchObject({
       execution: { agentHarnessRuntimeOverride: "codex" },
       auth: { authFingerprint, runtimeArtifactFingerprint: "codex-runtime-v1" },
@@ -788,48 +654,8 @@ describe("verified OpenClaw inference binding", () => {
   });
 
   it("freezes the actual successful harness when configured policy is auto", async () => {
-    const harnessConfig = {
-      agents: {
-        list: [
-          {
-            id: "ops",
-            default: true,
-            model: "openai/gpt-5.5",
-            models: { "openai/gpt-5.5": { agentRuntime: { id: "codex" } } },
-          },
-        ],
-      },
-    } satisfies OpenClawConfig;
-    const resolved = await resolveSystemAgentConfiguredRouteFromConfig(harnessConfig);
-    if (!resolved || resolved.runner !== "embedded") {
-      throw new Error("missing test plugin harness route");
-    }
-    const configuredRoute = {
-      ...resolved,
-      agentHarnessRuntimeOverride: "auto",
-    } satisfies typeof resolved;
-    const runtimeOwnerFingerprint = fingerprintOpaqueRuntimeOwner({
-      kind: "plugin-harness",
-      runner: "embedded",
-      provider: configuredRoute.provider,
-      backendId: "codex",
-      runtimeArtifactFingerprint: codexRuntimeArtifactAuth.runtimeArtifactFingerprint,
-    });
-    if (!runtimeOwnerFingerprint) {
-      throw new Error("missing test harness owner");
-    }
-
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute,
-      executionRoute: configuredRoute,
-      auth: {
-        agentHarnessId: "codex",
-        runtimeOwnerFingerprint,
-        runtimeOwnerKind: "plugin-harness",
-        runtimeOwnerId: "codex",
-        ...codexRuntimeArtifactAuth,
-      },
-      deps: pluginArtifactDeps(),
+    const { binding } = await opaqueHarnessBinding(codexHarnessConfig(), {
+      configuredAuto: true,
     });
 
     expect(binding.configuredRoute).toMatchObject({ agentHarnessRuntimeOverride: "auto" });
@@ -849,204 +675,85 @@ describe("verified OpenClaw inference binding", () => {
         profiles: { "openai:verified": { provider: "openai", mode: "api_key" } },
       },
     } satisfies OpenClawConfig;
-    const resolved = await resolveSystemAgentConfiguredRouteFromConfig(harnessConfig);
-    if (!resolved || resolved.runner !== "embedded") {
-      throw new Error("missing test embedded route");
-    }
+    const resolved = await requireRoute(harnessConfig, "embedded");
     const configuredRoute = {
       ...resolved,
       agentHarnessRuntimeOverride: "auto",
     } satisfies typeof resolved;
-    const authFingerprint = fingerprintResolvedProviderAuth({
-      apiKey: "verified-key",
-      profileId: "openai:verified",
-      source: "profile:openai:verified",
-      mode: "api-key",
-    });
-    if (!authFingerprint) {
-      throw new Error("missing test auth fingerprint");
-    }
+    const authFingerprint = requireFingerprint(
+      fingerprintResolvedProviderAuth(profileAuth("openai:verified", "verified-key")),
+    );
 
     await expect(
-      createSystemAgentVerifiedInferenceBinding({
+      createBinding(
         configuredRoute,
-        executionRoute: configuredRoute,
-        auth: { authProfileId: "openai:verified", authFingerprint },
-        deps: authDeps(),
-      }),
+        { authProfileId: "openai:verified", authFingerprint },
+        authDeps(),
+      ),
     ).rejects.toThrow("did not report its exact agent harness");
 
-    const binding = await createSystemAgentVerifiedInferenceBinding({
+    const binding = await createBinding(
       configuredRoute,
-      executionRoute: configuredRoute,
-      auth: {
+      {
         authProfileId: "openai:verified",
         authFingerprint,
         agentHarnessId: "openclaw",
         modelId: configuredRoute.model,
         modelApi: "openai-responses",
       },
-      deps: { ...authDeps(), ...pluginArtifactDeps() },
-    });
+      { ...authDeps(), ...pluginArtifactDeps() },
+    );
 
     expect(binding.execution).toMatchObject({ agentHarnessRuntimeOverride: "openclaw" });
     expect(binding.auth.agentHarnessId).toBe("openclaw");
   });
 
   it("rejects an opaque harness with no trusted manifest owner", async () => {
-    const harnessConfig = {
-      agents: {
-        list: [
-          {
-            id: "ops",
-            default: true,
-            model: "openai/gpt-5.5",
-            models: { "openai/gpt-5.5": { agentRuntime: { id: "codex" } } },
-          },
-        ],
-      },
-    } satisfies OpenClawConfig;
-    const resolved = await resolveSystemAgentConfiguredRouteFromConfig(harnessConfig);
-    if (!resolved || resolved.runner !== "embedded") {
-      throw new Error("missing test plugin harness route");
-    }
+    const resolved = await requireRoute(codexHarnessConfig(), "embedded");
     const configuredRoute = {
       ...resolved,
       agentHarnessRuntimeOverride: "auto",
     } satisfies typeof resolved;
-    const runtimeOwnerFingerprint = fingerprintOpaqueRuntimeOwner({
-      kind: "plugin-harness",
-      runner: "embedded",
-      provider: configuredRoute.provider,
-      backendId: "unowned-harness",
-      runtimeArtifactFingerprint: codexRuntimeArtifactAuth.runtimeArtifactFingerprint,
-    });
-    if (!runtimeOwnerFingerprint) {
-      throw new Error("missing test harness owner");
-    }
 
     await expect(
-      createSystemAgentVerifiedInferenceBinding({
-        configuredRoute,
-        executionRoute: configuredRoute,
-        auth: {
-          agentHarnessId: "unowned-harness",
-          runtimeOwnerFingerprint,
-          runtimeOwnerKind: "plugin-harness",
-          runtimeOwnerId: "unowned-harness",
-          ...codexRuntimeArtifactAuth,
-        },
-        deps: {
-          validateAgentHarnessRuntimeArtifact: vi.fn(async () => true),
-        },
+      createBinding(configuredRoute, opaqueHarnessAuth(configuredRoute, "unowned-harness"), {
+        validateAgentHarnessRuntimeArtifact: vi.fn(async () => true),
       }),
     ).rejects.toThrow("no trusted manifest owner");
   });
 
   it("invalidates a plugin-harness owner when its manifest-owned config drifts", async () => {
-    const harnessConfig = {
-      agents: {
-        list: [
-          {
-            id: "ops",
-            default: true,
-            model: "openai/gpt-5.5",
-            models: { "openai/gpt-5.5": { agentRuntime: { id: "codex" } } },
-          },
-        ],
-      },
-      plugins: { entries: { codex: { config: { appServer: { command: "codex" } } } } },
-    } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(harnessConfig);
-    if (!route || route.runner !== "embedded" || route.agentHarnessRuntimeOverride !== "codex") {
-      throw new Error("missing test plugin harness route");
-    }
-    const runtimeOwnerFingerprint = fingerprintOpaqueRuntimeOwner({
-      kind: "plugin-harness",
-      runner: "embedded",
-      provider: route.provider,
-      backendId: route.agentHarnessRuntimeOverride,
-      runtimeArtifactFingerprint: codexRuntimeArtifactAuth.runtimeArtifactFingerprint,
+    const harnessConfig = codexHarnessConfig(undefined, {
+      entries: { codex: { config: { appServer: { command: "codex" } } } },
     });
-    if (!runtimeOwnerFingerprint) {
-      throw new Error("missing test harness owner");
-    }
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute: route,
-      executionRoute: route,
-      auth: {
-        agentHarnessId: route.agentHarnessRuntimeOverride,
-        runtimeOwnerFingerprint,
-        runtimeOwnerKind: "plugin-harness",
-        runtimeOwnerId: route.agentHarnessRuntimeOverride,
-        ...codexRuntimeArtifactAuth,
-      },
-      deps: pluginArtifactDeps(),
-    });
+    const { binding } = await opaqueHarnessBinding(harnessConfig);
     const changed = structuredClone(harnessConfig);
     changed.plugins!.entries!.codex!.config = { appServer: { command: "/opt/other/codex" } };
 
-    await expect(
-      resolveSystemAgentVerifiedInferenceRoute(binding, {
-        readConfigFileSnapshot: vi.fn(async () => ({
-          exists: true,
-          valid: true,
-          config: changed,
-        })) as never,
-      }),
-    ).resolves.toBeNull();
+    await expect(revalidate(binding, changed)).resolves.toBeNull();
   });
 
   it("keeps core-bootstrap plugin harnesses on exact raw-profile revalidation", async () => {
     harnessRuntimeArtifactState.ownsAuthBootstrap = false;
-    const harnessConfig = {
-      agents: {
-        list: [
-          {
-            id: "ops",
-            default: true,
-            model: "openai/gpt-5.5@openai:verified",
-            models: { "openai/gpt-5.5": { agentRuntime: { id: "codex" } } },
-          },
-        ],
-      },
-      auth: { profiles: { "openai:verified": { provider: "openai", mode: "api_key" } } },
-    } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(harnessConfig);
-    if (!route || route.runner !== "embedded") {
-      throw new Error("missing test plugin harness route");
-    }
-    const authFingerprint = fingerprintResolvedAuthProfileCredential({
-      profileId: "openai:verified",
-      credential: profile,
-      resolvedAuth: {
-        apiKey: "verified-key",
+    const harnessConfig = codexHarnessConfig("openai:verified");
+    const route = await requireRoute(harnessConfig, "embedded");
+    const resolvedAuth = profileAuth("openai:verified", "verified-key");
+    const authFingerprint = requireFingerprint(
+      fingerprintResolvedAuthProfileCredential({
         profileId: "openai:verified",
-        source: "profile:openai:verified",
-        mode: "api-key",
-      },
-    });
-    if (!authFingerprint) {
-      throw new Error("missing test auth fingerprint");
-    }
-    const resolveAuth = vi.fn(async () => ({
-      apiKey: "verified-key",
-      profileId: "openai:verified",
-      source: "profile:openai:verified",
-      mode: "api-key" as const,
-    }));
+        credential: profile,
+        resolvedAuth,
+      }),
+    );
+    const resolveAuth = vi.fn(async () => resolvedAuth);
     const deps = {
       ...pluginArtifactDeps(),
-      ensureAuthProfileStore: vi.fn(() => ({
-        version: 1,
-        profiles: { "openai:verified": profile },
-      })) as never,
+      ensureAuthProfileStore: profileStore("openai:verified", profile),
       resolveApiKeyForProvider: resolveAuth,
     };
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute: route,
-      executionRoute: route,
-      auth: {
+    const binding = await createBinding(
+      route,
+      {
         authProfileId: "openai:verified",
         authFingerprint,
         agentHarnessId: "codex",
@@ -1057,18 +764,9 @@ describe("verified OpenClaw inference binding", () => {
         ...codexRuntimeArtifactAuth,
       },
       deps,
-    });
+    );
 
-    await expect(
-      resolveSystemAgentVerifiedInferenceRoute(binding, {
-        ...deps,
-        readConfigFileSnapshot: vi.fn(async () => ({
-          exists: true,
-          valid: true,
-          config: harnessConfig,
-        })) as never,
-      }),
-    ).resolves.toBe(binding.execution);
+    await expect(revalidate(binding, harnessConfig, deps)).resolves.toBe(binding.execution);
     expect(resolveAuth).toHaveBeenLastCalledWith(
       expect.objectContaining({
         profileId: "openai:verified",
@@ -1079,21 +777,9 @@ describe("verified OpenClaw inference binding", () => {
   });
 
   it("invalidates a plugin-harness binding when its forwarded SecretRef changes", async () => {
-    const harnessConfig = {
-      agents: {
-        list: [
-          {
-            id: "ops",
-            default: true,
-            model: "openai/gpt-5.5@openai:work",
-            models: { "openai/gpt-5.5": { agentRuntime: { id: "codex" } } },
-          },
-        ],
-      },
-      auth: { profiles: { "openai:work": { provider: "openai", mode: "api_key" } } },
-    } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(harnessConfig);
-    if (!route || route.runner !== "embedded" || route.authProfileId !== "openai:work") {
+    const harnessConfig = codexHarnessConfig("openai:work");
+    const route = await requireRoute(harnessConfig, "embedded");
+    if (route.authProfileId !== "openai:work") {
       throw new Error("missing test plugin harness profile route");
     }
     const credential = {
@@ -1106,31 +792,24 @@ describe("verified OpenClaw inference binding", () => {
       fingerprintResolvedAuthProfileCredential({
         profileId: "openai:work",
         credential,
-        resolvedAuth: {
-          apiKey: activeKey,
-          profileId: "openai:work",
-          source: "profile:openai:work",
-          mode: "api-key",
-        },
+        resolvedAuth: profileAuth("openai:work", activeKey),
       }),
     );
-    const authFingerprint = fingerprintResolvedAuthProfileCredential({
-      profileId: "openai:work",
-      credential,
-      resolvedAuth: {
-        apiKey: "work-key",
+    const authFingerprint = requireFingerprint(
+      fingerprintResolvedAuthProfileCredential({
         profileId: "openai:work",
-        source: "profile:openai:work",
-        mode: "api-key",
-      },
-    });
-    if (!authFingerprint) {
-      throw new Error("missing test profile owner");
-    }
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute: route,
-      executionRoute: route,
-      auth: {
+        credential,
+        resolvedAuth: profileAuth("openai:work", activeKey),
+      }),
+    );
+    const deps = {
+      ...pluginArtifactDeps(),
+      ensureAuthProfileStore: profileStore("openai:work", credential),
+      resolveAgentHarnessAuthBindingFingerprint: resolveHarnessAuth,
+    };
+    const binding = await createBinding(
+      route,
+      {
         authProfileId: "openai:work",
         authFingerprint,
         agentHarnessId: "codex",
@@ -1138,46 +817,13 @@ describe("verified OpenClaw inference binding", () => {
         runtimeOwnerId: "codex",
         ...codexRuntimeArtifactAuth,
       },
-      deps: {
-        ...pluginArtifactDeps(),
-        ensureAuthProfileStore: vi.fn(() => ({
-          version: 1,
-          profiles: { "openai:work": credential },
-        })) as never,
-        resolveAgentHarnessAuthBindingFingerprint: resolveHarnessAuth,
-      },
-    });
+      deps,
+    );
 
-    await expect(
-      resolveSystemAgentVerifiedInferenceRoute(binding, {
-        readConfigFileSnapshot: vi.fn(async () => ({
-          exists: true,
-          valid: true,
-          config: harnessConfig,
-        })) as never,
-        ensureAuthProfileStore: vi.fn(() => ({
-          version: 1,
-          profiles: { "openai:work": credential },
-        })) as never,
-        resolveAgentHarnessAuthBindingFingerprint: resolveHarnessAuth,
-      }),
-    ).resolves.toBe(binding.execution);
+    await expect(revalidate(binding, harnessConfig, deps)).resolves.toBe(binding.execution);
 
     activeKey = "replacement-key";
-    await expect(
-      resolveSystemAgentVerifiedInferenceRoute(binding, {
-        readConfigFileSnapshot: vi.fn(async () => ({
-          exists: true,
-          valid: true,
-          config: harnessConfig,
-        })) as never,
-        ensureAuthProfileStore: vi.fn(() => ({
-          version: 1,
-          profiles: { "openai:work": credential },
-        })) as never,
-        resolveAgentHarnessAuthBindingFingerprint: resolveHarnessAuth,
-      }),
-    ).resolves.toBeNull();
+    await expect(revalidate(binding, harnessConfig, deps)).resolves.toBeNull();
     expect(resolveHarnessAuth).toHaveBeenCalledWith(
       expect.objectContaining({ harnessId: "codex", authProfileId: "openai:work" }),
     );
@@ -1199,41 +845,28 @@ describe("verified OpenClaw inference binding", () => {
         },
       },
     } satisfies OpenClawConfig;
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(bedrockConfig);
-    if (!route || route.runner !== "embedded") {
-      throw new Error("missing test AWS route");
-    }
+    const route = await requireRoute(bedrockConfig, "embedded");
     const auth = { source: "aws-sdk default chain", mode: "aws-sdk" as const };
+    const fingerprint = () =>
+      fingerprintAwsSdkRuntimeOwner({
+        provider: route.provider,
+        backendId: route.agentHarnessRuntimeOverride,
+        auth,
+      });
     try {
       vi.stubEnv("AWS_BEARER_TOKEN_BEDROCK", "");
       vi.stubEnv("AWS_ACCESS_KEY_ID", "");
       vi.stubEnv("AWS_SECRET_ACCESS_KEY", "");
       vi.stubEnv("AWS_SESSION_TOKEN", "");
       vi.stubEnv("AWS_PROFILE", "work");
-      expect(
-        fingerprintAwsSdkRuntimeOwner({
-          provider: route.provider,
-          backendId: route.agentHarnessRuntimeOverride,
-          auth,
-        }),
-      ).toBeUndefined();
+      expect(fingerprint()).toBeUndefined();
 
       vi.stubEnv("AWS_PROFILE", "");
-      expect(
-        fingerprintAwsSdkRuntimeOwner({
-          provider: route.provider,
-          backendId: route.agentHarnessRuntimeOverride,
-          auth,
-        }),
-      ).toBeUndefined();
+      expect(fingerprint()).toBeUndefined();
 
-      await expect(
-        createSystemAgentVerifiedInferenceBinding({
-          configuredRoute: route,
-          executionRoute: route,
-          auth: {},
-        }),
-      ).rejects.toThrow("did not report one exact execution owner");
+      await expect(createBinding(route, {})).rejects.toThrow(
+        "did not report one exact execution owner",
+      );
     } finally {
       vi.unstubAllEnvs();
     }
@@ -1243,13 +876,7 @@ describe("verified OpenClaw inference binding", () => {
     const binding = await bindingFor(config());
     const changed = config("anthropic/claude-opus-4-8");
 
-    const route = await resolveSystemAgentVerifiedInferenceRoute(binding, {
-      readConfigFileSnapshot: vi.fn(async () => ({
-        exists: true,
-        valid: true,
-        config: changed,
-      })) as never,
-    });
+    const route = await revalidate(binding, changed);
 
     expect(route).toBeNull();
   });
@@ -1260,25 +887,14 @@ describe("verified OpenClaw inference binding", () => {
       ownerIds: ["provider-owner", "replacement-owner"],
       records: [pluginRecord("provider-owner"), pluginRecord("replacement-owner")],
     },
-    {
-      name: "an owner is removed",
-      ownerIds: [] as string[],
-      records: [] as Array<Record<string, unknown>>,
-    },
+    { name: "an owner is removed", ownerIds: [] as string[], records: [] },
   ])("invalidates a strict credential when $name", async ({ ownerIds, records }) => {
     const baseConfig = config();
     const binding = await bindingFor(baseConfig);
     pluginRegistryState.providerOwnerIds = ownerIds;
     pluginRegistryState.records = records;
 
-    const route = await resolveSystemAgentVerifiedInferenceRoute(binding, {
-      readConfigFileSnapshot: vi.fn(async () => ({
-        exists: true,
-        valid: true,
-        config: baseConfig,
-      })) as never,
-      ...authDeps(),
-    });
+    const route = await revalidate(binding, baseConfig, authDeps());
 
     expect(route).toBeNull();
   });
@@ -1288,14 +904,7 @@ describe("verified OpenClaw inference binding", () => {
     const binding = await bindingFor(baseConfig);
     pluginRegistryState.records = [];
 
-    const route = await resolveSystemAgentVerifiedInferenceRoute(binding, {
-      readConfigFileSnapshot: vi.fn(async () => ({
-        exists: true,
-        valid: true,
-        config: baseConfig,
-      })) as never,
-      ...authDeps(),
-    });
+    const route = await revalidate(binding, baseConfig, authDeps());
 
     expect(route).toBeNull();
   });
@@ -1309,10 +918,7 @@ describe("verified OpenClaw inference binding", () => {
         manifestPath: "/replacement/provider-owner/openclaw.plugin.json",
       },
     },
-    {
-      name: "package version",
-      replacement: { packageVersion: "2.0.0" },
-    },
+    { name: "package version", replacement: { packageVersion: "2.0.0" } },
     {
       name: "installed artifact identity",
       replacement: { installRecordHash: "provider-owner-install-v2" },
@@ -1322,14 +928,7 @@ describe("verified OpenClaw inference binding", () => {
     const binding = await bindingFor(baseConfig);
     pluginRegistryState.records = [pluginRecord("provider-owner", replacement)];
 
-    const route = await resolveSystemAgentVerifiedInferenceRoute(binding, {
-      readConfigFileSnapshot: vi.fn(async () => ({
-        exists: true,
-        valid: true,
-        config: baseConfig,
-      })) as never,
-      ...authDeps(),
-    });
+    const route = await revalidate(binding, baseConfig, authDeps());
 
     expect(route).toBeNull();
   });
@@ -1339,19 +938,18 @@ describe("verified OpenClaw inference binding", () => {
       name: "path/dev executable",
       origin: "config" as const,
       sourcePath: "src/index.ts",
-      runtimePath: "dist/index.js",
       installRecordHash: undefined,
     },
     {
       name: "installed executable",
       origin: "global" as const,
       sourcePath: "dist/index.js",
-      runtimePath: "dist/index.js",
       installRecordHash: "provider-owner-install-v1",
     },
   ])(
     "invalidates a strict credential after an in-place $name change with stable registry identity",
-    async ({ origin, sourcePath, runtimePath, installRecordHash }) => {
+    async ({ origin, sourcePath, installRecordHash }) => {
+      const runtimePath = "dist/index.js";
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-openclaw-plugin-"));
       try {
         const rootDir = path.join(tempDir, "provider-owner");
@@ -1400,14 +998,7 @@ describe("verified OpenClaw inference binding", () => {
           resolvePersistentApplyInference({
             binding,
             runtime,
-            deps: {
-              readConfigFileSnapshot: vi.fn(async () => ({
-                exists: true,
-                valid: true,
-                config: baseConfig,
-              })) as never,
-              ...deps,
-            },
+            deps: { ...configSnapshot(baseConfig), ...deps },
           }),
         ).resolves.toBe(binding.execution);
 
@@ -1417,14 +1008,7 @@ describe("verified OpenClaw inference binding", () => {
           resolvePersistentApplyInference({
             binding,
             runtime,
-            deps: {
-              readConfigFileSnapshot: vi.fn(async () => ({
-                exists: true,
-                valid: true,
-                config: baseConfig,
-              })) as never,
-              ...deps,
-            },
+            deps: { ...configSnapshot(baseConfig), ...deps },
           }),
         ).resolves.toBeNull();
       } finally {
@@ -1442,14 +1026,7 @@ describe("verified OpenClaw inference binding", () => {
       plugins: { entries: { discord: { enabled: true } } },
     } satisfies OpenClawConfig;
 
-    const route = await resolveSystemAgentVerifiedInferenceRoute(binding, {
-      readConfigFileSnapshot: vi.fn(async () => ({
-        exists: true,
-        valid: true,
-        config: changed,
-      })) as never,
-      ...authDeps(),
-    });
+    const route = await revalidate(binding, changed, authDeps());
 
     expect(route).toBe(binding.execution);
     expect(route?.runConfig).toEqual(baseConfig);
@@ -1459,29 +1036,14 @@ describe("verified OpenClaw inference binding", () => {
   it("fails closed when the selected credential content changes", async () => {
     const binding = await bindingFor(config());
 
-    const route = await resolveSystemAgentVerifiedInferenceRoute(binding, {
-      readConfigFileSnapshot: vi.fn(async () => ({
-        exists: true,
-        valid: true,
-        config: config(),
-      })) as never,
-      ...authDeps("replacement-key"),
-    });
+    const route = await revalidate(binding, config(), authDeps("replacement-key"));
 
     expect(route).toBeNull();
   });
 
   it.each([
-    {
-      name: "plugins.allow is omitted",
-      plugins: {},
-      remainsValid: true,
-    },
-    {
-      name: "plugins.allow is empty",
-      plugins: { allow: [] },
-      remainsValid: true,
-    },
+    { name: "plugins.allow is omitted", plugins: {}, remainsValid: true },
+    { name: "plugins.allow is empty", plugins: { allow: [] }, remainsValid: true },
     {
       name: "plugins.allow includes the owner",
       plugins: { allow: ["provider-owner", "codex"] },
@@ -1492,11 +1054,7 @@ describe("verified OpenClaw inference binding", () => {
       plugins: { allow: ["discord"] },
       remainsValid: false,
     },
-    {
-      name: "plugins.enabled is false",
-      plugins: { enabled: false },
-      remainsValid: false,
-    },
+    { name: "plugins.enabled is false", plugins: { enabled: false }, remainsValid: false },
     {
       name: "plugins.deny includes the owner",
       plugins: { deny: ["provider-owner"] },
@@ -1512,16 +1070,8 @@ describe("verified OpenClaw inference binding", () => {
     const binding = await bindingFor(baseConfig);
     const changed = { ...config(), plugins } satisfies OpenClawConfig;
 
-    const route = await resolveSystemAgentVerifiedInferenceRoute(binding, {
-      readConfigFileSnapshot: vi.fn(async () => ({
-        exists: true,
-        valid: true,
-        config: changed,
-      })) as never,
-      ...authDeps(),
-    });
+    const route = await revalidate(binding, changed, authDeps());
 
     expect(route).toBe(remainsValid ? binding.execution : null);
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The verified-inference security suite had accumulated hundreds of lines of repeated route, credential-store, runtime-artifact, and revalidation setup. That duplication made the ownership matrix harder to audit and left the file on the repository's max-lines exception list.

## Why This Change Was Made

This consolidates the repeated setup behind typed fixtures while retaining the route-derived Codex/OpenClaw harness, provider/model API, credential, plugin-owner, runtime-artifact, and revalidation facts. It also removes the now-obsolete max-lines baseline entry.

Architectural owner: `src/system-agent/verified-inference.test.ts`. Production code and public behavior are unchanged; no compatibility path or assertion was removed.

## User Impact

No user-visible behavior changes. Maintainers get a smaller, more legible security regression suite with one canonical fixture flow.

## Evidence

- LOC: test `+329/-779` (net `-450`); max-lines metadata `-1`; production `0`; total net `-451`.
- Parity: 25 test declarations, 14 named parameter rows (35 executed tests), and 49 assertions retained. Matcher histogram is unchanged.
- Focused Blacksmith Testbox: `src/system-agent/verified-inference.test.ts` — 35/35 passed.
- Full Blacksmith Testbox: `src/system-agent` — 445/445 passed.
- Remote `pnpm check:changed` — passed all `coreTests,tooling` lanes, including typecheck, full core/script lint, format, dead-export, boundary, declaration, and ratchet checks (lease `tbx_01kz0xkp6spgb05vp7byyp5345`).
- `git diff --check` and oxfmt — clean.
- Autoreview of the actual 55,403-byte uncommitted bundle — clean (`0.99`).
- Two independent xhigh reviews — CLEAN; both personally checked the sibling Codex contracts.
- Codex contract evidence checked directly: `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:57-61,171-175,325-351,404-408`; `codex-rs/app-server-protocol/src/protocol/common.rs:21-77,484-494,1211-1214`; `codex-rs/app-server-protocol/src/protocol/v2/account.rs:481-497`; `codex-rs/app-server/src/request_processors/thread_processor.rs:990-1047,1272-1303,1386-1405`.
- Final live traversal covered every open PR and every >100-file tail: no competing PR touches `src/system-agent/verified-inference.test.ts`; nine touch the shared max-lines baseline, and none of their patches touches this exact entry.
