### PR TITLE
fix(ui): avoid media prompts after Talk cancellation

### DIFF
--- a/ui/src/pages/chat/realtime-talk-input.test.ts
+++ b/ui/src/pages/chat/realtime-talk-input.test.ts
@@ -158,6 +158,43 @@ describe("realtime Talk microphone inputs", () => {
     expect(getUserMedia).not.toHaveBeenCalled();
   });
 
+  it("releases media when cancellation follows browser permission resolution", async () => {
+    const stop = vi.fn();
+    let resolveMedia: (stream: MediaStream) => void = () => undefined;
+    const pending = new Promise<MediaStream>((resolve) => {
+      resolveMedia = resolve;
+    });
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn(() => pending) },
+    });
+    const controller = new AbortController();
+    const opening = openRealtimeTalkInput(undefined, { signal: controller.signal });
+
+    resolveMedia({ getTracks: () => [{ stop }] } as unknown as MediaStream);
+    controller.abort();
+
+    await expect(opening).rejects.toMatchObject({ name: "AbortError" });
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("keeps cancellation precedence over a late media rejection", async () => {
+    let rejectMedia: (error: unknown) => void = () => undefined;
+    const pending = new Promise<MediaStream>((_resolve, reject) => {
+      rejectMedia = reject;
+    });
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: vi.fn(() => pending) },
+    });
+    const controller = new AbortController();
+    const reason = new DOMException("cancelled", "AbortError");
+    const opening = openRealtimeTalkCamera(undefined, { signal: controller.signal });
+
+    controller.abort(reason);
+    rejectMedia(new DOMException("denied", "NotAllowedError"));
+
+    await expect(opening).rejects.toBe(reason);
+  });
+
   it("acquires camera separately so camera errors cannot stop microphone input", async () => {
     const audio = { getTracks: () => [] } as unknown as MediaStream;
     const camera = { getTracks: () => [] } as unknown as MediaStream;

--- a/ui/src/pages/chat/realtime-talk-input.test.ts
+++ b/ui/src/pages/chat/realtime-talk-input.test.ts
@@ -142,6 +142,22 @@ describe("realtime Talk microphone inputs", () => {
     await vi.waitFor(() => expect(stop).toHaveBeenCalledOnce());
   });
 
+  it("does not request microphone or camera media after cancellation", async () => {
+    const getUserMedia = vi.fn();
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      openRealtimeTalkInput(undefined, { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    await expect(
+      openRealtimeTalkCamera(undefined, { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(getUserMedia).not.toHaveBeenCalled();
+  });
+
   it("acquires camera separately so camera errors cannot stop microphone input", async () => {
     const audio = { getTracks: () => [] } as unknown as MediaStream;
     const camera = { getTracks: () => [] } as unknown as MediaStream;

--- a/ui/src/pages/chat/realtime-talk-input.ts
+++ b/ui/src/pages/chat/realtime-talk-input.ts
@@ -168,18 +168,15 @@ function realtimeTalkAbortReason(signal: AbortSignal): Error {
 }
 
 async function awaitRealtimeTalkMediaRequest(
-  request: Promise<MediaStream>,
+  startRequest: () => Promise<MediaStream>,
   signal: AbortSignal | undefined,
 ): Promise<MediaStream> {
+  if (signal?.aborted) {
+    throw realtimeTalkAbortReason(signal);
+  }
+  const request = startRequest();
   if (!signal) {
     return await request;
-  }
-  if (signal.aborted) {
-    void request.then(
-      (stream) => stream.getTracks().forEach((track) => track.stop()),
-      () => undefined,
-    );
-    throw realtimeTalkAbortReason(signal);
   }
   let removeAbortListener: () => void = () => undefined;
   const aborted = new Promise<never>((_resolve, reject) => {
@@ -216,9 +213,10 @@ export async function openRealtimeTalkInput(
   let audio: MediaStream;
   try {
     audio = await awaitRealtimeTalkMediaRequest(
-      devices.getUserMedia({
-        audio: realtimeTalkAudioConstraints(inputDeviceId),
-      }),
+      () =>
+        devices.getUserMedia({
+          audio: realtimeTalkAudioConstraints(inputDeviceId),
+        }),
       options.signal,
     );
   } catch (error) {
@@ -250,9 +248,10 @@ export async function openRealtimeTalkCamera(
   let camera: MediaStream;
   try {
     camera = await awaitRealtimeTalkMediaRequest(
-      devices.getUserMedia({
-        video: deviceId ? { deviceId: { exact: deviceId } } : true,
-      }),
+      () =>
+        devices.getUserMedia({
+          video: deviceId ? { deviceId: { exact: deviceId } } : true,
+        }),
       options.signal,
     );
     if (options.signal?.aborted) {


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where users cancelling Realtime Talk before microphone or camera acquisition could still trigger a browser media permission request after that Talk session was already obsolete.

## Why This Change Was Made

Media acquisition now checks cancellation before calling `getUserMedia`, while preserving the existing cleanup and cancellation precedence for permission requests that are already in flight. The change is limited to the Control UI media acquisition helper and its focused tests.

## User Impact

Stopping or replacing Realtime Talk no longer opens a stale microphone or camera prompt. Active permission requests still release any late stream and cannot overwrite the terminal cancellation outcome.

## Evidence

- Focused Vitest: 18/18 passed.
- Exact-head Blacksmith Testbox changed gate passed: https://github.com/openclaw/openclaw/actions/runs/30743595423
- Real Chromium Talk stop/restart race: 1 passed, 7 skipped; exactly one `getUserMedia` acquisition, replacement reached visible `listening`, audio append stayed on the current relay.
- P1 autoreview: clean, confidence 0.98.
- `oxfmt` and `git diff --check`: clean.

AI-assisted: yes. I reviewed the implementation and validation evidence.
