### PR TITLE
fix(voice-call): keep active call when replacement setup fails

### DIFF
--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1993,17 +1993,20 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
-  it("restores the prior transcript owner when replacement bridge creation fails", async () => {
+  it("preserves the predecessor when replacement closes with error during creation", async () => {
     const callbacks: RealtimeBridgeRequest[] = [];
+    const oldTriggerGreeting = vi.fn();
     const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
       callbacks.push(request);
       if (callbacks.length === 1) {
-        return makeBridge();
+        return makeBridge({ triggerGreeting: oldTriggerGreeting });
       }
       request.onTranscript?.("user", "Failed ", false);
+      request.onClose?.("error");
       throw new Error("replacement bridge failed");
     });
     const processEvent = vi.fn();
+    const hangupCall = vi.fn(async () => {});
     const sharedCallSid = "CA-transcript-rollback";
     const call = makeCallRecord(sharedCallSid);
     const handler = makeHandler(undefined, {
@@ -2011,6 +2014,7 @@ describe("RealtimeCallHandler path routing", () => {
         getCallByProviderCallId: vi.fn(() => call),
         processEvent,
       },
+      provider: { hangupCall },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
     const oldServer = await startRealtimeServer(handler);
@@ -2042,6 +2046,17 @@ describe("RealtimeCallHandler path routing", () => {
         await waitForRealtimeTest(() => {
           expect(createBridge).toHaveBeenCalledTimes(2);
         });
+
+        expect(handler.speak(call.callId, "Continue the existing call.")).toEqual({
+          success: true,
+        });
+        expect(oldTriggerGreeting).toHaveBeenCalledWith("Continue the existing call.");
+        expect(hangupCall).not.toHaveBeenCalled();
+        expect(
+          processEvent.mock.calls
+            .map(([event]) => event as NormalizedEvent)
+            .filter((event) => event.type === "call.ended"),
+        ).toHaveLength(0);
 
         callbacks[0]?.onTranscript?.("user", "caller", true);
         await waitForRealtimeTest(() => {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -771,7 +771,7 @@ export class RealtimeCallHandler {
       typeof this.providerConfig.interruptResponseOnInputAudio === "boolean"
         ? this.providerConfig.interruptResponseOnInputAudio
         : undefined;
-    const predecessorBridge = this.activeBridgesByCallId.get(callId);
+    const hadPredecessorOnAdmission = this.activeBridgesByCallId.has(callId);
     // Providers may close synchronously before createBridge returns; no consult can exist yet.
     const nativeConsultOwner: { current?: ActiveRealtimeVoiceBridge } = {};
     // Provisional ownership accepts callbacks fired during createBridge. Commit
@@ -1019,7 +1019,7 @@ export class RealtimeCallHandler {
         // The active predecessor still owns call termination until creation succeeds.
         if (
           (owner && !ownsCallState) ||
-          (!owner && predecessorBridge && this.isActiveBridgeOwner(callId, predecessorBridge))
+          (!owner && hadPredecessorOnAdmission && this.activeBridgesByCallId.has(callId))
         ) {
           return;
         }

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -771,6 +771,7 @@ export class RealtimeCallHandler {
       typeof this.providerConfig.interruptResponseOnInputAudio === "boolean"
         ? this.providerConfig.interruptResponseOnInputAudio
         : undefined;
+    const predecessorBridge = this.activeBridgesByCallId.get(callId);
     // Providers may close synchronously before createBridge returns; no consult can exist yet.
     const nativeConsultOwner: { current?: ActiveRealtimeVoiceBridge } = {};
     // Provisional ownership accepts callbacks fired during createBridge. Commit
@@ -1014,7 +1015,12 @@ export class RealtimeCallHandler {
         if (ws.readyState === WebSocket.OPEN) {
           ws.close(1011, "Bridge disconnected");
         }
-        if (owner && !ownsCallState) {
+        // A provisional replacement may fail before its bridge owner is assigned.
+        // The active predecessor still owns call termination until creation succeeds.
+        if (
+          (owner && !ownsCallState) ||
+          (!owner && predecessorBridge && this.isActiveBridgeOwner(callId, predecessorBridge))
+        ) {
           return;
         }
         emitCallEnd("error");


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where an active voice call could be ended when a replacement realtime bridge reported an error synchronously during setup, before that replacement had become the call owner.

## Why This Change Was Made

Replacement setup records whether an active predecessor exists before provisional bridge creation. A failed provisional bridge still cleans up its own socket, but cannot emit `call.ended` or hang up the provider while the live owner map still contains an active bridge. The long-lived callback captures only this primitive admission fact, not a predecessor bridge object, so repeated replacements cannot retain a bridge/session chain. Existing transactional transcript adoption and rollback remain unchanged.

## User Impact

An established voice call remains available when a replacement realtime connection fails during creation, instead of being terminated by the failed replacement.

## Evidence

- Regression reproduced on current main: synchronous replacement `onClose("error")` ended the predecessor.
- Corrected-head focused replacement tests: 3/3 passed.
- Corrected-head synchronous-close lifecycle test: 1/1 passed.
- Exact-head full CI and `openclaw/ci-gate`: passed.
- P0 autoreview: clean, confidence 0.98.
- `oxfmt` and `git diff --check`: clean.
- Retention audit: the callback captures a boolean and performs a live map check; no predecessor bridge, provider, harness, or socket chain is retained.
- The focused unit is the exact proof for a callback fired synchronously inside `createBridge()`. Live OpenAI failures occur later during `connect()`, so live smoke is orthogonal rather than a reproduction of this admission edge.

AI-assisted: yes. I reviewed the implementation and validation evidence.
