### PR TITLE
fix(cli): preserve TTS output on copy failure

### DIFF
--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -224,6 +224,7 @@ openclaw infer tts status --json
 Notes:
 
 - `tts status` only supports `--gateway` (it reflects gateway-managed TTS state).
+- Local and loopback-Gateway `tts convert --output` copies stage beside the destination and replace it only after success; a failed copy leaves an existing file unchanged.
 - Use `tts convert --provider <id>` when selecting a provider without overriding its model.
 - Use `tts providers`, `tts voices`, `tts personas`, `tts set-provider`, and `tts set-persona` to inspect and configure TTS behavior.
 

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2904,6 +2904,74 @@ describe("capability cli", () => {
     expectRuntimeErrorContains("--output is not supported for remote gateway TTS yet");
   });
 
+  it.each(["local", "gateway"] as const)(
+    "preserves an existing %s TTS --output when the final copy fails",
+    async (transport) => {
+      const tempDir = tempDirs.make(`openclaw-tts-${transport}-copy-fail-`);
+      const sourcePath = path.join(tempDir, "source.mp3");
+      const outputDir = path.join(tempDir, "output");
+      const outputPath = path.join(outputDir, "speech.mp3");
+      await fs.mkdir(outputDir);
+      await fs.writeFile(sourcePath, Buffer.alloc(2_048, 0x41));
+      await fs.writeFile(outputPath, "existing-speech");
+      await fs.chmod(outputPath, 0o640);
+
+      if (transport === "gateway") {
+        mocks.callGateway.mockResolvedValueOnce({
+          audioPath: sourcePath,
+          provider: "openai",
+          outputFormat: "mp3",
+          voiceCompatible: false,
+        } as never);
+      } else {
+        mocks.textToSpeech.mockResolvedValueOnce({
+          success: true,
+          audioPath: sourcePath,
+          provider: "openai",
+          outputFormat: "mp3",
+          voiceCompatible: false,
+          attempts: [],
+        });
+      }
+
+      const copyFile = fs.copyFile.bind(fs);
+      const copyFileSpy = vi.spyOn(fs, "copyFile").mockImplementation(async (...args) => {
+        const [source, destination] = args;
+        if (typeof destination === "string" && path.dirname(destination) === outputDir) {
+          const bytes = await fs.readFile(source);
+          await fs.writeFile(destination, bytes.subarray(0, 17));
+          throw new Error("injected TTS copy failure");
+        }
+        await copyFile(...args);
+      });
+
+      try {
+        await expect(
+          runCapability(
+            "tts",
+            "convert",
+            `--${transport}`,
+            "--text",
+            "hello",
+            "--output",
+            outputPath,
+            "--json",
+          ),
+        ).rejects.toThrow("exit 1");
+
+        expectRuntimeErrorContains("injected TTS copy failure");
+        expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+        expect(await fs.readFile(outputPath, "utf8")).toBe("existing-speech");
+        if (process.platform !== "win32") {
+          expect((await fs.stat(outputPath)).mode & 0o777).toBe(0o640);
+        }
+        expect(await fs.readdir(outputDir)).toEqual(["speech.mp3"]);
+      } finally {
+        copyFileSpy.mockRestore();
+      }
+    },
+  );
+
   it("uses only embedding providers for embedding creation", async () => {
     await runCapability("embedding", "create", "--text", "hello", "--json");
 

--- a/src/cli/capability-cli/tts-runtime.ts
+++ b/src/cli/capability-cli/tts-runtime.ts
@@ -25,6 +25,7 @@ import {
   textToSpeech,
 } from "../../tts/tts.js";
 import { getTtsCommandSecretTargetIds } from "../command-secret-targets.js";
+import { publishOutputFileAtomically } from "./media-output.js";
 import type { CapabilityEnvelope, CapabilityTransport } from "./metadata.js";
 import {
   pinRuntimeConfigSnapshot,
@@ -32,6 +33,15 @@ import {
   resolveLocalCapabilityRuntimeConfig,
   resolveSelectedProviderFromModelRef,
 } from "./shared.js";
+
+async function copyTtsOutputAtomically(sourcePath: string, targetPath: string): Promise<void> {
+  await publishOutputFileAtomically({
+    filePath: targetPath,
+    writeTemp: async (tempPath) => {
+      await fs.copyFile(sourcePath, tempPath);
+    },
+  });
+}
 
 export async function runTtsConvert(params: {
   text: string;
@@ -71,8 +81,7 @@ export async function runTtsConvert(params: {
         );
       }
       const target = path.resolve(params.output);
-      await fs.mkdir(path.dirname(target), { recursive: true });
-      await fs.copyFile(result.audioPath, target);
+      await copyTtsOutputAtomically(result.audioPath, target);
       outputPath = target;
     }
     return {
@@ -134,8 +143,7 @@ export async function runTtsConvert(params: {
   let outputPath = result.audioPath;
   if (params.output) {
     const target = path.resolve(params.output);
-    await fs.mkdir(path.dirname(target), { recursive: true });
-    await fs.copyFile(result.audioPath, target);
+    await copyTtsOutputAtomically(result.audioPath, target);
     outputPath = target;
   }
   return {


### PR DESCRIPTION
Closes #117953

## What Problem This Solves

Fixes an issue where users replacing an existing local or loopback-Gateway TTS `--output` could lose the original audio when the final copy failed after truncation. The command exited nonzero, but partial synthesized bytes had already replaced the destination.

## Why This Change Was Made

Both TTS copy paths now use the atomic sibling-temp publication owner introduced for generated image/video output. The source audio copies beside the destination, then replaces it only after a complete copy succeeds. This completes the same CLI publication invariant without adding TTS-specific temp or mode policy.

Remote-Gateway `--output` remains explicitly unsupported; provider synthesis, Gateway RPC, and OpenClaw's no-`--output` TTS persistence are unchanged.

## User Impact

Failed TTS output copies no longer destroy an existing audio file. Successful local and loopback-Gateway conversion keeps the same command, JSON result, complete audio bytes, path, and destination mode.

## Evidence

- Built current-main baseline `9045484aea506c14aa2419b181a348d93a3d24ef` on Blacksmith Testbox `tbx_01kz0zv3wsd6d9c6zby2r9tvj8` / run `30743562486`: the real built CLI exited 1 after replacing `existing-speech` with 17 synthesized bytes.
- Exact head `e93bc7ddd610776bb1191a64b7c20bd195e72cd5` on Blacksmith Testbox `tbx_01kz114ga3nsjfq9aq4y50b5bk` / run `30744299295`: 138/138 focused capability-CLI assertions passed, including local and loopback-Gateway partial-copy failure coverage.
- The exact-head full unscoped `check:changed` gate passed, including formatting, production/test typechecks, lint, boundaries, dead-code scans, database/media guards, and import-cycle checks.
- Exact-head full build passed and verified all 149 public Plugin SDK subpaths.
- Exact-head source-blind built-CLI contract passed 2/2 through a temporary local speech provider: the valid control published all 2,048 bytes with mode `0640`; injected copy failure exited 1 while preserving `existing-speech-fault`, mode `0640`, and no sibling temp.

<details>
<summary>Redacted exact-head built-CLI output</summary>

```json
{
  "head": "e93bc7ddd610776bb1191a64b7c20bd195e72cd5",
  "summary": { "pass": 2, "fail": 0, "blocked": 0 },
  "valid": { "exit": 0, "size": 2048, "mode": "0640", "tempFiles": 0 },
  "fault": { "exit": 1, "preserved": "existing-speech-fault", "mode": "0640", "tempFiles": 0 }
}
```

</details>

- Final exact-head autoreview: clean, no accepted/actionable findings, correctness confidence 0.98.
- Public model identifier gate: PASS; the diff adds no model identifier.
- Hosted exact-head CI run `30744274755` completed successfully; `node scripts/watch-pr-ci.mjs 117962 e93bc7ddd610776bb1191a64b7c20bd195e72cd5` returned `GREEN`.

Production delta: +12/-4 (net +8). Tests: +68/-0. Docs: +1/-0. No config, protocol, storage, migration, dependency, provider-runtime, Gateway RPC, or remote-Gateway behavior change.

AI-assisted: yes.
