### PR TITLE
fix(agents): avoid false compaction after mid-turn precheck

### DIFF
--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -355,6 +355,10 @@ export async function runPreparedEmbeddedLoop(
       });
       startupStagesEmitted = dispatch.startupStagesEmitted;
       const { dispatchedAttempt, runtimePlan } = dispatch;
+      // Preserve the newest launch target before normalization can request an early retry.
+      latestMcpAppChannelView =
+        dispatchedAttempt.rawAttempt.latestMcpAppChannelView ?? latestMcpAppChannelView;
+      dispatchedAttempt.rawAttempt.latestMcpAppChannelView = latestMcpAppChannelView;
       const normalizedAttempt = await normalizeEmbeddedRunAttempt({
         runInput: input,
         preparedRuntime,
@@ -397,9 +401,6 @@ export async function runPreparedEmbeddedLoop(
         resolveReplayInvalidForAttempt,
         canRestartForLiveSwitch,
       } = normalizedAttempt;
-      // Continuation retries remain one user turn, so keep the newest launch target.
-      latestMcpAppChannelView = attempt.latestMcpAppChannelView ?? latestMcpAppChannelView;
-      attempt.latestMcpAppChannelView = latestMcpAppChannelView;
       const recovery = await recoverEmbeddedRunAttempt({
         runInput: input,
         preparedRuntime,

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -44,6 +44,12 @@ import {
   DEFAULT_REASONING_ONLY_RETRY_LIMIT,
 } from "./run/incomplete-turn.js";
 import { measureEmbeddedAgentPreparation } from "./run/preparation-timing.js";
+import {
+  beginRunAttempt,
+  createRunRetryBudget,
+  isRunRetryBudgetExhausted,
+  recordRunRetry,
+} from "./run/retry-budget.js";
 import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
 import { prepareEmbeddedRunRuntime } from "./run/runtime-preparation.js";
 import { createEmbeddedRunSessionPromptState } from "./run/session-prompt-state.js";
@@ -174,14 +180,14 @@ export async function runPreparedEmbeddedLoop(
   const maxReasoningOnlyRetryAttempts = DEFAULT_REASONING_ONLY_RETRY_LIMIT;
   const maxEmptyResponseRetryAttempts = DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT;
 
-  const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
+  const MAX_RUN_RETRY_ATTEMPTS = resolveMaxRunRetryIterations(profileCandidates.length);
+  const runRetryBudget = createRunRetryBudget(MAX_RUN_RETRY_ATTEMPTS);
   const contextRecoveryState = createEmbeddedRunContextRecoveryState();
   let bootstrapPromptWarningSignaturesSeen =
     params.bootstrapPromptWarningSignaturesSeen ??
     (params.bootstrapPromptWarningSignature ? [params.bootstrapPromptWarningSignature] : []);
   const usageAccumulator = createUsageAccumulator();
   let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
-  let runLoopIterations = 0;
   let overloadProfileRotations = 0;
   const terminalRetryState = createEmbeddedRunTerminalRetryState();
   let sameModelIdleTimeoutRetries = 0;
@@ -285,14 +291,14 @@ export async function runPreparedEmbeddedLoop(
     let latestMcpAppChannelView: McpAppChannelView | undefined;
     while (true) {
       refreshPreparedRuntimeSnapshot();
-      if (runLoopIterations >= MAX_RUN_LOOP_ITERATIONS) {
+      if (isRunRetryBudgetExhausted(runRetryBudget)) {
         const message =
-          `Exceeded retry limit after ${runLoopIterations} attempts ` +
-          `(max=${MAX_RUN_LOOP_ITERATIONS}).`;
+          `Exceeded retry limit after ${runRetryBudget.attemptsDispatched} attempts ` +
+          `(counted attempts=${runRetryBudget.attemptsCounted}, max=${runRetryBudget.maxAttempts}).`;
         log.error(
           `[run-retry-limit] sessionKey=${params.sessionKey ?? params.sessionId} ` +
-            `provider=${provider}/${modelId} attempts=${runLoopIterations} ` +
-            `maxAttempts=${MAX_RUN_LOOP_ITERATIONS}`,
+            `provider=${provider}/${modelId} attempts=${runRetryBudget.attemptsDispatched} ` +
+            `countedAttempts=${runRetryBudget.attemptsCounted} maxAttempts=${runRetryBudget.maxAttempts}`,
         );
         const retryLimitDecision = resolveRunFailoverDecision({
           stage: "retry_limit",
@@ -319,14 +325,14 @@ export async function runPreparedEmbeddedLoop(
           livenessState: "blocked",
         });
       }
-      runLoopIterations += 1;
+      beginRunAttempt(runRetryBudget);
       const runtimeAuthRetry: boolean = authRetryPending;
       authRetryPending = false;
       attemptedThinking.add(thinkLevel);
       const codexAppServerRecoveryRetryAvailable = hasCodexAppServerRecoveryRetryBudget({
         alreadyRetried: codexAppServerRecoveryRetries > 0,
-        runLoopIterations,
-        maxRunLoopIterations: MAX_RUN_LOOP_ITERATIONS,
+        runLoopIterations: runRetryBudget.attemptsCounted,
+        maxRunLoopIterations: runRetryBudget.maxAttempts,
       });
       const dispatch = await prepareAndDispatchEmbeddedRunAttempt({
         runInput: input,
@@ -382,6 +388,7 @@ export async function runPreparedEmbeddedLoop(
           normalizedAttempt.bootstrapPromptWarningSignaturesSeen;
         lastRunPromptUsage = normalizedAttempt.lastRunPromptUsage;
         accumulatedReplayState = normalizedAttempt.replayState;
+        recordRunRetry(runRetryBudget, normalizedAttempt.retryKind);
         continue;
       }
       bootstrapPromptWarningSignaturesSeen = normalizedAttempt.bootstrapPromptWarningSignaturesSeen;

--- a/src/agents/embedded-agent-runner/run.attempt-normalization.direct.test.ts
+++ b/src/agents/embedded-agent-runner/run.attempt-normalization.direct.test.ts
@@ -138,6 +138,10 @@ describe("normalizeEmbeddedRunAttempt", () => {
     );
 
     expect(result.action).toBe("retry");
+    if (result.action !== "retry") {
+      throw new Error(`expected retry, got ${result.action}`);
+    }
+    expect(result.retryKind).toBe("recovery");
     expect(state.continueFromCurrentTranscript).not.toHaveBeenCalled();
   });
 
@@ -157,7 +161,50 @@ describe("normalizeEmbeddedRunAttempt", () => {
     );
 
     expect(result.action).toBe("retry");
+    if (result.action !== "retry") {
+      throw new Error(`expected retry, got ${result.action}`);
+    }
+    expect(result.retryKind).toBe("recovery");
     expect(state.continueFromCurrentTranscript).toHaveBeenCalledOnce();
+  });
+
+  it("marks a successful no-op mid-turn retry as a progress continuation", async () => {
+    const state = makePromptState();
+    const attempt = makeAttempt({
+      route: "truncate_tool_results_only",
+      source: "mid-turn",
+      handled: true,
+      truncatedCount: 0,
+    });
+    attempt.toolMetas = [{ toolName: "read", isError: false }];
+
+    const result = await normalizeEmbeddedRunAttempt(makeNormalizationInput(attempt, state));
+
+    expect(result.action).toBe("retry");
+    if (result.action !== "retry") {
+      throw new Error(`expected retry, got ${result.action}`);
+    }
+    expect(result.retryKind).toBe("progress_continuation");
+    expect(state.continueFromCurrentTranscript).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a failed no-op mid-turn retry in the recovery budget", async () => {
+    const state = makePromptState();
+    const attempt = makeAttempt({
+      route: "truncate_tool_results_only",
+      source: "mid-turn",
+      handled: true,
+      truncatedCount: 0,
+    });
+    attempt.toolMetas = [{ toolName: "read", isError: true }];
+
+    const result = await normalizeEmbeddedRunAttempt(makeNormalizationInput(attempt, state));
+
+    expect(result.action).toBe("retry");
+    if (result.action !== "retry") {
+      throw new Error(`expected retry, got ${result.action}`);
+    }
+    expect(result.retryKind).toBe("recovery");
   });
 
   it("keeps replay state unsafe after a later clean attempt", async () => {

--- a/src/agents/embedded-agent-runner/run.midturn-precheck-retry.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.midturn-precheck-retry.test-support.ts
@@ -1,0 +1,117 @@
+// Full-entry coverage for retrying an already-capped mid-turn transcript.
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  makeAttemptResult,
+  makeCompactionSuccess,
+  makeOverflowError,
+} from "./run.overflow-compaction.fixture.js";
+import {
+  mockedCompactDirect,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetSharedRunIntegrationHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
+
+let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
+
+function requireAttemptCall(index: number): {
+  prompt?: string;
+  promptCacheKey?: string;
+  sessionId?: string;
+  suppressNextUserMessagePersistence?: boolean;
+} {
+  const call = mockedRunEmbeddedAttempt.mock.calls[index];
+  if (!call) {
+    throw new Error(`expected embedded attempt call ${index}`);
+  }
+  return call[0] as {
+    prompt?: string;
+    promptCacheKey?: string;
+    sessionId?: string;
+    suppressNextUserMessagePersistence?: boolean;
+  };
+}
+
+function expectRetryContinuesFromTranscript(): void {
+  const retry = requireAttemptCall(1);
+  expect(retry.prompt).toContain("Continue from the current transcript");
+  expect(retry.suppressNextUserMessagePersistence).toBe(true);
+  expect(retry.prompt).not.toBe(overflowBaseRunParams.prompt);
+}
+
+describe("runEmbeddedAgent mid-turn precheck retry", () => {
+  beforeAll(async () => {
+    runEmbeddedAgent = await loadSharedRunIntegrationHarness();
+  });
+
+  beforeEach(() => {
+    resetSharedRunIntegrationHarnessMocks();
+  });
+
+  it("continues once when persisted truncation is already a no-op", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          preflightRecovery: {
+            route: "truncate_tool_results_only",
+            source: "mid-turn",
+            handled: true,
+            truncatedCount: 0,
+          },
+          latestMcpAppChannelView: { viewId: "view-before-retry" },
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult());
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-midturn-precheck-noop",
+      promptCacheKey: "stable-cache-key",
+    });
+
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expectRetryContinuesFromTranscript();
+    const initial = requireAttemptCall(0);
+    const retry = requireAttemptCall(1);
+    expect(retry.sessionId).toBe(initial.sessionId);
+    expect(initial.promptCacheKey).toBe("stable-cache-key");
+    expect(retry.promptCacheKey).toBe(initial.promptCacheKey);
+    expect(result.latestMcpAppChannelView).toEqual({ viewId: "view-before-retry" });
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("still compacts after a real provider overflow follows the no-op", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          preflightRecovery: {
+            route: "truncate_tool_results_only",
+            source: "mid-turn",
+            handled: true,
+            truncatedCount: 0,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: makeOverflowError() }))
+      .mockResolvedValueOnce(makeAttemptResult());
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted after provider rejection",
+        firstKeptEntryId: "entry-provider-overflow",
+        tokensBefore: 155_000,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-midturn-precheck-provider-overflow",
+    });
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expectRetryContinuesFromTranscript();
+    expect(result.meta.error).toBeUndefined();
+  });
+});

--- a/src/agents/embedded-agent-runner/run.midturn-precheck-retry.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.midturn-precheck-retry.test-support.ts
@@ -59,6 +59,7 @@ describe("runEmbeddedAgent mid-turn precheck retry", () => {
             handled: true,
             truncatedCount: 0,
           },
+          toolMetas: [{ toolName: "read", meta: "step=1" }],
           latestMcpAppChannelView: { viewId: "view-before-retry" },
         }),
       )

--- a/src/agents/embedded-agent-runner/run.shared-integration.test.ts
+++ b/src/agents/embedded-agent-runner/run.shared-integration.test.ts
@@ -7,6 +7,7 @@ import "./run.compaction-loop-guard.test-support.js";
 import "./run.cross-provider-fallback-error-context.test-support.js";
 import "./run.empty-error-retry.test-support.js";
 import "./run.fast-mode-auto.test-support.js";
+import "./run.midturn-precheck-retry.test-support.js";
 import "./run.prompt-timeout-fallback.test-support.js";
 import "./run.timeout-triggered-compaction.test-support.js";
 import "./sessions-yield.orchestration.test-support.js";

--- a/src/agents/embedded-agent-runner/run/attempt-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-normalization.ts
@@ -27,6 +27,7 @@ import {
   type createIdleTimeoutBreakerState,
 } from "./idle-timeout-breaker.js";
 import { resolveReplayInvalidFlag } from "./incomplete-turn.js";
+import { resolveRunRetryKind, type RunRetryKind } from "./retry-budget.js";
 import { handleRetryLimitExhaustion } from "./retry-limit.js";
 import type { dispatchEmbeddedRunAttempt } from "./run-attempt-dispatch.js";
 import {
@@ -65,6 +66,7 @@ export async function normalizeEmbeddedRunAttempt(input: {
   | { action: "complete"; result: EmbeddedAgentRunResult }
   | {
       action: "retry";
+      retryKind: RunRetryKind;
       bootstrapPromptWarningSignaturesSeen: string[];
       lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       replayState: ReplayState;
@@ -259,8 +261,14 @@ export async function normalizeEmbeddedRunAttempt(input: {
     if (retryingFromTranscript) {
       sessionPromptState.continueFromCurrentTranscript();
     }
+    const retryKind = resolveRunRetryKind({
+      preflightRecovery,
+      retryingFromTranscript,
+      toolMetas: attempt.toolMetas,
+    });
     return {
       action: "retry",
+      retryKind,
       bootstrapPromptWarningSignaturesSeen,
       lastRunPromptUsage,
       replayState,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
@@ -67,7 +67,34 @@ describe("attempt prompt preflight", () => {
     });
   });
 
-  it("falls back to compaction when mid-turn tool-result truncation cannot help", () => {
+  it("admits a retry without changing history when persisted truncation cannot help", () => {
+    const toolResult = makeToolResultMessage("already capped tool output");
+    const sessionManager = createSessionManagerWithMessage(toolResult);
+    const messagesBefore = sessionManager.buildSessionContext().messages;
+    const replaceSessionMessages = vi.fn();
+    const outcome = handleEmbeddedAttemptMidTurnPrecheck({
+      attempt,
+      request: { ...request, route: "truncate_tool_results_only" },
+      sessionAgentId: "test",
+      sessionManager,
+      prePromptMessageCount: 4,
+      replaceSessionMessages,
+    });
+
+    expect(outcome.preflightRecovery).toEqual(
+      expect.objectContaining({
+        route: "truncate_tool_results_only",
+        source: "mid-turn",
+        handled: true,
+        truncatedCount: 0,
+      }),
+    );
+    expect(outcome.promptError).toBeUndefined();
+    expect(replaceSessionMessages).not.toHaveBeenCalled();
+    expect(sessionManager.buildSessionContext().messages).toEqual(messagesBefore);
+  });
+
+  it("keeps the compaction fallback when persisted truncation cannot inspect history", () => {
     const outcome = handleEmbeddedAttemptMidTurnPrecheck({
       attempt,
       request: { ...request, route: "truncate_tool_results_only" },

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
@@ -109,6 +109,24 @@ export function handleEmbeddedAttemptMidTurnPrecheck(input: {
       return { preflightRecovery };
     }
 
+    if (truncationResult.reason === "no oversized or aggregate tool results") {
+      const preflightRecovery = {
+        route: "truncate_tool_results_only" as const,
+        source: "mid-turn" as const,
+        ...buildPreflightRecoveryBudgetSnapshot(request),
+        handled: true as const,
+        truncatedCount: 0,
+      };
+      // The mid-turn estimate sees the in-memory prompt view, while persisted
+      // recovery may already have capped the same tool results. Retry without
+      // manufacturing compaction when the persisted branch has nothing to trim.
+      logMidTurnPrecheck(
+        request.route,
+        `handled=true truncatedCount=0 truncateSkippedReason=${truncationResult.reason}`,
+      );
+      return { preflightRecovery };
+    }
+
     const preflightRecovery = {
       route: "compact_only" as const,
       source: "mid-turn" as const,

--- a/src/agents/embedded-agent-runner/run/retry-budget.test.ts
+++ b/src/agents/embedded-agent-runner/run/retry-budget.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  beginRunAttempt,
+  createRunRetryBudget,
+  isRunRetryBudgetExhausted,
+  recordRunRetry,
+  resolveRunRetryKind,
+} from "./retry-budget.js";
+
+describe("run retry budget", () => {
+  it("allows more than 32 progressing continuations", () => {
+    const budget = createRunRetryBudget(32);
+
+    for (let step = 0; step < 33; step += 1) {
+      beginRunAttempt(budget);
+      recordRunRetry(
+        budget,
+        resolveRunRetryKind({
+          preflightRecovery: {
+            route: "truncate_tool_results_only",
+            truncatedCount: 0,
+          },
+          retryingFromTranscript: true,
+          toolMetas: [{ toolName: "read", meta: `step=${step}`, isError: false }],
+        }),
+      );
+    }
+
+    expect(budget).toEqual({ attemptsDispatched: 33, attemptsCounted: 0, maxAttempts: 32 });
+    expect(isRunRetryBudgetExhausted(budget)).toBe(false);
+  });
+
+  it("still stops 32 retries that make no progress", () => {
+    const budget = createRunRetryBudget(32);
+
+    for (let retry = 0; retry < 32; retry += 1) {
+      beginRunAttempt(budget);
+      recordRunRetry(budget, "recovery");
+    }
+
+    expect(isRunRetryBudgetExhausted(budget)).toBe(true);
+  });
+
+  it("does not erase retries used before a progress continuation", () => {
+    const budget = createRunRetryBudget(32);
+    for (let retry = 0; retry < 31; retry += 1) {
+      beginRunAttempt(budget);
+      recordRunRetry(budget, "recovery");
+    }
+
+    beginRunAttempt(budget);
+    recordRunRetry(budget, "progress_continuation");
+    expect(budget.attemptsCounted).toBe(31);
+
+    beginRunAttempt(budget);
+    recordRunRetry(budget, "recovery");
+    expect(isRunRetryBudgetExhausted(budget)).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/retry-budget.ts
+++ b/src/agents/embedded-agent-runner/run/retry-budget.ts
@@ -1,0 +1,39 @@
+export type RunRetryKind = "progress_continuation" | "recovery";
+
+type RunRetryBudget = {
+  attemptsDispatched: number;
+  attemptsCounted: number;
+  maxAttempts: number;
+};
+
+export function createRunRetryBudget(maxAttempts: number): RunRetryBudget {
+  return { attemptsDispatched: 0, attemptsCounted: 0, maxAttempts };
+}
+
+export function isRunRetryBudgetExhausted(budget: RunRetryBudget): boolean {
+  return budget.attemptsCounted >= budget.maxAttempts;
+}
+
+export function beginRunAttempt(budget: RunRetryBudget): void {
+  budget.attemptsDispatched += 1;
+  budget.attemptsCounted += 1;
+}
+
+export function resolveRunRetryKind(params: {
+  preflightRecovery: { route: string; truncatedCount?: number };
+  retryingFromTranscript: boolean;
+  toolMetas: Array<{ isError?: boolean; meta?: string; toolName: string }>;
+}): RunRetryKind {
+  return params.retryingFromTranscript &&
+    params.preflightRecovery.route === "truncate_tool_results_only" &&
+    params.preflightRecovery.truncatedCount === 0 &&
+    params.toolMetas.some((tool) => tool.isError !== true)
+    ? "progress_continuation"
+    : "recovery";
+}
+
+export function recordRunRetry(budget: RunRetryBudget, kind: RunRetryKind): void {
+  if (kind === "progress_continuation") {
+    budget.attemptsCounted = Math.max(0, budget.attemptsCounted - 1);
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where tool-heavy runs could enter compaction even though the saved session had no tool output left to shorten.

The failure happens when the mid-turn estimate chooses tool-result truncation, but persisted truncation reports `no oversized or aggregate tool results`. OpenClaw currently converts that no-op into a synthetic context overflow and compacts without first receiving a provider rejection.

## Why This Change Was Made

The narrow change treats only that exact already-capped result as a handled no-op. OpenClaw continues once from the current transcript without changing history; empty-session and truncation-error cases retain the existing compaction fallback.

The retry also preserves prompt-cache identity and carries the latest MCP App view across the early retry. A genuine provider context rejection still enters the normal compaction recovery path.

## User Impact

Affected tool-heavy turns should avoid an unnecessary compaction and cache-prefix break when persisted truncation is already a no-op.

Truly oversized requests still compact after the provider rejects them.

## Evidence

The focused tests cover unchanged persisted history, one continuation, duplicate-turn suppression, stable prompt-cache identity, MCP App view preservation, and genuine provider-overflow recovery.

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts` — 7 passed
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts` — 41 passed on Node 24
- `git diff --check`
- Final Codex review: no actionable regressions found

## Risks

This is intentionally narrow and does not remove the two-view mismatch that caused the bad routing decision.

- A real overflow now incurs one provider rejection before normal recovery.
- The handled no-op is restricted to the exact `no oversized or aggregate tool results` reason.
- Other truncation failures continue using the existing compaction fallback.
- Mid-turn precheck remains opt-in and disabled by default.
