### PR TITLE
fix(talk): bound relay tool-call lifecycle state

### DIFF
--- a/src/gateway/talk-realtime-relay-forced-consults.ts
+++ b/src/gateway/talk-realtime-relay-forced-consults.ts
@@ -100,7 +100,7 @@ export function submitRelayAgentControlProviderResults(
       final: true,
     });
     clearRelayAgentToolCall(session, callId);
-    session.completedAgentToolCalls.add(callId);
+    session.toolCalls.markAgentCompleted([callId]);
   };
   for (const callId of activeCallIds) {
     const forcedConsult = session.harness.forcedConsults
@@ -168,6 +168,9 @@ export function scheduleForcedAgentConsult(
   }
   session.harness.forcedConsults.schedule(handle, FORCED_CONSULT_FALLBACK_DELAY_MS, () => {
     if (!relaySessions.has(session.id)) {
+      return;
+    }
+    if (!session.toolCalls.tryAdmit([handle.id])) {
       return;
     }
     const turnId = ensureRelayTurn(session);
@@ -243,7 +246,7 @@ function drainForcedTerminalProviderResults(
   }
   const hasUnsubmittedCall = session.harness.forcedConsults
     .nativeCallIds(handle)
-    .some((callId) => !session.completedProviderToolResults.has(callId));
+    .some((callId) => !session.toolCalls.isProviderCompleted(callId));
   if (hasUnsubmittedCall) {
     return drainForcedTerminalProviderResults(session, handle, terminal);
   }
@@ -310,7 +313,7 @@ export function submitForcedTalkRealtimeRelayToolResult(
 ): void | Promise<void> {
   const cancelled = session.harness.forcedConsults.isCancelled(forcedConsult);
   const turnId = cancelled
-    ? (session.cancelledAgentToolCalls.get(params.callId) ?? session.harness.talk.activeTurnId)
+    ? (session.toolCalls.cancelledTurnId(params.callId) ?? session.harness.talk.activeTurnId)
     : ensureRelayTurn(session);
   if (!turnId) {
     throw new Error("Cancelled realtime consult is missing its original turn");
@@ -343,8 +346,10 @@ export function submitForcedTalkRealtimeRelayToolResult(
       }
       session.harness.forcedConsults.markCancelled(forcedConsult);
       clearRelayAgentToolCall(session, params.callId);
-      session.cancelledAgentToolCalls.delete(params.callId);
-      session.completedAgentToolCalls.add(params.callId);
+      session.toolCalls.deleteCancelled(params.callId);
+      if (!session.toolCalls.markAgentCompleted([params.callId])) {
+        return;
+      }
       broadcastToolResultToOwner(session, {
         callId: params.callId,
         turnId,
@@ -394,7 +399,9 @@ export function submitForcedTalkRealtimeRelayToolResult(
     }
     session.harness.forcedConsults.markDelivered(forcedConsult);
     clearRelayAgentToolCall(session, params.callId);
-    session.completedAgentToolCalls.add(params.callId);
+    if (!session.toolCalls.markAgentCompleted([params.callId])) {
+      return;
+    }
     const hasNativeCalls = session.harness.forcedConsults.nativeCallIds(forcedConsult).length > 0;
     if (text && (!hasNativeCalls || providerOptions)) {
       session.bridge.sendUserMessage(buildForcedConsultSpeechPrompt(text));

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -222,11 +222,14 @@ export function submitTalkRealtimeRelayToolResult(params: {
   options?: RealtimeVoiceToolResultOptions;
 }): void | Promise<void> {
   const session = getRelaySession(params.relaySessionId, params.connId);
-  if (session.completedAgentToolCalls.has(params.callId)) {
+  if (session.toolCalls.isAgentCompleted(params.callId)) {
+    return;
+  }
+  if (!session.toolCalls.tryAdmit([params.callId])) {
     return;
   }
   const pendingFinal = session.pendingFinalToolResults.get(params.callId);
-  const cancelledAgentCall = session.cancelledAgentToolCalls.has(params.callId);
+  const cancelledAgentCall = session.toolCalls.hasCancelled(params.callId);
   if (pendingFinal && !cancelledAgentCall) {
     return pendingFinal;
   }
@@ -253,8 +256,8 @@ export function submitTalkRealtimeRelayToolResult(params: {
         result: providerResult,
         options: suppressedToolResultOptions(session),
         onAccepted: () => {
-          session.cancelledAgentToolCalls.delete(params.callId);
-          session.completedAgentToolCalls.add(params.callId);
+          session.toolCalls.deleteCancelled(params.callId);
+          session.toolCalls.markAgentCompleted([params.callId]);
         },
       });
     const pendingProvider = session.pendingProviderToolResults.get(params.callId);
@@ -280,7 +283,9 @@ export function submitTalkRealtimeRelayToolResult(params: {
     }
     if (final) {
       clearRelayAgentToolCall(session, params.callId);
-      session.completedAgentToolCalls.add(params.callId);
+      if (!session.toolCalls.markAgentCompleted([params.callId])) {
+        return;
+      }
     }
     broadcastToolResultToOwner(session, {
       callId: params.callId,
@@ -336,7 +341,7 @@ export function registerTalkRealtimeRelayAgentRun(params: {
 }): void {
   const session = getRelaySession(params.relaySessionId, params.connId);
   const callId = params.callId?.trim();
-  if (callId && session.completedAgentToolCalls.has(callId)) {
+  if (callId && session.toolCalls.isAgentCompleted(callId)) {
     // Provider cancellation can win while chat.send is still acknowledging. Abort
     // the late run before it can escape the relay's call-ownership tombstone.
     abortChatRunById(session.context, {
@@ -345,6 +350,9 @@ export function registerTalkRealtimeRelayAgentRun(params: {
       stopReason: "realtime provider cancelled tool call",
     });
     throw new Error("Realtime provider cancelled the tool call before run registration");
+  }
+  if (callId && !session.toolCalls.tryAdmit([callId])) {
+    throw new Error("Realtime relay tool-call session limit exceeded");
   }
   if (!session.sessionKey) {
     bindRelaySessionKey(session, params.sessionKey);
@@ -387,13 +395,18 @@ export function cancelTalkRealtimeRelayProviderToolCall(
   const relayCallId = forcedConsult?.id ?? mappedRelayCallId;
   if (forcedConsult) {
     session.harness.forcedConsults.markCancelled(forcedConsult);
-    session.cancelledAgentToolCalls.set(relayCallId, ensureRelayTurn(session));
+    if (!session.toolCalls.markCancelled([relayCallId], ensureRelayTurn(session))) {
+      return undefined;
+    }
   } else {
-    session.cancelledAgentToolCalls.delete(relayCallId);
+    session.toolCalls.deleteCancelled(relayCallId);
   }
-  session.completedAgentToolCalls.add(relayCallId);
-  session.completedAgentToolCalls.add(mappedRelayCallId);
-  session.completedProviderToolResults.add(providerCallId);
+  if (
+    !session.toolCalls.markAgentCompleted([relayCallId, mappedRelayCallId]) ||
+    !session.toolCalls.markProviderCompleted([providerCallId])
+  ) {
+    return undefined;
+  }
 
   const runId = session.activeAgentToolCalls.get(relayCallId);
   const sessionKey = runId ? session.activeAgentRuns.get(runId) : undefined;
@@ -487,13 +500,19 @@ export function cancelTalkRealtimeRelayTurn(params: {
   const reason = params.reason ?? "client-cancelled";
   cancelForcedConsults(session);
   for (const callId of session.activeAgentToolCalls.keys()) {
-    session.cancelledAgentToolCalls.set(callId, turnId);
+    if (!session.toolCalls.markCancelled([callId], turnId)) {
+      return;
+    }
   }
   for (const forcedConsult of session.harness.forcedConsults.handles()) {
     if (session.harness.forcedConsults.isCancelled(forcedConsult)) {
-      session.cancelledAgentToolCalls.set(forcedConsult.id, turnId);
-      for (const nativeCallId of session.harness.forcedConsults.nativeCallIds(forcedConsult)) {
-        session.cancelledAgentToolCalls.set(nativeCallId, turnId);
+      if (
+        !session.toolCalls.markCancelled(
+          [forcedConsult.id, ...session.harness.forcedConsults.nativeCallIds(forcedConsult)],
+          turnId,
+        )
+      ) {
+        return;
       }
     }
   }
@@ -518,7 +537,7 @@ export function resetTalkRealtimeRelayContinuity(
   session.toolResultEpoch += 1;
   const retiredCallIds = new Set<string>([
     ...session.activeAgentToolCalls.keys(),
-    ...session.cancelledAgentToolCalls.keys(),
+    ...session.toolCalls.cancelledCallIds(),
     ...session.providerToolCallIds.keys(),
     ...session.providerToolCallIds.values(),
     ...session.pendingFinalToolResults.keys(),
@@ -532,14 +551,14 @@ export function resetTalkRealtimeRelayContinuity(
       retiredCallIds.add(nativeCallId);
     }
   }
-  for (const callId of retiredCallIds) {
-    session.completedAgentToolCalls.add(callId);
+  if (!session.toolCalls.markAgentCompleted(retiredCallIds)) {
+    return undefined;
   }
-  session.cancelledAgentToolCalls.clear();
+  session.toolCalls.clearCancelled();
   session.providerToolCallIds.clear();
   session.relayToolCallIdsByProviderId.clear();
   session.pendingFinalToolResults.clear();
-  session.completedProviderToolResults.clear();
+  session.toolCalls.clearProviderCompleted();
   session.pendingProviderToolResults.clear();
   session.pendingWorkingToolResults.clear();
   session.forcedTerminalProviderResults.clear();

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -393,6 +393,13 @@ export function cancelTalkRealtimeRelayProviderToolCall(
   // A native call can alias an already-started forced consult. Cancellation owns
   // the forced handle because that is where the browser run was registered.
   const relayCallId = forcedConsult?.id ?? mappedRelayCallId;
+  if (
+    session.toolCalls.isAgentCompleted(relayCallId) ||
+    session.toolCalls.isAgentCompleted(mappedRelayCallId) ||
+    session.toolCalls.isProviderCompleted(providerCallId)
+  ) {
+    return undefined;
+  }
   if (forcedConsult) {
     session.harness.forcedConsults.markCancelled(forcedConsult);
     if (!session.toolCalls.markCancelled([relayCallId], ensureRelayTurn(session))) {

--- a/src/gateway/talk-realtime-relay-provider-results.ts
+++ b/src/gateway/talk-realtime-relay-provider-results.ts
@@ -70,7 +70,7 @@ export function submitFinalProviderToolResult(params: {
 }): void | Promise<void> {
   const epoch = params.session.toolResultEpoch;
   const providerCallId = resolveRelayProviderToolCallId(params.session, params.callId);
-  if (params.session.completedProviderToolResults.has(providerCallId)) {
+  if (params.session.toolCalls.isProviderCompleted(providerCallId)) {
     if (
       relaySessions.get(params.session.id) === params.session &&
       params.session.toolResultEpoch === epoch
@@ -91,7 +91,7 @@ export function submitFinalProviderToolResult(params: {
       return false;
     }
     if (params.session.toolResultEpoch !== epoch) {
-      if (!params.session.cancelledAgentToolCalls.has(params.callId)) {
+      if (!params.session.toolCalls.hasCancelled(params.callId)) {
         return false;
       }
       // The browser already considers this final submitted while it waits behind
@@ -104,9 +104,13 @@ export function submitFinalProviderToolResult(params: {
         ),
         suppressedToolResultOptions(params.session),
       );
-      params.session.completedProviderToolResults.add(providerCallId);
-      params.session.cancelledAgentToolCalls.delete(params.callId);
-      params.session.completedAgentToolCalls.add(params.callId);
+      if (
+        !params.session.toolCalls.markProviderCompleted([providerCallId]) ||
+        !params.session.toolCalls.markAgentCompleted([params.callId])
+      ) {
+        return false;
+      }
+      params.session.toolCalls.deleteCancelled(params.callId);
       return false;
     }
     await submit();
@@ -117,7 +121,9 @@ export function submitFinalProviderToolResult(params: {
     if (params.session.toolResultEpoch !== epoch) {
       return;
     }
-    params.session.completedProviderToolResults.add(providerCallId);
+    if (!params.session.toolCalls.markProviderCompleted([providerCallId])) {
+      return;
+    }
     if (relaySessions.get(params.session.id) === params.session) {
       params.onAccepted?.();
     }

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -55,6 +55,7 @@ import {
 } from "./talk-realtime-relay-state.js";
 import {
   MAX_RELAY_TOOL_CALL_IDENTITIES,
+  MAX_RELAY_TOOL_CALL_IDENTITY_BYTES,
   RelayToolCallLedger,
 } from "./talk-realtime-relay-tool-call-ledger.js";
 import {
@@ -274,6 +275,9 @@ export function createTalkRealtimeRelaySession(
         currentOutputItemId = undefined;
         currentOutputResponseId = undefined;
         const talkEvent = resetTalkRealtimeRelayContinuity(relay, event.type);
+        if (!getActiveRelay()) {
+          return;
+        }
         const clearEvent = { relaySessionId, type: "clear" as const };
         broadcastToOwner(
           params.context,
@@ -591,7 +595,7 @@ export function createTalkRealtimeRelaySession(
     toolCalls: new RelayToolCallLedger({
       onOverflow: () =>
         failSession(
-          `Realtime relay tool-call session limit exceeded (${MAX_RELAY_TOOL_CALL_IDENTITIES})`,
+          `Realtime relay tool-call session limit exceeded (${MAX_RELAY_TOOL_CALL_IDENTITIES} identities or ${MAX_RELAY_TOOL_CALL_IDENTITY_BYTES} UTF-8 bytes)`,
         ),
     }),
     providerToolCallIds: new Map(),

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -54,6 +54,10 @@ import {
   type TalkRealtimeRelaySessionResult,
 } from "./talk-realtime-relay-state.js";
 import {
+  MAX_RELAY_TOOL_CALL_IDENTITIES,
+  RelayToolCallLedger,
+} from "./talk-realtime-relay-tool-call-ledger.js";
+import {
   closeRelayVoiceSession,
   enqueueRelayVoiceTranscript,
 } from "./talk-realtime-relay-voice.js";
@@ -110,7 +114,7 @@ export function createTalkRealtimeRelaySession(
   let ready = false;
   let continuityResetActive = false;
   let failureEmitted = false;
-  let transcriptPersistenceFailed = false;
+  let sessionFailureRequested = false;
   const constructionTerminal: {
     current?: { kind: "error"; error: Error } | { kind: "close"; reason: RealtimeVoiceCloseReason };
   } = {};
@@ -410,6 +414,9 @@ export function createTalkRealtimeRelaySession(
       }
       const providerCallId = toolCall.callId;
       const relayCallId = adoptRelayProviderToolCallId(relay, providerCallId);
+      if (!relayCallId) {
+        return;
+      }
       let shouldSubmitWorkingResult = false;
       if (toolCall.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
         const forcedConsult = relay.harness.forcedConsults.recordNativeConsult(
@@ -537,12 +544,12 @@ export function createTalkRealtimeRelaySession(
     throw new Error(`Realtime provider closed during session creation: ${earlyTerminal.reason}`);
   }
   const initialSessionKey = params.sessionKey?.trim() || undefined;
-  const failVoiceTranscriptPersistence = (message: string) => {
+  const failSession = (message: string) => {
     const active = relaySessions.get(relaySessionId);
-    if (!active || transcriptPersistenceFailed) {
+    if (!active || sessionFailureRequested) {
       return;
     }
-    transcriptPersistenceFailed = true;
+    sessionFailureRequested = true;
     if (!failureEmitted) {
       failureEmitted = true;
       emit(
@@ -581,12 +588,15 @@ export function createTalkRealtimeRelaySession(
     activeAgentRuns: new Map(),
     provider: params.provider.id,
     activeAgentToolCalls: new Map(),
-    completedAgentToolCalls: new Set(),
+    toolCalls: new RelayToolCallLedger({
+      onOverflow: () =>
+        failSession(
+          `Realtime relay tool-call session limit exceeded (${MAX_RELAY_TOOL_CALL_IDENTITIES})`,
+        ),
+    }),
     providerToolCallIds: new Map(),
     relayToolCallIdsByProviderId: new Map(),
-    cancelledAgentToolCalls: new Map(),
     pendingFinalToolResults: new Map(),
-    completedProviderToolResults: new Set(),
     pendingProviderToolResults: new Map(),
     pendingWorkingToolResults: new Map(),
     forcedTerminalProviderResults: new Map(),
@@ -595,7 +605,7 @@ export function createTalkRealtimeRelaySession(
     voiceSessionCreated: false,
     voiceTranscriptSeq: 0,
     voiceTranscriptQueue: VOICE_TRANSCRIPT_QUEUE_POLICY.createQueue(),
-    failVoiceTranscriptPersistence,
+    failSession,
     pendingVoiceTranscripts: [],
   };
   relayRef.current = relay;

--- a/src/gateway/talk-realtime-relay-state.ts
+++ b/src/gateway/talk-realtime-relay-state.ts
@@ -14,6 +14,7 @@ import type { RealtimeVoiceSessionHarness } from "../talk/realtime-session-harne
 import type { RealtimeVoiceBridgeSession } from "../talk/session-runtime.js";
 import type { TalkEvent } from "../talk/talk-session-controller.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
+import type { RelayToolCallLedger } from "./talk-realtime-relay-tool-call-ledger.js";
 
 export const RELAY_SESSION_TTL_MS = 30 * 60 * 1000;
 export const MAX_AUDIO_BASE64_BYTES = 512 * 1024;
@@ -95,16 +96,10 @@ export type RelaySession = {
   activeAgentRuns: Map<string, string>;
   provider: string;
   activeAgentToolCalls: Map<string, string>;
-  completedAgentToolCalls: Set<string>;
+  toolCalls: RelayToolCallLedger;
   providerToolCallIds: Map<string, string>;
   relayToolCallIdsByProviderId: Map<string, string>;
-  // Cancelled calls retain their original turn long enough to terminally satisfy
-  // late browser results without creating a replacement turn or owner success event.
-  cancelledAgentToolCalls: Map<string, string>;
   pendingFinalToolResults: Map<string, Promise<void>>;
-  // Provider acceptance survives partial retries independently from the owner-facing
-  // agent-call lifecycle, so accepted native ids are never submitted twice.
-  completedProviderToolResults: Set<string>;
   pendingProviderToolResults: Map<string, Promise<void>>;
   // A final result must wait until the provider accepts its continuation result;
   // otherwise async bridges can observe final-before-working ordering.
@@ -119,7 +114,7 @@ export type RelaySession = {
   voiceTranscriptSeq: number;
   voiceTranscriptQueue: BoundedSerialQueue;
   voiceSessionClose?: Promise<void>;
-  failVoiceTranscriptPersistence: (message: string) => void;
+  failSession: (message: string) => void;
   pendingVoiceTranscripts: Array<{ role: "user" | "assistant"; text: string }>;
 };
 
@@ -157,16 +152,21 @@ export const drainingRelaySessions = new Set<RelaySession>();
 export function adoptRelayProviderToolCallId(
   session: RelaySession,
   providerCallId: string,
-): string {
+): string | undefined {
   const current = session.relayToolCallIdsByProviderId.get(providerCallId);
   if (current) {
     return current;
   }
-  const relayCallId = session.completedAgentToolCalls.has(providerCallId)
+  const relayCallId = session.toolCalls.isAgentCompleted(providerCallId)
     ? `relay-${randomUUID()}`
     : providerCallId;
-  session.completedProviderToolResults.delete(providerCallId);
-  session.completedAgentToolCalls.delete(relayCallId);
+  // Realtime protocols define no replay window. Retain every admitted identity
+  // for the session and fail closed at the hard cap instead of evicting dedupe state.
+  if (!session.toolCalls.tryAdmit([providerCallId, relayCallId])) {
+    return undefined;
+  }
+  session.toolCalls.deleteProviderCompleted(providerCallId);
+  session.toolCalls.deleteAgentCompleted(relayCallId);
   session.providerToolCallIds.set(relayCallId, providerCallId);
   session.relayToolCallIdsByProviderId.set(providerCallId, relayCallId);
   return relayCallId;

--- a/src/gateway/talk-realtime-relay-state.ts
+++ b/src/gateway/talk-realtime-relay-state.ts
@@ -155,6 +155,12 @@ export function adoptRelayProviderToolCallId(
 ): string | undefined {
   const current = session.relayToolCallIdsByProviderId.get(providerCallId);
   if (current) {
+    if (
+      session.toolCalls.isAgentCompleted(current) ||
+      session.toolCalls.isProviderCompleted(providerCallId)
+    ) {
+      return undefined;
+    }
     return current;
   }
   const relayCallId = session.toolCalls.isAgentCompleted(providerCallId)

--- a/src/gateway/talk-realtime-relay-tool-call-ledger.test.ts
+++ b/src/gateway/talk-realtime-relay-tool-call-ledger.test.ts
@@ -36,6 +36,15 @@ describe("RelayToolCallLedger", () => {
     expect(onOverflow).toHaveBeenCalledOnce();
   });
 
+  it("rejects identity bytes that exceed the session budget", () => {
+    const onOverflow = vi.fn();
+    const ledger = new RelayToolCallLedger({ onOverflow, maxBytes: 3 });
+
+    expect(ledger.tryAdmit(["\u00e9\u00e9"])).toBe(false);
+    expect(ledger.size).toBe(0);
+    expect(onOverflow).toHaveBeenCalledOnce();
+  });
+
   it("clears lifecycle facts without releasing the retained identity", () => {
     const ledger = new RelayToolCallLedger({ onOverflow: vi.fn(), maxEntries: 1 });
 

--- a/src/gateway/talk-realtime-relay-tool-call-ledger.test.ts
+++ b/src/gateway/talk-realtime-relay-tool-call-ledger.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { RelayToolCallLedger } from "./talk-realtime-relay-tool-call-ledger.js";
+
+describe("RelayToolCallLedger", () => {
+  it("shares one retained identity across cancellation and terminal outcomes", () => {
+    const ledger = new RelayToolCallLedger({ onOverflow: vi.fn(), maxEntries: 2 });
+
+    expect(ledger.tryAdmit(["call-1"])).toBe(true);
+    expect(ledger.markCancelled(["call-1"], "turn-1")).toBe(true);
+    expect(ledger.markAgentCompleted(["call-1"])).toBe(true);
+    expect(ledger.markProviderCompleted(["call-1"])).toBe(true);
+
+    expect(ledger.size).toBe(1);
+    expect(ledger.cancelledTurnId("call-1")).toBe("turn-1");
+    expect(ledger.isAgentCompleted("call-1")).toBe(true);
+    expect(ledger.isProviderCompleted("call-1")).toBe(true);
+  });
+
+  it("rejects overflowing batches atomically while admitting retained duplicates", () => {
+    const onOverflow = vi.fn();
+    const ledger = new RelayToolCallLedger({ onOverflow, maxEntries: 2 });
+
+    expect(ledger.tryAdmit(["call-1"])).toBe(true);
+    expect(ledger.markAgentCompleted(["call-2", "call-3"])).toBe(false);
+    expect(ledger.size).toBe(1);
+    expect(ledger.has("call-2")).toBe(false);
+    expect(ledger.has("call-3")).toBe(false);
+    expect(onOverflow).toHaveBeenCalledOnce();
+
+    expect(ledger.tryAdmit(["call-1"])).toBe(true);
+    expect(onOverflow).toHaveBeenCalledOnce();
+  });
+
+  it("clears lifecycle facts without releasing the retained identity", () => {
+    const ledger = new RelayToolCallLedger({ onOverflow: vi.fn(), maxEntries: 1 });
+
+    ledger.markCancelled(["call-1"], "turn-1");
+    ledger.markAgentCompleted(["call-1"]);
+    ledger.markProviderCompleted(["call-1"]);
+    ledger.deleteCancelled("call-1");
+    ledger.deleteAgentCompleted("call-1");
+    ledger.clearProviderCompleted();
+
+    expect(ledger.has("call-1")).toBe(true);
+    expect(ledger.size).toBe(1);
+    expect(ledger.hasCancelled("call-1")).toBe(false);
+    expect(ledger.isAgentCompleted("call-1")).toBe(false);
+    expect(ledger.isProviderCompleted("call-1")).toBe(false);
+    expect(ledger.tryAdmit(["call-2"])).toBe(false);
+  });
+});

--- a/src/gateway/talk-realtime-relay-tool-call-ledger.test.ts
+++ b/src/gateway/talk-realtime-relay-tool-call-ledger.test.ts
@@ -2,16 +2,21 @@ import { describe, expect, it, vi } from "vitest";
 import { RelayToolCallLedger } from "./talk-realtime-relay-tool-call-ledger.js";
 
 describe("RelayToolCallLedger", () => {
-  it("shares one retained identity across cancellation and terminal outcomes", () => {
+  it("preserves the first cancellation turn until agent completion wins", () => {
     const ledger = new RelayToolCallLedger({ onOverflow: vi.fn(), maxEntries: 2 });
 
     expect(ledger.tryAdmit(["call-1"])).toBe(true);
     expect(ledger.markCancelled(["call-1"], "turn-1")).toBe(true);
+    expect(ledger.markCancelled(["call-1"], "turn-2")).toBe(true);
+    expect(ledger.cancelledTurnId("call-1")).toBe("turn-1");
+
     expect(ledger.markAgentCompleted(["call-1"])).toBe(true);
+    expect(ledger.hasCancelled("call-1")).toBe(false);
+    expect(ledger.markCancelled(["call-1"], "turn-3")).toBe(true);
     expect(ledger.markProviderCompleted(["call-1"])).toBe(true);
 
     expect(ledger.size).toBe(1);
-    expect(ledger.cancelledTurnId("call-1")).toBe("turn-1");
+    expect(ledger.cancelledTurnId("call-1")).toBeUndefined();
     expect(ledger.isAgentCompleted("call-1")).toBe(true);
     expect(ledger.isProviderCompleted("call-1")).toBe(true);
   });
@@ -35,9 +40,9 @@ describe("RelayToolCallLedger", () => {
     const ledger = new RelayToolCallLedger({ onOverflow: vi.fn(), maxEntries: 1 });
 
     ledger.markCancelled(["call-1"], "turn-1");
+    ledger.deleteCancelled("call-1");
     ledger.markAgentCompleted(["call-1"]);
     ledger.markProviderCompleted(["call-1"]);
-    ledger.deleteCancelled("call-1");
     ledger.deleteAgentCompleted("call-1");
     ledger.clearProviderCompleted();
 

--- a/src/gateway/talk-realtime-relay-tool-call-ledger.ts
+++ b/src/gateway/talk-realtime-relay-tool-call-ledger.ts
@@ -73,7 +73,10 @@ export class RelayToolCallLedger {
 
   markAgentCompleted(callIds: Iterable<string>): boolean {
     return this.mark(callIds, (entry) => {
+      // Completion is terminal for the owner-facing call. Do not let stale
+      // cancellation metadata route a later result through cancellation again.
       entry.agentCompleted = true;
+      delete entry.cancelledTurnId;
     });
   }
 
@@ -111,7 +114,11 @@ export class RelayToolCallLedger {
 
   markCancelled(callIds: Iterable<string>, turnId: string): boolean {
     return this.mark(callIds, (entry) => {
-      entry.cancelledTurnId = turnId;
+      // The first cancel owns the original turn until completion. Retries and
+      // late cancellation events must not replace or revive that lifecycle fact.
+      if (!entry.agentCompleted && entry.cancelledTurnId === undefined) {
+        entry.cancelledTurnId = turnId;
+      }
     });
   }
 

--- a/src/gateway/talk-realtime-relay-tool-call-ledger.ts
+++ b/src/gateway/talk-realtime-relay-tool-call-ledger.ts
@@ -1,0 +1,133 @@
+// Providers commonly cap native calls at 1,024, while the relay can retain both
+// a provider id and a synthetic owner-facing alias for one lifecycle.
+export const MAX_RELAY_TOOL_CALL_IDENTITIES = 2_048;
+
+type RelayToolCallEntry = {
+  agentCompleted?: true;
+  providerCompleted?: true;
+  cancelledTurnId?: string;
+};
+
+export class RelayToolCallLedger {
+  // Identities remain for the session lifetime even when individual terminal
+  // facts clear, so late events cannot regain admission after capacity pressure.
+  private readonly entries = new Map<string, RelayToolCallEntry>();
+  private overflowReported = false;
+
+  constructor(
+    private readonly options: {
+      onOverflow: () => void;
+      maxEntries?: number;
+    },
+  ) {}
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  has(callId: string): boolean {
+    return this.entries.has(callId);
+  }
+
+  tryAdmit(callIds: Iterable<string>): boolean {
+    const uniqueCallIds = new Set(callIds);
+    let additions = 0;
+    for (const callId of uniqueCallIds) {
+      if (callId && !this.entries.has(callId)) {
+        additions += 1;
+      }
+    }
+    const maxEntries = this.options.maxEntries ?? MAX_RELAY_TOOL_CALL_IDENTITIES;
+    if (this.entries.size + additions > maxEntries) {
+      if (!this.overflowReported) {
+        this.overflowReported = true;
+        this.options.onOverflow();
+      }
+      return false;
+    }
+    for (const callId of uniqueCallIds) {
+      if (callId && !this.entries.has(callId)) {
+        this.entries.set(callId, {});
+      }
+    }
+    return true;
+  }
+
+  private mark(callIds: Iterable<string>, mutate: (entry: RelayToolCallEntry) => void): boolean {
+    const retainedCallIds = [...callIds];
+    if (!this.tryAdmit(retainedCallIds)) {
+      return false;
+    }
+    for (const callId of retainedCallIds) {
+      const entry = this.entries.get(callId);
+      if (entry) {
+        mutate(entry);
+      }
+    }
+    return true;
+  }
+
+  isAgentCompleted(callId: string): boolean {
+    return this.entries.get(callId)?.agentCompleted === true;
+  }
+
+  markAgentCompleted(callIds: Iterable<string>): boolean {
+    return this.mark(callIds, (entry) => {
+      entry.agentCompleted = true;
+    });
+  }
+
+  deleteAgentCompleted(callId: string): void {
+    delete this.entries.get(callId)?.agentCompleted;
+  }
+
+  isProviderCompleted(callId: string): boolean {
+    return this.entries.get(callId)?.providerCompleted === true;
+  }
+
+  markProviderCompleted(callIds: Iterable<string>): boolean {
+    return this.mark(callIds, (entry) => {
+      entry.providerCompleted = true;
+    });
+  }
+
+  deleteProviderCompleted(callId: string): void {
+    delete this.entries.get(callId)?.providerCompleted;
+  }
+
+  clearProviderCompleted(): void {
+    for (const entry of this.entries.values()) {
+      delete entry.providerCompleted;
+    }
+  }
+
+  hasCancelled(callId: string): boolean {
+    return this.entries.get(callId)?.cancelledTurnId !== undefined;
+  }
+
+  cancelledTurnId(callId: string): string | undefined {
+    return this.entries.get(callId)?.cancelledTurnId;
+  }
+
+  markCancelled(callIds: Iterable<string>, turnId: string): boolean {
+    return this.mark(callIds, (entry) => {
+      entry.cancelledTurnId = turnId;
+    });
+  }
+
+  deleteCancelled(callId: string): void {
+    delete this.entries.get(callId)?.cancelledTurnId;
+  }
+
+  cancelledCallIds(): string[] {
+    return [...this.entries]
+      .filter(([, entry]) => entry.cancelledTurnId !== undefined)
+      .map(([callId]) => callId);
+  }
+
+  clearCancelled(): void {
+    for (const entry of this.entries.values()) {
+      delete entry.cancelledTurnId;
+    }
+  }
+}

--- a/src/gateway/talk-realtime-relay-tool-call-ledger.ts
+++ b/src/gateway/talk-realtime-relay-tool-call-ledger.ts
@@ -1,6 +1,9 @@
+import { Buffer } from "node:buffer";
+
 // Providers commonly cap native calls at 1,024, while the relay can retain both
 // a provider id and a synthetic owner-facing alias for one lifecycle.
 export const MAX_RELAY_TOOL_CALL_IDENTITIES = 2_048;
+export const MAX_RELAY_TOOL_CALL_IDENTITY_BYTES = 1024 * 1024;
 
 type RelayToolCallEntry = {
   agentCompleted?: true;
@@ -12,12 +15,14 @@ export class RelayToolCallLedger {
   // Identities remain for the session lifetime even when individual terminal
   // facts clear, so late events cannot regain admission after capacity pressure.
   private readonly entries = new Map<string, RelayToolCallEntry>();
+  private retainedBytes = 0;
   private overflowReported = false;
 
   constructor(
     private readonly options: {
       onOverflow: () => void;
       maxEntries?: number;
+      maxBytes?: number;
     },
   ) {}
 
@@ -31,24 +36,30 @@ export class RelayToolCallLedger {
 
   tryAdmit(callIds: Iterable<string>): boolean {
     const uniqueCallIds = new Set(callIds);
-    let additions = 0;
+    const additions: Array<{ callId: string; bytes: number }> = [];
+    let additionBytes = 0;
     for (const callId of uniqueCallIds) {
       if (callId && !this.entries.has(callId)) {
-        additions += 1;
+        const bytes = Buffer.byteLength(callId, "utf8");
+        additions.push({ callId, bytes });
+        additionBytes += bytes;
       }
     }
     const maxEntries = this.options.maxEntries ?? MAX_RELAY_TOOL_CALL_IDENTITIES;
-    if (this.entries.size + additions > maxEntries) {
+    const maxBytes = this.options.maxBytes ?? MAX_RELAY_TOOL_CALL_IDENTITY_BYTES;
+    if (
+      this.entries.size + additions.length > maxEntries ||
+      this.retainedBytes + additionBytes > maxBytes
+    ) {
       if (!this.overflowReported) {
         this.overflowReported = true;
         this.options.onOverflow();
       }
       return false;
     }
-    for (const callId of uniqueCallIds) {
-      if (callId && !this.entries.has(callId)) {
-        this.entries.set(callId, {});
-      }
+    for (const addition of additions) {
+      this.entries.set(addition.callId, {});
+      this.retainedBytes += addition.bytes;
     }
     return true;
   }

--- a/src/gateway/talk-realtime-relay-voice.test.ts
+++ b/src/gateway/talk-realtime-relay-voice.test.ts
@@ -24,9 +24,9 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 
 function createRelaySession(): {
   session: RelaySession;
-  failVoiceTranscriptPersistence: ReturnType<typeof vi.fn>;
+  failSession: ReturnType<typeof vi.fn>;
 } {
-  const failVoiceTranscriptPersistence = vi.fn(() => {
+  const failSession = vi.fn(() => {
     void closeRelayVoiceSession(session);
   });
   const session = {
@@ -41,10 +41,10 @@ function createRelaySession(): {
     voiceSessionCreated: false,
     voiceTranscriptSeq: 0,
     voiceTranscriptQueue: VOICE_TRANSCRIPT_QUEUE_POLICY.createQueue(),
-    failVoiceTranscriptPersistence,
+    failSession,
     pendingVoiceTranscripts: [],
   } as unknown as RelaySession;
-  return { session, failVoiceTranscriptPersistence };
+  return { session, failSession };
 }
 
 describe("realtime relay voice transcript persistence", () => {
@@ -63,7 +63,7 @@ describe("realtime relay voice transcript persistence", () => {
         }
       },
     );
-    const { session, failVoiceTranscriptPersistence } = createRelaySession();
+    const { session, failSession } = createRelaySession();
     let accepted = enqueueRelayVoiceTranscript(session, "user", `  ${"x".repeat(9_000)}  `) ? 1 : 0;
 
     for (let index = 0; index < 10_000; index += 1) {
@@ -84,7 +84,7 @@ describe("realtime relay voice transcript persistence", () => {
 
     expect(accepted).toBe(41);
     expect(voiceSessionMocks.appendRelayVoiceTranscript).toHaveBeenCalledOnce();
-    expect(failVoiceTranscriptPersistence).toHaveBeenCalledOnce();
+    expect(failSession).toHaveBeenCalledOnce();
     const close = session.voiceSessionClose;
     expect(close).toBeDefined();
     expect(closeRelayVoiceSession(session)).toBe(close);

--- a/src/gateway/talk-realtime-relay-voice.ts
+++ b/src/gateway/talk-realtime-relay-voice.ts
@@ -122,7 +122,7 @@ export function enqueueRelayVoiceTranscript(
   );
   if (!admission.accepted) {
     if (admission.reason === "overflow") {
-      session.failVoiceTranscriptPersistence(VOICE_TRANSCRIPT_QUEUE_POLICY.overflowMessage);
+      session.failSession(VOICE_TRANSCRIPT_QUEUE_POLICY.overflowMessage);
     }
     return false;
   }

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -3988,6 +3988,7 @@ describe("talk realtime gateway relay", () => {
   it("fails closed when retained relay tool-call identities reach their hard cap", () => {
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
     const close = vi.fn();
+    const submitToolResult = vi.fn();
     const provider: RealtimeVoiceProviderPlugin = {
       id: "relay-test",
       label: "Relay Test",
@@ -3999,7 +4000,7 @@ describe("talk realtime gateway relay", () => {
           sendAudio: vi.fn(),
           setMediaTimestamp: vi.fn(),
           handleBargeIn: vi.fn(),
-          submitToolResult: vi.fn(),
+          submitToolResult,
           acknowledgeMark: vi.fn(),
           close,
           isConnected: vi.fn(() => true),
@@ -4017,6 +4018,13 @@ describe("talk realtime gateway relay", () => {
     });
     const retainedSession = relaySessions.get(session.relaySessionId);
     expect(retainedSession).toBeDefined();
+    const toolCallEventCount = () =>
+      broadcastToConnIds.mock.calls.filter(
+        ([, payload]) =>
+          typeof payload === "object" &&
+          payload !== null &&
+          (payload as { type?: string }).type === "toolCall",
+      ).length;
 
     for (let index = 0; index < MAX_RELAY_TOOL_CALL_IDENTITIES; index += 1) {
       bridgeRequest?.onToolCall?.({
@@ -4029,6 +4037,7 @@ describe("talk realtime gateway relay", () => {
 
     expect(retainedSession?.toolCalls.size).toBe(MAX_RELAY_TOOL_CALL_IDENTITIES);
     expect(relaySessions.has(session.relaySessionId)).toBe(true);
+    expect(toolCallEventCount()).toBe(MAX_RELAY_TOOL_CALL_IDENTITIES);
 
     bridgeRequest?.onToolCall?.({
       itemId: "item-overflow",
@@ -4039,6 +4048,9 @@ describe("talk realtime gateway relay", () => {
 
     expect(close).toHaveBeenCalledOnce();
     expect(relaySessions.has(session.relaySessionId)).toBe(false);
+    expect(retainedSession?.toolCalls.has("call-overflow")).toBe(false);
+    expect(toolCallEventCount()).toBe(MAX_RELAY_TOOL_CALL_IDENTITIES);
+    expect(submitToolResult).not.toHaveBeenCalled();
     expect(
       broadcastToConnIds.mock.calls.filter(
         ([, payload]) =>
@@ -4064,6 +4076,9 @@ describe("talk realtime gateway relay", () => {
     });
     expect(close).toHaveBeenCalledOnce();
     expect(retainedSession?.toolCalls.size).toBe(MAX_RELAY_TOOL_CALL_IDENTITIES);
+    expect(retainedSession?.toolCalls.has("call-late")).toBe(false);
+    expect(toolCallEventCount()).toBe(MAX_RELAY_TOOL_CALL_IDENTITIES);
+    expect(submitToolResult).not.toHaveBeenCalled();
   });
 
   it("caps active relay sessions per browser connection", () => {

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -1113,6 +1113,60 @@ describe("talk realtime gateway relay", () => {
     expect(submitToolResult).not.toHaveBeenCalled();
   });
 
+  it("ignores provider replay and cancellation after accepted completion", async () => {
+    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+    const submitToolResult = vi.fn();
+    const provider = createIdleRelayProvider();
+    provider.createBridge = (request) => {
+      bridgeRequest = request;
+      return {
+        ...createIdleRelayProvider().createBridge?.(request),
+        submitToolResult,
+      } as RealtimeVoiceBridge;
+    };
+    const fixture = createAbortableRelayRunFixture(provider);
+    await Promise.resolve();
+    bridgeRequest?.onToolCall?.({
+      itemId: "call-1",
+      callId: "call-1",
+      name: "openclaw_agent_consult",
+      args: { question: "status?" },
+    });
+    await submitTalkRealtimeRelayToolResult({
+      relaySessionId: fixture.session.relaySessionId,
+      connId: "conn-1",
+      callId: "call-1",
+      result: { result: "done" },
+    });
+    const toolEvents = () =>
+      fixture.broadcastToConnIds.mock.calls
+        .map(([, payload]) => payload)
+        .filter(
+          (payload) =>
+            typeof payload === "object" &&
+            payload !== null &&
+            ["toolCall", "toolCallCancelled"].includes(
+              String((payload as Record<string, unknown>).type),
+            ),
+        );
+    expect(toolEvents()).toHaveLength(1);
+
+    bridgeRequest?.onToolCall?.({
+      itemId: "call-1-replay",
+      callId: "call-1",
+      name: "openclaw_agent_consult",
+      args: { question: "status?" },
+    });
+    bridgeRequest?.onEvent?.({
+      direction: "server",
+      type: "tool.call.cancelled",
+      itemId: "call-1",
+    });
+
+    expect(toolEvents()).toHaveLength(1);
+    expect(submitToolResult).toHaveBeenCalledTimes(1);
+  });
+
   function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
     if (!record || typeof record !== "object") {
       throw new Error("Expected record");
@@ -4079,6 +4133,63 @@ describe("talk realtime gateway relay", () => {
     expect(retainedSession?.toolCalls.has("call-late")).toBe(false);
     expect(toolCallEventCount()).toBe(MAX_RELAY_TOOL_CALL_IDENTITIES);
     expect(submitToolResult).not.toHaveBeenCalled();
+  });
+
+  it("does not emit continuity events after tool-call overflow closes the relay", () => {
+    vi.useFakeTimers();
+    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+    const close = vi.fn();
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "relay-test",
+      label: "Relay Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        bridgeRequest = request;
+        return {
+          connect: vi.fn(async () => undefined),
+          sendAudio: vi.fn(),
+          setMediaTimestamp: vi.fn(),
+          handleBargeIn: vi.fn(),
+          submitToolResult: vi.fn(),
+          acknowledgeMark: vi.fn(),
+          close,
+          isConnected: vi.fn(() => true),
+        };
+      },
+    };
+    const broadcastToConnIds = vi.fn();
+    const session = createTalkRealtimeRelaySession({
+      context: { broadcastToConnIds } as never,
+      connId: "conn-1",
+      provider,
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+      forceAgentConsultOnFinalTranscript: true,
+    });
+    const retainedSession = relaySessions.get(session.relaySessionId);
+    expect(
+      retainedSession?.toolCalls.tryAdmit(
+        Array.from({ length: MAX_RELAY_TOOL_CALL_IDENTITIES }, (_, index) => `call-${index}`),
+      ),
+    ).toBe(true);
+    bridgeRequest?.onTranscript?.("user", "check this", true);
+
+    bridgeRequest?.onEvent?.({
+      direction: "client",
+      type: "session.continuity.reset",
+    });
+
+    const terminalTypes = broadcastToConnIds.mock.calls
+      .map(([, payload]) =>
+        typeof payload === "object" && payload !== null
+          ? (payload as { type?: string }).type
+          : undefined,
+      )
+      .filter((type) => type === "error" || type === "close" || type === "clear");
+    expect(terminalTypes).toEqual(["error", "close"]);
+    expect(close).toHaveBeenCalledOnce();
+    expect(relaySessions.has(session.relaySessionId)).toBe(false);
   });
 
   it("caps active relay sessions per browser connection", () => {

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -24,6 +24,7 @@ import type {
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { createChatRunState } from "./server-chat-state.js";
 import { drainingRelaySessions, relaySessions } from "./talk-realtime-relay-state.js";
+import { MAX_RELAY_TOOL_CALL_IDENTITIES } from "./talk-realtime-relay-tool-call-ledger.js";
 import {
   acknowledgeTalkRealtimeRelayMark,
   cancelTalkRealtimeRelayTurn,
@@ -3982,6 +3983,87 @@ describe("talk realtime gateway relay", () => {
     expect(chatRunState.runs.get("run-1")?.agentText).toBeUndefined();
     expectChatAbortPayload(broadcast, "relay-closed");
     expectNodeAbortPayload(nodeSendToSession);
+  });
+
+  it("fails closed when retained relay tool-call identities reach their hard cap", () => {
+    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+    const close = vi.fn();
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "relay-test",
+      label: "Relay Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        bridgeRequest = request;
+        return {
+          connect: vi.fn(async () => undefined),
+          sendAudio: vi.fn(),
+          setMediaTimestamp: vi.fn(),
+          handleBargeIn: vi.fn(),
+          submitToolResult: vi.fn(),
+          acknowledgeMark: vi.fn(),
+          close,
+          isConnected: vi.fn(() => true),
+        };
+      },
+    };
+    const broadcastToConnIds = vi.fn();
+    const session = createTalkRealtimeRelaySession({
+      context: { broadcastToConnIds } as never,
+      connId: "conn-1",
+      provider,
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+    });
+    const retainedSession = relaySessions.get(session.relaySessionId);
+    expect(retainedSession).toBeDefined();
+
+    for (let index = 0; index < MAX_RELAY_TOOL_CALL_IDENTITIES; index += 1) {
+      bridgeRequest?.onToolCall?.({
+        itemId: `item-${index}`,
+        callId: `call-${index}`,
+        name: "lookup",
+        args: {},
+      });
+    }
+
+    expect(retainedSession?.toolCalls.size).toBe(MAX_RELAY_TOOL_CALL_IDENTITIES);
+    expect(relaySessions.has(session.relaySessionId)).toBe(true);
+
+    bridgeRequest?.onToolCall?.({
+      itemId: "item-overflow",
+      callId: "call-overflow",
+      name: "lookup",
+      args: {},
+    });
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(relaySessions.has(session.relaySessionId)).toBe(false);
+    expect(
+      broadcastToConnIds.mock.calls.filter(
+        ([, payload]) =>
+          typeof payload === "object" &&
+          payload !== null &&
+          (payload as { type?: string }).type === "error",
+      ),
+    ).toHaveLength(1);
+    expect(
+      broadcastToConnIds.mock.calls.filter(
+        ([, payload]) =>
+          typeof payload === "object" &&
+          payload !== null &&
+          (payload as { type?: string }).type === "close",
+      ),
+    ).toHaveLength(1);
+
+    bridgeRequest?.onToolCall?.({
+      itemId: "item-late",
+      callId: "call-late",
+      name: "lookup",
+      args: {},
+    });
+    expect(close).toHaveBeenCalledOnce();
+    expect(retainedSession?.toolCalls.size).toBe(MAX_RELAY_TOOL_CALL_IDENTITIES);
   });
 
   it("caps active relay sessions per browser connection", () => {


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

The realtime Talk relay retained provider and owner tool-call identity state in several unbounded collections for the full session lifetime. That state is required to reject duplicate and late events, so clearing it opportunistically would weaken terminal correctness.

## Why This Change Was Made

Add one relay-owned tool-call ledger with hard session caps of 2,048 identities and 1 MiB of retained UTF-8 identity data. The ledger keeps admission, provider completion, owner completion, and first-cancellation ownership together. Capacity overflow fails the relay session closed before emitting or submitting the overflowing call.

This keeps the change inside the Gateway relay owner. It adds no provider, config, environment-variable, protocol, or product surface.

## Maintainer Decision

Accept the fixed 2,048-identity and 1 MiB ceilings with fail-closed overflow. Continuing after either limit would require evicting terminal facts and weakening duplicate or late-event rejection; making the limits configurable would add operator surface for an internal safety invariant. An extreme session ending visibly is the intended availability tradeoff.

## User Impact

Long or adversarial realtime sessions can no longer grow relay tool-call lifecycle state without bound. Normal tool-call, cancellation, retry, continuity-reset, and terminal behavior remains unchanged.

## Evidence

- Exact reviewed head: `dcf1ce8f01e2bf9bd5acf9216794f6b01511e7c0`
- Focused proof: 3 files, 69/69 tests passed
- Overflow proof: count and UTF-8 byte admission are atomic; no event emission or provider submission after the hard cap
- Terminal precedence proof: first cancellation turn is preserved; completion clears cancellation and cannot be revived by a late cancel
- Late-event proof: accepted completion ignores same-generation provider replay and cancellation
- Continuity proof: synchronous overflow closes with `error` then `close`, without a late `clear`
- Formatting and `git diff --check`: clean
- Autoreview: clean after review fixes, patch confidence 0.90

## Deliberate Scope Boundary

Repeated outer `cancelTalkRealtimeRelayTurn` calls can still allocate an empty replacement turn. That behavior predates this retention fix and is not needed to bound the tool-call ledger; it remains a separate lifecycle follow-up.
