### PR TITLE
fix(nodes): preserve screen output on write failure

### DIFF
--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -76,6 +76,7 @@ openclaw nodes screen record --node <id> --duration 10s --fps 10 --out ./clip.mp
 - `push` sends an APNs test push to an iOS node. Options: `--title <text>` (default `OpenClaw`), `--body <text>`, `--environment <sandbox|production>` to override the detected APNs environment. Accepted delivery exits `0`; a typed APNs rejection preserves the complete text or JSON diagnostic and exits non-zero.
 - `location get` fetches the node's current location. Options: `--max-age <ms>` (reuse a cached fix), `--accuracy <coarse|balanced|precise>`, `--location-timeout <ms>` (default `10000`), `--invoke-timeout <ms>` (default `20000`).
 - `screen record` captures a short clip and prints the saved path (or writes JSON with `--json`). Options: `--screen <index>` (default `0`), `--duration <ms|10s>` (default `10000`), `--fps <fps>` (default `10`), `--no-audio`, `--out <path>`, `--invoke-timeout <ms>` (default `120000`).
+- Explicit screen output paths are staged beside the destination and replace it only after a complete write; a failed write leaves an existing file unchanged.
 
 Camera and Canvas commands have their own docs: [Camera nodes](/nodes/camera), [Canvas](/platforms/mac/canvas). Canvas is implemented by the bundled experimental Canvas plugin; core keeps `openclaw nodes canvas` as a compatibility mount point.
 

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -119,7 +119,12 @@ const NodesToolSchema = Type.Object({
   // screen_record
   fps: optionalFiniteNumberSchema({ exclusiveMinimum: 0 }),
   screenIndex: optionalNonNegativeIntegerSchema(),
-  outPath: Type.Optional(Type.String()),
+  outPath: Type.Optional(
+    Type.String({
+      description:
+        "screen_record or screen_snapshot: optional output file path; existing files are replaced only after a complete media write.",
+    }),
+  ),
   // location_get
   maxAgeMs: optionalNonNegativeIntegerSchema(),
   locationTimeoutMs: optionalPositiveIntegerSchema(),

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -119,12 +119,7 @@ const NodesToolSchema = Type.Object({
   // screen_record
   fps: optionalFiniteNumberSchema({ exclusiveMinimum: 0 }),
   screenIndex: optionalNonNegativeIntegerSchema(),
-  outPath: Type.Optional(
-    Type.String({
-      description:
-        "screen_record or screen_snapshot: optional output file path; existing files are replaced only after a complete media write.",
-    }),
-  ),
+  outPath: Type.Optional(Type.String()),
   // location_get
   maxAgeMs: optionalNonNegativeIntegerSchema(),
   locationTimeoutMs: optionalPositiveIntegerSchema(),

--- a/src/cli/capability-cli/image.ts
+++ b/src/cli/capability-cli/image.ts
@@ -28,8 +28,8 @@ import { getImageMetadata } from "../../media/media-services.js";
 import { defaultRuntime } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
+import { readInputFiles, writeOutputAsset } from "../media-output.js";
 import { collectOption } from "../program/helpers.js";
-import { readInputFiles, writeOutputAsset } from "./media-output.js";
 import { isMissingMediaUnderstandingProvider } from "./media-understanding-result.js";
 import type { CapabilityEnvelope } from "./metadata.js";
 import {

--- a/src/cli/capability-cli/tts-runtime.ts
+++ b/src/cli/capability-cli/tts-runtime.ts
@@ -25,7 +25,7 @@ import {
   textToSpeech,
 } from "../../tts/tts.js";
 import { getTtsCommandSecretTargetIds } from "../command-secret-targets.js";
-import { publishOutputFileAtomically } from "./media-output.js";
+import { publishOutputFileAtomically } from "../media-output.js";
 import type { CapabilityEnvelope, CapabilityTransport } from "./metadata.js";
 import {
   pinRuntimeConfigSnapshot,

--- a/src/cli/capability-cli/video.ts
+++ b/src/cli/capability-cli/video.ts
@@ -30,7 +30,7 @@ import {
 import type { VideoGenerationResolution } from "../../video-generation/types.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
-import { publishOutputFileAtomically, writeOutputAsset } from "./media-output.js";
+import { publishOutputFileAtomically, writeOutputAsset } from "../media-output.js";
 import type { CapabilityEnvelope } from "./metadata.js";
 import {
   emitJsonOrText,

--- a/src/cli/media-output.ts
+++ b/src/cli/media-output.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { detectMime, extensionForMime, normalizeMimeType } from "@openclaw/media-core/mime";
-import { writeSiblingTempFile } from "../../infra/sibling-temp-file.js";
-import { saveMediaBuffer } from "../../media/store.js";
+import { writeSiblingTempFile } from "../infra/sibling-temp-file.js";
+import { saveMediaBuffer } from "../media/store.js";
 
 const GENERATED_MEDIA_OUTPUT_TEMP_PREFIX = ".openclaw-media-output";
 

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -8,6 +8,8 @@ import {
 } from "../test-utils/camera-url-test-helpers.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 
+type PublishOutputFileAtomically = typeof import("./media-output.js").publishOutputFileAtomically;
+
 const fetchGuardMocks = vi.hoisted(() => ({
   fetchWithSsrFGuard: vi.fn(
     async (params: { url: string; timeoutMs?: number; requireHttps?: boolean }) => {
@@ -20,9 +22,24 @@ const fetchGuardMocks = vi.hoisted(() => ({
   ),
 }));
 
+const mediaOutputMocks = vi.hoisted(() => ({
+  publishOutputFileAtomically: vi.fn<PublishOutputFileAtomically>(),
+}));
+
 vi.mock("../infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: fetchGuardMocks.fetchWithSsrFGuard,
 }));
+
+vi.mock("./media-output.js", async () => {
+  const actual = await vi.importActual<typeof import("./media-output.js")>("./media-output.js");
+  mediaOutputMocks.publishOutputFileAtomically.mockImplementation(
+    actual.publishOutputFileAtomically,
+  );
+  return {
+    ...actual,
+    publishOutputFileAtomically: mediaOutputMocks.publishOutputFileAtomically,
+  };
+});
 
 let cameraTempPath: typeof import("./nodes-camera.js").cameraTempPath;
 let parseCameraClipPayload: typeof import("./nodes-camera.js").parseCameraClipPayload;
@@ -39,6 +56,7 @@ let screenSnapshotFormatForPath: typeof import("./nodes-screen.js").screenSnapsh
 let screenSnapshotTempPath: typeof import("./nodes-screen.js").screenSnapshotTempPath;
 let writeScreenRecordToFile: typeof import("./nodes-screen.js").writeScreenRecordToFile;
 let writeScreenSnapshotToFile: typeof import("./nodes-screen.js").writeScreenSnapshotToFile;
+let publishOutputFileAtomically: PublishOutputFileAtomically;
 
 async function withCameraTempDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
   return await withTempDir("openclaw-test-", run);
@@ -94,6 +112,7 @@ describe("nodes camera helpers", () => {
       writeScreenRecordToFile,
       writeScreenSnapshotToFile,
     } = await import("./nodes-screen.js"));
+    ({ publishOutputFileAtomically } = await vi.importActual("./media-output.js"));
   });
 
   beforeEach(() => {
@@ -258,11 +277,47 @@ describe("nodes camera helpers", () => {
     ).rejects.toThrow(/node remoteip/i);
   });
 
-  it("normalizes valid base64 before writing", async () => {
+  it("normalizes valid base64 and preserves the destination mode", async () => {
     await withCameraTempDir(async (dir) => {
       const out = path.join(dir, "x.bin");
+      await fs.writeFile(out, "existing-screen");
+      await fs.chmod(out, 0o640);
+
       await writeBase64ToFile(out, " aGk\n");
-      await expect(readFileUtf8AndCleanup(out)).resolves.toBe("hi");
+
+      await expect(fs.readFile(out, "utf8")).resolves.toBe("hi");
+      if (process.platform !== "win32") {
+        expect((await fs.stat(out)).mode & 0o777).toBe(0o640);
+      }
+      expect(await fs.readdir(dir)).toEqual(["x.bin"]);
+    });
+  });
+
+  it("preserves an existing output when the decoded media write fails", async () => {
+    await withCameraTempDir(async (dir) => {
+      const out = path.join(dir, "x.bin");
+      await fs.writeFile(out, "existing-screen");
+      await fs.chmod(out, 0o640);
+      mediaOutputMocks.publishOutputFileAtomically.mockImplementationOnce(async (params) => {
+        return await publishOutputFileAtomically({
+          ...params,
+          writeTemp: async (tempPath) => {
+            await params.writeTemp(tempPath);
+            await fs.truncate(tempPath, 1);
+            throw new Error("injected node media write failure");
+          },
+        });
+      });
+
+      await expect(writeScreenRecordToFile(out, "aGk=")).rejects.toThrow(
+        "injected node media write failure",
+      );
+
+      await expect(fs.readFile(out, "utf8")).resolves.toBe("existing-screen");
+      if (process.platform !== "win32") {
+        expect((await fs.stat(out)).mode & 0o777).toBe(0o640);
+      }
+      expect(await fs.readdir(dir)).toEqual(["x.bin"]);
     });
   });
 

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -7,6 +7,7 @@ import { toErrorObject } from "../infra/errors.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
 import { resolveCliName } from "./cli-name.js";
+import { publishOutputFileAtomically } from "./media-output.js";
 import {
   asBoolean,
   asNumber,
@@ -254,7 +255,13 @@ export async function writeBase64ToFile(
   if (buf.length > maxBytes) {
     throw new Error(`writeBase64ToFile: decoded ${buf.length} bytes, exceeds max ${maxBytes}`);
   }
-  await fs.writeFile(filePath, buf);
+  await fs.stat(path.dirname(filePath));
+  await publishOutputFileAtomically({
+    filePath,
+    writeTemp: async (tempPath) => {
+      await fs.writeFile(tempPath, buf, { flag: "wx" });
+    },
+  });
   return { path: filePath, bytes: buf.length };
 }
 


### PR DESCRIPTION
Closes #117970

## What Problem This Solves

Fixes an issue where users replacing an existing node screen recording or snapshot through CLI `--out` or agent-tool `outPath` could lose the original file when the final filesystem write failed. The command/tool reported failure after the destination had already been truncated or partially replaced.

## Why This Change Was Made

The shared node-media base64 writer now publishes through the same sibling-temp atomic owner used by generated CLI media. The owner moved from the infer-capability subdirectory to the shared CLI media boundary so image, video, TTS, node CLI, and node agent-tool callers keep one mode, cleanup, and final-rename policy. Existing missing-parent behavior remains unchanged.

No Gateway RPC, node protocol, capture format, workspace guard, config, storage, or provider behavior changes.

## User Impact

Failed `nodes screen record --out` and agent nodes-tool `screen_record` / `screen_snapshot` output writes leave an existing destination unchanged. Successful writes still return the requested path and complete media bytes while preserving an existing destination mode.

## Evidence

- Current-main built-artifact reproduction at `85e409452982c7a74589a86ef22115a39c456b6f`: a deterministic zero-file-size write failure exited 1 and truncated `existing-screen` to zero bytes.
- Blacksmith Testbox `tbx_01kz138pxg81d1yyzb7hhe1hcr`, run https://github.com/openclaw/openclaw/actions/runs/30745551646:
  - 134/134 final focused assertions passed across prompt snapshots, `nodes-camera`, the agent nodes tool, and the full CLI node-media command path.
  - Full unscoped `check:changed` passed, including production/test typechecks, all core and Control UI lint shards, media/database guards, dead-code scans, and zero runtime import cycles.
  - Full build passed and verified all 149 public Plugin SDK subpaths plus the production Control UI build.
  - Source-blind built-artifact contract passed: normal replacement wrote all 2,048 bytes at mode `0640`; injected write failure exited 1 while preserving `existing-screen`, mode `0640`, and no sibling temp.
- Exact head `875e5611ec2587d1e87cf795d4b32e004e6f53e1` on Blacksmith Testbox `tbx_01kz15mc6f6rb6rsqnnseefrm6`, run https://github.com/openclaw/openclaw/actions/runs/30746971236: remote `HEAD` and clean tree verified before the full build passed, including all 149 public Plugin SDK subpaths and the production Control UI build.
- The first hosted run exposed expected prompt-snapshot drift from optional schema prose plus an unrelated SQLite flip-proof model-call failure. The prose was removed to keep scope narrow; all 15 prompt snapshot tests and the 119 node-focused tests then passed on the final candidate.
- Final autoreview: full candidate clean at 0.98 correctness confidence; schema-only correction clean at 0.99, with no accepted/actionable finding.
- `git diff --check` passed.
- Public model identifier gate: PASS; the diff adds no model identifier.

Production delta: +13/-6 (net +7). Tests: +57/-2. Docs: +1/-0. The production growth is the shared writer call; the prior atomic publisher was moved rather than duplicated.

AI-assisted: yes. No agent transcript attached by user preference.
