### PR TITLE
fix(talk): bound detached browser voice owners

### DIFF
--- a/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
+++ b/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
@@ -804,12 +804,18 @@ describe("RealtimeTalkSession lifecycle", () => {
       expect(createCount).toBe(16);
 
       await vi.advanceTimersByTimeAsync(30_000);
+      expect(closeSignals.every((signal) => !signal.aborted)).toBe(true);
+      await expect(recovered.start()).rejects.toThrow(
+        "Too many active or closing realtime Talk voice sessions",
+      );
+
+      await vi.advanceTimersByTimeAsync(30_000);
       expect(closeSignals.every((signal) => signal.aborted)).toBe(true);
 
       await recovered.start();
       expect(createCount).toBe(17);
       recovered.stop();
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(60_000);
     } finally {
       vi.useRealTimers();
     }

--- a/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
+++ b/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
@@ -755,6 +755,66 @@ describe("RealtimeTalkSession lifecycle", () => {
     closes[2]?.resolve();
   });
 
+  it("bounds stalled detached owners across browser session keys", async () => {
+    vi.useFakeTimers();
+    try {
+      let createCount = 0;
+      const closeSignals: AbortSignal[] = [];
+      const request = vi.fn(
+        async (method: string, _params?: unknown, options?: { signal?: AbortSignal }) => {
+          if (method === "talk.client.create") {
+            createCount += 1;
+            return {
+              provider: "openai",
+              transport: "webrtc",
+              voiceSessionId: `voice-${createCount}`,
+              clientSecret: "secret",
+            };
+          }
+          if (method === "talk.client.close") {
+            const signal = options?.signal;
+            if (!signal) {
+              throw new Error("expected close abort signal");
+            }
+            closeSignals.push(signal);
+            await new Promise<void>((_resolve, reject) => {
+              signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+            });
+          }
+          return { ok: true };
+        },
+      );
+      const client = { request } as never;
+      const draining = Array.from(
+        { length: 16 },
+        (_, index) => new RealtimeTalkSession(client, `agent:main:session-${index}`),
+      );
+
+      for (const session of draining) {
+        await session.start();
+        session.stop();
+        await Promise.resolve();
+      }
+      expect(closeSignals).toHaveLength(16);
+
+      const recovered = new RealtimeTalkSession(client, "agent:main:session-recovered");
+      await expect(recovered.start()).rejects.toThrow(
+        "Too many active or closing realtime Talk voice sessions",
+      );
+      expect(createCount).toBe(16);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(closeSignals.every((signal) => signal.aborted)).toBe(true);
+
+      await recovered.start();
+      expect(createCount).toBe(17);
+      recovered.stop();
+      await vi.advanceTimersByTimeAsync(30_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("releases bounded startup owners after request deadlines", async () => {
     vi.useFakeTimers();
     let failCreate = true;

--- a/ui/src/pages/chat/realtime-talk-transcript-owner.ts
+++ b/ui/src/pages/chat/realtime-talk-transcript-owner.ts
@@ -5,6 +5,7 @@ import type { RealtimeTalkTransport } from "./realtime-talk-shared.ts";
 
 export type ClientVoiceSessionOwner = {
   signal: AbortSignal;
+  closeSignal: AbortSignal;
   beginDrain: () => void;
   release: () => void;
 };
@@ -19,10 +20,12 @@ export type DetachedVoiceSession = {
 
 const MAX_CLIENT_VOICE_SESSION_OWNERS_PER_SESSION = 2;
 const MAX_CLIENT_VOICE_SESSION_OWNERS_PER_CLIENT = 16;
-const CLIENT_VOICE_SESSION_DRAIN_TIMEOUT_MS = DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS;
+const CLIENT_VOICE_TRANSCRIPT_DRAIN_TIMEOUT_MS = DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS;
+const CLIENT_VOICE_SESSION_CLOSE_TIMEOUT_MS =
+  CLIENT_VOICE_TRANSCRIPT_DRAIN_TIMEOUT_MS + DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS;
 
 // One client may own multiple split-pane calls, but route churn must not create
-// unbounded detached drains. Every detached owner also has a hard release deadline.
+// unbounded detached drains. Transcript and close each get one request deadline.
 const clientVoiceSessionOwnerCounts = new WeakMap<GatewayBrowserClient, Map<string, number>>();
 
 export function reserveClientVoiceSessionOwner(
@@ -44,9 +47,11 @@ export function reserveClientVoiceSessionOwner(
   }
   counts.set(sessionKey, sessionCount + 1);
   const ownerCounts = counts;
-  const controller = new AbortController();
+  const transcriptController = new AbortController();
+  const closeController = new AbortController();
   let released = false;
   let drainTimer: ReturnType<typeof setTimeout> | undefined;
+  let closeTimer: ReturnType<typeof setTimeout> | undefined;
   const release = () => {
     if (released) {
       return;
@@ -56,6 +61,10 @@ export function reserveClientVoiceSessionOwner(
       clearTimeout(drainTimer);
       drainTimer = undefined;
     }
+    if (closeTimer !== undefined) {
+      clearTimeout(closeTimer);
+      closeTimer = undefined;
+    }
     const nextSessionCount = (ownerCounts.get(sessionKey) ?? 1) - 1;
     if (nextSessionCount > 0) {
       ownerCounts.set(sessionKey, nextSessionCount);
@@ -64,15 +73,20 @@ export function reserveClientVoiceSessionOwner(
     }
   };
   return {
-    signal: controller.signal,
+    signal: transcriptController.signal,
+    closeSignal: closeController.signal,
     beginDrain: () => {
-      if (released || drainTimer !== undefined) {
+      if (released || drainTimer !== undefined || closeTimer !== undefined) {
         return;
       }
       drainTimer = setTimeout(() => {
-        controller.abort();
+        transcriptController.abort();
+      }, CLIENT_VOICE_TRANSCRIPT_DRAIN_TIMEOUT_MS);
+      closeTimer = setTimeout(() => {
+        transcriptController.abort();
+        closeController.abort();
         release();
-      }, CLIENT_VOICE_SESSION_DRAIN_TIMEOUT_MS);
+      }, CLIENT_VOICE_SESSION_CLOSE_TIMEOUT_MS);
     },
     release,
   };

--- a/ui/src/pages/chat/realtime-talk-transcript-owner.ts
+++ b/ui/src/pages/chat/realtime-talk-transcript-owner.ts
@@ -5,7 +5,7 @@ import type { RealtimeTalkTransport } from "./realtime-talk-shared.ts";
 
 export type ClientVoiceSessionOwner = {
   signal: AbortSignal;
-  abort: () => void;
+  beginDrain: () => void;
   release: () => void;
 };
 
@@ -17,10 +17,12 @@ export type DetachedVoiceSession = {
   owner?: ClientVoiceSessionOwner;
 };
 
-const MAX_CLIENT_VOICE_SESSION_OWNERS = 2;
-export const CLIENT_VOICE_TRANSCRIPT_DRAIN_TIMEOUT_MS = DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS;
-// Count the active call and one retiring replacement across session objects.
-// The token stays owned through durable close so rapid restarts cannot orphan drains.
+const MAX_CLIENT_VOICE_SESSION_OWNERS_PER_SESSION = 2;
+const MAX_CLIENT_VOICE_SESSION_OWNERS_PER_CLIENT = 16;
+const CLIENT_VOICE_SESSION_DRAIN_TIMEOUT_MS = DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS;
+
+// One client may own multiple split-pane calls, but route churn must not create
+// unbounded detached drains. Every detached owner also has a hard release deadline.
 const clientVoiceSessionOwnerCounts = new WeakMap<GatewayBrowserClient, Map<string, number>>();
 
 export function reserveClientVoiceSessionOwner(
@@ -32,29 +34,47 @@ export function reserveClientVoiceSessionOwner(
     counts = new Map();
     clientVoiceSessionOwnerCounts.set(client, counts);
   }
-  const count = counts.get(sessionKey) ?? 0;
-  if (count >= MAX_CLIENT_VOICE_SESSION_OWNERS) {
+  const sessionCount = counts.get(sessionKey) ?? 0;
+  const clientCount = [...counts.values()].reduce((total, count) => total + count, 0);
+  if (
+    sessionCount >= MAX_CLIENT_VOICE_SESSION_OWNERS_PER_SESSION ||
+    clientCount >= MAX_CLIENT_VOICE_SESSION_OWNERS_PER_CLIENT
+  ) {
     throw new Error("Too many active or closing realtime Talk voice sessions");
   }
-  counts.set(sessionKey, count + 1);
+  counts.set(sessionKey, sessionCount + 1);
   const ownerCounts = counts;
   const controller = new AbortController();
   let released = false;
+  let drainTimer: ReturnType<typeof setTimeout> | undefined;
+  const release = () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    if (drainTimer !== undefined) {
+      clearTimeout(drainTimer);
+      drainTimer = undefined;
+    }
+    const nextSessionCount = (ownerCounts.get(sessionKey) ?? 1) - 1;
+    if (nextSessionCount > 0) {
+      ownerCounts.set(sessionKey, nextSessionCount);
+    } else {
+      ownerCounts.delete(sessionKey);
+    }
+  };
   return {
     signal: controller.signal,
-    abort: () => controller.abort(),
-    release: () => {
-      if (released) {
+    beginDrain: () => {
+      if (released || drainTimer !== undefined) {
         return;
       }
-      released = true;
-      const nextCount = (ownerCounts.get(sessionKey) ?? 1) - 1;
-      if (nextCount > 0) {
-        ownerCounts.set(sessionKey, nextCount);
-      } else {
-        ownerCounts.delete(sessionKey);
-      }
+      drainTimer = setTimeout(() => {
+        controller.abort();
+        release();
+      }, CLIENT_VOICE_SESSION_DRAIN_TIMEOUT_MS);
     },
+    release,
   };
 }
 

--- a/ui/src/pages/chat/realtime-talk-transcript-queue.test.ts
+++ b/ui/src/pages/chat/realtime-talk-transcript-queue.test.ts
@@ -235,14 +235,7 @@ describe("RealtimeTalkSession transcript queue", () => {
       expect(
         request.mock.calls.filter(([method]) => method === "talk.client.transcript"),
       ).toHaveLength(1);
-      expect(request).toHaveBeenCalledWith(
-        "talk.client.close",
-        {
-          sessionKey: "agent:main:main",
-          voiceSessionId: "voice-drain-timeout",
-        },
-        { timeoutMs: 30_000 },
-      );
+      expect(request.mock.calls.some(([method]) => method === "talk.client.close")).toBe(false);
       expect(onStatus.mock.calls.filter(([status]) => status === "error")).toHaveLength(0);
     } finally {
       vi.useRealTimers();

--- a/ui/src/pages/chat/realtime-talk-transcript-queue.test.ts
+++ b/ui/src/pages/chat/realtime-talk-transcript-queue.test.ts
@@ -182,6 +182,7 @@ describe("RealtimeTalkSession transcript queue", () => {
   it("aborts a detached transcript drain before releasing its client owner", async () => {
     vi.useFakeTimers();
     const transcriptSignals: AbortSignal[] = [];
+    const closeSignals: AbortSignal[] = [];
     try {
       const request = vi.fn(
         async (
@@ -206,6 +207,13 @@ describe("RealtimeTalkSession transcript queue", () => {
             await new Promise<void>((_resolve, reject) => {
               signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
             });
+          }
+          if (method === "talk.client.close") {
+            const signal = options?.signal;
+            if (!signal) {
+              throw new Error("expected close abort signal");
+            }
+            closeSignals.push(signal);
           }
           return { ok: true };
         },
@@ -235,7 +243,19 @@ describe("RealtimeTalkSession transcript queue", () => {
       expect(
         request.mock.calls.filter(([method]) => method === "talk.client.transcript"),
       ).toHaveLength(1);
-      expect(request.mock.calls.some(([method]) => method === "talk.client.close")).toBe(false);
+      expect(request).toHaveBeenCalledWith(
+        "talk.client.close",
+        {
+          sessionKey: "agent:main:main",
+          voiceSessionId: "voice-drain-timeout",
+        },
+        {
+          signal: closeSignals[0],
+          timeoutMs: 30_000,
+        },
+      );
+      expect(closeSignals[0]).not.toBe(transcriptSignals[0]);
+      expect(closeSignals[0]?.aborted).toBe(false);
       expect(onStatus.mock.calls.filter(([status]) => status === "error")).toHaveLength(0);
     } finally {
       vi.useRealTimers();

--- a/ui/src/pages/chat/realtime-talk.test.ts
+++ b/ui/src/pages/chat/realtime-talk.test.ts
@@ -325,6 +325,7 @@ describe("RealtimeTalkSession", () => {
           voiceSessionId: "voice-stale",
         },
         {
+          signal: expect.any(AbortSignal),
           timeoutMs: 30_000,
         },
       ),

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -20,7 +20,6 @@ import type {
   RealtimeTalkWebRtcSdpSessionResult,
 } from "./realtime-talk-shared.ts";
 import {
-  CLIENT_VOICE_TRANSCRIPT_DRAIN_TIMEOUT_MS,
   type ClientVoiceSessionOwner,
   type DetachedVoiceSession,
   reserveClientVoiceSessionOwner,
@@ -646,19 +645,17 @@ export class RealtimeTalkSession {
       detached.owner?.release();
       return;
     }
-    const drainTimer = setTimeout(
-      () => detached.owner?.abort(),
-      CLIENT_VOICE_TRANSCRIPT_DRAIN_TIMEOUT_MS,
-    );
+    const owner = detached.owner!;
+    owner.beginDrain();
     void detached.transcriptQueue
       .flush()
       .then(async () => {
         let lastError: unknown;
         for (const delayMs of [0, 500, 2_000]) {
           if (delayMs > 0) {
-            await new Promise<void>((resolve) => {
-              setTimeout(resolve, delayMs);
-            });
+            await waitForTranscriptRetry(delayMs, owner.signal);
+          } else if (owner.signal.aborted) {
+            throw transcriptPersistenceAbortError();
           }
           try {
             await this.client.request(
@@ -667,16 +664,25 @@ export class RealtimeTalkSession {
                 sessionKey: this.sessionKey,
                 voiceSessionId: detached.voiceSessionId,
               },
-              { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
+              {
+                signal: owner.signal,
+                timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+              },
             );
             return;
           } catch (error) {
+            if (owner.signal.aborted) {
+              throw transcriptPersistenceAbortError();
+            }
             lastError = error;
           }
         }
         throw transcriptWriteError(lastError, "Realtime Talk voice session close failed");
       })
       .catch((error: unknown) => {
+        if (owner.signal.aborted) {
+          return;
+        }
         console.warn("Realtime Talk voice session close failed", error);
         // Suppress if a newer transport has started: closing the old call is its own
         // teardown and must not push the active replacement call into an error state.
@@ -684,10 +690,7 @@ export class RealtimeTalkSession {
           this.callbacks.onStatus?.("error", "Realtime Talk voice session close failed");
         }
       })
-      .finally(() => {
-        clearTimeout(drainTimer);
-        detached.owner?.release();
-      });
+      .finally(owner.release);
   }
 
   async setVideoEnabled(enabled: boolean): Promise<void> {

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -653,8 +653,8 @@ export class RealtimeTalkSession {
         let lastError: unknown;
         for (const delayMs of [0, 500, 2_000]) {
           if (delayMs > 0) {
-            await waitForTranscriptRetry(delayMs, owner.signal);
-          } else if (owner.signal.aborted) {
+            await waitForTranscriptRetry(delayMs, owner.closeSignal);
+          } else if (owner.closeSignal.aborted) {
             throw transcriptPersistenceAbortError();
           }
           try {
@@ -665,13 +665,13 @@ export class RealtimeTalkSession {
                 voiceSessionId: detached.voiceSessionId,
               },
               {
-                signal: owner.signal,
+                signal: owner.closeSignal,
                 timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
               },
             );
             return;
           } catch (error) {
-            if (owner.signal.aborted) {
+            if (owner.closeSignal.aborted) {
               throw transcriptPersistenceAbortError();
             }
             lastError = error;
@@ -680,7 +680,7 @@ export class RealtimeTalkSession {
         throw transcriptWriteError(lastError, "Realtime Talk voice session close failed");
       })
       .catch((error: unknown) => {
-        if (owner.signal.aborted) {
+        if (owner.closeSignal.aborted) {
           return;
         }
         console.warn("Realtime Talk voice session close failed", error);


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Each browser Talk session already bounded its own transcript queue and allowed one retiring replacement per session key, but a client with many session keys could retain an unbounded number of detached transcript and close owners. A stalled transcript request could also consume the whole teardown deadline before `talk.client.close` was attempted.

## Why This Change Was Made

Keep the existing per-session owner cap of 2 and add a per-`GatewayBrowserClient` aggregate cap of 16. Detached teardown now has two phases:

- transcript work receives a 30-second abort deadline;
- close work receives an independent signal and the owner is forcibly released at the 60-second absolute deadline.

The owner token remains browser-local and is released idempotently. No protocol, provider, config, environment-variable, or server-state surface changes.

## User Impact

Repeated Talk restart or multi-pane churn cannot retain browser voice-session owners without bound. The aggregate ceiling permits up to 16 simultaneous active-or-retiring browser owners per client; it is a safety bound, not a UI pane limit. If server close cannot complete before the absolute deadline, browser ownership is released and the existing server stale-session cleanup remains the fallback.

## Evidence

- Exact reviewed head: `fbd502f83de674c93bcf9ec6ad0ffbcb70771400`
- Focused Talk and Gateway proof: 45 passed, 33 skipped
- Real `GatewayBrowserClient` AbortSignal watchdog contract included in focused proof
- Blacksmith Testbox changed gate: exit 0, `runStatus=succeeded`, 6m52 total
- Live OpenAI UI owner proof: exact-head `RealtimeTalkSession` completed two start/audio/response/stop cycles with `gpt-realtime-2.1`
- Live transcripts: each cycle produced one final user transcript and one final assistant transcript
- Live teardown: `talk.client.create=2`, `talk.client.transcript=4`, `talk.client.close=2`, request failures 0, pending requests returned from peak 1 to 0
- Owner release proof: two consecutive same-session reservations succeeded after teardown, proving no retained active or retiring owner
- Probe provenance: exact PR UI modules loaded from `fbd502f83de`; the ephemeral Gateway/provider build came from merged QA head `54cb02151fd`, whose Gateway Talk, OpenAI provider, browser client, and protocol-client sources are unchanged from the PR head
- Latest-main merge simulation: clean, with no same-file main changes
- Formatting and `git diff --check`: clean
- Autoreview: no P0/P1 findings, patch confidence 0.91

## Deliberate Scope Boundary

The cap intentionally rejects a 17th simultaneous active-or-retiring browser owner. This PR does not change the server stale-session sweep or Gateway relay durable-drain ownership.
