### PR TITLE
improve(qa): allow scorecard generation from incomplete evidence

### DIFF
--- a/.github/codex/prompts/maturity-scorecard-agent.md
+++ b/.github/codex/prompts/maturity-scorecard-agent.md
@@ -19,5 +19,7 @@ Required workflow:
 1. Use the `$claw-score` skill before editing.
 2. Read `taxonomy.yaml`, any existing maturity score file, and the release evidence artifacts.
 3. Refresh scores for every active surface in `taxonomy.yaml`.
+   - Treat failed, blocked, and skipped QA entries as missing Coverage; only passing evidence fulfills Coverage.
+   - Do not automatically lower Quality or Completeness because a lane was blocked by unavailable credentials. Score those dimensions from their own repository and evidence criteria.
 4. Run the QA Lab maturity score validation used by this repository.
 5. If no defensible score update is possible, leave a valid `qa/maturity-scores.yaml` and explain the uncertainty in the final message.

--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: true
         type: boolean
+      allow_failures:
+        description: Allow rendering from valid incomplete QA evidence
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       qa_evidence_run_id:
@@ -38,6 +43,11 @@ on:
         required: false
         default: ""
         type: string
+      allow_failures:
+        description: Allow rendering from valid incomplete QA evidence
+        required: false
+        default: false
+        type: boolean
     secrets:
       OPENAI_API_KEY:
         description: OpenAI API key used by live QA profile scenarios
@@ -321,6 +331,7 @@ jobs:
       ref: ${{ needs.validate_selected_ref.outputs.selected_revision }}
       expected_sha: ${{ needs.validate_selected_ref.outputs.selected_revision }}
       qa_profile: all
+      allow_failures: ${{ inputs.allow_failures }}
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
@@ -533,31 +544,46 @@ jobs:
           NODE
 
       - name: Render artifact docs
+        env:
+          ALLOW_FAILURES: ${{ inputs.allow_failures }}
         run: |
           set -euo pipefail
+          allow_failures_args=()
+          if [[ "$ALLOW_FAILURES" == "true" ]]; then
+            allow_failures_args+=(--allow-failures)
+          fi
           pnpm maturity:render -- \
             --output-dir .artifacts/maturity-docs \
             --static-assets-dir .artifacts/maturity-docs/assets/maturity \
             --scores qa/maturity-scores.yaml \
             --evidence-dir .artifacts/maturity-evidence \
-            --strict-inputs
+            --strict-inputs \
+            "${allow_failures_args[@]}"
           {
             echo "### Maturity scorecard docs"
             echo
             echo "- Source validation: passed"
             echo "- Artifact docs: \`.artifacts/maturity-docs\`"
             echo "- Strict inputs: \`true\`"
+            echo "- QA failures allowed: \`${ALLOW_FAILURES}\`"
             echo "- QA evidence: included"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Render committed docs preview
+        env:
+          ALLOW_FAILURES: ${{ inputs.allow_failures }}
         run: |
           set -euo pipefail
+          allow_failures_args=()
+          if [[ "$ALLOW_FAILURES" == "true" ]]; then
+            allow_failures_args+=(--allow-failures)
+          fi
           pnpm maturity:render -- \
             --output-dir docs \
             --scores qa/maturity-scores.yaml \
             --evidence-dir .artifacts/maturity-evidence \
-            --strict-inputs
+            --strict-inputs \
+            "${allow_failures_args[@]}"
 
       - name: Upload generated PR files
         if: ${{ inputs.publish_pull_request }}
@@ -721,7 +747,7 @@ jobs:
 
             ## Why This Change Was Made
 
-            The maturity workflow generated this update from the selected immutable source and strict QA evidence.
+            The maturity workflow generated this update from the selected immutable source and validated QA evidence.
 
             ## User Impact
 

--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -20,6 +20,11 @@ on:
         required: true
         default: all
         type: string
+      allow_failures:
+        description: Continue after validated QA result failures
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       ref:
@@ -35,6 +40,11 @@ on:
         description: Taxonomy QA profile id to run
         required: true
         type: string
+      allow_failures:
+        description: Continue after validated QA result failures
+        required: false
+        default: false
+        type: boolean
     secrets:
       OPENAI_API_KEY:
         description: OpenAI API key used by live QA profile scenarios
@@ -316,6 +326,7 @@ jobs:
         if: always()
         env:
           ARTIFACT_NAME: qa-profile-evidence-${{ steps.profile.outputs.profile }}-${{ needs.validate_selected_ref.outputs.selected_revision }}
+          ALLOW_FAILURES: ${{ inputs.allow_failures }}
           OUTPUT_DIR: ${{ steps.run_profile.outputs.output_dir }}
           QA_EXIT_CODE: ${{ steps.run_profile.outputs.qa_exit_code }}
           QA_PROFILE: ${{ steps.profile.outputs.profile }}
@@ -326,9 +337,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          node --input-type=module <<'NODE'
+          node --import tsx --input-type=module <<'NODE'
           import fs from "node:fs";
           import path from "node:path";
+          import { validateQaEvidenceSummaryJson } from "./extensions/qa-lab/src/evidence-summary.ts";
 
           const outputDir = process.env.OUTPUT_DIR;
           if (!outputDir) {
@@ -339,7 +351,9 @@ jobs:
           }
 
           const evidencePath = path.join(outputDir, "qa-evidence.json");
-          const payload = JSON.parse(fs.readFileSync(evidencePath, "utf8"));
+          const payload = validateQaEvidenceSummaryJson(
+            JSON.parse(fs.readFileSync(evidencePath, "utf8")),
+          );
           if (payload.profile !== process.env.QA_PROFILE) {
             throw new Error(`qa-evidence.json profile must be ${process.env.QA_PROFILE}, got ${JSON.stringify(payload.profile)}`);
           }
@@ -356,6 +370,7 @@ jobs:
             qaProfile: process.env.QA_PROFILE,
             qaExitCode: Number(process.env.QA_EXIT_CODE),
             qaPassed: process.env.QA_EXIT_CODE === "0",
+            allowFailures: process.env.ALLOW_FAILURES === "true",
             requestedRef: process.env.REQUESTED_REF,
             targetSha: process.env.TARGET_SHA,
             trustedReason: process.env.TRUSTED_REASON,
@@ -391,6 +406,7 @@ jobs:
             echo "- Artifact: \`${ARTIFACT_NAME}\`"
             echo "- QA profile: \`${QA_PROFILE}\`"
             echo "- QA exit code: \`${QA_EXIT_CODE}\`"
+            echo "- QA failures allowed: \`${ALLOW_FAILURES}\`"
             echo "- Target SHA: \`${TARGET_SHA}\`"
             echo "- Evidence path: \`${OUTPUT_DIR}/qa-evidence.json\`"
             echo "- Manifest: \`${OUTPUT_DIR}/qa-profile-evidence-manifest.json\`"
@@ -408,6 +424,8 @@ jobs:
       - name: Fail if QA profile failed
         if: always()
         env:
+          ALLOW_FAILURES: ${{ inputs.allow_failures }}
+          EVIDENCE_VALIDATED: ${{ steps.evidence.outcome == 'success' }}
           QA_EXIT_CODE: ${{ steps.run_profile.outputs.qa_exit_code }}
           QA_PROFILE: ${{ steps.profile.outputs.profile }}
         shell: bash
@@ -418,6 +436,10 @@ jobs:
             exit 1
           fi
           if [[ "$QA_EXIT_CODE" != "0" ]]; then
+            if [[ "$ALLOW_FAILURES" == "true" && "$EVIDENCE_VALIDATED" == "true" ]]; then
+              echo "::warning::QA profile '${QA_PROFILE}' failed with exit code ${QA_EXIT_CODE}; allow_failures accepted the validated evidence."
+              exit 0
+            fi
             echo "QA profile '${QA_PROFILE}' failed with exit code ${QA_EXIT_CODE}." >&2
             exit "$QA_EXIT_CODE"
           fi

--- a/scripts/qa/render-maturity-docs.ts
+++ b/scripts/qa/render-maturity-docs.ts
@@ -40,6 +40,7 @@ type Args = {
   evidenceDir?: string;
   check: boolean;
   strictInputs: boolean;
+  allowFailures: boolean;
 };
 
 type EvidenceSummary = {
@@ -75,6 +76,7 @@ type DocsRouteIndex = {
 
 type RenderMaturityScorecardInputs = Pick<RenderInputs, "taxonomy" | "scores" | "coverage"> & {
   evidenceSummaries: EvidenceSummary[];
+  acceptedIncompleteEvidence: boolean;
 };
 
 type DerivedCoverageScores = QaMaturityCoverageScores & {
@@ -98,6 +100,7 @@ function parseArgs(argv: string[]): Args {
     evidenceDir: undefined,
     check: false,
     strictInputs: false,
+    allowFailures: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -110,6 +113,10 @@ function parseArgs(argv: string[]): Args {
     }
     if (arg === "--strict-inputs") {
       args.strictInputs = true;
+      continue;
+    }
+    if (arg === "--allow-failures") {
+      args.allowFailures = true;
       continue;
     }
     const next = (): string => {
@@ -145,6 +152,7 @@ Options:
   --evidence-dir <path> Optional directory containing qa-evidence.json artifacts
   --check               Fail when output files are stale
   --strict-inputs       Fail on score or evidence input warnings
+  --allow-failures      Render valid incomplete QA evidence; non-passing checks earn no Coverage
   -h, --help            Show this help
 `);
       process.exit(0);
@@ -721,6 +729,12 @@ function rejectBlockingEvidence(evidenceSummaries: EvidenceSummary[]): void {
   );
 }
 
+function hasIncompleteEvidence(evidenceSummaries: EvidenceSummary[]): boolean {
+  return evidenceSummaries.some(
+    (item) => item.statuses.fail > 0 || item.statuses.blocked > 0 || item.statuses.skipped > 0,
+  );
+}
+
 function latestCoverageScorecard(
   evidenceSummaries: EvidenceSummary[],
 ): EvidenceSummary | undefined {
@@ -959,6 +973,7 @@ function renderMaturityScorecard({
   taxonomy,
   scores,
   evidenceSummaries,
+  acceptedIncompleteEvidence,
 }: RenderMaturityScorecardInputs): string {
   const levels = qaMaturityTaxonomyLevelMap(taxonomy);
   const scoreSurfaces = surfaceScoreMap(scores);
@@ -987,6 +1002,12 @@ function renderMaturityScorecard({
     '  <p className="maturity-jump-links"><a href="#surface-explorer">Browse surfaces</a> / <a href="#qa-evidence-summary">Inspect QA evidence</a> / <a href="/maturity/taxonomy">Read the taxonomy</a></p>',
     "</div>",
     "",
+    ...(acceptedIncompleteEvidence
+      ? [
+          "> **Incomplete QA evidence accepted.** Failed, blocked, and skipped checks provided no Coverage; only passing evidence fulfilled Coverage.",
+          "",
+        ]
+      : []),
     "## What this page is for",
     "",
     "Use this page to answer one question: which OpenClaw surfaces are credible choices for a release, and what evidence supports that judgment? Coverage comes from deterministic QA evidence; quality and completeness are maintained as reviewed maturity scores.",
@@ -1224,7 +1245,10 @@ function main(): void {
   }
 
   const evidenceSummaries = readEvidenceSummaries(args.evidenceDir);
-  rejectBlockingEvidence(evidenceSummaries);
+  if (!args.allowFailures) {
+    rejectBlockingEvidence(evidenceSummaries);
+  }
+  const acceptedIncompleteEvidence = args.allowFailures && hasIncompleteEvidence(evidenceSummaries);
   const coverage = deriveCoverageScores(taxonomy, evidenceSummaries);
   const { scores, warnings: scoreWarnings } = readValidatedQaMaturityScoreSources({
     coverageScores: coverage,
@@ -1255,6 +1279,7 @@ function main(): void {
         taxonomy,
         scores,
         evidenceSummaries,
+        acceptedIncompleteEvidence,
       }),
     ],
     [

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -420,6 +420,27 @@ function readQaProfileEvidenceWorkflow() {
   return parse(readFileSync(".github/workflows/qa-profile-evidence.yml", "utf8"));
 }
 
+function runQaProfileFailureGate(options: {
+  allowFailures: boolean;
+  evidenceValidated?: boolean;
+  qaExitCode?: string;
+}) {
+  const workflow = readQaProfileEvidenceWorkflow();
+  const failStep = workflow.jobs.run_qa_profile.steps.find(
+    (step: WorkflowStep) => step.name === "Fail if QA profile failed",
+  );
+  return spawnSync("bash", ["-c", failStep.run], {
+    encoding: "utf8",
+    env: {
+      ALLOW_FAILURES: String(options.allowFailures),
+      EVIDENCE_VALIDATED: String(options.evidenceValidated ?? true),
+      PATH: process.env.PATH ?? "",
+      QA_EXIT_CODE: options.qaExitCode ?? "",
+      QA_PROFILE: "all",
+    },
+  });
+}
+
 function readReleaseChecksWorkflow() {
   return parse(readFileSync(".github/workflows/openclaw-release-checks.yml", "utf8"));
 }
@@ -4970,6 +4991,18 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
         default: "",
         type: "string",
       },
+      allow_failures: {
+        description: "Allow rendering from valid incomplete QA evidence",
+        required: false,
+        default: false,
+        type: "boolean",
+      },
+    });
+    expect(maturityWorkflow.on.workflow_dispatch.inputs.allow_failures).toEqual({
+      description: "Allow rendering from valid incomplete QA evidence",
+      required: false,
+      default: false,
+      type: "boolean",
     });
     expect(maturityWorkflow.on.workflow_dispatch.inputs.publish_pull_request).toEqual({
       description: "Open or update a pull request for generated maturity files",
@@ -5001,6 +5034,14 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     }
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs).not.toHaveProperty("fail_on_qa_failure");
     expect(qaEvidenceWorkflow.on.workflow_call.inputs).not.toHaveProperty("fail_on_qa_failure");
+    for (const trigger of ["workflow_dispatch", "workflow_call"] as const) {
+      expect(qaEvidenceWorkflow.on[trigger].inputs.allow_failures).toEqual({
+        description: "Continue after validated QA result failures",
+        required: false,
+        default: false,
+        type: "boolean",
+      });
+    }
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.qa_profile).not.toHaveProperty("options");
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.qa_profile.default).toBe("all");
     expect(qaEvidenceWorkflow.on.workflow_call.inputs.qa_profile.type).toBe("string");
@@ -5026,10 +5067,20 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(runProfileStep.env?.OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS).toBe("120000");
     expect(runProfileStep.run).toContain("--concurrency 3");
     expect(runProfileStep.run).toContain("--fast");
+    expect(runProfileStep.run).toContain("qa_exit_code=$?");
+    expect(runProfileStep.run).not.toContain("--allow-failures");
     const failProfileStep = qaRunJob.steps.find(
       (step: WorkflowStep) => step.name === "Fail if QA profile failed",
     );
     expect(failProfileStep.if).toBe("always()");
+    expect(failProfileStep.env?.ALLOW_FAILURES).toBe("${{ inputs.allow_failures }}");
+    expect(failProfileStep.env?.EVIDENCE_VALIDATED).toBe(
+      "${{ steps.evidence.outcome == 'success' }}",
+    );
+    expect(failProfileStep.run).toContain(
+      '[[ "$ALLOW_FAILURES" == "true" && "$EVIDENCE_VALIDATED" == "true" ]]',
+    );
+    expect(failProfileStep.run).toContain('exit "$QA_EXIT_CODE"');
     expect(generateJob.needs).toEqual(["validate_selected_ref", "publisher_preflight"]);
     expect(generateJob.if.replace(/\s+/gu, " ")).toBe(
       "${{ always() && needs.validate_selected_ref.result == 'success' && (!inputs.publish_pull_request || needs.publisher_preflight.result == 'success') && inputs.qa_evidence_run_id == '' }}",
@@ -5040,6 +5091,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       ref: "${{ needs.validate_selected_ref.outputs.selected_revision }}",
       expected_sha: "${{ needs.validate_selected_ref.outputs.selected_revision }}",
       qa_profile: "all",
+      allow_failures: "${{ inputs.allow_failures }}",
     });
     expect(generateJob.with).not.toHaveProperty("fail_on_qa_failure");
     expect(generateJob.secrets).toMatchObject({
@@ -5189,6 +5241,12 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "qa-profile-evidence-${{ steps.profile.outputs.profile }}-${{ needs.validate_selected_ref.outputs.selected_revision }}",
     );
     expect(qaEvidenceStep.run).toContain("qa-profile-evidence-manifest.json");
+    expect(qaEvidenceStep.run).toContain("validateQaEvidenceSummaryJson");
+    expect(qaEvidenceStep.env.ALLOW_FAILURES).toBe("${{ inputs.allow_failures }}");
+    expect(qaEvidenceStep.run).toContain("qaExitCode: Number(process.env.QA_EXIT_CODE)");
+    expect(qaEvidenceStep.run).toContain('qaPassed: process.env.QA_EXIT_CODE === "0"');
+    expect(qaEvidenceStep.run).toContain('allowFailures: process.env.ALLOW_FAILURES === "true"');
+    expect(qaEvidenceStep.run).toContain("QA failures allowed:");
 
     const qaUploadStep = qaRunJob.steps.find(
       (step: WorkflowStep) => step.name === "Upload QA profile evidence",
@@ -5216,6 +5274,18 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       },
     });
     expect(generatedPrUploadStep.with.path.trim().split("\n")).toEqual(MATURITY_GENERATED_PR_PATHS);
+
+    for (const stepName of ["Render artifact docs", "Render committed docs preview"]) {
+      const renderStep = publishJob.steps.find((step: WorkflowStep) => step.name === stepName);
+      expect(renderStep.env.ALLOW_FAILURES).toBe("${{ inputs.allow_failures }}");
+      expect(renderStep.run).toContain('[[ "$ALLOW_FAILURES" == "true" ]]');
+      expect(renderStep.run).toContain("allow_failures_args+=(--allow-failures)");
+      expect(renderStep.run).toContain('"${allow_failures_args[@]}"');
+    }
+    const renderArtifactStep = publishJob.steps.find(
+      (step: WorkflowStep) => step.name === "Render artifact docs",
+    );
+    expect(renderArtifactStep.run).toContain("QA failures allowed:");
 
     expect(publishPrJob.needs).toEqual(["validate_selected_ref", "publisher_preflight", "publish"]);
     expect(publishPrJob["runs-on"]).toBe("ubuntu-24.04");
@@ -5303,6 +5373,23 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(maturityWorkflowSource).not.toContain("gh auth setup-git");
     expect(maturityWorkflowSource).not.toContain("git push --force-with-lease");
   });
+
+  it.skipIf(process.platform === "win32")(
+    "suppresses only reported QA result failures when explicitly allowed",
+    () => {
+      expect(runQaProfileFailureGate({ allowFailures: false, qaExitCode: "7" }).status).toBe(7);
+      expect(runQaProfileFailureGate({ allowFailures: true, qaExitCode: "7" }).status).toBe(0);
+      expect(
+        runQaProfileFailureGate({
+          allowFailures: true,
+          evidenceValidated: false,
+          qaExitCode: "7",
+        }).status,
+      ).toBe(7);
+      expect(runQaProfileFailureGate({ allowFailures: true }).status).toBe(1);
+      expect(runQaProfileFailureGate({ allowFailures: false, qaExitCode: "0" }).status).toBe(0);
+    },
+  );
 
   it.skipIf(process.platform === "win32")(
     "authorizes maturity PR publication only for a canonical direct dispatch",

--- a/test/scripts/render-maturity-docs.test.ts
+++ b/test/scripts/render-maturity-docs.test.ts
@@ -112,7 +112,7 @@ function writeQaEvidence(params: {
   );
 }
 
-function allProfileScorecardFixture() {
+function allProfileScorecardFixture(evidenceEntryCount = 1) {
   const taxonomy = parseYaml(
     fs.readFileSync(path.join(repoRoot, "taxonomy.yaml"), "utf8"),
   ) as TaxonomyFixture;
@@ -155,7 +155,7 @@ function allProfileScorecardFixture() {
   );
   return {
     filters: { surface: null, category: null },
-    run: { evidenceEntryCount: 1 },
+    run: { evidenceEntryCount },
     categories: {
       total: categoryReports.length,
       fulfilled: 0,
@@ -237,6 +237,38 @@ describe("maturity docs renderer CLI", () => {
     expect(result.stderr).toContain("maturity docs require passing QA evidence");
     expect(result.stderr).toContain("failing-scenario (fail)");
     expect(result.stderr).toContain("blocked-scenario (blocked)");
+  });
+
+  it("allows incomplete evidence without awarding Coverage to non-passing checks", () => {
+    const outputDir = tempDirs.make("openclaw-maturity-docs-output-");
+    const evidenceDir = tempDirs.make("openclaw-maturity-docs-evidence-");
+    writeQaEvidence({
+      dir: evidenceDir,
+      entries: [
+        { id: "failing-scenario", status: "fail" },
+        { id: "blocked-scenario", status: "blocked" },
+        { id: "skipped-scenario", status: "skipped" },
+      ],
+      scorecard: allProfileScorecardFixture(3),
+    });
+
+    const result = runCli(
+      "--output-dir",
+      outputDir,
+      "--evidence-dir",
+      evidenceDir,
+      "--allow-failures",
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const scorecard = fs.readFileSync(path.join(outputDir, "maturity", "scorecard.md"), "utf8");
+    expect(scorecard).toContain("Incomplete QA evidence accepted.");
+    expect(scorecard).toContain(
+      "Failed, blocked, and skipped checks provided no Coverage; only passing evidence fulfilled Coverage.",
+    );
+    expect(scorecard).toContain("Coverage Experimental - 0%");
+    expect(scorecard).toContain("0 passed, 1 failed, 1 blocked, 1 skipped");
   });
 
   it("renders passing evidence without impossible failed or blocked result counts", () => {


### PR DESCRIPTION
## What Problem This Solves

Maturity scorecard generation currently stops whenever QA reports a failed or blocked check, even when maintainers need a temporary per-run scorecard from otherwise valid evidence. That makes incomplete evidence impossible to inspect without weakening the QA command or committing a workflow-policy change that must later be reverted.

## Why This Change Was Made

This AI-assisted change adds an opt-in `allow_failures` input to the maturity and reusable QA workflows. Strict behavior remains the default. The QA command still runs without its CLI `--allow-failures` option, preserves the genuine exit code and `qaPassed=false`, validates and uploads the evidence, and suppresses only the final QA-result failure after valid evidence has been confirmed.

The renderer accepts valid incomplete evidence only when explicitly enabled. It continues to use the existing pass-only scorecard evidence calculation, so failed, blocked, and skipped checks provide no Coverage. Invalid or missing evidence, schema errors, wrong refs or profiles, setup failures, upload failures, and runtime crashes remain fatal.

Architectural ownership stays split at the existing boundaries: the reusable QA workflow owns execution truth and its final job result, the renderer owns evidence admissibility and disclosure, and the existing scorecard-evidence producer remains the single Coverage-policy owner. No compatibility path or duplicate coverage calculation was added.

Production/config delta: +81/-6 lines; tests: +121/-2 lines. The positive production delta is the explicit workflow input/propagation, integrity gate, renderer option, and operator-visible disclosure required for this per-run capability.

## User Impact

Maintainers can enable `allow_failures` for one workflow run and generate a visibly marked scorecard from valid incomplete evidence. QA failures remain recorded truthfully, and only passing evidence earns Coverage. The setting is temporary per run and requires no later re-enable or revert commit.

Credential-unavailable lanes remain missing Coverage, but the agent prompt no longer treats that blockage alone as a reason to lower Quality or Completeness.

## Evidence

- Focused tests: `corepack pnpm test test/scripts/render-maturity-docs.test.ts test/scripts/ci-workflow-guards.test.ts` — 103 passed ([run](https://github.com/openclaw/openclaw/actions/runs/30746285792)).
- Changed-check routing: `node scripts/check-changed.mjs` — scripts, test-root, docs, and tooling lanes passed ([run](https://github.com/openclaw/openclaw/actions/runs/30746401438)).
- Workflow/action validation: `corepack pnpm check:workflows` — actionlint, zizmor, and interpolation guards passed ([run](https://github.com/openclaw/openclaw/actions/runs/30746570823)).
- Targeted formatting and `git diff --check` passed.
- `autoreview --mode local` reported no accepted/actionable findings.
- Codex prompt/runtime contract inspected directly: `../codex/codex-rs/exec/src/cli.rs:81`, `../codex/codex-rs/exec/src/lib.rs:650`, `../codex/codex-rs/exec/src/lib.rs:1761`, and `../codex/codex-rs/core/tests/suite/prompt_debug_tests.rs:26`.
- Local `node scripts/check-workflows.mjs` was not used as proof because the machine's Python 3.9.6 cannot run the pinned zizmor hook; the repository workflow check passed remotely with its supported toolchain.

