### PR TITLE
🐛 fix(skills): authorize configured canonical workshop roots

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -212,6 +212,7 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
     },
     workshop: {
       allowSymlinkTargetWrites: false,
+      writableRoots: [],
     },
     entries: {
       "image-lab": {
@@ -231,6 +232,8 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
   resolve into when the link lives outside its configured source root.
 - `workshop.allowSymlinkTargetWrites`: allows Skill Workshop apply to write
   through already-trusted symlink targets (default: false).
+- `workshop.writableRoots`: explicit real skill roots that update proposals may
+  target. Canonical roots are preferred over shadow copies; the default is empty.
 - `install.preferBrew`: when true, prefer Homebrew installers when `brew` is
   available before falling back to other installer kinds.
 - `install.nodeManager`: node installer preference for `metadata.openclaw.install`

--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -29,6 +29,7 @@ Most skills configuration lives under `skills` in
     workshop: {
       autonomous: { mode: "auto" },
       allowSymlinkTargetWrites: false,
+      writableRoots: [],
       approvalPolicy: "auto",
       maxPending: 50,
       maxSkillBytes: 40000,
@@ -381,6 +382,12 @@ proposal-only permissions, and troubleshooting.
   real target is already trusted by `skills.load.allowSymlinkTargets`. Keep
   this disabled unless generated proposal applies should mutate that shared
   skill root.
+</ParamField>
+
+<ParamField path="skills.workshop.writableRoots" type="string[]" default="[]">
+  Explicit canonical skill roots that Skill Workshop may update. A configured
+  root wins over personal, project, and workspace shadow copies. This is a
+  narrow write allowlist and does not make other skill sources writable.
 </ParamField>
 
 <ParamField path="skills.workshop.maxPending" type="number" default="50">

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -431,6 +431,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "skills.load.watch": "Watch Skills",
   "skills.workshop.autonomous.mode": "Skill Workshop Autonomous Mode",
   "skills.workshop.allowSymlinkTargetWrites": "Allow Skill Workshop Symlink Writes",
+  "skills.workshop.writableRoots": "Skill Workshop Writable Roots",
   "agents.defaults.skills": "Skills",
   "agents.defaults.subagents.delegationMode": "Sub-agent Delegation Mode",
   "agents.entries.*.subagents.delegationMode": "Sub-agent Delegation Mode",

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -65,6 +65,8 @@ export type SkillsWorkshopConfig = {
   };
   /** Allow Skill Workshop apply to write through trusted skill symlink targets. */
   allowSymlinkTargetWrites?: boolean;
+  /** Explicit skill roots that Skill Workshop may update. */
+  writableRoots?: string[];
   /** Whether proposal lifecycle actions need explicit approval. */
   approvalPolicy?: "pending" | "auto";
   /** Maximum pending/quarantined proposals retained per workspace. */

--- a/src/config/zod-schema.root-shape.ts
+++ b/src/config/zod-schema.root-shape.ts
@@ -465,6 +465,7 @@ export const OpenClawSchemaShape = {
             .optional(),
           approvalPolicy: z.union([z.literal("pending"), z.literal("auto")]).optional(),
           allowSymlinkTargetWrites: z.boolean().optional(),
+          writableRoots: z.array(z.string()).optional(),
           maxPending: z.number().int().min(1).optional(),
           maxSkillBytes: z.number().int().min(1).optional(),
         })

--- a/src/skills/lifecycle/workspace-skill-write.ts
+++ b/src/skills/lifecycle/workspace-skill-write.ts
@@ -13,6 +13,7 @@ export const MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES = 256 * 1024;
 type WorkspaceSkillSymlinkWritePolicy = {
   allowWrites: boolean;
   allowedTargetRealPaths: readonly string[];
+  allowedExternalRootRealPaths?: readonly string[];
 };
 type WorkspaceSkillSupportFileWrite = { path: string; content: string };
 type WorkspaceSkillSupportFileRestoration = {
@@ -128,7 +129,12 @@ export async function prepareWorkspaceSkillMutation(params: {
   mode: "create" | "update";
   symlinkPolicy: WorkspaceSkillSymlinkWritePolicy;
 }): Promise<PreparedWorkspaceSkillMutation> {
-  assertInsideWorkspace(params.workspaceDir, params.skillDir, "skill directory");
+  assertWorkspaceSkillPathAllowed(
+    params.workspaceDir,
+    params.skillDir,
+    "skill directory",
+    params.symlinkPolicy.allowedExternalRootRealPaths ?? [],
+  );
   const supportFiles = normalizeSupportFiles(params.supportFiles ?? []);
   const skillTarget = await resolveWorkspaceSkillWriteTarget({
     workspaceDir: params.workspaceDir,
@@ -193,7 +199,12 @@ export async function prepareWorkspaceSkillRestoration(params: {
   mode: "create" | "update";
   symlinkPolicy: WorkspaceSkillSymlinkWritePolicy;
 }): Promise<PreparedWorkspaceSkillMutation> {
-  assertInsideWorkspace(params.workspaceDir, params.skillDir, "skill directory");
+  assertWorkspaceSkillPathAllowed(
+    params.workspaceDir,
+    params.skillDir,
+    "skill directory",
+    params.symlinkPolicy.allowedExternalRootRealPaths ?? [],
+  );
   const supportFiles = (params.supportFiles ?? []).map((file) => ({
     path: normalizeWorkspaceSkillSupportPath(file.path),
     previousContent: file.previousContent,
@@ -420,19 +431,25 @@ async function readPreparedWorkspaceFile(
 async function resolveWorkspaceSkillWriteTarget(
   params: WorkspaceSkillWriteTargetParams,
 ): Promise<{ rootDir: string; relativePath: string }> {
-  assertInsideWorkspace(params.workspaceDir, params.filePath, "skill file");
+  assertWorkspaceSkillPathAllowed(
+    params.workspaceDir,
+    params.filePath,
+    "skill file",
+    params.symlinkPolicy.allowedExternalRootRealPaths ?? [],
+  );
   const workspaceDir = path.resolve(params.workspaceDir);
   const filePath = path.resolve(params.filePath);
   const aliasTarget = await resolveWorkspaceAliasTarget({ workspaceDir, filePath });
   if (!aliasTarget) {
     return { rootDir: workspaceDir, relativePath: path.relative(workspaceDir, filePath) };
   }
-  const allowedRoot = params.symlinkPolicy.allowWrites
-    ? findContainingAllowedSkillSymlinkTarget(
-        params.symlinkPolicy.allowedTargetRealPaths,
-        aliasTarget.realTarget,
-      )
-    : null;
+  const allowedRoot = findContainingAllowedSkillSymlinkTarget(
+    [
+      ...(params.symlinkPolicy.allowWrites ? params.symlinkPolicy.allowedTargetRealPaths : []),
+      ...(params.symlinkPolicy.allowedExternalRootRealPaths ?? []),
+    ],
+    aliasTarget.realTarget,
+  );
   if (!allowedRoot) {
     throw new Error(
       `Skill file resolves through an untrusted symlink target: ${params.filePath}. Configure skills.load.allowSymlinkTargets and enable skills.workshop.allowSymlinkTargetWrites for intentional Skill Workshop symlink writes.`,
@@ -490,5 +507,27 @@ export function assertInsideWorkspace(
     !isPathInside(resolvedWorkspaceDir, resolvedTarget)
   ) {
     throw new Error(`${label} must stay inside the workspace.`);
+  }
+}
+
+function assertWorkspaceSkillPathAllowed(
+  workspaceDir: string,
+  targetPath: string,
+  label: string,
+  allowedExternalRootRealPaths: readonly string[],
+): void {
+  try {
+    assertInsideWorkspace(workspaceDir, targetPath, label);
+    return;
+  } catch (error) {
+    const targetRealPath = path.resolve(targetPath);
+    if (
+      allowedExternalRootRealPaths.some((rootRealPath) =>
+        isPathInside(path.resolve(rootRealPath), targetRealPath),
+      )
+    ) {
+      return;
+    }
+    throw error;
   }
 }

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -21,6 +21,7 @@ import type {
   SkillEligibilityContext,
   SkillEntry,
 } from "../types.js";
+import { resolveSkillWorkshopConfig } from "../workshop/config.js";
 import { getArchivedSkillFiles } from "../workshop/curator.js";
 import { resolveBundledSkillsDir } from "./bundled-dir.js";
 import { resolveBundledAllowlist, shouldIncludeSkill } from "./config.js";
@@ -366,6 +367,11 @@ function loadSkillEntries(
     ? []
     : loadSkills({ dir: projectAgentsSkillsDir, source: "agents-skills-project" });
   const workspaceSkills = loadSkills({ dir: workspaceSkillsDir, source: "openclaw-workspace" });
+  const workshopWritableSkills = workspaceOnly
+    ? []
+    : resolveSkillWorkshopConfig(opts?.config).writableRoots.flatMap((dir) =>
+        loadSkills({ dir, source: "openclaw-workshop" }),
+      );
 
   const merged = new Map<string, LoadedSkillRecord>();
   const archivedSkillFiles = opts?.includeArchived ? null : getArchivedSkillFiles();
@@ -391,6 +397,9 @@ function loadSkillEntries(
     mergeRecord(record);
   }
   for (const record of workspaceSkills) {
+    mergeRecord(record);
+  }
+  for (const record of workshopWritableSkills) {
     mergeRecord(record);
   }
 

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1,0 +1,1985 @@
+// Workspace skill loading helpers discover and load skills from workspace directories.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeTrimmedStringList,
+  uniqueStrings,
+} from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { resolveSandboxPath } from "../../agents/sandbox-paths.js";
+import { canonicalizePath } from "../../agents/utils/paths.js";
+import { isDefaultStateDir } from "../../config/paths.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { walkDirectorySync } from "../../infra/fs-safe.js";
+import { resolveOsHomeDir } from "../../infra/home-dir.js";
+import { isPathInside } from "../../infra/path-guards.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { CONFIG_DIR, resolveConfigDir, resolveUserPath } from "../../utils.js";
+import {
+  isSessionSkillEnabled,
+  resolveEffectiveAgentSkillFilter,
+  resolveEffectiveAgentSkillsLimits,
+} from "../discovery/agent-filter.js";
+import { normalizeSkillFilter } from "../discovery/filter.js";
+import { filterPromptVisibleSkillEntries } from "../discovery/skill-index.js";
+import { mergeRemoteNodeSkillEntries } from "../runtime/remote-skills.js";
+import type {
+  OpenClawSkillMetadata,
+  ParsedSkillFrontmatter,
+  SkillEligibilityContext,
+  SkillEntry,
+  SkillSnapshot,
+  SkillUsagePath,
+} from "../types.js";
+import { WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION } from "../types.js";
+import { resolveSkillWorkshopConfig } from "../workshop/config.js";
+import { getArchivedSkillFiles } from "../workshop/curator.js";
+import { resolveBundledSkillsDir } from "./bundled-dir.js";
+import {
+  hasUnavailableSkillSecretOwners,
+  isSkillSecretOwnerUnavailable,
+  resolveBundledAllowlist,
+  shouldIncludeSkill,
+} from "./config.js";
+import {
+  resolveSkillManifestMetadata,
+  resolveSkillInvocationPolicy,
+  resolveSkillKey,
+} from "./frontmatter.js";
+import {
+  loadSkillsFromDirSafe,
+  readSkillFrontmatterSafe,
+  type LocalSkillLoadDiagnostic,
+} from "./local-loader.js";
+import { resolvePluginSkillDirs } from "./plugin-skills.js";
+import { serializeByKey } from "./serialize.js";
+import { formatSkillsForPrompt } from "./session.js";
+import type { Skill } from "./skill-contract.js";
+import { resolveSkillTelemetrySource } from "./source.js";
+import { resolveAllowedSkillSymlinkTargetRealPaths, tryRealpath } from "./symlink-targets.js";
+
+const fsp = fs.promises;
+const skillsLogger = createSubsystemLogger("skills");
+const SKILL_SOURCE_ORIGIN_RELATIVE_PATH = path.join(".openclaw", "source-origin.json");
+const MAX_SKILL_SOURCE_ORIGIN_BYTES = 16 * 1024;
+
+/**
+ * Replace OS home directory prefixes with `~` in skill file paths to
+ * reduce system prompt token usage while matching host file-tool expansion.
+ *
+ * Example: `/Users/alice/.bun/.../skills/github/SKILL.md`
+ * → `~/.bun/.../skills/github/SKILL.md`
+ *
+ * Saves ~5–6 tokens per skill path × N skills ≈ 400–600 tokens total.
+ */
+function resolveUserHomeDir(): string | undefined {
+  return resolveOsHomeDir(process.env, os.homedir);
+}
+
+function resolveNativeUserHomeDir(): string | undefined {
+  try {
+    return path.resolve(os.homedir());
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveCompactHomePrefixes(): string[] {
+  const homes = [resolveUserHomeDir(), resolveNativeUserHomeDir()].filter((home): home is string =>
+    Boolean(home),
+  );
+  const resolvedHomes = homes.map((home) => path.resolve(home));
+  const realHomes = resolvedHomes
+    .map((home) => tryRealpath(home))
+    .filter((home): home is string => Boolean(home));
+  return uniqueStrings([...resolvedHomes, ...realHomes]).toSorted((a, b) => b.length - a.length);
+}
+
+function compactSkillPaths(skills: Skill[]): Skill[] {
+  const homes = resolveCompactHomePrefixes();
+  if (homes.length === 0) {
+    return skills;
+  }
+  const preservedRoots = resolvePreservedPromptSkillPathRoots();
+  const tildeRoots = resolvePromptTildeRoots();
+  return skills.map((s) => ({
+    ...s,
+    filePath: shouldPreservePromptSkillPath(s.filePath, preservedRoots, tildeRoots)
+      ? s.filePath
+      : compactHomePath(s.filePath, homes),
+  }));
+}
+
+function resolvePreservedPromptSkillPathRoots(): string[] {
+  const configDir = resolveConfigDir();
+  const promptSkillDirs = [
+    path.resolve(configDir, "skills"),
+    path.resolve(configDir, "plugin-skills"),
+  ];
+  const realPromptSkillDirs = promptSkillDirs
+    .map((dir) => tryRealpath(dir))
+    .filter((dir): dir is string => Boolean(dir));
+  return uniqueStrings([...promptSkillDirs, ...realPromptSkillDirs]);
+}
+
+function resolvePromptTildeRoots(): string[] {
+  const nativeHome = resolveNativeUserHomeDir();
+  if (!nativeHome) {
+    return [];
+  }
+  const resolvedNativeHome = path.resolve(nativeHome);
+  if (isContainerStateHomeWherePromptTildeEscapes(resolvedNativeHome)) {
+    return [];
+  }
+  const realNativeHome = tryRealpath(resolvedNativeHome);
+  return uniqueStrings([resolvedNativeHome, ...(realNativeHome ? [realNativeHome] : [])]);
+}
+
+function isContainerStateHomeWherePromptTildeEscapes(home: string): boolean {
+  const configDir = path.resolve(resolveConfigDir());
+  return (
+    home === "/data" &&
+    (configDir === "/data/.openclaw" || isPathInside("/data/.openclaw", configDir))
+  );
+}
+
+function shouldPreservePromptSkillPath(
+  filePath: string,
+  roots: readonly string[],
+  tildeRoots: readonly string[],
+): boolean {
+  const resolvedFilePath = path.resolve(filePath);
+  const isManagedPromptSkillPath = roots.some(
+    (root) => resolvedFilePath === root || isPathInside(root, resolvedFilePath),
+  );
+  if (!isManagedPromptSkillPath) {
+    return false;
+  }
+  return !tildeRoots.some(
+    (root) => resolvedFilePath === root || isPathInside(root, resolvedFilePath),
+  );
+}
+
+function compactHomePath(filePath: string, homes: readonly string[]): string {
+  for (const home of homes) {
+    for (const prefix of compactHomePrefixesForHome(home)) {
+      if (filePath.startsWith(prefix)) {
+        return "~/" + normalizeCompactedSkillPath(filePath.slice(prefix.length), prefix);
+      }
+    }
+  }
+  return filePath;
+}
+
+function compactHomePrefixesForHome(home: string): string[] {
+  const prefixes = [home.endsWith(path.sep) ? home : home + path.sep];
+  if (home.includes("\\") && !home.endsWith("\\")) {
+    prefixes.push(home + "\\");
+  }
+  return prefixes;
+}
+
+function normalizeCompactedSkillPath(filePath: string, matchedHomePrefix: string): string {
+  return matchedHomePrefix.includes("\\") ? filePath.replace(/\\/g, "/") : filePath;
+}
+
+function compactPathForConsoleMessage(filePath: string): string {
+  return compactHomePath(filePath, resolveCompactHomePrefixes());
+}
+
+function warnInvalidSkillFrontmatter(source: string, diagnostic: LocalSkillLoadDiagnostic): void {
+  skillsLogger.warn("Skipping skill with invalid frontmatter.", {
+    source,
+    filePath: diagnostic.path,
+    error: diagnostic.message,
+    consoleMessage:
+      `Skipping skill with invalid frontmatter: ` +
+      `file=${compactPathForConsoleMessage(diagnostic.path)} error=${diagnostic.message}`,
+  });
+}
+
+function filterSkillEntries(
+  entries: SkillEntry[],
+  config?: OpenClawConfig,
+  skillFilter?: string[],
+  skillOverrides?: Readonly<Record<string, boolean>>,
+  eligibility?: SkillEligibilityContext,
+): SkillEntry[] {
+  const bundledAllowlist = resolveBundledAllowlist(config);
+  let filtered = entries.filter((entry) =>
+    shouldIncludeSkill({ entry, config, bundledAllowlist, eligibility }),
+  );
+  if (skillFilter !== undefined || skillOverrides !== undefined) {
+    const normalized = normalizeSkillFilter(skillFilter) ?? [];
+    const label = normalized.length > 0 ? normalized.join(", ") : "(none)";
+    skillsLogger.debug(`Applying skill filter: ${label}`);
+    const resolvedFilter = skillFilter === undefined ? undefined : normalized;
+    filtered = filtered.filter((entry) =>
+      isSessionSkillEnabled(
+        entry.skill.name,
+        resolvedFilter,
+        skillOverrides,
+        resolveSkillKey(entry.skill, entry),
+      ),
+    );
+    skillsLogger.debug(
+      `After skill filter: ${filtered.map((entry) => entry.skill.name).join(", ") || "(none)"}`,
+    );
+  }
+  return filtered;
+}
+
+const DEFAULT_MAX_CANDIDATES_PER_ROOT = 300;
+const DEFAULT_MAX_SKILLS_LOADED_PER_SOURCE = 200;
+const DEFAULT_MAX_SKILLS_IN_PROMPT = 150;
+const DEFAULT_MAX_SKILLS_PROMPT_CHARS = 18_000;
+const DEFAULT_MAX_SKILL_FILE_BYTES = 256_000;
+const DEFAULT_MIN_RAW_ENTRIES_PER_DIRECTORY_SCAN = 1_000;
+const DEFAULT_MAX_RAW_ENTRIES_PER_DIRECTORY_SCAN = 10_000;
+// Match Codex's bounded recursive skills discovery without letting broad
+// workspace roots turn into unbounded filesystem walks.
+const MAX_GROUPED_SKILL_SCAN_DEPTH = 6;
+const MAX_CONFIGURED_ROOT_GROUPED_SKILL_SCAN_DEPTH = 2;
+
+type ResolvedSkillsLimits = {
+  maxCandidatesPerRoot: number;
+  maxSkillsLoadedPerSource: number;
+  maxSkillsInPrompt: number;
+  maxSkillsPromptChars: number;
+  maxSkillFileBytes: number;
+};
+
+type LoadedSkillRecord = {
+  skill: Skill;
+  frontmatter?: ParsedSkillFrontmatter;
+  syncSourceDir?: string;
+  syncDirName?: string;
+};
+
+type CandidateSkillDir = {
+  skillDir: string;
+  skillDirRealPath: string;
+  name: string;
+  skillMdRealPath: string;
+};
+
+type ChildDirectoryScan = {
+  dirs: string[];
+  scannedEntryCount: number;
+  truncated: boolean;
+};
+
+type SkillDiscoveryBudget = {
+  remainingDirectoryScans: number;
+  remainingRawEntries: number;
+  truncated: boolean;
+};
+
+function resolveSkillsLimits(config?: OpenClawConfig, agentId?: string): ResolvedSkillsLimits {
+  const limits = config?.skills?.limits;
+  const agentSkillsLimits = resolveEffectiveAgentSkillsLimits(config, agentId);
+  return {
+    maxCandidatesPerRoot: limits?.maxCandidatesPerRoot ?? DEFAULT_MAX_CANDIDATES_PER_ROOT,
+    maxSkillsLoadedPerSource:
+      limits?.maxSkillsLoadedPerSource ?? DEFAULT_MAX_SKILLS_LOADED_PER_SOURCE,
+    maxSkillsInPrompt: limits?.maxSkillsInPrompt ?? DEFAULT_MAX_SKILLS_IN_PROMPT,
+    maxSkillsPromptChars:
+      agentSkillsLimits?.maxSkillsPromptChars ??
+      limits?.maxSkillsPromptChars ??
+      DEFAULT_MAX_SKILLS_PROMPT_CHARS,
+    maxSkillFileBytes: limits?.maxSkillFileBytes ?? DEFAULT_MAX_SKILL_FILE_BYTES,
+  };
+}
+
+function listChildDirectories(
+  dir: string,
+  opts?: {
+    followSymlinks?: boolean;
+    maxCandidateDirs?: number;
+    maxRawEntriesToScan?: number;
+  },
+): ChildDirectoryScan {
+  const maxRawEntriesToScan =
+    opts?.maxRawEntriesToScan === undefined
+      ? resolveRawEntryScanLimit(opts?.maxCandidateDirs)
+      : Math.max(0, opts.maxRawEntriesToScan);
+  const scan = walkDirectorySync(dir, {
+    maxDepth: 1,
+    maxEntries: maxRawEntriesToScan,
+    symlinks: opts?.followSymlinks === false ? "skip" : "follow",
+    include: (entry) =>
+      entry.kind === "directory" && !entry.name.startsWith(".") && entry.name !== "node_modules",
+  });
+  if (scan.scannedEntryCount === 0 && scan.entries.length === 0) {
+    return { dirs: [], scannedEntryCount: 0, truncated: false };
+  }
+  return {
+    dirs: scan.entries.map((entry) => entry.name),
+    scannedEntryCount: scan.scannedEntryCount,
+    truncated: scan.truncated,
+  };
+}
+
+function resolveRawEntryScanLimit(maxCandidateDirs: number | undefined): number {
+  if (maxCandidateDirs === undefined) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const normalized = Math.max(0, maxCandidateDirs);
+  if (normalized === 0) {
+    return 0;
+  }
+  return Math.min(
+    DEFAULT_MAX_RAW_ENTRIES_PER_DIRECTORY_SCAN,
+    Math.max(DEFAULT_MIN_RAW_ENTRIES_PER_DIRECTORY_SCAN, normalized * 10),
+  );
+}
+
+function createSkillDiscoveryBudget(maxCandidateDirs: number): SkillDiscoveryBudget {
+  const normalized = Math.max(0, maxCandidateDirs);
+  return {
+    remainingDirectoryScans: normalized * MAX_GROUPED_SKILL_SCAN_DEPTH,
+    remainingRawEntries: resolveRawEntryScanLimit(normalized) * (normalized + 1),
+    truncated: false,
+  };
+}
+
+function listBudgetedChildDirectories(
+  dir: string,
+  budget: SkillDiscoveryBudget,
+  opts: { followSymlinks?: boolean; maxCandidateDirs: number },
+): ChildDirectoryScan {
+  if (budget.remainingDirectoryScans <= 0 || budget.remainingRawEntries <= 0) {
+    budget.truncated = true;
+    return { dirs: [], scannedEntryCount: 0, truncated: false };
+  }
+
+  budget.remainingDirectoryScans -= 1;
+  const maxRawEntriesToScan = Math.min(
+    resolveRawEntryScanLimit(opts.maxCandidateDirs),
+    budget.remainingRawEntries,
+  );
+  const scan = listChildDirectories(dir, {
+    followSymlinks: opts.followSymlinks,
+    maxCandidateDirs: opts.maxCandidateDirs,
+    maxRawEntriesToScan,
+  });
+  budget.remainingRawEntries = Math.max(0, budget.remainingRawEntries - scan.scannedEntryCount);
+  budget.truncated ||= scan.truncated;
+  return scan;
+}
+
+function containsDiscoverableSkill(
+  dir: string,
+  opts: {
+    maxCandidateDirs: number;
+    maxSkillFileBytes?: number;
+    skipTopLevelDirName?: string;
+  },
+): boolean {
+  const discoveryBudget = createSkillDiscoveryBudget(opts.maxCandidateDirs);
+  const queue: Array<{ dir: string; depth: number }> = [{ dir, depth: 0 }];
+  for (const candidate of queue) {
+    if (!candidate) {
+      continue;
+    }
+    if (candidate.depth > 0 && fs.existsSync(path.join(candidate.dir, "SKILL.md"))) {
+      if (hasLoadableSkillFrontmatter(dir, candidate.dir, opts.maxSkillFileBytes)) {
+        return true;
+      }
+      continue;
+    }
+    if (candidate.depth >= MAX_GROUPED_SKILL_SCAN_DEPTH) {
+      continue;
+    }
+    if (
+      hasCandidateSymlinkChild(
+        candidate.dir,
+        candidate.depth === 0 ? opts.skipTopLevelDirName : undefined,
+        resolveRawEntryScanLimit(opts.maxCandidateDirs),
+      )
+    ) {
+      return true;
+    }
+    const childDirs = listBudgetedChildDirectories(candidate.dir, discoveryBudget, {
+      followSymlinks: false,
+      maxCandidateDirs: opts.maxCandidateDirs,
+    }).dirs;
+    for (const childDir of childDirs.toSorted().slice(0, opts.maxCandidateDirs)) {
+      if (candidate.depth === 0 && childDir === opts.skipTopLevelDirName) {
+        continue;
+      }
+      queue.push({ dir: path.join(candidate.dir, childDir), depth: candidate.depth + 1 });
+    }
+  }
+  return false;
+}
+
+function hasCandidateSymlinkChild(
+  dir: string,
+  skipName: string | undefined,
+  maxEntriesToScan: number,
+): boolean {
+  const maxEntries = Math.max(0, maxEntriesToScan);
+  if (maxEntries === 0) {
+    return false;
+  }
+  let handle: fs.Dir | undefined;
+  try {
+    handle = fs.opendirSync(dir);
+    for (let scanned = 0; scanned < maxEntries; scanned += 1) {
+      const entry = handle.readSync();
+      if (!entry) {
+        break;
+      }
+      if (entry.name === skipName || entry.name.startsWith(".") || entry.name === "node_modules") {
+        continue;
+      }
+      if (entry.isSymbolicLink()) {
+        return true;
+      }
+    }
+  } catch {
+    return false;
+  } finally {
+    handle?.closeSync();
+  }
+  return false;
+}
+
+function hasLoadableSkillFrontmatter(
+  rootDir: string,
+  skillDir: string,
+  maxSkillFileBytes?: number,
+): boolean {
+  const frontmatter = readSkillFrontmatterSafe({
+    rootDir,
+    filePath: path.join(skillDir, "SKILL.md"),
+    maxBytes: maxSkillFileBytes ?? DEFAULT_MAX_SKILL_FILE_BYTES,
+  });
+  const fallbackName = path.basename(skillDir).trim();
+  const name = frontmatter?.name?.trim() || fallbackName;
+  return Boolean(name) && Boolean(frontmatter?.description?.trim());
+}
+
+function isSymlinkPath(filePath: string): boolean {
+  try {
+    return fs.lstatSync(filePath).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function buildEscapedSkillPathReason(params: { source: string; candidatePath: string }): {
+  reason: string;
+  consoleHint: string;
+} {
+  const candidateIsSymlink = isSymlinkPath(params.candidatePath);
+  if (params.source === "openclaw-bundled" && candidateIsSymlink) {
+    return {
+      reason: "bundled-symlink-escape",
+      consoleHint:
+        "reason=bundled-symlink-escape hint=likely-stray-local-symlink-or-checkout-mutation",
+    };
+  }
+  if (candidateIsSymlink) {
+    return {
+      reason: "symlink-escape",
+      consoleHint: "reason=symlink-escape",
+    };
+  }
+  if (params.source === "openclaw-bundled") {
+    return {
+      reason: "bundled-root-escape",
+      consoleHint:
+        "reason=bundled-root-escape hint=likely-stray-local-symlink-or-checkout-mutation",
+    };
+  }
+  return {
+    reason: "path-escape",
+    consoleHint: "reason=path-escape",
+  };
+}
+
+function warnEscapedSkillPath(params: {
+  source: string;
+  rootDir: string;
+  rootRealPath: string;
+  candidatePath: string;
+  candidateRealPath: string;
+}) {
+  const compactRootDir = compactPathForConsoleMessage(params.rootDir);
+  const compactRootRealPath = compactPathForConsoleMessage(params.rootRealPath);
+  const compactCandidatePath = compactPathForConsoleMessage(params.candidatePath);
+  const compactCandidateRealPath = compactPathForConsoleMessage(params.candidateRealPath);
+  const rootResolved =
+    path.resolve(params.rootDir) === params.rootRealPath
+      ? ""
+      : ` rootResolved=${compactRootRealPath}`;
+  const escapeReason = buildEscapedSkillPathReason({
+    source: params.source,
+    candidatePath: params.candidatePath,
+  });
+  skillsLogger.warn("Skipping escaped skill path outside its configured root.", {
+    source: params.source,
+    rootDir: params.rootDir,
+    rootRealPath: params.rootRealPath,
+    path: params.candidatePath,
+    realPath: params.candidateRealPath,
+    reason: escapeReason.reason,
+    consoleMessage:
+      `Skipping escaped skill path outside its configured root: ` +
+      `source=${params.source} root=${compactRootDir}${rootResolved} ` +
+      `${escapeReason.consoleHint} requested=${compactCandidatePath} ` +
+      `resolved=${compactCandidateRealPath}`,
+  });
+}
+
+function resolveContainedSkillPath(params: {
+  source: string;
+  rootDir: string;
+  rootRealPath: string;
+  candidatePath: string;
+  allowedSymlinkTargetRealPaths?: readonly string[];
+}): string | null {
+  const candidateRealPath = tryRealpath(params.candidatePath);
+  if (!candidateRealPath) {
+    return null;
+  }
+  if (
+    isPathInside(params.rootRealPath, candidateRealPath) ||
+    isPathInsideAnyRoot(params.allowedSymlinkTargetRealPaths ?? [], candidateRealPath)
+  ) {
+    return candidateRealPath;
+  }
+  warnEscapedSkillPath({
+    source: params.source,
+    rootDir: params.rootDir,
+    rootRealPath: params.rootRealPath,
+    candidatePath: path.resolve(params.candidatePath),
+    candidateRealPath,
+  });
+  return null;
+}
+
+function resolveNestedSkillsRoot(
+  dir: string,
+  opts?: {
+    maxEntriesToScan?: number;
+    maxSkillFileBytes?: number;
+  },
+): { baseDir: string; note?: string } {
+  if (hasLoadableSkillFrontmatter(dir, dir, opts?.maxSkillFileBytes)) {
+    return { baseDir: dir };
+  }
+  const rootSkillMdExists = fs.existsSync(path.join(dir, "SKILL.md"));
+  const nested = path.join(dir, "skills");
+  try {
+    if (!fs.existsSync(nested) || !fs.statSync(nested).isDirectory()) {
+      return { baseDir: dir };
+    }
+  } catch {
+    return { baseDir: dir };
+  }
+
+  const scanLimit = Math.max(0, opts?.maxEntriesToScan ?? 100);
+  if (
+    !rootSkillMdExists &&
+    containsDiscoverableSkill(dir, {
+      maxCandidateDirs: scanLimit,
+      maxSkillFileBytes: opts?.maxSkillFileBytes,
+      skipTopLevelDirName: "skills",
+    })
+  ) {
+    return { baseDir: dir };
+  }
+
+  // Heuristic: if `dir/skills` contains any discoverable SKILL.md within the
+  // bounded skill depth, treat `dir/skills` as the real root. Use the same
+  // child-directory filter as discovery so ignored folders cannot re-root.
+  const discoveryBudget = createSkillDiscoveryBudget(scanLimit);
+  const queue: Array<{ dir: string; depth: number }> = [{ dir: nested, depth: 0 }];
+  for (const candidate of queue) {
+    if (!candidate) {
+      continue;
+    }
+    if (hasLoadableSkillFrontmatter(nested, candidate.dir, opts?.maxSkillFileBytes)) {
+      return { baseDir: nested, note: `Detected nested skills root at ${nested}` };
+    }
+    if (candidate.depth >= MAX_GROUPED_SKILL_SCAN_DEPTH) {
+      continue;
+    }
+    const childDirs = listBudgetedChildDirectories(candidate.dir, discoveryBudget, {
+      followSymlinks: false,
+      maxCandidateDirs: scanLimit,
+    }).dirs;
+    for (const childDir of childDirs.toSorted().slice(0, scanLimit)) {
+      queue.push({ dir: path.join(candidate.dir, childDir), depth: candidate.depth + 1 });
+    }
+  }
+  return { baseDir: dir };
+}
+
+function unwrapLoadedSkillRecords(loaded: unknown): LoadedSkillRecord[] {
+  if (Array.isArray(loaded)) {
+    return (loaded as Skill[]).map((skill) => ({ skill }));
+  }
+  if (loaded && typeof loaded === "object" && "skills" in loaded) {
+    const skills = (loaded as { skills?: unknown }).skills;
+    if (Array.isArray(skills)) {
+      const loadedResult = loaded as { frontmatterByFilePath?: unknown };
+      const frontmatterByFilePath =
+        loadedResult.frontmatterByFilePath instanceof Map
+          ? (loadedResult.frontmatterByFilePath as ReadonlyMap<string, ParsedSkillFrontmatter>)
+          : undefined;
+      return (skills as Skill[]).map((skill) => ({
+        skill,
+        frontmatter: frontmatterByFilePath?.get(skill.filePath),
+      }));
+    }
+  }
+  return [];
+}
+
+function loadContainedSkillRecords(params: {
+  skillDir: string;
+  source: string;
+  maxSkillFileBytes: number;
+  canonicalSkillDir?: string;
+}): LoadedSkillRecord[] {
+  const expectedBaseDir = path.resolve(params.skillDir);
+  const loaded = loadSkillsFromDirSafe({
+    dir: params.skillDir,
+    source: params.source,
+    maxBytes: params.maxSkillFileBytes,
+    onDiagnostic: (diagnostic) => warnInvalidSkillFrontmatter(params.source, diagnostic),
+  });
+  const records = unwrapLoadedSkillRecords(loaded).filter(
+    (record) => path.resolve(record.skill.baseDir) === expectedBaseDir,
+  );
+  const canonicalSkillDir = params.canonicalSkillDir;
+  return canonicalSkillDir
+    ? records.map((record) => canonicalizeLoadedSkillRecord(record, canonicalSkillDir))
+    : records;
+}
+
+function readSourceInstallSkillKey(skillDir: string): string | undefined {
+  try {
+    const sourceOriginPath = path.join(skillDir, SKILL_SOURCE_ORIGIN_RELATIVE_PATH);
+    const stat = fs.lstatSync(sourceOriginPath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_SKILL_SOURCE_ORIGIN_BYTES) {
+      return undefined;
+    }
+    const skillDirRealPath = tryRealpath(skillDir);
+    const sourceOriginRealPath = tryRealpath(sourceOriginPath);
+    if (
+      !skillDirRealPath ||
+      !sourceOriginRealPath ||
+      !isPathInside(skillDirRealPath, sourceOriginRealPath)
+    ) {
+      return undefined;
+    }
+    const raw = fs.readFileSync(sourceOriginPath, "utf8");
+    const parsed = JSON.parse(raw) as { slug?: unknown };
+    return normalizeOptionalString(parsed.slug);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveSkillEntryMetadata(params: {
+  frontmatter: ParsedSkillFrontmatter;
+  skillDir: string;
+}): OpenClawSkillMetadata | undefined {
+  const metadata = resolveSkillManifestMetadata(params.frontmatter);
+  if (metadata?.skillKey) {
+    return metadata;
+  }
+  const sourceInstallSkillKey = readSourceInstallSkillKey(params.skillDir);
+  if (!sourceInstallSkillKey) {
+    return metadata;
+  }
+  return {
+    ...metadata,
+    skillKey: sourceInstallSkillKey,
+  };
+}
+
+function canonicalizeLoadedSkillRecord(
+  record: LoadedSkillRecord,
+  canonicalSkillDir: string,
+): LoadedSkillRecord {
+  const originalBaseDir = path.resolve(record.skill.baseDir);
+  const canonicalBaseDir = path.resolve(canonicalSkillDir);
+  if (originalBaseDir === canonicalBaseDir) {
+    return record;
+  }
+  const filePath = path.join(
+    canonicalBaseDir,
+    path.relative(originalBaseDir, record.skill.filePath),
+  );
+  return {
+    ...record,
+    syncSourceDir: canonicalBaseDir,
+    syncDirName: path.basename(originalBaseDir),
+    skill: {
+      ...record.skill,
+      filePath,
+      baseDir: canonicalBaseDir,
+      sourceInfo: record.skill.sourceInfo
+        ? {
+            ...record.skill.sourceInfo,
+            path: filePath,
+            baseDir: canonicalBaseDir,
+          }
+        : record.skill.sourceInfo,
+    },
+  };
+}
+
+/**
+ * Sets only the sync source directory for a skill record, without modifying
+ * the baseDir or filePath. This is used for plugin skills where the symlink
+ * path should be preserved for display purposes, but the real path is needed
+ * for syncing to the sandbox workspace.
+ */
+function setSyncSourceForPluginSkill(
+  record: LoadedSkillRecord,
+  syncSourceDir: string,
+): LoadedSkillRecord {
+  return {
+    ...record,
+    syncSourceDir,
+    syncDirName: path.basename(record.skill.baseDir),
+  };
+}
+
+function isPathInsideAnyRoot(rootRealPaths: readonly string[], candidateRealPath: string): boolean {
+  return rootRealPaths.some((rootRealPath) => isPathInside(rootRealPath, candidateRealPath));
+}
+
+function shouldEnforceConfiguredSkillRootContainment(source: string): boolean {
+  return source !== "openclaw-managed" && source !== "agents-skills-personal";
+}
+
+function shouldUseConfiguredSymlinkTargets(source: string): boolean {
+  return (
+    source === "openclaw-workspace" ||
+    source === "openclaw-extra" ||
+    source === "agents-skills-project"
+  );
+}
+
+function resolveSkillRootCandidatePath(params: {
+  source: string;
+  rootDir: string;
+  rootRealPath: string;
+  candidatePath: string;
+  allowedSymlinkTargetRealPaths: readonly string[];
+}): string | null {
+  if (!shouldEnforceConfiguredSkillRootContainment(params.source)) {
+    return tryRealpath(params.candidatePath);
+  }
+  return resolveContainedSkillPath({
+    source: params.source,
+    rootDir: params.rootDir,
+    rootRealPath: params.rootRealPath,
+    candidatePath: params.candidatePath,
+    allowedSymlinkTargetRealPaths: shouldUseConfiguredSymlinkTargets(params.source)
+      ? params.allowedSymlinkTargetRealPaths
+      : [],
+  });
+}
+
+function canonicalSkillDirForSource(source: string, skillDirRealPath: string): string | undefined {
+  return shouldEnforceConfiguredSkillRootContainment(source) ? undefined : skillDirRealPath;
+}
+
+function resolveSkillFilePath(params: {
+  source: string;
+  skillDir: string;
+  skillDirRealPath: string;
+  candidatePath: string;
+}): string | null {
+  return resolveContainedSkillPath({
+    source: params.source,
+    rootDir: params.skillDir,
+    rootRealPath: params.skillDirRealPath,
+    candidatePath: params.candidatePath,
+  });
+}
+
+function resolvePluginSkillRootRealPaths(pluginSkillDirs: readonly string[]): string[] {
+  return uniqueStrings(
+    pluginSkillDirs.map((dir) => tryRealpath(dir)).filter((dir): dir is string => Boolean(dir)),
+  );
+}
+
+function loadGeneratedPluginSkillRecords(params: {
+  pluginSkillsDir: string;
+  pluginSkillDirs: readonly string[];
+  source: string;
+  limits: ResolvedSkillsLimits;
+}): LoadedSkillRecord[] {
+  const allowedRootRealPaths = resolvePluginSkillRootRealPaths(params.pluginSkillDirs);
+  if (allowedRootRealPaths.length === 0) {
+    return [];
+  }
+
+  const rootDir = path.resolve(params.pluginSkillsDir);
+  if (!fs.existsSync(rootDir)) {
+    return [];
+  }
+  const rootRealPath = tryRealpath(rootDir) ?? rootDir;
+  const maxCandidatesPerRoot = Math.max(0, params.limits.maxCandidatesPerRoot);
+  const maxSkillsLoadedPerSource = Math.max(0, params.limits.maxSkillsLoadedPerSource);
+  const childDirScan = listChildDirectories(rootDir, {
+    maxCandidateDirs: maxCandidatesPerRoot,
+  });
+  const childDirs =
+    maxSkillsLoadedPerSource === 0
+      ? []
+      : childDirScan.dirs.toSorted().slice(0, maxCandidatesPerRoot);
+  const loadedSkills: LoadedSkillRecord[] = [];
+
+  for (const name of childDirs) {
+    const skillDir = path.join(rootDir, name);
+    if (!isSymlinkPath(skillDir)) {
+      continue;
+    }
+    const skillDirRealPath = tryRealpath(skillDir);
+    if (!skillDirRealPath || !isPathInsideAnyRoot(allowedRootRealPaths, skillDirRealPath)) {
+      if (skillDirRealPath) {
+        warnEscapedSkillPath({
+          source: params.source,
+          rootDir,
+          rootRealPath,
+          candidatePath: path.resolve(skillDir),
+          candidateRealPath: skillDirRealPath,
+        });
+      }
+      continue;
+    }
+
+    const skillMd = path.join(skillDir, "SKILL.md");
+    let skillMdStat: fs.Stats;
+    try {
+      skillMdStat = fs.lstatSync(skillMd);
+    } catch {
+      continue;
+    }
+    if (!skillMdStat.isFile() || skillMdStat.isSymbolicLink()) {
+      continue;
+    }
+    const skillMdRealPath = tryRealpath(skillMd);
+    if (!skillMdRealPath || !isPathInside(skillDirRealPath, skillMdRealPath)) {
+      continue;
+    }
+    if (skillMdStat.size > params.limits.maxSkillFileBytes) {
+      skillsLogger.warn("Skipping skill due to oversized SKILL.md.", {
+        skill: name,
+        filePath: skillMd,
+        size: skillMdStat.size,
+        maxSkillFileBytes: params.limits.maxSkillFileBytes,
+      });
+      continue;
+    }
+
+    // Plugin skills live as symlinks under ~/.openclaw/plugin-skills/, so
+    // skillDir is the symlink path while skillDirRealPath is the real target.
+    // We set syncSourceDir to the real path so syncSkillsToWorkspace can copy
+    // the actual skill directory into the sandbox workspace, but we preserve
+    // the symlink path as baseDir for display purposes.  Without this,
+    // sandboxed agents see host-only symlink paths in <available_skills> and
+    // every read of the SKILL.md fails with "Path escapes sandbox root".
+    // skillDirRealPath is safe to use here because it was already validated
+    // against allowedRootRealPaths above.
+    const loadedRecords = loadContainedSkillRecords({
+      skillDir,
+      source: params.source,
+      maxSkillFileBytes: params.limits.maxSkillFileBytes,
+    });
+    loadedSkills.push(
+      ...loadedRecords.map((record) => setSyncSourceForPluginSkill(record, skillDirRealPath)),
+    );
+    if (loadedSkills.length >= maxSkillsLoadedPerSource) {
+      break;
+    }
+  }
+
+  if (loadedSkills.length > maxSkillsLoadedPerSource) {
+    return loadedSkills
+      .toSorted((a, b) => a.skill.name.localeCompare(b.skill.name, "en"))
+      .slice(0, maxSkillsLoadedPerSource);
+  }
+  return loadedSkills;
+}
+
+function loadSkillEntries(
+  workspaceDir: string,
+  opts?: {
+    config?: OpenClawConfig;
+    agentId?: string;
+    managedSkillsDir?: string;
+    bundledSkillsDir?: string;
+    pluginSkillsDir?: string;
+    workspaceOnly?: boolean;
+    includeArchived?: boolean;
+  },
+): SkillEntry[] {
+  const limits = resolveSkillsLimits(opts?.config, opts?.agentId);
+  const allowedSymlinkTargetRealPaths = resolveAllowedSkillSymlinkTargetRealPaths(opts?.config);
+
+  const loadSkills = (params: { dir: string; source: string }): LoadedSkillRecord[] => {
+    const rootDir = path.resolve(params.dir);
+    if (!fs.existsSync(rootDir)) {
+      return [];
+    }
+    const rootRealPath = tryRealpath(rootDir) ?? rootDir;
+    const resolved = resolveNestedSkillsRoot(params.dir, {
+      maxEntriesToScan: limits.maxCandidatesPerRoot,
+      maxSkillFileBytes: limits.maxSkillFileBytes,
+    });
+    const baseDir = resolved.baseDir;
+    const baseDirRealPath = resolveSkillRootCandidatePath({
+      source: params.source,
+      rootDir,
+      rootRealPath,
+      candidatePath: baseDir,
+      allowedSymlinkTargetRealPaths,
+    });
+    if (!baseDirRealPath) {
+      return [];
+    }
+
+    // If the root itself is a skill directory, just load it directly (but enforce size cap).
+    const rootSkillMd = path.join(baseDir, "SKILL.md");
+    if (fs.existsSync(rootSkillMd)) {
+      const rootSkillRealPath = resolveSkillFilePath({
+        source: params.source,
+        skillDir: baseDir,
+        skillDirRealPath: baseDirRealPath,
+        candidatePath: rootSkillMd,
+      });
+      if (!rootSkillRealPath) {
+        return [];
+      }
+      try {
+        const size = fs.statSync(rootSkillRealPath).size;
+        if (size > limits.maxSkillFileBytes) {
+          skillsLogger.warn("Skipping skills root due to oversized SKILL.md.", {
+            dir: baseDir,
+            filePath: rootSkillMd,
+            size,
+            maxSkillFileBytes: limits.maxSkillFileBytes,
+          });
+          return [];
+        }
+      } catch {
+        return [];
+      }
+
+      return loadContainedSkillRecords({
+        skillDir: baseDir,
+        source: params.source,
+        maxSkillFileBytes: limits.maxSkillFileBytes,
+        canonicalSkillDir: canonicalSkillDirForSource(params.source, baseDirRealPath),
+      });
+    }
+
+    const maxCandidatesPerRoot = Math.max(0, limits.maxCandidatesPerRoot);
+    const maxSkillsLoadedPerSource = Math.max(0, limits.maxSkillsLoadedPerSource);
+    const nestedSkillsRootPath = path.resolve(baseDir, "skills");
+    const baseDirIsNestedSkillsRoot = path.resolve(baseDir) === path.resolve(rootDir, "skills");
+    const baseDirLooksLikeSkillsRoot = path.basename(baseDir) === "skills";
+    const discoveryBudget = createSkillDiscoveryBudget(maxCandidatesPerRoot);
+    const childDirScan = listBudgetedChildDirectories(baseDir, discoveryBudget, {
+      maxCandidateDirs: maxCandidatesPerRoot,
+    });
+    const childDirs = childDirScan.dirs;
+    const suspicious = childDirScan.truncated;
+    const sortedChildDirs = childDirs.toSorted();
+    const limitedChildren =
+      maxSkillsLoadedPerSource === 0 ? [] : sortedChildDirs.slice(0, maxCandidatesPerRoot);
+    if (
+      maxSkillsLoadedPerSource > 0 &&
+      sortedChildDirs.includes("skills") &&
+      !limitedChildren.includes("skills")
+    ) {
+      limitedChildren.push("skills");
+    }
+
+    if (suspicious) {
+      skillsLogger.warn("Skills root looks suspiciously large, truncating discovery.", {
+        dir: params.dir,
+        baseDir,
+        childDirCount: childDirs.length,
+        scannedEntryCount: childDirScan.scannedEntryCount,
+        maxEntriesToScan: resolveRawEntryScanLimit(maxCandidatesPerRoot),
+        maxCandidatesPerRoot: limits.maxCandidatesPerRoot,
+        maxSkillsLoadedPerSource: limits.maxSkillsLoadedPerSource,
+      });
+    } else if (childDirs.length > maxCandidatesPerRoot) {
+      skillsLogger.warn("Skills root has many entries, truncating discovery.", {
+        dir: params.dir,
+        baseDir,
+        childDirCount: childDirs.length,
+        maxCandidatesPerRoot: limits.maxCandidatesPerRoot,
+        maxSkillsLoadedPerSource: limits.maxSkillsLoadedPerSource,
+      });
+    }
+
+    const loadedSkills: LoadedSkillRecord[] = [];
+    const loadCandidateSkill = ({
+      skillDir,
+      skillDirRealPath,
+      name,
+      skillMdRealPath,
+    }: CandidateSkillDir) => {
+      try {
+        const size = fs.statSync(skillMdRealPath).size;
+        if (size > limits.maxSkillFileBytes) {
+          skillsLogger.warn("Skipping skill due to oversized SKILL.md.", {
+            skill: name,
+            filePath: path.join(skillDir, "SKILL.md"),
+            size,
+            maxSkillFileBytes: limits.maxSkillFileBytes,
+          });
+          return;
+        }
+      } catch {
+        return;
+      }
+
+      loadedSkills.push(
+        ...loadContainedSkillRecords({
+          skillDir,
+          source: params.source,
+          maxSkillFileBytes: limits.maxSkillFileBytes,
+          canonicalSkillDir: canonicalSkillDirForSource(params.source, skillDirRealPath),
+        }),
+      );
+    };
+
+    const skillCandidates: CandidateSkillDir[] = [];
+    const scanQueue: Array<{ skillDir: string; name: string; depth: number }> = limitedChildren.map(
+      (name) => ({
+        skillDir: path.join(baseDir, name),
+        name,
+        depth: name === "skills" && !fs.existsSync(path.join(baseDir, name, "SKILL.md")) ? 0 : 1,
+      }),
+    );
+
+    for (const candidate of scanQueue) {
+      if (!candidate) {
+        continue;
+      }
+      const skillDirRealPath = resolveSkillRootCandidatePath({
+        source: params.source,
+        rootDir,
+        rootRealPath: baseDirRealPath,
+        candidatePath: candidate.skillDir,
+        allowedSymlinkTargetRealPaths,
+      });
+      if (!skillDirRealPath) {
+        continue;
+      }
+
+      const skillMd = path.join(candidate.skillDir, "SKILL.md");
+      if (fs.existsSync(skillMd)) {
+        const skillMdRealPath = resolveSkillFilePath({
+          source: params.source,
+          skillDir: candidate.skillDir,
+          skillDirRealPath,
+          candidatePath: skillMd,
+        });
+        if (skillMdRealPath) {
+          skillCandidates.push({
+            skillDir: candidate.skillDir,
+            skillDirRealPath,
+            name: candidate.name,
+            skillMdRealPath,
+          });
+        }
+        continue;
+      }
+
+      const candidatePath = path.resolve(candidate.skillDir);
+      const maxGroupedDepth =
+        params.source === "openclaw-extra" &&
+        !baseDirIsNestedSkillsRoot &&
+        !baseDirLooksLikeSkillsRoot &&
+        candidatePath !== nestedSkillsRootPath &&
+        !isPathInside(nestedSkillsRootPath, candidatePath)
+          ? MAX_CONFIGURED_ROOT_GROUPED_SKILL_SCAN_DEPTH
+          : MAX_GROUPED_SKILL_SCAN_DEPTH;
+      if (candidate.depth >= maxGroupedDepth) {
+        continue;
+      }
+
+      const nestedChildScan = listBudgetedChildDirectories(candidate.skillDir, discoveryBudget, {
+        maxCandidateDirs: maxCandidatesPerRoot,
+      });
+      const nestedChildren = nestedChildScan.dirs;
+      const nestedSuspicious = nestedChildScan.truncated;
+      if (nestedSuspicious) {
+        skillsLogger.warn(
+          "Nested skills directory looks suspiciously large, truncating discovery.",
+          {
+            dir: params.dir,
+            baseDir,
+            nestedDir: candidate.skillDir,
+            nestedChildDirCount: nestedChildren.length,
+            scannedEntryCount: nestedChildScan.scannedEntryCount,
+            maxEntriesToScan: resolveRawEntryScanLimit(maxCandidatesPerRoot),
+            maxCandidatesPerRoot: limits.maxCandidatesPerRoot,
+            maxSkillsLoadedPerSource: limits.maxSkillsLoadedPerSource,
+            maxGroupedSkillScanDepth: MAX_GROUPED_SKILL_SCAN_DEPTH,
+          },
+        );
+      } else if (nestedChildren.length > maxCandidatesPerRoot) {
+        skillsLogger.warn("Nested skills directory has many entries, truncating discovery.", {
+          dir: params.dir,
+          baseDir,
+          nestedDir: candidate.skillDir,
+          nestedChildDirCount: nestedChildren.length,
+          maxCandidatesPerRoot: limits.maxCandidatesPerRoot,
+          maxSkillsLoadedPerSource: limits.maxSkillsLoadedPerSource,
+          maxGroupedSkillScanDepth: MAX_GROUPED_SKILL_SCAN_DEPTH,
+        });
+      }
+
+      for (const nestedName of nestedChildren.toSorted().slice(0, maxCandidatesPerRoot)) {
+        scanQueue.push({
+          skillDir: path.join(candidate.skillDir, nestedName),
+          name: `${candidate.name}/${nestedName}`,
+          depth: candidate.depth + 1,
+        });
+      }
+    }
+
+    for (const candidate of skillCandidates.toSorted((a, b) => a.name.localeCompare(b.name))) {
+      if (loadedSkills.length >= maxSkillsLoadedPerSource) {
+        break;
+      }
+      loadCandidateSkill(candidate);
+    }
+
+    if (discoveryBudget.truncated) {
+      skillsLogger.warn("Skills root hit recursive discovery budget, truncating discovery.", {
+        dir: params.dir,
+        baseDir,
+        maxCandidatesPerRoot: limits.maxCandidatesPerRoot,
+        maxSkillsLoadedPerSource: limits.maxSkillsLoadedPerSource,
+        maxGroupedSkillScanDepth: MAX_GROUPED_SKILL_SCAN_DEPTH,
+      });
+    }
+
+    if (loadedSkills.length > maxSkillsLoadedPerSource) {
+      return loadedSkills
+        .toSorted((a, b) => a.skill.name.localeCompare(b.skill.name, "en"))
+        .slice(0, maxSkillsLoadedPerSource);
+    }
+
+    return loadedSkills;
+  };
+
+  const workspaceOnly = opts?.workspaceOnly === true;
+  const managedSkillsDir = opts?.managedSkillsDir ?? path.join(CONFIG_DIR, "skills");
+  const workspaceSkillsDir = path.resolve(workspaceDir, "skills");
+  const bundledSkillsDir = workspaceOnly
+    ? undefined
+    : (opts?.bundledSkillsDir ?? resolveBundledSkillsDir());
+  const pluginSkillsDir = opts?.pluginSkillsDir ?? path.join(CONFIG_DIR, "plugin-skills");
+  const extraDirsRaw = workspaceOnly ? [] : (opts?.config?.skills?.load?.extraDirs ?? []);
+  const extraDirs = normalizeTrimmedStringList(extraDirsRaw);
+  const pluginSkillDirs = workspaceOnly
+    ? []
+    : resolvePluginSkillDirs({
+        workspaceDir,
+        config: opts?.config,
+        pluginSkillsDir,
+      });
+  const mergedExtraDirs = [...extraDirs, ...pluginSkillDirs];
+
+  const bundledSkills = bundledSkillsDir
+    ? loadSkills({
+        dir: bundledSkillsDir,
+        source: "openclaw-bundled",
+      })
+    : [];
+  const extraSkills = [
+    ...mergedExtraDirs.flatMap((dir) => {
+      const resolved = resolveUserPath(dir);
+      return loadSkills({
+        dir: resolved,
+        source: "openclaw-extra",
+      });
+    }),
+    ...loadGeneratedPluginSkillRecords({
+      pluginSkillsDir,
+      pluginSkillDirs,
+      source: "openclaw-extra",
+      limits,
+    }),
+  ];
+  const managedSkills = workspaceOnly
+    ? []
+    : loadSkills({
+        dir: managedSkillsDir,
+        source: "openclaw-managed",
+      });
+  const workshopWritableSkills = workspaceOnly
+    ? []
+    : resolveSkillWorkshopConfig(opts?.config).writableRoots.flatMap((dir) =>
+        loadSkills({
+          dir,
+          source: "openclaw-workshop",
+        }),
+      );
+  const osHomeDir = resolveUserHomeDir();
+  const personalAgentsSkillsDir = osHomeDir
+    ? path.resolve(osHomeDir, ".agents", "skills")
+    : path.resolve(".agents", "skills");
+  const personalAgentsSkills =
+    workspaceOnly || !isDefaultStateDir()
+      ? []
+      : loadSkills({
+          dir: personalAgentsSkillsDir,
+          source: "agents-skills-personal",
+        });
+  const projectAgentsSkillsDir = path.resolve(workspaceDir, ".agents", "skills");
+  const projectAgentsSkills = workspaceOnly
+    ? []
+    : loadSkills({
+        dir: projectAgentsSkillsDir,
+        source: "agents-skills-project",
+      });
+  const workspaceSkills = loadSkills({
+    dir: workspaceSkillsDir,
+    source: "openclaw-workspace",
+  });
+
+  const merged = new Map<string, LoadedSkillRecord>();
+  const archivedSkillFiles = opts?.includeArchived ? null : getArchivedSkillFiles();
+  const mergeRecord = (record: LoadedSkillRecord) => {
+    if (archivedSkillFiles?.has(canonicalizePath(record.skill.filePath))) {
+      return;
+    }
+    merged.set(record.skill.name, record);
+  };
+  // Precedence: extra < bundled < managed < agents-skills-personal < agents-skills-project < workspace < workshop roots
+  for (const record of extraSkills) {
+    mergeRecord(record);
+  }
+  for (const record of bundledSkills) {
+    mergeRecord(record);
+  }
+  for (const record of managedSkills) {
+    mergeRecord(record);
+  }
+  for (const record of personalAgentsSkills) {
+    mergeRecord(record);
+  }
+  for (const record of projectAgentsSkills) {
+    mergeRecord(record);
+  }
+  for (const record of workspaceSkills) {
+    mergeRecord(record);
+  }
+  for (const record of workshopWritableSkills) {
+    mergeRecord(record);
+  }
+
+  const skillEntries: SkillEntry[] = Array.from(merged.values())
+    .toSorted((a, b) => a.skill.name.localeCompare(b.skill.name, "en"))
+    .map((record) => {
+      const skill = record.skill;
+      const frontmatter =
+        record.frontmatter ??
+        readSkillFrontmatterSafe({
+          rootDir: skill.baseDir,
+          filePath: skill.filePath,
+          maxBytes: limits.maxSkillFileBytes,
+        }) ??
+        ({} as ParsedSkillFrontmatter);
+      const invocation = resolveSkillInvocationPolicy(frontmatter);
+      const entry: SkillEntry = {
+        skill,
+        frontmatter,
+        metadata: resolveSkillEntryMetadata({ frontmatter, skillDir: skill.baseDir }),
+        invocation,
+        exposure: {
+          includeInRuntimeRegistry: true,
+          // Freshly loaded entries preserve the documented disable-model-invocation
+          // contract, while legacy entries without exposure metadata still use
+          // the centralized prompt visibility fallback.
+          includeInAvailableSkillsPrompt: !invocation.disableModelInvocation,
+          userInvocable: invocation.userInvocable ?? true,
+        },
+      };
+      if (record.syncSourceDir !== undefined) {
+        entry.syncSourceDir = record.syncSourceDir;
+      }
+      if (record.syncDirName !== undefined) {
+        entry.syncDirName = record.syncDirName;
+      }
+      return entry;
+    });
+  return skillEntries;
+}
+
+function filterArchivedSkillEntries(entries: SkillEntry[]): SkillEntry[] {
+  // One discovery-level query covers prompts, commands, runtime entries, and sandbox sync.
+  const archivedSkillFiles = getArchivedSkillFiles();
+  return entries.filter((entry) => !archivedSkillFiles.has(canonicalizePath(entry.skill.filePath)));
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+const COMPACT_DESCRIPTION_MAX_CHARS = 220;
+const COMPACT_DESCRIPTION_MIN_CHARS = 4;
+
+function truncateSkillDescription(description: string, maxChars: number): string {
+  const normalized = description.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  if (maxChars <= 3) {
+    return truncateUtf16Safe(normalized, maxChars);
+  }
+  return `${truncateUtf16Safe(normalized, maxChars - 3).trimEnd()}...`;
+}
+
+/**
+ * Compact skill catalog with descriptions bounded independently from identities.
+ * A zero description budget preserves the previous name/location-only format.
+ */
+export function formatSkillsCompact(
+  skills: Skill[],
+  opts?: { descriptionMaxChars?: number },
+): string {
+  if (skills.length === 0) {
+    return "";
+  }
+  const descriptionMaxChars = Math.max(
+    0,
+    Math.floor(opts?.descriptionMaxChars ?? COMPACT_DESCRIPTION_MAX_CHARS),
+  );
+  const lines = [
+    "\n\nThe following skills provide specialized instructions for specific tasks.",
+    descriptionMaxChars > 0
+      ? "Use the read tool to load a skill's file when the task matches its name or description."
+      : "Use the read tool to load a skill's file when the task matches its name.",
+    "If a skill's <version> differs from a previous turn, re-read its SKILL.md before using it.",
+    "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
+    "",
+    "<available_skills>",
+  ];
+  for (const skill of skills) {
+    lines.push("  <skill>");
+    lines.push(`    <name>${escapeXml(skill.name)}</name>`);
+    if (descriptionMaxChars > 0) {
+      const description = truncateSkillDescription(skill.description, descriptionMaxChars);
+      if (description) {
+        lines.push(`    <description>${escapeXml(description)}</description>`);
+      }
+    }
+    lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
+    if (skill.locationNote) {
+      lines.push(`    <location_note>${escapeXml(skill.locationNote)}</location_note>`);
+    }
+    if (skill.promptVersion) {
+      lines.push(`    <version>${escapeXml(skill.promptVersion)}</version>`);
+    }
+    lines.push("  </skill>");
+  }
+  lines.push("</available_skills>");
+  return lines.join("\n");
+}
+
+type SkillsPromptFormat = { kind: "full" } | { kind: "compact"; descriptionMaxChars: number };
+
+function buildSkillsLimitNote(params: {
+  truncated: boolean;
+  format: SkillsPromptFormat;
+  included: number;
+  total: number;
+}): string {
+  if (params.truncated) {
+    const compactDetails =
+      params.format.kind === "compact"
+        ? ` (compact format, ${params.format.descriptionMaxChars > 0 ? "descriptions shortened" : "descriptions omitted"})`
+        : "";
+    return `⚠️ Skills truncated: included ${params.included} of ${params.total}${compactDetails}. Run \`openclaw skills check\` to audit.`;
+  }
+  if (params.format.kind === "compact") {
+    const compactDetails =
+      params.format.descriptionMaxChars > 0 ? "descriptions shortened" : "descriptions omitted";
+    return `⚠️ Skills catalog using compact format (${compactDetails}). Run \`openclaw skills check\` to audit.`;
+  }
+  return "";
+}
+
+function buildRenderedSkillsPrompt(params: {
+  remoteNote?: string;
+  skills: Skill[];
+  total: number;
+  format: SkillsPromptFormat;
+  includeLimitNote?: boolean;
+}): string {
+  // resolveCodeModeSkills in src/agents/code-mode-skills.ts parses this exact format; update both together.
+  // The production-renderer parity test in src/agents/code-mode.test.ts enforces this coupling.
+  const truncated = params.skills.length < params.total;
+  const limitNote =
+    params.includeLimitNote === false
+      ? ""
+      : buildSkillsLimitNote({
+          truncated,
+          format: params.format,
+          included: params.skills.length,
+          total: params.total,
+        });
+  const catalog =
+    params.format.kind === "compact"
+      ? formatSkillsCompact(params.skills, {
+          descriptionMaxChars: params.format.descriptionMaxChars,
+        })
+      : formatSkillsForPrompt(params.skills);
+  return [params.remoteNote, limitNote, catalog].filter(Boolean).join("\n");
+}
+
+function applySkillsPromptLimits(params: {
+  skills: Skill[];
+  config?: OpenClawConfig;
+  agentId?: string;
+  remoteNote?: string;
+}): string {
+  const limits = resolveSkillsLimits(params.config, params.agentId);
+  const total = params.skills.length;
+  const byCount = params.skills.slice(0, Math.max(0, limits.maxSkillsInPrompt));
+
+  let skillsForPrompt = byCount;
+
+  const renderWithinLimit = (
+    skills: Skill[],
+    format: SkillsPromptFormat,
+    includeLimitNote = true,
+  ): string | undefined => {
+    // Optional context must disappear whole; clipping it could corrupt skill guidance or XML.
+    const remoteNotes = params.remoteNote ? [params.remoteNote, undefined] : [undefined];
+    for (const remoteNote of remoteNotes) {
+      const prompt = buildRenderedSkillsPrompt({
+        remoteNote,
+        skills,
+        total,
+        format,
+        includeLimitNote,
+      });
+      if (prompt.length <= limits.maxSkillsPromptChars) {
+        return prompt;
+      }
+    }
+    return undefined;
+  };
+
+  const fitsFull = (skills: Skill[], includeLimitNote = true): boolean =>
+    renderWithinLimit(skills, { kind: "full" }, includeLimitNote) !== undefined;
+
+  const fitsCompact = (
+    skills: Skill[],
+    descriptionMaxChars: number,
+    includeLimitNote = true,
+  ): boolean =>
+    renderWithinLimit(skills, { kind: "compact", descriptionMaxChars }, includeLimitNote) !==
+    undefined;
+
+  if (!fitsFull(skillsForPrompt)) {
+    // Identity coverage takes priority over descriptions. Find the same largest
+    // name/location/version prefix as the previous compact format before using
+    // any leftover budget for trigger guidance.
+    if (!fitsCompact(skillsForPrompt, 0)) {
+      let lo = 0;
+      let hi = skillsForPrompt.length;
+      while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2);
+        if (fitsCompact(skillsForPrompt.slice(0, mid), 0)) {
+          lo = mid;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      skillsForPrompt = skillsForPrompt.slice(0, lo);
+    }
+
+    if (skillsForPrompt.length === 0 && byCount.length > 0) {
+      // Keep complete skill instructions ahead of a notice when only one can fit.
+      const fullWithoutNotice = renderWithinLimit(byCount, { kind: "full" }, false);
+      if (fullWithoutNotice !== undefined) {
+        return fullWithoutNotice;
+      }
+
+      let lo = 0;
+      let hi = byCount.length;
+      while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2);
+        if (fitsCompact(byCount.slice(0, mid), 0, false)) {
+          lo = mid;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      if (lo > 0) {
+        skillsForPrompt = byCount.slice(0, lo);
+      }
+    }
+
+    const includeLimitNote = fitsCompact(skillsForPrompt, 0);
+    let descriptionMaxChars = 0;
+    if (
+      skillsForPrompt.length > 0 &&
+      fitsCompact(skillsForPrompt, COMPACT_DESCRIPTION_MIN_CHARS, includeLimitNote)
+    ) {
+      let lo = COMPACT_DESCRIPTION_MIN_CHARS;
+      let hi = COMPACT_DESCRIPTION_MAX_CHARS;
+      while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2);
+        if (fitsCompact(skillsForPrompt, mid, includeLimitNote)) {
+          lo = mid;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      descriptionMaxChars = lo;
+    }
+    return (
+      renderWithinLimit(
+        skillsForPrompt,
+        { kind: "compact", descriptionMaxChars },
+        includeLimitNote,
+      ) ?? ""
+    );
+  }
+
+  return renderWithinLimit(skillsForPrompt, { kind: "full" }) ?? "";
+}
+
+export function buildWorkspaceSkillSnapshot(
+  workspaceDir: string,
+  opts?: WorkspaceSkillBuildOptions & { snapshotVersion?: number },
+): SkillSnapshot {
+  const { eligible, prompt, resolvedSkills } = resolveWorkspaceSkillPromptState(workspaceDir, opts);
+  const skillFilter = resolveEffectiveWorkspaceSkillFilter(opts);
+  return {
+    prompt,
+    skills: eligible.map((entry) => ({
+      name: entry.skill.name,
+      skillKey: resolveSkillKey(entry.skill, entry),
+      primaryEnv: entry.metadata?.primaryEnv,
+      requiredEnv: entry.metadata?.requires?.env?.slice(),
+    })),
+    ...(skillFilter === undefined ? {} : { skillFilter }),
+    ...(opts?.skillOverrides ? { skillOverrides: opts.skillOverrides } : {}),
+    ...(opts?.eligibility?.nodeSkills
+      ? { nodeSkillsEligibility: opts.eligibility.nodeSkills }
+      : {}),
+    resolvedSkills,
+    version: opts?.snapshotVersion,
+    promptFormatVersion: WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION,
+  };
+}
+
+export function buildWorkspaceSkillsPrompt(
+  workspaceDir: string,
+  opts?: WorkspaceSkillBuildOptions,
+): string {
+  return resolveWorkspaceSkillPromptState(workspaceDir, opts).prompt;
+}
+
+export const testing = {
+  compactHomePath,
+};
+
+type WorkspaceSkillBuildOptions = {
+  config?: OpenClawConfig;
+  managedSkillsDir?: string;
+  bundledSkillsDir?: string;
+  entries?: SkillEntry[];
+  agentId?: string;
+  /** If provided, only include skills with these names */
+  skillFilter?: string[];
+  skillOverrides?: Record<string, boolean>;
+  eligibility?: SkillEligibilityContext;
+};
+
+function resolveEffectiveWorkspaceSkillFilter(
+  opts?: WorkspaceSkillBuildOptions,
+): string[] | undefined {
+  if (opts?.skillFilter !== undefined) {
+    return normalizeSkillFilter(opts.skillFilter);
+  }
+  if (!opts?.config || !opts.agentId) {
+    return undefined;
+  }
+  return resolveEffectiveAgentSkillFilter(opts.config, opts.agentId);
+}
+
+function resolveWorkspaceSkillPromptState(
+  workspaceDir: string,
+  opts?: WorkspaceSkillBuildOptions,
+): {
+  eligible: SkillEntry[];
+  prompt: string;
+  resolvedSkills: Skill[];
+} {
+  const effectiveSkillFilter = resolveEffectiveWorkspaceSkillFilter(opts);
+  const skillEntries = opts?.entries
+    ? filterArchivedSkillEntries(opts.entries)
+    : mergeRemoteNodeSkillEntries(loadSkillEntries(workspaceDir, opts), {
+        canExec: opts?.eligibility?.nodeSkills?.canExec,
+        node: opts?.eligibility?.nodeSkills?.node,
+      });
+  const eligible = filterSkillEntries(
+    skillEntries,
+    opts?.config,
+    effectiveSkillFilter,
+    opts?.skillOverrides,
+    opts?.eligibility,
+  );
+  const promptEntries = filterPromptVisibleSkillEntries(eligible);
+  const remoteNote = opts?.eligibility?.remote?.note?.trim();
+  const resolvedSkills = promptEntries.map((entry) => entry.skill);
+  // Derive prompt-facing skills with compacted paths (e.g. ~/...) once.
+  // Budget checks and final render both use this same representation so the
+  // tier decision is based on the exact strings that end up in the prompt.
+  // resolvedSkills keeps canonical paths for snapshot / runtime consumers.
+  const promptSkills = compactSkillPaths(resolvedSkills).toSorted((a, b) =>
+    a.name.localeCompare(b.name, "en"),
+  );
+  const prompt = applySkillsPromptLimits({
+    skills: promptSkills,
+    config: opts?.config,
+    agentId: opts?.agentId,
+    remoteNote,
+  });
+  return { eligible, prompt, resolvedSkills };
+}
+
+export function resolveSkillsPromptForRun(params: {
+  skillsSnapshot?: SkillSnapshot;
+  entries?: SkillEntry[];
+  config?: OpenClawConfig;
+  workspaceDir: string;
+  agentId?: string;
+  eligibility?: SkillEligibilityContext;
+}): string {
+  const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
+  if (params.skillsSnapshot && !snapshotPrompt) {
+    return "";
+  }
+  const snapshotHasLegacySkillIdentity = params.skillsSnapshot?.skills.some(
+    (skill) => !skill.skillKey,
+  );
+  if (snapshotPrompt) {
+    const snapshotHasUnavailableSkill =
+      params.skillsSnapshot?.skills.some((skill) =>
+        isSkillSecretOwnerUnavailable(skill.skillKey ?? skill.name),
+      ) ||
+      (snapshotHasLegacySkillIdentity && hasUnavailableSkillSecretOwners());
+    if (
+      snapshotHasUnavailableSkill &&
+      params.skillsSnapshot?.promptFormatVersion !== WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION
+    ) {
+      return "";
+    }
+    if (snapshotHasLegacySkillIdentity && hasUnavailableSkillSecretOwners()) {
+      return "";
+    }
+    const unavailableNames = new Set(
+      params.skillsSnapshot?.skills
+        .filter(
+          (skill) => skill.skillKey !== undefined && isSkillSecretOwnerUnavailable(skill.skillKey),
+        )
+        .map((skill) => escapeXml(skill.name)),
+    );
+    if (unavailableNames.size === 0) {
+      return snapshotPrompt;
+    }
+    const catalogOpen = "<available_skills>";
+    const catalogClose = "</available_skills>";
+    const catalogStart = snapshotPrompt.indexOf(catalogOpen);
+    const catalogEnd = snapshotPrompt.indexOf(catalogClose, catalogStart + catalogOpen.length);
+    if (
+      catalogStart < 0 ||
+      catalogEnd < 0 ||
+      snapshotPrompt.includes(catalogOpen, catalogStart + catalogOpen.length) ||
+      snapshotPrompt.includes(catalogClose, catalogEnd + catalogClose.length)
+    ) {
+      return "";
+    }
+    const bodyStart = catalogStart + catalogOpen.length;
+    const catalogBody = snapshotPrompt.slice(bodyStart, catalogEnd);
+    const blockPattern = /\n[ ]{2}<skill>\n[\s\S]*?\n[ ]{2}<\/skill>/g;
+    let cursor = 0;
+    let filteredBody = "";
+    for (const match of catalogBody.matchAll(blockPattern)) {
+      const gap = catalogBody.slice(cursor, match.index);
+      const block = match[0];
+      const name = /^[ ]{4}<name>(.*)<\/name>$/m.exec(block)?.[1];
+      if (gap.trim() || !name) {
+        return "";
+      }
+      filteredBody += gap;
+      if (!unavailableNames.has(name)) {
+        filteredBody += block;
+      }
+      cursor = (match.index ?? 0) + block.length;
+    }
+    const tail = catalogBody.slice(cursor);
+    if (tail.trim()) {
+      return "";
+    }
+    return `${snapshotPrompt.slice(0, bodyStart)}${filteredBody}${tail}${snapshotPrompt.slice(catalogEnd)}`.trim();
+  }
+  if (params.entries && params.entries.length > 0) {
+    const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
+      entries: params.entries,
+      config: params.config,
+      agentId: params.agentId,
+      eligibility: params.eligibility,
+    });
+    return prompt.trim() ? prompt : "";
+  }
+  return "";
+}
+
+export function loadWorkspaceSkillEntries(
+  workspaceDir: string,
+  opts?: {
+    config?: OpenClawConfig;
+    managedSkillsDir?: string;
+    bundledSkillsDir?: string;
+    pluginSkillsDir?: string;
+    skillFilter?: string[];
+    skillOverrides?: Record<string, boolean>;
+    agentId?: string;
+    eligibility?: SkillEligibilityContext;
+    workspaceOnly?: boolean;
+    includeArchived?: boolean;
+  },
+): SkillEntry[] {
+  const entries = mergeRemoteNodeSkillEntries(loadSkillEntries(workspaceDir, opts), {
+    canExec: opts?.eligibility?.nodeSkills?.canExec,
+    node: opts?.eligibility?.nodeSkills?.node,
+  });
+  const effectiveSkillFilter = resolveEffectiveWorkspaceSkillFilter(opts);
+  if (
+    effectiveSkillFilter === undefined &&
+    opts?.skillOverrides === undefined &&
+    opts?.eligibility === undefined
+  ) {
+    return entries;
+  }
+  return filterSkillEntries(
+    entries,
+    opts?.config,
+    effectiveSkillFilter,
+    opts?.skillOverrides,
+    opts?.eligibility,
+  );
+}
+
+export function loadVisibleWorkspaceSkillEntries(
+  workspaceDir: string,
+  opts?: {
+    config?: OpenClawConfig;
+    managedSkillsDir?: string;
+    bundledSkillsDir?: string;
+    skillFilter?: string[];
+    skillOverrides?: Record<string, boolean>;
+    agentId?: string;
+    eligibility?: SkillEligibilityContext;
+  },
+): SkillEntry[] {
+  const entries = mergeRemoteNodeSkillEntries(loadSkillEntries(workspaceDir, opts), {
+    canExec: opts?.eligibility?.nodeSkills?.canExec,
+    node: opts?.eligibility?.nodeSkills?.node,
+  });
+  const effectiveSkillFilter = resolveEffectiveWorkspaceSkillFilter(opts);
+  return filterSkillEntries(
+    entries,
+    opts?.config,
+    effectiveSkillFilter,
+    opts?.skillOverrides,
+    opts?.eligibility,
+  );
+}
+
+function resolveUniqueSyncedSkillDirName(base: string, used: Set<string>): string {
+  if (!used.has(base)) {
+    used.add(base);
+    return base;
+  }
+  for (let index = 2; index < 10_000; index += 1) {
+    const candidate = `${base}-${index}`;
+    if (!used.has(candidate)) {
+      used.add(candidate);
+      return candidate;
+    }
+  }
+  let fallbackIndex = 10_000;
+  let fallback = `${base}-${fallbackIndex}`;
+  while (used.has(fallback)) {
+    fallbackIndex += 1;
+    fallback = `${base}-${fallbackIndex}`;
+  }
+  used.add(fallback);
+  return fallback;
+}
+
+function resolveSyncedSkillDestinationPath(params: {
+  targetSkillsDir: string;
+  entry: SkillEntry;
+  usedDirNames: Set<string>;
+}): string | null {
+  const sourceDirName = (
+    params.entry.syncDirName ?? path.basename(params.entry.skill.baseDir)
+  ).trim();
+  if (!sourceDirName || sourceDirName === "." || sourceDirName === "..") {
+    return null;
+  }
+  const uniqueDirName = resolveUniqueSyncedSkillDirName(sourceDirName, params.usedDirNames);
+  return resolveSandboxPath({
+    filePath: uniqueDirName,
+    cwd: params.targetSkillsDir,
+    root: params.targetSkillsDir,
+  }).resolved;
+}
+
+async function prepareSyncedSkillsDirectory(targetSkillsDir: string): Promise<void> {
+  let stats: fs.Stats;
+  try {
+    stats = await fsp.lstat(targetSkillsDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+    await fsp.mkdir(targetSkillsDir, { recursive: true });
+    return;
+  }
+
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    await fsp.rm(targetSkillsDir, { recursive: true, force: true });
+    await fsp.mkdir(targetSkillsDir, { recursive: true });
+    return;
+  }
+
+  for (const entry of await fsp.readdir(targetSkillsDir)) {
+    await fsp.rm(path.join(targetSkillsDir, entry), { recursive: true, force: true });
+  }
+}
+
+export async function syncSkillsToWorkspace(params: {
+  sourceWorkspaceDir: string;
+  targetWorkspaceDir: string;
+  config?: OpenClawConfig;
+  skillFilter?: string[];
+  agentId?: string;
+  eligibility?: SkillEligibilityContext;
+  managedSkillsDir?: string;
+  bundledSkillsDir?: string;
+  pluginSkillsDir?: string;
+}): Promise<SkillUsagePath[]> {
+  const sourceDir = resolveUserPath(params.sourceWorkspaceDir);
+  const targetDir = resolveUserPath(params.targetWorkspaceDir);
+  if (sourceDir === targetDir) {
+    return [];
+  }
+
+  return await serializeByKey(`syncSkills:${targetDir}`, async () => {
+    const targetSkillsDir = path.join(targetDir, "skills");
+
+    const entries = loadWorkspaceSkillEntries(sourceDir, {
+      config: params.config,
+      skillFilter: params.skillFilter,
+      agentId: params.agentId,
+      eligibility: params.eligibility,
+      managedSkillsDir: params.managedSkillsDir,
+      bundledSkillsDir: params.bundledSkillsDir,
+      pluginSkillsDir: params.pluginSkillsDir,
+    });
+
+    await prepareSyncedSkillsDirectory(targetSkillsDir);
+
+    const usedDirNames = new Set<string>();
+    const skillUsagePaths: SkillUsagePath[] = [];
+    for (const entry of entries) {
+      let dest: string | null;
+      try {
+        dest = resolveSyncedSkillDestinationPath({
+          targetSkillsDir,
+          entry,
+          usedDirNames,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : JSON.stringify(error);
+        skillsLogger.warn(`Failed to resolve safe destination for ${entry.skill.name}: ${message}`);
+        continue;
+      }
+      if (!dest) {
+        skillsLogger.warn(
+          `Failed to resolve safe destination for ${entry.skill.name}: invalid source directory name`,
+        );
+        continue;
+      }
+      try {
+        const syncSourceDir = entry.syncSourceDir ?? entry.skill.baseDir;
+        await fsp.cp(syncSourceDir, dest, {
+          recursive: true,
+          force: true,
+          filter: (src) => {
+            const name = path.basename(src);
+            return !(name === ".git" || name === "node_modules");
+          },
+        });
+        skillUsagePaths.push({
+          readPath: path.join(dest, path.relative(entry.skill.baseDir, entry.skill.filePath)),
+          skillFile: canonicalizePath(entry.skill.filePath),
+          skillName: entry.skill.name,
+          skillSource: resolveSkillTelemetrySource(entry.skill),
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : JSON.stringify(error);
+        skillsLogger.warn(`Failed to copy ${entry.skill.name} to sandbox: ${message}`);
+      }
+    }
+    return skillUsagePaths;
+  });
+}
+
+export function filterWorkspaceSkillEntriesWithOptions(
+  entries: SkillEntry[],
+  opts?: {
+    config?: OpenClawConfig;
+    skillFilter?: string[];
+    skillOverrides?: Record<string, boolean>;
+    eligibility?: SkillEligibilityContext;
+  },
+): SkillEntry[] {
+  return filterSkillEntries(
+    entries,
+    opts?.config,
+    opts?.skillFilter,
+    opts?.skillOverrides,
+    opts?.eligibility,
+  );
+}
+/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/skills/workshop/apply-transition.ts
+++ b/src/skills/workshop/apply-transition.ts
@@ -7,7 +7,6 @@ import {
 } from "../lifecycle/skill-change-hook.js";
 import {
   applyWorkspaceSkillMutation,
-  assertInsideWorkspace,
   isWorkspaceSkillMutationApplied,
   isWorkspaceSkillMutationRestored,
   prepareWorkspaceSkillMutation,
@@ -34,6 +33,7 @@ import {
   type PendingSkillProposalTransitionCommit,
 } from "./store-sqlite-transition.js";
 import { withSkillProposalCommitLock, withSkillProposalTargetLock } from "./target-lock.js";
+import { assertWritableProposalTarget } from "./target.js";
 import {
   SKILL_WORKSHOP_ROLLBACK_SCHEMA,
   type SkillProposalActionInput,
@@ -224,14 +224,18 @@ export async function applySkillProposalTransition(
         await quarantineSkillProposalAfterScan({ input, record, scan });
       }
 
-      assertInsideWorkspace(input.workspaceDir, record.target.skillFile, "skill file");
-      assertInsideWorkspace(input.workspaceDir, record.target.skillDir, "skill directory");
+      const authorizedExternalRootRealPaths = assertWritableProposalTarget({
+        workspaceDir: input.workspaceDir,
+        target: record.target,
+        config: input.config,
+      });
       const workshopConfig = resolveSkillWorkshopConfig(input.config);
       const symlinkPolicy = {
         allowWrites: workshopConfig.allowSymlinkTargetWrites,
         allowedTargetRealPaths: workshopConfig.allowSymlinkTargetWrites
           ? resolveAllowedSkillSymlinkTargetRealPaths(input.config)
           : [],
+        allowedExternalRootRealPaths: authorizedExternalRootRealPaths,
       };
       if (record.evaluation?.id !== evaluated.evaluation.id) {
         throw new Error("Skill proposal evaluation changed before apply; retry the operation.");

--- a/src/skills/workshop/config.ts
+++ b/src/skills/workshop/config.ts
@@ -1,7 +1,10 @@
 // Workshop config helpers resolve skill workshop settings from OpenClaw config.
+import fs from "node:fs";
+import path from "node:path";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SkillsWorkshopAutonomousMode } from "../../config/types.skills.js";
+import { resolveUserPath } from "../../utils.js";
 
 /** Runtime configuration for the skill workshop proposal flow. */
 type SkillWorkshopConfig = {
@@ -9,6 +12,7 @@ type SkillWorkshopConfig = {
     mode: SkillsWorkshopAutonomousMode;
   };
   allowSymlinkTargetWrites: boolean;
+  writableRoots: string[];
   approvalPolicy: "pending" | "auto";
   maxPending: number;
   maxSkillBytes: number;
@@ -19,6 +23,7 @@ const DEFAULT_CONFIG: SkillWorkshopConfig = {
     mode: "auto",
   },
   allowSymlinkTargetWrites: false,
+  writableRoots: [],
   approvalPolicy: "auto",
   maxPending: 50,
   maxSkillBytes: 40_000,
@@ -45,6 +50,25 @@ function readApprovalPolicy(value: unknown, fallback: SkillWorkshopConfig["appro
   return value === "pending" || value === "auto" ? value : fallback;
 }
 
+function readWritableRoots(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const roots = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== "string" || !item.trim()) {
+      continue;
+    }
+    const resolved = path.resolve(resolveUserPath(item));
+    try {
+      roots.add(fs.realpathSync(resolved));
+    } catch {
+      // Missing roots cannot authorize a write and are omitted from discovery.
+    }
+  }
+  return [...roots];
+}
+
 export function resolveSkillWorkshopConfig(config?: OpenClawConfig): SkillWorkshopConfig {
   const raw = asNullableRecord(config?.skills?.workshop) ?? {};
   const autonomous = asNullableRecord(raw.autonomous) ?? {};
@@ -56,6 +80,7 @@ export function resolveSkillWorkshopConfig(config?: OpenClawConfig): SkillWorksh
       raw.allowSymlinkTargetWrites,
       DEFAULT_CONFIG.allowSymlinkTargetWrites,
     ),
+    writableRoots: readWritableRoots(raw.writableRoots),
     approvalPolicy: readApprovalPolicy(raw.approvalPolicy, DEFAULT_CONFIG.approvalPolicy),
     maxPending: readInteger(raw.maxPending, DEFAULT_CONFIG.maxPending, 1, 200),
     maxSkillBytes: readInteger(raw.maxSkillBytes, DEFAULT_CONFIG.maxSkillBytes, 1024, 200_000),

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -20,6 +20,7 @@ import {
   applySkillProposal,
   getSkillProposalRunProgress,
   inspectSkillProposal,
+  listWritableWorkspaceSkillSummaries,
   listSkillProposals,
   proposeCreateSkill,
   proposeUpdateSkill,
@@ -205,6 +206,84 @@ describe("skill workshop proposals", () => {
     });
     expect((await inspectSkillProposal(proposal.record.id))?.record.status).toBe("applied");
   });
+
+  it.runIf(process.platform !== "win32")(
+    "resolves and applies updates to an explicitly configured canonical root ahead of shadows",
+    async () => {
+      const workspaceDir = await makeWorkspace();
+      const canonicalRoot = await tempDirs.make("openclaw-skill-workshop-canonical-");
+      const config = { skills: { workshop: { writableRoots: [canonicalRoot] } } };
+      await writeSkill({
+        dir: path.join(workspaceDir, "skills", "canonical-skill"),
+        name: "canonical-skill",
+        description: "Workspace shadow",
+        body: "# Shadow\n\nThis copy must not be selected.\n",
+      });
+      await writeSkill({
+        dir: path.join(canonicalRoot, "canonical-skill"),
+        name: "canonical-skill",
+        description: "Canonical source",
+        body: "# Canonical\n\nThis copy is authoritative.\n",
+      });
+
+      const listed = listWritableWorkspaceSkillSummaries(workspaceDir, { config });
+      expect(listed).toContainEqual({
+        name: "canonical-skill",
+        description: "Canonical source",
+        filePath: path.join(await fs.realpath(canonicalRoot), "canonical-skill", "SKILL.md"),
+      });
+
+      const proposal = await proposeUpdateSkill({
+        workspaceDir,
+        config,
+        skillName: "canonical-skill",
+        content: "# Canonical\n\nUpdated at the authoritative root.\n",
+      });
+      expect(proposal.record.target.source).toBe("openclaw-workshop");
+      expect(proposal.record.target.authorizedRootRealPath).toBe(await fs.realpath(canonicalRoot));
+
+      await applySkillProposal({ workspaceDir, config, proposalId: proposal.record.id });
+      await expect(
+        fs.readFile(path.join(canonicalRoot, "canonical-skill", "SKILL.md"), "utf8"),
+      ).resolves.toContain("Updated at the authoritative root.");
+      await expect(
+        fs.readFile(path.join(workspaceDir, "skills", "canonical-skill", "SKILL.md"), "utf8"),
+      ).resolves.toContain("This copy must not be selected.");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "fails closed when a canonical proposal root is no longer authorized",
+    async () => {
+      const workspaceDir = await makeWorkspace();
+      const originalRoot = await tempDirs.make("openclaw-skill-workshop-root-original-");
+      const replacementRoot = await tempDirs.make("openclaw-skill-workshop-root-replacement-");
+      await writeSkill({
+        dir: path.join(originalRoot, "root-bound-skill"),
+        name: "root-bound-skill",
+        description: "Bound target",
+        body: "# Bound\n\nOriginal.\n",
+      });
+      const originalConfig = { skills: { workshop: { writableRoots: [originalRoot] } } };
+      const proposal = await proposeUpdateSkill({
+        workspaceDir,
+        config: originalConfig,
+        skillName: "root-bound-skill",
+        content: "# Bound\n\nUpdated.\n",
+      });
+
+      await expect(
+        applySkillProposal({
+          workspaceDir,
+          config: { skills: { workshop: { writableRoots: [replacementRoot] } } },
+          proposalId: proposal.record.id,
+        }),
+      ).rejects.toThrow("no longer authorized");
+      await expect(
+        fs.readFile(path.join(originalRoot, "root-bound-skill", "SKILL.md"), "utf8"),
+      ).resolves.toContain("Original.");
+    },
+  );
 
   it("persists the reason when applying a proposal", async () => {
     const workspaceDir = await makeWorkspace();

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -3,7 +3,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
 import { buildWorkspaceSkillStatus, resolveSkillStatusEntry } from "../discovery/status.js";
 import {
-  assertInsideWorkspace,
   readWorkspaceSkillFile,
   readWorkspaceSupportFile,
 } from "../lifecycle/workspace-skill-write.js";
@@ -42,7 +41,9 @@ import {
   withSkillProposalTargetLock,
   type PreparedSkillProposalSupportFile,
 } from "./store.js";
+import { assertWritableProposalTarget, resolveWritableSkillTarget } from "./target.js";
 import { assertWritableSkillTarget } from "./workspace-skill-read.js";
+export { listWritableWorkspaceSkillSummaries } from "./workspace-skill-read.js";
 export {
   getSkillProposalRunProgress,
   inspectSkillProposal,
@@ -262,7 +263,12 @@ export async function proposeUpdateSkill(
   if (!targetSkill) {
     throw new Error(`Skill not found: ${skillName}`);
   }
-  assertWritableSkillTarget(input.workspaceDir, targetSkill);
+  assertWritableSkillTarget(input.workspaceDir, targetSkill, input.config);
+  const authorizedRootRealPath = resolveWritableSkillTarget({
+    workspaceDir: input.workspaceDir,
+    skill: targetSkill,
+    config: input.config,
+  });
   const currentContent = await readWorkspaceSkillFile(targetSkill.filePath);
   if (currentContent === null) {
     throw new Error(`Skill file is missing: ${targetSkill.filePath}`);
@@ -337,6 +343,7 @@ export async function proposeUpdateSkill(
       skillDir: targetSkill.baseDir,
       skillFile: targetSkill.filePath,
       source: targetSkill.source,
+      ...(authorizedRootRealPath ? { authorizedRootRealPath } : {}),
       currentContentHash: hashSkillProposalContent(currentContent),
     },
     scan,
@@ -386,8 +393,11 @@ export async function reviseSkillProposal(
   const config = resolveSkillWorkshopConfig(input.config);
   const revision = withPendingSkillProposalMutation(input, "revised", async (read) => {
     const { record } = read;
-    assertInsideWorkspace(input.workspaceDir, record.target.skillFile, "skill file");
-    assertInsideWorkspace(input.workspaceDir, record.target.skillDir, "skill directory");
+    assertWritableProposalTarget({
+      workspaceDir: input.workspaceDir,
+      target: record.target,
+      config: input.config,
+    });
 
     if (record.kind === "create") {
       const currentContent = await readWorkspaceSkillFile(record.target.skillFile);

--- a/src/skills/workshop/target.ts
+++ b/src/skills/workshop/target.ts
@@ -1,0 +1,125 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isPathInside } from "../../infra/path-guards.js";
+import type { SkillStatusEntry } from "../discovery/status.js";
+import { assertInsideWorkspace } from "../lifecycle/workspace-skill-write.js";
+import { tryRealpath } from "../loading/symlink-targets.js";
+import { resolveSkillWorkshopConfig } from "./config.js";
+
+export const WRITABLE_WORKSPACE_SOURCES = new Set(["openclaw-workspace", "agents-skills-project"]);
+export const WORKSHOP_WRITABLE_SOURCE = "openclaw-workshop";
+
+type SkillTargetLike = {
+  skillDir: string;
+  skillFile: string;
+  source?: string;
+  authorizedRootRealPath?: string;
+};
+
+function matchingWorkshopRoots(filePath: string, config?: OpenClawConfig): string[] {
+  const realPath = tryRealpath(filePath);
+  if (!realPath) {
+    return [];
+  }
+  return resolveSkillWorkshopConfig(config).writableRoots.filter((root) =>
+    isPathInside(root, realPath),
+  );
+}
+
+/** Returns the one configured real root that authorizes a discovered workshop target. */
+export function resolveWorkshopTargetRoot(
+  skill: Pick<SkillStatusEntry, "source" | "filePath">,
+  config?: OpenClawConfig,
+): string | undefined {
+  if (skill.source !== WORKSHOP_WRITABLE_SOURCE) {
+    return undefined;
+  }
+  const roots = matchingWorkshopRoots(skill.filePath, config);
+  if (roots.length > 1) {
+    throw new Error(
+      `Skill target is ambiguous across configured writable roots: ${skill.filePath}`,
+    );
+  }
+  return roots[0];
+}
+
+/** Resolves and authorizes an update target using the same policy as writable-skill listing. */
+export function resolveWritableSkillTarget(params: {
+  workspaceDir: string;
+  skill: SkillStatusEntry;
+  config?: OpenClawConfig;
+}): string | undefined {
+  if (WRITABLE_WORKSPACE_SOURCES.has(params.skill.source)) {
+    assertInsideWorkspace(params.workspaceDir, params.skill.filePath, "skill file");
+    assertInsideWorkspace(params.workspaceDir, params.skill.baseDir, "skill directory");
+    assertSkillMarkdownTarget(params.skill.filePath);
+    return undefined;
+  }
+  if (params.skill.source !== WORKSHOP_WRITABLE_SOURCE) {
+    throw new Error(`Skill source is not writable by Skill Workshop: ${params.skill.source}`);
+  }
+  const root = resolveWorkshopTargetRoot(params.skill, params.config);
+  if (!root) {
+    throw new Error(
+      `Skill target is not inside a configured writable root: ${params.skill.filePath}`,
+    );
+  }
+  assertSkillMarkdownTarget(params.skill.filePath);
+  return root;
+}
+
+/** Revalidates a persisted proposal target immediately before revision or apply. */
+export function assertWritableProposalTarget(params: {
+  workspaceDir: string;
+  target: SkillTargetLike;
+  config?: OpenClawConfig;
+}): string[] {
+  const { target } = params;
+  if (WRITABLE_WORKSPACE_SOURCES.has(target.source ?? "")) {
+    assertInsideWorkspace(params.workspaceDir, target.skillFile, "skill file");
+    assertInsideWorkspace(params.workspaceDir, target.skillDir, "skill directory");
+    assertSkillMarkdownTarget(target.skillFile);
+    return [];
+  }
+  if (target.source !== WORKSHOP_WRITABLE_SOURCE) {
+    throw new Error(`Skill source is not writable by Skill Workshop: ${target.source}`);
+  }
+  assertSkillMarkdownTarget(target.skillFile);
+  const authorizedRoot = target.authorizedRootRealPath;
+  if (!authorizedRoot) {
+    throw new Error("Skill proposal is missing its authorized writable root.");
+  }
+  const configuredRoots = resolveSkillWorkshopConfig(params.config).writableRoots;
+  if (!configuredRoots.includes(authorizedRoot)) {
+    throw new Error("Skill proposal writable root is no longer authorized.");
+  }
+  const fileRealPath = tryRealpath(target.skillFile);
+  const dirRealPath = tryRealpath(target.skillDir);
+  if (
+    !fileRealPath ||
+    !dirRealPath ||
+    !isPathInside(authorizedRoot, fileRealPath) ||
+    !isPathInside(authorizedRoot, dirRealPath)
+  ) {
+    throw new Error("Skill proposal target escaped its authorized writable root.");
+  }
+  return [authorizedRoot];
+}
+
+export function isWritableSkillStatusEntry(params: {
+  workspaceDir: string;
+  skill: SkillStatusEntry;
+  config?: OpenClawConfig;
+}): boolean {
+  try {
+    resolveWritableSkillTarget(params);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertSkillMarkdownTarget(filePath: string): void {
+  if (filePath.split(/[\\/]/).pop() !== "SKILL.md") {
+    throw new Error("Skill Workshop can only update SKILL.md targets.");
+  }
+}

--- a/src/skills/workshop/types.ts
+++ b/src/skills/workshop/types.ts
@@ -119,6 +119,8 @@ type SkillProposalTarget = {
   skillDir: string;
   skillFile: string;
   source?: string;
+  /** Real path of the configured root that authorized an external update target. */
+  authorizedRootRealPath?: string;
   currentContentHash?: string;
 };
 

--- a/src/skills/workshop/workspace-skill-read.ts
+++ b/src/skills/workshop/workspace-skill-read.ts
@@ -7,23 +7,16 @@ import {
   resolveSkillStatusEntry,
   type SkillStatusEntry,
 } from "../discovery/status.js";
-import {
-  assertInsideWorkspace,
-  readWorkspaceSkillFile,
-} from "../lifecycle/workspace-skill-write.js";
+import { readWorkspaceSkillFile } from "../lifecycle/workspace-skill-write.js";
 import { tryRealpath } from "../loading/symlink-targets.js";
+import { isWritableSkillStatusEntry, resolveWritableSkillTarget } from "./target.js";
 
-const WRITABLE_WORKSPACE_SOURCES = new Set(["openclaw-workspace", "agents-skills-project"]);
-
-export function assertWritableSkillTarget(workspaceDir: string, skill: SkillStatusEntry): void {
-  if (!WRITABLE_WORKSPACE_SOURCES.has(skill.source)) {
-    throw new Error(`Skill source is not writable by Skill Workshop: ${skill.source}`);
-  }
-  assertInsideWorkspace(workspaceDir, skill.filePath, "skill file");
-  assertInsideWorkspace(workspaceDir, skill.baseDir, "skill directory");
-  if (path.basename(skill.filePath) !== "SKILL.md") {
-    throw new Error("Skill Workshop can only update SKILL.md targets.");
-  }
+export function assertWritableSkillTarget(
+  workspaceDir: string,
+  skill: SkillStatusEntry,
+  config?: OpenClawConfig,
+): void {
+  resolveWritableSkillTarget({ workspaceDir, skill, config });
 }
 
 export function isWorkspaceOwnedSkillTarget(
@@ -58,7 +51,7 @@ export function listWritableWorkspaceSkillSummaries(
   });
   const summaries: WritableWorkspaceSkillSummary[] = [];
   for (const skill of status.skills) {
-    if (!WRITABLE_WORKSPACE_SOURCES.has(skill.source)) {
+    if (!isWritableSkillStatusEntry({ workspaceDir, skill, config: opts?.config })) {
       continue;
     }
     summaries.push(
@@ -88,7 +81,7 @@ export async function readWritableWorkspaceSkill(
   if (!targetSkill) {
     throw new Error(`Skill not found: ${name}`);
   }
-  assertWritableSkillTarget(workspaceDir, targetSkill);
+  assertWritableSkillTarget(workspaceDir, targetSkill, opts?.config);
   const content = await readWorkspaceSkillFile(targetSkill.filePath);
   if (content === null) {
     throw new Error(`Skill file is missing: ${targetSkill.filePath}`);


### PR DESCRIPTION
## Problem
Skill Workshop rejected the canonical Kaizen skills root because it was classified as agents-skills-personal, while agent workspace shadows could remain visible as competing sources.

## Change
- Add explicit skills.workshop.writableRoots configuration.
- Discover configured roots as the dedicated openclaw-workshop source with canonical precedence.
- Centralize target resolution for list, propose, revise, apply, and recovery.
- Persist and revalidate the authorized real root; reject ambiguity, traversal, and symlink escapes.
- Keep skill creation workspace-only.

Example configuration:
```json5
{
  skills: {
    workshop: {
      writableRoots: ["/home/paul/Kaizen/skills"]
    }
  }
}
```

## Verification
- 54 focused Skill Workshop tests passed.
- Core TypeScript check passed with declaration emission disabled.
- oxfmt check and git diff --check passed.

Patch-size/transport limits are unchanged and will be a separate follow-up for oversized skills such as kb-pr-ship.