### PR TITLE
fix(openai): preserve GPT-Live gateway error precedence

### DIFF
--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -4,6 +4,7 @@ import { OPENAI_QUICKSILVER_RELAY_FRAME_BYTES } from "./realtime-quicksilver-aud
 import { OpenAIQuicksilverGatewayBridge } from "./realtime-quicksilver-gateway-bridge.js";
 import {
   OpenAIQuicksilverAudioPeer,
+  type OpenAIQuicksilverAudioPeerCallbacks,
   type OpenAIQuicksilverAudioPeerContract,
 } from "./realtime-quicksilver-peer.runtime.js";
 import {
@@ -546,9 +547,13 @@ describe("GPT-Live werift audio peer", () => {
 });
 
 describe("GPT-Live gateway relay bridge", () => {
-  function createPendingPeerBridge() {
+  function createPendingPeerBridge(params?: {
+    onClose?: (reason: "completed" | "error") => void;
+    onError?: (error: Error) => void;
+  }) {
     let resolvePeer: ((peer: OpenAIQuicksilverAudioPeerContract) => void) | undefined;
     let rejectPeer: ((error: Error) => void) | undefined;
+    let peerCallbacks: OpenAIQuicksilverAudioPeerCallbacks | undefined;
     const peerPromise = new Promise<OpenAIQuicksilverAudioPeerContract>((resolve, reject) => {
       resolvePeer = resolve;
       rejectPeer = reject;
@@ -567,7 +572,8 @@ describe("GPT-Live gateway relay bridge", () => {
       audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
       onAudio: vi.fn(),
       onClearAudio: vi.fn(),
-      onClose,
+      onClose: params?.onClose ?? onClose,
+      onError: params?.onError,
       runAgentConsult: vi.fn(async () => ({ text: "done" })),
       logger: { debug: vi.fn(), warn: vi.fn() },
       resolveAuth: vi.fn(async () => ({
@@ -575,7 +581,10 @@ describe("GPT-Live gateway relay bridge", () => {
         token: "oauth-token",
         accountId: "account-1",
       })),
-      createPeer: vi.fn(() => peerPromise),
+      createPeer: vi.fn((callbacks) => {
+        peerCallbacks = callbacks;
+        return peerPromise;
+      }),
       fetchImpl: vi.fn(async () => createCallResponse("v=answer\r\n", "rtc_pending_audio")),
       webSocketFactory: () => new FakeSocket(),
     });
@@ -587,6 +596,7 @@ describe("GPT-Live gateway relay bridge", () => {
       peer,
       rejectPeer: (error: Error) => rejectPeer?.(error),
       resolvePeer: () => resolvePeer?.(peer),
+      triggerPeerError: (error: Error) => peerCallbacks?.onError(error),
     };
   }
 
@@ -642,6 +652,53 @@ describe("GPT-Live gateway relay bridge", () => {
     bridge.sendAudio(Buffer.from([0x43, 0x44]));
     expect(pendingAudioState.pendingAudio).toHaveLength(0);
     expect(peer.sendAudio).not.toHaveBeenCalled();
+  });
+
+  it("keeps error precedence when onError reentrantly closes the bridge", async () => {
+    const onClose = vi.fn();
+    const bridgeRef: { current?: OpenAIQuicksilverGatewayBridge } = {};
+    const harness = createPendingPeerBridge({
+      onClose,
+      onError: () => bridgeRef.current?.close(),
+    });
+    bridgeRef.current = harness.bridge;
+    const connectionRejected = expect(harness.connection).rejects.toThrow(
+      "GPT-Live gateway relay bridge closed",
+    );
+
+    harness.triggerPeerError(new Error("media peer failed"));
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledWith("error");
+    await connectionRejected;
+  });
+
+  it("releases queued audio and rejects a late peer when onError throws", async () => {
+    const callbackError = new Error("error callback failed");
+    const onClose = vi.fn();
+    const harness = createPendingPeerBridge({
+      onClose,
+      onError: () => {
+        throw callbackError;
+      },
+    });
+    const testBridge = harness.bridge as unknown as TestableGatewayBridge;
+    harness.bridge.sendAudio(Buffer.from([0x41, 0x42]));
+    const connectionRejected = expect(harness.connection).rejects.toThrow(
+      "GPT-Live gateway relay bridge closed",
+    );
+
+    expect(() => harness.triggerPeerError(new Error("media peer failed"))).toThrow(callbackError);
+    const retainedAudioBytes = testBridge.pendingAudio.byteLength;
+    const closeReason = onClose.mock.calls[0]?.[0];
+    harness.bridge.close();
+    harness.resolvePeer();
+
+    await connectionRejected;
+    await vi.waitFor(() => expect(harness.peer.close).toHaveBeenCalledOnce());
+    expect(retainedAudioBytes).toBe(0);
+    expect(closeReason).toBe("error");
+    expect(harness.peer.sendAudio).not.toHaveBeenCalled();
   });
 
   it("closes a sideband that opens in the abort handoff", async () => {

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -524,22 +524,24 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
   }
 
   private fail(error: Error): void {
-    if (this.closed) {
-      return;
-    }
-    this.config.onError?.(error);
-    this.teardown("error");
+    this.teardown("error", () => this.config.onError?.(error));
   }
 
-  private teardown(reason: "completed" | "error"): void {
+  private teardown(reason: "completed" | "error", beforeClose?: () => void): void {
     if (this.closed) {
       return;
     }
+    // Claim terminal ownership and release resources before callbacks so reentrant close
+    // cannot replace the outcome, while finally preserves error-before-close ordering.
     this.closed = true;
     this.releaseResources();
-    if (!this.closeNotified) {
-      this.closeNotified = true;
-      this.config.onClose?.(reason);
+    try {
+      beforeClose?.();
+    } finally {
+      if (!this.closeNotified) {
+        this.closeNotified = true;
+        this.config.onClose?.(reason);
+      }
     }
   }
 


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

When a GPT-Live Gateway media peer failed, the bridge called `onError` before claiming terminal ownership and releasing resources. A reentrant `close()` from that callback could replace the error outcome with completion, while a throwing callback could skip cleanup and retain queued audio.

## Why This Change Was Made

Route failure through the existing teardown owner. Teardown now claims the terminal outcome and releases resources before invoking `onError`, then uses `finally` to preserve error-before-close notification ordering even when the callback throws.

The change remains local to the OpenAI GPT-Live Gateway bridge. It adds no provider, model, protocol, config, or environment-variable surface.

## User Impact

GPT-Live Gateway relay failures now terminate once with the correct error outcome. Reentrant or throwing callbacks cannot retain queued audio, adopt a late media peer, or report a false completed close.

## Evidence

- Exact reviewed head: `c904881f7dab113c4517420c662242ecc1595ade`
- Full owning test file: 33/33 passed
- Focused callback-race regressions: 2/2 passed
- Exact-head live GPT-Live Gateway WebRTC: 1 passed, 1 OAuth-only case skipped
- Live startup-audio proof: 137,362 queued bytes before peer adoption, 0 after adoption
- Live terminal proof: transcript marker observed, close notifications 1, late audio bytes 0, errors 0
- P1 autoreview: clean, patch correct, confidence 0.94
- Targeted oxfmt, direct oxlint, and `git diff --check`: clean
- Latest-main merge simulation: clean; no overlapping changes in the two touched files

## Deliberate Scope Boundary

This PR fixes terminal ownership inside the GPT-Live Gateway bridge. It does not introduce a shared provider lifecycle framework or change retry policy.

