### PR TITLE
fix(onboarding): report browser opener failures

### DIFF
--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -172,6 +172,20 @@ describe("dashboardCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith("ssh hint");
   });
 
+  it("reports opener failure without claiming the host has no GUI", async () => {
+    mockSnapshot("shhhh");
+    copyToClipboardMock.mockResolvedValue(true);
+    detectBrowserOpenSupportMock.mockResolvedValue({ ok: true });
+    openUrlMock.mockResolvedValue(false);
+
+    await dashboardCommand(runtime);
+
+    expect(formatControlUiSshHintMock).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Browser launch failed. Open the Dashboard URL above manually.",
+    );
+  });
+
   it("never passes token to SSH hint (CVE regression — SSH path)", async () => {
     const secretToken = "super-secret-bearer-token";
     mockSnapshot(secretToken);

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -284,8 +284,8 @@ export async function dashboardCommand(
     const browserSupport = await detectBrowserOpenSupport();
     if (browserSupport.ok) {
       opened = await openUrl(dashboardUrl);
-    }
-    if (!opened) {
+      hint = opened ? undefined : "Browser launch failed. Open the Dashboard URL above manually.";
+    } else {
       hint = formatControlUiSshHint({
         port,
         basePath,

--- a/src/commands/onboard-browser-handoff.test.ts
+++ b/src/commands/onboard-browser-handoff.test.ts
@@ -205,6 +205,10 @@ describe("runBrowserHatchHandoff", () => {
       expect.stringContaining(target.dashboardUrl),
       "Continue in your browser",
     );
+    expect(prompter.note).not.toHaveBeenCalledWith(
+      expect.stringContaining(target.sshHint),
+      "Continue in your browser",
+    );
   });
 
   it("returns the poll timeout without claiming a handoff", async () => {

--- a/src/commands/onboard-browser-handoff.ts
+++ b/src/commands/onboard-browser-handoff.ts
@@ -315,7 +315,7 @@ export async function runBrowserHatchHandoff(
       t("wizard.guided.browserHandoffTitle"),
     );
   } else {
-    const sshHint = target.sshHint ? `\n\n${target.sshHint}` : "";
+    const sshHint = !graphical && target.sshHint ? `\n\n${target.sshHint}` : "";
     await params.prompter.note(
       `${t("wizard.guided.browserHandoffCopy", { url: target.dashboardUrl })}${sshHint}`,
       t("wizard.guided.browserHandoffTitle"),

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { SpawnResult } from "../process/exec-result.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
@@ -78,13 +79,14 @@ const mocks = vi.hoisted(() => ({
     (
       argv: string[],
       options?: { timeoutMs?: number; windowsVerbatimArguments?: boolean },
-    ) => Promise<{ stdout: string; stderr: string; code: number; signal: null; killed: boolean }>
+    ) => Promise<SpawnResult>
   >(async () => ({
     stdout: "",
     stderr: "",
     code: 0,
     signal: null,
     killed: false,
+    termination: "exit",
   })),
   pickPrimaryTailnetIPv4: vi.fn<() => string | undefined>(() => undefined),
   resolveAdvertisedLanHost: vi.fn<() => Promise<string | null>>(async () => null),

--- a/src/infra/browser-open.test.ts
+++ b/src/infra/browser-open.test.ts
@@ -1,11 +1,22 @@
 // Covers platform browser-open command resolution.
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SpawnResult } from "../process/exec-result.js";
 
-const { detectBinaryMock, getWindowsInstallRootsMock } = vi.hoisted(() => ({
-  detectBinaryMock: vi.fn(async () => false),
-  getWindowsInstallRootsMock: vi.fn(() => ({ systemRoot: "C:\\Windows" })),
-}));
+const { detectBinaryMock, getWindowsInstallRootsMock, runCommandWithTimeoutMock } = vi.hoisted(
+  () => ({
+    detectBinaryMock: vi.fn(async () => false),
+    getWindowsInstallRootsMock: vi.fn(() => ({ systemRoot: "C:\\Windows" })),
+    runCommandWithTimeoutMock: vi.fn<() => Promise<SpawnResult>>(async () => ({
+      stdout: "",
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    })),
+  }),
+);
 
 vi.mock("./detect-binary.js", () => ({
   detectBinary: detectBinaryMock,
@@ -18,13 +29,67 @@ vi.mock("./windows-install-roots.js", async () => {
   return { ...actual, getWindowsInstallRoots: getWindowsInstallRootsMock };
 });
 
-import { resolveBrowserOpenCommand } from "./browser-open.js";
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout: runCommandWithTimeoutMock,
+}));
+
+import { openUrl, resolveBrowserOpenCommand } from "./browser-open.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
   detectBinaryMock.mockReset().mockResolvedValue(false);
   getWindowsInstallRootsMock.mockReset().mockReturnValue({ systemRoot: "C:\\Windows" });
+  runCommandWithTimeoutMock.mockReset().mockResolvedValue({
+    stdout: "",
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: "exit",
+  });
+});
+
+describe("openUrl", () => {
+  it("returns true after a normal zero exit", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "development");
+
+    await expect(openUrl("https://example.com/")).resolves.toBe(true);
+  });
+
+  it("returns false after a non-zero exit", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "development");
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "browser opener failed",
+      code: 1,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+
+    await expect(openUrl("https://example.com/")).resolves.toBe(false);
+  });
+
+  it("returns false after a timeout", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "development");
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "",
+      code: 124,
+      signal: null,
+      killed: true,
+      termination: "timeout",
+    });
+
+    await expect(openUrl("https://example.com/")).resolves.toBe(false);
+  });
 });
 
 describe("resolveBrowserOpenCommand", () => {

--- a/src/infra/browser-open.ts
+++ b/src/infra/browser-open.ts
@@ -117,8 +117,8 @@ export async function openUrl(url: string): Promise<boolean> {
   const command = [...resolved.argv];
   command.push(normalizedUrl);
   try {
-    await runCommandWithTimeout(command, { timeoutMs: 5_000 });
-    return true;
+    const result = await runCommandWithTimeout(command, { timeoutMs: 5_000 });
+    return result.code === 0 && result.termination === "exit";
   } catch {
     return false;
   }

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -127,9 +127,6 @@ vi.mock("../commands/onboard-helpers.js", () => ({
     params.authMode === "token" && params.token && !params.suppressTokenOutput
       ? `${params.httpUrl}#token=${encodeURIComponent(params.token)}`
       : params.httpUrl,
-  detectBrowserOpenSupport: vi.fn(async () => ({ ok: false })),
-  formatControlUiSshHint: vi.fn(() => "ssh hint"),
-  openUrl: vi.fn(async () => false),
   probeGatewayReachable,
   resolveAdvertisedControlUiLinks,
   resolveControlUiLinks: vi.fn(() => ({

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -19,10 +19,7 @@ import { resolveGatewayInstallToken } from "../commands/gateway-install-token.js
 import { formatHealthCheckFailure } from "../commands/health-format.js";
 import { healthCommand } from "../commands/health.js";
 import {
-  detectBrowserOpenSupport,
   buildOnboardingControlUiUrl,
-  formatControlUiSshHint,
-  openUrl,
   probeGatewayReachable,
   waitForGatewayReachable,
   resolveAdvertisedControlUiLinks,
@@ -131,47 +128,6 @@ async function closeSessionGatewayForOnboarding(params: {
   await params.sessionGateway.close({ reason: params.reason }).catch((error: unknown) => {
     params.runtime.error(formatErrorMessage(error));
   });
-}
-
-async function showControlUiDashboardNote(params: {
-  prompter: WizardPrompter;
-  settings: GatewayWizardSettings;
-  authedUrl: string;
-  controlUiBasePath: string | undefined;
-  hintToken: string | undefined;
-}): Promise<{ opened: boolean }> {
-  let opened = false;
-  let openHint: string | undefined;
-  const browserSupport = await detectBrowserOpenSupport();
-  if (browserSupport.ok) {
-    opened = await openUrl(params.authedUrl);
-    if (!opened) {
-      openHint = formatControlUiSshHint({
-        port: params.settings.port,
-        basePath: params.controlUiBasePath,
-        token: params.hintToken,
-      });
-    }
-  } else {
-    openHint = formatControlUiSshHint({
-      port: params.settings.port,
-      basePath: params.controlUiBasePath,
-      token: params.hintToken,
-    });
-  }
-
-  await params.prompter.note(
-    [
-      t("wizard.finalize.dashboardLinkWithToken", { url: params.authedUrl }),
-      opened ? t("wizard.finalize.dashboardOpened") : t("wizard.finalize.dashboardCopyPaste"),
-      openHint,
-    ]
-      .filter(Boolean)
-      .join("\n"),
-    t("wizard.finalize.dashboardReady"),
-  );
-
-  return { opened };
 }
 
 function getLocalizedGatewayDaemonRuntimeOptions() {
@@ -650,8 +606,6 @@ export async function finalizeSetupWizard(
       "Control UI",
     );
 
-    let controlUiOpened = false;
-    const seededInBackground = false;
     let launchedTui = false;
     const shouldLaunchTui = !opts.skipUi;
 
@@ -708,24 +662,6 @@ export async function finalizeSetupWizard(
     await prompter.note(t("wizard.finalize.securityReminder"), t("wizard.security.title"));
 
     await setupWizardShellCompletion({ flow, prompter });
-
-    const shouldOpenControlUi =
-      !opts.skipUi &&
-      gatewayProbe.ok &&
-      settings.authMode === "token" &&
-      Boolean(settings.gatewayToken) &&
-      !suppressGatewayTokenOutput &&
-      !shouldLaunchTui;
-    if (shouldOpenControlUi) {
-      const dashboard = await showControlUiDashboardNote({
-        prompter,
-        settings,
-        authedUrl,
-        controlUiBasePath,
-        hintToken: settings.gatewayToken,
-      });
-      controlUiOpened = dashboard.opened;
-    }
 
     const codexNativeSummary = describeCodexNativeWebSearch(nextConfig);
     const webSearchProvider = nextConfig.tools?.web?.search?.provider;
@@ -878,13 +814,7 @@ export async function finalizeSetupWizard(
 
     await prompter.note(t("wizard.finalize.whatNow"), t("wizard.finalize.whatNowTitle"));
 
-    await prompter.outro(
-      controlUiOpened
-        ? t("wizard.finalize.outroDashboardOpened")
-        : seededInBackground
-          ? t("wizard.finalize.outroSeeded")
-          : t("wizard.finalize.outroDashboardLink"),
-    );
+    await prompter.outro(t("wizard.finalize.outroDashboardLink"));
 
     if (shouldLaunchTui) {
       restoreTerminalState("pre-setup tui", { resumeStdinIfPaused: false });


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

When an installed browser opener exited non-zero or timed out, browser handoffs still reported success or attached headless-only SSH guidance to a graphical launch failure. That false outcome could send users down the wrong recovery path during setup.

## Why This Change Was Made

The browser-open adapter now reports success only when the opener process completes through a normal exit with code 0. Dashboard and guided onboarding distinguish an available graphical opener that failed from a genuinely headless host, so only headless sessions receive SSH tunnel guidance.

The classic finalizer still contained an older browser-open branch, but its condition required both `shouldLaunchTui` and `!shouldLaunchTui`. That unreachable branch and its stale result state were removed instead of adding a synthetic regression for impossible behavior.

### Root Cause

`runCommandWithTimeout` returns non-zero, timeout, and signal outcomes as structured results, but `openUrl` ignored that result and returned `true` after every resolved invocation.

### Runtime ownership

`openUrl` owns the browser-handoff success contract. Dashboard and guided onboarding own their visible recovery messages: graphical opener failures get a manual-open instruction, while unsupported or headless environments retain the existing SSH guidance.

## User Impact

Users now receive a manual-open fallback when an installed opener fails, or the existing SSH guidance when no local GUI opener is available, instead of a misleading success message or false “No GUI detected” diagnosis. Successful browser launches, opener selection, URL validation, and the five-second process bound remain unchanged.

## Evidence

Validated at exact head `10d96b7efd3b353f474f602e6171972b0dc46435`: 139/139 focused owner and caller tests passed across four repo shards. The guided handoff regression was also run adversarially with the old condition restored: it failed by observing the SSH hint after a graphical launch failure, then passed after the fix was restored. Autoreview was clean at 0.97 against current `origin/main`.

The production adapter's real failing/successful opener proof was captured at parent `e8f08f1d81809ed57510400e1d5e36c9bb9771ea`; `src/infra/browser-open.ts` is byte-identical at the exact head.

<details>
<summary><strong>Inspect exact-head proof ledger</strong></summary>

<!-- pr-agent-proof-gate-v2 profile=focused-code tests=pass direct=pass real_behavior=pass -->

### Provenance

- **Base:** `a530a7bd70d4198b87f0ec32f21c2c0854494648`
- **Proof head:** `10d96b7efd3b353f474f602e6171972b0dc46435`
- **Direct runtime head:** `e8f08f1d81809ed57510400e1d5e36c9bb9771ea`
- **Current main reviewed:** `9bb7a3c8fd7a60284e2623f70e9f088ec74b3b36`
- **Revalidated:** focused tests and autoreview on the proof head; clean merge tree against current main; production adapter unchanged from the direct runtime head

### Direct behavior

<!-- pr-agent-direct-proof-v1 kind=production-runtime test_runner=none owners=all-real mocks=none head=e8f08f1d81809ed57510400e1d5e36c9bb9771ea -->

#### Browser opener handoff command

```bash
sudo -n unshare --mount --propagation private bash -s < run-browser-open-direct-proof.sh # production entrypoint: src/infra/browser-open.ts
```

- **Browser opener handoff (PRODUCTION_RUNTIME; boundary: production openUrl adapter through runCommandWithTimeout into real OS opener processes)** — Observed: With `wslview` masked only inside a private mount namespace, the production resolver selected the real `xdg-open` process and `openUrl` returned `false` after its non-zero result; with `wslview` available, `openUrl` returned `true`. Result: the failure scenario emitted `opened=false` and the success scenario emitted `opened=true` at parent `e8f08f1d81809ed57510400e1d5e36c9bb9771ea`. The exact head carries the same adapter blob plus dashboard fallback classification. Proves installed opener failures are reported to callers instead of being accepted as successful handoffs. Preserves the existing resolver order and successful WSL browser handoff.

#### Redacted exact-head terminal output

```text
direct_runtime_head=e8f08f1d81809ed57510400e1d5e36c9bb9771ea
test_runner=none
production_entrypoint=src/infra/browser-open.ts openUrl
runtime=local OpenClawUbuntu production module with real process runner and real OS opener binaries
fault_injection=private mount namespace masks wslview only for the failure scenario; real xdg-open receives BROWSER=/bin/false and exits non-zero
{"exactHead":"e8f08f1d81809ed57510400e1d5e36c9bb9771ea","scenario":"opener-nonzero","opener":"xdg-open","opened":false,"expected":false}
{"exactHead":"e8f08f1d81809ed57510400e1d5e36c9bb9771ea","scenario":"opener-success","opener":"wslview","opened":true,"expected":true}
exit_code=0
```

### Automated verification

#### Focused browser handoff regression

```bash
node scripts/run-vitest.mjs src/commands/onboard-browser-handoff.test.ts src/commands/onboard-guided.test.ts src/wizard/setup.finalize.test.ts src/infra/browser-open.test.ts src/commands/onboard-helpers.test.ts src/commands/dashboard.links.test.ts
```

- [TEST] 139/139 tests passed across four repo shards with 0 failures. Proves non-zero and timed-out opener results return false, dashboard and guided onboarding separate launch failure from no-GUI recovery, headless handoffs retain SSH guidance, and classic finalization remains intact after removal of its unreachable branch.

#### Adversarial guided-handoff regression

- With the old `target.sshHint` condition temporarily restored, the focused test failed because the graphical fallback contained `ssh -N -L ...`.
- After restoring the fix, the same focused test passed.

### Preserved boundaries

- Successful opener results still return true.
- Unsafe URLs remain rejected before spawning a process.
- Resolver order, headless SSH guidance, guided-handoff wait bounds, and the five-second opener timeout remain unchanged.

### Proof gap

Native macOS `open` and Windows PowerShell opener failures were not run because the proof environment exposes the WSL/Linux opener chain. The shared production adapter and real subprocess-result boundary were exercised directly; no full cross-platform GUI-launch claim is made.

</details>

### Artifacts

- None attached.
