### PR TITLE
fix(android): show all sidebar search results

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt
@@ -130,7 +130,7 @@ internal fun sidebarRecentSessions(
       compareByDescending<ChatSessionEntry> { it.pinned == true }
         .thenByDescending { it.lastActivityAt ?: it.updatedAtMs ?: 0L }
         .thenBy { it.key },
-    ).take(limit.coerceAtLeast(0))
+    ).let { if (normalizedQuery.isEmpty()) it.take(limit.coerceAtLeast(0)) else it }
     .toList()
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SidebarShellLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SidebarShellLogicTest.kt
@@ -125,20 +125,36 @@ class SidebarShellLogicTest {
   }
 
   @Test
-  fun recentSessionSearchCoversTitleLabelKeyAndOwnerBeforeApplyingLimit() {
+  fun recentSessionSearchCoversTitleLabelKeyAndOwnerWithoutApplyingRecentLimit() {
     val rows =
       sidebarRecentSessions(
         sessions =
           listOf(
-            session("agent:ops:one", activity = 1, displayName = "Release planning", owner = "ops"),
-            session("agent:main:two", activity = 2, displayName = "Product notes", owner = "main"),
-            session("agent:main:three", activity = 3, label = "Ops handoff", owner = "main"),
+            session("agent:main:title", activity = 1, displayName = "Ops planning"),
+            session("agent:main:label", activity = 2, label = "Ops handoff"),
+            session("agent:ops:key", activity = 3),
+            session("agent:main:owner", activity = 4, owner = "ops"),
+            session("agent:main:other", activity = 5, displayName = "Product notes"),
           ),
         query = "ops",
         limit = 1,
       )
 
-    assertEquals(listOf("agent:main:three"), rows.map(ChatSessionEntry::key))
+    assertEquals(
+      listOf("agent:main:owner", "agent:ops:key", "agent:main:label", "agent:main:title"),
+      rows.map(ChatSessionEntry::key),
+    )
+  }
+
+  @Test
+  fun activeSearchReturnsAllMatchesBeyondTheRecentSessionLimit() {
+    val rows =
+      sidebarRecentSessions(
+        sessions = (1L..12L).map { activity -> session("ops-session-$activity", activity = activity) },
+        query = "ops",
+      )
+
+    assertEquals(12, rows.size)
   }
 
   @Test


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

Android sidebar search reused the eight-item Recent sessions cap. Users with matching sessions across multiple agents could therefore see only the first eight results even though additional valid matches existed.

### Failure mode

A search can match more than eight sessions across the available agents, but the rendered result list stopped after item eight because the Recent sessions limit was applied after filtering.

## Why This Change Was Made

The sidebar now applies the Recent sessions limit only when the search query is empty. An active query returns every non-archived match while retaining the existing title, label, key, and owner matching plus pinned-first and recent-activity ordering.

### Root Cause

sidebarRecentSessions unconditionally called take(limit) after filtering and sorting, so the display cap intended for an empty Recent list also truncated active search results.

## User Impact

Android users can find all matching sessions from the sidebar instead of an arbitrary first eight. The normal empty-query sidebar remains compact at eight recent sessions, and archive filtering, ordering, session selection, Gateway behavior, and iOS remain unchanged.

## Evidence

Exact-head proof at `d78e1f1d9111f92e700face6edf63fbed615cae0` combines 14/14 focused tests with operator-attested Before and After physical Android videos.

<details>
<summary><strong>Inspect exact-head proof ledger</strong></summary>

<!-- pr-agent-proof-gate-v2 profile=android-physical tests=pass direct=pass real_behavior=pass -->

### Provenance

- **Base:** `247278262234e7396772411b07f3276873671594`
- **Proof head:** `d78e1f1d9111f92e700face6edf63fbed615cae0`
- **Revalidated:** on the bound base

### Direct behavior

<!-- pr-agent-direct-proof-v1 kind=media-operator-attested head=d78e1f1d9111f92e700face6edf63fbed615cae0 -->

- **Physical Android sidebar search (MEDIA_OPERATOR_ATTESTED; boundary: the same physical Android app state across data-preserving Before and After replace installs)** — Observed: The capture owner reports that the Before video first establishes multiple agents and more than eight applicable sessions, then shows search stopping at eight; the After video repeats the comparison and continues beyond eight. The agent did not inspect either video. Result: PASS for the exercised sidebar-search behavior. Proves an active sidebar query is no longer truncated by the Recent sessions display cap. Preserves the retained app data and identical user path across the Before and After comparison.

### Automated verification

#### Focused sidebar behavior

```bash
JAVA_HOME=<documented-jdk> ANDROID_SDK_ROOT=<documented-sdk> node scripts/run-android-gradle.mjs :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.SidebarShellLogicTest --no-daemon --console=plain --stacktrace
```

- `JAVA_HOME=<documented-jdk> ANDROID_SDK_ROOT=<documented-sdk> node scripts/run-android-gradle.mjs :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.SidebarShellLogicTest --no-daemon --console=plain --stacktrace` — [TEST] 14/14 tests passed with 0 skipped, 0 failures, and 0 errors. Proves active search returns all 12 regression matches and continues to match title, label, key, and owner fields. Preserves the empty-query Recent limit plus pinned-first and recent-activity ordering.

#### Patch hygiene

```bash
git diff --check 247278262234e7396772411b07f3276873671594...d78e1f1d9111f92e700face6edf63fbed615cae0
```

- `git diff --check 247278262234e7396772411b07f3276873671594...d78e1f1d9111f92e700face6edf63fbed615cae0` — [STATIC] completed with exit code 0 and no whitespace errors. Proves the committed Android patch is whitespace-clean. Preserves the bounded two-file sidebar implementation and regression-test scope.

### Preserved boundaries

- An empty search still shows at most eight recent sessions.
- Archived sessions remain excluded, and pinned-first plus activity ordering are unchanged.
- Session selection, Gateway transport and authentication, iOS, and Wear OS are unchanged.

### Proof gap

Agent-side media inspection was not run because the operator-owned capture contract forbids it. The two videos are recorded unchanged as OPERATOR_ATTESTED; no stronger agent-validated visual claim is made.

</details>

### Artifacts

#### Before video

- **Before video (`OPERATOR_ATTESTED`)**

  https://github.com/user-attachments/assets/5d6a42a0-428e-47d3-b53a-ad61637f9c0e


#### After video

- **After video (`OPERATOR_ATTESTED`)**

  https://github.com/user-attachments/assets/9bd96e60-923b-40a5-bec0-1774850153f4

