### PR TITLE
fix(googlechat): report a blocked account instead of staying healthy when webhookUrl cannot be parsed

### DIFF
--- a/extensions/googlechat/src/gateway.ts
+++ b/extensions/googlechat/src/gateway.ts
@@ -18,6 +18,9 @@ const loadGoogleChatChannelRuntime = createLazyRuntimeNamedExport(
   "googleChatChannelRuntime",
 );
 
+const UNRESOLVED_WEBHOOK_URL_ERROR =
+  "Invalid webhookUrl: expected an absolute URL such as https://chat.example.com/googlechat. No inbound webhook route was registered.";
+
 export async function startGoogleChatGatewayAccount(ctx: {
   account: ResolvedGoogleChatAccount;
   cfg: OpenClawConfig;
@@ -37,10 +40,23 @@ export async function startGoogleChatGatewayAccount(ctx: {
   ctx.log?.info?.(`[${account.accountId}] starting Google Chat webhook`);
   const { resolveGoogleChatWebhookPath, startGoogleChatMonitor } =
     await loadGoogleChatChannelRuntime();
+  // An unparseable webhookUrl resolves to no path, and the monitor bails before it
+  // creates ingress or registers the HTTP route. Reporting the default path instead
+  // would advertise a route nothing binds, and this channel never sets `connected`,
+  // so health evaluation would read "healthy" for the lifetime of the process.
+  // The status store patch-merges, so the blocked branch clears `webhookPath`
+  // explicitly: a restart with broken config must not keep the previous run's path.
+  const webhookPath = resolveGoogleChatWebhookPath({ account });
   statusSink({
     running: true,
     lastStartAt: Date.now(),
-    webhookPath: resolveGoogleChatWebhookPath({ account }),
+    ...(webhookPath
+      ? { webhookPath }
+      : {
+          webhookPath: undefined,
+          lifecycle: "blocked" as const,
+          lastError: UNRESOLVED_WEBHOOK_URL_ERROR,
+        }),
     audienceType: account.config.audienceType,
     audience: account.config.audience,
   });

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -545,14 +545,15 @@ export async function startGoogleChatMonitor(
   return await monitorGoogleChatProvider(params);
 }
 
+// Null keeps the same meaning it has in monitorGoogleChatProvider above: the
+// configured webhookUrl does not parse, so no route is ever bound. Falling back
+// to the default path here would report a route the monitor never registers.
 export function resolveGoogleChatWebhookPath(params: {
   account: ResolvedGoogleChatAccount;
-}): string {
-  return (
-    resolveWebhookPath({
-      webhookPath: params.account.config.webhookPath,
-      webhookUrl: params.account.config.webhookUrl,
-      defaultPath: "/googlechat",
-    }) ?? "/googlechat"
-  );
+}): string | null {
+  return resolveWebhookPath({
+    webhookPath: params.account.config.webhookPath,
+    webhookUrl: params.account.config.webhookUrl,
+    defaultPath: "/googlechat",
+  });
 }

--- a/extensions/googlechat/src/setup.test.ts
+++ b/extensions/googlechat/src/setup.test.ts
@@ -34,16 +34,17 @@ const hoisted = vi.hoisted(() => ({
   startGoogleChatMonitor: vi.fn(),
 }));
 
-vi.mock("./channel.runtime.js", () => ({
-  googleChatChannelRuntime: {
-    resolveGoogleChatWebhookPath: ({
-      account,
-    }: {
-      account: { config: { webhookPath?: string } };
-    }) => account.config.webhookPath ?? "/googlechat",
-    startGoogleChatMonitor: hoisted.startGoogleChatMonitor,
-  },
-}));
+// The path resolver stays real so the status assertions below cover the whole chain
+// from configured webhookUrl to published snapshot; only the monitor is stubbed.
+vi.mock("./channel.runtime.js", async () => {
+  const monitor = await vi.importActual<typeof import("./monitor.js")>("./monitor.js");
+  return {
+    googleChatChannelRuntime: {
+      resolveGoogleChatWebhookPath: monitor.resolveGoogleChatWebhookPath,
+      startGoogleChatMonitor: hoisted.startGoogleChatMonitor,
+    },
+  };
+});
 
 const googlechatSetupPlugin = {
   id: "googlechat",
@@ -362,6 +363,97 @@ describe("googlechat setup", () => {
     });
     expectLifecyclePatch(patches, { running: true });
     expectLifecyclePatch(patches, { running: false });
+  });
+
+  it("publishes the bound webhook path when the account resolves one", async () => {
+    hoisted.startGoogleChatMonitor.mockResolvedValue(vi.fn());
+
+    const { abort, patches, task, isSettled } = startAccountAndTrackLifecycle({
+      startAccount: startGoogleChatGatewayAccount,
+      account: buildAccount(),
+    });
+    await expectPendingUntilAbort({
+      waitForStarted: waitForGoogleChatMonitorStarted,
+      isSettled,
+      abort,
+      task,
+    });
+
+    expectLifecyclePatch(patches, { running: true, webhookPath: "/googlechat" });
+    expect(patches.some((patch) => patch.lifecycle === "blocked")).toBe(false);
+  });
+
+  it("reports a blocked lifecycle when the configured webhookUrl resolves to no path", async () => {
+    hoisted.startGoogleChatMonitor.mockResolvedValue(vi.fn());
+    const account = buildAccount();
+
+    const { abort, patches, task, isSettled } = startAccountAndTrackLifecycle({
+      startAccount: startGoogleChatGatewayAccount,
+      account: {
+        ...account,
+        config: {
+          ...account.config,
+          webhookPath: undefined,
+          webhookUrl: "chat.example.com/googlechat",
+        },
+      },
+    });
+    await expectPendingUntilAbort({
+      waitForStarted: waitForGoogleChatMonitorStarted,
+      isSettled,
+      abort,
+      task,
+    });
+
+    const startPatch = patches.find((patch) => patch.running === true);
+    expect(startPatch).toBeDefined();
+    expect(startPatch?.lifecycle).toBe("blocked");
+    expect(startPatch?.lastError).toContain("webhookUrl");
+    // The account must not advertise a route the monitor never registered.
+    expect(startPatch?.webhookPath).toBeUndefined();
+  });
+
+  it("clears a previously published webhook path when a restart resolves none", async () => {
+    hoisted.startGoogleChatMonitor.mockResolvedValue(vi.fn());
+    const account = buildAccount();
+    const resolvable = {
+      ...account,
+      config: {
+        ...account.config,
+        webhookPath: undefined,
+        webhookUrl: "https://chat.example.com/gc-inbound",
+      },
+    };
+    const firstAbort = new AbortController();
+    // One context, so both starts write through the same status snapshot the way
+    // the gateway's runtime store patch-merges successive plugin patches.
+    const ctx = createStartAccountContext({
+      account: resolvable,
+      abortSignal: firstAbort.signal,
+    });
+    const firstRun = startGoogleChatGatewayAccount(ctx);
+    await waitForGoogleChatMonitorStarted();
+    expect(ctx.getStatus().webhookPath).toBe("/gc-inbound");
+    firstAbort.abort();
+    await firstRun;
+
+    hoisted.startGoogleChatMonitor.mockClear();
+    const secondAbort = new AbortController();
+    const secondRun = startGoogleChatGatewayAccount({
+      ...ctx,
+      account: {
+        ...resolvable,
+        config: { ...resolvable.config, webhookUrl: "chat.example.com/gc-inbound" },
+      },
+      abortSignal: secondAbort.signal,
+    });
+    await waitForGoogleChatMonitorStarted();
+
+    const restarted = ctx.getStatus();
+    expect(restarted.lifecycle).toBe("blocked");
+    expect(restarted.webhookPath).toBeUndefined();
+    secondAbort.abort();
+    await secondRun;
   });
 
   it("clears running status when monitor startup fails", async () => {


### PR DESCRIPTION
Closes #117985

## What Problem This Solves

Fixes an issue where operators who set `channels.googlechat.webhookUrl` to a value that
`new URL()` cannot parse — most easily by leaving off `https://` — get a Google Chat account
that registers no inbound route and is still reported as healthy. The monitor gives up before
it creates the ingress monitor or registers the HTTP route, but the account never records that
it is unable to receive, so `evaluateChannelHealth` — the function both readiness and the
channel health monitor consume — keeps returning healthy. With no route registered the account
cannot receive; the health monitor has no unhealthy verdict to act on, `collectChannelStatusIssues`
reports nothing, and in the capture the only signal is one `invalid webhook path` line at
startup.

## Why This Change Was Made

The plugin SDK's `resolveWebhookPath` (`openclaw/plugin-sdk/webhook-ingress`) has two call
sites in this plugin, both in
`extensions/googlechat/src/monitor.ts`, and they disagreed about what an unresolvable path
means. `monitorGoogleChatProvider` calls it directly and treats `null` as fatal, returning
before it creates the ingress monitor or registers the HTTP route. The exported wrapper
`resolveGoogleChatWebhookPath`, whose only production consumer is the gateway, swallowed the
same `null` with `?? "/googlechat"` — so the gateway published that default as the account's
`webhookPath` while the monitor had already given up.

This PR makes the resolver honest — it now returns `string | null`, the same thing the
monitor already branches on — and has the gateway publish `lifecycle: "blocked"` with a
`lastError` instead of a path when no path could be resolved. The status store patch-merges,
so the blocked branch clears `webhookPath` explicitly — without that, an account whose earlier
run had bound a path would keep it in the row, because the blocked branch simply omits the key.
That field looks internal: `buildRuntimeAccountStatusSnapshot` does not project it, and
`openclaw channels status` shows the *config* value instead (`resolveAccountSnapshot` in
`channel.ts` puts `account.config.webhookPath` into `extra`, which is spread last and wins). A
grep across `src/gateway`, `src/infra`, `src/commands` and the gateway protocol found no
reader, though that is a search rather than a proof. Clearing it keeps the row internally
consistent; it is not claimed as a second operator-visible symptom.
`running` stays true because the account task is alive and waiting on its abort signal;
`lifecycle` is what says the account cannot receive, and `evaluateChannelHealth` reads
`lifecycle`, not `running` — the same combination Slack's enterprise-install path already
produces for a blocked account. `blocked` is the
plugin-authored lifecycle on `ChannelAccountSnapshot`
(`src/channels/plugins/types.core.ts`); Slack's enterprise-install path is currently its only
producer, and Google Chat becomes the second. The existing core plumbing does the rest: `evaluateChannelHealth` returns
`{healthy: false, reason: "blocked"}`, the health monitor deliberately skips restarting a
blocked account, and `collectChannelStatusIssues` surfaces
`"Channel runtime is blocked and needs operator action."`.

`ingressUnavailable` was considered and not used: it maps to a restart reason in
`resolveChannelRestartReason`, and a config typo is not fixable by restarting, so it would
put the account in a restart loop. The monitor keeps its own bail and its own registration
error path — parsing a path does not prove registration succeeded, so the later failure path
still has to exist.

### Non-scope

This PR is limited to the Google Chat gateway's status publish and the resolver it calls.
`resolveWebhookPath` keeps its current semantics. Validation of `webhookUrl` itself belongs to
the config schema (`src/config/zod-schema.providers-googlechat.ts`, where it is a plain
optional string) and would reject values accepted today, so it stays a separate decision. The
other channels that call this helper are covered in the sibling table under Evidence.

### What changed

| file | change |
|---|---|
| `extensions/googlechat/src/monitor.ts` | `resolveGoogleChatWebhookPath` returns `string \| null`; the `?? "/googlechat"` fallback is removed. The direct call site and its bail are untouched. |
| `extensions/googlechat/src/gateway.ts` | when the wrapper returns `null`, publish `lifecycle: "blocked"` + `lastError` and clear `webhookPath` instead of publishing a path. |
| `extensions/googlechat/src/setup.test.ts` | three tests: bound path published, blocked lifecycle on an unresolvable URL, stale path cleared on restart. |

## User Impact

An operator who mistypes `webhookUrl` now sees the Google Chat account reported as blocked,
flagged as needing operator action, instead of a healthy account that silently receives
nothing. The rendered issue text is the generic runtime one
("Channel runtime is blocked and needs operator action"); `lastError` is carried on the account
row and is not claimed to render anywhere specific. For a
correctly configured account the route registration and the runtime snapshot are unchanged
(shown in the second capture case); no Google Chat delivery was exercised either way.
Production files change by +26/-9 across two files, 9 of the added lines comments; the whole
three-file PR is +128/-19 including tests.

## Evidence

Behavior addressed: a Google Chat account whose `webhookUrl` cannot be parsed registers no
inbound route, and the health policy keeps returning healthy for it — at every uptime sampled
here, out to a computed 8760h — while inbound delivery is dead.

Real environment tested: Linux, Node v24.18.0, real `createChannelManager` (the gateway's own
channel manager), real bundled `googlechatPlugin`, real `startGoogleChatMonitor`, real
`registerPluginHttpRoute` against an ephemeral plugin registry, real `evaluateChannelHealth`,
real `collectChannelStatusIssues`. The `stored account row` below is the row the gateway
itself keeps (`ChannelManager.getRuntimeSnapshot()`) after its own patch merge, not a row the
harness assembled. No Google Chat workspace, no network.

Exact steps or command run after this patch: `./node_modules/.bin/tsx bl1-boundary-proof.mts`
(harness source at the end of this section). Head `96909756d793372c81d920c27f59c2ba22576f6e`, i.e. base `a530a7bd70d4198b87f0ec32f21c2c0854494648` plus this
patch; the before run is that base with the patch reverted.

Before evidence:

```
node v24.18.0

### case: unparseable webhookUrl (no scheme)
webhookUrl (first start): "chat.example.com/googlechat"
stored account row: {
  "accountId": "default",
  "running": true,
  "lifecycle": "starting",
  "webhookPath": "/googlechat",
  "lastError": null
}
plugin http routes: []
log lines:
  gateway googlechat info: [default] starting Google Chat webhook
  plugin error: [default] invalid webhook path
health verdict by uptime:
  up   0.01h -> {"healthy":true,"reason":"startup-connect-grace"}
  up      1h -> {"healthy":true,"reason":"healthy"}
  up     24h -> {"healthy":true,"reason":"healthy"}
  up    720h -> {"healthy":true,"reason":"healthy"}
  up   8760h -> {"healthy":true,"reason":"healthy"}
operator status issues: []

### case: valid webhookUrl
webhookUrl (first start): "https://chat.example.com/gc-inbound"
stored account row: {
  "accountId": "default",
  "running": true,
  "lifecycle": "starting",
  "webhookPath": "/gc-inbound",
  "lastError": null
}
plugin http routes: [{"path":"/gc-inbound","match":"exact","pluginId":"googlechat","source":"googlechat-webhook"}]
log lines:
  gateway googlechat info: [default] starting Google Chat webhook
  plugin log: [default] appPrincipal is missing for audienceType "app-url"; add-on token verification will fail. Set appPrincipal to the numeric OAuth 2.0 client ID (uniqueId, 21 digits), not an email.
health verdict by uptime:
  up   0.01h -> {"healthy":true,"reason":"startup-connect-grace"}
  up      1h -> {"healthy":true,"reason":"healthy"}
  up     24h -> {"healthy":true,"reason":"healthy"}
  up    720h -> {"healthy":true,"reason":"healthy"}
  up   8760h -> {"healthy":true,"reason":"healthy"}
operator status issues: []

### case: valid webhookUrl, then restarted with an unparseable one (same manager)
webhookUrl (first start): "https://chat.example.com/gc-inbound"
webhookUrl (after restart): "chat.example.com/gc-inbound"
stored account row: {
  "accountId": "default",
  "running": true,
  "lifecycle": "starting",
  "webhookPath": "/googlechat",
  "lastError": null
}
plugin http routes: []
log lines:
  gateway googlechat info: [default] starting Google Chat webhook
  plugin log: [default] appPrincipal is missing for audienceType "app-url"; add-on token verification will fail. Set appPrincipal to the numeric OAuth 2.0 client ID (uniqueId, 21 digits), not an email.
  gateway googlechat info: [default] starting Google Chat webhook
  plugin error: [default] invalid webhook path
health verdict by uptime:
  up   0.01h -> {"healthy":true,"reason":"startup-connect-grace"}
  up      1h -> {"healthy":true,"reason":"healthy"}
  up     24h -> {"healthy":true,"reason":"healthy"}
  up    720h -> {"healthy":true,"reason":"healthy"}
  up   8760h -> {"healthy":true,"reason":"healthy"}
operator status issues: []

### case: unparseable webhookUrl, then restarted with a valid one (recovery, same manager)
webhookUrl (first start): "chat.example.com/gc-inbound"
webhookUrl (after restart): "https://chat.example.com/gc-inbound"
stored account row: {
  "accountId": "default",
  "running": true,
  "lifecycle": "starting",
  "webhookPath": "/gc-inbound",
  "lastError": null
}
plugin http routes: [{"path":"/gc-inbound","match":"exact","pluginId":"googlechat","source":"googlechat-webhook"}]
log lines:
  gateway googlechat info: [default] starting Google Chat webhook
  plugin error: [default] invalid webhook path
  gateway googlechat info: [default] starting Google Chat webhook
  plugin log: [default] appPrincipal is missing for audienceType "app-url"; add-on token verification will fail. Set appPrincipal to the numeric OAuth 2.0 client ID (uniqueId, 21 digits), not an email.
health verdict by uptime:
  up   0.01h -> {"healthy":true,"reason":"startup-connect-grace"}
  up      1h -> {"healthy":true,"reason":"healthy"}
  up     24h -> {"healthy":true,"reason":"healthy"}
  up    720h -> {"healthy":true,"reason":"healthy"}
  up   8760h -> {"healthy":true,"reason":"healthy"}
operator status issues: []

### case: unparseable webhookUrl, then startChannel again with the account still live (refused: no second start)
webhookUrl (first start): "chat.example.com/gc-inbound"
webhookUrl (after restart): "https://chat.example.com/gc-inbound"
stored account row: {
  "accountId": "default",
  "running": true,
  "lifecycle": "starting",
  "webhookPath": "/googlechat",
  "lastError": null
}
plugin http routes: []
log lines:
  gateway googlechat info: [default] starting Google Chat webhook
  plugin error: [default] invalid webhook path
health verdict by uptime:
  up   0.01h -> {"healthy":true,"reason":"startup-connect-grace"}
  up      1h -> {"healthy":true,"reason":"healthy"}
  up     24h -> {"healthy":true,"reason":"healthy"}
  up    720h -> {"healthy":true,"reason":"healthy"}
  up   8760h -> {"healthy":true,"reason":"healthy"}
operator status issues: []
```

Evidence after fix:

```
node v24.18.0

### case: unparseable webhookUrl (no scheme)
webhookUrl (first start): "chat.example.com/googlechat"
stored account row: {
  "accountId": "default",
  "running": true,
  "lifecycle": "blocked",
  "lastError": "Invalid webhookUrl: expected an absolute URL such as https://chat.example.com/googlechat. No inbound webhook route was registered."
}
plugin http routes: []
log lines:
  gateway googlechat info: [default] starting Google Chat webhook
  plugin error: [default] invalid webhook path
health verdict by uptime:
  up   0.01h -> {"healthy":false,"reason":"blocked"}
  up      1h -> {"healthy":false,"reason":"blocked"}
  up     24h -> {"healthy":false,"reason":"blocked"}
  up    720h -> {"healthy":false,"reason":"blocked"}
  up   8760h -> {"healthy":false,"reason":"blocked"}
operator status issues: [
  {
    "channel": "googlechat",
    "accountId": "default",
    "kind": "runtime",
    "message": "Channel runtime is blocked and needs operator action.",
    "fix": "resolve the reported channel error, then restart the channel"
  }
]

### case: valid webhookUrl
webhookUrl (first start): "https://chat.example.com/gc-inbound"
stored account row: {
  "accountId": "default",
  "running": true,
  "lifecycle": "starting",
  "webhookPath": "/gc-inbound",
  "lastError": null
}
plugin http routes: [{"path":"/gc-inbound","match":"exact","pluginId":"googlechat","source":"googlechat-webhook"}]
log lines:
  gateway googlechat info: [default] starting Google Chat webhook
  plugin log: [default] appPrincipal is missing for audienceType "app-url"; add-on token verification will fail. Set appPrincipal to the numeric OAuth 2.0 client ID (uniqueId, 21 digits), not an email.
health verdict by uptime:
  up   0.01h -> {"healthy":true,"reason":"startup-connect-grace"}
  up      1h -> {"healthy":true,"reason":"healthy"}
  up     24h -> {"healthy":true,"reason":"healthy"}
  up    720h -> {"healthy":true,"reason":"healthy"}
  up   8760h -> {"healthy":true,"reason":"healthy"}
operator status issues: []

### case: valid webhookUrl, then restarted with an unparseable one (same manager)
webhookUrl (first start): "https://chat.example.com/gc-inbound"
webhookUrl (after restart): "chat.example.com/gc-inbound"
stored account row: {
  "accountId": "default",
  "running": true,
  "lifecycle": "blocked",
  "lastError": "Invalid webhookUrl: expected an absolute URL such as https://chat.example.com/googlechat. No inbound webhook route was registered."
}
plugin http routes: []
log lines:
  gateway googlechat info: [default] starting Google Chat webhook
  plugin log: [default] appPrincipal is missing for audienceType "app-url"; add-on token verification will fail. Set appPrincipal to the numeric OAuth 2.0 client ID (uniqueId, 21 digits), not an email.
  gateway googlechat info: [default] starting Google Chat webhook
  plugin error: [default] invalid webhook path
health verdict by uptime:
  up   0.01h -> {"healthy":false,"reason":"blocked"}
  up      1h -> {"healthy":false,"reason":"blocked"}
  up     24h -> {"healthy":false,"reason":"blocked"}
  up    720h -> {"healthy":false,"reason":"blocked"}
  up   8760h -> {"healthy":false,"reason":"blocked"}
operator status issues: [
  {
    "channel": "googlechat",
    "accountId": "default",
    "kind": "runtime",
    "message": "Channel runtime is blocked and needs operator action.",
    "fix": "resolve the reported channel error, then restart the channel"
  }
]

### case: unparseable webhookUrl, then restarted with a valid one (recovery, same manager)
webhookUrl (first start): "chat.example.com/gc-inbound"
webhookUrl (after restart): "https://chat.example.com/gc-inbound"
stored account row: {
  "accountId": "default",
  "running": true,
  "lifecycle": "starting",
  "webhookPath": "/gc-inbound",
  "lastError": null
}
plugin http routes: [{"path":"/gc-inbound","match":"exact","pluginId":"googlechat","source":"googlechat-webhook"}]
log lines:
  gateway googlechat info: [default] starting Google Chat webhook
  plugin error: [default] invalid webhook path
  gateway googlechat info: [default] starting Google Chat webhook
  plugin log: [default] appPrincipal is missing for audienceType "app-url"; add-on token verification will fail. Set appPrincipal to the numeric OAuth 2.0 client ID (uniqueId, 21 digits), not an email.
health verdict by uptime:
  up   0.01h -> {"healthy":true,"reason":"startup-connect-grace"}
  up      1h -> {"healthy":true,"reason":"healthy"}
  up     24h -> {"healthy":true,"reason":"healthy"}
  up    720h -> {"healthy":true,"reason":"healthy"}
  up   8760h -> {"healthy":true,"reason":"healthy"}
operator status issues: []

### case: unparseable webhookUrl, then startChannel again with the account still live (refused: no second start)
webhookUrl (first start): "chat.example.com/gc-inbound"
webhookUrl (after restart): "https://chat.example.com/gc-inbound"
stored account row: {
  "accountId": "default",
  "running": true,
  "lifecycle": "blocked",
  "lastError": "Invalid webhookUrl: expected an absolute URL such as https://chat.example.com/googlechat. No inbound webhook route was registered."
}
plugin http routes: []
log lines:
  gateway googlechat info: [default] starting Google Chat webhook
  plugin error: [default] invalid webhook path
health verdict by uptime:
  up   0.01h -> {"healthy":false,"reason":"blocked"}
  up      1h -> {"healthy":false,"reason":"blocked"}
  up     24h -> {"healthy":false,"reason":"blocked"}
  up    720h -> {"healthy":false,"reason":"blocked"}
  up   8760h -> {"healthy":false,"reason":"blocked"}
operator status issues: [
  {
    "channel": "googlechat",
    "accountId": "default",
    "kind": "runtime",
    "message": "Channel runtime is blocked and needs operator action.",
    "fix": "resolve the reported channel error, then restart the channel"
  }
]
```

Observed result after fix: for the unparseable URL the stored row records `blocked` with the
reason, no longer carries a `webhookPath`, and `plugin http routes: []` on the same run shows
that nothing was ever bound. Health flips from `healthy` at every sampled uptime out to one year to
`{"healthy":false,"reason":"blocked"}`, and the operator surface gains the blocked runtime
issue. The third case restarts the same account through the same manager: before the fix the
row reports the fabricated default `/googlechat` — replacing the `/gc-inbound` the first run
had bound — with `lifecycle: "starting"` and no error; after the fix the row carries no path
at all and is blocked. The fourth case is the recovery direction: an account that started
blocked and is restarted with a corrected URL comes back to `lifecycle: "starting"`,
`lastError: null`, the resolved path and a registered route, identically before and after the
fix. `blocked` cannot strand an account because every account start writes
`lifecycle: "starting"`, `lastError: null` and `ingressUnavailable: undefined` before the
plugin's patch is applied (`src/gateway/server-channels.ts`, whose comment on that write says
"Runtime rows are patch-merged, so a dead-ingress verdict from the previous lifecycle would
outlive the condition it described. Every start re-proves ingress, so every start must clear
it first."). The health monitor's restart takes the same path — it calls
`channelManager.startChannel(...)` in `src/gateway/channel-health-monitor.ts` — so a corrected
config recovers whether the operator restarts the channel or the monitor does. There is no
route into the plugin's resolved-path publish that skips that write: `startChannelInternal`
performs it immediately before the task that calls `startAccount`, and a start aimed at an
account whose task is still live returns early instead of re-entering. The fifth capture case
shows that refusal — a second `startChannel` with a corrected URL and no intervening stop
produces no second start at all (one `starting Google Chat webhook` line), which is why the
row there still reads blocked. The valid-URL case is identical before and after, including the route `/gc-inbound`
derived from the URL. In the two healthy cases the row keeps `lifecycle: "starting"` at every
sampled uptime. That is pre-existing behaviour for a passive webhook channel, which never sets
`connected` and so never derives `ready`. This PR leaves it as is.

The blocked snapshot is consumed by paths core already covers:
`src/gateway/channel-health-policy.test.ts` ("treats recorded blocked lifecycle as unhealthy")
and `src/infra/channels-status-issues.test.ts` ("reports blocked lifecycle through the generic
runtime path"). Both are channel-agnostic, so a second producer needs no new core test; the
capture above exercises the same two functions with the real Google Chat account row.

What was not tested: whether the runtime `webhookPath` reaches any operator surface — it does
not, by inspection (no reader in `src/gateway`, `src/infra`, `src/commands` or the protocol,
and the CLI status uses the config value), so that field is not claimed as a user-visible
symptom; delivery of an actual Google Chat event; the health monitor's restart
loop (it skips restart when the reason is `blocked`, at
`src/gateway/channel-health-monitor.ts` — the skip branch is read from source, and neither the
no-restart path nor a manual restart was driven through the monitor loop); the other
`resolveWebhookPath` call sites (enumerated below as unaffected).

| in the capture | what it is |
|---|---|
| `createChannelManager`, `googlechatPlugin`, `startGoogleChatMonitor`, `registerPluginHttpRoute`, `evaluateChannelHealth`, `collectChannelStatusIssues` | real production code |
| plugin registry, plugin HTTP route table, plugin state dir | ephemeral, created per case |
| `serviceAccount` credentials | placeholder strings; no outbound call is made on either path |
| uptimes `0.01h` … `8760h` | timestamps computed and handed to the health policy, not elapsed time |
| Google Chat message delivery, health-monitor restart loop | not run |

Proof limitations or environment constraints: no live Google Chat workspace — sufficient for
this claim because the failing branch returns before ingress creation and before any provider
call, and the same run shows `plugin error: [default] invalid webhook path` with zero
registered routes. The harness registers the bundled plugin directly instead of running the
bundled plugin loader, so it grants the plugin the same trusted state facade the loader grants
(`openChannelIngressQueue` over a temp state dir, `src/plugins/registry-runtime.ts`); every
other runtime member is the stock `createPluginRuntime()`. The `serviceAccount` values in the
harness config are syntactic placeholders — neither path makes an outbound call, so they are
never used. `up 8760h` is a computed uptime handed to the real health policy, not a process
that ran for a year. The capture was re-taken at each base `main` moved to during the
work (`af77477a2ad` -> `de0fa7c2084` -> `55816c47d133` -> `a530a7bd70d4`, 69 commits) and the
observations did not change.

### Tests

`extensions/googlechat/src/setup.test.ts` — 31 tests, whole file green. Three added:

1. `publishes the bound webhook path when the account resolves one` — no regression on the
   valid path.
2. `reports a blocked lifecycle when the configured webhookUrl resolves to no path` —
   reverting the production change makes exactly this test fail with
   `expected undefined to be 'blocked'`.
3. `clears a previously published webhook path when a restart resolves none` — drives two
   starts through one status snapshot; dropping the explicit `webhookPath` clear makes
   exactly this test fail.

The suite's `channel.runtime.js` mock now delegates the path resolver to the real
`./monitor.js` implementation (only the monitor start is stubbed), so the tests cover the
whole chain from configured `webhookUrl` to published snapshot.

Whole extension suite: 28 files / 300 tests green. `tsgo` extensions and extensions-test
lanes exit 0. oxlint exit 0.

### Sibling surfaces

`resolveWebhookPath` production call sites at base `a530a7bd70d4`:

| site | fabricates a default? |
|---|---|
| `extensions/googlechat/src/monitor.ts` — direct call in `monitorGoogleChatProvider` | no: already treats `null` as fatal (unchanged by this PR) |
| `extensions/googlechat/src/monitor.ts` — wrapper `resolveGoogleChatWebhookPath` | yes — fixed by this PR |
| `extensions/zalo/src/monitor.ts` | no: passes `defaultPath: null`, maps a null result to `undefined`, and gates media hosting on it |
| `extensions/zalo/src/outbound-media.ts` | no: passes `defaultPath: null` and throws on null |

`extensions/synology-chat/src/accounts.ts` has its own `resolveWebhookPathSource` and does not
use this helper.

### Proof harness

The harness is a one-off driver and is not part of the diff. It is reproduced in full below so
the capture can be re-run: save it at the repo root and run
`./node_modules/.bin/tsx bl1-boundary-proof.mts`. The other verification was
`node scripts/run-vitest.mjs extensions/googlechat`, both tsgo lanes for extensions
(production and test tsconfigs) via `scripts/run-tsgo.mjs`, and `scripts/run-oxlint.mjs` over
the two changed source files.

<details>
<summary>bl1-boundary-proof.mts (one-off driver, not part of the diff)</summary>

```ts
/**
 * BL-1 boundary proof.
 *
 * Drives the real gateway channel manager with the real bundled Google Chat
 * plugin and an ephemeral plugin HTTP route registry. Nothing about the webhook
 * path resolution, the account status merge, or the health verdict is
 * reimplemented here: the harness only supplies config, reads the runtime
 * snapshot the gateway itself stores, and prints it.
 *
 * Run from the worktree root:  ./node_modules/.bin/tsx bl1-boundary-proof.mts
 */
import fs from "node:fs";
import os from "node:os";
import path from "node:path";
import { googlechatPlugin } from "./extensions/googlechat/channel-plugin-api.js";
import { setGoogleChatRuntime } from "./extensions/googlechat/runtime-api.js";
import { createChannelIngressDrain } from "./src/channels/message/ingress-drain.js";
import { createChannelIngressQueue } from "./src/channels/message/ingress-queue.js";
import {
  DEFAULT_CHANNEL_CONNECT_GRACE_MS,
  DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
  evaluateChannelHealth,
} from "./src/gateway/channel-health-policy.js";
import { createChannelManager } from "./src/gateway/server-channels.js";
import { collectChannelStatusIssues } from "./src/infra/channels-status-issues.js";
import { createEmptyPluginRegistry } from "./src/plugins/registry.js";
import { createPluginRuntime } from "./src/plugins/runtime/index.js";
import { setActivePluginRegistry } from "./src/plugins/runtime.js";

const UPTIMES_H = [0.01, 1, 24, 720, 8760];

type Row = Record<string, unknown>;

function buildConfig(webhookUrl: string) {
  return {
    channels: {
      googlechat: {
        enabled: true,
        webhookUrl,
        audienceType: "app-url",
        audience: "https://chat.example.com/googlechat",
        serviceAccount: {
          client_email: "proof@example.iam.gserviceaccount.com",
          private_key: "-----BEGIN PRIVATE KEY-----\nproof\n-----END PRIVATE KEY-----\n",
        },
      },
    },
  } as never;
}

async function runCase(
  label: string,
  webhookUrl: string,
  restartWebhookUrl?: string,
  restartWithoutStop = false,
) {
  const registry = createEmptyPluginRegistry();
  registry.channels.push({
    pluginId: "googlechat",
    source: "bundled",
    plugin: googlechatPlugin as never,
  } as never);
  setActivePluginRegistry(registry);

  // Capture logs instead of printing them so the transcript below is exactly the
  // harness output, in order, with no interleaved terminal coloring.
  const logLines: string[] = [];
  const makeLogger = (subsystem: string): Row => ({
    subsystem,
    isEnabled: () => true,
    trace: (message: string) => logLines.push(`gateway ${subsystem} trace: ${message}`),
    debug: (message: string) => logLines.push(`gateway ${subsystem} debug: ${message}`),
    info: (message: string) => logLines.push(`gateway ${subsystem} info: ${message}`),
    warn: (message: string) => logLines.push(`gateway ${subsystem} warn: ${message}`),
    error: (message: string) => logLines.push(`gateway ${subsystem} error: ${message}`),
    fatal: (message: string) => logLines.push(`gateway ${subsystem} fatal: ${message}`),
    raw: (message: string) => logLines.push(`gateway ${subsystem} raw: ${message}`),
    child: (name: string) => makeLogger(`${subsystem}/${name}`),
  });
  const log = makeLogger("googlechat");
  const runtimeEnv = {
    log: (message: string) => logLines.push(`plugin log: ${message}`),
    error: (message: string) => logLines.push(`plugin error: ${message}`),
  };

  let currentWebhookUrl = webhookUrl;
  const manager = createChannelManager({
    getRuntimeConfig: () => buildConfig(currentWebhookUrl),
    channelLogs: { googlechat: log } as never,
    channelRuntimeEnvs: { googlechat: runtimeEnv } as never,
  } as never);

  await manager.startChannel("googlechat" as never);
  // Give the passive account task a tick to publish its start status.
  await new Promise((resolve) => setTimeout(resolve, 50));

  // Restart the same account through the same manager, so the second start
  // patch-merges onto the row the first start left behind.
  if (restartWebhookUrl !== undefined) {
    if (!restartWithoutStop) {
      await manager.stopChannel("googlechat" as never);
    }
    currentWebhookUrl = restartWebhookUrl;
    await manager.startChannel("googlechat" as never);
    await new Promise((resolve) => setTimeout(resolve, 50));
  }

  const snapshot = manager.getRuntimeSnapshot() as Row;
  const accounts = (snapshot.channelAccounts as Row | undefined)?.googlechat as
    | Record<string, Row>
    | undefined;
  const account = Object.values(accounts ?? {})[0] ?? {};

  const routes = (registry.httpRoutes ?? []).map((entry: Row) => ({
    path: entry.path,
    match: entry.match,
    pluginId: entry.pluginId,
    source: entry.source,
  }));

  const now = Date.now();
  const health = UPTIMES_H.map((hours) => {
    const verdict = evaluateChannelHealth(
      {
        ...account,
        lastStartAt: now - hours * 3_600_000,
      } as never,
      {
        channelId: "googlechat" as never,
        now,
        staleEventThresholdMs: DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
        channelConnectGraceMs: DEFAULT_CHANNEL_CONNECT_GRACE_MS,
      },
    );
    return { uptimeHours: hours, ...verdict };
  });

  const issues = collectChannelStatusIssues({
    channelAccounts: { googlechat: [account] },
  }).filter((issue) => issue.kind === "runtime");

  console.log(`\n### case: ${label}`);
  console.log(`webhookUrl (first start): ${JSON.stringify(webhookUrl)}`);
  if (restartWebhookUrl !== undefined) {
    console.log(`webhookUrl (after restart): ${JSON.stringify(restartWebhookUrl)}`);
  }
  console.log(
    `stored account row: ${JSON.stringify(
      {
        accountId: account.accountId,
        running: account.running,
        lifecycle: account.lifecycle,
        webhookPath: account.webhookPath,
        lastError: account.lastError,
        connected: account.connected,
      },
      null,
      2,
    )}`,
  );
  console.log(`plugin http routes: ${JSON.stringify(routes)}`);
  console.log("log lines:");
  for (const line of logLines) {
    console.log(`  ${line}`);
  }
  console.log("health verdict by uptime:");
  for (const entry of health) {
    console.log(
      `  up ${String(entry.uptimeHours).padStart(6)}h -> ${JSON.stringify({
        healthy: entry.healthy,
        reason: entry.reason,
      })}`,
    );
  }
  console.log(`operator status issues: ${JSON.stringify(issues, null, 2)}`);

  await manager.stopChannel("googlechat" as never);
}

/**
 * The bundled plugin loader hands trusted plugins a state facade whose
 * `openChannelIngressQueue` is wired to the real queue (`registry-runtime.ts`
 * openChannelIngressQueue branch). This harness registers the plugin directly
 * instead of running that loader, so it grants the same facade over a temp
 * state dir. Everything else on the runtime is the stock `createPluginRuntime`.
 */
function createTrustedPluginRuntime(stateDir: string) {
  const runtime = createPluginRuntime() as unknown as Record<string, Record<string, unknown>>;
  return {
    ...runtime,
    state: {
      ...runtime.state,
      resolveStateDir: () => stateDir,
      openChannelIngressQueue: (options?: Record<string, unknown>) =>
        createChannelIngressQueue({
          ...options,
          channelId: "googlechat",
          stateDir: (options?.stateDir as string | undefined) ?? stateDir,
        } as never),
      openChannelIngressDrain: (options: Record<string, unknown>) =>
        createChannelIngressDrain(options as never),
    },
  };
}

async function main() {
  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "bl1-proof-state-"));
  setGoogleChatRuntime(createTrustedPluginRuntime(stateDir) as never);
  console.log(`node ${process.version}`);
  await runCase("unparseable webhookUrl (no scheme)", "chat.example.com/googlechat");
  await runCase("valid webhookUrl", "https://chat.example.com/gc-inbound");
  await runCase(
    "valid webhookUrl, then restarted with an unparseable one (same manager)",
    "https://chat.example.com/gc-inbound",
    "chat.example.com/gc-inbound",
  );
  await runCase(
    "unparseable webhookUrl, then restarted with a valid one (recovery, same manager)",
    "chat.example.com/gc-inbound",
    "https://chat.example.com/gc-inbound",
  );
  await runCase(
    "unparseable webhookUrl, then startChannel again with the account still live (refused: no second start)",
    "chat.example.com/gc-inbound",
    "https://chat.example.com/gc-inbound",
    true,
  );
}

await main();
process.exit(0);
```

</details>
