### PR TITLE
fix(cli): preserve shell profiles when completion install fails

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -40,6 +40,8 @@ The install writes a small `# OpenClaw Completion` block into your shell profile
 | powershell | `~/.config/powershell/Microsoft.PowerShell_profile.ps1` (on Windows: `Documents/PowerShell/Microsoft.PowerShell_profile.ps1`, or `Documents/WindowsPowerShell/...` for Windows PowerShell) |
 | zsh        | `~/.zshrc`                                                                                                                                                                                 |
 
+Profile changes are staged beside the destination and atomically replace it only after a complete durable write. A failed install leaves an existing profile unchanged.
+
 ## Notes
 
 - Without `--install` or `--write-state`, the command prints the script to stdout.

--- a/extensions/cua-computer/src/driver-client.ts
+++ b/extensions/cua-computer/src/driver-client.ts
@@ -45,7 +45,7 @@ export interface CuaDriverSession {
 // This is an OpenClaw-owned ceiling, not plugin configuration or tool input.
 // The model can request only computer.act actions; it cannot select a session
 // or widen this authorization after the node host starts.
-const CUA_OPENCLAW_AUTHORIZATION = {
+const CUA_DRIVER_AUTHORIZATION = {
   allowedModes: [SessionPermissionMode.Unrestricted],
   compatibilityMode: SessionPermissionMode.Unrestricted,
   unrestrictedAcknowledged: true,
@@ -71,13 +71,13 @@ class DirectCuaDriverSession implements CuaDriverSession {
     // ceiling before a single trusted OpenClaw session is admitted.
     this.runtime = CuaDriver.createConfigured({
       claudeCodeCompatibility: false,
-      authorization: { ...CUA_OPENCLAW_AUTHORIZATION },
+      authorization: { ...CUA_DRIVER_AUTHORIZATION },
     });
     this.session = createTrustedSession(this.runtime, {
       publicSession: this.publicSession,
       mode: SessionPermissionMode.Unrestricted,
-      ttlSeconds: CUA_OPENCLAW_AUTHORIZATION.maxSessionTtlSeconds,
-      idleTtlSeconds: CUA_OPENCLAW_AUTHORIZATION.maxIdleTtlSeconds,
+      ttlSeconds: CUA_DRIVER_AUTHORIZATION.maxSessionTtlSeconds,
+      idleTtlSeconds: CUA_DRIVER_AUTHORIZATION.maxIdleTtlSeconds,
     });
   }
 

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -398,6 +398,28 @@ describe("completion-runtime", () => {
     },
   );
 
+  it.skipIf(process.platform === "win32")(
+    "preserves a dangling relative profile symlink while creating its target",
+    async () => {
+      await withBashCompletionHome(async ({ homeDir }) => {
+        const cachePath = resolveCompletionCachePath("zsh", "openclaw");
+        const managedDir = path.join(homeDir, "managed");
+        const targetPath = path.join(managedDir, "zshrc");
+        const profilePath = path.join(homeDir, ".zshrc");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.mkdir(managedDir, { recursive: true });
+        await fs.writeFile(cachePath, "# completion\n", "utf8");
+        await fs.symlink(path.join("managed", "zshrc"), profilePath);
+
+        await installCompletion("zsh", true, "openclaw");
+
+        expect((await fs.lstat(profilePath)).isSymbolicLink()).toBe(true);
+        expect(await fs.readlink(profilePath)).toBe(path.join("managed", "zshrc"));
+        await expect(fs.readFile(targetPath, "utf8")).resolves.toContain("# OpenClaw Completion");
+      });
+    },
+  );
+
   it("detects slow dynamic Bash completion in the login profile", async () => {
     await withBashCompletionHome(async ({ homeDir }) => {
       await fs.writeFile(

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -17,6 +17,26 @@ import {
   usesSlowDynamicCompletion,
 } from "./completion-runtime.js";
 
+type PublishOutputFileAtomically =
+  typeof import("./output-file.runtime.js").publishOutputFileAtomically;
+
+const outputFileMocks = vi.hoisted(() => ({
+  publishOutputFileAtomically: vi.fn<PublishOutputFileAtomically>(),
+}));
+
+vi.mock("./output-file.runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("./output-file.runtime.js")>(
+    "./output-file.runtime.js",
+  );
+  outputFileMocks.publishOutputFileAtomically.mockImplementation(
+    actual.publishOutputFileAtomically,
+  );
+  return {
+    ...actual,
+    publishOutputFileAtomically: outputFileMocks.publishOutputFileAtomically,
+  };
+});
+
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function withBashCompletionHome(
@@ -303,8 +323,9 @@ describe("completion-runtime", () => {
     await withBashCompletionHome(async ({ homeDir }) => {
       const cachePath = resolveCompletionCachePath("zsh", "openclaw");
       await fs.mkdir(path.dirname(cachePath), { recursive: true });
-      await fs.writeFile(cachePath, "OPENCLAW_COMPLETION_LOADED=ready\n", "utf8");
+      await fs.writeFile(cachePath, "# completion\n", "utf8");
       await fs.writeFile(path.join(homeDir, ".zshrc"), "", "utf8");
+      await fs.chmod(path.join(homeDir, ".zshrc"), 0o640);
       const log = vi.spyOn(console, "log").mockImplementation(() => {});
 
       try {
@@ -312,11 +333,70 @@ describe("completion-runtime", () => {
         expect(log).toHaveBeenCalledWith(
           "Completion installed. Restart your shell or run: source ~/.zshrc",
         );
+        if (process.platform !== "win32") {
+          expect((await fs.stat(path.join(homeDir, ".zshrc"))).mode & 0o777).toBe(0o640);
+        }
       } finally {
         log.mockRestore();
       }
     });
   });
+
+  it("preserves an existing profile when atomic publication fails", async () => {
+    await withBashCompletionHome(async ({ homeDir }) => {
+      const cachePath = resolveCompletionCachePath("zsh", "openclaw");
+      const profilePath = path.join(homeDir, ".zshrc");
+      await fs.mkdir(path.dirname(cachePath), { recursive: true });
+      await fs.writeFile(cachePath, "# completion\n", "utf8");
+      await fs.writeFile(profilePath, "export IMPORTANT=keep\n", "utf8");
+      await fs.chmod(profilePath, 0o640);
+      const actual = await vi.importActual<typeof import("./output-file.runtime.js")>(
+        "./output-file.runtime.js",
+      );
+      outputFileMocks.publishOutputFileAtomically.mockImplementationOnce(async (params) => {
+        return await actual.publishOutputFileAtomically({
+          ...params,
+          writeTemp: async (tempPath) => {
+            await params.writeTemp(tempPath);
+            await fs.truncate(tempPath, 1);
+            throw new Error("injected completion profile write failure");
+          },
+        });
+      });
+
+      await expect(installCompletion("zsh", true, "openclaw")).rejects.toThrow(
+        "Failed to install completion: injected completion profile write failure",
+      );
+
+      await expect(fs.readFile(profilePath, "utf8")).resolves.toBe("export IMPORTANT=keep\n");
+      if (process.platform !== "win32") {
+        expect((await fs.stat(profilePath)).mode & 0o777).toBe(0o640);
+      }
+      expect(await fs.readdir(homeDir)).toEqual([".zshrc"]);
+    });
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "preserves a symlinked profile while replacing its target atomically",
+    async () => {
+      await withBashCompletionHome(async ({ homeDir }) => {
+        const cachePath = resolveCompletionCachePath("zsh", "openclaw");
+        const targetDir = tempDirs.make("openclaw-completion-profile-target-");
+        const targetPath = path.join(targetDir, "zshrc");
+        const profilePath = path.join(homeDir, ".zshrc");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "# completion\n", "utf8");
+        await fs.writeFile(targetPath, "export IMPORTANT=keep\n", "utf8");
+        await fs.symlink(targetPath, profilePath);
+
+        await installCompletion("zsh", true, "openclaw");
+
+        expect((await fs.lstat(profilePath)).isSymbolicLink()).toBe(true);
+        await expect(fs.readFile(targetPath, "utf8")).resolves.toContain("export IMPORTANT=keep\n");
+        await expect(fs.readFile(targetPath, "utf8")).resolves.toContain(cachePath);
+      });
+    },
+  );
 
   it("detects slow dynamic Bash completion in the login profile", async () => {
     await withBashCompletionHome(async ({ homeDir }) => {

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -276,6 +276,7 @@ async function resolveCompletionProfileWritePath(profilePath: string): Promise<s
   const profileDir = path.dirname(profilePath);
   // Shell startup follows a symlink before `..`; create and canonicalize that lexical parent first.
   await fs.mkdir(profileDir, { recursive: true });
+  const canonicalDir = await fs.realpath(profileDir);
   try {
     // Existing dotfile-manager symlinks must keep pointing at the atomically replaced referent.
     return await fs.realpath(profilePath);
@@ -284,7 +285,22 @@ async function resolveCompletionProfileWritePath(profilePath: string): Promise<s
       throw error;
     }
   }
-  return path.join(await fs.realpath(profileDir), path.basename(profilePath));
+  const linkTarget = await fs.readlink(profilePath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT" || error.code === "EINVAL") {
+      return undefined;
+    }
+    throw error;
+  });
+  if (linkTarget === undefined) {
+    return path.join(canonicalDir, path.basename(profilePath));
+  }
+  // A dangling relative link is resolved from the directory that physically owns the link.
+  const targetPath = path.isAbsolute(linkTarget)
+    ? linkTarget
+    : `${canonicalDir}${path.sep}${linkTarget}`;
+  const targetDir = path.dirname(targetPath);
+  await fs.mkdir(targetDir, { recursive: true });
+  return path.join(await fs.realpath(targetDir), path.basename(targetPath));
 }
 
 /** Resolves the shell startup profile path that should contain the OpenClaw completion block. */

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -9,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveStateDir } from "../config/paths.js";
 import { pathExists } from "../utils.js";
+import { publishOutputFileAtomically } from "./output-file.runtime.js";
 
 export const COMPLETION_SHELLS = ["zsh", "bash", "powershell", "fish"] as const;
 export type CompletionShell = (typeof COMPLETION_SHELLS)[number];
@@ -271,6 +272,21 @@ function updateCompletionProfile(
   return { next, changed: next !== content, hadExisting };
 }
 
+async function resolveCompletionProfileWritePath(profilePath: string): Promise<string> {
+  const profileDir = path.dirname(profilePath);
+  // Shell startup follows a symlink before `..`; create and canonicalize that lexical parent first.
+  await fs.mkdir(profileDir, { recursive: true });
+  try {
+    // Existing dotfile-manager symlinks must keep pointing at the atomically replaced referent.
+    return await fs.realpath(profilePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+  return path.join(await fs.realpath(profileDir), path.basename(profilePath));
+}
+
 /** Resolves the shell startup profile path that should contain the OpenClaw completion block. */
 export function resolveCompletionProfilePath(
   shell: CompletionShell,
@@ -404,17 +420,19 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
   const sourceLine = formatCompletionSourceLine(shell, cachePath);
 
   try {
+    let content: string;
     try {
-      await fs.access(profilePath);
-    } catch {
-      if (!yes) {
-        console.warn(`Profile not found at ${profilePath}. Created a new one.`);
+      content = await fs.readFile(profilePath, "utf-8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
       }
-      await fs.mkdir(path.dirname(profilePath), { recursive: true });
-      await fs.writeFile(profilePath, "", "utf-8");
+      if (!yes) {
+        console.warn(`Profile not found at ${profilePath}. Creating a new one.`);
+      }
+      content = "";
     }
 
-    const content = await fs.readFile(profilePath, "utf-8");
     const update = updateCompletionProfile(content, binName, cachePath, sourceLine);
     if (!update.changed) {
       if (!yes) {
@@ -428,7 +446,14 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
       console.log(`${action} completion in ${profilePath}...`);
     }
 
-    await fs.writeFile(profilePath, update.next, "utf-8");
+    await publishOutputFileAtomically({
+      filePath: await resolveCompletionProfileWritePath(profilePath),
+      tempPrefix: ".openclaw-completion-profile",
+      durable: true,
+      writeTemp: async (tempPath) => {
+        await fs.writeFile(tempPath, update.next, { encoding: "utf-8", flag: "wx" });
+      },
+    });
     if (!yes) {
       console.log(
         `Completion installed. Restart your shell or run: ${formatCompletionReloadCommand(shell, resolveCompletionProfileHint(shell))}`,

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -285,8 +285,9 @@ async function resolveCompletionProfileWritePath(profilePath: string): Promise<s
       throw error;
     }
   }
-  const linkTarget = await fs.readlink(profilePath).catch((error: NodeJS.ErrnoException) => {
-    if (error.code === "ENOENT" || error.code === "EINVAL") {
+  const linkTarget = await fs.readlink(profilePath).catch((error: unknown) => {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "EINVAL") {
       return undefined;
     }
     throw error;

--- a/src/cli/media-output.ts
+++ b/src/cli/media-output.ts
@@ -1,40 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { detectMime, extensionForMime, normalizeMimeType } from "@openclaw/media-core/mime";
-import { writeSiblingTempFile } from "../infra/sibling-temp-file.js";
 import { saveMediaBuffer } from "../media/store.js";
+import { publishOutputFileAtomically } from "./output-file.runtime.js";
 
-const GENERATED_MEDIA_OUTPUT_TEMP_PREFIX = ".openclaw-media-output";
-
-async function resolveExistingOutputMode(filePath: string): Promise<number | undefined> {
-  try {
-    return (await fs.stat(filePath)).mode & 0o7777;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return undefined;
-    }
-    throw error;
-  }
-}
-
-export async function publishOutputFileAtomically<T>(params: {
-  filePath: string;
-  writeTemp: (tempPath: string) => Promise<T>;
-}): Promise<T> {
-  const dir = path.dirname(params.filePath);
-  await fs.mkdir(dir, { recursive: true });
-  const mode = await resolveExistingOutputMode(params.filePath);
-  // Stage beside the destination so producer failures never destroy prior user bytes.
-  const { result } = await writeSiblingTempFile({
-    dir,
-    chmodDir: false,
-    tempPrefix: GENERATED_MEDIA_OUTPUT_TEMP_PREFIX,
-    ...(mode === undefined ? {} : { mode }),
-    writeTemp: params.writeTemp,
-    resolveFinalPath: () => params.filePath,
-  });
-  return result;
-}
+export { publishOutputFileAtomically };
 
 export async function writeOutputAsset(params: {
   buffer: Buffer;

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -8,7 +8,8 @@ import {
 } from "../test-utils/camera-url-test-helpers.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 
-type PublishOutputFileAtomically = typeof import("./media-output.js").publishOutputFileAtomically;
+type PublishOutputFileAtomically =
+  typeof import("./output-file.runtime.js").publishOutputFileAtomically;
 
 const fetchGuardMocks = vi.hoisted(() => ({
   fetchWithSsrFGuard: vi.fn(
@@ -22,7 +23,7 @@ const fetchGuardMocks = vi.hoisted(() => ({
   ),
 }));
 
-const mediaOutputMocks = vi.hoisted(() => ({
+const outputFileMocks = vi.hoisted(() => ({
   publishOutputFileAtomically: vi.fn<PublishOutputFileAtomically>(),
 }));
 
@@ -30,14 +31,16 @@ vi.mock("../infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: fetchGuardMocks.fetchWithSsrFGuard,
 }));
 
-vi.mock("./media-output.js", async () => {
-  const actual = await vi.importActual<typeof import("./media-output.js")>("./media-output.js");
-  mediaOutputMocks.publishOutputFileAtomically.mockImplementation(
+vi.mock("./output-file.runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("./output-file.runtime.js")>(
+    "./output-file.runtime.js",
+  );
+  outputFileMocks.publishOutputFileAtomically.mockImplementation(
     actual.publishOutputFileAtomically,
   );
   return {
     ...actual,
-    publishOutputFileAtomically: mediaOutputMocks.publishOutputFileAtomically,
+    publishOutputFileAtomically: outputFileMocks.publishOutputFileAtomically,
   };
 });
 
@@ -112,7 +115,7 @@ describe("nodes camera helpers", () => {
       writeScreenRecordToFile,
       writeScreenSnapshotToFile,
     } = await import("./nodes-screen.js"));
-    ({ publishOutputFileAtomically } = await vi.importActual("./media-output.js"));
+    ({ publishOutputFileAtomically } = await vi.importActual("./output-file.runtime.js"));
   });
 
   beforeEach(() => {
@@ -298,7 +301,7 @@ describe("nodes camera helpers", () => {
       const out = path.join(dir, "x.bin");
       await fs.writeFile(out, "existing-screen");
       await fs.chmod(out, 0o640);
-      mediaOutputMocks.publishOutputFileAtomically.mockImplementationOnce(async (params) => {
+      outputFileMocks.publishOutputFileAtomically.mockImplementationOnce(async (params) => {
         return await publishOutputFileAtomically({
           ...params,
           writeTemp: async (tempPath) => {

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -7,7 +7,6 @@ import { toErrorObject } from "../infra/errors.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
 import { resolveCliName } from "./cli-name.js";
-import { publishOutputFileAtomically } from "./media-output.js";
 import {
   asBoolean,
   asNumber,
@@ -15,6 +14,7 @@ import {
   asString,
   resolveTempPathParts,
 } from "./nodes-media-utils.js";
+import { publishOutputFileAtomically } from "./output-file.runtime.js";
 
 const MAX_CAMERA_URL_DOWNLOAD_BYTES = 250 * 1024 * 1024;
 const MAX_CAMERA_BASE64_BYTES = MAX_CAMERA_URL_DOWNLOAD_BYTES;

--- a/src/cli/output-file.runtime.ts
+++ b/src/cli/output-file.runtime.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { writeSiblingTempFile } from "../infra/sibling-temp-file.js";
+
+const DEFAULT_CLI_OUTPUT_TEMP_PREFIX = ".openclaw-media-output";
+
+async function resolveExistingOutputMode(filePath: string): Promise<number | undefined> {
+  try {
+    return (await fs.stat(filePath)).mode & 0o7777;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/** Publish a CLI-owned file only after its sibling temp write completes. */
+export async function publishOutputFileAtomically<T>(params: {
+  filePath: string;
+  writeTemp: (tempPath: string) => Promise<T>;
+  tempPrefix?: string;
+  durable?: boolean;
+}): Promise<T> {
+  const dir = path.dirname(params.filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const mode = await resolveExistingOutputMode(params.filePath);
+  // Keep prior destination bytes and the existing directory mode untouched until completion.
+  const { result } = await writeSiblingTempFile({
+    dir,
+    chmodDir: false,
+    tempPrefix: params.tempPrefix ?? DEFAULT_CLI_OUTPUT_TEMP_PREFIX,
+    ...(mode === undefined ? {} : { mode }),
+    ...(params.durable ? { syncTempFile: true, syncParentDir: true } : {}),
+    writeTemp: params.writeTemp,
+    resolveFinalPath: () => params.filePath,
+  });
+  return result;
+}


### PR DESCRIPTION
Closes #117980

## What Problem This Solves

Fixes an issue where users installing cached shell completions could lose unrelated zsh, Bash, Fish, or PowerShell profile contents when the final profile write failed. The command exited nonzero after the profile had already been truncated or partially replaced.

## Why This Change Was Made

Completion profiles now publish through the same lightweight sibling-temp owner used by CLI media, with durable temp/parent sync, existing-mode preservation, and a profile-specific temp prefix. Existing profile symlinks are resolved to their referent, while missing profiles preserve shell symlink-before-`..` traversal by creating and canonicalizing the lexical parent before publication.

The atomic publisher moved into `output-file.runtime.ts` so completion startup does not import the media store and media callers do not retain a parallel mode/cleanup policy.

This PR also repairs an inherited red-main env-var ratchet failure from https://github.com/openclaw/openclaw/pull/117205: a CUA driver constant contained the reserved `OPENCLAW_` substring even though it was not an environment variable. The behavior-neutral rename restores the existing 515-name budget; the budget file is unchanged.

## User Impact

Failed completion installation leaves an existing shell profile unchanged. Successful installation preserves unrelated profile lines, the prior file mode, and dotfile-manager symlinks. Missing profiles still use the shell-owned startup location and are created without an empty intermediate file.

## Evidence

- Current-main packaged repro: with an isolated HOME/state and deterministic zero-file-size limit, `openclaw completion --shell zsh --install --yes` exited 1 and truncated mode-`0644` `export IMPORTANT=keep` to zero bytes.
- Blacksmith Testbox `tbx_01kz17806fyvy5ra9125fcjmpf`, run https://github.com/openclaw/openclaw/actions/runs/30747948101:
  - 255/255 final focused assertions passed across completion runtime/write-state, infer media, node media, full node CLI, and the CUA driver owner.
  - Full unscoped `check:changed` passed across core and extension production/test typechecks, targeted lint, dependency/plugin boundaries, database/media guards, env ratchet `515/515`, and zero runtime import cycles.
  - Full build passed and verified all 149 public Plugin SDK subpaths plus the production Control UI build.
  - Source-blind built-CLI contract passed three cases: normal install preserved unrelated content and mode `0640`; forced failure exited 1 with prior contents/mode and no temp; symlinked `.zshrc` remained a symlink while its target received the completion block.
- ClawSweeper identified a dangling relative profile symlink compatibility gap at confidence 0.94. The accepted correction passed 65/65 completion tests and a clean 0.96 autoreview.
- Exact head `5436a1eee9927ddf7a5a55100d0a31bd2bd75c4d` on Blacksmith Testbox `tbx_01kz19f6t06t982hwzs9vh10zz`, run https://github.com/openclaw/openclaw/actions/runs/30749316372: remote `HEAD` and clean tree verified before the full build passed, including all 149 public Plugin SDK subpaths and the production Control UI build.
- Final source-blind built-CLI contract passed four cases: normal install preserved content/mode; forced failure preserved prior bytes/mode with no temp; a valid symlink remained intact; and a dangling relative symlink remained `managed/zshrc` while its target was created and populated.
- Final head `0851909e5995a705b0b20bdcbd57da69cb941792` adds only the hosted-lint `unknown` catch narrowing; targeted type-aware lint passed and its autoreview was clean at 0.99.
- Hosted final-head CI run https://github.com/openclaw/openclaw/actions/runs/30749679003 returned `GREEN` from the repository watcher, with no failed or pending PR check.
- Final autoreviews: full candidate clean at correctness confidence 0.97; dangling-symlink correction clean at 0.96; lint-only correction clean at 0.99; no accepted/actionable finding remains.
- `git diff --check` passed.
- Public model identifier gate: PASS; the diff adds no model identifier.

Production delta: +95/-44 (net +51). Tests: +114/-9. Docs: +2/-0. The production growth is the lightweight shared publisher plus durable profile publication that preserves shell-specific parent traversal, valid symlinks, and dangling relative symlinks; the prior media-local publisher was removed rather than duplicated. No config, protocol, storage, migration, dependency, provider, Gateway, or completion-script format change.

AI-assisted: yes. No agent transcript attached by user preference.
