### PR TITLE
fix(plugins): contain rejected synchronous persistence hooks

### DIFF
--- a/src/infra/unhandled-rejections.plugin-sync-hooks.test.ts
+++ b/src/infra/unhandled-rejections.plugin-sync-hooks.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentMessage } from "../agents/runtime/index.js";
+import { createHookRunner } from "../plugins/hooks.js";
+import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
+import { spawnNodeEvalSync } from "../test-utils/node-process.js";
+
+const syncHookNames = ["tool_result_persist", "before_message_write"] as const;
+type SyncHookName = (typeof syncHookNames)[number];
+
+function createToolResultMessage(text: string, details?: Record<string, unknown>): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call_1",
+    content: [{ type: "text", text }],
+    isError: false,
+    ...(details ? { details } : {}),
+  } as AgentMessage;
+}
+
+function createLogger() {
+  return {
+    warn: vi.fn<(message: string) => void>(),
+    error: vi.fn<(message: string) => void>(),
+  };
+}
+
+function runSyncHook(params: {
+  hookName: SyncHookName;
+  runner: ReturnType<typeof createHookRunner>;
+  message: AgentMessage;
+}) {
+  return params.hookName === "tool_result_persist"
+    ? params.runner.runToolResultPersist({ message: params.message }, {})
+    : params.runner.runBeforeMessageWrite({ message: params.message }, {});
+}
+
+describe("sync-only plugin hooks", () => {
+  it.each(syncHookNames)(
+    "contains rejected %s handlers before the fatal rejection handler",
+    (hookName) => {
+      const method =
+        hookName === "tool_result_persist" ? "runToolResultPersist" : "runBeforeMessageWrite";
+      const result = spawnNodeEvalSync(
+        `import { installUnhandledRejectionHandler } from "./src/infra/unhandled-rejections.ts";
+       import { createHookRunner } from "./src/plugins/hooks.ts";
+       import { createEmptyPluginRegistry } from "./src/plugins/registry-empty.ts";
+       installUnhandledRejectionHandler();
+       const registry = createEmptyPluginRegistry();
+       registry.typedHooks.push({
+         hookName: "${hookName}",
+         pluginId: "rejected-sync-hook",
+         source: "sync-only-regression",
+         handler: () => Promise.reject(new Error("sync-hook-rejection")),
+       });
+       const warnings = [];
+       const errors = [];
+       const runner = createHookRunner(registry, {
+         logger: { warn: (message) => warnings.push(message), error: (message) => errors.push(message) },
+       });
+       const message = { role: "toolResult", toolCallId: "call_1", content: [], isError: false };
+       runner.${method}({ message }, {});
+       await new Promise((resolve) => setImmediate(resolve));
+       const expectedWarning = "[hooks] ${hookName} handler from rejected-sync-hook returned a Promise; this hook is synchronous and the result was ignored.";
+       if (warnings.length !== 1 || warnings[0] !== expectedWarning || errors.length !== 0) {
+         console.error(JSON.stringify({ warnings, errors }));
+         process.exit(2);
+       }
+       console.log("sync hook rejection contained");`,
+        { imports: ["tsx"], timeout: 20_000 },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("sync hook rejection contained");
+      expect(result.stderr).not.toContain("Unhandled promise rejection");
+    },
+  );
+
+  it.each(syncHookNames)("warns and ignores resolved %s handlers", (hookName) => {
+    const logger = createLogger();
+    const originalMessage = createToolResultMessage("original");
+    const replacementMessage = createToolResultMessage("replacement");
+    const runner = createHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName,
+          pluginId: "resolved-sync-hook",
+          handler: async () => ({ message: replacementMessage, block: true }),
+        },
+      ]),
+      { logger },
+    );
+
+    const result = runSyncHook({ hookName, runner, message: originalMessage });
+
+    expect(result).toEqual(
+      hookName === "tool_result_persist" ? { message: originalMessage } : undefined,
+    );
+    expect(logger.warn.mock.calls).toEqual([
+      [
+        `[hooks] ${hookName} handler from resolved-sync-hook returned a Promise; this hook is synchronous and the result was ignored.`,
+      ],
+    ]);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("preserves synchronous secret redaction and subsequent handler composition", () => {
+    const logger = createLogger();
+    const secret = ["fixture", "secret"].join("-");
+    const originalMessage = createToolResultMessage(JSON.stringify({ value: secret }), {
+      value: secret,
+    });
+    const observedMessages: AgentMessage[] = [];
+    const runner = createHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "tool_result_persist",
+          pluginId: "ignored-async-handler",
+          priority: 30,
+          handler: async () => ({ message: createToolResultMessage("ignored") }),
+        },
+        {
+          hookName: "tool_result_persist",
+          pluginId: "secret-redactor",
+          priority: 20,
+          handler: (event) => {
+            const message = (event as { message: AgentMessage }).message;
+            return {
+              message: {
+                ...message,
+                content: [{ type: "text", text: JSON.stringify({ redacted: true }) }],
+                details: { redacted: true },
+              },
+            };
+          },
+        },
+        {
+          hookName: "tool_result_persist",
+          pluginId: "subsequent-handler",
+          priority: 10,
+          handler: (event) => {
+            const message = (event as { message: AgentMessage }).message;
+            observedMessages.push(message);
+            return { message: { ...message, details: { redacted: true, observed: true } } };
+          },
+        },
+      ]),
+      { logger },
+    );
+
+    const result = runner.runToolResultPersist({ message: originalMessage }, {});
+
+    expect(observedMessages).toHaveLength(1);
+    expect(JSON.stringify(observedMessages[0])).not.toContain(secret);
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(result?.message).toMatchObject({ details: { redacted: true, observed: true } });
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("preserves synchronous message blocking and priority order", () => {
+    const logger = createLogger();
+    const calls: string[] = [];
+    const runner = createHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_message_write",
+          pluginId: "ignored-async-handler",
+          priority: 30,
+          handler: async () => {
+            calls.push("async");
+            return { block: false };
+          },
+        },
+        {
+          hookName: "before_message_write",
+          pluginId: "message-blocker",
+          priority: 20,
+          handler: () => {
+            calls.push("blocker");
+            return { block: true };
+          },
+        },
+        {
+          hookName: "before_message_write",
+          pluginId: "unreached-handler",
+          priority: 10,
+          handler: () => {
+            calls.push("unreached");
+          },
+        },
+      ]),
+      { logger },
+    );
+
+    expect(
+      runner.runBeforeMessageWrite({ message: createToolResultMessage("original") }, {}),
+    ).toEqual({ block: true });
+    expect(calls).toEqual(["async", "blocker"]);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it.each(syncHookNames)("preserves fail-closed behavior for async %s handlers", (hookName) => {
+    const logger = createLogger();
+    const runner = createHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName,
+          pluginId: "fail-closed-hook",
+          handler: async () => undefined,
+        },
+      ]),
+      { logger, failurePolicyByHook: { [hookName]: "fail-closed" } },
+    );
+
+    expect(() =>
+      runSyncHook({ hookName, runner, message: createToolResultMessage("original") }),
+    ).toThrow(
+      `[hooks] ${hookName} handler from fail-closed-hook failed: Error: ` +
+        `[hooks] ${hookName} handler from fail-closed-hook returned a Promise; ` +
+        "this hook is synchronous and the result was ignored.",
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -671,9 +671,23 @@ export function createHookRunner(
     hook: PluginHookRegistration<K>,
     event: SyncHookEvent<K>,
     ctx: SyncHookContext<K>,
-  ): SyncHookResult<K> | PromiseLike<unknown> => {
+  ): SyncHookResult<K> | undefined => {
     const handler = hook.handler as SyncHookHandler<K>;
-    return handler(event, ctx) as SyncHookResult<K> | PromiseLike<unknown>;
+    const out = handler(event, ctx) as SyncHookResult<K> | PromiseLike<unknown>;
+    if (!isPromiseLike(out)) {
+      return out;
+    }
+
+    // Sync-only hooks ignore async results; observe rejections so the global fatal handler cannot crash.
+    void Promise.resolve(out).catch(() => undefined);
+    const msg =
+      `[hooks] ${hook.hookName} handler from ${hook.pluginId} returned a Promise; ` +
+      `this hook is synchronous and the result was ignored.`;
+    if (shouldCatchHookErrors(hook.hookName)) {
+      logger?.warn?.(msg);
+      return undefined;
+    }
+    throw new Error(msg);
   };
 
   /**
@@ -1430,19 +1444,6 @@ export function createHookRunner(
     for (const hook of hooks) {
       try {
         const out = runSyncHookHandler(hook, { ...event, message: current }, ctx);
-
-        // Guard against accidental async handlers (this hook is sync-only).
-        if (isPromiseLike(out)) {
-          const msg =
-            `[hooks] tool_result_persist handler from ${hook.pluginId} returned a Promise; ` +
-            `this hook is synchronous and the result was ignored.`;
-          if (shouldCatchHookErrors("tool_result_persist")) {
-            logger?.warn?.(msg);
-            continue;
-          }
-          throw new Error(msg);
-        }
-
         const next = (out as PluginHookToolResultPersistResult | undefined)?.message;
         if (next) {
           current = next;
@@ -1490,19 +1491,6 @@ export function createHookRunner(
     for (const hook of hooks) {
       try {
         const out = runSyncHookHandler(hook, { ...event, message: current }, ctx);
-
-        // Guard against accidental async handlers (this hook is sync-only).
-        if (isPromiseLike(out)) {
-          const msg =
-            `[hooks] before_message_write handler from ${hook.pluginId} returned a Promise; ` +
-            `this hook is synchronous and the result was ignored.`;
-          if (shouldCatchHookErrors("before_message_write")) {
-            logger?.warn?.(msg);
-            continue;
-          }
-          throw new Error(msg);
-        }
-
         const result = out as PluginHookBeforeMessageWriteResult | undefined;
 
         // If any handler blocks, return immediately.


### PR DESCRIPTION
## What Problem This Solves

Fixes Gateway processes exiting when a plugin accidentally returns a rejecting Promise from either synchronous transcript-persistence hook (`tool_result_persist` or `before_message_write`). Previously the hook runner warned that asynchronous results were ignored but left their rejection unobserved, allowing the installed fatal unhandled-rejection handler to terminate the process.

## Why This Change Was Made

Move synchronous-hook validation, exact historical warning text, fail-open/fail-closed decisions, and immediate rejection observation into the one existing `runSyncHookHandler` owner. Delete both duplicated downstream guards while preserving the synchronous public hook contract, handler priority/composition/blocking, and secret-redaction ordering.

## User Impact

Malformed asynchronous plugin persistence hooks can no longer crash a running Gateway. Synchronous handlers, including 1Password secret redaction, still run in their original order and retain their original warning, block, and failure-policy behavior.

## Evidence

- Exact reviewed head: `8f57e439be3ded8c05bf14962123a871a521e9dd`; unchanged parent: `5739f42c48775e22b8463d94d4faf4486b11232b`.
- Authentic unchanged-parent RED: **2 failed / 6 passed**. Both failures exercise a real isolated Node process with the actual installed OpenClaw global fatal-rejection handler: one for `tool_result_persist`, one for `before_message_write`. Each parent process exits from a genuine unhandled rejected Promise.
- Exact-head GREEN: **62/62 passing** across real fatal-rejection containment, plugin hooks, phase/correlation behavior, session persistence, and the actual bundled 1Password integration. The exact previously failing hosted lane, **`pnpm check:test-types`**, passes across core, plugins, and root. Scoped type-aware lint and formatter both pass. [Exact-parent RED and final-exact-head GREEN remote proof](https://github.com/openclaw/openclaw/actions/runs/30749629453).

```json
{"head":"8f57e439be3ded8c05bf14962123a871a521e9dd","parent":"5739f42c48775e22b8463d94d4faf4486b11232b","parentRed":{"failed":2,"passed":6,"realFatalUnhandledRejectionCases":["tool_result_persist","before_message_write"]},"candidateGreen":{"passed":62,"verified":["actual fatal-child rejection containment","synchronous secret redaction composition","priority order and blocking","fail-open handling","fail-closed handling","real onepassword plugin integration","session persistence guard"]},"exactCiCheckTestTypes":"passed","scopedTypeAwareOxlint":"passed","scopedFormat":"passed","leaseStatus":"completed"}
```

- Four genuinely fresh independent complete-owner reviews found **no P0–P3 findings** at this final exact head. The official `gpt-5.6-sol` / high-reasoning review was explicitly run with `--max-priority P3`, found no actionable findings, and ran the real TruffleHog 3.96.0 scanner.
- Production delta: **16 additions / 28 deletions = 12 fewer production lines**; no plugin API, config, schema, auth, security policy, or protocol change. Async persistence hooks remain unsupported exactly as before; only their rejected Promise is now observed.

## Agent Transcript

Agent-assisted implementation was independently reviewed by four fresh hostile source reviewers and an explicit P0–P3 Sol/high review. Earlier review correctly identified two test-only type-import mistakes, which were corrected before the frozen final review and remote proof. No credentials or private chain-of-thought are included.

## Maintainer Decision and CI Coverage

- Explicit repository-owner authorization: land this bounded owner refactor after exact-parent process failure, exact-final-head process recovery, and current successful required CI.
- An earlier independent review correctly detected that a test under `src/plugins` would live in a release-only CI shard. The final regression now lives in its real fatal-error lifecycle owner, `src/infra/unhandled-rejections.plugin-sync-hooks.test.ts`; normal compact PR CI executes it in the `core-runtime-infra-events-runtime` shard.
- Final exact-head hosted [`openclaw/ci-gate` succeeded](https://github.com/openclaw/openclaw/actions/runs/30749558263/job/91501728846), and the exact `check-test-types` lane was independently rerun successfully on the final head.
- The proof above deliberately replaces the earlier-head artifact. All counts, JSON, source ownership, hosted CI, and TruffleHog review now reference exact immutable head `8f57e439be3ded8c05bf14962123a871a521e9dd`.
