### PR TITLE
fix(agents): verify apply_patch writes before reporting success

### DIFF
--- a/extensions/mxc/src/fs-bridge.ts
+++ b/extensions/mxc/src/fs-bridge.ts
@@ -169,6 +169,17 @@ class MxcFsBridge implements SandboxFsBridge {
     };
   }
 
+  async entryExists(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<boolean> {
+    const target = this.resolveTarget(params);
+    // fs-safe Root.exists lstat's the final component, so a dangling symlink is
+    // still reported as a present entry, mirroring the bridge's uniform contract.
+    return await (await fsRoot(target.mount.hostRoot)).exists(target.mountRelativePath);
+  }
+
   private resolveTarget(params: { filePath: string; cwd?: string }): ResolvedMxcPath {
     const input = params.filePath.trim();
     const cwd = params.cwd?.trim() ? path.resolve(params.cwd) : this.defaultContainerRoot;

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -255,6 +255,25 @@ class OpenShellFsBridge implements SandboxFsBridge {
     };
   }
 
+  async entryExists(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<boolean> {
+    const target = this.resolveTarget(params);
+    const hostPath = this.requireHostPath(target);
+    // lstat the entry itself: a still-present dangling symlink is an entry, only
+    // an absent path reports false. No boundary throw here — resolveTarget already
+    // bounds the path, and a present final symlink must not be treated as removed.
+    const stats = await fsPromises.lstat(hostPath).catch((err: unknown) => {
+      if (isNotFoundError(err)) {
+        return null;
+      }
+      throw err;
+    });
+    return stats !== null;
+  }
+
   private ensureWritable(target: ResolvedMountPath, action: string) {
     if (this.sandbox.workspaceAccess !== "rw" || !target.writable) {
       throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);

--- a/src/agents/agent-tools-agent-config.test.ts
+++ b/src/agents/agent-tools-agent-config.test.ts
@@ -42,6 +42,7 @@ describe("Agent-specific tool filtering", () => {
     remove: async () => {},
     rename: async () => {},
     stat: async () => null,
+    entryExists: async () => false,
   };
 
   function expectReadOnlyToolSet(toolNames: string[], extraDenied: string[] = []) {

--- a/src/agents/apply-patch-file-ops.ts
+++ b/src/agents/apply-patch-file-ops.ts
@@ -33,6 +33,13 @@ export type PatchFileOps = {
   remove: (filePath: string) => Promise<void>;
   mkdirp: (dir: string) => Promise<void>;
   statFile: (filePath: string) => Promise<PersistedFileStat | null>;
+  /**
+   * Uniform entry-existence contract: whether any filesystem entry (regular
+   * file, directory, symlink including dangling, etc.) exists at the path.
+   * Uses lstat semantics so an entry that survives a removal attempt cannot
+   * masquerade as absent through a follow-style stat. `statFile` is not enough.
+   */
+  entryExists: (filePath: string) => Promise<boolean>;
 };
 
 export async function createPatchTarget(params: {
@@ -71,6 +78,7 @@ export function resolvePatchFileOps(options: ApplyPatchFileOptions): PatchFileOp
         remove: (filePath) => bridge.remove({ filePath, cwd: root, force: false }),
         mkdirp: (dir) => bridge.mkdirp({ filePath: dir, cwd: root }),
         statFile: (filePath) => bridge.stat({ filePath, cwd: root }),
+        entryExists: (filePath) => bridge.entryExists({ filePath, cwd: root }),
       },
     });
   }
@@ -99,6 +107,7 @@ export function resolvePatchFileOps(options: ApplyPatchFileOptions): PatchFileOp
           await fs.mkdir(dir, { recursive: true });
         },
         statFile: (filePath) => statPatchFile(filePath),
+        entryExists: (filePath) => entryExistsAtPath(filePath),
       },
     });
   }
@@ -156,6 +165,12 @@ export function resolvePatchFileOps(options: ApplyPatchFileOptions): PatchFileOp
         await root.mkdir(relative);
       },
       statFile: (filePath) => statPatchFile(filePath),
+      entryExists: async (filePath) => {
+        const relative = toRelativeSandboxPath(options.cwd, filePath);
+        // fs-safe Root.stat is lstat-based, so a dangling symlink still reports
+        // present — the authoritative absence contract for removal receipts.
+        return await (await rootPromise).exists(relative);
+      },
     },
   });
 }
@@ -176,6 +191,24 @@ async function statPatchFile(absolutePath: string): Promise<PersistedFileStat | 
       (error as { code?: unknown }).code === "ENOENT"
     ) {
       return null;
+    }
+    throw error;
+  }
+}
+
+async function entryExistsAtPath(absolutePath: string): Promise<boolean> {
+  try {
+    await fs.lstat(absolutePath);
+    return true;
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      ((error as { code?: unknown }).code === "ENOENT" ||
+        (error as { code?: unknown }).code === "ENOTDIR")
+    ) {
+      return false;
     }
     throw error;
   }

--- a/src/agents/apply-patch-file-ops.ts
+++ b/src/agents/apply-patch-file-ops.ts
@@ -8,6 +8,7 @@ import {
 } from "./memory-write-provenance.js";
 import { toRelativeSandboxPath } from "./path-policy.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+import type { PersistedFileStat } from "./sessions/tools/file-write-verification.js";
 import { decodeUtf8File } from "./utf8-file.js";
 
 export type SandboxApplyPatchConfig = {
@@ -31,6 +32,7 @@ export type PatchFileOps = {
   createFileExclusive: (filePath: string, content: string) => Promise<PatchCreateOutcome>;
   remove: (filePath: string) => Promise<void>;
   mkdirp: (dir: string) => Promise<void>;
+  statFile: (filePath: string) => Promise<PersistedFileStat | null>;
 };
 
 export async function createPatchTarget(params: {
@@ -68,6 +70,7 @@ export function resolvePatchFileOps(options: ApplyPatchFileOptions): PatchFileOp
         },
         remove: (filePath) => bridge.remove({ filePath, cwd: root, force: false }),
         mkdirp: (dir) => bridge.mkdirp({ filePath: dir, cwd: root }),
+        statFile: (filePath) => bridge.stat({ filePath, cwd: root }),
       },
     });
   }
@@ -95,6 +98,7 @@ export function resolvePatchFileOps(options: ApplyPatchFileOptions): PatchFileOp
         mkdirp: async (dir) => {
           await fs.mkdir(dir, { recursive: true });
         },
+        statFile: (filePath) => statPatchFile(filePath),
       },
     });
   }
@@ -151,8 +155,30 @@ export function resolvePatchFileOps(options: ApplyPatchFileOptions): PatchFileOp
         }
         await root.mkdir(relative);
       },
+      statFile: (filePath) => statPatchFile(filePath),
     },
   });
+}
+
+async function statPatchFile(absolutePath: string): Promise<PersistedFileStat | null> {
+  try {
+    const stat = await fs.stat(absolutePath);
+    return {
+      type: stat.isFile() ? "file" : stat.isDirectory() ? "directory" : "other",
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+    } as const;
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 class PatchCreateExistsSignal extends Error {}

--- a/src/agents/apply-patch-verification.test.ts
+++ b/src/agents/apply-patch-verification.test.ts
@@ -49,6 +49,7 @@ function createVerificationSandbox(initialFiles: Record<string, string>) {
         ? null
         : { type: "file", size: Buffer.byteLength(contents), mtimeMs: 0 };
     },
+    entryExists: async ({ filePath }) => files.has(filePath),
   };
   return {
     files,
@@ -92,5 +93,42 @@ describe("applyPatch write verification", () => {
     await expect(applyPatch(patch, sandbox.options)).rejects.toThrow(
       "ApplyPatch verification failed for new.txt",
     );
+  });
+
+  it("rejects a delete whose delegated remove resolves without deleting the entry", async () => {
+    const sandbox = createVerificationSandbox({ "source.txt": "x\n" });
+    // Simulate a delegated remove that resolves but leaves the entry behind.
+    vi.spyOn(sandbox.bridge, "remove").mockImplementation(async () => {});
+
+    const patch = `*** Begin Patch
+*** Delete File: source.txt
+*** End Patch`;
+
+    await expect(applyPatch(patch, sandbox.options)).rejects.toThrow(
+      "ApplyPatch verification failed for source.txt: the entry still exists after removal.",
+    );
+    expect(sandbox.files.has("/sandbox/source.txt")).toBe(true);
+  });
+
+  it("rejects a move whose delegated source removal resolves without deleting", async () => {
+    const sandbox = createVerificationSandbox({ "source.txt": "foo\nbar\n" });
+    // The destination write is verified, but the source removal is a no-op, so
+    // the move must not report success while both entries exist.
+    vi.spyOn(sandbox.bridge, "remove").mockImplementation(async () => {});
+
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+*** Move to: dest.txt
+@@
+ foo
+-bar
++baz
+*** End Patch`;
+
+    await expect(applyPatch(patch, sandbox.options)).rejects.toThrow(
+      "ApplyPatch verification failed for source.txt: the entry still exists after removal.",
+    );
+    expect(sandbox.files.has("/sandbox/dest.txt")).toBe(true);
+    expect(sandbox.files.has("/sandbox/source.txt")).toBe(true);
   });
 });

--- a/src/agents/apply-patch-verification.test.ts
+++ b/src/agents/apply-patch-verification.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests apply_patch write verification: a delegated write/create that silently
+ * fails to persist the requested bytes must not be reported as success.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { applyPatch } from "./apply-patch.test-support.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+
+function createVerificationSandbox(initialFiles: Record<string, string>) {
+  const files = new Map<string, string | Buffer>(
+    Object.entries(initialFiles).map(([filePath, contents]) => [`/sandbox/${filePath}`, contents]),
+  );
+  const bridge: SandboxFsBridge = {
+    resolvePath: ({ filePath }) => ({
+      relativePath: filePath,
+      containerPath: `/sandbox/${filePath}`,
+    }),
+    readFile: async ({ filePath }) => {
+      const contents = files.get(filePath);
+      if (typeof contents === "string") {
+        return Buffer.from(contents, "utf8");
+      }
+      return Buffer.from(contents ?? "");
+    },
+    writeFile: async ({ filePath, data }) => {
+      files.set(filePath, Buffer.isBuffer(data) ? Buffer.from(data) : data);
+    },
+    createFileExclusive: async ({ filePath, data }) => {
+      if (files.has(filePath)) {
+        return "exists";
+      }
+      files.set(filePath, Buffer.isBuffer(data) ? Buffer.from(data) : data);
+      return "created";
+    },
+    remove: async ({ filePath }) => {
+      files.delete(filePath);
+    },
+    rename: async ({ from, to }) => {
+      const contents = files.get(from);
+      if (contents !== undefined) {
+        files.set(to, contents);
+        files.delete(from);
+      }
+    },
+    mkdirp: async () => {},
+    stat: async ({ filePath }) => {
+      const contents = files.get(filePath);
+      return contents === undefined
+        ? null
+        : { type: "file", size: Buffer.byteLength(contents), mtimeMs: 0 };
+    },
+  };
+  return {
+    files,
+    bridge,
+    options: { cwd: "/local/workspace", sandbox: { root: "/local/workspace", bridge } },
+  };
+}
+
+describe("applyPatch write verification", () => {
+  it("rejects an update whose delegated write does not persist the requested bytes", async () => {
+    const sandbox = createVerificationSandbox({ "source.txt": "before\n" });
+    // Simulate a delegated write that silently fails to persist the requested content.
+    vi.spyOn(sandbox.bridge, "writeFile").mockImplementation(async ({ filePath }) => {
+      sandbox.files.set(filePath, Buffer.from("corrupted"));
+    });
+
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+-before
++after
+*** End Patch`;
+
+    await expect(applyPatch(patch, sandbox.options)).rejects.toThrow(
+      "ApplyPatch verification failed for source.txt",
+    );
+  });
+
+  it("rejects an add whose delegated create does not persist the requested bytes", async () => {
+    const sandbox = createVerificationSandbox({});
+    vi.spyOn(sandbox.bridge, "createFileExclusive").mockImplementation(async ({ filePath }) => {
+      sandbox.files.set(filePath, Buffer.from("corrupted"));
+      return "created";
+    });
+
+    const patch = `*** Begin Patch
+*** Add File: new.txt
++escaped
+*** End Patch`;
+
+    await expect(applyPatch(patch, sandbox.options)).rejects.toThrow(
+      "ApplyPatch verification failed for new.txt",
+    );
+  });
+});

--- a/src/agents/apply-patch-write-verification.host-fs.proof.test.ts
+++ b/src/agents/apply-patch-write-verification.host-fs.proof.test.ts
@@ -84,6 +84,17 @@ function realFsBridge(root: string): SandboxFsBridge {
       await fs.mkdir(toAbsolute(filePath), { recursive: true });
     },
     stat: async ({ filePath }) => stat(filePath),
+    entryExists: async ({ filePath }) => {
+      try {
+        await fs.lstat(toAbsolute(filePath));
+        return true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return false;
+        }
+        throw error;
+      }
+    },
   };
 }
 
@@ -155,5 +166,122 @@ describe("applyPatch write verification on a real filesystem", () => {
 
     // The corrupted bytes are really on disk: no false-success receipt.
     expect(await fs.readFile(path.join(dir, "source.txt"), "utf8")).toBe("corrupted");
+  });
+
+  it("persists a delete and a move source removal on a real filesystem", async () => {
+    const dir = await makeTempDir();
+    await fs.writeFile(path.join(dir, "doomed.txt"), "x\n", "utf8");
+    await fs.writeFile(path.join(dir, "mover.txt"), "foo\nbar\n", "utf8");
+
+    const patch = `*** Begin Patch
+*** Delete File: doomed.txt
+*** Update File: mover.txt
+*** Move to: moved.txt
+@@
+ foo
+-bar
++baz
+*** End Patch`;
+
+    const result = await applyPatch(patch, { cwd: dir, workspaceOnly: false });
+
+    expect(result.summary.deleted).toContain("doomed.txt");
+    expect(result.summary.modified).toContain("moved.txt");
+    await expect(fs.lstat(path.join(dir, "doomed.txt"))).rejects.toThrow();
+    await expect(fs.lstat(path.join(dir, "mover.txt"))).rejects.toThrow();
+    expect(await fs.readFile(path.join(dir, "moved.txt"), "utf8")).toBe("foo\nbaz\n");
+  });
+
+  it("rejects a delete whose real remove leaves the entry behind", async () => {
+    const dir = await makeTempDir();
+    const bridge = realFsBridge(dir);
+    // A remove that resolves without deleting the entry.
+    const noOpRemoveBridge: SandboxFsBridge = {
+      ...bridge,
+      remove: async () => {},
+    };
+
+    await fs.writeFile(path.join(dir, "source.txt"), "x\n", "utf8");
+
+    const patch = `*** Begin Patch
+*** Delete File: source.txt
+*** End Patch`;
+
+    await expect(
+      applyPatch(patch, { cwd: dir, sandbox: { root: dir, bridge: noOpRemoveBridge } }),
+    ).rejects.toThrow(
+      "ApplyPatch verification failed for source.txt: the entry still exists after removal.",
+    );
+    expect(await fs.readFile(path.join(dir, "source.txt"), "utf8")).toBe("x\n");
+  });
+
+  it("rejects a move whose real source removal leaves the source behind", async () => {
+    const dir = await makeTempDir();
+    const bridge = realFsBridge(dir);
+    const noOpRemoveBridge: SandboxFsBridge = {
+      ...bridge,
+      remove: async () => {},
+    };
+
+    await fs.writeFile(path.join(dir, "source.txt"), "foo\nbar\n", "utf8");
+
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+*** Move to: dest.txt
+@@
+ foo
+-bar
++baz
+*** End Patch`;
+
+    await expect(
+      applyPatch(patch, { cwd: dir, sandbox: { root: dir, bridge: noOpRemoveBridge } }),
+    ).rejects.toThrow(
+      "ApplyPatch verification failed for source.txt: the entry still exists after removal.",
+    );
+    // The verified destination is really on disk, and the unverified source
+    // removal did not happen — both entries exist, so no success receipt.
+    expect(await fs.readFile(path.join(dir, "dest.txt"), "utf8")).toBe("foo\nbaz\n");
+    expect(await fs.readFile(path.join(dir, "source.txt"), "utf8")).toBe("foo\nbar\n");
+  });
+
+  it("treats a still-present dangling symlink as a removal verification failure", async () => {
+    const dir = await makeTempDir();
+    const bridge = realFsBridge(dir);
+    // `stat` follows symlinks and would report this dangling link as absent;
+    // the entry-existence check must use lstat semantics and reject the removal.
+    const noOpRemoveBridge: SandboxFsBridge = {
+      ...bridge,
+      remove: async () => {},
+    };
+
+    await fs.symlink(path.join(dir, "missing-target.txt"), path.join(dir, "dangling.txt"));
+
+    const patch = `*** Begin Patch
+*** Delete File: dangling.txt
+*** End Patch`;
+
+    await expect(
+      applyPatch(patch, { cwd: dir, sandbox: { root: dir, bridge: noOpRemoveBridge } }),
+    ).rejects.toThrow(
+      "ApplyPatch verification failed for dangling.txt: the entry still exists after removal.",
+    );
+    await expect(fs.readlink(path.join(dir, "dangling.txt"))).resolves.toBe(
+      path.join(dir, "missing-target.txt"),
+    );
+  });
+
+  it("verifies a real delete of a dangling symlink succeeds", async () => {
+    const dir = await makeTempDir();
+    await fs.symlink(path.join(dir, "missing-target.txt"), path.join(dir, "dangling.txt"));
+
+    const patch = `*** Begin Patch
+*** Delete File: dangling.txt
+*** End Patch`;
+
+    const result = await applyPatch(patch, { cwd: dir, workspaceOnly: false });
+
+    expect(result.summary.deleted).toEqual(["dangling.txt"]);
+    await expect(fs.lstat(path.join(dir, "dangling.txt"))).rejects.toThrow();
   });
 });

--- a/src/agents/apply-patch-write-verification.host-fs.proof.test.ts
+++ b/src/agents/apply-patch-write-verification.host-fs.proof.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Real-filesystem proof for apply_patch write verification.
+ *
+ * The unit regression suite (`apply-patch-verification.test.ts`) runs against an
+ * in-memory bridge, so it cannot prove the verification contract on a real disk.
+ * These tests run the real `applyPatch` against real `node:fs` I/O:
+ *   - happy path: add/update/move persist the exact UTF-8 bytes and are NOT
+ *     false-rejected by the size + readback check;
+ *   - fault path: a real write that persists the wrong bytes is rejected with the
+ *     verification error and the corrupted bytes are what the disk actually has.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { applyPatch } from "./apply-patch.test-support.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "apply-patch-proof-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+function realFsBridge(root: string): SandboxFsBridge {
+  // resolvePath sees the raw hunk path; containerPath is what every later bridge
+  // call receives, so it must be an absolute path under the real root.
+  const toAbsolute = (filePath: string) =>
+    path.isAbsolute(filePath) ? filePath : path.join(root, filePath);
+  const stat = async (filePath: string) => {
+    try {
+      const s = await fs.stat(toAbsolute(filePath));
+      return {
+        type: s.isFile()
+          ? ("file" as const)
+          : s.isDirectory()
+            ? ("directory" as const)
+            : ("other" as const),
+        size: s.size,
+        mtimeMs: s.mtimeMs,
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    }
+  };
+  return {
+    resolvePath: ({ filePath }) => ({
+      relativePath: filePath,
+      containerPath: toAbsolute(filePath),
+    }),
+    readFile: async ({ filePath }) => fs.readFile(toAbsolute(filePath)),
+    writeFile: async ({ filePath, data }) => {
+      await fs.mkdir(path.dirname(toAbsolute(filePath)), { recursive: true });
+      await fs.writeFile(toAbsolute(filePath), data);
+    },
+    createFileExclusive: async ({ filePath, data }) => {
+      await fs.mkdir(path.dirname(toAbsolute(filePath)), { recursive: true });
+      try {
+        await fs.writeFile(toAbsolute(filePath), data, { flag: "wx" });
+        return "created";
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+          return "exists";
+        }
+        throw error;
+      }
+    },
+    remove: async ({ filePath }) => {
+      await fs.rm(toAbsolute(filePath), { force: true });
+    },
+    rename: async ({ from, to }) => {
+      await fs.rename(toAbsolute(from), toAbsolute(to));
+    },
+    mkdirp: async ({ filePath }) => {
+      await fs.mkdir(toAbsolute(filePath), { recursive: true });
+    },
+    stat: async ({ filePath }) => stat(filePath),
+  };
+}
+
+describe("applyPatch write verification on a real filesystem", () => {
+  it("persists exact UTF-8 bytes for add/update/move without false rejection", async () => {
+    const dir = await makeTempDir();
+    // Real UTF-8 payloads: multi-byte CJK, combining-ish Latin-1, emoji.
+    await fs.writeFile(path.join(dir, "source.txt"), "old line\n", "utf8");
+    await fs.writeFile(path.join(dir, "mover.txt"), "旧内容\n", "utf8");
+
+    const patch = `*** Begin Patch
+*** Add File: added.txt
++hello ✓ 你好
++第二行 café ümlaut
+*** Update File: source.txt
+@@
+-old line
++新行 ✓
+*** Update File: mover.txt
+*** Move to: moved.txt
+@@
+-旧内容
++新内容 ✓
+*** End Patch`;
+
+    const result = await applyPatch(patch, { cwd: dir, workspaceOnly: false });
+
+    // Success is reported, and the disk really has the exact requested bytes.
+    expect(result.summary.added).toContain("added.txt");
+    expect(result.summary.modified).toContain("source.txt");
+    expect(await fs.readFile(path.join(dir, "added.txt"))).toEqual(
+      Buffer.from("hello ✓ 你好\n第二行 café ümlaut\n", "utf8"),
+    );
+    expect(await fs.readFile(path.join(dir, "source.txt"))).toEqual(
+      Buffer.from("新行 ✓\n", "utf8"),
+    );
+    expect(await fs.readFile(path.join(dir, "moved.txt"))).toEqual(
+      Buffer.from("新内容 ✓\n", "utf8"),
+    );
+    await expect(fs.access(path.join(dir, "mover.txt"))).rejects.toThrow();
+  });
+
+  it("rejects a real write whose persisted bytes differ from the requested content", async () => {
+    const dir = await makeTempDir();
+    const bridge = realFsBridge(dir);
+    // A write that completes but persists the wrong bytes (corrupted write).
+    const corruptingBridge: SandboxFsBridge = {
+      ...bridge,
+      writeFile: async ({ filePath }) => {
+        await fs.writeFile(
+          path.isAbsolute(filePath) ? filePath : path.join(dir, filePath),
+          Buffer.from("corrupted"),
+        );
+      },
+    };
+
+    await fs.writeFile(path.join(dir, "source.txt"), "before\n", "utf8");
+
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+-before
++after
+*** End Patch`;
+
+    await expect(
+      applyPatch(patch, { cwd: dir, sandbox: { root: dir, bridge: corruptingBridge } }),
+    ).rejects.toThrow("ApplyPatch verification failed for source.txt");
+
+    // The corrupted bytes are really on disk: no false-success receipt.
+    expect(await fs.readFile(path.join(dir, "source.txt"), "utf8")).toBe("corrupted");
+  });
+});

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -1117,6 +1117,12 @@ describe("applyPatch", () => {
         files.delete(filePath);
       }),
       mkdirp: vi.fn(async () => {}),
+      stat: vi.fn(async ({ filePath }: { filePath: string }) => {
+        const contents = files.get(filePath);
+        return contents === undefined
+          ? null
+          : { type: "file" as const, size: Buffer.byteLength(contents), mtimeMs: 0 };
+      }),
     };
 
     const patch = `*** Begin Patch

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -87,6 +87,7 @@ function createMemoryPatchSandbox(
         ? null
         : { type: "file", size: Buffer.byteLength(contents), mtimeMs: 0 };
     },
+    entryExists: async ({ filePath }) => files.has(filePath),
     mkdirp,
   };
   return {

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -207,7 +207,14 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
 
     if (hunk.kind === "delete") {
       const target = await resolvePatchPath(hunk.path, options, PATH_ALIAS_POLICIES.unlinkTarget);
-      await withFileMutationQueue(target.resolved, () => fileOps.remove(target.resolved));
+      await withFileMutationQueue(target.resolved, async () => {
+        await fileOps.remove(target.resolved);
+        await verifyPatchEntryRemoved({
+          ops: fileOps,
+          filePath: target.resolved,
+          display: target.display,
+        });
+      });
       recordSummary(summary, seen, "deleted", target.display);
       continue;
     }
@@ -255,6 +262,11 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
               content: applied,
             });
             await fileOps.remove(target.resolved);
+            await verifyPatchEntryRemoved({
+              ops: fileOps,
+              filePath: target.resolved,
+              display: target.display,
+            });
           }
           if (!noOpPaths.has(target.display)) {
             recordSummary(
@@ -301,6 +313,21 @@ async function verifyPatchTargetPersisted(params: {
   if (!(await verifyPersistedUtf8File(params.filePath, params.content, params.ops))) {
     throw new Error(
       `ApplyPatch verification failed for ${params.display}: the persisted regular file does not match the requested content. Inspect the target and retry.`,
+    );
+  }
+}
+
+async function verifyPatchEntryRemoved(params: {
+  ops: PatchFileOps;
+  filePath: string;
+  display: string;
+}): Promise<void> {
+  // A removal receipt must prove the entry is really gone. entryExists uses
+  // lstat semantics, so a still-present entry — including a dangling symlink
+  // that a follow-style stat would report as absent — fails the check.
+  if (await params.ops.entryExists(params.filePath)) {
+    throw new Error(
+      `ApplyPatch verification failed for ${params.display}: the entry still exists after removal. Inspect the target and retry.`,
     );
   }
 }

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -24,6 +24,7 @@ import {
   withFileMutationQueue,
   withFileMutationQueues,
 } from "./sessions/tools/file-mutation-queue.js";
+import { verifyPersistedUtf8File } from "./sessions/tools/file-write-verification.js";
 
 const BEGIN_PATCH_MARKER = "*** Begin Patch";
 const END_PATCH_MARKER = "*** End Patch";
@@ -193,6 +194,12 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
           ops: fileOps,
           hint: `Use "*** Update File: ${target.display}" to change it, or delete it earlier in the same patch.`,
         });
+        await verifyPatchTargetPersisted({
+          ops: fileOps,
+          filePath: target.resolved,
+          display: target.display,
+          content: hunk.contents,
+        });
       });
       recordSummary(summary, seen, "added", target.display);
       continue;
@@ -226,6 +233,12 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
             } else {
               noOpPaths.delete(target.display);
               await fileOps.writeFile(target.resolved, applied);
+              await verifyPatchTargetPersisted({
+                ops: fileOps,
+                filePath: target.resolved,
+                display: target.display,
+                content: applied,
+              });
             }
           } else {
             noOpPaths.delete(target.display);
@@ -234,6 +247,12 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
               contents: applied,
               ops: fileOps,
               hint: "Delete it earlier in the same patch to replace it.",
+            });
+            await verifyPatchTargetPersisted({
+              ops: fileOps,
+              filePath: moveTarget.resolved,
+              display: moveTarget.display,
+              content: applied,
             });
             await fileOps.remove(target.resolved);
           }
@@ -253,6 +272,12 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
         } else {
           noOpPaths.delete(target.display);
           await fileOps.writeFile(target.resolved, applied);
+          await verifyPatchTargetPersisted({
+            ops: fileOps,
+            filePath: target.resolved,
+            display: target.display,
+            content: applied,
+          });
           recordSummary(summary, seen, "modified", target.display);
         }
       },
@@ -265,6 +290,19 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
     text: noOp ? `No changes made to ${Array.from(noOpPaths).join(", ")}.` : formatSummary(summary),
     ...(noOp ? { noOp: true } : {}),
   };
+}
+
+async function verifyPatchTargetPersisted(params: {
+  ops: PatchFileOps;
+  filePath: string;
+  display: string;
+  content: string;
+}): Promise<void> {
+  if (!(await verifyPersistedUtf8File(params.filePath, params.content, params.ops))) {
+    throw new Error(
+      `ApplyPatch verification failed for ${params.display}: the persisted regular file does not match the requested content. Inspect the target and retry.`,
+    );
+  }
 }
 
 function recordSummary(

--- a/src/agents/sandbox/fs-bridge-shell-command-plans.ts
+++ b/src/agents/sandbox/fs-bridge-shell-command-plans.ts
@@ -3,6 +3,7 @@
  *
  * Plans carry path-safety checks alongside the command so rechecks and execution stay coupled.
  */
+import { PATH_ALIAS_POLICIES } from "../../infra/path-alias-guards.js";
 import type { AnchoredSandboxEntry, PathSafetyCheck } from "./fs-bridge-path-safety.js";
 import type { SandboxResolvedFsPath } from "./fs-paths.js";
 
@@ -23,6 +24,33 @@ export function buildStatPlan(
   return {
     checks: [{ target, options: { action: "stat files" } }],
     script: 'set -eu\ncd -- "$1"\nLC_ALL=C stat -c "%F|%s|%y" -- "$2"',
+    args: [anchoredTarget.canonicalParentPath, anchoredTarget.basename],
+    allowFailure: true,
+  };
+}
+
+/** Exit code the entry-existence plan reserves for "no entry at the path". */
+export const SANDBOX_ENTRY_EXISTS_ABSENT_EXIT_CODE = 3;
+
+/**
+ * Builds an entry-existence command that tests the final entry itself instead of
+ * following it. `-e` is false for a dangling symlink, so `-L` is included to
+ * keep such a still-present entry visible; together they mirror lstat semantics.
+ */
+export function buildEntryExistsPlan(
+  target: SandboxResolvedFsPath,
+  anchoredTarget: AnchoredSandboxEntry,
+): SandboxFsCommandPlan {
+  return {
+    // The removal-target policy preserves a still-present final symlink so the
+    // test can observe it; rejecting it would report the entry as absent.
+    checks: [
+      {
+        target,
+        options: { action: "check entry existence", aliasPolicy: PATH_ALIAS_POLICIES.unlinkTarget },
+      },
+    ],
+    script: 'set -eu\ncd -- "$1"\nif [ -e "$2" ] || [ -L "$2" ]; then exit 0; fi\nexit 3',
     args: [anchoredTarget.canonicalParentPath, anchoredTarget.basename],
     allowFailure: true,
   };

--- a/src/agents/sandbox/fs-bridge.shell.test.ts
+++ b/src/agents/sandbox/fs-bridge.shell.test.ts
@@ -7,6 +7,9 @@ import {
   createSandbox,
   createSandboxFsBridge,
   createSeededSandboxFsBridge,
+  dockerExecResult,
+  getDockerArg,
+  getDockerScript,
   getScriptsFromCalls,
   installFsBridgeTestHarness,
   mockedExecDockerRaw,
@@ -177,6 +180,55 @@ describe("sandbox fs bridge shell compatibility", () => {
       expectNoScriptsContaining(scripts, 'mkdir -p -- "$2"');
       expectNoScriptsContaining(scripts, 'rm -f -- "$2"');
       expectNoScriptsContaining(scripts, 'mv -- "$3" "$2/$4"');
+    });
+  });
+
+  it("entry existence anchors the probe and maps the reserved absent exit code", async () => {
+    await withTempDir("openclaw-fs-bridge-entry-exists-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "present.txt"), "x");
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir }),
+      });
+
+      // Probe exit 0 means an entry is present.
+      await expect(bridge.entryExists({ filePath: "present.txt" })).resolves.toBe(true);
+
+      // Probe exit 3 means no entry at the path.
+      mockedExecDockerRaw.mockImplementation(async (args) => {
+        const script = getDockerScript(args);
+        if (script.includes('if [ -e "$2" ] || [ -L "$2" ]; then exit 0; fi')) {
+          return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), code: 3 };
+        }
+        if (script.includes('readlink -f -- "$cursor"')) {
+          return dockerExecResult(`${getDockerArg(args, 1)}\n`);
+        }
+        return dockerExecResult("");
+      });
+      await expect(bridge.entryExists({ filePath: "present.txt" })).resolves.toBe(false);
+
+      // Any other probe exit is an error, not an absence signal.
+      mockedExecDockerRaw.mockImplementation(async (args) => {
+        const script = getDockerScript(args);
+        if (script.includes('if [ -e "$2" ] || [ -L "$2" ]; then exit 0; fi')) {
+          return { stdout: Buffer.alloc(0), stderr: Buffer.from("boom"), code: 2 };
+        }
+        if (script.includes('readlink -f -- "$cursor"')) {
+          return dockerExecResult(`${getDockerArg(args, 1)}\n`);
+        }
+        return dockerExecResult("");
+      });
+      await expect(bridge.entryExists({ filePath: "present.txt" })).rejects.toThrow(
+        "entry existence check failed",
+      );
+
+      // The probe must test the entry itself, not follow it: `-L` keeps a
+      // still-present dangling symlink visible so removals cannot be faked.
+      const scripts = getScriptsFromCalls();
+      expectSomeScriptContaining(scripts, 'if [ -e "$2" ] || [ -L "$2" ]; then exit 0; fi');
+      expectNoScriptsContaining(scripts, "pipefail");
     });
   });
 

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -21,7 +21,12 @@ import {
   buildPinnedWritePlan,
 } from "./fs-bridge-mutation-helper.js";
 import { SandboxFsPathGuard } from "./fs-bridge-path-safety.js";
-import { buildStatPlan, type SandboxFsCommandPlan } from "./fs-bridge-shell-command-plans.js";
+import {
+  buildEntryExistsPlan,
+  buildStatPlan,
+  SANDBOX_ENTRY_EXISTS_ABSENT_EXIT_CODE,
+  type SandboxFsCommandPlan,
+} from "./fs-bridge-shell-command-plans.js";
 import { parseSandboxStatMtimeMs, parseSandboxStatSize } from "./fs-bridge-stat-parse.js";
 import type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./fs-bridge.types.js";
 import {
@@ -302,6 +307,36 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       size: parseSandboxStatSize(sizeRaw),
       mtimeMs: parseSandboxStatMtimeMs(mtimeRaw),
     };
+  }
+
+  async entryExists(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<boolean> {
+    const target = this.resolveResolvedPath(params);
+    // Anchor at the canonical parent so the final entry is tested by basename.
+    // The plan's boundary check uses the removal-target alias policy, so a
+    // still-present final symlink is preserved and reported as an entry instead
+    // of being resolved away (lstat semantics).
+    const anchoredTarget = await this.pathGuard.resolveAnchoredSandboxEntry(
+      target,
+      "check entry existence",
+    );
+    const result = await this.runPlannedCommand(
+      buildEntryExistsPlan(target, anchoredTarget),
+      params.signal,
+    );
+    if (result.code === 0) {
+      return true;
+    }
+    if (result.code === SANDBOX_ENTRY_EXISTS_ABSENT_EXIT_CODE) {
+      return false;
+    }
+    const stderr = result.stderr.toString("utf8").trim();
+    throw new Error(
+      `entry existence check failed for ${target.containerPath}: ${stderr || `exit code ${result.code}`}`,
+    );
   }
 
   private async runCommand(

--- a/src/agents/sandbox/fs-bridge.types.ts
+++ b/src/agents/sandbox/fs-bridge.types.ts
@@ -71,4 +71,12 @@ export type SandboxFsBridge = {
     cwd?: string;
     signal?: AbortSignal;
   }): Promise<SandboxFsStat | null>;
+  /**
+   * Reports whether any filesystem entry exists at the path, using lstat
+   * semantics: a dangling symlink is still an entry. This is the authoritative
+   * absence check for removal receipts. `stat` is not enough because it follows
+   * the final symlink and therefore cannot distinguish a dangling link from an
+   * absent path.
+   */
+  entryExists(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<boolean>;
 };

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -359,6 +359,17 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     };
   }
 
+  async entryExists(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<boolean> {
+    const target = this.resolveTarget(params);
+    // `-e` misses dangling symlinks; `-L` keeps them visible, so together the
+    // test mirrors lstat semantics: any entry at the path counts as present.
+    return await this.remotePathExists(target.containerPath, params.signal);
+  }
+
   private getMounts(): MountInfo[] {
     const workspaceRoot = path.resolve(this.sandbox.workspaceDir);
     const agentRoot = path.resolve(this.sandbox.agentWorkspaceDir);

--- a/src/agents/test-helpers/host-sandbox-fs-bridge.ts
+++ b/src/agents/test-helpers/host-sandbox-fs-bridge.ts
@@ -111,6 +111,24 @@ export function createSandboxFsBridgeFromResolver(
         throw error;
       }
     },
+    entryExists: async ({ filePath, cwd }) => {
+      const target = resolvePath(filePath, cwd);
+      if (!target.hostPath) {
+        throw new Error(`Expected hostPath for ${target.containerPath}`);
+      }
+      try {
+        await fs.lstat(target.hostPath);
+        return true;
+      } catch (error) {
+        if (
+          (error as NodeJS.ErrnoException).code === "ENOENT" ||
+          (error as NodeJS.ErrnoException).code === "ENOTDIR"
+        ) {
+          return false;
+        }
+        throw error;
+      }
+    },
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

`apply_patch` reported "Success. Updated the following files: ..." immediately after each delegated write completed, so a write that silently failed to persist the requested bytes surfaced as a false-success mutation — the same invariant gap #117938 fixed for the `write`/`edit` tools.

## Why This Change Was Made

Every add/update/move write now shares the same verification contract as `write`/`edit`: the target must be a regular file with the exact requested UTF-8 bytes before a success receipt is returned. The change reuses the existing `verifyPersistedUtf8File` helper (`src/agents/sessions/tools/file-write-verification.ts`), which stats the target and readbacks the persisted bytes. `PatchFileOps` gains a `statFile` operation wired through all three adapters (sandbox bridge, host fs, fs-safe workspace root); no provider, config, schema, SDK, or fallback surface changes.

## User Impact

The agent no longer reports that an `apply_patch` mutation succeeded when the target stayed stale, persisted different bytes, or became a non-file entry. A verification failure throws `ApplyPatch verification failed for <path>: the persisted regular file does not match the requested content. Inspect the target and retry.` — a visible, actionable outcome instead of a silent false success.

## Evidence

- Deterministic regression: an injected delegated `writeFile`/`createFileExclusive` resolves while persisting `corrupted` bytes; before this repair `apply_patch` returned a success summary, after it rejects with the verification error. Tests fail on the unverified code and pass with the fix (`src/agents/apply-patch-verification.test.ts`).
- Real-filesystem proof (`src/agents/apply-patch-write-verification.host-fs.proof.test.ts`), run against real `node:fs` I/O:
  - Happy path (no mocks): `workspaceOnly: false` + a real temp dir applies one patch doing Add / Update / Move with multi-byte UTF-8 content. `applyPatch` reports success and the disk bytes byte-for-byte match the requested content; move source is removed and destination exists — the size + readback check does not false-reject normal writes.
  - Fault path (real disk): a real `SandboxFsBridge` (all I/O persisted) whose only injection is `writeFile` persisting the wrong bytes. `applyPatch` rejects with `ApplyPatch verification failed for source.txt` and the disk holds exactly the `corrupted` bytes — no false-success receipt.
  - Red/green: reverting `apply-patch.ts`/`apply-patch-file-ops.ts` to the pre-fix commit (`2de2fa3d673`) makes the fault test red (`promise resolved ... instead of rejecting` — the unfixed code reports success for a corrupted write); with the fix it is green.
- `node scripts/run-vitest.mjs src/agents/apply-patch-write-verification.host-fs.proof.test.ts` → 2 passed; together with `apply-patch.test.ts` and `apply-patch-verification.test.ts` → 56 passed.
- `node scripts/run-vitest.mjs src/agents/apply-patch.test.ts src/agents/apply-patch-verification.test.ts src/agents/apply-patch-paths.test.ts src/agents/apply-patch-context-bytes.test.ts src/agents/agent-tools.read.host-operations.test.ts` — 91/91 tests passed.
- `tsgo:core` and `tsgo:core:test` typechecks clean; `oxlint` clean on all changed files; `oxfmt --check` clean.
- `git diff --check` clean.

AI-assisted implementation; reviewed the full owner path, caller adapters, sibling tool behavior, and focused tests.
