### PR TITLE
ci(qa): extend maturity evidence timeout

### DIFF
--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -207,7 +207,9 @@ jobs:
     name: Generate QA profile evidence
     needs: validate_selected_ref
     runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 90
+    # The full live profile can exceed 90 minutes before aggregate evidence is finalized.
+    # Preserve enough headroom to record its terminal result instead of losing it to cancellation.
+    timeout-minutes: 150
     permissions:
       contents: read
     outputs:

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5045,7 +5045,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.qa_profile).not.toHaveProperty("options");
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.qa_profile.default).toBe("all");
     expect(qaEvidenceWorkflow.on.workflow_call.inputs.qa_profile.type).toBe("string");
-    expect(qaRunJob["timeout-minutes"]).toBe(90);
+    expect(qaRunJob["timeout-minutes"]).toBe(150);
     const validateProfileStep = qaRunJob.steps.find(
       (step: WorkflowStep) => step.name === "Validate QA profile input",
     );


### PR DESCRIPTION
## What Problem This Solves

The full live QA profile was canceled at the reusable evidence job's 90-minute limit before it could emit an exit code or finalize aggregate evidence. That prevented an explicitly allowed incomplete-evidence maturity run from reaching rendering or PR publication.

## Why This Change Was Made

Increase the QA evidence job timeout from 90 to 150 minutes as a temporary release unblock. The failed run produced normal QA progress through 58 minutes, then remained active until the 90-minute job cap; the additional hour gives the full profile and final aggregation room to complete while retaining a hard upper bound.

This does not weaken `allow_failures`, schema validation, exit-code preservation, or publication gates. A timeout, cancellation, missing terminal result, or invalid evidence remains fatal.

## User Impact

Maintainers can complete the full maturity evidence run without GitHub canceling the job at 90 minutes. Runtime performance and the post-scenario stall can be optimized separately, after the scorecard is published.

## Evidence

- Root-cause run: https://github.com/openclaw/openclaw/actions/runs/30747605405
- GitHub annotation: the QA evidence job exceeded its `1h30m0s` maximum; its last QA output was a passing `thread-isolation` scenario roughly 32 minutes before cancellation.
- Focused workflow guard: `corepack pnpm test test/scripts/ci-workflow-guards.test.ts` — 97 passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30751327184
- `actionlint .github/workflows/qa-profile-evidence.yml` passed.
- Targeted formatting, changed-lane classification, and `git diff --check` passed.
- `autoreview --mode local` reported no accepted/actionable findings.

