### PR TITLE
fix(gateway): restore fresh dev bootstrap

### DIFF
--- a/src/cli/gateway-cli/dev.integration.test.ts
+++ b/src/cli/gateway-cli/dev.integration.test.ts
@@ -1,0 +1,44 @@
+// Proves a fresh dev gateway can replace the synthetic implicit roster through real config IO.
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetConfigRuntimeState } from "../../config/config.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { ensureDevGatewayConfig } from "./dev.js";
+
+describe("ensureDevGatewayConfig integration", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    resetConfigRuntimeState();
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("writes the dedicated dev roster into a fresh state directory", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openclaw-dev-config-integration-"));
+    tempDirs.push(root);
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const workspace = path.join(root, "workspace");
+
+    await withEnvAsync(
+      {
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_WORKSPACE_DIR: workspace,
+      },
+      async () => {
+        resetConfigRuntimeState();
+        await ensureDevGatewayConfig({});
+      },
+    );
+
+    const config = JSON.parse(await readFile(configPath, "utf8")) as {
+      agents?: { entries?: Record<string, { default?: boolean; workspace?: string }> };
+    };
+    expect(config.agents?.entries).toEqual({
+      dev: { default: true, workspace: `${workspace}-dev`, identity: expect.any(Object) },
+    });
+  });
+});

--- a/src/cli/gateway-cli/dev.test.ts
+++ b/src/cli/gateway-cli/dev.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   configPath: "",
   workspace: "",
   nextConfig: undefined as unknown,
+  writeOptions: undefined as unknown,
   replaceConfigFile: vi.fn(),
 }));
 
@@ -48,9 +49,12 @@ describe("ensureDevGatewayConfig", () => {
     mocks.configPath = path.join(tempDir, "openclaw.json");
     mocks.workspace = path.join(tempDir, "workspace");
     mocks.nextConfig = undefined;
+    mocks.writeOptions = undefined;
     mocks.replaceConfigFile.mockReset();
     mocks.replaceConfigFile.mockImplementation(async (options: unknown) => {
-      mocks.nextConfig = (options as { nextConfig: unknown }).nextConfig;
+      const configOptions = options as { nextConfig: unknown; writeOptions?: unknown };
+      mocks.nextConfig = configOptions.nextConfig;
+      mocks.writeOptions = configOptions.writeOptions;
     });
   });
 
@@ -76,5 +80,6 @@ describe("ensureDevGatewayConfig", () => {
       },
     });
     expect(OpenClawSchema.safeParse(mocks.nextConfig).success).toBe(true);
+    expect(mocks.writeOptions).toEqual({ allowedAgentRosterRemovals: ["main"] });
   });
 });

--- a/src/cli/gateway-cli/dev.ts
+++ b/src/cli/gateway-cli/dev.ts
@@ -8,6 +8,7 @@ import { resolveWorkspaceTemplateSearchDirs } from "../../agents/workspace-templ
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { handleReset } from "../../commands/onboard-helpers.js";
 import { createConfigIO, replaceConfigFile } from "../../config/config.js";
+import { LEGACY_IMPLICIT_AGENT_ID } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveUserPath, shortenHomePath } from "../../utils.js";
 
@@ -128,6 +129,9 @@ export async function ensureDevGatewayConfig(opts: { reset?: boolean }) {
       },
     },
     afterWrite: { mode: "auto" },
+    // An absent config resolves to the implicit legacy agent before this full
+    // replacement. Declare only that synthetic deletion; authored rosters stay protected.
+    writeOptions: { allowedAgentRosterRemovals: [LEGACY_IMPLICIT_AGENT_ID] },
   });
   await ensureDevWorkspace(workspace);
   defaultRuntime.log(`Dev config ready: ${shortenHomePath(configPath)}`);


### PR DESCRIPTION
## Summary

- restore first-run `gateway run --dev` on an empty state directory
- declare only the expected synthetic legacy-agent removal to the roster-loss guard
- cover the real config-IO path so the regression cannot hide behind a mocked writer

## Root cause and fix

Fresh config resolution materializes the legacy implicit agent before the dev bootstrap performs its full replacement. The bootstrap intentionally owns a dedicated `dev` roster, but it did not declare removal of that synthetic entry after the roster-loss guard landed in #114054, so the safety boundary rejected every fresh dev startup.

The dev bootstrap now authorizes only removal of the legacy implicit agent. Existing authored configs remain protected because bootstrap still returns without writing when a config exists, and the general roster-loss guard is unchanged.

No old runtime path or fallback was added. Production delta is +4/−0 lines in the dev-bootstrap owner.

Closes https://github.com/openclaw/openclaw/issues/118001

## Proof

Exact candidate head: `9635459587c8a895933e8715207b97532c71a195`

- `node scripts/run-vitest.mjs src/cli/gateway-cli/dev.test.ts src/cli/gateway-cli/dev.integration.test.ts src/config/io.write-prepare.test.ts` — 99 assertions passed after the final rebase
- source-blind built-CLI contract — cold empty-state startup reached ready, generated only the default `dev` roster, served `/health` as live and `/` as OpenClaw Control, released the port on SIGINT, and passed a warm restart
- `node scripts/check-changed.mjs -- src/cli/gateway-cli/dev.ts src/cli/gateway-cli/dev.test.ts src/cli/gateway-cli/dev.integration.test.ts` — passed on Blacksmith Testbox `tbx_01kz1c25n4aks3zd72yd0b3c9e` ([run](https://github.com/openclaw/openclaw/actions/runs/30750929924))
- `pnpm build` — passed on Blacksmith Testbox `tbx_01kz1ckzvqv9zfe3fw2d8qxs86` ([run](https://github.com/openclaw/openclaw/actions/runs/30751288417))
- Codex autoreview — clean, no accepted/actionable findings, overall confidence 0.98
- rendered-browser inspection was blocked by the browser platform's admin-enforced localhost policy; the CLI bootstrap, generated config, HTTP document, and health boundary were all exercised directly

## Release note

Fixes fresh dev-gateway startup failing before configuration is created after the agent-roster safety guard was introduced.
