### PR TITLE
fix(qa): include pinned gateway restart in core runtime proof

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -386,6 +386,25 @@ jobs:
             --summary "${{ steps.run_lane.outputs.output_dir }}/runtime-suite/qa-suite-summary.json" \
             --output-dir "${{ steps.run_lane.outputs.output_dir }}/runtime-report"
 
+      - name: Run pinned GPT-5.4 gateway restart runtime pair
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENCLAW_LIVE_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          pnpm openclaw qa suite \
+            --repo-root . \
+            --provider-mode live-frontier \
+            --scenario gateway-restart-multi-live \
+            --concurrency 1 \
+            --model openai/gpt-5.4 \
+            --alt-model openai/gpt-5.4 \
+            --runtime-pair openclaw,codex \
+            --fast \
+            --output-dir "${{ steps.run_lane.outputs.output_dir }}/gateway-restart-gpt-5.4-runtime-pair"
+
       - name: Upload live runtime token-efficiency artifacts
         if: always() && steps.run_lane.outputs.output_dir != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -373,19 +373,6 @@ jobs:
             --allow-failures \
             --output-dir "${output_dir}/runtime-suite"
 
-      - name: Generate live runtime token-efficiency report
-        if: steps.run_lane.outcome == 'success'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          pnpm openclaw qa parity-report \
-            --repo-root . \
-            --runtime-axis \
-            --token-efficiency \
-            --summary "${{ steps.run_lane.outputs.output_dir }}/runtime-suite/qa-suite-summary.json" \
-            --output-dir "${{ steps.run_lane.outputs.output_dir }}/runtime-report"
-
       - name: Run pinned GPT-5.4 gateway restart runtime pair
         shell: bash
         env:
@@ -404,6 +391,19 @@ jobs:
             --runtime-pair openclaw,codex \
             --fast \
             --output-dir "${{ steps.run_lane.outputs.output_dir }}/gateway-restart-gpt-5.4-runtime-pair"
+
+      - name: Generate live runtime token-efficiency report
+        if: steps.run_lane.outcome == 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pnpm openclaw qa parity-report \
+            --repo-root . \
+            --runtime-axis \
+            --token-efficiency \
+            --summary "${{ steps.run_lane.outputs.output_dir }}/runtime-suite/qa-suite-summary.json" \
+            --output-dir "${{ steps.run_lane.outputs.output_dir }}/runtime-report"
 
       - name: Upload live runtime token-efficiency artifacts
         if: always() && steps.run_lane.outputs.output_dir != ''

--- a/extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts
@@ -1,12 +1,14 @@
 // Qa Lab tests cover canonical runtime-pair scenario membership metadata.
 import { describe, expect, it } from "vitest";
 import { resolveQaParityPackScenarioIds } from "./agentic-parity.js";
+import { resolveQaRuntimePairLaneScenarioIds } from "./runtime-pair-lane-selection.js";
 import {
   QA_RUNTIME_PAIR_LANES,
   readQaScenarioById,
   readQaScenarioExecutionConfig,
   readQaScenarioPack,
 } from "./scenario-catalog.js";
+import { selectQaFlowSuiteScenarios } from "./suite-planning.js";
 
 describe("QA runtime-pair scenario catalog", () => {
   it("uses the canonical lanes with audited declaration counts", () => {
@@ -81,5 +83,48 @@ describe("QA runtime-pair scenario catalog", () => {
     const longContextFlow = JSON.stringify(longContextScenario.execution.flow);
     expect(longContextFlow).toContain("OPENCLAW_QA_FORCE_RUNTIME");
     expect(longContextFlow).not.toContain("patchConfig");
+  });
+
+  it("selects the pinned gateway restart pair explicitly and implicitly at GPT-5.4", () => {
+    const scenarioId = "gateway-restart-multi-live";
+    const scenario = readQaScenarioById(scenarioId);
+    const scenarios = readQaScenarioPack().scenarios;
+    const lane = {
+      providerMode: "live-frontier" as const,
+      primaryModel: "openai/gpt-5.4",
+    };
+
+    expect(scenario.runtimePairLane).toBe("core");
+    expect(readQaScenarioExecutionConfig(scenarioId)).toMatchObject({
+      requiredProviderMode: "live-frontier",
+      requiredProvider: "openai",
+      requiredModel: "gpt-5.4",
+    });
+
+    const explicitIds = selectQaFlowSuiteScenarios({
+      scenarios,
+      scenarioIds: [scenarioId],
+      ...lane,
+    }).map((selected) => selected.id);
+    const implicitIds = selectQaFlowSuiteScenarios({ scenarios, ...lane }).map(
+      (selected) => selected.id,
+    );
+    const runtimePairLane = resolveQaRuntimePairLaneScenarioIds({
+      scenarios,
+      scenarioIds: [],
+      runtimePairLanes: ["core"],
+      runtimePair: true,
+      ...lane,
+    });
+
+    expect(explicitIds).toEqual([scenarioId]);
+    expect(implicitIds).toContain(scenarioId);
+    expect(runtimePairLane.scenarioIds).toContain(scenarioId);
+    expect(runtimePairLane.excludedLaneScenarios.map((excluded) => excluded.id)).not.toContain(
+      scenarioId,
+    );
+    expect(runtimePairLane.excludedNonFlowScenarios.map((excluded) => excluded.id)).not.toContain(
+      scenarioId,
+    );
   });
 });

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3231,6 +3231,24 @@ describe("package artifact reuse", () => {
     expect(reportStep.if).toBe("steps.run_lane.outcome == 'success'");
   });
 
+  it("runs the core gateway restart pair on its pinned live model", () => {
+    const job = workflowJob(QA_LIVE_TRANSPORTS_WORKFLOW, "run_live_runtime_token_efficiency");
+    const credentialStep = workflowStep(job, "Validate required QA credential env");
+    const runStep = workflowStep(job, "Run pinned GPT-5.4 gateway restart runtime pair");
+
+    expect(credentialStep.run).toContain('if [[ -z "${OPENAI_API_KEY:-}" ]]');
+    expect(credentialStep.run).toContain("exit 1");
+    expect(runStep.run).toContain("--provider-mode live-frontier");
+    expect(runStep.run).toContain("--scenario gateway-restart-multi-live");
+    expect(runStep.run).toContain("--model openai/gpt-5.4");
+    expect(runStep.run).toContain("--alt-model openai/gpt-5.4");
+    expect(runStep.run).toContain("--runtime-pair openclaw,codex");
+    expect(runStep.run).toContain(
+      "steps.run_lane.outputs.output_dir }}/gateway-restart-gpt-5.4-runtime-pair",
+    );
+    expect(runStep.run).not.toContain("--allow-failures");
+  });
+
   it("requires release-check QA evidence artifacts when lanes run", () => {
     const cases = [
       ["qa_lab_parity_lane_release_checks", "Upload parity lane artifacts"],

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3235,6 +3235,7 @@ describe("package artifact reuse", () => {
     const job = workflowJob(QA_LIVE_TRANSPORTS_WORKFLOW, "run_live_runtime_token_efficiency");
     const credentialStep = workflowStep(job, "Validate required QA credential env");
     const runStep = workflowStep(job, "Run pinned GPT-5.4 gateway restart runtime pair");
+    const stepNames = job.steps?.map((step) => step.name) ?? [];
 
     expect(credentialStep.run).toContain('if [[ -z "${OPENAI_API_KEY:-}" ]]');
     expect(credentialStep.run).toContain("exit 1");
@@ -3247,6 +3248,9 @@ describe("package artifact reuse", () => {
       "steps.run_lane.outputs.output_dir }}/gateway-restart-gpt-5.4-runtime-pair",
     );
     expect(runStep.run).not.toContain("--allow-failures");
+    expect(stepNames.indexOf("Run pinned GPT-5.4 gateway restart runtime pair")).toBeLessThan(
+      stepNames.indexOf("Generate live runtime token-efficiency report"),
+    );
   });
 
   it("requires release-check QA evidence artifacts when lanes run", () => {


### PR DESCRIPTION
Closes #118006

## What Problem This Solves

Fixes an issue where the scheduled canonical live core runtime-pair workflow silently omitted `gateway-restart-multi-live` because the broad lane requests the moving `openai/gpt-5.6-luna` default while this declared core member intentionally requires `openai/gpt-5.4`.

That left a false coverage claim: neither the OpenClaw nor Codex cell exercised the three-restart scenario, even though the catalog counted it in the core runtime-pair lane.

## Why This Change Was Made

The existing scheduled live core runtime-pair job now runs one additional targeted, blocking pair after its unchanged broad advisory lane/report. Both cells receive `openai/gpt-5.4`; the command has no `--allow-failures`, and its output lives under the job's existing artifact root.

This is the best fix because history shows the scenario was introduced by #105126 as `runtimeParityTier: live-only`, so its pair intent and explicit GPT-5.4 contract are deliberate. The change preserves the moving broad-lane default, provider/model and channel-driver orthogonality, canonical selector behavior, and the single scenario declaration. Removing `runtimePairLane: core` would discard intended coverage; repinning the scenario to GPT-5.6 would violate its live contract; changing selector/planner semantics would race draft #116446 at exact head `1885109ec45d5c954d7619956217c99c76a88026` and would be the wrong owner boundary.

The targeted suite already creates isolated gateway/runtime state, so it safely shares the canonical job's checkout, build, credentials, runner, timeout, and upload instead of duplicating the workflow lane.

Direct Codex contract audit used sibling `openai/codex` revision `2e1607ee2fa8099a233df7437adee5f16a741905`:

- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:56-65,167-175` — `thread/start` accepts the requested model/provider and returns the realized model/provider; provider-model fallback defaults off.
- `codex-rs/models-manager/src/manager.rs:150-179,483-518` and `manager_tests.rs:281-382` — explicit models are preserved unless fallback is explicitly enabled.
- `codex-rs/core/src/client.rs:824-907` — the resolved model slug is sent on the provider request.
- `codex-rs/model-provider-info/src/lib.rs:280-299`, `model-provider/src/auth.rs:267-279`, and `app-server/src/bespoke_event_handling.rs:901-941,1442-1467` — missing credentials and terminal provider errors fail rather than no-op or fulfill coverage.

## User Impact

No end-user runtime behavior or defaults change. Maintainers regain honest scheduled evidence for the pinned core restart scenario: both runtimes must complete it on live OpenAI GPT-5.4, and missing credentials, model unavailability, or either cell failing makes the targeted proof fail.

## Evidence

- Exact-head `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts`: 4/4 passed.
- Exact-head `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts`: 141/141 passed.
- Exact-head `actionlint .github/workflows/qa-live-transports-convex.yml`: passed.
- Exact-head targeted formatting and `git diff --check`: passed.
- Blacksmith Testbox changed gate: passed in 6m32s (`tbx_01kz1db6gzs92h312ce7dw5qy0`, [run 30751751225](https://github.com/openclaw/openclaw/actions/runs/30751751225)); proof is patch-identical to the final rebase, whose two intervening main commits touched unrelated workflow/UI files.
- Exact-head branch autoreview: clean, no accepted/actionable findings; TruffleHog clean.
- Production TypeScript delta: `+0/-0`. Workflow: `+19/-0`; tests: `+63/-0`.
