### PR TITLE
fix(cli): surface failed plugins in health summaries

### DIFF
--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => ({
     ok: true,
   })),
   emitReachableGatewayAuthDiagnostic: vi.fn(async (_params: unknown) => false),
-  formatHealthChannelLines: vi.fn(() => []),
+  formatHealthChannelLines: vi.fn((_summary: unknown): string[] => []),
   gatewayStatusCommand: vi.fn(async (_opts: unknown, _runtime: unknown) => {}),
   defaultRuntime: {
     log: vi.fn(),
@@ -67,7 +67,7 @@ vi.mock("../daemon-cli/register-service-commands.js", () => ({
 vi.mock("../../commands/health.js", () => ({
   emitReachableGatewayAuthDiagnostic: (params: unknown) =>
     mocks.emitReachableGatewayAuthDiagnostic(params),
-  formatHealthChannelLines: () => mocks.formatHealthChannelLines(),
+  formatHealthChannelLines: (summary: unknown) => mocks.formatHealthChannelLines(summary),
 }));
 
 vi.mock("../../config/read-best-effort-config.runtime.js", () => ({
@@ -249,6 +249,34 @@ describe("gateway register option collisions", () => {
     assert();
   });
 
+  it("prints actionable plugin failures in gateway health text output", async () => {
+    const snapshot = {
+      ok: true,
+      channels: {},
+      plugins: {
+        loaded: [],
+        errors: [
+          {
+            id: "openclaw-qqbot",
+            origin: "global",
+            activated: false,
+            activationSource: "explicit",
+            error: "missing buffered reply dispatcher",
+          },
+        ],
+      },
+    };
+    const warning = "Plugin: failed - openclaw-qqbot: missing buffered reply dispatcher";
+    callGatewayCli.mockResolvedValueOnce(snapshot);
+    mocks.formatHealthChannelLines.mockReturnValueOnce([warning]);
+
+    await sharedProgram.parseAsync(["gateway", "health"], { from: "user" });
+
+    expect(mocks.formatHealthChannelLines).toHaveBeenCalledWith(snapshot);
+    expect(defaultRuntime.log).toHaveBeenCalledWith(warning);
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+  });
+
   it("uses the effective local port config for gateway health auth diagnostics", async () => {
     const authError = new Error("gateway auth required");
     callGatewayCli.mockRejectedValueOnce(authError);
@@ -287,6 +315,23 @@ describe("gateway register option collisions", () => {
       loadGatewayHealthModule: loadGatewayHealthModule as never,
       loadHealthStyleModule: loadHealthStyleModule as never,
     });
+    const snapshot = {
+      ok: true,
+      channels: {},
+      plugins: {
+        loaded: [],
+        errors: [
+          {
+            id: "openclaw-qqbot",
+            origin: "global",
+            activated: false,
+            activationSource: "explicit",
+            error: "missing required runtime\nretry after repair",
+          },
+        ],
+      },
+    };
+    callGatewayCli.mockResolvedValueOnce(snapshot);
 
     await program.parseAsync(["node", "openclaw", "gateway", "health", "--json"]);
 
@@ -297,6 +342,6 @@ describe("gateway register option collisions", () => {
     );
     expect(loadGatewayHealthModule).not.toHaveBeenCalled();
     expect(loadHealthStyleModule).not.toHaveBeenCalled();
-    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({ ok: true });
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(snapshot);
   });
 });

--- a/src/commands/health-format.test.ts
+++ b/src/commands/health-format.test.ts
@@ -193,4 +193,141 @@ describe("formatHealthChannelLines", () => {
       "iMessage: failed (unknown) - imsg cannot access ~/Library/Messages/chat.db. Grant Full Disk Access to the Gateway/launcher process and restart Gateway.",
     );
   });
+
+  it("surfaces configured plugin failures in owner order without warning for disabled plugins", () => {
+    const summary = createHealthSummary({
+      channels: {
+        telegram: { accountId: "default", configured: true },
+      },
+      channelOrder: ["telegram"],
+      channelLabels: { telegram: "Telegram" },
+    });
+    summary.plugins = {
+      loaded: ["telegram"],
+      errors: [
+        {
+          id: "zeta",
+          origin: "global",
+          activated: true,
+          error: "registration failed",
+        },
+        {
+          id: "shared",
+          origin: "config",
+          activated: false,
+          activationSource: "explicit",
+          error: "configured owner failed",
+        },
+        {
+          id: "ignored",
+          origin: "workspace",
+          activated: false,
+          activationSource: "disabled",
+          error: "disabled plugin ignored",
+        },
+      ],
+      unavailable: [
+        {
+          id: "shared",
+          state: "configured-unavailable",
+          diagnostic: {
+            kind: "plugin-verification",
+            reason: "missing-main-entry",
+            detail: "main entry missing",
+          },
+        },
+        {
+          id: "alpha",
+          state: "configured-unavailable",
+          diagnostic: {
+            kind: "plugin-verification",
+            reason: "missing-package-json",
+            detail: "package metadata missing",
+          },
+        },
+      ],
+    };
+
+    expect(formatHealthChannelLines(summary)).toStrictEqual([
+      "Telegram: configured",
+      "Plugin: failed - alpha: configured-unavailable (missing-package-json): package metadata missing",
+      "Plugin: failed - shared: configured owner failed",
+      "Plugin: failed - shared: configured-unavailable (missing-main-entry): main entry missing",
+      "Plugin: failed - zeta: registration failed",
+    ]);
+  });
+
+  it("keeps untrusted plugin ids and diagnostics inside one fixed failed health line", () => {
+    const summary = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    summary.plugins = {
+      loaded: [],
+      errors: [
+        {
+          id: "\u001b[32msp\u202eoof:\u2066ok\u2069\u001b[0m\n\u200bnext\u2028",
+          origin: "global",
+          activated: false,
+          activationSource: "explicit",
+          error: "\u001b]52;c;YWJj\u0007fa\u{E0061}iled\nretry\t\u2029la\ufeffter\uD800",
+        },
+      ],
+    };
+
+    const [line] = formatHealthChannelLines(summary);
+
+    expect(line).toBe("Plugin: failed - spoof:ok\\nnext: failed\\nretry\\tlater");
+    expect(line?.split(":", 1)).toStrictEqual(["Plugin"]);
+    expect(line).not.toContain("\u001b");
+    expect(line).not.toContain("\n");
+    expect(line).not.toMatch(/[\p{Cf}\p{Cs}\p{Zl}\p{Zp}]/u);
+  });
+
+  it("bounds plugin ids and diagnostics without splitting Unicode code points", () => {
+    const summary = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    summary.plugins = {
+      loaded: [],
+      errors: [
+        {
+          id: "📦".repeat(90),
+          origin: "global",
+          activated: true,
+          error: "🦀".repeat(170),
+        },
+      ],
+    };
+
+    expect(formatHealthChannelLines(summary)).toStrictEqual([
+      `Plugin: failed - ${"📦".repeat(79)}…: ${"🦀".repeat(159)}…`,
+    ]);
+  });
+
+  it("does not add warnings for healthy loaded or explicitly disabled plugins", () => {
+    const summary = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    summary.plugins = {
+      loaded: ["healthy"],
+      errors: [
+        {
+          id: "ignored",
+          origin: "workspace",
+          activated: false,
+          activationSource: "disabled",
+          error: "disabled plugin ignored",
+        },
+      ],
+      unavailable: [],
+    };
+
+    expect(formatHealthChannelLines(summary)).toStrictEqual([]);
+  });
 });

--- a/src/commands/health-format.ts
+++ b/src/commands/health-format.ts
@@ -144,10 +144,7 @@ const isProbeFailure = (summary: ChannelAccountHealthSummary): boolean => {
 // Plugin diagnostics cross terminal/table trust boundaries; invisible Unicode
 // direction, surrogate, and line controls must not spoof the rendered status.
 const sanitizePluginHealthText = (value: string, maxLength: number): string =>
-  shortenText(
-    sanitizeTerminalText(value).replace(/[\p{Cf}\p{Cs}\p{Zl}\p{Zp}]/gu, ""),
-    maxLength,
-  );
+  shortenText(sanitizeTerminalText(value).replace(/[\p{Cf}\p{Cs}\p{Zl}\p{Zp}]/gu, ""), maxLength);
 
 /** Formats channel health and actionable plugin failures for human CLI output. */
 export const formatHealthChannelLines = (

--- a/src/commands/health-format.ts
+++ b/src/commands/health-format.ts
@@ -6,6 +6,7 @@ import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.
 import { formatChannelStatusState } from "../channels/plugins/status-state.js";
 import { isGatewayTransportError } from "../gateway/call.js";
 import type { ChannelAccountHealthSummary, HealthSummary } from "../gateway/health/types.js";
+import { shortenText } from "./text-format.js";
 
 export function formatGatewayClosedDiagnostic(err: unknown): string | undefined {
   if (!isGatewayTransportError(err) || err.kind !== "closed") {
@@ -140,7 +141,15 @@ const isProbeFailure = (summary: ChannelAccountHealthSummary): boolean => {
   return ok === false;
 };
 
-/** Formats one terse health line per channel, optionally including every account. */
+// Plugin diagnostics cross terminal/table trust boundaries; invisible Unicode
+// direction, surrogate, and line controls must not spoof the rendered status.
+const sanitizePluginHealthText = (value: string, maxLength: number): string =>
+  shortenText(
+    sanitizeTerminalText(value).replace(/[\p{Cf}\p{Cs}\p{Zl}\p{Zp}]/gu, ""),
+    maxLength,
+  );
+
+/** Formats channel health and actionable plugin failures for human CLI output. */
 export const formatHealthChannelLines = (
   summary: HealthSummary,
   opts: {
@@ -256,6 +265,23 @@ export const formatHealthChannelLines = (
             ? "configured"
             : "unknown";
     lines.push(`${label}: ${passiveState}`);
+  }
+
+  const pluginFailures = [
+    ...(summary.plugins?.errors ?? [])
+      .filter((plugin) => plugin.activationSource !== "disabled")
+      .map(({ id, error }) => ({ id, detail: error })),
+    ...(summary.plugins?.unavailable ?? []).map(({ id, diagnostic }) => ({
+      id,
+      detail: `configured-unavailable (${diagnostic.reason}): ${diagnostic.detail}`,
+    })),
+  ].toSorted((left, right) => left.id.localeCompare(right.id));
+  for (const { id, detail } of pluginFailures) {
+    const safeId = sanitizePluginHealthText(id, 80);
+    const safeDetail = sanitizePluginHealthText(detail, 160);
+    // Plugin ids can contain colons; keep the first-colon health label fixed so
+    // status tables cannot mistake an untrusted id for a successful state.
+    lines.push(`Plugin: failed - ${safeId}: ${safeDetail}`);
   }
   return lines;
 };

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -177,6 +177,18 @@ describe("healthCommand", () => {
       },
       sessions: agentSessions,
     });
+    snapshot.plugins = {
+      loaded: [],
+      errors: [
+        {
+          id: "openclaw-qqbot",
+          origin: "global",
+          activated: false,
+          activationSource: "explicit",
+          error: "missing required runtime\nretry after repair",
+        },
+      ],
+    };
     callGatewayMock.mockResolvedValueOnce(snapshot);
 
     await healthCommand({ json: true, timeoutMs: 5000, config: {} }, runtime as never);
@@ -187,6 +199,7 @@ describe("healthCommand", () => {
     expect(parsed.channels.whatsapp?.linked).toBe(true);
     expect(parsed.channels.telegram?.configured).toBe(true);
     expect(parsed.sessions.count).toBe(1);
+    expect(parsed.plugins).toStrictEqual(snapshot.plugins);
   });
 
   it("prints the gateway probe duration in text output", async () => {
@@ -201,6 +214,57 @@ describe("healthCommand", () => {
 
     const output = stripAnsi(runtime.log.mock.calls.map((call) => String(call[0])).join("\n"));
     expect(output).toContain("Gateway probe duration: 5ms");
+  });
+
+  it("prints actionable plugin failures without treating disabled records as failures", async () => {
+    const snapshot = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    snapshot.plugins = {
+      loaded: [],
+      errors: [
+        {
+          id: "openclaw-qqbot",
+          origin: "global",
+          activated: false,
+          activationSource: "explicit",
+          error: "missing buffered reply dispatcher",
+        },
+        {
+          id: "optional-broken",
+          origin: "workspace",
+          activated: false,
+          activationSource: "disabled",
+          error: "disabled plugin ignored",
+        },
+      ],
+      unavailable: [
+        {
+          id: "memory-owner",
+          state: "configured-unavailable",
+          diagnostic: {
+            kind: "plugin-verification",
+            reason: "missing-main-entry",
+            detail: "main entry missing",
+          },
+        },
+      ],
+    };
+    callGatewayMock.mockResolvedValueOnce(snapshot);
+
+    await healthCommand({ json: false, timeoutMs: 1000, config: {} }, runtime as never);
+
+    const output = stripAnsi(runtime.log.mock.calls.map((call) => String(call[0])).join("\n"));
+    expect(output).toContain(
+      "Plugin: failed - memory-owner: configured-unavailable (missing-main-entry): main entry missing",
+    );
+    expect(output).toContain(
+      "Plugin: failed - openclaw-qqbot: missing buffered reply dispatcher",
+    );
+    expect(output).not.toContain("optional-broken");
+    expect(runtime.exit).not.toHaveBeenCalled();
   });
 
   it("omits the probe duration for legacy gateway snapshots", async () => {

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -260,9 +260,7 @@ describe("healthCommand", () => {
     expect(output).toContain(
       "Plugin: failed - memory-owner: configured-unavailable (missing-main-entry): main entry missing",
     );
-    expect(output).toContain(
-      "Plugin: failed - openclaw-qqbot: missing buffered reply dispatcher",
-    );
+    expect(output).toContain("Plugin: failed - openclaw-qqbot: missing buffered reply dispatcher");
     expect(output).not.toContain("optional-broken");
     expect(runtime.exit).not.toHaveBeenCalled();
   });

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -237,12 +237,18 @@ describe("status.command-sections", () => {
   it("marks configured plugin registration failures as warnings without trusting plugin ids", () => {
     const rows = buildStatusHealthRows({
       health: {
+        ok: true,
+        ts: 0,
         durationMs: 42,
         channels: {
           qqbot: { accountId: "default", configured: true },
         },
         channelOrder: ["qqbot"],
         channelLabels: { qqbot: "QQ Bot" },
+        heartbeatSeconds: 60,
+        defaultAgentId: "main",
+        agents: [],
+        sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
         plugins: {
           loaded: [],
           errors: [
@@ -255,7 +261,7 @@ describe("status.command-sections", () => {
             },
           ],
         },
-      } as HealthSummary,
+      },
       formatHealthChannelLines,
       ok: (value) => `ok(${value})`,
       warn: (value) => `warn(${value})`,

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -1,5 +1,6 @@
 // Status command section tests cover footer, health, and report section rendering.
 import { describe, expect, it } from "vitest";
+import { formatHealthChannelLines } from "./health-format.js";
 import type { HealthSummary } from "./health.js";
 import {
   buildStatusFooterLines,
@@ -230,6 +231,45 @@ describe("status.command-sections", () => {
       { Item: "Forum", Status: "muted(OFF)", Detail: "not configured" },
       { Item: "Matrix", Status: "ok(LINKED)", Detail: "linked" },
       { Item: "Pager", Status: "warn(UNLINKED)", Detail: "not linked" },
+    ]);
+  });
+
+  it("marks configured plugin registration failures as warnings without trusting plugin ids", () => {
+    const rows = buildStatusHealthRows({
+      health: {
+        durationMs: 42,
+        channels: {
+          qqbot: { accountId: "default", configured: true },
+        },
+        channelOrder: ["qqbot"],
+        channelLabels: { qqbot: "QQ Bot" },
+        plugins: {
+          loaded: [],
+          errors: [
+            {
+              id: "qqbot:ok",
+              origin: "global",
+              activated: false,
+              activationSource: "explicit",
+              error: "missing buffered reply dispatcher",
+            },
+          ],
+        },
+      } as HealthSummary,
+      formatHealthChannelLines,
+      ok: (value) => `ok(${value})`,
+      warn: (value) => `warn(${value})`,
+      muted: (value) => `muted(${value})`,
+    });
+
+    expect(rows).toEqual([
+      { Item: "Gateway", Status: "ok(reachable)", Detail: "42ms" },
+      { Item: "QQ Bot", Status: "ok(OK)", Detail: "configured" },
+      {
+        Item: "Plugin",
+        Status: "warn(WARN)",
+        Detail: "failed - qqbot:ok: missing buffered reply dispatcher",
+      },
     ]);
   });
 


### PR DESCRIPTION
Refs #116258

This visibility-only fix does **not** resolve plugin metadata registration ownership, so the original issue must remain open.

## Root cause

Human health summaries could omit failed plugins when they were disabled or had hostile terminal text, leaving `health`, `status`, and Gateway CLI output without a visible failure signal.

## Fix

- Surface failed plugins consistently across the three human CLI summaries while intentionally skipping plugins that are only disabled.
- Sanitize IDs and detail text for ANSI plus Unicode bidi, zero-width, line-separator, surrogate, and other terminal-spoofing characters before bounded rendering.
- Keep JSON output and plugin loader ownership unchanged.

## Verification

- 65/65 focused owner tests passed remotely across the four relevant suites.
- Authenticated independent/security review and secret scan passed.
- Evidence: https://github.com/openclaw/openclaw/actions/runs/30752290943

## Agent Transcript

<details>
<summary>Redacted agent workflow transcript</summary>

- Maintainer authorized an isolated visibility-only fix while keeping issue #116258 open.
- The source lane traced missing human diagnostics to health-summary formatting, not plugin-loader registration.
- Adversarial review found Unicode terminal-spoofing gaps; the formatter was corrected to neutralize the risky categories before truncation.
- Independent reviewers verified disabled-only filtering, stable ordering, all three human consumers, and unchanged JSON behavior.
- Remote proof passed 65 focused tests; secret scanning found no findings.

</details>
