### PR TITLE
fix: avoid reusing an existing gateway on scheduled task launch

### DIFF
--- a/src/daemon/schtasks-control.ts
+++ b/src/daemon/schtasks-control.ts
@@ -123,11 +123,20 @@ async function shouldFallbackScheduledTaskLaunch(params: {
       return false;
     }
     if (
-      entries.some((entry) =>
-        normalizeLowercaseStringOrEmpty(entry.CommandLine ?? "")
+      entries.some((entry) => {
+        const processId = entry.ProcessId;
+        if (
+          typeof processId === "number" &&
+          Number.isFinite(processId) &&
+          processId > 0 &&
+          params.excludedPids?.has(processId)
+        ) {
+          return false;
+        }
+        return normalizeLowercaseStringOrEmpty(entry.CommandLine ?? "")
           .replaceAll("/", "\\")
-          .includes(scriptPathNeedle),
-      )
+          .includes(scriptPathNeedle);
+      })
     ) {
       return true;
     }

--- a/src/daemon/schtasks-control.ts
+++ b/src/daemon/schtasks-control.ts
@@ -58,9 +58,24 @@ function runtimeSignature(runtime: Awaited<ReturnType<typeof readScheduledTaskRu
     .join("|");
 }
 
+function readExistingProcessIds(): ReadonlySet<number> | undefined {
+  const snapshot = readWindowsProcessSnapshot();
+  if (!snapshot) {
+    return undefined;
+  }
+  return new Set(
+    snapshot.flatMap((entry) =>
+      typeof entry.ProcessId === "number" && Number.isFinite(entry.ProcessId) && entry.ProcessId > 0
+        ? [entry.ProcessId]
+        : [],
+    ),
+  );
+}
+
 async function shouldFallbackScheduledTaskLaunch(params: {
   env: GatewayServiceEnv;
   scriptPath: string;
+  excludedPids?: ReadonlySet<number>;
 }): Promise<boolean> {
   const readLaunchObservation = async (): Promise<{
     state: "running" | "not-yet-run" | "stopped-success" | "other";
@@ -90,6 +105,7 @@ async function shouldFallbackScheduledTaskLaunch(params: {
         params.env,
         { port: taskPort, probeHosts },
         command,
+        params.excludedPids,
       );
       if (ownedPids.length > 0) {
         return true;
@@ -129,6 +145,7 @@ async function shouldFallbackScheduledTaskLaunch(params: {
         manageGatewayPort
           ? (argv) => isGatewayArgv(argv, { allowGatewayBinary: true })
           : isNodeHostArgv,
+        params.excludedPids,
       ) != null
     );
   };
@@ -169,13 +186,18 @@ export async function runScheduledTaskOrThrow(params: {
   scriptPath: string;
   onMutation?: () => void;
 }): Promise<ScheduledTaskActivation> {
+  const existingProcessIds = readExistingProcessIds();
   const run = await execSchtasks(["/Run", "/TN", params.taskName]);
   if (run.code !== 0) {
     throw new Error(`schtasks run failed: ${run.stderr || run.stdout}`.trim());
   }
   params.onMutation?.();
   if (
-    !(await shouldFallbackScheduledTaskLaunch({ env: params.env, scriptPath: params.scriptPath }))
+    !(await shouldFallbackScheduledTaskLaunch({
+      env: params.env,
+      scriptPath: params.scriptPath,
+      excludedPids: existingProcessIds,
+    }))
   ) {
     return "scheduled-task";
   }

--- a/src/daemon/schtasks-process.ts
+++ b/src/daemon/schtasks-process.ts
@@ -67,6 +67,7 @@ export function findInstalledProcessPid(
   port: number,
   installedArguments: string[],
   matchesProcess: (argv: string[]) => boolean,
+  excludedPids?: ReadonlySet<number>,
 ): number | null {
   for (const entry of entries) {
     const commandLine = normalizeLowercaseStringOrEmpty(entry.CommandLine ?? "");
@@ -82,7 +83,7 @@ export function findInstalledProcessPid(
       continue;
     }
     const pid = getSnapshotProcessId(entry);
-    if (pid) {
+    if (pid && !excludedPids?.has(pid)) {
       return pid;
     }
   }
@@ -153,6 +154,7 @@ export async function resolveScheduledTaskOwnedGatewayPids(
   env: GatewayServiceEnv,
   context?: { port: number | null; probeHosts: readonly string[] },
   installedCommand?: GatewayServiceCommandConfig | null,
+  excludedPids?: ReadonlySet<number>,
 ): Promise<number[]> {
   const command =
     installedCommand === undefined
@@ -177,7 +179,13 @@ export async function resolveScheduledTaskOwnedGatewayPids(
     if (!snapshot) {
       return [];
     }
-    const pid = findInstalledProcessPid(snapshot, port, installedArguments, () => true);
+    const pid = findInstalledProcessPid(
+      snapshot,
+      port,
+      installedArguments,
+      () => true,
+      excludedPids,
+    );
     if (pid) {
       // The task is single-instance; persisted argv identifies its process before it starts listening.
       return [pid];
@@ -191,7 +199,11 @@ export async function resolveScheduledTaskOwnedGatewayPids(
   }).catch(() => null);
   if (diagnostics?.status === "busy") {
     for (const listener of diagnostics.listeners) {
-      if (typeof listener.pid !== "number" || !listener.commandLine) {
+      if (
+        typeof listener.pid !== "number" ||
+        excludedPids?.has(listener.pid) ||
+        !listener.commandLine
+      ) {
         continue;
       }
       const argv = parseCmdScriptCommandLine(listener.commandLine);

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -1578,11 +1578,12 @@ describe("Windows startup fallback", () => {
     });
   });
 
-  it("does not relaunch the task script when the scheduled task process is already starting", async () => {
+  it("does not relaunch a new task script process when it is already starting", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       vi.spyOn(process, "platform", "get").mockReturnValue("win32");
       const taskScriptPath = resolveTaskScriptPath(env);
       fastForwardTaskStartWait();
+      let processSnapshotCount = 0;
       spawnSync.mockImplementation((command, args) => {
         if (
           command === getWindowsPowerShellExePath() &&
@@ -1591,15 +1592,20 @@ describe("Windows startup fallback", () => {
             "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
           )
         ) {
+          const processId = processSnapshotCount++ === 0 ? undefined : 4242;
           return {
             pid: 0,
             output: [null, "", ""],
-            stdout: JSON.stringify([
-              {
-                ProcessId: 4242,
-                CommandLine: `cmd.exe /d /s /c "${taskScriptPath}"`,
-              },
-            ]),
+            stdout: JSON.stringify(
+              processId === undefined
+                ? []
+                : [
+                    {
+                      ProcessId: processId,
+                      CommandLine: `cmd.exe /d /s /c "${taskScriptPath}"`,
+                    },
+                  ],
+            ),
             stderr: "",
             status: 0,
             signal: null,
@@ -1619,6 +1625,35 @@ describe("Windows startup fallback", () => {
       await installGatewayScheduledTask(env);
 
       expect(spawn).not.toHaveBeenCalled();
+    });
+  });
+
+  it("falls back when a pre-existing task script process remains after /Run", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const taskScriptPath = resolveTaskScriptPath(env);
+      fastForwardTaskStartWait();
+      spawnSync.mockImplementation((command, args) =>
+        command === getWindowsPowerShellExePath() &&
+        Array.isArray(args) &&
+        args.includes(
+          "Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress",
+        )
+          ? makeSpawnSyncResult({
+              stdout: JSON.stringify([
+                {
+                  ProcessId: 4242,
+                  CommandLine: `cmd.exe /d /s /c "${taskScriptPath}"`,
+                },
+              ]),
+            })
+          : makeSpawnSyncResult(),
+      );
+      addAcceptedRunNeverStartsResponses();
+
+      await installGatewayScheduledTask(env);
+
+      expectStartupFallbackSpawn();
     });
   });
 

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -94,6 +94,7 @@ const {
   uninstallScheduledTask,
 } = await import("./schtasks.js");
 const { removeStartupEntries } = await import("./schtasks-runtime.js");
+const { resolveScheduledTaskOwnedGatewayPids } = await import("./schtasks-process.js");
 
 function resolveStartupEntryPath(env: Record<string, string>, extension = "cmd") {
   const taskName = env.OPENCLAW_WINDOWS_TASK_NAME ?? "OpenClaw Gateway";
@@ -912,7 +913,7 @@ describe("Windows startup fallback", () => {
 
       await installGatewayScheduledTask(env, new PassThrough(), "19433");
 
-      expect(processQueries).toBe(5);
+      expect(processQueries).toBe(7);
       await expect(fs.access(startupEntryPath)).rejects.toThrow();
     });
   });
@@ -1437,7 +1438,6 @@ describe("Windows startup fallback", () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       fastForwardTaskStartWait();
       addAcceptedRunCleanExitResponses();
-
       await installGatewayScheduledTask(env);
 
       expectStartupFallbackSpawn();
@@ -1701,6 +1701,42 @@ describe("Windows startup fallback", () => {
       expect(runtime.detail).toContain("Gateway process detected");
       expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
       expect(inspectPortUsage).not.toHaveBeenCalled();
+    });
+  });
+
+  it("excludes a pre-existing gateway process from task ownership", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      spawnSync.mockImplementation((command, args) =>
+        command === getWindowsPowerShellExePath() &&
+        Array.isArray(args) &&
+        args.includes(NODE_PROCESS_QUERY)
+          ? makeSpawnSyncResult({
+              stdout: JSON.stringify([
+                {
+                  ProcessId: 4242,
+                  CommandLine: "node gateway.js --port 18789",
+                },
+              ]),
+            })
+          : makeSpawnSyncResult(),
+      );
+      const command = {
+        programArguments: ["node", "gateway.js", "--port", "18789"],
+        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+      };
+
+      await expect(
+        resolveScheduledTaskOwnedGatewayPids(env, { port: 18789, probeHosts: [] }, command),
+      ).resolves.toEqual([4242]);
+      await expect(
+        resolveScheduledTaskOwnedGatewayPids(
+          env,
+          { port: 18789, probeHosts: [] },
+          command,
+          new Set([4242]),
+        ),
+      ).resolves.toEqual([]);
     });
   });
 


### PR DESCRIPTION
Closes #91144

AI-assisted: Codex

## What Problem This Solves

Fixes an issue where Windows users who already had a foreground gateway process running could have a Scheduled Task launch incorrectly treated as a new gateway start. The existing process was then mistaken for the task-owned process during startup fallback handling.

## Why This Change Was Made

Capture the Windows process snapshot immediately before invoking the Scheduled Task and exclude those existing process IDs from every task-launch evidence probe. This keeps the change within the Scheduled Task process-detection boundary and leaves genuinely started task processes eligible for detection.

## User Impact

Scheduled Task startup no longer reuses a gateway process that was already running before the task launch, so Windows startup status and fallback behavior reflect the actual task lifecycle.

## Evidence

- Current-head Windows CI: [checks-windows-node-test](https://github.com/openclaw/openclaw/actions/runs/30757196005/job/91521367660) passed on `2edad3a07da7fd021a022e668c59288331a01a30`; its log shows `src/daemon/schtasks.startup-fallback.test.ts` with `1 passed` file and `64 passed` tests.
- Supporting checks: [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/30757196005/job/91522960203) passed for the same head, with the full applicable CI matrix green.
- Merge result: the current head is directly based on the current PR base `b84e14f22255612cc8473ad132221f18c0265bcc`; this exact head is the rebase result tested by the green CI run.
- Regression coverage exercises the Scheduled Task activation path with a pre-existing process whose command line contains the task script path, verifies that the baseline PID is excluded, and confirms that the fallback launcher is selected.
- Supporting static checks: `git diff --check` passed before commit; the current-head `check-lint` job passed.
- Proof boundary: this evidence proves the Windows CI test and task-ownership decision paths, including the new activation-level regression. It does not claim a native installed Task Scheduler lifecycle outside the CI test harness or unrelated startup mechanisms and operating systems.
- Exact head: `2edad3a07da7fd021a022e668c59288331a01a30`
