### PR TITLE
fix(qa): prioritize and stream native suite work

### DIFF
--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -1952,6 +1952,7 @@ describe("qa suite runtime launcher", () => {
 
   it("runs script scenarios after flow Gateways stop without serializing Playwright", async () => {
     const repoRoot = await makeTempRepo("qa-suite-script-isolation-");
+    vi.stubEnv("OPENCLAW_QA_SUITE_PROGRESS", "1");
     const flow = blockNextQaFlowSuite();
 
     const runPromise = runQaSuite({
@@ -1985,6 +1986,8 @@ describe("qa suite runtime launcher", () => {
     expect(runQaTestFileScenarios).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
+        onCommandOutput: expect.any(Function),
+        progress: expect.any(Function),
         scenarios: [
           expect.objectContaining({ execution: expect.objectContaining({ kind: "script" }) }),
         ],

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -2010,6 +2010,39 @@ describe("qa suite runtime launcher", () => {
       params.onCommandOutput?.("stderr", Buffer.from("rer synthetic-bearer-secret-987654321\n"));
       params.onCommandOutput?.("stderr", Buffer.from("#"));
       params.onCommandOutput?.("stderr", Buffer.from("#[error]attacker\n"));
+      params.onCommandOutput?.("stdout", Buffer.from("prefix -----BEGIN RSA PRIVATE KEY-----\n"));
+      params.onCommandOutput?.("stdout", Buffer.from("synthetic-pem-secret-body-22334455\n"));
+      params.onCommandOutput?.("stdout", Buffer.from("-----END RSA PRIVATE KEY-----\n"));
+      params.onCommandOutput?.(
+        "stdout",
+        Buffer.from(`${"x".repeat(16_384)}-----BEGIN EC PRIVATE KEY-----\n`),
+      );
+      params.onCommandOutput?.("stdout", Buffer.from("synthetic-oversized-pem-secret-body\n"));
+      params.onCommandOutput?.(
+        "stdout",
+        Buffer.from("-----END EC PRIVATE KEY-----\nsafe PEM recovery\n"),
+      );
+      params.onCommandOutput?.("stdout", Buffer.from(`${"x".repeat(16_380)}-----BE`));
+      params.onCommandOutput?.("stdout", Buffer.from("GIN OPENSSH PRIVATE KEY-----\n"));
+      params.onCommandOutput?.("stdout", Buffer.from("synthetic-split-oversized-pem-secret\n"));
+      params.onCommandOutput?.("stdout", Buffer.from("-----END OPENSSH PRI"));
+      params.onCommandOutput?.("stdout", Buffer.from("VATE KEY-----\nsafe split PEM recovery\n"));
+      params.onCommandOutput?.("stderr", Buffer.from("channels.buzz.authTag: [\r\n"));
+      params.onCommandOutput?.("stderr", Buffer.from('  "synthetic-auth-tag-secret",\r\n'));
+      params.onCommandOutput?.("stderr", Buffer.from('  "synthetic-auth-signature"\r\n]\r\n'));
+      params.onCommandOutput?.("stderr", Buffer.from('  "authTag": [\n'));
+      params.onCommandOutput?.("stderr", Buffer.from('    "synthetic-json-auth-tag-secret"\n]\n'));
+      params.onCommandOutput?.(
+        "stderr",
+        Buffer.from(`${"x".repeat(16_384)} channels.buzz.authTag: [\n`),
+      );
+      params.onCommandOutput?.("stderr", Buffer.from('"synthetic-oversized-auth-tag-secret"\n]\n'));
+      params.onCommandOutput?.("stderr", Buffer.from(`${"x".repeat(16_375)} channels.buzz.auth`));
+      params.onCommandOutput?.("stderr", Buffer.from("Tag: [\n"));
+      params.onCommandOutput?.(
+        "stderr",
+        Buffer.from('"synthetic-split-oversized-auth-secret"\n]\n'),
+      );
       params.onCommandOutput?.("stderr", Buffer.from(`OPENAI_API_KEY=${"x".repeat(20_000)}`));
       params.onCommandOutput?.("stderr", Buffer.from("discarded-secret\nsafe output resumed\n"));
       params.onCommandOutput?.("stdout", Buffer.from("OPENAI_API_KEY="));
@@ -2024,6 +2057,24 @@ describe("qa suite runtime launcher", () => {
         outputDir: ".artifacts/qa-e2e/safe-native-output",
         scenarioIds: ["docker-npm-onboard-channel-agent"],
       });
+      const unsafeTailFragments = [
+        "OPENAI_API_K",
+        "EY=synthetic-cross-forwarder-secret-55667788",
+        ":",
+        ":stop-commands::cross-forwarder-attacker",
+        "-----BEGIN OPENSSH PRIVATE KEY-----\nsynthetic-incomplete-private-key",
+      ];
+      for (const [index, fragment] of unsafeTailFragments.entries()) {
+        runQaTestFileScenarios.mockImplementationOnce(async (params) => {
+          params.onCommandOutput?.("stdout", Buffer.from(fragment));
+          return await defaultTestFileImplementation(params);
+        });
+        await runQaSuite({
+          repoRoot,
+          outputDir: `.artifacts/qa-e2e/safe-native-output-${index}`,
+          scenarioIds: ["docker-npm-onboard-channel-agent"],
+        });
+      }
 
       const stdout = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join("");
       const stderr = stderrWrite.mock.calls.map(([chunk]) => String(chunk)).join("");
@@ -2031,12 +2082,26 @@ describe("qa suite runtime launcher", () => {
       expect(stdout).toContain(": :stop-commands::attacker");
       expect(stdout).not.toContain("synthetic-split-secret-123456789");
       expect(stdout).not.toContain("synthetic-trailing-secret-1122334455");
+      expect(stdout).not.toContain("synthetic-pem-secret-body-22334455");
+      expect(stdout).not.toContain("synthetic-oversized-pem-secret-body");
+      expect(stdout).toContain("safe PEM recovery");
+      expect(stdout).not.toContain("synthetic-split-oversized-pem-secret");
+      expect(stdout).toContain("safe split PEM recovery");
+      expect(stdout).not.toContain("synthetic-cross-forwarder-secret-55667788");
+      expect(stdout).not.toContain("synthetic-incomplete-private-key");
+      expect(stdout).not.toContain("cross-forwarder-attacker");
       expect(stdout).not.toContain("::stop-commands::");
       expect(stderr).toContain("Bearer <redacted>");
       expect(stderr).toContain("# #[error]attacker");
+      expect(stderr).toContain("channels.buzz.authTag: <redacted>");
       expect(stderr).toContain("native output line omitted: exceeded safe limit");
       expect(stderr).toContain("safe output resumed");
       expect(stderr).not.toContain("synthetic-bearer-secret-987654321");
+      expect(stderr).not.toContain("synthetic-auth-tag-secret");
+      expect(stderr).not.toContain("synthetic-auth-signature");
+      expect(stderr).not.toContain("synthetic-json-auth-tag-secret");
+      expect(stderr).not.toContain("synthetic-oversized-auth-tag-secret");
+      expect(stderr).not.toContain("synthetic-split-oversized-auth-secret");
       expect(stderr).not.toContain("discarded-secret");
       expect(stderr).not.toContain("##[error]");
     } finally {

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -2032,6 +2032,34 @@ describe("qa suite runtime launcher", () => {
       params.onCommandOutput?.("stderr", Buffer.from('  "synthetic-auth-signature"\r\n]\r\n'));
       params.onCommandOutput?.("stderr", Buffer.from('  "authTag": [\n'));
       params.onCommandOutput?.("stderr", Buffer.from('    "synthetic-json-auth-tag-secret"\n]\n'));
+      params.onCommandOutput?.("stderr", Buffer.from("channels.buzz.authTag:\n"));
+      params.onCommandOutput?.(
+        "stderr",
+        Buffer.from('[\n"synthetic-line-separated-auth-secret"\n]\n'),
+      );
+      params.onCommandOutput?.("stderr", Buffer.from('  "authTag":\r\n'));
+      params.onCommandOutput?.(
+        "stderr",
+        Buffer.from('[\r\n"synthetic-quoted-line-separated-auth-secret"\r\n]\r\n'),
+      );
+      params.onCommandOutput?.("stderr", Buffer.from('  "authTag"\r\n'));
+      params.onCommandOutput?.("stderr", Buffer.from(":\r\n"));
+      params.onCommandOutput?.(
+        "stderr",
+        Buffer.from('[\r\n"synthetic-key-colon-separated-auth-secret"\r\n]\r\n'),
+      );
+      params.onCommandOutput?.(
+        "stderr",
+        Buffer.from("authTag validation: channels.buzz.authTag:\n"),
+      );
+      params.onCommandOutput?.(
+        "stderr",
+        Buffer.from('[\n"synthetic-repeated-mention-auth-secret"\n]\n'),
+      );
+      params.onCommandOutput?.("stderr", Buffer.from("channels.buzz.AUTHTAG:\n"));
+      params.onCommandOutput?.("stderr", Buffer.from('[\n"synthetic-mixed-case-auth-secret"\n]\n'));
+      params.onCommandOutput?.("stderr", Buffer.from("ordinary mention of authTag\n"));
+      params.onCommandOutput?.("stderr", Buffer.from("ordinary progress resumed\n"));
       params.onCommandOutput?.(
         "stderr",
         Buffer.from(`${"x".repeat(16_384)} channels.buzz.authTag: [\n`),
@@ -2100,6 +2128,12 @@ describe("qa suite runtime launcher", () => {
       expect(stderr).not.toContain("synthetic-auth-tag-secret");
       expect(stderr).not.toContain("synthetic-auth-signature");
       expect(stderr).not.toContain("synthetic-json-auth-tag-secret");
+      expect(stderr).not.toContain("synthetic-line-separated-auth-secret");
+      expect(stderr).not.toContain("synthetic-quoted-line-separated-auth-secret");
+      expect(stderr).not.toContain("synthetic-key-colon-separated-auth-secret");
+      expect(stderr).not.toContain("synthetic-repeated-mention-auth-secret");
+      expect(stderr).not.toContain("synthetic-mixed-case-auth-secret");
+      expect(stderr).toContain("ordinary progress resumed");
       expect(stderr).not.toContain("synthetic-oversized-auth-tag-secret");
       expect(stderr).not.toContain("synthetic-split-oversized-auth-secret");
       expect(stderr).not.toContain("discarded-secret");

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -1986,7 +1986,6 @@ describe("qa suite runtime launcher", () => {
     expect(runQaTestFileScenarios).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        onCommandOutput: expect.any(Function),
         progress: expect.any(Function),
         scenarios: [
           expect.objectContaining({ execution: expect.objectContaining({ kind: "script" }) }),
@@ -1995,149 +1994,51 @@ describe("qa suite runtime launcher", () => {
     );
   });
 
-  it("redacts split native output and neutralizes CI commands before streaming", async () => {
-    const repoRoot = await makeTempRepo("qa-suite-safe-native-output-");
+  it("streams native owner progress without exposing child output to CI", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-safe-native-progress-");
     vi.stubEnv("OPENCLAW_QA_SUITE_PROGRESS", "1");
     const stdoutWrite = vi.spyOn(process.stdout, "write").mockReturnValue(true);
     const stderrWrite = vi.spyOn(process.stderr, "write").mockReturnValue(true);
     const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
     runQaTestFileScenarios.mockImplementationOnce(async (params) => {
-      params.onCommandOutput?.("stdout", Buffer.from("OPENAI_API_"));
-      params.onCommandOutput?.("stdout", Buffer.from("KEY=synthetic-split-secret-123456789\n"));
-      params.onCommandOutput?.("stdout", Buffer.from("::stop-"));
-      params.onCommandOutput?.("stdout", Buffer.from("commands::attacker\n"));
-      params.onCommandOutput?.("stderr", Buffer.from("Authorization: Bea"));
-      params.onCommandOutput?.("stderr", Buffer.from("rer synthetic-bearer-secret-987654321\n"));
-      params.onCommandOutput?.("stderr", Buffer.from("#"));
-      params.onCommandOutput?.("stderr", Buffer.from("#[error]attacker\n"));
-      params.onCommandOutput?.("stdout", Buffer.from("prefix -----BEGIN RSA PRIVATE KEY-----\n"));
-      params.onCommandOutput?.("stdout", Buffer.from("synthetic-pem-secret-body-22334455\n"));
-      params.onCommandOutput?.("stdout", Buffer.from("-----END RSA PRIVATE KEY-----\n"));
-      params.onCommandOutput?.(
-        "stdout",
-        Buffer.from(`${"x".repeat(16_384)}-----BEGIN EC PRIVATE KEY-----\n`),
+      params.progress?.("native docker-batch start scenarios=1 timeoutMs=60000");
+      expect(stderrWrite).toHaveBeenCalledWith(
+        expect.stringContaining("[qa-suite] native docker-batch start"),
       );
-      params.onCommandOutput?.("stdout", Buffer.from("synthetic-oversized-pem-secret-body\n"));
-      params.onCommandOutput?.(
-        "stdout",
-        Buffer.from("-----END EC PRIVATE KEY-----\nsafe PEM recovery\n"),
+      const childOutput = Buffer.from(
+        [
+          "OPENAI_API_KEY=synthetic-provider-secret",
+          'warning: invalid value " channels.buzz.authTag:',
+          "[",
+          '  "synthetic-auth-secret"',
+          "]",
+          "::stop-commands::synthetic-runner-attack",
+          "##[error]synthetic-runner-attack",
+        ].join("\n"),
       );
-      params.onCommandOutput?.("stdout", Buffer.from(`${"x".repeat(16_380)}-----BE`));
-      params.onCommandOutput?.("stdout", Buffer.from("GIN OPENSSH PRIVATE KEY-----\n"));
-      params.onCommandOutput?.("stdout", Buffer.from("synthetic-split-oversized-pem-secret\n"));
-      params.onCommandOutput?.("stdout", Buffer.from("-----END OPENSSH PRI"));
-      params.onCommandOutput?.("stdout", Buffer.from("VATE KEY-----\nsafe split PEM recovery\n"));
-      params.onCommandOutput?.("stderr", Buffer.from("channels.buzz.authTag: [\r\n"));
-      params.onCommandOutput?.("stderr", Buffer.from('  "synthetic-auth-tag-secret",\r\n'));
-      params.onCommandOutput?.("stderr", Buffer.from('  "synthetic-auth-signature"\r\n]\r\n'));
-      params.onCommandOutput?.("stderr", Buffer.from('  "authTag": [\n'));
-      params.onCommandOutput?.("stderr", Buffer.from('    "synthetic-json-auth-tag-secret"\n]\n'));
-      params.onCommandOutput?.("stderr", Buffer.from("channels.buzz.authTag:\n"));
-      params.onCommandOutput?.(
-        "stderr",
-        Buffer.from('[\n"synthetic-line-separated-auth-secret"\n]\n'),
-      );
-      params.onCommandOutput?.("stderr", Buffer.from('  "authTag":\r\n'));
-      params.onCommandOutput?.(
-        "stderr",
-        Buffer.from('[\r\n"synthetic-quoted-line-separated-auth-secret"\r\n]\r\n'),
-      );
-      params.onCommandOutput?.("stderr", Buffer.from('  "authTag"\r\n'));
-      params.onCommandOutput?.("stderr", Buffer.from(":\r\n"));
-      params.onCommandOutput?.(
-        "stderr",
-        Buffer.from('[\r\n"synthetic-key-colon-separated-auth-secret"\r\n]\r\n'),
-      );
-      params.onCommandOutput?.(
-        "stderr",
-        Buffer.from("authTag validation: channels.buzz.authTag:\n"),
-      );
-      params.onCommandOutput?.(
-        "stderr",
-        Buffer.from('[\n"synthetic-repeated-mention-auth-secret"\n]\n'),
-      );
-      params.onCommandOutput?.("stderr", Buffer.from("channels.buzz.AUTHTAG:\n"));
-      params.onCommandOutput?.("stderr", Buffer.from('[\n"synthetic-mixed-case-auth-secret"\n]\n'));
-      params.onCommandOutput?.("stderr", Buffer.from("ordinary mention of authTag\n"));
-      params.onCommandOutput?.("stderr", Buffer.from("ordinary progress resumed\n"));
-      params.onCommandOutput?.(
-        "stderr",
-        Buffer.from(`${"x".repeat(16_384)} channels.buzz.authTag: [\n`),
-      );
-      params.onCommandOutput?.("stderr", Buffer.from('"synthetic-oversized-auth-tag-secret"\n]\n'));
-      params.onCommandOutput?.("stderr", Buffer.from(`${"x".repeat(16_375)} channels.buzz.auth`));
-      params.onCommandOutput?.("stderr", Buffer.from("Tag: [\n"));
-      params.onCommandOutput?.(
-        "stderr",
-        Buffer.from('"synthetic-split-oversized-auth-secret"\n]\n'),
-      );
-      params.onCommandOutput?.("stderr", Buffer.from(`OPENAI_API_KEY=${"x".repeat(20_000)}`));
-      params.onCommandOutput?.("stderr", Buffer.from("discarded-secret\nsafe output resumed\n"));
-      params.onCommandOutput?.("stdout", Buffer.from("OPENAI_API_KEY="));
-      params.onCommandOutput?.("stdout", Buffer.from("synthetic-trailing-secret-1122334455"));
-      expect(stdoutWrite).toHaveBeenCalled();
+      params.onCommandOutput?.("stdout", childOutput);
+      params.onCommandOutput?.("stderr", childOutput);
       return await defaultTestFileImplementation(params);
     });
 
     try {
       await runQaSuite({
         repoRoot,
-        outputDir: ".artifacts/qa-e2e/safe-native-output",
+        outputDir: ".artifacts/qa-e2e/safe-native-progress",
         scenarioIds: ["docker-npm-onboard-channel-agent"],
       });
-      const unsafeTailFragments = [
-        "OPENAI_API_K",
-        "EY=synthetic-cross-forwarder-secret-55667788",
-        ":",
-        ":stop-commands::cross-forwarder-attacker",
-        "-----BEGIN OPENSSH PRIVATE KEY-----\nsynthetic-incomplete-private-key",
-      ];
-      for (const [index, fragment] of unsafeTailFragments.entries()) {
-        runQaTestFileScenarios.mockImplementationOnce(async (params) => {
-          params.onCommandOutput?.("stdout", Buffer.from(fragment));
-          return await defaultTestFileImplementation(params);
-        });
-        await runQaSuite({
-          repoRoot,
-          outputDir: `.artifacts/qa-e2e/safe-native-output-${index}`,
-          scenarioIds: ["docker-npm-onboard-channel-agent"],
-        });
-      }
 
-      const stdout = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join("");
-      const stderr = stderrWrite.mock.calls.map(([chunk]) => String(chunk)).join("");
-      expect(stdout).toContain("OPENAI_API_KEY=<redacted>");
-      expect(stdout).toContain(": :stop-commands::attacker");
-      expect(stdout).not.toContain("synthetic-split-secret-123456789");
-      expect(stdout).not.toContain("synthetic-trailing-secret-1122334455");
-      expect(stdout).not.toContain("synthetic-pem-secret-body-22334455");
-      expect(stdout).not.toContain("synthetic-oversized-pem-secret-body");
-      expect(stdout).toContain("safe PEM recovery");
-      expect(stdout).not.toContain("synthetic-split-oversized-pem-secret");
-      expect(stdout).toContain("safe split PEM recovery");
-      expect(stdout).not.toContain("synthetic-cross-forwarder-secret-55667788");
-      expect(stdout).not.toContain("synthetic-incomplete-private-key");
-      expect(stdout).not.toContain("cross-forwarder-attacker");
-      expect(stdout).not.toContain("::stop-commands::");
-      expect(stderr).toContain("Bearer <redacted>");
-      expect(stderr).toContain("# #[error]attacker");
-      expect(stderr).toContain("channels.buzz.authTag: <redacted>");
-      expect(stderr).toContain("native output line omitted: exceeded safe limit");
-      expect(stderr).toContain("safe output resumed");
-      expect(stderr).not.toContain("synthetic-bearer-secret-987654321");
-      expect(stderr).not.toContain("synthetic-auth-tag-secret");
-      expect(stderr).not.toContain("synthetic-auth-signature");
-      expect(stderr).not.toContain("synthetic-json-auth-tag-secret");
-      expect(stderr).not.toContain("synthetic-line-separated-auth-secret");
-      expect(stderr).not.toContain("synthetic-quoted-line-separated-auth-secret");
-      expect(stderr).not.toContain("synthetic-key-colon-separated-auth-secret");
-      expect(stderr).not.toContain("synthetic-repeated-mention-auth-secret");
-      expect(stderr).not.toContain("synthetic-mixed-case-auth-secret");
-      expect(stderr).toContain("ordinary progress resumed");
-      expect(stderr).not.toContain("synthetic-oversized-auth-tag-secret");
-      expect(stderr).not.toContain("synthetic-split-oversized-auth-secret");
-      expect(stderr).not.toContain("discarded-secret");
-      expect(stderr).not.toContain("##[error]");
+      const runnerParams = runQaTestFileScenarios.mock.calls[0]?.[0];
+      expect(runnerParams?.progress).toEqual(expect.any(Function));
+      expect(runnerParams).not.toHaveProperty("onCommandOutput");
+      const output = [...stdoutWrite.mock.calls, ...stderrWrite.mock.calls]
+        .map(([chunk]) => String(chunk))
+        .join("");
+      expect(output).toContain("[qa-suite] native docker-batch start");
+      expect(output).not.toContain("synthetic-provider-secret");
+      expect(output).not.toContain("synthetic-auth-secret");
+      expect(output).not.toContain("::stop-commands::");
+      expect(output).not.toContain("##[error]");
     } finally {
       stdoutWrite.mockRestore();
       stderrWrite.mockRestore();

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -1995,6 +1995,56 @@ describe("qa suite runtime launcher", () => {
     );
   });
 
+  it("redacts split native output and neutralizes CI commands before streaming", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-safe-native-output-");
+    vi.stubEnv("OPENCLAW_QA_SUITE_PROGRESS", "1");
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
+    runQaTestFileScenarios.mockImplementationOnce(async (params) => {
+      params.onCommandOutput?.("stdout", Buffer.from("OPENAI_API_"));
+      params.onCommandOutput?.("stdout", Buffer.from("KEY=synthetic-split-secret-123456789\n"));
+      params.onCommandOutput?.("stdout", Buffer.from("::stop-"));
+      params.onCommandOutput?.("stdout", Buffer.from("commands::attacker\n"));
+      params.onCommandOutput?.("stderr", Buffer.from("Authorization: Bea"));
+      params.onCommandOutput?.("stderr", Buffer.from("rer synthetic-bearer-secret-987654321\n"));
+      params.onCommandOutput?.("stderr", Buffer.from("#"));
+      params.onCommandOutput?.("stderr", Buffer.from("#[error]attacker\n"));
+      params.onCommandOutput?.("stderr", Buffer.from(`OPENAI_API_KEY=${"x".repeat(20_000)}`));
+      params.onCommandOutput?.("stderr", Buffer.from("discarded-secret\nsafe output resumed\n"));
+      params.onCommandOutput?.("stdout", Buffer.from("OPENAI_API_KEY="));
+      params.onCommandOutput?.("stdout", Buffer.from("synthetic-trailing-secret-1122334455"));
+      expect(stdoutWrite).toHaveBeenCalled();
+      return await defaultTestFileImplementation(params);
+    });
+
+    try {
+      await runQaSuite({
+        repoRoot,
+        outputDir: ".artifacts/qa-e2e/safe-native-output",
+        scenarioIds: ["docker-npm-onboard-channel-agent"],
+      });
+
+      const stdout = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join("");
+      const stderr = stderrWrite.mock.calls.map(([chunk]) => String(chunk)).join("");
+      expect(stdout).toContain("OPENAI_API_KEY=<redacted>");
+      expect(stdout).toContain(": :stop-commands::attacker");
+      expect(stdout).not.toContain("synthetic-split-secret-123456789");
+      expect(stdout).not.toContain("synthetic-trailing-secret-1122334455");
+      expect(stdout).not.toContain("::stop-commands::");
+      expect(stderr).toContain("Bearer <redacted>");
+      expect(stderr).toContain("# #[error]attacker");
+      expect(stderr).toContain("native output line omitted: exceeded safe limit");
+      expect(stderr).toContain("safe output resumed");
+      expect(stderr).not.toContain("synthetic-bearer-secret-987654321");
+      expect(stderr).not.toContain("discarded-secret");
+      expect(stderr).not.toContain("##[error]");
+    } finally {
+      stdoutWrite.mockRestore();
+      stderrWrite.mockRestore();
+    }
+  });
+
   it("settles flow and native work, then runs serial scripts before a bounded parallel tail", async () => {
     const repoRoot = await makeTempRepo("qa-suite-parallel-scripts-");
     const defaultFlowImplementation = requireDefaultQaFlowSuiteImplementation();

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -2054,6 +2054,7 @@ describe("qa suite runtime launcher", () => {
 
   it("runs script scenarios after flow Gateways stop without serializing Playwright", async () => {
     const repoRoot = await makeTempRepo("qa-suite-script-isolation-");
+    vi.stubEnv("OPENCLAW_QA_SUITE_PROGRESS", "1");
     let releaseFlow!: () => void;
     let markFlowStarted!: () => void;
     const flowStarted = new Promise<void>((resolve) => {
@@ -2117,6 +2118,8 @@ describe("qa suite runtime launcher", () => {
     expect(runQaTestFileScenarios).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
+        onCommandOutput: expect.any(Function),
+        progress: expect.any(Function),
         scenarios: [
           expect.objectContaining({ execution: expect.objectContaining({ kind: "script" }) }),
         ],

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -432,13 +432,25 @@ function createQaNativeOutputForwarder() {
     stdout: { decoder: new StringDecoder("utf8"), pending: "" },
     stderr: { decoder: new StringDecoder("utf8"), pending: "" },
   };
+  const authTagAssignmentState = (text: string): "prefix" | "array" | undefined => {
+    for (const match of text.matchAll(/(?:^|[^\w])"?authTag"?/giu)) {
+      const suffix = text.slice(match.index + match[0].length);
+      if (/^\s*[:=]\s*\[/u.test(suffix)) {
+        return "array";
+      }
+      if (/^\s*(?:[:=]\s*)?$/u.test(suffix)) {
+        return "prefix";
+      }
+    }
+    return undefined;
+  };
   const endsMultilineSecret = (kind: MultilineSecret, text: string) =>
     kind === "pem" ? /-----END [A-Z ]*PRIVATE KEY-----/u.test(text) : /\]\s*[,}\r\n]*$/u.test(text);
   const detectMultilineSecret = (text: string): MultilineSecret | undefined => {
     if (/-----BEGIN [A-Z ]*PRIVATE KEY-----/u.test(text)) {
       return "pem";
     }
-    if (/(?:^|[^\w])"?authTag"?\s*[:=]\s*\[/u.test(text)) {
+    if (authTagAssignmentState(text)) {
       return "authTag";
     }
     return undefined;
@@ -497,6 +509,9 @@ function createQaNativeOutputForwarder() {
         output.pending += segment;
         if (complete) {
           output.multiline ??= detectMultilineSecret(output.pending);
+          if (output.multiline === "authTag" && !authTagAssignmentState(output.pending)) {
+            output.multiline = detectMultilineSecret(output.pending);
+          }
           if (output.multiline && !endsMultilineSecret(output.multiline, output.pending)) {
             continue;
           }

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -43,10 +43,12 @@ import {
 import { createQaSuiteProgressController } from "./suite-progress.js";
 import {
   buildQaSuiteSummaryJson,
+  shouldLogQaSuiteProgress,
   type QaSuiteResult,
   type QaSuiteRunParams,
   type QaSuiteScenarioResult,
   type QaSuiteSummaryJson,
+  writeQaSuiteProgress,
 } from "./suite.js";
 import * as dockerBatch from "./test-file-scenario-docker-batch.js";
 import {
@@ -423,10 +425,19 @@ async function runQaTestFileSuiteFromRuntime(params: {
   const outputDir = await resolveQaSuiteOutputDir(repoRoot, runParams?.outputDir);
   const providerMode = normalizeQaProviderMode(runParams?.providerMode ?? DEFAULT_QA_PROVIDER_MODE);
   const primaryModel = runParams?.primaryModel?.trim() || defaultQaModelForMode(providerMode);
+  const progressEnabled = shouldLogQaSuiteProgress();
   return await runQaTestFileScenarios({
     evidenceMode: runParams?.evidenceMode,
     ...(params.env ? { env: params.env, envMode: "replace" as const } : {}),
     ...(runParams?.failFast ? { failFast: true } : {}),
+    ...(progressEnabled
+      ? {
+          onCommandOutput: (stream: "stderr" | "stdout", chunk: Buffer) => {
+            (stream === "stdout" ? process.stdout : process.stderr).write(chunk);
+          },
+          progress: (message: string) => writeQaSuiteProgress(true, message),
+        }
+      : {}),
     repoRoot,
     outputDir,
     providerMode,

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -1,6 +1,7 @@
 // QA Lab plugin module implements suite launch behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { isRepoRootRelativeRef, toRepoRelativePath } from "./cli-paths.js";
 import { QaSuiteArtifactError, QaSuiteInfraError } from "./errors.js";
@@ -11,6 +12,7 @@ import {
   validateQaEvidenceSummaryJson,
   type QaEvidenceSummaryJson,
 } from "./evidence-summary.js";
+import { redactQaGatewayDebugText } from "./gateway-log-redaction.js";
 import { isQaFastModeEnabled } from "./model-selection.js";
 import { resolveQaRuntimeModelPair } from "./model-selection.runtime.js";
 import { DEFAULT_QA_PROVIDER_MODE } from "./providers/index.js";
@@ -101,6 +103,7 @@ const MAX_ISOLATED_FLOW_CONCURRENCY = 8;
 // Three is the audited ceiling for concurrent Gateway and process-group lifecycles.
 // Raising it risks cleanup overlap and shared port/listener contention.
 const MAX_PARALLEL_SCRIPT_CONCURRENCY = 3;
+const MAX_NATIVE_OUTPUT_LINE_LENGTH = 16_384;
 const ISOLATED_FLOW_WORKER_START_STAGGER_MS = 1_500;
 const QA_SUITE_INFRA_RETRY_LIMIT = 1;
 const QA_SUITE_INFRA_RETRY_NETWORK_ERROR_CODES = new Set([
@@ -414,6 +417,53 @@ async function resolveSuiteExecutionPlan(
     testFileScenariosByKind,
   };
 }
+
+function createQaNativeOutputForwarder() {
+  const outputs = {
+    stdout: { decoder: new StringDecoder("utf8"), pending: "", dropping: false },
+    stderr: { decoder: new StringDecoder("utf8"), pending: "", dropping: false },
+  };
+
+  return {
+    write(stream: "stderr" | "stdout", chunk: Buffer) {
+      const output = outputs[stream];
+      let text = output.decoder.write(chunk);
+      while (text.length > 0) {
+        const newline = text.search(/[\r\n]/u);
+        const complete = newline !== -1;
+        const segment = complete ? text.slice(0, newline + 1) : text;
+        text = complete ? text.slice(newline + 1) : "";
+        if (output.dropping) {
+          output.dropping = !complete;
+          continue;
+        }
+        // Secrets and CI commands may span chunks; never flush an incomplete line.
+        if (output.pending.length + segment.length > MAX_NATIVE_OUTPUT_LINE_LENGTH) {
+          process[stream].write("[qa-suite] native output line omitted: exceeded safe limit\n");
+          output.pending = "";
+          output.dropping = !complete;
+          continue;
+        }
+        output.pending += segment;
+        if (complete) {
+          process[stream].write(redactQaGatewayDebugText(output.pending));
+          output.pending = "";
+        }
+      }
+    },
+    flush() {
+      for (const stream of ["stdout", "stderr"] as const) {
+        const output = outputs[stream];
+        output.pending += output.decoder.end();
+        if (output.pending && !output.dropping) {
+          process[stream].write(redactQaGatewayDebugText(output.pending));
+        }
+        output.pending = "";
+      }
+    },
+  };
+}
+
 async function runQaTestFileSuiteFromRuntime(params: {
   env?: NodeJS.ProcessEnv;
   runParams: QaSuiteRunParams | undefined;
@@ -425,26 +475,28 @@ async function runQaTestFileSuiteFromRuntime(params: {
   const outputDir = await resolveQaSuiteOutputDir(repoRoot, runParams?.outputDir);
   const providerMode = normalizeQaProviderMode(runParams?.providerMode ?? DEFAULT_QA_PROVIDER_MODE);
   const primaryModel = runParams?.primaryModel?.trim() || defaultQaModelForMode(providerMode);
-  const progressEnabled = shouldLogQaSuiteProgress();
-  return await runQaTestFileScenarios({
-    evidenceMode: runParams?.evidenceMode,
-    ...(params.env ? { env: params.env, envMode: "replace" as const } : {}),
-    ...(runParams?.failFast ? { failFast: true } : {}),
-    ...(progressEnabled
-      ? {
-          onCommandOutput: (stream: "stderr" | "stdout", chunk: Buffer) => {
-            (stream === "stdout" ? process.stdout : process.stderr).write(chunk);
-          },
-          progress: (message: string) => writeQaSuiteProgress(true, message),
-        }
-      : {}),
-    repoRoot,
-    outputDir,
-    providerMode,
-    primaryModel,
-    scenarios: params.scenarios,
-    writeEvidenceFile: runParams?.writeEvidenceFile,
-  });
+  const output = shouldLogQaSuiteProgress() ? createQaNativeOutputForwarder() : undefined;
+  try {
+    return await runQaTestFileScenarios({
+      evidenceMode: runParams?.evidenceMode,
+      ...(params.env ? { env: params.env, envMode: "replace" as const } : {}),
+      ...(runParams?.failFast ? { failFast: true } : {}),
+      ...(output
+        ? {
+            onCommandOutput: output.write,
+            progress: (message: string) => writeQaSuiteProgress(true, message),
+          }
+        : {}),
+      repoRoot,
+      outputDir,
+      providerMode,
+      primaryModel,
+      scenarios: params.scenarios,
+      writeEvidenceFile: runParams?.writeEvidenceFile,
+    });
+  } finally {
+    output?.flush();
+  }
 }
 
 function rejectFlowOnlySuiteOptionsForUnifiedRun(runParams: QaSuiteRunParams | undefined) {

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -104,6 +104,7 @@ const MAX_ISOLATED_FLOW_CONCURRENCY = 8;
 // Raising it risks cleanup overlap and shared port/listener contention.
 const MAX_PARALLEL_SCRIPT_CONCURRENCY = 3;
 const MAX_NATIVE_OUTPUT_LINE_LENGTH = 16_384;
+const MAX_NATIVE_OUTPUT_MARKER_SUFFIX_LENGTH = 256;
 const ISOLATED_FLOW_WORKER_START_STAGGER_MS = 1_500;
 const QA_SUITE_INFRA_RETRY_LIMIT = 1;
 const QA_SUITE_INFRA_RETRY_NETWORK_ERROR_CODES = new Set([
@@ -419,9 +420,28 @@ async function resolveSuiteExecutionPlan(
 }
 
 function createQaNativeOutputForwarder() {
-  const outputs = {
-    stdout: { decoder: new StringDecoder("utf8"), pending: "", dropping: false },
-    stderr: { decoder: new StringDecoder("utf8"), pending: "", dropping: false },
+  type MultilineSecret = "pem" | "authTag";
+  type OutputState = {
+    decoder: StringDecoder;
+    dropping?: MultilineSecret | "line";
+    droppedSuffix?: string;
+    multiline?: MultilineSecret;
+    pending: string;
+  };
+  const outputs: Record<"stderr" | "stdout", OutputState> = {
+    stdout: { decoder: new StringDecoder("utf8"), pending: "" },
+    stderr: { decoder: new StringDecoder("utf8"), pending: "" },
+  };
+  const endsMultilineSecret = (kind: MultilineSecret, text: string) =>
+    kind === "pem" ? /-----END [A-Z ]*PRIVATE KEY-----/u.test(text) : /\]\s*[,}\r\n]*$/u.test(text);
+  const detectMultilineSecret = (text: string): MultilineSecret | undefined => {
+    if (/-----BEGIN [A-Z ]*PRIVATE KEY-----/u.test(text)) {
+      return "pem";
+    }
+    if (/(?:^|[^\w])"?authTag"?\s*[:=]\s*\[/u.test(text)) {
+      return "authTag";
+    }
+    return undefined;
   };
 
   return {
@@ -434,20 +454,55 @@ function createQaNativeOutputForwarder() {
         const segment = complete ? text.slice(0, newline + 1) : text;
         text = complete ? text.slice(newline + 1) : "";
         if (output.dropping) {
-          output.dropping = !complete;
+          const discarded = (output.droppedSuffix ?? "") + segment;
+          if (output.dropping === "line") {
+            const multiline = detectMultilineSecret(discarded);
+            if (multiline) {
+              output.dropping = multiline;
+            }
+          }
+          if (
+            complete &&
+            (output.dropping === "line" || endsMultilineSecret(output.dropping, discarded))
+          ) {
+            output.dropping = undefined;
+            output.droppedSuffix = undefined;
+          } else {
+            output.droppedSuffix = complete
+              ? undefined
+              : discarded.slice(-MAX_NATIVE_OUTPUT_MARKER_SUFFIX_LENGTH);
+          }
           continue;
         }
-        // Secrets and CI commands may span chunks; never flush an incomplete line.
+        // Redaction needs complete lines and whole multiline secrets, never partial chunks.
         if (output.pending.length + segment.length > MAX_NATIVE_OUTPUT_LINE_LENGTH) {
+          const discarded = output.pending + segment;
+          const multiline = output.multiline ?? detectMultilineSecret(discarded);
           process[stream].write("[qa-suite] native output line omitted: exceeded safe limit\n");
           output.pending = "";
-          output.dropping = !complete;
+          output.dropping =
+            multiline && (!complete || !endsMultilineSecret(multiline, segment))
+              ? multiline
+              : undefined;
+          if (!complete) {
+            output.dropping ??= "line";
+          }
+          output.droppedSuffix =
+            output.dropping === "line"
+              ? discarded.slice(-MAX_NATIVE_OUTPUT_MARKER_SUFFIX_LENGTH)
+              : undefined;
+          output.multiline = undefined;
           continue;
         }
         output.pending += segment;
         if (complete) {
+          output.multiline ??= detectMultilineSecret(output.pending);
+          if (output.multiline && !endsMultilineSecret(output.multiline, output.pending)) {
+            continue;
+          }
           process[stream].write(redactQaGatewayDebugText(output.pending));
           output.pending = "";
+          output.multiline = undefined;
         }
       }
     },
@@ -456,7 +511,8 @@ function createQaNativeOutputForwarder() {
         const output = outputs[stream];
         output.pending += output.decoder.end();
         if (output.pending && !output.dropping) {
-          process[stream].write(redactQaGatewayDebugText(output.pending));
+          // Independent partitions must never concatenate unredactable partial secrets.
+          process[stream].write("[qa-suite] unterminated native output omitted\n");
         }
         output.pending = "";
       }

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -425,7 +425,7 @@ function createQaNativeOutputForwarder() {
   };
 
   return {
-    write(stream: "stderr" | "stdout", chunk: Buffer) {
+    write: (stream: "stderr" | "stdout", chunk: Buffer) => {
       const output = outputs[stream];
       let text = output.decoder.write(chunk);
       while (text.length > 0) {

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -1,7 +1,6 @@
 // QA Lab plugin module implements suite launch behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { StringDecoder } from "node:string_decoder";
 import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { isRepoRootRelativeRef, toRepoRelativePath } from "./cli-paths.js";
 import { QaSuiteArtifactError, QaSuiteInfraError } from "./errors.js";
@@ -12,7 +11,6 @@ import {
   validateQaEvidenceSummaryJson,
   type QaEvidenceSummaryJson,
 } from "./evidence-summary.js";
-import { redactQaGatewayDebugText } from "./gateway-log-redaction.js";
 import { isQaFastModeEnabled } from "./model-selection.js";
 import { resolveQaRuntimeModelPair } from "./model-selection.runtime.js";
 import { DEFAULT_QA_PROVIDER_MODE } from "./providers/index.js";
@@ -103,8 +101,6 @@ const MAX_ISOLATED_FLOW_CONCURRENCY = 8;
 // Three is the audited ceiling for concurrent Gateway and process-group lifecycles.
 // Raising it risks cleanup overlap and shared port/listener contention.
 const MAX_PARALLEL_SCRIPT_CONCURRENCY = 3;
-const MAX_NATIVE_OUTPUT_LINE_LENGTH = 16_384;
-const MAX_NATIVE_OUTPUT_MARKER_SUFFIX_LENGTH = 256;
 const ISOLATED_FLOW_WORKER_START_STAGGER_MS = 1_500;
 const QA_SUITE_INFRA_RETRY_LIMIT = 1;
 const QA_SUITE_INFRA_RETRY_NETWORK_ERROR_CODES = new Set([
@@ -419,122 +415,6 @@ async function resolveSuiteExecutionPlan(
   };
 }
 
-function createQaNativeOutputForwarder() {
-  type MultilineSecret = "pem" | "authTag";
-  type OutputState = {
-    decoder: StringDecoder;
-    dropping?: MultilineSecret | "line";
-    droppedSuffix?: string;
-    multiline?: MultilineSecret;
-    pending: string;
-  };
-  const outputs: Record<"stderr" | "stdout", OutputState> = {
-    stdout: { decoder: new StringDecoder("utf8"), pending: "" },
-    stderr: { decoder: new StringDecoder("utf8"), pending: "" },
-  };
-  const authTagAssignmentState = (text: string): "prefix" | "array" | undefined => {
-    for (const match of text.matchAll(/(?:^|[^\w])"?authTag"?/giu)) {
-      const suffix = text.slice(match.index + match[0].length);
-      if (/^\s*[:=]\s*\[/u.test(suffix)) {
-        return "array";
-      }
-      if (/^\s*(?:[:=]\s*)?$/u.test(suffix)) {
-        return "prefix";
-      }
-    }
-    return undefined;
-  };
-  const endsMultilineSecret = (kind: MultilineSecret, text: string) =>
-    kind === "pem" ? /-----END [A-Z ]*PRIVATE KEY-----/u.test(text) : /\]\s*[,}\r\n]*$/u.test(text);
-  const detectMultilineSecret = (text: string): MultilineSecret | undefined => {
-    if (/-----BEGIN [A-Z ]*PRIVATE KEY-----/u.test(text)) {
-      return "pem";
-    }
-    if (authTagAssignmentState(text)) {
-      return "authTag";
-    }
-    return undefined;
-  };
-
-  return {
-    write: (stream: "stderr" | "stdout", chunk: Buffer) => {
-      const output = outputs[stream];
-      let text = output.decoder.write(chunk);
-      while (text.length > 0) {
-        const newline = text.search(/[\r\n]/u);
-        const complete = newline !== -1;
-        const segment = complete ? text.slice(0, newline + 1) : text;
-        text = complete ? text.slice(newline + 1) : "";
-        if (output.dropping) {
-          const discarded = (output.droppedSuffix ?? "") + segment;
-          if (output.dropping === "line") {
-            const multiline = detectMultilineSecret(discarded);
-            if (multiline) {
-              output.dropping = multiline;
-            }
-          }
-          if (
-            complete &&
-            (output.dropping === "line" || endsMultilineSecret(output.dropping, discarded))
-          ) {
-            output.dropping = undefined;
-            output.droppedSuffix = undefined;
-          } else {
-            output.droppedSuffix = complete
-              ? undefined
-              : discarded.slice(-MAX_NATIVE_OUTPUT_MARKER_SUFFIX_LENGTH);
-          }
-          continue;
-        }
-        // Redaction needs complete lines and whole multiline secrets, never partial chunks.
-        if (output.pending.length + segment.length > MAX_NATIVE_OUTPUT_LINE_LENGTH) {
-          const discarded = output.pending + segment;
-          const multiline = output.multiline ?? detectMultilineSecret(discarded);
-          process[stream].write("[qa-suite] native output line omitted: exceeded safe limit\n");
-          output.pending = "";
-          output.dropping =
-            multiline && (!complete || !endsMultilineSecret(multiline, segment))
-              ? multiline
-              : undefined;
-          if (!complete) {
-            output.dropping ??= "line";
-          }
-          output.droppedSuffix =
-            output.dropping === "line"
-              ? discarded.slice(-MAX_NATIVE_OUTPUT_MARKER_SUFFIX_LENGTH)
-              : undefined;
-          output.multiline = undefined;
-          continue;
-        }
-        output.pending += segment;
-        if (complete) {
-          output.multiline ??= detectMultilineSecret(output.pending);
-          if (output.multiline === "authTag" && !authTagAssignmentState(output.pending)) {
-            output.multiline = detectMultilineSecret(output.pending);
-          }
-          if (output.multiline && !endsMultilineSecret(output.multiline, output.pending)) {
-            continue;
-          }
-          process[stream].write(redactQaGatewayDebugText(output.pending));
-          output.pending = "";
-          output.multiline = undefined;
-        }
-      }
-    },
-    flush() {
-      for (const stream of ["stdout", "stderr"] as const) {
-        const output = outputs[stream];
-        output.pending += output.decoder.end();
-        if (output.pending && !output.dropping) {
-          // Independent partitions must never concatenate unredactable partial secrets.
-          process[stream].write("[qa-suite] unterminated native output omitted\n");
-        }
-        output.pending = "";
-      }
-    },
-  };
-}
-
 async function runQaTestFileSuiteFromRuntime(params: {
   env?: NodeJS.ProcessEnv;
   runParams: QaSuiteRunParams | undefined;
@@ -546,28 +426,20 @@ async function runQaTestFileSuiteFromRuntime(params: {
   const outputDir = await resolveQaSuiteOutputDir(repoRoot, runParams?.outputDir);
   const providerMode = normalizeQaProviderMode(runParams?.providerMode ?? DEFAULT_QA_PROVIDER_MODE);
   const primaryModel = runParams?.primaryModel?.trim() || defaultQaModelForMode(providerMode);
-  const output = shouldLogQaSuiteProgress() ? createQaNativeOutputForwarder() : undefined;
-  try {
-    return await runQaTestFileScenarios({
-      evidenceMode: runParams?.evidenceMode,
-      ...(params.env ? { env: params.env, envMode: "replace" as const } : {}),
-      ...(runParams?.failFast ? { failFast: true } : {}),
-      ...(output
-        ? {
-            onCommandOutput: output.write,
-            progress: (message: string) => writeQaSuiteProgress(true, message),
-          }
-        : {}),
-      repoRoot,
-      outputDir,
-      providerMode,
-      primaryModel,
-      scenarios: params.scenarios,
-      writeEvidenceFile: runParams?.writeEvidenceFile,
-    });
-  } finally {
-    output?.flush();
-  }
+  return await runQaTestFileScenarios({
+    evidenceMode: runParams?.evidenceMode,
+    ...(params.env ? { env: params.env, envMode: "replace" as const } : {}),
+    ...(runParams?.failFast ? { failFast: true } : {}),
+    ...(shouldLogQaSuiteProgress()
+      ? { progress: (message: string) => writeQaSuiteProgress(true, message) }
+      : {}),
+    repoRoot,
+    outputDir,
+    providerMode,
+    primaryModel,
+    scenarios: params.scenarios,
+    writeEvidenceFile: runParams?.writeEvidenceFile,
+  });
 }
 
 function rejectFlowOnlySuiteOptionsForUnifiedRun(runParams: QaSuiteRunParams | undefined) {

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -43,10 +43,12 @@ import {
 import { createQaSuiteProgressController } from "./suite-progress.js";
 import {
   buildQaSuiteSummaryJson,
+  shouldLogQaSuiteProgress,
   type QaSuiteResult,
   type QaSuiteRunParams,
   type QaSuiteScenarioResult,
   type QaSuiteSummaryJson,
+  writeQaSuiteProgress,
 } from "./suite.js";
 import * as dockerBatch from "./test-file-scenario-docker-batch.js";
 import {
@@ -431,10 +433,19 @@ async function runQaTestFileSuiteFromRuntime(params: {
   const outputDir = await resolveQaSuiteOutputDir(repoRoot, runParams?.outputDir);
   const providerMode = normalizeQaProviderMode(runParams?.providerMode ?? DEFAULT_QA_PROVIDER_MODE);
   const primaryModel = runParams?.primaryModel?.trim() || defaultQaModelForMode(providerMode);
+  const progressEnabled = shouldLogQaSuiteProgress();
   return await runQaTestFileScenarios({
     evidenceMode: runParams?.evidenceMode,
     ...(params.env ? { env: params.env, envMode: "replace" as const } : {}),
     ...(runParams?.failFast ? { failFast: true } : {}),
+    ...(progressEnabled
+      ? {
+          onCommandOutput: (stream: "stderr" | "stdout", chunk: Buffer) => {
+            (stream === "stdout" ? process.stdout : process.stderr).write(chunk);
+          },
+          progress: (message: string) => writeQaSuiteProgress(true, message),
+        }
+      : {}),
     repoRoot,
     outputDir,
     providerMode,

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
@@ -53,12 +53,16 @@ function createChild(pid = 42) {
   return child;
 }
 
-function runCommand(timeoutMs?: number) {
+function runCommand(
+  timeoutMs?: number,
+  onOutput?: (stream: "stderr" | "stdout", chunk: Buffer) => void,
+) {
   return runQaScenarioCommandLifecycle({
     command: "/usr/local/bin/scenario-command",
     args: ["--run"],
     cwd: "/tmp/qa",
     env: { OPENCLAW_QA_REF: "test" },
+    ...(onOutput ? { onOutput } : {}),
     ...(timeoutMs === undefined ? {} : { timeoutMs }),
   });
 }
@@ -282,12 +286,18 @@ describe.skipIf(process.platform === "win32")("qa scenario command lifecycle", (
 
   it("preserves the exact close result and removes parent handlers", async () => {
     const child = createChild();
-    const resultPromise = runCommand(5_000);
+    const output = vi.fn();
+    const resultPromise = runCommand(5_000, output);
 
     child.stdout?.emit("data", Buffer.from("out\n"));
     child.stderr?.emit("data", Buffer.from("err\n"));
     child.emit("exit", 3, null);
     child.emit("close", 3, null);
+
+    expect(output.mock.calls).toEqual([
+      ["stdout", Buffer.from("out\n")],
+      ["stderr", Buffer.from("err\n")],
+    ]);
 
     await expect(resultPromise).resolves.toEqual({
       exitCode: 3,

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
@@ -53,12 +53,16 @@ function createChild(pid = 42) {
   return child;
 }
 
-function runCommand(timeoutMs?: number) {
+function runCommand(
+  timeoutMs?: number,
+  onOutput?: (stream: "stderr" | "stdout", chunk: Buffer) => void,
+) {
   return runQaScenarioCommandLifecycle({
     command: "/usr/local/bin/scenario-command",
     args: ["--run"],
     cwd: "/tmp/qa",
     env: { OPENCLAW_QA_REF: "test" },
+    ...(onOutput ? { onOutput } : {}),
     ...(timeoutMs === undefined ? {} : { timeoutMs }),
   });
 }
@@ -288,12 +292,18 @@ describe.skipIf(process.platform === "win32")("qa scenario command lifecycle", (
 
   it("preserves the exact close result and removes parent handlers", async () => {
     const child = createChild();
-    const resultPromise = runCommand(5_000);
+    const output = vi.fn();
+    const resultPromise = runCommand(5_000, output);
 
     child.stdout?.emit("data", Buffer.from("out\n"));
     child.stderr?.emit("data", Buffer.from("err\n"));
     child.emit("exit", 3, null);
     child.emit("close", 3, null);
+
+    expect(output.mock.calls).toEqual([
+      ["stdout", Buffer.from("out\n")],
+      ["stderr", Buffer.from("err\n")],
+    ]);
 
     await expect(resultPromise).resolves.toEqual({
       exitCode: 3,

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.ts
@@ -8,6 +8,7 @@ export type QaScenarioCommandExecution = {
   command: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
+  onOutput?: (stream: "stderr" | "stdout", chunk: Buffer) => void;
   timeoutMs?: number;
 };
 
@@ -112,8 +113,16 @@ export function runQaScenarioCommandLifecycle(
             : {}),
         });
       },
-      onStderrData: (chunk) => stderr.push(Buffer.from(chunk)),
-      onStdoutData: (chunk) => stdout.push(Buffer.from(chunk)),
+      onStderrData: (chunk) => {
+        const buffered = Buffer.from(chunk);
+        stderr.push(buffered);
+        execution.onOutput?.("stderr", buffered);
+      },
+      onStdoutData: (chunk) => {
+        const buffered = Buffer.from(chunk);
+        stdout.push(buffered);
+        execution.onOutput?.("stdout", buffered);
+      },
       processGroupId: isWindows ? undefined : child.pid,
       verifyAfterMs: timeoutForceSettleMs,
     });

--- a/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
+++ b/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
@@ -151,6 +151,7 @@ function laneMatches(
 export async function runDockerE2eBatch(params: {
   commandTimeoutMs: number;
   env: NodeJS.ProcessEnv;
+  onCommandOutput?: QaScenarioCommandExecution["onOutput"];
   outputDir: string;
   repoRoot: string;
   runCommand: typeof runQaScenarioCommandLifecycle;
@@ -183,6 +184,7 @@ export async function runDockerE2eBatch(params: {
         OPENCLAW_DOCKER_ALL_PROFILE: "all",
         OPENCLAW_DOCKER_ALL_TIMINGS_FILE: path.join(dockerOutputDir, "lane-timings.json"),
       },
+      ...(params.onCommandOutput ? { onOutput: params.onCommandOutput } : {}),
       // The scheduler owns each resolved lane deadline. Parent signals and the
       // enclosing QA workflow bound the aggregate run without alias-count guesses.
     });

--- a/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
+++ b/extensions/qa-lab/src/test-file-scenario-docker-batch.ts
@@ -4,7 +4,10 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { z } from "zod";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import { shellQuote } from "./shell-quote.js";
-import { runQaScenarioCommandLifecycle } from "./test-file-scenario-command-lifecycle.js";
+import {
+  runQaScenarioCommandLifecycle,
+  type QaScenarioCommandExecution,
+} from "./test-file-scenario-command-lifecycle.js";
 
 const QA_DOCKER_E2E_LANE_SCRIPT = "test/e2e/qa-lab/runtime/docker-e2e-lane.ts";
 const DOCKER_CANDIDATE_ENV_KEY =

--- a/extensions/qa-lab/src/test-file-scenario-runner.docker.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.docker.test.ts
@@ -13,7 +13,9 @@ import {
   QA_TEST_RUNNER_DEFAULTS,
   createScenarioRunnerTestHarness,
   makeDockerE2eScenario,
+  makeTestFileScenario,
   writeDockerCandidateManifest,
+  writeScriptProducerEvidence,
 } from "./test-file-scenario-runner.test-support.js";
 
 const harness = createScenarioRunnerTestHarness();
@@ -230,6 +232,95 @@ describe("qa test file scenario runner", () => {
       status: "pass",
     });
     expect(result.evidence.entries[0]?.result.status).toBe("pass");
+  });
+
+  it("prioritizes serial native work while preserving catalog-ordered mixed evidence", async () => {
+    const repoRoot = await makeTempRepo("qa-script-docker-priority-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "native-priority");
+    const makeScriptScenario = (id: string, timeoutMs: number) => {
+      const scenario = makeTestFileScenario("script", `scripts/${id}.ts`);
+      if (scenario.execution.kind !== "script") {
+        throw new Error("expected script scenario");
+      }
+      return { ...scenario, id, execution: { ...scenario.execution, timeoutMs } };
+    };
+    const dockerScenario = makeDockerE2eScenario("long-docker", "gateway-network");
+    if (dockerScenario.execution.kind !== "script") {
+      throw new Error("expected Docker script scenario");
+    }
+    const scenarios = [
+      makeScriptScenario("short-script", 1_000),
+      { ...dockerScenario, execution: { ...dockerScenario.execution, timeoutMs: 3_000 } },
+      makeScriptScenario("long-script-a", 3_000),
+      makeScriptScenario("long-script-b", 3_000),
+    ];
+    const executionOrder: string[] = [];
+    const output: string[] = [];
+    const progress: string[] = [];
+    let activeCommands = 0;
+    let maximumActiveCommands = 0;
+
+    const result = await runQaTestFileScenarios({
+      repoRoot,
+      outputDir,
+      ...QA_TEST_RUNNER_DEFAULTS,
+      scenarios,
+      onCommandOutput: (stream, chunk) => output.push(`${stream}:${chunk.toString("utf8")}`),
+      progress: (message) => progress.push(message),
+      runCommand: async (command) => {
+        const isDocker = command.args[0] === "scripts/test-docker-all.mjs";
+        const scenarioId = isDocker ? "long-docker" : path.basename(command.args[2], ".ts");
+        executionOrder.push(scenarioId);
+        activeCommands += 1;
+        maximumActiveCommands = Math.max(maximumActiveCommands, activeCommands);
+        try {
+          command.onOutput?.("stdout", Buffer.from(scenarioId));
+          if (isDocker) {
+            const logDir = command.env.OPENCLAW_DOCKER_ALL_LOG_DIR;
+            if (!logDir) {
+              throw new Error("missing Docker scheduler log dir");
+            }
+            await fs.mkdir(logDir, { recursive: true });
+            await fs.writeFile(
+              path.join(logDir, "summary.json"),
+              JSON.stringify({
+                failures: [],
+                lanes: [{ elapsedSeconds: 1, name: "gateway-network", status: 0 }],
+                selectedLanes: ["gateway-network"],
+              }),
+            );
+          } else {
+            await writeScriptProducerEvidence({
+              outputDir,
+              producerId: scenarioId,
+              scenarioId,
+              status: "pass",
+            });
+          }
+          return { exitCode: 0, stdout: `${scenarioId} passed\n`, stderr: "" };
+        } finally {
+          activeCommands -= 1;
+        }
+      },
+    });
+
+    expect(executionOrder).toEqual([
+      "long-docker",
+      "long-script-a",
+      "long-script-b",
+      "short-script",
+    ]);
+    expect(maximumActiveCommands).toBe(1);
+    expect(output).toEqual(executionOrder.map((scenarioId) => `stdout:${scenarioId}`));
+    expect(progress.filter((message) => message.includes(" start "))).toEqual([
+      "native docker-batch start scenarios=1 timeoutMs=3000",
+      "native script start scenario=long-script-a timeoutMs=3000",
+      "native script start scenario=long-script-b timeoutMs=3000",
+      "native script start scenario=short-script timeoutMs=1000",
+    ]);
+    const catalogOrder = scenarios.map((scenario) => scenario.id);
+    expect(result.results.map((entry) => entry.scenario.id)).toEqual(catalogOrder);
+    expect(result.evidence.entries.map((entry) => entry.test.id)).toEqual(catalogOrder);
   });
 
   it("runs Docker script scenarios through one aggregate scheduler invocation", async () => {

--- a/extensions/qa-lab/src/test-file-scenario-runner.docker.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.docker.test.ts
@@ -269,7 +269,14 @@ describe("qa test file scenario runner", () => {
       progress: (message) => progress.push(message),
       runCommand: async (command) => {
         const isDocker = command.args[0] === "scripts/test-docker-all.mjs";
-        const scenarioId = isDocker ? "long-docker" : path.basename(command.args[2], ".ts");
+        let scenarioId = "long-docker";
+        if (!isDocker) {
+          const scriptPath = command.args[2];
+          if (!scriptPath) {
+            throw new Error("missing script scenario path");
+          }
+          scenarioId = path.basename(scriptPath, ".ts");
+        }
         executionOrder.push(scenarioId);
         activeCommands += 1;
         maximumActiveCommands = Math.max(maximumActiveCommands, activeCommands);

--- a/extensions/qa-lab/src/test-file-scenario-runner.process.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.process.test.ts
@@ -22,6 +22,35 @@ afterEach(async () => {
 });
 
 describe("qa test file scenario runner", () => {
+  it("streams real native subprocess output before command settlement", async () => {
+    const observed: Array<{ stream: "stderr" | "stdout"; value: string }> = [];
+    let settled = false;
+    const result = await runQaScenarioCommandLifecycle({
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('native stdout'); process.stderr.write('native stderr')"],
+      cwd: process.cwd(),
+      env: process.env,
+      onOutput: (stream, chunk) => {
+        expect(settled).toBe(false);
+        observed.push({ stream, value: chunk.toString("utf8") });
+      },
+      timeoutMs: 5_000,
+    });
+    settled = true;
+
+    expect(observed).toEqual(
+      expect.arrayContaining([
+        { stream: "stdout", value: "native stdout" },
+        { stream: "stderr", value: "native stderr" },
+      ]),
+    );
+    expect(result).toMatchObject({
+      exitCode: 0,
+      stdout: "native stdout",
+      stderr: "native stderr",
+    });
+  });
+
   it.each([
     { executionKind: "vitest" as const, commandCount: 1 },
     { executionKind: "playwright" as const, commandCount: 2 },

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -556,24 +556,27 @@ function buildTestFileEvidence(params: {
       generatedAt: params.generatedAt,
       evidenceMode,
       profile: resolveQaEvidenceProfile({ env: params.env }),
-      entries: [
-        ...producerEntries.map((entry) => {
+      entries: params.results.flatMap((result) => [
+        ...(result.producerEvidence?.entries ?? []).map((entry) => {
+          const coveredEntry = withScenarioCoverage(entry, result.scenario);
           const fallbackFailure = fallbackEvidence?.entries.find(
-            (fallback) => fallback.test.id === entry.test.id && fallback.result.status === "fail",
+            (fallback) =>
+              fallback.test.id === coveredEntry.test.id && fallback.result.status === "fail",
           );
           const resolvedEntry =
-            entry.result.status !== "fail" && fallbackFailure
-              ? Object.assign({}, entry, { result: fallbackFailure.result })
-              : entry;
+            coveredEntry.result.status !== "fail" && fallbackFailure
+              ? Object.assign({}, coveredEntry, { result: fallbackFailure.result })
+              : coveredEntry;
           if (evidenceMode !== "slim") {
             return resolvedEntry;
           }
           const { execution: _execution, ...withoutExecution } = resolvedEntry;
           return withoutExecution;
         }),
-        ...(fallbackEvidence?.entries.filter((entry) => !producerEntryIds.has(entry.test.id)) ??
-          []),
-      ],
+        ...(fallbackEvidence?.entries.filter(
+          (entry) => entry.test.id === result.scenario.id && !producerEntryIds.has(entry.test.id),
+        ) ?? []),
+      ]),
     });
   }
   const definition = testFileRunnerDefinitions[params.kind];

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -16,6 +16,7 @@ import {
   resolveQaEvidenceProfile,
   validateQaEvidenceSummaryJson,
 } from "./evidence-summary.js";
+import { sanitizeQaProgressValue } from "./progress-format.js";
 import type { QaProviderMode } from "./providers/index.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
@@ -48,8 +49,10 @@ type QaTestFileScenarioRunParams = {
   env?: NodeJS.ProcessEnv;
   envMode?: "replace";
   failFast?: boolean;
+  onCommandOutput?: QaScenarioCommandExecution["onOutput"];
   outputDir: string;
   primaryModel: string;
+  progress?: (message: string) => void;
   providerMode: QaProviderMode;
   repoRoot: string;
   runCommand?: QaScenarioCommandRunner;
@@ -75,6 +78,20 @@ type QaTestFileScenarioResult = {
   scenario: QaTestFileScenario;
   status: QaEvidenceStatus;
 };
+
+type QaTestFileExecutionUnit =
+  | {
+      kind: "docker-batch";
+      order: number;
+      scenarios: Parameters<typeof runDockerE2eBatch>[0]["scenarios"];
+      timeoutMs: number;
+    }
+  | {
+      kind: "scenario";
+      order: number;
+      scenario: QaTestFileScenario;
+      timeoutMs: number;
+    };
 
 export type QaTestFileScenarioRunResult = {
   evidence: QaEvidenceSummaryJson;
@@ -239,6 +256,7 @@ function withScenarioCoverage(
 async function runScenarioCommandSteps(params: {
   commandTimeoutMs: number;
   env: NodeJS.ProcessEnv;
+  onCommandOutput?: QaScenarioCommandExecution["onOutput"];
   outputDir: string;
   repoRoot: string;
   runCommand: QaScenarioCommandRunner;
@@ -270,6 +288,9 @@ async function runScenarioCommandSteps(params: {
         args: step.args,
         cwd: params.repoRoot,
         env: params.env,
+        ...(params.scenario.execution.kind === "script" && params.onCommandOutput
+          ? { onOutput: params.onCommandOutput }
+          : {}),
         timeoutMs,
       });
       if (result.stdout) {
@@ -316,6 +337,7 @@ async function runScenarioCommandSteps(params: {
 async function runQaTestFileScenario(params: {
   env: NodeJS.ProcessEnv;
   commandTimeoutMs: number;
+  onCommandOutput?: QaScenarioCommandExecution["onOutput"];
   outputDir: string;
   repoRoot: string;
   runCommand: QaScenarioCommandRunner;
@@ -381,6 +403,56 @@ async function runQaTestFileScenario(params: {
       producerEvidence: producerEvidenceResult.producerEvidence,
     }),
   };
+}
+
+function resolveScenarioTimeoutMs(scenario: QaTestFileScenario, commandTimeoutMs: number) {
+  return scenario.execution.kind === "script"
+    ? resolvePositiveTimerTimeoutMs(scenario.execution.timeoutMs, commandTimeoutMs)
+    : commandTimeoutMs;
+}
+
+function buildExecutionUnits(params: {
+  commandTimeoutMs: number;
+  failFast: boolean;
+  scenarios: readonly QaTestFileScenario[];
+}): QaTestFileExecutionUnit[] {
+  const scenarioOrder = new Map(params.scenarios.map((scenario, index) => [scenario, index]));
+  const dockerBatchScenarios =
+    !params.failFast && params.scenarios[0]?.execution.kind === "script"
+      ? params.scenarios.filter(isDockerE2eScenario)
+      : [];
+  const dockerBatchGroups = new Map<number, typeof dockerBatchScenarios>();
+  for (const scenario of dockerBatchScenarios) {
+    const timeoutMs = resolveScenarioTimeoutMs(scenario, params.commandTimeoutMs);
+    const group = dockerBatchGroups.get(timeoutMs) ?? [];
+    group.push(scenario);
+    dockerBatchGroups.set(timeoutMs, group);
+  }
+  const batchedScenarioIds = new Set(dockerBatchScenarios.map((scenario) => scenario.id));
+  const units: QaTestFileExecutionUnit[] = [
+    ...[...dockerBatchGroups].map(([timeoutMs, scenarios]) => ({
+      kind: "docker-batch" as const,
+      order: Math.min(...scenarios.map((scenario) => scenarioOrder.get(scenario) ?? 0)),
+      scenarios,
+      timeoutMs,
+    })),
+    ...params.scenarios
+      .filter((scenario) => !batchedScenarioIds.has(scenario.id))
+      .map((scenario) => ({
+        kind: "scenario" as const,
+        order: scenarioOrder.get(scenario) ?? 0,
+        scenario,
+        timeoutMs: resolveScenarioTimeoutMs(scenario, params.commandTimeoutMs),
+      })),
+  ];
+  if (!params.failFast && params.scenarios[0]?.execution.kind === "script") {
+    // Native producers stay serial because they may rebuild shared dist output.
+    // Longest declared budgets run first so one late producer cannot starve at the suite deadline.
+    units.sort((left, right) => right.timeoutMs - left.timeoutMs || left.order - right.order);
+  } else {
+    units.sort((left, right) => left.order - right.order);
+  }
+  return units;
 }
 
 function statusFromProducerEvidence(params: {
@@ -572,46 +644,47 @@ export async function runQaTestFileScenarios(
   );
   const env = params.envMode === "replace" ? (params.env ?? {}) : { ...process.env, ...params.env };
   const results: QaTestFileScenarioResult[] = [];
-  const dockerBatchScenarios =
-    kind === "script" && !params.failFast ? scenarios.filter(isDockerE2eScenario) : [];
-  const dockerBatchGroups = new Map<number, typeof dockerBatchScenarios>();
-  for (const scenario of dockerBatchScenarios) {
-    const scenarioTimeoutMs = resolvePositiveTimerTimeoutMs(
-      scenario.execution.timeoutMs,
-      commandTimeoutMs,
-    );
-    const group = dockerBatchGroups.get(scenarioTimeoutMs) ?? [];
-    group.push(scenario);
-    dockerBatchGroups.set(scenarioTimeoutMs, group);
-  }
-  for (const [scenarioTimeoutMs, group] of dockerBatchGroups) {
-    // A scheduler invocation shares one fallback lane timeout, so timeout overrides
-    // stay in separate batches instead of borrowing another scenario's budget.
-    results.push(
-      ...(await runDockerE2eBatch({
-        commandTimeoutMs: scenarioTimeoutMs,
+  const executionUnits = buildExecutionUnits({
+    commandTimeoutMs,
+    failFast: params.failFast === true,
+    scenarios,
+  });
+  for (const unit of executionUnits) {
+    if (unit.kind === "docker-batch") {
+      params.progress?.(
+        `native docker-batch start scenarios=${unit.scenarios.length} timeoutMs=${unit.timeoutMs}`,
+      );
+      const startedAt = Date.now();
+      const batchResults = await runDockerE2eBatch({
+        commandTimeoutMs: unit.timeoutMs,
         env,
+        onCommandOutput: params.onCommandOutput,
         outputDir: params.outputDir,
         repoRoot: params.repoRoot,
         runCommand,
-        scenarios: group,
-      })),
-    );
-  }
-  const dockerBatchScenarioIds = new Set(dockerBatchScenarios.map((scenario) => scenario.id));
-  for (const scenario of scenarios) {
-    if (dockerBatchScenarioIds.has(scenario.id)) {
+        scenarios: unit.scenarios,
+      });
+      results.push(...batchResults);
+      params.progress?.(
+        `native docker-batch finish passed=${batchResults.filter((result) => result.status === "pass").length} failed=${batchResults.filter((result) => result.status !== "pass").length} durationMs=${Math.max(1, Date.now() - startedAt)}`,
+      );
       continue;
     }
+    const scenarioId = sanitizeQaProgressValue(unit.scenario.id);
+    params.progress?.(`native ${kind} start scenario=${scenarioId} timeoutMs=${unit.timeoutMs}`);
     const result = await runQaTestFileScenario({
       env,
       commandTimeoutMs,
+      onCommandOutput: params.onCommandOutput,
       outputDir: params.outputDir,
       repoRoot: params.repoRoot,
       runCommand,
-      scenario,
+      scenario: unit.scenario,
     });
     results.push(result);
+    params.progress?.(
+      `native ${kind} finish scenario=${scenarioId} status=${result.status} durationMs=${result.durationMs}`,
+    );
     if (params.failFast && result.status !== "pass") {
       break;
     }


### PR DESCRIPTION
## Summary

- keep native script producers deferred until every flow Gateway has stopped, and keep them serial because they can rebuild shared `dist` output
- schedule non-fail-fast native work by descending declared timeout with stable catalog-order ties, then restore catalog order in emitted results and evidence
- show only trusted runner-owned start/finish progress; keep raw subprocess stdout/stderr confined to existing private artifacts and explicitly opted-in private command-output callbacks
- emit bounded start/finish progress for each script and Docker batch

## Why

Enabling the update-run self-upgrade producer turned a formerly instant-blocked catalog tail into a native lane with a 60-minute declared timeout. The failed all-profile run completed every flow and the Docker batch, then reached that producer with only seconds left under the old 90-minute job cap. This is deterministic serial-tail starvation, not a Slack teardown hang.

The QA Lab runner owns native execution ordering, private command-output capture, and bounded scenario progress. This change repairs that boundary without parallelizing producers or weakening QA results: longer-budget work starts first, trusted runner-owned progress becomes operator-visible, and evidence/report order remains stable. Arbitrary subprocess bytes never enter shared CI progress streams.

## Behavior and safety

- Flow Gateways still settle before script producers begin.
- Script producers remain serial; no shared-build overlap is introduced.
- Fail-fast runs retain catalog order and individual Docker-lane execution.
- Command exit status, timeouts, private buffered logs, producer evidence validation, and final QA status are unchanged.
- Trusted runner-owned live progress follows the existing suite-progress policy, enabled by default in CI; subprocess bytes are never forwarded into shared progress.
- Direct, explicitly opted-in runner callers may still observe subprocess stdout/stderr privately without exposing those bytes to shared host or CI logs.

## Validation

- Focused QA Lab tests: 7 files, 129 tests passed, including mixed script/Docker timeout priority, stable ties, serial execution, catalog-ordered evidence, fail-fast behavior, and preserved private buffered output.
- Real spawned Node subprocess proof confirms direct opted-in output callbacks receive stdout/stderr before process settlement.
- Suite owner-boundary regression confirms trusted Docker progress is visible before runner settlement while provider secrets and workflow-command directives never reach shared stdout/stderr.
- Exact extension semantic lint, extension production typecheck, extension test typecheck, and touched-file formatting checks all passed.
- Fresh Codex autoreview found no actionable high-priority findings.

## LOC

Production: +96 net lines. Tests: +190 net lines. The production growth provides the native execution-plan capability, timeout-priority scheduling, stable catalog/evidence restoration, and trusted owner-minted progress. The security-boundary follow-up removes 57 production lines versus the contributor head by deleting arbitrary subprocess-to-CI forwarding instead of adding sanitization machinery.
