### PR TITLE
fix(release): validate MiniMax M3 in stable lanes

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -3084,7 +3084,7 @@ jobs:
             profiles: stable full
           - suite_id: native-live-src-gateway-profiles-minimax
             label: Native live gateway profiles MiniMax
-            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=minimax,minimax-portal OPENCLAW_LIVE_GATEWAY_MODELS=minimax/MiniMax-M2.7,minimax-portal/MiniMax-M2.7 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
+            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=minimax,minimax-portal OPENCLAW_LIVE_GATEWAY_MODELS=minimax/MiniMax-M3,minimax-portal/MiniMax-M3 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
             timeout_minutes: 60
             profile_env_only: false
             profiles: stable full
@@ -3417,7 +3417,7 @@ jobs:
             profiles: stable full
           - suite_id: live-gateway-minimax-docker
             label: Docker live gateway MiniMax
-            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=minimax,minimax-portal OPENCLAW_LIVE_GATEWAY_MODELS=minimax/MiniMax-M2.7,minimax-portal/MiniMax-M2.7 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 OPENCLAW_LIVE_GATEWAY_STEP_TIMEOUT_MS=90000 OPENCLAW_LIVE_GATEWAY_MODEL_TIMEOUT_MS=180000 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-gateway-models-docker.sh
+            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=minimax,minimax-portal OPENCLAW_LIVE_GATEWAY_MODELS=minimax/MiniMax-M3,minimax-portal/MiniMax-M3 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 OPENCLAW_LIVE_GATEWAY_STEP_TIMEOUT_MS=90000 OPENCLAW_LIVE_GATEWAY_MODEL_TIMEOUT_MS=180000 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-gateway-models-docker.sh
             timeout_minutes: 40
             profile_env_only: false
             profiles: stable full

--- a/scripts/plan-release-workflow-matrix.mjs
+++ b/scripts/plan-release-workflow-matrix.mjs
@@ -94,7 +94,7 @@ const LIVE_MODEL_PROVIDERS = [
   {
     provider_label: "MiniMax",
     providers: "minimax",
-    models: "minimax/MiniMax-M2.7,minimax-portal/MiniMax-M2.7",
+    models: "minimax/MiniMax-M3,minimax-portal/MiniMax-M3",
     max_models: "2",
     profiles: "stable full",
   },

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2297,7 +2297,7 @@ describe("package artifact reuse", () => {
       "OPENCLAW_LIVE_GATEWAY_MODELS=google/gemini-3.1-pro-preview node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles",
     );
     expect(workflow).toContain(
-      "OPENCLAW_LIVE_GATEWAY_MODELS=minimax/MiniMax-M2.7,minimax-portal/MiniMax-M2.7 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2",
+      "OPENCLAW_LIVE_GATEWAY_MODELS=minimax/MiniMax-M3,minimax-portal/MiniMax-M3 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2",
     );
     expect(workflow).toMatch(
       /suite_id: native-live-src-gateway-profiles-fireworks[\s\S]*?timeout_minutes: 30[\s\S]*?advisory: true/u,
@@ -2470,7 +2470,7 @@ describe("package artifact reuse", () => {
       "command: OPENCLAW_LIVE_GATEWAY_THINKING=off OPENCLAW_LIVE_GATEWAY_PROVIDERS=openai OPENCLAW_LIVE_GATEWAY_MODELS=openai/gpt-5.6-luna OPENCLAW_LIVE_GATEWAY_MAX_MODELS=1",
     );
     expect(workflow).toContain(
-      "command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=minimax,minimax-portal OPENCLAW_LIVE_GATEWAY_MODELS=minimax/MiniMax-M2.7,minimax-portal/MiniMax-M2.7 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2",
+      "command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=minimax,minimax-portal OPENCLAW_LIVE_GATEWAY_MODELS=minimax/MiniMax-M3,minimax-portal/MiniMax-M3 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2",
     );
     expect(workflow).toContain(
       'command: OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 45m bash .release-harness/scripts/test-live-cli-backend-docker.sh',

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -253,7 +253,7 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
     ]);
   });
 
-  it("limits MiniMax Docker live-model coverage to the stable M2.7 pair", () => {
+  it("limits MiniMax Docker live-model coverage to the stable M3 pair", () => {
     const plan = createReleaseWorkflowMatrixPlan({
       includeLiveSuites: true,
       includeReleasePathSuites: true,
@@ -263,7 +263,7 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
     expect(plan.liveModels.matrix.include).toContainEqual({
       provider_label: "MiniMax",
       providers: "minimax",
-      models: "minimax/MiniMax-M2.7,minimax-portal/MiniMax-M2.7",
+      models: "minimax/MiniMax-M3,minimax-portal/MiniMax-M3",
       max_models: "2",
       profiles: "stable full",
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where extended-stable candidates can exhaust both blocking MiniMax lanes without validating a usable model: the trusted release harness pins the older M2.7 pair even though the candidate’s MiniMax plugin defaults to and supports M3.

## Why This Change Was Made

Moves the stable/full MiniMax model pair to M3 in the release-matrix planner and the matching native and Docker live-suite entries. The workflow assertions and planner test keep the selected models synchronized.

## User Impact

Release operators get blocking MiniMax coverage for the model the shipped plugin selects by default. This is release-harness-only; it does not change provider routing, user configuration, or the release candidate.

## Evidence

- The 2026.6.34 candidate passed a direct MiniMax M3 run, while the full validation’s M2.7-only blocking lane skipped both selected models.
- actionlint passed for `openclaw-live-and-e2e-checks-reusable.yml`.
- Focused Vitest could not start in the isolated worktree because dependencies are absent; hosted PR CI will run the updated workflow and planner assertions.
