### PR TITLE
fix(release): fail early on invalid validation state

### DIFF
--- a/scripts/full-release-validation-at-sha.d.mts
+++ b/scripts/full-release-validation-at-sha.d.mts
@@ -19,11 +19,23 @@ export function releaseProfileForTarget(
   readPackageJson?: (sha: string) => string,
 ): "beta" | "stable";
 export function releaseEvidenceVerificationArgs(parentRunId: unknown): string[];
+export function runGhRead(
+  args: string[],
+  params?: {
+    execFileSyncImpl?: (...args: unknown[]) => unknown;
+    timeoutMs?: number;
+  },
+): string;
 export function shouldDeleteTemporaryWorkflowRef(params: {
   keepBranch: boolean;
   dryRun: boolean;
   parentConclusion: string;
+  evidenceVerified: boolean;
 }): boolean;
+export function assertTrustedWorkflowHarness(
+  workflowSha: string,
+  pathExists?: (relativePath: string) => boolean,
+): string;
 export function releaseEvidenceVerifierPath(worktreeRoot: unknown): string;
 export function resolveRemoteTargetRefSha(
   targetRef: string,

--- a/scripts/full-release-validation-at-sha.mjs
+++ b/scripts/full-release-validation-at-sha.mjs
@@ -7,6 +7,12 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const WORKFLOW = "full-release-validation.yml";
+const TRUSTED_WORKFLOW_PATH = `.github/workflows/${WORKFLOW}`;
+const RELEASE_EVIDENCE_VERIFIER_PATHS = [
+  "scripts/release-ci-summary.mjs",
+  ".agents/skills/release-openclaw-ci/scripts/release-ci-summary.mjs",
+];
+const GH_READ_TIMEOUT_MS = 60_000;
 const RELEASE_BRANCH_PATTERN =
   /^(?:release\/[0-9]{4}\.[0-9]+\.[0-9]+|extended-stable\/[0-9]{4}\.[0-9]+\.33)$/u;
 const RELEASE_TAG_PATTERN = /^v[0-9]{4}\.[0-9]+\.[0-9]+(?:-(?:alpha|beta)\.[0-9]+)?$/u;
@@ -54,6 +60,17 @@ function runStatus(command, args, options = {}) {
     encoding: "utf8",
     stdio: options.stdio ?? ["ignore", "pipe", "inherit"],
   });
+}
+
+export function runGhRead(args, params = {}) {
+  const execFileSyncImpl = params.execFileSyncImpl ?? execFileSync;
+  const output = execFileSyncImpl("gh", args, {
+    encoding: "utf8",
+    killSignal: "SIGKILL",
+    stdio: ["ignore", "pipe", "inherit"],
+    timeout: params.timeoutMs ?? GH_READ_TIMEOUT_MS,
+  });
+  return typeof output === "string" ? output.trim() : "";
 }
 
 function readOptionValue(argv, index, optionName) {
@@ -247,7 +264,7 @@ function collectRunId(dispatchOutput) {
 }
 
 function findLatestRunId(branch, sha) {
-  const json = run("gh", [
+  const json = runGhRead([
     "run",
     "list",
     "--workflow",
@@ -271,7 +288,7 @@ function readWorkflowRun(parentRunId, workflowSha) {
     throw new Error("parent run ID must be a positive decimal");
   }
   const workflowRun = JSON.parse(
-    run("gh", ["api", `repos/openclaw/openclaw/actions/runs/${parentRunId}`]),
+    runGhRead(["api", `repos/openclaw/openclaw/actions/runs/${parentRunId}`]),
   );
   if (workflowRun.head_sha !== workflowSha) {
     throw new Error(
@@ -326,21 +343,39 @@ export function releaseEvidenceVerificationArgs(parentRunId) {
 }
 
 export function shouldDeleteTemporaryWorkflowRef(params) {
-  return !params.keepBranch && (params.dryRun || params.parentConclusion === "success");
+  return (
+    !params.keepBranch &&
+    (params.dryRun || (params.parentConclusion === "success" && params.evidenceVerified))
+  );
+}
+
+export function assertTrustedWorkflowHarness(
+  workflowSha,
+  pathExists = (relativePath) =>
+    runStatus("git", ["cat-file", "-e", `${workflowSha}:${relativePath}`], {
+      stdio: ["ignore", "ignore", "ignore"],
+    }).status === 0,
+) {
+  if (!pathExists(TRUSTED_WORKFLOW_PATH)) {
+    throw new Error(
+      `trusted workflow SHA ${workflowSha} does not contain ${TRUSTED_WORKFLOW_PATH}`,
+    );
+  }
+  const verifierPath = RELEASE_EVIDENCE_VERIFIER_PATHS.find((relativePath) =>
+    pathExists(relativePath),
+  );
+  if (!verifierPath) {
+    throw new Error(
+      `trusted workflow SHA ${workflowSha} does not contain a supported release evidence verifier`,
+    );
+  }
+  return verifierPath;
 }
 
 export function releaseEvidenceVerifierPath(worktreeRoot) {
-  const candidates = [
-    join(worktreeRoot, "scripts", "release-ci-summary.mjs"),
-    join(
-      worktreeRoot,
-      ".agents",
-      "skills",
-      "release-openclaw-ci",
-      "scripts",
-      "release-ci-summary.mjs",
-    ),
-  ];
+  const candidates = RELEASE_EVIDENCE_VERIFIER_PATHS.map((relativePath) =>
+    join(worktreeRoot, relativePath),
+  );
   const verifier = candidates.find((candidate) => existsSync(candidate));
   if (!verifier) {
     throw new Error("trusted workflow checkout does not contain a release evidence verifier");
@@ -379,6 +414,7 @@ function main() {
   args.inputs.allow_unreleased_changelog ??= args.targetRef ? "false" : "true";
   const targetContextRef = verifyTargetRef(args.targetRef, targetSha);
   const workflowSha = resolveTrustedWorkflowSha(args.workflowSha);
+  assertTrustedWorkflowHarness(workflowSha);
   const shortSha = workflowSha.slice(0, 12);
   const branch = `release-ci/${shortSha}-${Date.now()}`;
   const remoteBranchRef = `refs/heads/${branch}`;
@@ -399,6 +435,7 @@ function main() {
 
   let parentRunId;
   let parentConclusion = "";
+  let evidenceVerified = false;
   try {
     const dispatchArgs = ["workflow", "run", WORKFLOW, "--ref", branch];
     for (const [key, value] of Object.entries(dispatchInputs)) {
@@ -435,12 +472,14 @@ function main() {
       );
     }
     verifyReleaseEvidence(parentRunId, workflowSha);
+    evidenceVerified = true;
   } finally {
     if (
       shouldDeleteTemporaryWorkflowRef({
         keepBranch: args.keepBranch,
         dryRun: args.dryRun,
         parentConclusion,
+        evidenceVerified,
       })
     ) {
       run("git", ["push", "origin", `:${remoteBranchRef}`], {
@@ -451,7 +490,11 @@ function main() {
       console.warn(
         args.keepBranch
           ? `Kept ${remoteBranchRef}`
-          : `Kept ${remoteBranchRef}: parent concluded ${parentConclusion || "without a conclusion"}. Keep it through any GitHub reruns; delete it after a successful parent attempt.`,
+          : `Kept ${remoteBranchRef}: ${
+              parentConclusion === "success"
+                ? "release evidence was not verified"
+                : `parent concluded ${parentConclusion || "without a conclusion"}`
+            }. Keep it through GitHub reruns or evidence diagnosis; delete it after verified success.`,
       );
     }
   }

--- a/scripts/release-ci-summary.d.mts
+++ b/scripts/release-ci-summary.d.mts
@@ -251,6 +251,13 @@ export function parseReleaseCiSummaryArgs(argv: string[]): {
   watch: boolean;
 };
 export function releaseCiWatchFingerprint(parent: unknown): string;
+export function terminalParentJobFailures(parent: {
+  jobs?: Array<{
+    conclusion?: string | null;
+    name?: string | null;
+    status?: string | null;
+  }>;
+}): string[];
 export function watchReleaseCiRun(
   options: unknown,
   overrides?: Record<string, unknown>,

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -26,6 +26,7 @@ const MAX_MANIFEST_ENTRY_LIST_BYTES = 8 * 1024;
 // headroom for GitHub latency while preventing one stalled read from consuming
 // the workflow budget.
 const GH_COMMAND_TIMEOUT_MS = 60_000;
+const SUCCESSFUL_PARENT_JOB_CONCLUSIONS = new Set(["neutral", "skipped", "success"]);
 
 const CHILD_DISPATCHES = [
   {
@@ -1506,6 +1507,16 @@ export function releaseCiWatchFingerprint(parent) {
   });
 }
 
+export function terminalParentJobFailures(parent) {
+  return (parent.jobs ?? [])
+    .filter(
+      (job) =>
+        job.status === "completed" &&
+        !SUCCESSFUL_PARENT_JOB_CONCLUSIONS.has(String(job.conclusion ?? "")),
+    )
+    .map((job) => String(job.name || "unnamed parent job"));
+}
+
 function summarizeReleaseCiRun(options) {
   execFileSync(
     process.execPath,
@@ -1548,6 +1559,12 @@ export async function watchReleaseCiRun(options, overrides = {}) {
     if (fingerprint !== previousFingerprint) {
       summarize();
       previousFingerprint = fingerprint;
+    }
+    const failedJobs = terminalParentJobFailures(parent);
+    if (failedJobs.length > 0) {
+      throw new Error(
+        `full release run ${options.runId} has terminal parent job failure(s): ${failedJobs.join(", ")}`,
+      );
     }
     if (parent.status === "completed") {
       if (parent.conclusion !== "success") {

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -3,11 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  assertTrustedWorkflowHarness,
   parseArgs,
   releaseProfileForTarget,
   releaseEvidenceVerificationArgs,
   releaseEvidenceVerifierPath,
   resolveRemoteTargetRefSha,
+  runGhRead,
   shouldDeleteTemporaryWorkflowRef,
 } from "../../scripts/full-release-validation-at-sha.mjs";
 
@@ -160,10 +162,61 @@ describe("full-release-validation-at-sha", () => {
     expect(source).not.toContain('["run", "watch"');
   });
 
+  it("bounds GitHub reads without applying a timeout to workflow dispatch", () => {
+    const calls: unknown[][] = [];
+    expect(
+      runGhRead(["api", "repos/openclaw/openclaw/actions/runs/123"], {
+        execFileSyncImpl: (...args: unknown[]) => {
+          calls.push(args);
+          return " result ";
+        },
+      }),
+    ).toBe("result");
+    expect(calls).toEqual([
+      [
+        "gh",
+        ["api", "repos/openclaw/openclaw/actions/runs/123"],
+        expect.objectContaining({
+          killSignal: "SIGKILL",
+          timeout: 60_000,
+        }),
+      ],
+    ]);
+
+    const source = readFileSync("scripts/full-release-validation-at-sha.mjs", "utf8");
+    expect(source).toContain(
+      'runGhRead(["api", `repos/openclaw/openclaw/actions/runs/${parentRunId}`])',
+    );
+    expect(source).toContain('const dispatchOutput = run("gh", dispatchArgs');
+  });
+
+  it("rejects incomplete trusted release harnesses before dispatch", () => {
+    const workflowPath = ".github/workflows/full-release-validation.yml";
+    const verifierPath = "scripts/release-ci-summary.mjs";
+    const checked: string[] = [];
+    expect(
+      assertTrustedWorkflowHarness("a".repeat(40), (relativePath) => {
+        checked.push(relativePath);
+        return relativePath === workflowPath || relativePath === verifierPath;
+      }),
+    ).toBe(verifierPath);
+    expect(checked).toEqual([workflowPath, verifierPath]);
+    expect(() => assertTrustedWorkflowHarness("a".repeat(40), () => false)).toThrow(workflowPath);
+    expect(() =>
+      assertTrustedWorkflowHarness("a".repeat(40), (relativePath) => relativePath === workflowPath),
+    ).toThrow("supported release evidence verifier");
+
+    const source = readFileSync("scripts/full-release-validation-at-sha.mjs", "utf8");
+    expect(source.indexOf("assertTrustedWorkflowHarness(workflowSha);")).toBeLessThan(
+      source.indexOf('run("git", ["push", "origin", `${workflowSha}:${remoteBranchRef}`]'),
+    );
+  });
+
   it("retains a failed parent workflow ref for GitHub reruns", () => {
     expect(
       shouldDeleteTemporaryWorkflowRef({
         dryRun: false,
+        evidenceVerified: false,
         keepBranch: false,
         parentConclusion: "failure",
       }),
@@ -171,6 +224,7 @@ describe("full-release-validation-at-sha", () => {
     expect(
       shouldDeleteTemporaryWorkflowRef({
         dryRun: false,
+        evidenceVerified: true,
         keepBranch: false,
         parentConclusion: "success",
       }),
@@ -178,10 +232,19 @@ describe("full-release-validation-at-sha", () => {
     expect(
       shouldDeleteTemporaryWorkflowRef({
         dryRun: true,
+        evidenceVerified: false,
         keepBranch: false,
         parentConclusion: "",
       }),
     ).toBe(true);
+    expect(
+      shouldDeleteTemporaryWorkflowRef({
+        dryRun: false,
+        evidenceVerified: false,
+        keepBranch: false,
+        parentConclusion: "success",
+      }),
+    ).toBe(false);
   });
 
   it("supports current and legacy verifier locations in trusted workflow checkouts", () => {

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -23,6 +23,7 @@ import {
   selectManifestArtifact,
   selectManifestParentJob,
   selectedChildKeys,
+  terminalParentJobFailures,
   validateEvidenceReuseChain,
   validateManifestArtifactCompatibility,
   validateManifestArtifactIdentity,
@@ -490,6 +491,20 @@ describe("release CI summary child correlation", () => {
     ).not.toBe(releaseCiWatchFingerprint(parent));
   });
 
+  it("classifies only terminal unsuccessful parent jobs as failures", () => {
+    expect(
+      terminalParentJobFailures({
+        jobs: [
+          { conclusion: "success", name: "success", status: "completed" },
+          { conclusion: "neutral", name: "neutral", status: "completed" },
+          { conclusion: "skipped", name: "skipped", status: "completed" },
+          { conclusion: "failure", name: "failed", status: "completed" },
+          { conclusion: "", name: "running", status: "in_progress" },
+        ],
+      }),
+    ).toEqual(["failed"]);
+  });
+
   it("summarizes only transitions while watching a release run", async () => {
     const states = [
       { attempt: 1, conclusion: "", jobs: [], status: "queued" },
@@ -520,6 +535,37 @@ describe("release CI summary child correlation", () => {
 
     expect(summaries).toBe(2);
     expect(sleeps).toBe(2);
+  });
+
+  it("stops watching after reporting a terminal parent job failure", async () => {
+    let summaries = 0;
+    let sleeps = 0;
+
+    await expect(
+      watchReleaseCiRun(parseReleaseCiSummaryArgs(["29071366025", "--watch", "--interval", "1"]), {
+        fetchParent: () => ({
+          attempt: 1,
+          conclusion: "",
+          jobs: [
+            {
+              conclusion: "failure",
+              name: "Run release/live/Docker/QA validation",
+              status: "completed",
+            },
+            { conclusion: "", name: "Run normal full CI", status: "in_progress" },
+          ],
+          status: "in_progress",
+        }),
+        sleep: async () => {
+          sleeps += 1;
+        },
+        summarize: () => {
+          summaries += 1;
+        },
+      }),
+    ).rejects.toThrow("Run release/live/Docker/QA validation");
+    expect(summaries).toBe(1);
+    expect(sleeps).toBe(0);
   });
 
   it("selects one immutable manifest artifact bound to the exact parent run", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release operators could wait through stalled GitHub reads, incomplete trusted workflow tooling, or already-failed parent jobs before the SHA-pinned validation wrapper reported a terminal failure.

It also fixes successful parent runs deleting their temporary workflow ref before strict release evidence had actually passed.

## Why This Change Was Made

The release wrapper now bounds read-only GitHub calls, validates the trusted workflow and evidence verifier before creating the remote ref, and keeps that ref until both the parent run and evidence verification succeed. The summary watcher exits after reporting the first terminal parent-job failure.

This intentionally does not change release publishing, plugin convergence, child retry policy, or any active Beta release lane.

## User Impact

Release operators get earlier actionable failures and retain the exact workflow ref needed for reruns or evidence diagnosis. Healthy release validation behavior is unchanged.

## Evidence

- Focused Vitest: 61 tests passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- Blacksmith Testbox changed gate: `tbx_01kz1fxe946q25z4d8gwmx8326`, exit 0.
- Hosted proof: https://github.com/openclaw/openclaw/actions/runs/30753417961
- No release was published and no active release lane was modified.
