### PR TITLE
fix(sqlite): keep concurrent startup checkpoints from failing

### DIFF
--- a/src/state/openclaw-state-db-startup-checkpoint.ts
+++ b/src/state/openclaw-state-db-startup-checkpoint.ts
@@ -2,6 +2,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
+import { configureSqlitePreSchemaPragmas } from "../infra/sqlite-wal.js";
 import {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   type OpenClawStateDatabaseOptions,
@@ -64,6 +65,9 @@ export function withOpenClawStateStartupMigrationCheckpointDatabase<T>(
   ensureOpenClawStatePermissions(pathname, env);
   const db = openNodeSqliteDatabase(pathname);
   try {
+    configureSqlitePreSchemaPragmas(db, {
+      busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+    });
     assertSqliteIntegrity(db, pathname);
     ensureStartupMigrationCheckpointSchema(db, pathname);
     return callback(db);

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -2819,6 +2819,17 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     expect(checkpointCallback).not.toHaveBeenCalled();
   });
 
+  it("configures checkpoint lock waits before schema mutation", () => {
+    const stateDir = createTempStateDir();
+
+    withOpenClawStateStartupMigrationCheckpointDatabase(
+      (db) => {
+        expect(readSqliteNumberPragma(db, "busy_timeout")).toBe(OPENCLAW_SQLITE_BUSY_TIMEOUT_MS);
+      },
+      { env: { OPENCLAW_STATE_DIR: stateDir } },
+    );
+  });
+
   it("runs full integrity before a pending state schema migration", () => {
     const stateDir = createTempStateDir();
     const databasePath = createCanonicalAuditStateDatabase(stateDir);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where concurrent OpenClaw startups could fail a migration checkpoint immediately with `SQLITE_BUSY` while another connection held the state database write lock.

## Why This Change Was Made

The startup-checkpoint connection now applies the canonical SQLite busy timeout before integrity checks or checkpoint schema work. This keeps the lock policy at the database connection owner and does not change the SQLite schema.

This is the canonical product repair forward-ported from Beta 7 validation; beta-only release mechanics are intentionally excluded.

## User Impact

Concurrent startup and migration-checkpoint attempts wait for the active writer instead of failing immediately.

## Evidence

- `node scripts/run-vitest.mjs src/state/openclaw-state-db.test.ts` — 108 passed, 1 skipped
- `./node_modules/.bin/oxfmt --check CHANGELOG.md src/state/openclaw-state-db-startup-checkpoint.ts src/state/openclaw-state-db.test.ts`
- `git diff --check`
- Fresh local autoreview: clean, correctness 0.98
- Production LOC: +4/-0; tests: +11/-0
- No schema version change
