### PR TITLE
fix(gateway): skip deleted agent stores during restart recovery

### DIFF
--- a/src/agents/main-session-restart-recovery-runtime.ts
+++ b/src/agents/main-session-restart-recovery-runtime.ts
@@ -261,8 +261,8 @@ export function scheduleRestartAbortedMainSessionRecoveryAfterOwnerRelease(param
 }
 
 export function scheduleRestartAbortedMainSessionRecovery(params: {
-  cfg?: OpenClawConfig;
   delayMs?: number;
+  getConfig: () => OpenClawConfig;
   maxRetries?: number;
   shouldContinue?: () => boolean;
   stateDir?: string;
@@ -278,21 +278,28 @@ export function scheduleRestartAbortedMainSessionRecovery(params: {
     params.shouldContinue?.() !== false &&
     isAgentEventLifecycleGenerationCurrent(lifecycleGeneration);
   const startupRecoveryCutoffMs = Date.now();
-  let startupMarked = false;
+  const markedStorePaths = new Set<string>();
   const runRecoveryAttempt = async (
     exhaustedTargets: Map<string, ExhaustedRestartRecoveryTarget>,
   ): Promise<RecoveryCounts> => {
     return await runWithGatewayIndependentRootWorkAdmission(async () => {
-      if (!startupMarked) {
+      const cfg = params.getConfig();
+      const currentStorePaths = await resolveRestartRecoveryStorePaths({
+        cfg,
+        stateDir: params.stateDir,
+      });
+      if (currentStorePaths.some((storePath) => !markedStorePaths.has(storePath))) {
         await markStartupOrphanedMainSessionsForRecovery({
-          cfg: params.cfg,
+          cfg,
           stateDir: params.stateDir,
           updatedBeforeMs: startupRecoveryCutoffMs,
         });
-        startupMarked = true;
+        for (const storePath of currentStorePaths) {
+          markedStorePaths.add(storePath);
+        }
       }
       return await recoverRestartAbortedMainSessions({
-        cfg: params.cfg,
+        cfg,
         onExhaustedTarget: (target) => {
           exhaustedTargets.set(`${target.storePath}\u0000${target.sessionKey}`, target);
         },
@@ -309,7 +316,7 @@ export function scheduleRestartAbortedMainSessionRecovery(params: {
       [...targets].map((target) =>
         runWithGatewayIndependentRootWorkAdmission(async () =>
           recoverExpectedRestartRecovery({
-            cfg: params.cfg,
+            cfg: params.getConfig(),
             expectedTarget: {
               canonicalSessionKey: target.canonicalSessionKey,
               sessionId: target.sessionId,

--- a/src/agents/main-session-restart-recovery-shared.ts
+++ b/src/agents/main-session-restart-recovery-shared.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import {
   listConfiguredSessionStoreAgentIds,
+  resolveStorePath,
   type InternalSessionEntry as SessionEntry,
   resolveAllAgentSessionStoreTargetsSync,
 } from "../config/sessions.js";
@@ -94,12 +95,22 @@ export async function resolveRestartRecoveryStorePaths(params: {
     // Recovery must not reopen a deleted or otherwise unconfigured agent database merely
     // because its old directory still exists on disk. Those stores are intentionally fenced
     // by the deletion journal, and stale auth-probe directories are not agent roster entries.
-    const configuredAgentIds = new Set(listConfiguredSessionStoreAgentIds(params.cfg));
+    const configuredAgentIds = listConfiguredSessionStoreAgentIds(params.cfg);
+    const configuredStorePaths = new Set(
+      configuredAgentIds.map((agentId) =>
+        path.resolve(resolveStorePath(params.cfg?.session?.store, { agentId, env })),
+      ),
+    );
+    const configuredAgentIdSet = new Set(configuredAgentIds);
     for (const target of resolveAllAgentSessionStoreTargetsSync(params.cfg, { env })) {
-      if (!configuredAgentIds.has(target.agentId)) {
+      const storePath = path.resolve(target.storePath);
+      // Fixed configured stores can retain a durable owner whose ID differs from the
+      // current roster entry. The validated path is the configuration fact; the target's
+      // owner label is not evidence that the path itself is unconfigured.
+      if (!configuredAgentIdSet.has(target.agentId) && !configuredStorePaths.has(storePath)) {
         continue;
       }
-      storePaths.add(path.resolve(target.storePath));
+      storePaths.add(storePath);
     }
   } else {
     for (const sessionsDir of await resolveAgentSessionDirs(stateDir)) {

--- a/src/agents/main-session-restart-recovery-shared.ts
+++ b/src/agents/main-session-restart-recovery-shared.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import {
+  listConfiguredSessionStoreAgentIds,
   type InternalSessionEntry as SessionEntry,
   resolveAllAgentSessionStoreTargetsSync,
 } from "../config/sessions.js";
@@ -89,12 +90,20 @@ export async function resolveRestartRecoveryStorePaths(params: {
   const storePaths = new Set<string>();
   const stateDir = params.stateDir ?? resolveStateDir(process.env);
   const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
-  for (const sessionsDir of await resolveAgentSessionDirs(stateDir)) {
-    storePaths.add(path.join(sessionsDir, "sessions.json"));
-  }
   if (params.cfg) {
+    // Recovery must not reopen a deleted or otherwise unconfigured agent database merely
+    // because its old directory still exists on disk. Those stores are intentionally fenced
+    // by the deletion journal, and stale auth-probe directories are not agent roster entries.
+    const configuredAgentIds = new Set(listConfiguredSessionStoreAgentIds(params.cfg));
     for (const target of resolveAllAgentSessionStoreTargetsSync(params.cfg, { env })) {
+      if (!configuredAgentIds.has(target.agentId)) {
+        continue;
+      }
       storePaths.add(path.resolve(target.storePath));
+    }
+  } else {
+    for (const sessionsDir of await resolveAgentSessionDirs(stateDir)) {
+      storePaths.add(path.join(sessionsDir, "sessions.json"));
     }
   }
   // Agent databases also hold auth and model-catalog state. Enter the writer

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -65,6 +65,7 @@ import {
 } from "./internal-runtime-context.js";
 import * as recoveryOwnerRelease from "./main-session-recovery-owner-release.js";
 import { claimMainSessionRecoveryOwner } from "./main-session-recovery-store.js";
+import { resolveRestartRecoveryStorePaths } from "./main-session-restart-recovery-shared.js";
 import {
   markRestartAbortedMainSessions,
   markStartupOrphanedMainSessionsForRecovery,
@@ -73,7 +74,6 @@ import {
   scheduleRestartAbortedMainSessionRecoveryAfterOwnerRelease,
   scheduleRestartAbortedMainSessionRecovery as scheduleRestartAbortedMainSessionRecoveryBase,
 } from "./main-session-restart-recovery.js";
-import { resolveRestartRecoveryStorePaths } from "./main-session-restart-recovery-shared.js";
 import { AGENT_RUN_RESTART_ABORT_ERROR_CODE } from "./run-termination.js";
 import {
   createAssistantToolCallMessage,

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -73,6 +73,7 @@ import {
   scheduleRestartAbortedMainSessionRecoveryAfterOwnerRelease,
   scheduleRestartAbortedMainSessionRecovery as scheduleRestartAbortedMainSessionRecoveryBase,
 } from "./main-session-restart-recovery.js";
+import { resolveRestartRecoveryStorePaths } from "./main-session-restart-recovery-shared.js";
 import { AGENT_RUN_RESTART_ABORT_ERROR_CODE } from "./run-termination.js";
 import {
   createAssistantToolCallMessage,
@@ -405,6 +406,24 @@ describe("main-session-restart-recovery", () => {
       { runId: "key-only-run", lifecycleGeneration },
       { runId: "restart-run", lifecycleGeneration },
     ]);
+  });
+
+  it("does not scan stale stores for agents absent from the configured roster", async () => {
+    const configuredSessionsDir = await makeSessionsDir("main");
+    await writeMainSession({ sessionsDir: configuredSessionsDir });
+    const staleSessionsDir = await makeSessionsDir("amnesia-probe");
+    await writeMainSession({
+      sessionsDir: staleSessionsDir,
+      sessionKey: "agent:amnesia-probe:main",
+    });
+
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    const storePaths = await resolveRestartRecoveryStorePaths({ cfg, stateDir: tmpDir });
+
+    expect(storePaths).toContain(path.join(configuredSessionsDir, "sessions.json"));
+    expect(storePaths).not.toContain(path.join(staleSessionsDir, "sessions.json"));
   });
 
   it("marks active sessions in a configured custom session store", async () => {

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -426,6 +426,21 @@ describe("main-session-restart-recovery", () => {
     expect(storePaths).not.toContain(path.join(staleSessionsDir, "sessions.json"));
   });
 
+  it("keeps a configured fixed store when its path carries a retired owner id", async () => {
+    const sessionsDir = await makeSessionsDir("old");
+    const storePath = path.join(sessionsDir, "sessions.json");
+    await writeMainSession({ sessionsDir, sessionKey: "agent:old:main" });
+
+    const cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    await expect(resolveRestartRecoveryStorePaths({ cfg, stateDir: tmpDir })).resolves.toContain(
+      storePath,
+    );
+  });
+
   it("marks active sessions in a configured custom session store", async () => {
     const storePath = path.join(tmpDir, "custom", "sessions.json");
     await writeStorePath(storePath, {
@@ -2122,7 +2137,7 @@ describe("main-session-restart-recovery", () => {
     }
 
     const recovery = scheduleRestartAbortedMainSessionRecovery({
-      cfg: {},
+      getConfig: () => ({}),
       delayMs: 0,
       stateDir: tmpDir,
     });
@@ -2179,7 +2194,7 @@ describe("main-session-restart-recovery", () => {
         return await originalApply(params);
       });
     const recovery = scheduleRestartAbortedMainSessionRecovery({
-      cfg: {},
+      getConfig: () => ({}),
       delayMs: 0,
       stateDir: tmpDir,
     });
@@ -2255,7 +2270,7 @@ describe("main-session-restart-recovery", () => {
     ]);
 
     const recovery = scheduleRestartAbortedMainSessionRecovery({
-      cfg: { session: { store: customStorePath } },
+      getConfig: () => ({ session: { store: customStorePath } }),
       delayMs: 0,
       stateDir: tmpDir,
     });
@@ -2291,7 +2306,7 @@ describe("main-session-restart-recovery", () => {
     vi.useFakeTimers();
     try {
       const recovery = scheduleRestartAbortedMainSessionRecovery({
-        cfg: {},
+        getConfig: () => ({}),
         delayMs: 5_000,
         stateDir: tmpDir,
       });
@@ -2324,7 +2339,7 @@ describe("main-session-restart-recovery", () => {
     });
 
     const recovery = scheduleRestartAbortedMainSessionRecovery({
-      cfg: {},
+      getConfig: () => ({}),
       delayMs: 0,
       stateDir: tmpDir,
     });
@@ -2354,7 +2369,7 @@ describe("main-session-restart-recovery", () => {
     ]);
 
     const recovery = scheduleRestartAbortedMainSessionRecovery({
-      cfg: {},
+      getConfig: () => ({}),
       delayMs: 0,
       stateDir: tmpDir,
       waitForStart: () => releaseStartup.promise,
@@ -2388,6 +2403,38 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:fresh"]?.abortedLastRun).toBeUndefined();
   });
 
+  it("uses the live configured roster after the startup recovery barrier", async () => {
+    const sessionsDir = await makeSessionsDir("work");
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const releaseStartup = createDeferred();
+    await writeMainSession({ sessionsDir, sessionKey: "agent:work:main" });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "resume after config reload" },
+      { role: "toolResult", content: "done" },
+    ]);
+    let currentConfig = {
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+
+    const recovery = scheduleRestartAbortedMainSessionRecovery({
+      delayMs: 0,
+      getConfig: () => currentConfig,
+      stateDir: tmpDir,
+      waitForStart: () => releaseStartup.promise,
+    });
+    await Promise.resolve();
+    currentConfig = {
+      agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+    } as OpenClawConfig;
+    releaseStartup.resolve();
+
+    await waitForFast(() => expect(callGateway).toHaveBeenCalledOnce());
+    await recovery.stop();
+    expect(loadSessionEntry({ sessionKey: "agent:work:main", storePath })).toMatchObject({
+      abortedLastRun: false,
+    });
+  });
+
   it("stops without waiting for an unresolved startup release", async () => {
     const sessionsDir = await makeSessionsDir();
     const storePath = path.join(sessionsDir, "sessions.json");
@@ -2402,7 +2449,7 @@ describe("main-session-restart-recovery", () => {
     });
 
     const recovery = scheduleRestartAbortedMainSessionRecovery({
-      cfg: {},
+      getConfig: () => ({}),
       delayMs: 0,
       stateDir: tmpDir,
       waitForStart: () => releaseStartup.promise,
@@ -2447,7 +2494,7 @@ describe("main-session-restart-recovery", () => {
       });
 
     const recovery = scheduleRestartAbortedMainSessionRecovery({
-      cfg: {},
+      getConfig: () => ({}),
       delayMs: 0,
       stateDir: tmpDir,
     });
@@ -2503,7 +2550,7 @@ describe("main-session-restart-recovery", () => {
     });
 
     const recovery = scheduleRestartAbortedMainSessionRecovery({
-      cfg: {},
+      getConfig: () => ({}),
       delayMs: 0,
       stateDir: tmpDir,
     });
@@ -2559,7 +2606,7 @@ describe("main-session-restart-recovery", () => {
     });
 
     const recovery = scheduleRestartAbortedMainSessionRecovery({
-      cfg: {},
+      getConfig: () => ({}),
       delayMs: 0,
       stateDir: tmpDir,
     });
@@ -2646,7 +2693,7 @@ describe("main-session-restart-recovery", () => {
     let recovery: ReturnType<typeof scheduleRestartAbortedMainSessionRecovery> | undefined;
     try {
       recovery = scheduleRestartAbortedMainSessionRecovery({
-        cfg: {},
+        getConfig: () => ({}),
         delayMs: 0,
         maxRetries: 2,
         stateDir: tmpDir,
@@ -2719,7 +2766,7 @@ describe("main-session-restart-recovery", () => {
       });
 
     scheduleRestartAbortedMainSessionRecovery({
-      cfg: {},
+      getConfig: () => ({}),
       delayMs: 1,
       maxRetries: 2,
       stateDir: tmpDir,
@@ -3074,7 +3121,7 @@ describe("main-session-restart-recovery", () => {
       .mockResolvedValueOnce({ runId: "run-resumed" });
 
     scheduleRestartAbortedMainSessionRecovery({
-      cfg: { agents: { entries: { main: { default: true } } } },
+      getConfig: () => ({ agents: { entries: { main: { default: true } } } }),
       delayMs: 0,
       maxRetries: 1,
       stateDir: tmpDir,

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -399,6 +399,7 @@ export async function finishGatewayStartup(params: {
         startGatewayPostAttachRuntime({
           minimalTestGateway,
           cfgAtStart,
+          getConfig: getRuntimeConfig,
           bindHost,
           bindHosts: httpBindHosts,
           port,

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -390,14 +390,19 @@ describe("startGatewayPostAttachRuntime", () => {
   it("re-enables startup-gated methods after post-attach sidecars start", async () => {
     const unavailableGatewayMethods = new Set<string>(["chat.history", "models.list"]);
     const methodsAtRecoveryRegistration: string[][] = [];
-    hoisted.scheduleRestartAbortedMainSessionRecovery.mockImplementationOnce(() => {
-      methodsAtRecoveryRegistration.push([...unavailableGatewayMethods]);
-    });
+    const currentConfig = { agents: { list: [{ id: "main" }, { id: "work" }] } };
+    hoisted.scheduleRestartAbortedMainSessionRecovery.mockImplementationOnce(
+      (params: { getConfig: () => unknown }) => {
+        methodsAtRecoveryRegistration.push([...unavailableGatewayMethods]);
+        expect(params.getConfig()).toBe(currentConfig);
+      },
+    );
     const onSidecarsReady = vi.fn();
     const log = { info: vi.fn(), warn: vi.fn() };
 
     await startGatewayPostAttachRuntime({
       ...createPostAttachParams(),
+      getConfig: () => currentConfig,
       log,
       unavailableGatewayMethods,
       onSidecarsReady,
@@ -419,8 +424,8 @@ describe("startGatewayPostAttachRuntime", () => {
     );
     expect(log.info).toHaveBeenCalledWith("gateway ready");
     expect(hoisted.scheduleRestartAbortedMainSessionRecovery).toHaveBeenCalledWith({
-      cfg: { hooks: { internal: { enabled: false } } },
       delayMs: 0,
+      getConfig: expect.any(Function),
       shouldContinue: expect.any(Function),
       waitForStart: undefined,
       gatewayRuntime: expect.any(Object),
@@ -2757,6 +2762,7 @@ function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): Post
   return {
     minimalTestGateway: false,
     cfgAtStart: { hooks: { internal: { enabled: false } } } as never,
+    getConfig: () => ({ hooks: { internal: { enabled: false } } }) as never,
     bindHost: "127.0.0.1",
     bindHosts: ["127.0.0.1"],
     port: 18789,

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1030,6 +1030,7 @@ export async function startGatewayPostAttachRuntime(
   params: {
     minimalTestGateway: boolean;
     cfgAtStart: OpenClawConfig;
+    getConfig: () => OpenClawConfig;
     bindHost: string;
     bindHosts: string[];
     port: number;
@@ -1271,8 +1272,8 @@ export async function startGatewayPostAttachRuntime(
             // would miss lifetime registration and race the replacement gateway.
             if (params.isClosing?.() !== true) {
               mainSessionRecoverySidecar = scheduleRestartAbortedMainSessionRecovery({
-                cfg: params.cfgAtStart,
                 delayMs: 0,
+                getConfig: params.getConfig,
                 shouldContinue: () => params.isClosing?.() !== true,
                 waitForStart: params.waitForPostReadyWork,
                 gatewayRuntime: params.recoveryRuntime,


### PR DESCRIPTION
## What Problem This Solves

Gateway restart recovery can reopen stale agent databases that are no longer in the configured agent roster. If the stale agent has a durable deletion-journal entry, the database lease correctly refuses the claim with:

```text
OpenClaw agent database is unavailable while agent amnesia-probe is deleted.
```

That expected deletion fence currently becomes a repeated main-session recovery failure because recovery discovers every on-disk agent directory, including deleted agents and ephemeral auth-probe directories.

## Why This Change Was Made

When runtime configuration is available, restart recovery now filters discovered session-store targets to the configured session-store agent roster. Configured custom stores remain eligible, while stale directories for deleted or unconfigured agents are no longer opened by the recovery writer path. Config-less callers retain the existing broad discovery behavior.

## User Impact

Deleted-agent state and interrupted auth-probe directories no longer cause restart recovery to repeatedly claim a fenced database. The gateway can continue startup while the durable deletion fence remains intact.

## Regression Coverage

The recovery test creates a configured `main` store and an unconfigured `amnesia-probe` store, then verifies that only the configured store is selected for restart recovery.

## Evidence

- Exact current-main base: `807506381a0362a748e01e28839f15a38a4a911e`
- Focused regression added in `src/agents/main-session-restart-recovery.test.ts`
- Source and test blobs were inspected against the exact current-main contents before commit.
- GitHub PR diff is limited to the recovery resolver and its regression test.
- Repository Evidence gate passed on the PR.
- `no-tabs` and `actionlint` checks passed.
- Failing-first / green proof below demonstrates that the regression test detects the old behavior.

The broad core test/typecheck shards were skipped by the repository's external-fork CI policy; a full local run was not possible because the large upstream checkout could not be fetched reliably in this environment.

### Failing-first / green proof

The proof ran in a clean filtered upstream checkout at `e75ae0c9a96406e169127a923bf78b033e5aafc1`; the two changed files are unchanged between that current-main checkout and the PR base.

Command (the stale-store regression plus the existing configured-custom-store recovery coverage):

```bash
node node_modules/vitest/vitest.mjs run \
  --config test/vitest/vitest.agents-core.config.ts \
  src/agents/main-session-restart-recovery.test.ts \
  -t 'does not scan stale stores|marks active sessions in a configured custom session store'
```

Before the implementation change, with the regression test retained:

```text
Test Files  1 failed (1)
Tests       1 failed | 1 passed | 148 skipped (150)
AssertionError: expected [...] to not include '.../agents/amnesia-probe/sessions/sessions.json'
```

After the implementation change:

```text
Test Files  1 passed (1)
Tests       2 passed | 148 skipped (150)
```

The green run therefore demonstrates both sides of the recovery boundary: the stale `amnesia-probe` store is excluded, and the configured custom store remains eligible.

The full focused recovery suite also passed:

```text
Test Files  1 passed (1)
Tests       150 passed (150)
```

### Real gateway lifecycle proof

The following proof runs the actual source-level `startGatewayServer` twice (a simulated gateway restart), then invokes the recovery path through a real gateway WebSocket `agent` RPC backed by a local OpenAI-compatible model stub. It uses a disposable state directory containing a configured custom store and a separate deletion-fenced `amnesia-probe` store. No recovery runtime or writer is mocked.

Command:

```bash
node node_modules/vitest/vitest.mjs run \
  --config test/vitest/vitest.e2e.config.ts \
  --reporter verbose --silent=false \
  test/clawsweeper-restart-recovery-direct-proof.e2e.test.ts
```

Redacted terminal transcript:

```text
[proof] recovery result after gateway restart: {"recovered":1,"failed":0,"skipped":0}
[proof] REAL GATEWAY STARTUP RECOVERY
[proof] fenced stale store: <temp>/home/.openclaw/agents/amnesia-probe/sessions/sessions.json
[proof] configured custom store: <temp>/home/.openclaw/custom/sessions.json
[proof] configured store after recovery: {"sessionId":"custom-restart-proof","status":"running","abortedLastRun":false,...}
[proof] fenced stale store after recovery: {"sessionId":"stale-restart-proof","status":"running","abortedLastRun":true,...}
[proof] stale deletion-fenced store skipped: true
✓ test/... > real gateway skips fenced stale store and recovers configured custom store
Test Files  1 passed (1)
Tests       1 passed (1)
```

This demonstrates the requested runtime boundary: the configured custom session completed recovery (`abortedLastRun=false`, `recovered=1`), while the deletion-fenced stale store was not opened or mutated (`abortedLastRun=true`, no recovery failure).

AI-assisted: yes. The change is limited to restart-recovery target selection and its regression test.
