### PR TITLE
fix(telegram): ignore commands addressed to other bots

### DIFF
--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -494,6 +494,51 @@ describe("resolveTelegramInboundBody", () => {
     expect(result?.effectiveWasMentioned).toBe(true);
   });
 
+  it("ignores leading commands addressed to another bot when mentions are optional", async () => {
+    const logger = createLogger();
+    const command = "/status@other_bot";
+    const result = await resolveGroup({
+      logger,
+      message: {
+        text: command,
+        entities: [{ type: "bot_command", offset: 0, length: command.length }],
+      },
+      overrides: {
+        groupConfig: { requireMention: false } as never,
+        requireMention: false,
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps this bot's leading command when a later command targets another bot", async () => {
+    const logger = createLogger();
+    const ownCommand = "/inspect@bot";
+    const otherCommand = "/weather@other_bot";
+    const text = `${ownCommand} ${otherCommand}`;
+    const result = await resolveGroup({
+      logger,
+      message: {
+        text,
+        entities: [
+          { type: "bot_command", offset: 0, length: ownCommand.length },
+          {
+            type: "bot_command",
+            offset: ownCommand.length + 1,
+            length: otherCommand.length,
+          },
+        ],
+      },
+      overrides: {
+        groupConfig: { requireMention: false } as never,
+        requireMention: false,
+      },
+    });
+
+    expect(result?.rawBody).toBe(text);
+  });
+
   it("does not transcribe group audio for unauthorized senders", async () => {
     transcribeFirstAudioMock.mockReset();
     const logger = createLogger();

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -44,6 +44,7 @@ import {
   buildSenderName,
   extractTelegramLocation,
   getTelegramTextParts,
+  hasLeadingBotCommandAddressedToOtherBot,
   hasBotMentionInText,
   hasBotMention,
   renderTelegramTextEntities,
@@ -191,6 +192,15 @@ export async function resolveTelegramInboundBody(params: {
     providerPolicy: providerMentionPatterns,
   });
   const messageTextParts = getTelegramTextParts(msg);
+  if (botUsername && hasLeadingBotCommandAddressedToOtherBot(msg, botUsername)) {
+    logInboundDrop({
+      log: logVerbose,
+      channel: "telegram",
+      reason: "command addressed to another bot",
+      target: senderId ?? "unknown",
+    });
+    return null;
+  }
   const allowForCommands = isGroup ? effectiveGroupAllow : effectiveDmAllow;
   const useAccessGroups = true;
   const hasControlCommandInMessage = hasControlCommand(messageTextParts.text, cfg, {

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -327,6 +327,26 @@ export function hasBotMention(msg: Message, botUsername: string) {
   return false;
 }
 
+export function hasLeadingBotCommandAddressedToOtherBot(
+  msg: Message,
+  botUsername: string,
+): boolean {
+  const { text, entities } = getTelegramTextParts(msg);
+  const normalizedBotUsername = normalizeLowercaseStringOrEmpty(botUsername).replace(/^@/u, "");
+  if (!normalizedBotUsername) {
+    return false;
+  }
+  const leadingCommand = entities.find(
+    (entity) => entity.type === "bot_command" && entity.offset === 0,
+  );
+  if (!leadingCommand) {
+    return false;
+  }
+  const command = text.slice(0, leadingCommand.length);
+  const target = command.match(/^\/[^@\s]+@([a-z0-9_]+)$/iu)?.[1];
+  return Boolean(target && target.toLowerCase() !== normalizedBotUsername);
+}
+
 export function hasBotMentionInText(text: string, botUsername: string): boolean {
   return hasStandaloneTelegramMention(
     normalizeLowercaseStringOrEmpty(text),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram groups with optional mentions could send `/command@other_bot` into the OpenClaw agent as a normal user request.

## Why This Change Was Made

Telegram's `bot_command` entity is now checked at the inbound body owner before command authorization, history, or agent dispatch. A leading command explicitly addressed to another bot is dropped, while commands for this bot and later command tokens remain unchanged.

This is the canonical runtime repair discovered during Beta 7 live QA. Beta-only QA adapter and scenario changes are intentionally excluded.

## User Impact

OpenClaw no longer responds to Telegram commands intended for another bot in the same group.

## Evidence

- Before fix: focused regression returned `inboundEventKind: "user_request"` for `/status@other_bot`
- After fix: `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.body.test.ts` — 30 passed
- grammY 1.45.1 contract inspected: command middleware rejects `@other_bot` targets before invoking the registered command handler
- Targeted oxfmt and `git diff --check` passed
- Fresh local autoreview: clean, correctness 0.99
- Production LOC: +30/-0; tests: +45/-0
- No config, protocol, or public API change
