### PR TITLE
fix(gateway): preserve restart recovery after lease handoff

### DIFF
--- a/src/agents/session-write-lock-error.ts
+++ b/src/agents/session-write-lock-error.ts
@@ -33,6 +33,17 @@ export class SessionWriteLockStaleError extends Error {
   }
 }
 
+/** Returns whether another owner replaced the active SQLite session lease. */
+export function isSessionWriteLockLeaseLostError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null)?.code;
+  const staleReasons = (error as { staleReasons?: unknown } | null)?.staleReasons;
+  return (
+    (error instanceof SessionWriteLockStaleError || code === STALE_CODE) &&
+    Array.isArray(staleReasons) &&
+    staleReasons.includes("lease-lost")
+  );
+}
+
 export function isSessionWriteLockAcquireError(error: unknown): boolean {
   const code = (error as { code?: unknown } | null)?.code;
   return (

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -20,6 +20,7 @@ import {
   AGENT_RUN_RESTART_ABORT_STOP_REASON,
   resolveAgentRunErrorLifecycleFields,
 } from "../../agents/run-termination.js";
+import { isSessionWriteLockLeaseLostError } from "../../agents/session-write-lock-error.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
@@ -107,6 +108,24 @@ export async function cancelOverloadRetryNotice(state: OverloadRetryState): Prom
 type ErrorAction =
   | { kind: "retry"; liveModelSwitchError?: LiveSessionModelSwitchError }
   | Extract<AgentTurnInternalResult, { kind: "final" }>;
+
+function isSessionLeaseLoss(error: unknown): boolean {
+  const pending = [error];
+  const seen = new Set<unknown>();
+  for (const candidate of pending) {
+    if (!candidate || seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    if (isSessionWriteLockLeaseLostError(candidate)) {
+      return true;
+    }
+    if (candidate instanceof Error && "cause" in candidate && candidate.cause !== undefined) {
+      pending.push(candidate.cause);
+    }
+  }
+  return false;
+}
 
 export async function handleAgentExecutionError(params: {
   turn: AgentTurnParams;
@@ -233,6 +252,16 @@ export async function handleAgentExecutionError(params: {
   const replyOperationAbortAction = resolveReplyOperationAbortAction(err);
   if (replyOperationAbortAction) {
     return replyOperationAbortAction;
+  }
+  if (
+    isSessionLeaseLoss(err) &&
+    (await turn.confirmRestartRecoveryArmedAfterLeaseLoss?.()) === true
+  ) {
+    // The replacement owns recovery only after the latest SQLite row confirms
+    // the active claim or its terminal marker. The old owner then exits silently.
+    turn.replyOperation?.abortForRestart();
+    takePendingLifecycleTerminal()?.emit("end", err);
+    return { kind: "final", payload: { text: SILENT_REPLY_TOKEN } };
   }
   const restartLifecycleError = resolveRestartLifecycleError(err);
   if (

--- a/src/auto-reply/reply/agent-runner-execute.ts
+++ b/src/auto-reply/reply/agent-runner-execute.ts
@@ -74,6 +74,9 @@ type ExecutePreparedReplyAgentRunInput = Pick<
   checkpointBeforeAgentReply: ReturnType<
     typeof createReplyRestartRecoveryClaimController
   >["checkpointBeforeAgentReply"];
+  confirmRestartRecoveryArmedAfterLeaseLoss: ReturnType<
+    typeof createReplyRestartRecoveryClaimController
+  >["confirmRestartRecoveryArmedAfterLeaseLoss"];
   getActiveIsNewSession: () => boolean;
   getActiveSessionEntry: () => SessionEntry | undefined;
   isHeartbeat: boolean;
@@ -113,6 +116,7 @@ export async function executePreparedReplyAgentRun(
     blockStreamingEnabled,
     cfg,
     checkpointBeforeAgentReply: checkpointBeforeAgentReplyWithRecovery,
+    confirmRestartRecoveryArmedAfterLeaseLoss,
     commandBody,
     defaultModel,
     followupRun,
@@ -386,6 +390,7 @@ export async function executePreparedReplyAgentRun(
           resolvedVerboseLevel,
           toolProgressDetail,
           replyMediaContext,
+          confirmRestartRecoveryArmedAfterLeaseLoss,
           isRestartRecoveryArmed,
         }),
       ),
@@ -483,6 +488,7 @@ export function createReplyAgentRestartRecoveryController(
     beginBeforeAgentReply,
     checkpointBeforeAgentReply,
     clear: clearRestartRecoveryDeliveryClaim,
+    confirmRestartRecoveryArmedAfterLeaseLoss,
     isArmed: isRestartRecoveryArmed,
   } = createReplyRestartRecoveryClaimController({
     admissionRunId:
@@ -551,6 +557,7 @@ export function createReplyAgentRestartRecoveryController(
     admitUserTurn,
     beginBeforeAgentReply,
     checkpointBeforeAgentReply,
+    confirmRestartRecoveryArmedAfterLeaseLoss,
     clear: clearRestartRecoveryDeliveryClaim,
     isArmed: isRestartRecoveryArmed,
   };

--- a/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { FailoverError } from "../../agents/failover-error.js";
 import { AgentHarnessSessionSupersededError } from "../../agents/harness/errors.js";
+import { SessionWriteLockStaleError } from "../../agents/session-write-lock-error.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
@@ -379,6 +380,55 @@ describe("executeAgentTurn: terminal failures", () => {
           event.data.stopReason === "restart",
       ),
     ).toBe(true);
+  });
+
+  it("hands a confirmed restart lease loss to the replacement owner", async () => {
+    const agentEvents = await import("../../infra/agent-events.js");
+    const emitAgentEvent = vi.mocked(agentEvents.emitAgentEvent);
+    const { replyOperation, failMock } = createMockReplyOperation();
+    const abortForRestart = vi.spyOn(replyOperation, "abortForRestart");
+    abortForRestart.mockImplementationOnce(() => {
+      Object.defineProperty(replyOperation, "result", {
+        value: { kind: "aborted", code: "aborted_for_restart" } as const,
+        configurable: true,
+      });
+      return true;
+    });
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new Error("embedded runner failed", {
+        cause: new SessionWriteLockStaleError({
+          lockPath: "sqlite:session-write:agent:main:main",
+          owner: "replacement gateway",
+          staleReasons: ["lease-lost"],
+        }),
+      }),
+    );
+    const confirmRestartRecoveryArmedAfterLeaseLoss = vi.fn(async () => true);
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn({
+      ...createMinimalRunAgentTurnParams({ replyOperation }),
+      confirmRestartRecoveryArmedAfterLeaseLoss,
+      isRestartRecoveryArmed: () => false,
+    });
+
+    expect(result).toEqual({ kind: "final", payload: { text: SILENT_REPLY_TOKEN } });
+    expect(confirmRestartRecoveryArmedAfterLeaseLoss).toHaveBeenCalledOnce();
+    expect(abortForRestart).toHaveBeenCalledOnce();
+    expect(failMock).not.toHaveBeenCalled();
+    expect(
+      emitAgentEvent.mock.calls.filter(
+        ([event]) =>
+          event.stream === "lifecycle" &&
+          event.data.phase === "end" &&
+          event.data.stopReason === "restart",
+      ),
+    ).toHaveLength(1);
+    expect(
+      emitAgentEvent.mock.calls.some(
+        ([event]) => event.stream === "lifecycle" && event.data.phase === "error",
+      ),
+    ).toBe(false);
   });
 
   it("preserves restart ownership when an aborted embedded runner resolves normally", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.types.ts
+++ b/src/auto-reply/reply/agent-runner-execution.types.ts
@@ -105,6 +105,7 @@ export type AgentTurnParams = {
   toolProgressDetail?: "explain" | "raw";
   replyMediaContext?: ReplyMediaContext;
   onCompactionNoticePayload?: (payload: ReplyPayload) => Promise<void> | void;
+  confirmRestartRecoveryArmedAfterLeaseLoss?: () => Promise<boolean>;
   isRestartRecoveryArmed?: () => boolean;
 };
 

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -577,6 +577,7 @@ export async function runReplyAgent(
     beginBeforeAgentReply,
     checkpointBeforeAgentReply,
     clear: clearRestartRecoveryDeliveryClaim,
+    confirmRestartRecoveryArmedAfterLeaseLoss,
     isArmed: isRestartRecoveryArmed,
   } = createReplyAgentRestartRecoveryController({
     activeSessionStore,
@@ -645,6 +646,7 @@ export async function runReplyAgent(
       blockStreamingEnabled,
       cfg,
       checkpointBeforeAgentReply,
+      confirmRestartRecoveryArmedAfterLeaseLoss,
       commandBody,
       defaultModel,
       followupRun,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { SessionWriteLockStaleError } from "../../agents/session-write-lock-error.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
@@ -24,6 +25,7 @@ import {
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
 import type { TemplateContext } from "../templating.js";
+import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions } from "../types.js";
 import {
   GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
@@ -2246,6 +2248,77 @@ describe("runReplyAgent pending final delivery capture", () => {
       expect(stored.restartRecoveryDeliveryRunId).toBeUndefined();
       expect(stored.restartRecoveryDeliverySourceRunId).toBeUndefined();
       expect(stored.restartRecoveryTerminalRunIds).toEqual(["control-ui-run"]);
+    } finally {
+      replyOperation.complete();
+    }
+  });
+
+  it("preserves an adopted restart claim when the replacement takes the SQLite lease", async () => {
+    const sessionEntry: SessionEntry = {
+      abortedLastRun: false,
+      restartRecoveryDeliveryRequestFingerprint: "request-fingerprint",
+      restartRecoveryDeliveryRunId: "msg",
+      restartRecoveryDeliverySourceRunId: "control-ui-run",
+      sessionId: "session",
+      status: "running",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: sessionEntry };
+    const storePath = await createSessionStoreFile(sessionEntry);
+    const replyOperation = createReplyOperation({
+      sessionKey: "main",
+      sessionId: "session",
+      resetTriggered: false,
+    });
+    replyOperation.setPhase("running");
+    state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      const current = await readStoredMainSession(storePath);
+      expect(current.restartRecoveryDeliveryRunId).toBe("msg");
+      await replaceSessionEntry(
+        { storePath, sessionKey: "main" },
+        {
+          ...current,
+          abortedLastRun: true,
+          status: "killed",
+          updatedAt: Date.now(),
+        },
+      );
+      throw new SessionWriteLockStaleError({
+        lockPath: "sqlite:session-write:agent:main:main",
+        owner: "replacement gateway",
+        staleReasons: ["lease-lost"],
+      });
+    });
+
+    try {
+      const { run } = createMinimalRun({
+        replyOperation,
+        sessionCtx: {
+          Provider: "webchat",
+          OriginatingChannel: "webchat",
+        },
+        runOverrides: { agentId: "main", messageProvider: "webchat" },
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+
+      await expect(run()).resolves.toEqual({ text: SILENT_REPLY_TOKEN });
+
+      expect(replyOperation.result).toEqual({
+        kind: "aborted",
+        code: "aborted_for_restart",
+      });
+      expect(await readStoredMainSession(storePath)).toMatchObject({
+        abortedLastRun: true,
+        restartRecoveryDeliveryRunId: "msg",
+        restartRecoveryDeliverySourceRunId: "control-ui-run",
+        status: "killed",
+      });
+      expect(
+        (await readStoredMainSession(storePath)).restartRecoveryTerminalRunIds,
+      ).toBeUndefined();
     } finally {
       replyOperation.complete();
     }

--- a/src/auto-reply/reply/restart-recovery-claim.test.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
@@ -6,15 +7,35 @@ import {
   replaceSessionEntry,
   updateSessionEntry,
 } from "../../config/sessions/session-accessor.js";
+import { resolveSqliteReadScope } from "../../config/sessions/session-accessor.sqlite-scope.js";
 import type { InternalSessionEntry, SessionEntry } from "../../config/sessions/types.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import type {
   UserTurnTranscriptRecorder,
   UserTurnTranscriptTarget,
 } from "../../sessions/user-turn-transcript.types.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { createReplyRestartRecoveryClaimController } from "./restart-recovery-claim.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function replaceSessionEntryFromIndependentConnection(params: {
+  entry: SessionEntry;
+  sessionKey: string;
+  storePath: string;
+}): void {
+  const database = openOpenClawAgentDatabase(
+    resolveSqliteReadScope({ storePath: params.storePath, sessionKey: params.sessionKey }),
+  );
+  const external = new DatabaseSync(database.path);
+  try {
+    external
+      .prepare("UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?")
+      .run(JSON.stringify(params.entry), params.entry.updatedAt, params.sessionKey);
+  } finally {
+    external.close();
+  }
+}
 
 describe("createReplyRestartRecoveryClaimController", () => {
   it("retargets durable user-turn admission to the prepared reply session", async () => {
@@ -239,5 +260,121 @@ describe("createReplyRestartRecoveryClaimController", () => {
       restartRecoveryDeliverySourceRunId: "telegram-update-old",
       status: "done",
     });
+  });
+
+  it("confirms an active replacement claim after SQLite lease loss", async () => {
+    const root = tempDirs.make("openclaw-reply-restart-handoff-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:main";
+    const sessionId = "session";
+    let entry: SessionEntry = {
+      abortedLastRun: false,
+      restartRecoveryDeliveryRunId: "old-run",
+      restartRecoveryDeliverySourceRunId: "source-run",
+      sessionId,
+      status: "running",
+      updatedAt: Date.now(),
+    };
+    await replaceSessionEntry({ storePath, sessionKey }, entry);
+    const controller = createReplyRestartRecoveryClaimController({
+      admissionRunId: "old-run",
+      getEntry: () => entry,
+      getSessionId: () => sessionId,
+      isRestartAbort: () => false,
+      resolveDeliveryContext: () => undefined,
+      sessionKey,
+      setEntry: (next) => {
+        entry = next;
+      },
+      storePath,
+    });
+    await expect(controller.admitUserTurn()).resolves.toBe("admitted");
+
+    replaceSessionEntryFromIndependentConnection({
+      entry: {
+        ...entry,
+        abortedLastRun: true,
+        status: "killed",
+        updatedAt: Date.now() + 1,
+      },
+      sessionKey,
+      storePath,
+    });
+
+    expect(entry.abortedLastRun).toBe(false);
+    await expect(controller.confirmRestartRecoveryArmedAfterLeaseLoss()).resolves.toBe(true);
+    expect(entry).toMatchObject({
+      abortedLastRun: true,
+      restartRecoveryDeliveryRunId: "old-run",
+      restartRecoveryDeliverySourceRunId: "source-run",
+      status: "killed",
+    });
+
+    await controller.clear();
+    expect(loadSessionEntry({ storePath, sessionKey, readConsistency: "latest" })).toMatchObject({
+      abortedLastRun: true,
+      restartRecoveryDeliveryRunId: "old-run",
+      restartRecoveryDeliverySourceRunId: "source-run",
+      status: "killed",
+    });
+  });
+
+  it("confirms a completed replacement handoff by its terminal source marker", async () => {
+    const root = tempDirs.make("openclaw-reply-completed-handoff-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:main";
+    const sessionId = "session";
+    let entry: SessionEntry = {
+      abortedLastRun: false,
+      restartRecoveryDeliveryRunId: "old-run",
+      restartRecoveryDeliverySourceRunId: "source-run",
+      sessionId,
+      status: "running",
+      updatedAt: Date.now(),
+    };
+    await replaceSessionEntry({ storePath, sessionKey }, entry);
+    const controller = createReplyRestartRecoveryClaimController({
+      admissionRunId: "old-run",
+      getEntry: () => entry,
+      getSessionId: () => sessionId,
+      isRestartAbort: () => false,
+      resolveDeliveryContext: () => undefined,
+      sessionKey,
+      setEntry: (next) => {
+        entry = next;
+      },
+      storePath,
+    });
+    await expect(controller.admitUserTurn()).resolves.toBe("admitted");
+
+    replaceSessionEntryFromIndependentConnection({
+      entry: {
+        ...entry,
+        abortedLastRun: false,
+        restartRecoveryDeliveryRunId: undefined,
+        restartRecoveryDeliverySourceRunId: undefined,
+        restartRecoveryTerminalRunIds: ["source-run"],
+        status: "done",
+        updatedAt: Date.now() + 1,
+      },
+      sessionKey,
+      storePath,
+    });
+
+    expect(entry.restartRecoveryTerminalRunIds).toBeUndefined();
+    await expect(controller.confirmRestartRecoveryArmedAfterLeaseLoss()).resolves.toBe(true);
+    expect(entry).toMatchObject({
+      abortedLastRun: false,
+      restartRecoveryTerminalRunIds: ["source-run"],
+      status: "done",
+    });
+    expect(entry.restartRecoveryDeliveryRunId).toBeUndefined();
+    expect(entry.restartRecoveryDeliverySourceRunId).toBeUndefined();
+
+    await controller.clear();
+    const persisted = loadSessionEntry({ storePath, sessionKey, readConsistency: "latest" });
+    expect(persisted?.restartRecoveryTerminalRunIds).toEqual(["source-run"]);
+    expect(persisted?.restartRecoveryDeliveryRunId).toBeUndefined();
+    expect(persisted?.restartRecoveryDeliverySourceRunId).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -34,6 +34,7 @@ type ReplyRestartRecoveryClaimController = {
     };
   }) => Promise<void>;
   clear: () => Promise<void>;
+  confirmRestartRecoveryArmedAfterLeaseLoss: () => Promise<boolean>;
   isArmed: () => boolean;
 };
 
@@ -129,6 +130,7 @@ export function createReplyRestartRecoveryClaimController(params: {
   let recoveryRunId: string = randomUUID();
   let recoverySourceRunId: string | undefined;
   let tracked = false;
+  let leaseLossRestartHandoffConfirmed = false;
 
   const persistAdmissionPatch = async (options: {
     entry: SessionEntry;
@@ -436,8 +438,43 @@ export function createReplyRestartRecoveryClaimController(params: {
       return true;
     };
 
+  const confirmRestartRecoveryArmedAfterLeaseLoss = async (): Promise<boolean> => {
+    if (!tracked || !params.sessionKey || !params.storePath || !recoverySourceRunId) {
+      return false;
+    }
+    // Lease loss means the replacement may have advanced the authoritative row
+    // past this process's cache. This cold error path performs one latest read.
+    const persisted = loadSessionEntry({
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      clone: false,
+      hydrateSkillPromptRefs: false,
+      readConsistency: "latest",
+    });
+    if (!persisted || persisted.sessionId !== params.getSessionId()) {
+      return false;
+    }
+    params.setEntry(persisted);
+    const activeHandoff =
+      persisted.abortedLastRun === true &&
+      normalizeOptionalString(persisted.restartRecoveryDeliveryRunId) === recoveryRunId &&
+      hasRestartRecoverySourceClaim(persisted, recoverySourceRunId);
+    // The replacement may finish and clear the active claim before the old
+    // owner observes lease loss. Its terminal source marker proves completion.
+    const completedHandoff = hasRestartRecoveryTerminalRun(persisted, recoverySourceRunId);
+    const armed = activeHandoff || completedHandoff;
+    leaseLossRestartHandoffConfirmed ||= armed;
+    return armed;
+  };
+
   const clear = async (): Promise<void> => {
-    if (!tracked || !params.sessionKey || !params.storePath || params.isRestartAbort()) {
+    if (
+      !tracked ||
+      !params.sessionKey ||
+      !params.storePath ||
+      params.isRestartAbort() ||
+      leaseLossRestartHandoffConfirmed
+    ) {
       return;
     }
     const persisted = await updateSessionEntry(
@@ -524,5 +561,12 @@ export function createReplyRestartRecoveryClaimController(params: {
     return persisted?.abortedLastRun === true || params.getEntry()?.abortedLastRun === true;
   };
 
-  return { admitUserTurn, beginBeforeAgentReply, checkpointBeforeAgentReply, clear, isArmed };
+  return {
+    admitUserTurn,
+    beginBeforeAgentReply,
+    checkpointBeforeAgentReply,
+    clear,
+    confirmRestartRecoveryArmedAfterLeaseLoss,
+    isArmed,
+  };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an old Gateway process could surface a failure and clear restart-recovery state after the replacement Gateway had already taken the SQLite session lease.

## Why This Change Was Made

Lease loss is now classified through wrapped error causes, then confirmed against one authoritative latest SQLite read. The old owner hands off silently only when the row proves either the replacement's active recovery claim or the matching terminal source marker; cleanup then remains owned by the replacement.

This is the combined canonical repair from the two Beta 7 handoff fixes. Neither partial behavior is ported alone.

## User Impact

In-flight replies interrupted by a Gateway restart are no longer failed or stripped of their recovery claim when the replacement process wins the session lease first.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/restart-recovery-claim.test.ts src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts` — 26 passed
- Exact run-level case: 1 passed, 122 skipped
- Broad E2E file: the new handoff case passed; one unrelated pre-existing active-steering test timed out after 122 passes
- Targeted oxfmt and `git diff --check` passed
- Fresh local autoreview: clean, correctness 0.94
- Production LOC: +96/-2; tests: +260/-0
- No config, protocol, schema-version, or public API change
