### PR TITLE
fix(agents): preserve model-specific reasoning defaults

### DIFF
--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -2272,6 +2272,169 @@ describe("createModelSelectionState auth-profile override flapping regression", 
 });
 
 describe("createModelSelectionState resolveDefaultReasoningLevel", () => {
+  const createConfiguredReasoningState = async (params?: {
+    configuredReasoning?: boolean;
+    usePreparedCatalog?: boolean;
+  }) => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "local/fast-reasoner": {},
+          },
+        },
+      },
+      models: {
+        providers: {
+          local: {
+            baseUrl: "http://localhost:9000/v1",
+            models: [
+              makeConfiguredModel({
+                id: "fast-reasoner",
+                name: "Fast Reasoner",
+                reasoning: params?.configuredReasoning,
+              }),
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const preparedModelCatalog = params?.usePreparedCatalog
+      ? {
+          entries: [
+            { provider: "local", id: "fast-reasoner", name: "Fast Reasoner", reasoning: true },
+          ],
+          routeVariants: [],
+          authoritative: true,
+        }
+      : undefined;
+
+    return createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      defaultProvider: "local",
+      defaultModel: "fast-reasoner",
+      provider: "local",
+      model: "fast-reasoner",
+      hasModelDirective: false,
+      ...(preparedModelCatalog ? { preparedModelCatalog } : {}),
+    });
+  };
+
+  it.each(["reasoning-first", "thinking-first"] as const)(
+    "shares discovered capability metadata across %s default resolution",
+    async (resolutionOrder) => {
+      vi.mocked(loadModelCatalogLocal).mockClear();
+      catalogRuntimeMocks.loadModelCatalogSnapshot.mockClear();
+      vi.mocked(loadModelCatalogLocal).mockResolvedValueOnce([
+        { provider: "local", id: "fast-reasoner", name: "Fast Reasoner", reasoning: true },
+      ]);
+      const state = await createConfiguredReasoningState();
+      const expectedCatalog = [
+        expect.objectContaining({ provider: "local", id: "fast-reasoner", reasoning: true }),
+      ];
+
+      if (resolutionOrder === "reasoning-first") {
+        await expect(state.resolveDefaultReasoningLevel()).resolves.toBe("on");
+        await expect(state.resolveThinkingCatalog()).resolves.toEqual(expectedCatalog);
+      } else {
+        await expect(state.resolveThinkingCatalog()).resolves.toEqual(expectedCatalog);
+        await expect(state.resolveDefaultReasoningLevel()).resolves.toBe("on");
+      }
+
+      await expect(state.resolveDefaultReasoningLevel()).resolves.toBe("on");
+      expect(loadModelCatalogLocal).toHaveBeenCalledOnce();
+      expect(catalogRuntimeMocks.loadModelCatalogSnapshot).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("reuses the prepared owner for incomplete configured reasoning metadata", async () => {
+    vi.mocked(loadModelCatalogLocal).mockClear();
+    catalogRuntimeMocks.loadModelCatalogSnapshot.mockClear();
+    const state = await createConfiguredReasoningState({ usePreparedCatalog: true });
+
+    await expect(state.resolveDefaultReasoningLevel()).resolves.toBe("on");
+    await expect(state.resolveThinkingCatalog()).resolves.toEqual([
+      expect.objectContaining({ provider: "local", id: "fast-reasoner", reasoning: true }),
+    ]);
+    expect(loadModelCatalogLocal).not.toHaveBeenCalled();
+    expect(catalogRuntimeMocks.loadModelCatalogSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("keeps locked model reasoning without exposing it through the allowed catalog", async () => {
+    vi.mocked(loadModelCatalogLocal).mockClear();
+    vi.mocked(loadManifestModelCatalog).mockClear();
+    catalogRuntimeMocks.loadModelCatalogSnapshot.mockClear();
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "local/allowed-model" },
+          models: {
+            "local/allowed-model": {},
+            "other/*": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:main:direct:locked-local-reasoner";
+    const sessionEntry = makeEntry({
+      providerOverride: "local",
+      modelOverride: "locked-reasoner",
+      modelOverrideSource: "user",
+      modelSelectionLocked: true,
+    });
+    const preparedModelCatalog = {
+      entries: [
+        { provider: "local", id: "allowed-model", name: "Allowed Model", reasoning: false },
+        { provider: "local", id: "locked-reasoner", name: "Locked Reasoner", reasoning: true },
+      ],
+      routeVariants: [],
+      authoritative: true,
+    };
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultProvider: "local",
+      defaultModel: "allowed-model",
+      provider: "local",
+      model: "allowed-model",
+      hasModelDirective: false,
+      preparedModelCatalog,
+    });
+
+    expect(state.provider).toBe("local");
+    expect(state.model).toBe("locked-reasoner");
+    expect(state.allowedModelKeys.has("local/locked-reasoner")).toBe(false);
+    expect(state.allowedModelCatalog).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "locked-reasoner" })]),
+    );
+    await expect(state.resolveThinkingCatalog()).resolves.not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "locked-reasoner" })]),
+    );
+    await expect(state.resolveDefaultReasoningLevel()).resolves.toBe("on");
+    expect(loadManifestModelCatalog).not.toHaveBeenCalled();
+    expect(loadModelCatalogLocal).not.toHaveBeenCalled();
+    expect(catalogRuntimeMocks.loadModelCatalogSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicitly non-reasoning configured models discovery-free", async () => {
+    vi.mocked(loadModelCatalogLocal).mockClear();
+    vi.mocked(loadManifestModelCatalog).mockClear();
+    catalogRuntimeMocks.loadModelCatalogSnapshot.mockClear();
+    const state = await createConfiguredReasoningState({ configuredReasoning: false });
+
+    await expect(state.resolveDefaultReasoningLevel()).resolves.toBe("off");
+    await expect(state.resolveThinkingCatalog()).resolves.toEqual([
+      expect.objectContaining({ provider: "local", id: "fast-reasoner", reasoning: false }),
+    ]);
+    expect(loadManifestModelCatalog).not.toHaveBeenCalled();
+    expect(loadModelCatalogLocal).not.toHaveBeenCalled();
+    expect(catalogRuntimeMocks.loadModelCatalogSnapshot).not.toHaveBeenCalled();
+  });
+
   it("uses manifest metadata before hydrating the runtime reasoning catalog", async () => {
     vi.mocked(loadModelCatalogLocal).mockClear();
     vi.mocked(loadManifestModelCatalog).mockClear();

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -673,40 +673,21 @@ export async function createModelSelectionState(params: {
     if (defaultReasoningLevel) {
       return defaultReasoningLevel;
     }
-    let catalogForReasoning = modelCatalog ?? allowedModelCatalog;
-    let selectedReasoningEntry = findSelectedCatalogEntry({
-      catalog: catalogForReasoning,
+    const visibleCapabilityCatalog = await resolveThinkingCatalog();
+    const visibleSelectedEntry = findSelectedCatalogEntry({
+      catalog: visibleCapabilityCatalog,
       provider,
       model,
     });
-    if (!modelCatalog && selectedReasoningEntry?.reasoning === undefined) {
-      const manifestCatalog = await loadManifestCatalog();
-      const manifestReasoningCatalog =
-        hasAllowlist || hasConfiguredModels
-          ? buildThinkingCatalog(manifestCatalog)
-          : manifestCatalog;
-      const manifestSelectedEntry = findSelectedCatalogEntry({
-        catalog: manifestReasoningCatalog,
-        provider,
-        model,
-      });
-      if (manifestSelectedEntry?.reasoning !== undefined) {
-        catalogForReasoning = manifestReasoningCatalog;
-        selectedReasoningEntry = manifestSelectedEntry;
-      }
-    }
-    if (
-      (!catalogForReasoning || catalogForReasoning.length === 0) &&
-      selectedReasoningEntry?.reasoning === undefined
-    ) {
-      modelCatalog = (await loadRuntimeCatalogSnapshot()).entries;
-      logStage("catalog-loaded-for-reasoning", `entries=${modelCatalog.length}`);
-      catalogForReasoning = modelCatalog;
-    }
+    // A locked session owns its selected model even when picker visibility excludes it.
+    const lockedSelectedEntry =
+      modelSelectionLocked && modelCatalog && !visibleSelectedEntry
+        ? findSelectedCatalogEntry({ catalog: modelCatalog, provider, model })
+        : undefined;
     defaultReasoningLevel = resolveReasoningDefault({
       provider,
       model,
-      catalog: catalogForReasoning,
+      catalog: lockedSelectedEntry ? [lockedSelectedEntry] : visibleCapabilityCatalog,
     });
     return defaultReasoningLevel;
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a configured reasoning-capable model defaulted to reasoning **off** when its configured model row omitted reasoning metadata and default reasoning was resolved before the existing authoritative prepared thinking catalog. Resolution order accidentally decided the answer even though the capability was already available.

## Why This Change Was Made

Resolve default reasoning through the existing cached thinking-catalog owner, reuse the prepared authoritative catalog, and remove duplicate discovery and 19 production lines. An explicitly locked hidden model continues to use its private authoritative row without exposing that model to the picker; this is an unchanged compatibility invariant, not the behavior being changed.

## User Impact

A reasoning-capable configured model now defaults to `on` regardless of whether reasoning or the thinking catalog is resolved first. Explicitly non-reasoning models stay `off`, hidden locked models remain hidden and keep the same `on` result before and after, and no configuration, persisted-session format, public SDK, or picker-visibility contract changes.

## Evidence

- Exact candidate: `66264757fc68033a78981178f3127e00644cc293`; exact parent: `fe81123fe80ba85a4223555c4fa6542a8e422c35`.
- **Actual unmocked production runtime, exact parent:** The identical configured `local/fast-reasoner` model omits its local `reasoning` field while the already-prepared authoritative model row has `reasoning: true`. Calling the real `createModelSelectionState` and resolving default reasoning first produces:

  ```json
  {
    "selectedModel": "local/fast-reasoner",
    "configuredReasoningMetadata": "missing",
    "authoritativeCatalogReasoning": true,
    "resolutionOrder": "default-reasoning-before-thinking-catalog",
    "effectiveDefaultReasoning": "off",
    "pickerModels": ["local/fast-reasoner"],
    "thinkingCatalogReportsReasoning": true
  }
  ```

- **Actual unmocked production runtime, exact candidate:** The identical input through the candidate's real model-selection owner produces:

  ```json
  {
    "selectedModel": "local/fast-reasoner",
    "configuredReasoningMetadata": "missing",
    "authoritativeCatalogReasoning": true,
    "resolutionOrder": "default-reasoning-before-thinking-catalog",
    "effectiveDefaultReasoning": "on",
    "pickerModels": ["local/fast-reasoner"],
    "thinkingCatalogReportsReasoning": true
  }
  ```

- **Locked-hidden compatibility control, actual unmocked production runtime:** BOTH exact parent and exact candidate independently report the same result below. In particular, this PR does **not** change an existing locked session from `off` to `on`; any review premise asserting that compatibility change is contradicted by both exact-parent runtime and the parent regression test.

  ```json
  {
    "selectedModel": "local/locked-reasoner",
    "locked": true,
    "pickerContainsLockedModel": false,
    "pickerModels": ["local/allowed-model"],
    "thinkingCatalogContainsLockedModel": false,
    "effectiveDefaultReasoning": "on"
  }
  ```

- **Exact-parent RED:** On the same Blacksmith Testbox, the final owner suite against exact parent production failed three actual regressions: reasoning-first configured discovery, incomplete configured metadata with an authoritative prepared catalog, and a catalog model explicitly marked reasoning-capable; 74 existing tests passed. The locked-hidden compatibility regression already passed on the parent.
- **Exact-head GREEN:** owner suite 77/77; four related model-catalog, model-selection, and directive suites 175/175; exact-head `pnpm tsgo:core`, `pnpm tsgo:core:test`, scoped oxlint, and scoped oxfmt all passed.
- Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30754717534; lease was explicitly stopped and independently confirmed completed.
- Four fresh independent hostile source/dependency reviewers approved the immutable head; actual autoreview passed with `gpt-5.6-sol`, high reasoning, `--max-priority P3`, and a real TruffleHog scan.
- **Personally inspected actual sibling Codex source:** `../codex/codex-rs/protocol/src/openai_models.rs:202` defines model-default reasoning independently of picker presentation; `../codex/codex-rs/protocol/src/openai_models.rs:368` retains independent reasoning and visibility metadata; `../codex/codex-rs/protocol/src/openai_models.rs:618` maps authoritative reasoning and `show_in_picker` independently; `../codex/codex-rs/app-server/src/models.rs:13` filters picker visibility separately from model reasoning; and `../codex/codex-rs/app-server-protocol/src/protocol/v2/model.rs:79` exposes hidden status alongside supported/default reasoning. These files were directly read from the sibling source checkout, not inferred from wrappers, generated schemas, or a subagent summary.
- **Maintainer/owner decision:** @steipete explicitly authorizes the narrow owner-level restoration of `off` → `on` only for configured models whose authoritative catalog says reasoning is supported. Existing hidden locked-session behavior and visibility remain unchanged (`on` → `on`, absent from the picker); there is no persisted-session compatibility or changed-default migration decision to waive. The protected `maintainer` label reflects the PR owner, not an unresolved product-owner decision.
