### PR TITLE
docs(cli): explain reserved catalog roots and drop stale entries

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -151,11 +151,6 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
   },
   {
-    commandPath: ["config", "models"],
-    exact: true,
-    policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
-  },
-  {
     commandPath: ["migrate"],
     policy: { configGuard: "skip", loadPlugins: "never", networkProxy: "bypass" },
   },
@@ -201,7 +196,6 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   { commandPath: ["gateway", "call"], exact: true, policy: { networkProxy: "bypass" } },
   { commandPath: ["gateway", "diagnostics"], exact: true, policy: { networkProxy: "bypass" } },
   { commandPath: ["gateway", "discover"], exact: true, policy: { networkProxy: "bypass" } },
-  { commandPath: ["gateway", "export"], exact: true, policy: { networkProxy: "bypass" } },
   {
     commandPath: ["gateway", "health"],
     exact: true,
@@ -331,10 +325,14 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     route: { id: "tasks-list" },
   },
   {
+    // This unregistered root is reserved so plugin registration cannot claim it;
+    // the catalog entry preserves its startup policy.
     commandPath: ["tool"],
     policy: { loadPlugins: "never", ensureCliPath: false, networkProxy: "bypass" },
   },
   {
+    // This unregistered root is reserved so plugin registration cannot claim it;
+    // the catalog entry preserves its startup policy.
     commandPath: ["tools"],
     policy: { loadPlugins: "never", ensureCliPath: false, networkProxy: "bypass" },
   },

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -2,7 +2,6 @@
 // registered Commander commands. Keep those user-facing descriptions aligned.
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadBundledPluginPublicSurface } from "../../test-utils/bundled-plugin-public-surface.js";
 import { cliCommandCatalog } from "../command-catalog.js";
 import { isReservedNonPluginCommandRoot } from "../command-registration-policy.js";
 import { collectShellCompletionCommandTree } from "../completion-command-tree.js";
@@ -15,6 +14,11 @@ import { getSubCliEntries } from "./subcli-descriptors.js";
 const RESERVED_CATALOG_ROOTS = {
   tool: "reserved so plugin registration cannot claim this unregistered root",
   tools: "reserved so plugin registration cannot claim this unregistered root",
+} as const;
+
+const PLUGIN_CATALOG_PATHS = {
+  "memory search": "registered and covered by the memory-core plugin",
+  "memory status": "registered and covered by the memory-core plugin",
 } as const;
 
 const JSON_NOT_APPLICABLE = {
@@ -304,10 +308,6 @@ describe("root command descriptions", () => {
 
   it("keeps startup policy catalog paths registered or explicitly reserved", async () => {
     const program = await registerAllBuiltInCommands();
-    const { registerMemoryCli } = await loadBundledPluginPublicSurface<{
-      registerMemoryCli: (program: Command) => void;
-    }>({ pluginId: "memory-core", artifactBasename: "cli" });
-    registerMemoryCli(program);
 
     // Private QA is a lazy source-checkout command. Its root placeholder proves
     // registration without importing the private build omitted from normal dist.
@@ -318,14 +318,17 @@ describe("root command descriptions", () => {
     const registeredPaths = collectRegisteredCommandPaths(program, lazyProgram);
     const catalogPaths = new Set(cliCommandCatalog.map((entry) => entry.commandPath.join(" ")));
     const reservedPaths = new Set(Object.keys(RESERVED_CATALOG_ROOTS));
+    const pluginPaths = new Set(Object.keys(PLUGIN_CATALOG_PATHS));
 
     expect(
-      Object.entries(RESERVED_CATALOG_ROOTS).filter(([, reason]) => reason.trim().length === 0),
-      "every reserved catalog root must document why it has no command",
+      Object.entries({ ...RESERVED_CATALOG_ROOTS, ...PLUGIN_CATALOG_PATHS }).filter(
+        ([, reason]) => reason.trim().length === 0,
+      ),
+      "every catalog exception must document why core has no command",
     ).toEqual([]);
 
     const missing = [...catalogPaths].filter(
-      (path) => !registeredPaths.has(path) && !reservedPaths.has(path),
+      (path) => !registeredPaths.has(path) && !reservedPaths.has(path) && !pluginPaths.has(path),
     );
     expect(missing, "catalog entries with no registered command or reserved-root decision").toEqual(
       [],
@@ -338,6 +341,11 @@ describe("root command descriptions", () => {
       staleReservedRoots,
       "reserved catalog roots must remain cataloged and blocked from plugin registration",
     ).toEqual([]);
+
+    const stalePluginPaths = [...pluginPaths].filter(
+      (path) => !catalogPaths.has(path) || registeredPaths.has(path),
+    );
+    expect(stalePluginPaths, "plugin catalog paths must remain plugin-owned").toEqual([]);
 
     const reservedRootsThatNowRegister = [...reservedPaths].filter((path) =>
       registeredPaths.has(path),

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -2,6 +2,7 @@
 // registered Commander commands. Keep those user-facing descriptions aligned.
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerPluginCliCommands } from "../../plugins/cli.js";
 import { cliCommandCatalog } from "../command-catalog.js";
 import { isReservedNonPluginCommandRoot } from "../command-registration-policy.js";
 import { collectShellCompletionCommandTree } from "../completion-command-tree.js";
@@ -303,8 +304,15 @@ describe("root command descriptions", () => {
 
   it("keeps startup policy catalog paths registered or explicitly reserved", async () => {
     const program = await registerAllBuiltInCommands();
-    const { registerMemoryCli } = await import("../../../extensions/memory-core/cli.js");
-    registerMemoryCli(program);
+    await registerPluginCliCommands(
+      program,
+      {},
+      undefined,
+      { pluginSdkResolution: "src" },
+      {
+        primary: "memory",
+      },
+    );
 
     // Private QA is a lazy source-checkout command. Its root placeholder proves
     // registration without importing the private build omitted from normal dist.

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -2,12 +2,19 @@
 // registered Commander commands. Keep those user-facing descriptions aligned.
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cliCommandCatalog } from "../command-catalog.js";
+import { isReservedNonPluginCommandRoot } from "../command-registration-policy.js";
 import { collectShellCompletionCommandTree } from "../completion-command-tree.js";
 import { getCoreCliCommandNames, registerCoreCliByName } from "./command-registry-core.js";
 import { createProgramContext } from "./context.js";
 import { getCoreCliCommandDescriptors } from "./core-command-descriptors.js";
-import { registerSubCliByName } from "./register.subclis.js";
+import { registerSubCliByName, registerSubCliCommands } from "./register.subclis.js";
 import { getSubCliEntries } from "./subcli-descriptors.js";
+
+const RESERVED_CATALOG_ROOTS = {
+  tool: "reserved so plugin registration cannot claim this unregistered root",
+  tools: "reserved so plugin registration cannot claim this unregistered root",
+} as const;
 
 const JSON_NOT_APPLICABLE = {
   namespaces: {
@@ -241,6 +248,16 @@ function supportsJsonOutput(path: string, command: Command): boolean {
   );
 }
 
+function collectRegisteredCommandPaths(...programs: Command[]): Set<string> {
+  return new Set(
+    programs.flatMap((program) =>
+      collectShellCompletionCommandTree(program).descendants.flatMap((context) =>
+        context.pathVariants.map((path) => path.join(" ")),
+      ),
+    ),
+  );
+}
+
 describe("root command descriptions", () => {
   beforeEach(() => {
     vi.stubEnv("OPENCLAW_ENABLE_PRIVATE_QA_CLI", "");
@@ -282,6 +299,50 @@ describe("root command descriptions", () => {
 
     expect(missing, "catalog entries with no registered command or alias").toEqual([]);
     expect(mismatches, "root help vs registered command description drift").toEqual([]);
+  });
+
+  it("keeps startup policy catalog paths registered or explicitly reserved", async () => {
+    const program = await registerAllBuiltInCommands();
+    const { registerMemoryCli } = await import("../../../extensions/memory-core/cli.js");
+    registerMemoryCli(program);
+
+    // Private QA is a lazy source-checkout command. Its root placeholder proves
+    // registration without importing the private build omitted from normal dist.
+    vi.stubEnv("OPENCLAW_ENABLE_PRIVATE_QA_CLI", "1");
+    const lazyProgram = new Command().name("openclaw");
+    registerSubCliCommands(lazyProgram, ["node", "openclaw", "--help"]);
+
+    const registeredPaths = collectRegisteredCommandPaths(program, lazyProgram);
+    const catalogPaths = new Set(cliCommandCatalog.map((entry) => entry.commandPath.join(" ")));
+    const reservedPaths = new Set(Object.keys(RESERVED_CATALOG_ROOTS));
+
+    expect(
+      Object.entries(RESERVED_CATALOG_ROOTS).filter(([, reason]) => reason.trim().length === 0),
+      "every reserved catalog root must document why it has no command",
+    ).toEqual([]);
+
+    const missing = [...catalogPaths].filter(
+      (path) => !registeredPaths.has(path) && !reservedPaths.has(path),
+    );
+    expect(missing, "catalog entries with no registered command or reserved-root decision").toEqual(
+      [],
+    );
+
+    const staleReservedRoots = [...reservedPaths].filter(
+      (path) => !catalogPaths.has(path) || !isReservedNonPluginCommandRoot(path),
+    );
+    expect(
+      staleReservedRoots,
+      "reserved catalog roots must remain cataloged and blocked from plugin registration",
+    ).toEqual([]);
+
+    const reservedRootsThatNowRegister = [...reservedPaths].filter((path) =>
+      registeredPaths.has(path),
+    );
+    expect(
+      reservedRootsThatNowRegister,
+      "registered commands must leave the reserved-root exception list",
+    ).toEqual([]);
   });
 
   it("classifies every built-in command as JSON output or explicitly not applicable", async () => {

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -2,7 +2,7 @@
 // registered Commander commands. Keep those user-facing descriptions aligned.
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { registerPluginCliCommands } from "../../plugins/cli.js";
+import { loadBundledPluginPublicSurface } from "../../test-utils/bundled-plugin-public-surface.js";
 import { cliCommandCatalog } from "../command-catalog.js";
 import { isReservedNonPluginCommandRoot } from "../command-registration-policy.js";
 import { collectShellCompletionCommandTree } from "../completion-command-tree.js";
@@ -304,15 +304,10 @@ describe("root command descriptions", () => {
 
   it("keeps startup policy catalog paths registered or explicitly reserved", async () => {
     const program = await registerAllBuiltInCommands();
-    await registerPluginCliCommands(
-      program,
-      {},
-      undefined,
-      { pluginSdkResolution: "src" },
-      {
-        primary: "memory",
-      },
-    );
+    const { registerMemoryCli } = await loadBundledPluginPublicSurface<{
+      registerMemoryCli: (program: Command) => void;
+    }>({ pluginId: "memory-core", artifactBasename: "cli" });
+    registerMemoryCli(program);
 
     // Private QA is a lazy source-checkout command. Its root placeholder proves
     // registration without importing the private build omitted from normal dist.


### PR DESCRIPTION
## What Problem This Solves

`src/cli/command-catalog.ts` contained four entries whose command path cannot be invoked. Verified against the live CLI on a production host:

| entry | live result |
| --- | --- |
| `["gateway","export"]` | `Too many arguments for this command.` — the real command is `gateway diagnostics export` |
| `["config","models"]` | `Too many arguments for this command.` |
| `["tool"]` | `OpenClaw does not know the command "tool".` |
| `["tools"]` | `OpenClaw does not know the command "tools".` |

Two of these are dead configuration; two are deliberate and were simply undocumented, which is why they read as bugs during a CLI audit.

## Why This Change Was Made

Each entry was verified from source, not assumed:

- **`gateway export` is stale.** Commander registers only `gateway diagnostics export` (`src/cli/gateway-cli/register.ts:768`); there is no alias or hidden direct child. Removed.
- **`config models` is stale.** `config` registers get/set/patch/unset/file/schema/validate; `models` is a separate root command. Removed.
- **`tool` and `tools` are intentional.** `src/cli/command-registration-policy.ts:5` defines `RESERVED_NON_PLUGIN_COMMAND_ROOTS = new Set(["auth","tool","tools"])`, and `shouldSkipPluginCommandRegistration` uses it so plugin registration cannot claim those roots. Their catalog entries exist to give the reserved roots a startup policy. Kept, and now carry a comment saying why — removing them would silently drop that policy.
- **`auth` is reserved too** but has no catalog entry, so nothing was needed there.

A dead catalog entry is policy that can never apply, which the repo's lean-code rules treat as stale state to delete rather than keep "just in case" — so the two unreachable entries are removed rather than annotated.

## User Impact

No behavior change: the removed entries could never match an invocation. The reserved roots keep their startup policy and now explain themselves to the next reader.

The durable part is the new guard: `src/cli/program/root-command-descriptions.test.ts` builds the **real core Commander tree** (including the source-only QA placeholder) and asserts every core-owned catalog path and alias variant resolves to a registered command. The memory paths remain explicit plugin-owned exceptions covered by the memory-core CLI suite, while `tool`/`tools` remain documented reserved-root exceptions. Reverse checks reject stale exceptions and paths that later become core commands. A future stale entry now fails CI instead of accumulating silently. This follows the guard patterns established in #117880 (cross-dispatch parity) and #117928 (`--json` surface).

## Evidence

- Root command descriptions (incl. new guard): 3 tests; startup policy 12; registration policy 3; memory CLI 81 — all passing, run individually.
- `pnpm tsgo:core`, `pnpm build`, `pnpm docs:list`: passed.
- Autoreview (Codex `gpt-5.6-sol`, high): clean, no actionable findings.
- Docs already referenced `gateway diagnostics export`, and no `config models` documentation exists, so no doc edits were needed.
- Production LOC `+4/-6` (net **-2**); tests net +72.
