### PR TITLE
test: gateway and CLI process-test hygiene

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -1,9 +1,9 @@
 // Process coverage for CLI help exits and route-first fallback validation.
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { promisify } from "node:util";
 import { Command, CommanderError } from "commander";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -11,13 +11,11 @@ import { registerCoreCliByName } from "./program/command-registry.js";
 import { createProgramContext } from "./program/context.js";
 import { registerSubCliByName } from "./program/register.subclis.js";
 
-const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 // This is a deadlock guard, not a startup SLO. Fork CI can take over a minute
 // to cold-load the CLI graph on shared hosted runners, while still exiting correctly.
-// It must stay below Vitest's 120s testTimeout so a hung child fails through
-// execFile with captured stdout/stderr instead of a blind vitest test timeout.
-const CHILD_PROCESS_TIMEOUT_MS = 100_000;
+const CHILD_PROCESS_TIMEOUT_MS = 240_000;
+const CHILD_PROCESS_TEST_TIMEOUT_MS = CHILD_PROCESS_TIMEOUT_MS + 10_000;
 const LAZY_GROUP_HELP_CASES = [
   { group: "backup", usageCommand: "backup", registry: "core" },
   { group: "capability", usageCommand: "infer|capability", registry: "subcli" },
@@ -153,7 +151,7 @@ async function runCliProcess(params: {
     );
     await fs.writeFile(path.join(fixture.stateDir, ".env"), `${lines.join("\n")}\n`);
   }
-  const result = await execFileAsync(
+  const child = spawn(
     process.execPath,
     [
       ...(params.forbidTlsImport
@@ -174,7 +172,6 @@ async function runCliProcess(params: {
     ],
     {
       cwd: path.resolve("."),
-      encoding: "utf8",
       env: {
         ...process.env,
         HOME: fixture.root,
@@ -195,11 +192,55 @@ async function runCliProcess(params: {
         VITEST: undefined,
         ...params.env,
       },
-      killSignal: "SIGKILL",
-      timeout: CHILD_PROCESS_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "pipe"],
     },
   );
-  return { ...result, fixture };
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const stdoutEnded = once(child.stdout, "end");
+  const stderrEnded = once(child.stderr, "end");
+  let timeout: NodeJS.Timeout | undefined;
+  const exit = await Promise.race([
+    Promise.all([once(child, "exit"), stdoutEnded, stderrEnded]).then(([[code, signal]]) => ({
+      code: code as number | null,
+      signal: signal as NodeJS.Signals | null,
+    })),
+    new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(
+          Object.assign(new Error("CLI process did not exit before the deadlock guard"), {
+            code: child.exitCode,
+            signal: child.signalCode,
+            stderr,
+            stdout,
+          }),
+        );
+      }, CHILD_PROCESS_TIMEOUT_MS);
+      timeout.unref();
+    }),
+  ]).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
+  if (exit.code !== 0) {
+    throw Object.assign(new Error(`CLI process exited with code ${exit.code}`), {
+      ...exit,
+      stderr,
+      stdout,
+    });
+  }
+  return { stderr, stdout, fixture };
 }
 
 function parseJsonLines(stdout: string): Array<Record<string, unknown>> {
@@ -603,32 +644,36 @@ describe("JSON console style process output", () => {
     );
   });
 
-  it("loads dotenv before formatting entry validation diagnostics", async () => {
-    let failure: CliProcessFailure | undefined;
-    try {
-      await runCliProcess({
-        args: ["--container"],
-        config: {
-          logging: {
-            consoleStyle: "${OPENCLAW_TEST_CONSOLE_STYLE}",
-            level: "silent",
+  it(
+    "loads dotenv before formatting entry validation diagnostics",
+    async () => {
+      let failure: CliProcessFailure | undefined;
+      try {
+        await runCliProcess({
+          args: ["--container"],
+          config: {
+            logging: {
+              consoleStyle: "${OPENCLAW_TEST_CONSOLE_STYLE}",
+              level: "silent",
+            },
           },
-        },
-        env: { OPENCLAW_TEST_CONSOLE_STYLE: undefined },
-        stateEnv: () => ({ OPENCLAW_TEST_CONSOLE_STYLE: "json" }),
-      });
-    } catch (error) {
-      failure = error as CliProcessFailure;
-    }
+          env: { OPENCLAW_TEST_CONSOLE_STYLE: undefined },
+          stateEnv: () => ({ OPENCLAW_TEST_CONSOLE_STYLE: "json" }),
+        });
+      } catch (error) {
+        failure = error as CliProcessFailure;
+      }
 
-    expect(failure?.code).toBe(2);
-    expect(parseJsonLines(failure?.stderr ?? "")).toEqual([
-      expect.objectContaining({
-        level: "error",
-        message: expect.stringContaining("--container requires a value"),
-      }),
-    ]);
-  });
+      expect(failure?.code).toBe(2);
+      expect(parseJsonLines(failure?.stderr ?? "")).toEqual([
+        expect.objectContaining({
+          level: "error",
+          message: expect.stringContaining("--container requires a value"),
+        }),
+      ]);
+    },
+    CHILD_PROCESS_TEST_TIMEOUT_MS,
+  );
 
   it("loads eligible dotenv before formatting a run-main import failure", async () => {
     let failure: CliProcessFailure | undefined;

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import { Command, CommanderError } from "commander";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { DEFAULT_VITEST_TEST_TIMEOUT_MS } from "../../test/vitest/vitest.timeouts.js";
 import { registerCoreCliByName } from "./program/command-registry.js";
 import { createProgramContext } from "./program/context.js";
 import { registerSubCliByName } from "./program/register.subclis.js";
@@ -14,8 +15,11 @@ import { registerSubCliByName } from "./program/register.subclis.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 // This is a deadlock guard, not a startup SLO. Fork CI can take over a minute
 // to cold-load the CLI graph on shared hosted runners, while still exiting correctly.
-const CHILD_PROCESS_TIMEOUT_MS = 240_000;
-const CHILD_PROCESS_TEST_TIMEOUT_MS = CHILD_PROCESS_TIMEOUT_MS + 10_000;
+// Keep the default guard below the shared Vitest deadline so it always reports
+// captured child output before the framework can replace it with an opaque timeout.
+const DEFAULT_CHILD_PROCESS_TIMEOUT_MS = DEFAULT_VITEST_TEST_TIMEOUT_MS - 20_000;
+const SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS = 240_000;
+const SLOW_DOTENV_TEST_TIMEOUT_MS = SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS + 10_000;
 const LAZY_GROUP_HELP_CASES = [
   { group: "backup", usageCommand: "backup", registry: "core" },
   { group: "capability", usageCommand: "infer|capability", registry: "subcli" },
@@ -139,6 +143,7 @@ async function runCliProcess(params: {
   loggingViaInclude?: boolean;
   loggingViaRootInclude?: boolean;
   stateEnv?: (stateDir: string) => Record<string, string>;
+  timeoutMs?: number;
 }) {
   const fixture = await createHelpProcessFixture(
     params.config,
@@ -178,7 +183,7 @@ async function runCliProcess(params: {
         // CI shard runners export NODE_COMPILE_CACHE; in a source checkout entry.ts
         // then respawns a detached grandchild that shares this child's stdio pipes.
         // If the deadlock guard SIGKILLs the parent, the orphan keeps the pipes open
-        // and execFile never settles, turning any slow child into a blind vitest
+        // and the process wait never settles, turning any slow child into a blind vitest
         // timeout with no diagnostics. Keep these children single-process; the
         // compile-cache respawn contract has dedicated entry.compile-cache coverage.
         NODE_DISABLE_COMPILE_CACHE: "1",
@@ -225,7 +230,7 @@ async function runCliProcess(params: {
             stdout,
           }),
         );
-      }, CHILD_PROCESS_TIMEOUT_MS);
+      }, params.timeoutMs ?? DEFAULT_CHILD_PROCESS_TIMEOUT_MS);
       timeout.unref();
     }),
   ]).finally(() => {
@@ -645,7 +650,7 @@ describe("JSON console style process output", () => {
   });
 
   it(
-    "loads dotenv before formatting entry validation diagnostics",
+    "captures exact exit code 2 after loading dotenv for entry validation diagnostics",
     async () => {
       let failure: CliProcessFailure | undefined;
       try {
@@ -659,6 +664,7 @@ describe("JSON console style process output", () => {
           },
           env: { OPENCLAW_TEST_CONSOLE_STYLE: undefined },
           stateEnv: () => ({ OPENCLAW_TEST_CONSOLE_STYLE: "json" }),
+          timeoutMs: SLOW_DOTENV_CHILD_PROCESS_TIMEOUT_MS,
         });
       } catch (error) {
         failure = error as CliProcessFailure;
@@ -672,7 +678,7 @@ describe("JSON console style process output", () => {
         }),
       ]);
     },
-    CHILD_PROCESS_TEST_TIMEOUT_MS,
+    SLOW_DOTENV_TEST_TIMEOUT_MS,
   );
 
   it("loads eligible dotenv before formatting a run-main import failure", async () => {

--- a/src/gateway/server-startup-model-runtime.event-loop.test.ts
+++ b/src/gateway/server-startup-model-runtime.event-loop.test.ts
@@ -150,7 +150,6 @@ describe("Gateway prepared model runtime startup", () => {
             startup: {
               sidecar: false,
               memory: false,
-              deferConfiguredChannelFullLoadUntilAfterListen: false,
               agentHarnesses: [],
             },
             compat: [],

--- a/src/gateway/server.startup-websocket-race.test.ts
+++ b/src/gateway/server.startup-websocket-race.test.ts
@@ -1,6 +1,6 @@
 // Startup WebSocket race tests ensure upgrade handlers are attached before the
 // gateway reports its listen step as ready.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import { tryListenOnPort } from "../infra/ports-probe.js";
 import { getFreePort, installGatewayTestHooks, startGatewayServer } from "./test-helpers.js";
@@ -10,6 +10,17 @@ type StartGatewayServer = typeof import("./test-helpers.js").startGatewayServer;
 type GatewayServerForTest = Awaited<ReturnType<StartGatewayServer>>;
 
 installGatewayTestHooks({ scope: "suite" });
+
+let loopbackAliasBindable = false;
+
+beforeAll(async () => {
+  try {
+    await tryListenOnPort({ host: "127.0.0.2", port: 0, exclusive: true });
+    loopbackAliasBindable = true;
+  } catch {
+    loopbackAliasBindable = false;
+  }
+});
 
 async function connectWebSocket(url: string): Promise<WebSocket> {
   const ws = new WebSocket(url);
@@ -90,7 +101,11 @@ describe("gateway startup websocket readiness", () => {
     }
   });
 
-  it("serves a specific IPv4 bind and its required loopback alias", async () => {
+  it("serves a specific IPv4 bind and its required loopback alias", async ({ skip }) => {
+    if (!loopbackAliasBindable) {
+      skip("127.0.0.2 is not bindable on this host");
+      return;
+    }
     const previousMinimal = process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
     process.env.OPENCLAW_TEST_MINIMAL_GATEWAY = "0";
     let server: GatewayServerForTest | undefined;

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -22,6 +22,7 @@ import {
 } from "./vitest.bundled-plugin-paths.ts";
 import { loadVitestExperimentalConfig } from "./vitest.performance-config.ts";
 import { shouldPrintVitestThrottle } from "./vitest.system-load.ts";
+import { DEFAULT_VITEST_TEST_TIMEOUT_MS } from "./vitest.timeouts.ts";
 
 export type OpenClawVitestPool = "forks" | "threads";
 
@@ -555,7 +556,7 @@ export const sharedVitestConfig = {
   },
   test: {
     dir: repoRoot,
-    testTimeout: 120_000,
+    testTimeout: DEFAULT_VITEST_TEST_TIMEOUT_MS,
     hookTimeout: isWindows ? 180_000 : 120_000,
     unstubEnvs: true,
     unstubGlobals: true,

--- a/test/vitest/vitest.timeouts.ts
+++ b/test/vitest/vitest.timeouts.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_VITEST_TEST_TIMEOUT_MS = 120_000;


### PR DESCRIPTION
## What Problem This Solves

Three test-hygiene defects observed during the plugin-lifecycle series (#117236…#117852):

1. `src/gateway/server-startup-model-runtime.event-loop.test.ts` still passed the `deferConfiguredChannelFullLoadUntilAfterListen` fixture key removed end-to-end by #117852 — dead data readers silently ignore.
2. `src/gateway/server.startup-websocket-race.test.ts` binds `127.0.0.2`, which default macOS `lo0` doesn't alias — the test fails locally on Macs (`EADDRNOTAVAIL`, observed on unrelated branches) while passing on Linux CI.
3. `src/cli/help-exit.process.test.ts` intermittently reported exit code `null` on loaded CI runners: its subprocess helper used fixed-window waits, so a slow spawn looked like a missing exit.

## Why This Change Was Made

Dead key deleted (the intentional tolerant-parse regression in `installed-plugin-index-store.test.ts` is untouched). The alias-specific race test now runtime-probes `127.0.0.2` bindability and skips with a clear reason where absent — the #117261 macOS-hygiene precedent — leaving Linux assertions intact. The CLI subprocess helper awaits exit and stream completion with a bounded 240s hard cap; the exit-code `2` assertion stays exact, and sibling process suites were checked (distinct harnesses — one-file fix, not a class).

## User Impact

None at runtime — test-only. macOS contributors get green local runs for these suites; CI loses a flake source.

## Evidence

- Focused: 3 files, 58 passed + 1 expected skip on macOS (Darwin 27); `pnpm tsgo:test` clean; changed-file oxlint, formatting, `git diff --check` clean; structured autoreview clean.
- Production delta: 0 bytes (`git diff --numstat`: test files only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review correction + transcript (added post-review)

Deadline ordering made structural: ordinary callers 100s (derived from the shared 120s Vitest constant), slow dotenv case paired 240s/250s; all 41 invocations verified. After-fix terminal transcript (alias skip with reason, exact exit-code-2 pass through the event-based harness): see the proof comment.
