### PR TITLE
fix(macos): preserve external remote gateway config edits

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30195,7 +30195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 824,
+      "line": 978,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host)",
       "surface": "apple",
@@ -30203,7 +30203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 824,
+      "line": 978,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host):\\(port)",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30194,8 +30194,16 @@
       "id": "native.apple.c8d2fe5403e9df00"
     },
     {
+      "kind": "ui-localized-call-multiline",
+      "line": 399,
+      "path": "apps/macos/Sources/OpenClaw/AppState.swift",
+      "source": "These settings changed outside the app while you were editing: \\(fieldList). Choose which version to keep.",
+      "surface": "apple",
+      "id": "native.apple.3b776a593deeab22"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 978,
+      "line": 1014,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host)",
       "surface": "apple",
@@ -30203,7 +30211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 978,
+      "line": 1014,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host):\\(port)",
       "surface": "apple",
@@ -32954,6 +32962,78 @@
       "id": "native.apple.1b8ba1cf6f9dfdc9"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 36,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConfigConflict.swift",
+      "source": "Gateway location",
+      "surface": "apple",
+      "id": "native.apple.52b517452a108b59"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 38,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConfigConflict.swift",
+      "source": "Transport",
+      "surface": "apple",
+      "id": "native.apple.2961fe211d71d35a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 40,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConfigConflict.swift",
+      "source": "Gateway URL",
+      "surface": "apple",
+      "id": "native.apple.3dfb5eefb5f66202"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 42,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConfigConflict.swift",
+      "source": "SSH target",
+      "surface": "apple",
+      "id": "native.apple.d771ae993a61fdf7"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 44,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConfigConflict.swift",
+      "source": "Identity file",
+      "surface": "apple",
+      "id": "native.apple.e817b77dd5751910"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 46,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConfigConflict.swift",
+      "source": "SSH host key policy",
+      "surface": "apple",
+      "id": "native.apple.1d7afbe829a31e8d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 48,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConfigConflict.swift",
+      "source": "Gateway token",
+      "surface": "apple",
+      "id": "native.apple.ba3cf88d2dadb205"
+    },
+    {
+      "kind": "ui-call",
+      "line": 117,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConfigConflict.swift",
+      "source": "Use file version",
+      "surface": "apple",
+      "id": "native.apple.83779c40a38ec48e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 122,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConfigConflict.swift",
+      "source": "Keep my edits",
+      "surface": "apple",
+      "id": "native.apple.eab4dbc3ca4a9352"
+    },
+    {
       "kind": "conditional-branch",
       "line": 62,
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryHelpers.swift",
@@ -33563,7 +33643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 359,
+      "line": 367,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "\\(Int(ping)) ms",
       "surface": "apple",
@@ -33571,7 +33651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 393,
+      "line": 401,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local Gateway",
       "surface": "apple",
@@ -33579,7 +33659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 394,
+      "line": 402,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Gateway direct",
       "surface": "apple",
@@ -33587,7 +33667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 394,
+      "line": 402,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Gateway via SSH",
       "surface": "apple",
@@ -33595,7 +33675,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 395,
+      "line": 403,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway not configured",
       "surface": "apple",
@@ -33603,7 +33683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 402,
+      "line": 410,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw starts and monitors the Gateway on this Mac.",
       "surface": "apple",
@@ -33611,7 +33691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 411,
+      "line": 419,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Choose local or remote before the app can attach to a Gateway.",
       "surface": "apple",
@@ -33619,7 +33699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 416,
+      "line": 424,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -33627,7 +33707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 418,
+      "line": 426,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw runs",
       "surface": "apple",
@@ -33635,7 +33715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 419,
+      "line": 427,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Pick whether this app owns a local Gateway or attaches to another host.",
       "surface": "apple",
@@ -33643,7 +33723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 422,
+      "line": 430,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway location",
       "surface": "apple",
@@ -33651,7 +33731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 423,
+      "line": 431,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -33659,7 +33739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 424,
+      "line": 432,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local (this Mac)",
       "surface": "apple",
@@ -33667,7 +33747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 425,
+      "line": 433,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote (another host)",
       "surface": "apple",
@@ -33675,7 +33755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 434,
+      "line": 442,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Setup needed",
       "surface": "apple",
@@ -33683,7 +33763,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 435,
+      "line": 443,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local is best for this Mac. Remote is best when the Gateway already runs on a Mac Studio or server.",
       "surface": "apple",
@@ -33691,7 +33771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 466,
+      "line": 474,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Access",
       "surface": "apple",
@@ -33699,7 +33779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 477,
+      "line": 486,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Discovery & Status",
       "surface": "apple",
@@ -33707,7 +33787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 493,
+      "line": 502,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Nearby gateways",
       "surface": "apple",
@@ -33715,7 +33795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 516,
+      "line": 525,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote test",
       "surface": "apple",
@@ -33723,7 +33803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 524,
+      "line": 533,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Control channel",
       "surface": "apple",
@@ -33731,7 +33811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 553,
+      "line": 562,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recommended setup",
       "surface": "apple",
@@ -33739,7 +33819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 555,
+      "line": 564,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "surface": "apple",
@@ -33747,7 +33827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 556,
+      "line": 565,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
       "surface": "apple",
@@ -33755,7 +33835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 565,
+      "line": 574,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Advanced",
       "surface": "apple",
@@ -33763,7 +33843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 568,
+      "line": 577,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Identity file",
       "surface": "apple",
@@ -33771,7 +33851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 570,
+      "line": 579,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
@@ -33779,7 +33859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 572,
+      "line": 581,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Project root",
       "surface": "apple",
@@ -33787,7 +33867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 574,
+      "line": 583,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
@@ -33795,7 +33875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 576,
+      "line": 585,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "CLI path",
       "surface": "apple",
@@ -33803,7 +33883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 578,
+      "line": 587,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
@@ -33811,7 +33891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 583,
+      "line": 592,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH command details",
       "surface": "apple",
@@ -33819,7 +33899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 603,
+      "line": 612,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Transport",
       "surface": "apple",
@@ -33827,7 +33907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 604,
+      "line": 613,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH keeps the Gateway private; direct is best for HTTPS or Tailscale Serve.",
       "surface": "apple",
@@ -33835,7 +33915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 607,
+      "line": 616,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH tunnel",
       "surface": "apple",
@@ -33843,7 +33923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 608,
+      "line": 617,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
@@ -33851,7 +33931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 621,
+      "line": 630,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH target",
       "surface": "apple",
@@ -33859,7 +33939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 621,
+      "line": 630,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "User and host for the remote Gateway machine.",
       "surface": "apple",
@@ -33867,7 +33947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 638,
+      "line": 647,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway URL",
       "surface": "apple",
@@ -33875,7 +33955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 638,
+      "line": 647,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The WebSocket URL exposed by the remote Gateway.",
       "surface": "apple",
@@ -33883,7 +33963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 641,
+      "line": 650,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
@@ -33891,7 +33971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 647,
+      "line": 656,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use wss:// for public hosts. ws:// is allowed for localhost, LAN, .local, and Tailnet hosts.",
       "surface": "apple",
@@ -33899,7 +33979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 658,
+      "line": 667,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway token",
       "surface": "apple",
@@ -33907,7 +33987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 659,
+      "line": 668,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Used when the remote gateway requires token auth.",
       "surface": "apple",
@@ -33915,7 +33995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 662,
+      "line": 671,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "remote gateway auth token (gateway.remote.token)",
       "surface": "apple",
@@ -33923,7 +34003,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 667,
+      "line": 676,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
@@ -33931,7 +34011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 686,
+      "line": 695,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Test remote",
       "surface": "apple",
@@ -33939,7 +34019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 709,
+      "line": 718,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Testing…",
       "surface": "apple",
@@ -33947,7 +34027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 747,
+      "line": 756,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Installed: \\(gatewayVersion) · Required: \\(required)",
       "surface": "apple",
@@ -33955,7 +34035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 751,
+      "line": 760,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway \\(gatewayVersion) detected",
       "surface": "apple",
@@ -33963,7 +34043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 757,
+      "line": 766,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Node \\(node)",
       "surface": "apple",
@@ -33971,7 +34051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 769,
+      "line": 778,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Last failure: \\(failure)",
       "surface": "apple",
@@ -33979,7 +34059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 774,
+      "line": 783,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recheck",
       "surface": "apple",
@@ -33987,7 +34067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 777,
+      "line": 786,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway auto-starts in local mode via launchd (\\(gatewayLaunchdLabel)).",
       "surface": "apple",
@@ -33995,7 +34075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 830,
+      "line": 839,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Retry now",
       "surface": "apple",
@@ -34003,7 +34083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 835,
+      "line": 844,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Open logs",
       "surface": "apple",
@@ -35715,7 +35795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 129,
+      "line": 131,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Set up later",
       "surface": "apple",
@@ -35723,7 +35803,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 135,
+      "line": 137,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skip Gateway setup for now; pick Local or Remote later in Settings → General.",
       "surface": "apple",
@@ -35731,7 +35811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 139,
+      "line": 141,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OK — OpenClaw won’t start anything yet. Pick Local or Remote later in Settings → General.",
       "surface": "apple",
@@ -35739,7 +35819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 178,
+      "line": 180,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Existing gateway detected",
       "surface": "apple",
@@ -35747,7 +35827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 179,
+      "line": 181,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Port \\(probe.port) already in use",
       "surface": "apple",
@@ -35755,7 +35835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 180,
+      "line": 182,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " (\\(probe.command) pid \\(probe.pid))",
       "surface": "apple",
@@ -35763,7 +35843,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 191,
+      "line": 193,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "1 gateway found on your network — click to choose it.",
       "surface": "apple",
@@ -35771,7 +35851,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 192,
+      "line": 194,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "\\(count) gateways found on your network — click to choose one.",
       "surface": "apple",
@@ -35779,7 +35859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 206,
+      "line": 208,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No gateways found on your network yet.",
       "surface": "apple",
@@ -35787,7 +35867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 209,
+      "line": 211,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Look again",
       "surface": "apple",
@@ -35795,7 +35875,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 214,
+      "line": 216,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Retry discovery (Bonjour + Tailscale DNS-SD).",
       "surface": "apple",
@@ -35803,7 +35883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 243,
+      "line": 245,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Advanced…",
       "surface": "apple",
@@ -35811,7 +35891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 361,
+      "line": 363,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote connection",
       "surface": "apple",
@@ -35819,7 +35899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 363,
+      "line": 365,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Verify OpenClaw can reach this gateway.",
       "surface": "apple",
@@ -35827,7 +35907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 376,
+      "line": 378,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Check connection",
       "surface": "apple",
@@ -35835,7 +35915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 418,
+      "line": 420,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Advanced options",
       "surface": "apple",
@@ -35843,7 +35923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 418,
+      "line": 420,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Hide advanced options",
       "surface": "apple",
@@ -35851,7 +35931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 437,
+      "line": 439,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway token",
       "surface": "apple",
@@ -35859,7 +35939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 440,
+      "line": 442,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Paste the token from your gateway",
       "surface": "apple",
@@ -35867,7 +35947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 447,
+      "line": 449,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Only needed when the gateway requires token auth.",
       "surface": "apple",
@@ -35875,7 +35955,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 456,
+      "line": 458,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
@@ -35883,7 +35963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 474,
+      "line": 476,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Transport",
       "surface": "apple",
@@ -35891,7 +35971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 475,
+      "line": 477,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH tunnel",
       "surface": "apple",
@@ -35899,7 +35979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 476,
+      "line": 478,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
@@ -35907,7 +35987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 484,
+      "line": 486,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway URL",
       "surface": "apple",
@@ -35915,7 +35995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 487,
+      "line": 489,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
@@ -35923,7 +36003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 494,
+      "line": 496,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH target",
       "surface": "apple",
@@ -35931,7 +36011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 514,
+      "line": 516,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Identity file",
       "surface": "apple",
@@ -35939,7 +36019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 517,
+      "line": 519,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
@@ -35947,7 +36027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 522,
+      "line": 524,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Project root",
       "surface": "apple",
@@ -35955,7 +36035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 525,
+      "line": 527,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
@@ -35963,7 +36043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 530,
+      "line": 532,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "CLI path",
       "surface": "apple",
@@ -35971,7 +36051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 533,
+      "line": 535,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
@@ -35979,7 +36059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 544,
+      "line": 546,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "surface": "apple",
@@ -35987,7 +36067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 545,
+      "line": 547,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
       "surface": "apple",
@@ -35995,7 +36075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 559,
+      "line": 561,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Checking remote gateway…",
       "surface": "apple",
@@ -36003,7 +36083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 749,
+      "line": 751,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " · ssh \\(parsed.port)",
       "surface": "apple",
@@ -36011,7 +36091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 818,
+      "line": 820,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Grant permissions",
       "surface": "apple",
@@ -36019,7 +36099,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 825,
+      "line": 827,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "These macOS permissions let OpenClaw automate apps and capture context on this Mac. Status updates automatically.",
       "surface": "apple",
@@ -36027,7 +36107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 860,
+      "line": 862,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Getting things ready",
       "surface": "apple",
@@ -36035,7 +36115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 871,
+      "line": 873,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Install OpenClaw",
       "surface": "apple",
@@ -36043,7 +36123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 878,
+      "line": 880,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Prepare the Mac node",
       "surface": "apple",
@@ -36051,7 +36131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 878,
+      "line": 880,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Start the background service",
       "surface": "apple",
@@ -36059,7 +36139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 880,
+      "line": 882,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs inside the app and uses its macOS permissions.",
       "surface": "apple",
@@ -36067,7 +36147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 881,
+      "line": 883,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs quietly and starts again after a restart.",
       "surface": "apple",
@@ -36075,7 +36155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 884,
+      "line": 886,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Ready for the next step",
       "surface": "apple",
@@ -36083,7 +36163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 886,
+      "line": 888,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once ready, this Mac connects to your selected Gateway.",
       "surface": "apple",
@@ -36091,7 +36171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 887,
+      "line": 889,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once the service answers, you’ll connect your AI.",
       "surface": "apple",
@@ -36099,7 +36179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 892,
+      "line": 894,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The Gateway didn’t start",
       "surface": "apple",
@@ -36107,7 +36187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 895,
+      "line": 897,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try again",
       "surface": "apple",
@@ -36115,7 +36195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 986,
+      "line": 988,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "You’re all set!",
       "surface": "apple",
@@ -36123,7 +36203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 989,
+      "line": 991,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Finish opens the chat — say hi to your new agent.",
       "surface": "apple",
@@ -36131,7 +36211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 997,
+      "line": 999,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Configure later",
       "surface": "apple",
@@ -36139,7 +36219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 998,
+      "line": 1000,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Pick Local or Remote in Settings → General whenever you’re ready.",
       "surface": "apple",
@@ -36147,7 +36227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1005,
+      "line": 1007,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote gateway checklist",
       "surface": "apple",
@@ -36155,7 +36235,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 1006,
+      "line": 1008,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On your gateway host: install/update the `openclaw` package and make sure credentials exist\n(typically `~/.openclaw/credentials/oauth.json`). Then connect again if needed.",
       "surface": "apple",
@@ -36163,7 +36243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1015,
+      "line": 1017,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel",
       "surface": "apple",
@@ -36171,7 +36251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1016,
+      "line": 1018,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Click the OpenClaw menu bar icon for the compact chat panel and status.",
       "surface": "apple",
@@ -36179,7 +36259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1019,
+      "line": 1021,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Connect Discord, Slack, Telegram, WhatsApp, …",
       "surface": "apple",
@@ -36187,7 +36267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1020,
+      "line": 1022,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels to link channels and monitor status.",
       "surface": "apple",
@@ -36195,7 +36275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1022,
+      "line": 1024,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels",
       "surface": "apple",
@@ -36203,7 +36283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1027,
+      "line": 1029,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try Voice Wake",
       "surface": "apple",
@@ -36211,7 +36291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1028,
+      "line": 1030,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable Voice Wake in Settings for hands-free commands with a live transcript overlay.",
       "surface": "apple",
@@ -36219,7 +36299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1031,
+      "line": 1033,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Use the panel + Canvas",
       "surface": "apple",
@@ -36227,7 +36307,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 1032,
+      "line": 1034,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the compact chat panel; the agent can show previews and richer visuals in Canvas.",
       "surface": "apple",
@@ -36235,7 +36315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1036,
+      "line": 1038,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your agent more powers",
       "surface": "apple",
@@ -36243,7 +36323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1037,
+      "line": 1039,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable optional skills (Peekaboo, oracle, camsnap, …) from Settings → Skills.",
       "surface": "apple",
@@ -36251,7 +36331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1039,
+      "line": 1041,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Skills",
       "surface": "apple",
@@ -36259,7 +36339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1044,
+      "line": 1046,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Launch at login",
       "surface": "apple",
@@ -36267,7 +36347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1071,
+      "line": 1073,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skills included",
       "surface": "apple",
@@ -36275,7 +36355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1078,
+      "line": 1080,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -36283,7 +36363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1087,
+      "line": 1089,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Couldn’t load skills from the Gateway.",
       "surface": "apple",
@@ -36291,7 +36371,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 1090,
+      "line": 1092,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Make sure the Gateway is running and connected, then hit Refresh (or open Settings → Skills).",
       "surface": "apple",
@@ -36299,7 +36379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1096,
+      "line": 1098,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Details: \\(error)",
       "surface": "apple",
@@ -36307,7 +36387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1102,
+      "line": 1104,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No skills reported yet.",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -85,12 +85,13 @@ final class AppState {
     @ObservationIgnored private let execApprovalsDefaultsAsyncResolver:
         @MainActor () async -> Result<ExecApprovalsResolvedDefaults, ExecApprovalsReadError>
     @ObservationIgnored private let execApprovalsReadRetryDelay: Duration
+    @ObservationIgnored private let gatewayConfigSaver: ([String: Any]) -> Bool
     @ObservationIgnored let bundleLocationAllowsPersistentIntegration: Bool
     @ObservationIgnored private var execApprovalsReadRetryTask: Task<Void, Never>?
     @ObservationIgnored private var execApprovalsReadGeneration = 0
     @ObservationIgnored private var isHydratingLaunchAtLogin = false
     private var isInitializing = true
-    private var isApplyingRemoteTokenConfig = false
+    private var isApplyingGatewayConfig = false
     private enum GatewayConfigSyncState: Equatable {
         case current
         case pending
@@ -105,6 +106,9 @@ final class AppState {
     #endif
     private var configWatcher: ConfigFileWatcher?
     private var lastConfigFingerprint: Data?
+    private var lastObservedGatewayConfig: GatewayConfigSnapshot = .empty
+    private var dirtyGatewayConfigFields: Set<GatewayConfigField> = []
+    private var conflictedGatewayConfigFields: Set<GatewayConfigField> = []
     private var suppressVoiceWakeGlobalSync = false
     @ObservationIgnored private let voiceWakeGlobalSyncScheduler = VoiceWakeGlobalSyncScheduler()
     @ObservationIgnored private var activeComputerPresenceTask: Task<Void, Never>?
@@ -294,12 +298,26 @@ final class AppState {
     var connectionMode: ConnectionMode {
         didSet {
             self.ifNotPreview { UserDefaults.standard.set(self.connectionMode.rawValue, forKey: connectionModeKey) }
+            if oldValue != self.connectionMode {
+                self.markGatewayConfigDirty([.mode])
+            }
             syncGatewayConfigIfNeeded()
         }
     }
 
     var remoteTransport: RemoteTransport {
-        didSet { syncGatewayConfigIfNeeded() }
+        didSet {
+            if oldValue != self.remoteTransport {
+                let fields: Set<GatewayConfigField> = switch self.remoteTransport {
+                case .direct:
+                    [.remoteTransport, .remoteUrl]
+                case .ssh:
+                    [.remoteTransport, .remoteUrl, .remoteTarget, .remoteIdentity, .remoteHostKeyPolicy]
+                }
+                self.markGatewayConfigDirty(fields)
+            }
+            syncGatewayConfigIfNeeded()
+        }
     }
 
     var canvasEnabled: Bool {
@@ -344,29 +362,43 @@ final class AppState {
     var remoteTarget: String {
         didSet {
             self.ifNotPreview { UserDefaults.standard.set(self.remoteTarget, forKey: remoteTargetKey) }
+            if oldValue != self.remoteTarget {
+                self.markGatewayConfigDirty([.remoteTarget, .remoteUrl, .remoteHostKeyPolicy])
+            }
             syncGatewayConfigIfNeeded()
         }
     }
 
     var remoteUrl: String {
-        didSet { syncGatewayConfigIfNeeded() }
+        didSet {
+            if oldValue != self.remoteUrl {
+                self.markGatewayConfigDirty([.remoteUrl])
+            }
+            syncGatewayConfigIfNeeded()
+        }
     }
 
     var remoteToken: String {
         didSet {
-            guard !self.isApplyingRemoteTokenConfig else { return }
-            self.remoteTokenDirty = true
+            guard oldValue != self.remoteToken else { return }
+            self.markGatewayConfigDirty([.remoteToken])
             self.remoteTokenUnsupported = false
             syncGatewayConfigIfNeeded()
         }
     }
 
-    private(set) var remoteTokenDirty = false
+    var remoteTokenDirty: Bool {
+        self.dirtyGatewayConfigFields.contains(.remoteToken)
+    }
+
     private(set) var remoteTokenUnsupported = false
 
     var remoteIdentity: String {
         didSet {
             self.ifNotPreview { UserDefaults.standard.set(self.remoteIdentity, forKey: remoteIdentityKey) }
+            if oldValue != self.remoteIdentity {
+                self.markGatewayConfigDirty([.remoteIdentity])
+            }
             syncGatewayConfigIfNeeded()
         }
     }
@@ -389,7 +421,8 @@ final class AppState {
         > = {
             await ExecApprovalsStore.resolveDefaultsAsyncResult()
         },
-        execApprovalsReadRetryDelay: Duration = .milliseconds(250))
+        execApprovalsReadRetryDelay: Duration = .milliseconds(250),
+        gatewayConfigSaver: @escaping ([String: Any]) -> Bool = { OpenClawConfigFile.saveDict($0) })
     {
         let isPreview = preview || ProcessInfo.processInfo.isRunningTests
         self.isPreview = isPreview
@@ -397,6 +430,7 @@ final class AppState {
             isPreview || ApplicationRelocator.currentBundleAllowsPersistentIntegration()
         self.execApprovalsDefaultsAsyncResolver = execApprovalsDefaultsAsyncResolver
         self.execApprovalsReadRetryDelay = execApprovalsReadRetryDelay
+        self.gatewayConfigSaver = gatewayConfigSaver
         let onboardingSeen = UserDefaults.standard.bool(forKey: onboardingSeenKey)
         self.isPaused = UserDefaults.standard.bool(forKey: pauseDefaultsKey)
         self.launchAtLogin = false
@@ -465,6 +499,7 @@ final class AppState {
 
         let configRoot = OpenClawConfigFile.loadDict()
         self.lastConfigFingerprint = Self.configFingerprint(configRoot)
+        self.lastObservedGatewayConfig = Self.gatewayConfigSnapshot(configRoot)
         let configRemoteToken = GatewayRemoteConfig.resolveTokenValue(root: configRoot)
         let configRemoteResolution = GatewayRemoteConfig.resolveTransportResolution(root: configRoot)
         let configRemoteTransport = configRemoteResolution.transport
@@ -495,7 +530,6 @@ final class AppState {
         }
         self.remoteUrl = configRemoteUrl ?? ""
         self.remoteToken = configRemoteToken.textFieldValue
-        self.remoteTokenDirty = false
         self.remoteTokenUnsupported = configRemoteToken.isUnsupportedNonString
         let hasConfigRemoteIdentity = configRemote?.keys.contains("sshIdentity") == true
         let configRemoteIdentity = (configRemote?["sshIdentity"] as? String)?
@@ -620,17 +654,17 @@ final class AppState {
         return false
     }
 
+    private func markGatewayConfigDirty(_ fields: Set<GatewayConfigField>) {
+        guard !self.isInitializing, !self.isApplyingGatewayConfig else { return }
+        self.dirtyGatewayConfigFields.formUnion(fields)
+    }
+
     private func applyRemoteTokenState(_ tokenValue: GatewayRemoteConfig.TokenValue) {
         let nextToken = tokenValue.textFieldValue
         let unsupported = tokenValue.isUnsupportedNonString
-        guard self.remoteToken != nextToken || self.remoteTokenDirty || self.remoteTokenUnsupported != unsupported
-        else {
-            return
+        if self.remoteToken != nextToken {
+            self.remoteToken = nextToken
         }
-        self.isApplyingRemoteTokenConfig = true
-        self.remoteToken = nextToken
-        self.isApplyingRemoteTokenConfig = false
-        self.remoteTokenDirty = false
         self.remoteTokenUnsupported = unsupported
     }
 
@@ -643,36 +677,51 @@ final class AppState {
 
         switch draft.transport {
         case .direct:
-            changed = Self.updateGatewayString(
-                &remote,
-                key: "transport",
-                value: RemoteTransport.direct.rawValue) || changed
+            if draft.dirtyFields.contains(.remoteTransport) {
+                changed = Self.updateGatewayString(
+                    &remote,
+                    key: "transport",
+                    value: RemoteTransport.direct.rawValue) || changed
+            }
 
-            let trimmedUrl = draft.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedUrl.isEmpty {
-                changed = Self.updateGatewayString(&remote, key: "url", value: nil) || changed
-            } else if let normalizedUrl = GatewayRemoteConfig.normalizeGatewayUrlString(trimmedUrl) {
-                changed = Self.updateGatewayString(&remote, key: "url", value: normalizedUrl) || changed
+            if draft.dirtyFields.contains(.remoteUrl) {
+                let trimmedUrl = draft.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmedUrl.isEmpty {
+                    changed = Self.updateGatewayString(&remote, key: "url", value: nil) || changed
+                } else if let normalizedUrl = GatewayRemoteConfig.normalizeGatewayUrlString(trimmedUrl) {
+                    changed = Self.updateGatewayString(&remote, key: "url", value: normalizedUrl) || changed
+                }
             }
 
         case .ssh:
-            changed = Self.updateGatewayString(
-                &remote,
-                key: "transport",
-                value: RemoteTransport.ssh.rawValue) || changed
+            if draft.dirtyFields.contains(.remoteTransport) {
+                changed = Self.updateGatewayString(
+                    &remote,
+                    key: "transport",
+                    value: RemoteTransport.ssh.rawValue) || changed
+            }
 
             let existingTarget = Self.sanitizeSSHTarget(remote["sshTarget"] as? String ?? "")
             let sanitizedTarget = Self.sanitizeSSHTarget(draft.remoteTarget)
             let expectedRemoteHost = CommandResolver.parseSSHTarget(sanitizedTarget)?.host ?? draft.remoteHost
-            let existingUrl = (remote["url"] as? String)?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            let desiredUrl = Self.sshTunnelGatewayUrl(
-                existingUrl: existingUrl,
-                expectedRemoteHost: expectedRemoteHost)
-            changed = Self.updateGatewayString(&remote, key: "url", value: desiredUrl) || changed
-            changed = Self.updateGatewayString(&remote, key: "sshTarget", value: sanitizedTarget) || changed
-            changed = Self.updateGatewayString(&remote, key: "sshIdentity", value: draft.remoteIdentity) || changed
-            if existingTarget != sanitizedTarget {
+            if draft.dirtyFields.contains(.remoteUrl) {
+                let existingUrl = (remote["url"] as? String)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let desiredUrl = Self.sshTunnelGatewayUrl(
+                    existingUrl: existingUrl,
+                    expectedRemoteHost: expectedRemoteHost)
+                changed = Self.updateGatewayString(&remote, key: "url", value: desiredUrl) || changed
+            }
+            if draft.dirtyFields.contains(.remoteTarget) {
+                changed = Self.updateGatewayString(&remote, key: "sshTarget", value: sanitizedTarget) || changed
+            }
+            if draft.dirtyFields.contains(.remoteIdentity) {
+                changed = Self.updateGatewayString(
+                    &remote,
+                    key: "sshIdentity",
+                    value: draft.remoteIdentity) || changed
+            }
+            if draft.dirtyFields.contains(.remoteHostKeyPolicy), existingTarget != sanitizedTarget {
                 changed = Self.updateGatewayString(
                     &remote,
                     key: "sshHostKeyPolicy",
@@ -680,7 +729,7 @@ final class AppState {
             }
         }
 
-        if draft.remoteTokenDirty {
+        if draft.dirtyFields.contains(.remoteToken) {
             changed = Self.updateGatewayString(&remote, key: "token", value: draft.remoteToken) || changed
         }
 
@@ -723,9 +772,77 @@ final class AppState {
         return try? JSONSerialization.data(withJSONObject: comparableRoot, options: [.sortedKeys])
     }
 
+    private static func gatewayConfigSnapshot(_ root: [String: Any]) -> GatewayConfigSnapshot {
+        let gateway = root["gateway"] as? [String: Any]
+        let remote = gateway?["remote"] as? [String: Any]
+        var values: [GatewayConfigField: GatewayConfigValue] = [:]
+        for field in GatewayConfigField.allCases {
+            let value = if let remoteKey = field.remoteKey {
+                remote?[remoteKey]
+            } else {
+                gateway?["mode"]
+            }
+            guard let value else {
+                values[field] = .missing
+                continue
+            }
+            let data = try? JSONSerialization.data(
+                withJSONObject: ["value": value],
+                options: [.sortedKeys])
+            values[field] = data.map(GatewayConfigValue.json) ?? .missing
+        }
+        return GatewayConfigSnapshot(values: values)
+    }
+
+    private func gatewayConfigDraft() -> GatewayConfigSyncDraft {
+        GatewayConfigSyncDraft(
+            connectionMode: self.connectionMode,
+            remoteTransport: self.remoteTransport,
+            remoteTarget: self.remoteTarget,
+            remoteIdentity: self.remoteIdentity,
+            remoteUrl: self.remoteUrl,
+            remoteToken: self.remoteToken,
+            dirtyFields: self.dirtyGatewayConfigFields)
+    }
+
+    private static func gatewayConfigFieldsPersisted(by draft: GatewayConfigSyncDraft) -> Set<GatewayConfigField> {
+        var fields = draft.dirtyFields.intersection([.mode, .remoteTransport, .remoteUrl, .remoteToken])
+        if draft.remoteTransport == .ssh {
+            fields.formUnion(draft.dirtyFields.intersection([
+                .remoteTarget,
+                .remoteIdentity,
+                .remoteHostKeyPolicy,
+            ]))
+        }
+        return fields
+    }
+
     private func applyConfigOverrides(_ root: [String: Any]) {
         advanceGatewayRoutingGeneration()
         let previousSelection = self.gatewaySelectionSnapshot()
+        let diskSnapshot = Self.gatewayConfigSnapshot(root)
+        let desiredRoot = Self.syncedGatewayRoot(
+            currentRoot: root,
+            draft: self.gatewayConfigDraft()).root
+        let desiredSnapshot = Self.gatewayConfigSnapshot(desiredRoot)
+        let priorConflicts = self.conflictedGatewayConfigFields
+
+        // Dirty fields retain the user's pending UI value. A disk value that moved
+        // from the last observed baseline is a conflict, never write authorization.
+        let persistedFields = Self.gatewayConfigFieldsPersisted(by: self.gatewayConfigDraft())
+        var externallyPersistedFields: Set<GatewayConfigField> = []
+        for field in persistedFields {
+            if diskSnapshot[field] == desiredSnapshot[field] {
+                externallyPersistedFields.insert(field)
+            } else if diskSnapshot[field] != self.lastObservedGatewayConfig[field] {
+                self.conflictedGatewayConfigFields.insert(field)
+            }
+        }
+        self.dirtyGatewayConfigFields.subtract(externallyPersistedFields)
+        self.conflictedGatewayConfigFields.subtract(externallyPersistedFields)
+        self.conflictedGatewayConfigFields.formIntersection(self.dirtyGatewayConfigFields)
+        self.lastObservedGatewayConfig = diskSnapshot
+
         let gateway = root["gateway"] as? [String: Any]
         let remote = gateway?["remote"] as? [String: Any]
         let modeRaw = (gateway?["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -748,25 +865,37 @@ final class AppState {
             nil
         }
 
-        if let desiredMode {
-            if desiredMode != self.connectionMode {
-                self.connectionMode = desiredMode
+        self.isApplyingGatewayConfig = true
+        if !self.dirtyGatewayConfigFields.contains(.mode) {
+            if let desiredMode {
+                if desiredMode != self.connectionMode {
+                    self.connectionMode = desiredMode
+                }
+            } else if hasRemoteUrl, self.connectionMode != .remote {
+                self.connectionMode = .remote
             }
-        } else if hasRemoteUrl, self.connectionMode != .remote {
-            self.connectionMode = .remote
         }
 
-        if remoteTransport != self.remoteTransport {
+        if !self.dirtyGatewayConfigFields.contains(.remoteTransport),
+           remoteTransport != self.remoteTransport
+        {
             self.remoteTransport = remoteTransport
         }
-        let remoteUrlText = remoteResolution.directURL?.absoluteString ?? remoteUrl ?? ""
-        if remoteUrlText != self.remoteUrl {
-            self.remoteUrl = remoteUrlText
+        if !self.dirtyGatewayConfigFields.contains(.remoteUrl) {
+            let remoteUrlText = remoteResolution.directURL?.absoluteString ?? remoteUrl ?? ""
+            if remoteUrlText != self.remoteUrl {
+                self.remoteUrl = remoteUrlText
+            }
         }
-        self.applyRemoteTokenState(remoteToken)
+        if !self.dirtyGatewayConfigFields.contains(.remoteToken) {
+            self.applyRemoteTokenState(remoteToken)
+        }
 
         let targetMode = desiredMode ?? self.connectionMode
-        if targetMode == .remote, remoteTransport != .direct {
+        if !self.dirtyGatewayConfigFields.contains(.remoteTarget),
+           targetMode == .remote,
+           remoteTransport != .direct
+        {
             let hasConfiguredTarget = remote?.keys.contains("sshTarget") == true
             let configuredTarget = Self.sanitizeSSHTarget(remote?["sshTarget"] as? String ?? "")
             if hasConfiguredTarget, configuredTarget != Self.sanitizeSSHTarget(self.remoteTarget) {
@@ -778,19 +907,34 @@ final class AppState {
                 self.updateRemoteTarget(host: host)
             }
         }
-        if remote?.keys.contains("sshIdentity") == true {
+        if !self.dirtyGatewayConfigFields.contains(.remoteIdentity),
+           remote?.keys.contains("sshIdentity") == true
+        {
             let configuredIdentity = (remote?["sshIdentity"] as? String)?
                 .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             if configuredIdentity != self.remoteIdentity {
                 self.remoteIdentity = configuredIdentity
             }
         }
+        self.isApplyingGatewayConfig = false
+
         if self.gatewaySelectionSnapshot() != previousSelection {
             // Discovery ids describe one concrete endpoint. An external config
             // edit has no discovery selection event to update that ownership,
             // so retaining the old id would apply its activation lease to the
             // replacement Gateway.
             GatewayDiscoveryPreferences.setPreferredStableID(nil)
+        }
+
+        let newConflicts = self.conflictedGatewayConfigFields.subtracting(priorConflicts)
+        if !newConflicts.isEmpty {
+            let names = self.conflictedGatewayConfigFields.map(\.rawValue).sorted().joined(separator: ", ")
+            Self.logger.warning("gateway config sync conflict fields=\(names)")
+        }
+        if !self.conflictedGatewayConfigFields.isEmpty {
+            self.setGatewayConfigSyncState(.failed)
+        } else if !priorConflicts.isEmpty, self.dirtyGatewayConfigFields.isEmpty {
+            self.setGatewayConfigSyncState(.current)
         }
     }
 
@@ -1092,20 +1236,22 @@ extension AppState {
             nil
         }
 
-        let currentMode = (gateway["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let desiredMode {
-            if currentMode != desiredMode {
-                gateway["mode"] = desiredMode
+        if draft.dirtyFields.contains(.mode) {
+            let currentMode = (gateway["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let desiredMode {
+                if currentMode != desiredMode {
+                    gateway["mode"] = desiredMode
+                    changed = true
+                }
+            } else if currentMode != nil {
+                gateway.removeValue(forKey: "mode")
                 changed = true
             }
-        } else if currentMode != nil {
-            gateway.removeValue(forKey: "mode")
-            changed = true
         }
 
         var remote = gateway["remote"] as? [String: Any] ?? [:]
         var remoteChanged = false
-        if draft.connectionMode == .remote {
+        if draft.dirtyFields.contains(where: { $0.remoteKey != nil }) {
             let remoteHost = CommandResolver.parseSSHTarget(draft.remoteTarget)?.host
             let updated = Self.updatedRemoteGatewayConfig(
                 current: remote,
@@ -1116,7 +1262,7 @@ extension AppState {
                     remoteTarget: draft.remoteTarget,
                     remoteIdentity: draft.remoteIdentity,
                     remoteToken: draft.remoteToken,
-                    remoteTokenDirty: draft.remoteTokenDirty))
+                    dirtyFields: draft.dirtyFields))
             remote = updated.remote
             remoteChanged = updated.changed
         }
@@ -1146,6 +1292,7 @@ extension AppState {
     }
 
     private func syncGatewayConfigIfNeeded() {
+        guard !self.isApplyingGatewayConfig else { return }
         self.advanceGatewayRoutingGeneration()
         guard self.gatewayConfigSyncIsEnabled, !self.isInitializing else { return }
         self.setGatewayConfigSyncState(.pending)
@@ -1185,7 +1332,10 @@ extension AppState {
     }
 
     private static func gatewayDraftCanPersist(_ draft: GatewayConfigSyncDraft) -> Bool {
-        guard draft.connectionMode == .remote else { return true }
+        let ownsRemoteRoute = draft.dirtyFields.contains(.remoteTransport) ||
+            draft.dirtyFields.contains(.remoteUrl) ||
+            draft.dirtyFields.contains(.remoteTarget)
+        guard draft.connectionMode == .remote || ownsRemoteRoute else { return true }
         switch draft.remoteTransport {
         case .direct:
             return GatewayRemoteConfig.normalizeGatewayUrl(draft.remoteUrl) != nil
@@ -1211,14 +1361,11 @@ extension AppState {
         guard self.gatewayConfigSyncIsEnabled, !self.isInitializing else { return true }
         self.setGatewayConfigSyncState(.pending)
 
-        let draft = GatewayConfigSyncDraft(
-            connectionMode: connectionMode,
-            remoteTransport: remoteTransport,
-            remoteTarget: remoteTarget,
-            remoteIdentity: remoteIdentity,
-            remoteUrl: remoteUrl,
-            remoteToken: remoteToken,
-            remoteTokenDirty: remoteTokenDirty)
+        let currentRoot = OpenClawConfigFile.loadDict()
+        self.applyConfigOverrides(currentRoot)
+        guard self.conflictedGatewayConfigFields.isEmpty else { return false }
+
+        let draft = self.gatewayConfigDraft()
         guard Self.gatewayDraftCanPersist(draft) else {
             self.setGatewayConfigSyncState(.failed)
             return false
@@ -1226,22 +1373,35 @@ extension AppState {
 
         // Keep app-only connection settings local to avoid overwriting remote gateway config.
         let synced = Self.syncedGatewayRoot(
-            currentRoot: OpenClawConfigFile.loadDict(),
+            currentRoot: currentRoot,
             draft: draft,
             remoteTLSFingerprintUpdate: remoteTLSFingerprintUpdate)
         guard synced.changed else {
+            self.acknowledgeGatewayConfigPersistence(draft.dirtyFields, root: currentRoot)
             self.setGatewayConfigSyncState(.current)
             return true
         }
-        guard OpenClawConfigFile.saveDict(synced.root) else {
+        guard self.gatewayConfigSaver(synced.root) else {
             self.setGatewayConfigSyncState(.failed)
             Self.logger.warning("gateway config sync rejected to protect persisted gateway auth/mode")
             return false
         }
+        self.acknowledgeGatewayConfigPersistence(draft.dirtyFields, root: synced.root)
         self.lastConfigFingerprint = Self.configFingerprint(synced.root)
         self.setGatewayConfigSyncState(.current)
         NotificationCenter.default.post(name: .openclawConfigDidChange, object: nil)
         return true
+    }
+
+    private func acknowledgeGatewayConfigPersistence(
+        _ fields: Set<GatewayConfigField>,
+        root: [String: Any])
+    {
+        let persistedFields = Self.gatewayConfigFieldsPersisted(by: self.gatewayConfigDraft())
+            .intersection(fields)
+        self.dirtyGatewayConfigFields.subtract(persistedFields)
+        self.conflictedGatewayConfigFields.subtract(persistedFields)
+        self.lastObservedGatewayConfig = Self.gatewayConfigSnapshot(root)
     }
 }
 
@@ -1335,6 +1495,49 @@ extension AppState {
         case direct
     }
 
+    enum GatewayConfigField: String, CaseIterable {
+        case mode = "gateway.mode"
+        case remoteTransport = "gateway.remote.transport"
+        case remoteUrl = "gateway.remote.url"
+        case remoteTarget = "gateway.remote.sshTarget"
+        case remoteIdentity = "gateway.remote.sshIdentity"
+        case remoteHostKeyPolicy = "gateway.remote.sshHostKeyPolicy"
+        case remoteToken = "gateway.remote.token"
+
+        var remoteKey: String? {
+            switch self {
+            case .mode:
+                nil
+            case .remoteTransport:
+                "transport"
+            case .remoteUrl:
+                "url"
+            case .remoteTarget:
+                "sshTarget"
+            case .remoteIdentity:
+                "sshIdentity"
+            case .remoteHostKeyPolicy:
+                "sshHostKeyPolicy"
+            case .remoteToken:
+                "token"
+            }
+        }
+    }
+
+    private enum GatewayConfigValue: Equatable {
+        case missing
+        case json(Data)
+    }
+
+    private struct GatewayConfigSnapshot {
+        static let empty = GatewayConfigSnapshot(values: [:])
+        let values: [GatewayConfigField: GatewayConfigValue]
+
+        subscript(field: GatewayConfigField) -> GatewayConfigValue {
+            self.values[field] ?? .missing
+        }
+    }
+
     struct RemoteGatewayConfigDraft {
         var transport: RemoteTransport
         var remoteUrl: String
@@ -1342,7 +1545,7 @@ extension AppState {
         var remoteTarget: String
         var remoteIdentity: String
         var remoteToken: String
-        var remoteTokenDirty: Bool
+        var dirtyFields: Set<GatewayConfigField>
     }
 
     struct GatewayConfigSyncDraft {
@@ -1352,7 +1555,7 @@ extension AppState {
         var remoteIdentity: String
         var remoteUrl: String
         var remoteToken: String
-        var remoteTokenDirty: Bool
+        var dirtyFields: Set<GatewayConfigField>
     }
 
     private struct GatewaySelectionSnapshot: Equatable {
@@ -1396,6 +1599,10 @@ extension AppState {
         self.applyConfigOverrides(root)
     }
 
+    func _testApplyConfigFromDisk() {
+        self.applyConfigFromDisk()
+    }
+
     func _testEnableGatewayConfigSync() {
         self.gatewayConfigSyncEnabledForTesting = true
     }
@@ -1406,6 +1613,14 @@ extension AppState {
 
     var _testGatewayConfigIsCurrentForRouting: Bool {
         self.gatewayConfigIsCurrentForRouting
+    }
+
+    var _testDirtyGatewayConfigFields: [String] {
+        self.dirtyGatewayConfigFields.map(\.rawValue).sorted()
+    }
+
+    var _testConflictedGatewayConfigFields: [String] {
+        self.conflictedGatewayConfigFields.map(\.rawValue).sorted()
     }
 
     @discardableResult

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -391,6 +391,21 @@ final class AppState {
         self.dirtyGatewayConfigFields.contains(.remoteToken)
     }
 
+    var gatewayConfigConflict: GatewayConfigConflict? {
+        let fields = GatewayConfigField.allCases.filter(self.conflictedGatewayConfigFields.contains)
+        guard !fields.isEmpty else { return nil }
+        let fieldNames = fields.map(\.displayName)
+        let fieldList = ListFormatter.localizedString(byJoining: fieldNames)
+        let message = String(localized: """
+        These settings changed outside the app while you were editing: \(fieldList). \
+        Choose which version to keep.
+        """)
+        return GatewayConfigConflict(
+            fields: fields,
+            fieldNames: fieldNames,
+            message: message)
+    }
+
     private(set) var remoteTokenUnsupported = false
 
     var remoteIdentity: String {
@@ -845,7 +860,10 @@ extension AppState {
         return priorConflicts
     }
 
-    private func applyGatewayConfigView(_ root: [String: Any]) {
+    private func applyGatewayConfigView(
+        _ root: [String: Any],
+        forcing forcedFields: Set<GatewayConfigField> = [])
+    {
         let gateway = root["gateway"] as? [String: Any]
         let remote = gateway?["remote"] as? [String: Any]
         let modeRaw = (gateway?["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -869,35 +887,35 @@ extension AppState {
         }
 
         self.isApplyingGatewayConfig = true
-        if !self.dirtyGatewayConfigFields.contains(.mode) {
-            if let desiredMode {
-                if desiredMode != self.connectionMode {
-                    self.connectionMode = desiredMode
-                }
-            } else if hasRemoteUrl, self.connectionMode != .remote {
-                self.connectionMode = .remote
-            }
-        }
+        self.applyGatewayConfigMode(
+            desiredMode,
+            hasRemoteUrl: hasRemoteUrl,
+            forcing: forcedFields.contains(.mode))
 
-        if !self.dirtyGatewayConfigFields.contains(.remoteTransport),
-           remoteTransport != self.remoteTransport
-        {
+        let shouldApplyTransport = forcedFields.contains(.remoteTransport) ||
+            !self.dirtyGatewayConfigFields.contains(.remoteTransport)
+        if shouldApplyTransport, remoteTransport != self.remoteTransport {
             self.remoteTransport = remoteTransport
         }
-        if !self.dirtyGatewayConfigFields.contains(.remoteUrl) {
+        if forcedFields.contains(.remoteUrl) || !self.dirtyGatewayConfigFields.contains(.remoteUrl) {
             let remoteUrlText = remoteResolution.directURL?.absoluteString ?? remoteUrl ?? ""
             if remoteUrlText != self.remoteUrl {
                 self.remoteUrl = remoteUrlText
             }
         }
-        if !self.dirtyGatewayConfigFields.contains(.remoteToken) {
+        if forcedFields.contains(.remoteToken) || !self.dirtyGatewayConfigFields.contains(.remoteToken) {
             self.applyRemoteTokenState(remoteToken)
         }
 
         let targetMode = desiredMode ?? self.connectionMode
-        if !self.dirtyGatewayConfigFields.contains(.remoteTarget),
-           targetMode == .remote,
-           remoteTransport != .direct
+        if forcedFields.contains(.remoteTarget) {
+            let configuredTarget = Self.sanitizeSSHTarget(remote?["sshTarget"] as? String ?? "")
+            if configuredTarget != Self.sanitizeSSHTarget(self.remoteTarget) {
+                self.remoteTarget = configuredTarget
+            }
+        } else if !self.dirtyGatewayConfigFields.contains(.remoteTarget),
+                  targetMode == .remote,
+                  remoteTransport != .direct
         {
             let hasConfiguredTarget = remote?.keys.contains("sshTarget") == true
             let configuredTarget = Self.sanitizeSSHTarget(remote?["sshTarget"] as? String ?? "")
@@ -910,8 +928,14 @@ extension AppState {
                 self.updateRemoteTarget(host: host)
             }
         }
-        if !self.dirtyGatewayConfigFields.contains(.remoteIdentity),
-           remote?.keys.contains("sshIdentity") == true
+        if forcedFields.contains(.remoteIdentity) {
+            let configuredIdentity = (remote?["sshIdentity"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if configuredIdentity != self.remoteIdentity {
+                self.remoteIdentity = configuredIdentity
+            }
+        } else if !self.dirtyGatewayConfigFields.contains(.remoteIdentity),
+                  remote?.keys.contains("sshIdentity") == true
         {
             let configuredIdentity = (remote?["sshIdentity"] as? String)?
                 .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -920,6 +944,18 @@ extension AppState {
             }
         }
         self.isApplyingGatewayConfig = false
+    }
+
+    private func applyGatewayConfigMode(
+        _ desiredMode: ConnectionMode?,
+        hasRemoteUrl: Bool,
+        forcing: Bool)
+    {
+        guard forcing || !self.dirtyGatewayConfigFields.contains(.mode) else { return }
+        let nextMode = desiredMode ?? (hasRemoteUrl ? .remote : forcing ? .unconfigured : nil)
+        if let nextMode, nextMode != self.connectionMode {
+            self.connectionMode = nextMode
+        }
     }
 
     private func applyConfigOverrides(_ root: [String: Any]) {
@@ -1413,6 +1449,72 @@ extension AppState {
         self.conflictedGatewayConfigFields.subtract(persistedFields)
         self.lastObservedGatewayConfig = Self.gatewayConfigSnapshot(root)
     }
+
+    @discardableResult
+    func useFileGatewayConfigConflict() -> Bool {
+        let fields = self.conflictedGatewayConfigFields
+        guard !fields.isEmpty else { return true }
+
+        let priorDraft = self.gatewayConfigDraft()
+        let priorRemoteTokenUnsupported = self.remoteTokenUnsupported
+        let root = OpenClawConfigFile.loadDict()
+        self.dirtyGatewayConfigFields.subtract(fields)
+        self.conflictedGatewayConfigFields.subtract(fields)
+        self.applyGatewayConfigView(root, forcing: fields)
+
+        guard self.syncGatewayConfigNow() else {
+            self.restoreGatewayConfigDraft(priorDraft, fields: fields)
+            self.remoteTokenUnsupported = priorRemoteTokenUnsupported
+            self.dirtyGatewayConfigFields.formUnion(fields)
+            self.conflictedGatewayConfigFields.formUnion(fields)
+            self.setGatewayConfigSyncState(.failed)
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
+    func keepGatewayConfigEdits() -> Bool {
+        let fields = self.conflictedGatewayConfigFields
+        guard !fields.isEmpty else { return true }
+
+        self.conflictedGatewayConfigFields.subtract(fields)
+        self.dirtyGatewayConfigFields.formUnion(fields)
+        guard self.syncGatewayConfigNow(),
+              self.dirtyGatewayConfigFields.isDisjoint(with: fields)
+        else {
+            self.conflictedGatewayConfigFields.formUnion(fields)
+            self.setGatewayConfigSyncState(.failed)
+            return false
+        }
+        return true
+    }
+
+    private func restoreGatewayConfigDraft(
+        _ draft: GatewayConfigSyncDraft,
+        fields: Set<GatewayConfigField>)
+    {
+        self.isApplyingGatewayConfig = true
+        if fields.contains(.mode) {
+            self.connectionMode = draft.connectionMode
+        }
+        if fields.contains(.remoteTransport) {
+            self.remoteTransport = draft.remoteTransport
+        }
+        if fields.contains(.remoteUrl) {
+            self.remoteUrl = draft.remoteUrl
+        }
+        if fields.contains(.remoteTarget) {
+            self.remoteTarget = draft.remoteTarget
+        }
+        if fields.contains(.remoteIdentity) {
+            self.remoteIdentity = draft.remoteIdentity
+        }
+        if fields.contains(.remoteToken) {
+            self.remoteToken = draft.remoteToken
+        }
+        self.isApplyingGatewayConfig = false
+    }
 }
 
 extension AppState {
@@ -1503,76 +1605,6 @@ extension AppState {
     enum RemoteTransport: String {
         case ssh
         case direct
-    }
-
-    enum GatewayConfigField: String, CaseIterable {
-        case mode = "gateway.mode"
-        case remoteTransport = "gateway.remote.transport"
-        case remoteUrl = "gateway.remote.url"
-        case remoteTarget = "gateway.remote.sshTarget"
-        case remoteIdentity = "gateway.remote.sshIdentity"
-        case remoteHostKeyPolicy = "gateway.remote.sshHostKeyPolicy"
-        case remoteToken = "gateway.remote.token"
-
-        var remoteKey: String? {
-            switch self {
-            case .mode:
-                nil
-            case .remoteTransport:
-                "transport"
-            case .remoteUrl:
-                "url"
-            case .remoteTarget:
-                "sshTarget"
-            case .remoteIdentity:
-                "sshIdentity"
-            case .remoteHostKeyPolicy:
-                "sshHostKeyPolicy"
-            case .remoteToken:
-                "token"
-            }
-        }
-    }
-
-    private enum GatewayConfigValue: Equatable {
-        case missing
-        case json(Data)
-    }
-
-    private struct GatewayConfigSnapshot {
-        static let empty = GatewayConfigSnapshot(values: [:])
-        let values: [GatewayConfigField: GatewayConfigValue]
-
-        subscript(field: GatewayConfigField) -> GatewayConfigValue {
-            self.values[field] ?? .missing
-        }
-    }
-
-    struct RemoteGatewayConfigDraft {
-        var transport: RemoteTransport
-        var remoteUrl: String
-        var remoteHost: String?
-        var remoteTarget: String
-        var remoteIdentity: String
-        var remoteToken: String
-        var dirtyFields: Set<GatewayConfigField>
-    }
-
-    struct GatewayConfigSyncDraft {
-        var connectionMode: ConnectionMode
-        var remoteTransport: RemoteTransport
-        var remoteTarget: String
-        var remoteIdentity: String
-        var remoteUrl: String
-        var remoteToken: String
-        var dirtyFields: Set<GatewayConfigField>
-    }
-
-    private struct GatewaySelectionSnapshot: Equatable {
-        let connectionMode: ConnectionMode
-        let remoteTransport: RemoteTransport
-        let remoteUrl: String
-        let remoteTarget: String
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -653,7 +653,9 @@ final class AppState {
         }
         return false
     }
+}
 
+extension AppState {
     private func markGatewayConfigDirty(_ fields: Set<GatewayConfigField>) {
         guard !self.isInitializing, !self.isApplyingGatewayConfig else { return }
         self.dirtyGatewayConfigFields.formUnion(fields)
@@ -817,9 +819,7 @@ final class AppState {
         return fields
     }
 
-    private func applyConfigOverrides(_ root: [String: Any]) {
-        advanceGatewayRoutingGeneration()
-        let previousSelection = self.gatewaySelectionSnapshot()
+    private func reconcileGatewayConfigOwnership(_ root: [String: Any]) -> Set<GatewayConfigField> {
         let diskSnapshot = Self.gatewayConfigSnapshot(root)
         let desiredRoot = Self.syncedGatewayRoot(
             currentRoot: root,
@@ -842,7 +842,10 @@ final class AppState {
         self.conflictedGatewayConfigFields.subtract(externallyPersistedFields)
         self.conflictedGatewayConfigFields.formIntersection(self.dirtyGatewayConfigFields)
         self.lastObservedGatewayConfig = diskSnapshot
+        return priorConflicts
+    }
 
+    private func applyGatewayConfigView(_ root: [String: Any]) {
         let gateway = root["gateway"] as? [String: Any]
         let remote = gateway?["remote"] as? [String: Any]
         let modeRaw = (gateway?["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -917,6 +920,13 @@ final class AppState {
             }
         }
         self.isApplyingGatewayConfig = false
+    }
+
+    private func applyConfigOverrides(_ root: [String: Any]) {
+        advanceGatewayRoutingGeneration()
+        let previousSelection = self.gatewaySelectionSnapshot()
+        let priorConflicts = self.reconcileGatewayConfigOwnership(root)
+        self.applyGatewayConfigView(root)
 
         if self.gatewaySelectionSnapshot() != previousSelection {
             // Discovery ids describe one concrete endpoint. An external config

--- a/apps/macos/Sources/OpenClaw/GatewayConfigConflict.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConfigConflict.swift
@@ -1,0 +1,136 @@
+import Foundation
+import SwiftUI
+
+extension AppState {
+    enum GatewayConfigField: String, CaseIterable {
+        case mode = "gateway.mode"
+        case remoteTransport = "gateway.remote.transport"
+        case remoteUrl = "gateway.remote.url"
+        case remoteTarget = "gateway.remote.sshTarget"
+        case remoteIdentity = "gateway.remote.sshIdentity"
+        case remoteHostKeyPolicy = "gateway.remote.sshHostKeyPolicy"
+        case remoteToken = "gateway.remote.token"
+
+        var remoteKey: String? {
+            switch self {
+            case .mode:
+                nil
+            case .remoteTransport:
+                "transport"
+            case .remoteUrl:
+                "url"
+            case .remoteTarget:
+                "sshTarget"
+            case .remoteIdentity:
+                "sshIdentity"
+            case .remoteHostKeyPolicy:
+                "sshHostKeyPolicy"
+            case .remoteToken:
+                "token"
+            }
+        }
+
+        var displayName: String {
+            switch self {
+            case .mode:
+                String(localized: "Gateway location")
+            case .remoteTransport:
+                String(localized: "Transport")
+            case .remoteUrl:
+                String(localized: "Gateway URL")
+            case .remoteTarget:
+                String(localized: "SSH target")
+            case .remoteIdentity:
+                String(localized: "Identity file")
+            case .remoteHostKeyPolicy:
+                String(localized: "SSH host key policy")
+            case .remoteToken:
+                String(localized: "Gateway token")
+            }
+        }
+    }
+
+    struct GatewayConfigConflict: Equatable {
+        let fields: [GatewayConfigField]
+        let fieldNames: [String]
+        let message: String
+    }
+
+    enum GatewayConfigValue: Equatable {
+        case missing
+        case json(Data)
+    }
+
+    struct GatewayConfigSnapshot {
+        static let empty = GatewayConfigSnapshot(values: [:])
+        let values: [GatewayConfigField: GatewayConfigValue]
+
+        subscript(field: GatewayConfigField) -> GatewayConfigValue {
+            self.values[field] ?? .missing
+        }
+    }
+
+    struct RemoteGatewayConfigDraft {
+        var transport: RemoteTransport
+        var remoteUrl: String
+        var remoteHost: String?
+        var remoteTarget: String
+        var remoteIdentity: String
+        var remoteToken: String
+        var dirtyFields: Set<GatewayConfigField>
+    }
+
+    struct GatewayConfigSyncDraft {
+        var connectionMode: ConnectionMode
+        var remoteTransport: RemoteTransport
+        var remoteTarget: String
+        var remoteIdentity: String
+        var remoteUrl: String
+        var remoteToken: String
+        var dirtyFields: Set<GatewayConfigField>
+    }
+
+    struct GatewaySelectionSnapshot: Equatable {
+        let connectionMode: ConnectionMode
+        let remoteTransport: RemoteTransport
+        let remoteUrl: String
+        let remoteTarget: String
+    }
+}
+
+struct GatewayConfigConflictRecoveryView: View {
+    @Bindable var state: AppState
+
+    var body: some View {
+        if let conflict = state.gatewayConfigConflict {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(verbatim: conflict.message)
+                        .font(.footnote)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack(spacing: 8) {
+                        Button("Use file version") {
+                            self.state.useFileGatewayConfigConflict()
+                        }
+                        .buttonStyle(.bordered)
+
+                        Button("Keep my edits") {
+                            self.state.keepGatewayConfigEdits()
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .controlSize(.small)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 11)
+            .background(.orange.opacity(0.08))
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoverySelectionSupport.swift
@@ -23,18 +23,6 @@ enum GatewayDiscoverySelectionSupport {
             state.remoteUrl = self.sshTunnelGatewayUrl(current: state.remoteUrl)
         }
         state.remoteTarget = GatewayDiscoveryHelpers.sshTarget(for: gateway) ?? ""
-
-        if preferredTransport == .direct {
-            OpenClawConfigFile.setRemoteGatewayTransport(AppState.RemoteTransport.direct.rawValue)
-            if !state.remoteUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                OpenClawConfigFile.setRemoteGatewayUrlString(state.remoteUrl)
-            } else {
-                OpenClawConfigFile.clearRemoteGatewayUrl()
-            }
-        } else {
-            OpenClawConfigFile.setRemoteGatewayTransport(AppState.RemoteTransport.ssh.rawValue)
-            OpenClawConfigFile.setRemoteGatewayUrlString(state.remoteUrl)
-        }
     }
 
     private static func sshTunnelGatewayUrl(current: String) -> String {

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -275,6 +275,14 @@ struct GeneralSettings: View {
             self.connectionStatusPanel
             self.gatewayModeGroup
 
+            if self.state.connectionMode != .remote,
+               self.state.gatewayConfigConflict != nil
+            {
+                SettingsCardGroup("Remote Access") {
+                    GatewayConfigConflictRecoveryView(state: self.state)
+                }
+            }
+
             switch self.state.connectionMode {
             case .unconfigured:
                 EmptyView()
@@ -472,6 +480,7 @@ struct GeneralSettings: View {
                     self.remoteDirectRow
                 }
                 self.remoteTokenRow
+                GatewayConfigConflictRecoveryView(state: self.state)
             }
 
             SettingsCardGroup("Discovery & Status") {
@@ -657,7 +666,7 @@ struct GeneralSettings: View {
             SettingsCardRow(
                 title: "Gateway token",
                 subtitle: "Used when the remote gateway requires token auth.",
-                showsDivider: false)
+                showsDivider: self.state.gatewayConfigConflict != nil)
             {
                 SecureField("remote gateway auth token (gateway.remote.token)", text: self.$state.remoteToken)
                     .textFieldStyle(.roundedBorder)

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -124,6 +124,8 @@ extension OnboardingView {
                 }
             }
 
+            GatewayConfigConflictRecoveryView(state: self.state)
+
             HStack {
                 Spacer(minLength: 0)
                 Button("Set up later") {

--- a/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
+++ b/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
@@ -422,53 +422,6 @@ extension OpenClawConfigFile {
         return port
     }
 
-    static func setRemoteGatewayUrl(host: String, port: Int?) {
-        guard let port, port > 0 else { return }
-        let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedHost.isEmpty else { return }
-        self.updateGatewayDict { gateway in
-            var remote = gateway["remote"] as? [String: Any] ?? [:]
-            let existingUrl = (remote["url"] as? String)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let scheme = URL(string: existingUrl)?.scheme ?? "ws"
-            remote["url"] = "\(scheme)://\(trimmedHost):\(port)"
-            gateway["remote"] = remote
-        }
-    }
-
-    static func setRemoteGatewayUrlString(_ value: String) {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        self.updateGatewayDict { gateway in
-            var remote = gateway["remote"] as? [String: Any] ?? [:]
-            remote["url"] = trimmed
-            gateway["remote"] = remote
-        }
-    }
-
-    static func setRemoteGatewayTransport(_ value: String) {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        self.updateGatewayDict { gateway in
-            var remote = gateway["remote"] as? [String: Any] ?? [:]
-            remote["transport"] = trimmed
-            gateway["remote"] = remote
-        }
-    }
-
-    static func clearRemoteGatewayUrl() {
-        self.updateGatewayDict { gateway in
-            guard var remote = gateway["remote"] as? [String: Any] else { return }
-            guard remote["url"] != nil else { return }
-            remote.removeValue(forKey: "url")
-            if remote.isEmpty {
-                gateway.removeValue(forKey: "remote")
-            } else {
-                gateway["remote"] = remote
-            }
-        }
-    }
-
     private static func remoteGatewayUrl() -> URL? {
         let root = self.loadDict()
         guard let gateway = root["gateway"] as? [String: Any],

--- a/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
+++ b/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
@@ -207,18 +207,6 @@ enum OpenClawConfigFile {
         }
     }
 
-    static func updateGatewayDict(_ mutate: (inout [String: Any]) -> Void) {
-        var root = self.loadDict()
-        var gateway = root["gateway"] as? [String: Any] ?? [:]
-        mutate(&gateway)
-        if gateway.isEmpty {
-            root.removeValue(forKey: "gateway")
-        } else {
-            root["gateway"] = gateway
-        }
-        self.saveDict(root)
-    }
-
     static func gatewayUpdateChannel() -> String? {
         let root = self.loadDict()
         let update = root["update"] as? [String: Any]

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -137,7 +137,7 @@ struct AppStateRemoteConfigTests {
             remoteIdentity: "",
             remoteUrl: "not a gateway URL",
             remoteToken: "",
-            remoteTokenDirty: false)
+            dirtyFields: [])
 
         #expect(!AppState._testGatewayDraftCanPersist(base))
         #expect(AppState._testGatewayDraftCanPersist(.init(
@@ -147,7 +147,7 @@ struct AppStateRemoteConfigTests {
             remoteIdentity: "",
             remoteUrl: "wss://gateway.example.test",
             remoteToken: "",
-            remoteTokenDirty: false)))
+            dirtyFields: [])))
         #expect(!AppState._testGatewayDraftCanPersist(.init(
             connectionMode: .remote,
             remoteTransport: .ssh,
@@ -155,7 +155,7 @@ struct AppStateRemoteConfigTests {
             remoteIdentity: "",
             remoteUrl: "ws://127.0.0.1:18789",
             remoteToken: "",
-            remoteTokenDirty: false)))
+            dirtyFields: [])))
     }
 
     @Test
@@ -223,6 +223,226 @@ struct AppStateRemoteConfigTests {
             let remote = (OpenClawConfigFile.loadDict()["gateway"] as? [String: Any])?["remote"]
                 as? [String: Any]
             #expect(remote?["sshIdentity"] as? String == "/tmp/new-identity")
+        }
+    }
+
+    @Test
+    func `successful gateway config sync clears dirty fields`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            #expect(OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "transport": "direct",
+                        "url": "wss://gateway.example.test",
+                        "token": "disk-token",
+                    ],
+                ],
+            ]))
+            let state = AppState(preview: true)
+            state._testEnableGatewayConfigSync()
+
+            state.remoteToken = "app-token"
+            #expect(state.remoteTokenDirty)
+            await state._testAwaitGatewayConfigSync()
+
+            #expect(!state.remoteTokenDirty)
+            #expect(state._testDirtyGatewayConfigFields.isEmpty)
+            #expect(state._testGatewayConfigIsCurrentForRouting)
+            let remote = (OpenClawConfigFile.loadDict()["gateway"] as? [String: Any])?["remote"]
+                as? [String: Any]
+            #expect(remote?["token"] as? String == "app-token")
+
+            state.remoteToken = " app-token "
+            #expect(state.remoteTokenDirty)
+            await state._testAwaitGatewayConfigSync()
+            #expect(!state.remoteTokenDirty)
+        }
+    }
+
+    @Test
+    func `failed gateway config sync retains dirty fields`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            #expect(OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "transport": "direct",
+                        "url": "wss://gateway.example.test",
+                        "token": "disk-token",
+                    ],
+                ],
+            ]))
+            let state = AppState(preview: true, gatewayConfigSaver: { _ in false })
+            state._testEnableGatewayConfigSync()
+
+            state.remoteToken = "app-token"
+            await state._testAwaitGatewayConfigSync()
+
+            #expect(state.remoteTokenDirty)
+            #expect(state._testDirtyGatewayConfigFields == ["gateway.remote.token"])
+            #expect(!state._testGatewayConfigIsCurrentForRouting)
+            let remote = (OpenClawConfigFile.loadDict()["gateway"] as? [String: Any])?["remote"]
+                as? [String: Any]
+            #expect(remote?["token"] as? String == "disk-token")
+        }
+    }
+
+    @Test
+    func `config watcher adopts non-dirty remote gateway fields`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            #expect(OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "transport": "direct",
+                        "url": "wss://old-gateway.example.test",
+                        "token": "old-token",
+                    ],
+                ],
+            ]))
+            let state = AppState(preview: true)
+
+            #expect(OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "transport": "ssh",
+                        "url": "ws://127.0.0.1:19999",
+                        "sshTarget": "alice@new-gateway.example.test",
+                        "sshIdentity": "/tmp/new-identity",
+                        "token": "new-token",
+                    ],
+                ],
+            ]))
+            state._testApplyConfigFromDisk()
+
+            #expect(state.remoteTransport == .ssh)
+            #expect(state.remoteUrl == "ws://127.0.0.1:19999")
+            #expect(state.remoteTarget == "alice@new-gateway.example.test")
+            #expect(state.remoteIdentity == "/tmp/new-identity")
+            #expect(state.remoteToken == "new-token")
+            #expect(state._testDirtyGatewayConfigFields.isEmpty)
+            #expect(state._testConflictedGatewayConfigFields.isEmpty)
+        }
+    }
+
+    @Test
+    func `external token edit after successful sync is not reverted`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            #expect(OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "transport": "direct",
+                        "url": "wss://gateway.example.test",
+                        "token": "initial-token",
+                    ],
+                ],
+            ]))
+            let state = AppState(preview: true)
+            state._testEnableGatewayConfigSync()
+
+            state.remoteToken = "app-token"
+            await state._testAwaitGatewayConfigSync()
+            #expect(!state.remoteTokenDirty)
+
+            var externalRoot = OpenClawConfigFile.loadDict()
+            var gateway = externalRoot["gateway"] as? [String: Any] ?? [:]
+            var remote = gateway["remote"] as? [String: Any] ?? [:]
+            remote["token"] = "external-token"
+            gateway["remote"] = remote
+            externalRoot["gateway"] = gateway
+            #expect(OpenClawConfigFile.saveDict(externalRoot))
+
+            #expect(state.syncGatewayConfigNow())
+            #expect(state.remoteToken == "external-token")
+            let persistedRemote = (OpenClawConfigFile.loadDict()["gateway"] as? [String: Any])?["remote"]
+                as? [String: Any]
+            #expect(persistedRemote?["token"] as? String == "external-token")
+        }
+    }
+
+    @Test
+    func `dirty external token conflict keeps UI and disk values separate`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            #expect(OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "transport": "direct",
+                        "url": "wss://gateway.example.test",
+                        "token": "initial-token",
+                    ],
+                ],
+            ]))
+            let state = AppState(preview: true)
+            state.remoteToken = "app-token"
+
+            var externalRoot = OpenClawConfigFile.loadDict()
+            var gateway = externalRoot["gateway"] as? [String: Any] ?? [:]
+            var remote = gateway["remote"] as? [String: Any] ?? [:]
+            remote["token"] = "external-token"
+            gateway["remote"] = remote
+            externalRoot["gateway"] = gateway
+            #expect(OpenClawConfigFile.saveDict(externalRoot))
+            state._testApplyConfigFromDisk()
+
+            #expect(state.remoteToken == "app-token")
+            #expect(state.remoteTokenDirty)
+            #expect(state._testConflictedGatewayConfigFields == ["gateway.remote.token"])
+            #expect(!state._testGatewayConfigIsCurrentForRouting)
+
+            state._testEnableGatewayConfigSync()
+            #expect(!state.syncGatewayConfigNow())
+            let persistedRemote = (OpenClawConfigFile.loadDict()["gateway"] as? [String: Any])?["remote"]
+                as? [String: Any]
+            #expect(persistedRemote?["token"] as? String == "external-token")
+            #expect(state.remoteToken == "app-token")
+        }
+    }
+
+    @Test
+    func `dirty token does not claim an externally changed remote URL`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            #expect(OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "remote": [
+                        "transport": "direct",
+                        "url": "wss://old-gateway.example.test",
+                        "token": "initial-token",
+                    ],
+                ],
+            ]))
+            let state = AppState(preview: true)
+            state.remoteToken = "app-token"
+
+            var externalRoot = OpenClawConfigFile.loadDict()
+            var gateway = externalRoot["gateway"] as? [String: Any] ?? [:]
+            var remote = gateway["remote"] as? [String: Any] ?? [:]
+            remote["url"] = "wss://new-gateway.example.test"
+            gateway["remote"] = remote
+            externalRoot["gateway"] = gateway
+            #expect(OpenClawConfigFile.saveDict(externalRoot))
+            state._testApplyConfigFromDisk()
+
+            #expect(state.remoteToken == "app-token")
+            #expect(state.remoteUrl == "wss://new-gateway.example.test")
+            #expect(state._testConflictedGatewayConfigFields.isEmpty)
+
+            state._testEnableGatewayConfigSync()
+            #expect(state.syncGatewayConfigNow())
+            let persistedRemote = (OpenClawConfigFile.loadDict()["gateway"] as? [String: Any])?["remote"]
+                as? [String: Any]
+            #expect(persistedRemote?["token"] as? String == "app-token")
+            #expect(persistedRemote?["url"] as? String == "wss://new-gateway.example.test")
         }
     }
 
@@ -456,7 +676,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "alice@gateway.example",
                 remoteIdentity: "/tmp/id_ed25519",
                 remoteToken: "  secret-token  ",
-                remoteTokenDirty: true))
+                dirtyFields: [.remoteToken]))
 
         #expect(remote["token"] as? String == "secret-token")
     }
@@ -472,7 +692,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "",
                 remoteIdentity: "",
                 remoteToken: "   ",
-                remoteTokenDirty: true))
+                dirtyFields: [.remoteToken]))
 
         #expect((remote["token"] as? String) == nil)
     }
@@ -488,7 +708,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "alice@gateway.example",
                 remoteIdentity: "",
                 remoteToken: "",
-                remoteTokenDirty: false))
+                dirtyFields: [.remoteTransport, .remoteUrl, .remoteTarget, .remoteHostKeyPolicy]))
 
         #expect(remote["url"] as? String == "ws://127.0.0.1:18789")
         #expect(remote["transport"] as? String == "ssh")
@@ -509,7 +729,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "alice@gateway.example",
                 remoteIdentity: "",
                 remoteToken: "",
-                remoteTokenDirty: false))
+                dirtyFields: [.remoteTarget, .remoteHostKeyPolicy]))
         let changedTarget = AppState._testUpdatedRemoteGatewayConfig(
             current: [
                 "sshHostKeyPolicy": "openssh",
@@ -522,7 +742,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "new-gateway-alias",
                 remoteIdentity: "",
                 remoteToken: "",
-                remoteTokenDirty: false))
+                dirtyFields: [.remoteTarget, .remoteHostKeyPolicy]))
 
         #expect(sameTarget["sshHostKeyPolicy"] as? String == "openssh")
         #expect(changedTarget["sshHostKeyPolicy"] as? String == "strict")
@@ -539,7 +759,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "alice@gateway.example",
                 remoteIdentity: "",
                 remoteToken: "",
-                remoteTokenDirty: false))
+                dirtyFields: [.remoteUrl]))
 
         #expect(remote["url"] as? String == "ws://127.0.0.1:29876")
     }
@@ -555,7 +775,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "alice@gateway.example",
                 remoteIdentity: "",
                 remoteToken: "",
-                remoteTokenDirty: false))
+                dirtyFields: [.remoteUrl]))
 
         #expect(remote["url"] as? String == "ws://127.0.0.1:19999")
     }
@@ -571,7 +791,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "alice@gateway.example",
                 remoteIdentity: "",
                 remoteToken: "",
-                remoteTokenDirty: false))
+                dirtyFields: [.remoteUrl]))
 
         #expect(remote["url"] as? String == "ws://127.0.0.1:18789")
     }
@@ -587,7 +807,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "alice@example.com",
                 remoteIdentity: "",
                 remoteToken: "",
-                remoteTokenDirty: false))
+                dirtyFields: [.remoteUrl]))
 
         #expect(remote["url"] as? String == "ws://127.0.0.1:18789")
     }
@@ -681,7 +901,13 @@ struct AppStateRemoteConfigTests {
                 remoteIdentity: "",
                 remoteUrl: "",
                 remoteToken: "",
-                remoteTokenDirty: false))
+                dirtyFields: [
+                    .remoteTransport,
+                    .remoteUrl,
+                    .remoteTarget,
+                    .remoteIdentity,
+                    .remoteHostKeyPolicy,
+                ]))
         let sshRemote = (sshRoot["gateway"] as? [String: Any])?["remote"] as? [String: Any]
         #expect((sshRemote?["token"] as? [String: String])?["$secretRef"] ==
             "gateway-token") // pragma: allowlist secret
@@ -695,7 +921,7 @@ struct AppStateRemoteConfigTests {
                 remoteIdentity: "",
                 remoteUrl: "",
                 remoteToken: "",
-                remoteTokenDirty: false))
+                dirtyFields: [.mode]))
         let localGateway = localRoot["gateway"] as? [String: Any]
         let localRemote = localGateway?["remote"] as? [String: Any]
         #expect(localGateway?["mode"] as? String == "local")
@@ -718,7 +944,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "",
                 remoteIdentity: "",
                 remoteToken: "  fresh-token  ",
-                remoteTokenDirty: true))
+                dirtyFields: [.remoteToken]))
 
         #expect(remote["token"] as? String == "fresh-token")
     }
@@ -740,7 +966,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "",
                 remoteIdentity: "",
                 remoteToken: "",
-                remoteTokenDirty: false))
+                dirtyFields: []))
         #expect((preserved["token"] as? [String: String])?["$secretRef"] == "gateway-token") // pragma: allowlist secret
 
         let cleared = AppState._testUpdatedRemoteGatewayConfig(
@@ -752,7 +978,7 @@ struct AppStateRemoteConfigTests {
                 remoteTarget: "",
                 remoteIdentity: "",
                 remoteToken: "   ",
-                remoteTokenDirty: true))
+                dirtyFields: [.remoteToken]))
         #expect((cleared["token"] as? String) == nil)
     }
 
@@ -781,7 +1007,7 @@ struct AppStateRemoteConfigTests {
                 remoteIdentity: "",
                 remoteUrl: "",
                 remoteToken: "",
-                remoteTokenDirty: false))
+                dirtyFields: [.mode]))
         let localGateway = localRoot["gateway"] as? [String: Any]
         let auth = localGateway?["auth"] as? [String: Any]
         #expect(localGateway?["mode"] as? String == "local")

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -459,9 +459,15 @@ struct AppStateRemoteConfigTests {
             }
         }
         let state = AppState(preview: true)
-        state.connectionMode = .remote
-        state.remoteTransport = .direct
-        state.remoteUrl = "wss://gateway-a.example.test"
+        state._testApplyConfigOverrides([
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "transport": "direct",
+                    "url": "wss://gateway-a.example.test",
+                ],
+            ],
+        ])
         GatewayDiscoveryPreferences.setPreferredStableID("gateway-a")
         OnboardingSystemAgentResumeStore.markPending(routeIdentity: "remote:id:gateway-a")
         let view = OnboardingView(state: state)
@@ -494,10 +500,16 @@ struct AppStateRemoteConfigTests {
         let previousGatewayPreference = captureGatewayPreference()
         defer { restoreGatewayPreference(previousGatewayPreference) }
         let state = AppState(preview: true)
-        state.connectionMode = .remote
-        state.remoteTransport = .ssh
-        state.remoteUrl = "ws://127.0.0.1:18789"
-        state.remoteTarget = "alice@gateway-a.example.test"
+        state._testApplyConfigOverrides([
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "transport": "ssh",
+                    "url": "ws://127.0.0.1:18789",
+                    "sshTarget": "alice@gateway-a.example.test",
+                ],
+            ],
+        ])
         GatewayDiscoveryPreferences.setPreferredStableID("gateway-a")
         let view = OnboardingView(state: state)
         view.preferredGatewayID = "gateway-a"
@@ -523,11 +535,17 @@ struct AppStateRemoteConfigTests {
         let previousGatewayPreference = captureGatewayPreference()
         defer { restoreGatewayPreference(previousGatewayPreference) }
         let state = AppState(preview: true)
-        state.connectionMode = .remote
-        state.remoteTransport = .ssh
-        state.remoteUrl = "ws://127.0.0.1:18789"
-        state.remoteTarget = "alice@gateway-a.example.test"
-        state.remoteIdentity = "/tmp/gateway-a-id"
+        state._testApplyConfigOverrides([
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "transport": "ssh",
+                    "url": "ws://127.0.0.1:18789",
+                    "sshTarget": "alice@gateway-a.example.test",
+                    "sshIdentity": "/tmp/gateway-a-id",
+                ],
+            ],
+        ])
         GatewayDiscoveryPreferences.setPreferredStableID("gateway-a")
 
         state._testApplyConfigOverrides([

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -368,42 +368,110 @@ struct AppStateRemoteConfigTests {
     }
 
     @Test
-    func `dirty external token conflict keeps UI and disk values separate`() async {
+    func `dirty external token conflict offers both recovery choices`() async {
         let configPath = TestIsolation.tempConfigPath()
         await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
             #expect(OpenClawConfigFile.saveDict([
                 "gateway": [
                     "mode": "remote",
                     "remote": [
-                        "transport": "direct",
-                        "url": "wss://gateway.example.test",
+                        "transport": "ssh",
+                        "url": "ws://127.0.0.1:18789",
+                        "sshTarget": "alice@gateway.example.test",
+                        "sshIdentity": "/tmp/initial-identity",
                         "token": "initial-token",
                     ],
                 ],
             ]))
-            let state = AppState(preview: true)
+            var rejectSaves = false
+            let state = AppState(
+                preview: true,
+                gatewayConfigSaver: { root in
+                    rejectSaves ? false : OpenClawConfigFile.saveDict(root)
+                })
+            state.remoteIdentity = "/tmp/app-identity"
             state.remoteToken = "app-token"
 
             var externalRoot = OpenClawConfigFile.loadDict()
             var gateway = externalRoot["gateway"] as? [String: Any] ?? [:]
             var remote = gateway["remote"] as? [String: Any] ?? [:]
+            remote.removeValue(forKey: "sshIdentity")
             remote["token"] = "external-token"
             gateway["remote"] = remote
             externalRoot["gateway"] = gateway
             #expect(OpenClawConfigFile.saveDict(externalRoot))
             state._testApplyConfigFromDisk()
 
+            #expect(state.remoteIdentity == "/tmp/app-identity")
             #expect(state.remoteToken == "app-token")
             #expect(state.remoteTokenDirty)
-            #expect(state._testConflictedGatewayConfigFields == ["gateway.remote.token"])
+            #expect(state._testConflictedGatewayConfigFields == [
+                "gateway.remote.sshIdentity",
+                "gateway.remote.token",
+            ])
+            #expect(state.gatewayConfigConflict?.fields == [.remoteIdentity, .remoteToken])
+            #expect(state.gatewayConfigConflict?.fieldNames == ["Identity file", "Gateway token"])
+            #expect(state.gatewayConfigConflict?.message ==
+                "These settings changed outside the app while you were editing: " +
+                    "Identity file and Gateway token. " +
+                    "Choose which version to keep.")
             #expect(!state._testGatewayConfigIsCurrentForRouting)
 
             state._testEnableGatewayConfigSync()
             #expect(!state.syncGatewayConfigNow())
-            let persistedRemote = (OpenClawConfigFile.loadDict()["gateway"] as? [String: Any])?["remote"]
+            var persistedRemote = (OpenClawConfigFile.loadDict()["gateway"] as? [String: Any])?["remote"]
                 as? [String: Any]
             #expect(persistedRemote?["token"] as? String == "external-token")
             #expect(state.remoteToken == "app-token")
+
+            #expect(state.useFileGatewayConfigConflict())
+            #expect(state.remoteIdentity.isEmpty)
+            #expect(state.remoteToken == "external-token")
+            #expect(!state.remoteTokenDirty)
+            #expect(state.gatewayConfigConflict == nil)
+            #expect(state._testConflictedGatewayConfigFields.isEmpty)
+            #expect(state._testGatewayConfigIsCurrentForRouting)
+
+            state.remoteToken = "kept-token"
+            externalRoot = OpenClawConfigFile.loadDict()
+            gateway = externalRoot["gateway"] as? [String: Any] ?? [:]
+            remote = gateway["remote"] as? [String: Any] ?? [:]
+            remote["token"] = "second-external-token"
+            gateway["remote"] = remote
+            externalRoot["gateway"] = gateway
+            #expect(OpenClawConfigFile.saveDict(externalRoot))
+            state._testApplyConfigFromDisk()
+
+            #expect(state.gatewayConfigConflict?.fields == [.remoteToken])
+            #expect(state.keepGatewayConfigEdits())
+            persistedRemote = (OpenClawConfigFile.loadDict()["gateway"] as? [String: Any])?["remote"]
+                as? [String: Any]
+            #expect(persistedRemote?["token"] as? String == "kept-token")
+            #expect(state.remoteToken == "kept-token")
+            #expect(!state.remoteTokenDirty)
+            #expect(state.gatewayConfigConflict == nil)
+            #expect(state._testConflictedGatewayConfigFields.isEmpty)
+            #expect(state._testGatewayConfigIsCurrentForRouting)
+
+            state.remoteToken = "unsaved-token"
+            externalRoot = OpenClawConfigFile.loadDict()
+            gateway = externalRoot["gateway"] as? [String: Any] ?? [:]
+            remote = gateway["remote"] as? [String: Any] ?? [:]
+            remote["token"] = "third-external-token"
+            gateway["remote"] = remote
+            externalRoot["gateway"] = gateway
+            #expect(OpenClawConfigFile.saveDict(externalRoot))
+            state._testApplyConfigFromDisk()
+
+            rejectSaves = true
+            #expect(!state.keepGatewayConfigEdits())
+            persistedRemote = (OpenClawConfigFile.loadDict()["gateway"] as? [String: Any])?["remote"]
+                as? [String: Any]
+            #expect(persistedRemote?["token"] as? String == "third-external-token")
+            #expect(state.remoteToken == "unsaved-token")
+            #expect(state.gatewayConfigConflict?.fields == [.remoteToken])
+            #expect(state._testConflictedGatewayConfigFields == ["gateway.remote.token"])
+            #expect(!state._testGatewayConfigIsCurrentForRouting)
         }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoverySelectionSupportTests.swift
@@ -113,11 +113,6 @@ struct GatewayDiscoverySelectionSupportTests {
             #expect(state.remoteTransport == .ssh)
             #expect(state.remoteUrl == "ws://127.0.0.1:29876")
             #expect(CommandResolver.parseSSHTarget(state.remoteTarget)?.host == "nearby-gateway.local")
-
-            let configRoot = OpenClawConfigFile.loadDict()
-            let remote = ((configRoot["gateway"] as? [String: Any])?["remote"] as? [String: Any]) ?? [:]
-            #expect(remote["transport"] as? String == "ssh")
-            #expect(remote["url"] as? String == "ws://127.0.0.1:29876")
         }
     }
 
@@ -138,11 +133,6 @@ struct GatewayDiscoverySelectionSupportTests {
 
             #expect(state.remoteTransport == .direct)
             #expect(state.remoteUrl == "ws://nearby-gateway.local:19999")
-
-            let configRoot = OpenClawConfigFile.loadDict()
-            let remote = ((configRoot["gateway"] as? [String: Any])?["remote"] as? [String: Any]) ?? [:]
-            #expect(remote["transport"] as? String == "direct")
-            #expect(remote["url"] as? String == "ws://nearby-gateway.local:19999")
         }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
@@ -56,68 +56,6 @@ struct OpenClawConfigFileTests {
         }
     }
 
-    @MainActor
-    @Test
-    func `set remote gateway url string replaces scheme`() async {
-        let override = self.makeConfigOverridePath()
-
-        await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": override]) {
-            OpenClawConfigFile.saveDict([
-                "gateway": [
-                    "remote": [
-                        "url": "wss://old-host:111",
-                    ],
-                ],
-            ])
-            OpenClawConfigFile.setRemoteGatewayUrlString("ws://127.0.0.1:18789")
-            let root = OpenClawConfigFile.loadDict()
-            let url = ((root["gateway"] as? [String: Any])?["remote"] as? [String: Any])?["url"] as? String
-            #expect(url == "ws://127.0.0.1:18789")
-        }
-    }
-
-    @MainActor
-    @Test
-    func `set remote gateway url preserves scheme`() async {
-        let override = self.makeConfigOverridePath()
-
-        await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": override]) {
-            OpenClawConfigFile.saveDict([
-                "gateway": [
-                    "remote": [
-                        "url": "wss://old-host:111",
-                    ],
-                ],
-            ])
-            OpenClawConfigFile.setRemoteGatewayUrl(host: "new-host", port: 2222)
-            let root = OpenClawConfigFile.loadDict()
-            let url = ((root["gateway"] as? [String: Any])?["remote"] as? [String: Any])?["url"] as? String
-            #expect(url == "wss://new-host:2222")
-        }
-    }
-
-    @MainActor
-    @Test
-    func `clear remote gateway url removes only url field`() async {
-        let override = self.makeConfigOverridePath()
-
-        await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": override]) {
-            OpenClawConfigFile.saveDict([
-                "gateway": [
-                    "remote": [
-                        "url": "wss://old-host:111",
-                        "token": "tok",
-                    ],
-                ],
-            ])
-            OpenClawConfigFile.clearRemoteGatewayUrl()
-            let root = OpenClawConfigFile.loadDict()
-            let remote = ((root["gateway"] as? [String: Any])?["remote"] as? [String: Any]) ?? [:]
-            #expect((remote["url"] as? String) == nil)
-            #expect((remote["token"] as? String) == "tok")
-        }
-    }
-
     @Test
     func `state dir override sets config path`() async {
         let dir = FileManager().temporaryDirectory


### PR DESCRIPTION
Closes #118037

Related: #117903, #117904, #117942

## What Problem This Solves

Fixes an issue where users running the macOS app in remote mode could have a newer external CLI/tool edit to `gateway.remote.*` silently overwritten by a later app config sync. In the live 2026-08-02 reproduction on shipped 2026.7.1, an external tool wrote a valid raw remote token; a later app sync restored the app's stale in-memory value and left the user in unexplained gateway-auth loops.

This is adjacent to #117942, where redacted-token CLI guidance pushes users toward direct config edits, and belongs to the same visible-auth-failure doctrine family as #117903 / PR #117904.

## Why This Change Was Made

The config file is now the canonical source for the macOS remote-gateway view. AppState tracks ownership per field for `gateway.mode` and app-modeled `gateway.remote.*` values, clears ownership immediately after successful persistence, adopts non-dirty external changes, and fails routing closed when a dirty field also changed externally. Conflicts preserve both sides: the pending UI value stays visible, the file remains untouched, sync state becomes failed, and one redacted warning lists field names only.

Every sync reconciles against a freshly loaded root before merging, so it is safe even when the app write wins the watcher's coalescing window. The merge writes only fields owned by the current draft. The discovery picker now uses AppState as its sole persistence owner; its duplicate direct config setters and obsolete tests were removed. No config keys, schema, protocol, gateway, or TypeScript surfaces changed.

## User Impact

External remote-gateway edits are no longer silently reverted by stale app state. Non-conflicting changes appear in the running app, successful saves stop being treated as pending edits, and true concurrent edits produce a visible fail-closed state instead of an unexplained last-writer-wins result.

Release-note context: macOS remote gateway settings now preserve external config edits and surface concurrent edit conflicts rather than silently overwriting credentials.

## Evidence

### Live behavior verification (maintainer hardware)

**External-edit adoption.** With the app running and the SSH-target field non-dirty, an external process rewrote `gateway.remote.sshTarget` in the active config file to `steipete@adopted.example.com`. Within seconds, the running app's connection UI showed exactly that value, captured via an accessibility snapshot.

**Failed-write retention.** With the state directory made unwritable, an in-app edit to the SSH target remained in the UI while before-and-after file reads proved that the config file did not change. The dirty state survived failed persistence.

**Conflict surfacing.** After write access was restored, an external process wrote a different SSH target while the in-app edit was still dirty. The running app displayed the new conflict row verbatim: “These settings changed outside the app while you were editing: SSH target. Choose which version to keep.” The row offered “Use file version” and “Keep my edits,” while the field retained the user's edit. This was captured in both an accessibility snapshot and a screenshot.

**Recovery.** Clicking “Use file version” dismissed the conflict row and adopted the on-disk value into the field. The result was verified in the UI and by reading the file, with no residual conflict state.

These captures used an isolated `OPENCLAW_STATE_DIR` and fully synthetic `example.com` values. The maintainer retained the screenshots; the textual accessibility extracts are reproduced above.

- Sanitized live failure: shipped 2026.7.1 app running in remote mode; external CLI/tool replaced `gateway.remote.token`; later app sync removed that value and restored stale in-memory state. No hostnames or credential values are included.
- Added dirty-lifecycle coverage for changed and normalized no-op successes, plus failed-save retention.
- Added the real AppState watcher-callback seam coverage for adopting non-dirty transport, URL, SSH target, identity, and token changes.
- Added the original ordering regression: app edit -> successful sync/dirty clear -> external token write -> next app sync preserves and adopts the external token.
- Added dirty/external token conflict coverage: UI value retained, disk value retained, sync state failed, later sync refused.
- Added selective-ownership coverage showing a dirty token does not claim or revert an externally changed remote URL.
- Updated merge-helper tests for explicit per-field ownership and removed tests for the deleted duplicate direct-write path.
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build --package-path apps/macos`: passed; final tail: `Build complete! (18.16 sec)`.
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/macos --filter AppStateRemoteConfigTests`: all test sources compiled; local bundle launch is blocked by the known Xcode-beta SwiftPM Sparkle `dlopen`/rpath limitation. The exact-head `macos-swift` CI lane is the runtime test authority.
- Targeted SwiftFormat lint and `git diff --check`: clean.
- Screenshots: N/A; this is non-visual config reconciliation behavior.
