### PR TITLE
fix(macos): cron editor drops advanced delivery routes

### DIFF
--- a/apps/macos/Sources/OpenClaw/CronJobEditor+Helpers.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobEditor+Helpers.swift
@@ -148,6 +148,13 @@ extension CronJobEditor {
             } else if self.job?.delivery?.bestEffort == true {
                 delivery["bestEffort"] = false
             }
+            if let destination = self.job?.delivery?.completionDestination {
+                delivery["completionDestination"] = destination.mapValues(\.value)
+            }
+        }
+        if let threadId = self.job?.delivery?.threadId { delivery["threadId"] = threadId.value }
+        if let destination = self.job?.delivery?.failureDestination {
+            delivery["failureDestination"] = destination.mapValues(\.value)
         }
         return delivery
     }

--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -57,17 +57,9 @@ enum CronDeliveryMode: String, CaseIterable, Identifiable, Codable {
 
 struct CronDelivery: Codable, Equatable {
     var mode: CronDeliveryMode
-    var channel: String?
-    var to: String?
-    var bestEffort: Bool?
-    // The Gateway owns validation for these heterogeneous routing values. Keep
-    // their exact JSON representation so native edits do not erase them.
-    // Defaults keep ordinary delivery construction terse while exposing the fields when needed.
-    // swiftlint:disable implicit_optional_initialization
-    var threadId: AnyCodable? = nil
-    var completionDestination: [String: AnyCodable]? = nil
-    var failureDestination: [String: AnyCodable]? = nil
-    // swiftlint:enable implicit_optional_initialization
+    var channel: String?, to: String?, bestEffort: Bool?, threadId: AnyCodable?
+    /// Preserve Gateway-validated destination objects exactly so native edits cannot erase routing state.
+    var completionDestination: [String: AnyCodable]?, failureDestination: [String: AnyCodable]?
 }
 
 enum CronSchedule: Codable, Equatable {

--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -60,6 +60,14 @@ struct CronDelivery: Codable, Equatable {
     var channel: String?
     var to: String?
     var bestEffort: Bool?
+    // The Gateway owns validation for these heterogeneous routing values. Keep
+    // their exact JSON representation so native edits do not erase them.
+    // Defaults keep ordinary delivery construction terse while exposing the fields when needed.
+    // swiftlint:disable implicit_optional_initialization
+    var threadId: AnyCodable? = nil
+    var completionDestination: [String: AnyCodable]? = nil
+    var failureDestination: [String: AnyCodable]? = nil
+    // swiftlint:enable implicit_optional_initialization
 }
 
 enum CronSchedule: Codable, Equatable {

--- a/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
@@ -243,17 +243,19 @@ extension CronSettings {
                                     StatusPill(text: "no delivery", tint: .secondary)
                                 }
                                 if let threadId = delivery.threadId?.value {
-                                    StatusPill(text: "thread \(String(describing: threadId))", tint: .secondary)
+                                    StatusPill.verbatim(
+                                        "threadId \(String(describing: threadId))",
+                                        tint: .secondary)
                                 }
                                 if let to = delivery.completionDestination?["to"]?.value as? String {
-                                    StatusPill(text: "completion \(to)", tint: .secondary)
+                                    StatusPill.verbatim("completionDestination \(to)", tint: .secondary)
                                 }
                                 if let failure = delivery.failureDestination {
                                     let target = failure["to"]?.value as? String
                                         ?? failure["channel"]?.value as? String
                                         ?? failure["accountId"]?.value as? String
-                                        ?? "configured"
-                                    StatusPill(text: "failure \(target)", tint: .secondary)
+                                    let suffix = target.map { " \($0)" } ?? ""
+                                    StatusPill.verbatim("failureDestination" + suffix, tint: .secondary)
                                 }
                             }
                         }

--- a/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
@@ -231,8 +231,8 @@ extension CronSettings {
                         if let thinking, !thinking.isEmpty { StatusPill(text: "think \(thinking)", tint: .secondary) }
                         if let timeoutSeconds { StatusPill(text: "\(timeoutSeconds)s", tint: .secondary) }
                         if job.supportsAnnounceDelivery {
-                            let delivery = job.delivery
-                            if let delivery {
+                            if let delivery = job.delivery {
+                                self.advancedDeliveryPills(delivery)
                                 if delivery.mode == .announce {
                                     StatusPill(text: "announce", tint: .secondary)
                                     if let channel = delivery.channel, !channel.isEmpty {
@@ -241,21 +241,6 @@ extension CronSettings {
                                     if let to = delivery.to, !to.isEmpty { StatusPill(text: to, tint: .secondary) }
                                 } else {
                                     StatusPill(text: "no delivery", tint: .secondary)
-                                }
-                                if let threadId = delivery.threadId?.value {
-                                    StatusPill.verbatim(
-                                        "threadId \(String(describing: threadId))",
-                                        tint: .secondary)
-                                }
-                                if let to = delivery.completionDestination?["to"]?.value as? String {
-                                    StatusPill.verbatim("completionDestination \(to)", tint: .secondary)
-                                }
-                                if let failure = delivery.failureDestination {
-                                    let target = failure["to"]?.value as? String
-                                        ?? failure["channel"]?.value as? String
-                                        ?? failure["accountId"]?.value as? String
-                                    let suffix = target.map { " \($0)" } ?? ""
-                                    StatusPill.verbatim("failureDestination" + suffix, tint: .secondary)
                                 }
                             }
                         }
@@ -284,6 +269,25 @@ extension CronSettings {
                     }
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private func advancedDeliveryPills(_ delivery: CronDelivery) -> some View {
+        if let threadId = delivery.threadId?.value {
+            StatusPill.verbatim(
+                "threadId \(String(describing: threadId))",
+                tint: .secondary)
+        }
+        if let to = delivery.completionDestination?["to"]?.value as? String {
+            StatusPill.verbatim("completionDestination \(to)", tint: .secondary)
+        }
+        if let failure = delivery.failureDestination {
+            let target = failure["to"]?.value as? String
+                ?? failure["channel"]?.value as? String
+                ?? failure["accountId"]?.value as? String
+            let suffix = target.map { " \($0)" } ?? ""
+            StatusPill.verbatim("failureDestination" + suffix, tint: .secondary)
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
@@ -242,6 +242,19 @@ extension CronSettings {
                                 } else {
                                     StatusPill(text: "no delivery", tint: .secondary)
                                 }
+                                if let threadId = delivery.threadId?.value {
+                                    StatusPill(text: "thread \(String(describing: threadId))", tint: .secondary)
+                                }
+                                if let to = delivery.completionDestination?["to"]?.value as? String {
+                                    StatusPill(text: "completion \(to)", tint: .secondary)
+                                }
+                                if let failure = delivery.failureDestination {
+                                    let target = failure["to"]?.value as? String
+                                        ?? failure["channel"]?.value as? String
+                                        ?? failure["accountId"]?.value as? String
+                                        ?? "configured"
+                                    StatusPill(text: "failure \(target)", tint: .secondary)
+                                }
                             }
                         }
                     }

--- a/apps/macos/Sources/OpenClaw/StatusPill.swift
+++ b/apps/macos/Sources/OpenClaw/StatusPill.swift
@@ -4,6 +4,11 @@ struct StatusPill: View {
     let text: String
     let tint: Color
 
+    /// Protocol identifiers and runtime values are operator data, not localized UI copy.
+    static func verbatim(_ text: String, tint: Color) -> Self {
+        Self(text: text, tint: tint)
+    }
+
     var body: some View {
         Text(self.text)
             .font(.caption2.weight(.semibold))

--- a/apps/macos/Tests/OpenClawIPCTests/CronJobEditorSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CronJobEditorSmokeTests.swift
@@ -47,7 +47,22 @@ struct CronJobEditorSmokeTests {
                 channel: nil,
                 to: nil,
                 bestEffortDeliver: nil),
-            delivery: CronDelivery(mode: .announce, channel: "whatsapp", to: "+15551234567", bestEffort: true),
+            delivery: CronDelivery(
+                mode: .announce,
+                channel: "whatsapp",
+                to: "+15551234567",
+                bestEffort: true,
+                threadId: AnyCodable(42),
+                completionDestination: [
+                    "mode": AnyCodable("webhook"),
+                    "to": AnyCodable("https://example.test/complete"),
+                ],
+                failureDestination: [
+                    "mode": AnyCodable("announce"),
+                    "channel": AnyCodable("telegram"),
+                    "to": AnyCodable("ops"),
+                    "accountId": AnyCodable("alerts"),
+                ]),
             state: CronJobState(
                 nextRunAtMs: 1_700_000_100_000,
                 runningAtMs: nil,
@@ -58,6 +73,12 @@ struct CronJobEditorSmokeTests {
 
         let view = self.makeEditor(job: job, channelsStore: channelsStore)
         _ = view.body
+
+        let delivery = view.buildDelivery()
+        #expect(delivery["threadId"] as? Int == 42)
+        #expect((delivery["completionDestination"] as? [String: Any])?["to"] as? String ==
+            "https://example.test/complete")
+        #expect((delivery["failureDestination"] as? [String: Any])?["accountId"] as? String == "alerts")
     }
 
     @Test func `cron job editor exercises builders`() {

--- a/apps/macos/Tests/OpenClawIPCTests/CronModelsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CronModelsTests.swift
@@ -72,6 +72,30 @@ struct CronModelsTests {
         #expect(decoded == payload)
     }
 
+    @Test func `delivery advanced routing encodes and decodes`() throws {
+        for threadId in [#""thread-42""#, "42"] {
+            let json = """
+            {
+              "mode": "announce",
+              "threadId": \(threadId),
+              "completionDestination": { "mode": "webhook", "to": "https://example.test/complete" },
+              "failureDestination": {
+                "mode": "announce",
+                "channel": "telegram",
+                "to": "ops",
+                "accountId": "alerts"
+              }
+            }
+            """
+            let delivery = try JSONDecoder().decode(CronDelivery.self, from: Data(json.utf8))
+            let roundTripped = try JSONDecoder().decode(CronDelivery.self, from: JSONEncoder().encode(delivery))
+
+            #expect(roundTripped == delivery)
+            #expect(roundTripped.completionDestination?["mode"]?.value as? String == "webhook")
+            #expect(roundTripped.failureDestination?["accountId"]?.value as? String == "alerts")
+        }
+    }
+
     @Test func `payload command encodes and decodes`() throws {
         let payload = CronPayload.command(
             argv: ["printf", "done"],


### PR DESCRIPTION
Related: #117909

## What Problem This Solves

Fixes an issue where users editing an existing cron job in the macOS app would lose its thread, completion, or failure delivery routing when saving because the native client did not mirror those gateway fields.

## Why This Change Was Made

The macOS delivery mirror now preserves `threadId`, `completionDestination`, and `failureDestination` using their exact heterogeneous JSON representation, matching the gateway protocol without native defaults. The existing delivery summary shows the exact protocol field names and configured values as verbatim operator data, and editor saves retain them while keeping `completionDestination` scoped to announce delivery.

## User Impact

Cron jobs edited in the native macOS client retain their advanced delivery routing instead of silently dropping it. Existing delivery details also expose the configured thread and completion/failure destinations.

## Evidence

- Hosted `macos-swift` passed on head `819f8559b111c6532cbd9b57291c5516c764731d`, including strict lint, release build, OpenClawKit tests, and full Swift tests.
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/macos --filter 'CronModelsTests|CronJobEditorSmokeTests'` — passed 21 tests in 2 suites on the final source.
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build --package-path apps/macos --product OpenClaw --configuration release` — passed locally; hosted CI repeated the release build on the final source.
- `node --import tsx scripts/native-app-i18n.ts verify` — passed with `changed=false` and all native source guards green.
- Targeted strict SwiftLint on all six touched files — 0 violations.
- Targeted SwiftFormat with the repository configuration — clean.
- `git diff --check origin/main...HEAD` — passed.
- Autoreview — clean after the implementation and each CI repair, with no accepted or actionable findings.
- `node scripts/check-changed.mjs` could not acquire a ready hosted Crabbox provider from this worktree; the PR's hosted macOS, i18n, Periphery, and repository checks supplied the heavy proof and finished green.

AI-assisted: yes. I reviewed the complete change and understand the protocol-preservation behavior.
