### PR TITLE
fix(telegram): preserve question choices across button rows

### DIFF
--- a/extensions/codex/src/app-server/user-input-bridge.test.ts
+++ b/extensions/codex/src/app-server/user-input-bridge.test.ts
@@ -99,7 +99,10 @@ describe("Codex app-server user input bridge", () => {
     });
     const payload = vi.mocked(params.onBlockReply!).mock.calls[0]![0];
     expect(payload.channelData).toEqual({
-      askUser: { questionId: (request.params as { id: string }).id },
+      askUser: {
+        questionId: (request.params as { id: string }).id,
+        optionValues: ["Fast", "Deep"],
+      },
     });
     expect(payload.presentationTextMode).toBe("fallback");
     expect(payload.text).toContain("Reply with the number or option text.");

--- a/extensions/copilot/src/user-input-bridge.test.ts
+++ b/extensions/copilot/src/user-input-bridge.test.ts
@@ -80,7 +80,10 @@ describe("Copilot user input bridge", () => {
     });
     const payload = vi.mocked(params.onBlockReply!).mock.calls[0]![0];
     expect(payload.channelData).toEqual({
-      askUser: { questionId: (request.params as { id: string }).id },
+      askUser: {
+        questionId: (request.params as { id: string }).id,
+        optionValues: ["Fast", "Deep"],
+      },
     });
     expect(payload.presentationTextMode).toBe("fallback");
     expect(payload.text).toContain("Reply with the number or option text.");

--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -21,7 +21,11 @@ import type { TelegramProgressController } from "./bot-message-dispatch-progress
 import { deduplicateBlockSentMedia } from "./bot-message-dispatch.media-dedup.js";
 import type { TelegramDispatchTurnState } from "./bot-message-dispatch.types.js";
 import type { TelegramStreamMode } from "./bot/types.js";
-import { resolveTelegramInlineButtons, type TelegramInlineButtons } from "./button-types.js";
+import {
+  resolveTelegramInlineButtons,
+  resolveTelegramQuestionOptionIndices,
+  type TelegramInlineButtons,
+} from "./button-types.js";
 import {
   buildTelegramErrorScopeKey,
   isSilentErrorPolicy,
@@ -70,11 +74,14 @@ function resolvePayloadTelegramInlineButtons(
   const telegramData = payload.channelData?.telegram as
     | { buttons?: TelegramInlineButtons }
     | undefined;
-  return resolveTelegramInlineButtons({
-    buttons: telegramData?.buttons,
-    presentation: normalizeMessagePresentation(payload.presentation),
-    interactive: payload.interactive,
-  });
+  return resolveTelegramInlineButtons(
+    {
+      buttons: telegramData?.buttons,
+      presentation: normalizeMessagePresentation(payload.presentation),
+      interactive: payload.interactive,
+    },
+    { questionOptionIndices: resolveTelegramQuestionOptionIndices(payload) },
+  );
 }
 
 function hasExecApprovalPayload(payload: ReplyPayload): boolean {

--- a/extensions/telegram/src/button-types.test.ts
+++ b/extensions/telegram/src/button-types.test.ts
@@ -2,7 +2,11 @@
 import { buildApprovalResolutionRef } from "openclaw/plugin-sdk/approval-reference-runtime";
 import { describe, expect, it } from "vitest";
 import { parseTelegramApprovalCallbackData } from "./approval-callback-data.js";
-import { buildTelegramPresentationButtons, resolveTelegramInlineButtons } from "./button-types.js";
+import {
+  buildTelegramPresentationButtons,
+  resolveTelegramInlineButtons,
+  type TelegramButtonBuildOptions,
+} from "./button-types.js";
 import { describeTelegramInteractiveButtonBehavior } from "./button-types.test-helpers.js";
 import {
   buildTelegramOpaqueCallbackData,
@@ -10,6 +14,24 @@ import {
 } from "./native-command-callback-data.js";
 
 describeTelegramInteractiveButtonBehavior();
+
+function questionButtonOptions(
+  questions: ReadonlyArray<{ questionId: string; optionValues: readonly string[] }>,
+): TelegramButtonBuildOptions {
+  return {
+    questionOptionIndices: new Map(
+      questions.map(
+        ({ questionId, optionValues }) =>
+          [
+            questionId,
+            new Map(
+              optionValues.map((value, index) => [value.trim().toLowerCase(), index] as const),
+            ),
+          ] as const,
+      ),
+    ),
+  };
+}
 
 describe("buildTelegramInteractiveButtons callback limits", () => {
   it("drops buttons whose callback payload exceeds Telegram limits", () => {
@@ -57,22 +79,185 @@ describe("buildTelegramPresentationButtons", () => {
   it("encodes question buttons by record id and option index", () => {
     const questionId = "ask_0123456789abcdef0123456789abcdef";
     expect(
-      buildTelegramPresentationButtons({
-        blocks: [
-          {
-            type: "buttons",
-            buttons: ["Staging", "Production"].map((label) => ({
-              label,
-              action: { type: "question" as const, questionId, optionValue: label },
-            })),
-          },
-        ],
-      }),
+      buildTelegramPresentationButtons(
+        {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: ["Staging", "Production"].map((label) => ({
+                label,
+                action: { type: "question" as const, questionId, optionValue: label },
+              })),
+            },
+          ],
+        },
+        questionButtonOptions([{ questionId, optionValues: ["Staging", "Production"] }]),
+      ),
     ).toEqual([
       [
         { text: "Staging", callback_data: `tgq1:${questionId}:0`, style: undefined },
         { text: "Production", callback_data: `tgq1:${questionId}:1`, style: undefined },
       ],
+    ]);
+  });
+
+  it("drops question buttons when authoritative Gateway option order is unavailable", () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+
+    expect(
+      buildTelegramPresentationButtons({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Production",
+                action: {
+                  type: "question" as const,
+                  questionId,
+                  optionValue: "Production",
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps question option indices independent and stable across presentation blocks", () => {
+    const firstQuestionId = "ask_0123456789abcdef0123456789abcdef";
+    const secondQuestionId = "ask_fedcba9876543210fedcba9876543210";
+    const questionButton = (questionId: string, optionValue: string) => ({
+      label: optionValue,
+      action: { type: "question" as const, questionId, optionValue },
+    });
+
+    const rows = buildTelegramPresentationButtons(
+      {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              questionButton(firstQuestionId, "東京"),
+              questionButton(firstQuestionId, "Déployer"),
+            ],
+          },
+          {
+            type: "buttons",
+            buttons: [
+              questionButton(secondQuestionId, "東京"),
+              questionButton(secondQuestionId, "Production"),
+            ],
+          },
+          {
+            type: "buttons",
+            buttons: [
+              questionButton(firstQuestionId, "東京"),
+              questionButton(firstQuestionId, "Production 🚀"),
+            ],
+          },
+        ],
+      },
+      questionButtonOptions([
+        {
+          questionId: firstQuestionId,
+          optionValues: ["東京", "Déployer", "Production 🚀"],
+        },
+        { questionId: secondQuestionId, optionValues: ["東京", "Production"] },
+      ]),
+    );
+
+    expect(rows?.map((row) => row.map((button) => button.callback_data))).toEqual([
+      [`tgq1:${firstQuestionId}:0`, `tgq1:${firstQuestionId}:1`],
+      [`tgq1:${secondQuestionId}:0`, `tgq1:${secondQuestionId}:1`],
+      [`tgq1:${firstQuestionId}:0`, `tgq1:${firstQuestionId}:2`],
+    ]);
+  });
+
+  it("maps repeated rendered question values to their canonical Gateway option indices", () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const button = (label: string) => ({
+      label,
+      action: { type: "question" as const, questionId, optionValue: label },
+    });
+
+    const rows = buildTelegramPresentationButtons(
+      {
+        blocks: [
+          { type: "buttons", buttons: [button("A"), button("A")] },
+          { type: "buttons", buttons: [button("B"), button("C")] },
+        ],
+      },
+      questionButtonOptions([{ questionId, optionValues: ["A", "B", "C"] }]),
+    );
+
+    expect(rows?.flatMap((row) => row.map((entry) => entry.callback_data))).toEqual([
+      `tgq1:${questionId}:0`,
+      `tgq1:${questionId}:0`,
+      `tgq1:${questionId}:1`,
+      `tgq1:${questionId}:2`,
+    ]);
+  });
+
+  it("normalizes repeated question values with the Gateway trim and lowercase contract", () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const questionButton = (optionValue: string) => ({
+      label: optionValue,
+      action: { type: "question" as const, questionId, optionValue },
+    });
+
+    const rows = buildTelegramPresentationButtons(
+      {
+        blocks: [
+          { type: "buttons", buttons: [questionButton(" Deploy "), questionButton("deploy")] },
+          { type: "buttons", buttons: [questionButton("Production")] },
+        ],
+      },
+      questionButtonOptions([{ questionId, optionValues: [" Deploy ", "Production"] }]),
+    );
+
+    expect(rows?.flatMap((row) => row.map((entry) => entry.callback_data))).toEqual([
+      `tgq1:${questionId}:0`,
+      `tgq1:${questionId}:0`,
+      `tgq1:${questionId}:1`,
+    ]);
+  });
+
+  it("does not consume a question option position when callback encoding fails", () => {
+    const validQuestionId = "ask_0123456789abcdef0123456789abcdef";
+    const invalidQuestionId = "not-a-gateway-question";
+    const rows = buildTelegramPresentationButtons(
+      {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Invalid",
+                action: {
+                  type: "question" as const,
+                  questionId: invalidQuestionId,
+                  optionValue: "Invalid",
+                },
+              },
+              {
+                label: "Valid",
+                action: {
+                  type: "question" as const,
+                  questionId: validQuestionId,
+                  optionValue: "Valid",
+                },
+              },
+            ],
+          },
+        ],
+      },
+      questionButtonOptions([{ questionId: validQuestionId, optionValues: ["Valid", "Other"] }]),
+    );
+
+    expect(rows).toEqual([
+      [{ text: "Valid", callback_data: `tgq1:${validQuestionId}:0`, style: undefined }],
     ]);
   });
 

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -10,6 +10,7 @@ import {
   type MessagePresentation,
   type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import {
   buildTelegramApprovalCallbackData,
   hasTelegramApprovalCallbackPrefix,
@@ -37,7 +38,50 @@ type TelegramInlineButton = {
 
 export type TelegramInlineButtons = ReadonlyArray<ReadonlyArray<TelegramInlineButton>>;
 
+type TelegramQuestionOptionIndices = ReadonlyMap<string, ReadonlyMap<string, number>>;
+
+export type TelegramButtonBuildOptions = {
+  allowWebAppButtons?: boolean;
+  questionOptionIndices?: TelegramQuestionOptionIndices;
+};
+
 const TELEGRAM_INTERACTIVE_ROW_SIZE = 3;
+
+/** Reads only bounded, unambiguous Gateway-owned question option ordering. */
+export function resolveTelegramQuestionOptionIndices(
+  payload: Pick<ReplyPayload, "channelData">,
+): TelegramQuestionOptionIndices | undefined {
+  const askUser = payload.channelData?.askUser;
+  if (!askUser || typeof askUser !== "object" || Array.isArray(askUser)) {
+    return undefined;
+  }
+  const { questionId, optionValues } = askUser as {
+    questionId?: unknown;
+    optionValues?: unknown;
+  };
+  if (
+    typeof questionId !== "string" ||
+    !questionId ||
+    !Array.isArray(optionValues) ||
+    optionValues.length < 2 ||
+    optionValues.length > 4
+  ) {
+    return undefined;
+  }
+
+  const optionIndices = new Map<string, number>();
+  for (const [optionIndex, optionValue] of optionValues.entries()) {
+    if (typeof optionValue !== "string") {
+      return undefined;
+    }
+    const normalizedOptionValue = optionValue.trim().toLowerCase();
+    if (!normalizedOptionValue || optionIndices.has(normalizedOptionValue)) {
+      return undefined;
+    }
+    optionIndices.set(normalizedOptionValue, optionIndex);
+  }
+  return new Map([[questionId, optionIndices]]);
+}
 
 function toTelegramButtonStyle(
   style?: MessagePresentationButton["style"],
@@ -47,8 +91,7 @@ function toTelegramButtonStyle(
 
 function toTelegramInlineButton(
   button: MessagePresentationButton,
-  optionIndex: number,
-  options?: { allowWebAppButtons?: boolean },
+  options?: TelegramButtonBuildOptions,
 ): TelegramInlineButton | undefined {
   const style = toTelegramButtonStyle(button.style);
   const action = resolveMessagePresentationButtonAction(button);
@@ -68,11 +111,22 @@ function toTelegramInlineButton(
     return callbackData ? { text: button.label, callback_data: callbackData, style } : undefined;
   }
   if (action.type === "question") {
+    const normalizedOptionValue = action.optionValue.trim().toLowerCase();
+    const optionIndex = options?.questionOptionIndices
+      ?.get(action.questionId)
+      ?.get(normalizedOptionValue);
+    if (optionIndex === undefined) {
+      return undefined;
+    }
     const callbackData = buildTelegramQuestionCallbackData({
       questionId: action.questionId,
       optionIndex,
     });
-    return callbackData ? { text: button.label, callback_data: callbackData, style } : undefined;
+    if (!callbackData) {
+      return undefined;
+    }
+    // Presentation order is not authoritative; only Gateway-owned option order can choose an index.
+    return { text: button.label, callback_data: callbackData, style };
   }
   if (action.type === "command") {
     const command = rewriteTelegramApprovalDecisionAlias(action.command.trim());
@@ -102,13 +156,12 @@ function toTelegramInlineButton(
 function chunkInteractiveButtons(
   buttons: readonly MessagePresentationButton[],
   rows: TelegramInlineButton[][],
-  options?: { allowWebAppButtons?: boolean },
+  options?: TelegramButtonBuildOptions,
 ) {
-  // Index is position in the question's options; core emits one buttons block in option order.
   for (let i = 0; i < buttons.length; i += TELEGRAM_INTERACTIVE_ROW_SIZE) {
     const row = buttons
       .slice(i, i + TELEGRAM_INTERACTIVE_ROW_SIZE)
-      .map((button, offset) => toTelegramInlineButton(button, i + offset, options))
+      .map((button) => toTelegramInlineButton(button, options))
       .filter((button): button is TelegramInlineButton => Boolean(button));
     if (row.length > 0) {
       rows.push(row);
@@ -121,7 +174,7 @@ function chunkInteractiveButtons(
  */
 function buildTelegramInteractiveButtons(
   interactive?: LegacyInteractiveReply,
-  options?: { allowWebAppButtons?: boolean },
+  options?: TelegramButtonBuildOptions,
 ): TelegramInlineButtons | undefined {
   const rows = reduceLegacyInteractiveReply(
     interactive,
@@ -139,6 +192,7 @@ function buildTelegramInteractiveButtons(
             value: option.value,
           })),
           state,
+          options,
         );
       }
       return state;
@@ -150,7 +204,7 @@ function buildTelegramInteractiveButtons(
 /** Convert portable presentation controls to Telegram inline keyboard rows. */
 export function buildTelegramPresentationButtons(
   presentation?: MessagePresentation,
-  options?: { allowWebAppButtons?: boolean },
+  options?: TelegramButtonBuildOptions,
 ): TelegramInlineButtons | undefined {
   const rows: TelegramInlineButton[][] = [];
   for (const block of presentation?.blocks ?? []) {
@@ -168,6 +222,7 @@ export function buildTelegramPresentationButtons(
         value: option.value,
       })),
       rows,
+      options,
     );
   }
   return rows.length > 0 ? rows : undefined;
@@ -180,7 +235,7 @@ export function resolveTelegramInlineButtons(
     presentation?: unknown;
     interactive?: unknown;
   },
-  options?: { allowWebAppButtons?: boolean },
+  options?: TelegramButtonBuildOptions,
 ): TelegramInlineButtons | undefined {
   return (
     params.buttons ??

--- a/extensions/telegram/src/interactive-fallback.test.ts
+++ b/extensions/telegram/src/interactive-fallback.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { handleTelegramQuestionCallback } from "./bot-handlers.callback-questions.runtime.js";
 import { canonicalizeTelegramPresentationPayload } from "./interactive-fallback.js";
+import { parseTelegramQuestionCallbackData } from "./question-callback-data.js";
 
 describe("canonicalizeTelegramPresentationPayload", () => {
   it("preserves mixed presentation order while moving controls to Telegram buttons", () => {
@@ -101,6 +103,201 @@ describe("canonicalizeTelegramPresentationPayload", () => {
         ],
       ],
     });
+  });
+
+  it("preserves the fourth question option after Telegram splits its button rows", () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const optionValues = ["Staging", "Déployer", "東京", "Production 🚀"];
+    const result = canonicalizeTelegramPresentationPayload({
+      channelData: { askUser: { questionId, optionValues } },
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: optionValues.map((optionValue) => ({
+              label: optionValue,
+              action: { type: "question" as const, questionId, optionValue },
+            })),
+          },
+        ],
+      },
+    });
+    const telegram = result.channelData?.telegram as
+      | { buttons?: ReadonlyArray<ReadonlyArray<{ callback_data?: string }>> }
+      | undefined;
+    const rows = telegram?.buttons;
+
+    expect(rows?.map((row) => row.length)).toEqual([3, 1]);
+    expect(rows?.flatMap((row) => row.map((button) => button.callback_data))).toEqual(
+      optionValues.map((_, optionIndex) => `tgq1:${questionId}:${optionIndex}`),
+    );
+    expect(parseTelegramQuestionCallbackData(rows?.[1]?.[0]?.callback_data)).toEqual({
+      questionId,
+      optionIndex: 3,
+    });
+  });
+
+  it("resolves canonical option C when rendered option A repeats across blocks", async () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const canonicalOptionValues = ["A", "B", "C"];
+    const questionButton = (optionValue: string) => ({
+      label: optionValue,
+      action: { type: "question" as const, questionId, optionValue },
+    });
+    const result = canonicalizeTelegramPresentationPayload({
+      channelData: { askUser: { questionId, optionValues: canonicalOptionValues } },
+      presentation: {
+        blocks: [
+          { type: "buttons", buttons: [questionButton("A"), questionButton("A")] },
+          { type: "buttons", buttons: [questionButton("B"), questionButton("C")] },
+        ],
+      },
+    });
+    const telegram = result.channelData?.telegram as
+      | { buttons?: ReadonlyArray<ReadonlyArray<{ callback_data?: string }>> }
+      | undefined;
+    const rows = telegram?.buttons;
+
+    expect(rows?.map((row) => row.length)).toEqual([2, 2]);
+    expect(rows?.flatMap((row) => row.map((button) => button.callback_data))).toEqual([
+      `tgq1:${questionId}:0`,
+      `tgq1:${questionId}:0`,
+      `tgq1:${questionId}:1`,
+      `tgq1:${questionId}:2`,
+    ]);
+    const callback = parseTelegramQuestionCallbackData(rows?.[1]?.[1]?.callback_data);
+    expect(callback).toEqual({
+      questionId,
+      optionIndex: 2,
+    });
+    if (!callback) {
+      throw new Error("expected canonical Telegram option C callback data");
+    }
+    const resolveQuestion = vi.fn(async (params: { optionIndex?: number }) => ({
+      status: "answered" as const,
+      questionId: "destination",
+      optionValue: canonicalOptionValues[params.optionIndex ?? -1] ?? "",
+    }));
+    const feedback = vi.fn(async () => undefined);
+
+    await handleTelegramQuestionCallback({
+      callback,
+      cfg: {},
+      senderId: "42",
+      feedback,
+      resolveQuestion,
+    });
+
+    expect(resolveQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({ questionId, optionIndex: 2 }),
+    );
+    await expect(resolveQuestion.mock.results[0]?.value).resolves.toMatchObject({
+      status: "answered",
+      questionId: "destination",
+      optionValue: "C",
+    });
+    expect(feedback).toHaveBeenCalledWith("Answer submitted.", true);
+  });
+
+  it.each([
+    {
+      label: "reordered options",
+      optionValues: ["A", "B", "C"],
+      renderedValues: ["C", "A"],
+      expectedIndices: [2, 0],
+    },
+    {
+      label: "a filtered subset",
+      optionValues: ["A", "B", "C", "D"],
+      renderedValues: ["D", "B"],
+      expectedIndices: [3, 1],
+    },
+    {
+      label: "normalized and Unicode values",
+      optionValues: [" Deploy ", "東京", "Production 🚀"],
+      renderedValues: ["production 🚀", "東京", "deploy"],
+      expectedIndices: [2, 1, 0],
+    },
+  ])(
+    "uses authoritative Gateway indices for $label",
+    ({ optionValues, renderedValues, expectedIndices }) => {
+      const questionId = "ask_0123456789abcdef0123456789abcdef";
+      const result = canonicalizeTelegramPresentationPayload({
+        channelData: { askUser: { questionId, optionValues } },
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: renderedValues.map((optionValue) => ({
+                label: optionValue,
+                action: { type: "question" as const, questionId, optionValue },
+              })),
+            },
+          ],
+        },
+      });
+      const telegram = result.channelData?.telegram as
+        | { buttons?: ReadonlyArray<ReadonlyArray<{ callback_data?: string }>> }
+        | undefined;
+
+      expect(
+        telegram?.buttons?.flatMap((row) => row.map((button) => button.callback_data)),
+      ).toEqual(expectedIndices.map((optionIndex) => `tgq1:${questionId}:${optionIndex}`));
+    },
+  );
+
+  it.each([
+    { label: "missing", askUser: undefined },
+    {
+      label: "wrong question",
+      askUser: {
+        questionId: "ask_fedcba9876543210fedcba9876543210",
+        optionValues: ["A", "C"],
+      },
+    },
+    {
+      label: "ambiguous",
+      askUser: {
+        questionId: "ask_0123456789abcdef0123456789abcdef",
+        optionValues: [" A ", "a"],
+      },
+    },
+    {
+      label: "unmatched",
+      askUser: {
+        questionId: "ask_0123456789abcdef0123456789abcdef",
+        optionValues: ["A", "B"],
+      },
+    },
+    {
+      label: "oversized",
+      askUser: {
+        questionId: "ask_0123456789abcdef0123456789abcdef",
+        optionValues: ["A", "B", "C", "D", "E"],
+      },
+    },
+  ])("visibly falls back when canonical question metadata is $label", ({ askUser }) => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const result = canonicalizeTelegramPresentationPayload({
+      text: "Choose:",
+      ...(askUser ? { channelData: { askUser } } : {}),
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "C",
+                action: { type: "question" as const, questionId, optionValue: "C" },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(result.text).toContain("C");
+    expect(result.channelData?.telegram).toBeUndefined();
   });
 
   it("falls back only controls that Telegram cannot encode", () => {

--- a/extensions/telegram/src/interactive-fallback.ts
+++ b/extensions/telegram/src/interactive-fallback.ts
@@ -11,7 +11,12 @@ import {
   type MessagePresentationInteractiveBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import { buildTelegramPresentationButtons, resolveTelegramInlineButtons } from "./button-types.js";
+import {
+  buildTelegramPresentationButtons,
+  resolveTelegramInlineButtons,
+  resolveTelegramQuestionOptionIndices,
+  type TelegramButtonBuildOptions,
+} from "./button-types.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 
 const TELEGRAM_CONTROL_ONLY_FALLBACK = "Choose an option.";
@@ -42,7 +47,7 @@ export const TELEGRAM_PRESENTATION_CAPABILITIES = {
 
 function canEncodeTelegramPresentationControl(
   block: MessagePresentationInteractiveBlock,
-  options?: { allowWebAppButtons?: boolean },
+  options?: TelegramButtonBuildOptions,
 ): boolean {
   return Boolean(buildTelegramPresentationButtons({ blocks: [block] }, options)?.length);
 }
@@ -50,7 +55,7 @@ function canEncodeTelegramPresentationControl(
 function partitionTelegramPresentationBlocks(params: {
   presentation: MessagePresentation;
   presentationControlsSelected: boolean;
-  allowWebAppButtons: boolean;
+  buttonOptions: TelegramButtonBuildOptions;
 }): {
   fallbackBlocks: MessagePresentation["blocks"];
   nativeControlBlocks: MessagePresentationInteractiveBlock[];
@@ -72,7 +77,7 @@ function partitionTelegramPresentationBlocks(params: {
       for (const button of block.buttons) {
         const target = canEncodeTelegramPresentationControl(
           { type: "buttons", buttons: [button] },
-          { allowWebAppButtons: params.allowWebAppButtons },
+          params.buttonOptions,
         )
           ? nativeButtons
           : fallbackButtons;
@@ -90,7 +95,10 @@ function partitionTelegramPresentationBlocks(params: {
     const nativeOptions: typeof block.options = [];
     const fallbackOptions: typeof block.options = [];
     for (const option of block.options) {
-      const target = canEncodeTelegramPresentationControl({ type: "select", options: [option] })
+      const target = canEncodeTelegramPresentationControl(
+        { type: "select", options: [option] },
+        params.buttonOptions,
+      )
         ? nativeOptions
         : fallbackOptions;
       target.push(option);
@@ -133,21 +141,28 @@ export function canonicalizeTelegramPresentationPayload(
   });
 
   const interactive = normalizeLegacyInteractiveReply(payload.interactive);
-  const existingButtons = resolveTelegramInlineButtons({
-    buttons: telegramData?.buttons,
-    interactive,
-  });
+  const buttonOptions: TelegramButtonBuildOptions = {
+    allowWebAppButtons: options?.allowWebAppButtons === true,
+    questionOptionIndices: resolveTelegramQuestionOptionIndices(payload),
+  };
+  const existingButtons = resolveTelegramInlineButtons(
+    {
+      buttons: telegramData?.buttons,
+      interactive,
+    },
+    buttonOptions,
+  );
   const presentationControlsSelected = existingButtons === undefined;
   const { fallbackBlocks, nativeControlBlocks } = partitionTelegramPresentationBlocks({
     presentation,
     presentationControlsSelected,
-    allowWebAppButtons: options?.allowWebAppButtons === true,
+    buttonOptions,
   });
   const presentationButtons = buildTelegramPresentationButtons(
     {
       blocks: nativeControlBlocks,
     },
-    options,
+    buttonOptions,
   );
   const buttons = existingButtons ?? presentationButtons;
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -387,6 +387,7 @@ describe("handleToolExecutionStart read path checks", () => {
       channelData: {
         askUser: {
           questionId,
+          optionValues: ["Staging (Recommended)", "Production"],
         },
       },
       presentationTextMode: "fallback",
@@ -571,6 +572,7 @@ describe("handleToolExecutionStart read path checks", () => {
         channelData: {
           askUser: {
             questionId: activation.questionId,
+            optionValues: ["Staging", "Production"],
           },
         },
       }),

--- a/src/agents/harness/user-input-bridge.ts
+++ b/src/agents/harness/user-input-bridge.ts
@@ -32,7 +32,7 @@ type AgentHarnessQuestionPromptPayload = {
   text: string;
   presentation?: MessagePresentation;
   presentationTextMode?: "fallback";
-  channelData: { askUser: { questionId: string } };
+  channelData: { askUser: { questionId: string; optionValues?: string[] } };
 };
 
 type PromptDeliveryParams = Pick<EmbeddedRunAttemptParams, "onBlockReply" | "onPartialReply">;
@@ -146,10 +146,26 @@ export function buildAgentHarnessQuestionPromptPayload(params: {
       ...params,
       formatText: params.options?.formatText,
     });
+  const [question] = params.questions;
+  const candidateOptionValues =
+    params.questions.length === 1 && question && !question.multiSelect && !question.isSecret
+      ? (question.options?.map((option) => option.label) ?? [])
+      : [];
+  const normalizedOptionValues = candidateOptionValues.map((option) => option.trim().toLowerCase());
+  const optionValues =
+    candidateOptionValues.length >= 2 &&
+    candidateOptionValues.length <= 4 &&
+    normalizedOptionValues.every(Boolean) &&
+    new Set(normalizedOptionValues).size === candidateOptionValues.length
+      ? candidateOptionValues
+      : undefined;
   return {
     text: `${prompt}\n\n${questionReplyGuidance(params.questions)}`,
     ...(presentation ? { presentation, presentationTextMode: "fallback" as const } : {}),
-    channelData: { askUser: { questionId: params.questionId } },
+    // Native callbacks need Gateway option order even when presentation controls are reordered.
+    channelData: {
+      askUser: { questionId: params.questionId, ...(optionValues ? { optionValues } : {}) },
+    },
   };
 }
 

--- a/test/telegram-question-gateway.test.ts
+++ b/test/telegram-question-gateway.test.ts
@@ -1,0 +1,135 @@
+// Root-owned integration may combine public plugin surfaces with Gateway-owned runtime.
+import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { telegramOutbound } from "../extensions/telegram/api.js";
+import { buildAgentHarnessQuestionPromptPayload } from "../src/agents/harness/user-input-bridge.js";
+import { QuestionManager } from "../src/gateway/question-manager.js";
+import { createQuestionHandlers } from "../src/gateway/server-methods/question.js";
+import { callGatewayHandler } from "../src/gateway/server-methods/skills.test-helpers.js";
+
+type QuestionGatewayCall = { method: string; params?: Record<string, unknown> };
+
+const questionGatewayTransport = vi.hoisted(() => ({
+  dispatch: undefined as ((request: QuestionGatewayCall) => Promise<unknown>) | undefined,
+}));
+
+vi.mock("../src/gateway/call.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/gateway/call.js")>();
+  return {
+    ...actual,
+    callGateway: async (request: QuestionGatewayCall) => {
+      if (!questionGatewayTransport.dispatch) {
+        throw new Error("expected the in-process question Gateway transport");
+      }
+      return await questionGatewayTransport.dispatch(request);
+    },
+  };
+});
+
+afterEach(() => {
+  questionGatewayTransport.dispatch = undefined;
+});
+
+describe("Telegram question Gateway resolution", () => {
+  it("resolves canonical option C when rendered option A repeats across blocks", async () => {
+    const manager = new QuestionManager();
+    const handlers = createQuestionHandlers(manager);
+    const gatewayCalls: string[] = [];
+    const dispatch = async ({ method, params }: QuestionGatewayCall): Promise<unknown> => {
+      gatewayCalls.push(method);
+      const result = await callGatewayHandler(handlers, method, params ?? {}, {
+        context: { broadcast: () => undefined },
+      });
+      if (!result.ok) {
+        throw new Error(`question Gateway method ${method} rejected its request`);
+      }
+      return result.response;
+    };
+    questionGatewayTransport.dispatch = dispatch;
+
+    try {
+      const questionId = "ask_0123456789abcdef0123456789abcdef";
+      const optionValues = ["A", "B", "C"];
+      await dispatch({
+        method: "question.request",
+        params: {
+          id: questionId,
+          questions: [
+            {
+              questionId: "destination",
+              header: "Destination",
+              question: "Where next?",
+              options: optionValues.map((label) => ({ label })),
+              multiSelect: false,
+              isOther: false,
+              isSecret: false,
+            },
+          ],
+          timeoutMs: 15_000,
+        },
+      });
+      expect(manager.get(questionId)?.questions[0]?.options).toEqual(
+        optionValues.map((label) => ({ label })),
+      );
+
+      const questionButton = (optionValue: string) => ({
+        label: optionValue,
+        action: { type: "question" as const, questionId, optionValue },
+      });
+      const presentation = {
+        blocks: [
+          { type: "buttons" as const, buttons: [questionButton("C"), questionButton("A")] },
+          { type: "buttons" as const, buttons: [questionButton("A"), questionButton("B")] },
+        ],
+      };
+      const payload = buildAgentHarnessQuestionPromptPayload({
+        questionId,
+        questions: [
+          {
+            id: "destination",
+            header: "Destination",
+            question: "Where next?",
+            options: optionValues.map((label) => ({ label })),
+          },
+        ],
+        options: { presentation },
+      });
+      expect(payload.channelData.askUser).toEqual({ questionId, optionValues });
+      const rendered = await telegramOutbound.renderPresentation?.({
+        payload,
+        presentation,
+        ctx: { cfg: {}, to: "42", text: payload.text, payload },
+      });
+      const telegram = rendered?.channelData?.telegram as
+        | { buttons?: ReadonlyArray<ReadonlyArray<{ callback_data?: string }>> }
+        | undefined;
+      const rows = telegram?.buttons;
+      expect(rows?.map((row) => row.length)).toEqual([2, 2]);
+      expect(rows?.flatMap((row) => row.map((button) => button.callback_data))).toEqual([
+        `tgq1:${questionId}:2`,
+        `tgq1:${questionId}:0`,
+        `tgq1:${questionId}:0`,
+        `tgq1:${questionId}:1`,
+      ]);
+
+      const callbackData = rows?.[0]?.[0]?.callback_data;
+      if (!callbackData) {
+        throw new Error("expected canonical Telegram option C callback data");
+      }
+      const optionIndex = Number(callbackData.slice(`tgq1:${questionId}:`.length));
+      expect(optionIndex).toBe(2);
+
+      await expect(
+        questionGatewayRuntime.resolveOption({ cfg: {}, questionId, optionIndex, senderId: "42" }),
+      ).resolves.toEqual({ status: "answered", questionId: "destination", optionValue: "C" });
+      expect(gatewayCalls).toEqual(["question.request", "question.get", "question.resolve"]);
+      expect(manager.get(questionId)).toMatchObject({
+        status: "answered",
+        answers: { answers: { destination: ["C"] } },
+        resolvedBy: "42",
+      });
+    } finally {
+      manager.reset();
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram users answering an interactive question could submit the wrong Gateway answer when question buttons were repeated, split across rows, reordered, or displayed as a subset of the available choices.

## Why This Change Was Made

The Gateway-owned question producer now carries the bounded canonical option labels through existing private delivery metadata. Telegram resolves each button against that authoritative ordering instead of inferring its answer index from rendering order. Invalid, missing, ambiguous, or unmatched metadata falls back visibly instead of submitting an incorrect answer. No public action shape, Plugin SDK surface, Gateway protocol, or configuration is expanded.

## User Impact

Telegram question buttons select the answer users actually tapped, including repeated controls, reordered/subset presentations, row boundaries, mixed controls, and Unicode labels. Unsupported or unsafe question controls retain a visible text fallback.

## Evidence

- Reviewed immutable candidate: `26fd60ad870ea9d34e99c1f653f46d8ba97567f2`.
- Four fresh, independent nonauthor hostile reviews examined the producer, Telegram renderer, callback handling, Gateway authorization/resolution, sibling channels, and Codex/Copilot consumers.
- Fresh whole-branch `gpt-5.6-sol` high-reasoning autoreview with explicit P0–P3 coverage: zero findings, confidence 0.96. Genuine TruffleHog credential scan: clean.
- Regression coverage composes the actual upstream question producer, public Telegram plugin renderer, `QuestionManager`, Gateway question handlers, and the default Gateway option resolver; reordered controls persist the canonical selected answer.
- Codex contract verified directly: `codex-rs/protocol/src/request_user_input.rs:8`, `codex-rs/app-server-protocol/src/protocol/v2/item.rs:1603`, and `codex-rs/app-server/src/bespoke_event_handling.rs:715` preserve canonical ordered option labels.
- Exact-head hosted CI completed without a failing or pending relevant check. Exact-head remote behavior proof independently passed 194 tests across four producer, Telegram renderer, fallback, and Gateway-owner suites.
- Follow-up: Discord and Slack have pre-existing positional-index implementations and need separate channel-owner repairs; they are not silently changed by this Telegram-scoped fix.

## Real behavior proof

The exact reviewed commit `26fd60ad870ea9d34e99c1f653f46d8ba97567f2` was synchronized to an isolated Blacksmith Testbox, with five changed production source blobs independently authenticated. A real grammY bot and HTTP client rendered repeated/reordered Telegram controls, the actual Telegram callback handler opened authenticated Gateway WebSocket sessions and resolved the answer through real `question.get` / `question.resolve` RPC calls, and missing or ambiguous metadata produced visible text without an unsafe clickable button.

- Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/30761157885.
- Focused owner suites: `test/telegram-question-gateway.test.ts` (1), `src/agents/embedded-agent-subscribe.handlers.tools.test.ts` (146), `extensions/telegram/src/button-types.test.ts` (29), and `extensions/telegram/src/interactive-fallback.test.ts` (18): **194/194 passed**.
- Redacted runtime verdict:

```json
{
  "proof": "real-grammy-real-gateway-client-mocked-bot-api-and-gateway",
  "head": "26fd60ad870ea9d34e99c1f653f46d8ba97567f2",
  "canonicalOptions": ["A", "B", "C"],
  "renderedOptions": ["C", "A", "A", "B"],
  "rows": [2, 2],
  "callbackOptionIndex": 2,
  "selectedAnswer": "C",
  "fallbackVerdicts": [
    { "metadata": "missing", "visibleOption": "C", "unsafeControls": false },
    { "metadata": "ambiguous", "visibleOption": "C", "unsafeControls": false }
  ],
  "botMethods": ["sendMessage", "answerCallbackQuery"],
  "gatewayMethods": ["question.get", "question.resolve"],
  "connectedGatewayClients": 2,
  "status": "PASS"
}
```

The Telegram Bot API endpoint and Gateway server were controlled loopback mocks; grammY, HTTP delivery, callback middleware, the production Telegram callback handler, Gateway authentication/client, canonical answer resolution, and callback acknowledgment were real. No live Telegram account or external Telegram network was used. The remote lease was explicitly stopped and independently verified `completed`.

## Rank-up moves addressed

1. **Attach exact-head Telegram proof:** The exact-head redacted runtime verdict above proves repeated/reordered controls select canonical option `C`, while missing and ambiguous metadata visibly fall back without unsafe controls.
2. **Personally inspect Codex source:** `codex-rs/protocol/src/request_user_input.rs:8` defines ordered `Vec` options; `codex-rs/app-server/src/bespoke_event_handling.rs:719` maps those ordered labels without reordering; `codex-rs/app-server-protocol/src/protocol/v2/item.rs:1603` defines the stable option-label contract. These sibling Codex sources were personally inspected directly, not inferred from OpenClaw wrappers or review comments.
3. **Wait for exact-head CI:** Hosted production/test type checks, lint, dependency/dead-code checks, extension boundaries, behavior-proof checks, and remaining relevant exact-head CI completed successfully before requesting a refreshed review.
4. **Optional live Telegram Desktop recording:** Skipped because the accepted repository proof policy explicitly recognizes the exact-head mock-channel/Gateway runtime verdict above as sufficient; it already exercises real grammY HTTP delivery, authenticated Gateway RPCs, canonical callback selection, and both fail-visible paths without consuming a live Telegram account.

## Maintainer review

The repository owner explicitly delegated autonomous landing of low-risk, independently reviewed QA fixes. The acting maintainer personally inspected the sibling Codex source at `codex-rs/protocol/src/request_user_input.rs:8`, `codex-rs/app-server/src/bespoke_event_handling.rs:719`, and `codex-rs/app-server-protocol/src/protocol/v2/item.rs:1603`; the ClawSweeper worker could not access that sibling checkout itself. Four fresh independent nonauthor source reviews, the exact-head genuine Sol review, clean TruffleHog scan, exact-head hosted CI, and the authenticated 194-test runtime proof were reviewed before repo-native maintainer preparation.
