### PR TITLE
fix(ui): keep Dreams diary navigation visible while scrolling

### DIFF
--- a/ui/src/pages/agents/memory/view.browser.test.ts
+++ b/ui/src/pages/agents/memory/view.browser.test.ts
@@ -1,0 +1,106 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { render } from "lit";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDreamingViewState, renderDreaming } from "./view.ts";
+
+const hasBrowserLayout = !navigator.userAgent.toLowerCase().includes("jsdom");
+let host: HTMLDivElement | undefined;
+
+afterEach(() => {
+  host?.remove();
+  host = undefined;
+});
+
+describe.skipIf(!hasBrowserLayout)("dream diary browser layout", () => {
+  it("keeps diary dates visible and clickable while a long entry scrolls", async () => {
+    host = document.createElement("div");
+    host.style.height = "420px";
+    host.style.width = "760px";
+    host.style.overflow = "hidden";
+    document.body.append(host);
+
+    const viewState = createDreamingViewState();
+    viewState.activeSubTab = "diary";
+    viewState.activeDiarySubTab = "dreams";
+    const props: Parameters<typeof renderDreaming>[0] = {
+      viewState,
+      active: true,
+      selectedAgentId: "main",
+      shortTermCount: 0,
+      promotedCount: 0,
+      shortTermEntries: [],
+      promotedEntries: [],
+      dreamingOf: null,
+      nextCycle: null,
+      timezone: null,
+      statusError: null,
+      modeSaving: false,
+      dreamDiaryLoading: false,
+      dreamDiaryActionLoading: false,
+      dreamDiaryActionMessage: null,
+      dreamDiaryActionArchivePath: null,
+      dreamDiaryError: null,
+      dreamDiaryContent: [
+        "# Dream Diary",
+        "---",
+        "*January 1, 2026*",
+        "The earlier diary entry remains available.",
+        "---",
+        "*January 2, 2026*",
+        ...Array.from(
+          { length: 24 },
+          (_, index) => `Long diary paragraph ${index + 1}: ${"a visible memory ".repeat(8)}`,
+        ),
+      ].join("\n\n"),
+      memoryWikiEnabled: false,
+      wikiImportInsightsLoading: false,
+      wikiImportInsightsError: null,
+      wikiImportInsights: null,
+      wikiOverviewLoading: false,
+      wikiOverviewError: null,
+      wikiOverview: null,
+      onRefreshDiary: () => {},
+      onRefreshImports: () => {},
+      onRefreshWikiOverview: () => {},
+      onOpenConfig: () => {},
+      onOpenWikiPage: async () => null,
+      onBackfillDiary: () => {},
+      onCopyDreamingArchivePath: () => {},
+      onDedupeDreamDiary: () => {},
+      onResetDiary: () => {},
+      onResetGroundedShortTerm: () => {},
+      onRepairDreamingArtifacts: () => {},
+      onViewStateChange: () => render(renderDreaming(props), host!),
+    };
+    render(renderDreaming(props), host);
+
+    const diary = host.querySelector<HTMLElement>(".dreams-diary");
+    const navigation = host.querySelector<HTMLElement>(".dreams-diary__daychips");
+    expect(diary).not.toBeNull();
+    expect(navigation).not.toBeNull();
+    expect(getComputedStyle(diary!).overflowY).toBe("auto");
+    expect(getComputedStyle(navigation!.parentElement!).position).toBe("sticky");
+    expect(diary!.scrollHeight).toBeGreaterThan(diary!.clientHeight);
+
+    diary!.scrollTop = 500;
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+
+    const olderDate = expectDefined(
+      navigation!.querySelectorAll<HTMLButtonElement>(".dreams-diary__day-chip")[1],
+      "older diary date button",
+    );
+    expect(diary!.scrollTop).toBeGreaterThan(100);
+    expect(olderDate.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      diary!.getBoundingClientRect().top,
+    );
+    expect(olderDate.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      diary!.getBoundingClientRect().bottom,
+    );
+
+    olderDate.click();
+    expect(viewState.diaryPage).toBe(1);
+    expect(host.querySelector(".dreams-diary__date")?.textContent).toBe("January 1, 2026");
+  });
+});

--- a/ui/src/pages/agents/memory/view.test.ts
+++ b/ui/src/pages/agents/memory/view.test.ts
@@ -1,5 +1,6 @@
 /* @vitest-environment jsdom */
 
+import { expectDefined } from "@openclaw/normalization-core";
 import { render } from "lit";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../../../i18n/index.ts";
@@ -833,6 +834,50 @@ describe("dreaming view", () => {
     expect(container.querySelector(".dreams-diary__heatmap-cell")).toBeNull();
     expect(container.querySelector(".dreams-diary__timeline-month")).toBeNull();
     setDreamSubTab("scene");
+  });
+
+  it.each([
+    { tab: "dreams", labels: ["1/2", "1/1"] },
+    { tab: "insights", labels: ["Travel", "Health"] },
+    { tab: "wiki", labels: ["Syntheses", "Concepts"] },
+  ] as const)("keeps $tab navigation inside the sticky diary controls", ({ tab, labels }) => {
+    setDreamSubTab("diary");
+    setDreamDiarySubTab(tab);
+    const props = buildProps({
+      dreamDiaryContent: [
+        "# Dream Diary",
+        "---",
+        "*January 1, 2026*",
+        "An earlier dream.",
+        "---",
+        "*January 2, 2026*",
+        ...Array.from({ length: 12 }, (_, index) => `Long diary paragraph ${index + 1}.`),
+      ].join("\n\n"),
+      onViewStateChange: vi.fn(),
+    });
+    const wikiOverview = props.wikiOverview;
+    if (wikiOverview) {
+      const firstCluster = expectDefined(wikiOverview.clusters[0], "first memory wiki cluster");
+      props.wikiOverview = {
+        ...wikiOverview,
+        clusters: [
+          ...wikiOverview.clusters,
+          { ...firstCluster, key: "concept", label: "Concepts" },
+        ],
+      };
+    }
+
+    const container = renderInto(props);
+    const stickyChrome = expectElement(container, ".dreams-diary__chrome");
+    const navigation = expectElement(stickyChrome, ".dreams-diary__daychips");
+    const buttons = [...navigation.querySelectorAll<HTMLButtonElement>(".dreams-diary__day-chip")];
+
+    expect(buttons.map((button) => compactText(button))).toEqual(labels);
+    expect(container.querySelector("#dream-diary-panel .dreams-diary__daychips")).toBeNull();
+
+    buttons[1]?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(viewState.diaryPage).toBe(1);
+    expect(props.onViewStateChange).toHaveBeenCalledOnce();
   });
 
   it("renders diary empty, error, and removed-navigation states", () => {

--- a/ui/src/pages/agents/memory/view.ts
+++ b/ui/src/pages/agents/memory/view.ts
@@ -22,11 +22,9 @@ type DiaryEntry = {
   body: string;
 };
 
-type DiaryEntryNav = {
-  date: string;
-  body: string;
-  page: number;
-};
+type DiaryPanel =
+  | ReturnType<typeof html>
+  | { navigation: ReturnType<typeof html>; content: ReturnType<typeof html> };
 
 const DIARY_START_RE = /<!--\s*openclaw:dreaming:diary:start\s*-->/;
 const DIARY_END_RE = /<!--\s*openclaw:dreaming:diary:end\s*-->/;
@@ -85,11 +83,6 @@ function formatDiaryChipLabel(date: string): string {
   }
   const value = new Date(parsed);
   return `${value.getMonth() + 1}/${value.getDate()}`;
-}
-
-function buildDiaryNavigation(entries: DiaryEntry[]): DiaryEntryNav[] {
-  const reversed = [...entries].toReversed();
-  return reversed.map((entry, page) => Object.assign({}, entry, { page }));
 }
 
 type DreamingPhaseInfo = {
@@ -1112,6 +1105,29 @@ function renderWikiInsightCard(props: DreamingProps, card: WikiInsightCard) {
   `;
 }
 
+function renderDiaryNavigation(props: DreamingProps, labels: string[], selectedPage: number) {
+  const state = props.viewState;
+  return html`
+    <div class="dreams-diary__daychips">
+      ${labels.map(
+        (label, index) => html`
+          <button
+            class="dreams-diary__day-chip ${index === selectedPage
+              ? "dreams-diary__day-chip--active"
+              : ""}"
+            @click=${() => {
+              setDiaryPage(state, index, labels.length);
+              props.onViewStateChange();
+            }}
+          >
+            ${label}
+          </button>
+        `,
+      )}
+    </div>
+  `;
+}
+
 function renderWikiClusterSection<
   Cluster extends { key: string; label: string; items: { pagePath: string }[] },
 >(
@@ -1127,7 +1143,7 @@ function renderWikiClusterSection<
     prose: (cluster: Cluster) => ReturnType<typeof html>;
     renderItem: (item: Cluster["items"][number]) => ReturnType<typeof html>;
   },
-) {
+): DiaryPanel {
   const { clusters } = params;
   if (clusters.length === 0) {
     return html`
@@ -1150,31 +1166,21 @@ function renderWikiClusterSection<
       ? "selected imported insight cluster"
       : "selected memory overview cluster",
   );
-  return html`
-    <div class="dreams-diary__daychips">
-      ${clusters.map(
-        (entry, index) => html`
-          <button
-            class="dreams-diary__day-chip ${index === clusterIndex
-              ? "dreams-diary__day-chip--active"
-              : ""}"
-            @click=${() => {
-              setDiaryPage(state, index, clusters.length);
-              props.onViewStateChange();
-            }}
-          >
-            ${entry.label}
-          </button>
-        `,
-      )}
-    </div>
-    <article class="dreams-diary__entry" key="${params.kind}-${cluster.key}">
-      <div class="dreams-diary__accent"></div>
-      <div class="dreams-diary__date">${params.date(cluster)}</div>
-      <div class="dreams-diary__prose">${params.prose(cluster)}</div>
-      <div class="dreams-diary__insights">${cluster.items.map(params.renderItem)}</div>
-    </article>
-  `;
+  return {
+    navigation: renderDiaryNavigation(
+      props,
+      clusters.map((entry) => entry.label),
+      clusterIndex,
+    ),
+    content: html`
+      <article class="dreams-diary__entry" key="${params.kind}-${cluster.key}">
+        <div class="dreams-diary__accent"></div>
+        <div class="dreams-diary__date">${params.date(cluster)}</div>
+        <div class="dreams-diary__prose">${params.prose(cluster)}</div>
+        <div class="dreams-diary__insights">${cluster.items.map(params.renderItem)}</div>
+      </article>
+    `,
+  };
 }
 
 function renderDiaryImportsSection(props: DreamingProps) {
@@ -1262,7 +1268,7 @@ function renderWikiOverviewSection(props: DreamingProps) {
   });
 }
 
-function renderDreamDiaryEntries(props: DreamingProps) {
+function renderDreamDiaryEntries(props: DreamingProps): DiaryPanel {
   const state = props.viewState;
   if (typeof props.dreamDiaryContent !== "string") {
     return html`
@@ -1289,41 +1295,31 @@ function renderDreamDiaryEntries(props: DreamingProps) {
     `;
   }
 
-  const reversed = buildDiaryNavigation(entries);
+  const reversed = entries.toReversed();
   const page = Math.max(0, Math.min(state.diaryPage, reversed.length - 1));
   const entry = expectDefined(reversed[page], "selected dreaming diary entry");
 
-  return html`
-    <div class="dreams-diary__daychips">
-      ${reversed.map(
-        (e) => html`
-          <button
-            class="dreams-diary__day-chip ${e.page === page
-              ? "dreams-diary__day-chip--active"
-              : ""}"
-            @click=${() => {
-              setDiaryPage(state, e.page, reversed.length);
-              props.onViewStateChange();
-            }}
-          >
-            ${formatDiaryChipLabel(e.date)}
-          </button>
-        `,
-      )}
-    </div>
-    <article class="dreams-diary__entry" key="${page}">
-      <div class="dreams-diary__accent"></div>
-      ${entry.date ? html`<time class="dreams-diary__date">${entry.date}</time>` : nothing}
-      <div class="dreams-diary__prose">
-        ${flattenDiaryBody(entry.body).map(
-          (para, i) =>
-            html`<p class="dreams-diary__para" style="animation-delay: ${0.3 + i * 0.15}s;">
-              ${unsafeHTML(toSanitizedMarkdownHtml(para))}
-            </p>`,
-        )}
-      </div>
-    </article>
-  `;
+  return {
+    navigation: renderDiaryNavigation(
+      props,
+      reversed.map((diaryEntry) => formatDiaryChipLabel(diaryEntry.date)),
+      page,
+    ),
+    content: html`
+      <article class="dreams-diary__entry" key="${page}">
+        <div class="dreams-diary__accent"></div>
+        ${entry.date ? html`<time class="dreams-diary__date">${entry.date}</time>` : nothing}
+        <div class="dreams-diary__prose">
+          ${flattenDiaryBody(entry.body).map(
+            (para, i) =>
+              html`<p class="dreams-diary__para" style="animation-delay: ${0.3 + i * 0.15}s;">
+                ${unsafeHTML(toSanitizedMarkdownHtml(para))}
+              </p>`,
+          )}
+        </div>
+      </article>
+    `,
+  };
 }
 
 // ── Diary section renderer ────────────────────────────────────────────
@@ -1346,6 +1342,15 @@ function renderDiarySection(props: DreamingProps) {
       </section>
     `;
   }
+
+  const diaryPanel =
+    activeDiarySubTab === "dreams"
+      ? renderDreamDiaryEntries(props)
+      : activeDiarySubTab === "insights"
+        ? renderDiaryImportsSection(props)
+        : renderWikiOverviewSection(props);
+  const diaryNavigation = "navigation" in diaryPanel ? diaryPanel.navigation : nothing;
+  const diaryContent = "content" in diaryPanel ? diaryPanel.content : diaryPanel;
 
   return html`
     <section class="dreams-diary">
@@ -1409,6 +1414,7 @@ function renderDiarySection(props: DreamingProps) {
           </button>
         </div>
         ${renderDiarySubtabExplainer(activeDiarySubTab)}
+        ${memoryWikiUnavailable ? nothing : diaryNavigation}
       </div>
 
       <div
@@ -1437,11 +1443,7 @@ function renderDiarySection(props: DreamingProps) {
                 </div>
               </div>
             `
-          : activeDiarySubTab === "dreams"
-            ? renderDreamDiaryEntries(props)
-            : activeDiarySubTab === "insights"
-              ? renderDiaryImportsSection(props)
-              : renderWikiOverviewSection(props)}
+          : diaryContent}
       </div>
       ${renderWikiPreviewOverlay(props)}
     </section>


### PR DESCRIPTION
Closes #76638

## What Problem This Solves

Fixes an issue where users reading a long entry in Dreams → Diary could no longer see or click the date selector, leaving them unable to switch to another diary entry.

## Why This Change Was Made

Render Dreams date chips, Imported Insights clusters, and Memory Wiki clusters inside their existing sticky diary chrome instead of the scrolling content panel. One shared navigation renderer now owns all three sibling surfaces; existing CSS, configuration, Gateway, and plugin contracts remain unchanged.

This builds on the earlier direction in closed PR #76646 by @Thatgfsj. The separate, still-open Imported Insights presentation work in #83242 is intentionally untouched.

## User Impact

Long diary entries and insight lists no longer hide their date or cluster selectors. Users can keep scrolling, see the available sections, and switch entries immediately.

## Evidence

- Verified the regression in the reporter’s exact `de88b37` revision and traced it to #64505, which moved navigation out of the already-sticky owner before the report was filed.
- Added failing-first regressions for all three sibling navigation surfaces; focused owner and caller suites pass 36 tests with only two expected environment skips.
- Actual remote Playwright Chromium: `corepack pnpm --dir ui test src/pages/agents/memory/view.browser.test.ts` → **1 passed**. The test renders the real Dreams view and production CSS, creates a 24-paragraph diary, scrolls the actual container, measures the older date chip inside the visible viewport, clicks it, and verifies the displayed entry changes.
- Remote UI test type-check: `corepack pnpm tsgo:test:ui` → **passed**.
- Remote proof: provider `blacksmith-testbox`, lease `tbx_01kz1m9vs0jvqnbkk2y9gptva1`, https://github.com/openclaw/openclaw/actions/runs/30756327432. The delegated command’s authoritative exit status was `0`.
- Targeted formatting/lint, `git diff --check`, fresh xhigh/P2 autoreview, and a separate fresh xhigh maintainer review all passed.
- AI-assisted implementation and review; independently reproduced and understood end to end.

## ClawSweeper Rank-Up Disposition

The reported scrolling-fixture concern is disproven on the exact reviewed head. The fixed-height host renders the actual production ancestor chain `.dreams-page` (`display: flex; height: 100%`) -> `.dreams__panel` (`display: flex; flex: 1; min-height: 0`) -> `.dreams-diary` (`overflow: auto`); the diary is not a direct child of the block host. The exact-head hosted Chromium job passed both mandatory assertions `scrollHeight > clientHeight` and `scrollTop > 100`, then verified sticky bounds and clickable date switching: https://github.com/openclaw/openclaw/actions/runs/30756955568/job/91520720497. Actual scrolling is therefore directly proven, and changing the already-correct fixture for this false-positive rank-up would be inappropriate.
