### PR TITLE
fix(reply): register composed upstream abort signal sources for identity lookups

### DIFF
--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -150,6 +150,11 @@ export async function admitFollowupTurn(params: {
     resetTriggered: false,
     routeThreadId: params.queued.originatingThreadId,
     upstreamAbortSignal: resolveFollowupAbortSignal(params.queued),
+    // The composed signal above is a fresh object per admission; pass its sources
+    // so the registry can also answer identity lookups made with the raw signals.
+    upstreamAbortSignalAliases: [params.queued.abortSignal, params.queued.queueAbortSignal].filter(
+      (signal): signal is AbortSignal => signal !== undefined,
+    ),
     onReplyAdmissionWaitChange: params.queued.onReplyAdmissionWaitChange,
   });
   if (admission.status === "skipped") {

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -888,6 +888,30 @@ describe("reply run registry", () => {
     expect(isReplyRunAbortableForSignal(upstreamAbort.signal)).toBe(false);
   });
 
+  it("answers abortability for the source signals of a composed upstream signal", () => {
+    const upstreamAbort = new AbortController();
+    const queueAbort = new AbortController();
+    // Mirror the followup admission path (followup-turn-admission.ts → queue/types.ts):
+    // the registry key is a fresh AbortSignal.any() composite per admission, while
+    // the chat.abort gate asks with the raw controller signal
+    // (gateway/server-methods/chat-send-admission.ts:287).
+    const composite = AbortSignal.any([upstreamAbort.signal, queueAbort.signal]);
+    const operation = createTestReplyOperation({
+      sessionKey: "agent:main:followup-composed",
+      sessionId: "session-followup-composed",
+      upstreamAbortSignal: composite,
+      upstreamAbortSignalAliases: [upstreamAbort.signal, queueAbort.signal],
+    });
+    operation.freezeAbort();
+
+    expect(isReplyRunAbortableForSignal(composite)).toBe(false);
+    expect(isReplyRunAbortableForSignal(upstreamAbort.signal)).toBe(false);
+    expect(isReplyRunAbortableForSignal(queueAbort.signal)).toBe(false);
+    expect(isReplyRunAbortableForSignal(new AbortController().signal)).toBe(true);
+
+    operation.complete();
+  });
+
   it("expires finalization when its owner stops making progress", async () => {
     vi.useFakeTimers();
     try {

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -560,6 +560,7 @@ export function createReplyOperation(params: {
   resetTriggered: boolean;
   routeThreadId?: string | number;
   upstreamAbortSignal?: AbortSignal;
+  upstreamAbortSignalAliases?: readonly AbortSignal[];
   respectFollowupAdmissionBarrier?: boolean;
 }): ReplyOperation {
   const sessionKey = normalizeOptionalString(params.sessionKey);
@@ -1057,6 +1058,15 @@ export function createReplyOperation(params: {
   });
   if (upstreamAbortSignal) {
     operationsByUpstreamAbortSignal.set(upstreamAbortSignal, operation);
+    // Admission may compose the upstream signal (AbortSignal.any), creating a
+    // fresh identity each time. Register the original source signals too, so
+    // identity-based lookups (e.g. the chat.abort gate, which only knows the
+    // raw controller signal) resolve to this same operation.
+    for (const alias of params.upstreamAbortSignalAliases ?? []) {
+      if (alias !== upstreamAbortSignal) {
+        operationsByUpstreamAbortSignal.set(alias, operation);
+      }
+    }
     const abortFromUpstream = () => {
       if (result) {
         return;

--- a/src/auto-reply/reply/reply-turn-admission.ts
+++ b/src/auto-reply/reply/reply-turn-admission.ts
@@ -130,6 +130,8 @@ type ReplyTurnAdmissionParams = {
    */
   adoptOperation?: ReplyOperation;
   upstreamAbortSignal?: AbortSignal;
+  /** Source signals `upstreamAbortSignal` was composed from; registered as lookup aliases. */
+  upstreamAbortSignalAliases?: readonly AbortSignal[];
   waitTimeoutMs?: number;
   waitForActive?: boolean;
   retainLifecycleAdmissionOnActive?: boolean;
@@ -297,6 +299,7 @@ async function admitReplyTurnWithWaitSignal(
             resetTriggered: params.resetTriggered,
             routeThreadId: params.routeThreadId,
             upstreamAbortSignal: params.upstreamAbortSignal,
+            upstreamAbortSignalAliases: params.upstreamAbortSignalAliases,
             respectFollowupAdmissionBarrier:
               params.kind === "queued_followup" || params.kind === "heartbeat",
           });


### PR DESCRIPTION
## What Problem This Solves

`chat.abort` can report a run as aborted while its reply operation is actually still finalizing and delivering. The abort gate resolves abortability by signal identity, but the followup-admission path registers operations under a fresh `AbortSignal.any()` composite — so the gate's lookup always misses and defaults to "abortable".

Refs #118028 (the `reply-run-registry` site of the signal-identity class; same class as #117884, different site and path).

### Root cause

- Every enqueued followup gets a `queueAbortSignal` (`queue/enqueue.ts:189`), so admission always composes: `followup-turn-admission.ts:152` → `resolveFollowupAbortSignal` (`queue/types.ts:219`) → `AbortSignal.any(...)` — a **new object per admission**.
- The operation is registered under that composite: `reply-run-registry.ts:1059` (`WeakMap<AbortSignal, ReplyOperation>`).
- The `chat.abort` gate asks with the **raw** controller signal: `gateway/server-methods/chat-send-admission.ts:287` → `chat-abort.ts:488-494,530-533` → `isReplyRunAbortableForSignal` (`reply-run-registry.ts:398-401`), which returns `true` on a WeakMap miss.
- Net effect: when the operation is frozen/finalizing (`freezeAbort` → non-abortable), the gate should say `false` but says `true`; `abortChatRunById` then marks the run aborted and broadcasts it while the operation keeps finalizing and delivering. A direct (non-followup) `chat.send` registers the raw signal and is not affected.

## Fix

`createReplyOperation` accepts `upstreamAbortSignalAliases` and registers each source signal as an alias key to the same operation; the followup admission passes the composite's two sources through. The abort listener stays on the composite, so cancellation semantics are unchanged — identity lookups made with either the composite or any raw source now resolve to the same operation.

4 files, +42/−0.

## Evidence

### Runtime proof — real chain, no mocks

Loopback harness driving the real production path on this head and on `main` — no mocks of the logic under test, no fake timers (Windows, Node v24.14.1):

```text
chat.send admission (registerChatAbortController; gate verbatim from chat-send-admission.ts:287)
-> enqueueFollowupRun (real queue assigns queueAbortSignal, queue/enqueue.ts:189)
-> resolveFollowupAbortSignal (AbortSignal.any -> fresh identity, queue/types.ts:219)
-> admitReplyTurn -> createReplyOperation (identity WeakMap under test, reply-run-registry.ts:1059)
-> freezeAbort() (finalization, as in agent-runner-execution.ts:531)
-> isChatAbortControllerEntryAbortable -> abortChatRunById (chat-abort.ts:488,516) over real createChatRunState()
```

Declared simplifications: minimal `FollowupRun` literal; `broadcast`/`nodeSendToSession` captured in arrays; no SQLite session store (blocked on this Node by the repo's own WAL guard, `node-sqlite.ts:81`); no real model turn — "delivery" is the operation's real lifecycle (`freezeAbort` → `complete`), exactly the span the bug desynchronizes from the chat run.

**Run 1 — pre-fix** (the three touched source files reverted to `upstream/main` for the run, restored after):

```text
[+0.033s] probe     post-freeze isReplyRunAbortableForSignal(raw)=true isReplyRunAbortableForSignal(composed)=false
[+0.048s] gate      isChatAbortControllerEntryAbortable(entry)=true
[+0.050s] abort     abortChatRunById -> {"aborted":true} abortBroadcasts=1 rawSignal.aborted=true
[+0.050s] abort     broadcast "chat" payload.state=aborted stopReason=rpc partialMessage=included
[+0.064s] operation after chat.abort: operation.result=null operation.abortSignal.aborted=false phase=queued
[+0.065s] delivery  final delivery settled AFTER the chat.abort attempt: operation.result=completed
```

Bug reproduced end to end: the composite answers correctly (`composed=false`), but the gate asks with the raw signal — unregistered on `main` — so it misses and returns `true`; the gateway marks the run aborted and broadcasts it (partial draft included) while the frozen operation keeps going and **completes delivery afterwards**.

**Run 2 — post-fix (this head `f1f170a8839`):**

```text
[+0.031s] probe     post-freeze isReplyRunAbortableForSignal(raw)=false isReplyRunAbortableForSignal(composed)=false
[+0.042s] gate      isChatAbortControllerEntryAbortable(entry)=false
[+0.043s] abort     abortChatRunById -> {"aborted":false} abortBroadcasts=0 rawSignal.aborted=false
[+0.057s] operation after chat.abort: operation.result=null operation.abortSignal.aborted=false phase=queued
[+0.058s] delivery  final delivery settled AFTER the chat.abort attempt: operation.result=completed
```

Fix verified: both identities agree, the gate closes, no abort broadcast, no controller abort, and finalization completes delivery intact.

**Run 3 — post-fix control (live, non-frozen operation):**

```text
[+0.103s] gate      isChatAbortControllerEntryAbortable(entry)=true
[+0.106s] abort     abortChatRunById -> {"aborted":true} abortBroadcasts=1 rawSignal.aborted=true
[+0.118s] operation after chat.abort: operation.result={"kind":"aborted","code":"aborted_by_user"} operation.abortSignal.aborted=true phase=aborted
```

Control verified: a genuinely abortable run still aborts through the composite (`aborted_by_user`, own signal aborted) — the fix does not over-block.

### Unit coverage and local gates

New regression test in `reply-run-registry.test.ts` mirroring the admission path (`AbortSignal.any` composite as the registry key, gate asking with the raw signal):

- **Red (before the fix):** `AssertionError: expected true to be false` at `isReplyRunAbortableForSignal(upstreamAbort.signal)` (51/52 passing, only the new test failing).
- **Green (after the fix):** 52/52.

Verification:

- `vitest run` (area): `reply-run-registry` 52/52 ✅ · `followup-turn-admission` 36/36 ✅ · `chat-abort` 126/126 ✅
- `reply-turn-admission.test.ts`: 27 failures **also present on clean `main`** on this machine — the repo's SQLite runtime guard rejects Node 24.14.1's embedded SQLite 3.51.2 (`node-sqlite.ts:81`); verified identical via `git stash`. Unrelated to this diff.
- `oxlint`: 0 errors ✅ · `oxfmt --check` ✅ · `tsgo -p tsconfig.core.json` ✅

AI-assisted: the defect was found and the fix drafted with AI assistance; every link of the causal chain above was opened and verified against `main` (`38a5d39b`), and both the red→green unit cycle and the three harness runs were executed locally (and re-executed by the author) before this update. I understand the change and stand by it.