### PR TITLE
fix(channels): preserve command privacy in progress drafts

### DIFF
--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -1,8 +1,6 @@
 import { EmbeddedBlockChunker } from "openclaw/plugin-sdk/agent-runtime";
 import {
   type AgentPlanStep,
-  buildChannelProgressDraftLine,
-  buildChannelProgressDraftLineForEntry,
   type ChannelProgressDraftLine,
   createChannelProgressDraftCompositor,
   resolveChannelStreamingBlockEnabled,
@@ -123,10 +121,6 @@ export function createDiscordDraftPreviewController(params: {
     commentaryLinePrefix: "💬 ",
     reasoningGate: previewToolProgressEnabled,
     commentaryItalics: false,
-    buildProgressEventLine: (input, options) =>
-      input.event === "tool" || input.event === "item"
-        ? buildChannelProgressDraftLineForEntry(params.discordConfig, input, options)
-        : buildChannelProgressDraftLine(input, options),
     update: async (previewText, options) => {
       lastPartialText = previewText;
       draftText = previewText;

--- a/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
@@ -741,7 +741,19 @@ describe("processDiscordMessage draft streaming progress", () => {
         args: { command: "pnpm test -- --watch=false" },
         detailMode: "raw",
       });
+      await params?.replyOptions?.onItemEvent?.({
+        itemId: "tool:private-command",
+        kind: "command",
+        name: "exec",
+        summary: "pnpm test -- --watch=false",
+      });
       await params?.replyOptions?.onItemEvent?.({ progressText: "done" });
+      await params?.replyOptions?.onCommandOutput?.({
+        phase: "end",
+        title: "pnpm test -- --watch=false",
+        name: "exec",
+        exitCode: 0,
+      });
       await elapseProgressDraftStartDelay();
       return createNoQueuedDispatchResult();
     });
@@ -760,7 +772,10 @@ describe("processDiscordMessage draft streaming progress", () => {
 
     await runProcessDiscordMessage(ctx);
 
-    expect(draftStream.update).toHaveBeenCalledWith("Shelling\n\n🛠️ Exec\n• done");
+    expect(draftStream.update).toHaveBeenCalledWith(
+      expect.stringMatching(/^Shelling\n\n(?:🛠️ Exec\n)+• done(?:\n🛠️ Exec)*$/u),
+    );
+    expect(draftStream.update.mock.calls.flat().join("\n")).not.toContain("pnpm test");
   });
 
   it("keeps Discord progress lines below the configured label", async () => {

--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -634,6 +634,45 @@ describe("createMSTeamsReplyDispatcher", () => {
     expect(lastUpdate).not.toContain("completed");
   });
 
+  it("hides command details while preserving failed command status", async () => {
+    vi.useFakeTimers();
+    const dispatcher = createDispatcher("personal", {
+      streaming: {
+        mode: "progress",
+        progress: {
+          label: "Working",
+          commandText: "status",
+        },
+      },
+    });
+
+    await dispatcher.replyOptions.onItemEvent?.({
+      itemId: "tool:private-command",
+      toolCallId: "private-command",
+      kind: "command",
+      name: "exec",
+      meta: "curl https://private.example/metadata",
+      summary: "curl https://private.example/summary",
+      progressText: "curl https://private.example/progress",
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await dispatcher.replyOptions.onCommandOutput?.({
+      itemId: "tool:private-command-output",
+      toolCallId: "private-command",
+      phase: "end",
+      title: "curl https://private.example/output",
+      name: "exec",
+      exitCode: 2,
+    });
+
+    const updates = getStreamMock()
+      .update.mock.calls.map(([text]) => text)
+      .join("\n");
+    expect(updates).toContain("🛠️ Exec");
+    expect(updates).toContain("exit 2");
+    expect(updates).not.toContain("private.example");
+  });
+
   it("replaces reasoning progress snapshots in progress mode", async () => {
     vi.useFakeTimers();
     const dispatcher = createDispatcher("personal", {

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -654,7 +654,7 @@ export function createMSTeamsReplyDispatcher(params: {
             return;
           }
           await streamController.pushProgressLine(
-            buildChannelProgressDraftLine({
+            buildChannelProgressDraftLineForEntry(msteamsCfg, {
               event: "command-output",
               ...(typeof payload?.itemId === "string" ? { itemId: payload.itemId } : {}),
               ...(typeof payload?.toolCallId === "string"

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -8,6 +8,7 @@ import {
   isChannelProgressDraftWorkToolName,
   resolveChannelProgressDraftMaxLineChars,
   resolveChannelProgressDraftRender,
+  resolveChannelStreamingPreviewCommandText,
   resolveChannelStreamingPreviewToolProgress,
   resolveChannelStreamingSuppressDefaultToolProgressMessages,
   type ChannelProgressDraftCompositorSnapshot,
@@ -330,7 +331,10 @@ export function createSlackProgressRuntime(runtimeParams: {
     buildProgressEventLine: (input, options) =>
       input.event === "tool" || input.event === "item"
         ? buildChannelProgressDraftLineForEntry(account.config, input, options)
-        : buildChannelProgressDraftLine(input, options),
+        : buildChannelProgressDraftLine(input, {
+            ...options,
+            commandText: resolveChannelStreamingPreviewCommandText(account.config),
+          }),
     updateOnLineChange: useNativeProgressStreaming || useRichProgressDraft,
     update: async (previewText, options) => {
       if (useNativeProgressStreaming) {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -94,6 +94,7 @@ let mockedDispatcherCapturesDeliveryErrors = false;
 
 let mockedProgressEvents: string[] = [];
 let mockedEmptyProgressToolName: string | undefined;
+let capturedCommandOutputCommandText: "raw" | "status" | undefined;
 let mockedReplyOptionEvents: Array<
   | {
       kind: "item";
@@ -515,18 +516,21 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
       return "automatic";
     },
     resolveAgentOutboundIdentity: () => undefined,
-    buildChannelProgressDraftLine: (params: {
-      event?: string;
-      itemId?: string;
-      toolCallId?: string;
-      progressText?: string;
-      summary?: string;
-      explanation?: string;
-      title?: string;
-      name?: string;
-      status?: string;
-      exitCode?: number | null;
-    }) => {
+    buildChannelProgressDraftLine: (
+      params: {
+        event?: string;
+        itemId?: string;
+        toolCallId?: string;
+        progressText?: string;
+        summary?: string;
+        explanation?: string;
+        title?: string;
+        name?: string;
+        status?: string;
+        exitCode?: number | null;
+      },
+      options?: Parameters<typeof actual.buildChannelProgressDraftLine>[1],
+    ) => {
       if (params.event === "plan") {
         return params.explanation
           ? {
@@ -539,6 +543,13 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
           : undefined;
       }
       if (params.event === "command-output") {
+        capturedCommandOutputCommandText = options?.commandText;
+        if (options?.commandText === "status") {
+          return actual.buildChannelProgressDraftLine(
+            { ...params, event: "command-output" },
+            options,
+          );
+        }
         const status =
           params.exitCode === 0
             ? "completed"
@@ -1129,6 +1140,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     mockedDispatcherCapturesDeliveryErrors = false;
     mockedProgressEvents = [];
     mockedEmptyProgressToolName = undefined;
+    capturedCommandOutputCommandText = undefined;
     mockedReplyOptionEvents = [];
 
     createSlackDraftStreamMock.mockReturnValue(createDraftStreamStub());
@@ -3661,11 +3673,24 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     mockedReplyOptionEvents = [
       {
         kind: "item",
+        itemId: "tool:private-command",
+        toolCallId: "private-command",
         itemKind: "command",
         name: "exec",
+        meta: "exec pnpm test -- --watch=false",
+        summary: "exec pnpm test -- --watch=false",
         progressText: "exec pnpm test -- --watch=false",
       },
       { kind: "item", progressText: "done" },
+      {
+        kind: "command_output",
+        itemId: "tool:private-command-output",
+        toolCallId: "private-command",
+        phase: "end",
+        title: "exec pnpm test -- --watch=false",
+        name: "exec",
+        exitCode: 0,
+      },
     ];
 
     await dispatchPreparedSlackMessage(
@@ -3676,6 +3701,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       }),
     );
 
+    expect(capturedCommandOutputCommandText).toBe("status");
     expect(draftStream.update).toHaveBeenCalledWith("Shelling\n\n🛠️ Exec\n• done");
     expect(draftStream.update.mock.calls.flat().join("\n")).not.toContain("pnpm test");
   });

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -103,6 +103,68 @@ describe("buildChannelProgressDraftLine", () => {
     });
     expect(line?.text).not.toContain("command false");
   });
+
+  it.each([
+    { source: "metadata", detail: { meta: "curl https://private.example/metadata" } },
+    { source: "summary", detail: { summary: "curl https://private.example/summary" } },
+    {
+      source: "progress text",
+      detail: { progressText: "curl https://private.example/progress" },
+    },
+  ])("hides command item $source in status-only progress lines", ({ detail }) => {
+    const line = buildChannelProgressDraftLine(
+      {
+        event: "item",
+        itemId: "tool:exec-1",
+        toolCallId: "exec-1",
+        itemKind: "command",
+        name: "exec",
+        status: "running",
+        ...detail,
+      },
+      { commandText: "status" },
+    );
+
+    expect(line).toMatchObject({
+      id: "tool:exec-1",
+      kind: "item",
+      text: "🛠️ Exec",
+      status: "running",
+    });
+    expect(line?.detail).toBeUndefined();
+  });
+
+  it("keeps command metadata precedence in raw progress lines", () => {
+    const line = buildChannelProgressDraftLine(
+      {
+        event: "item",
+        itemKind: "command",
+        name: "exec",
+        meta: "command metadata",
+        summary: "command summary",
+        progressText: "command progress",
+      },
+      { commandText: "raw" },
+    );
+
+    expect(line?.detail).toBe("command metadata");
+    expect(line?.text).toContain("command metadata");
+  });
+
+  it("keeps non-command metadata in status-only progress lines", () => {
+    const line = buildChannelProgressDraftLine(
+      {
+        event: "item",
+        itemKind: "tool",
+        name: "read",
+        meta: "/tmp/important.ts",
+      },
+      { commandText: "status" },
+    );
+
+    expect(line?.detail).toBe("/tmp/important.ts");
+    expect(line?.text).toContain("/tmp/important.ts");
+  });
 });
 
 // Claude CLI tool names arrive capitalized. Each tool call is described twice —

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -552,11 +552,9 @@ export function buildChannelProgressDraftLine(
     case "item": {
       const name = input.name ?? itemKindToToolName(input.itemKind);
       const meta =
-        input.meta ??
-        input.summary ??
-        (options?.commandText === "status" && isCommandProgressItem(input)
+        options?.commandText === "status" && isCommandProgressItem(input)
           ? undefined
-          : input.progressText);
+          : (input.meta ?? input.summary ?? input.progressText);
       if (isEmptyReasoningProgressItem(input, meta)) {
         return undefined;
       }


### PR DESCRIPTION
Refs #113631

## What Problem This Solves

Status-mode channel progress previews could expose raw shell command text through command metadata, summaries, or command-output formatting. Apply the documented command-privacy setting consistently across core rendering, Discord, Slack, and Microsoft Teams.

**Original issue #113631 remains open.** Its separate raw-mode Discord symptom—missing command-argument detail from completed tool calls—has not been demonstrated as addressed by this change.

## What Changed

- Apply status-mode privacy before selecting command metadata, summaries, or progress text.
- Use the entry-aware progress formatter for Discord, Slack, and Microsoft Teams.
- Preserve raw-mode behavior, native progress IDs, exit/status text, and non-command metadata.
- Reduce production code by four net lines.

## Verification

- Focused channel-owner tests: **232/232 passed** remotely.
- Full changed-file gate: formatting, all four typecheck lanes, lint, and security passed.
- Independent authenticated review: **zero findings**, confidence **0.90**.
- TruffleHog secret scan: **clean**.
- Exact published head: `f698eace5a8fb3b35077128fc1e0e81fb001d27a`.
- Validation run: https://github.com/openclaw/openclaw/actions/runs/30756256294
