### PR TITLE
docs(browser): note mcporter auto-detects the extension relay

### DIFF
--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -115,6 +115,13 @@ headers }` for scripting. The token is the same host-local relay secret the
 pairing string carries: treat it as private, and rotate it by deleting
 `credentials/browser-extension-relay.secret` and pairing again.
 
+[mcporter](https://github.com/openclaw/mcporter) needs no wiring at all: when a
+paired relay answers on this host, it transparently rewrites
+`chrome-devtools-mcp --autoConnect` server commands to the relay endpoint, so
+agents calling Chrome DevTools through mcporter skip the remote-debugging
+prompt automatically (set `MCPORTER_DISABLE_CHROME_DEVTOOLS_RELAY=1` there to
+opt out).
+
 ### Tab copilot side panel
 
 After pairing the extension, click **Open tab copilot** in its toolbar popup.


### PR DESCRIPTION
## Summary

Add a short paragraph to the Chrome extension page's external-CDP-clients section: mcporter auto-detects a paired relay and rewrites `chrome-devtools-mcp --autoConnect` to the relay endpoint, so agents going through mcporter skip the remote-debugging prompt with zero wiring (companion to openclaw/mcporter#250).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
