### PR TITLE
improve(qa): make module flow selection implementation-aware

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1237,6 +1237,9 @@ The minimum adoption bar for a new channel:
    changing the command's existing scenario catalog. Same-channel partitions
    are serial unless the factory declares that every instance owns isolated
    credentials or disposable servers, Gateway state, and artifact paths.
+   Module-backed flow scenarios additionally require
+   `adapterFactory.supportsModuleFlows: true`; those factories must return
+   adapters that implement `prepareFlow`.
 5. Author or adapt YAML scenarios under the themed `qa/scenarios/`
    directories.
 6. Use the generic scenario helpers for new scenarios.

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -499,6 +499,11 @@ accepted through 2026-10-01 while authors migrate. An
 optional `adapterFactory` exposes the transport to shared QA scenarios without
 changing the registered command's runner.
 
+Module-backed flow scenarios are an adapter-owned execution form. Set
+`adapterFactory.supportsModuleFlows` to `true` only when every adapter created
+by that factory implements `prepareFlow`; QA planning excludes module flows
+from implementations that do not declare support.
+
 ```json
 {
   "qaRunners": [

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -67,7 +67,11 @@ import {
   type QaCredentialRecord,
 } from "./qa-credentials-admin.runtime.js";
 import { normalizeQaThinkingLevel, type QaThinkingLevel } from "./qa-gateway-config.js";
-import { normalizeQaTransportId, type QaTransportId } from "./qa-transport-registry.js";
+import {
+  normalizeQaTransportId,
+  qaTransportSupportsModuleFlows,
+  type QaTransportId,
+} from "./qa-transport-registry.js";
 import {
   defaultQaModelForMode,
   normalizeQaProviderMode,
@@ -663,6 +667,8 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
           ...scenarioPack.scenarios.filter((scenario) => missingScenarioIdSet.has(scenario.id)),
         ]
       : taxonomyScenarios;
+  const liveAdapterFactories =
+    profileReport.channelDriver === "live" ? listLiveTransportQaAdapterFactories() : undefined;
   const executionSelection = resolveQaRunProfileExecutionSelection({
     scenarios: executionScenarios,
     providerMode: normalizedProviderMode,
@@ -672,6 +678,16 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
       profileReport.channelDriver === "crabline" ? OPENCLAW_CRABLINE_DEFAULT_CHANNEL : undefined,
     supportsChannel:
       profileReport.channelDriver === "crabline" ? isCrablineServerChannel : undefined,
+    resolveModuleFlowSupport:
+      profileReport.channelDriver === "live"
+        ? (channel) =>
+            channel
+              ? qaTransportSupportsModuleFlows(liveAdapterFactories, {
+                  channelId: channel,
+                  driver: "live",
+                })
+              : false
+        : undefined,
   });
   if (requestedScenarioIds.length > 0 && executionSelection.excludedScenarios.length > 0) {
     const exclusions = executionSelection.excludedScenarios
@@ -852,6 +868,19 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     parityPack: opts.parityPack,
     scenarioIds: opts.scenarioIds,
   });
+  const liveChannelId = channelDriver === "live" ? opts.channel?.trim() : undefined;
+  const liveAdapterFactories =
+    channelDriver === "live" ? listLiveTransportQaAdapterFactories() : undefined;
+  const resolveModuleFlowSupport =
+    channelDriver === "live"
+      ? (channel?: string) =>
+          channel
+            ? qaTransportSupportsModuleFlows(liveAdapterFactories, {
+                channelId: channel,
+                driver: "live",
+              })
+            : false
+      : undefined;
   const runtimePairLanes = parseQaRuntimePairLaneFilters(opts.runtimePairLane);
   const runtimePairLaneSelection = resolveQaRuntimePairLaneScenarioIds({
     channel: opts.channel,
@@ -863,6 +892,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     scenarioIds: explicitScenarioIds,
     runtimePairLanes,
     runtimePair: runtimePair !== undefined,
+    resolveModuleFlowSupport,
   });
   const scenarioIds = runtimePairLaneSelection.scenarioIds;
   if (runtimePair) {
@@ -882,9 +912,6 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
   if (opts.channel?.trim() && channelDriver !== "crabline" && channelDriver !== "live") {
     throw new Error("--channel override requires --channel-driver crabline or live.");
   }
-  const liveChannelId = channelDriver === "live" ? opts.channel?.trim() : undefined;
-  const liveAdapterFactories =
-    channelDriver === "live" ? listLiveTransportQaAdapterFactories() : undefined;
   const liveAdapterFactory = liveChannelId
     ? liveAdapterFactories?.find((factory) => factory.id === liveChannelId)
     : undefined;

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -50,7 +50,10 @@ import type {
 } from "./lab-server.types.js";
 import type { QaRunnerModelOption } from "./model-catalog.runtime.js";
 import { createQaChannelGatewayConfig } from "./qa-channel-transport.js";
-import type { QaTransportAdapterFactory } from "./qa-transport-registry.js";
+import {
+  qaTransportSupportsModuleFlows,
+  type QaTransportAdapterFactory,
+} from "./qa-transport-registry.js";
 import {
   createIdleQaRunnerSnapshot,
   createQaRunOutputDir,
@@ -348,6 +351,13 @@ export async function startQaLabServer(
                 adapterFactories.some((factory) =>
                   factory.matches({ channelId: channel, driver: "live" }),
                 ),
+              resolveModuleFlowSupport: (channel?: string) =>
+                channel
+                  ? qaTransportSupportsModuleFlows(adapterFactories, {
+                      channelId: channel,
+                      driver: "live",
+                    })
+                  : false,
             }
           : {}),
     });

--- a/extensions/qa-lab/src/live-transports/discord/cli.ts
+++ b/extensions/qa-lab/src/live-transports/discord/cli.ts
@@ -28,6 +28,7 @@ export const discordQaCliRegistration: LiveTransportQaCliRegistration =
     commandName: "discord",
     adapterFactory: createLiveTransportQaAdapterFactory({
       id: "discord",
+      supportsModuleFlows: true,
       async create(context) {
         return (await loadDiscordQaAdapterRuntime()).createDiscordQaTransportAdapter(context);
       },

--- a/extensions/qa-lab/src/live-transports/discord/scenario-selection.ts
+++ b/extensions/qa-lab/src/live-transports/discord/scenario-selection.ts
@@ -9,6 +9,7 @@ export function resolveDiscordQaScenarioIds(params: {
 }) {
   return resolveLiveTransportQaScenarioIds({
     channelId: "discord",
+    supportsModuleFlows: true,
     ...params,
     providerMode: params.providerMode ?? "live-frontier",
   });

--- a/extensions/qa-lab/src/live-transports/live-transport-adapters.test.ts
+++ b/extensions/qa-lab/src/live-transports/live-transport-adapters.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "../bus-state.js";
 import { createQaChannelTransport } from "../qa-channel-transport.js";
 import { createQaTransportAdapter } from "../qa-transport-registry.js";
+import type { QaTransportAdapter } from "../qa-transport.js";
 
 const { createDiscord, createMatrix, createSlack, createTelegram, createWhatsApp } = vi.hoisted(
   () => ({
@@ -62,6 +63,14 @@ describe("live transport adapter factories", () => {
     expect(whatsappQaAdapterFactory.isolatesInstances).toBeUndefined();
   });
 
+  it("declares module-flow support only for adapters that prepare module context", () => {
+    expect(discordQaAdapterFactory.supportsModuleFlows).toBe(true);
+    expect(matrixQaAdapterFactory.supportsModuleFlows).toBe(true);
+    expect(slackQaAdapterFactory.supportsModuleFlows).toBe(true);
+    expect(whatsappQaAdapterFactory.supportsModuleFlows).toBe(true);
+    expect(telegramQaAdapterFactory.supportsModuleFlows).toBeUndefined();
+  });
+
   it.each([
     ["discord", createDiscord],
     ["matrix", createMatrix],
@@ -73,7 +82,10 @@ describe("live transport adapter factories", () => {
     async (channelId, create) => {
       const adapterOptions = { sutAccountId: `${channelId}-sut` };
       const state = createQaBusState();
-      const adapter = createQaChannelTransport(state);
+      const adapter: QaTransportAdapter = createQaChannelTransport(state);
+      if (channelId !== "telegram") {
+        adapter.prepareFlow = async () => ({});
+      }
       create.mockResolvedValueOnce(adapter);
       const created = await createQaTransportAdapter(
         {

--- a/extensions/qa-lab/src/live-transports/matrix/cli.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/cli.ts
@@ -52,6 +52,7 @@ async function runQaMatrix(opts: LiveTransportQaCommandOptions) {
           primaryModel: selection.primaryModel,
           providerMode: selection.providerMode,
           scenarioIds: selection.scenarioIds,
+          supportsModuleFlows: true,
         }),
     });
   };
@@ -76,6 +77,7 @@ export const matrixQaCliRegistration: LiveTransportQaCliRegistration =
     commandName: "matrix",
     adapterFactory: createLiveTransportQaAdapterFactory({
       id: "matrix",
+      supportsModuleFlows: true,
       // Every worker owns a uniquely named disposable homeserver, Gateway, and state tree.
       isolatesInstances: true,
       async create(context) {

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
@@ -166,10 +166,12 @@ export function createLiveTransportQaAdapterFactory(params: {
   create: NonNullable<LiveTransportQaCliRegistrationOptions["adapterFactory"]>["create"];
   id: string;
   isolatesInstances?: boolean;
+  supportsModuleFlows?: true;
 }): NonNullable<LiveTransportQaCliRegistrationOptions["adapterFactory"]> {
   return {
     id: params.id,
     isolatesInstances: params.isolatesInstances,
+    supportsModuleFlows: params.supportsModuleFlows,
     matches: ({ channelId, driver }) => driver === "live" && channelId === params.id,
     create: params.create,
   };

--- a/extensions/qa-lab/src/live-transports/shared/scenario-selection.ts
+++ b/extensions/qa-lab/src/live-transports/shared/scenario-selection.ts
@@ -18,6 +18,7 @@ export function resolveCatalogLiveTransportQaScenarioIds(params: {
   primaryModel?: string;
   providerMode: QaProviderModeInput;
   scenarioIds?: readonly string[];
+  supportsModuleFlows?: boolean;
 }) {
   const channelId = params.channelId.trim().toLowerCase();
   const catalog = readQaScenarioPack().scenarios;
@@ -32,6 +33,7 @@ export function resolveCatalogLiveTransportQaScenarioIds(params: {
     primaryModel: params.primaryModel?.trim() || defaultQaModelForMode(providerMode),
     channelDriver: params.channelDriver ?? "live",
     channel: channelId,
+    resolveModuleFlowSupport: () => params.supportsModuleFlows === true,
   });
   if (selectedScenarios.length === 0) {
     throw new Error(`${channelId} QA catalog selection resolved no scenarios.`);
@@ -45,6 +47,7 @@ export function resolveLiveTransportQaScenarioIds(params: {
   primaryModel?: string;
   providerMode: QaProviderModeInput;
   scenarioIds?: readonly string[];
+  supportsModuleFlows?: boolean;
 }) {
   return resolveQaProfileScenarios({
     profile: params.profile?.trim() || "release",
@@ -54,6 +57,7 @@ export function resolveLiveTransportQaScenarioIds(params: {
     channel: params.channelId,
     executionKind: "flow",
     requireDeclaredChannel: true,
+    resolveModuleFlowSupport: () => params.supportsModuleFlows === true,
     scenarioIds: params.scenarioIds,
   }).scenarios.map((scenario) => scenario.id);
 }
@@ -62,6 +66,7 @@ export function listLiveTransportQaScenarios(params: {
   channelId: string;
   primaryModel?: string;
   providerMode: QaProviderModeInput;
+  supportsModuleFlows?: boolean;
 }) {
   const defaultIds = new Set(resolveLiveTransportQaScenarioIds(params));
   const providerMode = normalizeQaProviderMode(params.providerMode);
@@ -76,6 +81,7 @@ export function listLiveTransportQaScenarios(params: {
     channelDriver: "live",
     channel: params.channelId,
     executionKind: "flow",
+    resolveModuleFlowSupport: () => params.supportsModuleFlows === true,
   }).selectedScenarios;
   return scenarios.map((scenario) => {
     return {

--- a/extensions/qa-lab/src/live-transports/slack/cli.ts
+++ b/extensions/qa-lab/src/live-transports/slack/cli.ts
@@ -28,6 +28,7 @@ export const slackQaCliRegistration: LiveTransportQaCliRegistration =
     commandName: "slack",
     adapterFactory: createLiveTransportQaAdapterFactory({
       id: "slack",
+      supportsModuleFlows: true,
       async create(context) {
         return (await loadSlackQaAdapterRuntime()).createSlackQaTransportAdapter(context);
       },

--- a/extensions/qa-lab/src/live-transports/slack/scenario-selection.ts
+++ b/extensions/qa-lab/src/live-transports/slack/scenario-selection.ts
@@ -9,6 +9,7 @@ export function resolveSlackQaScenarioIds(params: {
 }) {
   return resolveLiveTransportQaScenarioIds({
     channelId: "slack",
+    supportsModuleFlows: true,
     ...params,
     providerMode: params.providerMode ?? "live-frontier",
   });

--- a/extensions/qa-lab/src/live-transports/whatsapp/cli.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/cli.ts
@@ -28,6 +28,7 @@ export const whatsappQaCliRegistration: LiveTransportQaCliRegistration =
     commandName: "whatsapp",
     adapterFactory: createLiveTransportQaAdapterFactory({
       id: "whatsapp",
+      supportsModuleFlows: true,
       async create(context) {
         return (await loadWhatsAppQaAdapterRuntime()).createWhatsAppQaTransportAdapter(context);
       },

--- a/extensions/qa-lab/src/live-transports/whatsapp/scenario-selection.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/scenario-selection.ts
@@ -7,5 +7,9 @@ export function resolveWhatsAppQaScenarioIds(params: {
   providerMode: QaProviderModeInput;
   scenarioIds?: readonly string[];
 }) {
-  return resolveLiveTransportQaScenarioIds({ channelId: "whatsapp", ...params });
+  return resolveLiveTransportQaScenarioIds({
+    channelId: "whatsapp",
+    supportsModuleFlows: true,
+    ...params,
+  });
 }

--- a/extensions/qa-lab/src/profile-planning.ts
+++ b/extensions/qa-lab/src/profile-planning.ts
@@ -123,6 +123,7 @@ export function resolveQaRunProfileExecutionSelection(params: {
   claudeCliAuthMode?: QaCliBackendAuthMode;
   executionKind?: QaSeedScenarioWithSource["execution"]["kind"];
   supportsChannel?: (channel: string) => boolean;
+  resolveModuleFlowSupport?: (channel?: string) => boolean;
 }): QaRunProfileExecutionSelection {
   const selectedScenarios: QaSeedScenarioWithSource[] = [];
   const excludedScenarios: QaRunProfileExecutionSelection["excludedScenarios"] = [];
@@ -150,6 +151,7 @@ export function resolveQaRunProfileExecutionSelection(params: {
         channelDriver: params.channelDriver,
         channel: effectiveChannel,
         claudeCliAuthMode: params.claudeCliAuthMode,
+        supportsModuleFlows: params.resolveModuleFlowSupport?.(effectiveChannel),
       }),
     );
     if (
@@ -191,6 +193,7 @@ export function resolveQaProfileScenarios(params: {
   eligibleChannels?: readonly string[];
   executionKind?: QaSeedScenarioWithSource["execution"]["kind"];
   requireDeclaredChannel?: boolean;
+  resolveModuleFlowSupport?: (channel?: string) => boolean;
   scenarioIds?: readonly string[];
 }) {
   const membership = resolveQaRunProfileMembership({
@@ -236,6 +239,7 @@ export function resolveQaProfileScenarios(params: {
         channelDriver,
         channel: channel ?? scenario.execution.channel,
         executionKind: params.executionKind,
+        resolveModuleFlowSupport: params.resolveModuleFlowSupport,
       }).excludedScenarios.flatMap((entry) => entry.reasons),
     );
     return { scenario, reasons: uniqueStrings(reasons) };

--- a/extensions/qa-lab/src/qa-transport-registry.test.ts
+++ b/extensions/qa-lab/src/qa-transport-registry.test.ts
@@ -4,6 +4,7 @@ import { createQaBusState } from "./bus-state.js";
 import {
   createQaTransportAdapter,
   normalizeQaTransportId,
+  qaTransportSupportsModuleFlows,
   type QaTransportAdapterFactory,
   type QaTransportFactoryContext,
 } from "./qa-transport-registry.js";
@@ -117,6 +118,50 @@ describe("qa transport registry", () => {
     });
     expect(skippedCreate).not.toHaveBeenCalled();
     expect(selectedCreate).toHaveBeenCalledOnce();
+  });
+
+  it("reads module-flow support from the selected factory", () => {
+    const factories: QaTransportAdapterFactory[] = [
+      { id: "skipped", matches: () => false, create: vi.fn() },
+      {
+        id: "selected",
+        supportsModuleFlows: true,
+        matches: () => true,
+        create: vi.fn(),
+      },
+    ];
+
+    expect(
+      qaTransportSupportsModuleFlows(factories, { channelId: "selected", driver: "live" }),
+    ).toBe(true);
+    expect(qaTransportSupportsModuleFlows([], { channelId: "selected", driver: "live" })).toBe(
+      false,
+    );
+  });
+
+  it("rejects module-flow support when the created adapter lacks prepareFlow", async () => {
+    const cleanup = vi.fn(async () => {
+      throw new Error("cleanup failed");
+    });
+    const cleanupAfterGatewayStop = vi.fn(async () => undefined);
+    const factory: QaTransportAdapterFactory = {
+      id: "selected",
+      supportsModuleFlows: true,
+      matches: () => true,
+      async create() {
+        return createAdapterDefinition(cleanup, cleanupAfterGatewayStop);
+      },
+    };
+
+    await expect(
+      createQaTransportAdapter(createFactoryContext({ channelId: "selected", driver: "live" }), [
+        factory,
+      ]),
+    ).rejects.toThrow(
+      'QA transport factory "selected" supports module flows but its adapter does not implement prepareFlow',
+    );
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(cleanupAfterGatewayStop).toHaveBeenCalledOnce();
   });
 
   it("returns cleanup owned by the selected adapter", async () => {

--- a/extensions/qa-lab/src/qa-transport-registry.ts
+++ b/extensions/qa-lab/src/qa-transport-registry.ts
@@ -73,6 +73,13 @@ function requireQaTransportFactory(
   return factory;
 }
 
+export function qaTransportSupportsModuleFlows(
+  factories: readonly QaTransportAdapterFactory[] | undefined,
+  context: Pick<QaTransportFactoryContext, "channelId" | "driver">,
+): boolean {
+  return factories?.find((factory) => factory.matches(context))?.supportsModuleFlows === true;
+}
+
 function createQaTransportCleanup(cleanup: () => Promise<void> | undefined): () => Promise<void> {
   let pending: Promise<void> | undefined;
 
@@ -89,6 +96,20 @@ function createQaTransportCleanup(cleanup: () => Promise<void> | undefined): () 
     }
     return pending;
   };
+}
+
+async function collectQaTransportCleanupErrors(
+  cleanups: readonly (() => Promise<void> | undefined)[],
+): Promise<unknown[]> {
+  const errors: unknown[] = [];
+  for (const cleanup of cleanups) {
+    try {
+      await cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  return errors;
 }
 
 function createQaTransportAdapterFactoryRegistry(
@@ -118,6 +139,19 @@ function createQaTransportAdapterFactoryRegistry(
             },
             outputDir: context.outputDir,
           });
+          if (factory.supportsModuleFlows && typeof definition.prepareFlow !== "function") {
+            const mismatch = new Error(
+              `QA transport factory "${factory.id}" supports module flows but its adapter does not implement prepareFlow`,
+            );
+            const cleanupErrors = await collectQaTransportCleanupErrors([
+              () => definition.cleanup?.(),
+              () => definition.cleanupAfterGatewayStop?.(),
+            ]);
+            if (cleanupErrors.length > 0) {
+              throw new AggregateError([mismatch, ...cleanupErrors], mismatch.message);
+            }
+            throw mismatch;
+          }
           adapter = createQaStateBackedTransportAdapter(context.state, definition);
         }
       } catch (error) {
@@ -134,14 +168,10 @@ function createQaTransportAdapterFactoryRegistry(
         adapter.cleanupAfterGatewayStop?.(),
       );
       const cleanupWithoutGateway = async () => {
-        const errors: unknown[] = [];
-        for (const cleanup of [cleanupBeforeGatewayStop, cleanupAfterGatewayStop]) {
-          try {
-            await cleanup();
-          } catch (error) {
-            errors.push(error);
-          }
-        }
+        const errors = await collectQaTransportCleanupErrors([
+          cleanupBeforeGatewayStop,
+          cleanupAfterGatewayStop,
+        ]);
         if (errors.length === 1) {
           throw errors[0];
         }

--- a/extensions/qa-lab/src/run-config.test.ts
+++ b/extensions/qa-lab/src/run-config.test.ts
@@ -352,7 +352,7 @@ describe("qa run config", () => {
     expect(execution.excludedScenarios).toEqual([]);
   });
 
-  it("keeps portable threads but excludes live-only scenarios from Crabline plans", () => {
+  it("keeps portable threads but excludes module flows from Crabline plans", () => {
     const catalog = readQaScenarioPack();
     const scenarioIds = new Set([
       "matrix-approval-channel-target-both",
@@ -387,15 +387,33 @@ describe("qa run config", () => {
         execution.excludedScenarios.map(({ scenario, reasons }) => [scenario.id, reasons]),
       ),
     ).toEqual({
-      "matrix-approval-channel-target-both": ["channelDriver=live"],
-      "matrix-approval-deny-reaction": ["channelDriver=live"],
-      "matrix-approval-exec-metadata-chunked": ["channelDriver=live"],
-      "matrix-approval-exec-metadata-single-event": ["channelDriver=live"],
-      "matrix-approval-plugin-metadata-single-event": ["channelDriver=live"],
-      "matrix-approval-thread-target": ["channelDriver=live"],
-      "matrix-mxid-prefixed-command-block": ["channelDriver=live"],
-      "slack-codex-approval-exec-native": ["channelDriver=live"],
-      "slack-codex-approval-plugin-native": ["channelDriver=live"],
+      "matrix-approval-channel-target-both": [
+        "module flow unsupported by implementation=crabline:matrix",
+      ],
+      "matrix-approval-deny-reaction": [
+        "module flow unsupported by implementation=crabline:matrix",
+      ],
+      "matrix-approval-exec-metadata-chunked": [
+        "module flow unsupported by implementation=crabline:matrix",
+      ],
+      "matrix-approval-exec-metadata-single-event": [
+        "module flow unsupported by implementation=crabline:matrix",
+      ],
+      "matrix-approval-plugin-metadata-single-event": [
+        "module flow unsupported by implementation=crabline:matrix",
+      ],
+      "matrix-approval-thread-target": [
+        "module flow unsupported by implementation=crabline:matrix",
+      ],
+      "matrix-mxid-prefixed-command-block": [
+        "module flow unsupported by implementation=crabline:matrix",
+      ],
+      "slack-codex-approval-exec-native": [
+        "module flow unsupported by implementation=crabline:slack",
+      ],
+      "slack-codex-approval-plugin-native": [
+        "module flow unsupported by implementation=crabline:slack",
+      ],
     });
   });
 

--- a/extensions/qa-lab/src/run-config.ts
+++ b/extensions/qa-lab/src/run-config.ts
@@ -278,6 +278,7 @@ export function resolveQaLabRunPlan(params: {
   scorecardReport: QaScorecardTaxonomyReport;
   defaultChannel?: string;
   supportsChannel?: (channel: string) => boolean;
+  resolveModuleFlowSupport?: (channel?: string) => boolean;
 }): QaLabResolvedRunPlan {
   const { selection } = params;
   const explicitScenarioSelection = selection.scenarioIds !== null;
@@ -314,6 +315,7 @@ export function resolveQaLabRunPlan(params: {
       scenarios: membership.profileScenarios,
       runtimePairLanes: selection.runtimePairLane ? [selection.runtimePairLane] : [],
       runtimePair: selection.runtimePair !== null,
+      resolveModuleFlowSupport: params.resolveModuleFlowSupport,
     });
   } catch (error) {
     errors.push(error instanceof Error ? error.message : String(error));
@@ -368,6 +370,7 @@ export function resolveQaLabRunPlan(params: {
     channel: selection.channel,
     defaultChannel: selection.channelDriver === "crabline" ? params.defaultChannel : undefined,
     supportsChannel: params.supportsChannel,
+    resolveModuleFlowSupport: params.resolveModuleFlowSupport,
   });
   exclusions.push(
     ...profileExecution.excludedScenarios.map(({ scenario, reasons }) => ({

--- a/extensions/qa-lab/src/runtime-pair-lane-selection.ts
+++ b/extensions/qa-lab/src/runtime-pair-lane-selection.ts
@@ -30,6 +30,7 @@ export function resolveQaRuntimePairLaneScenarioIds(params: {
   scenarios?: QaSeedScenarioWithSource[];
   runtimePairLanes: readonly QaRuntimePairLane[];
   runtimePair: boolean;
+  resolveModuleFlowSupport?: (channel?: string) => boolean;
 }): {
   scenarioIds: string[];
   excludedLaneScenarios: QaSeedScenarioWithSource[];
@@ -62,6 +63,9 @@ export function resolveQaRuntimePairLaneScenarioIds(params: {
       channelDriver: params.channelDriver,
       channel: params.channel ?? scenario.execution.channel ?? params.defaultChannel,
       claudeCliAuthMode: params.claudeCliAuthMode,
+      supportsModuleFlows: params.resolveModuleFlowSupport?.(
+        params.channel ?? scenario.execution.channel ?? params.defaultChannel,
+      ),
     }),
   );
   const excludedLaneScenarios = compatibleScenarios.filter(

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   readQaScenarioById,
   readQaScenarioExecutionConfig,
+  readQaScenarioPack,
   validateQaScenarioExecutionConfig,
 } from "./scenario-catalog.js";
 
@@ -20,6 +21,15 @@ function requireFlowScenario(scenario: CatalogScenario): FlowCatalogScenario {
 
 describe("qa scenario catalog channel contracts", () => {
   const agentRuntime = "agent-runtime";
+
+  it("classifies every current module flow intrinsically", () => {
+    const moduleFlows = readQaScenarioPack().scenarios.filter(
+      (scenario) => scenario.execution.flowKind === "module",
+    );
+
+    expect(moduleFlows).toHaveLength(143);
+    expect(moduleFlows.every((scenario) => scenario.execution.flow)).toBe(true);
+  });
 
   it("routes native command session targeting through Crabline Telegram", () => {
     const scenario = readQaScenarioById("native-command-session-target");
@@ -83,16 +93,19 @@ describe("qa scenario catalog channel contracts", () => {
     expect(flow).not.toContain('"call":"runAgentPrompt"');
   });
 
-  it("marks live transport modules as live-driver-only", () => {
+  it("preserves module flow identity without mutating the driver contract", () => {
     for (const scenarioId of [
       "matrix-approval-exec-metadata-single-event",
       "matrix-mxid-prefixed-command-block",
       "slack-codex-approval-exec-native",
       "slack-codex-approval-plugin-native",
     ]) {
-      expect(readQaScenarioExecutionConfig(scenarioId)?.requiredChannelDriver, scenarioId).toBe(
-        "live",
-      );
+      const scenario = requireFlowScenario(readQaScenarioById(scenarioId));
+      expect(scenario.execution.flowKind, scenarioId).toBe("module");
+      expect(
+        readQaScenarioExecutionConfig(scenarioId)?.requiredChannelDriver,
+        scenarioId,
+      ).toBeUndefined();
     }
   });
 

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -349,6 +349,7 @@ export type QaSeedScenarioWithSource = QaSeedScenario & {
   sourcePath: string;
   execution: QaScenarioExecution & {
     flow?: QaScenarioFlow;
+    flowKind?: "module" | "steps";
   };
 };
 
@@ -454,20 +455,9 @@ export function readQaScenarioPack(): QaScenarioPack {
         parsedScenario.execution ?? {},
         relativePath,
       );
-      const requiredChannelDriver = qaScenarioModuleFlow.resolveRequiredChannelDriver(
-        parsedScenarioFile.flow,
-      );
-      const configuredChannelDriver =
-        execution.kind === "flow" ? execution.config?.requiredChannelDriver : undefined;
-      if (
-        requiredChannelDriver &&
-        configuredChannelDriver !== undefined &&
-        configuredChannelDriver !== requiredChannelDriver
-      ) {
-        throw new Error(
-          `${relativePath}: live transport module requires channelDriver=${requiredChannelDriver}`,
-        );
-      }
+      // Module shorthand normalizes to ordinary steps below. Preserve its authored form so
+      // planning cannot schedule it on an adapter that does not support module flows.
+      const flowKind = qaScenarioModuleFlow.resolveKind(parsedScenarioFile.flow);
       const flow = qaScenarioModuleFlow.resolveFlow(
         parsedScenarioFile.flow,
         parsedScenarioFile.title,
@@ -478,15 +468,7 @@ export function readQaScenarioPack(): QaScenarioPack {
         sourcePath: relativePath,
         execution: {
           ...execution,
-          ...(requiredChannelDriver && execution.kind === "flow"
-            ? {
-                config: {
-                  ...execution.config,
-                  requiredChannelDriver,
-                },
-              }
-            : {}),
-          ...(flow ? { flow } : {}),
+          ...(flow ? { flow, flowKind } : {}),
         },
       } satisfies QaSeedScenarioWithSource;
     })(),

--- a/extensions/qa-lab/src/scenario-lane.test.ts
+++ b/extensions/qa-lab/src/scenario-lane.test.ts
@@ -105,6 +105,7 @@ describe("QA scenario lane matching", () => {
         primaryModel: "openai/gpt-5.6-luna",
         channelDriver: "live" as const,
         channel: "matrix",
+        supportsModuleFlows: true,
       };
 
       expect(scenarioMatchesQaProviderLane(liveLane)).toBe(false);
@@ -122,6 +123,7 @@ describe("QA scenario lane matching", () => {
         primaryModel: "openai/gpt-5.6-luna",
         channelDriver: "live",
         channel: "matrix",
+        resolveModuleFlowSupport: () => true,
       }),
     ).toEqual({
       selectedScenarios: [],
@@ -282,6 +284,38 @@ describe("QA scenario lane matching", () => {
         channel: "matrix",
       }),
     ).toBe(true);
+  });
+
+  it("keeps module-flow support independent from driver and channel constraints", () => {
+    const scenario = makeQaSuiteTestScenario("matrix-module", {
+      channel: "matrix",
+      flowKind: "module",
+      config: { requiredChannelDriver: "live" },
+    });
+
+    expect(
+      describeQaProviderLaneMismatches({
+        scenario,
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        channelDriver: "crabline",
+        channel: "telegram",
+      }),
+    ).toEqual([
+      "channelDriver=live",
+      "channel=matrix",
+      "module flow unsupported by implementation=crabline:telegram",
+    ]);
+    expect(
+      describeQaProviderLaneMismatches({
+        scenario,
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        channelDriver: "live",
+        channel: "matrix",
+        supportsModuleFlows: true,
+      }),
+    ).toEqual([]);
   });
 
   it("keeps the built-in driver bound to the qa-channel channel", () => {

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -102,6 +102,7 @@ export function describeQaProviderLaneMismatches(params: {
   channelDriver?: QaScorecardChannelDriver | null;
   channel?: string | null;
   claudeCliAuthMode?: QaCliBackendAuthMode;
+  supportsModuleFlows?: boolean;
 }) {
   const mismatches: string[] = [];
   const config = params.scenario.execution.config ?? {};
@@ -126,6 +127,17 @@ export function describeQaProviderLaneMismatches(params: {
     params.scenario.execution.kind === "flow" ? params.scenario.execution.channels : undefined;
   if (allowedChannels && !allowedChannels.includes(effectiveChannel ?? "")) {
     mismatches.push(`channel=${allowedChannels.join("|")}`);
+  }
+  if (
+    params.scenario.execution.kind === "flow" &&
+    params.scenario.execution.flowKind === "module" &&
+    params.supportsModuleFlows !== true
+  ) {
+    const implementation =
+      effectiveChannel && effectiveChannel !== effectiveChannelDriver
+        ? `${effectiveChannelDriver}:${effectiveChannel}`
+        : effectiveChannelDriver;
+    mismatches.push(`module flow unsupported by implementation=${implementation}`);
   }
   const selected = splitQaModelRef(params.primaryModel);
   const requiredProvider = normalizeQaConfigString(config.requiredProvider);

--- a/extensions/qa-lab/src/scenario-module-flow.test.ts
+++ b/extensions/qa-lab/src/scenario-module-flow.test.ts
@@ -9,6 +9,7 @@ describe("QA scenario module flow", () => {
       args: [{ expr: "scenarioContext" }, { moduleExport: "scenarioImplementation" }],
     });
 
+    expect(qaScenarioModuleFlow.resolveKind(flow)).toBe("module");
     expect(qaScenarioModuleFlow.resolveFlow(flow, "Scenario title")).toMatchObject({
       steps: [
         {
@@ -28,6 +29,17 @@ describe("QA scenario module flow", () => {
         },
       ],
     });
+  });
+
+  it("distinguishes module syntax without relying on its source path", () => {
+    const moduleFlow = qaScenarioModuleFlow.moduleSchema.parse({
+      module: "example-package/scenario.js",
+      call: "runScenario",
+    });
+
+    expect(qaScenarioModuleFlow.resolveKind(moduleFlow)).toBe("module");
+    expect(qaScenarioModuleFlow.resolveKind({ steps: [] })).toBe("steps");
+    expect(qaScenarioModuleFlow.resolveKind(undefined)).toBeUndefined();
   });
 
   it("rejects malformed module export arguments", () => {

--- a/extensions/qa-lab/src/scenario-module-flow.ts
+++ b/extensions/qa-lab/src/scenario-module-flow.ts
@@ -35,14 +35,10 @@ const qaFlowExecutionShape = {
 type QaScenarioModuleFlow = z.infer<typeof qaFlowModuleSchema>;
 type QaScenarioFlowShape = { steps: unknown[] };
 
-function resolveRequiredChannelDriver(
+function resolveQaScenarioFlowKind(
   flow: QaScenarioFlowShape | QaScenarioModuleFlow | undefined,
-): "live" | undefined {
-  // Modules under live-transports consume adapter-prepared runtime context.
-  // Crabline implements normalized transport only and cannot supply that context.
-  return flow && "module" in flow && flow.module.startsWith("./live-transports/")
-    ? "live"
-    : undefined;
+): "module" | "steps" | undefined {
+  return flow ? ("module" in flow ? "module" : "steps") : undefined;
 }
 
 function normalizeQaScenarioFileMetadata<
@@ -110,6 +106,6 @@ export const qaScenarioModuleFlow = {
   moduleSchema: qaFlowModuleSchema,
   executionShape: qaFlowExecutionShape,
   normalizeMetadata: normalizeQaScenarioFileMetadata,
-  resolveRequiredChannelDriver,
+  resolveKind: resolveQaScenarioFlowKind,
   resolveFlow: resolveQaScenarioFileFlow,
 };

--- a/extensions/qa-lab/src/suite-planning-module-flows.test.ts
+++ b/extensions/qa-lab/src/suite-planning-module-flows.test.ts
@@ -1,0 +1,34 @@
+// Qa Lab tests cover module-flow-aware suite selection.
+import { describe, expect, it } from "vitest";
+import { selectQaFlowSuiteScenarios } from "./suite-planning.js";
+import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
+
+describe("qa suite planning module flows", () => {
+  it("filters implicit module flows and rejects unsupported explicit selection", () => {
+    const scenarios = [
+      makeQaSuiteTestScenario("portable", { channel: "matrix" }),
+      makeQaSuiteTestScenario("module-backed", {
+        channel: "matrix",
+        flowKind: "module",
+      }),
+    ];
+    const lane = {
+      scenarios,
+      providerMode: "mock-openai" as const,
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      channelDriver: "live" as const,
+      channel: "matrix",
+    };
+
+    expect(selectQaFlowSuiteScenarios(lane).map((scenario) => scenario.id)).toEqual(["portable"]);
+    expect(
+      selectQaFlowSuiteScenarios({
+        ...lane,
+        resolveModuleFlowSupport: () => true,
+      }).map((scenario) => scenario.id),
+    ).toEqual(["portable", "module-backed"]);
+    expect(() => selectQaFlowSuiteScenarios({ ...lane, scenarioIds: ["module-backed"] })).toThrow(
+      "selected QA scenario(s) do not match the current QA lane: module-backed (module flow unsupported by implementation=live:matrix)",
+    );
+  });
+});

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -34,6 +34,7 @@ function selectQaFlowSuiteScenarios(params: {
   channelDriver?: QaScorecardChannelDriver | null;
   channel?: string | null;
   claudeCliAuthMode?: QaCliBackendAuthMode;
+  resolveModuleFlowSupport?: (channel?: string) => boolean;
 }) {
   const requestedScenarioIds =
     params.scenarioIds && params.scenarioIds.length > 0 ? new Set(params.scenarioIds) : null;
@@ -67,6 +68,9 @@ function selectQaFlowSuiteScenarios(params: {
         channelDriver: params.channelDriver,
         channel: params.channel,
         claudeCliAuthMode: params.claudeCliAuthMode,
+        supportsModuleFlows: params.resolveModuleFlowSupport?.(
+          params.channel ?? scenario.execution.channel,
+        ),
       });
       return mismatches.length > 0 ? [`${scenario.id} (${mismatches.join(", ")})`] : [];
     });
@@ -87,6 +91,9 @@ function selectQaFlowSuiteScenarios(params: {
         channelDriver: params.channelDriver,
         channel: params.channel,
         claudeCliAuthMode: params.claudeCliAuthMode,
+        supportsModuleFlows: params.resolveModuleFlowSupport?.(
+          params.channel ?? scenario.execution.channel,
+        ),
       }),
   );
 }

--- a/extensions/qa-lab/src/suite-run.runtime.ts
+++ b/extensions/qa-lab/src/suite-run.runtime.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import {
   defaultQaSuiteConcurrencyForTransport,
   normalizeQaTransportId,
+  qaTransportSupportsModuleFlows,
 } from "./qa-transport-registry.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
 import { resolveRequestedQaSuiteModels } from "./suite-model-selection.js";
@@ -45,6 +46,11 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
     channelDriver,
     channel: params?.channelId ?? params?.channelDriverSelection?.channel,
     claudeCliAuthMode: params?.claudeCliAuthMode,
+    resolveModuleFlowSupport: (channel) =>
+      qaTransportSupportsModuleFlows(params?.adapterFactories, {
+        channelId: channel ?? params?.channelId ?? transportId,
+        driver: channelDriver ?? transportId,
+      }),
   });
   if (selectedScenarios.length === 0) {
     throw new Error(

--- a/extensions/qa-lab/src/suite-test-helpers.ts
+++ b/extensions/qa-lab/src/suite-test-helpers.ts
@@ -16,6 +16,7 @@ export function makeQaSuiteTestScenario(
       forwardHostHome?: boolean;
       preserveDebugArtifacts?: boolean;
     };
+    flowKind?: "module" | "steps";
     runtimePairLane?: QaSuiteTestScenario["runtimePairLane"];
     suiteIsolation?: "isolated";
     surface?: string;
@@ -39,6 +40,7 @@ export function makeQaSuiteTestScenario(
       ...(params.suiteIsolation ? { suiteIsolation: params.suiteIsolation } : {}),
       ...(params.transportPolicy ? { transportPolicy: params.transportPolicy } : {}),
       ...(params.config ? { config: params.config } : {}),
+      flowKind: params.flowKind ?? "steps",
       flow: { steps: [{ name: "noop", actions: [{ assert: "true" }] }] },
     },
   } as QaSuiteTestScenario;

--- a/src/plugin-sdk/qa-runner-runtime.test.ts
+++ b/src/plugin-sdk/qa-runner-runtime.test.ts
@@ -135,6 +135,7 @@ describe("plugin-sdk qa-runner-runtime", () => {
     const adapterFactory = {
       id: "example",
       isolatesInstances: true,
+      supportsModuleFlows: true as const,
       matches: vi.fn(),
       create: vi.fn(),
     };
@@ -177,6 +178,40 @@ describe("plugin-sdk qa-runner-runtime", () => {
       dirName: "qa-example",
       artifactBasename: "qa-runner-api.js",
     });
+  });
+
+  it("rejects invalid module-flow support metadata", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "qa-example",
+          origin: "bundled",
+          qaRunners: [{ commandName: "example" }],
+          rootDir: "/tmp/qa-example",
+        },
+      ],
+      diagnostics: [],
+    });
+    loadBundledPluginPublicSurfaceModuleSync.mockReturnValue({
+      qaRunnerCliRegistrations: [
+        {
+          commandName: "example",
+          adapterFactory: {
+            id: "example",
+            supportsModuleFlows: false,
+            matches: vi.fn(),
+            create: vi.fn(),
+          },
+          register: vi.fn(),
+        },
+      ],
+    });
+
+    const module = await import("./qa-runner-runtime.js");
+
+    expect(() => module.listQaRunnerCliContributions()).toThrow(
+      'QA runner plugin "qa-example" exported an invalid transport factory for "example"',
+    );
   });
 
   it("reports declared runners as blocked when the plugin is present but not activated", async () => {

--- a/src/plugin-sdk/qa-runner-runtime.ts
+++ b/src/plugin-sdk/qa-runner-runtime.ts
@@ -182,6 +182,8 @@ type QaRunnerTransportAdapterDefinition = {
 
 type QaRunnerTransportFactory = {
   id: string;
+  /** Enables module-backed scenarios; every created adapter must implement `prepareFlow`. */
+  supportsModuleFlows?: true;
   /** Each create() call owns isolated runtime state and may run concurrently. */
   isolatesInstances?: boolean;
   matches: (context: { channelId: string; driver: string }) => boolean;
@@ -593,9 +595,13 @@ export function listQaRunnerCliContributions(): readonly QaRunnerCliContribution
         );
       }
       const adapterFactory = registration.adapterFactory;
+      const supportsModuleFlows: unknown = adapterFactory
+        ? Reflect.get(adapterFactory, "supportsModuleFlows")
+        : undefined;
       if (
         adapterFactory &&
         (adapterFactory.id !== runner.commandName ||
+          (supportsModuleFlows !== undefined && supportsModuleFlows !== true) ||
           (adapterFactory.isolatesInstances !== undefined &&
             typeof adapterFactory.isolatesInstances !== "boolean") ||
           typeof adapterFactory.matches !== "function" ||


### PR DESCRIPTION
Closes #118005

## What Problem This Solves

QA Lab normalizes top-level module flows into ordinary flow steps before planning. That erased the fact that module flows depend on adapter-owned preparation, so eligibility was inferred from the module's `./live-transports/` source path instead of the selected transport implementation.

As a result, catalog layout owned an execution decision it could not prove. An implementation without module-flow preparation could be selected until runtime, where missing prepared context risked an unsupported execution being treated as QA coverage.

## Why This Change Was Made

The catalog now preserves whether a flow was authored with module syntax as internal planning provenance. Transport factories use one narrow declaration, `supportsModuleFlows: true`, and every declared adapter is checked for `prepareFlow` when created. Planning filters unsupported module flows during implicit selection and reports the exact selected implementation during explicit selection.

This is not scenario metadata or a generic capability framework. No scenario YAML changes. The previous path-derived rule is removed. Named driver/channel constraints, selected implementation support, provider mode, model constraints, and auth constraints remain independent.

Discord, Matrix, Slack, and WhatsApp declare module-flow support because their adapters prepare flows. Telegram, Crabline, and the built-in QA channel do not. The catalog currently contains 143 module flows after main independently converted one prior module scenario to inline steps.

Historical overlap is resolved: #115777 and #116262 are closed, and #115777's evidence work was superseded by merged #119761. This patch preserves #119761's realized-driver/evidence semantics and does not change no-factory fallback behavior.

Production delta is `+151/-45` (net `+106`), excluding tests and docs. The positive delta is the owner contract, lifecycle-safe rejection, and propagation through the independent CLI, profile, lab-server, runtime-pair, suite-planning, and runtime entry points; there is no compatibility or deprecation layer.

## User Impact

No end-user behavior changes. QA operators get honest selection: module flows run only on implementations that prepare them, unsupported explicit selections explain which implementation cannot run the flow, and unsupported flows cannot fulfill coverage.

## Evidence

- Exact head: `36113539403ed9f9ef84b591ce8282c196191da1`.
- Catalog proof: 143 module flows classified from their authored syntax; zero `qa/scenarios/**` files changed.
- Focused proof: 13 files, 259 tests passed across QA Lab and Plugin SDK shards.
- Blacksmith changed-gate proof passed SDK surface/boundary checks, dead-code scans, and core/extension production and test typechecks. It found two patch-local issues in sequence (a fixture type and a lint expression); both were repaired, with focused tests and targeted lint green. Exact-head CI owns the final complete gate.
- Required private-QA build passed on Blacksmith Testbox `tbx_01kzbchf6y9pmrwyzvhewkckr8`, [Actions run 31096509614](https://github.com/openclaw/openclaw/actions/runs/31096509614), including all 149 public Plugin SDK subpaths.
- A factory/adapter mismatch attempts both cleanup phases before rejection; focused registry proof passed 13 tests, including cleanup failure without skipping post-gateway cleanup.
- Fresh post-repair whole-branch autoreview: clean, no accepted/actionable findings; correctness confidence 0.97.
- `git diff --check` passed.
