### PR TITLE
fix(agents): stop repeated equivalent terminal exec failures

### DIFF
--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -495,6 +495,49 @@ describe("before_tool_call loop detection behavior", () => {
     expectToolLoopBlockedResult(result, "identical outcomes");
   });
 
+  it("blocks changing-argument terminal exec failures and escalates vetoes", async () => {
+    const output = "Traceback: missing package\n\n(Command exited with code 1)";
+    const execute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: output }],
+      details: { status: "completed", exitCode: 1, aggregated: output },
+    });
+    const tool = createWrappedTool("exec", execute);
+
+    await withToolLoopEvents(async (emitted) => {
+      for (let index = 0; index <= GLOBAL_CIRCUIT_BREAKER_THRESHOLD; index += 1) {
+        const result = await tool.execute(
+          `exec-semantic-${index}`,
+          { command: `python job-${index}.py` },
+          undefined,
+          undefined,
+        );
+        if (index >= CRITICAL_THRESHOLD) {
+          expectToolLoopBlockedResult(
+            result,
+            index === GLOBAL_CIRCUIT_BREAKER_THRESHOLD
+              ? "global circuit breaker"
+              : "identical outcomes",
+          );
+        }
+      }
+
+      expect(execute).toHaveBeenCalledTimes(CRITICAL_THRESHOLD);
+      expect(emitted.find((event) => event.detector === "generic_repeat")).toMatchObject({
+        level: "critical",
+        action: "block",
+        count: CRITICAL_THRESHOLD,
+        toolName: "exec",
+      });
+      expect(emitted.at(-1)).toMatchObject({
+        detector: "global_circuit_breaker",
+        level: "critical",
+        action: "block",
+        count: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+        toolName: "exec",
+      });
+    });
+  });
+
   it("warns on non-strict same-tool argument churn while preserving tool execution", async () => {
     const execute = vi.fn().mockImplementation(async (toolCallId: string, _params: unknown) => {
       const progressed = toolCallId === "write-churn-progress";

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -80,6 +80,24 @@ function recordFailedCall(
   });
 }
 
+function createExecLoopResult(params: {
+  status: "completed" | "failed";
+  exitCode: number | null;
+  output: string;
+  aggregated?: string;
+  timedOut?: boolean;
+}) {
+  return {
+    content: [{ type: "text", text: params.output }],
+    details: {
+      status: params.status,
+      exitCode: params.exitCode,
+      aggregated: params.aggregated ?? params.output,
+      ...(params.timedOut === undefined ? {} : { timedOut: params.timedOut }),
+    },
+  };
+}
+
 function recordRepeatedSuccessfulCalls(params: {
   state: SessionState;
   toolName: string;
@@ -955,6 +973,246 @@ describe("tool-loop-detection", () => {
       );
 
       expect(loopResult.stuck).toBe(false);
+    });
+
+    it.each([
+      {
+        label: "completed normal process failures",
+        status: "completed",
+        exitCode: 1,
+        output: "Traceback: missing package\n\n(Command exited with code 1)",
+      },
+      {
+        label: "failed non-executable commands",
+        status: "failed",
+        exitCode: 126,
+        output: "Command not executable (permission denied)",
+        aggregated: "",
+      },
+      {
+        label: "failed missing commands",
+        status: "failed",
+        exitCode: 127,
+        output: "Command not found",
+        aggregated: "",
+      },
+    ] as const)("blocks repeated $label across changing exec arguments", (testCase) => {
+      const state = createState();
+      const result = createExecLoopResult(testCase);
+
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+        recordSuccessfulCall(state, "exec", { command: `python job-${index}.py` }, result, index);
+      }
+
+      expect(
+        state.toolCallHistory?.every((record) => record.outcomeKind === "terminal-exec-failure"),
+      ).toBe(true);
+      expect(
+        detectToolCallLoop(
+          state,
+          "exec",
+          { command: "python next-job.py" },
+          enabledLoopDetectionConfig,
+        ),
+      ).toMatchObject({
+        stuck: true,
+        level: "critical",
+        detector: "generic_repeat",
+        count: CRITICAL_THRESHOLD,
+      });
+    });
+
+    it("anchors changing-argument exec vetoes until the global circuit breaker", () => {
+      const state = createState();
+      const result = createExecLoopResult({
+        status: "completed",
+        exitCode: 1,
+        output: "Traceback: missing package\n\n(Command exited with code 1)",
+      });
+
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+        recordSuccessfulCall(state, "exec", { command: `python job-${index}.py` }, result, index);
+      }
+      for (let index = CRITICAL_THRESHOLD; index < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; index += 1) {
+        const params = { command: `python job-${index}.py` };
+        expect(detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig)).toMatchObject(
+          {
+            stuck: true,
+            level: "critical",
+            detector: "generic_repeat",
+            count: index,
+          },
+        );
+        expect(
+          recordToolCallOutcome(state, {
+            toolName: "exec",
+            toolParams: params,
+            toolCallId: `exec-veto-${index}`,
+            result: {
+              content: [{ type: "text", text: "blocked" }],
+              details: { status: "blocked", deniedReason: "tool-loop" },
+            },
+            config: enabledLoopDetectionConfig,
+          }),
+        ).toMatchObject({ outcomeKind: "tool-loop-veto", resultHash: undefined });
+      }
+
+      expect(
+        detectToolCallLoop(
+          state,
+          "exec",
+          { command: "python final-job.py" },
+          enabledLoopDetectionConfig,
+        ),
+      ).toMatchObject({
+        stuck: true,
+        level: "critical",
+        detector: "global_circuit_breaker",
+        count: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+      });
+    });
+
+    it.each([
+      {
+        label: "synthetic exit-code-only output",
+        result: createExecLoopResult({
+          status: "completed",
+          exitCode: 1,
+          output: "\n\n(Command exited with code 1)",
+        }),
+      },
+      {
+        label: "successful command batches",
+        result: createExecLoopResult({ status: "completed", exitCode: 0, output: "done" }),
+      },
+      {
+        label: "timed-out executions",
+        result: createExecLoopResult({
+          status: "failed",
+          exitCode: 1,
+          output: "Command timed out",
+          timedOut: true,
+        }),
+      },
+      {
+        label: "non-finite exit codes",
+        result: createExecLoopResult({
+          status: "failed",
+          exitCode: Number.POSITIVE_INFINITY,
+          output: "process failed",
+        }),
+      },
+      {
+        label: "failures without an exit code",
+        result: createExecLoopResult({
+          status: "failed",
+          exitCode: null,
+          output: "process failed before spawning",
+        }),
+      },
+    ])("does not semantically block $label", ({ result }) => {
+      const state = createState();
+      for (let index = 0; index < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; index += 1) {
+        recordSuccessfulCall(state, "exec", { command: `grep target-${index}` }, result, index);
+      }
+
+      expect(state.toolCallHistory?.every((record) => record.outcomeKind === undefined)).toBe(true);
+      expect(
+        detectToolCallLoop(
+          state,
+          "exec",
+          { command: "grep next-target" },
+          enabledLoopDetectionConfig,
+        ),
+      ).toEqual({ stuck: false });
+    });
+
+    it.each([
+      {
+        label: "a distinct terminal failure",
+        toolName: "exec",
+        result: createExecLoopResult({
+          status: "completed",
+          exitCode: 1,
+          output: "Traceback: different package\n\n(Command exited with code 1)",
+        }),
+      },
+      {
+        label: "a successful execution",
+        toolName: "exec",
+        result: createExecLoopResult({ status: "completed", exitCode: 0, output: "done" }),
+      },
+      {
+        label: "a timed-out execution",
+        toolName: "exec",
+        result: createExecLoopResult({
+          status: "failed",
+          exitCode: 1,
+          output: "Command timed out",
+          timedOut: true,
+        }),
+      },
+      {
+        label: "another tool",
+        toolName: "read",
+        result: { content: [{ type: "text", text: "read complete" }], details: { ok: true } },
+      },
+    ])("resets the semantic exec failure tail after $label", ({ toolName, result }) => {
+      const state = createState();
+      const failure = createExecLoopResult({
+        status: "completed",
+        exitCode: 1,
+        output: "Traceback: missing package\n\n(Command exited with code 1)",
+      });
+      for (let index = 0; index < CRITICAL_THRESHOLD - 1; index += 1) {
+        recordSuccessfulCall(state, "exec", { command: `python job-${index}.py` }, failure, index);
+      }
+      recordSuccessfulCall(state, toolName, { command: "interruption" }, result, 19);
+      recordSuccessfulCall(state, "exec", { command: "python latest.py" }, failure, 20);
+
+      expect(
+        detectToolCallLoop(
+          state,
+          "exec",
+          { command: "python next.py" },
+          enabledLoopDetectionConfig,
+        ),
+      ).toEqual({ stuck: false });
+    });
+
+    it("does not carry semantic exec failures into another run", () => {
+      const state = createState();
+      const result = createExecLoopResult({
+        status: "completed",
+        exitCode: 1,
+        output: "Traceback: missing package\n\n(Command exited with code 1)",
+      });
+
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+        const params = { command: `python job-${index}.py` };
+        const toolCallId = `exec-old-run-${index}`;
+        recordToolCall(state, "exec", params, toolCallId, enabledLoopDetectionConfig, {
+          runId: "old-run",
+        });
+        recordToolCallOutcome(state, {
+          toolName: "exec",
+          toolParams: params,
+          toolCallId,
+          result,
+          config: enabledLoopDetectionConfig,
+          runId: "old-run",
+        });
+      }
+
+      expect(
+        detectToolCallLoop(
+          state,
+          "exec",
+          { command: "python next.py" },
+          enabledLoopDetectionConfig,
+          { runId: "new-run" },
+        ),
+      ).toEqual({ stuck: false });
     });
 
     it("blocks repeated completed exec calls despite volatile runtime details", () => {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -310,7 +310,20 @@ function hashToolOutcome(
   if (toolName === "exec") {
     const execHash = hashExecToolOutcome(details, text);
     if (execHash) {
-      return { resultHash: execHash };
+      const exitCode = details.exitCode;
+      const output = nonEmptyStringField(details.aggregated) ?? text;
+      // Normal nonzero exits append this footer even when the command emitted nothing.
+      const terminalFailure =
+        (details.status === "completed" || details.status === "failed") &&
+        typeof exitCode === "number" &&
+        Number.isFinite(exitCode) &&
+        exitCode !== 0 &&
+        details.timedOut !== true &&
+        output !== "" &&
+        output !== `(Command exited with code ${exitCode})`;
+      return terminalFailure
+        ? { resultHash: execHash, outcomeKind: "terminal-exec-failure" }
+        : { resultHash: execHash };
     }
   }
   if (toolName === "write" && isWriteNoProgressOutcome(details)) {
@@ -631,7 +644,7 @@ export function detectToolCallLoop(
       level: "critical",
       detector: "generic_repeat",
       count: noProgressStreak,
-      message: `CRITICAL: Called ${toolName} with identical arguments and identical outcomes ${noProgressStreak} times. Session execution blocked to prevent runaway loops.`,
+      message: `CRITICAL: Called ${toolName} with identical outcomes ${noProgressStreak} times. Session execution blocked to prevent runaway loops.`,
       warningKey: `generic:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
     };
   }

--- a/src/agents/tool-loop-no-progress.ts
+++ b/src/agents/tool-loop-no-progress.ts
@@ -5,6 +5,21 @@ export function getNoProgressStreak(
   toolName: string,
   argsHash: string,
 ): { count: number; latestResultHash?: string } {
+  const repeatedArguments = countNoProgressStreak(history, toolName, argsHash, false);
+  if (toolName !== "exec") {
+    return repeatedArguments;
+  }
+  // Real terminal failures may repeat across fresh args; only a contiguous typed tail qualifies.
+  const terminalFailures = countNoProgressStreak(history, toolName, argsHash, true);
+  return terminalFailures.count > repeatedArguments.count ? terminalFailures : repeatedArguments;
+}
+
+function countNoProgressStreak(
+  history: readonly ToolCallRecord[],
+  toolName: string,
+  argsHash: string,
+  terminalExecFailuresOnly: boolean,
+): { count: number; latestResultHash?: string } {
   let streak = 0;
   let latestResultHash: string | undefined;
   // Vetoes are provisional until an older concrete outcome anchors them; a newer
@@ -13,7 +28,16 @@ export function getNoProgressStreak(
 
   for (let i = history.length - 1; i >= 0; i -= 1) {
     const record = history[i];
-    if (!record || record.toolName !== toolName || record.argsHash !== argsHash) {
+    if (!record) {
+      continue;
+    }
+    if (record.toolName !== toolName) {
+      if (terminalExecFailuresOnly) {
+        break;
+      }
+      continue;
+    }
+    if (!terminalExecFailuresOnly && record.argsHash !== argsHash) {
       continue;
     }
     if (record.outcomeKind === "tool-loop-veto") {
@@ -22,6 +46,9 @@ export function getNoProgressStreak(
     }
     if (typeof record.resultHash !== "string" || !record.resultHash) {
       continue;
+    }
+    if (terminalExecFailuresOnly && record.outcomeKind !== "terminal-exec-failure") {
+      break;
     }
     if (!latestResultHash) {
       latestResultHash = record.resultHash;
@@ -37,7 +64,7 @@ export function getNoProgressStreak(
   }
 
   return {
-    count: latestResultHash ? streak : pendingLoopVetoes,
+    count: latestResultHash ? streak : terminalExecFailuresOnly ? 0 : pendingLoopVetoes,
     latestResultHash,
   };
 }

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -24,7 +24,7 @@ export type ToolCallRecord = {
   argsHash: string;
   toolCallId?: string;
   runId?: string;
-  outcomeKind?: "tool-loop-veto";
+  outcomeKind?: "tool-loop-veto" | "terminal-exec-failure";
   resultHash?: string;
   noProgress?: true;
   unknownToolName?: string;


### PR DESCRIPTION
Fixes #117637

## What Problem This Solves

Forty argument-varying `exec` calls can repeat the same terminal failure without ever tripping loop detection because every command has a different argument hash. The agent continues consuming model calls, blocks its session, and repeats a meaningful failure indefinitely.

## What Changed

- Recognize completed or failed terminal `exec` results with a finite, nonzero exit code and the same meaningful output.
- Reuse the existing canonical outcome hash and contiguous same-tool, same-run failure history without parsing command strings, paths, or provider text.
- Ignore successful commands, timeouts, empty output, and synthetic exit-code-only footers to avoid blocking legitimate probes.
- Preserve the existing critical threshold of 20, global circuit-breaker threshold of 30, typed loop vetoes, and reset boundaries for tool, run, success, and changed output.

## Verification

- Focused loop-owner suite: **83/83 passed**.
- Actual before-tool-call boundary end-to-end suite: **99/99 passed**.
- Full five-path changed-file gate: **passed**.
- Independent authenticated review: **zero findings**, confidence **0.90**.
- Secret scanner: **clean**.
- Exact published head: `66eb1cbdb7b46fc901a16298a24db2a7c6bbc859`.
- Validation run: https://github.com/openclaw/openclaw/actions/runs/30757468899

## Live terminal proof (current head)

The actual terminal invocation `node <<'NODE'` loaded the committed production `src/agents/agent-tools.before-tool-call.wrapper.ts`, `src/agents/tool-loop-detection.ts`, and `src/logging/diagnostic-session-state.ts`. It executed `wrapToolWithBeforeToolCallHook` against synthetic exit-7 fixtures; the following are the actual redacted output lines:

```json
{"scenario":"identical-meaningful-failure","attempt":20,"status":"completed","exitCode":7,"stderr":"fixture stderr: FIXTURE_FAILURE_A"}
{"scenario":"identical-meaningful-failure","attempt":21,"status":"blocked","deniedReason":"tool-loop","detector":"generic_repeat"}
{"scenario":"identical-meaningful-failure","attempt":31,"status":"blocked","deniedReason":"tool-loop","detector":"global_circuit_breaker"}
{"scenario":"changed-output-reset","attempt":19,"status":"completed","exitCode":7,"stderr":"fixture stderr: FIXTURE_FAILURE_A"}
{"scenario":"changed-output-reset","attempt":20,"status":"completed","exitCode":7,"stderr":"fixture stderr: FIXTURE_FAILURE_B"}
{"scenario":"changed-output-reset","attempt":21,"status":"completed","exitCode":7,"stderr":"fixture stderr: FIXTURE_FAILURE_A"}
```

Actual terminal verdict:

```json
{"pr":118071,"head":"66eb1cbdb7b46fc901a16298a24db2a7c6bbc859","productionWrapper":"wrapToolWithBeforeToolCallHook","criticalThreshold":20,"firstBlockedAttempt":21,"globalCircuitBreakerThreshold":30,"globalBlockedAttempt":31,"sameMeaningfulNonzeroFailureBlocked":true,"nonzeroExitCode":7,"typedVeto":"tool-loop","typedVetoHistoryEntries":11,"blockedCallsNeverExecuted":true,"changedFailureOutputReset":true,"subsequentCallPermitted":true,"nextDetectorDecision":{"stuck":false},"resetScenarioActualExecutions":22,"redacted":true}
```
