### PR TITLE
refactor(ios): consolidate gateway connection test fixtures

### DIFF
--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -27,8 +27,12 @@ private func saveActiveManualGateway(
 
 private struct GatewayRegistryTestIsolation {
     private static let service = GatewaySettingsStore._testGatewayService
-    private static let registryAccount = "gateway-registry"
-    private static let legacyAccount = "lastConnection"
+    private static let keychainAccounts = [
+        "gateway-registry",
+        "lastConnection",
+        "preferredStableID",
+        "lastDiscoveredStableID",
+    ]
     private static let legacyDefaultsKeys = [
         "gateway.last.kind",
         "gateway.last.host",
@@ -37,62 +41,130 @@ private struct GatewayRegistryTestIsolation {
         "gateway.last.stableID",
     ]
 
-    private let previousRegistry: String?
-    private let previousLegacyConnection: String?
+    private let previousKeychain: [String: String?]
     private let previousDefaults: [String: Any?]
+    private let previousRelay: ShareGatewayRelayConfig?
 
     init() {
         gatewayPersistenceTestSemaphore.wait()
-        self.previousRegistry = KeychainStore.loadString(
-            service: Self.service,
-            account: Self.registryAccount)
-        self.previousLegacyConnection = KeychainStore.loadString(
-            service: Self.service,
-            account: Self.legacyAccount)
+        self.previousKeychain = Dictionary(uniqueKeysWithValues: Self.keychainAccounts.map { account in
+            (account, KeychainStore.loadString(service: Self.service, account: account))
+        })
         self.previousDefaults = Dictionary(uniqueKeysWithValues: Self.legacyDefaultsKeys.map { key in
             (key, UserDefaults.standard.object(forKey: key))
         })
-        _ = KeychainStore.delete(service: Self.service, account: Self.registryAccount)
-        _ = KeychainStore.delete(service: Self.service, account: Self.legacyAccount)
+        self.previousRelay = ShareGatewayRelaySettings.loadConfig()
+        for account in Self.keychainAccounts {
+            _ = KeychainStore.delete(service: Self.service, account: account)
+        }
         for key in Self.legacyDefaultsKeys {
             UserDefaults.standard.removeObject(forKey: key)
         }
     }
 
     func restore() {
-        if let previousRegistry {
-            _ = KeychainStore.saveString(
-                previousRegistry,
-                service: Self.service,
-                account: Self.registryAccount)
-        } else {
-            _ = KeychainStore.delete(service: Self.service, account: Self.registryAccount)
-        }
-        if let previousLegacyConnection {
-            _ = KeychainStore.saveString(
-                previousLegacyConnection,
-                service: Self.service,
-                account: Self.legacyAccount)
-        } else {
-            _ = KeychainStore.delete(service: Self.service, account: Self.legacyAccount)
+        for (account, value) in self.previousKeychain {
+            _ = KeychainStore.delete(service: Self.service, account: account)
+            if let value {
+                _ = KeychainStore.saveString(value, service: Self.service, account: account)
+            }
         }
         for (key, value) in self.previousDefaults {
+            UserDefaults.standard.removeObject(forKey: key)
             if let value {
                 UserDefaults.standard.set(value, forKey: key)
-            } else {
-                UserDefaults.standard.removeObject(forKey: key)
             }
+        }
+        ShareGatewayRelaySettings.clearConfig()
+        if let previousRelay {
+            ShareGatewayRelaySettings.saveConfig(previousRelay)
         }
         gatewayPersistenceTestSemaphore.signal()
     }
 }
 
+private struct TemporaryOpenClawState {
+    private let previousStateDirectory: String?
+    private let previousInstanceID: Any?
+    private let instanceID: String?
+    private let dir: URL
+
+    init(instanceID: String? = nil) throws {
+        self.previousStateDirectory = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
+        self.previousInstanceID = UserDefaults.standard.object(forKey: "node.instanceId")
+        self.instanceID = instanceID
+        self.dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: self.dir, withIntermediateDirectories: true)
+        setenv("OPENCLAW_STATE_DIR", self.dir.path, 1)
+        if let instanceID {
+            UserDefaults.standard.set(instanceID, forKey: "node.instanceId")
+        }
+    }
+
+    func restore() {
+        if let instanceID {
+            GatewaySettingsStore.deleteAllGatewayCredentials(instanceId: instanceID)
+        }
+        UserDefaults.standard.removeObject(forKey: "node.instanceId")
+        if let previousInstanceID {
+            UserDefaults.standard.set(previousInstanceID, forKey: "node.instanceId")
+        }
+        unsetenv("OPENCLAW_STATE_DIR")
+        if let previousStateDirectory {
+            setenv("OPENCLAW_STATE_DIR", previousStateDirectory, 1)
+        }
+        try? FileManager.default.removeItem(at: self.dir)
+    }
+}
+
+private let pairingScopeUpgradeProblem = GatewayConnectionProblem(
+    kind: .pairingScopeUpgradeRequired,
+    owner: .gateway,
+    title: "Additional permissions required",
+    message: "Approve the requested permissions on the gateway.",
+    requestId: "req-admin",
+    retryable: false,
+    pauseReconnect: true)
+
+private struct ControllableTLSProbe {
+    let started = AsyncStream<Void>.makeStream()
+    let results = AsyncStream<GatewayTLSFingerprintProbeResult>.makeStream()
+
+    @MainActor
+    func makeController(appModel: NodeAppModel) -> GatewayConnectionController {
+        GatewayConnectionController(
+            appModel: appModel,
+            startDiscovery: false,
+            tcpReachabilityProbe: { _, _, _, _ in true },
+            tlsFingerprintProbe: { _ in
+                self.started.continuation.yield()
+                for await result in self.results.stream {
+                    return result
+                }
+                return .failure(.certificateUnavailable)
+            })
+    }
+}
+
 @MainActor
-private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) async {
-    let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-    while appModel.activeGatewayConnectConfig?.effectiveStableID != stableID,
-          ContinuousClock().now < deadline
-    {
+private func makeTLSProbeController(
+    appModel: NodeAppModel,
+    fingerprint: String) -> GatewayConnectionController
+{
+    GatewayConnectionController(
+        appModel: appModel,
+        startDiscovery: false,
+        tcpReachabilityProbe: { _, _, _, _ in true },
+        tlsFingerprintProbe: { _ in .fingerprint(fingerprint) })
+}
+
+@MainActor
+private func waitUntil(
+    timeout: Duration = .seconds(3),
+    _ condition: @MainActor () -> Bool) async
+{
+    let deadline = ContinuousClock().now.advanced(by: timeout)
+    while !condition(), ContinuousClock().now < deadline {
         await Task.yield()
     }
 }
@@ -101,14 +173,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `retained display problem does not control next retry`() {
         let appModel = NodeAppModel()
         defer { appModel.disconnectGateway() }
-        let problem = GatewayConnectionProblem(
-            kind: .pairingScopeUpgradeRequired,
-            owner: .gateway,
-            title: "Additional permissions required",
-            message: "Approve the requested permissions on the gateway.",
-            requestId: "req-admin",
-            retryable: false,
-            pauseReconnect: true)
+        let problem = pairingScopeUpgradeProblem
         appModel._test_applyOperatorGatewayConnectionProblem(problem)
 
         appModel._test_prepareForGatewayConnect(
@@ -133,14 +198,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `active operator problem survives node cancellation`() {
         let appModel = NodeAppModel()
         defer { appModel.disconnectGateway() }
-        let problem = GatewayConnectionProblem(
-            kind: .pairingScopeUpgradeRequired,
-            owner: .gateway,
-            title: "Additional permissions required",
-            message: "Approve the requested permissions on the gateway.",
-            requestId: "req-admin",
-            retryable: false,
-            pauseReconnect: true)
+        let problem = pairingScopeUpgradeProblem
         appModel._test_applyOperatorGatewayConnectionProblem(problem)
 
         let cancelled = NSError(
@@ -477,14 +535,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         appModel._test_setGatewayConnected(true)
         appModel.gatewayServerName = "gateway.example.com"
         appModel.gatewayRemoteAddress = "127.0.0.1:53380"
-        let problem = GatewayConnectionProblem(
-            kind: .pairingScopeUpgradeRequired,
-            owner: .gateway,
-            title: "Additional permissions required",
-            message: "Approve the requested permissions on the gateway.",
-            requestId: "req-admin",
-            retryable: false,
-            pauseReconnect: true)
+        let problem = pairingScopeUpgradeProblem
 
         appModel._test_applyOperatorGatewayConnectionProblem(problem)
 
@@ -579,15 +630,10 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             token: lhs.token,
             bootstrapToken: lhs.bootstrapToken,
             password: lhs.password,
-            nodeOptions: GatewayConnectOptions(
-                role: "node",
-                scopes: [],
+            nodeOptions: Self.makeNodeOptions(
                 caps: ["canvas", "screen"],
                 commands: ["location.get", "notify"],
-                permissions: ["screen": true],
-                clientId: "ios",
-                clientMode: "node",
-                clientDisplayName: "Phone"))
+                permissions: ["screen": true]))
 
         #expect(lhs.hasSameConnectionInputs(as: rhs))
     }
@@ -637,14 +683,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         defer { appModel.disconnectGateway() }
         let config = Self.makeGatewayConnectConfig()
         appModel.applyGatewayConnectConfig(config)
-        let problem = GatewayConnectionProblem(
-            kind: .pairingScopeUpgradeRequired,
-            owner: .gateway,
-            title: "Additional permissions required",
-            message: "Approve the requested permissions on the gateway.",
-            requestId: "req-admin",
-            retryable: false,
-            pauseReconnect: true)
+        let problem = pairingScopeUpgradeProblem
         appModel._test_applyOperatorGatewayConnectionProblem(problem)
         #expect(appModel.gatewayPairingPaused)
 
@@ -667,14 +706,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         defer { appModel.disconnectGateway() }
         let config = Self.makeGatewayConnectConfig()
         appModel.applyGatewayConnectConfig(config)
-        let problem = GatewayConnectionProblem(
-            kind: .pairingScopeUpgradeRequired,
-            owner: .gateway,
-            title: "Additional permissions required",
-            message: "Approve the requested permissions on the gateway.",
-            requestId: "req-admin",
-            retryable: false,
-            pauseReconnect: true)
+        let problem = pairingScopeUpgradeProblem
         appModel._test_applyOperatorGatewayConnectionProblem(problem)
 
         appModel.beginGatewayPreconnectVerification(statusText: "Verifying gateway TLS fingerprint…")
@@ -855,15 +887,9 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `empty setup auth does not reuse stored gateway credentials`() async throws {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        let defaults = UserDefaults.standard
-        let previousInstanceID = defaults.object(forKey: "node.instanceId")
         let instanceID = "ios-test-\(UUID().uuidString)"
-        defaults.set(instanceID, forKey: "node.instanceId")
+        let temporaryState = try TemporaryOpenClawState(instanceID: instanceID)
+        defer { temporaryState.restore() }
         GatewaySettingsStore.saveGatewayCredentials(
             token: "stored-token",
             bootstrapToken: nil,
@@ -871,21 +897,6 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             gatewayStableID: "manual|stored.example.com|443",
             suppressStoredDeviceAuth: false,
             instanceId: instanceID)
-        defer {
-            GatewaySettingsStore.deleteAllGatewayCredentials(instanceId: instanceID)
-            if let previousInstanceID {
-                defaults.set(previousInstanceID, forKey: "node.instanceId")
-            } else {
-                defaults.removeObject(forKey: "node.instanceId")
-            }
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let link = GatewayConnectDeepLink(
             host: "192.168.1.41",
             port: 18789,
@@ -903,10 +914,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             port: link.port,
             useTLS: link.tls,
             authOverride: setupAuth.manualAuthOverride)
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while appModel.activeGatewayConnectConfig == nil, ContinuousClock().now < deadline {
-            await Task.yield()
-        }
+        await waitUntil { appModel.activeGatewayConnectConfig != nil }
 
         #expect(appModel.activeGatewayConnectConfig != nil)
         #expect(appModel.activeGatewayConnectConfig?.token == nil)
@@ -919,48 +927,10 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `legacy auth preserves proven relay credentials and otherwise requires full re-pair`() throws {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        let defaults = UserDefaults.standard
-        let previousInstanceID = defaults.string(forKey: "node.instanceId")
         let instanceID = "legacy-relay-\(UUID().uuidString)"
+        let temporaryState = try TemporaryOpenClawState(instanceID: instanceID)
+        defer { temporaryState.restore() }
         let gatewayService = GatewaySettingsStore._testGatewayService
-        let lastConnectionAccount = "gateway-registry"
-        let previousLastConnection = KeychainStore.loadString(
-            service: gatewayService,
-            account: lastConnectionAccount)
-        let previousRelay = ShareGatewayRelaySettings.loadConfig()
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defaults.set(instanceID, forKey: "node.instanceId")
-        defer {
-            GatewaySettingsStore.deleteAllGatewayCredentials(instanceId: instanceID)
-            if let previousInstanceID {
-                defaults.set(previousInstanceID, forKey: "node.instanceId")
-            } else {
-                defaults.removeObject(forKey: "node.instanceId")
-            }
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            if let previousLastConnection {
-                _ = KeychainStore.saveString(
-                    previousLastConnection,
-                    service: gatewayService,
-                    account: lastConnectionAccount)
-            } else {
-                _ = KeychainStore.delete(service: gatewayService, account: lastConnectionAccount)
-            }
-            if let previousRelay {
-                ShareGatewayRelaySettings.saveConfig(previousRelay)
-            } else {
-                ShareGatewayRelaySettings.clearConfig()
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
 
         let stableID = "manual|gateway.example.com|443"
         let primaryIdentity = DeviceIdentityStore.loadOrCreate()
@@ -1074,34 +1044,12 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     }
 
     @Test @MainActor func `successful setup handoff enables target scoped auth`() throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
-        let identity = DeviceIdentityStore.loadOrCreate()
         let previousStableID = "manual|previous.gateway.example.com|443"
         let stableID = "manual|new.gateway.example.com|443"
         let instanceID = "bootstrap-handoff-\(UUID().uuidString)"
-        let previousInstanceID = UserDefaults.standard.string(forKey: "node.instanceId")
-        UserDefaults.standard.set(instanceID, forKey: "node.instanceId")
-        defer {
-            GatewaySettingsStore.deleteAllGatewayCredentials(instanceId: instanceID)
-            if let previousInstanceID {
-                UserDefaults.standard.set(previousInstanceID, forKey: "node.instanceId")
-            } else {
-                UserDefaults.standard.removeObject(forKey: "node.instanceId")
-            }
-        }
+        let temporaryState = try TemporaryOpenClawState(instanceID: instanceID)
+        defer { temporaryState.restore() }
+        let identity = DeviceIdentityStore.loadOrCreate()
         _ = DeviceAuthStore.storeToken(
             deviceId: identity.deviceId,
             role: "node",
@@ -1112,15 +1060,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             role: "operator",
             token: "previous-operator-token",
             gatewayID: previousStableID)
-        var nodeOptions = GatewayConnectOptions(
-            role: "node",
-            scopes: [],
-            caps: [],
-            commands: [],
-            permissions: [:],
-            clientId: "ios",
-            clientMode: "node",
-            clientDisplayName: "Phone",
+        var nodeOptions = Self.makeNodeOptions(
             allowStoredDeviceAuth: false,
             deviceAuthGatewayID: stableID)
         let config = try GatewayConnectConfig(
@@ -1201,22 +1141,13 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     }
 
     @Test @MainActor func `bootstrap pairing clears only the target gateway`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
+        let temporaryState = try TemporaryOpenClawState()
+        defer { temporaryState.restore() }
         let gatewayA = "manual|gateway-a-\(UUID().uuidString)|443"
         let gatewayB = "manual|gateway-b-\(UUID().uuidString)|443"
         defer {
             GatewayTLSStore.clearFingerprint(stableID: gatewayA)
             GatewayTLSStore.clearFingerprint(stableID: gatewayB)
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
         }
 
         let primaryIdentity = DeviceIdentityStore.loadOrCreate()
@@ -1279,15 +1210,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             token: "shared-token",
             bootstrapToken: nil,
             password: nil,
-            nodeOptions: GatewayConnectOptions(
-                role: "node",
-                scopes: [],
-                caps: [],
-                commands: [],
-                permissions: [:],
-                clientId: "ios",
-                clientMode: "node",
-                clientDisplayName: "Phone",
+            nodeOptions: Self.makeNodeOptions(
                 allowStoredDeviceAuth: false,
                 deviceAuthGatewayID: stableID))
 
@@ -1353,10 +1276,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             await appModel.resetGatewaySessionsForForcedReconnect()
             resetFinished = true
         }
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while !cleanupStarted, ContinuousClock().now < deadline {
-            await Task.yield()
-        }
+        await waitUntil { cleanupStarted }
 
         #expect(cleanupStarted)
         #expect(appModel.hasGatewaySessionResetInFlight)
@@ -1401,7 +1321,6 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `target switch reset clears previous reconnect route`() async {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let defaults = UserDefaults.standard
         let reconnectDefaults: [String: Any?] = [
             "gateway.autoconnect": true,
             "gateway.manual.enabled": true,
@@ -1409,119 +1328,74 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             "gateway.manual.port": 443,
             "gateway.manual.tls": true,
         ]
-        var reconnectDefaultsSnapshot: [String: Any?] = [:]
-        for key in reconnectDefaults.keys {
-            reconnectDefaultsSnapshot[key] = defaults.object(forKey: key)
-        }
-        let gatewayService = GatewaySettingsStore._testGatewayService
-        let lastConnectionAccount = "gateway-registry"
-        let priorLastConnection = KeychainStore.loadString(
-            service: gatewayService,
-            account: lastConnectionAccount)
-        let priorRelayConfig = ShareGatewayRelaySettings.loadConfig()
-        defer {
-            if let priorRelayConfig {
-                ShareGatewayRelaySettings.saveConfig(priorRelayConfig)
-            } else {
-                ShareGatewayRelaySettings.clearConfig()
-            }
-        }
-        defer {
-            for (key, value) in reconnectDefaultsSnapshot {
-                if let value {
-                    defaults.set(value, forKey: key)
-                } else {
-                    defaults.removeObject(forKey: key)
-                }
-            }
-            if let priorLastConnection {
-                _ = KeychainStore.saveString(
-                    priorLastConnection,
-                    service: gatewayService,
-                    account: lastConnectionAccount)
-            } else {
-                _ = KeychainStore.delete(service: gatewayService, account: lastConnectionAccount)
-            }
-        }
-        for (key, value) in reconnectDefaults {
-            defaults.set(value, forKey: key)
-        }
-        saveActiveManualGateway(
-            host: "previous.gateway.invalid",
-            port: 443,
-            useTLS: true,
-            stableID: "manual|previous.gateway.invalid|443")
-        let appModel = NodeAppModel()
-        defer { appModel.disconnectGateway() }
+        await withUserDefaults(reconnectDefaults) {
+            let defaults = UserDefaults.standard
+            saveActiveManualGateway(
+                host: "previous.gateway.invalid",
+                port: 443,
+                useTLS: true,
+                stableID: "manual|previous.gateway.invalid|443")
+            let appModel = NodeAppModel()
+            defer { appModel.disconnectGateway() }
 
-        ShareGatewayRelaySettings.saveConfig(ShareGatewayRelayConfig(
-            gatewayURLString: "wss://previous.gateway.invalid",
-            token: "previous-token",
-            password: nil,
-            sessionKey: "main"))
-        appModel.applyGatewayConnectConfig(Self.makeGatewayConnectConfig())
-        await appModel.resetGatewaySessionsForTargetSwitch()
+            ShareGatewayRelaySettings.saveConfig(ShareGatewayRelayConfig(
+                gatewayURLString: "wss://previous.gateway.invalid",
+                token: "previous-token",
+                password: nil,
+                sessionKey: "main"))
+            appModel.applyGatewayConnectConfig(Self.makeGatewayConnectConfig())
+            await appModel.resetGatewaySessionsForTargetSwitch()
 
-        #expect(!appModel.gatewayAutoReconnectEnabled)
-        #expect(!defaults.bool(forKey: "gateway.autoconnect"))
-        #expect(appModel.activeGatewayConnectConfig == nil)
-        #expect(appModel.gatewayServerName == nil)
-        #expect(!appModel._test_hasGatewayLoopTasks().node)
-        #expect(!appModel._test_hasGatewayLoopTasks().operator)
-        #expect(!appModel._test_hasChatSessionRoutingRestoreTask())
-        #expect(ShareGatewayRelaySettings.loadConfig() == nil)
+            #expect(!appModel.gatewayAutoReconnectEnabled)
+            #expect(!defaults.bool(forKey: "gateway.autoconnect"))
+            #expect(appModel.activeGatewayConnectConfig == nil)
+            #expect(appModel.gatewayServerName == nil)
+            #expect(!appModel._test_hasGatewayLoopTasks().node)
+            #expect(!appModel._test_hasGatewayLoopTasks().operator)
+            #expect(!appModel._test_hasChatSessionRoutingRestoreTask())
+            #expect(ShareGatewayRelaySettings.loadConfig() == nil)
 
-        let relaunchedModel = NodeAppModel()
-        defer { relaunchedModel.disconnectGateway() }
-        let relaunchedController = GatewayConnectionController(
-            appModel: relaunchedModel,
-            startDiscovery: false)
-        relaunchedController._test_triggerAutoConnect()
+            let relaunchedModel = NodeAppModel()
+            defer { relaunchedModel.disconnectGateway() }
+            let relaunchedController = GatewayConnectionController(
+                appModel: relaunchedModel,
+                startDiscovery: false)
+            relaunchedController._test_triggerAutoConnect()
 
-        #expect(!relaunchedController._test_didAutoConnect())
-        #expect(relaunchedModel.activeGatewayConnectConfig == nil)
+            #expect(!relaunchedController._test_didAutoConnect())
+            #expect(relaunchedModel.activeGatewayConnectConfig == nil)
+        }
     }
 
     @Test @MainActor func `target switch reset reasserts persisted reconnect pause after teardown`() async {
-        let defaults = UserDefaults.standard
-        let priorAutoConnect = defaults.object(forKey: "gateway.autoconnect")
-        defer {
-            if let priorAutoConnect {
-                defaults.set(priorAutoConnect, forKey: "gateway.autoconnect")
-            } else {
-                defaults.removeObject(forKey: "gateway.autoconnect")
+        await withUserDefaults(["gateway.autoconnect": true]) {
+            let defaults = UserDefaults.standard
+            let teardownRelease = AsyncStream<Void>.makeStream()
+            let appModel = NodeAppModel()
+            defer {
+                appModel._test_setGatewaySessionResetTask(nil)
+                appModel.disconnectGateway()
             }
-        }
-        defaults.set(true, forKey: "gateway.autoconnect")
-
-        let teardownRelease = AsyncStream<Void>.makeStream()
-        let appModel = NodeAppModel()
-        defer {
-            appModel._test_setGatewaySessionResetTask(nil)
-            appModel.disconnectGateway()
-        }
-        let staleTeardownTask = Task {
-            for await _ in teardownRelease.stream {
-                defaults.set(true, forKey: "gateway.autoconnect")
-                return
+            let staleTeardownTask = Task {
+                for await _ in teardownRelease.stream {
+                    defaults.set(true, forKey: "gateway.autoconnect")
+                    return
+                }
             }
-        }
-        appModel._test_setGatewaySessionResetTask(staleTeardownTask)
+            appModel._test_setGatewaySessionResetTask(staleTeardownTask)
 
-        let targetResetTask = Task {
-            await appModel.resetGatewaySessionsForTargetSwitch()
-        }
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while defaults.bool(forKey: "gateway.autoconnect"), ContinuousClock().now < deadline {
-            await Task.yield()
-        }
-        #expect(!defaults.bool(forKey: "gateway.autoconnect"))
+            let targetResetTask = Task {
+                await appModel.resetGatewaySessionsForTargetSwitch()
+            }
+            await waitUntil { !defaults.bool(forKey: "gateway.autoconnect") }
+            #expect(!defaults.bool(forKey: "gateway.autoconnect"))
 
-        teardownRelease.continuation.yield()
-        teardownRelease.continuation.finish()
-        await targetResetTask.value
+            teardownRelease.continuation.yield()
+            teardownRelease.continuation.finish()
+            await targetResetTask.value
 
-        #expect(!defaults.bool(forKey: "gateway.autoconnect"))
+            #expect(!defaults.bool(forKey: "gateway.autoconnect"))
+        }
     }
 
     @Test @MainActor func `newer gateway connect generation rejects queued config`() throws {
@@ -1568,21 +1442,10 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         defer { GatewayTLSStore.clearFingerprint(stableID: stableID) }
         GatewayTLSStore.clearFingerprint(stableID: stableID)
 
-        let probeStarted = AsyncStream<Void>.makeStream()
-        let probeResults = AsyncStream<GatewayTLSFingerprintProbeResult>.makeStream()
+        let probe = ControllableTLSProbe()
         let appModel = NodeAppModel()
         defer { appModel.disconnectGateway() }
-        let controller = GatewayConnectionController(
-            appModel: appModel,
-            startDiscovery: false,
-            tcpReachabilityProbe: { _, _, _, _ in true },
-            tlsFingerprintProbe: { _ in
-                probeStarted.continuation.yield()
-                for await result in probeResults.stream {
-                    return result
-                }
-                return .failure(.certificateUnavailable)
-            })
+        let controller = probe.makeController(appModel: appModel)
         let staleGeneration = appModel.beginGatewayConnectAttempt()
         let staleConfig = try Self.makeGatewayConnectConfig(
             url: #require(URL(string: "wss://old-target.gateway.invalid")),
@@ -1590,7 +1453,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         let duringResolutionConfig = try Self.makeGatewayConnectConfig(
             url: #require(URL(string: "wss://resolution-window.gateway.invalid")),
             stableID: "manual|resolution-window.gateway.invalid|443")
-        var startedIterator = probeStarted.stream.makeAsyncIterator()
+        var startedIterator = probe.started.stream.makeAsyncIterator()
 
         let connectTask = Task {
             await controller.connectManual(host: host, port: 443, useTLS: true)
@@ -1601,8 +1464,8 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         #expect(appModel.activeGatewayConnectConfig == nil)
 
         let duringResolutionGeneration = appModel.gatewayConnectGeneration
-        probeResults.continuation.yield(.fingerprint("new-target-fingerprint"))
-        probeResults.continuation.finish()
+        probe.results.continuation.yield(.fingerprint("new-target-fingerprint"))
+        probe.results.continuation.finish()
         await connectTask.value
         await controller.acceptPendingTrustPrompt()
         appModel.applyGatewayConnectConfig(
@@ -1612,7 +1475,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         #expect(appModel.activeGatewayConnectConfig?.stableID != duringResolutionConfig.stableID)
     }
 
-    @Test @MainActor func `trusted certificate keeps device auth route scoped`() async throws {
+    @Test @MainActor func `trusted certificate keeps device auth route scoped`() async {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
         let host = "127.0.0.1"
@@ -1621,23 +1484,19 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         GatewayTLSStore.clearFingerprint(stableID: stableID)
         let appModel = NodeAppModel()
         defer { appModel.disconnectGateway() }
-        let controller = GatewayConnectionController(
+        let controller = makeTLSProbeController(
             appModel: appModel,
-            startDiscovery: false,
-            tcpReachabilityProbe: { _, _, _, _ in true },
-            tlsFingerprintProbe: { _ in .fingerprint("route-independent-fingerprint") })
+            fingerprint: "route-independent-fingerprint")
 
         await controller.connectManual(host: host, port: 1, useTLS: true)
         await controller.acceptPendingTrustPrompt()
-        for _ in 0..<100 where appModel.activeGatewayConnectConfig == nil {
-            try await Task.sleep(for: .milliseconds(10))
-        }
+        await waitUntil(timeout: .seconds(1)) { appModel.activeGatewayConnectConfig != nil }
 
         #expect(appModel.activeGatewayConnectConfig?.stableID == stableID)
         #expect(appModel.activeGatewayConnectConfig?.nodeOptions.deviceAuthGatewayID == stableID)
     }
 
-    @Test @MainActor func `discovered connect preserves exact device auth owner bytes`() async throws {
+    @Test @MainActor func `discovered connect preserves exact device auth owner bytes`() async {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
         let stableID = "\u{0085}gateway-e\u{0301}"
@@ -1674,9 +1533,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
 
         #expect(await controller.connectWithDiagnostics(gateway) == nil)
         await controller.acceptPendingTrustPrompt()
-        for _ in 0..<100 where appModel.activeGatewayConnectConfig == nil {
-            try await Task.sleep(for: .milliseconds(10))
-        }
+        await waitUntil(timeout: .seconds(1)) { appModel.activeGatewayConnectConfig != nil }
 
         #expect(persistedOwnerBytes.withLock { $0 } == Array(stableID.utf8))
         #expect(appModel.activeGatewayConnectConfig.map { Array($0.stableID.utf8) } == Array(stableID.utf8))
@@ -1716,17 +1573,9 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         #expect(GatewayTLSStore.replaceFingerprint("old-certificate", stableID: stableID))
         let appModel = NodeAppModel()
         defer { appModel.disconnectGateway() }
-        var options = GatewayConnectOptions(
-            role: "node",
-            scopes: [],
-            caps: [],
-            commands: [],
-            permissions: [:],
-            clientId: "openclaw-ios",
-            clientMode: "node",
-            clientDisplayName: nil,
+        let options = Self.makeNodeOptions(
+            client: ("openclaw-ios", nil),
             deviceAuthGatewayID: stableID)
-        options.allowStoredDeviceAuth = true
         let config = try GatewayConnectConfig(
             url: #require(URL(string: "wss://127.0.0.1:1")),
             stableID: stableID,
@@ -1794,10 +1643,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         controller.cancelPendingConnectionAttempts()
         resetRelease.continuation.yield()
         resetRelease.continuation.finish()
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while !appModel._test_hasGatewayLoopTasks().node, ContinuousClock().now < deadline {
-            await Task.yield()
-        }
+        await waitUntil { appModel._test_hasGatewayLoopTasks().node }
 
         #expect(appModel.activeGatewayConnectConfig?.hasSameConnectionInputs(as: currentConfig) == true)
         #expect(appModel._test_hasGatewayLoopTasks().node)
@@ -1857,10 +1703,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         await controller.connectManual(host: forceHost, port: 18789, useTLS: false, forceReconnect: true)
         // Simulator WebSocket teardown can take several seconds under the aggregate iOS suite.
         // Keep this bounded while allowing the real session barrier to finish before superseding it.
-        let resetStartDeadline = ContinuousClock().now.advanced(by: .seconds(10))
-        while !resetStarted, ContinuousClock().now < resetStartDeadline {
-            await Task.yield()
-        }
+        await waitUntil(timeout: .seconds(10)) { resetStarted }
         #expect(resetStarted)
         await controller.connectManual(host: "192.168.1.40", port: 18789, useTLS: false)
 
@@ -1870,12 +1713,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         resetRelease.continuation.yield()
         resetRelease.continuation.finish()
         let replacementStableID = "manual|192.168.1.40|18789"
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while appModel.activeGatewayConnectConfig?.stableID != replacementStableID,
-              ContinuousClock().now < deadline
-        {
-            await Task.yield()
-        }
+        await waitUntil { appModel.activeGatewayConnectConfig?.stableID == replacementStableID }
 
         #expect(appModel.activeGatewayConnectConfig?.stableID == replacementStableID)
         #expect(appModel._test_hasGatewayLoopTasks().node)
@@ -1910,12 +1748,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         resetRelease.continuation.yield()
         resetRelease.continuation.finish()
         let replacementStableID = "manual|192.168.1.41|18789"
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while appModel.activeGatewayConnectConfig?.stableID != replacementStableID,
-              ContinuousClock().now < deadline
-        {
-            await Task.yield()
-        }
+        await waitUntil { appModel.activeGatewayConnectConfig?.stableID == replacementStableID }
 
         #expect(appModel.activeGatewayConnectConfig?.stableID == replacementStableID)
     }
@@ -1923,7 +1756,6 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `trust decline releases suppression without reconnecting unpinned target`() async {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let defaults = UserDefaults.standard
         let updates: [String: Any?] = [
             "gateway.autoconnect": false,
             "gateway.manual.enabled": true,
@@ -1932,64 +1764,38 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             "gateway.manual.tls": true,
             "node.instanceId": "ios-test",
         ]
-        var snapshot: [String: Any?] = [:]
-        for key in updates.keys {
-            snapshot[key] = defaults.object(forKey: key)
-        }
-        for (key, value) in updates {
-            defaults.set(value, forKey: key)
-        }
-        defer {
-            for (key, value) in snapshot {
-                if let value {
-                    defaults.set(value, forKey: key)
-                } else {
-                    defaults.removeObject(forKey: key)
-                }
+        await withUserDefaults(updates) {
+            let explicitHost = "explicit.gateway.invalid"
+            let explicitStableID = "manual|\(explicitHost)|443"
+            defer { GatewayTLSStore.clearFingerprint(stableID: explicitStableID) }
+            GatewayTLSStore.clearFingerprint(stableID: explicitStableID)
+            let probe = ControllableTLSProbe()
+            let appModel = NodeAppModel()
+            defer { appModel.disconnectGateway() }
+            let controller = probe.makeController(appModel: appModel)
+            UserDefaults.standard.set(true, forKey: "gateway.autoconnect")
+            var startedIterator = probe.started.stream.makeAsyncIterator()
+
+            let connectTask = Task {
+                await controller.connectManual(host: explicitHost, port: 443, useTLS: true)
             }
+            _ = await startedIterator.next()
+            controller._test_triggerAutoConnect()
+
+            #expect(!controller._test_didAutoConnect())
+            #expect(appModel.activeGatewayConnectConfig == nil)
+
+            probe.results.continuation.yield(.fingerprint("explicit-fingerprint"))
+            probe.results.continuation.finish()
+            await connectTask.value
+            #expect(controller.pendingTrustPrompt?.fingerprintSha256 == "explicit-fingerprint")
+
+            controller.declinePendingTrustPrompt()
+
+            #expect(!controller._test_didAutoConnect())
+            #expect(!controller._test_isAutoConnectSuppressed())
+            #expect(appModel.activeGatewayConnectConfig == nil)
         }
-
-        let explicitHost = "explicit.gateway.invalid"
-        let explicitStableID = "manual|\(explicitHost)|443"
-        defer { GatewayTLSStore.clearFingerprint(stableID: explicitStableID) }
-        GatewayTLSStore.clearFingerprint(stableID: explicitStableID)
-        let probeStarted = AsyncStream<Void>.makeStream()
-        let probeResults = AsyncStream<GatewayTLSFingerprintProbeResult>.makeStream()
-        let appModel = NodeAppModel()
-        defer { appModel.disconnectGateway() }
-        let controller = GatewayConnectionController(
-            appModel: appModel,
-            startDiscovery: false,
-            tcpReachabilityProbe: { _, _, _, _ in true },
-            tlsFingerprintProbe: { _ in
-                probeStarted.continuation.yield()
-                for await result in probeResults.stream {
-                    return result
-                }
-                return .failure(.certificateUnavailable)
-            })
-        defaults.set(true, forKey: "gateway.autoconnect")
-        var startedIterator = probeStarted.stream.makeAsyncIterator()
-
-        let connectTask = Task {
-            await controller.connectManual(host: explicitHost, port: 443, useTLS: true)
-        }
-        _ = await startedIterator.next()
-        controller._test_triggerAutoConnect()
-
-        #expect(!controller._test_didAutoConnect())
-        #expect(appModel.activeGatewayConnectConfig == nil)
-
-        probeResults.continuation.yield(.fingerprint("explicit-fingerprint"))
-        probeResults.continuation.finish()
-        await connectTask.value
-        #expect(controller.pendingTrustPrompt?.fingerprintSha256 == "explicit-fingerprint")
-
-        controller.declinePendingTrustPrompt()
-
-        #expect(!controller._test_didAutoConnect())
-        #expect(!controller._test_isAutoConnectSuppressed())
-        #expect(appModel.activeGatewayConnectConfig == nil)
     }
 
     @Test @MainActor func `active manual TLS auto connect wins over legacy manual defaults`() async {
@@ -2039,7 +1845,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             GatewayTLSStore.saveFingerprint("trusted-certificate", stableID: stableID)
             controller._test_triggerAutoConnect()
             #expect(controller._test_didAutoConnect())
-            await waitForActiveGateway(stableID: stableID, appModel: appModel)
+            await waitUntil { appModel.activeGatewayConnectConfig?.effectiveStableID == stableID }
             #expect(appModel.activeGatewayConnectConfig?.effectiveStableID == stableID)
         }
     }
@@ -2066,7 +1872,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             controller._test_triggerAutoConnect()
 
             #expect(controller._test_didAutoConnect())
-            await waitForActiveGateway(stableID: stableID, appModel: appModel)
+            await waitUntil { appModel.activeGatewayConnectConfig?.effectiveStableID == stableID }
             #expect(appModel.activeGatewayConnectConfig?.effectiveStableID == stableID)
             #expect(appModel.activeGatewayConnectConfig?.url == URL(string: "ws://127.0.0.1:1"))
         }
@@ -2101,7 +1907,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             controller._test_triggerAutoConnect()
 
             #expect(controller._test_didAutoConnect())
-            await waitForActiveGateway(stableID: manualID, appModel: appModel)
+            await waitUntil { appModel.activeGatewayConnectConfig?.effectiveStableID == manualID }
             #expect(appModel.activeGatewayConnectConfig?.effectiveStableID == manualID)
             #expect(GatewaySettingsStore.activeGatewayEntry()?.stableID == manualID)
         }
@@ -2110,14 +1916,6 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `forget gateway clears matching share relay only`() async {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let priorRelay = ShareGatewayRelaySettings.loadConfig()
-        defer {
-            if let priorRelay {
-                ShareGatewayRelaySettings.saveConfig(priorRelay)
-            } else {
-                ShareGatewayRelaySettings.clearConfig()
-            }
-        }
         let stableID = "manual|forgotten.example.com|443"
         ShareGatewayRelaySettings.saveConfig(.init(
             gatewayURLString: "wss://forgotten.example.com",
@@ -2186,17 +1984,6 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `forget connected gateway waits for disconnect before device auth cleanup`() async throws {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let service = GatewaySettingsStore._testGatewayService
-        let account = "gateway-registry"
-        let prior = KeychainStore.loadString(service: service, account: account)
-        defer {
-            if let prior {
-                _ = KeychainStore.saveString(prior, service: service, account: account)
-            } else {
-                _ = KeychainStore.delete(service: service, account: account)
-            }
-        }
-        _ = KeychainStore.delete(service: service, account: account)
         let connectedID = "manual|connected.example.com|443"
         let selectedID = "manual|selected.example.com|443"
         saveActiveManualGateway(host: "selected.example.com", port: 443, useTLS: true, stableID: selectedID)
@@ -2231,10 +2018,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         let forgetTask = Task { @MainActor in
             await controller.forgetGateway(stableID: connectedID)
         }
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while appModel.activeGatewayConnectConfig != nil, ContinuousClock().now < deadline {
-            await Task.yield()
-        }
+        await waitUntil { appModel.activeGatewayConnectConfig == nil }
         #expect(appModel.activeGatewayConnectConfig == nil)
 
         _ = DeviceAuthStore.storeToken(
@@ -2257,17 +2041,6 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `forget selected gateway preserves a different live route`() async throws {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let service = GatewaySettingsStore._testGatewayService
-        let account = "gateway-registry"
-        let prior = KeychainStore.loadString(service: service, account: account)
-        defer {
-            if let prior {
-                _ = KeychainStore.saveString(prior, service: service, account: account)
-            } else {
-                _ = KeychainStore.delete(service: service, account: account)
-            }
-        }
-        _ = KeychainStore.delete(service: service, account: account)
         let selectedID = "manual|selected.example.com|443"
         let connectedID = "manual|connected.example.com|443"
         saveActiveManualGateway(host: "selected.example.com", port: 443, useTLS: true, stableID: selectedID)
@@ -2300,20 +2073,6 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         let service = GatewaySettingsStore._testGatewayService
         let preferredAccount = "preferredStableID"
         let lastAccount = "lastDiscoveredStableID"
-        let priorPreferred = KeychainStore.loadString(service: service, account: preferredAccount)
-        let priorLast = KeychainStore.loadString(service: service, account: lastAccount)
-        defer {
-            if let priorPreferred {
-                _ = KeychainStore.saveString(priorPreferred, service: service, account: preferredAccount)
-            } else {
-                _ = KeychainStore.delete(service: service, account: preferredAccount)
-            }
-            if let priorLast {
-                _ = KeychainStore.saveString(priorLast, service: service, account: lastAccount)
-            } else {
-                _ = KeychainStore.delete(service: service, account: lastAccount)
-            }
-        }
         let forgottenID = "bonjour|forgotten"
         let keptID = "bonjour|kept"
         _ = KeychainStore.saveString(forgottenID, service: service, account: preferredAccount)
@@ -2340,17 +2099,6 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `forget gateway cancels its pending trust handoff`() async {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let service = GatewaySettingsStore._testGatewayService
-        let account = "gateway-registry"
-        let prior = KeychainStore.loadString(service: service, account: account)
-        defer {
-            if let prior {
-                _ = KeychainStore.saveString(prior, service: service, account: account)
-            } else {
-                _ = KeychainStore.delete(service: service, account: account)
-            }
-        }
-        _ = KeychainStore.delete(service: service, account: account)
         let host = "pending-trust.example.com"
         let port = 443
         let stableID = GatewayConnectionController.ManualAuthOverride.manualStableID(host: host, port: port)
@@ -2358,11 +2106,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         GatewayTLSStore.clearFingerprint(stableID: stableID)
         let appModel = NodeAppModel()
         defer { appModel.disconnectGateway() }
-        let controller = GatewayConnectionController(
-            appModel: appModel,
-            startDiscovery: false,
-            tcpReachabilityProbe: { _, _, _, _ in true },
-            tlsFingerprintProbe: { _ in .fingerprint("forgotten-fingerprint") })
+        let controller = makeTLSProbeController(appModel: appModel, fingerprint: "forgotten-fingerprint")
 
         await controller.connectManual(host: host, port: port, useTLS: true)
         #expect(controller.pendingTrustPrompt?.stableID == stableID)
@@ -2385,11 +2129,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         GatewayTLSStore.clearFingerprint(stableID: pendingID)
         let appModel = NodeAppModel()
         defer { appModel.disconnectGateway() }
-        let controller = GatewayConnectionController(
-            appModel: appModel,
-            startDiscovery: false,
-            tcpReachabilityProbe: { _, _, _, _ in true },
-            tlsFingerprintProbe: { _ in .fingerprint("kept-fingerprint") })
+        let controller = makeTLSProbeController(appModel: appModel, fingerprint: "kept-fingerprint")
 
         await controller.connectManual(host: pendingHost, port: 443, useTLS: true)
         #expect(controller.pendingTrustPrompt?.stableID == pendingID)
@@ -2413,22 +2153,13 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         try appModel.applyGatewayConnectConfig(Self.makeGatewayConnectConfig(
             url: #require(URL(string: "wss://connected-before-forget.example.com")),
             stableID: connectedID))
-        let controller = GatewayConnectionController(
-            appModel: appModel,
-            startDiscovery: false,
-            tcpReachabilityProbe: { _, _, _, _ in true },
-            tlsFingerprintProbe: { _ in .fingerprint("replacement-fingerprint") })
+        let controller = makeTLSProbeController(appModel: appModel, fingerprint: "replacement-fingerprint")
 
         await controller.connectManual(host: replacementHost, port: 443, useTLS: true)
         #expect(controller.pendingTrustPrompt?.stableID == replacementID)
         await controller.forgetGateway(stableID: connectedID)
         await controller.acceptPendingTrustPrompt()
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while appModel.activeGatewayConnectConfig?.effectiveStableID != replacementID,
-              ContinuousClock().now < deadline
-        {
-            try await Task.sleep(for: .milliseconds(10))
-        }
+        await waitUntil { appModel.activeGatewayConnectConfig?.effectiveStableID == replacementID }
 
         #expect(appModel.activeGatewayConnectConfig?.effectiveStableID == replacementID)
     }
@@ -2511,7 +2242,6 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `failed replacement restores inherited scanner reconnect state`() async throws {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let defaults = UserDefaults.standard
         let updates: [String: Any?] = [
             "gateway.autoconnect": true,
             "gateway.manual.enabled": false,
@@ -2519,54 +2249,33 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             "gateway.preferredStableID": nil,
             "gateway.lastDiscoveredStableID": nil,
         ]
-        var snapshot: [String: Any?] = [:]
-        for key in updates.keys {
-            snapshot[key] = defaults.object(forKey: key)
-        }
-        for (key, value) in updates {
-            if let value {
-                defaults.set(value, forKey: key)
-            } else {
-                defaults.removeObject(forKey: key)
-            }
-        }
-        defer {
-            for (key, value) in snapshot {
-                if let value {
-                    defaults.set(value, forKey: key)
-                } else {
-                    defaults.removeObject(forKey: key)
-                }
-            }
-        }
-        let appModel = NodeAppModel()
-        defer { appModel.disconnectGateway() }
-        let suspendedConfig = try Self.makeGatewayConnectConfig(
-            url: #require(URL(string: "ws://127.0.0.1:1")),
-            stableID: "manual|127.0.0.1|1")
-        appModel.applyGatewayConnectConfig(suspendedConfig)
-        appModel.gatewayAutoReconnectEnabled = true
-        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
-        _ = controller.cancelPendingConnectionAttempts(suspendCurrentGateway: true)
+        try await withUserDefaults(updates) {
+            let defaults = UserDefaults.standard
+            let appModel = NodeAppModel()
+            defer { appModel.disconnectGateway() }
+            let suspendedConfig = try Self.makeGatewayConnectConfig(
+                url: #require(URL(string: "ws://127.0.0.1:1")),
+                stableID: "manual|127.0.0.1|1")
+            appModel.applyGatewayConnectConfig(suspendedConfig)
+            appModel.gatewayAutoReconnectEnabled = true
+            let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+            _ = controller.cancelPendingConnectionAttempts(suspendCurrentGateway: true)
 
-        await controller.connectManual(host: "invalid.example.com", port: 70000, useTLS: true)
+            await controller.connectManual(host: "invalid.example.com", port: 70000, useTLS: true)
+            await waitUntil {
+                appModel.activeGatewayConnectConfig?.hasSameConnectionInputs(as: suspendedConfig) == true
+            }
 
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while appModel.activeGatewayConnectConfig?.hasSameConnectionInputs(as: suspendedConfig) != true,
-              ContinuousClock().now < deadline
-        {
-            await Task.yield()
+            #expect(!controller._test_isAutoConnectSuppressed())
+            #expect(appModel.gatewayAutoReconnectEnabled)
+            #expect(appModel.activeGatewayConnectConfig?.hasSameConnectionInputs(as: suspendedConfig) == true)
+            #expect(defaults.bool(forKey: "gateway.autoconnect"))
         }
-        #expect(!controller._test_isAutoConnectSuppressed())
-        #expect(appModel.gatewayAutoReconnectEnabled)
-        #expect(appModel.activeGatewayConnectConfig?.hasSameConnectionInputs(as: suspendedConfig) == true)
-        #expect(defaults.bool(forKey: "gateway.autoconnect"))
     }
 
     @Test @MainActor func `foreground reconnect cannot replace queued explicit handoff`() async {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let defaults = UserDefaults.standard
         let updates: [String: Any?] = [
             "gateway.autoconnect": false,
             "gateway.manual.enabled": true,
@@ -2575,91 +2284,60 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             "gateway.manual.tls": false,
             "node.instanceId": "ios-test",
         ]
-        var snapshot: [String: Any?] = [:]
-        for key in updates.keys {
-            snapshot[key] = defaults.object(forKey: key)
-        }
-        for (key, value) in updates {
-            defaults.set(value, forKey: key)
-        }
-        defer {
-            for (key, value) in snapshot {
-                if let value {
-                    defaults.set(value, forKey: key)
-                } else {
-                    defaults.removeObject(forKey: key)
+        await withUserDefaults(updates) {
+            let resetRelease = AsyncStream<Void>.makeStream()
+            let appModel = NodeAppModel()
+            defer {
+                resetRelease.continuation.finish()
+                appModel._test_setGatewaySessionResetTask(nil)
+                appModel.disconnectGateway()
+            }
+            let modelResetTask = Task {
+                for await _ in resetRelease.stream {
+                    return
                 }
             }
-        }
+            appModel._test_setGatewaySessionResetTask(modelResetTask)
+            let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
+            UserDefaults.standard.set(true, forKey: "gateway.autoconnect")
 
-        let resetRelease = AsyncStream<Void>.makeStream()
-        let appModel = NodeAppModel()
-        defer {
-            resetRelease.continuation.finish()
-            appModel._test_setGatewaySessionResetTask(nil)
-            appModel.disconnectGateway()
-        }
-        let modelResetTask = Task {
-            for await _ in resetRelease.stream {
-                return
+            let explicitStableID = "manual|192.168.1.41|18789"
+            await controller.connectManual(host: "192.168.1.41", port: 18789, useTLS: false)
+            #expect(appModel.activeGatewayConnectConfig == nil)
+
+            controller._test_triggerAutoReconnect()
+            for _ in 0..<10 {
+                await Task.yield()
             }
+            #expect(controller._test_didAutoConnect())
+            #expect(appModel.activeGatewayConnectConfig == nil)
+
+            resetRelease.continuation.yield()
+            resetRelease.continuation.finish()
+            await waitUntil { appModel.activeGatewayConnectConfig?.stableID == explicitStableID }
+
+            #expect(appModel.activeGatewayConnectConfig?.stableID == explicitStableID)
+            controller._test_triggerAutoConnect()
+            #expect(controller._test_didAutoConnect())
+            #expect(appModel.activeGatewayConnectConfig?.stableID == explicitStableID)
         }
-        appModel._test_setGatewaySessionResetTask(modelResetTask)
-        let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
-        defaults.set(true, forKey: "gateway.autoconnect")
-
-        let explicitStableID = "manual|192.168.1.41|18789"
-        await controller.connectManual(host: "192.168.1.41", port: 18789, useTLS: false)
-        #expect(appModel.activeGatewayConnectConfig == nil)
-
-        controller._test_triggerAutoReconnect()
-        for _ in 0..<10 {
-            await Task.yield()
-        }
-        #expect(controller._test_didAutoConnect())
-        #expect(appModel.activeGatewayConnectConfig == nil)
-
-        resetRelease.continuation.yield()
-        resetRelease.continuation.finish()
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while appModel.activeGatewayConnectConfig?.stableID != explicitStableID,
-              ContinuousClock().now < deadline
-        {
-            await Task.yield()
-        }
-
-        #expect(appModel.activeGatewayConnectConfig?.stableID == explicitStableID)
-        controller._test_triggerAutoConnect()
-        #expect(controller._test_didAutoConnect())
-        #expect(appModel.activeGatewayConnectConfig?.stableID == explicitStableID)
     }
 
     @Test @MainActor func `clearing trust prompt invalidates in flight probe`() async {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let probeStarted = AsyncStream<Void>.makeStream()
-        let probeResults = AsyncStream<GatewayTLSFingerprintProbeResult>.makeStream()
+        let probe = ControllableTLSProbe()
         let appModel = NodeAppModel()
-        let controller = GatewayConnectionController(
-            appModel: appModel,
-            startDiscovery: false,
-            tcpReachabilityProbe: { _, _, _, _ in true },
-            tlsFingerprintProbe: { _ in
-                probeStarted.continuation.yield()
-                for await result in probeResults.stream {
-                    return result
-                }
-                return .failure(.certificateUnavailable)
-            })
-        var startedIterator = probeStarted.stream.makeAsyncIterator()
+        let controller = probe.makeController(appModel: appModel)
+        var startedIterator = probe.started.stream.makeAsyncIterator()
 
         let connectTask = Task {
             await controller.connectManual(host: "trust-probe-cancel.invalid", port: 443, useTLS: true)
         }
         _ = await startedIterator.next()
         controller.clearPendingTrustPrompt()
-        probeResults.continuation.yield(.fingerprint("stale-fingerprint"))
-        probeResults.continuation.finish()
+        probe.results.continuation.yield(.fingerprint("stale-fingerprint"))
+        probe.results.continuation.finish()
         await connectTask.value
 
         #expect(controller.pendingTrustPrompt == nil)
@@ -2685,17 +2363,6 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `switch to manual gateway applies its stable I D and URL`() async {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let service = GatewaySettingsStore._testGatewayService
-        let account = "gateway-registry"
-        let prior = KeychainStore.loadString(service: service, account: account)
-        defer {
-            if let prior {
-                _ = KeychainStore.saveString(prior, service: service, account: account)
-            } else {
-                _ = KeychainStore.delete(service: service, account: account)
-            }
-        }
-        _ = KeychainStore.delete(service: service, account: account)
         let stableID = "manual|127.0.0.1|1"
         saveActiveManualGateway(host: "127.0.0.1", port: 1, useTLS: false, stableID: stableID)
         let appModel = NodeAppModel()
@@ -2706,10 +2373,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             forceReconnectReset: { _ in })
 
         let failure = await controller.switchToGateway(stableID: stableID)
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while appModel.activeGatewayConnectConfig == nil, ContinuousClock().now < deadline {
-            await Task.yield()
-        }
+        await waitUntil { appModel.activeGatewayConnectConfig != nil }
 
         #expect(failure == nil)
         #expect(appModel.activeGatewayConnectConfig?.effectiveStableID == stableID)
@@ -2720,17 +2384,6 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `switch to undiscoverable gateway returns failure without changing active gateway`() async {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let service = GatewaySettingsStore._testGatewayService
-        let account = "gateway-registry"
-        let prior = KeychainStore.loadString(service: service, account: account)
-        defer {
-            if let prior {
-                _ = KeychainStore.saveString(prior, service: service, account: account)
-            } else {
-                _ = KeychainStore.delete(service: service, account: account)
-            }
-        }
-        _ = KeychainStore.delete(service: service, account: account)
         let activeID = "manual|127.0.0.1|1"
         let discoveredID = "bonjour|missing"
         saveActiveManualGateway(host: "127.0.0.1", port: 1, useTLS: false, stableID: activeID)
@@ -2755,28 +2408,8 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
     @Test @MainActor func `chat cache remains isolated when active gateway switches`() async throws {
         let registryIsolation = GatewayRegistryTestIsolation()
         defer { registryIsolation.restore() }
-        let service = GatewaySettingsStore._testGatewayService
-        let account = "gateway-registry"
-        let prior = KeychainStore.loadString(service: service, account: account)
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let prior {
-                _ = KeychainStore.saveString(prior, service: service, account: account)
-            } else {
-                _ = KeychainStore.delete(service: service, account: account)
-            }
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-        _ = KeychainStore.delete(service: service, account: account)
+        let temporaryState = try TemporaryOpenClawState()
+        defer { temporaryState.restore() }
         let gatewayA = "manual|gateway-a|18789"
         let gatewayB = "manual|gateway-b|18789"
         saveActiveManualGateway(host: "gateway-a", port: 18789, useTLS: false, stableID: gatewayA)
@@ -2817,6 +2450,27 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         #expect(await appModel.loadCachedChatSessions() == [session])
     }
 
+    private static func makeNodeOptions(
+        caps: [String] = [],
+        commands: [String] = [],
+        permissions: [String: Bool] = [:],
+        client: (id: String, displayName: String?) = ("ios", "Phone"),
+        allowStoredDeviceAuth: Bool = true,
+        deviceAuthGatewayID: String? = nil) -> GatewayConnectOptions
+    {
+        GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: caps,
+            commands: commands,
+            permissions: permissions,
+            clientId: client.id,
+            clientMode: "node",
+            clientDisplayName: client.displayName,
+            allowStoredDeviceAuth: allowStoredDeviceAuth,
+            deviceAuthGatewayID: deviceAuthGatewayID)
+    }
+
     private static func makeGatewayConnectConfig(
         // Fail locally instead of making lifecycle tests depend on DNS or external network timing.
         url: URL = URL(string: "wss://127.0.0.1:1")!,
@@ -2833,14 +2487,9 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             token: "token",
             bootstrapToken: nil,
             password: nil,
-            nodeOptions: GatewayConnectOptions(
-                role: "node",
-                scopes: [],
+            nodeOptions: self.makeNodeOptions(
                 caps: ["screen", "canvas"],
                 commands: ["notify", "location.get"],
-                permissions: ["screen": true],
-                clientId: "ios",
-                clientMode: "node",
-                clientDisplayName: "Phone"))
+                permissions: ["screen": true]))
     }
 }


### PR DESCRIPTION
## What Problem This Solves

The iOS gateway connection suite repeated process-global Keychain, UserDefaults, relay, temporary-state, TLS-probe, timeout, and connection-option setup across many lifecycle tests. That duplication made security-sensitive pairing and reconnect tests harder to audit and maintain.

## Why This Change Was Made

Consolidates those fixtures behind test-local helpers while preserving every test title and assertion expression. The change stays entirely in the test target: no production, config, protocol, schema, or compatibility surface changes.

## User Impact

No user-visible behavior change. Maintainers get a smaller, more consistent iOS gateway test suite with one canonical owner for shared state cleanup and asynchronous probe setup.

## Evidence

- Exact reviewed head: `2d20762b256e5df2aafb9e2c5aa5f5d7148026d0`.
- Production delta: `0`.
- Test/total delta: `+314/-665`, net `-351 LOC`.
- Exact parity: `78/78` test titles and `379/379` ordered `#expect` / `#require` expressions.
- `swiftformat --lint apps/ios/Tests/GatewayConnectionControllerTests.swift --config config/swiftformat` passes.
- `git diff --check` passes.
- Blacksmith changed-scope gate passed on the reviewed diff: https://github.com/openclaw/openclaw/actions/runs/30757362223
- Exact-head hosted Blacksmith macOS `ios-build` passed Swift lint, Debug and Release builds, adjacent lifecycle simulator tests, and screenshot capture: https://github.com/openclaw/openclaw/actions/runs/30758176286/job/91523951051
- Exact changed-file local fallback passed after the official Blacksmith macOS runner SSH endpoint rejected the configured agent key. On an `iPhone 17 Pro` simulated device running iOS Simulator 27.0 (not a physical or personal device), `xcodebuild` ran only `OpenClawTests/GatewayReconnectErrorRetentionTests` and `OpenClawTests/GatewayConnectionControllerTests` with parallel testing disabled and separate temporary DerivedData and `.xcresult` paths. The result bundle reports `78 passed, 0 failed, 0 skipped`.
- Two independent xhigh reviews completed clean after restoring temporary-state-before-identity ordering.
