### PR TITLE
refactor(plugins): consolidate loader test fixtures

### DIFF
--- a/src/plugins/loader.hooks-and-runtime.test-utils.ts
+++ b/src/plugins/loader.hooks-and-runtime.test-utils.ts
@@ -26,6 +26,178 @@ import { loadPluginManifestRegistry } from "./manifest-registry.js";
 afterEach(globalAfterEach0);
 afterAll(globalAfterAll1);
 
+function writeFixtureText(rootDir: string, relativePath: string, body: string) {
+  const filePath = path.join(rootDir, relativePath);
+  mkdirSafe(path.dirname(filePath));
+  fs.writeFileSync(filePath, body, "utf-8");
+}
+
+function writeFixtureJson(rootDir: string, relativePath: string, value: unknown) {
+  writeFixtureText(rootDir, relativePath, JSON.stringify(value, null, 2));
+}
+
+function pluginManifest(id: string, channels?: string[]) {
+  return {
+    id,
+    configSchema: EMPTY_PLUGIN_SCHEMA,
+    ...(channels ? { channels } : {}),
+  };
+}
+
+function channelPluginSource(params: {
+  pluginId: string;
+  channelId?: string;
+  label: string;
+  docsPath: string;
+  blurb: string;
+}) {
+  const channelId = params.channelId ?? params.pluginId;
+  return `module.exports = { id: ${JSON.stringify(params.pluginId)}, register(api) {
+    api.registerChannel({
+      plugin: {
+        id: ${JSON.stringify(channelId)},
+        meta: {
+          id: ${JSON.stringify(channelId)},
+          label: ${JSON.stringify(params.label)},
+          selectionLabel: ${JSON.stringify(params.label)},
+          docsPath: ${JSON.stringify(params.docsPath)},
+          blurb: ${JSON.stringify(params.blurb)},
+        },
+        capabilities: { chatTypes: ["direct"] },
+        config: {
+          listAccountIds: () => [],
+          resolveAccount: () => ({ accountId: "default" }),
+        },
+        outbound: { deliveryMode: "direct" },
+      },
+    });
+  } };`;
+}
+
+function createSetupFailureFixture(params: {
+  id: string;
+  channelId?: string;
+  setupEntrySource: string;
+}) {
+  const pluginDir = makeTempDir();
+  writeFixtureJson(pluginDir, "package.json", {
+    name: `@openclaw/${params.id}`,
+    openclaw: {
+      extensions: ["./index.cjs"],
+      setupEntry: "./setup-entry.cjs",
+    },
+  });
+  writeFixtureJson(
+    pluginDir,
+    "openclaw.plugin.json",
+    pluginManifest(params.id, [params.channelId ?? params.id]),
+  );
+  writeFixtureText(
+    pluginDir,
+    "index.cjs",
+    `module.exports = { id: ${JSON.stringify(params.id)}, register() {} };`,
+  );
+  writeFixtureText(pluginDir, "setup-entry.cjs", params.setupEntrySource);
+  return pluginDir;
+}
+
+const THROWING_SETUP_ENTRY_SOURCE = `module.exports = {
+  kind: "bundled-channel-setup-entry",
+  loadSetupPlugin: () => { throw new Error("boom: setup plugin missing"); },
+};`;
+
+function loadSetupPlugins(params: { paths: string[]; ids: string[]; enabled?: boolean }) {
+  return loadOpenClawPlugins({
+    cache: false,
+    channelPluginLoadIntent: "setup",
+    config: {
+      plugins: {
+        ...(params.enabled === undefined ? {} : { enabled: params.enabled }),
+        load: { paths: params.paths },
+        allow: params.ids,
+      },
+    },
+  });
+}
+
+type SetupEntryScenario = {
+  name: string;
+  fixture: Parameters<typeof createSetupEntryChannelPluginFixture>[0];
+  loadOptions?: {
+    setupIntent?: boolean;
+    setupOnly?: boolean;
+    scopePlugin?: boolean;
+    disableEntry?: boolean;
+  };
+  expectFullLoaded: boolean;
+  expectSetupLoaded: boolean;
+  expectedChannelSetups?: number;
+  expectedChannels: number;
+  expectedSetupSecretId?: string;
+  expectSetupRuntimeLoaded?: boolean;
+  expectBundledFullRuntimeLoaded?: boolean;
+};
+
+type BuiltArtifactScenario = {
+  id: string;
+  origin: "bundled" | "workspace";
+  sourceEntry: string;
+  sourceBody: string;
+  artifactLocation: "core" | "package";
+  artifactEntry: string;
+  artifactBody: string;
+  packageBeforeManifest?: boolean;
+  packageEntry?: string;
+};
+
+function loadBuiltArtifactScenario(scenario: BuiltArtifactScenario) {
+  const repoRoot = makeTempDir();
+  const pluginDir =
+    scenario.origin === "bundled" ? path.join(repoRoot, "extensions", scenario.id) : makeTempDir();
+  const packageManifest = scenario.packageEntry
+    ? { openclaw: { extensions: [scenario.packageEntry] } }
+    : undefined;
+  if (scenario.packageBeforeManifest && packageManifest) {
+    writeFixtureJson(pluginDir, "package.json", packageManifest);
+  }
+  writeFixtureJson(pluginDir, "openclaw.plugin.json", pluginManifest(scenario.id));
+  if (!scenario.packageBeforeManifest && packageManifest) {
+    writeFixtureJson(pluginDir, "package.json", packageManifest);
+  }
+  writeFixtureText(pluginDir, scenario.sourceEntry, scenario.sourceBody);
+  const artifactDir =
+    scenario.artifactLocation === "core"
+      ? path.join(repoRoot, "dist-runtime", "extensions", scenario.id)
+      : path.join(pluginDir, "dist");
+  writeFixtureText(artifactDir, scenario.artifactEntry, scenario.artifactBody);
+
+  const load = () =>
+    loadOpenClawPlugins({
+      cache: false,
+      preferBuiltPluginArtifacts: true,
+      ...(scenario.origin === "bundled" ? { onlyPluginIds: [scenario.id] } : {}),
+      config: {
+        plugins: {
+          allow: [scenario.id],
+          ...(scenario.origin === "workspace" ? { load: { paths: [pluginDir] } } : {}),
+          entries: { [scenario.id]: { enabled: true } },
+        },
+      },
+    });
+  const registry =
+    scenario.origin === "bundled"
+      ? withEnv(
+          {
+            OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(repoRoot, "extensions"),
+            OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+          },
+          load,
+        )
+      : load();
+  return registry.plugins.find((entry) => entry.id === scenario.id)?.status;
+}
+
 describe("loadOpenClawPlugins", () => {
   it("setup-loads a trusted global channel plugin when the caller scopes to it", () => {
     useNoBundledPlugins();
@@ -33,63 +205,30 @@ describe("loadOpenClawPlugins", () => {
     withStateDir((stateDir) => {
       const globalDir = path.join(stateDir, "extensions", "trusted-global-channel");
       mkdirSafe(globalDir);
-      fs.writeFileSync(
-        path.join(globalDir, "index.cjs"),
+      writeFixtureText(
+        globalDir,
+        "index.cjs",
         `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
-  module.exports = {
-    id: "trusted-global-channel",
-    register(api) {
-      api.registerChannel({
-        plugin: {
-          id: "trusted-global-channel",
-          meta: {
-            id: "trusted-global-channel",
-            label: "Trusted Global Channel",
-            selectionLabel: "Trusted Global Channel",
-            docsPath: "/channels/trusted-global-channel",
-            blurb: "trusted global setup gate",
-          },
-          capabilities: { chatTypes: ["direct"] },
-          config: {
-            listAccountIds: () => [],
-            resolveAccount: () => ({ accountId: "default" }),
-          },
-          outbound: { deliveryMode: "direct" },
+${channelPluginSource({
+  pluginId: "trusted-global-channel",
+  label: "Trusted Global Channel",
+  docsPath: "/channels/trusted-global-channel",
+  blurb: "trusted global setup gate",
+})}`,
+      );
+      writeFixtureJson(
+        globalDir,
+        "openclaw.plugin.json",
+        pluginManifest("trusted-global-channel", ["trusted-global-channel"]),
+      );
+      writeFixtureJson(globalDir, "package.json", {
+        name: "@openclaw/trusted-global-channel",
+        version: "0.0.0-test",
+        main: "./index.cjs",
+        openclaw: {
+          extensions: ["./index.cjs"],
         },
       });
-    },
-  };`,
-        "utf-8",
-      );
-      fs.writeFileSync(
-        path.join(globalDir, "openclaw.plugin.json"),
-        JSON.stringify(
-          {
-            id: "trusted-global-channel",
-            configSchema: EMPTY_PLUGIN_SCHEMA,
-            channels: ["trusted-global-channel"],
-          },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
-      fs.writeFileSync(
-        path.join(globalDir, "package.json"),
-        JSON.stringify(
-          {
-            name: "@openclaw/trusted-global-channel",
-            version: "0.0.0-test",
-            main: "./index.cjs",
-            openclaw: {
-              extensions: ["./index.cjs"],
-            },
-          },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
 
       const scopedSetupRegistry = loadOpenClawPlugins({
         cache: false,
@@ -122,29 +261,12 @@ describe("loadOpenClawPlugins", () => {
       id: "auto-enabled-load-path-channel",
       filename: "auto-enabled-load-path-channel.cjs",
       body: `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
-  module.exports = {
-    id: "auto-enabled-load-path-channel",
-    register(api) {
-      api.registerChannel({
-        plugin: {
-          id: "auto-enabled-load-path-channel",
-          meta: {
-            id: "auto-enabled-load-path-channel",
-            label: "Auto Enabled Load Path Channel",
-            selectionLabel: "Auto Enabled Load Path Channel",
-            docsPath: "/channels/auto-enabled-load-path-channel",
-            blurb: "auto-enabled load-path setup gate",
-          },
-          capabilities: { chatTypes: ["direct"] },
-          config: {
-            listAccountIds: () => [],
-            resolveAccount: () => ({ accountId: "default" }),
-          },
-          outbound: { deliveryMode: "direct" },
-        },
-      });
-    },
-  };`,
+${channelPluginSource({
+  pluginId: "auto-enabled-load-path-channel",
+  label: "Auto Enabled Load Path Channel",
+  docsPath: "/channels/auto-enabled-load-path-channel",
+  blurb: "auto-enabled load-path setup gate",
+})}`,
     });
     fs.writeFileSync(
       path.join(plugin.dir, "openclaw.plugin.json"),
@@ -196,22 +318,12 @@ describe("loadOpenClawPlugins", () => {
         setupBlurb: "setup entry",
         configured: false,
       },
-      load: ({ pluginDir }: { pluginDir: string }) =>
-        loadOpenClawPlugins({
-          cache: false,
-          channelPluginLoadIntent: "setup",
-          config: {
-            plugins: {
-              load: { paths: [pluginDir] },
-              allow: ["setup-entry-test"],
-              entries: {
-                "setup-entry-test": { enabled: false },
-              },
-            },
-          },
-          includeSetupOnlyChannelPlugins: true,
-          onlyPluginIds: ["setup-entry-test"],
-        }),
+      loadOptions: {
+        setupIntent: true,
+        setupOnly: true,
+        scopePlugin: true,
+        disableEntry: true,
+      },
       expectFullLoaded: false,
       expectSetupLoaded: false,
       expectedChannelSetups: 0,
@@ -228,22 +340,12 @@ describe("loadOpenClawPlugins", () => {
         configured: false,
         useBundledSetupEntryContract: true,
       },
-      load: ({ pluginDir }: { pluginDir: string }) =>
-        loadOpenClawPlugins({
-          cache: false,
-          channelPluginLoadIntent: "setup",
-          config: {
-            plugins: {
-              load: { paths: [pluginDir] },
-              allow: ["setup-only-bundled-contract-test"],
-              entries: {
-                "setup-only-bundled-contract-test": { enabled: false },
-              },
-            },
-          },
-          includeSetupOnlyChannelPlugins: true,
-          onlyPluginIds: ["setup-only-bundled-contract-test"],
-        }),
+      loadOptions: {
+        setupIntent: true,
+        setupOnly: true,
+        scopePlugin: true,
+        disableEntry: true,
+      },
       expectFullLoaded: false,
       expectSetupLoaded: false,
       expectedChannelSetups: 0,
@@ -259,17 +361,7 @@ describe("loadOpenClawPlugins", () => {
         setupBlurb: "setup runtime",
         configured: false,
       },
-      load: ({ pluginDir }: { pluginDir: string }) =>
-        loadOpenClawPlugins({
-          cache: false,
-          channelPluginLoadIntent: "setup",
-          config: {
-            plugins: {
-              load: { paths: [pluginDir] },
-              allow: ["setup-runtime-test"],
-            },
-          },
-        }),
+      loadOptions: { setupIntent: true },
       expectFullLoaded: false,
       expectSetupLoaded: true,
       expectedChannels: 1,
@@ -285,17 +377,7 @@ describe("loadOpenClawPlugins", () => {
         configured: false,
         useBundledSetupEntryContract: true,
       },
-      load: ({ pluginDir }: { pluginDir: string }) =>
-        loadOpenClawPlugins({
-          cache: false,
-          channelPluginLoadIntent: "setup",
-          config: {
-            plugins: {
-              load: { paths: [pluginDir] },
-              allow: ["setup-runtime-bundled-contract-test"],
-            },
-          },
-        }),
+      loadOptions: { setupIntent: true },
       expectFullLoaded: true,
       expectSetupLoaded: true,
       expectedChannels: 1,
@@ -312,17 +394,7 @@ describe("loadOpenClawPlugins", () => {
         useBundledSetupEntryContract: true,
         splitBundledSetupSecrets: true,
       },
-      load: ({ pluginDir }: { pluginDir: string }) =>
-        loadOpenClawPlugins({
-          cache: false,
-          channelPluginLoadIntent: "setup",
-          config: {
-            plugins: {
-              load: { paths: [pluginDir] },
-              allow: ["setup-runtime-bundled-contract-secrets-test"],
-            },
-          },
-        }),
+      loadOptions: { setupIntent: true },
       expectFullLoaded: true,
       expectSetupLoaded: true,
       expectedChannels: 1,
@@ -340,17 +412,7 @@ describe("loadOpenClawPlugins", () => {
         useBundledSetupEntryContract: true,
         bundledSetupRuntimeMarker: path.join(makeTempDir(), "setup-runtime-applied.txt"),
       },
-      load: ({ pluginDir }: { pluginDir: string }) =>
-        loadOpenClawPlugins({
-          cache: false,
-          channelPluginLoadIntent: "setup",
-          config: {
-            plugins: {
-              load: { paths: [pluginDir] },
-              allow: ["setup-runtime-bundled-contract-runtime-test"],
-            },
-          },
-        }),
+      loadOptions: { setupIntent: true },
       expectFullLoaded: true,
       expectSetupLoaded: true,
       expectedChannels: 1,
@@ -369,17 +431,7 @@ describe("loadOpenClawPlugins", () => {
         useBundledSetupEntryContract: true,
         bundledFullRuntimeMarker: path.join(makeTempDir(), "bundled-runtime-applied.txt"),
       },
-      load: ({ pluginDir }: { pluginDir: string }) =>
-        loadOpenClawPlugins({
-          cache: false,
-          channelPluginLoadIntent: "setup",
-          config: {
-            plugins: {
-              load: { paths: [pluginDir] },
-              allow: ["setup-runtime-bundled-runtime-merge-test"],
-            },
-          },
-        }),
+      loadOptions: { setupIntent: true },
       expectFullLoaded: true,
       expectSetupLoaded: true,
       expectedChannels: 1,
@@ -395,25 +447,15 @@ describe("loadOpenClawPlugins", () => {
         setupBlurb: "setup runtime should not load by default",
         configured: false,
       },
-      load: ({ pluginDir }: { pluginDir: string }) =>
-        loadOpenClawPlugins({
-          cache: false,
-          config: {
-            plugins: {
-              load: { paths: [pluginDir] },
-              allow: ["setup-runtime-default-full-test"],
-            },
-          },
-        }),
       expectFullLoaded: true,
       expectSetupLoaded: false,
       expectedChannels: 1,
     },
-  ])(
+  ] satisfies SetupEntryScenario[])(
     "$name",
     ({
       fixture,
-      load,
+      loadOptions,
       expectFullLoaded,
       expectSetupLoaded,
       expectedChannelSetups,
@@ -421,9 +463,21 @@ describe("loadOpenClawPlugins", () => {
       expectedSetupSecretId,
       expectSetupRuntimeLoaded,
       expectBundledFullRuntimeLoaded,
-    }) => {
+    }: SetupEntryScenario) => {
       const built = createSetupEntryChannelPluginFixture(fixture);
-      const registry = load({ pluginDir: built.pluginDir });
+      const registry = loadOpenClawPlugins({
+        cache: false,
+        ...(loadOptions?.setupIntent ? { channelPluginLoadIntent: "setup" as const } : {}),
+        config: {
+          plugins: {
+            load: { paths: [built.pluginDir] },
+            allow: [fixture.id],
+            ...(loadOptions?.disableEntry ? { entries: { [fixture.id]: { enabled: false } } } : {}),
+          },
+        },
+        ...(loadOptions?.setupOnly ? { includeSetupOnlyChannelPlugins: true } : {}),
+        ...(loadOptions?.scopePlugin ? { onlyPluginIds: [fixture.id] } : {}),
+      });
 
       expect(fs.existsSync(built.fullMarker)).toBe(expectFullLoaded);
       expect(fs.existsSync(built.setupMarker)).toBe(expectSetupLoaded);
@@ -469,15 +523,9 @@ describe("loadOpenClawPlugins", () => {
       requireBundledFullRuntimeBeforeLoad: true,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      channelPluginLoadIntent: "setup",
-      config: {
-        plugins: {
-          load: { paths: [built.pluginDir] },
-          allow: ["setup-runtime-order-test"],
-        },
-      },
+    const registry = loadSetupPlugins({
+      paths: [built.pluginDir],
+      ids: ["setup-runtime-order-test"],
     });
 
     expect(registry.plugins.find((entry) => entry.id === "setup-runtime-order-test")?.status).toBe(
@@ -503,15 +551,9 @@ describe("loadOpenClawPlugins", () => {
       body: `module.exports = { id: "setup-runtime-helper-test", register() {} };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      channelPluginLoadIntent: "setup",
-      config: {
-        plugins: {
-          load: { paths: [built.pluginDir, helperPlugin.file] },
-          allow: ["setup-runtime-error-test", "setup-runtime-helper-test"],
-        },
-      },
+    const registry = loadSetupPlugins({
+      paths: [built.pluginDir, helperPlugin.file],
+      ids: ["setup-runtime-error-test", "setup-runtime-helper-test"],
     });
 
     expect(registry.plugins.find((entry) => entry.id === "setup-runtime-error-test")?.status).toBe(
@@ -543,15 +585,9 @@ describe("loadOpenClawPlugins", () => {
       body: `module.exports = { id: "setup-runtime-route-helper-test", register() {} };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      channelPluginLoadIntent: "setup",
-      config: {
-        plugins: {
-          load: { paths: [built.pluginDir, helperPlugin.file] },
-          allow: ["setup-runtime-route-error-test", "setup-runtime-route-helper-test"],
-        },
-      },
+    const registry = loadSetupPlugins({
+      paths: [built.pluginDir, helperPlugin.file],
+      ids: ["setup-runtime-route-error-test", "setup-runtime-route-helper-test"],
     });
 
     expect(
@@ -581,15 +617,9 @@ describe("loadOpenClawPlugins", () => {
       bundledSetupRuntimeLateRoutePath: "/setup-runtime-late-route",
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      channelPluginLoadIntent: "setup",
-      config: {
-        plugins: {
-          load: { paths: [built.pluginDir] },
-          allow: ["setup-runtime-late-route-test"],
-        },
-      },
+    const registry = loadSetupPlugins({
+      paths: [built.pluginDir],
+      ids: ["setup-runtime-late-route-test"],
     });
 
     await Promise.resolve();
@@ -617,15 +647,9 @@ describe("loadOpenClawPlugins", () => {
       bundledFullRuntimeMarker: runtimeMarker,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      channelPluginLoadIntent: "setup",
-      config: {
-        plugins: {
-          load: { paths: [built.pluginDir] },
-          allow: ["setup-runtime-mismatch-test"],
-        },
-      },
+    const registry = loadSetupPlugins({
+      paths: [built.pluginDir],
+      ids: ["setup-runtime-mismatch-test"],
     });
 
     expect(
@@ -653,15 +677,9 @@ describe("loadOpenClawPlugins", () => {
       bundledFullRuntimeMarker: runtimeMarker,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      channelPluginLoadIntent: "setup",
-      config: {
-        plugins: {
-          load: { paths: [built.pluginDir] },
-          allow: ["setup-export-mismatch-test"],
-        },
-      },
+    const registry = loadSetupPlugins({
+      paths: [built.pluginDir],
+      ids: ["setup-export-mismatch-test"],
     });
 
     expect(
@@ -677,62 +695,13 @@ describe("loadOpenClawPlugins", () => {
 
   it("isolates loadSetupPlugin errors as per-plugin diagnostics instead of crashing registry load", () => {
     useNoBundledPlugins();
-    const pluginDir = makeTempDir();
-
-    // Plugin whose setup-entry uses the bundled contract but loadSetupPlugin() throws
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "@openclaw/setup-entry-throws-test",
-          openclaw: {
-            extensions: ["./index.cjs"],
-            setupEntry: "./setup-entry.cjs",
-          },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "setup-entry-throws-test",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["setup-entry-throws-test"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    // index.cjs: full entry (should NOT be reached if setup-entry is used)
-    fs.writeFileSync(
-      path.join(pluginDir, "index.cjs"),
-      `module.exports = { id: "setup-entry-throws-test", register() {} };`,
-      "utf-8",
-    );
-    // setup-entry.cjs: bundled contract whose loadSetupPlugin throws
-    fs.writeFileSync(
-      path.join(pluginDir, "setup-entry.cjs"),
-      `module.exports = {
-    kind: "bundled-channel-setup-entry",
-    loadSetupPlugin: () => { throw new Error("boom: setup plugin missing"); },
-  };`,
-      "utf-8",
-    );
-
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      channelPluginLoadIntent: "setup",
-      config: {
-        plugins: {
-          load: { paths: [pluginDir] },
-          allow: ["setup-entry-throws-test"],
-        },
-      },
+    const pluginDir = createSetupFailureFixture({
+      id: "setup-entry-throws-test",
+      setupEntrySource: THROWING_SETUP_ENTRY_SOURCE,
+    });
+    const registry = loadSetupPlugins({
+      paths: [pluginDir],
+      ids: ["setup-entry-throws-test"],
     });
 
     // The registry load should NOT crash; the error should be recorded as a
@@ -746,85 +715,28 @@ describe("loadOpenClawPlugins", () => {
 
   it("keeps healthy sibling channel plugins loadable when a setup entry throws", () => {
     useNoBundledPlugins();
-    const brokenDir = makeTempDir();
-
-    fs.writeFileSync(
-      path.join(brokenDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "@openclaw/setup-entry-throws-sibling-test",
-          openclaw: {
-            extensions: ["./index.cjs"],
-            setupEntry: "./setup-entry.cjs",
-          },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(brokenDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "setup-entry-throws-sibling-test",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["broken-chat"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(brokenDir, "index.cjs"),
-      `module.exports = { id: "setup-entry-throws-sibling-test", register() {} };`,
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(brokenDir, "setup-entry.cjs"),
-      `module.exports = {
-    kind: "bundled-channel-setup-entry",
-    loadSetupPlugin: () => { throw new Error("boom: setup plugin missing"); },
-  };`,
-      "utf-8",
-    );
+    const brokenDir = createSetupFailureFixture({
+      id: "setup-entry-throws-sibling-test",
+      channelId: "broken-chat",
+      setupEntrySource: THROWING_SETUP_ENTRY_SOURCE,
+    });
 
     const healthy = writePlugin({
       id: "healthy-channel",
       filename: "healthy-channel.cjs",
-      body: `module.exports = { id: "healthy-channel", register(api) {
-    api.registerChannel({
-      plugin: {
-        id: "healthy-chat",
-        meta: {
-          id: "healthy-chat",
-          label: "Healthy Chat",
-          selectionLabel: "Healthy Chat",
-          docsPath: "/channels/healthy-chat",
-          blurb: "healthy sibling channel",
-        },
-        capabilities: { chatTypes: ["direct"] },
-        config: {
-          listAccountIds: () => [],
-          resolveAccount: () => ({ accountId: "default" }),
-        },
-        outbound: { deliveryMode: "direct" },
-      }
-    });
-  } };`,
+      body: channelPluginSource({
+        pluginId: "healthy-channel",
+        channelId: "healthy-chat",
+        label: "Healthy Chat",
+        docsPath: "/channels/healthy-chat",
+        blurb: "healthy sibling channel",
+      }),
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      channelPluginLoadIntent: "setup",
-      config: {
-        plugins: {
-          enabled: true,
-          load: { paths: [brokenDir, healthy.file] },
-          allow: ["setup-entry-throws-sibling-test", "healthy-channel"],
-        },
-      },
+    const registry = loadSetupPlugins({
+      paths: [brokenDir, healthy.file],
+      ids: ["setup-entry-throws-sibling-test", "healthy-channel"],
+      enabled: true,
     });
 
     const healthyMeta = registry.channels.find((entry) => entry.plugin.id === "healthy-chat")
@@ -845,47 +757,9 @@ describe("loadOpenClawPlugins", () => {
 
   it("records a diagnostic when registerChannel throws in the setup-entry path", () => {
     useNoBundledPlugins();
-    const brokenDir = makeTempDir();
-
-    fs.writeFileSync(
-      path.join(brokenDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "@openclaw/register-channel-throws-test",
-          openclaw: {
-            extensions: ["./index.cjs"],
-            setupEntry: "./setup-entry.cjs",
-          },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(brokenDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "register-channel-throws-test",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["register-channel-throws-test"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(brokenDir, "index.cjs"),
-      `module.exports = { id: "register-channel-throws-test", register() {} };`,
-      "utf-8",
-    );
-    // setup-entry.cjs: loadSetupPlugin succeeds, but the returned plugin
-    // has a nested throwing getter on config.listAccountIds that triggers
-    // inside registerChannel -> normalizeRegisteredChannelPlugin.
-    fs.writeFileSync(
-      path.join(brokenDir, "setup-entry.cjs"),
-      `const configObj = {
+    const brokenDir = createSetupFailureFixture({
+      id: "register-channel-throws-test",
+      setupEntrySource: `const configObj = {
     resolveAccount: () => ({ accountId: "default" }),
   };
   Object.defineProperty(configObj, "listAccountIds", {
@@ -909,44 +783,24 @@ describe("loadOpenClawPlugins", () => {
       outbound: { deliveryMode: "direct" },
     }),
   };`,
-      "utf-8",
-    );
+    });
 
     const healthy = writePlugin({
       id: "healthy-after-register-throw",
       filename: "healthy-after-register-throw.cjs",
-      body: `module.exports = { id: "healthy-after-register-throw", register(api) {
-    api.registerChannel({
-      plugin: {
-        id: "healthy-after-register-throw-chat",
-        meta: {
-          id: "healthy-after-register-throw-chat",
-          label: "Healthy After Register Throw",
-          selectionLabel: "Healthy After Register Throw",
-          docsPath: "/channels/healthy-after-register-throw",
-          blurb: "survives sibling registerChannel throw",
-        },
-        capabilities: { chatTypes: ["direct"] },
-        config: {
-          listAccountIds: () => [],
-          resolveAccount: () => ({ accountId: "default" }),
-        },
-        outbound: { deliveryMode: "direct" },
-      }
-    });
-  } };`,
+      body: channelPluginSource({
+        pluginId: "healthy-after-register-throw",
+        channelId: "healthy-after-register-throw-chat",
+        label: "Healthy After Register Throw",
+        docsPath: "/channels/healthy-after-register-throw",
+        blurb: "survives sibling registerChannel throw",
+      }),
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      channelPluginLoadIntent: "setup",
-      config: {
-        plugins: {
-          enabled: true,
-          load: { paths: [brokenDir, healthy.file] },
-          allow: ["register-channel-throws-test", "healthy-after-register-throw"],
-        },
-      },
+    const registry = loadSetupPlugins({
+      paths: [brokenDir, healthy.file],
+      ids: ["register-channel-throws-test", "healthy-after-register-throw"],
+      enabled: true,
     });
 
     // The broken plugin should be recorded as a diagnostic, not crash the loop.
@@ -970,199 +824,79 @@ describe("loadOpenClawPlugins", () => {
   });
 
   it("prefers built bundled plugin artifacts over source TS when requested", () => {
-    const repoRoot = makeTempDir();
-    const sourceDir = path.join(repoRoot, "extensions", "startup-artifact-test");
-    const runtimeDir = path.join(repoRoot, "dist-runtime", "extensions", "startup-artifact-test");
-    mkdirSafe(sourceDir);
-    mkdirSafe(runtimeDir);
-    fs.writeFileSync(
-      path.join(sourceDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "startup-artifact-test",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(sourceDir, "index.ts"),
-      'throw new Error("source TS should not load during gateway startup");\n',
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(runtimeDir, "index.js"),
-      'module.exports = { id: "startup-artifact-test", register() {} };\n',
-      "utf-8",
-    );
-
-    const registry = withEnv(
-      {
-        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(repoRoot, "extensions"),
-        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
-      },
-      () =>
-        loadOpenClawPlugins({
-          cache: false,
-          preferBuiltPluginArtifacts: true,
-          onlyPluginIds: ["startup-artifact-test"],
-          config: {
-            plugins: {
-              allow: ["startup-artifact-test"],
-              entries: {
-                "startup-artifact-test": {
-                  enabled: true,
-                },
-              },
-            },
-          },
-        }),
-    );
-
-    expect(registry.plugins.find((entry) => entry.id === "startup-artifact-test")?.status).toBe(
-      "loaded",
-    );
+    expect(
+      loadBuiltArtifactScenario({
+        id: "startup-artifact-test",
+        origin: "bundled",
+        sourceEntry: "index.ts",
+        sourceBody: 'throw new Error("source TS should not load during gateway startup");\n',
+        artifactLocation: "core",
+        artifactEntry: "index.js",
+        artifactBody: 'module.exports = { id: "startup-artifact-test", register() {} };\n',
+      }),
+    ).toBe("loaded");
   });
 
   it("prefers package-local dist artifacts for bundled source checkout plugins", () => {
-    const repoRoot = makeTempDir();
-    const sourceDir = path.join(repoRoot, "extensions", "startup-package-artifact-test");
-    const runtimeDir = path.join(sourceDir, "dist");
-    mkdirSafe(sourceDir);
-    mkdirSafe(runtimeDir);
-    fs.writeFileSync(
-      path.join(sourceDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "startup-package-artifact-test",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(sourceDir, "package.json"),
-      JSON.stringify(
-        {
-          openclaw: {
-            extensions: ["./index.ts"],
-          },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(sourceDir, "index.ts"),
-      'throw new Error("source TS should not load during gateway startup");\n',
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(runtimeDir, "index.js"),
-      'module.exports = { id: "startup-package-artifact-test", register() {} };\n',
-      "utf-8",
-    );
-
-    const registry = withEnv(
-      {
-        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(repoRoot, "extensions"),
-        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
-      },
-      () =>
-        loadOpenClawPlugins({
-          cache: false,
-          preferBuiltPluginArtifacts: true,
-          onlyPluginIds: ["startup-package-artifact-test"],
-          config: {
-            plugins: {
-              allow: ["startup-package-artifact-test"],
-              entries: {
-                "startup-package-artifact-test": {
-                  enabled: true,
-                },
-              },
-            },
-          },
-        }),
-    );
-
     expect(
-      registry.plugins.find((entry) => entry.id === "startup-package-artifact-test")?.status,
+      loadBuiltArtifactScenario({
+        id: "startup-package-artifact-test",
+        origin: "bundled",
+        sourceEntry: "index.ts",
+        sourceBody: 'throw new Error("source TS should not load during gateway startup");\n',
+        artifactLocation: "package",
+        artifactEntry: "index.js",
+        artifactBody: 'module.exports = { id: "startup-package-artifact-test", register() {} };\n',
+        packageEntry: "./index.ts",
+      }),
     ).toBe("loaded");
   });
 
   it("ignores built artifacts when the bundled source plugin opts out of core dist", () => {
     const repoRoot = makeTempDir();
     const sourceDir = path.join(repoRoot, "extensions", "source-only-artifact-test");
-    const runtimeDir = path.join(sourceDir, "dist");
     const builtPluginDir = path.join(repoRoot, "dist", "extensions", "source-only-artifact-test");
     mkdirSafe(path.join(repoRoot, ".git"));
     mkdirSafe(path.join(repoRoot, "src"));
-    mkdirSafe(sourceDir);
-    mkdirSafe(runtimeDir);
-    mkdirSafe(builtPluginDir);
-    fs.writeFileSync(path.join(repoRoot, "pnpm-workspace.yaml"), "packages: []\n", "utf-8");
-    fs.writeFileSync(
-      path.join(sourceDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        { id: "source-only-artifact-test", configSchema: EMPTY_PLUGIN_SCHEMA },
-        null,
-        2,
-      ),
-      "utf-8",
+    writeFixtureText(repoRoot, "pnpm-workspace.yaml", "packages: []\n");
+    writeFixtureJson(
+      sourceDir,
+      "openclaw.plugin.json",
+      pluginManifest("source-only-artifact-test"),
     );
-    fs.writeFileSync(
-      path.join(sourceDir, "package.json"),
-      JSON.stringify({
-        openclaw: {
-          extensions: ["./index.ts"],
-          build: { bundledDist: false },
-        },
-      }),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(sourceDir, "index.ts"),
+    writeFixtureJson(sourceDir, "package.json", {
+      openclaw: {
+        extensions: ["./index.ts"],
+        build: { bundledDist: false },
+      },
+    });
+    writeFixtureText(
+      sourceDir,
+      "index.ts",
       'export default { id: "source-only-artifact-test", register() {} };\n',
-      "utf-8",
     );
-    fs.writeFileSync(
-      path.join(runtimeDir, "index.js"),
+    writeFixtureText(
+      sourceDir,
+      "dist/index.js",
       'throw new Error("stale package-local dist should not load");\n',
-      "utf-8",
     );
+    mkdirSafe(builtPluginDir);
     fs.copyFileSync(
       path.join(sourceDir, "openclaw.plugin.json"),
       path.join(builtPluginDir, "openclaw.plugin.json"),
     );
-    fs.writeFileSync(
-      path.join(builtPluginDir, "package.json"),
-      JSON.stringify({ openclaw: { extensions: ["./index.js"] } }),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(builtPluginDir, "index.js"),
+    writeFixtureJson(builtPluginDir, "package.json", {
+      openclaw: { extensions: ["./index.js"] },
+    });
+    writeFixtureText(
+      builtPluginDir,
+      "index.js",
       'throw new Error("stale discovered core dist should not load");\n',
-      "utf-8",
     );
-    const bundledRuntimeDir = path.join(
+    writeFixtureText(
       repoRoot,
-      "dist-runtime",
-      "extensions",
-      "source-only-artifact-test",
-    );
-    mkdirSafe(bundledRuntimeDir);
-    fs.writeFileSync(
-      path.join(bundledRuntimeDir, "index.js"),
+      "dist-runtime/extensions/source-only-artifact-test/index.js",
       'throw new Error("stale core dist should not load");\n',
-      "utf-8",
     );
 
     const config = {
@@ -1196,189 +930,55 @@ describe("loadOpenClawPlugins", () => {
 
   it("prefers package-local dist artifacts over workspace source TS when requested", () => {
     useNoBundledPlugins();
-    const pluginDir = makeTempDir();
-    const distDir = path.join(pluginDir, "dist");
-    mkdirSafe(distDir);
-    mkdirSafe(path.join(pluginDir, "src"));
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          openclaw: {
-            extensions: ["./src/index.mts"],
-          },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "workspace-artifact-test",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "src", "index.mts"),
-      'throw new Error("workspace source TS should not load during gateway startup");\n',
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(distDir, "index.mjs"),
-      'export default { id: "workspace-artifact-test", register() {} };\n',
-      "utf-8",
-    );
-
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      preferBuiltPluginArtifacts: true,
-      config: {
-        plugins: {
-          allow: ["workspace-artifact-test"],
-          load: { paths: [pluginDir] },
-          entries: {
-            "workspace-artifact-test": {
-              enabled: true,
-            },
-          },
-        },
-      },
-    });
-
-    expect(registry.plugins.find((entry) => entry.id === "workspace-artifact-test")?.status).toBe(
-      "loaded",
-    );
+    expect(
+      loadBuiltArtifactScenario({
+        id: "workspace-artifact-test",
+        origin: "workspace",
+        sourceEntry: "src/index.mts",
+        sourceBody:
+          'throw new Error("workspace source TS should not load during gateway startup");\n',
+        artifactLocation: "package",
+        artifactEntry: "index.mjs",
+        artifactBody: 'export default { id: "workspace-artifact-test", register() {} };\n',
+        packageBeforeManifest: true,
+        packageEntry: "./src/index.mts",
+      }),
+    ).toBe("loaded");
   });
 
   it("probes supported package-local dist artifact extensions before source TS", () => {
     useNoBundledPlugins();
-    const pluginDir = makeTempDir();
-    const distDir = path.join(pluginDir, "dist");
-    mkdirSafe(distDir);
-    mkdirSafe(path.join(pluginDir, "src"));
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          openclaw: {
-            extensions: ["./src/index.ts"],
-          },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "workspace-artifact-extension-test",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "src", "index.ts"),
-      'throw new Error("workspace source TS should not load during gateway startup");\n',
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(distDir, "index.mjs"),
-      'export default { id: "workspace-artifact-extension-test", register() {} };\n',
-      "utf-8",
-    );
-
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      preferBuiltPluginArtifacts: true,
-      config: {
-        plugins: {
-          allow: ["workspace-artifact-extension-test"],
-          load: { paths: [pluginDir] },
-          entries: {
-            "workspace-artifact-extension-test": {
-              enabled: true,
-            },
-          },
-        },
-      },
-    });
-
     expect(
-      registry.plugins.find((entry) => entry.id === "workspace-artifact-extension-test")?.status,
+      loadBuiltArtifactScenario({
+        id: "workspace-artifact-extension-test",
+        origin: "workspace",
+        sourceEntry: "src/index.ts",
+        sourceBody:
+          'throw new Error("workspace source TS should not load during gateway startup");\n',
+        artifactLocation: "package",
+        artifactEntry: "index.mjs",
+        artifactBody:
+          'export default { id: "workspace-artifact-extension-test", register() {} };\n',
+        packageBeforeManifest: true,
+        packageEntry: "./src/index.ts",
+      }),
     ).toBe("loaded");
   });
 
   it("does not replace explicit JavaScript entries with package-local dist artifacts", () => {
     useNoBundledPlugins();
-    const pluginDir = makeTempDir();
-    const distDir = path.join(pluginDir, "dist");
-    mkdirSafe(distDir);
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          openclaw: {
-            extensions: ["./index.js"],
-          },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "workspace-explicit-js-test",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "index.js"),
-      'export default { id: "workspace-explicit-js-test", register() {} };\n',
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(distDir, "index.js"),
-      'throw new Error("explicit JS entry should not be replaced by dist");\n',
-      "utf-8",
-    );
-
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      preferBuiltPluginArtifacts: true,
-      config: {
-        plugins: {
-          allow: ["workspace-explicit-js-test"],
-          load: { paths: [pluginDir] },
-          entries: {
-            "workspace-explicit-js-test": {
-              enabled: true,
-            },
-          },
-        },
-      },
-    });
-
     expect(
-      registry.plugins.find((entry) => entry.id === "workspace-explicit-js-test")?.status,
+      loadBuiltArtifactScenario({
+        id: "workspace-explicit-js-test",
+        origin: "workspace",
+        sourceEntry: "index.js",
+        sourceBody: 'export default { id: "workspace-explicit-js-test", register() {} };\n',
+        artifactLocation: "package",
+        artifactEntry: "index.js",
+        artifactBody: 'throw new Error("explicit JS entry should not be replaced by dist");\n',
+        packageBeforeManifest: true,
+        packageEntry: "./index.js",
+      }),
     ).toBe("loaded");
   });
 
@@ -1386,41 +986,23 @@ describe("loadOpenClawPlugins", () => {
     useNoBundledPlugins();
     const pluginDir = makeTempDir();
     const outsideDistDir = makeTempDir();
-    mkdirSafe(path.join(pluginDir, "src"));
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify(
-        {
-          openclaw: {
-            extensions: ["./src/index.mts"],
-          },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
+    writeFixtureJson(pluginDir, "package.json", {
+      openclaw: { extensions: ["./src/index.mts"] },
+    });
+    writeFixtureJson(
+      pluginDir,
+      "openclaw.plugin.json",
+      pluginManifest("workspace-artifact-symlink-test"),
     );
-    fs.writeFileSync(
-      path.join(pluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "workspace-artifact-symlink-test",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "src", "index.mts"),
+    writeFixtureText(
+      pluginDir,
+      "src/index.mts",
       'throw new Error("workspace source TS should not load during gateway startup");\n',
-      "utf-8",
     );
-    fs.writeFileSync(
-      path.join(outsideDistDir, "index.mjs"),
+    writeFixtureText(
+      outsideDistDir,
+      "index.mjs",
       'export default { id: "workspace-artifact-symlink-test", register() {} };\n',
-      "utf-8",
     );
     try {
       fs.symlinkSync(outsideDistDir, path.join(pluginDir, "dist"), "dir");


### PR DESCRIPTION
## What Problem This Solves

The plugin loader fixture suite repeated large manifest, package, channel, setup-runtime, and built-artifact constructions. That duplication made loader security and lifecycle invariants harder to review and maintain.

## Why This Change Was Made

This test-only refactor introduces narrow fixture writers and explicit scenario data for repeated setup-runtime and artifact cases. Security-boundary tests, failure-path assertions, timer restoration, fixture write order, and each individual test name remain intact. No production, config, API, default, compatibility, or dependency behavior changes.

## User Impact

No user-visible behavior changes. The loader tests are 418 net lines smaller and their shared invariants are easier for maintainers to audit.

## Evidence

- Final diff: one test-support file, +386/-804, net -418; production LOC delta 0.
- Static parity: 29 ordinary tests plus two parameterized tables with 8 and 2 rows (39 runtime cases), 73 expectations, and exactly three each of fake-timer setup, timer advancement, and real-timer restoration.
- Blacksmith Testbox tbx_01kz1q195r4x38wcadpw4pyejd: full pnpm check:changed passed on the exact final diff.
- The exact final diff passed the complete 27-file loader/hook/security selection: 419/419 tests across unit-fast, contracts-plugin, bundled, and plugins projects.
- Hosted proof: https://github.com/openclaw/openclaw/actions/runs/30758125174
- Two independent xhigh reviews passed after tracing loader ownership, hook/security policy, history, sibling tests, and @openclaw/fs-safe 0.5.0.
- Exact-path open-PR collision audit found no competing changes through the final pre-publish check.
- git diff --check passed.
