### PR TITLE
fix(ui): align config validation errors with visible row numbers

### DIFF
--- a/ui/src/e2e/config-form-integrity.e2e.test.ts
+++ b/ui/src/e2e/config-form-integrity.e2e.test.ts
@@ -1,5 +1,5 @@
 // Control UI tests cover schema-backed form constraints, draft recovery, and accessible names.
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -183,6 +183,132 @@ describeControlUiE2e("Control UI config form integrity mocked Gateway E2E", () =
       await expect
         .poll(() => codes.locator("input[aria-label='Codes']").last().inputValue())
         .toBe("123");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("matches rejected Settings-save errors to visible one-based model rows", async () => {
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1000, width: 1440 },
+    });
+    const page = await context.newPage();
+    const providerId = "z.ai";
+    const config = {
+      models: {
+        providers: {
+          [providerId]: {
+            models: [{ name: "First" }, { name: "Second" }, { name: "Third" }, { name: "Fourth" }],
+          },
+        },
+      },
+    };
+    const issue = {
+      path: `models.providers.${providerId}.models.3.name`,
+      message: "Invalid model name",
+    };
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "config.get": {
+          appliedConfigHash: "model-row-e2e",
+          config,
+          configRevisionHash: "model-row-e2e",
+          hash: "model-row-e2e",
+          issues: [],
+          raw: JSON.stringify(config),
+          valid: true,
+        },
+        "config.schema": {
+          generatedAt: "2026-08-01T00:00:00.000Z",
+          schema: {
+            type: "object",
+            properties: {
+              models: {
+                type: "object",
+                title: "Models",
+                properties: {
+                  providers: {
+                    type: "object",
+                    title: "Providers",
+                    additionalProperties: {
+                      type: "object",
+                      properties: {
+                        models: {
+                          type: "array",
+                          title: "Configured models",
+                          items: {
+                            type: "object",
+                            properties: {
+                              name: { type: "string", title: "Model name" },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          uiHints: {},
+          version: "e2e",
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/advanced?section=models`);
+      expect(response?.status()).toBe(200);
+      const panel = page.locator("#config-section-panel");
+      const fourthRow = panel.locator(".settings-row__title").getByText("#4", { exact: true });
+      await expect.poll(() => fourthRow.isVisible()).toBe(true);
+
+      await gateway.deferNext("config.set");
+      await panel.getByRole("textbox", { name: "Model name" }).nth(3).fill("Broken");
+      const request = await gateway.waitForRequest("config.set");
+      const params = request.params as { baseHash?: string; raw?: string };
+      const submitted = JSON.parse(String(params.raw)) as {
+        models: { providers: Record<string, { models: Array<{ name: string }> }> };
+      };
+      expect(submitted.models.providers[providerId]?.models[3]?.name).toBe("Broken");
+      expect(params.baseHash).toBe("model-row-e2e");
+
+      const rejection = {
+        code: "INVALID_REQUEST",
+        message: `invalid config: ${issue.path}: ${issue.message}`,
+        details: { issues: [issue] },
+      };
+      await gateway.rejectDeferred("config.set", rejection);
+
+      const status = page.locator('.settings-save-indicator--danger[role="status"]');
+      await expect.poll(() => status.isVisible()).toBe(true);
+      await expect
+        .poll(() => status.getAttribute("title"))
+        .toBe(
+          `GatewayRequestError: invalid config: models.providers.${providerId}.models.#4.name: Invalid model name`,
+        );
+      expect(await status.getAttribute("aria-label")).toContain(
+        `models.providers.${providerId}.models.#4.name`,
+      );
+      expect(await status.textContent()).toContain("Save failed");
+      expect(issue.path).toBe(`models.providers.${providerId}.models.3.name`);
+      expect(rejection.message).toContain(".3.name");
+
+      if (captureUiProofEnabled) {
+        await mkdir(uiProofArtifactDir, { recursive: true });
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(uiProofArtifactDir, "03-model-row-rejection.png"),
+        });
+        await writeFile(
+          path.join(uiProofArtifactDir, "03-model-row-rejection-accessibility.yml"),
+          await status.ariaSnapshot(),
+        );
+      }
     } finally {
       await context.close();
     }

--- a/ui/src/lib/config/index.test.ts
+++ b/ui/src/lib/config/index.test.ts
@@ -633,6 +633,269 @@ describe("config form auto-save", () => {
     runtimeConfig.dispose();
   });
 
+  it.each([
+    ["automatic save", "123"],
+    ["automatic save", "z.ai"],
+    ["automatic save", "a.models.3"],
+    ["manual save", "123"],
+    ["manual save", "z.ai"],
+    ["manual save", "a.models.3"],
+    ["manual save", "$&"],
+    ["apply", "123"],
+    ["apply", "z.ai"],
+    ["apply", "a.models.3"],
+  ] as const)(
+    "formats the rejected %s validation path for provider %s without changing the Gateway issue",
+    async (operation, providerId) => {
+      vi.useFakeTimers();
+      const issue = {
+        path: `models.providers.${providerId}.models.3.name`,
+        message: "Invalid model name",
+      };
+      const rejection = new GatewayRequestError({
+        code: "INVALID_REQUEST",
+        message: `invalid config: ${issue.path}: ${issue.message}`,
+        details: { issues: [issue] },
+      });
+      const config = {
+        models: {
+          providers: {
+            [providerId]: {
+              models: [
+                { name: "First" },
+                { name: "Second" },
+                { name: "Third" },
+                { name: "Fourth" },
+              ],
+            },
+          },
+        },
+      };
+      const request = vi.fn(async (method: string) => {
+        if (method === "config.get") {
+          return { config, raw: JSON.stringify(config), hash: "hash-1", valid: true, issues: [] };
+        }
+        if (method === "config.set" || method === "config.apply") {
+          throw rejection;
+        }
+        return {};
+      });
+      const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+      await runtimeConfig.ensureLoaded();
+      expect(runtimeConfig.state.configSchema).toBeNull();
+
+      if (operation === "automatic save") {
+        runtimeConfig.patchForm(["models", "providers", providerId, "models", 3, "name"], "");
+        await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+      } else if (operation === "manual save") {
+        runtimeConfig.patchForm(["models", "providers", providerId, "models", 3, "name"], "");
+        await expect(runtimeConfig.save()).resolves.toBe(false);
+      } else {
+        await expect(runtimeConfig.apply()).resolves.toBe(false);
+      }
+
+      expect(runtimeConfig.state.configSnapshot?.valid).toBe(true);
+      expect(runtimeConfig.state.configIssues).toEqual([]);
+      expect(runtimeConfig.state.lastError).toBe(
+        `GatewayRequestError: invalid config: models.providers.${providerId}.models.#4.name: Invalid model name`,
+      );
+      expect(issue.path).toBe(`models.providers.${providerId}.models.3.name`);
+      expect(rejection.message).toBe(
+        `invalid config: models.providers.${providerId}.models.3.name: Invalid model name`,
+      );
+      expect(rejection.details).toEqual({ issues: [issue] });
+      runtimeConfig.dispose();
+    },
+  );
+
+  it("preserves raw validation paths when dotted draft keys have multiple interpretations", async () => {
+    const issue = {
+      path: "models.providers.a.models.3.name",
+      message: "Invalid model name",
+    };
+    const config = {
+      models: {
+        providers: {
+          a: {
+            models: [{ name: "First" }, { name: "Second" }, { name: "Third" }, { name: "Fourth" }],
+          },
+          "a.models.3.name": { models: [{ name: "Ambiguous provider" }] },
+        },
+      },
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        return { config, raw: JSON.stringify(config), hash: "hash-1", valid: true, issues: [] };
+      }
+      if (method === "config.set") {
+        throw new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: `invalid config: ${issue.path}: ${issue.message}`,
+          details: { issues: [issue] },
+        });
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    runtimeConfig.patchForm(["models", "providers", "a", "models", 3, "name"], "");
+
+    await expect(runtimeConfig.save()).resolves.toBe(false);
+    expect(runtimeConfig.state.lastError).toBe(
+      "GatewayRequestError: invalid config: models.providers.a.models.3.name: Invalid model name",
+    );
+    expect(issue.path).toBe("models.providers.a.models.3.name");
+    runtimeConfig.dispose();
+  });
+
+  it("rewrites only complete validation fields when issue paths overlap", async () => {
+    const issues = [
+      { path: "foo.items.0.name", message: "Invalid numeric record" },
+      { path: "items.0.name", message: "Invalid array item" },
+    ];
+    const config = {
+      foo: { items: { "0": { name: "Record" } } },
+      items: [{ name: "Array" }],
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        return { config, raw: JSON.stringify(config), hash: "hash-1", valid: true, issues: [] };
+      }
+      if (method === "config.set") {
+        throw new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message:
+            "invalid config: foo.items.0.name: Invalid numeric record; items.0.name: Invalid array item",
+          details: { issues },
+        });
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    runtimeConfig.patchForm(["items", 0, "name"], "");
+
+    await expect(runtimeConfig.save()).resolves.toBe(false);
+    expect(runtimeConfig.state.lastError).toBe(
+      "GatewayRequestError: invalid config: foo.items.0.name: Invalid numeric record; items.#1.name: Invalid array item",
+    );
+    expect(issues.map((issue) => issue.path)).toEqual(["foo.items.0.name", "items.0.name"]);
+    runtimeConfig.dispose();
+  });
+
+  it("preserves machine-indexed validation paths for raw-editor submissions", async () => {
+    const issue = { path: "models.3.name", message: "Invalid model name" };
+    const config = {
+      models: [{ name: "First" }, { name: "Second" }, { name: "Third" }, { name: "Fourth" }],
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        return { config, raw: JSON.stringify(config), hash: "hash-1", valid: true, issues: [] };
+      }
+      if (method === "config.set") {
+        throw new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: `invalid config: ${issue.path}: ${issue.message}`,
+          details: { issues: [issue] },
+        });
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    runtimeConfig.setRaw(
+      JSON.stringify({
+        models: [{ name: "First" }, { name: "Second" }, { name: "Third" }, { name: "" }],
+      }),
+    );
+
+    await expect(runtimeConfig.save()).resolves.toBe(false);
+    expect(runtimeConfig.state.configFormMode).toBe("raw");
+    expect(runtimeConfig.state.lastError).toBe(
+      "GatewayRequestError: invalid config: models.3.name: Invalid model name",
+    );
+    runtimeConfig.dispose();
+  });
+
+  it.each(["automatic save", "manual save", "apply"] as const)(
+    "formats rejected %s paths against the submitted draft after a mid-flight edit",
+    async (operation) => {
+      vi.useFakeTimers();
+      const pendingWrite = deferred<unknown>();
+      const issue = {
+        path: "models.providers.a.models.3.models.3.name",
+        message: "Invalid model name",
+      };
+      const config = {
+        models: {
+          providers: {
+            "a.models.3": {
+              models: [
+                { name: "First" },
+                { name: "Second" },
+                { name: "Third" },
+                { name: "Fourth" },
+              ],
+            },
+          },
+        },
+      };
+      const request = vi.fn((method: string) => {
+        if (method === "config.get") {
+          return Promise.resolve({
+            config,
+            raw: JSON.stringify(config),
+            hash: "hash-1",
+            valid: true,
+            issues: [],
+          });
+        }
+        if (method === "config.set" || method === "config.apply") {
+          return pendingWrite.promise;
+        }
+        return Promise.resolve({});
+      });
+      const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+      await runtimeConfig.ensureLoaded();
+
+      let write: Promise<boolean> | undefined;
+      if (operation === "automatic save") {
+        runtimeConfig.patchForm(["models", "providers", "a.models.3", "models", 3, "name"], "");
+        await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+      } else if (operation === "manual save") {
+        runtimeConfig.patchForm(["models", "providers", "a.models.3", "models", 3, "name"], "");
+        write = runtimeConfig.save();
+      } else {
+        write = runtimeConfig.apply();
+      }
+      expect(request).toHaveBeenCalledWith(
+        operation === "apply" ? "config.apply" : "config.set",
+        expect.any(Object),
+      );
+
+      runtimeConfig.patchForm(["models", "providers", "a"], {
+        models: [{}, {}, {}, { models: [{}, {}, {}, { name: "Overlapping provider" }] }],
+      });
+      pendingWrite.reject(
+        new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: `invalid config: ${issue.path}: ${issue.message}`,
+          details: { issues: [issue] },
+        }),
+      );
+      if (write) {
+        await expect(write).resolves.toBe(false);
+      } else {
+        await vi.advanceTimersByTimeAsync(0);
+      }
+
+      expect(runtimeConfig.state.lastError).toBe(
+        "GatewayRequestError: invalid config: models.providers.a.models.3.models.#4.name: Invalid model name",
+      );
+      runtimeConfig.dispose();
+    },
+  );
+
   it("clears needsApply only on apply; a discarding refresh keeps the banner", async () => {
     vi.useFakeTimers();
     const server = createConfigServerMock();

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -94,6 +94,91 @@ type ConfigState = {
   chatError?: string | null;
 };
 
+function formatConfigMutationError(error: unknown, submittedRaw: string | null): string {
+  let message = String(error);
+  if (!submittedRaw || !(error instanceof GatewayRequestError) || !isRecord(error.details)) {
+    return message;
+  }
+  const issues = error.details.issues;
+  if (!Array.isArray(issues)) {
+    return message;
+  }
+  const summaryPrefix = `${error.name}: invalid config: `;
+  if (!message.startsWith(summaryPrefix)) {
+    return message;
+  }
+  const submittedForm = parseConfigRawDraft(submittedRaw);
+  if (!submittedForm) {
+    return message;
+  }
+  let offset = summaryPrefix.length;
+  for (const issue of issues) {
+    if (
+      !isRecord(issue) ||
+      typeof issue.path !== "string" ||
+      typeof issue.message !== "string" ||
+      !message.startsWith(`${issue.path}: ${issue.message}`, offset)
+    ) {
+      break;
+    }
+    const displayPath = formatConfigIssuePathFromDraft(issue.path, submittedForm);
+    if (displayPath !== issue.path) {
+      message = `${message.slice(0, offset)}${displayPath}${message.slice(offset + issue.path.length)}`;
+    }
+    offset += displayPath.length + 2 + issue.message.length;
+    if (!message.startsWith("; ", offset)) {
+      break;
+    }
+    offset += 2;
+  }
+  return message;
+}
+
+function formatConfigIssuePathFromDraft(path: string, draft: unknown): string {
+  const segments = path.split(".");
+
+  const visit = (value: unknown, offset: number): string[] => {
+    if (offset === segments.length) {
+      return [""];
+    }
+    const segment = segments[offset];
+    if (segment === undefined) {
+      return [];
+    }
+    if (Array.isArray(value)) {
+      const index = Number(segment);
+      if (!/^\d+$/u.test(segment) || !Number.isSafeInteger(index) || !Object.hasOwn(value, index)) {
+        return [segments.slice(offset).join(".")];
+      }
+      return visit(value[index], offset + 1).map((tail) =>
+        tail ? `#${index + 1}.${tail}` : `#${index + 1}`,
+      );
+    }
+    if (!isRecord(value)) {
+      return [segments.slice(offset).join(".")];
+    }
+
+    const matches = Object.keys(value).flatMap((key) => {
+      const keySegments = key.split(".");
+      if (
+        keySegments.length > segments.length - offset ||
+        !keySegments.every((keySegment, index) => keySegment === segments[offset + index])
+      ) {
+        return [];
+      }
+      return visit(value[key], offset + keySegments.length).map((tail) =>
+        tail ? `${key}.${tail}` : key,
+      );
+    });
+    return matches.length > 0 ? matches : [segments.slice(offset).join(".")];
+  };
+
+  // Flattened Gateway paths cannot distinguish overlapping dotted object keys;
+  // keep the machine path unless the actual draft proves one display spelling.
+  const displayPaths = new Set(visit(draft, 0));
+  return displayPaths.size === 1 ? (displayPaths.values().next().value ?? path) : path;
+}
+
 const autoAllowlistedPluginIdsByState = new WeakMap<ConfigState, Set<string>>();
 const requestVersionsByState = new WeakMap<ConfigState, { config: number; schema: number }>();
 const connectionEpochsByState = new WeakMap<object, number>();
@@ -624,6 +709,7 @@ async function submitConfigChange(
   state[busyKey] = true;
   state.lastError = null;
   state.chatError = null;
+  let submittedFormRaw: string | null = null;
   try {
     if (state.configRawOriginalParsePending) {
       // JSON5 originals parse asynchronously on first load; sanitize needs them.
@@ -633,6 +719,9 @@ async function submitConfigChange(
       }
     }
     const raw = serializeFormForSubmit(state);
+    // The serialized candidate includes schema coercion; a live draft can
+    // change while the request is pending, so never infer from it afterward.
+    submittedFormRaw = state.configFormMode === "form" ? raw : null;
     const baseHash = state.configDraftBaseHash ?? state.configSnapshot?.hash;
     if (!baseHash) {
       state.lastError = "Config hash missing; reload and retry.";
@@ -688,7 +777,7 @@ async function submitConfigChange(
     return true;
   } catch (err) {
     if (isCurrent()) {
-      state.lastError = String(err);
+      state.lastError = formatConfigMutationError(err, submittedFormRaw);
       if (isConfigBaseHashConflictError(err)) {
         // Applies conflict the same way saves do so the UI offers Reload.
         state.configAutoSaveStatus = "conflict";
@@ -800,7 +889,7 @@ async function autoSaveConfig(
     return true;
   } catch (err) {
     if (isCurrent()) {
-      state.lastError = String(err);
+      state.lastError = formatConfigMutationError(err, submittedRaw);
       state.configAutoSaveStatus = isConfigBaseHashConflictError(err) ? "conflict" : "error";
     }
     return false;


### PR DESCRIPTION
Closes #73971

## What Problem This Solves

The Control UI numbers configured model rows starting at 1, but Gateway validation errors returned from a rejected Settings form save identify array elements with their machine-facing zero-based index. Users see row #4 while the failure points to row 3.

## Why This Change Was Made

Format validation paths only at the Control UI's existing whole-form config.set/config.apply write owner. Capture the exact immutable serialized candidate before dispatch, then use its real array/object shape to translate rejected array indexes into the row numbers shown in the form.

Dotted and numeric provider IDs remain object keys; ambiguous dotted paths fail closed without rewriting. Raw-editor submissions, config.patch, redacted snapshots, Gateway errors/details, CLI output, schemas, and the public protocol remain unchanged. The formatter only parses rejected form submissions, preserving successful-write hot paths.

Thanks @bladin for the earlier direction in closed PR #93519.

## User Impact

A failed Settings form save now identifies the same model row visible in the interface, across automatic save, manual save, and apply. Raw JSON errors remain machine-oriented.

## Evidence

- Failing-first owner regressions exercise real config.get -> config.set/config.apply rejection across automatic save, manual save, and apply.
- 106 owner tests pass, including numeric provider IDs, dotted z.ai IDs, adversarial dotted keys, ambiguous overlapping keys, literal dollar replacement sequences, overlapping validation paths, and edits made while a request is in flight.
- Real remote Chromium: all 51 existing Control UI Settings browser tests pass.
- Full UI test type-check passes; complete production Control UI build succeeds (3,030 transformed modules).
- Remote proof: Blacksmith Testbox lease tbx_01kz1q14k8289rarpdzjes3rpj, https://github.com/openclaw/openclaw/actions/runs/30758122062; both delegated proof commands exited 0.
- Targeted formatting/lint and git diff --check pass.
- Fresh independent xhigh maintainer review and a separate fresh xhigh/P2 autoreview both found no remaining actionable findings.
- AI-assisted implementation and review; independently reproduced and understood end to end.

## Inspectable Real Browser Proof

A checked-in production Chromium end-to-end scenario boots the actual Vite Control UI, performs the normal Gateway WebSocket handshake, renders Settings -> Advanced -> Models, edits the visible fourth model row, and rejects the real outgoing config.set request with the unchanged machine path models.providers.z.ai.models.3.name.

The actual Settings save indicator then exposes this accessibility snapshot:

```yaml
- 'status "Save failed: GatewayRequestError: invalid config: models.providers.z.ai.models.#4.name: Invalid model name"':
  - text: Save failed
  - button "Retry"
```

The raw Gateway issue remains .3; no server response or protocol field is rewritten. Real Chromium generated a 1440x1000 screenshot and the matching accessible snapshot. The focused browser scenario and the full UI test-type gate both passed on the remote Blacksmith Testbox (exit 0).

## Verified Real Gateway + Real Chromium (No Mocks)

Exact reviewed commit: `131095f803d79807ed8523fe6ec55ada8b74e840`.

A trusted Blacksmith Testbox built the production Vite Control UI, launched an actual isolated OpenClaw Gateway, and opened the actual Settings screen in Chromium. The browser expanded **Model Policy → Allowed Models**, edited visible row **#4** from `openai/gpt-5.5` to `not-a-model-ref`, and performed a real save.

The Gateway and browser exchanged genuine `config.get`, `config.schema`, and `config.set` WebSocket requests. No WebSocket route interception, fake server, mocked Gateway, or synthetic rejection was used.

Actual Gateway validation response, observed passively on the production socket:

```text
invalid config: agents.defaults.modelPolicy.allow.3:
invalid model policy ref: "not-a-model-ref".
```

Actual visible Settings failure:

```text
GatewayRequestError: invalid config: agents.defaults.modelPolicy.allow.#4:
invalid model policy ref: "not-a-model-ref".
```

Actual Chromium accessibility snapshot:

```yaml
- 'status "Save failed: GatewayRequestError: invalid config: agents.defaults.modelPolicy.allow.#4: invalid model policy ref: \"not-a-model-ref\"..."':
  - text: Save failed
  - button "Retry"
```

The untouched real Gateway wire path remains `.3`; the actual operator-facing UI shows `.#4`. Real Chromium screenshot: 119,970 bytes; SHA-256 `c742d1f5bfd82738055dff89e22e6a12d55c8bb3e2d8f86d5e724364a1f9b378`. Trusted proof run: https://github.com/openclaw/openclaw/actions/runs/30760958609.
