### PR TITLE
test(ai): consolidate Google and Mistral provider fixtures

### DIFF
--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -1,7 +1,14 @@
 // Google shared provider tests cover response conversion and finish reasons.
-import { ApiError, FinishReason, GoogleGenAI, type GenerateContentResponse } from "@google/genai";
+import {
+  ApiError,
+  BlockedReason,
+  FinishReason,
+  GoogleGenAI,
+  type GenerateContentResponse,
+  type Part,
+} from "@google/genai";
 import { describe, expect, it, vi } from "vitest";
-import type { AssistantMessage, Model } from "../types.js";
+import type { Model } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 import {
@@ -9,6 +16,7 @@ import {
   buildGoogleSimpleThinking,
   convertMessages,
   consumeGoogleGenerateContentStream,
+  createGoogleAssistantOutput,
   runGoogleGenerateContentLifecycle,
 } from "./google-shared.js";
 
@@ -30,31 +38,7 @@ const model: Model<"google-generative-ai"> = {
   maxTokens: 8_192,
 };
 
-function createOutput(): AssistantMessage {
-  return {
-    role: "assistant",
-    content: [],
-    api: model.api,
-    provider: model.provider,
-    model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        total: 0,
-      },
-    },
-    stopReason: "stop",
-    timestamp: 0,
-  };
-}
+const createOutput = () => createGoogleAssistantOutput(model);
 
 describe("buildGoogleSimpleThinking", () => {
   it.each([
@@ -136,35 +120,145 @@ async function* chunks(items: GenerateContentResponse[]) {
   yield* items;
 }
 
+type GoogleResponseFixture = {
+  parts?: Part[];
+  finishReason?: FinishReason;
+  finishMessage?: string;
+  responseId?: string;
+  usageMetadata?: GenerateContentResponse["usageMetadata"];
+  promptFeedback?: GenerateContentResponse["promptFeedback"];
+};
+
+function googleResponse(fixture: GoogleResponseFixture): GenerateContentResponse {
+  const { parts, finishReason, finishMessage, ...response } = fixture;
+  const hasCandidate =
+    parts !== undefined || finishReason !== undefined || finishMessage !== undefined;
+  return {
+    ...response,
+    ...(hasCandidate && {
+      candidates: [
+        {
+          ...(parts !== undefined && { content: { parts } }),
+          ...(finishReason !== undefined && { finishReason }),
+          ...(finishMessage !== undefined && { finishMessage }),
+        },
+      ],
+    }),
+  } as GenerateContentResponse;
+}
+
+function finishedGoogleParts(parts: Part[], finishReason = FinishReason.STOP) {
+  return googleResponse({ parts, finishReason });
+}
+
+function lookupPart(args: Record<string, unknown> = {}, thoughtSignature?: string): Part {
+  return {
+    functionCall: { id: "call_1", name: "lookup", args },
+    ...(thoughtSignature && { thoughtSignature }),
+  };
+}
+
+function lookupContent(
+  args: Record<string, unknown> = {},
+  thoughtSignature?: string,
+  id = "call_1",
+) {
+  return {
+    type: "toolCall" as const,
+    id,
+    name: "lookup",
+    arguments: args,
+    ...(thoughtSignature && { thoughtSignature }),
+  };
+}
+
+type StreamEvent = { type: string; delta?: string; reason?: string };
+
+async function consumeGoogleFixture(responses: GenerateContentResponse[], collectEvents = false) {
+  const output = createOutput();
+  const stream = new AssistantMessageEventStream();
+  const events: StreamEvent[] = [];
+  const collect = collectEvents
+    ? (async () => {
+        for await (const event of stream) {
+          events.push(event);
+        }
+      })()
+    : undefined;
+
+  await consumeGoogleGenerateContentStream({
+    chunks: chunks(responses),
+    model,
+    output,
+    stream,
+    nextToolCallId: (name) => `generated-${name}`,
+  });
+  await collect;
+  return { output, stream, events };
+}
+
+type GoogleLifecycleParams = Parameters<typeof runGoogleGenerateContentLifecycle>[0];
+type GoogleGenerateContentStream = ReturnType<
+  GoogleLifecycleParams["createClient"]
+>["models"]["generateContentStream"];
+type GoogleFixtureOptions = {
+  targetModel?: Model<"google-generative-ai" | "google-vertex">;
+  options?: GoogleLifecycleParams["options"];
+  createClient?: GoogleLifecycleParams["createClient"];
+  generateContentStream?: GoogleGenerateContentStream;
+  buildParams?: GoogleLifecycleParams["buildParams"];
+  collectEvents?: boolean;
+};
+
+async function runGoogleFixture(
+  responses: GenerateContentResponse[] = [],
+  fixture: GoogleFixtureOptions = {},
+) {
+  const targetModel = fixture.targetModel ?? model;
+  const output = createGoogleAssistantOutput(targetModel);
+  const stream = new AssistantMessageEventStream();
+  const events: StreamEvent[] = [];
+  const collect = fixture.collectEvents
+    ? (async () => {
+        for await (const event of stream) {
+          events.push(event);
+        }
+      })()
+    : undefined;
+
+  await runGoogleGenerateContentLifecycle({
+    stream,
+    model: targetModel,
+    output,
+    options: fixture.options,
+    createClient:
+      fixture.createClient ??
+      (() => ({
+        models: {
+          generateContentStream: fixture.generateContentStream ?? (async () => chunks(responses)),
+        },
+      })),
+    buildParams: fixture.buildParams ?? (() => ({ model: targetModel.id, contents: [] })),
+    nextToolCallId: () => "call_1",
+  });
+  await collect;
+  return { output, stream, events, result: await stream.result() };
+}
+
 describe("consumeGoogleGenerateContentStream", () => {
   it("projects text, thinking, tool calls, response id, and usage into one stream", async () => {
-    const output = createOutput();
-    const stream = new AssistantMessageEventStream();
-    const events: string[] = [];
-    const collect = (async () => {
-      for await (const event of stream) {
-        events.push(event.type);
-      }
-    })();
-
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
-        {
+    const { output, events } = await consumeGoogleFixture(
+      [
+        googleResponse({
           responseId: "response-1",
-          candidates: [
-            {
-              content: {
-                parts: [
-                  { text: "thinking", thought: true, thoughtSignature: "dGhpbms=" },
-                  { text: "hello" },
-                  { functionCall: { name: "lookup", args: { query: "cats" } } },
-                ],
-              },
-            },
+          parts: [
+            { text: "thinking", thought: true, thoughtSignature: "dGhpbms=" },
+            { text: "hello" },
+            { functionCall: { name: "lookup", args: { query: "cats" } } },
           ],
-        } as GenerateContentResponse,
-        {
-          candidates: [{ finishReason: FinishReason.STOP }],
+        }),
+        googleResponse({
+          finishReason: FinishReason.STOP,
           usageMetadata: {
             promptTokenCount: 10,
             cachedContentTokenCount: 2,
@@ -172,16 +266,12 @@ describe("consumeGoogleGenerateContentStream", () => {
             thoughtsTokenCount: 4,
             totalTokenCount: 17,
           },
-        } as GenerateContentResponse,
-      ]),
-      model,
-      output,
-      stream,
-      nextToolCallId: (name) => `generated-${name}`,
-    });
-    await collect;
+        }),
+      ],
+      true,
+    );
 
-    expect(events).toEqual([
+    expect(events.map((event) => event.type)).toEqual([
       "start",
       "thinking_start",
       "thinking_delta",
@@ -199,12 +289,7 @@ describe("consumeGoogleGenerateContentStream", () => {
     expect(output.content).toEqual([
       { type: "thinking", thinking: "thinking", thinkingSignature: "dGhpbms=" },
       { type: "text", text: "hello" },
-      {
-        type: "toolCall",
-        id: "generated-lookup",
-        name: "lookup",
-        arguments: { query: "cats" },
-      },
+      lookupContent({ query: "cats" }, undefined, "generated-lookup"),
     ]);
     expect(output.usage).toMatchObject({
       input: 8,
@@ -241,20 +326,9 @@ describe("consumeGoogleGenerateContentStream", () => {
       expectedTotal: 14,
     },
   ])("$name", async ({ usageMetadata, expectedInput, expectedTotal }) => {
-    const output = createOutput();
-
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
-        {
-          candidates: [{ finishReason: FinishReason.STOP }],
-          usageMetadata,
-        } as GenerateContentResponse,
-      ]),
-      model,
-      output,
-      stream: new AssistantMessageEventStream(),
-      nextToolCallId: () => "call_1",
-    });
+    const { output } = await consumeGoogleFixture([
+      googleResponse({ finishReason: FinishReason.STOP, usageMetadata }),
+    ]);
 
     expect(output.usage).toMatchObject({
       input: expectedInput,
@@ -266,186 +340,72 @@ describe("consumeGoogleGenerateContentStream", () => {
   });
 
   it("retains prompt, cache, and tool-token facts across sparse Google usage chunks", async () => {
-    const output = createOutput();
-
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
-        {
-          usageMetadata: {
-            promptTokenCount: 100,
-            cachedContentTokenCount: 40,
-            toolUsePromptTokenCount: 6,
-            candidatesTokenCount: 1,
-            totalTokenCount: 107,
-          },
-        } as GenerateContentResponse,
-        {
-          candidates: [{ finishReason: FinishReason.STOP }],
-          usageMetadata: { candidatesTokenCount: 12, thoughtsTokenCount: 3 },
-        } as GenerateContentResponse,
-      ]),
-      model,
-      output,
-      stream: new AssistantMessageEventStream(),
-      nextToolCallId: () => "call_1",
-    });
+    const { output } = await consumeGoogleFixture([
+      googleResponse({
+        usageMetadata: {
+          promptTokenCount: 100,
+          cachedContentTokenCount: 40,
+          toolUsePromptTokenCount: 6,
+          candidatesTokenCount: 1,
+          totalTokenCount: 107,
+        },
+      }),
+      googleResponse({
+        finishReason: FinishReason.STOP,
+        usageMetadata: { candidatesTokenCount: 12, thoughtsTokenCount: 3 },
+      }),
+    ]);
 
     expect(output.usage).toMatchObject({ input: 66, output: 15, cacheRead: 40, totalTokens: 121 });
   });
 
   it("never reports negative input when Google only provides sparse cached-token facts", async () => {
-    const output = createOutput();
-
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
-        {
-          candidates: [{ finishReason: FinishReason.STOP }],
-          usageMetadata: { cachedContentTokenCount: 40, toolUsePromptTokenCount: 6 },
-        } as GenerateContentResponse,
-      ]),
-      model,
-      output,
-      stream: new AssistantMessageEventStream(),
-      nextToolCallId: () => "call_1",
-    });
+    const { output } = await consumeGoogleFixture([
+      googleResponse({
+        finishReason: FinishReason.STOP,
+        usageMetadata: { cachedContentTokenCount: 40, toolUsePromptTokenCount: 6 },
+      }),
+    ]);
 
     expect(output.usage).toMatchObject({ input: 6, cacheRead: 40 });
   });
 
   it("preserves MAX_TOKENS when the partial response contains a function call", async () => {
-    const output = createOutput();
-    const stream = new AssistantMessageEventStream();
-    const terminalReason = (async () => {
-      for await (const event of stream) {
-        if (event.type === "done") {
-          return event.reason;
-        }
-      }
-      return undefined;
-    })();
+    const { output, events } = await consumeGoogleFixture(
+      [
+        googleResponse({
+          parts: [{ functionCall: { name: "lookup", args: { query: "cats" } } }],
+          finishReason: FinishReason.MAX_TOKENS,
+        }),
+      ],
+      true,
+    );
 
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
-        {
-          candidates: [
-            {
-              content: {
-                parts: [{ functionCall: { name: "lookup", args: { query: "cats" } } }],
-              },
-              finishReason: FinishReason.MAX_TOKENS,
-            },
-          ],
-        } as unknown as GenerateContentResponse,
-      ]),
-      model,
-      output,
-      stream,
-      nextToolCallId: (name) => `generated-${name}`,
-    });
-
-    expect(await terminalReason).toBe("length");
+    expect(events.find((event) => event.type === "done")?.reason).toBe("length");
     expect(output.stopReason).toBe("length");
     expect(output.content).toEqual([expect.objectContaining({ type: "toolCall", name: "lookup" })]);
   });
 
   it("generates a new id when Google repeats a streamed tool-call id", async () => {
-    const output = createOutput();
-    const stream = new AssistantMessageEventStream();
-    const events: string[] = [];
-    const collect = (async () => {
-      for await (const event of stream) {
-        events.push(event.type);
-      }
-    })();
+    const { output, events } = await consumeGoogleFixture(
+      [googleResponse({ parts: [lookupPart()] }), finishedGoogleParts([lookupPart()])],
+      true,
+    );
 
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
-        {
-          candidates: [
-            {
-              content: {
-                parts: [{ functionCall: { id: "call_1", name: "lookup", args: {} } }],
-              },
-            },
-          ],
-        } as GenerateContentResponse,
-        {
-          candidates: [
-            {
-              content: {
-                parts: [{ functionCall: { id: "call_1", name: "lookup", args: {} } }],
-              },
-              finishReason: FinishReason.STOP,
-            },
-          ],
-        } as GenerateContentResponse,
-      ]),
-      model,
-      output,
-      stream,
-      nextToolCallId: (name) => `generated-${name}`,
-    });
-    await collect;
-
-    expect(events.at(-1)).toBe("done");
+    expect(events.at(-1)?.type).toBe("done");
     expect(output.content).toEqual([
-      {
-        type: "toolCall",
-        id: "call_1",
-        name: "lookup",
-        arguments: {},
-      },
-      {
-        type: "toolCall",
-        id: "generated-lookup",
-        name: "lookup",
-        arguments: {},
-      },
+      lookupContent(),
+      lookupContent({}, undefined, "generated-lookup"),
     ]);
   });
 
   it("attaches a standalone thought signature to the preceding canonical tool call", async () => {
-    const output = createOutput();
-
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
-        {
-          candidates: [
-            {
-              content: {
-                parts: [
-                  {
-                    functionCall: { id: "call_1", name: "lookup", args: { query: "cats" } },
-                  },
-                ],
-              },
-            },
-          ],
-        } as unknown as GenerateContentResponse,
-        {
-          candidates: [
-            {
-              content: { parts: [{ thoughtSignature: "Y2FsbF9zaWc=" }] },
-              finishReason: FinishReason.STOP,
-            },
-          ],
-        } as GenerateContentResponse,
-      ]),
-      model,
-      output,
-      stream: new AssistantMessageEventStream(),
-      nextToolCallId: () => "generated-lookup",
-    });
-
-    expect(output.content).toEqual([
-      {
-        type: "toolCall",
-        id: "call_1",
-        name: "lookup",
-        arguments: { query: "cats" },
-        thoughtSignature: "Y2FsbF9zaWc=",
-      },
+    const { output } = await consumeGoogleFixture([
+      googleResponse({ parts: [lookupPart({ query: "cats" })] }),
+      finishedGoogleParts([{ thoughtSignature: "Y2FsbF9zaWc=" }]),
     ]);
+
+    expect(output.content).toEqual([lookupContent({ query: "cats" }, "Y2FsbF9zaWc=")]);
   });
 
   it.each([
@@ -476,27 +436,7 @@ describe("consumeGoogleGenerateContentStream", () => {
       ],
     },
   ])("retains a standalone thought signature beside $label", async ({ parts, content }) => {
-    const output = createOutput();
-    const stream = new AssistantMessageEventStream();
-    const events: Array<{ type: string; delta?: string }> = [];
-    const collect = (async () => {
-      for await (const event of stream) {
-        events.push(event);
-      }
-    })();
-
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
-        {
-          candidates: [{ content: { parts }, finishReason: FinishReason.STOP }],
-        } as GenerateContentResponse,
-      ]),
-      model,
-      output,
-      stream,
-      nextToolCallId: () => "generated-lookup",
-    });
-    await collect;
+    const { output, events } = await consumeGoogleFixture([finishedGoogleParts(parts)], true);
 
     expect(output.content).toEqual(content);
     expect(events).toContainEqual(expect.objectContaining({ type: "text_delta", delta: "" }));
@@ -511,33 +451,16 @@ describe("consumeGoogleGenerateContentStream", () => {
   });
 
   it("keeps an explicit signature-only thought separate from the preceding tool call", async () => {
-    const output = createOutput();
-
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
-        {
-          candidates: [
-            {
-              content: {
-                parts: [
-                  { functionCall: { id: "call_1", name: "lookup", args: {} } },
-                  { thought: true, thoughtSignature: "dGhvdWdodF9zaWc=" },
-                  { thought: true, text: "draft" },
-                ],
-              },
-              finishReason: FinishReason.STOP,
-            },
-          ],
-        } as GenerateContentResponse,
+    const { output } = await consumeGoogleFixture([
+      finishedGoogleParts([
+        lookupPart(),
+        { thought: true, thoughtSignature: "dGhvdWdodF9zaWc=" },
+        { thought: true, text: "draft" },
       ]),
-      model,
-      output,
-      stream: new AssistantMessageEventStream(),
-      nextToolCallId: () => "generated-lookup",
-    });
+    ]);
 
     expect(output.content).toEqual([
-      { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+      lookupContent(),
       { type: "thinking", thinking: "", thinkingSignature: "dGhvdWdodF9zaWc=" },
       { type: "thinking", thinking: "draft", thinkingSignature: undefined },
     ]);
@@ -549,106 +472,38 @@ describe("consumeGoogleGenerateContentStream", () => {
   ])(
     "never overwrites a signed tool call with a separate $label provider signature part",
     async ({ signature }) => {
-      const output = createOutput();
-
-      await consumeGoogleGenerateContentStream({
-        chunks: chunks([
-          {
-            candidates: [
-              {
-                content: {
-                  parts: [
-                    {
-                      functionCall: { id: "call_1", name: "lookup", args: {} },
-                      thoughtSignature: "c2lnXzE=",
-                    },
-                    { thoughtSignature: signature },
-                  ],
-                },
-                finishReason: FinishReason.STOP,
-              },
-            ],
-          } as GenerateContentResponse,
-        ]),
-        model,
-        output,
-        stream: new AssistantMessageEventStream(),
-        nextToolCallId: () => "generated-lookup",
-      });
+      const { output } = await consumeGoogleFixture([
+        finishedGoogleParts([lookupPart({}, "c2lnXzE="), { thoughtSignature: signature }]),
+      ]);
 
       expect(output.content).toEqual([
-        {
-          type: "toolCall",
-          id: "call_1",
-          name: "lookup",
-          arguments: {},
-          thoughtSignature: "c2lnXzE=",
-        },
+        lookupContent({}, "c2lnXzE="),
         { type: "text", text: "", textSignature: signature },
       ]);
     },
   );
 
   it("never attaches a signed media Part to the preceding unsigned tool call", async () => {
-    const output = createOutput();
-
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
+    const { output } = await consumeGoogleFixture([
+      finishedGoogleParts([
+        lookupPart(),
         {
-          candidates: [
-            {
-              content: {
-                parts: [
-                  { functionCall: { id: "call_1", name: "lookup", args: {} } },
-                  {
-                    inlineData: { mimeType: "image/png", data: "aW1hZ2U=" },
-                    thoughtSignature: "c2lnXzE=",
-                  },
-                ],
-              },
-              finishReason: FinishReason.STOP,
-            },
-          ],
-        } as GenerateContentResponse,
+          inlineData: { mimeType: "image/png", data: "aW1hZ2U=" },
+          thoughtSignature: "c2lnXzE=",
+        },
       ]),
-      model,
-      output,
-      stream: new AssistantMessageEventStream(),
-      nextToolCallId: () => "generated-lookup",
-    });
-
-    expect(output.content).toEqual([
-      { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
     ]);
+
+    expect(output.content).toEqual([lookupContent()]);
   });
 
   it("keeps a same-candidate standalone signature separate from an unsigned tool call", async () => {
-    const output = createOutput();
-
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
-        {
-          candidates: [
-            {
-              content: {
-                parts: [
-                  { functionCall: { id: "call_1", name: "lookup", args: {} } },
-                  { thoughtSignature: "c2lnXzE=" },
-                ],
-              },
-              finishReason: FinishReason.STOP,
-            },
-          ],
-        } as GenerateContentResponse,
-      ]),
-      model,
-      output,
-      stream: new AssistantMessageEventStream(),
-      nextToolCallId: () => "generated-lookup",
-    });
+    const { output } = await consumeGoogleFixture([
+      finishedGoogleParts([lookupPart(), { thoughtSignature: "c2lnXzE=" }]),
+    ]);
 
     expect(output.content).toEqual([
-      { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+      lookupContent(),
       { type: "text", text: "", textSignature: "c2lnXzE=" },
     ]);
   });
@@ -707,19 +562,7 @@ describe("consumeGoogleGenerateContentStream", () => {
       ],
     },
   ])("keeps exact provider part ownership for $label", async ({ parts, content }) => {
-    const output = createOutput();
-
-    await consumeGoogleGenerateContentStream({
-      chunks: chunks([
-        {
-          candidates: [{ content: { parts }, finishReason: FinishReason.STOP }],
-        } as GenerateContentResponse,
-      ]),
-      model,
-      output,
-      stream: new AssistantMessageEventStream(),
-      nextToolCallId: () => "generated-lookup",
-    });
+    const { output } = await consumeGoogleFixture([finishedGoogleParts(parts)]);
 
     expect(output.content).toEqual(content);
     expect(convertMessages(model, { messages: [output] })).toEqual([{ role: "model", parts }]);
@@ -735,32 +578,12 @@ describe("runGoogleGenerateContentLifecycle", () => {
         api,
         provider: api === "google-vertex" ? "google-vertex" : "google",
       } satisfies Model<"google-generative-ai" | "google-vertex">;
-      const output: AssistantMessage = {
-        ...createOutput(),
-        api: targetModel.api,
-        provider: targetModel.provider,
-      };
-      const stream = new AssistantMessageEventStream();
+      const { result } = await runGoogleFixture(
+        [googleResponse({ parts: [{ text: "partial output" }] })],
+        { targetModel },
+      );
 
-      await runGoogleGenerateContentLifecycle({
-        stream,
-        model: targetModel,
-        output,
-        createClient: () => ({
-          models: {
-            generateContentStream: async () =>
-              chunks([
-                {
-                  candidates: [{ content: { parts: [{ text: "partial output" }] } }],
-                } as GenerateContentResponse,
-              ]),
-          },
-        }),
-        buildParams: () => ({ model: targetModel.id, contents: [] }),
-        nextToolCallId: () => "call_1",
-      });
-
-      expect(await stream.result()).toMatchObject({
+      expect(result).toMatchObject({
         stopReason: "error",
         errorCode: "STREAM_INCOMPLETE",
         errorType: "google_incomplete_stream",
@@ -772,33 +595,14 @@ describe("runGoogleGenerateContentLifecycle", () => {
   it.each([FinishReason.SAFETY, FinishReason.MALFORMED_FUNCTION_CALL])(
     "preserves the actionable %s candidate finish message",
     async (finishReason) => {
-      const output = createOutput();
-      const stream = new AssistantMessageEventStream();
-
-      await runGoogleGenerateContentLifecycle({
-        stream,
-        model,
-        output,
-        createClient: () => ({
-          models: {
-            generateContentStream: async () =>
-              chunks([
-                {
-                  candidates: [
-                    {
-                      finishReason,
-                      finishMessage: "Provider rejected the generated response",
-                    },
-                  ],
-                } as GenerateContentResponse,
-              ]),
-          },
+      const { result } = await runGoogleFixture([
+        googleResponse({
+          finishReason,
+          finishMessage: "Provider rejected the generated response",
         }),
-        buildParams: () => ({ model: model.id, contents: [] }),
-        nextToolCallId: () => "call_1",
-      });
+      ]);
 
-      expect(await stream.result()).toMatchObject({
+      expect(result).toMatchObject({
         stopReason: "error",
         errorCode: finishReason,
         errorType: "google_generation_failed",
@@ -808,42 +612,25 @@ describe("runGoogleGenerateContentLifecycle", () => {
   );
 
   it("closes partial text before reporting a failed candidate", async () => {
-    const output = createOutput();
-    const stream = new AssistantMessageEventStream();
-    const eventTypes: string[] = [];
-    const collect = (async () => {
-      for await (const event of stream) {
-        eventTypes.push(event.type);
-      }
-    })();
+    const { events, result } = await runGoogleFixture(
+      [
+        googleResponse({
+          parts: [{ text: "partial output" }],
+          finishReason: FinishReason.SAFETY,
+          finishMessage: "Provider rejected the generated response",
+        }),
+      ],
+      { collectEvents: true },
+    );
 
-    await runGoogleGenerateContentLifecycle({
-      stream,
-      model,
-      output,
-      createClient: () => ({
-        models: {
-          generateContentStream: async () =>
-            chunks([
-              {
-                candidates: [
-                  {
-                    content: { parts: [{ text: "partial output" }] },
-                    finishReason: FinishReason.SAFETY,
-                    finishMessage: "Provider rejected the generated response",
-                  },
-                ],
-              } as GenerateContentResponse,
-            ]),
-        },
-      }),
-      buildParams: () => ({ model: model.id, contents: [] }),
-      nextToolCallId: () => "call_1",
-    });
-    await collect;
-
-    expect(eventTypes).toEqual(["start", "text_start", "text_delta", "text_end", "error"]);
-    expect((await stream.result()).errorCode).toBe("SAFETY");
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "text_start",
+      "text_delta",
+      "text_end",
+      "error",
+    ]);
+    expect(result.errorCode).toBe("SAFETY");
   });
 
   it("preserves cancellation precedence over an observed candidate failure", async () => {
@@ -851,36 +638,20 @@ describe("runGoogleGenerateContentLifecycle", () => {
     const abortReason = Object.assign(new Error("Google run restarted"), {
       code: "GATEWAY_RESTART",
     });
-    const output = createOutput();
-    const stream = new AssistantMessageEventStream();
-
-    await runGoogleGenerateContentLifecycle({
-      stream,
-      model,
-      output,
+    const { output, result } = await runGoogleFixture([], {
       options: { signal: controller.signal },
-      createClient: () => ({
-        models: {
-          generateContentStream: async () => ({
-            async *[Symbol.asyncIterator]() {
-              yield {
-                candidates: [
-                  {
-                    content: { parts: [{ text: "partial output" }] },
-                    finishReason: FinishReason.SAFETY,
-                  },
-                ],
-              } as GenerateContentResponse;
-              controller.abort(abortReason);
-            },
-          }),
+      generateContentStream: async () => ({
+        async *[Symbol.asyncIterator]() {
+          yield googleResponse({
+            parts: [{ text: "partial output" }],
+            finishReason: FinishReason.SAFETY,
+          });
+          controller.abort(abortReason);
         },
       }),
-      buildParams: () => ({ model: model.id, contents: [] }),
-      nextToolCallId: () => "call_1",
     });
 
-    expect(await stream.result()).toMatchObject({
+    expect(result).toMatchObject({
       stopReason: "aborted",
       errorCode: "GATEWAY_RESTART",
       errorMessage: "Google run restarted",
@@ -889,25 +660,13 @@ describe("runGoogleGenerateContentLifecycle", () => {
   });
 
   it.each([429, 503])("preserves the official Google SDK's %s API error status", async (status) => {
-    const output = createOutput();
-    const stream = new AssistantMessageEventStream();
-
-    await runGoogleGenerateContentLifecycle({
-      stream,
-      model,
-      output,
-      createClient: () => ({
-        models: {
-          generateContentStream: async () => {
-            throw new ApiError({ status, message: "Google quota exceeded" });
-          },
-        },
-      }),
-      buildParams: () => ({ model: model.id, contents: [] }),
-      nextToolCallId: () => "call_1",
+    const { result } = await runGoogleFixture([], {
+      generateContentStream: async () => {
+        throw new ApiError({ status, message: "Google quota exceeded" });
+      },
     });
 
-    expect(await stream.result()).toMatchObject({
+    expect(result).toMatchObject({
       stopReason: "error",
       errorCode: String(status),
       errorMessage: `${status}: Google quota exceeded`,
@@ -928,23 +687,16 @@ describe("runGoogleGenerateContentLifecycle", () => {
         { headers: { "content-type": "text/event-stream" } },
       ),
     );
-    const output = createOutput();
-    const stream = new AssistantMessageEventStream();
-
     try {
-      await runGoogleGenerateContentLifecycle({
-        stream,
-        model,
-        output,
+      const { result } = await runGoogleFixture([], {
         createClient: () => new GoogleGenAI({ apiKey: "test-gemini-api-key" }),
         buildParams: () => ({
           model: model.id,
           contents: [{ role: "user", parts: [{ text: "hello" }] }],
         }),
-        nextToolCallId: () => "call_1",
       });
 
-      expect(await stream.result()).toMatchObject({
+      expect(result).toMatchObject({
         stopReason: "error",
         errorCode: "SAFETY",
         errorType: "google_generation_failed",
@@ -957,9 +709,9 @@ describe("runGoogleGenerateContentLifecycle", () => {
   });
 
   it.each([
-    { api: "google-generative-ai", blockReason: "SAFETY" },
+    { api: "google-generative-ai", blockReason: BlockedReason.SAFETY },
     { api: "google-generative-ai", blockReason: undefined },
-    { api: "google-vertex", blockReason: "SAFETY" },
+    { api: "google-vertex", blockReason: BlockedReason.SAFETY },
     { api: "google-vertex", blockReason: undefined },
   ] as const)(
     "surfaces blocked $api prompts as typed stream errors when blockReason is $blockReason",
@@ -969,40 +721,23 @@ describe("runGoogleGenerateContentLifecycle", () => {
         api,
         provider: api === "google-vertex" ? "google-vertex" : "google",
       } satisfies Model<"google-generative-ai" | "google-vertex">;
-      const output: AssistantMessage = {
-        ...createOutput(),
-        api: targetModel.api,
-        provider: targetModel.provider,
-      };
-      const stream = new AssistantMessageEventStream();
+      const { result } = await runGoogleFixture(
+        [
+          googleResponse({
+            promptFeedback: {
+              ...(blockReason ? { blockReason } : {}),
+              blockReasonMessage: "Prompt violates provider safety policy",
+            },
+            usageMetadata: {
+              promptTokenCount: 12,
+              cachedContentTokenCount: 2,
+              totalTokenCount: 12,
+            },
+          }),
+        ],
+        { targetModel },
+      );
 
-      await runGoogleGenerateContentLifecycle({
-        stream,
-        model: targetModel,
-        output,
-        createClient: () => ({
-          models: {
-            generateContentStream: async () =>
-              chunks([
-                {
-                  promptFeedback: {
-                    ...(blockReason ? { blockReason } : {}),
-                    blockReasonMessage: "Prompt violates provider safety policy",
-                  },
-                  usageMetadata: {
-                    promptTokenCount: 12,
-                    cachedContentTokenCount: 2,
-                    totalTokenCount: 12,
-                  },
-                } as GenerateContentResponse,
-              ]),
-          },
-        }),
-        buildParams: () => ({ model: targetModel.id, contents: [] }),
-        nextToolCallId: () => "call_1",
-      });
-
-      const result = await stream.result();
       const expectedBlockReason = blockReason ?? "PROMPT_BLOCKED";
       expect(result).toMatchObject({
         stopReason: "error",
@@ -1017,26 +752,15 @@ describe("runGoogleGenerateContentLifecycle", () => {
   );
 
   it("surfaces HTTP response body text from Google-compatible errors", async () => {
-    const output = createOutput();
-    const stream = new AssistantMessageEventStream();
     const error = Object.assign(new Error("502 status code (no body)"), {
       status: 502,
       body: "gateway maintenance",
     });
 
-    await runGoogleGenerateContentLifecycle({
-      stream,
-      model,
-      output,
-      createClient: () => ({
-        models: {
-          generateContentStream: async () => {
-            throw error;
-          },
-        },
-      }),
-      buildParams: () => ({ model: model.id, contents: [] }),
-      nextToolCallId: () => "call_1",
+    const { output } = await runGoogleFixture([], {
+      generateContentStream: async () => {
+        throw error;
+      },
     });
 
     expect(output.errorMessage).toBe("502: gateway maintenance");

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -1,5 +1,4 @@
-// Mistral provider tests cover request mapping and stream conversion.
-import { toolCallFromJSON } from "@mistralai/mistralai/models/components";
+import { toolCallFromJSON, type ToolCall } from "@mistralai/mistralai/models/components";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import type { Context, Model } from "../types.js";
@@ -23,11 +22,6 @@ vi.mock("node:crypto", async () => {
 });
 
 vi.mock("@mistralai/mistralai", async () => {
-  // Preserve real exports for everything except `Mistral`, so the new
-  // imports of `HTTPClient` and `Fetcher` introduced by the bounded-stream
-  // helper (`createBoundedMistralHttpClient`) resolve correctly. Only
-  // `Mistral` itself is overridden so the test can capture payloads without
-  // any actual HTTP traffic.
   const actual =
     await vi.importActual<typeof import("@mistralai/mistralai")>("@mistralai/mistralai");
   return {
@@ -77,9 +71,7 @@ function makeUnreadableParameterTool() {
     name: "broken_tool",
     description: "broken tool",
     parameters: { type: "object", properties: {} },
-    async execute() {
-      return { content: [{ type: "text", text: "broken" }] };
-    },
+    execute: async () => ({ content: [{ type: "text", text: "broken" }] }),
   };
   Object.defineProperty(tool, "parameters", {
     enumerable: true,
@@ -88,6 +80,126 @@ function makeUnreadableParameterTool() {
     },
   });
   return tool;
+}
+
+function makeHealthyTool(parameters: Record<string, unknown> = { type: "object", properties: {} }) {
+  return {
+    name: "healthy_tool",
+    description: "healthy tool",
+    parameters,
+    execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  };
+}
+
+function parseMistralToolCall(value: unknown): ToolCall {
+  const parsed = toolCallFromJSON(JSON.stringify(value));
+  if (!parsed.ok) {
+    throw new Error("Mistral SDK failed to parse tool-call fixture");
+  }
+  return parsed.value;
+}
+
+function requireMistralFixtureValue<T>(value: T | undefined): T {
+  if (value === undefined) {
+    throw new Error("Mistral fixture is missing an expected value");
+  }
+  return value;
+}
+
+function mistralToolStream(responseId: string, ...chunks: ToolCall[][]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const toolCalls of chunks) {
+        yield {
+          data: {
+            id: responseId,
+            model: "mistral-large-latest",
+            choices: [
+              {
+                finishReason: "tool_calls",
+                delta: { content: null, toolCalls },
+              },
+            ],
+          },
+        };
+      }
+    },
+  };
+}
+
+type MistralTestOptions = NonNullable<Parameters<typeof streamMistral>[2]>;
+type SimpleMistralTestOptions = NonNullable<Parameters<typeof streamSimpleMistral>[2]>;
+
+function runMistralFixture(
+  testContext: Context = context,
+  options: MistralTestOptions = {},
+  testModel = makeMistralModel(),
+) {
+  return streamMistral(testModel, testContext, {
+    apiKey: "sk-mistral-provider",
+    ...options,
+  }).result();
+}
+
+function runSimpleMistralFixture(
+  testContext: Context = context,
+  options: SimpleMistralTestOptions = {},
+  testModel = makeMistralModel(),
+) {
+  return streamSimpleMistral(testModel, testContext, {
+    apiKey: "sk-mistral-provider",
+    ...options,
+  }).result();
+}
+
+async function runMistralToolFixture(
+  responseId: string,
+  rawChunks: unknown[][],
+  randomUUID?: string,
+) {
+  if (randomUUID) {
+    mistralMockState.randomUUIDs = [randomUUID];
+  }
+  const parsedChunks = rawChunks.map((chunk) => chunk.map(parseMistralToolCall));
+  mistralMockState.streamResult = mistralToolStream(responseId, ...parsedChunks);
+  const result = await runMistralFixture();
+  return {
+    result,
+    parsedChunks,
+    toolCalls: result.content.filter((block) => block.type === "toolCall"),
+  };
+}
+
+function makeMistralToolResultContext(
+  toolName: string,
+  content: unknown[],
+  options: { toolCallId?: string; includeUser?: boolean; includeToolResultName?: boolean } = {},
+): Context {
+  const toolCallId = options.toolCallId ?? "tool_1";
+  return {
+    messages: [
+      ...(options.includeUser === false
+        ? []
+        : [{ ...requireMistralFixtureValue(context.messages[0]), timestamp: 1 }]),
+      {
+        role: "assistant",
+        provider: "mistral",
+        api: "mistral-conversations",
+        model: "mistral-large-latest",
+        stopReason: "toolUse",
+        timestamp: 0,
+        content: [{ type: "toolCall", id: toolCallId, name: toolName, arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId,
+        ...(options.includeToolResultName ? { toolName } : {}),
+        content,
+        isError: false,
+        timestamp: 0,
+      },
+    ],
+  } as unknown as Context;
 }
 
 describe("Mistral provider", () => {
@@ -105,12 +217,9 @@ describe("Mistral provider", () => {
   });
 
   it("forwards simple stop sequences to Mistral stop", async () => {
-    const stream = streamSimpleMistral(makeMistralModel(), context, {
-      apiKey: "sk-mistral-provider",
+    const result = await runSimpleMistralFixture(context, {
       stop: ["STOP"],
     });
-
-    const result = await stream.result();
 
     expect(result.stopReason).toBe("error");
     expect((mistralMockState.payloads[0] as { stop?: unknown }).stop).toEqual(["STOP"]);
@@ -123,9 +232,7 @@ describe("Mistral provider", () => {
       body: `${prefix}😀tail`,
     });
 
-    const result = await streamMistral(makeMistralModel(), context, {
-      apiKey: "sk-mistral-provider",
-    }).result();
+    const result = await runMistralFixture();
 
     expect(result.errorMessage).toBe(`Mistral API error (400): ${prefix}... [truncated 6 chars]`);
   });
@@ -134,7 +241,7 @@ describe("Mistral provider", () => {
     const hostFetch = vi.fn<typeof fetch>(async () => new Response("guarded"));
     configureAiTransportHost({ buildModelFetch: () => hostFetch });
 
-    await streamMistral(makeMistralModel(), context, { apiKey: "sentinel-key" }).result();
+    await runMistralFixture(context, { apiKey: "sentinel-key" });
 
     const config = mistralMockState.configs[0] as {
       apiKey?: string;
@@ -147,21 +254,16 @@ describe("Mistral provider", () => {
   });
 
   it("uses reasoning effort for Mistral Medium 3.5", async () => {
-    const stream = streamSimpleMistral(
+    const result = await runSimpleMistralFixture(
+      context,
+      { reasoning: "high" },
       {
         ...makeMistralModel(),
         id: "mistral-medium-3-5",
         name: "Mistral Medium 3.5",
         reasoning: true,
       },
-      context,
-      {
-        apiKey: "sk-mistral-provider",
-        reasoning: "high",
-      },
     );
-
-    const result = await stream.result();
     const payload = mistralMockState.payloads[0] as Record<string, unknown>;
 
     expect(result.stopReason).toBe("error");
@@ -170,33 +272,11 @@ describe("Mistral provider", () => {
   });
 
   it("skips unreadable tool schemas while preserving healthy Mistral tools", async () => {
-    const stream = streamMistral(
-      makeMistralModel(),
-      {
-        ...context,
-        tools: [
-          makeUnreadableParameterTool(),
-          {
-            name: "healthy_tool",
-            description: "healthy tool",
-            parameters: {
-              type: "object",
-              properties: {
-                query: { type: "string" },
-              },
-            },
-            async execute() {
-              return { content: [{ type: "text", text: "ok" }] };
-            },
-          },
-        ] as never,
-      },
-      {
-        apiKey: "sk-mistral-provider",
-      },
-    );
-
-    const result = await stream.result();
+    const healthyParameters = { type: "object", properties: { query: { type: "string" } } };
+    const result = await runMistralFixture({
+      ...context,
+      tools: [makeUnreadableParameterTool(), makeHealthyTool(healthyParameters)] as never,
+    });
 
     expect(result.stopReason).toBe("error");
     expect((mistralMockState.payloads[0] as { tools?: unknown[] }).tools).toEqual([
@@ -205,12 +285,7 @@ describe("Mistral provider", () => {
         function: {
           name: "healthy_tool",
           description: "healthy tool",
-          parameters: {
-            type: "object",
-            properties: {
-              query: { type: "string" },
-            },
-          },
+          parameters: healthyParameters,
           strict: false,
         },
       },
@@ -218,19 +293,15 @@ describe("Mistral provider", () => {
   });
 
   it("omits tools and automatic tool choice when every schema is unreadable", async () => {
-    const stream = streamMistral(
-      makeMistralModel(),
+    const result = await runMistralFixture(
       {
         ...context,
         tools: [makeUnreadableParameterTool()] as never,
       },
       {
-        apiKey: "sk-mistral-provider",
         toolChoice: "auto",
       },
     );
-
-    const result = await stream.result();
     const payload = mistralMockState.payloads[0] as Record<string, unknown>;
 
     expect(result.stopReason).toBe("error");
@@ -245,63 +316,26 @@ describe("Mistral provider", () => {
     ];
     const responseIds: string[][] = [];
     for (const responseId of ["response-a", "response-b"]) {
-      mistralMockState.streamResult = {
-        async *[Symbol.asyncIterator]() {
-          yield {
-            data: {
-              id: responseId,
-              model: "mistral-large-latest",
-              choices: [
-                {
-                  finishReason: "tool_calls",
-                  delta: {
-                    content: null,
-                    toolCalls: [
-                      {
-                        index: 0,
-                        id: "null",
-                        function: { name: "computer", arguments: '{"step"' },
-                      },
-                      {
-                        index: 1,
-                        id: responseId === "response-a" ? "explicitA" : "explicitB",
-                        function: { name: "computer", arguments: '{"other"' },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          };
-          yield {
-            data: {
-              id: responseId,
-              model: "mistral-large-latest",
-              choices: [
-                {
-                  finishReason: "tool_calls",
-                  delta: {
-                    content: null,
-                    toolCalls: [
-                      {
-                        index: 0,
-                        function: { name: "", arguments: ":1}" },
-                      },
-                      {
-                        index: 1,
-                        function: { name: "", arguments: ":true}" },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          };
-        },
-      };
-      const result = await streamMistral(makeMistralModel(), context, {
-        apiKey: "sk-mistral-provider",
-      }).result();
+      mistralMockState.streamResult = mistralToolStream(
+        responseId,
+        [
+          {
+            index: 0,
+            id: "null",
+            function: { name: "computer", arguments: '{"step"' },
+          },
+          {
+            index: 1,
+            id: responseId === "response-a" ? "explicitA" : "explicitB",
+            function: { name: "computer", arguments: '{"other"' },
+          },
+        ],
+        [
+          { index: 0, function: { name: "", arguments: ":1}" } },
+          { index: 1, function: { name: "", arguments: ":true}" } },
+        ],
+      );
+      const result = await runMistralFixture();
       const toolCalls = result.content.filter((block) => block.type === "toolCall");
       expect(toolCalls).toHaveLength(2);
       expect(toolCalls[0]?.arguments).toEqual({ step: 1 });
@@ -316,70 +350,22 @@ describe("Mistral provider", () => {
   });
 
   it("keeps explicit streamed tool calls distinct when index is omitted", async () => {
-    const firstCall = toolCallFromJSON(
-      JSON.stringify({
-        id: "explicitA",
-        function: { name: "first_tool", arguments: '{"value"' },
-      }),
-    );
-    const secondCall = toolCallFromJSON(
-      JSON.stringify({
-        id: "explicitB",
-        function: { name: "second_tool", arguments: '{"value"' },
-      }),
-    );
-    const firstContinuation = toolCallFromJSON(
-      JSON.stringify({ function: { name: "first_tool", arguments: ":1}" } }),
-    );
-    const secondContinuation = toolCallFromJSON(
-      JSON.stringify({ function: { name: "second_tool", arguments: ":2}" } }),
-    );
-    if (!firstCall.ok || !secondCall.ok || !firstContinuation.ok || !secondContinuation.ok) {
-      throw new Error("Mistral SDK failed to parse tool-call fixtures");
-    }
+    const { parsedChunks, toolCalls } = await runMistralToolFixture("response-unindexed", [
+      [
+        { id: "explicitA", function: { name: "first_tool", arguments: '{"value"' } },
+        { id: "explicitB", function: { name: "second_tool", arguments: '{"value"' } },
+      ],
+      [
+        { function: { name: "first_tool", arguments: ":1}" } },
+        { function: { name: "second_tool", arguments: ":2}" } },
+      ],
+    ]);
+    const firstCall = requireMistralFixtureValue(parsedChunks[0]?.[0]);
+    const secondCall = requireMistralFixtureValue(parsedChunks[0]?.[1]);
     // The SDK defaults an omitted wire index to zero. Explicit provider ids
     // must still win over that ambiguous compatibility default.
-    expect(firstCall.value.index).toBe(0);
-    expect(secondCall.value.index).toBe(0);
-    mistralMockState.streamResult = {
-      async *[Symbol.asyncIterator]() {
-        yield {
-          data: {
-            id: "response-unindexed",
-            model: "mistral-large-latest",
-            choices: [
-              {
-                finishReason: "tool_calls",
-                delta: {
-                  content: null,
-                  toolCalls: [firstCall.value, secondCall.value],
-                },
-              },
-            ],
-          },
-        };
-        yield {
-          data: {
-            id: "response-unindexed",
-            model: "mistral-large-latest",
-            choices: [
-              {
-                finishReason: "tool_calls",
-                delta: {
-                  content: null,
-                  toolCalls: [firstContinuation.value, secondContinuation.value],
-                },
-              },
-            ],
-          },
-        };
-      },
-    };
-
-    const result = await streamMistral(makeMistralModel(), context, {
-      apiKey: "sk-mistral-provider",
-    }).result();
-    const toolCalls = result.content.filter((block) => block.type === "toolCall");
+    expect(firstCall.index).toBe(0);
+    expect(secondCall.index).toBe(0);
 
     expect(toolCalls).toMatchObject([
       { id: "explicitA", name: "first_tool", arguments: { value: 1 } },
@@ -388,67 +374,26 @@ describe("Mistral provider", () => {
   });
 
   it("keeps missing-id streamed tool calls distinct when index is omitted", async () => {
-    mistralMockState.randomUUIDs = ["00000000-0000-4000-8000-000000429246"];
-    const firstCall = toolCallFromJSON(
-      JSON.stringify({ function: { name: "first_tool", arguments: '{"value"' } }),
+    const { parsedChunks, toolCalls } = await runMistralToolFixture(
+      "response-unidentified",
+      [
+        [
+          { function: { name: "first_tool", arguments: '{"value"' } },
+          { index: 1, function: { name: "second_tool", arguments: '{"value"' } },
+        ],
+        [
+          { function: { name: "first_tool", arguments: ":1}" } },
+          { function: { name: "second_tool", arguments: ":2}" } },
+        ],
+      ],
+      "00000000-0000-4000-8000-000000429246",
     );
-    const secondCall = toolCallFromJSON(
-      JSON.stringify({
-        index: 1,
-        function: { name: "second_tool", arguments: '{"value"' },
-      }),
-    );
-    const firstContinuation = toolCallFromJSON(
-      JSON.stringify({ function: { name: "first_tool", arguments: ":1}" } }),
-    );
-    const secondContinuation = toolCallFromJSON(
-      JSON.stringify({ function: { name: "second_tool", arguments: ":2}" } }),
-    );
-    if (!firstCall.ok || !secondCall.ok || !firstContinuation.ok || !secondContinuation.ok) {
-      throw new Error("Mistral SDK failed to parse tool-call fixtures");
-    }
-    expect(firstCall.value).toMatchObject({ id: "null", index: 0 });
-    expect(secondCall.value).toMatchObject({ id: "null", index: 1 });
-    expect(secondContinuation.value).toMatchObject({ id: "null", index: 0 });
-    mistralMockState.streamResult = {
-      async *[Symbol.asyncIterator]() {
-        yield {
-          data: {
-            id: "response-unidentified",
-            model: "mistral-large-latest",
-            choices: [
-              {
-                finishReason: "tool_calls",
-                delta: {
-                  content: null,
-                  toolCalls: [firstCall.value, secondCall.value],
-                },
-              },
-            ],
-          },
-        };
-        yield {
-          data: {
-            id: "response-unidentified",
-            model: "mistral-large-latest",
-            choices: [
-              {
-                finishReason: "tool_calls",
-                delta: {
-                  content: null,
-                  toolCalls: [firstContinuation.value, secondContinuation.value],
-                },
-              },
-            ],
-          },
-        };
-      },
-    };
-
-    const result = await streamMistral(makeMistralModel(), context, {
-      apiKey: "sk-mistral-provider",
-    }).result();
-    const toolCalls = result.content.filter((block) => block.type === "toolCall");
+    const firstCall = requireMistralFixtureValue(parsedChunks[0]?.[0]);
+    const secondCall = requireMistralFixtureValue(parsedChunks[0]?.[1]);
+    const secondContinuation = requireMistralFixtureValue(parsedChunks[1]?.[1]);
+    expect(firstCall).toMatchObject({ id: "null", index: 0 });
+    expect(secondCall).toMatchObject({ id: "null", index: 1 });
+    expect(secondContinuation).toMatchObject({ id: "null", index: 0 });
 
     expect(toolCalls).toMatchObject([
       { name: "first_tool", arguments: { value: 1 } },
@@ -461,63 +406,25 @@ describe("Mistral provider", () => {
   });
 
   it("routes an asymmetric omitted-index continuation by its persistent function name", async () => {
-    mistralMockState.randomUUIDs = ["00000000-0000-4000-8000-000000429247"];
-    const firstCall = toolCallFromJSON(
-      JSON.stringify({ function: { name: "first_tool", arguments: '{"value":1}' } }),
+    const { parsedChunks, toolCalls } = await runMistralToolFixture(
+      "response-asymmetric-unindexed",
+      [
+        [
+          { function: { name: "first_tool", arguments: '{"value":1}' } },
+          { index: 1, function: { name: "second_tool", arguments: '{"value"' } },
+        ],
+        [{ function: { name: "second_tool", arguments: ":2}" } }],
+      ],
+      "00000000-0000-4000-8000-000000429247",
     );
-    const secondCall = toolCallFromJSON(
-      JSON.stringify({
-        index: 1,
-        function: { name: "second_tool", arguments: '{"value"' },
-      }),
-    );
-    const secondContinuation = toolCallFromJSON(
-      JSON.stringify({ function: { name: "second_tool", arguments: ":2}" } }),
-    );
-    if (!firstCall.ok || !secondCall.ok || !secondContinuation.ok) {
-      throw new Error("Mistral SDK failed to parse tool-call fixtures");
-    }
-    expect(firstCall.value).toMatchObject({ id: "null", index: 0 });
-    expect(secondCall.value).toMatchObject({ id: "null", index: 1 });
+    const firstCall = requireMistralFixtureValue(parsedChunks[0]?.[0]);
+    const secondCall = requireMistralFixtureValue(parsedChunks[0]?.[1]);
+    const secondContinuation = requireMistralFixtureValue(parsedChunks[1]?.[0]);
+    expect(firstCall).toMatchObject({ id: "null", index: 0 });
+    expect(secondCall).toMatchObject({ id: "null", index: 1 });
     // The SDK defaults the omitted continuation index to zero; the persistent
     // function name must still bind it back to the index-1 call.
-    expect(secondContinuation.value).toMatchObject({ id: "null", index: 0 });
-    mistralMockState.streamResult = {
-      async *[Symbol.asyncIterator]() {
-        yield {
-          data: {
-            id: "response-asymmetric-unindexed",
-            model: "mistral-large-latest",
-            choices: [
-              {
-                finishReason: "tool_calls",
-                delta: {
-                  content: null,
-                  toolCalls: [firstCall.value, secondCall.value],
-                },
-              },
-            ],
-          },
-        };
-        yield {
-          data: {
-            id: "response-asymmetric-unindexed",
-            model: "mistral-large-latest",
-            choices: [
-              {
-                finishReason: "tool_calls",
-                delta: { content: null, toolCalls: [secondContinuation.value] },
-              },
-            ],
-          },
-        };
-      },
-    };
-
-    const result = await streamMistral(makeMistralModel(), context, {
-      apiKey: "sk-mistral-provider",
-    }).result();
-    const toolCalls = result.content.filter((block) => block.type === "toolCall");
+    expect(secondContinuation).toMatchObject({ id: "null", index: 0 });
 
     expect(toolCalls).toMatchObject([
       { name: "first_tool", arguments: { value: 1 } },
@@ -526,109 +433,34 @@ describe("Mistral provider", () => {
   });
 
   it("rejects an ambiguous idless and nameless omitted-index continuation", async () => {
-    mistralMockState.randomUUIDs = ["00000000-0000-4000-8000-000000429248"];
-    const firstCall = toolCallFromJSON(
-      JSON.stringify({ function: { name: "first_tool", arguments: '{"value"' } }),
+    const { result } = await runMistralToolFixture(
+      "response-ambiguous-unindexed",
+      [
+        [
+          { function: { name: "first_tool", arguments: '{"value"' } },
+          { function: { name: "second_tool", arguments: '{"value"' } },
+        ],
+        [{ function: { name: "", arguments: ":2}" } }],
+      ],
+      "00000000-0000-4000-8000-000000429248",
     );
-    const secondCall = toolCallFromJSON(
-      JSON.stringify({ function: { name: "second_tool", arguments: '{"value"' } }),
-    );
-    const ambiguousContinuation = toolCallFromJSON(
-      JSON.stringify({ function: { name: "", arguments: ":2}" } }),
-    );
-    if (!firstCall.ok || !secondCall.ok || !ambiguousContinuation.ok) {
-      throw new Error("Mistral SDK failed to parse tool-call fixtures");
-    }
-    mistralMockState.streamResult = {
-      async *[Symbol.asyncIterator]() {
-        yield {
-          data: {
-            id: "response-ambiguous-unindexed",
-            model: "mistral-large-latest",
-            choices: [
-              {
-                finishReason: "tool_calls",
-                delta: {
-                  content: null,
-                  toolCalls: [firstCall.value, secondCall.value],
-                },
-              },
-            ],
-          },
-        };
-        yield {
-          data: {
-            id: "response-ambiguous-unindexed",
-            model: "mistral-large-latest",
-            choices: [
-              {
-                finishReason: "tool_calls",
-                delta: { content: null, toolCalls: [ambiguousContinuation.value] },
-              },
-            ],
-          },
-        };
-      },
-    };
-
-    const result = await streamMistral(makeMistralModel(), context, {
-      apiKey: "sk-mistral-provider",
-    }).result();
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("tool-call continuation is ambiguous");
   });
 
   it("keeps same-name omitted-index siblings distinct and rejects their ambiguous continuation", async () => {
-    mistralMockState.randomUUIDs = ["00000000-0000-4000-8000-000000429249"];
-    const firstCall = toolCallFromJSON(
-      JSON.stringify({ function: { name: "computer", arguments: '{"step"' } }),
+    const { result, toolCalls } = await runMistralToolFixture(
+      "response-same-name-unindexed",
+      [
+        [
+          { function: { name: "computer", arguments: '{"step"' } },
+          { function: { name: "computer", arguments: '{"step"' } },
+        ],
+        [{ function: { name: "computer", arguments: ":2}" } }],
+      ],
+      "00000000-0000-4000-8000-000000429249",
     );
-    const secondCall = toolCallFromJSON(
-      JSON.stringify({ function: { name: "computer", arguments: '{"step"' } }),
-    );
-    const ambiguousContinuation = toolCallFromJSON(
-      JSON.stringify({ function: { name: "computer", arguments: ":2}" } }),
-    );
-    if (!firstCall.ok || !secondCall.ok || !ambiguousContinuation.ok) {
-      throw new Error("Mistral SDK failed to parse tool-call fixtures");
-    }
-    mistralMockState.streamResult = {
-      async *[Symbol.asyncIterator]() {
-        yield {
-          data: {
-            id: "response-same-name-unindexed",
-            model: "mistral-large-latest",
-            choices: [
-              {
-                finishReason: "tool_calls",
-                delta: {
-                  content: null,
-                  toolCalls: [firstCall.value, secondCall.value],
-                },
-              },
-            ],
-          },
-        };
-        yield {
-          data: {
-            id: "response-same-name-unindexed",
-            model: "mistral-large-latest",
-            choices: [
-              {
-                finishReason: "tool_calls",
-                delta: { content: null, toolCalls: [ambiguousContinuation.value] },
-              },
-            ],
-          },
-        };
-      },
-    };
-
-    const result = await streamMistral(makeMistralModel(), context, {
-      apiKey: "sk-mistral-provider",
-    }).result();
-    const toolCalls = result.content.filter((block) => block.type === "toolCall");
 
     expect(toolCalls).toHaveLength(0);
     expect(result.stopReason).toBe("error");
@@ -637,43 +469,23 @@ describe("Mistral provider", () => {
 
   it("keeps a later same-name call distinct when it has a nonzero index", async () => {
     mistralMockState.randomUUIDs = ["00000000-0000-4000-8000-000000429250"];
-    const firstCall = toolCallFromJSON(
-      JSON.stringify({
-        index: 0,
-        function: { name: "computer", arguments: '{"step":1}' },
-      }),
-    );
-    const secondCall = toolCallFromJSON(
-      JSON.stringify({
-        index: 1,
-        function: { name: "computer", arguments: '{"step":2}' },
-      }),
-    );
-    if (!firstCall.ok || !secondCall.ok) {
-      throw new Error("Mistral SDK failed to parse tool-call fixtures");
-    }
+    const firstCall = parseMistralToolCall({
+      index: 0,
+      function: { name: "computer", arguments: '{"step":1}' },
+    });
+    const secondCall = parseMistralToolCall({
+      index: 1,
+      function: { name: "computer", arguments: '{"step":2}' },
+    });
     mistralMockState.streamResult = {
       async *[Symbol.asyncIterator]() {
-        for (const [id, toolCall] of [firstCall.value, secondCall.value].entries()) {
-          yield {
-            data: {
-              id: `response-same-name-indexed-${id}`,
-              model: "mistral-large-latest",
-              choices: [
-                {
-                  finishReason: "tool_calls",
-                  delta: { content: null, toolCalls: [toolCall] },
-                },
-              ],
-            },
-          };
+        for (const [id, toolCall] of [firstCall, secondCall].entries()) {
+          yield* mistralToolStream(`response-same-name-indexed-${id}`, [toolCall]);
         }
       },
     };
 
-    const result = await streamMistral(makeMistralModel(), context, {
-      apiKey: "sk-mistral-provider",
-    }).result();
+    const result = await runMistralFixture();
     const toolCalls = result.content.filter((block) => block.type === "toolCall");
 
     expect(toolCalls).toMatchObject([
@@ -684,29 +496,15 @@ describe("Mistral provider", () => {
   });
 
   it("fails locally when a pinned Mistral tool choice is skipped", async () => {
-    const stream = streamMistral(
-      makeMistralModel(),
+    const result = await runMistralFixture(
       {
         ...context,
-        tools: [
-          makeUnreadableParameterTool(),
-          {
-            name: "healthy_tool",
-            description: "healthy tool",
-            parameters: { type: "object", properties: {} },
-            async execute() {
-              return { content: [{ type: "text", text: "ok" }] };
-            },
-          },
-        ] as never,
+        tools: [makeUnreadableParameterTool(), makeHealthyTool()] as never,
       },
       {
-        apiKey: "sk-mistral-provider",
         toolChoice: { type: "function", function: { name: "broken_tool" } },
       },
     );
-
-    const result = await stream.result();
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain(
@@ -717,23 +515,12 @@ describe("Mistral provider", () => {
 
   it("validates and emits one snapshot of a pinned Mistral tool name", async () => {
     let nameReads = 0;
-    const stream = streamMistral(
-      makeMistralModel(),
+    const result = await runMistralFixture(
       {
         ...context,
-        tools: [
-          {
-            name: "healthy_tool",
-            description: "healthy tool",
-            parameters: { type: "object", properties: {} },
-            async execute() {
-              return { content: [{ type: "text", text: "ok" }] };
-            },
-          },
-        ] as never,
+        tools: [makeHealthyTool()] as never,
       },
       {
-        apiKey: "sk-mistral-provider",
         toolChoice: {
           type: "function",
           function: {
@@ -746,8 +533,6 @@ describe("Mistral provider", () => {
       },
     );
 
-    const result = await stream.result();
-
     expect(result.stopReason).toBe("error");
     expect(nameReads).toBe(1);
     expect((mistralMockState.payloads[0] as { toolChoice?: unknown }).toolChoice).toEqual({
@@ -757,16 +542,10 @@ describe("Mistral provider", () => {
   });
 
   it("strips the internal cache boundary marker from the system message", async () => {
-    const stream = streamSimpleMistral(
-      makeMistralModel(),
-      {
-        systemPrompt: `Stable${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic`,
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      },
-      { apiKey: "sk-mistral-provider" },
-    );
-
-    await stream.result();
+    await runSimpleMistralFixture({
+      systemPrompt: `Stable${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic`,
+      messages: [{ role: "user", content: "hello", timestamp: 0 }],
+    });
 
     const payload = mistralMockState.payloads[0] as {
       messages: Array<{ role: string; content: string }>;
@@ -780,12 +559,12 @@ describe("Mistral provider", () => {
     for (const cacheRetention of [undefined, "none"] as const) {
       mistralMockState.payloads = [];
       mistralMockState.requestOptions = [];
-      await streamSimpleMistral(makeMistralModel(), context, {
+      await runSimpleMistralFixture(context, {
         apiKey: "fixture",
         sessionId: "session-affinity",
         promptCacheKey: "prompt-cache-key",
         ...(cacheRetention ? { cacheRetention } : {}),
-      }).result();
+      });
 
       const payload = mistralMockState.payloads[0] as { promptCacheKey?: string };
       const requestOptions = mistralMockState.requestOptions[0] as {
@@ -802,10 +581,10 @@ describe("Mistral provider", () => {
   });
 
   it("uses the session id as the prompt cache key when no dedicated key is supplied", async () => {
-    await streamSimpleMistral(makeMistralModel(), context, {
+    await runSimpleMistralFixture(context, {
       apiKey: "fixture",
       sessionId: "session-cache-key",
-    }).result();
+    });
 
     expect((mistralMockState.payloads[0] as { promptCacheKey?: string }).promptCacheKey).toBe(
       "session-cache-key",
@@ -839,9 +618,7 @@ describe("Mistral provider", () => {
       },
     };
 
-    const result = await streamMistral(makeMistralModel(), context, {
-      apiKey: "fixture",
-    }).result();
+    const result = await runMistralFixture(context, { apiKey: "fixture" });
 
     expect(result.usage).toMatchObject({
       input: 36,
@@ -857,45 +634,18 @@ describe("Mistral provider", () => {
     configureAiTransportHost({
       redactToolPayloadText: (text) => text.replaceAll('"value"', '"***"'),
     });
-    const testContext = {
-      messages: [
-        {
-          role: "user",
-          content: "hello",
-          timestamp: 1,
+    const testContext = makeMistralToolResultContext("fetch", [
+      {
+        type: "resource",
+        resource: {
+          uri: "https://example.com/data.json",
+          mimeType: "application/json",
+          text: '{"key":"value"}',
         },
-        {
-          role: "assistant",
-          provider: "mistral",
-          api: "mistral-conversations",
-          model: "mistral-large-latest",
-          stopReason: "toolUse",
-          timestamp: 0,
-          content: [{ type: "toolCall", id: "tool_1", name: "fetch", arguments: {} }],
-        },
-        {
-          role: "toolResult",
-          toolCallId: "tool_1",
-          content: [
-            {
-              type: "resource",
-              resource: {
-                uri: "https://example.com/data.json",
-                mimeType: "application/json",
-                text: '{"key":"value"}',
-              },
-            },
-          ],
-          isError: false,
-          timestamp: 0,
-        },
-      ],
-    } as unknown as Context;
+      },
+    ]);
 
-    const stream = streamMistral(makeMistralModel(), testContext, {
-      apiKey: "sk-mistral-provider",
-    });
-    await stream.result();
+    await runMistralFixture(testContext);
 
     const payload = mistralMockState.payloads[0] as {
       messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }>;
@@ -910,32 +660,17 @@ describe("Mistral provider", () => {
   });
 
   it("does not emit image chunks or placeholders for payload-less tool media", async () => {
-    const testContext = {
-      messages: [
-        {
-          role: "assistant",
-          provider: "mistral",
-          api: "mistral-conversations",
-          model: "mistral-large-latest",
-          stopReason: "toolUse",
-          timestamp: 0,
-          content: [{ type: "toolCall", id: "tool_husk", name: "screenshot", arguments: {} }],
-        },
-        {
-          role: "toolResult",
-          toolCallId: "tool_husk",
-          toolName: "screenshot",
-          content: [{ type: "image", mimeType: "image/png", data: "" }],
-          isError: false,
-          timestamp: 0,
-        },
-      ],
-    } as unknown as Context;
+    const testContext = makeMistralToolResultContext(
+      "screenshot",
+      [{ type: "image", mimeType: "image/png", data: "" }],
+      { toolCallId: "tool_husk", includeUser: false, includeToolResultName: true },
+    );
 
-    const stream = streamMistral({ ...makeMistralModel(), input: ["text", "image"] }, testContext, {
-      apiKey: "fake",
-    });
-    await stream.result();
+    await runMistralFixture(
+      testContext,
+      { apiKey: "fake" },
+      { ...makeMistralModel(), input: ["text", "image"] },
+    );
 
     const payload = mistralMockState.payloads[0] as {
       messages: Array<{ role: string; content: Array<{ type: string; text?: string }> }>;
@@ -947,44 +682,17 @@ describe("Mistral provider", () => {
   });
 
   it("serializes structured-only tool results instead of empty fallback", async () => {
-    const testContext = {
-      messages: [
-        {
-          role: "user",
-          content: "hello",
-          timestamp: 1,
-        },
-        {
-          role: "assistant",
-          provider: "mistral",
-          api: "mistral-conversations",
-          model: "mistral-large-latest",
-          stopReason: "toolUse",
-          timestamp: 0,
-          content: [{ type: "toolCall", id: "tool_1", name: "get_file", arguments: {} }],
-        },
-        {
-          role: "toolResult",
-          toolCallId: "tool_1",
-          content: [
-            {
-              type: "resource_link",
-              uri: "https://example.com/file.txt",
-              name: "file.txt",
-              mimeType: "text/plain",
-              size: 100,
-            },
-          ],
-          isError: false,
-          timestamp: 0,
-        },
-      ],
-    } as unknown as Context;
+    const testContext = makeMistralToolResultContext("get_file", [
+      {
+        type: "resource_link",
+        uri: "https://example.com/file.txt",
+        name: "file.txt",
+        mimeType: "text/plain",
+        size: 100,
+      },
+    ]);
 
-    const stream = streamMistral(makeMistralModel(), testContext, {
-      apiKey: "sk-mistral-provider",
-    });
-    await stream.result();
+    await runMistralFixture(testContext);
 
     const payload = mistralMockState.payloads[0] as {
       messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }>;


### PR DESCRIPTION
## Summary

- consolidate repeated Google response, stream, lifecycle, and event fixtures behind typed test-local helpers
- consolidate Mistral SDK-parsed tool-stream and tool-result fixtures while preserving wire-default and omission semantics
- remove 568 test LOC with no production, provider, config, or public-export changes

## Why this is the right boundary

The repeated inline fixtures duplicated provider lifecycle mechanics across many cases, making the invariants harder to audit. The canonical fix is local to each owning test file: production behavior remains untouched, while every case still drives the real Google/Mistral provider owner and official SDK types/parsers.

- Google continues to use the production output constructor and subscribes event collectors before stream consumption.
- Mistral omitted tool IDs/indexes still pass through `@mistralai/mistralai` parsing (`id: "null"`, `index: 0`).
- Tool-result `toolName` omission is preserved for the structured-resource cases; only the original screenshot fixture includes it.
- MAX_TOKENS still asserts the first observed terminal event.

## Parity

- exact `describe` / `it` / `it.each` declaration streams preserved
- 48 Google + 23 Mistral expanded cases preserved
- assertion counts preserved: Google 45/45, Mistral 66/66
- event sequence, terminal/lifecycle, abort/error, usage, thought-signature ownership, tool identity, and cache contracts preserved
- diff: `+568/-1136`, net `-568`; production delta `0`
- final diff SHA-256: `ae55a0774eafbe5de5f2f3ff7e8e7444ce75445fa4f5bc725b14aa4475b8b00e`

## Validation

- Blacksmith Testbox `tbx_01kz1q5wjwq33dm5rck5h9da5w`: focused affected tests 71/71
- full `packages/ai/src/providers` suite: 788/788
- `pnpm check:changed`
- `pnpm build`
- `git diff --check`
- two independent direct gpt-5.6-sol xhigh reviewers: CLEAN on the final diff
- Actions proof: https://github.com/openclaw/openclaw/actions/runs/30758216018

## Collision audit

Central exhaustive open-PR census through 2026-08-02T16:27:45Z found zero matches for either changed path: prior zero cutoff plus 453 fully paged updated open PRs and tail PR #117582.
