### PR TITLE
refactor(doctor): consolidate test fixture builders

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -606,7 +606,6 @@ src/commands/doctor-state-migrations.test.ts
 src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
 src/commands/doctor/cron/index.test.ts
 src/commands/doctor/repair-sequencing.test.ts
-src/commands/doctor/shared/channel-plugin-blockers.test.ts
 src/commands/doctor/shared/codex-route-warnings.test.ts
 src/commands/doctor/shared/legacy-config-core-normalizers.ts
 src/commands/doctor/shared/legacy-config-migrate.test.ts

--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -13,33 +13,87 @@ async function makeFixtureRoot(prefix: string): Promise<string> {
   return await fs.mkdtemp(path.join(os.tmpdir(), `doctor-post-upgrade-${prefix}-`));
 }
 
-async function writeDeclaredPackageFixture(root: string, packageContents: string): Promise<string> {
-  const pluginDir = path.join(root, "user-plugins", "broken");
+async function withFixtureRoot<T>(prefix: string, run: (root: string) => Promise<T>): Promise<T> {
+  const root = await makeFixtureRoot(prefix);
+  try {
+    return await run(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+async function writePluginFixture(
+  root: string,
+  params: {
+    id: string;
+    location?: string;
+    packageJson?: unknown;
+    packageJsonRaw?: string;
+    files?: Record<string, string>;
+    origin?: string;
+    includePackageJsonRecord?: boolean;
+    manifest?: Record<string, unknown> | false;
+    manifestHash?: string;
+  },
+) {
+  const pluginDir = path.join(root, params.location ?? "user-plugins", params.id);
   await fs.mkdir(pluginDir, { recursive: true });
-  await fs.writeFile(path.join(pluginDir, "package.json"), packageContents, "utf-8");
+  for (const [relativePath, contents] of Object.entries(params.files ?? {})) {
+    const pathname = path.join(pluginDir, relativePath);
+    await fs.mkdir(path.dirname(pathname), { recursive: true });
+    await fs.writeFile(pathname, contents, "utf-8");
+  }
+  const hasPackageJson =
+    Object.hasOwn(params, "packageJson") || params.packageJsonRaw !== undefined;
+  if (hasPackageJson) {
+    await fs.writeFile(
+      path.join(pluginDir, "package.json"),
+      params.packageJsonRaw ?? JSON.stringify(params.packageJson),
+      "utf-8",
+    );
+  }
+  const manifestPath = path.join(pluginDir, "openclaw.plugin.json");
+  if (params.manifest !== false) {
+    await fs.writeFile(manifestPath, JSON.stringify(params.manifest ?? { id: params.id }), "utf-8");
+  }
   const installsPath = path.join(root, "plugins", "installs.json");
   await fs.mkdir(path.dirname(installsPath), { recursive: true });
   await fs.writeFile(
     installsPath,
     JSON.stringify({
+      version: 1,
       plugins: [
         {
-          pluginId: "broken",
+          pluginId: params.id,
           rootDir: pluginDir,
           enabled: true,
-          packageJson: { path: "package.json" },
+          ...(params.origin ? { origin: params.origin } : {}),
+          ...(hasPackageJson && params.includePackageJsonRecord !== false
+            ? { packageJson: { path: "package.json" } }
+            : {}),
+          ...(params.manifest === false ? {} : { manifestPath }),
+          ...(params.manifestHash ? { manifestHash: params.manifestHash } : {}),
         },
       ],
     }),
     "utf-8",
   );
-  return installsPath;
+  return { installsPath, pluginDir, manifestPath };
+}
+
+async function writeDeclaredPackageFixture(root: string, packageContents: string): Promise<string> {
+  return (
+    await writePluginFixture(root, {
+      id: "broken",
+      packageJsonRaw: packageContents,
+      manifest: false,
+    })
+  ).installsPath;
 }
 
 describe("runPostUpgradeProbes — plugin.index_unavailable", () => {
   it("returns a structured finding when the installed plugin index is missing", async () => {
-    const root = await makeFixtureRoot("index-missing");
-    try {
+    await withFixtureRoot("index-missing", async (root) => {
       const report = await runPostUpgradeProbes({
         installsPath: path.join(root, "plugins", "installs.json"),
       });
@@ -51,14 +105,11 @@ describe("runPostUpgradeProbes — plugin.index_unavailable", () => {
           code: "plugin.index_unavailable",
         }),
       ]);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("returns a structured finding when the installed plugin index is malformed", async () => {
-    const root = await makeFixtureRoot("index-malformed");
-    try {
+    await withFixtureRoot("index-malformed", async (root) => {
       const installsPath = path.join(root, "plugins", "installs.json");
       await fs.mkdir(path.dirname(installsPath), { recursive: true });
       await fs.writeFile(installsPath, "{ not json", "utf-8");
@@ -72,14 +123,11 @@ describe("runPostUpgradeProbes — plugin.index_unavailable", () => {
           code: "plugin.index_unavailable",
         }),
       ]);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("returns a structured finding when an installed plugin record is malformed", async () => {
-    const root = await makeFixtureRoot("record-malformed");
-    try {
+    await withFixtureRoot("record-malformed", async (root) => {
       const installsPath = path.join(root, "plugins", "installs.json");
       await fs.mkdir(path.dirname(installsPath), { recursive: true });
       await fs.writeFile(installsPath, JSON.stringify({ plugins: [{}] }), "utf-8");
@@ -92,9 +140,7 @@ describe("runPostUpgradeProbes — plugin.index_unavailable", () => {
           code: "plugin.index_unavailable",
         }),
       ]);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 });
 
@@ -247,8 +293,7 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
   );
 
   it("reads the canonical SQLite plugin index by default", async () => {
-    const root = await makeFixtureRoot("entry-sqlite");
-    try {
+    await withFixtureRoot("entry-sqlite", async (root) => {
       const pluginDir = path.join(root, "user-plugins", "sqlite-ghost");
       await fs.mkdir(pluginDir, { recursive: true });
       await fs.writeFile(
@@ -300,51 +345,20 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
       expect(finding).toBeDefined();
       expect(finding?.plugin).toBe("sqlite-ghost");
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("flags an enabled plugin whose declared entry does not exist on disk", async () => {
-    const root = await makeFixtureRoot("entry-unresolved");
-    try {
-      const pluginDir = path.join(root, "user-plugins", "ghost");
-      await fs.mkdir(pluginDir, { recursive: true });
-      // Plugin package.json declares ./dist/index.js but no dist/.
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+    await withFixtureRoot("entry-unresolved", async (root) => {
+      const { installsPath } = await writePluginFixture(root, {
+        id: "ghost",
+        packageJson: {
           name: "ghost",
           version: "0.0.1",
           type: "module",
           openclaw: { extensions: ["./dist/index.js"] },
-        }),
-        "utf-8",
-      );
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "ghost" }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "ghost",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              rootDir: pluginDir,
-              enabled: true,
-              packageJson: { path: "package.json" },
-            },
-          ],
-        }),
-        "utf-8",
-      );
+        },
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
@@ -352,190 +366,78 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       expect(finding?.level).toBe("error");
       expect(finding?.plugin).toBe("ghost");
       expect(finding?.entry).toBe("./dist/index.js");
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("emits no entry_unresolved findings when the entry resolves", async () => {
-    const root = await makeFixtureRoot("entry-ok");
-    try {
-      const pluginDir = path.join(root, "user-plugins", "good");
-      await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
-      await fs.writeFile(path.join(pluginDir, "dist", "index.js"), "export default {};", "utf-8");
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+    await withFixtureRoot("entry-ok", async (root) => {
+      const { installsPath } = await writePluginFixture(root, {
+        id: "good",
+        packageJson: {
           name: "good",
           version: "0.0.1",
           type: "module",
           openclaw: { extensions: ["./dist/index.js"] },
-        }),
-        "utf-8",
-      );
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "good" }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "good",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              rootDir: pluginDir,
-              enabled: true,
-              packageJson: { path: "package.json" },
-            },
-          ],
-        }),
-        "utf-8",
-      );
+        },
+        files: { "dist/index.js": "export default {};" },
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("skips package entry validation for non-package registry records", async () => {
-    const root = await makeFixtureRoot("no-package-json-ref");
-    try {
-      const pluginDir = path.join(root, "dist", "extensions", "runtime-only");
-      await fs.mkdir(pluginDir, { recursive: true });
-      await fs.writeFile(path.join(pluginDir, "index.js"), "export default {};", "utf-8");
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "runtime-only" }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "runtime-only",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              rootDir: pluginDir,
-              origin: "bundled",
-              enabled: true,
-            },
-          ],
-        }),
-        "utf-8",
-      );
+    await withFixtureRoot("no-package-json-ref", async (root) => {
+      const { installsPath } = await writePluginFixture(root, {
+        id: "runtime-only",
+        location: "dist/extensions",
+        origin: "bundled",
+        files: { "index.js": "export default {};" },
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       expect(report.findings).toHaveLength(0);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("validates legacy package records without packageJson metadata", async () => {
-    const root = await makeFixtureRoot("legacy-package-json-ref");
-    try {
-      const pluginDir = path.join(root, "user-plugins", "legacy-package");
-      await fs.mkdir(path.join(pluginDir, "src"), { recursive: true });
-      await fs.writeFile(path.join(pluginDir, "src", "index.ts"), "export default {};", "utf-8");
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+    await withFixtureRoot("legacy-package-json-ref", async (root) => {
+      const { installsPath } = await writePluginFixture(root, {
+        id: "legacy-package",
+        packageJson: {
           name: "legacy-package",
           version: "0.0.1",
           type: "module",
           openclaw: { extensions: ["./src/index.ts"] },
-        }),
-        "utf-8",
-      );
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "legacy-package" }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "legacy-package",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              rootDir: pluginDir,
-              enabled: true,
-            },
-          ],
-        }),
-        "utf-8",
-      );
+        },
+        files: { "src/index.ts": "export default {};" },
+        includePackageJsonRecord: false,
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
       expect(finding?.level).toBe("error");
       expect(finding?.plugin).toBe("legacy-package");
       expect(finding?.message).toMatch(/compiled runtime output/);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("flags an entry that escapes the plugin package directory", async () => {
-    const root = await makeFixtureRoot("entry-escape");
-    try {
-      const pluginDir = path.join(root, "user-plugins", "escape");
-      await fs.mkdir(pluginDir, { recursive: true });
+    await withFixtureRoot("entry-escape", async (root) => {
       // Create a sibling file outside the plugin root that the entry resolves to.
       const outsideDir = path.join(root, "outside");
       await fs.mkdir(outsideDir, { recursive: true });
       await fs.writeFile(path.join(outsideDir, "leak.js"), "export default {};", "utf-8");
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+      const { installsPath } = await writePluginFixture(root, {
+        id: "escape",
+        packageJson: {
           name: "escape",
           version: "0.0.1",
           type: "module",
           openclaw: { extensions: ["../outside/leak.js"] },
-        }),
-        "utf-8",
-      );
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "escape" }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "escape",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              rootDir: pluginDir,
-              enabled: true,
-              packageJson: { path: "package.json" },
-            },
-          ],
-        }),
-        "utf-8",
-      );
+        },
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
@@ -543,103 +445,44 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       expect(finding?.level).toBe("error");
       expect(finding?.plugin).toBe("escape");
       expect(finding?.message).toMatch(/escapes plugin directory/);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("accepts a TypeScript source entry that ships a compiled dist peer", async () => {
-    const root = await makeFixtureRoot("ts-with-dist");
-    try {
-      const pluginDir = path.join(root, "user-plugins", "ts-dist");
-      await fs.mkdir(path.join(pluginDir, "src"), { recursive: true });
-      await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
-      await fs.writeFile(path.join(pluginDir, "src", "index.ts"), "export default {};", "utf-8");
-      await fs.writeFile(path.join(pluginDir, "dist", "index.js"), "export default {};", "utf-8");
+    await withFixtureRoot("ts-with-dist", async (root) => {
       // No explicit runtimeExtensions; the resolver should infer dist/index.js.
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+      const { installsPath } = await writePluginFixture(root, {
+        id: "ts-dist",
+        packageJson: {
           name: "ts-dist",
           version: "0.0.1",
           type: "module",
           openclaw: { extensions: ["./src/index.ts"] },
-        }),
-        "utf-8",
-      );
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "ts-dist" }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "ts-dist",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              rootDir: pluginDir,
-              enabled: true,
-              packageJson: { path: "package.json" },
-            },
-          ],
-        }),
-        "utf-8",
-      );
+        },
+        files: {
+          "src/index.ts": "export default {};",
+          "dist/index.js": "export default {};",
+        },
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("flags a TypeScript source-only entry with no compiled output", async () => {
-    const root = await makeFixtureRoot("ts-source-only");
-    try {
-      const pluginDir = path.join(root, "user-plugins", "ts-only");
-      await fs.mkdir(path.join(pluginDir, "src"), { recursive: true });
-      await fs.writeFile(path.join(pluginDir, "src", "index.ts"), "export default {};", "utf-8");
+    await withFixtureRoot("ts-source-only", async (root) => {
       // Source exists, no dist peer — installed plugins must ship compiled JS.
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+      const { installsPath } = await writePluginFixture(root, {
+        id: "ts-only",
+        packageJson: {
           name: "ts-only",
           version: "0.0.1",
           type: "module",
           openclaw: { extensions: ["./src/index.ts"] },
-        }),
-        "utf-8",
-      );
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "ts-only" }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "ts-only",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              rootDir: pluginDir,
-              enabled: true,
-              packageJson: { path: "package.json" },
-            },
-          ],
-        }),
-        "utf-8",
-      );
+        },
+        files: { "src/index.ts": "export default {};" },
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
@@ -647,125 +490,60 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       expect(finding?.level).toBe("error");
       expect(finding?.plugin).toBe("ts-only");
       expect(finding?.message).toMatch(/compiled runtime output/);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("allows TypeScript source-only entries for source checkout plugin records", async () => {
-    const root = await makeFixtureRoot("ts-source-checkout");
-    try {
+    await withFixtureRoot("ts-source-checkout", async (root) => {
       await fs.mkdir(path.join(root, ".git"), { recursive: true });
       await fs.writeFile(path.join(root, "pnpm-workspace.yaml"), "packages: []\n", "utf-8");
       await fs.mkdir(path.join(root, "src"), { recursive: true });
-      const pluginDir = path.join(root, "extensions", "ts-source");
-      await fs.mkdir(path.join(pluginDir, "src"), { recursive: true });
-      await fs.writeFile(path.join(pluginDir, "src", "index.ts"), "export default {};", "utf-8");
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+      const { installsPath } = await writePluginFixture(root, {
+        id: "ts-source",
+        location: "extensions",
+        origin: "bundled",
+        packageJson: {
           name: "ts-source",
           version: "0.0.1",
           type: "module",
           openclaw: { extensions: ["./src/index.ts"] },
-        }),
-        "utf-8",
-      );
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "ts-source" }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "ts-source",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              rootDir: pluginDir,
-              origin: "bundled",
-              enabled: true,
-              packageJson: { path: "package.json" },
-            },
-          ],
-        }),
-        "utf-8",
-      );
+        },
+        files: { "src/index.ts": "export default {};" },
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("flags TypeScript source-only entries for packaged bundled plugin records", async () => {
-    const root = await makeFixtureRoot("ts-packaged-bundled");
-    try {
-      const pluginDir = path.join(root, "dist", "extensions", "ts-packaged");
-      await fs.mkdir(path.join(pluginDir, "src"), { recursive: true });
-      await fs.writeFile(path.join(pluginDir, "src", "index.ts"), "export default {};", "utf-8");
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+    await withFixtureRoot("ts-packaged-bundled", async (root) => {
+      const { installsPath } = await writePluginFixture(root, {
+        id: "ts-packaged",
+        location: "dist/extensions",
+        origin: "bundled",
+        packageJson: {
           name: "ts-packaged",
           version: "0.0.1",
           type: "module",
           openclaw: { extensions: ["./src/index.ts"] },
-        }),
-        "utf-8",
-      );
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "ts-packaged" }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "ts-packaged",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              rootDir: pluginDir,
-              origin: "bundled",
-              enabled: true,
-              packageJson: { path: "package.json" },
-            },
-          ],
-        }),
-        "utf-8",
-      );
+        },
+        files: { "src/index.ts": "export default {};" },
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
       expect(finding?.level).toBe("error");
       expect(finding?.plugin).toBe("ts-packaged");
       expect(finding?.message).toMatch(/compiled runtime output/);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("flags a runtimeExtensions length mismatch", async () => {
-    const root = await makeFixtureRoot("runtime-len-mismatch");
-    try {
-      const pluginDir = path.join(root, "user-plugins", "len-mismatch");
-      await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
-      await fs.writeFile(path.join(pluginDir, "dist", "a.js"), "export default {};", "utf-8");
-      await fs.writeFile(path.join(pluginDir, "dist", "b.js"), "export default {};", "utf-8");
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+    await withFixtureRoot("runtime-len-mismatch", async (root) => {
+      const { installsPath } = await writePluginFixture(root, {
+        id: "len-mismatch",
+        packageJson: {
           name: "len-mismatch",
           version: "0.0.1",
           type: "module",
@@ -773,33 +551,12 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
             extensions: ["./dist/a.js", "./dist/b.js"],
             runtimeExtensions: ["./dist/a.js"],
           },
-        }),
-        "utf-8",
-      );
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "len-mismatch" }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "len-mismatch",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              rootDir: pluginDir,
-              enabled: true,
-              packageJson: { path: "package.json" },
-            },
-          ],
-        }),
-        "utf-8",
-      );
+        },
+        files: {
+          "dist/a.js": "export default {};",
+          "dist/b.js": "export default {};",
+        },
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       const finding = report.findings.find((f) => f.code === "plugin.entry_unresolved");
@@ -807,22 +564,16 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
       expect(finding?.level).toBe("error");
       expect(finding?.plugin).toBe("len-mismatch");
       expect(finding?.message).toMatch(/runtimeExtensions length/);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("does not flag entry_unresolved when runtimeExtensions exists even if source entry is missing", async () => {
-    const root = await makeFixtureRoot("runtime-extensions");
-    try {
-      const pluginDir = path.join(root, "user-plugins", "runtime-only");
-      await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
-      await fs.writeFile(path.join(pluginDir, "dist", "index.js"), "export default {};", "utf-8");
+    await withFixtureRoot("runtime-extensions", async (root) => {
       // Source entry (./src/index.ts) does NOT exist
       // But runtime entry (./dist/index.js) DOES exist
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+      const { installsPath } = await writePluginFixture(root, {
+        id: "runtime-only",
+        packageJson: {
           name: "runtime-only",
           version: "0.0.1",
           type: "module",
@@ -830,96 +581,40 @@ describe("runPostUpgradeProbes — plugin.entry_unresolved", () => {
             extensions: ["./src/index.ts"],
             runtimeExtensions: ["./dist/index.js"],
           },
-        }),
-        "utf-8",
-      );
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "runtime-only" }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "runtime-only",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              rootDir: pluginDir,
-              enabled: true,
-              packageJson: { path: "package.json" },
-            },
-          ],
-        }),
-        "utf-8",
-      );
+        },
+        files: { "dist/index.js": "export default {};" },
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       expect(report.findings.filter((f) => f.code === "plugin.entry_unresolved")).toHaveLength(0);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 });
 
 describe("runPostUpgradeProbes — plugin.manifest_drift", () => {
   it("flags a plugin whose manifest hash differs from installs.json", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-post-upgrade-manifest-drift-"));
-    try {
-      const pluginDir = path.join(root, "user-plugins", "drifted");
-      await fs.mkdir(path.join(pluginDir, "dist"), { recursive: true });
-      await fs.writeFile(path.join(pluginDir, "dist", "index.js"), "export default {};", "utf-8");
-      await fs.writeFile(
-        path.join(pluginDir, "package.json"),
-        JSON.stringify({
+    await withFixtureRoot("manifest-drift", async (root) => {
+      const oldManifestRaw = JSON.stringify({ id: "drifted", version: 1 });
+      const oldManifestHash = crypto.createHash("sha256").update(oldManifestRaw).digest("hex");
+      // Write a NEW manifest after installs.json was snapshotted.
+      const { installsPath } = await writePluginFixture(root, {
+        id: "drifted",
+        packageJson: {
           name: "drifted",
           version: "0.0.1",
           type: "module",
           openclaw: { extensions: ["./dist/index.js"] },
-        }),
-        "utf-8",
-      );
-
-      const oldManifestRaw = JSON.stringify({ id: "drifted", version: 1 });
-      const oldManifestHash = crypto.createHash("sha256").update(oldManifestRaw).digest("hex");
-      // Write a NEW manifest after installs.json was snapshotted.
-      await fs.writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: "drifted", version: 2 }),
-        "utf-8",
-      );
-
-      const installsPath = path.join(root, "plugins", "installs.json");
-      await fs.mkdir(path.dirname(installsPath), { recursive: true });
-      await fs.writeFile(
-        installsPath,
-        JSON.stringify({
-          version: 1,
-          plugins: [
-            {
-              pluginId: "drifted",
-              manifestPath: path.join(pluginDir, "openclaw.plugin.json"),
-              manifestHash: oldManifestHash,
-              rootDir: pluginDir,
-              enabled: true,
-              packageJson: { path: "package.json" },
-            },
-          ],
-        }),
-        "utf-8",
-      );
+        },
+        files: { "dist/index.js": "export default {};" },
+        manifest: { id: "drifted", version: 2 },
+        manifestHash: oldManifestHash,
+      });
 
       const report = await runPostUpgradeProbes({ installsPath });
       const finding = report.findings.find((f) => f.code === "plugin.manifest_drift");
       expect(finding).toBeDefined();
       expect(finding?.level).toBe("warn");
       expect(finding?.plugin).toBe("drifted");
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 });

--- a/src/commands/doctor/shared/channel-plugin-blockers.test.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.test.ts
@@ -19,6 +19,26 @@ function createPackageChannelEnv(channelId: string, envVars: string[]) {
   };
 }
 
+function plugin(
+  id: string,
+  options: {
+    origin?: "bundled" | "config" | "global" | "workspace";
+    channelId?: string;
+    enabledByDefault?: boolean;
+    [key: string]: unknown;
+  } = {},
+) {
+  const { origin = "global", channelId = id, enabledByDefault = false, ...metadata } = options;
+  return { id, origin, channels: [channelId], enabledByDefault, ...metadata };
+}
+
+function mockManifestPlugins(plugins: unknown[]) {
+  vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+    plugins,
+    diagnostics: [],
+  } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+}
+
 describe("channel plugin blockers", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -44,17 +64,7 @@ describe("channel plugin blockers", () => {
   });
 
   it("reports external channel plugins that are installed but not explicitly enabled", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([plugin("discord")]);
 
     const hits = scanConfiguredChannelPluginBlockers({
       channels: {
@@ -135,17 +145,7 @@ describe("channel plugin blockers", () => {
   });
 
   it("reports blockers for enabled-only channel intent", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([plugin("discord")]);
 
     const hits = scanConfiguredChannelPluginBlockers({
       plugins: {
@@ -168,17 +168,7 @@ describe("channel plugin blockers", () => {
   });
 
   it("normalizes explicit channel ids before matching plugin owners", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([plugin("discord")]);
 
     const hits = scanConfiguredChannelPluginBlockers({
       channels: {
@@ -198,17 +188,7 @@ describe("channel plugin blockers", () => {
   });
 
   it("accepts plugins.allow as explicit trust for external channel plugins", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([plugin("discord")]);
 
     const hits = scanConfiguredChannelPluginBlockers({
       plugins: {
@@ -226,17 +206,7 @@ describe("channel plugin blockers", () => {
   });
 
   it("diagnoses trust from the pre-auto-enable config", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([plugin("discord")]);
 
     const channels = {
       discord: {
@@ -267,29 +237,19 @@ describe("channel plugin blockers", () => {
   });
 
   it("uses effective config for preferOver fallback disablement", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "legacy-chat",
-          origin: "bundled",
-          channels: ["legacy-chat"],
-          enabledByDefault: true,
-        },
-        {
-          id: "modern-chat",
-          origin: "config",
-          channels: ["legacy-chat"],
-          enabledByDefault: false,
-          channelConfigs: {
-            "legacy-chat": {
-              schema: { type: "object" },
-              preferOver: ["legacy-chat"],
-            },
+    mockManifestPlugins([
+      plugin("legacy-chat", { origin: "bundled", enabledByDefault: true }),
+      plugin("modern-chat", {
+        origin: "config",
+        channelId: "legacy-chat",
+        channelConfigs: {
+          "legacy-chat": {
+            schema: { type: "object" },
+            preferOver: ["legacy-chat"],
           },
         },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+      }),
+    ]);
 
     const channels = {
       "legacy-chat": {
@@ -320,29 +280,19 @@ describe("channel plugin blockers", () => {
   });
 
   it("diagnoses an env-only channel whose preferred external owner lacks trust", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "telegram",
-          origin: "bundled",
-          channels: ["telegram"],
-          enabledByDefault: true,
-        },
-        {
-          id: "modern-telegram",
-          origin: "config",
-          channels: ["telegram"],
-          enabledByDefault: false,
-          channelConfigs: {
-            telegram: {
-              schema: { type: "object" },
-              preferOver: ["telegram"],
-            },
+    mockManifestPlugins([
+      plugin("telegram", { origin: "bundled", enabledByDefault: true }),
+      plugin("modern-telegram", {
+        origin: "config",
+        channelId: "telegram",
+        channelConfigs: {
+          telegram: {
+            schema: { type: "object" },
+            preferOver: ["telegram"],
           },
         },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers(
       {
@@ -369,18 +319,11 @@ describe("channel plugin blockers", () => {
   });
 
   it("diagnoses an external-only package env channel that lacks source trust", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          packageChannel: createPackageChannelEnv("discord", ["DISCORD_BOT_TOKEN"]),
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("discord", {
+        packageChannel: createPackageChannelEnv("discord", ["DISCORD_BOT_TOKEN"]),
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers(
       {
@@ -406,18 +349,11 @@ describe("channel plugin blockers", () => {
   });
 
   it("suppresses ambient-only package env blockers for dev gateway startup", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          packageChannel: createPackageChannelEnv("discord", ["DISCORD_FAKE_TEST_TRIGGER"]),
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("discord", {
+        packageChannel: createPackageChannelEnv("discord", ["DISCORD_FAKE_TEST_TRIGGER"]),
+      }),
+    ]);
 
     expect(
       scanConfiguredChannelPluginBlockers(
@@ -430,21 +366,14 @@ describe("channel plugin blockers", () => {
   });
 
   it("requires every package channel allOf environment variable", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
+    mockManifestPlugins([
+      plugin("irc", {
+        packageChannel: {
           id: "irc",
-          origin: "global",
-          channels: ["irc"],
-          packageChannel: {
-            id: "irc",
-            configuredState: { env: { allOf: ["IRC_HOST", "IRC_NICK"] } },
-          },
-          enabledByDefault: false,
+          configuredState: { env: { allOf: ["IRC_HOST", "IRC_NICK"] } },
         },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+      }),
+    ]);
 
     expect(
       scanConfiguredChannelPluginBlockers({}, { IRC_HOST: "configured" } as NodeJS.ProcessEnv),
@@ -464,24 +393,18 @@ describe("channel plugin blockers", () => {
   });
 
   it("keeps package env trust diagnostics scoped to the declaring owner", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "bundled-chat",
-          origin: "bundled",
-          channels: ["shared-chat"],
-          enabledByDefault: true,
-        },
-        {
-          id: "external-chat",
-          origin: "config",
-          channels: ["shared-chat"],
-          packageChannel: createPackageChannelEnv("shared-chat", ["EXTERNAL_CHAT_TOKEN"]),
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("bundled-chat", {
+        origin: "bundled",
+        channelId: "shared-chat",
+        enabledByDefault: true,
+      }),
+      plugin("external-chat", {
+        origin: "config",
+        channelId: "shared-chat",
+        packageChannel: createPackageChannelEnv("shared-chat", ["EXTERNAL_CHAT_TOKEN"]),
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers(
       {
@@ -530,25 +453,19 @@ describe("channel plugin blockers", () => {
   });
 
   it("accepts an available co-owner for the same package env trigger", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "bundled-chat",
-          origin: "bundled",
-          channels: ["shared-chat"],
-          packageChannel: createPackageChannelEnv("shared-chat", ["SHARED_CHAT_TOKEN"]),
-          enabledByDefault: true,
-        },
-        {
-          id: "external-chat",
-          origin: "config",
-          channels: ["shared-chat"],
-          packageChannel: createPackageChannelEnv("shared-chat", ["SHARED_CHAT_TOKEN"]),
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("bundled-chat", {
+        origin: "bundled",
+        channelId: "shared-chat",
+        packageChannel: createPackageChannelEnv("shared-chat", ["SHARED_CHAT_TOKEN"]),
+        enabledByDefault: true,
+      }),
+      plugin("external-chat", {
+        origin: "config",
+        channelId: "shared-chat",
+        packageChannel: createPackageChannelEnv("shared-chat", ["SHARED_CHAT_TOKEN"]),
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers({}, {
       SHARED_CHAT_TOKEN: "configured",
@@ -558,25 +475,18 @@ describe("channel plugin blockers", () => {
   });
 
   it("deduplicates global plugin disablement across package env triggers", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "first-chat",
-          origin: "config",
-          channels: ["shared-chat"],
-          packageChannel: createPackageChannelEnv("shared-chat", ["FIRST_CHAT_TOKEN"]),
-          enabledByDefault: false,
-        },
-        {
-          id: "second-chat",
-          origin: "config",
-          channels: ["shared-chat"],
-          packageChannel: createPackageChannelEnv("shared-chat", ["SECOND_CHAT_TOKEN"]),
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("first-chat", {
+        origin: "config",
+        channelId: "shared-chat",
+        packageChannel: createPackageChannelEnv("shared-chat", ["FIRST_CHAT_TOKEN"]),
+      }),
+      plugin("second-chat", {
+        origin: "config",
+        channelId: "shared-chat",
+        packageChannel: createPackageChannelEnv("shared-chat", ["SECOND_CHAT_TOKEN"]),
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers(
       {
@@ -600,24 +510,14 @@ describe("channel plugin blockers", () => {
   });
 
   it("does not report unrelated blocked owners for a package env trigger", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "triggered-chat",
-          origin: "config",
-          channels: ["shared-chat"],
-          packageChannel: createPackageChannelEnv("shared-chat", ["TRIGGERED_CHAT_TOKEN"]),
-          enabledByDefault: false,
-        },
-        {
-          id: "unrelated-chat",
-          origin: "config",
-          channels: ["shared-chat"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("triggered-chat", {
+        origin: "config",
+        channelId: "shared-chat",
+        packageChannel: createPackageChannelEnv("shared-chat", ["TRIGGERED_CHAT_TOKEN"]),
+      }),
+      plugin("unrelated-chat", { origin: "config", channelId: "shared-chat" }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers({}, {
       TRIGGERED_CHAT_TOKEN: "configured",
@@ -633,18 +533,12 @@ describe("channel plugin blockers", () => {
   });
 
   it("ignores package env mappings for channels the plugin does not own", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "external-chat",
-          origin: "config",
-          channels: ["external-chat"],
-          packageChannel: createPackageChannelEnv("discord", ["EXTERNAL_CHAT_TOKEN"]),
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("external-chat", {
+        origin: "config",
+        packageChannel: createPackageChannelEnv("discord", ["EXTERNAL_CHAT_TOKEN"]),
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers({}, {
       EXTERNAL_CHAT_TOKEN: "configured",
@@ -654,18 +548,12 @@ describe("channel plugin blockers", () => {
   });
 
   it("diagnoses a package env channel whose bundled owner is opt-in", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "twitch",
-          origin: "bundled",
-          channels: ["twitch"],
-          packageChannel: createPackageChannelEnv("twitch", ["OPENCLAW_TWITCH_ACCESS_TOKEN"]),
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("twitch", {
+        origin: "bundled",
+        packageChannel: createPackageChannelEnv("twitch", ["OPENCLAW_TWITCH_ACCESS_TOKEN"]),
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers({}, {
       OPENCLAW_TWITCH_ACCESS_TOKEN: "configured",
@@ -684,18 +572,12 @@ describe("channel plugin blockers", () => {
   });
 
   it("includes both actions for a bundled opt-in owner under a restrictive allowlist", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "twitch",
-          origin: "bundled",
-          channels: ["twitch"],
-          packageChannel: createPackageChannelEnv("twitch", ["OPENCLAW_TWITCH_ACCESS_TOKEN"]),
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("twitch", {
+        origin: "bundled",
+        packageChannel: createPackageChannelEnv("twitch", ["OPENCLAW_TWITCH_ACCESS_TOKEN"]),
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers(
       {
@@ -721,18 +603,11 @@ describe("channel plugin blockers", () => {
   });
 
   it("keeps package env blockers when another channel is explicitly configured", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          packageChannel: createPackageChannelEnv("discord", ["DISCORD_BOT_TOKEN"]),
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("discord", {
+        packageChannel: createPackageChannelEnv("discord", ["DISCORD_BOT_TOKEN"]),
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers(
       {
@@ -769,18 +644,11 @@ describe("channel plugin blockers", () => {
   });
 
   it("honors explicit channel disablement over package env triggers", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          packageChannel: createPackageChannelEnv("discord", ["DISCORD_BOT_TOKEN"]),
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("discord", {
+        packageChannel: createPackageChannelEnv("discord", ["DISCORD_BOT_TOKEN"]),
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers(
       {
@@ -811,23 +679,10 @@ describe("channel plugin blockers", () => {
   });
 
   it("accepts an auto-enabled bundled owner under a restrictive source allowlist", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "telegram-plugin",
-          origin: "bundled",
-          channels: ["telegram"],
-          enabledByDefault: false,
-        },
-        {
-          id: "untrusted-telegram",
-          origin: "config",
-          channels: ["telegram"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("telegram-plugin", { origin: "bundled", channelId: "telegram" }),
+      plugin("untrusted-telegram", { origin: "config", channelId: "telegram" }),
+    ]);
 
     const channels = {
       telegram: {
@@ -857,17 +712,7 @@ describe("channel plugin blockers", () => {
   });
 
   it("preserves explicit external trust across an auto-materialized allowlist", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([plugin("discord")]);
 
     const sourceConfig: OpenClawConfig = {
       channels: {
@@ -898,17 +743,9 @@ describe("channel plugin blockers", () => {
   });
 
   it("preserves explicit workspace trust across an auto-materialized allowlist", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "workspace-chat",
-          origin: "workspace",
-          channels: ["workspace-chat"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("workspace-chat", { origin: "workspace", channelId: "workspace-chat" }),
+    ]);
 
     const sourceConfig: OpenClawConfig = {
       channels: {
@@ -939,17 +776,7 @@ describe("channel plugin blockers", () => {
   });
 
   it("accepts an env-auto-enabled bundled owner absent from the source config", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "telegram",
-          origin: "bundled",
-          channels: ["telegram"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([plugin("telegram", { origin: "bundled", channelId: "telegram" })]);
 
     const hits = scanConfiguredChannelPluginBlockers(
       {
@@ -974,17 +801,7 @@ describe("channel plugin blockers", () => {
   });
 
   it("reports external channel plugins omitted from a restrictive allowlist", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([plugin("discord")]);
 
     const hits = scanConfiguredChannelPluginBlockers({
       plugins: {
@@ -1011,23 +828,10 @@ describe("channel plugin blockers", () => {
   });
 
   it("keeps blocker reasons scoped to each external owner", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "denied-chat",
-          origin: "config",
-          channels: ["shared-chat"],
-          enabledByDefault: false,
-        },
-        {
-          id: "untrusted-chat",
-          origin: "config",
-          channels: ["shared-chat"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("denied-chat", { origin: "config", channelId: "shared-chat" }),
+      plugin("untrusted-chat", { origin: "config", channelId: "shared-chat" }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers({
       plugins: {
@@ -1055,17 +859,7 @@ describe("channel plugin blockers", () => {
   });
 
   it("reports a single channel owner blocked by plugins.deny", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          origin: "global",
-          channels: ["discord"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([plugin("discord")]);
 
     const hits = scanConfiguredChannelPluginBlockers({
       plugins: {
@@ -1091,17 +885,9 @@ describe("channel plugin blockers", () => {
   });
 
   it("accepts workspace channel owners activated through a plugin slot", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "workspace-chat",
-          origin: "workspace",
-          channels: ["workspace-chat"],
-          enabledByDefault: false,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("workspace-chat", { origin: "workspace", channelId: "workspace-chat" }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers({
       plugins: {
@@ -1121,17 +907,7 @@ describe("channel plugin blockers", () => {
   });
 
   it("still evaluates configured channels when plugins are disabled globally", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "slack",
-          origin: "bundled",
-          channels: ["slack"],
-          enabledByDefault: true,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([plugin("slack", { origin: "bundled", enabledByDefault: true })]);
 
     const hits = scanConfiguredChannelPluginBlockers({
       plugins: {
@@ -1158,23 +934,10 @@ describe("channel plugin blockers", () => {
   });
 
   it("ignores ambient channel env when reporting plugin blockers", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "slack",
-          origin: "bundled",
-          channels: ["slack"],
-          enabledByDefault: true,
-        },
-        {
-          id: "telegram",
-          origin: "bundled",
-          channels: ["telegram"],
-          enabledByDefault: true,
-        },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+    mockManifestPlugins([
+      plugin("slack", { origin: "bundled", enabledByDefault: true }),
+      plugin("telegram", { origin: "bundled", enabledByDefault: true }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers(
       {
@@ -1202,30 +965,20 @@ describe("channel plugin blockers", () => {
   });
 
   it("does not report a disabled bundled owner when a configured external plugin owns the channel", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "feishu",
-          origin: "bundled",
-          channels: ["feishu"],
-          enabledByDefault: true,
-        },
-        {
-          id: "openclaw-lark",
-          origin: "config",
-          channels: ["feishu"],
-          enabledByDefault: false,
-          channelConfigs: {
-            feishu: {
-              schema: {
-                type: "object",
-              },
+    mockManifestPlugins([
+      plugin("feishu", { origin: "bundled", enabledByDefault: true }),
+      plugin("openclaw-lark", {
+        origin: "config",
+        channelId: "feishu",
+        channelConfigs: {
+          feishu: {
+            schema: {
+              type: "object",
             },
           },
         },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers({
       plugins: {
@@ -1251,30 +1004,20 @@ describe("channel plugin blockers", () => {
   });
 
   it("reports each blocked owner when no channel owner is active", () => {
-    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
-      plugins: [
-        {
-          id: "feishu",
-          origin: "bundled",
-          channels: ["feishu"],
-          enabledByDefault: true,
-        },
-        {
-          id: "openclaw-lark",
-          origin: "config",
-          channels: ["feishu"],
-          enabledByDefault: false,
-          channelConfigs: {
-            feishu: {
-              schema: {
-                type: "object",
-              },
+    mockManifestPlugins([
+      plugin("feishu", { origin: "bundled", enabledByDefault: true }),
+      plugin("openclaw-lark", {
+        origin: "config",
+        channelId: "feishu",
+        channelConfigs: {
+          feishu: {
+            schema: {
+              type: "object",
             },
           },
         },
-      ],
-      diagnostics: [],
-    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+      }),
+    ]);
 
     const hits = scanConfiguredChannelPluginBlockers({
       plugins: {
@@ -1307,4 +1050,3 @@ describe("channel plugin blockers", () => {
     ]);
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/commands/doctor/shared/stale-auth-order.test.ts
+++ b/src/commands/doctor/shared/stale-auth-order.test.ts
@@ -81,6 +81,17 @@ function tokenStore(params: {
   };
 }
 
+function writeTokenStore(agentDir: string, params: Parameters<typeof tokenStore>[0]): void {
+  writePersistedAuthProfileStoreRaw(tokenStore(params), agentDir);
+}
+
+function anthropicOrderConfig(
+  profileId: string,
+  agents?: OpenClawConfig["agents"],
+): OpenClawConfig {
+  return { ...(agents ? { agents } : {}), auth: { order: { anthropic: [profileId] } } };
+}
+
 function repair(
   cfg: OpenClawConfig,
   stores: AuthProfileStore[],
@@ -91,6 +102,17 @@ function repair(
     stores,
     ...(runtimeProfileIds ? { runtimeProfileIds } : {}),
   });
+}
+
+async function withStateDir<T>(prefix: string, run: (stateDir: string) => Promise<T>): Promise<T> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    return await run(stateDir);
+  } finally {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
 }
 
 describe("repairStaleConfiguredAuthOrders", () => {
@@ -138,8 +160,7 @@ describe("repairStaleConfiguredAuthOrders", () => {
   });
 
   it("repairs an undeclared order id to the only declared profile for that provider", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-auth-order-"));
-    try {
+    await withStateDir("openclaw-stale-auth-order-", async (stateDir) => {
       const cfg = {
         memory: {},
         auth: {
@@ -159,14 +180,11 @@ describe("repairStaleConfiguredAuthOrders", () => {
       expect(result.changes).toEqual([
         "auth.order.openai: replaced undeclared openai:manual with openai:chatgpt-manual.",
       ]);
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("reports an undeclared order id without changing ambiguous provider profiles", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-auth-order-"));
-    try {
+    await withStateDir("openclaw-stale-auth-order-", async (stateDir) => {
       const cfg = {
         memory: {},
         auth: {
@@ -194,14 +212,11 @@ describe("repairStaleConfiguredAuthOrders", () => {
         "declared profiles for this provider are ambiguous (openai:chatgpt-manual, openai:api-manual)",
       );
       expect(result.warnings?.join("\n")).toContain("Set auth.order.openai explicitly");
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("preserves an undeclared order id backed by a usable stored credential", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-auth-order-"));
-    try {
+    await withStateDir("openclaw-stale-auth-order-", async (stateDir) => {
       const cfg = {
         auth: {
           profiles: {
@@ -226,14 +241,11 @@ describe("repairStaleConfiguredAuthOrders", () => {
       });
 
       expect(result).toEqual({ config: cfg, changes: [] });
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("drops undeclared-profile warnings after automatic fallback removes the order", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-auth-order-"));
-    try {
+    await withStateDir("openclaw-stale-auth-order-", async (stateDir) => {
       const cfg = {
         auth: {
           profiles: {
@@ -260,9 +272,7 @@ describe("repairStaleConfiguredAuthOrders", () => {
 
       expect(result.config.auth?.order?.openai).toBeUndefined();
       expect(result.warnings).toBeUndefined();
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("preserves an explicit empty order", () => {
@@ -345,9 +355,7 @@ describe("repairStaleConfiguredAuthOrders", () => {
   });
 
   it("does not use a stored profile from another provider", () => {
-    const cfg = {
-      auth: { order: { anthropic: ["anthropic:removed"] } },
-    } satisfies OpenClawConfig;
+    const cfg = anthropicOrderConfig("anthropic:removed");
     const store = tokenStore({
       profileId: "openai:manual",
       provider: "openai",
@@ -359,9 +367,7 @@ describe("repairStaleConfiguredAuthOrders", () => {
   });
 
   it("does not remove an order when the only fallback credential is expired", () => {
-    const cfg = {
-      auth: { order: { anthropic: ["anthropic:removed"] } },
-    } satisfies OpenClawConfig;
+    const cfg = anthropicOrderConfig("anthropic:removed");
     const store = tokenStore({
       profileId: "claude-cli:expired",
       expires: Date.now() - 1,
@@ -373,9 +379,7 @@ describe("repairStaleConfiguredAuthOrders", () => {
   });
 
   it("preserves a stale config order when the agent's stored order has no usable fallback", () => {
-    const cfg = {
-      auth: { order: { anthropic: ["anthropic:removed"] } },
-    } satisfies OpenClawConfig;
+    const cfg = anthropicOrderConfig("anthropic:removed");
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
@@ -441,9 +445,7 @@ describe("repairStaleConfiguredAuthOrders", () => {
   });
 
   it("preserves a stale order unless every active agent has an automatic fallback", () => {
-    const cfg = {
-      auth: { order: { anthropic: ["anthropic:removed"] } },
-    } satisfies OpenClawConfig;
+    const cfg = anthropicOrderConfig("anthropic:removed");
     const healthyStore = tokenStore({ profileId: "claude-cli:setup-token" });
     const missingFallbackStore: AuthProfileStore = { version: 1, profiles: {} };
 
@@ -457,17 +459,12 @@ describe("repairStaleConfiguredAuthOrders", () => {
   });
 
   it("includes inherited main credentials when main is not a configured agent", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-auth-order-"));
-    try {
+    await withStateDir("openclaw-stale-auth-order-", async (stateDir) => {
       const mainAgentDir = path.join(stateDir, "agents", "main", "agent");
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:setup-token" }),
-        mainAgentDir,
-      );
-      const cfg = {
-        agents: { list: [{ id: "work", default: true }] },
-        auth: { order: { anthropic: ["anthropic:removed"] } },
-      } satisfies OpenClawConfig;
+      writeTokenStore(mainAgentDir, { profileId: "claude-cli:setup-token" });
+      const cfg = anthropicOrderConfig("anthropic:removed", {
+        list: [{ id: "work", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -475,22 +472,17 @@ describe("repairStaleConfiguredAuthOrders", () => {
       });
 
       expect(result.config.auth?.order?.anthropic).toBeUndefined();
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("does not require the inherited main store itself to have a fallback", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-auth-order-"));
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:work-token" }),
-        path.join(stateDir, "agents", "work", "agent"),
-      );
-      const cfg = {
-        agents: { list: [{ id: "work", default: true }] },
-        auth: { order: { anthropic: ["anthropic:removed"] } },
-      } satisfies OpenClawConfig;
+    await withStateDir("openclaw-stale-auth-order-", async (stateDir) => {
+      writeTokenStore(path.join(stateDir, "agents", "work", "agent"), {
+        profileId: "claude-cli:work-token",
+      });
+      const cfg = anthropicOrderConfig("anthropic:removed", {
+        list: [{ id: "work", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -498,21 +490,15 @@ describe("repairStaleConfiguredAuthOrders", () => {
       });
 
       expect(result.config.auth?.order?.anthropic).toBeUndefined();
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it.skipIf(process.platform === "win32")(
     "fails closed on an unreadable SQLite sidecar beside a present database",
     async () => {
-      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-auth-order-"));
-      const agentDir = path.join(stateDir, "agents", "main", "agent");
-      try {
-        writePersistedAuthProfileStoreRaw(
-          tokenStore({ profileId: "claude-cli:setup-token" }),
-          agentDir,
-        );
+      await withStateDir("openclaw-stale-auth-order-", async (stateDir) => {
+        const agentDir = path.join(stateDir, "agents", "main", "agent");
+        writeTokenStore(agentDir, { profileId: "claude-cli:setup-token" });
         closeOpenClawAgentDatabasesForTest();
         closeOpenClawStateDatabaseForTest();
         const [, walPath] = resolveAuthProfileDatabaseFilePaths(agentDir);
@@ -521,9 +507,7 @@ describe("repairStaleConfiguredAuthOrders", () => {
         }
         await fs.rm(walPath, { force: true });
         await fs.symlink(path.join(stateDir, "missing-wal"), walPath);
-        const cfg = {
-          auth: { order: { anthropic: ["anthropic:removed"] } },
-        } satisfies OpenClawConfig;
+        const cfg = anthropicOrderConfig("anthropic:removed");
 
         const result = maybeRepairStaleConfiguredAuthOrders({
           cfg,
@@ -535,28 +519,20 @@ describe("repairStaleConfiguredAuthOrders", () => {
         expect(result.warnings).toEqual([
           expect.stringContaining("SQLite auth profile store is unreadable"),
         ]);
-      } finally {
-        closeOpenClawAgentDatabasesForTest();
-        closeOpenClawStateDatabaseForTest();
-        await fs.rm(stateDir, { recursive: true, force: true });
-      }
+      });
     },
   );
 
   it("preserves an ordered profile owned by a retained unconfigured agent", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-retained-auth-order-"));
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:setup-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "anthropic:retained", provider: "anthropic" }),
-        path.join(stateDir, "agents", "retained", "agent"),
-      );
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:retained"] } },
-      } satisfies OpenClawConfig;
+    await withStateDir("openclaw-retained-auth-order-", async (stateDir) => {
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:setup-token",
+      });
+      writeTokenStore(path.join(stateDir, "agents", "retained", "agent"), {
+        profileId: "anthropic:retained",
+        provider: "anthropic",
+      });
+      const cfg = anthropicOrderConfig("anthropic:retained");
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -564,19 +540,15 @@ describe("repairStaleConfiguredAuthOrders", () => {
       });
 
       expect(result).toEqual({ config: cfg, changes: [] });
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("preserves an ordered profile in a registered custom agent directory", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-custom-auth-order-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:setup-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-custom-auth-order-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:setup-token",
+      });
       const customAgentDir = path.join(stateDir, "custom-agents", "retained");
       const database = openOpenClawAgentDatabase({
         agentId: "retained",
@@ -590,24 +562,17 @@ describe("repairStaleConfiguredAuthOrders", () => {
       );
       closeOpenClawAgentDatabasesForTest();
       closeOpenClawStateDatabaseForTest();
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:retained"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:retained");
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result).toEqual({ config: cfg, changes: [] });
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("does not use a registered inactive store as the automatic fallback proof", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-custom-fallback-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
+    await withStateDir("openclaw-custom-fallback-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
       const customAgentDir = path.join(stateDir, "custom-agents", "retained");
       const database = openOpenClawAgentDatabase({
         agentId: "retained",
@@ -621,29 +586,22 @@ describe("repairStaleConfiguredAuthOrders", () => {
       );
       closeOpenClawAgentDatabasesForTest();
       closeOpenClawStateDatabaseForTest();
-      const cfg = {
-        agents: { list: [{ id: "main", default: true }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "main", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result).toEqual({ config: cfg, changes: [] });
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("preserves an ordered runtime profile from a registered custom agent directory", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-custom-runtime-auth-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-custom-runtime-auth-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const customAgentDir = path.join(stateDir, "custom-agents", "retained");
       const database = openOpenClawAgentDatabase({
         agentId: "retained",
@@ -675,28 +633,20 @@ describe("repairStaleConfiguredAuthOrders", () => {
             ]
           : [],
       );
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:runtime-only"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:runtime-only");
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result).toEqual({ config: cfg, changes: [] });
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("does not repair while a registered custom agent has an unmigrated auth store", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-custom-legacy-auth-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-custom-legacy-auth-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const customAgentDir = path.join(stateDir, "custom-agents", "retained");
       const databasePath = resolveAuthProfileDatabasePath(customAgentDir);
       openOpenClawAgentDatabase({ agentId: "retained", env, path: databasePath });
@@ -706,32 +656,24 @@ describe("repairStaleConfiguredAuthOrders", () => {
         resolveAuthStorePath(customAgentDir),
         JSON.stringify(tokenStore({ profileId: "anthropic:legacy", provider: "anthropic" })),
       );
-      const cfg = {
-        agents: { list: [{ id: "main", default: true }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "main", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result).toEqual({ config: cfg, changes: [] });
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("does not use an inactive retained agent as the automatic fallback proof", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-inactive-auth-order-"));
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:inactive-token" }),
-        path.join(stateDir, "agents", "retained", "agent"),
-      );
-      const cfg = {
-        agents: { list: [{ id: "main", default: true }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+    await withStateDir("openclaw-inactive-auth-order-", async (stateDir) => {
+      writeTokenStore(path.join(stateDir, "agents", "retained", "agent"), {
+        profileId: "claude-cli:inactive-token",
+      });
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "main", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -739,20 +681,16 @@ describe("repairStaleConfiguredAuthOrders", () => {
       });
 
       expect(result).toEqual({ config: cfg, changes: [] });
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it.skipIf(process.platform === "win32")(
     "fails closed on a dangling retained-agent symlink",
     async () => {
-      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dangling-auth-order-"));
-      try {
-        writePersistedAuthProfileStoreRaw(
-          tokenStore({ profileId: "claude-cli:main-token" }),
-          path.join(stateDir, "agents", "main", "agent"),
-        );
+      await withStateDir("openclaw-dangling-auth-order-", async (stateDir) => {
+        writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+          profileId: "claude-cli:main-token",
+        });
         const retainedRoot = path.join(stateDir, "agents", "retained");
         await fs.mkdir(retainedRoot, { recursive: true });
         await fs.symlink(
@@ -760,9 +698,7 @@ describe("repairStaleConfiguredAuthOrders", () => {
           path.join(retainedRoot, "agent"),
           "dir",
         );
-        const cfg = {
-          auth: { order: { anthropic: ["anthropic:missing"] } },
-        } satisfies OpenClawConfig;
+        const cfg = anthropicOrderConfig("anthropic:missing");
 
         const result = maybeRepairStaleConfiguredAuthOrders({
           cfg,
@@ -772,29 +708,20 @@ describe("repairStaleConfiguredAuthOrders", () => {
         expect(result.config).toBe(cfg);
         expect(result.changes).toEqual([]);
         expect(result.warnings?.join("\n")).toContain("unavailable");
-      } finally {
-        await fs.rm(stateDir, { recursive: true, force: true });
-      }
+      });
     },
   );
 
   it.each(["OPENCLAW_AGENT_DIR", "PI_CODING_AGENT_DIR"] as const)(
     "preserves profiles in the %s-selected auth store",
     async (envKey) => {
-      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-env-auth-order-"));
-      try {
+      await withStateDir("openclaw-env-auth-order-", async (stateDir) => {
         const selectedAgentDir = path.join(stateDir, "selected-agent");
-        writePersistedAuthProfileStoreRaw(
-          tokenStore({ profileId: "claude-cli:selected-token" }),
-          selectedAgentDir,
-        );
-        writePersistedAuthProfileStoreRaw(
-          tokenStore({ profileId: "claude-cli:main-token" }),
-          path.join(stateDir, "agents", "main", "agent"),
-        );
-        const cfg = {
-          auth: { order: { anthropic: ["claude-cli:selected-token"] } },
-        } satisfies OpenClawConfig;
+        writeTokenStore(selectedAgentDir, { profileId: "claude-cli:selected-token" });
+        writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+          profileId: "claude-cli:main-token",
+        });
+        const cfg = anthropicOrderConfig("claude-cli:selected-token");
 
         const result = maybeRepairStaleConfiguredAuthOrders({
           cfg,
@@ -805,23 +732,18 @@ describe("repairStaleConfiguredAuthOrders", () => {
         });
 
         expect(result).toEqual({ config: cfg, changes: [] });
-      } finally {
-        await fs.rm(stateDir, { recursive: true, force: true });
-      }
+      });
     },
   );
 
   it("uses OPENCLAW_AGENT_DIR as the inherited shared-main auth store", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-main-auth-order-"));
-    try {
+    await withStateDir("openclaw-main-auth-order-", async (stateDir) => {
       const sharedMainAgentDir = path.join(stateDir, "relocated-main-agent");
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "anthropic:relocated-main", provider: "anthropic" }),
-        sharedMainAgentDir,
-      );
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      writeTokenStore(sharedMainAgentDir, {
+        profileId: "anthropic:relocated-main",
+        provider: "anthropic",
+      });
+      const cfg = anthropicOrderConfig("anthropic:missing");
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -834,14 +756,11 @@ describe("repairStaleConfiguredAuthOrders", () => {
       expect(result.config.auth?.order?.anthropic).toBeUndefined();
       expect(result.changes).toHaveLength(1);
       expect(result.warnings).toBeUndefined();
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("preserves an order that selects a runtime-only external profile", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-runtime-auth-order-"));
-    try {
+    await withStateDir("openclaw-runtime-auth-order-", async (stateDir) => {
       const workAgentDir = path.join(stateDir, "agents", "work", "agent");
       const cfg = {
         agents: { list: [{ id: "work", default: true }] },
@@ -885,25 +804,20 @@ describe("repairStaleConfiguredAuthOrders", () => {
       });
 
       expect(result).toEqual({ config: cfg, changes: [] });
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("warns and does not repair when an active auth database is unreadable", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-unreadable-auth-order-"));
-    try {
+    await withStateDir("openclaw-unreadable-auth-order-", async (stateDir) => {
       const workAgentDir = path.join(stateDir, "agents", "work", "agent");
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       await fs.mkdir(workAgentDir, { recursive: true });
       await fs.writeFile(resolveAuthProfileDatabasePath(workAgentDir), "not-a-sqlite-database");
-      const cfg = {
-        agents: { list: [{ id: "work", default: true }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "work", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -920,32 +834,25 @@ describe("repairStaleConfiguredAuthOrders", () => {
           env: { OPENCLAW_STATE_DIR: stateDir },
         }).join("\n"),
       ).toContain("SQLite auth profile store is unreadable");
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it.skipIf(process.platform === "win32")(
     "fails closed on a dangling active auth database symlink",
     async () => {
-      const stateDir = await fs.mkdtemp(
-        path.join(os.tmpdir(), "openclaw-active-dangling-auth-order-"),
-      );
-      try {
-        writePersistedAuthProfileStoreRaw(
-          tokenStore({ profileId: "claude-cli:main-token" }),
-          path.join(stateDir, "agents", "main", "agent"),
-        );
+      await withStateDir("openclaw-active-dangling-auth-order-", async (stateDir) => {
+        writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+          profileId: "claude-cli:main-token",
+        });
         const workAgentDir = path.join(stateDir, "agents", "work", "agent");
         await fs.mkdir(workAgentDir, { recursive: true });
         await fs.symlink(
           path.join(workAgentDir, "missing.sqlite"),
           resolveAuthProfileDatabasePath(workAgentDir),
         );
-        const cfg = {
-          agents: { list: [{ id: "work", default: true }] },
-          auth: { order: { anthropic: ["anthropic:missing"] } },
-        } satisfies OpenClawConfig;
+        const cfg = anthropicOrderConfig("anthropic:missing", {
+          list: [{ id: "work", default: true }],
+        });
 
         const result = maybeRepairStaleConfiguredAuthOrders({
           cfg,
@@ -955,23 +862,17 @@ describe("repairStaleConfiguredAuthOrders", () => {
         expect(result.config).toBe(cfg);
         expect(result.changes).toEqual([]);
         expect(result.warnings?.join("\n")).toContain("unavailable");
-      } finally {
-        await fs.rm(stateDir, { recursive: true, force: true });
-      }
+      });
     },
   );
 
   it.skipIf(process.platform === "win32")(
     "fails closed on a dangling legacy auth source beside a legacy database",
     async () => {
-      const stateDir = await fs.mkdtemp(
-        path.join(os.tmpdir(), "openclaw-dangling-legacy-auth-order-"),
-      );
-      try {
-        writePersistedAuthProfileStoreRaw(
-          tokenStore({ profileId: "claude-cli:main-token" }),
-          path.join(stateDir, "agents", "main", "agent"),
-        );
+      await withStateDir("openclaw-dangling-legacy-auth-order-", async (stateDir) => {
+        writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+          profileId: "claude-cli:main-token",
+        });
         const workAgentDir = path.join(stateDir, "agents", "work", "agent");
         await fs.mkdir(workAgentDir, { recursive: true });
         const legacyDatabase = new DatabaseSync(resolveAuthProfileDatabasePath(workAgentDir));
@@ -981,10 +882,9 @@ describe("repairStaleConfiguredAuthOrders", () => {
           path.join(workAgentDir, "missing-auth-profiles.json"),
           resolveAuthStorePath(workAgentDir),
         );
-        const cfg = {
-          agents: { list: [{ id: "work", default: true }] },
-          auth: { order: { anthropic: ["anthropic:missing"] } },
-        } satisfies OpenClawConfig;
+        const cfg = anthropicOrderConfig("anthropic:missing", {
+          list: [{ id: "work", default: true }],
+        });
 
         const result = maybeRepairStaleConfiguredAuthOrders({
           cfg,
@@ -994,25 +894,19 @@ describe("repairStaleConfiguredAuthOrders", () => {
         expect(result.config).toBe(cfg);
         expect(result.changes).toEqual([]);
         expect(result.warnings?.join("\n")).toContain("unavailable");
-      } finally {
-        await fs.rm(stateDir, { recursive: true, force: true });
-      }
+      });
     },
   );
 
   it("fails closed when a retained unconfigured auth database is unreadable", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-retained-invalid-auth-"));
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-retained-invalid-auth-", async (stateDir) => {
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const retainedAgentDir = path.join(stateDir, "agents", "retained", "agent");
       await fs.mkdir(retainedAgentDir, { recursive: true });
       await fs.writeFile(resolveAuthProfileDatabasePath(retainedAgentDir), "not-sqlite");
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing");
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -1022,49 +916,37 @@ describe("repairStaleConfiguredAuthOrders", () => {
       expect(result.config).toBe(cfg);
       expect(result.changes).toEqual([]);
       expect(result.warnings?.join("\n")).toContain("Skipped auth.order repair");
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("fails closed when a registered custom auth database is unreadable", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-custom-invalid-auth-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-custom-invalid-auth-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const customAgentDir = path.join(stateDir, "custom-agents", "retained");
       const databasePath = resolveAuthProfileDatabasePath(customAgentDir);
       openOpenClawAgentDatabase({ agentId: "retained", env, path: databasePath });
       closeOpenClawAgentDatabasesForTest();
       closeOpenClawStateDatabaseForTest();
       await fs.writeFile(databasePath, "not-sqlite");
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing");
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result.config).toBe(cfg);
       expect(result.changes).toEqual([]);
       expect(result.warnings?.join("\n")).toContain("Skipped auth.order repair");
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("fails closed when registered auth runtime state is unreadable without a secrets row", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-custom-state-auth-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-custom-state-auth-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const customAgentDir = path.join(stateDir, "custom-agents", "retained");
       const databasePath = resolveAuthProfileDatabasePath(customAgentDir);
       const database = openOpenClawAgentDatabase({
@@ -1084,30 +966,22 @@ describe("repairStaleConfiguredAuthOrders", () => {
         .prepare("UPDATE auth_profile_state SET state_json = ? WHERE state_key = ?")
         .run("{", "primary");
       rawDatabase.close();
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing");
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result.config).toBe(cfg);
       expect(result.changes).toEqual([]);
       expect(result.warnings?.join("\n")).toContain("unreadable");
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("fails closed when a registered auth database owner no longer matches", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-custom-owner-auth-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-custom-owner-auth-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const customAgentDir = path.join(stateDir, "custom-agents", "retained");
       const databasePath = resolveAuthProfileDatabasePath(customAgentDir);
       openOpenClawAgentDatabase({ agentId: "retained", env, path: databasePath });
@@ -1118,30 +992,22 @@ describe("repairStaleConfiguredAuthOrders", () => {
         .prepare("UPDATE schema_meta SET agent_id = ? WHERE meta_key = ?")
         .run("replacement", "primary");
       rawDatabase.close();
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing");
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result.config).toBe(cfg);
       expect(result.changes).toEqual([]);
       expect(result.warnings?.join("\n")).toContain("Skipped auth.order repair");
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("uses the live owner after a registered database pathname is recreated", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reowned-auth-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-reowned-auth-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const customAgentDir = path.join(stateDir, "custom-agents", "retained");
       const databasePath = resolveAuthProfileDatabasePath(customAgentDir);
       openOpenClawAgentDatabase({ agentId: "retired", env, path: databasePath });
@@ -1152,31 +1018,24 @@ describe("repairStaleConfiguredAuthOrders", () => {
       openOpenClawAgentDatabase({ agentId: "replacement", env, path: databasePath });
       closeOpenClawAgentDatabasesForTest();
       closeOpenClawStateDatabaseForTest();
-      const cfg = {
-        agents: { list: [{ id: "main", default: true }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "main", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result.config.auth?.order?.anthropic).toBeUndefined();
       expect(result.changes).toHaveLength(1);
       expect(result.warnings).toBeUndefined();
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("fails closed when an active agent points at another agent's database", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-active-owner-auth-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-active-owner-auth-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const customAgentDir = path.join(stateDir, "custom-agents", "shared");
       const database = openOpenClawAgentDatabase({
         agentId: "other",
@@ -1190,26 +1049,20 @@ describe("repairStaleConfiguredAuthOrders", () => {
       );
       closeOpenClawAgentDatabasesForTest();
       closeOpenClawStateDatabaseForTest();
-      const cfg = {
-        agents: { list: [{ id: "work", default: true, agentDir: customAgentDir }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "work", default: true, agentDir: customAgentDir }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result.config).toBe(cfg);
       expect(result.changes).toEqual([]);
       expect(result.warnings?.join("\n")).toContain("Skipped auth.order repair");
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("fails closed when an ownerless active database contains auth tables", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ownerless-auth-"));
-    try {
+    await withStateDir("openclaw-ownerless-auth-", async (stateDir) => {
       const agentDir = path.join(stateDir, "agents", "main", "agent");
       const databasePath = resolveAuthProfileDatabasePath(agentDir);
       await fs.mkdir(agentDir, { recursive: true });
@@ -1236,9 +1089,7 @@ describe("repairStaleConfiguredAuthOrders", () => {
           Date.now(),
         );
       rawDatabase.close();
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing");
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -1248,21 +1099,15 @@ describe("repairStaleConfiguredAuthOrders", () => {
       expect(result.config).toBe(cfg);
       expect(result.changes).toEqual([]);
       expect(result.warnings?.join("\n")).toContain("Skipped auth.order repair");
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("prefers a configured owner over the retained directory basename", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-renamed-owner-auth-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-renamed-owner-auth-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const renamedAgentDir = path.join(stateDir, "agents", "old", "agent");
       openOpenClawAgentDatabase({
         agentId: "work",
@@ -1271,31 +1116,24 @@ describe("repairStaleConfiguredAuthOrders", () => {
       });
       closeOpenClawAgentDatabasesForTest();
       closeOpenClawStateDatabaseForTest();
-      const cfg = {
-        agents: { list: [{ id: "work", default: true, agentDir: renamedAgentDir }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "work", default: true, agentDir: renamedAgentDir }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result.config.auth?.order?.anthropic).toBeUndefined();
       expect(result.changes).toHaveLength(1);
       expect(result.warnings).toBeUndefined();
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("uses durable ownership for a deconfigured relocated agent directory", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-relocated-owner-auth-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-relocated-owner-auth-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const relocatedAgentDir = path.join(stateDir, "agents", "old", "agent");
       openOpenClawAgentDatabase({
         agentId: "work",
@@ -1304,32 +1142,25 @@ describe("repairStaleConfiguredAuthOrders", () => {
       });
       closeOpenClawAgentDatabasesForTest();
       closeOpenClawStateDatabaseForTest();
-      const cfg = {
-        agents: { list: [{ id: "main", default: true }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "main", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result.config.auth?.order?.anthropic).toBeUndefined();
       expect(result.changes).toHaveLength(1);
       expect(result.warnings).toBeUndefined();
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("fails closed when an environment-selected directory belongs to another agent", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-env-owner-auth-"));
-    const envAgentDir = path.join(stateDir, "custom-env-agent");
-    const env = { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_AGENT_DIR: envAgentDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-env-owner-auth-", async (stateDir) => {
+      const envAgentDir = path.join(stateDir, "custom-env-agent");
+      const env = { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_AGENT_DIR: envAgentDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const database = openOpenClawAgentDatabase({
         agentId: "other",
         env,
@@ -1342,43 +1173,31 @@ describe("repairStaleConfiguredAuthOrders", () => {
       );
       closeOpenClawAgentDatabasesForTest();
       closeOpenClawStateDatabaseForTest();
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing");
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result.config).toBe(cfg);
       expect(result.changes).toEqual([]);
       expect(result.warnings?.join("\n")).toContain("Skipped auth.order repair");
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("fails closed when an active auth database has only one auth table", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-partial-schema-auth-"));
-    try {
+    await withStateDir("openclaw-partial-schema-auth-", async (stateDir) => {
       const workAgentDir = path.join(stateDir, "agents", "work", "agent");
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "anthropic:work", provider: "anthropic" }),
-        workAgentDir,
-      );
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
+      writeTokenStore(workAgentDir, { profileId: "anthropic:work", provider: "anthropic" });
       closeOpenClawAgentDatabasesForTest();
       closeOpenClawStateDatabaseForTest();
       const rawDatabase = new DatabaseSync(resolveAuthProfileDatabasePath(workAgentDir));
       rawDatabase.exec("DROP TABLE auth_profile_state;");
       rawDatabase.close();
-      const cfg = {
-        agents: { list: [{ id: "work", default: true }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "work", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -1388,21 +1207,15 @@ describe("repairStaleConfiguredAuthOrders", () => {
       expect(result.config).toBe(cfg);
       expect(result.changes).toEqual([]);
       expect(result.warnings?.join("\n")).toContain("Skipped auth.order repair");
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("fails closed when a stale registered database leaves a SQLite sidecar", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-custom-sidecar-auth-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-custom-sidecar-auth-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const customAgentDir = path.join(stateDir, "custom-agents", "retained");
       const databasePath = resolveAuthProfileDatabasePath(customAgentDir);
       openOpenClawAgentDatabase({ agentId: "retained", env, path: databasePath });
@@ -1414,63 +1227,48 @@ describe("repairStaleConfiguredAuthOrders", () => {
         throw new Error("expected SQLite WAL path");
       }
       await fs.writeFile(walPath, "orphaned-wal");
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing");
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result.config).toBe(cfg);
       expect(result.changes).toEqual([]);
       expect(result.warnings?.join("\n")).toContain("unavailable");
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("ignores a stale registered auth database after its pathname is removed", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-custom-missing-auth-"));
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    try {
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
+    await withStateDir("openclaw-custom-missing-auth-", async (stateDir) => {
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
       const customAgentDir = path.join(stateDir, "custom-agents", "retained");
       const databasePath = resolveAuthProfileDatabasePath(customAgentDir);
       openOpenClawAgentDatabase({ agentId: "retained", env, path: databasePath });
       closeOpenClawAgentDatabasesForTest();
       closeOpenClawStateDatabaseForTest();
       await fs.rm(databasePath);
-      const cfg = {
-        agents: { list: [{ id: "main", default: true }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "main", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
       expect(result.config.auth?.order?.anthropic).toBeUndefined();
       expect(result.changes).toHaveLength(1);
       expect(result.warnings).toBeUndefined();
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it.skipIf(process.platform === "win32")(
     "fails closed on a dangling registered auth database symlink",
     async () => {
-      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-custom-dangling-auth-"));
-      const env = { OPENCLAW_STATE_DIR: stateDir };
-      try {
-        writePersistedAuthProfileStoreRaw(
-          tokenStore({ profileId: "claude-cli:main-token" }),
-          path.join(stateDir, "agents", "main", "agent"),
-        );
+      await withStateDir("openclaw-custom-dangling-auth-", async (stateDir) => {
+        const env = { OPENCLAW_STATE_DIR: stateDir };
+        writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+          profileId: "claude-cli:main-token",
+        });
         const customAgentDir = path.join(stateDir, "custom-agents", "retained");
         const databasePath = resolveAuthProfileDatabasePath(customAgentDir);
         openOpenClawAgentDatabase({ agentId: "retained", env, path: databasePath });
@@ -1478,35 +1276,25 @@ describe("repairStaleConfiguredAuthOrders", () => {
         closeOpenClawStateDatabaseForTest();
         await fs.rm(databasePath);
         await fs.symlink(path.join(customAgentDir, "missing.sqlite"), databasePath);
-        const cfg = {
-          auth: { order: { anthropic: ["anthropic:missing"] } },
-        } satisfies OpenClawConfig;
+        const cfg = anthropicOrderConfig("anthropic:missing");
 
         const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
         expect(result.config).toBe(cfg);
         expect(result.changes).toEqual([]);
         expect(result.warnings?.join("\n")).toContain("unavailable");
-      } finally {
-        closeOpenClawAgentDatabasesForTest();
-        closeOpenClawStateDatabaseForTest();
-        await fs.rm(stateDir, { recursive: true, force: true });
-      }
+      });
     },
   );
 
   it.skipIf(process.platform === "win32")(
     "fails closed on a dangling registered auth database parent symlink",
     async () => {
-      const stateDir = await fs.mkdtemp(
-        path.join(os.tmpdir(), "openclaw-custom-dangling-parent-auth-"),
-      );
-      const env = { OPENCLAW_STATE_DIR: stateDir };
-      try {
-        writePersistedAuthProfileStoreRaw(
-          tokenStore({ profileId: "claude-cli:main-token" }),
-          path.join(stateDir, "agents", "main", "agent"),
-        );
+      await withStateDir("openclaw-custom-dangling-parent-auth-", async (stateDir) => {
+        const env = { OPENCLAW_STATE_DIR: stateDir };
+        writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+          profileId: "claude-cli:main-token",
+        });
         const customAgentDir = path.join(stateDir, "custom-agents", "retained");
         const originalAgentDir = path.join(stateDir, "custom-agent-target");
         await fs.mkdir(originalAgentDir, { recursive: true });
@@ -1521,26 +1309,19 @@ describe("repairStaleConfiguredAuthOrders", () => {
         closeOpenClawStateDatabaseForTest();
         await fs.rm(customAgentDir);
         await fs.symlink(path.join(stateDir, "missing-agent-target"), customAgentDir, "dir");
-        const cfg = {
-          auth: { order: { anthropic: ["anthropic:missing"] } },
-        } satisfies OpenClawConfig;
+        const cfg = anthropicOrderConfig("anthropic:missing");
 
         const result = maybeRepairStaleConfiguredAuthOrders({ cfg, env });
 
         expect(result.config).toBe(cfg);
         expect(result.changes).toEqual([]);
         expect(result.warnings?.join("\n")).toContain("unavailable");
-      } finally {
-        closeOpenClawAgentDatabasesForTest();
-        closeOpenClawStateDatabaseForTest();
-        await fs.rm(stateDir, { recursive: true, force: true });
-      }
+      });
     },
   );
 
   it("warns and preserves an ordered profile dropped by store coercion", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-invalid-auth-order-"));
-    try {
+    await withStateDir("openclaw-invalid-auth-order-", async (stateDir) => {
       writePersistedAuthProfileStoreRaw(
         {
           version: 1,
@@ -1555,9 +1336,7 @@ describe("repairStaleConfiguredAuthOrders", () => {
         },
         path.join(stateDir, "agents", "main", "agent"),
       );
-      const cfg = {
-        auth: { order: { anthropic: ["anthropic:old"] } },
-      } satisfies OpenClawConfig;
+      const cfg = anthropicOrderConfig("anthropic:old");
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -1567,24 +1346,19 @@ describe("repairStaleConfiguredAuthOrders", () => {
       expect(result.config).toBe(cfg);
       expect(result.changes).toEqual([]);
       expect(result.warnings?.join("\n")).toContain("contains invalid credentials");
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("repairs when an active agent database has no auth-profile row", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-empty-auth-order-"));
-    try {
+    await withStateDir("openclaw-empty-auth-order-", async (stateDir) => {
       const workAgentDir = path.join(stateDir, "agents", "work", "agent");
       writePersistedAuthProfileStateRaw({ version: 1 }, workAgentDir);
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
-      const cfg = {
-        agents: { list: [{ id: "work", default: true }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "work", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -1592,28 +1366,23 @@ describe("repairStaleConfiguredAuthOrders", () => {
       });
 
       expect(result.config.auth?.order?.anthropic).toBeUndefined();
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("repairs when an active legacy agent database predates auth tables", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-db-auth-order-"));
-    try {
+    await withStateDir("openclaw-legacy-db-auth-order-", async (stateDir) => {
       const workAgentDir = path.join(stateDir, "agents", "work", "agent");
       const databasePath = resolveAuthProfileDatabasePath(workAgentDir);
       await fs.mkdir(workAgentDir, { recursive: true });
       const legacyDatabase = new DatabaseSync(databasePath);
       legacyDatabase.exec("CREATE TABLE legacy_state (id INTEGER PRIMARY KEY);");
       legacyDatabase.close();
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
-      const cfg = {
-        agents: { list: [{ id: "work", default: true }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "work", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -1621,25 +1390,20 @@ describe("repairStaleConfiguredAuthOrders", () => {
       });
 
       expect(result.config.auth?.order?.anthropic).toBeUndefined();
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("does not repair while an invalid legacy auth source remains", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-auth-order-"));
-    try {
+    await withStateDir("openclaw-legacy-auth-order-", async (stateDir) => {
       const workAgentDir = path.join(stateDir, "agents", "work", "agent");
       await fs.mkdir(workAgentDir, { recursive: true });
       await fs.writeFile(resolveLegacyAuthStorePath(workAgentDir), "not-json", "utf8");
-      writePersistedAuthProfileStoreRaw(
-        tokenStore({ profileId: "claude-cli:main-token" }),
-        path.join(stateDir, "agents", "main", "agent"),
-      );
-      const cfg = {
-        agents: { list: [{ id: "work", default: true }] },
-        auth: { order: { anthropic: ["anthropic:missing"] } },
-      } satisfies OpenClawConfig;
+      writeTokenStore(path.join(stateDir, "agents", "main", "agent"), {
+        profileId: "claude-cli:main-token",
+      });
+      const cfg = anthropicOrderConfig("anthropic:missing", {
+        list: [{ id: "work", default: true }],
+      });
 
       const result = maybeRepairStaleConfiguredAuthOrders({
         cfg,
@@ -1647,9 +1411,7 @@ describe("repairStaleConfiguredAuthOrders", () => {
       });
 
       expect(result).toEqual({ config: cfg, changes: [] });
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Doctor coverage had accumulated hundreds of lines of repeated manifest, installed-plugin, temporary-state, auth-store, and config fixtures. That repetition obscured the lifecycle differences each case is meant to test and made future coverage expensive to maintain.

## Why This Change Was Made

This keeps fixture ownership local to the three doctor suites and introduces one canonical builder per repeated boundary:

- channel manifest records and registry mocks,
- post-upgrade installed-plugin packages and temporary roots,
- stale-auth temporary state, token stores, and Anthropic order config.

The repeated inline construction and the now-unnecessary max-lines suppression/baseline entry are removed. Production, config, schema, protocol, and public API behavior are untouched.

Root cause: the tests encoded common fixture policy inline instead of through their local lifecycle owner. Architectural owner: test fixture setup only. Canonical fix: private suite-local builders; no production abstraction or compatibility path was added.

## User Impact

No user-visible behavior changes. The same doctor, auth fail-closed, channel trust/default, package resolution, and manifest-drift behavior remains covered with 802 fewer repository lines.

## Evidence

- Head: `9c8f15c3713d01b7348f929b865a0203e37cbb7e`
- Delta: `+646/-1448`, net `-802`
  - tests: net `-801`
  - max-lines baseline: `-1`
  - production: `0`
- Static parity against the pre-change blobs:
  - channel blockers: 34 declarations, 34 expanded tests, 44 assertions
  - stale auth order: 50 declarations, 53 expanded tests, 108 assertions
  - post-upgrade: 20 declarations, 25 expanded tests, 44 assertions
  - no test-title or assertion call line changed
- Focused post-rebase proof:
  - channel blockers: 34/34 passed
  - stale auth order: 53/53 passed
  - post-upgrade: 25/25 passed
- Blacksmith Testbox `tbx_01kz1nv7y6c6ne57y4xq6dbczt`:
  - full doctor/auth/migration selection: 2,908 passed, 2 platform skips across 5 Vitest shards
  - final `check:changed`: passed, including typecheck, max-lines ratchet, dead-export scan, full core lint, and scripts lint
  - [hosted run](https://github.com/openclaw/openclaw/actions/runs/30757342481)
- Two independent xhigh reviews: no findings; both judged the suite-local helpers the best fix after complete owner/caller/history checks.
- Fresh collision census at 2026-08-02 17:24Z: zero open PR matches on all three doctor test paths. The sole authorized metadata overlap is #118079 on `config/max-lines-baseline.txt`; synthetic merge tree `14aff136384cbe3e98d8cba978d48a9452b41cda` is clean, the deletions are disjoint, and the merged baseline remains sorted.

Codex dependency contract was checked directly in sibling source:

- canonical OpenAI provider and registry: `../codex/codex-rs/model-provider-info/src/lib.rs:35-52`, `:244-262`, `:332-350`, `:438-459`
- default provider: `../codex/codex-rs/core/src/config/mod.rs:3650-3672`
- auth modes: `../codex/codex-rs/protocol/src/auth.rs:6-55`
- auth normalization/storage: `../codex/codex-rs/login/src/auth/manager.rs:418-459`, `:500-545`
- provider auth resolution: `../codex/codex-rs/model-provider/src/provider.rs:155-178`, `:223-240`, `:265-349`
- session/provider ownership: `../codex/codex-rs/core/src/session/session.rs:530-650`
