### PR TITLE
fix(slack): finalize answered questions on the correct message

### DIFF
--- a/extensions/slack/src/monitor/replies.questions.test.ts
+++ b/extensions/slack/src/monitor/replies.questions.test.ts
@@ -1,0 +1,458 @@
+// Native Slack question controls must finalize the exact delivered Block Kit message.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildSlackBlocksFallbackText } from "../blocks-fallback.js";
+
+type QuestionDeliveryRegistration = {
+  questionId: string;
+  deliveryId: string;
+  finalize: (statusLine: string) => void | Promise<void>;
+};
+
+type SlackQuestionUpdate = {
+  text: string;
+  blocks: Array<{
+    type?: string;
+    elements?: Array<{ type?: string; text: string }>;
+  }>;
+};
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  update: vi.fn(),
+  writeClient: vi.fn(),
+  registrations: [] as QuestionDeliveryRegistration[],
+}));
+
+vi.mock("./send.runtime.js", () => ({
+  sendMessageSlack: async (...args: unknown[]) => {
+    const result = await mocks.send(...args);
+    const options = args[2] as {
+      blocks?: Array<{ type?: string }>;
+      onQuestionControlDelivery?: (delivery: {
+        channelId: string;
+        messageId: string;
+        text: string;
+        blocks: Array<{ type?: string }>;
+      }) => void;
+    };
+    if (options.blocks?.some((block) => block.type === "actions")) {
+      const controlResult =
+        (result.controlDelivery as { channelId: string; messageId: string } | undefined) ?? result;
+      options.onQuestionControlDelivery?.({
+        channelId: controlResult.channelId,
+        messageId: controlResult.messageId,
+        text:
+          typeof args[1] === "string" && args[1]
+            ? args[1]
+            : buildSlackBlocksFallbackText(options.blocks),
+        blocks: options.blocks,
+      });
+    }
+    return result;
+  },
+}));
+
+vi.mock("../client.js", () => ({
+  getSlackWriteClient: (...args: unknown[]) => mocks.writeClient(...args),
+}));
+
+vi.mock("openclaw/plugin-sdk/question-gateway-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/question-gateway-runtime")>();
+  return {
+    ...actual,
+    questionGatewayRuntime: {
+      ...actual.questionGatewayRuntime,
+      registerChannelDelivery: (registration: QuestionDeliveryRegistration) => {
+        mocks.registrations.push(registration);
+      },
+    },
+  };
+});
+
+import { deliverReplies } from "./replies.js";
+
+const QUESTION_ID = "ask_0123456789abcdef0123456789abcdef";
+const QUESTION_THREAD_TS = "1712345678.000001";
+
+function buildQuestionPayload(options?: { mediaUrl?: string; splitPresentation?: boolean }) {
+  const questionBlocks = [
+    { type: "text" as const, text: "Where should this deploy?" },
+    {
+      type: "buttons" as const,
+      buttons: ["Staging", "Production"].map((label) => ({
+        label,
+        action: { type: "question" as const, questionId: QUESTION_ID, optionValue: label },
+      })),
+    },
+  ];
+  const headers = Array.from({ length: 21 }, (_entry, index) => `Column ${String(index)}`);
+  return {
+    text: "Choose a deploy target",
+    ...(options?.mediaUrl ? { mediaUrl: options.mediaUrl } : {}),
+    channelData: { askUser: { questionId: QUESTION_ID } },
+    presentation: {
+      blocks: options?.splitPresentation
+        ? [
+            {
+              type: "table" as const,
+              caption: "Deployment metadata",
+              headers,
+              rows: [headers.map((_header, index) => `Value ${String(index)}`)],
+            },
+            ...questionBlocks,
+          ]
+        : questionBlocks,
+    },
+  };
+}
+
+function buildParams(overrides?: Record<string, unknown>) {
+  return {
+    cfg: { channels: { slack: { botToken: "xoxb-test" } } },
+    replies: [buildQuestionPayload()],
+    target: "C123",
+    token: "xoxp-authoring-user",
+    accountId: "work",
+    runtime: { log: () => {}, error: () => {}, exit: () => {} },
+    textLimit: 4000,
+    replyThreadTs: QUESTION_THREAD_TS,
+    replyToMode: "all" as const,
+    ...overrides,
+  };
+}
+
+function requireQuestionRegistration(): QuestionDeliveryRegistration {
+  expect(mocks.registrations).toHaveLength(1);
+  const registration = mocks.registrations[0];
+  if (!registration) {
+    throw new Error("native Slack question delivery was not registered");
+  }
+  return registration;
+}
+
+function requireQuestionUpdate(): SlackQuestionUpdate {
+  const update = mocks.update.mock.calls[0]?.[0] as SlackQuestionUpdate | undefined;
+  if (!update) {
+    throw new Error("native Slack question terminal edit was not delivered");
+  }
+  return update;
+}
+
+describe("native Slack question delivery finalization", () => {
+  beforeEach(() => {
+    mocks.send.mockReset();
+    mocks.update.mockReset();
+    mocks.writeClient.mockReset();
+    mocks.writeClient.mockReturnValue({ chat: { update: mocks.update } });
+    mocks.registrations.length = 0;
+  });
+
+  it.each([
+    ["answered", "Answered: <!channel>", "Answered: &lt;!channel&gt;"],
+    ["expired", "Expired", "Expired"],
+    ["cancelled", "Cancelled", "Cancelled"],
+  ])(
+    "removes delivered question buttons when the question is %s",
+    async (_phase, status, expected) => {
+      mocks.send.mockResolvedValue({ messageId: "1712345678.000010", channelId: "C123" });
+
+      await deliverReplies(buildParams());
+
+      const registration = requireQuestionRegistration();
+      expect(registration).toMatchObject({
+        questionId: QUESTION_ID,
+        deliveryId: "slack:work:C123:1712345678.000010",
+      });
+      expect(mocks.send.mock.calls[0]?.[2]).toMatchObject({ threadTs: QUESTION_THREAD_TS });
+
+      await registration.finalize(status);
+
+      expect(mocks.writeClient).toHaveBeenCalledWith("xoxp-authoring-user");
+      expect(mocks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: "C123",
+          ts: "1712345678.000010",
+          text: expect.stringContaining(expected),
+          blocks: expect.arrayContaining([
+            { type: "context", elements: [{ type: "mrkdwn", text: expected }] },
+          ]),
+        }),
+      );
+      const { blocks } = requireQuestionUpdate();
+      expect(blocks.some((block) => block.type === "actions")).toBe(false);
+    },
+  );
+
+  it("finalizes a valid maximum Gateway answer within Slack context element limits", async () => {
+    const questions = Array.from({ length: 3 }, (_question, questionIndex) => ({
+      questionId: `question_${String(questionIndex)}`,
+      header: `Choice ${String(questionIndex)}`,
+      question: "Which options should run?",
+      multiSelect: true,
+      options: Array.from({ length: 4 }, (_option, optionIndex) => ({
+        label: `${"&".repeat(63)}${String(optionIndex)}`,
+      })),
+    }));
+    const selectedLabels = questions.flatMap((question) =>
+      question.options.map((option) => option.label),
+    );
+    const status = `Answered: ${selectedLabels.join(", ")}`;
+    const escapedStatus = `Answered: ${selectedLabels
+      .map((label) => label.replaceAll("&", "&amp;"))
+      .join(", ")}`;
+    expect(questions).toHaveLength(3);
+    expect(questions.every((question) => question.options.length === 4)).toBe(true);
+    expect(
+      questions.every(
+        (question) => new Set(question.options.map((option) => option.label)).size === 4,
+      ),
+    ).toBe(true);
+    expect(selectedLabels.every((label) => Array.from(label).length === 64)).toBe(true);
+    expect(escapedStatus).toHaveLength(3_824);
+
+    mocks.send.mockResolvedValue({ messageId: "1712345678.000026", channelId: "C123" });
+    mocks.update.mockImplementation(
+      async (message: {
+        blocks: Array<{ type?: string; elements?: Array<{ text?: string }> }>;
+      }) => {
+        for (const block of message.blocks) {
+          if (block.type !== "context") {
+            continue;
+          }
+          if (
+            (block.elements?.length ?? 0) > 10 ||
+            block.elements?.some((element) => {
+              const text = element.text ?? "";
+              return (
+                Array.from(text).length > 3_000 ||
+                text
+                  .replaceAll("&amp;", "")
+                  .replaceAll("&lt;", "")
+                  .replaceAll("&gt;", "")
+                  .includes("&")
+              );
+            })
+          ) {
+            throw new Error("invalid_blocks");
+          }
+        }
+      },
+    );
+
+    await deliverReplies(buildParams());
+    await expect(requireQuestionRegistration().finalize(status)).resolves.toBeUndefined();
+
+    const update = requireQuestionUpdate();
+    const contextBlocks = update.blocks.filter((block) => block.type === "context");
+    const contextElements = contextBlocks.flatMap((block) => block.elements ?? []);
+    expect(contextBlocks).toHaveLength(1);
+    expect(contextElements).toHaveLength(2);
+    expect(contextElements.every((element) => Array.from(element.text).length <= 3_000)).toBe(true);
+    expect(contextElements.map((element) => element.text).join("")).toBe(escapedStatus);
+    expect(Buffer.byteLength(update.text, "utf8")).toBeLessThanOrEqual(4_000);
+    expect(update.text.endsWith(`\n\n${escapedStatus}`)).toBe(true);
+    expect(update.blocks.some((block) => block.type === "actions")).toBe(false);
+    expect(mocks.writeClient).toHaveBeenCalledWith("xoxp-authoring-user");
+  });
+
+  it.each([
+    {
+      name: "an exact 3,000-character boundary",
+      status: `Answered: ${"a".repeat(2_990)}`,
+      expectedLengths: [3_000],
+    },
+    {
+      name: "an astral character at the exact Unicode boundary",
+      status: `Answered: ${"a".repeat(2_989)}😀`,
+      expectedLengths: [3_000],
+    },
+    {
+      name: "an astral character beyond the Unicode boundary",
+      status: `Answered: ${"a".repeat(2_990)}😀`,
+      expectedLengths: [3_000, 1],
+    },
+    {
+      name: "an escaped entity and mention across the Unicode boundary",
+      status: `Answered: ${"a".repeat(2_988)}&😀<!channel>`,
+      expectedLengths: [2_998, 22],
+    },
+  ])("keeps complete Slack context text at $name", async ({ status, expectedLengths }) => {
+    mocks.send.mockResolvedValue({ messageId: "1712345678.000027", channelId: "C123" });
+
+    await deliverReplies(buildParams());
+    await requireQuestionRegistration().finalize(status);
+
+    const update = requireQuestionUpdate();
+    const elements = update.blocks
+      .filter((block) => block.type === "context")
+      .flatMap((block) => block.elements ?? []);
+    expect(elements.map((element) => Array.from(element.text).length)).toEqual(expectedLengths);
+    expect(elements.map((element) => element.text).join("")).toBe(
+      update.text.slice(update.text.lastIndexOf("\n\n") + 2),
+    );
+    expect(elements.every((element) => !element.text.includes("�"))).toBe(true);
+    expect(Buffer.byteLength(update.text, "utf8")).toBeLessThanOrEqual(4_000);
+    if (status.includes("<!channel>")) {
+      expect(elements[1]?.text).toBe("&amp;😀&lt;!channel&gt;");
+      expect(update.text).not.toContain("<!channel>");
+    }
+  });
+
+  it("binds the actual control message after a media upload and split text segment", async () => {
+    mocks.send
+      .mockResolvedValueOnce({ messageId: "F123UPLOAD", channelId: "C123" })
+      .mockResolvedValueOnce({ messageId: "1712345678.000011", channelId: "C123" })
+      .mockResolvedValueOnce({ messageId: "1712345678.000012", channelId: "C123" });
+
+    await deliverReplies(
+      buildParams({
+        replies: [
+          buildQuestionPayload({
+            mediaUrl: "https://example.com/deploy.png",
+            splitPresentation: true,
+          }),
+        ],
+      }),
+    );
+
+    expect(mocks.send).toHaveBeenCalledTimes(3);
+    const registration = requireQuestionRegistration();
+    expect(registration.deliveryId).toBe("slack:work:C123:1712345678.000012");
+
+    await registration.finalize("Expired");
+
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "C123", ts: "1712345678.000012" }),
+    );
+  });
+
+  it("keeps the actual controls receipt when provider fallback returns a later message", async () => {
+    mocks.send.mockResolvedValue({
+      messageId: "1712345678.000041",
+      channelId: "C123",
+      controlDelivery: { messageId: "1712345678.000040", channelId: "C123" },
+    });
+
+    await deliverReplies(buildParams());
+
+    expect(requireQuestionRegistration().deliveryId).toBe("slack:work:C123:1712345678.000040");
+    await requireQuestionRegistration().finalize("Expired");
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "C123", ts: "1712345678.000040" }),
+    );
+  });
+
+  it("finalizes Enterprise Grid questions through the original scoped listener client", async () => {
+    const updateScopedMessage = vi.fn();
+    const listenerClient = { chat: { update: updateScopedMessage } };
+    mocks.send.mockResolvedValue({ messageId: "1712345678.000020", channelId: "C456" });
+
+    await deliverReplies(
+      buildParams({
+        cfg: { channels: { slack: { enterpriseOrgInstall: true } } },
+        target: "C456",
+        eventScope: {
+          apiAppId: "A123",
+          enterpriseId: "E123",
+          isEnterpriseInstall: true,
+          teamId: "T123",
+          client: listenerClient,
+        },
+      }),
+    );
+
+    await requireQuestionRegistration().finalize("Cancelled");
+
+    expect(mocks.writeClient).not.toHaveBeenCalled();
+    expect(updateScopedMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "C456", ts: "1712345678.000020" }),
+    );
+  });
+
+  it.each([
+    {
+      name: "answered",
+      originalText: "😀".repeat(1_000),
+      status: "Answered: <!channel> & résumé 😀",
+      expectedStatus: "Answered: &lt;!channel&gt; &amp; résumé 😀",
+    },
+    {
+      name: "cancelled",
+      originalText: `${"😀".repeat(999)}éé`,
+      status: "Cancelled",
+      expectedStatus: "Cancelled",
+    },
+  ])(
+    "preserves the complete $name terminal suffix for a delivered 4,000-byte card",
+    async ({ originalText, status, expectedStatus }) => {
+      mocks.send.mockImplementation(
+        async (
+          _channel: string,
+          _text: string,
+          options: { blocks?: Array<{ type?: string }> },
+        ) => ({
+          messageId: options.blocks?.some((block) => block.type === "actions")
+            ? "1712345678.000025"
+            : "1712345678.000024",
+          channelId: "C123",
+        }),
+      );
+      const payload = buildQuestionPayload();
+
+      await deliverReplies(
+        buildParams({
+          replies: [
+            {
+              ...payload,
+              text: originalText,
+              presentation: {
+                blocks: payload.presentation.blocks.slice(1),
+              },
+            },
+          ],
+        }),
+      );
+
+      expect(mocks.send).toHaveBeenCalledTimes(1);
+      const controlsDelivery = mocks.send.mock.calls.find((call) => {
+        const options = call[2] as { blocks?: Array<{ type?: string }> } | undefined;
+        return options?.blocks?.some((block) => block.type === "actions");
+      });
+      if (!controlsDelivery) {
+        throw new Error("the 4,000-byte Slack question controls were not delivered");
+      }
+      const sentOptions = controlsDelivery[2] as { blocks: Array<{ type?: string }> };
+      expect(sentOptions.blocks.map((block) => block.type)).toEqual(["section", "actions"]);
+      const controlsFallback = buildSlackBlocksFallbackText(sentOptions.blocks);
+      expect(controlsFallback).toBe(originalText);
+      expect(Buffer.byteLength(controlsFallback, "utf8")).toBe(4_000);
+
+      const registration = requireQuestionRegistration();
+      expect(registration.deliveryId).toBe("slack:work:C123:1712345678.000025");
+      await registration.finalize(status);
+
+      const update = requireQuestionUpdate();
+      expect(Buffer.byteLength(update.text, "utf8")).toBeLessThanOrEqual(4_000);
+      expect(update.text.endsWith(`\n\n${expectedStatus}`)).toBe(true);
+      expect(update.text).not.toContain("�");
+      expect(update.blocks).toContainEqual({
+        type: "context",
+        elements: [{ type: "mrkdwn", text: expectedStatus }],
+      });
+      expect(update.blocks.some((block) => block.type === "actions")).toBe(false);
+      expect(mocks.writeClient).toHaveBeenCalledWith("xoxp-authoring-user");
+    },
+  );
+
+  it("preserves terminal update failures for Gateway-owned finalization reporting", async () => {
+    mocks.send.mockResolvedValue({ messageId: "1712345678.000030", channelId: "C123" });
+    mocks.update.mockRejectedValue(new Error("question update failed"));
+
+    await deliverReplies(buildParams());
+
+    await expect(requireQuestionRegistration().finalize("Expired")).rejects.toThrow(
+      "question update failed",
+    );
+  });
+});

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -589,6 +589,7 @@ describe("deliverSlackSlashReplies chunking", () => {
     expect(respond).toHaveBeenCalledTimes(2);
     const messages = respond.mock.calls.map((_call, index) => requireSlashMessage(respond, index));
     expect(messages.every((message) => message.text.length <= 40_000)).toBe(true);
+    expect(messages[0]?.text.length).toBeGreaterThan(4_000);
     expect(messages.every((message) => message.mrkdwn === false)).toBe(true);
     expect(messages.flatMap((message) => message.blocks ?? [])).toEqual(blocks);
   });
@@ -752,9 +753,61 @@ describe("deliverSlackSlashReplies chunking", () => {
     expect(messages.every((message) => message.blocks === undefined)).toBe(true);
     expect(messages.every((message) => message.mrkdwn === false)).toBe(true);
     expect(messages.every((message) => message.text.length <= 40_000)).toBe(true);
+    expect(messages[0]?.text).toHaveLength(40_000);
     expect(messages.map((message) => message.text).join("")).toBe(
       `${caption} (table)\nAccount\nAcme`,
     );
+  });
+
+  it("fits native fallback and three visible replies into five response_url calls", async () => {
+    const respond = vi.fn(async () => undefined);
+    const caption = "c".repeat(41_000);
+    const settlements: Array<{ replyIndex: number; visibleReplySent: boolean }> = [];
+
+    await deliverSlackSlashReplies({
+      replies: [
+        {
+          channelData: {
+            slack: {
+              blocks: [
+                {
+                  type: "data_table",
+                  caption,
+                  rows: [
+                    [{ type: "raw_text", text: "Account" }],
+                    [{ type: "raw_text", text: "Acme" }],
+                  ],
+                },
+              ],
+            },
+          },
+        },
+        { text: "second" },
+        { text: "third" },
+        { text: "fourth" },
+      ],
+      respond,
+      ephemeral: true,
+      textLimit: 8000,
+      onReplySettled: (settlement) => settlements.push(settlement),
+    });
+
+    expect(respond).toHaveBeenCalledTimes(5);
+    const messages = respond.mock.calls.map((_call, index) => requireSlashMessage(respond, index));
+    expect(messages[0]?.text).toHaveLength(40_000);
+    expect(
+      messages
+        .slice(0, 2)
+        .map((message) => message.text)
+        .join(""),
+    ).toBe(`${caption} (table)\nAccount\nAcme`);
+    expect(messages.slice(2).map((message) => message.text)).toEqual(["second", "third", "fourth"]);
+    expect(settlements).toEqual([
+      { replyIndex: 0, visibleReplySent: true },
+      { replyIndex: 1, visibleReplySent: true },
+      { replyIndex: 2, visibleReplySent: true },
+      { replyIndex: 3, visibleReplySent: true },
+    ]);
   });
 
   it("batches in-place native fallback at 50 blocks without losing content", async () => {

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -4,6 +4,7 @@ import type { Block, KnownBlock } from "@slack/web-api";
 import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
 import {
   chunkMarkdownTextWithMode,
   isSilentReplyText,
@@ -19,6 +20,7 @@ import {
 import { createReplyReferencePlanner } from "openclaw/plugin-sdk/reply-reference";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { buildSlackBlocksFallbackText } from "../blocks-fallback.js";
+import { getSlackWriteClient } from "../client.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { SLACK_TEXT_LIMIT } from "../limits.js";
 import { emitSlackMessageSentHooks } from "../message-sent-hook.js";
@@ -33,6 +35,7 @@ import {
   chunkSlackTextAtHardLimit,
   type SlackFormattingDisabledMessage,
 } from "../native-data-fallback.js";
+import { registerSlackQuestionDelivery } from "../question-delivery.js";
 import {
   hasSlackReplyStructuredContent,
   resolveSlackReplyBlockResolution,
@@ -109,6 +112,9 @@ export async function deliverReplies(params: {
     nativeDataFallbackBaseText?: string;
     textIsSlackMrkdwn?: boolean;
     textIsSlackPlainText?: boolean;
+    onQuestionControlDelivery?: NonNullable<
+      Parameters<typeof sendMessageSlack>[2]
+    >["onQuestionControlDelivery"];
   }): Promise<SlackSendResult> => {
     return await sendMessageSlack(params.target, input.text, {
       cfg: params.cfg,
@@ -125,6 +131,9 @@ export async function deliverReplies(params: {
         : {}),
       ...(input.textIsSlackMrkdwn ? { textIsSlackMrkdwn: true } : {}),
       ...(input.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+      ...(input.onQuestionControlDelivery
+        ? { onQuestionControlDelivery: input.onQuestionControlDelivery }
+        : {}),
       ...(params.eventScope
         ? {
             client: params.eventScope.client,
@@ -155,6 +164,7 @@ export async function deliverReplies(params: {
     const { authoredTextPlacement, segments } = resolveSlackReplyBlockResolution(payload, {
       materializeAuthoredText,
     });
+    const questionId = questionGatewayRuntime.readAskUserQuestionId(payload);
     if (!textRaw && !reply.hasMedia && segments.length === 0) {
       continue;
     }
@@ -252,6 +262,26 @@ export async function deliverReplies(params: {
           blocks: segment.blocks,
           authoredTextPlacement: segmentPlacement,
           ...(baseText ? { nativeDataFallbackBaseText: baseText } : {}),
+          ...(questionId
+            ? {
+                onQuestionControlDelivery: (delivery) => {
+                  registerSlackQuestionDelivery({
+                    questionId,
+                    accountId: params.accountId,
+                    ...delivery,
+                    update: async ({ channelId, messageTs, text, blocks }) => {
+                      const client = params.eventScope?.client ?? getSlackWriteClient(params.token);
+                      await client.chat.update({
+                        channel: channelId,
+                        ts: messageTs,
+                        text,
+                        blocks,
+                      });
+                    },
+                  });
+                },
+              }
+            : {}),
         });
         delivered = true;
       }
@@ -406,6 +436,7 @@ export async function deliverSlackSlashReplies(params: {
     const plan = buildSlackNativeDataDeliveryPlan({
       blocks: input.blocks,
       baseText: input.baseText,
+      transport: "response-url",
     });
     return {
       message: {

--- a/extensions/slack/src/native-data-fallback.test.ts
+++ b/extensions/slack/src/native-data-fallback.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SLACK_MESSAGE_TEXT_RECOMMENDED_LIMIT } from "./limits.js";
+import { SLACK_MESSAGE_TEXT_HARD_LIMIT, SLACK_MESSAGE_TEXT_RECOMMENDED_LIMIT } from "./limits.js";
 import {
   buildSlackNativeDataDeliveryPlan,
   chunkSlackTextAtHardLimit,
@@ -53,6 +53,72 @@ describe("buildSlackNativeDataDeliveryPlan", () => {
     expect(plan.fallbackMessages.map((message) => message.text).join("")).toBe(
       `${caption} (table)\nAccount\nAcme`,
     );
+  });
+
+  it("packs response_url native-only fallback to Slack's 40,000-character hard limit", () => {
+    const caption = "x".repeat(41_000);
+    const plan = buildSlackNativeDataDeliveryPlan({
+      blocks: [tableBlock(caption)],
+      transport: "response-url",
+    });
+
+    expect(plan.skipOriginalBlocks).toBe(true);
+    expect(plan.fallbackMessages).toHaveLength(2);
+    expect(plan.fallbackMessages[0]?.text).toHaveLength(SLACK_MESSAGE_TEXT_HARD_LIMIT);
+    expect(plan.fallbackMessages.every((message) => message.blocks === undefined)).toBe(true);
+    expect(plan.fallbackMessages.map((message) => message.text).join("")).toBe(
+      `${caption} (table)\nAccount\nAcme`,
+    );
+  });
+
+  it("batches response_url survivor sections under Slack's hard limit", () => {
+    const blocks = Array.from({ length: 20 }, (_block, index) => ({
+      type: "section" as const,
+      text: { type: "plain_text" as const, text: `${String(index)}-${"x".repeat(2_990)}` },
+    }));
+    const plan = buildSlackNativeDataDeliveryPlan({
+      blocks,
+      transport: "response-url",
+    });
+
+    expect(plan.skipOriginalBlocks).toBe(true);
+    expect(plan.fallbackMessages).toHaveLength(2);
+    expect(
+      plan.fallbackMessages.every(
+        (message) => message.text.length <= SLACK_MESSAGE_TEXT_HARD_LIMIT,
+      ),
+    ).toBe(true);
+    expect(plan.fallbackMessages[0]?.text.length).toBeGreaterThan(
+      SLACK_MESSAGE_TEXT_RECOMMENDED_LIMIT,
+    );
+    expect(plan.fallbackMessages.flatMap((message) => message.blocks ?? [])).toEqual(blocks);
+  });
+
+  it("preserves response_url controls and 50-block batching during native fallback", () => {
+    const caption = "x".repeat(9_000);
+    const controls = actionBlock("Refresh", "hidden-refresh");
+    const plan = buildSlackNativeDataDeliveryPlan({
+      blocks: [
+        ...Array.from({ length: 48 }, () => ({ type: "divider" as const })),
+        controls,
+        tableBlock(caption),
+      ],
+      transport: "response-url",
+    });
+
+    expect(plan.fallbackMessages).toHaveLength(2);
+    expect(plan.fallbackMessages.every((message) => (message.blocks?.length ?? 0) <= 50)).toBe(
+      true,
+    );
+    expect(plan.fallbackMessages[0]?.blocks?.[48]).toBe(controls);
+    const fallbackText = plan.fallbackMessages.flatMap((message) =>
+      (message.blocks ?? []).flatMap((block) => {
+        const text = (block as { text?: { type?: string; text?: string } }).text;
+        return text?.type === "plain_text" && text.text ? [text.text] : [];
+      }),
+    );
+    expect(fallbackText.join("")).toBe(`${caption} (table)\nAccount\nAcme`);
+    expect(plan.fallbackMessages.map((message) => message.text).join(" ")).not.toContain("hidden-");
   });
 
   it("batches survivor controls and replacement sections without changing block order", () => {

--- a/extensions/slack/src/native-data-fallback.ts
+++ b/extensions/slack/src/native-data-fallback.ts
@@ -156,12 +156,18 @@ export function buildSlackNativeDataDeliveryPlan(params: {
   baseText?: string;
   blocks: readonly (Block | KnownBlock)[];
   textLimit?: number;
+  transport?: "chat" | "response-url";
 }): SlackNativeDataDeliveryPlan {
   const baseText = params.baseText?.trim() ?? "";
+  // response_url has only five attempts; packing to Slack's hard cap avoids dropping visible data.
+  const transportTextLimit =
+    params.transport === "response-url"
+      ? SLACK_MESSAGE_TEXT_HARD_LIMIT
+      : SLACK_MESSAGE_TEXT_RECOMMENDED_LIMIT;
   const textLimit = Math.min(
-    SLACK_MESSAGE_TEXT_RECOMMENDED_LIMIT,
+    transportTextLimit,
     SLACK_MESSAGE_TEXT_HARD_LIMIT,
-    Math.max(1, Math.floor(params.textLimit ?? SLACK_MESSAGE_TEXT_HARD_LIMIT)),
+    Math.max(1, Math.floor(params.textLimit ?? transportTextLimit)),
   );
   const hasNativeData = hasSlackNativeDataBlock(params.blocks);
   const accessibilityText =

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -25,8 +25,8 @@ import {
   type SlackAuthoredTextPlacement,
 } from "./authored-text.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
-import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 import { SLACK_PRESENTATION_CAPABILITIES } from "./presentation.js";
+import { registerSlackQuestionDelivery } from "./question-delivery.js";
 import {
   parseSlackReplyBlockSegments,
   resolveSlackReplyBlockResolution,
@@ -201,6 +201,7 @@ async function sendSlackOutboundMessage(params: {
   onDeliveryResult?: Parameters<
     NonNullable<ChannelOutboundAdapter["sendText"]>
   >[0]["onDeliveryResult"];
+  onQuestionControlDelivery?: NonNullable<Parameters<SlackSendFn>[2]>["onQuestionControlDelivery"];
 }) {
   const send =
     resolveOutboundSendDep<SlackSendFn>(params.deps, "slack") ??
@@ -243,6 +244,9 @@ async function sendSlackOutboundMessage(params: {
             await params.onDeliveryResult?.(attachChannelToResult("slack", progress));
           },
         }
+      : {}),
+    ...(params.onQuestionControlDelivery
+      ? { onQuestionControlDelivery: params.onQuestionControlDelivery }
       : {}),
   };
   const result = await send(params.to, params.text, sendOptions);
@@ -299,6 +303,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
       segments: resolution.segments,
       text: payload.text,
     });
+    const questionId = questionGatewayRuntime.readAskUserQuestionId(payload);
     const useSingleDeliveryMarker = mediaUrls.length === 0 && deliveryMessages.length === 1;
     return attachChannelToResult(
       "slack",
@@ -333,6 +338,29 @@ export const slackOutbound: ChannelOutboundAdapter = {
               onPlatformSendDispatch: useSingleDeliveryMarker
                 ? ctx.onPlatformSendDispatch
                 : undefined,
+              ...(questionId && message.blocks?.some((block) => block.type === "actions")
+                ? {
+                    // Capture actual posted controls, not a send's aggregate fallback receipt.
+                    onQuestionControlDelivery: (delivery) => {
+                      registerSlackQuestionDelivery({
+                        questionId,
+                        accountId: ctx.accountId ?? undefined,
+                        ...delivery,
+                        update: async ({ channelId, messageTs, text, blocks }) => {
+                          const { updateMessageSlack } = await loadSlackSendRuntime();
+                          await updateMessageSlack({
+                            cfg: ctx.cfg,
+                            accountId: ctx.accountId ?? undefined,
+                            channelId,
+                            messageTs,
+                            text,
+                            blocks,
+                          });
+                        },
+                      });
+                    },
+                  }
+                : {}),
             });
           }
           if (!lastResult) {
@@ -342,56 +370,6 @@ export const slackOutbound: ChannelOutboundAdapter = {
         },
       }),
     );
-  },
-  afterDeliverPayload: async ({ cfg, target, payload, results }) => {
-    const questionId = questionGatewayRuntime.readAskUserQuestionId(payload);
-    const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
-    if (!questionId) {
-      return;
-    }
-    const resolution = readSlackRenderedPresentation(slackData);
-    if (!resolution) {
-      return;
-    }
-    const deliveryMessages = resolveSlackReplyDeliveryMessages({
-      authoredTextPlacement: resolution.authoredTextPlacement,
-      segments: resolution.segments,
-      text: payload.text,
-    });
-    const blockMessageIndex = deliveryMessages.findIndex((message) =>
-      message.blocks?.some((block) => block.type === "actions"),
-    );
-    const deliveryMessage = deliveryMessages[blockMessageIndex];
-    const result =
-      results[blockMessageIndex] ?? results.find((candidate) => candidate.channel === "slack");
-    const deliveryBlocks = deliveryMessage?.blocks;
-    if (!deliveryMessage || !deliveryBlocks || !result?.messageId) {
-      return;
-    }
-    const channelId = result.channelId;
-    if (!channelId) {
-      return;
-    }
-    questionGatewayRuntime.registerChannelDelivery({
-      questionId,
-      deliveryId: `slack:${target.accountId ?? "default"}:${channelId}:${result.messageId}`,
-      finalize: async (statusLine) => {
-        const { updateMessageSlack } = await loadSlackSendRuntime();
-        const escapedStatusLine = escapeSlackMrkdwn(statusLine);
-        const blocks = [
-          ...deliveryBlocks.filter((block) => block.type !== "actions"),
-          { type: "context", elements: [{ type: "mrkdwn", text: escapedStatusLine }] },
-        ];
-        await updateMessageSlack({
-          cfg,
-          accountId: target.accountId ?? undefined,
-          channelId,
-          messageTs: result.messageId,
-          text: `${deliveryMessage.text}\n\n${escapedStatusLine}`,
-          blocks,
-        });
-      },
-    });
   },
   ...createSlackAttachedSendAdapter(),
 };

--- a/extensions/slack/src/question-delivery.ts
+++ b/extensions/slack/src/question-delivery.ts
@@ -1,0 +1,81 @@
+// Slack owns one terminal lifecycle for every delivered native question surface.
+import type { Block, KnownBlock } from "@slack/web-api";
+import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
+import { SLACK_EDIT_TEXT_MAX_BYTES } from "./limits.js";
+import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
+import { countSlackTextUtf8Bytes, truncateSlackTextByUtf8Bytes } from "./truncate.js";
+
+type SlackQuestionMessageUpdate = {
+  channelId: string;
+  messageTs: string;
+  text: string;
+  blocks: (Block | KnownBlock)[];
+};
+
+const SLACK_CONTEXT_ELEMENTS_MAX = 10;
+const SLACK_CONTEXT_TEXT_MAX_CHARS = 3_000;
+
+function buildSlackQuestionStatusContextBlocks(statusLine: string): (Block | KnownBlock)[] {
+  const elements: Array<{ type: "mrkdwn"; text: string }> = [];
+  let text = "";
+  let characterCount = 0;
+
+  for (const character of statusLine) {
+    // Escape complete code points before packing so entities and surrogate pairs never split.
+    const escapedCharacter = escapeSlackMrkdwn(character);
+    const escapedCharacterCount = Array.from(escapedCharacter).length;
+    if (characterCount + escapedCharacterCount > SLACK_CONTEXT_TEXT_MAX_CHARS) {
+      elements.push({ type: "mrkdwn", text });
+      text = "";
+      characterCount = 0;
+    }
+    text += escapedCharacter;
+    characterCount += escapedCharacterCount;
+  }
+
+  if (text) {
+    elements.push({ type: "mrkdwn", text });
+  }
+
+  const blocks: (Block | KnownBlock)[] = [];
+  for (let index = 0; index < elements.length; index += SLACK_CONTEXT_ELEMENTS_MAX) {
+    blocks.push({
+      type: "context",
+      elements: elements.slice(index, index + SLACK_CONTEXT_ELEMENTS_MAX),
+    });
+  }
+  return blocks;
+}
+
+export function registerSlackQuestionDelivery(params: {
+  questionId: string;
+  accountId?: string;
+  channelId: string;
+  messageId: string;
+  text: string;
+  blocks: (Block | KnownBlock)[];
+  update: (message: SlackQuestionMessageUpdate) => Promise<void>;
+}): void {
+  questionGatewayRuntime.registerChannelDelivery({
+    questionId: params.questionId,
+    deliveryId: `slack:${params.accountId ?? "default"}:${params.channelId}:${params.messageId}`,
+    finalize: async (statusLine) => {
+      const escapedStatusLine = escapeSlackMrkdwn(statusLine);
+      const statusSuffix = `\n\n${escapedStatusLine}`;
+      // Reserve the complete outcome first; notifications must never lose terminal state.
+      const originalText = truncateSlackTextByUtf8Bytes(
+        params.text,
+        SLACK_EDIT_TEXT_MAX_BYTES - countSlackTextUtf8Bytes(statusSuffix),
+      );
+      await params.update({
+        channelId: params.channelId,
+        messageTs: params.messageId,
+        text: originalText ? `${originalText}${statusSuffix}` : escapedStatusLine,
+        blocks: [
+          ...params.blocks.filter((block) => block.type !== "actions"),
+          ...buildSlackQuestionStatusContextBlocks(statusLine),
+        ],
+      });
+    },
+  });
+}

--- a/extensions/slack/src/question-finalization.test.ts
+++ b/extensions/slack/src/question-finalization.test.ts
@@ -1,7 +1,8 @@
 // Covers Slack question delivery capture and Block Kit final edit.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
+  send: vi.fn(),
   update: vi.fn(),
   registration: undefined as
     | { finalize: (statusLine: string) => void | Promise<void>; deliveryId: string }
@@ -20,7 +21,12 @@ vi.mock("openclaw/plugin-sdk/question-gateway-runtime", async (importOriginal) =
     },
   };
 });
-vi.mock("./send.js", () => ({ updateMessageSlack: hoisted.update }));
+vi.mock("./send.js", () => ({
+  reconcileSlackUnknownSend: vi.fn(),
+  resolveSlackDmChannelId: vi.fn(),
+  sendMessageSlack: hoisted.send,
+  updateMessageSlack: hoisted.update,
+}));
 
 import { slackOutbound } from "./outbound-adapter.js";
 
@@ -30,71 +36,151 @@ function jsonRoundTrip<T>(value: T): T {
 }
 
 describe("Slack question finalization", () => {
-  it("removes action blocks and appends terminal context", async () => {
-    const questionId = "ask_0123456789abcdef0123456789abcdef";
-    const headers = Array.from({ length: 21 }, (_value, index) => `Column ${String(index)}`);
-    const payload = {
-      channelData: { askUser: { questionId } },
-      presentation: {
-        blocks: [
-          {
-            type: "table" as const,
-            caption: "Option metadata",
-            headers,
-            rows: [headers.map((_header, index) => `Value ${String(index)}`)],
-          },
-          { type: "text" as const, text: "Pick one" },
-          {
-            type: "buttons" as const,
-            buttons: ["One", "Two"].map((label) => ({
-              label,
-              action: { type: "question" as const, questionId, optionValue: label },
-            })),
-          },
-        ],
-      },
-    };
-    const rendered = await slackOutbound.renderPresentation?.({
-      payload,
-      presentation: payload.presentation,
-      ctx: { cfg: {}, to: "C123", text: "Pick one", payload },
-    });
-    expect(rendered).not.toBeNull();
-    const renderedAfterTransport = jsonRoundTrip(rendered);
-    const renderedSegments = (
-      renderedAfterTransport?.channelData?.slack as
-        | { renderedPresentationSegments?: unknown[] }
-        | undefined
-    )?.renderedPresentationSegments;
-    expect(renderedSegments?.map((segment) => (segment as { kind?: unknown }).kind)).toEqual([
-      "text",
-      "blocks",
-    ]);
-    await slackOutbound.afterDeliverPayload?.({
-      cfg: {},
-      target: { channel: "slack", to: "C123", accountId: "default" },
-      payload: renderedAfterTransport!,
-      results: [
-        { channel: "slack", messageId: "44", channelId: "C123" },
-        { channel: "slack", messageId: "55", channelId: "C123" },
-      ],
-    });
-
-    await hoisted.registration?.finalize("Answered: <!channel>");
-    expect(hoisted.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        channelId: "C123",
-        messageTs: "55",
-        text: expect.stringContaining("Answered: &lt;!channel&gt;"),
-        blocks: expect.arrayContaining([
-          {
-            type: "context",
-            elements: [{ type: "mrkdwn", text: "Answered: &lt;!channel&gt;" }],
-          },
-        ]),
-      }),
-    );
-    const blocks = hoisted.update.mock.calls[0]?.[0]?.blocks as Array<{ type?: string }>;
-    expect(blocks.some((block) => block.type === "actions")).toBe(false);
+  beforeEach(() => {
+    hoisted.send.mockReset();
+    hoisted.update.mockReset();
+    hoisted.registration = undefined;
   });
+
+  it.each([
+    {
+      name: "split text and controls",
+      mediaUrl: undefined,
+      messageIds: ["33", "44", "55"],
+      trailingFallback: false,
+    },
+    {
+      name: "uploaded media, split text, and controls",
+      mediaUrl: "https://example.com/options.png",
+      messageIds: ["F123UPLOAD", "33", "44", "55"],
+      trailingFallback: false,
+    },
+    {
+      name: "uploaded media and controls followed by a native-data fallback",
+      mediaUrl: "https://example.com/options.png",
+      messageIds: ["F123UPLOAD", "33", "44", "55", "66"],
+      trailingFallback: true,
+    },
+  ])(
+    "finalizes the actual controls message after $name",
+    async ({ mediaUrl, messageIds, trailingFallback }) => {
+      const questionId = "ask_0123456789abcdef0123456789abcdef";
+      const headers = Array.from({ length: 21 }, (_value, index) => `Column ${String(index)}`);
+      const payload = {
+        text: "Pick one",
+        ...(mediaUrl ? { mediaUrl } : {}),
+        channelData: { askUser: { questionId } },
+        presentation: {
+          blocks: [
+            {
+              type: "table" as const,
+              caption: "Option metadata",
+              headers,
+              rows: [headers.map((_header, index) => `Value ${String(index)}`)],
+            },
+            { type: "text" as const, text: "Pick one" },
+            {
+              type: "buttons" as const,
+              buttons: ["One", "Two"].map((label) => ({
+                label,
+                action: { type: "question" as const, questionId, optionValue: label },
+              })),
+            },
+          ],
+        },
+      };
+      const rendered = await slackOutbound.renderPresentation?.({
+        payload,
+        presentation: payload.presentation,
+        ctx: { cfg: {}, to: "C123", text: "Pick one", payload },
+      });
+      expect(rendered).not.toBeNull();
+      const renderedAfterTransport = jsonRoundTrip(rendered);
+      const renderedSegments = (
+        renderedAfterTransport?.channelData?.slack as
+          | { renderedPresentationSegments?: unknown[] }
+          | undefined
+      )?.renderedPresentationSegments;
+      expect(renderedSegments?.map((segment) => (segment as { kind?: unknown }).kind)).toEqual([
+        "blocks",
+        "text",
+        "blocks",
+      ]);
+      let nextMessageIndex = 0;
+      const requireNextMessageId = () => {
+        const messageId = messageIds[nextMessageIndex++];
+        if (!messageId) {
+          throw new Error("Slack question test is missing a real delivery receipt");
+        }
+        return messageId;
+      };
+      const reportedResults: string[] = [];
+      hoisted.send.mockImplementation(
+        async (
+          _to: string,
+          _text: string,
+          options: {
+            blocks?: Array<{ type?: string }>;
+            onDeliveryResult?: (result: unknown) => Promise<void>;
+            onQuestionControlDelivery?: (delivery: {
+              channelId: string;
+              messageId: string;
+              text: string;
+              blocks: Array<{ type?: string }>;
+            }) => void;
+          },
+        ) => {
+          const messageId = requireNextMessageId();
+          const result = { messageId, channelId: "C123" };
+          await options.onDeliveryResult?.(result);
+          if (options.blocks?.some((block) => block.type === "actions")) {
+            options.onQuestionControlDelivery?.({
+              ...result,
+              text: _text,
+              blocks: options.blocks,
+            });
+            if (trailingFallback) {
+              const trailingResult = {
+                messageId: requireNextMessageId(),
+                channelId: "C123",
+              };
+              await options.onDeliveryResult?.(trailingResult);
+              return trailingResult;
+            }
+          }
+          return result;
+        },
+      );
+      await slackOutbound.sendPayload?.({
+        cfg: { channels: { slack: { botToken: "xoxb-test" } } },
+        to: "C123",
+        accountId: "default",
+        text: payload.text,
+        payload: renderedAfterTransport!,
+        deps: { sendSlack: hoisted.send },
+        onDeliveryResult: async (result) => {
+          reportedResults.push(result.messageId);
+        },
+      });
+
+      expect(reportedResults).toEqual(messageIds);
+      expect(hoisted.registration?.deliveryId).toBe("slack:default:C123:55");
+      await hoisted.registration?.finalize("Answered: <!channel>");
+      expect(hoisted.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channelId: "C123",
+          messageTs: "55",
+          text: expect.stringContaining("Answered: &lt;!channel&gt;"),
+          blocks: expect.arrayContaining([
+            {
+              type: "context",
+              elements: [{ type: "mrkdwn", text: "Answered: &lt;!channel&gt;" }],
+            },
+          ]),
+        }),
+      );
+      const blocks = hoisted.update.mock.calls[0]?.[0]?.blocks as Array<{ type?: string }>;
+      expect(blocks.some((block) => block.type === "actions")).toBe(false);
+    },
+  );
 });

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -1,7 +1,9 @@
 // Slack tests cover send.blocks plugin behavior.
+import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { createSlackSendTestClient } from "./blocks.test-helpers.js";
 import { SLACK_MESSAGE_TEXT_RECOMMENDED_LIMIT } from "./limits.js";
+import { registerSlackQuestionDelivery } from "./question-delivery.js";
 import {
   clearSlackThreadParticipationCache,
   hasSlackThreadParticipation,
@@ -12,6 +14,15 @@ const SLACK_TEST_CFG = { channels: { slack: { botToken: "xoxb-test" } } };
 const SLACK_TEXT_LIMIT = 8000;
 
 type MockCallSource = { mock: { calls: Array<Array<unknown>> } };
+type SlackGatewayQuestionDelivery = Parameters<
+  typeof questionGatewayRuntime.registerChannelDelivery
+>[0];
+type SlackQuestionControlDelivery = Parameters<
+  NonNullable<Parameters<typeof sendMessageSlack>[2]["onQuestionControlDelivery"]>
+>[0];
+type SlackQuestionFinalizationUpdate = Parameters<
+  Parameters<typeof registerSlackQuestionDelivery>[0]["update"]
+>[0];
 
 function mockObjectArg(
   source: MockCallSource,
@@ -451,6 +462,239 @@ describe("sendMessageSlack blocks", () => {
     for (const index of [0, 1]) {
       expect(postedMessage(client, index).text).not.toMatch(/private|Secret option/u);
     }
+  });
+
+  it("records the actual controls card before a later native-data fallback receipt", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage
+      .mockRejectedValueOnce({ data: { error: "invalid_blocks" } })
+      .mockResolvedValueOnce({ ts: "55", channel: "C123" })
+      .mockResolvedValueOnce({ ts: "66", channel: "C123" });
+    const onQuestionControlDelivery = vi.fn();
+    const onDeliveryResult = vi.fn();
+    const blocks = [
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            action_id: "question",
+            text: { type: "plain_text", text: "Approve" },
+            value: "approve",
+          },
+        ],
+      },
+      {
+        type: "data_table",
+        caption: "x".repeat(4_100),
+        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
+      },
+    ];
+
+    const result = await sendMessageSlack("channel:C123", "", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      blocks: blocks as never,
+      onDeliveryResult,
+      onQuestionControlDelivery,
+    });
+
+    expect(result.messageId).toBe("66");
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["55", "66"]);
+    expect(onQuestionControlDelivery).toHaveBeenCalledOnce();
+    expect(onQuestionControlDelivery).toHaveBeenCalledWith({
+      channelId: "C123",
+      messageId: "55",
+      text: postedMessage(client, 1).text,
+      blocks: postedMessage(client, 1).blocks,
+    });
+    expect(
+      (postedMessage(client, 1).blocks as Array<{ type?: string }>).some(
+        (block) => block.type === "actions",
+      ),
+    ).toBe(true);
+    expect(
+      (postedMessage(client, 2).blocks as Array<{ type?: string }>).some(
+        (block) => block.type === "actions",
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    {
+      name: "directly accepted",
+      nativeFallback: false,
+      hasNativeData: false,
+      terminalStatus: "Cancelled",
+      observerFailure: "queued post-send persistence failed",
+      observerInvalidBlocks: false,
+    },
+    {
+      name: "accepted native-data",
+      nativeFallback: false,
+      hasNativeData: true,
+      terminalStatus: "Answered: Production",
+      observerFailure: "queued observer rejected with invalid_blocks",
+      observerInvalidBlocks: true,
+    },
+    {
+      name: "native-data fallback",
+      nativeFallback: true,
+      hasNativeData: true,
+      terminalStatus: "Expired",
+      observerFailure: "queued delivery-result observer failed",
+      observerInvalidBlocks: false,
+    },
+  ])(
+    "keeps $name question controls finalizable when durable delivery persistence rejects",
+    async ({
+      nativeFallback,
+      hasNativeData,
+      terminalStatus,
+      observerFailure,
+      observerInvalidBlocks,
+    }) => {
+      const client = createSlackSendTestClient();
+      if (nativeFallback) {
+        client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+      }
+      client.chat.postMessage.mockResolvedValueOnce({ ts: "55", channel: "C456" });
+      const controls = {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            action_id: "question",
+            text: { type: "plain_text", text: "Approve" },
+            value: "approve",
+          },
+        ],
+      };
+      const blocks = hasNativeData
+        ? [
+            controls,
+            {
+              type: "data_table",
+              caption: "x".repeat(4_100),
+              rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
+            },
+          ]
+        : [controls];
+      const registrations: SlackGatewayQuestionDelivery[] = [];
+      const registerChannelDelivery = vi
+        .spyOn(questionGatewayRuntime, "registerChannelDelivery")
+        .mockImplementation((registration) => {
+          registrations.push(registration);
+        });
+      const terminalUpdate = vi.fn(async (_message: SlackQuestionFinalizationUpdate) => undefined);
+      const deliveryOrder: string[] = [];
+      const onQuestionControlDelivery = vi.fn((delivery: SlackQuestionControlDelivery) => {
+        deliveryOrder.push(`controls:${delivery.messageId}`);
+        registerSlackQuestionDelivery({
+          questionId: "ask_0123456789abcdef0123456789abcdef",
+          accountId: "work",
+          ...delivery,
+          update: terminalUpdate,
+        });
+      });
+      const onDeliveryResult = vi.fn(async (result: { messageId: string }) => {
+        deliveryOrder.push(`observer:${result.messageId}`);
+        throw observerInvalidBlocks
+          ? Object.assign(new Error(observerFailure), { data: { error: "invalid_blocks" } })
+          : new Error(observerFailure);
+      });
+
+      try {
+        await expect(
+          sendMessageSlack("channel:C123", "", {
+            token: "xoxb-test",
+            cfg: SLACK_TEST_CFG,
+            client,
+            blocks: blocks as never,
+            deliveryQueueId: "question-delivery-queue",
+            onDeliveryResult,
+            onQuestionControlDelivery,
+          }),
+        ).rejects.toThrow(observerFailure);
+
+        expect(client.chat.postMessage).toHaveBeenCalledTimes(nativeFallback ? 2 : 1);
+        expect(deliveryOrder).toEqual(["controls:55", "observer:55"]);
+        expect(onQuestionControlDelivery).toHaveBeenCalledOnce();
+        const acceptedPost = postedMessage(client, nativeFallback ? 1 : 0);
+        expect(onQuestionControlDelivery).toHaveBeenCalledWith({
+          channelId: "C456",
+          messageId: "55",
+          text: acceptedPost.text,
+          blocks: acceptedPost.blocks,
+        });
+        expect(onDeliveryResult).toHaveBeenCalledWith(
+          expect.objectContaining({
+            messageId: "55",
+            channelId: "C456",
+            receipt: expect.objectContaining({ platformMessageIds: ["55"] }),
+          }),
+        );
+        expect(registerChannelDelivery).toHaveBeenCalledOnce();
+        const registration = registrations[0];
+        if (!registration) {
+          throw new Error("accepted Slack question controls were not registered with the Gateway");
+        }
+        expect(registration.deliveryId).toBe("slack:work:C456:55");
+
+        await registration.finalize(terminalStatus);
+
+        expect(terminalUpdate).toHaveBeenCalledOnce();
+        const update = terminalUpdate.mock.calls[0]?.[0];
+        if (!update) {
+          throw new Error("the accepted Slack controls were not finalized");
+        }
+        expect(update.channelId).toBe("C456");
+        expect(update.messageTs).toBe("55");
+        expect(update.text).toContain(terminalStatus);
+        expect(update.blocks.some((block) => block.type === "actions")).toBe(false);
+      } finally {
+        registerChannelDelivery.mockRestore();
+      }
+    },
+  );
+
+  it("does not register controls when Slack rejects the provider post", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockRejectedValueOnce(
+      Object.assign(new Error("An API error occurred: invalid_auth"), {
+        data: { error: "invalid_auth" },
+      }),
+    );
+    const onQuestionControlDelivery = vi.fn();
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageSlack("channel:C123", "", {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+        blocks: [
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "button",
+                action_id: "question",
+                text: { type: "plain_text", text: "Approve" },
+                value: "approve",
+              },
+            ],
+          },
+        ],
+        onDeliveryResult,
+        onQuestionControlDelivery,
+      }),
+    ).rejects.toThrow("invalid_auth");
+
+    expect(client.chat.postMessage).toHaveBeenCalledOnce();
+    expect(onQuestionControlDelivery).not.toHaveBeenCalled();
+    expect(onDeliveryResult).not.toHaveBeenCalled();
   });
 
   it("retries rejected native charts as accessible text", async () => {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -138,6 +138,13 @@ type SlackSendOpts = {
   onPlatformSendDispatch?: () => Promise<void>;
   /** Persist each concrete platform send before any later chunk can fail. */
   onDeliveryResult?: (result: SlackSendResult) => Promise<void> | void;
+  /** Record the exact posted Block Kit controls before fallback fanout changes the aggregate. */
+  onQuestionControlDelivery?: (delivery: {
+    channelId: string;
+    messageId: string;
+    text: string;
+    blocks: (Block | KnownBlock)[];
+  }) => void;
 };
 
 type SlackWebApiErrorData = {
@@ -275,8 +282,8 @@ export async function updateMessageSlack(params: {
   const account = resolveSlackAccount({ cfg, accountId: params.accountId });
   const token = resolveToken({
     accountId: account.accountId,
-    fallbackToken: account.botToken,
-    fallbackSource: account.botTokenSource,
+    fallbackToken: resolveSlackOperationToken(account, "write"),
+    fallbackSource: account.identity === "user" ? account.userTokenSource : account.botTokenSource,
   });
   const client = getSlackWriteClient(token);
   await client.chat.update({
@@ -1115,6 +1122,27 @@ async function sendMessageSlackQueuedInner(params: {
     await opts.onDeliveryResult?.(result);
     return result;
   };
+  const reportQuestionControlDelivery = (
+    result: SlackSendResult,
+    deliveredBlocks: (Block | KnownBlock)[],
+    text: string,
+  ) => {
+    if (
+      !opts.onQuestionControlDelivery ||
+      !result.channelId ||
+      !result.messageId ||
+      result.messageId === "unknown" ||
+      !deliveredBlocks.some((block) => block.type === "actions")
+    ) {
+      return;
+    }
+    opts.onQuestionControlDelivery({
+      channelId: result.channelId,
+      messageId: result.messageId,
+      text,
+      blocks: deliveredBlocks,
+    });
+  };
   let didDispatch = false;
   const dispatchOnce = async () => {
     if (didDispatch) {
@@ -1198,6 +1226,7 @@ async function sendMessageSlackQueuedInner(params: {
         partCount: 1,
       });
       await dispatchOnce();
+      let acceptedCardResult: SlackSendResult | undefined;
       try {
         const { response } = await postSlackMessageBestEffort({
           client,
@@ -1222,7 +1251,7 @@ async function sendMessageSlackQueuedInner(params: {
         deliveredChannelId = resolvePostedMessageChannelId(response, channelId);
         const deliveredThreadTs =
           resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
-        return await reportDelivery({
+        acceptedCardResult = {
           messageId,
           channelId: deliveredChannelId,
           threadTs: deliveredThreadTs,
@@ -1232,13 +1261,18 @@ async function sendMessageSlackQueuedInner(params: {
             kind: "card",
             threadTs: deliveredThreadTs,
           }),
-        });
+        };
       } catch (error) {
         if (!hasNativeData || !isSlackInvalidBlocksError(error)) {
           throw error;
         }
         logVerbose("slack send: native data rejected, delivering complete text fallback");
         pendingBlockFallback = orderedBlockDeliveryPlan;
+      }
+      if (acceptedCardResult) {
+        // Provider rejection owns the catch above; durable observers must not trigger a repost.
+        reportQuestionControlDelivery(acceptedCardResult, blocks, accessibilityText);
+        return await reportDelivery(acceptedCardResult);
       }
     }
     if (pendingBlockFallback) {
@@ -1284,7 +1318,7 @@ async function sendMessageSlackQueuedInner(params: {
         sentMessageIds.push(response.ts);
         const deliveredThreadTs =
           resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
-        await reportDelivery({
+        const result: SlackSendResult = {
           messageId: response.ts,
           channelId: deliveredChannelId,
           threadTs: deliveredThreadTs,
@@ -1294,7 +1328,12 @@ async function sendMessageSlackQueuedInner(params: {
             kind: fallback.blocks ? "card" : "text",
             threadTs: deliveredThreadTs,
           }),
-        });
+        };
+        if (fallback.blocks) {
+          // The provider already accepted these controls even if receipt persistence now fails.
+          reportQuestionControlDelivery(result, fallback.blocks, fallback.text);
+        }
+        await reportDelivery(result);
       }
       const messageId = lastMessageId || "unknown";
       const deliveredThreadTs =

--- a/extensions/slack/src/send.update.test.ts
+++ b/extensions/slack/src/send.update.test.ts
@@ -6,17 +6,13 @@ import { SLACK_EDIT_TEXT_MAX_BYTES } from "./limits.js";
 import { countSlackTextUtf8Bytes } from "./truncate.js";
 
 const getSlackWriteClientMock = vi.hoisted(() => vi.fn());
+const resolveSlackAccountMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./accounts.js", async () => {
   const actual = await vi.importActual<typeof import("./accounts.js")>("./accounts.js");
   return {
     ...actual,
-    resolveSlackAccount: () => ({
-      accountId: "default",
-      botToken: "xoxb-test",
-      botTokenSource: "config",
-      config: {},
-    }),
+    resolveSlackAccount: resolveSlackAccountMock,
   };
 });
 
@@ -46,6 +42,46 @@ const statusBlocks: (Block | KnownBlock)[] = [
 describe("updateMessageSlack", () => {
   beforeEach(() => {
     getSlackWriteClientMock.mockReset();
+    resolveSlackAccountMock.mockReset();
+    resolveSlackAccountMock.mockReturnValue({
+      accountId: "default",
+      identity: "bot",
+      botToken: "xoxb-test",
+      botTokenSource: "config",
+      userTokenSource: "none",
+      config: {},
+    });
+  });
+
+  it.each([
+    { name: "user-only credentials", botToken: undefined },
+    { name: "mixed bot and user credentials", botToken: "xoxb-companion" },
+  ])("edits as the original user identity with $name", async ({ botToken }) => {
+    const client = createUpdateClient();
+    getSlackWriteClientMock.mockReturnValue(client);
+    resolveSlackAccountMock.mockReturnValue({
+      accountId: "work",
+      identity: "user",
+      ...(botToken ? { botToken } : {}),
+      botTokenSource: botToken ? "config" : "none",
+      userToken: "xoxp-authoring-user",
+      userTokenSource: "config",
+      config: { postAs: "user" },
+    });
+
+    await updateMessageSlack({
+      cfg: SLACK_TEST_CFG,
+      accountId: "work",
+      channelId: "C123",
+      messageTs: "171234.567",
+      text: "Resolved",
+      blocks: statusBlocks,
+    });
+
+    expect(getSlackWriteClientMock).toHaveBeenCalledWith("xoxp-authoring-user");
+    expect(client.chat.update).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "C123", ts: "171234.567" }),
+    );
   });
 
   it("caps chat.update text at the 4000-byte edit limit, not the 8000 send limit", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack questions could remain interactive after being answered or cancelled, update the wrong message, use the wrong Slack account identity, or silently omit their terminal outcome from notifications and screen readers.

## Why This Change Was Made

Move delivery ownership to the actual Slack provider-post boundary, register accepted controls before fallible delivery observers, share one terminal lifecycle across native and generic question surfaces, retain the correct posting identity, and preserve complete terminal status text while respecting Slack's 4,000-byte message, 3,000-character text-object, and 10-element context limits. Slack response-URL fallbacks use their actual 40,000-character transport limit without changing the existing 4,000-character chat-message policy.

## User Impact

Answered, cancelled, and expired Slack questions visibly finish on the correct message. Screen readers and notifications receive the complete outcome, mixed media and fallback deliveries update the actual controls message, and Enterprise Grid or user-token messages retain their original account scope.

## Evidence

- Immutable candidate: `25ed835138781caacbfa41da5433d31765d28846`.
- Four fresh independent nonauthor hostile reviewers verified the complete provider, controls-card, fallback, account, Gateway, response-URL budget, and Unicode owner paths.
- Genuine `gpt-5.6-sol` high-reasoning `$autoreview`, real TruffleHog, and `--max-priority P3` completed with zero findings.
- Added provider-boundary cases exercise controls-card timestamp `55` followed by unrelated aggregate timestamp `66`, media/text fanout, bot and user tokens, Enterprise Grid scoped clients, and propagated update errors.
- Hosted regression now constructs exactly one real 4,000-byte Unicode controls-card post with its authentic section plus actions, then verifies the exact accepted receipt, complete terminal outcome, and bounded accessibility fallback.
- Actual provider-accepted controls remain registered and finalizable even when durable persistence or delivery observers reject; an observer error resembling `invalid_blocks` cannot repost an already-accepted message.
- Existing response-URL delivery cases now preserve their five-attempt budget by using the legitimate 40,000-character provider limit while ordinary chat/actions/preview fallbacks retain their intentional 4,000-character cap.
- The maximum legitimate Gateway answer shape—three questions with four distinct 64-character ampersand-heavy labels—produces a 3,824-character escaped status. Tests exercise actual provider update validation, multiple valid context elements, exact entity/Unicode boundaries, and a complete notification outcome under the 4,000-byte limit.
- Slack's authoritative [text-object contract](https://docs.slack.dev/reference/block-kit/composition-objects/text-object/) and [context-block contract](https://docs.slack.dev/reference/block-kit/blocks/context-block/) are respected.
- Exact-head hosted CI and remote parent-RED/final-GREEN proof are still required before landing.
