### PR TITLE
test(macos): deduplicate onboarding AI setup fixtures

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -1,5 +1,7 @@
+import ConcurrencyExtras
 import CryptoKit
 import Foundation
+import ObjectiveC
 import OpenClawChatUI
 import OpenClawProtocol
 import Testing
@@ -28,93 +30,83 @@ private actor ActivationMarkerObservation {
 }
 
 private final class ActivationOwnerObservation: @unchecked Sendable {
-    private let lock = NSLock()
-    private var observedOwner: OnboardingSystemAgentResumeStore.ActivationOwner?
+    private let owner = LockIsolated<OnboardingSystemAgentResumeStore.ActivationOwner?>(nil)
 
     func record(_ owner: OnboardingSystemAgentResumeStore.ActivationOwner?) {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        self.observedOwner = owner
+        self.owner.withValue { $0 = owner }
     }
 
     func value() -> OnboardingSystemAgentResumeStore.ActivationOwner? {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        return self.observedOwner
+        self.owner.withValue { $0 }
     }
 }
 
 private final class AISetupSocketGeneration: @unchecked Sendable {
-    private let lock = NSLock()
-    private var nextGeneration = 0
+    private let generation = LockIsolated(0)
 
     func claim() -> Int {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        defer { self.nextGeneration += 1 }
-        return self.nextGeneration
+        self.generation.withValue { value in
+            defer { value += 1 }
+            return value
+        }
     }
 }
 
 private final class AISetupGatewayConfig: @unchecked Sendable {
-    private let lock = NSLock()
+    private struct State {
+        var token: String
+        var switchTokenAfterReads: (remaining: Int, token: String)?
+    }
+
     private let url: URL
-    private var token: String
-    private var switchTokenAfterReads: (remaining: Int, token: String)?
+    private let state: LockIsolated<State>
 
     init(url: URL, token: String) {
         self.url = url
-        self.token = token
+        self.state = LockIsolated(State(token: token))
     }
 
     func setToken(_ token: String) {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        self.token = token
-        self.switchTokenAfterReads = nil
+        self.state.withValue {
+            $0.token = token
+            $0.switchTokenAfterReads = nil
+        }
     }
 
     func switchToken(to token: String, afterReads: Int) {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        self.switchTokenAfterReads = (remaining: afterReads, token: token)
+        self.state.withValue { $0.switchTokenAfterReads = (afterReads, token) }
     }
 
     func snapshot() -> GatewayConnection.Config {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        if let pending = switchTokenAfterReads {
-            if pending.remaining == 0 {
-                self.token = pending.token
-                self.switchTokenAfterReads = nil
-            } else {
-                self.switchTokenAfterReads = (
-                    remaining: pending.remaining - 1,
-                    token: pending.token)
+        self.state.withValue { state in
+            if let pending = state.switchTokenAfterReads {
+                if pending.remaining == 0 {
+                    state.token = pending.token
+                    state.switchTokenAfterReads = nil
+                } else {
+                    state.switchTokenAfterReads = (
+                        remaining: pending.remaining - 1,
+                        token: pending.token)
+                }
             }
+            return (url: self.url, token: state.token, password: nil)
         }
-        return (url: self.url, token: self.token, password: nil)
     }
 }
 
 private final class AISetupRouteIdentity: @unchecked Sendable {
-    private let lock = NSLock()
-    private var value: String
+    private let value: LockIsolated<String>
 
     init(_ value: String) {
-        self.value = value
+        self.value = LockIsolated(value)
     }
 
     func set(_ value: String) {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        self.value = value
+        self.value.withValue { $0 = value }
     }
 
     func snapshot() -> String {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        return self.value
+        self.value.withValue { $0 }
     }
 }
 
@@ -167,6 +159,32 @@ private actor AISetupRequestGate {
         self.releaseWaiters.forEach { $0.resume() }
         self.releaseWaiters.removeAll()
     }
+}
+
+private final class AISetupDefaultsCleanup {
+    private let suiteName: String
+
+    init(suiteName: String) {
+        self.suiteName = suiteName
+    }
+
+    deinit {
+        UserDefaults.standard.removePersistentDomain(forName: self.suiteName)
+    }
+}
+
+private func isolatedAISetupDefaults(prefix: String) -> UserDefaults? {
+    isolatedAISetupDefaults(suiteName: "\(prefix)-\(UUID().uuidString)")
+}
+
+private func isolatedAISetupDefaults(suiteName: String) -> UserDefaults? {
+    guard let defaults = UserDefaults(suiteName: suiteName) else { return nil }
+    objc_setAssociatedObject(
+        defaults,
+        Unmanaged.passUnretained(defaults).toOpaque(),
+        AISetupDefaultsCleanup(suiteName: suiteName),
+        .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    return defaults
 }
 
 private actor AISetupConfigReadGate {
@@ -232,58 +250,26 @@ private func detectedSetupResponse(
 {
     Data(
         """
-        {
-          "type": "res",
-          "id": "\(id)",
-          "ok": true,
-          "payload": {
-            "candidates": [{
-              "kind": "\(kind)",
-              "label": "Test AI",
-              "detail": "installed",
-              "modelRef": "\(modelRef)",
-              "recommended": false,
-              "credentials": false
-            }],
-            "manualProviders": [{
-              "id": "openai-api-key",
-              "label": "OpenAI API key",
-              "hint": null
-            }],
-            "prepareOptions": [{
-              "id": "ollama",
-              "brandId": "ollama",
-              "label": "Ollama",
-              "hint": "Connect to an Ollama server and select a cloud or local model",
-              "actionLabel": "Choose connection"
-            }, {
-              "id": "llama-cpp",
-              "brandId": "llama-cpp",
-              "label": "Local model (llama.cpp)",
-              "hint": "Download and run a private GGUF model",
-              "actionLabel": "Review download"
-            }, {
-              "id": "lmstudio",
-              "brandId": "lmstudio",
-              "label": "LM Studio",
-              "hint": "Connect to a running LM Studio server and use an already loaded model",
-              "actionLabel": "Connect server",
-              "icon": "https://cdn.simpleicons.org/lmstudio",
-              "website": "https://lmstudio.ai/download"
-            }],
-            "workspace": "/tmp/openclaw-workspace",
-            "configuredModel": null,
-            "setupComplete": false
-          }
-        }
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "candidates":[{"kind":"\(kind)","label":"Test AI","detail":"installed",
+            "modelRef":"\(modelRef)","recommended":false,"credentials":false}],
+          "manualProviders":[{"id":"openai-api-key","label":"OpenAI API key","hint":null}],
+          "prepareOptions":[
+            {"id":"ollama","brandId":"ollama","label":"Ollama",
+              "hint":"Connect to an Ollama server and select a cloud or local model",
+              "actionLabel":"Choose connection"},
+            {"id":"llama-cpp","brandId":"llama-cpp","label":"Local model (llama.cpp)",
+              "hint":"Download and run a private GGUF model","actionLabel":"Review download"},
+            {"id":"lmstudio","brandId":"lmstudio","label":"LM Studio",
+              "hint":"Connect to a running LM Studio server and use an already loaded model",
+              "actionLabel":"Connect server","icon":"https://cdn.simpleicons.org/lmstudio",
+              "website":"https://lmstudio.ai/download"}],
+          "workspace":"/tmp/openclaw-workspace","configuredModel":null,"setupComplete":false}}
         """.utf8)
 }
 
 private func successfulEmptyResponse(id: String) -> Data {
-    Data(
-        """
-        {"type":"res","id":"\(id)","ok":true,"payload":{}}
-        """.utf8)
+    Data(#"{"type":"res","id":"\#(id)","ok":true,"payload":{}}"#.utf8)
 }
 
 private func respondToAISetupHealth(
@@ -314,7 +300,7 @@ private func respondToAISetupPreparation(
 
 private func actionableDetectedSetupResponse(id: String) -> Data {
     let response = String(decoding: detectedSetupResponse(id: id), as: UTF8.self)
-        .replacingOccurrences(of: #""credentials": false"#, with: #""credentials": true"#)
+        .replacingOccurrences(of: #""credentials":false"#, with: #""credentials":true"#)
     return Data(response.utf8)
 }
 
@@ -327,46 +313,26 @@ private func persistedDetectedSetupResponse(
         kind: "codex-cli",
         modelRef: "openai/gpt-5.5"), as: UTF8.self)
         .replacingOccurrences(
-            of: #""configuredModel": null"#,
-            with: #""configuredModel": "\#(configuredModel)""#)
-        .replacingOccurrences(of: #""setupComplete": false"#, with: #""setupComplete": true"#)
+            of: #""configuredModel":null"#,
+            with: #""configuredModel":"\#(configuredModel)""#)
+        .replacingOccurrences(of: #""setupComplete":false"#, with: #""setupComplete":true"#)
     return Data(response.utf8)
 }
 
 private func missingConfiguredModelResponse(id: String) -> Data {
     Data(
         """
-        {
-          "type": "res",
-          "id": "\(id)",
-          "ok": true,
-          "payload": {
-            "defaultId": "main",
-            "mainKey": "main",
-            "scope": "per-sender",
-            "agents": [{ "id": "main" }]
-          }
-        }
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "defaultId":"main","mainKey":"main","scope":"per-sender","agents":[{"id":"main"}]}}
         """.utf8)
 }
 
 private func configuredModelResponse(id: String) -> Data {
     Data(
         """
-        {
-          "type": "res",
-          "id": "\(id)",
-          "ok": true,
-          "payload": {
-            "defaultId": "main",
-            "mainKey": "main",
-            "scope": "per-sender",
-            "agents": [{
-              "id": "main",
-              "model": { "primary": "openai/gpt-5.5" }
-            }]
-          }
-        }
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "defaultId":"main","mainKey":"main","scope":"per-sender",
+          "agents":[{"id":"main","model":{"primary":"openai/gpt-5.5"}}]}}
         """.utf8)
 }
 
@@ -386,11 +352,8 @@ private func waitForAISetupRequests(
 
 private func wizardStartResponse(id: String, sessionID: String) -> Data {
     Data(
-        """
-        {"type":"res","id":"\(id)","ok":true,"payload":{
-          "sessionId":"\(sessionID)","done":false,"status":"running"
-        }}
-        """.utf8)
+        #"{"type":"res","id":"\#(id)","ok":true,"payload":{"sessionId":"\#(sessionID)","done":false,"status":"running"}}"#
+            .utf8)
 }
 
 private func wizardProgressResponse(id: String, sessionID: String, message: String) -> Data {
@@ -398,22 +361,235 @@ private func wizardProgressResponse(id: String, sessionID: String, message: Stri
         """
         {"type":"res","id":"\(id)","ok":true,"payload":{
           "sessionId":"\(sessionID)","done":false,"status":"running",
-          "step":{"id":"download","type":"progress","executor":"gateway","message":"\(message)"}
-        }}
+          "step":{"id":"download","type":"progress","executor":"gateway","message":"\(message)"}}}
         """.utf8)
 }
 
 private func wizardDoneResponse(id: String, sessionID: String) -> Data {
-    Data(
-        """
-        {"type":"res","id":"\(id)","ok":true,"payload":{
-          "sessionId":"\(sessionID)","done":true,"status":"done"
-        }}
-        """.utf8)
+    Data(#"{"type":"res","id":"\#(id)","ok":true,"payload":{"sessionId":"\#(sessionID)","done":true,"status":"done"}}"#
+        .utf8)
 }
 
 private func settleQueuedAISetupTasks() async {
     try? await Task.sleep(nanoseconds: 100_000_000)
+}
+
+private func pendingState(
+    _ defaults: UserDefaults,
+    for route: String = "local",
+    now: Date = Date()) -> OnboardingSystemAgentResumeStore.PendingState
+{
+    OnboardingSystemAgentResumeStore.pendingState(for: route, defaults: defaults, now: now)
+}
+
+private func storedActivationOwner(
+    _ defaults: UserDefaults,
+    for route: String = "local",
+    now: Date = Date()) -> OnboardingSystemAgentResumeStore.ActivationOwner?
+{
+    OnboardingSystemAgentResumeStore.activationOwner(for: route, defaults: defaults, now: now)
+}
+
+private func isPending(
+    _ defaults: UserDefaults,
+    for route: String = "local",
+    now: Date = Date()) -> Bool
+{
+    OnboardingSystemAgentResumeStore.isPending(for: route, defaults: defaults, now: now)
+}
+
+private func isOwned(
+    by owner: OnboardingSystemAgentResumeStore.ActivationOwner,
+    defaults: UserDefaults,
+    for route: String = "local") -> Bool
+{
+    OnboardingSystemAgentResumeStore.isOwned(by: owner, for: route, defaults: defaults)
+}
+
+@discardableResult
+private func markPending(
+    _ defaults: UserDefaults,
+    for route: String = "local",
+    owner: OnboardingSystemAgentResumeStore.ActivationOwner? = nil,
+    timeoutMs: Double = OnboardingSystemAgentResumeStore.maximumActivationTimeoutMs,
+    now: Date = Date()) -> Date?
+{
+    OnboardingSystemAgentResumeStore.markPending(
+        routeIdentity: route,
+        activationOwner: owner,
+        activationTimeoutMs: timeoutMs,
+        defaults: defaults,
+        now: now)
+}
+
+@discardableResult
+private func markCompleted(
+    _ defaults: UserDefaults,
+    for route: String = "local",
+    owner: OnboardingSystemAgentResumeStore.ActivationOwner? = nil) -> Bool
+{
+    OnboardingSystemAgentResumeStore.markCompleted(
+        ifOwnedBy: route,
+        activationOwner: owner,
+        defaults: defaults)
+}
+
+private func routeIdentity(
+    _ connectionMode: AppState.ConnectionMode,
+    transport: AppState.RemoteTransport = .direct,
+    url: String = "",
+    target: String = "",
+    localStateDir: URL = OpenClawConfigFile.stateDirURL(),
+    sshRemotePort: Int = 18789) -> String?
+{
+    OnboardingSystemAgentResumeStore.routeIdentity(
+        connectionMode: connectionMode,
+        preferredGatewayID: nil,
+        remoteTransport: transport,
+        remoteURL: url,
+        remoteTarget: target,
+        localStateDir: localStateDir,
+        sshRemotePort: sshRemotePort)
+}
+
+private typealias AISetupRequest = (id: String, method: String, params: [String: Any])
+private typealias AISetupRequestHandler = @Sendable (GatewayTestWebSocketTask, AISetupRequest) async throws -> Void
+private typealias AISetupHarnessHandler = @Sendable (
+    GatewayTestWebSocketTask,
+    AISetupRequest,
+    AISetupRequestRecorder) async throws -> Data?
+
+private func makeAISetupRequestSession(
+    recorder: AISetupRequestRecorder? = nil,
+    preparationKind: String? = nil,
+    receiveHook: GatewayTestWebSocketTask.ReceiveHook? = nil,
+    handler: @escaping AISetupRequestHandler = { _, _ in }) -> GatewayTestWebSocketSession
+{
+    GatewayTestWebSocketSession(taskFactory: {
+        GatewayTestWebSocketTask(
+            sendHook: { task, message, sendIndex in
+                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
+                if let preparationKind,
+                   respondToAISetupPreparation(task: task, request: request, kind: preparationKind)
+                {
+                    return
+                }
+                if preparationKind == nil, respondToAISetupHealth(task: task, request: request) {
+                    return
+                }
+                if let recorder {
+                    await recorder.record(message)
+                }
+                try await handler(task, request)
+            },
+            receiveHook: receiveHook)
+    })
+}
+
+private func makeAISetupGateway(
+    url: URL,
+    token: String? = nil,
+    password: String? = nil,
+    session: GatewayTestWebSocketSession) -> GatewayConnection
+{
+    GatewayConnection(
+        configProvider: { (url: url, token: token, password: password) },
+        sessionBox: WebSocketSessionBox(session: session))
+}
+
+@MainActor
+private func makeAISetupModel(
+    gateway: GatewayConnection = .shared,
+    defaults: UserDefaults = .standard,
+    routeIdentityProvider: @escaping @MainActor () -> String? = { "local" },
+    connectionModeProvider: @escaping @MainActor () -> AppState.ConnectionMode = { .local })
+    -> OnboardingAISetupModel
+{
+    OnboardingAISetupModel(
+        gateway: gateway,
+        defaults: defaults,
+        routeIdentityProvider: routeIdentityProvider,
+        connectionModeProvider: connectionModeProvider)
+}
+
+@MainActor
+private func makeAISetupView(
+    state: AppState,
+    gateway: GatewayConnection = .shared,
+    defaults: UserDefaults = .standard,
+    routeIdentityProvider: @escaping @MainActor () -> String?,
+    configuredGatewayProbeTimeoutMs: Double = 15000,
+    gatewaySelectionPersister: (@MainActor () -> Bool)? = nil) -> OnboardingView
+{
+    OnboardingView(
+        state: state,
+        aiSetupGateway: gateway,
+        systemAgentDefaults: defaults,
+        aiSetupRouteIdentityProvider: routeIdentityProvider,
+        configuredGatewayProbeTimeoutMs: configuredGatewayProbeTimeoutMs,
+        gatewaySelectionPersister: gatewaySelectionPersister)
+}
+
+@MainActor
+private struct AISetupHarness {
+    let recorder: AISetupRequestRecorder
+    let session: GatewayTestWebSocketSession
+    let gateway: GatewayConnection
+
+    init(
+        url: URL,
+        token: String? = nil,
+        password: String? = nil,
+        preparationKind: String? = nil,
+        receiveHook: GatewayTestWebSocketTask.ReceiveHook? = nil,
+        handler: @escaping AISetupHarnessHandler = { _, _, _ in nil })
+    {
+        let recorder = AISetupRequestRecorder()
+        self.recorder = recorder
+        self.session = makeAISetupRequestSession(
+            recorder: recorder,
+            preparationKind: preparationKind,
+            receiveHook: receiveHook,
+            handler: { task, request in
+                if let response = try await handler(task, request, recorder) {
+                    task.emitReceiveSuccess(.data(response))
+                }
+            })
+        self.gateway = makeAISetupGateway(
+            url: url,
+            token: token,
+            password: password,
+            session: self.session)
+    }
+
+    func model(
+        defaults: UserDefaults = .standard,
+        routeIdentityProvider: @escaping @MainActor () -> String? = { "local" },
+        connectionModeProvider: @escaping @MainActor () -> AppState.ConnectionMode = { .local })
+        -> OnboardingAISetupModel
+    {
+        makeAISetupModel(
+            gateway: self.gateway,
+            defaults: defaults,
+            routeIdentityProvider: routeIdentityProvider,
+            connectionModeProvider: connectionModeProvider)
+    }
+
+    func view(
+        state: AppState,
+        defaults: UserDefaults = .standard,
+        routeIdentityProvider: @escaping @MainActor () -> String?,
+        configuredGatewayProbeTimeoutMs: Double = 15000,
+        gatewaySelectionPersister: (@MainActor () -> Bool)? = nil) -> OnboardingView
+    {
+        makeAISetupView(
+            state: state,
+            gateway: self.gateway,
+            defaults: defaults,
+            routeIdentityProvider: routeIdentityProvider,
+            configuredGatewayProbeTimeoutMs: configuredGatewayProbeTimeoutMs,
+            gatewaySelectionPersister: gatewaySelectionPersister)
+    }
 }
 
 private func makeAISetupSession(
@@ -504,83 +680,36 @@ private func makeRestartingAISetupSession(
 }
 
 private func failedActivationResponse(id: String) -> Data {
-    Data(
-        """
-        {
-          "type": "res",
-          "id": "\(id)",
-          "ok": true,
-          "payload": { "ok": false, "status": "auth", "error": "rejected" }
-        }
-        """.utf8)
+    Data(#"{"type":"res","id":"\#(id)","ok":true,"payload":{"ok":false,"status":"auth","error":"rejected"}}"#.utf8)
 }
 
 private func successfulActivationResponse(id: String, modelRef: String, latencyMs: Int) -> Data {
     Data(
         """
-        {
-          "type": "res",
-          "id": "\(id)",
-          "ok": true,
-          "payload": {
-            "ok": true,
-            "modelRef": "\(modelRef)",
-            "latencyMs": \(latencyMs),
-            "lines": ["Model ready"]
-          }
-        }
+        {"type":"res","id":"\(id)","ok":true,"payload":{
+          "ok":true,"modelRef":"\(modelRef)","latencyMs":\(latencyMs),"lines":["Model ready"]}}
         """.utf8)
 }
 
 private func indeterminateActivationResponse(id: String) -> Data {
     Data(
         """
-        {
-          "type": "res",
-          "id": "\(id)",
-          "ok": false,
-          "error": {
-            "code": "UNAVAILABLE",
-            "message": "Setup inference activation is indeterminate"
-          }
-        }
+        {"type":"res","id":"\(id)","ok":false,"error":{
+          "code":"UNAVAILABLE","message":"Setup inference activation is indeterminate"}}
         """.utf8)
 }
 
 private func verifiedSetupResponse(id: String) -> Data {
-    Data(
-        """
-        {
-          "type": "res",
-          "id": "\(id)",
-          "ok": true,
-          "payload": { "ok": true, "modelRef": "openai/gpt-5.5", "latencyMs": 42 }
-        }
-        """.utf8)
+    Data(#"{"type":"res","id":"\#(id)","ok":true,"payload":{"ok":true,"modelRef":"openai/gpt-5.5","latencyMs":42}}"#
+        .utf8)
 }
 
 private func rejectedSetupVerificationResponse(id: String) -> Data {
-    Data(
-        """
-        {
-          "type": "res",
-          "id": "\(id)",
-          "ok": true,
-          "payload": { "ok": false, "status": "auth", "error": "expired login" }
-        }
-        """.utf8)
+    Data(#"{"type":"res","id":"\#(id)","ok":true,"payload":{"ok":false,"status":"auth","error":"expired login"}}"#.utf8)
 }
 
 private func unavailableGatewayResponse(id: String) -> Data {
-    Data(
-        """
-        {
-          "type": "res",
-          "id": "\(id)",
-          "ok": false,
-          "error": { "code": "UNAVAILABLE", "message": "temporary failure" }
-        }
-        """.utf8)
+    Data(#"{"type":"res","id":"\#(id)","ok":false,"error":{"code":"UNAVAILABLE","message":"temporary failure"}}"#.utf8)
 }
 
 @Suite(.serialized)
@@ -723,85 +852,75 @@ struct OnboardingAISetupTests {
         let detections = AISetupSocketGeneration()
         let completion = AISetupRequestGate()
         let preparedModelRef = "llama-cpp/gemma-4-e4b-it-q4_k_m"
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(
-                sendHook: { task, message, sendIndex in
-                    guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                    if respondToAISetupHealth(task: task, request: request) {
-                        return
-                    }
-                    await recorder.record(message)
-                    switch request.method {
-                    case "openclaw.setup.detect":
-                        if detections.claim() == 0 {
-                            task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
-                        } else {
-                            let response = String(decoding: detectedSetupResponse(
-                                id: request.id,
-                                kind: "provider-auto:llama-cpp",
-                                modelRef: preparedModelRef), as: UTF8.self)
-                                .replacingOccurrences(
-                                    of: #""credentials": false"#,
-                                    with: #""credentials": true"#)
-                            task.emitReceiveSuccess(.data(Data(response.utf8)))
-                        }
-                    case "openclaw.setup.activate":
-                        task.emitReceiveSuccess(.data(successfulActivationResponse(
+        let session = makeAISetupRequestSession(
+            recorder: recorder,
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                let id = task.snapshotConnectRequestID() ?? "connect"
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: id,
+                    methods: [
+                        "openclaw.setup.prepare.start",
+                        "openclaw.setup.activate",
+                    ],
+                    capabilities: ["openclaw-setup-model-ref"]))
+            },
+            handler: { task, request in
+                switch request.method {
+                case "openclaw.setup.detect":
+                    if detections.claim() == 0 {
+                        task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
+                    } else {
+                        let response = String(decoding: detectedSetupResponse(
                             id: request.id,
-                            modelRef: preparedModelRef,
-                            latencyMs: 731)))
-                    case "openclaw.setup.prepare.start":
-                        let sessionID = request.params["sessionId"] as? String ?? "prepare-session"
-                        task.emitReceiveSuccess(.data(wizardStartResponse(
+                            kind: "provider-auto:llama-cpp",
+                            modelRef: preparedModelRef), as: UTF8.self)
+                            .replacingOccurrences(
+                                of: #""credentials":false"#,
+                                with: #""credentials":true"#)
+                        task.emitReceiveSuccess(.data(Data(response.utf8)))
+                    }
+                case "openclaw.setup.activate":
+                    task.emitReceiveSuccess(.data(successfulActivationResponse(
+                        id: request.id,
+                        modelRef: preparedModelRef,
+                        latencyMs: 731)))
+                case "openclaw.setup.prepare.start":
+                    let sessionID = request.params["sessionId"] as? String ?? "prepare-session"
+                    task.emitReceiveSuccess(.data(wizardStartResponse(
+                        id: request.id,
+                        sessionID: sessionID)))
+                case "wizard.next":
+                    let sessionID = request.params["sessionId"] as? String ?? "prepare-session"
+                    // Two gateway-executed progress frames, then the terminal
+                    // result: a client that stops after the first frame never
+                    // reaches either follow-up.
+                    switch frames.claim() {
+                    case 0:
+                        task.emitReceiveSuccess(.data(wizardProgressResponse(
+                            id: request.id,
+                            sessionID: sessionID,
+                            message: "Downloading model: 25%")))
+                    case 1:
+                        task.emitReceiveSuccess(.data(wizardProgressResponse(
+                            id: request.id,
+                            sessionID: sessionID,
+                            message: "Downloading model: 80%")))
+                    default:
+                        await completion.wait()
+                        task.emitReceiveSuccess(.data(wizardDoneResponse(
                             id: request.id,
                             sessionID: sessionID)))
-                    case "wizard.next":
-                        let sessionID = request.params["sessionId"] as? String ?? "prepare-session"
-                        // Two gateway-executed progress frames, then the terminal
-                        // result: a client that stops after the first frame never
-                        // reaches either follow-up.
-                        switch frames.claim() {
-                        case 0:
-                            task.emitReceiveSuccess(.data(wizardProgressResponse(
-                                id: request.id,
-                                sessionID: sessionID,
-                                message: "Downloading model: 25%")))
-                        case 1:
-                            task.emitReceiveSuccess(.data(wizardProgressResponse(
-                                id: request.id,
-                                sessionID: sessionID,
-                                message: "Downloading model: 80%")))
-                        default:
-                            await completion.wait()
-                            task.emitReceiveSuccess(.data(wizardDoneResponse(
-                                id: request.id,
-                                sessionID: sessionID)))
-                        }
-                    default:
-                        break
                     }
-                },
-                receiveHook: { task, receiveIndex in
-                    if receiveIndex == 0 {
-                        return .data(GatewayWebSocketTestSupport.connectChallengeData())
-                    }
-                    let id = task.snapshotConnectRequestID() ?? "connect"
-                    return .data(GatewayWebSocketTestSupport.connectOkData(
-                        id: id,
-                        methods: [
-                            "openclaw.setup.prepare.start",
-                            "openclaw.setup.activate",
-                        ],
-                        capabilities: ["openclaw-setup-model-ref"]))
-                })
-        })
+                default:
+                    break
+                }
+            })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            routeIdentityProvider: { "local" })
+        let gateway = makeAISetupGateway(url: url, session: session)
+        let model = makeAISetupModel(gateway: gateway)
 
         await model.detectAndAutoConnect()
         let option = try #require(model.prepareOptions.first { $0.id == "llama-cpp" })
@@ -1019,27 +1138,12 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `successful activation hands off and completion clears its owned receipt`() async throws {
-        let suiteName = "OnboardingCompletedActivationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupPreparation(task: task, request: request, kind: "claude-cli") {
-                    return
-                }
-                guard request.method == "openclaw.setup.activate" else { return }
-                task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
-            })
-        })
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingCompletedActivationTests"))
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let harness = AISetupHarness(url: url, preparationKind: "claude-cli") { _, request, _ in
+            request.method == "openclaw.setup.activate" ? verifiedSetupResponse(id: request.id) : nil
+        }
+        let model = harness.model(defaults: defaults)
         var handedOff = false
         model.onConnected = { handedOff = true }
 
@@ -1048,49 +1152,27 @@ struct OnboardingAISetupTests {
 
         #expect(model.connected)
         #expect(handedOff)
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .completed)
+        #expect(pendingState(defaults) == .completed)
 
         model.clearCompletedHandoffIfOwned()
 
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .none)
+        #expect(pendingState(defaults) == .none)
     }
 
     @Test func `choose a different AI relists routes without auto-activating`() async throws {
-        let suiteName = "OnboardingChooseDifferentAITests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let recorder = AISetupRequestRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                await recorder.record(message)
-                switch request.method {
-                case "openclaw.setup.detect":
-                    // credentials:true would auto-activate; the choose-different
-                    // pass must end at the picker even for actionable candidates.
-                    task.emitReceiveSuccess(.data(actionableDetectedSetupResponse(id: request.id)))
-                case "openclaw.setup.activate":
-                    task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
-                default:
-                    break
-                }
-            })
-        })
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingChooseDifferentAITests"))
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            switch request.method {
+            case "openclaw.setup.detect":
+                // credentials:true would auto-activate; the choose-different
+                // pass must end at the picker even for actionable candidates.
+                actionableDetectedSetupResponse(id: request.id)
+            case "openclaw.setup.activate": verifiedSetupResponse(id: request.id)
+            default: nil
+            }
+        }
+        let model = harness.model(defaults: defaults)
 
         await model.detectAndAutoConnect()
         #expect(model.connected)
@@ -1105,42 +1187,28 @@ struct OnboardingAISetupTests {
         #expect(model.showManualEntry)
         // Exactly one activation: the initial auto-connect. The re-detect pass
         // must not redo the choice the user just asked to change.
-        let snapshot = await recorder.snapshot()
+        let snapshot = await harness.recorder.snapshot()
         #expect(snapshot.methods.filter { $0 == "openclaw.setup.activate" }.count == 1)
         #expect(snapshot.methods.last == "openclaw.setup.detect")
     }
 
     @Test func `choose a different AI requires a connected setup`() throws {
-        let suiteName = "OnboardingChooseDifferentAIGuardTests-\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = isolatedAISetupDefaults(prefix: "OnboardingChooseDifferentAIGuardTests") ?? .standard
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: GatewayTestWebSocketSession(taskFactory: {
-                GatewayTestWebSocketTask(sendHook: { _, _, _ in })
-            })))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let model = AISetupHarness(url: url).model(defaults: defaults)
 
         #expect(!model.beginChooseDifferentAI())
     }
 
     @Test func `adopts pending activation stored under the retired crestodian key`() throws {
-        let suiteName = "OnboardingRetiredKeyMigrationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingRetiredKeyMigrationTests"))
 
-        _ = OnboardingSystemAgentResumeStore.markPending(routeIdentity: "local", defaults: defaults)
+        _ = markPending(defaults)
         let payload = try #require(defaults.object(forKey: onboardingSystemAgentPendingKey))
         defaults.removeObject(forKey: onboardingSystemAgentPendingKey)
         defaults.set(payload, forKey: onboardingSystemAgentPendingRetiredKey)
 
-        guard case .activating = OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults)
+        guard case .activating = pendingState(defaults)
         else {
             Issue.record("expected the retired-key activation lease to survive the rename")
             return
@@ -1151,8 +1219,7 @@ struct OnboardingAISetupTests {
 
     @Test func `managed Gateway restart reconciles exact persisted activation before handoff`() async throws {
         let suiteName = "OnboardingManagedRestartReconciliationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(suiteName: suiteName))
         let recorder = AISetupRequestRecorder()
         let ownerObservation = ActivationOwnerObservation()
         let session = makeRestartingAISetupSession(
@@ -1161,13 +1228,8 @@ struct OnboardingAISetupTests {
             ownerObservation: ownerObservation,
             postRestartConfiguredModel: "openai/gpt-5.5")
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: "route-token", password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let gateway = makeAISetupGateway(url: url, token: "route-token", session: session)
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
         var handoffCount = 0
         model.onConnected = { handoffCount += 1 }
 
@@ -1185,18 +1247,13 @@ struct OnboardingAISetupTests {
         #expect(model.connected)
         #expect(model.connectedModelRef == "openai/gpt-5.5")
         #expect(handoffCount == 1)
-        #expect(OnboardingSystemAgentResumeStore.activationOwner(
-            for: "local",
-            defaults: defaults) == activationOwner)
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .completed)
+        #expect(storedActivationOwner(defaults) == activationOwner)
+        #expect(pendingState(defaults) == .completed)
     }
 
     @Test func `managed Gateway restart rejects mismatched persisted transition`() async throws {
         let suiteName = "OnboardingManagedRestartMismatchTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(suiteName: suiteName))
         let recorder = AISetupRequestRecorder()
         let ownerObservation = ActivationOwnerObservation()
         let session = makeRestartingAISetupSession(
@@ -1205,13 +1262,8 @@ struct OnboardingAISetupTests {
             ownerObservation: ownerObservation,
             postRestartConfiguredModel: "anthropic/other-model")
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: "route-token", password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let gateway = makeAISetupGateway(url: url, token: "route-token", session: session)
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
         var handoffCount = 0
         model.onConnected = { handoffCount += 1 }
 
@@ -1230,59 +1282,31 @@ struct OnboardingAISetupTests {
         #expect(!reconciledRequests.methods.contains("openclaw.setup.verify"))
         #expect(!model.connected)
         #expect(handoffCount == 0)
-        #expect(OnboardingSystemAgentResumeStore.isOwned(
-            by: activationOwner,
-            for: "local",
-            defaults: defaults))
+        #expect(isOwned(by: activationOwner, defaults: defaults))
         #expect(model.pendingActivationVerification)
         #expect(model.waitingForPendingActivationDeadline)
     }
 
     @Test func `completion cannot clear a replacement activation owner`() async throws {
-        let suiteName = "OnboardingCompletionReplacementOwnerTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupPreparation(task: task, request: request, kind: "claude-cli") {
-                    return
-                }
-                guard request.method == "openclaw.setup.activate" else { return }
-                task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
-            })
-        })
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingCompletionReplacementOwnerTests"))
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let harness = AISetupHarness(url: url, preparationKind: "claude-cli") { _, request, _ in
+            request.method == "openclaw.setup.activate" ? verifiedSetupResponse(id: request.id) : nil
+        }
+        let model = harness.model(defaults: defaults)
 
         await model.detectAndAutoConnect()
         await model.activate(kind: "claude-cli")
-        let completedOwner = try #require(OnboardingSystemAgentResumeStore.activationOwner(
-            for: "local",
-            defaults: defaults))
+        let completedOwner = try #require(storedActivationOwner(defaults))
         let replacementOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "replacement-activation",
             routeFingerprint: completedOwner.routeFingerprint)
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "local",
-            activationOwner: replacementOwner,
-            defaults: defaults)
+        markPending(defaults, for: "local", owner: replacementOwner)
 
         model.clearCompletedHandoffIfOwned()
 
-        #expect(OnboardingSystemAgentResumeStore.isOwned(
-            by: replacementOwner,
-            for: "local",
-            defaults: defaults))
-        guard case .activating = OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults)
+        #expect(isOwned(by: replacementOwner, defaults: defaults))
+        guard case .activating = pendingState(defaults)
         else {
             Issue.record("expected replacement activation to retain its lease")
             return
@@ -1291,38 +1315,25 @@ struct OnboardingAISetupTests {
 
     @Test func `successful response cannot complete a replaced same route activation`() async throws {
         let suiteName = "OnboardingReplacedActivationOwnerTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(suiteName: suiteName))
         let replacementID = "replacement-activation"
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupPreparation(task: task, request: request, kind: "claude-cli") {
-                    return
-                }
-                guard request.method == "openclaw.setup.activate",
-                      let callbackDefaults = UserDefaults(suiteName: suiteName),
-                      let originalOwner = OnboardingSystemAgentResumeStore.activationOwner(
-                          for: "local",
-                          defaults: callbackDefaults)
-                else { return }
-                OnboardingSystemAgentResumeStore.markPending(
-                    routeIdentity: "local",
-                    activationOwner: .init(
-                        id: replacementID,
-                        routeFingerprint: originalOwner.routeFingerprint),
-                    defaults: callbackDefaults)
-                task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let harness = AISetupHarness(url: url, preparationKind: "claude-cli") { _, request, _ in
+            guard request.method == "openclaw.setup.activate",
+                  let callbackDefaults = UserDefaults(suiteName: suiteName),
+                  let originalOwner = OnboardingSystemAgentResumeStore.activationOwner(
+                      for: "local",
+                      defaults: callbackDefaults)
+            else { return nil }
+            OnboardingSystemAgentResumeStore.markPending(
+                routeIdentity: "local",
+                activationOwner: .init(
+                    id: replacementID,
+                    routeFingerprint: originalOwner.routeFingerprint),
+                defaults: callbackDefaults)
+            return verifiedSetupResponse(id: request.id)
+        }
+        let model = harness.model(defaults: defaults)
         var handoffCount = 0
         model.onConnected = { handoffCount += 1 }
 
@@ -1332,12 +1343,8 @@ struct OnboardingAISetupTests {
         #expect(!model.connected)
         #expect(handoffCount == 0)
         #expect(model.phase == .ready)
-        #expect(OnboardingSystemAgentResumeStore.activationOwner(
-            for: "local",
-            defaults: defaults)?.id == replacementID)
-        guard case .activating = OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults)
+        #expect(storedActivationOwner(defaults)?.id == replacementID)
+        guard case .activating = pendingState(defaults)
         else {
             Issue.record("expected replacement activation to retain its lease")
             return
@@ -1345,21 +1352,13 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `reset during final route validation rejects stale activation handoff`() async throws {
-        let suiteName = "OnboardingFinalRouteValidationResetTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingFinalRouteValidationResetTests"))
         let configGate = AISetupConfigReadGate()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupPreparation(task: task, request: request, kind: "codex-cli") {
-                    return
-                }
-                guard request.method == "openclaw.setup.activate" else { return }
-                await configGate.armNextRead()
-                task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
-            })
-        })
+        let session = makeAISetupRequestSession(preparationKind: "codex-cli") { task, request in
+            guard request.method == "openclaw.setup.activate" else { return }
+            await configGate.armNextRead()
+            task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
+        }
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: {
@@ -1367,10 +1366,7 @@ struct OnboardingAISetupTests {
                 return (url: url, token: token, password: nil)
             },
             sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
         var handoffCount = 0
         model.onConnected = { handoffCount += 1 }
 
@@ -1384,9 +1380,7 @@ struct OnboardingAISetupTests {
         #expect(!model.connected)
         #expect(model.phase == .idle)
         #expect(handoffCount == 0)
-        #expect(OnboardingSystemAgentResumeStore.isPending(
-            for: "local",
-            defaults: defaults))
+        #expect(isPending(defaults, for: "local"))
     }
 
     @Test func `gateway change clears route-bound setup state`() {
@@ -1454,9 +1448,7 @@ struct OnboardingAISetupTests {
         // Isolated defaults + fixed route: the default init reads the machine's
         // real resume store, whose leftover activation leases fail this test on
         // any Mac that completed onboarding.
-        let suiteName = "OnboardingConfiguredLabelTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConfiguredLabelTests"))
         let model = OnboardingAISetupModel(
             defaults: defaults,
             routeIdentityProvider: { "local" })
@@ -1482,31 +1474,16 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `pending handoff connects only after route-bound live verification`() async throws {
-        let recorder = AISetupRequestRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                await recorder.record(message)
-                if request.method == "openclaw.setup.verify" {
-                    task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
-                }
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            routeIdentityProvider: { "local" })
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            request.method == "openclaw.setup.verify" ? verifiedSetupResponse(id: request.id) : nil
+        }
+        let model = harness.model()
 
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
         await model.verifyPendingConfiguredInference()
 
-        let requests = await recorder.snapshot()
+        let requests = await harness.recorder.snapshot()
         #expect(requests.methods == ["openclaw.setup.verify"])
         #expect(model.connected)
         #expect(model.connectedModelRef == "openai/gpt-5.5")
@@ -1514,27 +1491,14 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `overlapping pending verification callers share one route-bound request`() async throws {
-        let recorder = AISetupRequestRecorder()
         let gate = AISetupRequestGate()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                await recorder.record(message)
-                guard request.method == "openclaw.setup.verify" else { return }
-                await gate.wait()
-                task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            routeIdentityProvider: { "local" })
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            guard request.method == "openclaw.setup.verify" else { return nil }
+            await gate.wait()
+            return verifiedSetupResponse(id: request.id)
+        }
+        let model = harness.model()
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
 
         let first = Task { await model.verifyPendingConfiguredInference() }
@@ -1542,36 +1506,21 @@ struct OnboardingAISetupTests {
         let second = Task { await model.verifyPendingConfiguredInference() }
         await Task.yield()
 
-        #expect(await (recorder.snapshot()).methods == ["openclaw.setup.verify"])
+        #expect(await (harness.recorder.snapshot()).methods == ["openclaw.setup.verify"])
         await gate.release()
         #expect(await first.value == .connected)
         #expect(await second.value == .connected)
-        #expect(await (recorder.snapshot()).methods == ["openclaw.setup.verify"])
+        #expect(await (harness.recorder.snapshot()).methods == ["openclaw.setup.verify"])
     }
 
     @Test func `pending verification revalidates route after shared task completes`() async throws {
-        let suiteName = "OnboardingPendingRouteRevalidationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                guard request.method == "openclaw.setup.verify" else { return }
-                task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
-            })
-        })
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingPendingRouteRevalidationTests"))
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
         let routeIdentity = AISetupRouteIdentity("remote:id:gateway-a")
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { routeIdentity.snapshot() })
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            request.method == "openclaw.setup.verify" ? verifiedSetupResponse(id: request.id) : nil
+        }
+        let model = harness.model(defaults: defaults, routeIdentityProvider: { routeIdentity.snapshot() })
         model.onConnected = { routeIdentity.set("remote:id:gateway-b") }
 
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
@@ -1581,37 +1530,24 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `disappearing onboarding invalidates detection before activation`() async throws {
-        let recorder = AISetupRequestRecorder()
         let gate = AISetupRequestGate()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                await recorder.record(message)
-                switch request.method {
-                case "openclaw.setup.detect":
-                    await gate.wait()
-                    task.emitReceiveSuccess(.data(actionableDetectedSetupResponse(id: request.id)))
-                case "openclaw.setup.activate":
-                    task.emitReceiveSuccess(.data(failedActivationResponse(id: request.id)))
-                default:
-                    break
-                }
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            switch request.method {
+            case "openclaw.setup.detect":
+                await gate.wait()
+                return actionableDetectedSetupResponse(id: request.id)
+            case "openclaw.setup.activate": return failedActivationResponse(id: request.id)
+            default: return nil
+            }
+        }
         let appState = AppState(preview: true)
         appState.connectionMode = .remote
         appState.remoteTransport = .direct
         appState.remoteUrl = "ws://example.invalid"
         let view = OnboardingView(
             state: appState,
-            aiSetupGateway: gateway,
+            aiSetupGateway: harness.gateway,
             aiSetupRouteIdentityProvider: { "remote:direct:example.invalid" })
         view.onboardingVisible = true
 
@@ -1621,33 +1557,18 @@ struct OnboardingAISetupTests {
         await gate.release()
         await settleQueuedAISetupTasks()
 
-        #expect(await (recorder.snapshot()).methods == ["openclaw.setup.detect"])
+        #expect(await (harness.recorder.snapshot()).methods == ["openclaw.setup.detect"])
         #expect(view.aiSetup.phase == .idle)
     }
 
     @Test func `failed pending verification keeps activation lease before deadline`() async throws {
-        let suiteName = "OnboardingPendingVerificationFailureTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        OnboardingSystemAgentResumeStore.markPending(routeIdentity: "local", defaults: defaults)
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                guard request.method == "openclaw.setup.verify" else { return }
-                task.emitReceiveSuccess(.data(rejectedSetupVerificationResponse(id: request.id)))
-            })
-        })
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingPendingVerificationFailureTests"))
+        markPending(defaults)
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            request.method == "openclaw.setup.verify" ? rejectedSetupVerificationResponse(id: request.id) : nil
+        }
+        let model = harness.model(defaults: defaults)
 
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
         let outcome = await model.verifyPendingConfiguredInference()
@@ -1656,29 +1577,20 @@ struct OnboardingAISetupTests {
         #expect(model.pendingActivationVerification)
         #expect(model.detectError?.detail == "expired login")
         #expect(outcome == .notConnected)
-        #expect(OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(isPending(defaults))
     }
 
     @Test func `completed activation receipt survives verification transport failure`() async throws {
-        let suiteName = "OnboardingCompletedVerificationRetryTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingCompletedVerificationRetryTests"))
         let recorder = AISetupRequestRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                guard request.method == "openclaw.setup.verify" else { return }
-                await recorder.record(message)
-                let verifyCount = await recorder.snapshot().methods.count
-                let response = verifyCount == 1
-                    ? unavailableGatewayResponse(id: request.id)
-                    : verifiedSetupResponse(id: request.id)
-                task.emitReceiveSuccess(.data(response))
-            })
-        })
+        let session = makeAISetupRequestSession(recorder: recorder) { task, request in
+            guard request.method == "openclaw.setup.verify" else { return }
+            let verifyCount = await recorder.snapshot().methods.count
+            let response = verifyCount == 1
+                ? unavailableGatewayResponse(id: request.id)
+                : verifiedSetupResponse(id: request.id)
+            task.emitReceiveSuccess(.data(response))
+        }
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: "completed-route", password: nil) },
@@ -1687,18 +1599,9 @@ struct OnboardingAISetupTests {
         let activationOwner = try OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "completed-before-verification",
             routeFingerprint: #require(route.activationOwnershipFingerprint))
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "local",
-            activationOwner: activationOwner,
-            defaults: defaults)
-        #expect(OnboardingSystemAgentResumeStore.markCompleted(
-            ifOwnedBy: "local",
-            activationOwner: activationOwner,
-            defaults: defaults))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        markPending(defaults, for: "local", owner: activationOwner)
+        #expect(markCompleted(defaults, owner: activationOwner))
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
 
         let failedOutcome = await model.verifyPendingConfiguredInference()
@@ -1706,9 +1609,7 @@ struct OnboardingAISetupTests {
         #expect(failedOutcome == .notConnected)
         #expect(model.pendingActivationVerification)
         #expect(!model.connected)
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .completed)
+        #expect(pendingState(defaults) == .completed)
 
         let retryOutcome = await model.verifyPendingConfiguredInference()
         let requests = await waitForAISetupRequests(recorder, count: 2)
@@ -1719,15 +1620,13 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `pending OpenClaw marker is app local and clearable`() throws {
-        let suiteName = "OnboardingSystemAgentResumeStoreTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingSystemAgentResumeStoreTests"))
 
-        #expect(!OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
-        OnboardingSystemAgentResumeStore.markPending(routeIdentity: "local", defaults: defaults)
-        #expect(OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(!isPending(defaults))
+        markPending(defaults)
+        #expect(isPending(defaults))
         OnboardingSystemAgentResumeStore.clear(defaults: defaults)
-        #expect(!OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(!isPending(defaults))
     }
 
     @Test func `persisted route owner ignores tunnel URL but changes with Gateway auth`() async throws {
@@ -1775,9 +1674,7 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `unsafe v3 credential fingerprint record is scrubbed`() throws {
-        let suiteName = "OnboardingUnsafeOwnerMigrationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingUnsafeOwnerMigrationTests"))
         defaults.set([
             "version": 3,
             "records": [
@@ -1789,31 +1686,23 @@ struct OnboardingAISetupTests {
             ],
         ], forKey: onboardingSystemAgentPendingKey)
 
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .none)
+        #expect(pendingState(defaults) == .none)
         #expect(defaults.object(forKey: onboardingSystemAgentPendingKey) == nil)
     }
 
     @Test func `ownerless v2 completion record is scrubbed`() throws {
-        let suiteName = "OnboardingOwnerlessReceiptMigrationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingOwnerlessReceiptMigrationTests"))
         defaults.set([
             "version": 2,
             "records": ["local": ["phase": "completed"]],
         ], forKey: onboardingSystemAgentPendingKey)
 
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .none)
+        #expect(pendingState(defaults) == .none)
         #expect(defaults.object(forKey: onboardingSystemAgentPendingKey) == nil)
     }
 
     @Test func `activation fails closed when Keychain binding is unavailable`() async throws {
-        let suiteName = "OnboardingMissingKeychainBindingTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingMissingKeychainBindingTests"))
         let recorder = AISetupRequestRecorder()
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
@@ -1822,16 +1711,13 @@ struct OnboardingAISetupTests {
             sessionBox: WebSocketSessionBox(session: makeAISetupSession(
                 recorder: recorder,
                 detectedKind: "codex-cli")))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
 
         await model.detectAndAutoConnect()
         await model.activate(kind: "codex-cli")
 
         #expect(await (recorder.snapshot()).methods == ["openclaw.setup.detect"])
-        #expect(!OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(!isPending(defaults))
         #expect(model.phase == .ready)
         guard case let .failed(failure) = model.statuses["codex-cli"] else {
             Issue.record("expected secure-storage failure")
@@ -1841,9 +1727,7 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `active v3 record keeps its deadline while credential verifier is scrubbed`() throws {
-        let suiteName = "OnboardingActiveUnsafeOwnerMigrationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingActiveUnsafeOwnerMigrationTests"))
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let deadline = now.addingTimeInterval(120)
         defaults.set([
@@ -1873,9 +1757,7 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `legacy marker relaunch migrates to a full conservative lease`() throws {
-        let suiteName = "OnboardingLegacySystemAgentResumeStoreTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingLegacySystemAgentResumeStoreTests"))
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         defaults.set("local", forKey: onboardingSystemAgentPendingKey)
 
@@ -1904,55 +1786,30 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `missing model cannot start a second activation before pending deadline`() async throws {
-        let suiteName = "OnboardingPendingDeadlineBlockTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingPendingDeadlineBlockTests"))
         let url = try #require(URL(string: "ws://localhost:18789"))
         let appState = AppState(preview: true)
         appState.connectionMode = .local
         let routeIdentity = OnboardingSystemAgentResumeStore.selectedRouteIdentity(state: appState)
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: routeIdentity,
-            activationTimeoutMs: 30000,
-            defaults: defaults)
-        let recorder = AISetupRequestRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                await recorder.record(message)
-                if request.method == "agents.list" {
-                    task.emitReceiveSuccess(.data(missingConfiguredModelResponse(id: request.id)))
-                }
-            })
-        })
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let view = OnboardingView(
-            state: appState,
-            aiSetupGateway: gateway,
-            systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { routeIdentity })
+        markPending(defaults, for: routeIdentity, timeoutMs: 30000)
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            request.method == "agents.list" ? missingConfiguredModelResponse(id: request.id) : nil
+        }
+        let view = harness.view(state: appState, defaults: defaults, routeIdentityProvider: { routeIdentity })
 
         let initialProbe = try #require(view.onboardingDidAppear())
         await initialProbe.value
         await settleQueuedAISetupTasks()
 
-        #expect(await (recorder.snapshot()).methods == ["agents.list"])
+        #expect(await (harness.recorder.snapshot()).methods == ["agents.list"])
         #expect(view.aiSetup.waitingForPendingActivationDeadline)
-        #expect(OnboardingSystemAgentResumeStore.isPending(
-            for: routeIdentity,
-            defaults: defaults))
+        #expect(isPending(defaults, for: routeIdentity))
         view.onboardingDidDisappear()
     }
 
     @Test func `expired pending activation safely permits a fresh activation`() async throws {
         let suiteName = "OnboardingExpiredPendingActivationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(suiteName: suiteName))
         let url = try #require(URL(string: "ws://localhost:18789"))
         let appState = AppState(preview: true)
         appState.connectionMode = .local
@@ -1960,50 +1817,35 @@ struct OnboardingAISetupTests {
         let activationOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "expired-owner",
             routeFingerprint: "selected-route")
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: routeIdentity,
-            activationOwner: activationOwner,
-            activationTimeoutMs: 0,
-            defaults: defaults,
+        markPending(
+            defaults,
+            for: routeIdentity,
+            owner: activationOwner,
+            timeoutMs: 0,
             now: Date(timeIntervalSinceNow: -10))
-        let recorder = AISetupRequestRecorder()
         let markerObservation = ActivationMarkerObservation()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            switch request.method {
+            case "agents.list":
+                return missingConfiguredModelResponse(id: request.id)
+            case "openclaw.setup.detect":
+                if let callbackDefaults = UserDefaults(suiteName: suiteName) {
+                    await markerObservation.record(!OnboardingSystemAgentResumeStore.isPending(
+                        for: routeIdentity,
+                        defaults: callbackDefaults))
                 }
-                await recorder.record(message)
-                switch request.method {
-                case "agents.list":
-                    task.emitReceiveSuccess(.data(missingConfiguredModelResponse(id: request.id)))
-                case "openclaw.setup.detect":
-                    if let callbackDefaults = UserDefaults(suiteName: suiteName) {
-                        await markerObservation.record(!OnboardingSystemAgentResumeStore.isPending(
-                            for: routeIdentity,
-                            defaults: callbackDefaults))
-                    }
-                    task.emitReceiveSuccess(.data(actionableDetectedSetupResponse(id: request.id)))
-                case "openclaw.setup.activate":
-                    task.emitReceiveSuccess(.data(failedActivationResponse(id: request.id)))
-                default:
-                    break
-                }
-            })
-        })
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let view = OnboardingView(
-            state: appState,
-            aiSetupGateway: gateway,
-            systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { routeIdentity })
+                return actionableDetectedSetupResponse(id: request.id)
+            case "openclaw.setup.activate":
+                return failedActivationResponse(id: request.id)
+            default:
+                return nil
+            }
+        }
+        let view = harness.view(state: appState, defaults: defaults, routeIdentityProvider: { routeIdentity })
 
         let initialProbe = try #require(view.onboardingDidAppear())
         await initialProbe.value
-        let requests = await waitForAISetupRequests(recorder, count: 3)
+        let requests = await waitForAISetupRequests(harness.recorder, count: 3)
 
         #expect(requests.methods == [
             "agents.list",
@@ -2017,8 +1859,7 @@ struct OnboardingAISetupTests {
 
     @Test func `stale missing probe cannot clear a replacement expired owner`() async throws {
         let suiteName = "OnboardingExpiredReplacementOwnerTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(suiteName: suiteName))
         let routeIdentity = "local"
         let originalOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "expired-owner-a",
@@ -2026,101 +1867,62 @@ struct OnboardingAISetupTests {
         let replacementOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "expired-owner-b",
             routeFingerprint: "selected-route")
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: routeIdentity,
-            activationOwner: originalOwner,
-            activationTimeoutMs: 0,
-            defaults: defaults,
+        markPending(
+            defaults,
+            for: routeIdentity,
+            owner: originalOwner,
+            timeoutMs: 0,
             now: Date(timeIntervalSinceNow: -10))
-        let recorder = AISetupRequestRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                await recorder.record(message)
-                switch request.method {
-                case "agents.list":
-                    if let callbackDefaults = UserDefaults(suiteName: suiteName) {
-                        OnboardingSystemAgentResumeStore.markPending(
-                            routeIdentity: routeIdentity,
-                            activationOwner: replacementOwner,
-                            activationTimeoutMs: 0,
-                            defaults: callbackDefaults,
-                            now: Date(timeIntervalSinceNow: -10))
-                    }
-                    task.emitReceiveSuccess(.data(missingConfiguredModelResponse(id: request.id)))
-                case "openclaw.setup.detect":
-                    task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
-                default:
-                    break
-                }
-            })
-        })
         let url = try #require(URL(string: "ws://localhost:18789"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            switch request.method {
+            case "agents.list":
+                if let callbackDefaults = UserDefaults(suiteName: suiteName) {
+                    markPending(
+                        callbackDefaults,
+                        for: routeIdentity,
+                        owner: replacementOwner,
+                        timeoutMs: 0,
+                        now: Date(timeIntervalSinceNow: -10))
+                }
+                return missingConfiguredModelResponse(id: request.id)
+            case "openclaw.setup.detect": return detectedSetupResponse(id: request.id)
+            default: return nil
+            }
+        }
         let appState = AppState(preview: true)
         appState.connectionMode = .local
-        let view = OnboardingView(
-            state: appState,
-            aiSetupGateway: gateway,
-            systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { routeIdentity })
+        let view = harness.view(state: appState, defaults: defaults, routeIdentityProvider: { routeIdentity })
 
         let initialProbe = try #require(view.onboardingDidAppear())
         await initialProbe.value
         await settleQueuedAISetupTasks()
 
-        #expect(await (recorder.snapshot()).methods == ["agents.list"])
-        #expect(OnboardingSystemAgentResumeStore.isOwned(
-            by: replacementOwner,
-            for: routeIdentity,
-            defaults: defaults))
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: routeIdentity,
-            defaults: defaults) == .activationExpired)
+        #expect(await (harness.recorder.snapshot()).methods == ["agents.list"])
+        #expect(isOwned(by: replacementOwner, defaults: defaults, for: routeIdentity))
+        #expect(pendingState(defaults, for: routeIdentity) == .activationExpired)
         #expect(view.aiSetup.phase == .idle)
         view.onboardingDidDisappear()
     }
 
     @Test func `stale missing probe cannot reset inference connected while suspended`() async throws {
-        let suiteName = "OnboardingStaleMissingConnectedTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "local",
-            defaults: defaults)
-        OnboardingSystemAgentResumeStore.markCompleted(
-            ifOwnedBy: "local",
-            defaults: defaults)
-        let recorder = AISetupRequestRecorder()
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingStaleMissingConnectedTests"))
+        markPending(defaults, for: "local")
+        markCompleted(defaults, for: "local")
         let gate = AISetupRequestGate()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                await recorder.record(message)
-                switch request.method {
-                case "agents.list":
-                    await gate.wait()
-                    task.emitReceiveSuccess(.data(missingConfiguredModelResponse(id: request.id)))
-                case "openclaw.setup.detect":
-                    task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
-                default:
-                    break
-                }
-            })
-        })
         let url = try #require(URL(string: "ws://localhost:18789"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            switch request.method {
+            case "agents.list":
+                await gate.wait()
+                return missingConfiguredModelResponse(id: request.id)
+            case "openclaw.setup.detect": return detectedSetupResponse(id: request.id)
+            default: return nil
+            }
+        }
         let appState = AppState(preview: true)
         appState.connectionMode = .local
-        let view = OnboardingView(
-            state: appState,
-            aiSetupGateway: gateway,
-            systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" })
+        let view = harness.view(state: appState, defaults: defaults, routeIdentityProvider: { "local" })
 
         let staleProbe = try #require(view.probeConfiguredGatewayForDashboard(
             startAISetupWhenMissing: true,
@@ -2135,16 +1937,12 @@ struct OnboardingAISetupTests {
         await settleQueuedAISetupTasks()
 
         #expect(view.aiSetup.connected)
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .completed)
-        #expect(await (recorder.snapshot()).methods == ["agents.list"])
+        #expect(pendingState(defaults) == .completed)
+        #expect(await (harness.recorder.snapshot()).methods == ["agents.list"])
     }
 
     @Test func `unavailable configured gateway timeout does not start inference setup`() async throws {
-        let suiteName = "OnboardingUnavailableGatewayTimeoutTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingUnavailableGatewayTimeoutTests"))
         let recorder = AISetupRequestRecorder()
         let session = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(sendHook: { _, message, sendIndex in
@@ -2153,9 +1951,7 @@ struct OnboardingAISetupTests {
             })
         })
         let url = try #require(URL(string: "ws://localhost:18789"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
+        let gateway = makeAISetupGateway(url: url, session: session)
         let appState = AppState(preview: true)
         appState.connectionMode = .local
         let view = OnboardingView(
@@ -2177,32 +1973,26 @@ struct OnboardingAISetupTests {
         #expect(view.aiSetup.phase == .ready)
         #expect(view.aiSetup.configuredGatewayProbeUnavailable)
         #expect(view.aiSetup.detectError != nil)
-        #expect(!OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(!isPending(defaults))
     }
 
     @Test func `remote configured gateway auth routes back without AI detection`() async throws {
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(receiveHook: { task, receiveIndex in
-                if receiveIndex == 0 {
-                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
-                }
-                return .data(GatewayWebSocketTestSupport.connectAuthFailureData(
-                    id: task.snapshotConnectRequestID() ?? "connect",
-                    detailCode: GatewayConnectAuthDetailCode.authTokenMissing.rawValue))
-            })
-        })
         let url = try #require(URL(string: "wss://gateway.example.test"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
+        let harness = AISetupHarness(url: url, receiveHook: { task, receiveIndex in
+            if receiveIndex == 0 {
+                return .data(GatewayWebSocketTestSupport.connectChallengeData())
+            }
+            return .data(GatewayWebSocketTestSupport.connectAuthFailureData(
+                id: task.snapshotConnectRequestID() ?? "connect",
+                detailCode: GatewayConnectAuthDetailCode.authTokenMissing.rawValue))
+        })
         let appState = AppState(preview: true)
         appState.connectionMode = .remote
         appState.remoteTransport = .direct
         appState.remoteUrl = url.absoluteString
-        let view = OnboardingView(
+        let view = harness.view(
             state: appState,
-            aiSetupGateway: gateway,
-            aiSetupRouteIdentityProvider: { "remote:direct:gateway" },
+            routeIdentityProvider: { "remote:direct:gateway" },
             gatewaySelectionPersister: { true })
         view.onboardingVisible = true
         view.currentPage = try #require(view.pageOrder.firstIndex(of: view.aiPageIndex))
@@ -2217,7 +2007,7 @@ struct OnboardingAISetupTests {
         #expect(!view.aiSetup.configuredGatewayProbeUnavailable)
         #expect(view.aiSetup.detectError == nil)
         #expect(view.aiSetup.candidates.isEmpty)
-        #expect(session.latestTask()?.snapshotSendCount() == 1)
+        #expect(harness.session.latestTask()?.snapshotSendCount() == 1)
         let card = OnboardingAISetupView.gatewayAuthCard(for: .tokenRequired)
         #expect(card.title == "Gateway authentication required")
         #expect(card.primaryTitle == "Back to Gateway")
@@ -2245,22 +2035,16 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `remote AI detection auth blocks without candidate fallthrough`() async throws {
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(receiveHook: { task, receiveIndex in
-                if receiveIndex == 0 {
-                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
-                }
-                return .data(GatewayWebSocketTestSupport.connectAuthFailureData(
-                    id: task.snapshotConnectRequestID() ?? "connect",
-                    detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue))
-            })
-        })
         let url = try #require(URL(string: "wss://gateway.example.test"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
+        let harness = AISetupHarness(url: url, receiveHook: { task, receiveIndex in
+            if receiveIndex == 0 {
+                return .data(GatewayWebSocketTestSupport.connectChallengeData())
+            }
+            return .data(GatewayWebSocketTestSupport.connectAuthFailureData(
+                id: task.snapshotConnectRequestID() ?? "connect",
+                detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue))
+        })
+        let model = harness.model(
             routeIdentityProvider: { "remote:direct:gateway" },
             connectionModeProvider: { .remote })
 
@@ -2271,29 +2055,21 @@ struct OnboardingAISetupTests {
         #expect(model.detectError == nil)
         #expect(model.candidates.isEmpty)
         #expect(!model.showManualEntry)
-        #expect(session.latestTask()?.snapshotSendCount() == 1)
+        #expect(harness.session.latestTask()?.snapshotSendCount() == 1)
     }
 
     @Test func `configured gateway probe refuses an unpersisted endpoint selection`() async throws {
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                task.emitReceiveSuccess(.data(configuredModelResponse(id: request.id)))
-            })
-        })
         let url = try #require(URL(string: "ws://localhost:18789"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
+        let harness = AISetupHarness(url: url) { _, request, _ in configuredModelResponse(id: request.id) }
         let appState = AppState(preview: true)
         appState.connectionMode = .remote
         appState.remoteTransport = .direct
         appState.remoteUrl = "wss://replacement.example.test"
         var persistAttempts = 0
-        let view = OnboardingView(
+        let view = makeAISetupView(
             state: appState,
-            aiSetupGateway: gateway,
-            aiSetupRouteIdentityProvider: { "remote:direct:replacement.example.test" },
+            gateway: harness.gateway,
+            routeIdentityProvider: { "remote:direct:replacement.example.test" },
             gatewaySelectionPersister: {
                 persistAttempts += 1
                 return false
@@ -2305,7 +2081,7 @@ struct OnboardingAISetupTests {
 
         #expect(probe == nil)
         #expect(persistAttempts == 1)
-        #expect(session.snapshotMakeCount() == 0)
+        #expect(harness.session.snapshotMakeCount() == 0)
         #expect(!view.aiSetup.connected)
     }
 
@@ -2335,41 +2111,21 @@ struct OnboardingAISetupTests {
 
     @Test func `unavailable gateway error preserves expired and completed markers`() async throws {
         for markerPhase in ["expired", "completed"] {
-            let suiteName = "OnboardingUnavailableGatewayMarkerTests-\(markerPhase)-\(UUID().uuidString)"
-            let defaults = try #require(UserDefaults(suiteName: suiteName))
-            defer { defaults.removePersistentDomain(forName: suiteName) }
-            OnboardingSystemAgentResumeStore.markPending(
-                routeIdentity: "local",
-                activationTimeoutMs: markerPhase == "expired" ? 0 : 30000,
-                defaults: defaults,
+            let defaults =
+                try #require(isolatedAISetupDefaults(prefix: "OnboardingUnavailableGatewayMarkerTests-\(markerPhase)"))
+            markPending(
+                defaults,
+                for: "local",
+                timeoutMs: markerPhase == "expired" ? 0 : 30000,
                 now: markerPhase == "expired" ? Date(timeIntervalSinceNow: -10) : Date())
             if markerPhase == "completed" {
-                OnboardingSystemAgentResumeStore.markCompleted(
-                    ifOwnedBy: "local",
-                    defaults: defaults)
+                markCompleted(defaults, for: "local")
             }
-            let recorder = AISetupRequestRecorder()
-            let session = GatewayTestWebSocketSession(taskFactory: {
-                GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                    guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                    if respondToAISetupHealth(task: task, request: request) {
-                        return
-                    }
-                    await recorder.record(message)
-                    task.emitReceiveSuccess(.data(unavailableGatewayResponse(id: request.id)))
-                })
-            })
             let url = try #require(URL(string: "ws://localhost:18789"))
-            let gateway = GatewayConnection(
-                configProvider: { (url: url, token: nil, password: nil) },
-                sessionBox: WebSocketSessionBox(session: session))
+            let harness = AISetupHarness(url: url) { _, request, _ in unavailableGatewayResponse(id: request.id) }
             let appState = AppState(preview: true)
             appState.connectionMode = .local
-            let view = OnboardingView(
-                state: appState,
-                aiSetupGateway: gateway,
-                systemAgentDefaults: defaults,
-                aiSetupRouteIdentityProvider: { "local" })
+            let view = harness.view(state: appState, defaults: defaults, routeIdentityProvider: { "local" })
             view.onboardingVisible = true
             view.currentPage = try #require(view.pageOrder.firstIndex(of: view.aiPageIndex))
 
@@ -2379,69 +2135,47 @@ struct OnboardingAISetupTests {
             await probe.value
             await settleQueuedAISetupTasks()
 
-            #expect(await (recorder.snapshot()).methods == ["agents.list"])
+            #expect(await (harness.recorder.snapshot()).methods == ["agents.list"])
             #expect(view.aiSetup.phase == .ready)
             #expect(view.aiSetup.configuredGatewayProbeUnavailable)
-            let pendingState = OnboardingSystemAgentResumeStore.pendingState(
-                for: "local",
-                defaults: defaults)
+            let markerState = pendingState(defaults)
             if markerPhase == "expired" {
-                #expect(pendingState == .activationExpired)
+                #expect(markerState == .activationExpired)
             } else {
-                #expect(pendingState == .completed)
+                #expect(markerState == .completed)
             }
 
             let retry = try #require(view.retryConfiguredGatewayProbe())
             await retry.value
-            let retried = await recorder.snapshot()
+            let retried = await harness.recorder.snapshot()
             await settleQueuedAISetupTasks()
 
             #expect(retried.methods == ["agents.list", "agents.list"])
             #expect(view.aiSetup.phase == .ready)
             #expect(view.aiSetup.configuredGatewayProbeUnavailable)
-            #expect(OnboardingSystemAgentResumeStore.pendingState(
-                for: "local",
-                defaults: defaults) == pendingState)
+            #expect(pendingState(defaults) == markerState)
         }
     }
 
     @Test func `unavailable probe resets stale ready setup before successful missing retry`() async throws {
-        let suiteName = "OnboardingUnavailableReadyRetryTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let recorder = AISetupRequestRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                await recorder.record(message)
-                switch request.method {
-                case "openclaw.setup.detect":
-                    task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
-                case "agents.list":
-                    let probeCount = await recorder.snapshot().methods.filter { $0 == "agents.list" }.count
-                    let response = probeCount == 1
-                        ? unavailableGatewayResponse(id: request.id)
-                        : missingConfiguredModelResponse(id: request.id)
-                    task.emitReceiveSuccess(.data(response))
-                default:
-                    break
-                }
-            })
-        })
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingUnavailableReadyRetryTests"))
         let url = try #require(URL(string: "ws://localhost:18789"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
+        let harness = AISetupHarness(url: url) { _, request, recorder in
+            switch request.method {
+            case "openclaw.setup.detect":
+                return detectedSetupResponse(id: request.id)
+            case "agents.list":
+                let probeCount = await recorder.snapshot().methods.filter { $0 == "agents.list" }.count
+                return probeCount == 1
+                    ? unavailableGatewayResponse(id: request.id)
+                    : missingConfiguredModelResponse(id: request.id)
+            default:
+                return nil
+            }
+        }
         let appState = AppState(preview: true)
         appState.connectionMode = .local
-        let view = OnboardingView(
-            state: appState,
-            aiSetupGateway: gateway,
-            systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" })
+        let view = harness.view(state: appState, defaults: defaults, routeIdentityProvider: { "local" })
         view.onboardingVisible = true
         view.currentPage = try #require(view.pageOrder.firstIndex(of: view.aiPageIndex))
 
@@ -2458,7 +2192,7 @@ struct OnboardingAISetupTests {
 
         let retry = try #require(view.retryConfiguredGatewayProbe())
         await retry.value
-        let requests = await waitForAISetupRequests(recorder, count: 4)
+        let requests = await waitForAISetupRequests(harness.recorder, count: 4)
         await settleQueuedAISetupTasks()
 
         #expect(requests.methods == [
@@ -2473,36 +2207,18 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `unavailable retry cannot mutate while activation lease is active`() async throws {
-        let suiteName = "OnboardingUnavailableActiveLeaseRetryTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "local",
-            activationTimeoutMs: 30000,
-            defaults: defaults)
-        let recorder = AISetupRequestRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                await recorder.record(message)
-                let probeCount = await recorder.snapshot().methods.filter { $0 == "agents.list" }.count
-                let response = probeCount == 1
-                    ? unavailableGatewayResponse(id: request.id)
-                    : missingConfiguredModelResponse(id: request.id)
-                task.emitReceiveSuccess(.data(response))
-            })
-        })
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingUnavailableActiveLeaseRetryTests"))
+        markPending(defaults, for: "local", timeoutMs: 30000)
         let url = try #require(URL(string: "ws://localhost:18789"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
+        let harness = AISetupHarness(url: url) { _, request, recorder in
+            let probeCount = await recorder.snapshot().methods.filter { $0 == "agents.list" }.count
+            return probeCount == 1
+                ? unavailableGatewayResponse(id: request.id)
+                : missingConfiguredModelResponse(id: request.id)
+        }
         let appState = AppState(preview: true)
         appState.connectionMode = .local
-        let view = OnboardingView(
-            state: appState,
-            aiSetupGateway: gateway,
-            systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" })
+        let view = harness.view(state: appState, defaults: defaults, routeIdentityProvider: { "local" })
 
         let unavailableProbe = try #require(view.probeConfiguredGatewayForDashboard(
             startAISetupWhenMissing: true,
@@ -2515,54 +2231,33 @@ struct OnboardingAISetupTests {
         await retry.value
         await settleQueuedAISetupTasks()
 
-        #expect(await (recorder.snapshot()).methods == ["agents.list", "agents.list"])
+        #expect(await (harness.recorder.snapshot()).methods == ["agents.list", "agents.list"])
         #expect(view.aiSetup.waitingForPendingActivationDeadline)
-        #expect(OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(isPending(defaults))
     }
 
     @Test func `verified configured model stays read only until pending deadline`() async throws {
-        let suiteName = "OnboardingPendingConfiguredVerificationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingPendingConfiguredVerificationTests"))
         let url = try #require(URL(string: "ws://localhost:18789"))
         let appState = AppState(preview: true)
         appState.connectionMode = .local
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "local",
-            activationTimeoutMs: 30000,
-            defaults: defaults)
-        let recorder = AISetupRequestRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                await recorder.record(message)
-                switch request.method {
-                case "agents.list":
-                    let agentsListCount = await recorder.snapshot().methods.filter {
-                        $0 == "agents.list"
-                    }.count
-                    let response = agentsListCount == 1
-                        ? missingConfiguredModelResponse(id: request.id)
-                        : configuredModelResponse(id: request.id)
-                    task.emitReceiveSuccess(.data(response))
-                case "openclaw.setup.verify":
-                    task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
-                default:
-                    break
-                }
-            })
-        })
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let view = OnboardingView(
-            state: appState,
-            aiSetupGateway: gateway,
-            systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" })
+        markPending(defaults, for: "local", timeoutMs: 30000)
+        let harness = AISetupHarness(url: url) { _, request, recorder in
+            switch request.method {
+            case "agents.list":
+                let agentsListCount = await recorder.snapshot().methods.filter {
+                    $0 == "agents.list"
+                }.count
+                return agentsListCount == 1
+                    ? missingConfiguredModelResponse(id: request.id)
+                    : configuredModelResponse(id: request.id)
+            case "openclaw.setup.verify":
+                return verifiedSetupResponse(id: request.id)
+            default:
+                return nil
+            }
+        }
+        let view = harness.view(state: appState, defaults: defaults, routeIdentityProvider: { "local" })
 
         let initialProbe = try #require(view.onboardingDidAppear())
         await initialProbe.value
@@ -2571,16 +2266,13 @@ struct OnboardingAISetupTests {
             view.probeConfiguredGatewayForDashboard(knownVisible: true))
         await configuredProbe.value
         for _ in 0..<200 {
-            if case .verified = OnboardingSystemAgentResumeStore.pendingState(
-                for: "local",
-                defaults: defaults)
-            {
+            if case .verified = pendingState(defaults) {
                 break
             }
             try? await Task.sleep(nanoseconds: 5_000_000)
         }
 
-        let methods = await recorder.snapshot().methods
+        let methods = await harness.recorder.snapshot().methods
         #expect(Array(methods.prefix(3)) == [
             "agents.list",
             "agents.list",
@@ -2591,10 +2283,7 @@ struct OnboardingAISetupTests {
         #expect(!view.aiSetup.connected)
         #expect(view.aiSetup.waitingForPendingActivationDeadline)
         #expect({
-            if case .verified = OnboardingSystemAgentResumeStore.pendingState(
-                for: "local",
-                defaults: defaults)
-            {
+            if case .verified = pendingState(defaults) {
                 return true
             }
             return false
@@ -2606,9 +2295,7 @@ struct OnboardingAISetupTests {
     func `replacement auth waits for active or verified owner deadline`(
         wasVerified: Bool) async throws
     {
-        let suiteName = "OnboardingReplacementAuthActiveLeaseTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingReplacementAuthActiveLeaseTests"))
         let url = try #require(URL(string: "ws://127.0.0.1:49152"))
         let seedGateway = GatewayConnection(
             configProvider: { (url: url, token: "route-a", password: nil) },
@@ -2631,10 +2318,7 @@ struct OnboardingAISetupTests {
                 defaults: defaults)
         }
         let expectedDeadline: Date
-        switch OnboardingSystemAgentResumeStore.pendingState(
-            for: "remote:ssh:stable-gateway",
-            defaults: defaults)
-        {
+        switch pendingState(defaults, for: "remote:ssh:stable-gateway") {
         case let .activating(storedDeadline), let .verified(storedDeadline):
             expectedDeadline = storedDeadline
         case .activationExpired, .completed, .none:
@@ -2666,20 +2350,16 @@ struct OnboardingAISetupTests {
         #expect(!model.pendingActivationVerification)
         #expect(model.waitingForPendingActivationDeadline)
         #expect(scheduledDeadlines == [expectedDeadline])
-        #expect(OnboardingSystemAgentResumeStore.activationOwner(
-            for: "remote:ssh:stable-gateway",
-            defaults: defaults) == activationOwner)
-        let pendingState = OnboardingSystemAgentResumeStore.pendingState(
-            for: "remote:ssh:stable-gateway",
-            defaults: defaults)
+        #expect(storedActivationOwner(defaults, for: "remote:ssh:stable-gateway") == activationOwner)
+        let storedPendingState = pendingState(defaults, for: "remote:ssh:stable-gateway")
         if wasVerified {
-            guard case let .verified(storedDeadline) = pendingState else {
+            guard case let .verified(storedDeadline) = storedPendingState else {
                 Issue.record("expected verified activation lease")
                 return
             }
             #expect(storedDeadline == expectedDeadline)
         } else {
-            guard case let .activating(storedDeadline) = pendingState else {
+            guard case let .activating(storedDeadline) = storedPendingState else {
                 Issue.record("expected active activation lease")
                 return
             }
@@ -2688,49 +2368,30 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `expired ambiguous activation cannot hand off from same model verification`() async throws {
-        let suiteName = "OnboardingVerifiedExpiredActivationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingVerifiedExpiredActivationTests"))
         let recorder = AISetupRequestRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                await recorder.record(message)
-                switch request.method {
-                case "openclaw.setup.verify":
-                    task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
-                case "openclaw.setup.detect":
-                    task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
-                default:
-                    break
-                }
-            })
-        })
+        let session = makeAISetupRequestSession(recorder: recorder) { task, request in
+            switch request.method {
+            case "openclaw.setup.verify":
+                task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
+            case "openclaw.setup.detect":
+                task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
+            default:
+                break
+            }
+        }
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
+        let gateway = makeAISetupGateway(url: url, session: session)
         let route = try #require(await gateway.captureRoute())
         let activationOwner = try OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "expired-activation",
             routeFingerprint: #require(route.activationOwnershipFingerprint))
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "local",
-            activationOwner: activationOwner,
-            activationTimeoutMs: 0,
-            defaults: defaults,
-            now: Date(timeIntervalSinceNow: -10))
+        markPending(defaults, for: "local", owner: activationOwner, timeoutMs: 0, now: Date(timeIntervalSinceNow: -10))
         OnboardingSystemAgentResumeStore.markVerified(
             ifOwnedBy: "local",
             activationOwner: activationOwner,
             defaults: defaults)
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
         var handedOff = false
         model.onConnected = { handedOff = true }
 
@@ -2742,15 +2403,11 @@ struct OnboardingAISetupTests {
         #expect(!model.connected)
         #expect(!handedOff)
         #expect(requests.methods == ["openclaw.setup.verify", "openclaw.setup.detect"])
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .none)
+        #expect(pendingState(defaults) == .none)
     }
 
     @Test func `relaunch cannot reuse a completed receipt on replacement Gateway auth`() async throws {
-        let suiteName = "OnboardingReplacementRouteReceiptTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingReplacementRouteReceiptTests"))
         let url = try #require(URL(string: "ws://example.invalid"))
         let seedGateway = GatewayConnection(
             configProvider: { (url: url, token: "route-a", password: nil) },
@@ -2761,14 +2418,8 @@ struct OnboardingAISetupTests {
         let activationOwner = try OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "completed-activation",
             routeFingerprint: #require(seedRoute.activationOwnershipFingerprint))
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "local",
-            activationOwner: activationOwner,
-            defaults: defaults)
-        #expect(OnboardingSystemAgentResumeStore.markCompleted(
-            ifOwnedBy: "local",
-            activationOwner: activationOwner,
-            defaults: defaults))
+        markPending(defaults, for: "local", owner: activationOwner)
+        #expect(markCompleted(defaults, owner: activationOwner))
 
         let recorder = AISetupRequestRecorder()
         let gateway = GatewayConnection(
@@ -2797,15 +2448,11 @@ struct OnboardingAISetupTests {
         #expect(outcome == .freshSetupAllowed)
         #expect(!relaunched.connected)
         #expect(requests.methods == ["openclaw.setup.detect"])
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .none)
+        #expect(pendingState(defaults) == .none)
     }
 
     @Test func `relaunch cannot reuse a completed receipt after device token rotation`() async throws {
-        let suiteName = "OnboardingDeviceTokenReceiptRotationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingDeviceTokenReceiptRotationTests"))
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -2854,14 +2501,8 @@ struct OnboardingAISetupTests {
                 routeFingerprint: #require(await seedGateway.activationOwnershipFingerprint(
                     ifCurrentServerLease: seedLease)))
             #expect(await seedGateway.authSource() == .deviceToken)
-            OnboardingSystemAgentResumeStore.markPending(
-                routeIdentity: "local",
-                activationOwner: activationOwner,
-                defaults: defaults)
-            #expect(OnboardingSystemAgentResumeStore.markCompleted(
-                ifOwnedBy: "local",
-                activationOwner: activationOwner,
-                defaults: defaults))
+            markPending(defaults, for: "local", owner: activationOwner)
+            #expect(markCompleted(defaults, owner: activationOwner))
             let persistedReceipt = String(describing: defaults.object(forKey: onboardingSystemAgentPendingKey))
             #expect(!persistedReceipt.contains(originalToken))
             #expect(DeviceAuthStore.loadToken(
@@ -2892,9 +2533,7 @@ struct OnboardingAISetupTests {
             #expect(outcome == .freshSetupAllowed)
             #expect(!relaunched.connected)
             #expect(requests.methods == ["openclaw.setup.detect"])
-            #expect(OnboardingSystemAgentResumeStore.pendingState(
-                for: "local",
-                defaults: defaults) == .none)
+            #expect(pendingState(defaults) == .none)
             #expect(!String(describing: defaults.object(forKey: onboardingSystemAgentPendingKey))
                 .contains(replacementToken))
             await replacementGateway.shutdown()
@@ -2903,8 +2542,7 @@ struct OnboardingAISetupTests {
 
     @Test func `relaunch cannot hand off after completed receipt owner is replaced`() async throws {
         let suiteName = "OnboardingSameModelReplacementOwnerTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(suiteName: suiteName))
         let url = try #require(URL(string: "ws://example.invalid"))
         let recorder = AISetupRequestRecorder()
         let replacementID = "replacement-after-relaunch"
@@ -2927,14 +2565,8 @@ struct OnboardingAISetupTests {
                             let replacementOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
                                 id: replacementID,
                                 routeFingerprint: originalOwner.routeFingerprint)
-                            OnboardingSystemAgentResumeStore.markPending(
-                                routeIdentity: "local",
-                                activationOwner: replacementOwner,
-                                defaults: callbackDefaults)
-                            OnboardingSystemAgentResumeStore.markCompleted(
-                                ifOwnedBy: "local",
-                                activationOwner: replacementOwner,
-                                defaults: callbackDefaults)
+                            markPending(callbackDefaults, for: "local", owner: replacementOwner)
+                            markCompleted(callbackDefaults, for: "local", owner: replacementOwner)
                         }
                         task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
                     default:
@@ -2946,14 +2578,8 @@ struct OnboardingAISetupTests {
         let activationOwner = try OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "completed-before-relaunch",
             routeFingerprint: #require(route.activationOwnershipFingerprint))
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "local",
-            activationOwner: activationOwner,
-            defaults: defaults)
-        #expect(OnboardingSystemAgentResumeStore.markCompleted(
-            ifOwnedBy: "local",
-            activationOwner: activationOwner,
-            defaults: defaults))
+        markPending(defaults, for: "local", owner: activationOwner)
+        #expect(markCompleted(defaults, owner: activationOwner))
         let relaunched = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
@@ -2969,81 +2595,48 @@ struct OnboardingAISetupTests {
         #expect(!relaunched.connected)
         #expect(handoffCount == 0)
         #expect(requests.methods == ["openclaw.setup.verify"])
-        #expect(OnboardingSystemAgentResumeStore.activationOwner(
-            for: "local",
-            defaults: defaults)?.id == replacementID)
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .completed)
+        #expect(storedActivationOwner(defaults)?.id == replacementID)
+        #expect(pendingState(defaults) == .completed)
     }
 
     @Test func `ownerless mutations cannot match an owned activation`() throws {
-        let suiteName = "OnboardingOwnedActivationMutationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingOwnedActivationMutationTests"))
         let activationOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "owned-activation",
             routeFingerprint: "owned-route")
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "local",
-            activationOwner: activationOwner,
-            defaults: defaults)
+        markPending(defaults, for: "local", owner: activationOwner)
 
         OnboardingSystemAgentResumeStore.markVerified(
             ifOwnedBy: "local",
             defaults: defaults)
         #expect({
-            if case .activating = OnboardingSystemAgentResumeStore.pendingState(
-                for: "local",
-                defaults: defaults)
-            {
+            if case .activating = pendingState(defaults) {
                 return true
             }
             return false
         }())
-        #expect(!OnboardingSystemAgentResumeStore.markCompleted(
-            ifOwnedBy: "local",
-            defaults: defaults))
+        #expect(!markCompleted(defaults))
 
         OnboardingSystemAgentResumeStore.clear(
             ifOwnedBy: "local",
             defaults: defaults)
-        #expect(OnboardingSystemAgentResumeStore.isOwned(
-            by: activationOwner,
-            for: "local",
-            defaults: defaults))
+        #expect(isOwned(by: activationOwner, defaults: defaults))
     }
 
     @Test func `pending marker for another route is preserved`() throws {
-        let suiteName = "OnboardingSystemAgentRouteMismatchTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "remote:id:gateway-a",
-            defaults: defaults)
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingSystemAgentRouteMismatchTests"))
+        markPending(defaults, for: "remote:id:gateway-a")
 
-        #expect(!OnboardingSystemAgentResumeStore.isPending(
-            for: "remote:id:gateway-b",
-            defaults: defaults))
-        #expect(OnboardingSystemAgentResumeStore.isPending(
-            for: "remote:id:gateway-a",
-            defaults: defaults))
+        #expect(!isPending(defaults, for: "remote:id:gateway-b"))
+        #expect(isPending(defaults, for: "remote:id:gateway-a"))
     }
 
     @Test func `A to B to A preserves first activation lease`() throws {
-        let suiteName = "OnboardingSystemAgentMultiRouteTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingSystemAgentMultiRouteTests"))
         let now = Date(timeIntervalSince1970: 1_800_000_000)
 
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "remote:id:gateway-a",
-            defaults: defaults,
-            now: now)
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "remote:id:gateway-b",
-            defaults: defaults,
-            now: now.addingTimeInterval(1))
+        markPending(defaults, for: "remote:id:gateway-a", now: now)
+        markPending(defaults, for: "remote:id:gateway-b", now: now.addingTimeInterval(1))
 
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-a",
@@ -3068,39 +2661,25 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `route reset clears only current route lease`() throws {
-        let suiteName = "OnboardingSystemAgentRouteResetTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingSystemAgentRouteResetTests"))
         let routeIdentity = AISetupRouteIdentity("remote:id:gateway-b")
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "remote:id:gateway-a",
-            defaults: defaults)
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "remote:id:gateway-b",
-            defaults: defaults)
+        markPending(defaults, for: "remote:id:gateway-a")
+        markPending(defaults, for: "remote:id:gateway-b")
         let model = OnboardingAISetupModel(
             defaults: defaults,
             routeIdentityProvider: { routeIdentity.snapshot() })
 
         model.resetForGatewayChange()
 
-        #expect(OnboardingSystemAgentResumeStore.isPending(
-            for: "remote:id:gateway-a",
-            defaults: defaults))
-        #expect(!OnboardingSystemAgentResumeStore.isPending(
-            for: "remote:id:gateway-b",
-            defaults: defaults))
+        #expect(isPending(defaults, for: "remote:id:gateway-a"))
+        #expect(!isPending(defaults, for: "remote:id:gateway-b"))
     }
 
     @Test func `gateway selection reset preserves in flight lease`() throws {
-        let suiteName = "OnboardingSystemAgentSelectionResetTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingSystemAgentSelectionResetTests"))
         let appState = AppState(preview: true)
         appState.connectionMode = .local
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "local",
-            defaults: defaults)
+        markPending(defaults, for: "local")
         let view = OnboardingView(
             state: appState,
             systemAgentDefaults: defaults,
@@ -3108,15 +2687,11 @@ struct OnboardingAISetupTests {
 
         view.resetGatewayBoundAIState()
 
-        #expect(OnboardingSystemAgentResumeStore.isPending(
-            for: "local",
-            defaults: defaults))
+        #expect(isPending(defaults, for: "local"))
     }
 
     @Test func `v1 route marker migrates without blocking another route`() throws {
-        let suiteName = "OnboardingSystemAgentV1MigrationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingSystemAgentV1MigrationTests"))
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         defaults.set([
             "version": 1,
@@ -3134,10 +2709,7 @@ struct OnboardingAISetupTests {
             }
             return false
         }())
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "remote:id:gateway-b",
-            defaults: defaults,
-            now: now)
+        markPending(defaults, for: "remote:id:gateway-b", now: now)
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-a",
             defaults: defaults,
@@ -3149,30 +2721,12 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `fallback remote route identity omits auth but preserves endpoint`() {
-        let authenticatedIdentity = OnboardingSystemAgentResumeStore.routeIdentity(
-            connectionMode: .remote,
-            preferredGatewayID: nil,
-            remoteTransport: .direct,
-            remoteURL: "wss://user:secret@gateway.example.test/path?tenant=team-a&token=secret#fragment",
-            remoteTarget: "")
-        let cleanIdentity = OnboardingSystemAgentResumeStore.routeIdentity(
-            connectionMode: .remote,
-            preferredGatewayID: nil,
-            remoteTransport: .direct,
-            remoteURL: "wss://gateway.example.test/path?tenant=team-a",
-            remoteTarget: "")
-        let otherEndpointIdentity = OnboardingSystemAgentResumeStore.routeIdentity(
-            connectionMode: .remote,
-            preferredGatewayID: nil,
-            remoteTransport: .direct,
-            remoteURL: "wss://gateway.example.test/other",
-            remoteTarget: "")
-        let otherQueryIdentity = OnboardingSystemAgentResumeStore.routeIdentity(
-            connectionMode: .remote,
-            preferredGatewayID: nil,
-            remoteTransport: .direct,
-            remoteURL: "wss://gateway.example.test/path?tenant=team-b",
-            remoteTarget: "")
+        let authenticatedIdentity = routeIdentity(
+            .remote,
+            url: "wss://user:secret@gateway.example.test/path?tenant=team-a&token=secret#fragment")
+        let cleanIdentity = routeIdentity(.remote, url: "wss://gateway.example.test/path?tenant=team-a")
+        let otherEndpointIdentity = routeIdentity(.remote, url: "wss://gateway.example.test/other")
+        let otherQueryIdentity = routeIdentity(.remote, url: "wss://gateway.example.test/path?tenant=team-b")
 
         #expect(authenticatedIdentity?.hasPrefix("remote:direct:") == true)
         #expect(authenticatedIdentity?.contains("secret") == false)
@@ -3183,33 +2737,13 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `fallback route identity distinguishes local state dirs and ssh gateway ports`() {
-        let localA = OnboardingSystemAgentResumeStore.routeIdentity(
-            connectionMode: .local,
-            preferredGatewayID: nil,
-            remoteTransport: .direct,
-            remoteURL: "",
-            remoteTarget: "",
-            localStateDir: URL(fileURLWithPath: "/tmp/openclaw-state-a"))
-        let localB = OnboardingSystemAgentResumeStore.routeIdentity(
-            connectionMode: .local,
-            preferredGatewayID: nil,
-            remoteTransport: .direct,
-            remoteURL: "",
-            remoteTarget: "",
-            localStateDir: URL(fileURLWithPath: "/tmp/openclaw-state-b"))
-        let sshA = OnboardingSystemAgentResumeStore.routeIdentity(
-            connectionMode: .remote,
-            preferredGatewayID: nil,
-            remoteTransport: .ssh,
-            remoteURL: "",
-            remoteTarget: "user@gateway.example.test",
-            sshRemotePort: 18789)
-        let sshB = OnboardingSystemAgentResumeStore.routeIdentity(
-            connectionMode: .remote,
-            preferredGatewayID: nil,
-            remoteTransport: .ssh,
-            remoteURL: "",
-            remoteTarget: "user@gateway.example.test",
+        let localA = routeIdentity(.local, localStateDir: URL(fileURLWithPath: "/tmp/openclaw-state-a"))
+        let localB = routeIdentity(.local, localStateDir: URL(fileURLWithPath: "/tmp/openclaw-state-b"))
+        let sshA = routeIdentity(.remote, transport: .ssh, target: "user@gateway.example.test")
+        let sshB = routeIdentity(
+            .remote,
+            transport: .ssh,
+            target: "user@gateway.example.test",
             sshRemotePort: 18790)
 
         #expect(localA?.hasPrefix("local:") == true)
@@ -3218,63 +2752,39 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `fallback remote route identity canonicalizes the persisted URL`() {
-        let beforePersistence = OnboardingSystemAgentResumeStore.routeIdentity(
-            connectionMode: .remote,
-            preferredGatewayID: nil,
-            remoteTransport: .direct,
-            remoteURL: "ws://localhost",
-            remoteTarget: "")
-        let afterPersistence = OnboardingSystemAgentResumeStore.routeIdentity(
-            connectionMode: .remote,
-            preferredGatewayID: nil,
-            remoteTransport: .direct,
-            remoteURL: "ws://localhost:18789",
-            remoteTarget: "")
+        let beforePersistence = routeIdentity(.remote, url: "ws://localhost")
+        let afterPersistence = routeIdentity(.remote, url: "ws://localhost:18789")
 
         #expect(beforePersistence == afterPersistence)
     }
 
     @Test func `activation marks pending before request and clears definitive failure`() async throws {
         let suiteName = "OnboardingActivationMarkerTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(suiteName: suiteName))
         let observation = ActivationMarkerObservation()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupPreparation(task: task, request: request, kind: "codex-cli") {
-                    return
-                }
-                let requestDefaults = UserDefaults(suiteName: suiteName)
-                await observation.record(
-                    requestDefaults.map {
-                        OnboardingSystemAgentResumeStore.isPending(
-                            for: "local",
-                            defaults: $0)
-                    } == true)
-                task.emitReceiveSuccess(.data(failedActivationResponse(id: request.id)))
-            })
-        })
+        let session = makeAISetupRequestSession(preparationKind: "codex-cli") { task, request in
+            let requestDefaults = UserDefaults(suiteName: suiteName)
+            await observation.record(
+                requestDefaults.map {
+                    OnboardingSystemAgentResumeStore.isPending(
+                        for: "local",
+                        defaults: $0)
+                } == true)
+            task.emitReceiveSuccess(.data(failedActivationResponse(id: request.id)))
+        }
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let gateway = makeAISetupGateway(url: url, session: session)
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
 
         await model.detectAndAutoConnect()
         await model.activate(kind: "codex-cli")
 
         #expect(await observation.value())
-        #expect(!OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(!isPending(defaults))
     }
 
     @Test func `stale queued detection cannot probe a replacement Gateway`() async throws {
-        let suiteName = "OnboardingQueuedDetectionRouteTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingQueuedDetectionRouteTests"))
         let url = try #require(URL(string: "ws://example.invalid"))
         let config = AISetupGatewayConfig(url: url, token: "route-a-token")
         let recorder = AISetupRequestRecorder()
@@ -3302,9 +2812,7 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `stale queued selection cannot activate on a replacement Gateway`() async throws {
-        let suiteName = "OnboardingQueuedSelectionRouteTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingQueuedSelectionRouteTests"))
         let url = try #require(URL(string: "ws://example.invalid"))
         let config = AISetupGatewayConfig(url: url, token: "route-a-token")
         let recorder = AISetupRequestRecorder()
@@ -3326,16 +2834,12 @@ struct OnboardingAISetupTests {
 
         let requests = await recorder.snapshot()
         #expect(requests.methods == ["openclaw.setup.detect"])
-        #expect(!OnboardingSystemAgentResumeStore.isPending(
-            for: "remote:id:gateway-b",
-            defaults: defaults))
+        #expect(!isPending(defaults, for: "remote:id:gateway-b"))
         #expect(model.phase == .idle)
     }
 
     @Test func `stale manual key task never sends credentials to a replacement Gateway`() async throws {
-        let suiteName = "OnboardingQueuedManualRouteTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingQueuedManualRouteTests"))
         let url = try #require(URL(string: "ws://example.invalid"))
         let config = AISetupGatewayConfig(url: url, token: "route-a-token")
         let recorder = AISetupRequestRecorder()
@@ -3360,9 +2864,7 @@ struct OnboardingAISetupTests {
         let requests = await recorder.snapshot()
         #expect(requests.methods == ["openclaw.setup.detect"])
         #expect(!requests.apiKeys.contains("old-route-secret"))
-        #expect(!OnboardingSystemAgentResumeStore.isPending(
-            for: "remote:id:gateway-b",
-            defaults: defaults))
+        #expect(!isPending(defaults, for: "remote:id:gateway-b"))
         #expect(!model.manualTesting)
     }
 
@@ -3373,9 +2875,7 @@ struct OnboardingAISetupTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         try await DeviceIdentityStore.withStateDirectory(tempDir) {
-            let suiteName = "OnboardingAutomaticActivationTokenTests-\(UUID().uuidString)"
-            let defaults = try #require(UserDefaults(suiteName: suiteName))
-            defer { defaults.removePersistentDomain(forName: suiteName) }
+            let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingAutomaticActivationTokenTests"))
             let url = try #require(URL(string: "ws://example.invalid"))
             let config = AISetupGatewayConfig(url: url, token: "token-a")
             let recorder = AISetupRequestRecorder()
@@ -3384,36 +2884,28 @@ struct OnboardingAISetupTests {
                 sessionBox: WebSocketSessionBox(session: makeAISetupSession(
                     recorder: recorder,
                     detectedKind: "codex-cli")))
-            let model = OnboardingAISetupModel(
-                gateway: gateway,
-                defaults: defaults,
-                routeIdentityProvider: { "local" })
+            let model = makeAISetupModel(gateway: gateway, defaults: defaults)
 
             await model.detectAndAutoConnect()
             config.switchToken(to: "token-b", afterReads: 2)
             await model.activate(kind: "codex-cli")
 
             #expect(await (recorder.snapshot()).methods == ["openclaw.setup.detect"])
-            #expect(!OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+            #expect(!isPending(defaults))
             #expect(!model.pendingActivationVerification)
             #expect(model.phase == .ready)
         }
     }
 
     @Test func `manual activation rejects an auth-token change before sending the key`() async throws {
-        let suiteName = "OnboardingManualActivationTokenTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingManualActivationTokenTests"))
         let url = try #require(URL(string: "ws://example.invalid"))
         let config = AISetupGatewayConfig(url: url, token: "token-a")
         let recorder = AISetupRequestRecorder()
         let gateway = GatewayConnection(
             configProvider: { config.snapshot() },
             sessionBox: WebSocketSessionBox(session: makeAISetupSession(recorder: recorder)))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
         await model.detectAndAutoConnect()
         model.manualProviderID = "openai-api-key"
         model.manualKey = "must-not-send"
@@ -3428,45 +2920,33 @@ struct OnboardingAISetupTests {
         let requests = await recorder.snapshot()
         #expect(requests.methods == ["openclaw.setup.detect"])
         #expect(!requests.apiKeys.contains("must-not-send"))
-        #expect(!OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(!isPending(defaults))
         #expect(!model.pendingActivationVerification)
         #expect(model.detectError != nil)
     }
 
     @Test func `cancellation after activation dispatch retains pending resume marker`() async throws {
-        let suiteName = "OnboardingDispatchedCancellationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingDispatchedCancellationTests"))
         let url = try #require(URL(string: "ws://example.invalid"))
         let config = AISetupGatewayConfig(url: url, token: "token-a")
         let recorder = AISetupRequestRecorder()
         let gate = AISetupRequestGate()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
-                }
-                await recorder.record(message)
-                if respondToAISetupPreparation(
-                    task: task,
-                    request: request,
-                    kind: "codex-cli")
-                {
-                    return
-                }
-                guard request.method == "openclaw.setup.activate" else { return }
-                await gate.wait()
-                throw CancellationError()
-            })
-        })
+        let session = makeAISetupRequestSession(recorder: recorder) { task, request in
+            if respondToAISetupPreparation(
+                task: task,
+                request: request,
+                kind: "codex-cli")
+            {
+                return
+            }
+            guard request.method == "openclaw.setup.activate" else { return }
+            await gate.wait()
+            throw CancellationError()
+        }
         let gateway = GatewayConnection(
             configProvider: { config.snapshot() },
             sessionBox: WebSocketSessionBox(session: session))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
         var scheduledDeadlines: [(deadline: Date, routeIdentity: String)] = []
         model.onPendingActivationDeadline = { deadline, routeIdentity in
             scheduledDeadlines.append((deadline, routeIdentity))
@@ -3483,7 +2963,7 @@ struct OnboardingAISetupTests {
             "openclaw.setup.detect",
             "openclaw.setup.activate",
         ])
-        #expect(OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(isPending(defaults))
         #expect(model.pendingActivationVerification)
         #expect(model.waitingForPendingActivationDeadline)
         #expect(model.isBusy)
@@ -3493,9 +2973,7 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `indeterminate Gateway activation error retains pending resume marker`() async throws {
-        let suiteName = "OnboardingIndeterminateGatewayActivationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingIndeterminateGatewayActivationTests"))
         let url = try #require(URL(string: "ws://example.invalid"))
         let recorder = AISetupRequestRecorder()
         let gateway = GatewayConnection(
@@ -3510,10 +2988,7 @@ struct OnboardingAISetupTests {
                     task.emitReceiveSuccess(.data(indeterminateActivationResponse(id: request.id)))
                 })
             })))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
         var scheduledRoutes: [String] = []
         model.onPendingActivationDeadline = { _, routeIdentity in
             scheduledRoutes.append(routeIdentity)
@@ -3523,7 +2998,7 @@ struct OnboardingAISetupTests {
         await model.activate(kind: "codex-cli")
 
         #expect(await (recorder.snapshot()).methods == ["openclaw.setup.activate"])
-        #expect(OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(isPending(defaults))
         #expect(model.pendingActivationVerification)
         #expect(model.waitingForPendingActivationDeadline)
         #expect(model.phase == .detecting)
@@ -3532,8 +3007,7 @@ struct OnboardingAISetupTests {
 
     @Test func `ambiguous activation recreates a marker cleared by an earlier probe`() async throws {
         let suiteName = "OnboardingMarkerClearedActivationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(suiteName: suiteName))
         let url = try #require(URL(string: "ws://example.invalid"))
         let recorder = AISetupRequestRecorder()
         let markerObservation = ActivationMarkerObservation()
@@ -3560,15 +3034,10 @@ struct OnboardingAISetupTests {
                     task.emitReceiveSuccess(.data(indeterminateActivationResponse(id: request.id)))
                 })
             })))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
         var scheduledDeadlines: [(deadline: Date, routeIdentity: String)] = []
         model.onPendingActivationDeadline = { deadline, routeIdentity in
-            #expect(OnboardingSystemAgentResumeStore.isPending(
-                for: routeIdentity,
-                defaults: defaults))
+            #expect(isPending(defaults, for: routeIdentity))
             scheduledDeadlines.append((deadline, routeIdentity))
         }
 
@@ -3576,16 +3045,14 @@ struct OnboardingAISetupTests {
         await model.activate(kind: "codex-cli")
 
         #expect(await (recorder.snapshot()).methods == ["openclaw.setup.activate"])
-        #expect(OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(isPending(defaults))
         #expect(model.pendingActivationVerification)
         #expect(model.waitingForPendingActivationDeadline)
         #expect(model.phase == .detecting)
         #expect(scheduledDeadlines.count == 1)
         #expect(scheduledDeadlines.first?.routeIdentity == "local")
         let originalDeadline = try #require(await markerObservation.deadline())
-        let restoredState = OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults)
+        let restoredState = pendingState(defaults)
         guard case let .activating(restoredDeadline) = restoredState else {
             Issue.record("expected restored activation marker")
             return
@@ -3602,8 +3069,7 @@ struct OnboardingAISetupTests {
 
     @Test func `ambiguous activation with cleared marker cannot hand off from same model`() async throws {
         let suiteName = "OnboardingClearedMarkerConfiguredRouteTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(suiteName: suiteName))
         let url = try #require(URL(string: "ws://localhost:18789"))
         let appState = AppState(preview: true)
         appState.connectionMode = .local
@@ -3639,11 +3105,11 @@ struct OnboardingAISetupTests {
                     }
                 })
             })))
-        let view = OnboardingView(
+        let view = makeAISetupView(
             state: appState,
-            aiSetupGateway: gateway,
-            systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" })
+            gateway: gateway,
+            defaults: defaults,
+            routeIdentityProvider: { "local" })
         view.onboardingVisible = true
         var scheduledDeadlines: [Date] = []
         var handoffCount = 0
@@ -3655,7 +3121,7 @@ struct OnboardingAISetupTests {
 
         await view.aiSetup.detectAndAutoConnect()
         await view.aiSetup.activate(kind: "codex-cli")
-        #expect(OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(isPending(defaults))
         #expect(scheduledDeadlines.count == 1)
 
         let initialRecheck = try #require(view.probeConfiguredGatewayForDashboard(
@@ -3675,24 +3141,14 @@ struct OnboardingAISetupTests {
         #expect(!view.aiSetup.connected)
         #expect(view.aiSetup.waitingForPendingActivationDeadline)
         #expect({
-            if case .verified = OnboardingSystemAgentResumeStore.pendingState(
-                for: "local",
-                defaults: defaults)
-            {
+            if case .verified = pendingState(defaults) {
                 return true
             }
             return false
         }())
 
-        let activationOwner = try #require(OnboardingSystemAgentResumeStore.activationOwner(
-            for: "local",
-            defaults: defaults))
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "local",
-            activationOwner: activationOwner,
-            activationTimeoutMs: 0,
-            defaults: defaults,
-            now: Date(timeIntervalSinceNow: -10))
+        let storedOwner = try #require(storedActivationOwner(defaults))
+        markPending(defaults, for: "local", owner: storedOwner, timeoutMs: 0, now: Date(timeIntervalSinceNow: -10))
         let deadlineRecheck = try #require(view.probeConfiguredGatewayForDashboard(
             startAISetupWhenMissing: true,
             knownVisible: true,
@@ -3715,59 +3171,47 @@ struct OnboardingAISetupTests {
         #expect(!view.aiSetup.pendingActivationVerification)
         #expect(!view.aiSetup.waitingForPendingActivationDeadline)
         #expect(handoffCount == 0)
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .none)
+        #expect(pendingState(defaults) == .none)
         view.onboardingDidDisappear()
     }
 
     @Test func `ambiguous activation after lease expiry rechecks before fresh setup`() async throws {
         let suiteName = "OnboardingExpiredDispatchedCancellationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(suiteName: suiteName))
         let url = try #require(URL(string: "ws://localhost:18789"))
         let appState = AppState(preview: true)
         appState.connectionMode = .local
         let recorder = AISetupRequestRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupHealth(task: task, request: request) {
-                    return
+        let session = makeAISetupRequestSession(recorder: recorder) { task, request in
+            switch request.method {
+            case "openclaw.setup.activate":
+                if let requestDefaults = UserDefaults(suiteName: suiteName),
+                   let activationOwner = OnboardingSystemAgentResumeStore.activationOwner(
+                       for: "local",
+                       defaults: requestDefaults)
+                {
+                    markPending(
+                        requestDefaults,
+                        for: "local",
+                        owner: activationOwner,
+                        timeoutMs: 0,
+                        now: Date(timeIntervalSinceNow: -10))
                 }
-                await recorder.record(message)
-                switch request.method {
-                case "openclaw.setup.activate":
-                    if let requestDefaults = UserDefaults(suiteName: suiteName),
-                       let activationOwner = OnboardingSystemAgentResumeStore.activationOwner(
-                           for: "local",
-                           defaults: requestDefaults)
-                    {
-                        OnboardingSystemAgentResumeStore.markPending(
-                            routeIdentity: "local",
-                            activationOwner: activationOwner,
-                            activationTimeoutMs: 0,
-                            defaults: requestDefaults,
-                            now: Date(timeIntervalSinceNow: -10))
-                    }
-                    task.emitReceiveSuccess(.data(indeterminateActivationResponse(id: request.id)))
-                case "agents.list":
-                    task.emitReceiveSuccess(.data(missingConfiguredModelResponse(id: request.id)))
-                case "openclaw.setup.detect":
-                    task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
-                default:
-                    break
-                }
-            })
-        })
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let view = OnboardingView(
+                task.emitReceiveSuccess(.data(indeterminateActivationResponse(id: request.id)))
+            case "agents.list":
+                task.emitReceiveSuccess(.data(missingConfiguredModelResponse(id: request.id)))
+            case "openclaw.setup.detect":
+                task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
+            default:
+                break
+            }
+        }
+        let gateway = makeAISetupGateway(url: url, session: session)
+        let view = makeAISetupView(
             state: appState,
-            aiSetupGateway: gateway,
-            systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" })
+            gateway: gateway,
+            defaults: defaults,
+            routeIdentityProvider: { "local" })
         var recheckTask: Task<Void, Never>?
         var recheckRoute: String?
         view.aiSetup.onPendingActivationDeadline = { _, routeIdentity in
@@ -3794,16 +3238,12 @@ struct OnboardingAISetupTests {
         #expect(view.aiSetup.phase == .ready)
         #expect(!view.aiSetup.pendingActivationVerification)
         #expect(!view.aiSetup.waitingForPendingActivationDeadline)
-        #expect(OnboardingSystemAgentResumeStore.pendingState(
-            for: "local",
-            defaults: defaults) == .none)
+        #expect(pendingState(defaults) == .none)
         view.onboardingDidDisappear()
     }
 
     @Test func `manual indeterminate response schedules pending deadline recheck`() async throws {
-        let suiteName = "OnboardingManualDispatchedCancellationTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingManualDispatchedCancellationTests"))
         let url = try #require(URL(string: "ws://example.invalid"))
         let recorder = AISetupRequestRecorder()
         let gateway = GatewayConnection(
@@ -3811,10 +3251,7 @@ struct OnboardingAISetupTests {
             sessionBox: WebSocketSessionBox(session: makeAISetupSession(
                 recorder: recorder,
                 indeterminateActivationAfterDispatch: true)))
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" })
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
         await model.detectAndAutoConnect()
         model.manualProviderID = "openai-api-key"
         model.manualKey = "temporary-key"
@@ -3836,7 +3273,7 @@ struct OnboardingAISetupTests {
             "openclaw.setup.detect",
             "openclaw.setup.activate",
         ])
-        #expect(OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(isPending(defaults))
         #expect(model.pendingActivationVerification)
         #expect(model.waitingForPendingActivationDeadline)
         #expect(model.phase == .detecting)
@@ -3845,22 +3282,12 @@ struct OnboardingAISetupTests {
     }
 
     @Test func `superseded activation cannot clear the current gateway handoff`() async throws {
-        let suiteName = "OnboardingSupersededActivationMarkerTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
-                if respondToAISetupPreparation(task: task, request: request, kind: "codex-cli") {
-                    return
-                }
-                task.emitReceiveFailure()
-            })
-        })
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingSupersededActivationMarkerTests"))
+        let session = makeAISetupRequestSession(preparationKind: "codex-cli") { task, _ in
+            task.emitReceiveFailure()
+        }
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
+        let gateway = makeAISetupGateway(url: url, session: session)
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
@@ -3868,38 +3295,29 @@ struct OnboardingAISetupTests {
 
         await model.detectAndAutoConnect()
         let staleActivation = Task { await model.activate(kind: "codex-cli") }
-        while !OnboardingSystemAgentResumeStore.isPending(
-            for: "remote:id:gateway-a",
-            defaults: defaults)
-        {
+        while !isPending(defaults, for: "remote:id:gateway-a") {
             await Task.yield()
         }
         model.resetForGatewayChange()
-        OnboardingSystemAgentResumeStore.markPending(
-            routeIdentity: "remote:id:gateway-b",
-            defaults: defaults)
+        markPending(defaults, for: "remote:id:gateway-b")
         staleActivation.cancel()
         await staleActivation.value
 
-        #expect(OnboardingSystemAgentResumeStore.isPending(
-            for: "remote:id:gateway-b",
-            defaults: defaults))
+        #expect(isPending(defaults, for: "remote:id:gateway-b"))
     }
 
     @Test func `configured resume preserves marker until route reset`() throws {
-        let suiteName = "OnboardingConfiguredResumeMarkerTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingConfiguredResumeMarkerTests"))
         let model = OnboardingAISetupModel(
             defaults: defaults,
             routeIdentityProvider: { "local" })
-        OnboardingSystemAgentResumeStore.markPending(routeIdentity: "local", defaults: defaults)
+        markPending(defaults)
 
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
-        #expect(OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(isPending(defaults))
 
         model.resetForGatewayChange()
-        #expect(!OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+        #expect(!isPending(defaults))
     }
 
     @Test func `retired setup socket requires a fresh detection lease`() {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -376,7 +376,7 @@ private func settleQueuedAISetupTasks() async {
 
 private func pendingState(
     _ defaults: UserDefaults,
-    for route: String = "local",
+    for route: String? = "local",
     now: Date = Date()) -> OnboardingSystemAgentResumeStore.PendingState
 {
     OnboardingSystemAgentResumeStore.pendingState(for: route, defaults: defaults, now: now)
@@ -384,7 +384,7 @@ private func pendingState(
 
 private func storedActivationOwner(
     _ defaults: UserDefaults,
-    for route: String = "local",
+    for route: String? = "local",
     now: Date = Date()) -> OnboardingSystemAgentResumeStore.ActivationOwner?
 {
     OnboardingSystemAgentResumeStore.activationOwner(for: route, defaults: defaults, now: now)
@@ -392,7 +392,7 @@ private func storedActivationOwner(
 
 private func isPending(
     _ defaults: UserDefaults,
-    for route: String = "local",
+    for route: String? = "local",
     now: Date = Date()) -> Bool
 {
     OnboardingSystemAgentResumeStore.isPending(for: route, defaults: defaults, now: now)
@@ -401,7 +401,7 @@ private func isPending(
 private func isOwned(
     by owner: OnboardingSystemAgentResumeStore.ActivationOwner,
     defaults: UserDefaults,
-    for route: String = "local") -> Bool
+    for route: String? = "local") -> Bool
 {
     OnboardingSystemAgentResumeStore.isOwned(by: owner, for: route, defaults: defaults)
 }
@@ -409,7 +409,7 @@ private func isOwned(
 @discardableResult
 private func markPending(
     _ defaults: UserDefaults,
-    for route: String = "local",
+    for route: String? = "local",
     owner: OnboardingSystemAgentResumeStore.ActivationOwner? = nil,
     timeoutMs: Double = OnboardingSystemAgentResumeStore.maximumActivationTimeoutMs,
     now: Date = Date()) -> Date?
@@ -425,7 +425,7 @@ private func markPending(
 @discardableResult
 private func markCompleted(
     _ defaults: UserDefaults,
-    for route: String = "local",
+    for route: String? = "local",
     owner: OnboardingSystemAgentResumeStore.ActivationOwner? = nil) -> Bool
 {
     OnboardingSystemAgentResumeStore.markCompleted(
@@ -462,8 +462,8 @@ private typealias AISetupHarnessHandler = @Sendable (
 private func makeAISetupRequestSession(
     recorder: AISetupRequestRecorder? = nil,
     preparationKind: String? = nil,
-    receiveHook: GatewayTestWebSocketTask.ReceiveHook? = nil,
-    handler: @escaping AISetupRequestHandler = { _, _ in }) -> GatewayTestWebSocketSession
+    handler: @escaping AISetupRequestHandler = { _, _ in },
+    receiveHook: GatewayTestWebSocketTask.ReceiveHook? = nil) -> GatewayTestWebSocketSession
 {
     GatewayTestWebSocketSession(taskFactory: {
         GatewayTestWebSocketTask(
@@ -541,20 +541,20 @@ private struct AISetupHarness {
         token: String? = nil,
         password: String? = nil,
         preparationKind: String? = nil,
-        receiveHook: GatewayTestWebSocketTask.ReceiveHook? = nil,
-        handler: @escaping AISetupHarnessHandler = { _, _, _ in nil })
+        handler: @escaping AISetupHarnessHandler = { _, _, _ in nil },
+        receiveHook: GatewayTestWebSocketTask.ReceiveHook? = nil)
     {
         let recorder = AISetupRequestRecorder()
         self.recorder = recorder
         self.session = makeAISetupRequestSession(
             recorder: recorder,
             preparationKind: preparationKind,
-            receiveHook: receiveHook,
             handler: { task, request in
                 if let response = try await handler(task, request, recorder) {
                     task.emitReceiveSuccess(.data(response))
                 }
-            })
+            },
+            receiveHook: receiveHook)
         self.gateway = makeAISetupGateway(
             url: url,
             token: token,
@@ -854,19 +854,6 @@ struct OnboardingAISetupTests {
         let preparedModelRef = "llama-cpp/gemma-4-e4b-it-q4_k_m"
         let session = makeAISetupRequestSession(
             recorder: recorder,
-            receiveHook: { task, receiveIndex in
-                if receiveIndex == 0 {
-                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
-                }
-                let id = task.snapshotConnectRequestID() ?? "connect"
-                return .data(GatewayWebSocketTestSupport.connectOkData(
-                    id: id,
-                    methods: [
-                        "openclaw.setup.prepare.start",
-                        "openclaw.setup.activate",
-                    ],
-                    capabilities: ["openclaw-setup-model-ref"]))
-            },
             handler: { task, request in
                 switch request.method {
                 case "openclaw.setup.detect":
@@ -917,6 +904,19 @@ struct OnboardingAISetupTests {
                 default:
                     break
                 }
+            },
+            receiveHook: { task, receiveIndex in
+                if receiveIndex == 0 {
+                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                }
+                let id = task.snapshotConnectRequestID() ?? "connect"
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: id,
+                    methods: [
+                        "openclaw.setup.prepare.start",
+                        "openclaw.setup.activate",
+                    ],
+                    capabilities: ["openclaw-setup-model-ref"]))
             })
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = makeAISetupGateway(url: url, session: session)


### PR DESCRIPTION
## Summary

- centralize repeated macOS onboarding AI setup gateway, model, view, resume-state, route, and isolated-defaults fixtures
- preserve lifecycle-sensitive restart, cancellation, authentication, request-gate, and device-token scenarios as explicit tests
- compact repeated response JSON while retaining exact mutation semantics

## Root cause and owner boundary

The single onboarding AI setup test suite repeated the same session, gateway, model, view, route, and UserDefaults scaffolding across dozens of cases. The duplication belonged to test fixture ownership, not production. This change creates one canonical test-only harness and leaves the production onboarding, gateway, auth, config, persistence, and protocol owners untouched.

## Canonical fix and removed paths

The fixture now owns decoded request dispatch, health handling, recording, response emission, isolated defaults cleanup, and common model/view construction. Obsolete per-test copies of those flows are removed. Restart generations, mutable auth/route reads, request gates, Keychain/device state, and lazy model/view lifecycle remain specialized where consolidation would hide ordering.

## Scope and LOC

- production: +0 / -0
- tests: +879 / -1461
- net: -582 LOC
- config/API/default/schema/protocol changes: none

## Parity

- 89 test declarations; declaration lines and titles byte-identical
- 90 expanded runtime cases
- 401 #expect
- 153 #require
- 8 Issue.record

## Validation

- canonical SwiftFormat write + lint
- swiftc parser
- git diff --check
- helper-shadowing and compact-JSON mutation scans
- exact final Blacksmith check:changed delegation: passed, including 217 relevant app/tooling tests and repository guards
- two independent gpt-5.6-sol xhigh reviews: clean after correcting URL typing, JSON replacement, and Swift name-shadowing findings
- central open-PR collision census and immediate delta: zero exact-path matches through 2026-08-02T17:44Z

Exact corrected-head native proof is green at a43049c3154c06ab19d7a67f425e1d3203a2bb8a:
- [macOS Swift job](https://github.com/openclaw/openclaw/actions/runs/30760683923/job/91530534506): release build, OpenClawKit opt-out build, 1,314 OpenClawKit tests in 101 suites, and 1,597 macOS tests in 178 suites all passed; OnboardingAISetupTests explicitly passed in 4.447s
- [macOS Periphery](https://github.com/openclaw/openclaw/actions/runs/30760676890): passed
- [Shared OpenClawKit Periphery](https://github.com/openclaw/openclaw/actions/runs/30760677070): passed

The normal ready-PR required CI gate remains the final landing gate.

## Dependency and Codex contracts

The review checked pinned ConcurrencyExtras LockIsolated behavior and existing same-target usage. Both independent reviewers personally inspected sibling Codex at ee0247f95a6f, including canonical openai provider/auth routing and session persistence in codex-rs/model-provider-info/src/lib.rs, codex-rs/login/src/auth/manager.rs, codex-rs/core/src/session/session.rs, and the gpt-5.5 model catalog.