### PR TITLE
fix(memory): handle QMD watcher errors

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager-lifecycle.ts
+++ b/extensions/memory-core/src/memory/qmd-manager-lifecycle.ts
@@ -48,6 +48,10 @@ export abstract class QmdManagerLifecycle extends QmdManagerSync {
     watcher.on("add", markDirty);
     watcher.on("change", markDirty);
     watcher.on("unlink", markDirty);
+    watcher.on("error", (err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      qmdManagerLog.warn(`qmd watcher error: ${message}`);
+    });
     watcher.once("ready", () => {
       this.warnIfWatchPressure(countChokidarWatchedEntries(watcher));
       qmdManagerLog.info(

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1325,6 +1325,31 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("logs qmd watcher errors instead of throwing", async () => {
+    configureQmd(
+      { update: { interval: "0s", debounceMs: 0, onBoot: false } },
+      {
+        search: {
+          provider: "openai",
+          model: "mock-embed",
+          store: { vector: { enabled: false } },
+          sync: { watch: true, onSessionStart: false, onSearch: false },
+        },
+      },
+    );
+
+    const { manager } = await createManager({ mode: "full" });
+    expect(watchMock).toHaveBeenCalledTimes(1);
+    const watcher = watchMock.mock.results[0]?.value as EventEmitter;
+
+    expect(() => {
+      watcher.emit("error", new Error("ENOSPC: watcher limit reached"));
+    }).not.toThrow();
+    expectMockMessageContains(logWarnMock, "qmd watcher error: ENOSPC: watcher limit reached");
+
+    await manager.close();
+  });
+
   it("runs qmd sync when watched collection files change", async () => {
     vi.useFakeTimers();
     configureQmd(


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

Fixes an issue where operators using QMD memory collections could have the owning OpenClaw process terminate when the operating system rejected a filesystem watch.

## Why This Change Was Made

The QMD lifecycle now handles the Chokidar watcher's `error` event at the same owner boundary as add, change, unlink, ready, and close. It logs the concrete failure and leaves the manager available for explicit sync, search, and shutdown.

### Root Cause

`QmdManagerLifecycle.ensureWatcher()` created a long-lived Chokidar watcher without an `error` listener. Chokidar 5 emits watch failures through Node's special EventEmitter `error` event; without a listener, the event is thrown.

## User Impact

QMD watcher failures are visible in logs without terminating the owning process. Existing file-change synchronization, debounce behavior, pressure reporting, and shutdown ownership are unchanged.

## Evidence

Final maintainer head: `fa5f6af5e536e084f67f50d6895cb776b6d28c32`

- Baseline reproduction on `cafb5887fee1bf58501d2596f1efc8a509c5cebc`: the focused regression failed because `watcher.emit("error", ...)` threw (`1 failed`, `162 skipped`).
- Focused final-head regression: `1 passed`, `162 skipped`.
- Final-head Blacksmith Testbox proof: `4` files and `303` tests passed, including the two former CI timeout surfaces:
  - `extensions/memory-core/src/memory/qmd-manager.test.ts`
  - `extensions/memory-core/src/memory/manager.watcher-config.test.ts`
  - `extensions/memory-core/src/memory/index.test.ts`
  - `extensions/memory-wiki/src/corpus-supplement.visibility.test.ts`
  - Run: https://github.com/openclaw/openclaw/actions/runs/30760772648
- Final-head changed gate passed formatting, extension production/test typechecks, lint, dependency pins, plugin boundaries, database-first guards, dead-code checks, and runtime import-cycle checks.
  - Run: https://github.com/openclaw/openclaw/actions/runs/30761108214
- `git diff --check` passed.
- Production delta: `+4/-0`; tests: `+25/-0`.

The contributor also supplied an all-real QMD/Chokidar EACCES transcript on source head `0417662046a31d48cd0a4c4af42387fd82867583`, showing the errors logged, the manager remaining alive, and clean close. The final maintainer head is a rebase-only rewrite of that same two-file patch.

### Dependency Contract

- Chokidar `5.0.0` declares `error` in `FSWatcherEventMap`.
- Its `_handleError` implementation emits `EV.ERROR` for non-ignored watch failures.
- The sibling non-QMD memory watcher already uses the same log-and-continue ownership policy.

### Preserved Boundaries

- No config, SDK, protocol, schema, storage, or migration surface changed.
- QMD add/change/unlink scheduling is unchanged.
- No watcher restart or fallback policy was introduced.