### PR TITLE
test(msteams): avoid hanging response clones

### DIFF
--- a/extensions/msteams/src/attachments/bot-framework.test.ts
+++ b/extensions/msteams/src/attachments/bot-framework.test.ts
@@ -107,7 +107,9 @@ function createMockFetch(entries: Array<{ match: RegExp; response: Response }>):
     if (!entry) {
       return new Response("not found", { status: 404 });
     }
-    return entry.response.clone();
+    // Fetch returns one body. Cloning tees it, so canceling the returned branch
+    // would wait forever for the untouched fixture branch to be canceled too.
+    return entry.response;
   }) as typeof fetch;
 }
 


### PR DESCRIPTION
## Summary

- return the one-shot mocked fetch response directly in the Teams Bot Framework attachment tests
- avoid teeing response bodies whose untouched fixture branch prevents cancellation from settling
- preserve all 25 assertions, including cleanup failures, invalid content lengths, response size bounds, and attachment fallback behavior

## Performance

Before this change, the focused file reproduced a 120-second timeout on its first cleanup case, and the full test baseline showed four such cases exhausting the timeout. After the change, all 25 tests pass in 5.08 seconds wall time with 50 ms spent in test bodies.

## Proof

- `/usr/bin/time -l node scripts/run-vitest.mjs extensions/msteams/src/attachments/bot-framework.test.ts --maxWorkers=1 --reporter=verbose`
- `git diff --check`
- Codex autoreview: clean, no accepted/actionable findings

The changed-file gate attempted approved remote delegation but neither Blacksmith Testbox nor brokered Crabbox was available, so focused trusted-source proof ran locally under the documented fallback.
