### PR TITLE
docs(plugins): document session-end shutdown drain deadline

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -192,6 +192,12 @@ turn with a synthetic reply or silence, use `before_agent_reply`.
 | `before_compaction` / `after_compaction` | Observe or annotate compaction cycles                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `before_reset`                           | Observe session-reset events (`/reset`, programmatic resets)                                                                                                                                                                                                                                                                                                                                                                                                     |
 
+Shutdown and restart share one **2-second total `session_end` drain budget**
+across all active sessions and plugin handlers; the budget is not per handler.
+Return quickly or keep finalization bounded and persistence crash-consistent.
+If the budget expires, OpenClaw logs `session-end-drain timed out` and continues
+shutdown, so unfinished plugin work can be interrupted.
+
 For `sessions.create` calls with `parentSessionKey` and `emitCommandHooks: true`, a distinct child always receives `session_start`. Callers declare whether the parent also receives terminal `session_end` with `succeedsParent`: `true` means successor, `false` means parallel child. Omission preserves the legacy parent-rollover behavior. The `command:new` and `before_reset` hooks still describe the requested `/new` action in both cases.
 
 **Subagents**


### PR DESCRIPTION
Closes #81310

## What Problem This Solves

Plugin maintainers can receive session_end with shutdown or restart but the public hook reference did not document the shared termination deadline, allowing plugins to assume unbounded cleanup time.

## Why This Change Was Made

Document the existing gateway contract in the canonical plugin hook reference: one two-second total session_end drain budget covers every active session and every handler; expiry logs a warning and shutdown continues.

## User Impact

Plugin authors can keep termination cleanup bounded and persistence crash-consistent. Existing runtime behavior, plugin APIs, configuration, and defaults are unchanged.

## Evidence

- Gateway constant ACTIVE_SESSIONS_SHUTDOWN_DRAIN_TIMEOUT_MS is 2,000 ms and the close owner passes it as totalTimeoutMs.
- Existing shutdown regression verifies the timeout warning and continued termination.
- pnpm docs:list succeeded; canonical oxfmt check and git diff --check passed.
- Docs-only change: one public hook reference, six lines.
