### PR TITLE
fix(cron): reject malformed Code Mode scripts when scheduling

### DIFF
--- a/src/agents/code-mode-runtime.test.ts
+++ b/src/agents/code-mode-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   prepareSource,
   resolveCodeModeConfig,
 } from "./code-mode-runtime.js";
+import { parseCodeModeScriptSyntax } from "./code-mode-script-syntax.js";
 
 const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
 
@@ -104,6 +105,15 @@ describe("Code Mode master switch resolution", () => {
 });
 
 describe("Code Mode guest source validation", () => {
+  it("reports syntax errors at user-relative locations", () => {
+    expect(parseCodeModeScriptSyntax("const x = ;")).toEqual({
+      ok: false,
+      message: "Unexpected token",
+      line: 1,
+      column: 10,
+    });
+  });
+
   it.each([
     {
       name: "import-shaped template text",

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -9,6 +9,10 @@ import { resolveAgentConfig } from "./agent-scope-config.js";
 import { toCodeModeJsonSafe } from "./code-mode-json.js";
 import type { CodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
 import {
+  buildCodeModeScriptParseSource,
+  parseCodeModeScriptSyntax,
+} from "./code-mode-script-syntax.js";
+import {
   CODE_MODE_SHELL_SOURCE_ERROR,
   isShellLikeCodeModeSource,
 } from "./code-mode-shell-source.js";
@@ -381,10 +385,10 @@ function maskCodeLiteralsAndComments(
   };
 
   try {
-    const prefix = "(async () => {\n";
-    parse(`${prefix}${code}\n})`, {
+    const wrapped = buildCodeModeScriptParseSource(code);
+    parse(wrapped.source, {
       ecmaVersion: "latest",
-      onComment: (_isBlock, _text, start, end) => maskRange(start, end, prefix.length),
+      onComment: (_isBlock, _text, start, end) => maskRange(start, end, wrapped.codeOffset),
       onToken: (token) => {
         // Parse in the real async guest context: standalone tokenization can
         // mistake executable division for a regex after contextual keywords.
@@ -393,7 +397,7 @@ function maskCodeLiteralsAndComments(
           token.type.label === "regexp" ||
           token.type.label === "template"
         ) {
-          maskRange(token.start, token.end, prefix.length);
+          maskRange(token.start, token.end, wrapped.codeOffset);
         }
       },
     });
@@ -549,20 +553,17 @@ function rejectsModuleAccess(
   code: string,
   typescriptRuntime?: typeof import("typescript"),
 ): boolean {
-  try {
-    const source = parse(`(async () => {\n${code}\n})`, {
-      ecmaVersion: "latest",
-    });
+  const parsed = parseCodeModeScriptSyntax(code);
+  if (parsed.ok) {
     // The WASI guest has no host module loader. Only executable module syntax
     // belongs in this early check; ordinary guest methods are not capabilities.
-    return containsModuleAccess(source);
-  } catch {
-    if (typescriptRuntime) {
-      try {
-        return typeScriptContainsModuleAccess(code, typescriptRuntime);
-      } catch {
-        // Keep malformed input on the conservative lexical fallback.
-      }
+    return containsModuleAccess(parsed.program);
+  }
+  if (typescriptRuntime) {
+    try {
+      return typeScriptContainsModuleAccess(code, typescriptRuntime);
+    } catch {
+      // Keep malformed input on the conservative lexical fallback.
     }
   }
   const source = maskCodeLiteralsAndComments(code, typescriptRuntime);

--- a/src/agents/code-mode-script-syntax.ts
+++ b/src/agents/code-mode-script-syntax.ts
@@ -1,0 +1,34 @@
+import { parse, type Position, type Program } from "acorn";
+
+type AcornSyntaxError = SyntaxError & { loc: Position };
+
+type CodeModeScriptParseResult =
+  | { ok: true; program: Program }
+  | { ok: false; message: string; line: number; column: number };
+
+/** Mirrors the worker's async-arrow body grammar so valid top-level await/return stay legal. */
+export function buildCodeModeScriptParseSource(code: string): {
+  source: string;
+  codeOffset: number;
+} {
+  const prefix = "(async () => {\n";
+  return { source: `${prefix}${code}\n})`, codeOffset: prefix.length };
+}
+
+export function parseCodeModeScriptSyntax(code: string): CodeModeScriptParseResult {
+  const { source } = buildCodeModeScriptParseSource(code);
+  try {
+    return {
+      ok: true,
+      program: parse(source, { ecmaVersion: "latest" }),
+    };
+  } catch (error) {
+    const syntaxError = error as AcornSyntaxError;
+    return {
+      ok: false,
+      message: syntaxError.message.replace(/ \(\d+:\d+\)$/u, ""),
+      line: syntaxError.loc.line - 1,
+      column: syntaxError.loc.column,
+    };
+  }
+}

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -741,6 +741,17 @@ describe("script payload validation", () => {
     ).toThrow("cron script payload has a syntax error");
   });
 
+  it("still allows disabling a job stored with a malformed script", () => {
+    const job = createJob(createMockState(now, { scriptPayloadsEnabled: true }), input());
+    // Simulate a job persisted before syntax validation shipped.
+    job.payload = { ...job.payload, kind: "script", script: "const x = ;" };
+
+    expect(() =>
+      applyJobPatch(job, { enabled: false }, { cronConfig: { triggers: { enabled: true } } }),
+    ).not.toThrow();
+    expect(job.enabled).toBe(false);
+  });
+
   it.each([
     ["top-level await", "await tools.wait(1); return 1"],
     ["top-level return", "return 1"],

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -697,7 +697,10 @@ describe("cron tool authority defaults", () => {
 
 describe("script payload validation", () => {
   const now = Date.parse("2026-07-18T12:00:00.000Z");
-  const input = (sessionTarget: CronJob["sessionTarget"] = "isolated") => ({
+  const input = (
+    sessionTarget: CronJob["sessionTarget"] = "isolated",
+    script = "return { state: { count: 1 } }",
+  ) => ({
     name: "script-job",
     enabled: true,
     schedule: { kind: "every" as const, everyMs: 60_000 },
@@ -705,7 +708,7 @@ describe("script payload validation", () => {
     wakeMode: "now" as const,
     payload: {
       kind: "script" as const,
-      script: "return { state: { count: 1 } }",
+      script,
       timeoutSeconds: 4_000,
       toolBudget: 4_000,
     },
@@ -715,6 +718,36 @@ describe("script payload validation", () => {
     expect(() =>
       createJob(createMockState(now, { scriptPayloadsEnabled: false }), input()),
     ).toThrow("cron.triggers.enabled=true");
+  });
+
+  it("rejects malformed scripts on creation with a user-relative location", () => {
+    expect(() =>
+      createJob(
+        createMockState(now, { scriptPayloadsEnabled: true }),
+        input("isolated", "const x = ;"),
+      ),
+    ).toThrow("cron script payload has a syntax error: Unexpected token (line 1, column 10)");
+  });
+
+  it("rejects malformed scripts on patch", () => {
+    const job = createJob(createMockState(now, { scriptPayloadsEnabled: true }), input());
+
+    expect(() =>
+      applyJobPatch(
+        job,
+        { payload: { kind: "script", script: "const x = ;" } },
+        { cronConfig: { triggers: { enabled: true } } },
+      ),
+    ).toThrow("cron script payload has a syntax error");
+  });
+
+  it.each([
+    ["top-level await", "await tools.wait(1); return 1"],
+    ["top-level return", "return 1"],
+  ])("accepts %s", (_name, script) => {
+    expect(() =>
+      createJob(createMockState(now, { scriptPayloadsEnabled: true }), input("isolated", script)),
+    ).not.toThrow();
   });
 
   it.each(["current", "session:reporting"] as const)(

--- a/src/cron/service/jobs-validation.ts
+++ b/src/cron/service/jobs-validation.ts
@@ -1,4 +1,5 @@
 /** Validation helpers for cron schedules, targets, payloads, and delivery. */
+import { parseCodeModeScriptSyntax } from "../../agents/code-mode-script-syntax.js";
 import { resolveCronTriggerMinIntervalMs } from "../../config/cron-limits.js";
 import type { CronConfig } from "../../config/types.cron.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -60,6 +61,12 @@ export function assertScriptPayloadSupport(
   }
   if (!job.payload.script.trim()) {
     throw new Error("cron script payload must not be empty");
+  }
+  const parsed = parseCodeModeScriptSyntax(job.payload.script);
+  if (!parsed.ok) {
+    throw new Error(
+      `cron script payload has a syntax error: ${parsed.message} (line ${parsed.line}, column ${parsed.column})`,
+    );
   }
   if (job.trigger) {
     // Both script kinds expose trigger.state, so composing them would give one

--- a/src/cron/service/jobs-validation.ts
+++ b/src/cron/service/jobs-validation.ts
@@ -54,7 +54,7 @@ export function assertSupportedJobSpec(
 
 export function assertScriptPayloadSupport(
   job: Pick<CronJob, "payload" | "trigger">,
-  opts?: { cronConfig?: CronConfig; requireEnabled?: boolean },
+  opts?: { cronConfig?: CronConfig; requireEnabled?: boolean; validateSyntax?: boolean },
 ) {
   if (job.payload.kind !== "script") {
     return;
@@ -62,11 +62,13 @@ export function assertScriptPayloadSupport(
   if (!job.payload.script.trim()) {
     throw new Error("cron script payload must not be empty");
   }
-  const parsed = parseCodeModeScriptSyntax(job.payload.script);
-  if (!parsed.ok) {
-    throw new Error(
-      `cron script payload has a syntax error: ${parsed.message} (line ${parsed.line}, column ${parsed.column})`,
-    );
+  if (opts?.validateSyntax !== false) {
+    const parsed = parseCodeModeScriptSyntax(job.payload.script);
+    if (!parsed.ok) {
+      throw new Error(
+        `cron script payload has a syntax error: ${parsed.message} (line ${parsed.line}, column ${parsed.column})`,
+      );
+    }
   }
   if (job.trigger) {
     // Both script kinds expose trigger.state, so composing them would give one

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -417,6 +417,10 @@ export function applyJobPatch(
   assertScriptPayloadSupport(job, {
     cronConfig: opts?.cronConfig,
     requireEnabled: patch.payload?.kind === "script",
+    // Enabled-only/rename patches must keep working on jobs stored with a
+    // malformed script (pre-validation persistence); re-check syntax only
+    // when this patch rewrites the payload, or disable becomes a dead end.
+    validateSyntax: patch.payload !== undefined,
   });
   assertStreamScheduleSupport(job, {
     cronConfig: opts?.cronConfig,

--- a/src/gateway/server-methods/cron-error-classification.test.ts
+++ b/src/gateway/server-methods/cron-error-classification.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { isCronInvalidRequestError } from "./cron-error-classification.js";
+
+describe("isCronInvalidRequestError", () => {
+  it.each([
+    "cron script payload has a syntax error: Unexpected token (line 1, column 10)",
+    "cron script payload must not be empty",
+    "cron script payloads cannot be combined with a condition trigger",
+    "cron script payloads are disabled; set cron.triggers.enabled=true to allow unattended scripts",
+  ])("classifies script payload validation: %s", (message) => {
+    expect(isCronInvalidRequestError(new Error(message))).toBe(true);
+  });
+
+  it("does not classify unrelated script runtime failures", () => {
+    expect(isCronInvalidRequestError(new Error("cron script payload runtime failed"))).toBe(false);
+  });
+});

--- a/src/gateway/server-methods/cron-error-classification.ts
+++ b/src/gateway/server-methods/cron-error-classification.ts
@@ -8,6 +8,10 @@ export function isCronInvalidRequestError(err: unknown): boolean {
     message.includes("cron job id must not be blank") ||
     message.includes("cron declarationKey") ||
     message.includes("cron displayName") ||
+    message.includes("cron script payload has a syntax error") ||
+    message.includes("cron script payload must not be empty") ||
+    message.includes("cron script payloads cannot be combined") ||
+    message.includes("cron script payloads are disabled") ||
     message.includes("cron triggers are disabled") ||
     message.includes("cron triggers require") ||
     message.includes("cron trigger every interval") ||

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -709,6 +709,33 @@ describe("gateway server cron", () => {
     }
   });
 
+  test("returns INVALID_REQUEST for malformed cron scripts", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-script-syntax-",
+      cronEnabled: true,
+    });
+    const cronState = await createDirectCronState();
+
+    try {
+      const response = await directCronReq(cronState, "cron.add", {
+        name: "malformed script",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: { kind: "script", script: "const x = ;" },
+      });
+
+      expect(response.ok).toBe(false);
+      expect(response.error?.code).toBe("INVALID_REQUEST");
+      expect(response.error?.message).toContain(
+        "cron script payload has a syntax error: Unexpected token (line 1, column 10)",
+      );
+    } finally {
+      await cleanupCronTestRun({ cronState, prevSkipCron });
+    }
+  });
+
   test("cron.add leaves legacy top-level array stores for doctor migration", async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-legacy-array-",


### PR DESCRIPTION
Fixes #118088

## What Problem This Solves

Fixes an issue where operators or agents creating Code Mode cron jobs could persist malformed JavaScript successfully, only for every scheduled run to fail later without feeding the syntax error back to the creating call.

## Why This Change Was Made

Cron script payload validation now parses JavaScript in the same async-arrow body grammar used by the Code Mode worker before add, update, or declarative apply can persist the job. Parse failures include user-relative line and column details, and the cron gateway classifies every error owned by the script-payload validator as `INVALID_REQUEST`; interactive Code Mode still preserves malformed JavaScript for guest-side diagnostics.

The researched Acorn wrapper is grammar-equivalent rather than byte-for-byte identical to the worker's assignment and invoked-IIFE source. This change centralizes the shared async-arrow parse wrapper without changing worker execution. There was also no standalone classification test on the base revision, so this adds focused colocated coverage plus a real-service cron handler test.

## User Impact

CLI and agent-tool callers now receive an actionable syntax error in the original cron create or update response, before a broken job is saved. Legal top-level `await` and `return` remain accepted.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs src/cron/service.jobs.test.ts` failed the new create and patch cases because malformed scripts were accepted (2 failed, 99 passed).
- `node scripts/run-vitest.mjs src/cron/service.jobs.test.ts` — 101 passed.
- `node scripts/run-vitest.mjs src/agents/code-mode-runtime.test.ts` — 94 passed.
- `node scripts/run-vitest.mjs src/gateway/server-methods/cron-error-classification.test.ts` — 5 passed.
- `node scripts/run-vitest.mjs src/gateway/server.cron.test.ts` — 24 passed, including the real cron service returning `INVALID_REQUEST` with the adjusted syntax location.
- `node scripts/check-changed.mjs` — remote routing could not start because Blacksmith was unavailable and no brokered cloud provider was authenticated.
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs` — passed locally as the trusted-source fallback, including formatting, dead exports, core/core-test typecheck, core lint, import cycles, and state/database guards.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
- A source-blind public-CLI probe launched an isolated gateway successfully, but the gateway restart after public config changes was blocked by missing rebuilt runtime artifacts. No black-box creation pass is claimed; the isolated process and temporary state were removed.


---

## Follow-up: stored-malformed-job recovery + black-box proof (896c6b71a0a)

ClawSweeper's compatibility flag was confirmed real: `applyJobPatch` runs `assertScriptPayloadSupport` on the merged job for **every** patch, so a job persisted with a malformed script (pre-validation) could not even be disabled — the operator recovery path dead-ended. Fixed by gating syntax validation to patches that actually rewrite the payload (`validateSyntax: patch.payload !== undefined`); create and declarative-apply always validate. Regression test: "still allows disabling a job stored with a malformed script".

### Black-box CLI proof (dist build, ephemeral gateway, isolated state dir, port 19871)

```
=== 1. malformed script rejected at creation ===
GatewayClientRequestError: invalid cron.add params: cron script payload has a syntax error: Unexpected token (line 1, column 10)
exit=1
=== 2. nothing persisted ===
automations list --all --json | grep -c proof-malformed  ->  0
=== 3. legal top-level await + return accepted ===
job created, "nextRunAtMs": 1798801200000, exit=0
=== 4. multiline error location is user-relative ===
script "const a = 1;\nconst b = )" -> syntax error (line 2, column 10)
```

Validation for the follow-up commit: `node scripts/run-vitest.mjs src/cron/service.jobs.test.ts` (102 passed), `src/gateway/server-methods/cron-error-classification.test.ts` + `src/agents/code-mode-runtime.test.ts` (2 shards passed), `scripts/run-oxlint.mjs` on touched files, `pnpm tsgo` exit 0. Testbox delegation was unavailable (Crabbox broker auth); type/lint lanes ran locally per the documented fallback, hosted CI on this head is the authoritative gate.
