### PR TITLE
fix(agents): preserve model selection during gateway draining

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
+import { GatewayDrainingError } from "../process/gateway-work-admission.js";
 import { classifyFailoverSignal } from "./embedded-agent-helpers/errors.js";
 import {
   buildFailoverRemediationHint,
@@ -1426,6 +1427,20 @@ describe("failover-error", () => {
       const abortWrapper = new Error("request was aborted", { cause: staleLifecycle });
       abortWrapper.name = "AbortError";
       expect(isNonProviderRuntimeCoordinationError(abortWrapper)).toBe(true);
+    });
+
+    it("returns true for direct and nested gateway drain admission failures", () => {
+      const draining = new GatewayDrainingError();
+      const causeWrapper = new Error("session send failed", { cause: draining });
+      const aggregateWrapper = new AggregateError(
+        [new Error("cleanup failed"), { error: draining }],
+        "agent run failed",
+      );
+
+      for (const error of [draining, causeWrapper, aggregateWrapper]) {
+        expect(isNonProviderRuntimeCoordinationError(error)).toBe(true);
+        expect(resolveModelFallbackError(error)).toEqual({ kind: "coordination", error });
+      }
     });
 
     it("returns true when the coordination error is nested via cause", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -6,7 +6,7 @@
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { formatCliCommand } from "../cli/command-format.js";
 import { isAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
-import { readErrorName } from "../infra/errors.js";
+import { collectErrorGraphCandidates, readErrorName } from "../infra/errors.js";
 import {
   classifyFailoverSignal,
   extractFailoverSignalDetails,
@@ -505,6 +505,13 @@ function hasStaleAgentRunLifecycleFailure(err: unknown): boolean {
   );
 }
 
+function hasGatewayDrainingFailure(err: unknown): boolean {
+  return collectErrorGraphCandidates(err, (candidate) => {
+    const errors = candidate.errors;
+    return [candidate.error, candidate.cause, ...(Array.isArray(errors) ? errors : [])];
+  }).some((candidate) => readErrorName(candidate) === "GatewayDrainingError");
+}
+
 function hasDirectProviderFailureIdentity(err: unknown): boolean {
   if (isFailoverError(err)) {
     return true;
@@ -917,6 +924,11 @@ export function resolveModelFallbackError(
   context?: FailoverErrorContext,
 ): ModelFallbackErrorResolution {
   if (err instanceof AgentHarnessSessionSupersededError) {
+    return { kind: "coordination", error: err };
+  }
+  // Gateway admission can fail before any provider turn starts. Preserve that
+  // identity through wrappers and aggregates so fallback cannot blame a model.
+  if (hasGatewayDrainingFailure(err)) {
     return { kind: "coordination", error: err };
   }
   const staleLifecycleFailure = hasStaleAgentRunLifecycleFailure(err);

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -16,6 +16,7 @@ import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.j
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { GatewayDrainingError } from "../process/gateway-work-admission.js";
 import { AgentRunTerminalOutcomeError } from "./agent-run-terminal-outcome.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
@@ -2078,6 +2079,60 @@ describe("runWithModelFallback", () => {
     expect(onFallbackStep).not.toHaveBeenCalledWith(
       expect.objectContaining({ decision: "candidate_failed" }),
     );
+  });
+
+  it.each([
+    ["direct", () => new GatewayDrainingError()],
+    ["cause", () => new Error("session send failed", { cause: new GatewayDrainingError() })],
+    [
+      "aggregate",
+      () =>
+        new AggregateError(
+          [new Error("cleanup failed"), new GatewayDrainingError()],
+          "agent run failed",
+        ),
+    ],
+  ])("aborts fallback on %s gateway drain failures", async (_label, makeError) => {
+    const error = makeError();
+    const run = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce("too late");
+    const onError = vi.fn();
+    const onFallbackStep = vi.fn();
+
+    await expect(
+      runWithModelFallback({
+        cfg: undefined,
+        provider: "openai",
+        model: "gpt-5.6-sol",
+        fallbacksOverride: ["openai/gpt-5.4-mini"],
+        skipAuthProfileRuntime: true,
+        run,
+        onError,
+        onFallbackStep,
+      }),
+    ).rejects.toBe(error);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onFallbackStep).not.toHaveBeenCalled();
+  });
+
+  it("still advances after a genuine provider rate limit", async () => {
+    const rateLimit = Object.assign(new Error("rate limit exceeded"), { status: 429 });
+    const run = vi.fn().mockRejectedValueOnce(rateLimit).mockResolvedValueOnce("fallback ok");
+
+    const result = await runWithModelFallback({
+      cfg: undefined,
+      provider: "openai",
+      model: "gpt-5.6-sol",
+      fallbacksOverride: ["openai/gpt-5.4-mini"],
+      skipAuthProfileRuntime: true,
+      run,
+    });
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.result).toBe("fallback ok");
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-5.4-mini");
+    expect(result.attempts[0]).toMatchObject({ reason: "rate_limit", status: 429 });
   });
 
   it("aborts the fallback chain on transcript continuation failures without candidate_failed attribution", async () => {


### PR DESCRIPTION
Related: #63279

AI-assisted: yes. I reviewed the implementation, ownership boundary, and proof. No agent transcript is included.

## What Problem This Solves

A gateway lifecycle rejection could be treated as an unknown model failure, advance to a configured fallback, and expose or persist that fallback as the session model even though no provider turn had started.

## Why This Change Was Made

The shared model-fallback classifier now treats direct, cause-wrapped, and aggregate-contained `GatewayDrainingError` values as runtime coordination failures. The existing fallback runner therefore rethrows the original outer error without recording a candidate failure or trying another model. Genuine provider failures such as HTTP 429 remain eligible for configured fallback.

This is permanent defense in depth at the shared policy owner. The root-cause `sessions_send` admission-lifetime repair landed separately in #118105 as `7e5e4483c5eef416517b41c1822825886a9f1d12`; this PR protects every fallback caller when a genuine gateway lifecycle failure still reaches the runner.

Alternatives rejected: a `sessions_send` special case would miss sibling callers; persistence or UI suppression would occur after an invalid fallback already ran; matching one message string would discard the stable named-error contract.

## User Impact

During gateway restart/draining windows, sessions keep their existing model selection rather than silently switching because of a gateway lifecycle failure. Real provider throttling and overload fallback behavior is unchanged.

## Evidence

- Red reproduction on unmodified canonical base `603321a315692444d63ad3d5941a66753856874a`: direct, cause-wrapped, and aggregate drain errors each invoked `openai/gpt-5.6-sol`, then `openai/gpt-5.4-mini`, and returned Mini. [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30759378157)
- Focused classifier/runner regressions: 254 tests passed after incorporating #118105. [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30761880794)
- Exact pushed head `26830f18622e7231ec5b28f75503aa9d336b0b73`: direct, cause-wrapped, and aggregate drains each invoked only Sol, rethrew the original outer object, and selected no fallback; HTTP 429 invoked Sol then Mini and selected Mini. Source-blind behavior validation passed the same observable contract. [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30762101481)
- Fresh uncommitted autoreview after rebasing: no accepted/actionable findings (0.98 confidence); secret scan clean.
- Publication base was canonical `08d0952df24a1e1bb715a2727fa0534438cb6f4a`; the branch contains #118105. The full intervening range was inspected. Only #118105 changed the incident owner path; later movement touched unrelated release/QA, terminal-exec loop, browser, Telegram, cron, UI, system-agent, and realtime-transcription paths and did not invalidate the fallback contract.

## Review Evidence Map

- Entry point / classifier: `resolveModelFallbackError` in `src/agents/failover-error.ts`.
- Runner policy: `runWithModelFallback` aborts runtime-coordination errors before candidate telemetry or advancement in `src/agents/model-fallback-runner.ts`.
- Producer boundary: `GatewayDrainingError` is emitted by gateway work admission before provider execution.
- Root owner: #118105 now gives detached `sessions_send` A2A flows an independent root; its real-restart negative control still proves genuine draining rejects before provider execution.
- Persistence consequence: fallback results become `providerUsed`/`modelUsed` and are written to session model state, so presentation-only suppression is too late.
- Siblings / negative control: stale lifecycle and session-coordination errors already abort; HTTP 429 still advances.

Root cause: `resolveModelFallbackError` omitted the stable gateway lifecycle error identity, so the runner reached its deliberate unknown-error fallback path. The runner and persistence consumers were already behaving according to that classification.

Best-fix verdict: yes. The shared classifier is the narrow canonical owner for a cross-caller fallback policy invariant; #118105 is the separate producer-side root-cause repair.

Codex boundary check was performed directly against sibling Codex source at `2b5bdcf67547860f2e5c5a605009a70026796b2b`: OpenClaw can reject gateway work before dispatch, while Codex only receives a turn at [`turn/start`](https://github.com/openai/codex/blob/2b5bdcf67547860f2e5c5a605009a70026796b2b/codex-rs/app-server/src/message_processor.rs#L1294-L1304), submits it as `Op::UserInput` in [`turn_processor.rs`](https://github.com/openai/codex/blob/2b5bdcf67547860f2e5c5a605009a70026796b2b/codex-rs/app-server/src/request_processors/turn_processor.rs#L569-L588), and begins provider streaming later in [`turn.rs`](https://github.com/openai/codex/blob/2b5bdcf67547860f2e5c5a605009a70026796b2b/codex-rs/core/src/session/turn.rs#L2155-L2198). A gateway admission drain is therefore not a Codex/provider candidate failure.

Remaining uncertainty: no live gateway restart was induced. The invisible policy transition is directly observed at the fallback runner boundary, and #118105 separately proves the real restart producer boundary.
