### PR TITLE
test(onepassword): speed resolver process fixtures

### DIFF
--- a/extensions/onepassword/src/secret-ref-resolver.test.ts
+++ b/extensions/onepassword/src/secret-ref-resolver.test.ts
@@ -23,9 +23,17 @@ const rootTsconfigPath = path.resolve("tsconfig.json");
 const secretRefRuntimeSourceUrl = pathToFileURL(
   path.resolve("src/plugin-sdk/secret-ref-runtime.ts"),
 ).href;
+// The manifest test reads the production source; the timeout-only staged executable needs a
+// shorter deadline to prove cleanup without sleeping for the production seven seconds.
+const TEST_OP_READ_TIMEOUT_MS = process.platform === "win32" ? 5_000 : 500;
+const TEST_DESCENDANT_MARKER_DELAY_MS = TEST_OP_READ_TIMEOUT_MS + 500;
+const TEST_DESCENDANT_SETTLE_MARGIN_MS = 2_000;
 const tempDirs: string[] = [];
 let resolverPath = sourceResolverPath;
+let timeoutResolverPath: string | undefined;
 let stagedResolverRoot: string | undefined;
+let trustedNodeRoot: string | undefined;
+let trustedNodePath: string | undefined;
 
 beforeAll(() => {
   const tempRoot = path.join(process.cwd(), ".tmp");
@@ -50,13 +58,44 @@ beforeAll(() => {
   // Keep the relative static assets together, but resolve the real SDK from source so this
   // focused test does not depend on a parallel build producing dist/plugin-sdk first.
   resolverPath = path.join(stagedResolverRoot, path.basename(sourceResolverPath));
+  const resolverSource = fs.readFileSync(sourceResolverPath, "utf8");
+  const timeoutResolverSource = resolverSource.replace(
+    "const OP_READ_TIMEOUT_MS = 7_000;",
+    `const OP_READ_TIMEOUT_MS = ${TEST_OP_READ_TIMEOUT_MS};`,
+  );
+  if (timeoutResolverSource === resolverSource) {
+    throw new Error("failed to shorten the staged 1Password resolver timeout");
+  }
+  timeoutResolverPath = path.join(stagedResolverRoot, "onepassword-timeout-resolver.js");
+  fs.writeFileSync(timeoutResolverPath, timeoutResolverSource);
+  // The fake op paths remain per-test; only their trusted Node interpreter is shared.
+  // Re-copying the runtime does not strengthen path-ownership coverage.
+  trustedNodeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-1password-node-"));
+  trustedNodePath = createTrustedNodeFixture(trustedNodeRoot);
 });
 
 afterAll(() => {
   if (stagedResolverRoot) {
     fs.rmSync(stagedResolverRoot, { recursive: true, force: true });
   }
+  if (trustedNodeRoot) {
+    fs.rmSync(trustedNodeRoot, { recursive: true, force: true });
+  }
 });
+
+function getTrustedNodePath(): string {
+  if (!trustedNodePath) {
+    throw new Error("trusted Node fixture was not initialized");
+  }
+  return trustedNodePath;
+}
+
+function getTimeoutResolverPath(): string {
+  if (!timeoutResolverPath) {
+    throw new Error("timeout resolver fixture was not initialized");
+  }
+  return timeoutResolverPath;
+}
 
 function makeTempDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-1password-test-"));
@@ -80,6 +119,7 @@ function runResolver(params: {
   request: unknown;
   cwd?: string;
   env?: Record<string, string>;
+  resolverExecutablePath?: string;
   token?: string | null;
 }): Promise<{ stdout: string; stderr: string; code: number | null }> {
   const stateDir = params.env?.OPENCLAW_STATE_DIR ?? makeTempDir();
@@ -95,7 +135,7 @@ function runResolver(params: {
   return new Promise((resolve, reject) => {
     const child = spawn(
       process.execPath,
-      [tsxCliPath, "--tsconfig", rootTsconfigPath, resolverPath],
+      [tsxCliPath, "--tsconfig", rootTsconfigPath, params.resolverExecutablePath ?? resolverPath],
       {
         ...(params.cwd ? { cwd: params.cwd } : {}),
         stdio: ["pipe", "pipe", "pipe"],
@@ -276,7 +316,7 @@ describe("1Password SecretRef resolver", () => {
       const logPath = path.join(tempDir, "op-args.json");
       fs.writeFileSync(
         opPath,
-        `#!${createTrustedNodeFixture(tempDir)}
+        `#!${getTrustedNodePath()}
 const fs = require("node:fs");
 fs.writeFileSync(${JSON.stringify(logPath)}, JSON.stringify({
   args: process.argv.slice(2),
@@ -328,7 +368,7 @@ process.stdout.write("not-a-real-value \\t");
       const nativeRef = "op://Personal/OpenClaw QA API Key/password?attribute=value%20one";
       fs.writeFileSync(
         opPath,
-        `#!${createTrustedNodeFixture(tempDir)}
+        `#!${getTrustedNodePath()}
 const fs = require("node:fs");
 fs.writeFileSync(${JSON.stringify(logPath)}, JSON.stringify(process.argv.slice(2)));
 process.stdout.write("not-a-real-value");
@@ -368,7 +408,7 @@ process.stdout.write("not-a-real-value");
       const opPath = path.join(tempDir, "op");
       fs.writeFileSync(
         opPath,
-        `#!${createTrustedNodeFixture(tempDir)}
+        `#!${getTrustedNodePath()}
 const { spawn } = require("node:child_process");
 spawn(process.execPath, ["-e", "setTimeout(() => process.stdout.write('tail'), 50)"], {
   stdio: ["ignore", process.stdout, "ignore"],
@@ -401,7 +441,7 @@ process.stdout.write("head");
       const logPath = path.join(tempDir, "op-args.json");
       fs.writeFileSync(
         opPath,
-        `#!${createTrustedNodeFixture(tempDir)}
+        `#!${getTrustedNodePath()}
 const fs = require("node:fs");
 fs.writeFileSync(${JSON.stringify(logPath)}, JSON.stringify(process.argv.slice(2)));
 process.stdout.write("not-a-real-value");
@@ -552,7 +592,7 @@ process.stdout.write("not-a-real-value");
       fs.linkSync(targetPath, tokenPath);
       fs.writeFileSync(
         opPath,
-        `#!${createTrustedNodeFixture(stateDir)}\nprocess.stdout.write(process.env.OP_SERVICE_ACCOUNT_TOKEN === "linked-service-account-token" ? "ok" : "bad");\n`,
+        `#!${getTrustedNodePath()}\nprocess.stdout.write(process.env.OP_SERVICE_ACCOUNT_TOKEN === "linked-service-account-token" ? "ok" : "bad");\n`,
         { mode: 0o755 },
       );
 
@@ -590,7 +630,7 @@ process.stdout.write("not-a-real-value");
       });
       fs.writeFileSync(
         opPath,
-        `#!${createTrustedNodeFixture(home)}\nprocess.stdout.write(process.env.OP_SERVICE_ACCOUNT_TOKEN);\n`,
+        `#!${getTrustedNodePath()}\nprocess.stdout.write(process.env.OP_SERVICE_ACCOUNT_TOKEN);\n`,
         { mode: 0o755 },
       );
 
@@ -624,7 +664,7 @@ process.stdout.write("not-a-real-value");
       const opPath = path.join(tempDir, "op");
       fs.writeFileSync(
         opPath,
-        `#!${createTrustedNodeFixture(tempDir)}
+        `#!${getTrustedNodePath()}
 process.stdout.write("secret-output-must-not-escape");
 process.stderr.write("secret-error-must-not-escape");
 process.exitCode = 1;
@@ -656,7 +696,7 @@ process.exitCode = 1;
       const descendantMarker = path.join(tempDir, "descendant-survived");
       fs.writeFileSync(
         opPath,
-        `#!${createTrustedNodeFixture(tempDir)}
+        `#!${getTrustedNodePath()}
 const { spawn } = require("node:child_process");
 spawn(process.execPath, ["-e", ${JSON.stringify(`process.on("SIGTERM", () => {}); setTimeout(() => require("node:fs").writeFileSync(${JSON.stringify(descendantMarker)}, "survived"), 800); setInterval(() => {}, 1000);`)}], { stdio: "ignore" });
 process.stdout.write("x".repeat(70 * 1024));
@@ -691,20 +731,33 @@ setInterval(() => {}, 1000);
       const tempDir = makeTempDir();
       const descendantReady = path.join(tempDir, "timed-out-descendant-ready");
       const descendantMarker = path.join(tempDir, "timed-out-descendant-survived");
-      const opBody = `const { spawn } = require("node:child_process");
-spawn(process.execPath, ["-e", ${JSON.stringify(`const fs = require("node:fs"); fs.writeFileSync(${JSON.stringify(descendantReady)}, "ready"); process.on("SIGTERM", () => {}); setTimeout(() => fs.writeFileSync(${JSON.stringify(descendantMarker)}, "survived"), 7500); setInterval(() => {}, 1000);`)}], { stdio: "ignore" });
+      const descendantBody = `const fs = require("node:fs");
+process.on("SIGTERM", () => {});
+setTimeout(() => fs.writeFileSync(${JSON.stringify(descendantMarker)}, "survived"), ${TEST_DESCENDANT_MARKER_DELAY_MS});
 setInterval(() => {}, 1000);
 `;
       let opPath = process.execPath;
       if (process.platform === "win32") {
+        const opBody = `const fs = require("node:fs");
+const { spawn } = require("node:child_process");
+const descendant = spawn(process.execPath, ["-e", ${JSON.stringify(descendantBody)}], { stdio: "ignore" });
+descendant.once("spawn", () => fs.writeFileSync(${JSON.stringify(descendantReady)}, "ready"));
+setInterval(() => {}, 1000);
+`;
         fs.writeFileSync(path.join(tempDir, "read"), opBody);
       } else {
-        // Do not assume the test runner's Node binary passes production path-trust policy.
-        // A per-test executable keeps the scenario independent of package-manager ownership.
+        const descendantPath = path.join(tempDir, "descendant.cjs");
         opPath = path.join(tempDir, "op");
-        fs.writeFileSync(opPath, `#!${createTrustedNodeFixture(tempDir)}\n${opBody}`, {
-          mode: 0o755,
-        });
+        fs.writeFileSync(descendantPath, descendantBody);
+        fs.writeFileSync(
+          opPath,
+          `#!/bin/sh
+${JSON.stringify(getTrustedNodePath())} ${JSON.stringify(descendantPath)} &
+printf ready > ${JSON.stringify(descendantReady)}
+while true; do sleep 1; done
+`,
+          { mode: 0o755 },
+        );
       }
 
       const resultPromise = runResolver({
@@ -715,6 +768,7 @@ setInterval(() => {}, 1000);
         },
         cwd: tempDir,
         env: { CLAW_1PASSWORD_OP: opPath },
+        resolverExecutablePath: getTimeoutResolverPath(),
       });
       // Windows verifies the executable owner and ACL chain through OS tooling before op starts.
       // Keep the synchronization bound above that preflight without weakening the kill deadline.
@@ -730,10 +784,13 @@ setInterval(() => {}, 1000);
       const result = await resultPromise;
       expect(JSON.parse(result.stdout).errors).toEqual({
         "op://Engineering/OpenRouter/apiKey": {
-          message: "op read timed out after 7000ms.",
+          message: `op read timed out after ${TEST_OP_READ_TIMEOUT_MS}ms.`,
         },
       });
-      const remainingMarkerDelayMs = 8_000 - (Date.now() - descendantReadyAt);
+      const remainingMarkerDelayMs =
+        TEST_DESCENDANT_MARKER_DELAY_MS +
+        TEST_DESCENDANT_SETTLE_MARGIN_MS -
+        (Date.now() - descendantReadyAt);
       if (remainingMarkerDelayMs > 0) {
         await new Promise((resolve) => {
           setTimeout(resolve, remainingMarkerDelayMs);
@@ -750,7 +807,7 @@ setInterval(() => {}, 1000);
     const logPath = path.join(tempDir, "events.log");
     fs.writeFileSync(
       opPath,
-      `#!${createTrustedNodeFixture(tempDir)}
+      `#!${getTrustedNodePath()}
 const fs = require("node:fs");
 fs.appendFileSync(${JSON.stringify(logPath)}, "start " + process.pid + "\\n");
 setTimeout(() => {
@@ -779,13 +836,9 @@ setTimeout(() => {
   it.runIf(process.platform !== "win32")("resolves the op CLI from PATH", async () => {
     const tempDir = makeTempDir();
     const opPath = path.join(tempDir, process.platform === "win32" ? "op.exe" : "op");
-    fs.writeFileSync(
-      opPath,
-      `#!${createTrustedNodeFixture(tempDir)}\nprocess.stdout.write('from-path');\n`,
-      {
-        mode: 0o755,
-      },
-    );
+    fs.writeFileSync(opPath, `#!${getTrustedNodePath()}\nprocess.stdout.write('from-path');\n`, {
+      mode: 0o755,
+    });
     const result = await runResolver({
       request: {
         protocolVersion: 1,
@@ -811,7 +864,7 @@ setTimeout(() => {
       const tokenLogPath = path.join(tempDir, "token.log");
       fs.writeFileSync(
         opPath,
-        `#!${createTrustedNodeFixture(tempDir)}\nrequire("node:fs").writeFileSync(${JSON.stringify(tokenLogPath)}, process.env.OP_SERVICE_ACCOUNT_TOKEN);\n`,
+        `#!${getTrustedNodePath()}\nrequire("node:fs").writeFileSync(${JSON.stringify(tokenLogPath)}, process.env.OP_SERVICE_ACCOUNT_TOKEN);\n`,
         { mode: 0o755 },
       );
       fs.chmodSync(tempDir, 0o777);

--- a/extensions/onepassword/src/secret-ref-resolver.test.ts
+++ b/extensions/onepassword/src/secret-ref-resolver.test.ts
@@ -25,7 +25,7 @@ const secretRefRuntimeSourceUrl = pathToFileURL(
 ).href;
 // The manifest test reads the production source; the timeout-only staged executable needs a
 // shorter deadline to prove cleanup without sleeping for the production seven seconds.
-const TEST_OP_READ_TIMEOUT_MS = process.platform === "win32" ? 5_000 : 500;
+const TEST_OP_READ_TIMEOUT_MS = process.platform === "win32" ? 5_000 : 1_500;
 const TEST_DESCENDANT_MARKER_DELAY_MS = TEST_OP_READ_TIMEOUT_MS + 500;
 const TEST_DESCENDANT_SETTLE_MARGIN_MS = 2_000;
 const tempDirs: string[] = [];

--- a/extensions/onepassword/src/secret-ref-resolver.test.ts
+++ b/extensions/onepassword/src/secret-ref-resolver.test.ts
@@ -746,12 +746,14 @@ setInterval(() => {}, 1000);
 `;
         fs.writeFileSync(path.join(tempDir, "read"), opBody);
       } else {
+        // Executable trust validation requires the literal shebang path to be canonical.
+        const shellPath = fs.realpathSync("/bin/sh");
         const descendantPath = path.join(tempDir, "descendant.cjs");
         opPath = path.join(tempDir, "op");
         fs.writeFileSync(descendantPath, descendantBody);
         fs.writeFileSync(
           opPath,
-          `#!/bin/sh
+          `#!${shellPath}
 ${JSON.stringify(getTrustedNodePath())} ${JSON.stringify(descendantPath)} &
 printf ready > ${JSON.stringify(descendantReady)}
 while true; do sleep 1; done


### PR DESCRIPTION
## Summary

- reuse one suite-owned trusted Node interpreter while keeping every fake `op` executable and state directory isolated per test
- give only the timeout lifecycle test a staged resolver with a shorter deadline; the production seven-second constant and manifest budget assertions still read the untouched source
- use a POSIX launcher that records descendant startup before testing process-tree termination, avoiding a second Node-startup readiness race

## Performance

Same-machine focused runs with one worker after raising the staged POSIX deadline from 500ms to 1500ms for loaded Linux runners:

| Metric | Before | After | Gain |
| --- | ---: | ---: | ---: |
| File wall time | 38.16s | 25.30s | -12.86s (-33.7%) |
| Vitest test time | 35.12s | 23.47s | -11.65s (-33.2%) |
| Maximum RSS | 407.3 MB | 289.9 MB | -117.4 MB (-28.8%) |

The timeout case itself fell from 10.41 seconds to 4.97 seconds while retaining the real descendant-survival assertion.

## Coverage

All 20 runnable tests still pass and the Windows-only case remains platform-gated. The patch preserves process execution, path ownership validation, token-file safety, output bounds, concurrency, failure redaction, and process-tree cleanup coverage. No production source, manifest, configuration, or sharding changed.

## Proof

Redacted terminal output from the requested one-worker verbose run:

```text
$ node scripts/run-vitest.mjs extensions/onepassword/src/secret-ref-resolver.test.ts --maxWorkers=1 --reporter=verbose
✓ kills the op process tree when output exceeds the limit 2272ms
✓ kills the op process tree when a read times out 4968ms

Test Files  1 passed (1)
     Tests  20 passed | 1 skipped (21)
  Duration  23.75s (transform 193ms, setup 193ms, import 9ms, tests 23.47s, environment 0ms)
```

Two additional full focused runs passed in 25.30s and 25.91s wall time. Targeted formatting and `git diff --check` are clean. Codex autoreview reported no accepted/actionable findings after the Linux deadline adjustment.

The changed-file gate attempted approved remote delegation, but neither Blacksmith Testbox nor brokered Crabbox was available, so focused trusted-source proof ran locally under the documented fallback. Hosted CI is the broad Linux gate.
