### PR TITLE
fix(plugins): unblock prerelease validation

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -238,6 +238,7 @@ const rootBundledPluginRuntimeDependencies = [
   "@homebridge/ciao",
   "@mozilla/readability",
   "@silvia-odwyer/photon-node",
+  "@trycua/cua-driver",
   "@slack/bolt",
   "@slack/types",
   "@slack/web-api",

--- a/extensions/cua-computer/src/driver-client.test.ts
+++ b/extensions/cua-computer/src/driver-client.test.ts
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   shutdown: vi.fn(async () => {}),
 }));
 
-vi.mock("@trycua/cua-driver", () => ({
+const sdk = {
   CaptureScope: { Desktop: "desktop" },
   ClickButton: { Left: 0, Right: 1, Middle: 2 },
   CuaDriver: { create: mocks.create, createConfigured: mocks.createConfigured },
@@ -21,7 +21,7 @@ vi.mock("@trycua/cua-driver", () => ({
   ScrollDirection: { Up: 0, Down: 1, Left: 2, Right: 3 },
   SessionPermissionMode: { Unrestricted: "unrestricted" },
   createTrustedSession: mocks.createTrustedSession,
-}));
+};
 
 import { createCuaDriver } from "./driver-client.js";
 
@@ -49,8 +49,9 @@ describe("CUA Driver direct session", () => {
   });
 
   it("uses configured creation and one fixed trusted OpenClaw session", async () => {
-    const driver = createCuaDriver();
+    const driver = createCuaDriver({ loadSdk: () => sdk as never });
 
+    expect(driver.isAvailable()).toBe(true);
     expect(mocks.create).not.toHaveBeenCalled();
     expect(mocks.createConfigured).toHaveBeenCalledWith({
       claudeCodeCompatibility: false,
@@ -73,10 +74,10 @@ describe("CUA Driver direct session", () => {
   });
 
   it("starts the fixed desktop capture session once before using driver tools", async () => {
-    const driver = createCuaDriver();
-    const sessionOptions = mocks.createTrustedSession.mock.calls[0]?.[1];
+    const driver = createCuaDriver({ loadSdk: () => sdk as never });
 
     await Promise.all([driver.getDesktopState(), driver.getDesktopState()]);
+    const sessionOptions = mocks.createTrustedSession.mock.calls[0]?.[1];
 
     expect(mocks.startSession).toHaveBeenCalledOnce();
     expect(mocks.startSession).toHaveBeenCalledWith(
@@ -90,5 +91,24 @@ describe("CUA Driver direct session", () => {
 
     await driver.dispose();
     expect(mocks.endSession).toHaveBeenCalledWith({ session: sessionOptions.publicSession });
+  });
+
+  it("keeps a missing native desktop library behind command availability", async () => {
+    const loadSdk = vi.fn(() => {
+      throw new Error("libX11.so.6: cannot open shared object file");
+    });
+    const driver = createCuaDriver({ loadSdk });
+
+    expect(loadSdk).not.toHaveBeenCalled();
+    expect(driver.isAvailable()).toBe(false);
+    expect(loadSdk).toHaveBeenCalledOnce();
+    await expect(driver.getScreenSize()).rejects.toThrow(
+      "COMPUTER_DRIVER_UNAVAILABLE: failed to load CUA Driver SDK: libX11.so.6",
+    );
+
+    driver.resetAvailabilityCache();
+    expect(driver.isAvailable()).toBe(false);
+    expect(loadSdk).toHaveBeenCalledTimes(2);
+    await driver.dispose();
   });
 });

--- a/extensions/cua-computer/src/driver-client.ts
+++ b/extensions/cua-computer/src/driver-client.ts
@@ -1,19 +1,39 @@
 import { randomUUID } from "node:crypto";
-import {
-  CaptureScope,
-  ClickButton,
-  CuaDriver,
-  DesktopScope,
-  ScrollBy,
-  ScrollDirection,
-  SessionPermissionMode,
-  createTrustedSession,
-  type CuaDriverLike,
-  type CuaDriverSessionLike,
-  type ToolResult,
-} from "@trycua/cua-driver";
+import { createRequire } from "node:module";
 
-export type CuaToolResult = ToolResult;
+type DriverClickButton = import("@trycua/cua-driver").ClickButton;
+type CuaDriverLike = import("@trycua/cua-driver").CuaDriverLike;
+type CuaDriverSessionLike = import("@trycua/cua-driver").CuaDriverSessionLike;
+type DriverScrollDirection = import("@trycua/cua-driver").ScrollDirection;
+type CuaDriverSdk = Pick<
+  typeof import("@trycua/cua-driver"),
+  | "CaptureScope"
+  | "CuaDriver"
+  | "DesktopScope"
+  | "ScrollBy"
+  | "SessionPermissionMode"
+  | "createTrustedSession"
+>;
+
+export type CuaToolResult = import("@trycua/cua-driver").ToolResult;
+
+// These numeric values are part of the pinned 0.14.1 SDK contract and are also
+// frozen in driver-contract-fixtures. Keeping them local avoids loading the
+// native library while OpenClaw is only registering the bundled plugin.
+export const ClickButton = {
+  Left: 0 as DriverClickButton,
+  Right: 1 as DriverClickButton,
+  Middle: 2 as DriverClickButton,
+} as const;
+export type ClickButton = (typeof ClickButton)[keyof typeof ClickButton];
+
+export const ScrollDirection = {
+  Up: 0 as DriverScrollDirection,
+  Down: 1 as DriverScrollDirection,
+  Left: 2 as DriverScrollDirection,
+  Right: 3 as DriverScrollDirection,
+} as const;
+export type ScrollDirection = (typeof ScrollDirection)[keyof typeof ScrollDirection];
 
 export interface CuaDriverSession {
   readonly generation: string;
@@ -42,17 +62,6 @@ export interface CuaDriverSession {
   dispose(): Promise<void>;
 }
 
-// This is an OpenClaw-owned ceiling, not plugin configuration or tool input.
-// The model can request only computer.act actions; it cannot select a session
-// or widen this authorization after the node host starts.
-const CUA_DRIVER_AUTHORIZATION = {
-  allowedModes: [SessionPermissionMode.Unrestricted],
-  compatibilityMode: SessionPermissionMode.Unrestricted,
-  unrestrictedAcknowledged: true,
-  maxSessionTtlSeconds: 3_600n,
-  maxIdleTtlSeconds: 300n,
-};
-
 function asyncOptions(signal?: AbortSignal) {
   return signal ? { signal } : undefined;
 }
@@ -66,18 +75,28 @@ class DirectCuaDriverSession implements CuaDriverSession {
   private started = false;
   private disposed = false;
 
-  constructor() {
+  constructor(private readonly sdk: CuaDriverSdk) {
+    const unrestricted = sdk.SessionPermissionMode.Unrestricted;
+    // This is an OpenClaw-owned ceiling, not plugin configuration or tool input.
+    // The model cannot select a session or widen this authorization after start.
+    const authorization = {
+      allowedModes: [unrestricted],
+      compatibilityMode: unrestricted,
+      unrestrictedAcknowledged: true,
+      maxSessionTtlSeconds: 3_600n,
+      maxIdleTtlSeconds: 300n,
+    };
     // Never use CuaDriver.create(): configured creation fixes the authorization
     // ceiling before a single trusted OpenClaw session is admitted.
-    this.runtime = CuaDriver.createConfigured({
+    this.runtime = sdk.CuaDriver.createConfigured({
       claudeCodeCompatibility: false,
-      authorization: { ...CUA_DRIVER_AUTHORIZATION },
+      authorization,
     });
-    this.session = createTrustedSession(this.runtime, {
+    this.session = sdk.createTrustedSession(this.runtime, {
       publicSession: this.publicSession,
-      mode: SessionPermissionMode.Unrestricted,
-      ttlSeconds: CUA_DRIVER_AUTHORIZATION.maxSessionTtlSeconds,
-      idleTtlSeconds: CUA_DRIVER_AUTHORIZATION.maxIdleTtlSeconds,
+      mode: unrestricted,
+      ttlSeconds: authorization.maxSessionTtlSeconds,
+      idleTtlSeconds: authorization.maxIdleTtlSeconds,
     });
   }
 
@@ -88,7 +107,7 @@ class DirectCuaDriverSession implements CuaDriverSession {
     if (!this.startPromise) {
       const start = this.session
         .startSession(
-          { session: this.publicSession, captureScope: CaptureScope.Desktop },
+          { session: this.publicSession, captureScope: this.sdk.CaptureScope.Desktop },
           asyncOptions(signal),
         )
         .then(() => {
@@ -131,7 +150,7 @@ class DirectCuaDriverSession implements CuaDriverSession {
     signal?: AbortSignal,
   ) {
     return await this.invoke(signal, () =>
-      this.session.click({ ...input, scope: DesktopScope.Desktop }, asyncOptions(signal)),
+      this.session.click({ ...input, scope: this.sdk.DesktopScope.Desktop }, asyncOptions(signal)),
     );
   }
   async drag(
@@ -139,12 +158,15 @@ class DirectCuaDriverSession implements CuaDriverSession {
     signal?: AbortSignal,
   ) {
     return await this.invoke(signal, () =>
-      this.session.drag({ ...input, scope: DesktopScope.Desktop }, asyncOptions(signal)),
+      this.session.drag({ ...input, scope: this.sdk.DesktopScope.Desktop }, asyncOptions(signal)),
     );
   }
   async moveCursor(input: { x: number; y: number }, signal?: AbortSignal) {
     return await this.invoke(signal, () =>
-      this.session.moveCursor({ ...input, scope: DesktopScope.Desktop }, asyncOptions(signal)),
+      this.session.moveCursor(
+        { ...input, scope: this.sdk.DesktopScope.Desktop },
+        asyncOptions(signal),
+      ),
     );
   }
   async scroll(
@@ -153,19 +175,26 @@ class DirectCuaDriverSession implements CuaDriverSession {
   ) {
     return await this.invoke(signal, () =>
       this.session.scroll(
-        { ...input, scope: DesktopScope.Desktop, by: ScrollBy.Line },
+        {
+          ...input,
+          scope: this.sdk.DesktopScope.Desktop,
+          by: this.sdk.ScrollBy.Line,
+        },
         asyncOptions(signal),
       ),
     );
   }
   async typeText(text: string, signal?: AbortSignal) {
     return await this.invoke(signal, () =>
-      this.session.typeText({ text, scope: DesktopScope.Desktop }, asyncOptions(signal)),
+      this.session.typeText({ text, scope: this.sdk.DesktopScope.Desktop }, asyncOptions(signal)),
     );
   }
   async pressKey(input: { key: string; modifiers: string[] }, signal?: AbortSignal) {
     return await this.invoke(signal, () =>
-      this.session.pressKey({ ...input, scope: DesktopScope.Desktop }, asyncOptions(signal)),
+      this.session.pressKey(
+        { ...input, scope: this.sdk.DesktopScope.Desktop },
+        asyncOptions(signal),
+      ),
     );
   }
 
@@ -212,8 +241,115 @@ class DirectCuaDriverSession implements CuaDriverSession {
   }
 }
 
-export function createCuaDriver(): CuaDriverSession {
-  return new DirectCuaDriverSession();
+const require = createRequire(import.meta.url);
+
+function loadCuaDriverSdk(): CuaDriverSdk {
+  return require("@trycua/cua-driver") as CuaDriverSdk;
 }
 
-export { ClickButton, ScrollDirection };
+function unavailableError(failure: unknown): Error {
+  const detail = failure instanceof Error ? failure.message : String(failure);
+  return new Error(`COMPUTER_DRIVER_UNAVAILABLE: failed to load CUA Driver SDK: ${detail}`, {
+    cause: failure,
+  });
+}
+
+class LazyCuaDriverSession implements CuaDriverSession {
+  private readonly unloadedGeneration = randomUUID();
+  private runtime: DirectCuaDriverSession | undefined;
+  private loadFailure: unknown;
+  private hasLoadFailure = false;
+  private disposed = false;
+
+  constructor(private readonly loadSdk: () => CuaDriverSdk) {}
+
+  get generation(): string {
+    return this.runtime?.generation ?? this.unloadedGeneration;
+  }
+
+  private resolveRuntime(): DirectCuaDriverSession | undefined {
+    if (this.disposed || this.hasLoadFailure) {
+      return undefined;
+    }
+    if (this.runtime) {
+      return this.runtime;
+    }
+    try {
+      this.runtime = new DirectCuaDriverSession(this.loadSdk());
+      return this.runtime;
+    } catch (error) {
+      this.loadFailure = error;
+      this.hasLoadFailure = true;
+      return undefined;
+    }
+  }
+
+  private requireRuntime(): DirectCuaDriverSession {
+    const runtime = this.resolveRuntime();
+    if (runtime) {
+      return runtime;
+    }
+    throw unavailableError(
+      this.disposed ? new Error("cua-computer is stopping") : this.loadFailure,
+    );
+  }
+
+  isAvailable(): boolean {
+    return this.resolveRuntime()?.isAvailable() ?? false;
+  }
+
+  resetAvailabilityCache(): void {
+    if (this.runtime) {
+      this.runtime.resetAvailabilityCache();
+    } else if (!this.disposed) {
+      this.loadFailure = undefined;
+      this.hasLoadFailure = false;
+    }
+  }
+
+  async getDesktopState(signal?: AbortSignal) {
+    return await this.requireRuntime().getDesktopState(signal);
+  }
+  async getScreenSize(signal?: AbortSignal) {
+    return await this.requireRuntime().getScreenSize(signal);
+  }
+  async click(
+    input: { x: number; y: number; button: ClickButton; count: number },
+    signal?: AbortSignal,
+  ) {
+    return await this.requireRuntime().click(input, signal);
+  }
+  async drag(
+    input: { fromX: number; fromY: number; toX: number; toY: number; durationMs?: bigint },
+    signal?: AbortSignal,
+  ) {
+    return await this.requireRuntime().drag(input, signal);
+  }
+  async moveCursor(input: { x: number; y: number }, signal?: AbortSignal) {
+    return await this.requireRuntime().moveCursor(input, signal);
+  }
+  async scroll(
+    input: { x: number; y: number; direction: ScrollDirection; amount: bigint },
+    signal?: AbortSignal,
+  ) {
+    return await this.requireRuntime().scroll(input, signal);
+  }
+  async typeText(text: string, signal?: AbortSignal) {
+    return await this.requireRuntime().typeText(text, signal);
+  }
+  async pressKey(input: { key: string; modifiers: string[] }, signal?: AbortSignal) {
+    return await this.requireRuntime().pressKey(input, signal);
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    await this.runtime?.dispose();
+  }
+}
+
+export function createCuaDriver(options: { loadSdk?: () => CuaDriverSdk } = {}): CuaDriverSession {
+  return new LazyCuaDriverSession(options.loadSdk ?? loadCuaDriverSdk);
+}

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -483,6 +483,7 @@ const testConfig: OpenClawConfig = {
 
 vi.mock("../runtime.js", () => ({
   getMattermostRuntime: () => mockState.runtimeCore,
+  getOptionalMattermostRuntime: () => mockState.runtimeCore,
 }));
 
 const testRuntime = (): RuntimeEnv =>

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -757,6 +757,39 @@ describe("deliverSlackSlashReplies chunking", () => {
     );
   });
 
+  it("keeps 4k native fallback chunks for uncapped Web API delivery", async () => {
+    const respond = vi
+      .fn(async () => undefined)
+      .mockRejectedValueOnce({ response: { data: { error: "invalid_blocks" } } });
+    const caption = "c".repeat(9_000);
+    const blocks = [
+      {
+        type: "data_table",
+        caption,
+        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
+      },
+    ] as never;
+
+    await deliverSlackSlashReplies({
+      replies: [{ channelData: { slack: { blocks } } }],
+      respond,
+      responseBudget: {
+        respond,
+        remaining: () => undefined,
+      },
+      ephemeral: true,
+      textLimit: 8000,
+    });
+
+    expect(respond).toHaveBeenCalledTimes(4);
+    const fallback = [1, 2, 3].map((index) => requireSlashMessage(respond, index));
+    expect(fallback.every((message) => message.blocks === undefined)).toBe(true);
+    expect(fallback.every((message) => message.text.length <= 4_000)).toBe(true);
+    expect(fallback.map((message) => message.text).join("")).toBe(
+      `${caption} (table)\nAccount\nAcme`,
+    );
+  });
+
   it("batches in-place native fallback at 50 blocks without losing content", async () => {
     const respond = vi
       .fn(async () => undefined)

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -19,8 +19,9 @@ import {
 import { createReplyReferencePlanner } from "openclaw/plugin-sdk/reply-reference";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { buildSlackBlocksFallbackText } from "../blocks-fallback.js";
+import { SLACK_MAX_BLOCKS } from "../blocks-input.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
-import { SLACK_TEXT_LIMIT } from "../limits.js";
+import { SLACK_MESSAGE_TEXT_HARD_LIMIT, SLACK_TEXT_LIMIT } from "../limits.js";
 import { emitSlackMessageSentHooks } from "../message-sent-hook.js";
 import {
   buildSlackNativeDataAccessibilityText,
@@ -45,6 +46,51 @@ import {
   type SlackResponseUrlBudget as ResponseUrlBudget,
 } from "./response-url-budget.js";
 import { sendMessageSlack, type SlackSendIdentity, type SlackSendResult } from "./send.runtime.js";
+
+// Receipt-tracked Web API fallbacks stay at 4k, but response_url gets only five calls.
+// Repack its complete fallback parts up to Slack's hard text and block limits.
+function compactSlackResponseUrlFallback(
+  messages: readonly SlackFormattingDisabledMessage[],
+): SlackFormattingDisabledMessage[] {
+  if (messages.length <= 1) {
+    return [...messages];
+  }
+  if (messages.every((message) => !message.blocks?.length)) {
+    return chunkSlackTextAtHardLimit(messages.map((message) => message.text).join("")).map(
+      (text) => ({ text, mrkdwn: false }),
+    );
+  }
+
+  const compacted: SlackFormattingDisabledMessage[] = [];
+  let pending: SlackFormattingDisabledMessage | undefined;
+  const flush = () => {
+    if (pending) {
+      compacted.push(pending);
+      pending = undefined;
+    }
+  };
+  for (const message of messages) {
+    if (!message.blocks?.length) {
+      flush();
+      compacted.push(message);
+      continue;
+    }
+    if (!pending?.blocks?.length) {
+      pending = { ...message, blocks: [...message.blocks] };
+      continue;
+    }
+    const text = `${pending.text}\n\n${message.text}`;
+    const blocks = [...pending.blocks, ...message.blocks];
+    if (text.length > SLACK_MESSAGE_TEXT_HARD_LIMIT || blocks.length > SLACK_MAX_BLOCKS) {
+      flush();
+      pending = { ...message, blocks: [...message.blocks] };
+      continue;
+    }
+    pending = { text, blocks, mrkdwn: false };
+  }
+  flush();
+  return compacted;
+}
 
 export function readSlackReplyBlocks(payload: ReplyPayload) {
   return resolveSlackReplyBlocks(payload);
@@ -407,13 +453,17 @@ export async function deliverSlackSlashReplies(params: {
       blocks: input.blocks,
       baseText: input.baseText,
     });
+    const nativeFallback =
+      responseBudget.remaining() === undefined
+        ? plan.fallbackMessages
+        : compactSlackResponseUrlFallback(plan.fallbackMessages);
     return {
       message: {
         text: plan.accessibilityText,
         blocks: input.blocks,
         mrkdwn: false,
       },
-      nativeFallback: plan.fallbackMessages,
+      nativeFallback,
       ...(plan.skipOriginalBlocks ? { skipOriginalBlocks: true as const } : {}),
     };
   };

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -856,16 +856,19 @@ describe("web outbound", () => {
       { verbose: false, cfg: WHATSAPP_TEST_CFG },
     );
 
+    const redactedTarget = redactIdentifier("+1555");
+    const redactedJid = redactIdentifier("1555@s.whatsapp.net");
+    let content = "";
     await vi.waitFor(
       () => {
-        expect(fsSync.existsSync(logPath)).toBe(true);
+        content = fsSync.existsSync(logPath) ? fsSync.readFileSync(logPath, "utf-8") : "";
+        expect(content).toContain(redactedTarget);
+        expect(content).toContain(redactedJid);
+        expect(content).toContain("sent poll");
       },
       { timeout: 2_000, interval: 5 },
     );
 
-    const content = fsSync.readFileSync(logPath, "utf-8");
-    expect(content).toContain(redactIdentifier("+1555"));
-    expect(content).toContain(redactIdentifier("1555@s.whatsapp.net"));
     expect(content).not.toContain(`"to":"+1555"`);
     expect(content).not.toContain(`"jid":"1555@s.whatsapp.net"`);
     expect(content).not.toContain("Lunch?");

--- a/package.json
+++ b/package.json
@@ -1957,6 +1957,7 @@
     "@openclaw/fs-safe": "0.5.0",
     "@openclaw/proxyline": "0.3.4",
     "@silvia-odwyer/photon-node": "0.3.4",
+    "@trycua/cua-driver": "0.14.1",
     "acorn": "8.17.0",
     "chalk": "6.0.0",
     "chokidar": "5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@silvia-odwyer/photon-node':
         specifier: 0.3.4
         version: 0.3.4
+      '@trycua/cua-driver':
+        specifier: 0.14.1
+        version: 0.14.1
       acorn:
         specifier: 8.17.0
         version: 8.17.0

--- a/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
+++ b/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
@@ -1082,6 +1082,7 @@ async function smokePlugin(pluginId, pluginDir, requiresConfig, pluginIndex, plu
   });
   try {
     await waitForReady({ child, port, logPath });
+    assertPluginLoaded(logPath, pluginId);
     await assertBaseGatewayProbes({
       entrypoint,
       port,
@@ -1256,6 +1257,19 @@ export function assertGatewayLogNotTruncated(logPath) {
         GATEWAY_LOG_CAPTURE_BYTES,
       )} bytes; runtime smoke cannot validate complete post-ready output`,
     );
+  }
+}
+
+export function assertPluginLoaded(logPath, pluginId) {
+  let text;
+  try {
+    text = fs.readFileSync(logPath, "utf8");
+  } catch {
+    return;
+  }
+  const failurePrefix = `[plugins] ${pluginId} failed to load`;
+  if (text.includes(failurePrefix)) {
+    throw new Error(`${failurePrefix}: ${tailText(text)}`);
   }
 }
 

--- a/src/plugins/prepared-message-tool-catalog.test.ts
+++ b/src/plugins/prepared-message-tool-catalog.test.ts
@@ -103,8 +103,12 @@ describe("prepared message-tool catalog", () => {
     expect(listMessageActionDiscoveryChannels(runtimeCatalog).map((entry) => entry.id)).toEqual([
       "beta",
     ]);
-    expect(resolveCurrentChannelMessageToolDiscoveryAdapter("alpha")?.pluginId).toBe("alpha");
-    expect(resolveCurrentChannelMessageToolDiscoveryAdapter("beta")).toBeNull();
+    expect(resolveCurrentChannelMessageToolDiscoveryAdapter("alpha")).toBeNull();
+    expect(resolveCurrentChannelMessageToolDiscoveryAdapter("beta")?.pluginId).toBe("beta");
+    expect(resolveCurrentChannelMessageToolDiscoveryAdapter("alpha", firstCatalog)?.pluginId).toBe(
+      "alpha",
+    );
+    expect(resolveCurrentChannelMessageToolDiscoveryAdapter("beta", firstCatalog)).toBeNull();
     expect(resolveCurrentChannelMessageToolDiscoveryAdapter("beta", runtimeCatalog)?.pluginId).toBe(
       "beta",
     );

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -557,7 +557,7 @@ export function buildPluginCompatibilitySnapshotNotices(params?: {
   const report = buildPluginSnapshotReport(params);
   const context = resolvePluginRuntimeLoadContext(params);
   const runtimeRegistry = resolveCompatibleRuntimePluginRegistry(
-    buildPluginRuntimeLoadOptions(context, { activate: false }),
+    buildPluginRuntimeLoadOptions(context),
   );
   const registeredPlugins = new Map(runtimeRegistry?.plugins.map((plugin) => [plugin.id, plugin]));
   // Hook shape is a runtime registration fact. Reuse compatible live registrations without

--- a/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
+++ b/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
@@ -410,6 +410,25 @@ describe("bundled plugin install/uninstall probe", () => {
     }
   });
 
+  it("rejects an enabled plugin that failed during gateway load", async () => {
+    const runtimeSmoke = await import(pathToFileURL(runtimeSmokePath).href);
+    const root = makePackageRoot();
+    const logPath = path.join(root, "gateway.log");
+    fs.writeFileSync(
+      logPath,
+      [
+        "[gateway] ready",
+        "[plugins] cua-computer failed to load from /app/dist/extensions/cua-computer/index.js: missing libX11",
+      ].join("\n"),
+      "utf8",
+    );
+
+    expect(() => runtimeSmoke.assertPluginLoaded(logPath, "cua-computer")).toThrow(
+      /cua-computer failed to load/u,
+    );
+    expect(() => runtimeSmoke.assertPluginLoaded(logPath, "slack")).not.toThrow();
+  });
+
   it("matches runtime slash aliases across command list surfaces", async () => {
     const runtimeSmoke = await import(pathToFileURL(runtimeSmokePath).href);
     const payload = {


### PR DESCRIPTION
## What Problem This Solves

Resolves Beta 8 prerelease failures across plugin registry identity, Slack native fallback limits, bundled CUA packaging/runtime loading, and two asynchronous plugin tests. It also closes a false-green in the packaged plugin lifecycle smoke that previously missed enabled-plugin load failures.

## Why This Change Was Made

Use the active plugin registry snapshot, compact only Slack's capped `response_url` fallback path, include the CUA driver in the root package closure, defer native CUA loading until availability or command execution, and make the affected tests wait on their actual completion contracts. The packaged lifecycle smoke now fails when its target plugin logs a load error.

## User Impact

Beta packages can register the bundled CUA plugin on minimal or headless hosts without desktop libraries present; CUA commands remain unavailable until their native prerequisites exist. Long Slack fallback replies stay within native limits, and prerelease validation catches real packaged-plugin load failures.

## Evidence

- Exact PR head: `6a084c37b02c93aa800846b3e3995355863e80db`, rebased onto `d4b96d98cfe8c1fa3315feef9399921cfd271ac0`.
- Fresh branch autoreview: no accepted/actionable findings, confidence `0.99`.
- Blacksmith `pnpm check:changed`: passed typecheck, lint, dependency guards, plugin boundaries, and runtime cycle checks.
- Exact-head packaged CUA lifecycle: package build, tarball integrity, bundled install, runtime smoke, and uninstall passed; the runtime registry loaded `cua-computer` without a plugin load error.
- Focused regressions: CUA driver tests `3/3`; bundled lifecycle harness `58/58`; plugin compatibility/status `33/33`; Mattermost `28/28`; Slack `47/47`; WhatsApp focused `42/42`; full WhatsApp project `1298/1298`.
- Independent `@trycua/cua-driver@0.14.1` audit: registry integrity `sha512-/o16k+vcTbdqwmvQqgFCKzrYksSQHz282qO8RkpD67GQoY4Vp3pyDndQexRJ8AbzNQpUt1bIXSAAaFBaMad6rg==`; downloaded tarball SHA-512 `fe8d7a93ebdc4db76ac26bd0aa01422b3ad892c4901f3dbcdaa3bc464a43ebb190a18e15a77a720e77507b1449f006f3350a54b756c85d200068505a31a77aae`; exports and 20-file package contents inspected; npm signature and SLSA provenance present.
- All six optional native packages are pinned to `0.14.1`, publish SLSA provenance, and declare the expected Darwin/Linux/Windows OS, CPU, and Linux glibc selectors.
- Hosted exact-head CI: 88 checks passed with no failures or pending checks, including the Windows Node lane.
