### PR TITLE
improve(tests): accelerate local service timeout fixture

### DIFF
--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -820,19 +820,34 @@ describe("provider local service", () => {
     const tempDir = tempDirs.make("openclaw-local-service-failed-unref-");
     const servicePidPath = path.join(tempDir, "service.pid");
     const moduleUrl = new URL("./provider-local-service.ts", import.meta.url).href;
-    // The assertion targets diagnostic-pipe cleanup after failed readiness.
-    // Give the nested Node child enough startup time under loaded CI.
-    const failedServiceReadyTimeoutMs = 5_000;
+    const failedServiceReadyTimeoutMs = 60_000;
     const serviceScript = [
       `const fs=require("node:fs");`,
       `fs.writeFileSync(${JSON.stringify(servicePidPath)},String(process.pid));`,
       `process.on("SIGTERM",()=>{});`,
       `setInterval(()=>process.stderr.write("tick\\n"),10);`,
     ].join("");
+    // Advance only the nested host's readiness clock after the service PID exists.
+    // This preserves live-child failure cleanup without spending the deadline in wall time.
     const script = [
+      `import fs from "node:fs";`,
       `import { ensureProviderLocalService } from ${JSON.stringify(moduleUrl)};`,
       `if (!process.send) throw new Error("missing one-shot host IPC");`,
       `process.on("disconnect", () => {});`,
+      `const realNow = Date.now.bind(Date);`,
+      `const realSetTimeout = globalThis.setTimeout.bind(globalThis);`,
+      `let clockOffsetMs = 0;`,
+      `Date.now = () => realNow() + clockOffsetMs;`,
+      `globalThis.setTimeout = (callback, delay, ...args) => {`,
+      `  if (clockOffsetMs === 0 && fs.existsSync(${JSON.stringify(servicePidPath)})) {`,
+      `    return realSetTimeout(() => {`,
+      `      clockOffsetMs = ${failedServiceReadyTimeoutMs + 1};`,
+      `      globalThis.setTimeout = realSetTimeout;`,
+      `      callback(...args);`,
+      `    }, 0);`,
+      `  }`,
+      `  return realSetTimeout(callback, delay, ...args);`,
+      `};`,
       `try {`,
       `  await ensureProviderLocalService({`,
       `    providerId: "local-failed-unref",`,
@@ -843,7 +858,10 @@ describe("provider local service", () => {
       `      readyTimeoutMs: ${failedServiceReadyTimeoutMs},`,
       `    },`,
       `  });`,
-      `} catch {}`,
+      `} catch (error) {`,
+      `  if (!(error instanceof Error) || !error.message.includes("did not become ready")) throw error;`,
+      `}`,
+      `if (clockOffsetMs === 0) throw new Error("test clock did not advance");`,
       `process.send({ kind: ${JSON.stringify(ONE_SHOT_HOST_READY_KIND)} });`,
     ].join("\n");
     const parent = spawn(


### PR DESCRIPTION
## What Problem This Solves

The provider local-service test suite spent five seconds of wall time waiting for a real readiness deadline solely to verify that diagnostic pipes are released after a failed startup. That made one cleanup regression test dominate the focused file.

## Why This Change Was Made

The test still starts a real child process and exercises the production timeout and cleanup path. Its nested host advances only its own clock after the service PID exists, then asserts both the exact readiness-timeout error and that the clock advance actually occurred. Production code, production timeout values, coverage, and test sharding are unchanged.

## User Impact

No product behavior changes. The focused test file completes substantially faster while retaining the same process-lifecycle coverage.

## Evidence

- Focused wall time: 12.31s -> 7.32s (40.5% faster).
- Vitest test-body time: 9.19s -> 4.30s (53.2% faster).
- Former 5.575s cleanup case: approximately 0.78s.
- `node scripts/run-vitest.mjs src/agents/provider-local-service.test.ts`: 22/22 passing on repeated runs.
- `git diff --check`: clean.
- Autoreview: no accepted/actionable findings.
- `node scripts/check-changed.mjs` attempted remote delegation; Blacksmith Testbox and brokered Crabbox were unavailable, so focused local proof was used and hosted CI is the broad gate.
