### PR TITLE
fix: sessions_send follow-ups fail after parent request completes

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Value } from "typebox/value";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelMessagingAdapter } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
@@ -11,6 +11,13 @@ import {
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { createSessionVisibilityChecker } from "../plugin-sdk/session-visibility.js";
+import {
+  GatewayDrainingError,
+  getActiveGatewayRootWorkCount,
+  isGatewaySubordinateWorkAdmissionClosed,
+  resetGatewayWorkAdmission,
+} from "../process/gateway-work-admission.js";
+import { runWithGatewayRootWorkAdmissionForTest } from "../process/gateway-work-admission.test-helpers.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 
 const callGatewayMock = vi.fn();
@@ -259,6 +266,7 @@ function sessionsSendDetails(details: unknown): SessionsSendDetails {
 
 describe("sessions tools", () => {
   beforeEach(() => {
+    resetGatewayWorkAdmission();
     callGatewayMock.mockClear();
     embeddedRunsTesting.resetActiveEmbeddedRuns();
     loadSessionEntryByKeyMock.mockReset();
@@ -278,6 +286,7 @@ describe("sessions tools", () => {
       callGateway: (opts: unknown) => callGatewayMock(opts),
     });
   });
+  afterEach(resetGatewayWorkAdmission);
 
   it("uses integer schemas for session count and window parameters", () => {
     const tools = createOpenClawTools();
@@ -1420,11 +1429,19 @@ describe("sessions tools", () => {
     expect(sendParams.message).toBe("announce now");
   });
 
-  it("sessions_send keeps delayed requester replies alive after a wait timeout", async () => {
+  it("sessions_send admits delayed ping-pong and final announce after the parent root releases", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     const requesterKey = "agent:main:main";
     const targetKey = "agent:director1:main";
     let targetWaitCount = 0;
+    let releaseDelayedWait = () => {};
+    const delayedWaitGate = new Promise<void>((resolve) => {
+      releaseDelayedWait = resolve;
+    });
+    let requesterProviderStarts = 0;
+    let requesterAdmissionClosed: boolean | undefined;
+    let finalAnnounceProviderStarts = 0;
+    let finalAnnounceAdmissionClosed: boolean | undefined;
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };
       calls.push(request);
@@ -1434,6 +1451,11 @@ describe("sessions tools", () => {
           return { runId: "run-target", status: "accepted", acceptedAt: 2000 };
         }
         if (params?.sessionKey === requesterKey) {
+          requesterAdmissionClosed = isGatewaySubordinateWorkAdmissionClosed();
+          if (requesterAdmissionClosed) {
+            throw new GatewayDrainingError();
+          }
+          requesterProviderStarts += 1;
           return { runId: "run-requester", status: "accepted", acceptedAt: 2001 };
         }
       }
@@ -1441,9 +1463,11 @@ describe("sessions tools", () => {
         const params = request.params as { runId?: string } | undefined;
         if (params?.runId === "run-target") {
           targetWaitCount += 1;
-          return targetWaitCount === 1
-            ? { runId: "run-target", status: "timeout" }
-            : { runId: "run-target", status: "ok" };
+          if (targetWaitCount === 1) {
+            return { runId: "run-target", status: "timeout" };
+          }
+          await delayedWaitGate;
+          return { runId: "run-target", status: "ok" };
         }
         if (params?.runId === "run-requester") {
           return { runId: "run-requester", status: "ok" };
@@ -1477,6 +1501,20 @@ describe("sessions tools", () => {
       }
       return {};
     });
+    agentStepTesting.setDepsForTest({
+      agentCommandFromIngress: async () => {
+        finalAnnounceAdmissionClosed = isGatewaySubordinateWorkAdmissionClosed();
+        if (finalAnnounceAdmissionClosed) {
+          throw new GatewayDrainingError();
+        }
+        finalAnnounceProviderStarts += 1;
+        return {
+          payloads: [{ text: "ANNOUNCE_SKIP", mediaUrl: null }],
+          meta: { durationMs: 1 },
+        };
+      },
+      callGateway: (opts: unknown) => callGatewayMock(opts),
+    });
 
     const tool = getSessionTool("sessions_send", {
       agentSessionKey: requesterKey,
@@ -1484,30 +1522,28 @@ describe("sessions tools", () => {
       config: cloneTestConfig(),
     });
 
-    const result = await tool.execute("call-delayed", {
-      sessionKey: targetKey,
-      message: "ping",
-      timeoutSeconds: 1,
-    });
+    const result = await runWithGatewayRootWorkAdmissionForTest(() =>
+      tool.execute("call-delayed", {
+        sessionKey: targetKey,
+        message: "ping",
+        timeoutSeconds: 1,
+      }),
+    );
     const details = sessionsSendDetails(result.details);
     expect(details.status).toBe("accepted");
     expect(details.sessionKey).toBe(targetKey);
     expect(details.delivery?.status).toBe("pending");
     expect(details.delivery?.mode).toBe("announce");
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+    releaseDelayedWait();
 
     await vi.waitFor(
       () => {
-        const requesterReplyCall = calls.find(
-          (call) =>
-            call.method === "agent" &&
-            (call.params as { sessionKey?: string } | undefined)?.sessionKey === requesterKey,
-        );
-        if (!requesterReplyCall) {
-          throw new Error("expected requester reply call");
-        }
+        expect(requesterAdmissionClosed).toBe(false);
       },
       { timeout: 2_000, interval: 5 },
     );
+    expect(requesterProviderStarts).toBe(3);
 
     const requesterReplyCall = calls.find(
       (call) =>
@@ -1528,6 +1564,11 @@ describe("sessions tools", () => {
     expect(replyParams?.extraSystemPrompt).toContain("Agent-to-agent reply step");
     expect(replyParams?.extraSystemPrompt).toContain("Current agent: Agent 1 (requester)");
     expect(calls.find((call) => call.method === "send")).toBeUndefined();
+    await vi.waitFor(() => {
+      expect(finalAnnounceAdmissionClosed).toBe(false);
+      expect(finalAnnounceProviderStarts).toBe(1);
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+    });
   });
 
   it("sessions_send reports active-run queue rejection without durable-session fallback", async () => {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -15,6 +15,8 @@ import type { AgentRouteBinding } from "../../config/types.agents.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { runWithGatewayIndependentRootWorkContinuation } from "../../process/gateway-work-admission.js";
 import { normalizeRouteBindingChannelId } from "../../routing/binding-scope.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import {
@@ -85,6 +87,8 @@ const SessionsSendToolSchema = Type.Object({
   timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
   watch: Type.Optional(Type.Boolean()),
 });
+
+const log = createSubsystemLogger("agents/sessions-send");
 
 const SessionsSendDeliverySchema = Type.Object(
   {
@@ -904,20 +908,29 @@ export function createSessionsSendTool(opts?: {
               flowTargetSessionKey === fallbackA2ASessionKey
                 ? fallbackBaselineReply
                 : baselineReply;
-            void runSessionsSendA2AFlow({
-              targetSessionKey: flowTargetSessionKey,
-              displayKey: flowDisplayKey,
-              message,
-              announceTimeoutMs,
-              // Cron runs are isolated jobs; target replies must not become new
-              // requester turns, but the target-side announce still runs.
-              maxPingPongTurns: isIsolatedCronRequester ? 0 : maxPingPongTurns,
-              requesterSessionKey: replyRequesterSessionKey,
-              requesterChannel,
-              baseline: flowBaseline,
-              roundOneReply,
-              waitRunId,
-              notifyRequesterOnWaitFailure,
+            // This detached flow can outlive the tool request that launched it.
+            // Own a fresh root so parent release cannot retire later nested turns.
+            void runWithGatewayIndependentRootWorkContinuation(() =>
+              runSessionsSendA2AFlow({
+                targetSessionKey: flowTargetSessionKey,
+                displayKey: flowDisplayKey,
+                message,
+                announceTimeoutMs,
+                // Cron runs are isolated jobs; target replies must not become new
+                // requester turns, but the target-side announce still runs.
+                maxPingPongTurns: isIsolatedCronRequester ? 0 : maxPingPongTurns,
+                requesterSessionKey: replyRequesterSessionKey,
+                requesterChannel,
+                baseline: flowBaseline,
+                roundOneReply,
+                waitRunId,
+                notifyRequesterOnWaitFailure,
+              }),
+            ).catch((err: unknown) => {
+              log.warn("sessions_send announce flow admission failed", {
+                runId: waitRunId ?? "unknown",
+                error: formatErrorMessage(err),
+              });
             });
           };
 

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -183,6 +183,32 @@ it("does not admit an unrelated continuation through restart drain", async () =>
   expect(ran).not.toHaveBeenCalled();
 });
 
+it("real restart drain blocks a reserved continuation before provider execution and releases it", async () => {
+  let releaseContinuation = () => {};
+  const continuationGate = new Promise<void>((resolve) => {
+    releaseContinuation = resolve;
+  });
+  const providerStarted = vi.fn();
+  let continuation: Promise<void> | undefined;
+
+  await runWithGatewayRootWorkAdmissionForTest(async () => {
+    continuation = runWithGatewayIndependentRootWorkContinuation(async () => {
+      await continuationGate;
+      if (isGatewaySubordinateWorkAdmissionClosed()) {
+        throw new GatewayDrainingError();
+      }
+      providerStarted();
+    });
+  });
+
+  expect(getActiveGatewayRootWorkCount()).toBe(1);
+  markGatewayRestartDraining();
+  releaseContinuation();
+  await expect(continuation).rejects.toThrow(GatewayDrainingError);
+  expect(providerStarted).not.toHaveBeenCalled();
+  expect(getActiveGatewayRootWorkCount()).toBe(0);
+});
+
 it("does not let a stale suspension release clear restart drain", () => {
   const invalidated = vi.fn();
   const suspension = tryBeginGatewaySuspendAdmission(invalidated);


### PR DESCRIPTION
<!-- AI-assisted change. No agent transcript is included. -->

## What Problem This Solves

Fixes an issue where a delayed `sessions_send` agent-to-agent reply could fail before provider execution after the tool request that launched it had already completed. The detached follow-up inherited the completed request's released gateway admission root, so later ping-pong or final-announce work could receive `GatewayDrainingError` even though the gateway was not actually restarting.

## Why This Change Was Made

The detached A2A flow now reserves its own independently tracked gateway root at the common launch boundary for its complete wait, ping-pong, and final-announce lifetime. Actual restart drain remains authoritative and still blocks later provider work; this does not relax admission globally, retain the parent request, retry failures, or change model fallback classification.

## User Impact

Delayed `sessions_send` follow-ups can complete after their parent tool request returns instead of silently losing the nested turn. Operators still get the existing restart safety: genuinely draining gateways reject new provider work.

## Evidence

- Red on exact base `1704ea591820f3eee6e655fef302987e1ba5eac6`: the delayed fixture released the parent root, then observed `requesterAdmissionClosed=true` and zero provider starts (`35 passed, 1 failed`) on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30759491465).
- Green on the proposed diff: the same fixture observed open admission through delayed ping-pong and final announce, then zero active roots; the real-restart negative control observed `GatewayDrainingError`, zero provider starts, and zero leaked roots (`54 passed`) on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30759909913).
- Source-blind behavior validation passed both named lifecycle contracts and distinguished the green behavior from the exact-base red control.
- `pnpm check:changed` passed on Blacksmith Testbox: core/core-test typecheck, lint, formatting, import-cycle, dependency, storage, API, and boundary guards.
- `pnpm build` passed on the exact proposed diff at committed head `df08aa262701c7efcfdc98a3e85cc48dcfeafc6d` before its no-conflict rebase onto current `main`; the rebase changed only the commit identity to `32e49c91c1be49d2c7d2c9651c04c8ea5d654bf3` on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30760417857).
- Fresh uncommitted autoreview: no accepted/actionable findings; overall `patch is correct (0.96)`.

### Maintainer review evidence map

- **Best-fix verdict:** yes. The detached launcher owns the lifetime transition, so it is the narrowest canonical boundary that covers the wait, both ping-pong directions, and final announce without weakening gateway drain semantics.
- **Root cause:** gateway admission added released-root authority after delayed A2A work already existed; `sessions_send` continued launching detached work inside its request root, then reused that released async context after waiting.
- **Owner/call path:** `sessions_send` common `startA2AFlow` launch → `runSessionsSendA2AFlow` wait → nested `runAgentStep` → session lifecycle admission → provider execution. The fix changes only the launch ownership transition.
- **Sibling coverage:** existing webhook, reply-queue, and cron continuations already use the same independent-root primitive. New tests cover delayed ping-pong plus final announce, root accounting, and real restart drain before provider execution.
- **Alternatives considered:** retaining the parent request root conflates request and background lifetimes; wrapping each nested step duplicates policy downstream; retrying or relaxing drain masks the owner defect and can violate restart safety; wrapping the A2A helper itself broadens behavior for direct callers instead of fixing the detached launcher.
- **Code read:** full A2A flow, launcher branches, nested-agent lifecycle admission, command queue, root admission implementation/tests, gateway request release, sibling continuation owners, relevant history, and Codex turn-start/runtime boundaries.
- **Provenance:** delayed A2A follow-up behavior predates gateway root admission. The interaction became faulty when PR #103618 (`1bcc4c5e7063`) made released inherited roots authoritative without retrofitting the `sessions_send` detached launcher; delayed continuation behavior was expanded in PR #76484 (`b0a6543838ac`).
- **Production LOC:** `+27/-14` (`+13` net), used for the explicit owner transfer, required lifecycle comment, and observable rejection logging; tests are `+85/-18`.
- **Remaining uncertainty:** the generic stale-root mechanism is reproduced and repaired. Historical incident attribution would still require proving that no real restart drain overlapped the original timestamps; this PR intentionally does not change fallback classification.
