### PR TITLE
fix(realtime): stop stalled transcription sockets from retaining audio

### DIFF
--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -506,6 +506,102 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     expect(session.isConnected()).toBe(false);
   });
 
+  it("terminates once when binary audio reaches the active socket buffer cap", async () => {
+    const onError = vi.fn();
+    const server = await createRealtimeServer();
+    const session = createRealtimeTranscriptionWebSocketSession({
+      providerId: "test",
+      callbacks: { onError },
+      url: server.url,
+      readyOnOpen: true,
+      sendAudio: (audio, transport) => {
+        transport.sendBinary(audio);
+      },
+    });
+
+    await session.connect();
+    const ownedSocket = Reflect.get(session, "ws") as WebSocket;
+    const terminate = vi.spyOn(ownedSocket, "terminate");
+    Object.defineProperty(ownedSocket, "bufferedAmount", {
+      configurable: true,
+      get: () => 1024 * 1024,
+    });
+
+    session.sendAudio(Buffer.from([1]));
+    await vi.waitFor(() => expect(terminate).toHaveBeenCalledOnce());
+    expect(session.isConnected()).toBe(false);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(requireFirstMockArg(onError, "binary backpressure error").message).toMatch(
+      /send buffer exceeded/,
+    );
+
+    session.sendAudio(Buffer.from([2]));
+    expect(terminate).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the active socket buffer cap to JSON provider frames", async () => {
+    let providerTransport: RealtimeTranscriptionWebSocketTransport | undefined;
+    const onError = vi.fn();
+    const server = await createRealtimeServer();
+    const session = createRealtimeTranscriptionWebSocketSession({
+      providerId: "test",
+      callbacks: { onError },
+      url: server.url,
+      readyOnOpen: true,
+      onOpen: (transport) => {
+        providerTransport = transport;
+      },
+      sendAudio: (audio, transport) => {
+        transport.sendBinary(audio);
+      },
+    });
+
+    await session.connect();
+    const ownedSocket = Reflect.get(session, "ws") as WebSocket;
+    const terminate = vi.spyOn(ownedSocket, "terminate");
+    Object.defineProperty(ownedSocket, "bufferedAmount", {
+      configurable: true,
+      get: () => 1024 * 1024,
+    });
+
+    expect(providerTransport?.sendJson({ type: "provider.control" })).toBe(false);
+    await vi.waitFor(() => expect(terminate).toHaveBeenCalledOnce());
+    expect(session.isConnected()).toBe(false);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(requireFirstMockArg(onError, "json backpressure error").message).toMatch(
+      /send buffer exceeded/,
+    );
+  });
+
+  it("rejects connect when provider handshake frames exceed the socket buffer cap", async () => {
+    const onError = vi.fn();
+    const server = await createRealtimeServer();
+    const session = createRealtimeTranscriptionWebSocketSession({
+      providerId: "test",
+      callbacks: { onError },
+      url: server.url,
+      onOpen: (transport) => {
+        const ownedSocket = Reflect.get(session, "ws") as WebSocket;
+        Object.defineProperty(ownedSocket, "bufferedAmount", {
+          configurable: true,
+          get: () => 1024 * 1024,
+        });
+        expect(transport.sendJson({ type: "session.update" })).toBe(false);
+      },
+      sendAudio: (audio, transport) => {
+        transport.sendBinary(audio);
+      },
+    });
+
+    await expect(session.connect()).rejects.toThrow(/send buffer exceeded/);
+    expect(session.isConnected()).toBe(false);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(requireFirstMockArg(onError, "handshake backpressure error").message).toMatch(
+      /send buffer exceeded/,
+    );
+  });
+
   it("lets providers mark ready after a JSON handshake", async () => {
     const frames: unknown[] = [];
     const framesReady = createSignal();

--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -58,6 +58,9 @@ const RECONNECT_STABLE_RESET_MS = 30_000;
 // matches realtime voice; ws rejects larger messages with close 1009 before
 // they reach onMessage, replacing its 100 MiB client default.
 const REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
+// ws retains outbound frames until the provider socket drains. Match the
+// voice-call egress ceiling so a stalled provider cannot grow heap indefinitely.
+const REALTIME_TRANSCRIPTION_WS_MAX_BUFFERED_BYTES = 1024 * 1024;
 
 function defaultParseMessage(payload: Buffer): unknown {
   try {
@@ -239,6 +242,19 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
       };
       this.cancelConnecting = finishClosedConnect;
 
+      const handleBackpressure = () => {
+        const error = new Error(
+          `${this.options.providerId} realtime transcription send buffer exceeded ${REALTIME_TRANSCRIPTION_WS_MAX_BUFFERED_BYTES} bytes; closing stalled connection`,
+        );
+        if (!settled) {
+          failConnect(error);
+          return;
+        }
+        if (socket) {
+          this.closeForBackpressure(socket, error);
+        }
+      };
+
       const transport: RealtimeTranscriptionWebSocketTransport = {
         callbacks: this.options.callbacks,
         closeNow: () => {
@@ -262,8 +278,9 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
             finishConnect();
           }
         },
-        sendBinary: (payload) => this.send(payload, socket, generation),
-        sendJson: (payload) => this.send(JSON.stringify(payload), socket, generation),
+        sendBinary: (payload) => this.send(payload, socket, generation, handleBackpressure),
+        sendJson: (payload) =>
+          this.send(JSON.stringify(payload), socket, generation, handleBackpressure),
       };
 
       connectTimeout = setTimeout(() => {
@@ -480,6 +497,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
     payload: Buffer | string,
     socket: WebSocket | undefined,
     generation: number,
+    handleBackpressure: () => void,
   ): boolean {
     if (
       !socket ||
@@ -489,9 +507,30 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
     ) {
       return false;
     }
+    const payloadBytes =
+      typeof payload === "string" ? Buffer.byteLength(payload) : payload.byteLength;
+    if (socket.bufferedAmount + payloadBytes > REALTIME_TRANSCRIPTION_WS_MAX_BUFFERED_BYTES) {
+      handleBackpressure();
+      return false;
+    }
     this.captureFrame("outbound", payload);
     socket.send(payload);
     return true;
+  }
+
+  private closeForBackpressure(socket: WebSocket, error: Error): void {
+    if (socket !== this.ws) {
+      return;
+    }
+    const shouldReport = !this.closed;
+    this.closed = true;
+    this.cancelConnecting?.();
+    this.reconnectSupervisor.cancel();
+    this.clearQueuedAudio();
+    this.forceClose(socket);
+    if (shouldReport) {
+      this.emitError(error);
+    }
   }
 
   private forceClose(socket: WebSocket | null | undefined = this.ws): void {


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where realtime transcription sessions could retain an unbounded outbound WebSocket queue when a provider connection stopped draining while audio or control frames continued arriving.

The shared session owns OpenAI, Deepgram, ElevenLabs, Mistral, and xAI streaming transcription, so one stalled provider socket could otherwise grow process memory until the session was closed externally.

## Why This Change Was Made

The shared WebSocket session now admits the next binary or JSON frame only while total active socket retention stays within 1 MiB, matching the existing voice-call egress ceiling.

At the highest raw PCM rate used by this path, 24 kHz mono 16-bit audio, 1 MiB represents about 21.8 seconds of unsent audio before protocol overhead. Healthy realtime delivery should remain far below that high-water mark; reaching it means the peer is materially stalled.

Pre-ready overflow rejects through the existing connection-failure owner. Overflow after readiness is terminal exactly once: reconnect ownership is cancelled, queued audio is cleared, and the owned socket is terminated. No provider-specific policy, retry path, config, environment variable, protocol, or public SDK surface is added.

## User Impact

Voice Call and meeting workflows using any registered realtime transcription provider no longer allow a stalled provider socket to accumulate outbound audio indefinitely. Healthy streaming, provider readiness, reconnect behavior, cancellation, and idempotent close remain unchanged.

## Evidence

- Before the implementation, the new regression tests failed because binary overflow did not terminate the socket and JSON overflow was still accepted.
- Shared lifecycle suite: 26/26 passed.
- Provider suites: 58/58 passed across OpenAI, Deepgram, ElevenLabs, Mistral, and xAI.
- Live OpenAI realtime STT: synthesized telephony audio streamed through the registered provider and produced the expected transcription in 6.6 seconds.
- Scoped `oxlint`, `oxfmt`, `git diff --check`, and signed-commit verification passed.
- P1 autoreview: clean, no actionable findings, 0.91 correctness confidence.
- Blacksmith changed gate passed on exact head in 8m07s: https://github.com/openclaw/openclaw/actions/runs/30760897449
- PR CI passed with 52 successful checks, 0 pending, and 0 failing.

Production delta: +41/-2. Tests: +96.
