### PR TITLE
feat(channels): publish recorded lifecycle from bundled channel transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Channel lifecycle status:** publish channel-authored ready, recovering, and blocked lifecycle facts from Discord, Telegram, WhatsApp, and bundled channels with canonical transition publishers, while preserving existing channel-specific health labels.
 - **Browser extension relay CDP compat:** answer `Target.getBrowserContexts` so Puppeteer-based clients (chrome-devtools-mcp) can drive the paired Chrome without the remote-debugging permission prompt, serve DevTools-style `/json/list` target descriptors, and add `openclaw browser extension cdp` to print the relay endpoint plus auth header for external CDP clients.
 - **Local model setup:** advertise provider-owned Ollama, llama.cpp, and LM Studio setup choices to Control UI and macOS, retry unavailable LM Studio services in place, and verify the exact prepared model before showing success.
 - **Control UI first-run setup:** continue verified model setup into Custodian, explain that the web app is ready without a channel, and offer an optional dismissible path to Channels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Channel lifecycle status:** publish channel-authored ready, recovering, and blocked lifecycle facts from Discord, Telegram, WhatsApp, and bundled channels with canonical transition publishers, while preserving existing channel-specific health labels.
 - **Browser extension relay CDP compat:** answer `Target.getBrowserContexts` so Puppeteer-based clients (chrome-devtools-mcp) can drive the paired Chrome without the remote-debugging permission prompt, serve DevTools-style `/json/list` target descriptors, and add `openclaw browser extension cdp` to print the relay endpoint plus auth header for external CDP clients.
 - **Local model setup:** advertise provider-owned Ollama, llama.cpp, and LM Studio setup choices to Control UI and macOS, retry unavailable LM Studio services in place, and verify the exact prepared model before showing success.
 - **Control UI first-run setup:** continue verified model setup into Custodian, explain that the web app is ready without a channel, and offer an optional dismissible path to Channels.

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -213,6 +213,13 @@ resolved config unchanged, stopping one account settles only that account's
 monitor and drain, and a fresh monitor recovers that account's rows exactly
 once. If any guarantee cannot be proved, omit the flag.
 
+### Runtime lifecycle status
+
+For channel-authored runtime state, `ChannelAccountSnapshot.lifecycle` is the
+successor to `healthState`. Existing plugins may keep publishing `healthState`
+during adoption, and core-derived policy writes remain supported. There is no
+removal date; removal waits for external channel-plugin adoption.
+
 ### Typing indicators
 
 If your channel supports typing indicators outside inbound replies, expose

--- a/extensions/buzz/src/gateway.lifecycle.test.ts
+++ b/extensions/buzz/src/gateway.lifecycle.test.ts
@@ -165,6 +165,16 @@ describe("Buzz gateway lifecycle", () => {
 
     await vi.waitFor(() => expect(gatewayMocks.startBuzzBus).toHaveBeenCalledOnce());
     expect(gatewayMocks.startBuzzBus.mock.calls[0]?.[0].profileName).toBe("Molt");
+    expect(setStatus).toHaveBeenCalledWith({
+      accountId: account.accountId,
+      running: true,
+      lifecycle: "ready",
+      configured: true,
+      enabled: account.enabled,
+      baseUrl: account.relayUrl,
+      publicKey: BOT_PUBLIC_KEY,
+      lastError: null,
+    });
     gatewayMocks.onFatalError?.(new Error("relay failed"));
 
     await vi.waitFor(() => expect(gatewayMocks.startBuzzBus).toHaveBeenCalledTimes(2), {
@@ -174,6 +184,7 @@ describe("Buzz gateway lifecycle", () => {
     expect(setStatus).toHaveBeenCalledWith({
       accountId: account.accountId,
       running: false,
+      lifecycle: "recovering",
       lastError: "relay failed",
     });
 

--- a/extensions/buzz/src/gateway.ts
+++ b/extensions/buzz/src/gateway.ts
@@ -141,6 +141,7 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
       ctx.setStatus({
         accountId: account.accountId,
         running: true,
+        lifecycle: "ready",
         configured: true,
         enabled: account.enabled,
         baseUrl: account.relayUrl,
@@ -170,6 +171,7 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
       ctx.setStatus({
         accountId: account.accountId,
         running: false,
+        ...(cycleError ? { lifecycle: "recovering" as const } : {}),
         ...(cycleError ? { lastError: cycleError.message } : {}),
       });
     }

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -2,7 +2,7 @@
 import { EventEmitter } from "node:events";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
-import type { GatewayPlugin } from "../internal/gateway.js";
+import { GatewayCloseCodes, type GatewayPlugin } from "../internal/gateway.js";
 import type { waitForDiscordGatewayStop } from "../monitor.gateway.js";
 import {
   DISCORD_GATEWAY_TRANSPORT_ACTIVITY_EVENT,
@@ -194,6 +194,8 @@ describe("runDiscordGatewayLifecycle", () => {
 
   type StatusPatch = {
     connected?: boolean;
+    lifecycle?: "ready" | "recovering" | "blocked";
+    terminalDisconnect?: boolean;
     lastDisconnect?: null | Record<string, unknown>;
     lastError?: string | null;
   };
@@ -268,7 +270,8 @@ describe("runDiscordGatewayLifecycle", () => {
 
     expectStatusPatch(
       statusSink,
-      (patch) => patch.connected === true && patch.lastDisconnect === null,
+      (patch) =>
+        patch.connected === true && patch.lifecycle === "ready" && patch.lastDisconnect === null,
     );
   });
 
@@ -363,7 +366,14 @@ describe("runDiscordGatewayLifecycle", () => {
       expectStatusPatch(
         statusSink,
         (patch) =>
-          patch.connected === true && patch.lastDisconnect === null && patch.lastError === null,
+          patch.connected === true &&
+          patch.lifecycle === "ready" &&
+          patch.lastDisconnect === null &&
+          patch.lastError === null,
+      );
+      expectStatusPatch(
+        statusSink,
+        (patch) => patch.connected === false && patch.lifecycle === "recovering",
       );
     } finally {
       vi.useRealTimers();
@@ -618,10 +628,37 @@ describe("runDiscordGatewayLifecycle", () => {
       statusSink,
       (patch) =>
         patch.connected === false &&
+        patch.lifecycle === "recovering" &&
         patch.lastDisconnect !== null &&
         patch.lastDisconnect?.status === 1006,
     );
   });
+
+  it.each([GatewayCloseCodes.AuthenticationFailed, GatewayCloseCodes.InvalidIntents])(
+    "publishes blocked lifecycle for fatal gateway close code %s",
+    async (closeCode) => {
+      const { emitter, gateway } = createGatewayHarness();
+      gateway.isConnected = true;
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+        emitter.emit("debug", `Gateway websocket closed: ${closeCode}`);
+      });
+
+      const { lifecycleParams, statusSink } = createLifecycleHarness({ gateway });
+
+      await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+      expectStatusPatch(
+        statusSink,
+        (patch) =>
+          patch.connected === false &&
+          patch.lifecycle === "blocked" &&
+          patch.terminalDisconnect === true &&
+          patch.lastError === `Gateway websocket closed: ${closeCode}` &&
+          patch.lastDisconnect?.status === closeCode,
+      );
+    },
+  );
 
   it("pushes disconnected status when the gateway schedules a reconnect", async () => {
     const { emitter, gateway } = createGatewayHarness();
@@ -639,6 +676,7 @@ describe("runDiscordGatewayLifecycle", () => {
       statusSink,
       (patch) =>
         patch.connected === false &&
+        patch.lifecycle === "recovering" &&
         patch.lastError === "Gateway reconnect scheduled in 1000ms (zombie, resume=true)",
     );
   });
@@ -665,7 +703,8 @@ describe("runDiscordGatewayLifecycle", () => {
       expectStatusPatch(statusSink, (patch) => patch.connected === false);
       expectStatusPatch(
         statusSink,
-        (patch) => patch.connected === true && patch.lastDisconnect === null,
+        (patch) =>
+          patch.connected === true && patch.lifecycle === "ready" && patch.lastDisconnect === null,
       );
     } finally {
       vi.useRealTimers();

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -1,13 +1,12 @@
 // Discord provider module implements model/runtime integration.
-import {
-  createConnectedChannelStatusPatch,
-  createTransportActivityStatusPatch,
-} from "openclaw/plugin-sdk/gateway-runtime";
+import { createTransportActivityStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { asDateTimestampMs, parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { danger, sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
+import { isFatalGatewayCloseCode } from "../internal/gateway-close-codes.js";
+import { GatewayCloseCodes } from "../internal/gateway.js";
 import { getDiscordGatewayEmitter, waitForDiscordGatewayStop } from "../monitor.gateway.js";
 import type { DiscordVoiceManager } from "../voice/manager.js";
 import {
@@ -20,7 +19,7 @@ import {
   type DiscordGatewayEvent,
   type DiscordGatewaySupervisor,
 } from "./gateway-supervisor.js";
-import type { DiscordMonitorStatusSink } from "./status.js";
+import { createDiscordReadyStatusPatch, type DiscordMonitorStatusSink } from "./status.js";
 
 const DEFAULT_DISCORD_GATEWAY_READY_TIMEOUT_MS = 15_000;
 const DEFAULT_DISCORD_GATEWAY_RUNTIME_READY_TIMEOUT_MS = 30_000;
@@ -214,11 +213,7 @@ function createGatewayStatusObserver(params: {
     queuedForceStopError = err;
   };
   const pushConnectedStatus = (at: number) => {
-    params.pushStatus({
-      ...createConnectedChannelStatusPatch(at),
-      lastDisconnect: null,
-      lastError: null,
-    });
+    params.pushStatus(createDiscordReadyStatusPatch(at));
   };
   const startReadyWatch = () => {
     clearReadyWatch();
@@ -249,6 +244,7 @@ function createGatewayStatusObserver(params: {
         );
         params.pushStatus({
           connected: false,
+          lifecycle: "recovering",
           lastEventAt: at,
           lastDisconnect: {
             at,
@@ -277,8 +273,14 @@ function createGatewayStatusObserver(params: {
     if (message.includes("Gateway websocket closed")) {
       clearReadyWatch();
       const code = parseGatewayCloseCode(message);
+      // Fatal gateway closes require operator repair. Keep the outer channel supervisor from
+      // turning an invalid credential or configuration into an automatic restart loop.
+      const terminalDisconnect =
+        code !== undefined && isFatalGatewayCloseCode(code as GatewayCloseCodes);
       params.pushStatus({
         connected: false,
+        lifecycle: terminalDisconnect ? "blocked" : "recovering",
+        ...(terminalDisconnect ? { terminalDisconnect: true, lastError: message } : {}),
         lastEventAt: at,
         lastDisconnect: {
           at,
@@ -291,6 +293,7 @@ function createGatewayStatusObserver(params: {
       clearReadyWatch();
       params.pushStatus({
         connected: false,
+        lifecycle: "recovering",
         lastEventAt: at,
         lastError: message,
       });
@@ -333,11 +336,7 @@ async function waitForGatewayReady(params: {
       }
       if (params.gateway?.isConnected === true) {
         const at = Date.now();
-        params.pushStatus?.({
-          ...createConnectedChannelStatusPatch(at),
-          lastDisconnect: null,
-          lastError: null,
-        });
+        params.pushStatus?.(createDiscordReadyStatusPatch(at));
         return "ready";
       }
       if (Date.now() >= deadlineAt) {
@@ -375,6 +374,7 @@ async function waitForGatewayReady(params: {
     );
     params.pushStatus?.({
       connected: false,
+      lifecycle: "recovering",
       lastEventAt: restartAt,
       lastDisconnect: {
         at: restartAt,

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -1172,8 +1172,12 @@ describe("monitorDiscordProvider", () => {
       setStatus,
     });
 
-    const statuses = setStatus.mock.calls.map((call) => call[0] as { connected?: boolean });
-    expect(statuses.some((status) => status.connected === true)).toBe(true);
+    const statuses = setStatus.mock.calls.map(
+      (call) => call[0] as { connected?: boolean; lifecycle?: string },
+    );
+    expect(
+      statuses.some((status) => status.connected === true && status.lifecycle === "ready"),
+    ).toBe(true);
     expect(statuses.some((status) => status.connected === false)).toBe(true);
   });
 

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -1,7 +1,6 @@
 // Discord provider module implements model/runtime integration.
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig, ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
-import { createConnectedChannelStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
@@ -42,7 +41,7 @@ import {
 } from "./provider.startup.js";
 import { resolveDiscordRestFetch } from "./rest-fetch.js";
 import { formatDiscordStartupStatusMessage } from "./startup-status.js";
-import type { DiscordMonitorStatusSink } from "./status.js";
+import { createDiscordReadyStatusPatch, type DiscordMonitorStatusSink } from "./status.js";
 
 export type MonitorDiscordOpts = {
   token?: string;
@@ -482,7 +481,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       }),
     );
     if (lifecycleGateway?.isConnected) {
-      opts.setStatus?.(createConnectedChannelStatusPatch());
+      opts.setStatus?.(createDiscordReadyStatusPatch());
     }
 
     lifecycleStarted = true;

--- a/extensions/discord/src/monitor/status.ts
+++ b/extensions/discord/src/monitor/status.ts
@@ -1,4 +1,6 @@
 // Discord plugin module implements status behavior.
+import { createConnectedChannelStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
+
 type DiscordMonitorStatusPatch = {
   connected?: boolean;
   lastEventAt?: number | null;
@@ -15,9 +17,22 @@ type DiscordMonitorStatusPatch = {
     | null;
   lastInboundAt?: number | null;
   lastError?: string | null;
+  lifecycle?: "ready" | "recovering" | "blocked";
+  terminalDisconnect?: boolean;
   busy?: boolean;
   activeRuns?: number;
   lastRunActivityAt?: number | null;
 };
 
 export type DiscordMonitorStatusSink = (patch: DiscordMonitorStatusPatch) => void;
+
+/** READY proves a prior terminal failure was repaired, so the account is restartable again. */
+export function createDiscordReadyStatusPatch(at: number = Date.now()) {
+  return {
+    ...createConnectedChannelStatusPatch(at),
+    lifecycle: "ready" as const,
+    terminalDisconnect: undefined,
+    lastDisconnect: null,
+    lastError: null,
+  };
+}

--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -103,7 +103,11 @@ async function startDisconnectingIrcServer(): Promise<DisconnectingIrcServer> {
         idx = buffer.indexOf("\n");
         lines.push(line);
         if (line.startsWith("USER ")) {
-          socket.write(":server 001 bot :welcome\r\n");
+          if (connectionNumber === 2) {
+            socket.destroy();
+          } else {
+            socket.write(":server 001 bot :welcome\r\n");
+          }
           if (connectionNumber === 1) {
             setTimeout(() => socket.destroy(), 10);
           }
@@ -333,6 +337,7 @@ describe("irc monitor reconnect", () => {
   it("reconnects when an established IRC socket closes", async () => {
     await withIngressQueue(async (ingressQueue) => {
       installMonitorRuntime();
+      const statusSink = vi.fn();
       const server = await startDisconnectingIrcServer();
       const config = {
         channels: {
@@ -350,14 +355,20 @@ describe("irc monitor reconnect", () => {
       let monitor: { stop: () => Promise<void> } | undefined;
 
       try {
-        monitor = await monitorIrcProvider({ config, ingressQueue });
+        monitor = await monitorIrcProvider({ config, ingressQueue, statusSink });
         await waitForIrcCondition(
           () =>
-            server.connectionCount >= 2 &&
-            server.lines.filter((line) => line === "USER bot 0 * :OpenClaw").length >= 2,
-          "expected IRC monitor to reconnect after the first socket closed",
+            server.connectionCount >= 3 &&
+            server.lines.filter((line) => line === "USER bot 0 * :OpenClaw").length >= 3 &&
+            statusSink.mock.calls.filter(([patch]) => patch.lifecycle).length >= 4,
+          "expected IRC monitor to recover after a failed reconnect attempt",
         );
-        expect(server.connectionCount).toBeGreaterThanOrEqual(2);
+        expect(server.connectionCount).toBeGreaterThanOrEqual(3);
+        expect(
+          statusSink.mock.calls.flatMap(([patch]) =>
+            patch.lifecycle ? [patch.lifecycle as string] : [],
+          ),
+        ).toEqual(["ready", "recovering", "recovering", "ready"]);
       } finally {
         if (monitor) {
           await monitor.stop();

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -1,5 +1,6 @@
 // Irc plugin module implements monitor behavior.
 import { resolveLoggerBackedRuntime } from "openclaw/plugin-sdk/extension-shared";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/status-helpers";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveIrcAccount } from "./accounts.js";
 import { connectIrcClient, type IrcClient } from "./client.js";
@@ -19,7 +20,11 @@ type IrcMonitorOptions = {
   config?: CoreConfig;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: (patch: {
+    lastInboundAt?: number;
+    lastOutboundAt?: number;
+    lifecycle?: ChannelAccountSnapshot["lifecycle"];
+  }) => void;
   onMessage?: (message: IrcInboundMessage, client: IrcClient) => void | Promise<void>;
   ingressQueue?: NonNullable<Parameters<typeof createIrcIngressMonitor>[0]["queue"]>;
 };
@@ -135,6 +140,7 @@ export async function monitorIrcProvider(
     if (stopped || monitorAbort.signal.aborted || reconnectTimer) {
       return;
     }
+    opts.statusSink?.({ lifecycle: "recovering" });
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
       void connect().catch((error: unknown) => {
@@ -215,6 +221,7 @@ export async function monitorIrcProvider(
       return;
     }
     ingress.start();
+    opts.statusSink?.({ lifecycle: "ready" });
 
     logger.info(
       `[${account.accountId}] connected to ${account.host}:${account.port}${account.tls ? " (tls)" : ""} as ${nextClient.nick}`,

--- a/extensions/nextcloud-talk/src/monitor-runtime.abort.test.ts
+++ b/extensions/nextcloud-talk/src/monitor-runtime.abort.test.ts
@@ -11,6 +11,7 @@ describe("Nextcloud Talk monitor abort", () => {
     const abortController = new AbortController();
     const serverStop = vi.fn(async () => {});
     const spoolStop = vi.fn(async () => {});
+    const statusSink = vi.fn();
     const createSpool = vi.fn(() => ({
       receive: vi.fn(async () => "accepted" as const),
       ready: vi.fn(async () => {}),
@@ -33,6 +34,7 @@ describe("Nextcloud Talk monitor abort", () => {
       },
       runtime: { error: vi.fn(), log: vi.fn(), exit: vi.fn() as never },
       abortSignal: abortController.signal,
+      statusSink,
       createSpool,
       createServer,
     });
@@ -40,10 +42,48 @@ describe("Nextcloud Talk monitor abort", () => {
     expect(createSpool).toHaveBeenCalledWith(
       expect.objectContaining({ abortSignal: abortController.signal }),
     );
+    expect(statusSink).toHaveBeenCalledExactlyOnceWith({ lifecycle: "ready" });
     abortController.abort();
     await vi.waitFor(() => expect(spoolStop).toHaveBeenCalledOnce());
     await monitor.stop();
 
+    expect(serverStop).toHaveBeenCalledOnce();
+    expect(spoolStop).toHaveBeenCalledOnce();
+  });
+
+  it("does not publish ready when startup is aborted after the listener opens", async () => {
+    setNextcloudTalkRuntime(createPluginRuntimeMock() as unknown as PluginRuntime);
+    const abortController = new AbortController();
+    const statusSink = vi.fn();
+    const serverStop = vi.fn(async () => {});
+    const spoolStop = vi.fn(async () => {});
+
+    await monitorNextcloudTalkProvider({
+      config: {
+        channels: {
+          "nextcloud-talk": {
+            baseUrl: "https://cloud.example.com",
+            botSecret: "test-bot-secret",
+          },
+        },
+      },
+      runtime: { error: vi.fn(), log: vi.fn(), exit: vi.fn() as never },
+      abortSignal: abortController.signal,
+      statusSink,
+      createSpool: () => ({
+        receive: vi.fn(async () => "accepted" as const),
+        ready: vi.fn(async () => {}),
+        stop: spoolStop,
+        waitForIdle: vi.fn(async () => {}),
+      }),
+      createServer: () => ({
+        server: {} as never,
+        start: vi.fn(async () => abortController.abort()),
+        stop: serverStop,
+      }),
+    });
+
+    expect(statusSink).not.toHaveBeenCalled();
     expect(serverStop).toHaveBeenCalledOnce();
     expect(spoolStop).toHaveBeenCalledOnce();
   });

--- a/extensions/nextcloud-talk/src/monitor-runtime.ts
+++ b/extensions/nextcloud-talk/src/monitor-runtime.ts
@@ -1,6 +1,7 @@
 // Nextcloud Talk plugin module implements monitor runtime behavior.
 import { resolveLoggerBackedRuntime } from "openclaw/plugin-sdk/extension-shared";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/status-helpers";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveNextcloudTalkAccount } from "./accounts.js";
 import { handleNextcloudTalkInbound } from "./inbound.js";
@@ -33,7 +34,11 @@ type NextcloudTalkMonitorOptions = {
     message: NextcloudTalkInboundMessage,
     lifecycle: NextcloudTalkIngressLifecycle,
   ) => void | Promise<void>;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: (patch: {
+    lastInboundAt?: number;
+    lastOutboundAt?: number;
+    lifecycle?: ChannelAccountSnapshot["lifecycle"];
+  }) => void;
   createSpool?: typeof createNextcloudTalkWebhookSpool;
   createServer?: typeof createNextcloudTalkWebhookServer;
 };
@@ -138,6 +143,7 @@ export async function monitorNextcloudTalkProvider(
     await stop();
     return { stop };
   }
+  opts.statusSink?.({ lifecycle: "ready" });
 
   const publicUrl =
     account.config.webhookPublicUrl ??

--- a/extensions/qqbot/src/channel.gateway-status.test.ts
+++ b/extensions/qqbot/src/channel.gateway-status.test.ts
@@ -68,11 +68,13 @@ describe("qqbot channel gateway status", () => {
 
     options.onReady?.({});
     expect(getStatus().connected).toBe(true);
+    expect(getStatus().lifecycle).toBe("ready");
 
     expect(options.onDisconnected).toBeDefined();
     options.onDisconnected?.({ reason: "close code 1006", fatal: false });
     expect(getStatus().connected).toBe(false);
     expect(getStatus().running).toBe(true);
+    expect(getStatus().lifecycle).toBe("recovering");
   });
 
   it("marks fatal disconnects unhealthy and records the close reason", async () => {
@@ -87,6 +89,7 @@ describe("qqbot channel gateway status", () => {
     // flip it here (a Start action would no-op against a held task).
     expect(getStatus().running).toBe(true);
     expect(getStatus().lastError).toBe("banned");
+    expect(getStatus().lifecycle).toBe("blocked");
 
     const publicStatus = await qqbotPlugin.status?.buildAccountSnapshot?.({
       account,
@@ -95,6 +98,15 @@ describe("qqbot channel gateway status", () => {
     });
     expect(publicStatus?.connected).toBe(false);
     expect(publicStatus?.lastError).toBe("banned");
+    expect(publicStatus?.lifecycle).toBe("blocked");
+
+    const publicSummary = await qqbotPlugin.status?.buildChannelSummary?.({
+      account,
+      cfg: {},
+      defaultAccountId: "test-account",
+      snapshot: getStatus(),
+    });
+    expect(publicSummary?.lifecycle).toBe("blocked");
   });
 
   it("clears fatal errors when the gateway becomes ready or resumes", async () => {
@@ -106,11 +118,13 @@ describe("qqbot channel gateway status", () => {
 
     expect(getStatus().connected).toBe(true);
     expect(getStatus().lastError).toBeNull();
+    expect(getStatus().lifecycle).toBe("ready");
 
     options.onDisconnected?.({ reason: "offline/sandbox-only", fatal: true });
     options.onReady?.({});
 
     expect(getStatus().connected).toBe(true);
     expect(getStatus().lastError).toBeNull();
+    expect(getStatus().lifecycle).toBe("ready");
   });
 });

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -387,6 +387,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
             connected: true,
             lastConnectedAt: Date.now(),
             lastError: null,
+            lifecycle: "ready",
           });
           // Snapshot credentials so we can recover from the next hot
           // upgrade that might wipe openclaw.json mid-flight.
@@ -400,6 +401,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
             connected: true,
             lastConnectedAt: Date.now(),
             lastError: null,
+            lifecycle: "ready",
           });
           persistAccountCredentialSnapshot(account);
         },
@@ -420,6 +422,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
           ctx.setStatus({
             ...ctx.getStatus(),
             connected: false,
+            lifecycle: fatal ? "blocked" : "recovering",
             ...(fatal && reason ? { lastError: reason } : {}),
           });
         },
@@ -457,6 +460,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
       tokenSource: snapshot.tokenSource ?? "none",
       running: snapshot.running ?? false,
       connected: snapshot.connected ?? false,
+      lifecycle: snapshot.lifecycle ?? undefined,
       lastConnectedAt: snapshot.lastConnectedAt ?? null,
       lastError: snapshot.lastError ?? null,
     }),
@@ -468,6 +472,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
       tokenSource: account?.secretSource,
       running: runtime?.running ?? false,
       connected: runtime?.connected ?? false,
+      lifecycle: runtime?.lifecycle,
       lastConnectedAt: runtime?.lastConnectedAt ?? null,
       lastError: runtime?.lastError ?? null,
       lastInboundAt: runtime?.lastInboundAt ?? null,

--- a/extensions/raft/src/gateway.test.ts
+++ b/extensions/raft/src/gateway.test.ts
@@ -198,6 +198,7 @@ describe("Raft wake gateway", () => {
 
     const wakeEndpoint = await waitFor(() => endpoint);
     const bridgeToken = await waitFor(() => token);
+    expect(ctx.getStatus()).toMatchObject({ lifecycle: "ready" });
     await expect(fetch(wakeEndpoint.replace("/wake", "/health"))).resolves.toMatchObject({
       status: 200,
     });

--- a/extensions/raft/src/gateway.ts
+++ b/extensions/raft/src/gateway.ts
@@ -380,6 +380,7 @@ export async function startRaftGatewayAccount(
     ctx.setStatus({
       accountId: ctx.accountId,
       running: true,
+      lifecycle: "ready",
       connected: true,
       lastStartAt: Date.now(),
       lastError: null,

--- a/extensions/reef/src/channel.test.ts
+++ b/extensions/reef/src/channel.test.ts
@@ -115,6 +115,21 @@ describe("Reef conversation directory", () => {
   });
 });
 
+describe("Reef channel status", () => {
+  it("preserves the channel-authored lifecycle in account snapshots", async () => {
+    const cfg = { channels: { reef: { handle: "clawd" } } };
+    const account = reefPlugin.config.resolveAccount(cfg);
+
+    const snapshot = await reefPlugin.status?.buildAccountSnapshot?.({
+      account,
+      cfg,
+      runtime: { accountId: "default", lifecycle: "recovering" },
+    });
+
+    expect(snapshot).toMatchObject({ lifecycle: "recovering" });
+  });
+});
+
 describe("Reef channel lifecycle", () => {
   function hangingInbox() {
     const seen: AbortSignal[] = [];

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -209,6 +209,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
       configured: account.configured,
       running: runtime?.running ?? false,
       connected: runtime?.connected ?? false,
+      lifecycle: runtime?.lifecycle,
       lastConnectedAt: runtime?.lastConnectedAt ?? null,
       lastError: runtime?.lastError ?? null,
       extra: { handle: account.config.handle },
@@ -441,10 +442,16 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
                     accountId: "default",
                     running: true,
                     connected: true,
+                    lifecycle: "ready",
                     lastConnectedAt: Date.now(),
                     lastError: null,
                   }
-                : { accountId: "default", running: true, connected: false },
+                : {
+                    accountId: "default",
+                    running: true,
+                    connected: false,
+                    lifecycle: "recovering",
+                  },
             );
           },
           onError: (error) => {
@@ -456,6 +463,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
               accountId: "default",
               running: true,
               connected: false,
+              lifecycle: "recovering",
               lastError: error.message,
             });
           },

--- a/extensions/telegram/src/channel.gateway.test.ts
+++ b/extensions/telegram/src/channel.gateway.test.ts
@@ -282,26 +282,34 @@ describe("telegramPlugin gateway startup", () => {
     );
   });
 
-  it("stops before monitor startup when getMe rejects the token", async () => {
-    installTelegramRuntime();
-    probeTelegram.mockResolvedValue({
-      ok: false,
-      status: 401,
-      error: "Unauthorized",
-      elapsedMs: 12,
-    });
+  it.each([401, 404] as const)(
+    "stops before monitor startup when getMe rejects the token with %s",
+    async (status) => {
+      installTelegramRuntime();
+      probeTelegram.mockResolvedValue({
+        ok: false,
+        status,
+        error: "Unauthorized",
+        elapsedMs: 12,
+      });
 
-    const { ctx, task } = startTelegramAccount("ops");
+      const { ctx, task } = startTelegramAccount("ops");
 
-    await expect(task).rejects.toThrow(
-      'Telegram bot token unauthorized for account "ops" (getMe returned 401',
-    );
-    await expect(task).rejects.toThrow("channels.telegram.accounts.ops.botToken/tokenFile");
-    expect(monitorTelegramProvider).not.toHaveBeenCalled();
-    expect(ctx.log?.error).toHaveBeenCalledWith(
-      '[ops] Telegram bot token unauthorized for account "ops" (getMe returned 401 from Telegram; source: config token). Update channels.telegram.accounts.ops.botToken/tokenFile with the current BotFather token.',
-    );
-  });
+      await expect(task).rejects.toThrow(
+        `Telegram bot token unauthorized for account "ops" (getMe returned ${status}`,
+      );
+      await expect(task).rejects.toThrow("channels.telegram.accounts.ops.botToken/tokenFile");
+      expect(monitorTelegramProvider).not.toHaveBeenCalled();
+      expect(ctx.log?.error).toHaveBeenCalledWith(
+        `[ops] Telegram bot token unauthorized for account "ops" (getMe returned ${status} from Telegram; source: config token). Update channels.telegram.accounts.ops.botToken/tokenFile with the current BotFather token.`,
+      );
+      expect(ctx.getStatus()).toMatchObject({
+        lifecycle: "blocked",
+        terminalDisconnect: true,
+        lastError: expect.stringContaining(`getMe returned ${status}`),
+      });
+    },
+  );
 
   it("keeps existing fallback startup for non-auth probe failures", async () => {
     installTelegramRuntime();

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -184,14 +184,17 @@ function resolveTelegramMonitor() {
   );
 }
 
-function formatTelegramUnauthorizedTokenError(account: ResolvedTelegramAccount): string {
+function formatTelegramUnauthorizedTokenError(
+  account: ResolvedTelegramAccount,
+  status: 401 | 404,
+): string {
   const source =
     account.tokenSource === "none" ? "no configured token" : `${account.tokenSource} token`;
   const credentialPath =
     account.accountId === DEFAULT_ACCOUNT_ID
       ? "channels.telegram.botToken, channels.telegram.tokenFile, or TELEGRAM_BOT_TOKEN"
       : `channels.telegram.accounts.${account.accountId}.botToken/tokenFile`;
-  return `Telegram bot token unauthorized for account "${account.accountId}" (getMe returned 401 from Telegram; source: ${source}). Update ${credentialPath} with the current BotFather token.`;
+  return `Telegram bot token unauthorized for account "${account.accountId}" (getMe returned ${status} from Telegram; source: ${source}). Update ${credentialPath} with the current BotFather token.`;
 }
 
 function getOptionalTelegramRuntime() {
@@ -1055,6 +1058,10 @@ export const telegramPlugin = createChatChannelPlugin({
     gateway: {
       startAccount: async (ctx) => {
         const account = ctx.account;
+        const setStatus = createAccountStatusSink({
+          accountId: account.accountId,
+          setStatus: ctx.setStatus,
+        });
         const ownerAccountId = findTelegramTokenOwnerAccountId({
           cfg: ctx.cfg,
           accountId: account.accountId,
@@ -1095,9 +1102,9 @@ export const telegramPlugin = createChatChannelPlugin({
               log: ctx.log,
             });
           }
-          if (!probe.ok && probe.status === 401) {
+          if (!probe.ok && (probe.status === 401 || probe.status === 404)) {
             await deleteStartupBotInfoCache(account.accountId);
-            unauthorizedTokenReason = formatTelegramUnauthorizedTokenError(account);
+            unauthorizedTokenReason = formatTelegramUnauthorizedTokenError(account, probe.status);
           } else if (!probe.ok) {
             botInfo = await readStartupBotInfoCache({
               accountId: account.accountId,
@@ -1126,13 +1133,14 @@ export const telegramPlugin = createChatChannelPlugin({
         }
         if (unauthorizedTokenReason) {
           ctx.log?.error?.(`[${account.accountId}] ${unauthorizedTokenReason}`);
+          setStatus({
+            lifecycle: "blocked",
+            terminalDisconnect: true,
+            lastError: unauthorizedTokenReason,
+          });
           throw new Error(unauthorizedTokenReason);
         }
         ctx.log?.info(`[${account.accountId}] starting provider${telegramBotLabel}`);
-        const setStatus = createAccountStatusSink({
-          accountId: account.accountId,
-          setStatus: ctx.setStatus,
-        });
         return resolveTelegramMonitor()({
           token,
           accountId: account.accountId,

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   isRecoverableTelegramNetworkError,
   isRetryableTelegramApiError,
+  isTelegramAuthenticationError,
   isTelegramRateLimitError,
   isSafeToRetrySendError,
   isTelegramClientRejection,
@@ -57,6 +58,20 @@ describe("Telegram error_code predicate contracts", () => {
       expect(predicate(outer)).toBe(true);
     },
   );
+});
+
+describe("isTelegramAuthenticationError", () => {
+  it.each([
+    ["Unauthorized", 401, true],
+    ["Forbidden", 403, false],
+    ["Not Found", 404, true],
+  ])("returns %s for error_code %s", (message, errorCode, expected) => {
+    expect(isTelegramAuthenticationError(errorWithTelegramCode(message, errorCode))).toBe(expected);
+  });
+
+  it("does not infer authentication failure from an unstructured message", () => {
+    expect(isTelegramAuthenticationError(new Error("Unauthorized"))).toBe(false);
+  });
 });
 
 describe("isRecoverableTelegramNetworkError", () => {

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -230,6 +230,10 @@ function hasTelegramErrorCode(err: unknown, matches: (code: number) => boolean):
   return false;
 }
 
+export function isTelegramAuthenticationError(err: unknown): boolean {
+  return hasTelegramErrorCode(err, (code) => code === 401 || code === 404);
+}
+
 /** Reads Telegram's flood-control retry_after hint (in ms) from any error nesting shape. */
 export function readTelegramRetryAfterMs(err: unknown): number | undefined {
   for (const candidate of collectTelegramErrorCandidates(err)) {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -51,6 +51,7 @@ async function waitForTelegramTestState<T>(assertion: () => T | Promise<T>): Pro
 const runMock = vi.hoisted(() => vi.fn());
 const createTelegramBotMock = vi.hoisted(() => vi.fn());
 const isRecoverableTelegramNetworkErrorMock = vi.hoisted(() => vi.fn(() => true));
+const isTelegramAuthenticationErrorMock = vi.hoisted(() => vi.fn(() => false));
 const computeBackoffMock = vi.hoisted(() =>
   vi.fn((_policy: { initialMs: number }, _attempt: number) => 0),
 );
@@ -67,6 +68,7 @@ vi.mock("./bot.js", () => ({
 
 vi.mock("./network-errors.js", () => ({
   isRecoverableTelegramNetworkError: isRecoverableTelegramNetworkErrorMock,
+  isTelegramAuthenticationError: isTelegramAuthenticationErrorMock,
 }));
 
 vi.mock("openclaw/plugin-sdk/delivery-queue-runtime", () => ({
@@ -858,6 +860,7 @@ describe("TelegramPollingSession", () => {
     runMock.mockReset();
     createTelegramBotMock.mockReset();
     isRecoverableTelegramNetworkErrorMock.mockReset().mockReturnValue(true);
+    isTelegramAuthenticationErrorMock.mockReset().mockReturnValue(false);
     computeBackoffMock.mockReset().mockReturnValue(0);
     sleepWithAbortMock.mockReset().mockResolvedValue(undefined);
     drainPendingDeliveriesMock.mockReset().mockResolvedValue(undefined);
@@ -876,6 +879,7 @@ describe("TelegramPollingSession", () => {
   it("uses backoff helpers for recoverable polling retries", async () => {
     const abort = new AbortController();
     const recoverableError = new Error("recoverable polling error");
+    const setStatus = vi.fn();
     const botStop = vi.fn(async () => undefined);
     const runnerStop = vi.fn(async () => undefined);
     const bot = {
@@ -921,6 +925,7 @@ describe("TelegramPollingSession", () => {
       persistUpdateId: async () => undefined,
       log: () => undefined,
       telegramTransport: undefined,
+      setStatus,
     });
 
     await session.runUntilAbort();
@@ -940,6 +945,7 @@ describe("TelegramPollingSession", () => {
       1,
     );
     expect(sleepWithAbortMock).toHaveBeenCalledTimes(1);
+    expect(statusPatches(setStatus)).toContainEqual({ lifecycle: "recovering" });
   });
 
   it("resets restart backoff after a healthy polling cycle", () => {
@@ -3610,6 +3616,7 @@ describe("TelegramPollingSession", () => {
         listener?.({
           type: "poll-error",
           message: "Unauthorized",
+          errorCode: 401,
           finishedAt: Date.now(),
         });
         throw new Error("Telegram ingress worker exited with code 1");
@@ -3635,7 +3642,10 @@ describe("TelegramPollingSession", () => {
       expectLogExcludes(log, "isolated polling ingress failed");
       expect(
         statusPatches(setStatus).some(
-          (patch) => patch.connected === false && patch.lastError === "Unauthorized",
+          (patch) =>
+            patch.connected === false &&
+            patch.lifecycle === "blocked" &&
+            patch.lastError === "Unauthorized",
         ),
       ).toBe(true);
     } finally {
@@ -4233,6 +4243,7 @@ describe("TelegramPollingSession", () => {
     expect(connectedPatch?.lastConnectedAt).toBeTypeOf("number");
     expect(connectedPatch?.lastEventAt).toBeTypeOf("number");
     expect(connectedPatch?.lastTransportActivityAt).toBeTypeOf("number");
+    expect(connectedPatch?.lifecycle).toBe("ready");
     expect(connectedPatch?.lastError).toBeNull();
     expect(connectedPatch?.lastConnectedAt).toBe(connectedPatch?.lastEventAt);
     expect(connectedPatch?.lastTransportActivityAt).toBe(connectedPatch?.lastEventAt);
@@ -4415,6 +4426,7 @@ describe("TelegramPollingSession", () => {
 
     expect(runMock).toHaveBeenCalledTimes(2);
     expectPollingConnectedPatch(statusPatches(setStatus).find((patch) => patch.connected === true));
+    expect(statusPatches(setStatus)).toContainEqual({ lifecycle: "recovering" });
     const disconnectedPatches = statusPatches(setStatus).filter(
       (patch) => patch.connected === false,
     );
@@ -4480,7 +4492,9 @@ describe("TelegramPollingSession", () => {
       expect(
         statusPatches(setStatus).some(
           (patch) =>
-            patch.connected === false && String(patch.lastError).includes("Polling stall detected"),
+            patch.connected === false &&
+            patch.lifecycle === "recovering" &&
+            String(patch.lastError).includes("Polling stall detected"),
         ),
       ).toBe(true);
     } finally {
@@ -4516,7 +4530,9 @@ describe("TelegramPollingSession", () => {
     expect(
       statusPatches(setStatus).some(
         (patch) =>
-          patch.connected === false && String(patch.lastError).includes("Another OpenClaw gateway"),
+          patch.connected === false &&
+          patch.lifecycle === "recovering" &&
+          String(patch.lastError).includes("Another OpenClaw gateway"),
       ),
     ).toBe(true);
   });

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -9,7 +9,10 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import type { TelegramTransport } from "./fetch.js";
-import { isRecoverableTelegramNetworkError } from "./network-errors.js";
+import {
+  isRecoverableTelegramNetworkError,
+  isTelegramAuthenticationError,
+} from "./network-errors.js";
 import { TelegramPollingLivenessTracker } from "./polling-liveness.js";
 import {
   createTelegramRestartBackoffState,
@@ -206,6 +209,7 @@ export class TelegramPollingSession {
     );
     const delay = formatDurationPrecise(delayMs);
     this.opts.log(`${buildLine(delay)}${stopTimeoutSuffix}`);
+    this.#status.notePollingRecovery();
     try {
       await sleepWithAbort(delayMs, this.opts.abortSignal);
     } catch (sleepErr) {
@@ -616,7 +620,7 @@ export class TelegramPollingSession {
       this.#transportState.markDirty();
       stalledRestart = true;
       this.opts.log(`[telegram] ${stall.message}`);
-      this.#status.notePollingError(stall.message);
+      this.#status.notePollingError(stall.message, "recovering");
       requestStopForRestart();
     }, POLL_WATCHDOG_INTERVAL_MS);
     watchdog.unref?.();
@@ -642,14 +646,17 @@ export class TelegramPollingSession {
           pollState.error &&
           !isRecoverableTelegramNetworkError(new Error(pollState.error), { context: "polling" })
         ) {
-          this.#status.notePollingError(pollState.error);
+          this.#status.notePollingError(
+            pollState.error,
+            pollState.errorCode === 401 || pollState.errorCode === 404 ? "blocked" : undefined,
+          );
           throw new Error(pollState.error, { cause: err });
         }
         const message = isConflict
           ? `Telegram getUpdates conflict: ${pollState.error}.${TELEGRAM_GET_UPDATES_CONFLICT_HINT}`
           : formatErrorMessage(err);
         this.opts.log(`[telegram][diag] isolated polling ingress failed: ${message}`);
-        this.#status.notePollingError(message);
+        this.#status.notePollingError(message, "recovering");
         clearForceCycleTimer();
         const shouldRestart = await this.#waitBeforeRestart(
           (delay) => `Telegram isolated polling ingress failed; restarting in ${delay}.`,
@@ -803,7 +810,7 @@ export class TelegramPollingSession {
         this.#transportState.markDirty();
         stalledRestart = true;
         this.opts.log(`[telegram] ${stall.message}`);
-        this.#status.notePollingError(stall.message);
+        this.#status.notePollingError(stall.message, "recovering");
         requestStopForRestart();
       }
     }, POLL_WATCHDOG_INTERVAL_MS);
@@ -848,6 +855,10 @@ export class TelegramPollingSession {
         this.#transportState.markDirty();
       }
       if (!isConflict && !isRecoverable) {
+        this.#status.notePollingError(
+          formatErrorMessage(err),
+          isTelegramAuthenticationError(err) ? "blocked" : undefined,
+        );
         throw err;
       }
       const reason = isConflict ? "getUpdates conflict" : "network error";
@@ -860,7 +871,10 @@ export class TelegramPollingSession {
       // status. Recoverable network blips stay log-only; the stall watchdog
       // owns status for extended outages (see detectStall above).
       if (isConflict) {
-        this.#status.notePollingError(`Telegram ${reason}: ${errMsg}.${conflictHint}`);
+        this.#status.notePollingError(
+          `Telegram ${reason}: ${errMsg}.${conflictHint}`,
+          "recovering",
+        );
       }
       clearForceCycleTimer();
       const shouldRestart = await this.#waitBeforeRestart(

--- a/extensions/telegram/src/polling-status.test.ts
+++ b/extensions/telegram/src/polling-status.test.ts
@@ -3,12 +3,15 @@ import { describe, expect, it, vi } from "vitest";
 import { createTelegramPollingStatusPublisher } from "./polling-status.js";
 
 describe("createTelegramPollingStatusPublisher", () => {
-  it("publishes start, successful poll, and stop status patches", () => {
+  it("publishes lifecycle at polling transition points", () => {
     const setStatus = vi.fn();
     const status = createTelegramPollingStatusPublisher(setStatus);
 
     status.notePollingStart();
     status.notePollSuccess(1234);
+    status.notePollingRecovery();
+    status.notePollingError("fetch failed", "recovering");
+    status.notePollingError("unauthorized", "blocked");
     status.notePollingStop();
 
     expect(setStatus).toHaveBeenNthCalledWith(1, {
@@ -24,9 +27,25 @@ describe("createTelegramPollingStatusPublisher", () => {
       lastConnectedAt: 1234,
       lastEventAt: 1234,
       lastTransportActivityAt: 1234,
+      lifecycle: "ready",
+      terminalDisconnect: undefined,
       lastError: null,
     });
-    expect(setStatus).toHaveBeenNthCalledWith(3, {
+    expect(setStatus).toHaveBeenNthCalledWith(3, { lifecycle: "recovering" });
+    expect(setStatus).toHaveBeenNthCalledWith(4, {
+      mode: "polling",
+      connected: false,
+      lifecycle: "recovering",
+      lastError: "fetch failed",
+    });
+    expect(setStatus).toHaveBeenNthCalledWith(5, {
+      mode: "polling",
+      connected: false,
+      lifecycle: "blocked",
+      terminalDisconnect: true,
+      lastError: "unauthorized",
+    });
+    expect(setStatus).toHaveBeenNthCalledWith(6, {
       mode: "polling",
       connected: false,
     });

--- a/extensions/telegram/src/polling-status.ts
+++ b/extensions/telegram/src/polling-status.ts
@@ -25,13 +25,21 @@ export function createTelegramPollingStatusPublisher(setStatus?: TelegramPolling
         // even when the response has no user-visible updates.
         ...createTransportActivityStatusPatch(at),
         mode: "polling",
+        lifecycle: "ready",
+        // Runtime patches merge, so a repaired token must clear the prior terminal auth fact.
+        terminalDisconnect: undefined,
         lastError: null,
       });
     },
-    notePollingError(error: string) {
+    notePollingRecovery() {
+      setStatus?.({ lifecycle: "recovering" });
+    },
+    notePollingError(error: string, lifecycle?: "recovering" | "blocked") {
       setStatus?.({
         mode: "polling",
         connected: false,
+        ...(lifecycle ? { lifecycle } : {}),
+        ...(lifecycle === "blocked" ? { terminalDisconnect: true } : {}),
         lastError: error,
       });
     },

--- a/extensions/telegram/src/webhook-status.test.ts
+++ b/extensions/telegram/src/webhook-status.test.ts
@@ -3,14 +3,16 @@ import { describe, expect, it, vi } from "vitest";
 import { createTelegramWebhookStatusPublisher } from "./webhook-status.js";
 
 describe("createTelegramWebhookStatusPublisher", () => {
-  it("publishes start, advertised, update, failure, and stop status patches", () => {
+  it("publishes lifecycle at webhook transition points", () => {
     const setStatus = vi.fn();
     const status = createTelegramWebhookStatusPublisher(setStatus);
 
     status.noteWebhookStart();
     status.noteWebhookAdvertised(1234);
     status.noteWebhookUpdateReceived(2345);
-    status.noteWebhookRegistrationFailure("fetch failed");
+    status.noteWebhookRecovery();
+    status.noteWebhookRegistrationFailure("fetch failed", "recovering");
+    status.noteWebhookRegistrationFailure("unauthorized", "blocked");
     status.noteWebhookStop();
 
     expect(setStatus).toHaveBeenNthCalledWith(1, {
@@ -25,6 +27,8 @@ describe("createTelegramWebhookStatusPublisher", () => {
       connected: true,
       lastConnectedAt: 1234,
       lastEventAt: 1234,
+      lifecycle: "ready",
+      terminalDisconnect: undefined,
       lastError: null,
     });
     expect(setStatus).toHaveBeenNthCalledWith(3, {
@@ -32,14 +36,25 @@ describe("createTelegramWebhookStatusPublisher", () => {
       connected: true,
       lastConnectedAt: 2345,
       lastEventAt: 2345,
+      lifecycle: "ready",
+      terminalDisconnect: undefined,
       lastError: null,
     });
-    expect(setStatus).toHaveBeenNthCalledWith(4, {
+    expect(setStatus).toHaveBeenNthCalledWith(4, { lifecycle: "recovering" });
+    expect(setStatus).toHaveBeenNthCalledWith(5, {
       mode: "webhook",
       connected: false,
+      lifecycle: "recovering",
       lastError: "fetch failed",
     });
-    expect(setStatus).toHaveBeenNthCalledWith(5, {
+    expect(setStatus).toHaveBeenNthCalledWith(6, {
+      mode: "webhook",
+      connected: false,
+      lifecycle: "blocked",
+      terminalDisconnect: true,
+      lastError: "unauthorized",
+    });
+    expect(setStatus).toHaveBeenNthCalledWith(7, {
       mode: "webhook",
       connected: false,
     });

--- a/extensions/telegram/src/webhook-status.ts
+++ b/extensions/telegram/src/webhook-status.ts
@@ -19,6 +19,8 @@ export function createTelegramWebhookStatusPublisher(setStatus?: TelegramWebhook
       setStatus?.({
         ...createConnectedChannelStatusPatch(at),
         mode: "webhook",
+        lifecycle: "ready",
+        terminalDisconnect: undefined,
         lastError: null,
       });
     },
@@ -26,13 +28,21 @@ export function createTelegramWebhookStatusPublisher(setStatus?: TelegramWebhook
       setStatus?.({
         ...createConnectedChannelStatusPatch(at),
         mode: "webhook",
+        lifecycle: "ready",
+        // Runtime patches merge, so a repaired token must clear the prior terminal auth fact.
+        terminalDisconnect: undefined,
         lastError: null,
       });
     },
-    noteWebhookRegistrationFailure(error: string) {
+    noteWebhookRecovery() {
+      setStatus?.({ lifecycle: "recovering" });
+    },
+    noteWebhookRegistrationFailure(error: string, lifecycle?: "recovering" | "blocked") {
       setStatus?.({
         mode: "webhook",
         connected: false,
+        ...(lifecycle ? { lifecycle } : {}),
+        ...(lifecycle === "blocked" ? { terminalDisconnect: true } : {}),
         lastError: error,
       });
     },

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -617,6 +617,7 @@ describe("startTelegramWebhook", () => {
         expect(connectedStatus.connected).toBe(true);
         expect(typeof connectedStatus.lastConnectedAt).toBe("number");
         expect(typeof connectedStatus.lastEventAt).toBe("number");
+        expect(connectedStatus.lifecycle).toBe("ready");
         expect(connectedStatus.lastError).toBeNull();
       },
     );
@@ -687,6 +688,7 @@ describe("startTelegramWebhook", () => {
         expect(setStatus).toHaveBeenCalledWith({
           mode: "webhook",
           connected: false,
+          lifecycle: "recovering",
           lastError: "fetch failed",
         });
         expectStatusCall(setStatus, { mode: "webhook", connected: true, lastError: null });
@@ -696,6 +698,7 @@ describe("startTelegramWebhook", () => {
 
   it("fails startup when setWebhook has a non-recoverable rejection", async () => {
     const runtimeError = vi.fn();
+    const setStatus = vi.fn();
     const error = Object.assign(new Error("unauthorized"), { error_code: 401 });
     setWebhookSpy.mockRejectedValueOnce(error);
 
@@ -706,12 +709,37 @@ describe("startTelegramWebhook", () => {
         secret: TELEGRAM_SECRET,
         path: TELEGRAM_WEBHOOK_PATH,
         runtime: { log: vi.fn(), error: runtimeError, exit: vi.fn() },
+        setStatus,
       }),
     ).rejects.toThrow("unauthorized");
 
     expect(stopSpy).toHaveBeenCalledTimes(1);
     expect(transportCloseSpies[0]).toHaveBeenCalledTimes(1);
     expectMockMessageContains(runtimeError, "telegram setWebhook failed: unauthorized");
+    expectStatusCall(setStatus, {
+      lifecycle: "blocked",
+      lastError: "unauthorized",
+    });
+  });
+
+  it("does not mark a non-auth setWebhook rejection as blocked", async () => {
+    const setStatus = vi.fn();
+    const error = Object.assign(new Error("bad webhook URL"), { error_code: 400 });
+    setWebhookSpy.mockRejectedValueOnce(error);
+
+    await expect(
+      startTelegramWebhook({
+        token: TELEGRAM_TOKEN,
+        port: 0,
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        setStatus,
+      }),
+    ).rejects.toThrow("bad webhook URL");
+
+    const failedStatus = expectStatusCall(setStatus, { lastError: "bad webhook URL" });
+    expect(failedStatus.lifecycle).toBeUndefined();
   });
 
   it("stops local listener and bot when retry loop encounters a non-recoverable error", async () => {
@@ -744,6 +772,10 @@ describe("startTelegramWebhook", () => {
         expect(stopSpy).toHaveBeenCalledTimes(1);
         expect(transportCloseSpies[0]).toHaveBeenCalledTimes(1);
       });
+      expectStatusCall(setStatus, {
+        lifecycle: "blocked",
+        lastError: "unauthorized",
+      });
       expect(setStatus).toHaveBeenLastCalledWith({ mode: "webhook", connected: false });
       expectMockMessageContains(
         runtimeError,
@@ -760,6 +792,7 @@ describe("startTelegramWebhook", () => {
 
   it("retries transient getMe startup init failures before starting the account", async () => {
     const runtimeLog = vi.fn();
+    const setStatus = vi.fn();
     initSpy.mockRejectedValueOnce(new TypeError("fetch failed")).mockResolvedValueOnce(undefined);
 
     await withStartedWebhook(
@@ -767,6 +800,7 @@ describe("startTelegramWebhook", () => {
         secret: TELEGRAM_SECRET,
         path: TELEGRAM_WEBHOOK_PATH,
         runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
+        setStatus,
         webhookRegistrationRetryPolicy: {
           initialMs: 0,
           maxMs: 0,
@@ -782,11 +816,13 @@ describe("startTelegramWebhook", () => {
 
     expect(initSpy).toHaveBeenCalledTimes(2);
     expect(runtimeLog).toHaveBeenCalledWith("telegram getMe retry 1 scheduled in 0ms");
+    expectStatusCall(setStatus, { lifecycle: "recovering" });
     expect(setWebhookSpy).toHaveBeenCalledTimes(1);
   });
 
   it("fails startup on non-recoverable getMe errors", async () => {
     const runtimeError = vi.fn();
+    const setStatus = vi.fn();
     const error = Object.assign(new Error("unauthorized"), { error_code: 401 });
     initSpy.mockRejectedValueOnce(error);
 
@@ -798,6 +834,7 @@ describe("startTelegramWebhook", () => {
         path: TELEGRAM_WEBHOOK_PATH,
         spoolDir: requireWebhookSpoolDir(),
         runtime: { log: vi.fn(), error: runtimeError, exit: vi.fn() },
+        setStatus,
       }),
     ).rejects.toThrow("unauthorized");
 
@@ -805,6 +842,10 @@ describe("startTelegramWebhook", () => {
     expect(stopSpy).toHaveBeenCalledTimes(1);
     expect(transportCloseSpies[0]).toHaveBeenCalledTimes(1);
     expectMockMessageContains(runtimeError, "telegram getMe failed: unauthorized");
+    expectStatusCall(setStatus, {
+      lifecycle: "blocked",
+      lastError: "unauthorized",
+    });
   });
 
   it("registers webhook with certificate when webhookCertPath is provided", async () => {

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -35,7 +35,7 @@ import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import { resolveTelegramTransport } from "./fetch.js";
-import { isRetryableTelegramApiError } from "./network-errors.js";
+import { isRetryableTelegramApiError, isTelegramAuthenticationError } from "./network-errors.js";
 import { createTelegramTransportIngressMonitor } from "./telegram-ingress-drain-factory.js";
 import {
   resolveTelegramIngressSpoolDir,
@@ -130,6 +130,7 @@ async function initializeTelegramWebhookBotOnce(params: {
 async function initializeTelegramWebhookBot(params: {
   abortSignal?: AbortSignal;
   bot: ReturnType<typeof createTelegramBot>;
+  onRetry: () => void;
   retryPolicy: BackoffPolicy;
   runtime: RuntimeEnv;
 }) {
@@ -150,6 +151,7 @@ async function initializeTelegramWebhookBot(params: {
         throw err;
       }
       attempt += 1;
+      params.onRetry();
       const delayMs = computeBackoff(params.retryPolicy, attempt);
       params.runtime.log?.(
         `telegram getMe retry ${attempt} scheduled in ${formatDurationPrecise(delayMs)}`,
@@ -362,9 +364,16 @@ export async function startTelegramWebhook(opts: {
       bot,
       runtime,
       abortSignal: opts.abortSignal,
+      onRetry: () => status.noteWebhookRecovery(),
       retryPolicy: webhookRegistrationRetryPolicy,
     });
   } catch (err) {
+    if (!opts.abortSignal?.aborted) {
+      status.noteWebhookRegistrationFailure(
+        formatErrorMessage(err),
+        isTelegramAuthenticationError(err) ? "blocked" : undefined,
+      );
+    }
     botAbortController.abort();
     await bot.stop();
     await closeTransportOnce();
@@ -584,7 +593,14 @@ export async function startTelegramWebhook(opts: {
           }),
       });
     } catch (err) {
-      status.noteWebhookRegistrationFailure(formatErrorMessage(err));
+      status.noteWebhookRegistrationFailure(
+        formatErrorMessage(err),
+        isTelegramAuthenticationError(err)
+          ? "blocked"
+          : isRetryableTelegramApiError(err, { context: "webhook" })
+            ? "recovering"
+            : undefined,
+      );
       throw err;
     }
     if (shutDown) {

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -28,6 +28,7 @@ import {
   deliverWebReply,
 } from "./auto-reply/deliver-reply.js";
 import { buildInboundLine } from "./auto-reply/monitor/message-line.js";
+import type { WebChannelStatus } from "./auto-reply/types.js";
 import {
   createTestLegacyFlatWebInboundMessage,
   createTestWebInboundMessage,
@@ -304,12 +305,7 @@ describe("web auto-reply connection", () => {
     });
     const listenerFactory = vi.fn(async () => createMockWebListener());
     const sleep = vi.fn(async () => {});
-    const statuses: Array<{
-      running?: boolean;
-      connected?: boolean;
-      healthState?: string;
-      terminalDisconnect?: boolean;
-    }> = [];
+    const statuses: Array<Partial<WebChannelStatus>> = [];
     const { runtime, run } = startWebAutoReplyMonitor({
       monitorWebChannelFn: monitorWebChannel as never,
       listenerFactory,
@@ -326,6 +322,7 @@ describe("web auto-reply connection", () => {
       running: false,
       connected: false,
       healthState: "logged-out",
+      lifecycle: "blocked",
       terminalDisconnect: true,
     });
     expectErrorContaining(runtime.error, "openclaw channels login --channel whatsapp");
@@ -534,7 +531,7 @@ describe("web auto-reply connection", () => {
       });
 
       const sleep = vi.fn(async () => {});
-      const statuses: Array<{ healthState?: string; running?: boolean; connected?: boolean }> = [];
+      const statuses: Array<Partial<WebChannelStatus>> = [];
       const scripted = createScriptedWebListenerFactory();
       const { run } = startWebAutoReplyMonitor({
         monitorWebChannelFn: monitorWebChannel as never,
@@ -570,6 +567,7 @@ describe("web auto-reply connection", () => {
       expect(finalStatus?.running).toBe(false);
       expect(finalStatus?.connected).toBe(false);
       expect(finalStatus?.healthState).toBe(healthState);
+      expect(finalStatus?.lifecycle).toBe("blocked");
     },
   );
 
@@ -667,6 +665,7 @@ describe("web auto-reply connection", () => {
           statuses.filter(
             (status) =>
               status.healthState === "reconnecting" &&
+              status.lifecycle === "recovering" &&
               status.reconnectAttempts === 1 &&
               (status.lastDisconnect as { status?: number } | null)?.status === 499,
           ),
@@ -684,6 +683,7 @@ describe("web auto-reply connection", () => {
             (status) =>
               status.connected === true &&
               status.healthState === "healthy" &&
+              status.lifecycle === "ready" &&
               status.reconnectAttempts === 0 &&
               status.lastDisconnect === null,
           ),

--- a/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
@@ -3,6 +3,20 @@ import { describe, expect, it } from "vitest";
 import { createWebChannelStatusController } from "./monitor-state.js";
 
 describe("createWebChannelStatusController", () => {
+  it("publishes the initial starting lifecycle", () => {
+    const patches: Record<string, unknown>[] = [];
+    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
+
+    controller.emit();
+
+    expect(patches.at(-1)).toMatchObject({
+      running: true,
+      connected: false,
+      healthState: "starting",
+      lifecycle: "starting",
+    });
+  });
+
   it("sets lastTransportActivityAt on noteConnected", () => {
     const patches: Record<string, unknown>[] = [];
     const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
@@ -12,6 +26,7 @@ describe("createWebChannelStatusController", () => {
     const last = patches.at(-1)!;
     expect(last.connected).toBe(true);
     expect(last.lastTransportActivityAt).toBe(1000);
+    expect(last.lifecycle).toBe("ready");
   });
 
   it("updates lastTransportActivityAt on noteInbound", () => {
@@ -65,6 +80,8 @@ describe("createWebChannelStatusController", () => {
     // Watchdog staleness should not refresh transport activity — it means
     // the check loop is running but the socket itself is idle/stale.
     expect(last.lastTransportActivityAt).toBe(1000);
+    expect(last.healthState).toBe("stale");
+    expect(last.lifecycle).toBe("recovering");
   });
 
   it("produces snapshots that enable stale-socket health detection", () => {
@@ -135,12 +152,40 @@ describe("createWebChannelStatusController", () => {
   });
 
   it.each([
-    { healthState: "logged-out", statusCode: 401, terminalDisconnect: true },
-    { healthState: "conflict", statusCode: 440, terminalDisconnect: true },
-    { healthState: "reconnecting", statusCode: 408, terminalDisconnect: false },
+    {
+      healthState: "logged-out",
+      statusCode: 401,
+      lifecycle: "blocked",
+      finalHealthState: "logged-out",
+      finalLifecycle: "blocked",
+      terminalDisconnect: true,
+    },
+    {
+      healthState: "conflict",
+      statusCode: 440,
+      lifecycle: "blocked",
+      finalHealthState: "conflict",
+      finalLifecycle: "blocked",
+      terminalDisconnect: true,
+    },
+    {
+      healthState: "reconnecting",
+      statusCode: 408,
+      lifecycle: "recovering",
+      finalHealthState: "stopped",
+      finalLifecycle: "stopped",
+      terminalDisconnect: false,
+    },
   ] as const)(
-    "sets terminalDisconnect=$terminalDisconnect after a $healthState stop",
-    ({ healthState, statusCode, terminalDisconnect }) => {
+    "publishes lifecycle=$lifecycle and terminalDisconnect=$terminalDisconnect after a $healthState stop",
+    ({
+      healthState,
+      statusCode,
+      lifecycle,
+      finalHealthState,
+      finalLifecycle,
+      terminalDisconnect,
+    }) => {
       const patches: Record<string, unknown>[] = [];
       const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
 
@@ -152,8 +197,13 @@ describe("createWebChannelStatusController", () => {
         reconnectAttempts: healthState === "reconnecting" ? 1 : 0,
         healthState,
       });
+      expect(patches.at(-1)!.healthState).toBe(healthState);
+      expect(patches.at(-1)!.lifecycle).toBe(lifecycle);
+
       controller.markStopped(2100);
 
+      expect(patches.at(-1)!.healthState).toBe(finalHealthState);
+      expect(patches.at(-1)!.lifecycle).toBe(finalLifecycle);
       expect(patches.at(-1)!.terminalDisconnect).toBe(terminalDisconnect);
     },
   );
@@ -175,5 +225,22 @@ describe("createWebChannelStatusController", () => {
 
     controller.noteConnected(3000);
     expect(patches.at(-1)!.terminalDisconnect).toBeUndefined();
+    expect(patches.at(-1)!.healthState).toBe("healthy");
+    expect(patches.at(-1)!.lifecycle).toBe("ready");
+  });
+
+  it("publishes stopped lifecycle without changing the shipped health label", () => {
+    const patches: Record<string, unknown>[] = [];
+    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
+
+    controller.noteConnected(1000);
+    controller.markStopped(2000);
+
+    expect(patches.at(-1)).toMatchObject({
+      running: false,
+      connected: false,
+      healthState: "stopped",
+      lifecycle: "stopped",
+    });
   });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor-state.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor-state.ts
@@ -5,6 +5,16 @@ import {
 } from "openclaw/plugin-sdk/gateway-runtime";
 import type { WebChannelHealthState, WebChannelStatus } from "./types.js";
 
+const LIFECYCLE_BY_HEALTH_STATE = {
+  starting: "starting",
+  healthy: "ready",
+  stale: "recovering",
+  reconnecting: "recovering",
+  conflict: "blocked",
+  "logged-out": "blocked",
+  stopped: "stopped",
+} satisfies Record<WebChannelHealthState, NonNullable<WebChannelStatus["lifecycle"]>>;
+
 function cloneStatus(status: WebChannelStatus): WebChannelStatus {
   return {
     ...status,
@@ -31,6 +41,7 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
     busy: false,
     lastRunActivityAt: null,
     healthState: "starting",
+    lifecycle: "starting",
   };
 
   const emit = () => {
@@ -50,6 +61,7 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
       }
       status.lastError = null;
       status.healthState = "healthy";
+      status.lifecycle = "ready";
       status.terminalDisconnect = undefined;
       emit();
     },
@@ -60,6 +72,7 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
       Object.assign(status, createTransportActivityStatusPatch(at));
       if (status.connected) {
         status.healthState = "healthy";
+        status.lifecycle = "ready";
       }
       emit();
     },
@@ -78,6 +91,7 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
       status.lastRunActivityAt = at;
       if (status.connected && busy) {
         status.healthState = "healthy";
+        status.lifecycle = "ready";
       }
       emit();
     },
@@ -85,6 +99,7 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
       status.lastEventAt = at;
       if (status.connected) {
         status.healthState = "stale";
+        status.lifecycle = "recovering";
       }
       emit();
     },
@@ -114,6 +129,7 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
       status.lastError = params.error ?? null;
       status.reconnectAttempts = params.reconnectAttempts;
       status.healthState = params.healthState;
+      status.lifecycle = LIFECYCLE_BY_HEALTH_STATE[params.healthState];
       emit();
     },
     markStopped(at = Date.now()) {
@@ -124,6 +140,7 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
         status.healthState === "logged-out" || status.healthState === "conflict";
       if (!isTerminalHealthState(status.healthState)) {
         status.healthState = "stopped";
+        status.lifecycle = "stopped";
       }
       emit();
     },

--- a/extensions/whatsapp/src/auto-reply/types.ts
+++ b/extensions/whatsapp/src/auto-reply/types.ts
@@ -1,5 +1,8 @@
 // Whatsapp type declarations define plugin contracts.
-import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
+import type {
+  ChannelAccountSnapshot,
+  ChannelRuntimeSurface,
+} from "openclaw/plugin-sdk/channel-contract";
 import type { WebInboundMessage } from "../inbound/types.js";
 import type { ReconnectPolicy } from "../reconnect.js";
 import type { WhatsAppSocketTimingOptions } from "../socket-timing.js";
@@ -35,6 +38,7 @@ export type WebChannelStatus = {
   lastRunActivityAt?: number | null;
   lastError?: string | null;
   healthState?: WebChannelHealthState;
+  lifecycle?: ChannelAccountSnapshot["lifecycle"];
   terminalDisconnect?: boolean;
 };
 

--- a/extensions/whatsapp/src/channel.status.test.ts
+++ b/extensions/whatsapp/src/channel.status.test.ts
@@ -47,6 +47,7 @@ describe("WhatsApp channel status", () => {
       running: false,
       connected: false,
       healthState: "logged-out",
+      lifecycle: "blocked" as const,
       lastError: "status=401",
     };
 
@@ -69,12 +70,14 @@ describe("WhatsApp channel status", () => {
       authAgeMs: null,
       self: { e164: null, jid: null, lid: null },
       healthState: "logged-out",
+      lifecycle: "blocked",
     });
     expect(accountSnapshot).toMatchObject({
       configured: true,
       statusState: "not-linked",
       linked: false,
       healthState: "logged-out",
+      lifecycle: "blocked",
     });
   });
 });

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -238,6 +238,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
           busy: false,
           lastRunActivityAt: null,
           healthState: "stopped",
+          lifecycle: "stopped" as const,
         }),
         collectStatusIssues: collectWhatsAppStatusIssues,
         buildChannelSummary: async ({ account, snapshot }) => {
@@ -290,6 +291,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
             lastRunActivityAt: snapshot.lastRunActivityAt ?? null,
             lastError: snapshot.lastError ?? null,
             healthState: snapshot.healthState ?? undefined,
+            lifecycle: snapshot.lifecycle ?? undefined,
             ...(snapshot.terminalDisconnect
               ? { terminalDisconnect: snapshot.terminalDisconnect }
               : {}),

--- a/extensions/zalouser/src/monitor.account-scope.test.ts
+++ b/extensions/zalouser/src/monitor.account-scope.test.ts
@@ -150,3 +150,41 @@ describe("zalouser monitor pairing account scoping", () => {
     expect(sendMessageZalouserMock).toHaveBeenCalled();
   });
 });
+
+describe("zalouser monitor lifecycle", () => {
+  it("publishes ready after the listener starts", async () => {
+    setZalouserRuntime({
+      logging: {
+        shouldLogVerbose: () => false,
+      },
+    } as unknown as PluginRuntime);
+    startZaloListenerMock.mockResolvedValueOnce({ stop: vi.fn() });
+    const statusSink = vi.fn();
+
+    await withZalouserIngressTestQueue(async (ingressQueue) => {
+      const abortController = new AbortController();
+      const run = monitorZalouserProvider({
+        account: {
+          accountId: "default",
+          enabled: true,
+          profile: "default",
+          authenticated: true,
+          config: {},
+        },
+        config: {},
+        runtime: createZalouserRuntimeEnv(),
+        abortSignal: abortController.signal,
+        statusSink,
+        ingressQueue,
+      });
+      try {
+        await vi.waitFor(() => {
+          expect(statusSink).toHaveBeenCalledWith({ lifecycle: "ready" });
+        });
+      } finally {
+        abortController.abort();
+        await run;
+      }
+    });
+  });
+});

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -1,4 +1,5 @@
 import { mergeAllowlist, summarizeMapping } from "openclaw/plugin-sdk/allow-from";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import {
   createChannelInboundEnvelopeBuilder,
   createChannelPartialDeliveryError,
@@ -67,7 +68,11 @@ type ZalouserMonitorOptions = {
   config: OpenClawConfig;
   runtime: RuntimeEnv;
   abortSignal: AbortSignal;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: (patch: {
+    lastInboundAt?: number;
+    lastOutboundAt?: number;
+    lifecycle?: ChannelAccountSnapshot["lifecycle"];
+  }) => void;
   ingressQueue?: Parameters<typeof createZalouserIngressMonitor>[0]["queue"];
 };
 
@@ -958,6 +963,8 @@ export async function monitorZalouserProvider(
   if (stopped) {
     listenerStop();
     listenerStop = null;
+  } else if (!abortSignal.aborted) {
+    statusSink?.({ lifecycle: "ready" });
   }
 
   if (abortSignal.aborted) {

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -167,6 +167,11 @@ export type ChannelAccountSnapshot = {
   lastTransportActivityAt?: number | null;
   stateReason?: string;
   lastError?: string | null;
+  /**
+   * Legacy channel-authored health label; channel plugins should publish `lifecycle` instead.
+   * Core-derived policy writes remain supported. There is no removal date; removal awaits
+   * external plugin adoption.
+   */
   healthState?: string;
   /**
    * Recorded account lifecycle, independent of inferred transport health.


### PR DESCRIPTION
## What Problem This Solves

The recorded channel lifecycle fact (#117300) gave `evaluateChannelHealth` an authoritative signal above the inference waterfall, but only Slack and Google Chat published it. Every other bundled channel still relied on indirect inference — the exact multi-signal rot the lifecycle series was built to remove. Operators saw "starting" grace behavior or stale inferences for channels that knew their real state.

## Why This Change Was Made

Ten channels now publish lifecycle at their existing status transitions:

- **Discord**: READY → `ready`; READY timeout, socket drop, reconnect scheduling → `recovering`; fatal gateway close → `blocked` + terminal disconnect.
- **Telegram**: poll/webhook success → `ready`; backoff, stall, 409 conflict, retryable webhook failure → `recovering`; structured 401/404 → `blocked` + terminal disconnect.
- **WhatsApp**: additive projection from its monitor state (`healthy`→`ready`, `stale`/`reconnecting`→`recovering`, `logged-out`/`conflict`→`blocked`, `stopped`→`stopped`); channel-authored `healthState` values and guidance are untouched.
- **Buzz, IRC, Nextcloud Talk, QQBot, Raft, Reef, Zalo Personal**: ready/recovering (and QQBot blocked) at their canonical transition sites.

READY transitions clear retained terminal-auth state so repaired credentials restart cleanly. The remaining bundled channels were surveyed and classified rather than force-fitted: twelve need their own ownership work first (e.g. Signal's split SSE/WebSocket lifecycle, Matrix collapsing transient outages and invalid tokens into one ERROR, Nostr needing aggregate usable-relay semantics), three have no runtime status publisher at all (LINE, SMS, Synology Chat), and Slack/Google Chat already publish with named residual gaps. The full classification table is in the survey section below.

`healthState` is now documented as deprecated-successor territory: JSDoc on the SDK type and the channel-plugin docs point authors at lifecycle; no removal date until external plugin adoption.

## User Impact

Operators of the ten adopted channels get truthful health: `blocked` (non-restarting, actionable) vs `recovering` (transient) vs `ready`, instead of inference-derived guesses. No config surface changes; no behavior change for channels not yet adopted.

## Survey: remaining bundled channels

| Channel | Classification | Why |
|---|---|---|
| ClickClack | needs-own-followup | Running publishes before WebSocket readiness; close/error not status-wired |
| Feishu | needs-own-followup | Dual WebSocket/webhook topology; collapsed terminal/transient errors |
| iMessage | needs-own-followup | No canonical sink; duplicate-source/parked-state semantics |
| Matrix | needs-own-followup | SDK ERROR mixes transient outages and invalid tokens |
| Mattermost | needs-own-followup | Connected publishes before WebSocket auth; 401 intentionally retryable |
| MS Teams | needs-own-followup | Publisher carries port metadata, not listener readiness |
| Nostr | needs-own-followup | Multi-relay aggregate usable-relay ownership needed |
| QA Channel | needs-own-followup | Running publishes before first successful poll |
| Signal | needs-own-followup | No monitor sink; split SSE/WebSocket lifecycle |
| Tlon | needs-own-followup | Status spans monitor/SSE boundaries; ambiguous auth failures |
| Twitch | needs-own-followup | Twurple reconnect/auth events lack a runtime-status owner |
| Zalo | needs-own-followup | Dual webhook/polling transports need terminal/transient classification |
| LINE / SMS / Synology Chat | no-runtime-status | No runtime status publisher (Synology omits setStatus) |
| Slack / Google Chat | adopted, partial | Residuals: Slack socket-start + auth edges; Google Chat ready-on-registration |

## Known limitations (intentionally out of scope — gateway/consumer boundary)

- Task finalization can replace a transiently published `blocked` with gateway-owned `stopped` after a terminal channel task exits; terminal disconnect still suppresses restart.
- Discord's pre-gateway REST token rejection loses the original HTTP status; honest mapping needs a probe-result refactor.
- WhatsApp's derived unhealthy projection can supersede authored `conflict` in collected output; raw runtime state retains both.

## Evidence

### Real gateway boundary proof

Reused the lifecycle-series QA harness from #117300/#117805 (`qa suite` + Crabline mock channel API + mock OpenAI provider + ephemeral child gateway). The current head was first built with `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`; every proof gateway ran from dist with a harness-owned ephemeral `OPENCLAW_STATE_DIR` and isolated loopback port. No operator gateway, state, credentials, or ports were used.

```json
{
  "verdict": "PASS",
  "headSha": "2a97f8614b50990c1dfee068e23644e7e0c94af0",
  "harness": "qa-lab dist child gateway + Crabline mock channel API + mock-openai",
  "isolation": {
    "stateDir": "ephemeral",
    "gatewayPort": "isolated-loopback",
    "operatorGatewayTouched": false,
    "credentials": "mock-only"
  },
  "checks": [
    {
      "id": "blocked-status-no-restart",
      "channel": "slack",
      "status": "pass",
      "statusSurface": "channels.status",
      "lifecycle": "blocked",
      "healthState": "blocked",
      "running": true,
      "restartPending": false,
      "lastStartAtUnchanged": true
    },
    {
      "id": "adopted-telegram-recovering-ready",
      "channel": "telegram",
      "status": "pass",
      "fault": "mock Bot API overlapping getUpdates (409)",
      "statusSurface": "channels.status",
      "transition": ["ready", "recovering", "ready"],
      "restartPending": false,
      "lastStartAtUnchanged": true
    },
    {
      "id": "adopted-telegram-structured-auth-terminal",
      "channel": "telegram",
      "status": "pass",
      "fault": "mock Bot API structured 401",
      "statusSurface": "channels.status + gateway logs",
      "terminalDisconnect": true,
      "restartPending": false,
      "lastStartAtUnchanged": true,
      "supervisorRestartSuppressed": true,
      "healthMonitorRestartSuppressed": true
    }
  ],
  "knownLimitationObserved": "Telegram publishes blocked before the terminal task exits; gateway task finalization then durably projects lifecycle=stopped and healthState=terminal-disconnect. This is the named consumer-boundary limitation above, not hidden as blocked status evidence."
}
```

Redacted `channels.status` excerpts:

```json
{
  "slackBlocked": {
    "lifecycle": "blocked",
    "healthState": "blocked",
    "running": true,
    "restartPending": false,
    "lastStartAtUnchanged": true
  },
  "telegramRecovery": {
    "transition": ["ready", "recovering", "ready"],
    "recovering": { "running": true, "connected": false, "restartPending": false },
    "ready": { "running": true, "connected": true, "restartPending": false, "lastError": null },
    "lastStartAtUnchanged": true
  },
  "telegramStructured401Terminal": {
    "before": { "lifecycle": "ready", "running": true, "connected": true },
    "terminal": {
      "lifecycle": "stopped",
      "healthState": "terminal-disconnect",
      "terminalDisconnect": true,
      "running": false,
      "restartPending": false,
      "lastError": "Unauthorized | Telegram ingress worker exited with code 1"
    },
    "lastStartAtUnchanged": true
  }
}
```

Sanitized gateway log excerpts from the structured-401 run:

```text
[telegram] [default] auto-restart skipped, terminal disconnect
[health-monitor] [telegram:default] health-monitor: skipping restart, terminal-disconnect
```

- 341 tests passed across 19 files post-rebase (Discord 59, Telegram 182, WhatsApp 42, seven adopted channels 43, Slack regression 15); 770 total executions pre-rebase including source-blind behavior validation (122/122, all 3 contract clauses)
- SDK surface check, both extension tsgo lanes, changed-file oxlint, `git diff --check`, structured autoreview: clean
- Madge 0 cycles; build passed with no `INEFFECTIVE_DYNAMIC_IMPORT`; `vi.mock` sweep clean
- Numstat: production +179/−41, tests +408/−51, docs +7/−0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
