### PR TITLE
improve(ci): cut QA smoke build overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1758,10 +1758,14 @@ jobs:
 
       - name: Build QA smoke runtime
         env:
-          OPENCLAW_BUILD_PRIVATE_QA: "1"
           NODE_OPTIONS: --max-old-space-size=8192
         run: |
+          # Pack the public runtime before overlaying private QA artifacts so they cannot leak.
+          unset OPENCLAW_BUILD_PRIVATE_QA
+          node scripts/build-all.mjs qaRuntime
+          pnpm ui:build
           package_args=(
+            --skip-build
             --output-dir .artifacts/qa-e2e/smoke-ci-package
             --output-name openclaw-current.tgz
           )
@@ -1769,8 +1773,7 @@ jobs:
             package_args=(--allow-unreleased-changelog "${package_args[@]}")
           fi
           node scripts/package-openclaw-for-docker.mjs "${package_args[@]}"
-          node scripts/build-all.mjs qaRuntime
-          pnpm ui:build
+          OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/build-all.mjs qaRuntime
 
       - name: Run smoke profile part
         env:

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5561,16 +5561,27 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(runStep.run).toContain("ci-routing)");
     expect(fastCoreJob["runs-on"]).toContain("matrix.runner");
     expect(smokeProfileJob.name).toBe("QA Smoke CI (${{ matrix.name }})");
+    const publicRuntimeBuild = smokeBuildStep.run.indexOf("node scripts/build-all.mjs qaRuntime");
+    const uiBuild = smokeBuildStep.run.indexOf("pnpm ui:build");
+    const packageBuild = smokeBuildStep.run.indexOf("node scripts/package-openclaw-for-docker.mjs");
+    const privateRuntimeBuild = smokeBuildStep.run.lastIndexOf(
+      "node scripts/build-all.mjs qaRuntime",
+    );
     expect(smokeBuildStep.run).toContain("node scripts/build-all.mjs qaRuntime");
     expect(smokeBuildStep.run).toContain("pnpm ui:build");
-    expect(smokeBuildStep.env.OPENCLAW_BUILD_PRIVATE_QA).toBe("1");
-    expect(smokeBuildStep.run).not.toContain("--skip-build");
+    expect(smokeBuildStep.env).not.toHaveProperty("OPENCLAW_BUILD_PRIVATE_QA");
+    expect(smokeBuildStep.run).toContain("unset OPENCLAW_BUILD_PRIVATE_QA");
+    expect(smokeBuildStep.run).toContain("--skip-build");
+    expect(smokeBuildStep.run).toContain(
+      "OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/build-all.mjs qaRuntime",
+    );
+    expect(smokeBuildStep.run.match(/node scripts\/build-all\.mjs qaRuntime/g)).toHaveLength(2);
     expect(smokeBuildStep.run).toContain("--allow-unreleased-changelog");
     expect(smokeBuildStep.run).toContain("grep -Fq");
     expect(smokeBuildStep.run).toContain('"${package_args[@]}"');
-    expect(smokeBuildStep.run.indexOf("node scripts/package-openclaw-for-docker.mjs")).toBeLessThan(
-      smokeBuildStep.run.indexOf("node scripts/build-all.mjs qaRuntime"),
-    );
+    expect(publicRuntimeBuild).toBeLessThan(uiBuild);
+    expect(uiBuild).toBeLessThan(packageBuild);
+    expect(packageBuild).toBeLessThan(privateRuntimeBuild);
     expect(workflow.jobs["qa-smoke-ci-artifacts"]).toBeUndefined();
     expect(workflow.jobs["qa-smoke-ci"]).toBeUndefined();
     expect(smokeProfileJob.needs).toEqual(["preflight"]);


### PR DESCRIPTION
## What Problem This Solves

Every QA smoke profile currently spends 202–213 seconds building a full publish-shape package before rebuilding the runtime needed by the smoke harness. The same four profiles repeat that work independently, so it adds roughly three minutes to the CI critical path and about twelve minutes of aggregate runner time.

## Why This Change Was Made

Restore the runtime-only package sequence while preserving the package-safety repair from #113821: build the public QA runtime and UI, create and strictly validate the tarball with `--skip-build`, then overlay private QA runtime artifacts into the source checkout only after the public tarball is sealed. Private QA never enters the package, and the smoke profiles still receive both the validated package and the private source runtime they need. Test partitions, sharding, and scenario coverage are unchanged.

## User Impact

No product behavior changes. Pull request and main CI should reach QA smoke results roughly 2.6–2.8 minutes sooner, removing the QA job as the ceiling for the broader test-performance work.

## Evidence

- Clean CI baseline [30757987976](https://github.com/openclaw/openclaw/actions/runs/30757987976): the four `Build QA smoke runtime` steps took 202–213 seconds each.
- Historical pre-regression CI [30174863503](https://github.com/openclaw/openclaw/actions/runs/30174863503): the runtime-only package sequence completed in 18–19 seconds and all four profiles passed, including the package-consuming plugin lifecycle scenario.
- Exact local sequence on the current base:
  - public `qaRuntime`: 13.08s
  - Control UI build and validation: 4.88s
  - strict `--skip-build` package creation and import-graph check: 17.38s
  - private QA runtime overlay: 11.97s
  - total: 47.31s, an estimated 155–166s saved per profile against current CI
- `check-openclaw-package-tarball`: passed, including the complete dist import graph.
- Tarball inspection: no private QA extension, Plugin SDK, or runtime JavaScript artifacts; the post-package source overlay contains the expected `qa-lab`, `qa-channel`, and QA Plugin SDK files.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts --reporter=verbose`: 96 passed, 1 platform-gated skip.
- `actionlint .github/workflows/ci.yml`, targeted formatting, and `git diff --check`: clean.
- Codex autoreview: no accepted/actionable findings.

The fresh QA worktree intentionally had no private dependency install, and approved remote backends were unavailable. The exact build/package proof therefore ran in an already-hydrated worktree at the same base SHA; hosted CI is the broad Linux and four-profile gate.
