### PR TITLE
fix(telegram): reject retired native button input

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -513,13 +513,18 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
   channel: "telegram",
   to: "123456789",
   message: "Choose an option:",
-  buttons: [
-    [
-      { text: "Yes", callback_data: "yes" },
-      { text: "No", callback_data: "no" },
+  presentation: {
+    blocks: [
+      {
+        type: "buttons",
+        buttons: [
+          { label: "Yes", action: { type: "callback", value: "yes" }, style: "success" },
+          { label: "No", action: { type: "callback", value: "no" }, style: "danger" },
+          { label: "Cancel", action: { type: "callback", value: "cancel" } },
+        ],
+      },
     ],
-    [{ text: "Cancel", callback_data: "cancel" }],
-  ],
+  },
 }
 ```
 
@@ -535,16 +540,21 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     blocks: [
       {
         type: "buttons",
-        buttons: [{ label: "Launch", web_app: { url: "https://example.com/app" } }],
+        buttons: [
+          {
+            label: "Launch",
+            action: { type: "web-app", url: "https://example.com/app" },
+          },
+        ],
       },
     ],
   },
 }
 ```
 
-    `web_app` buttons only work in private chats between a user and the bot.
+    Mini App buttons only work in private chats between a user and the bot.
 
-    Callback clicks not claimed by a registered plugin interactive handler are passed to the agent as text: `callback_data: <value>`.
+    Callback action values not claimed by a registered plugin interactive handler are passed to the agent as text: `callback_data: <value>`.
 
   </Accordion>
 

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -2560,6 +2560,19 @@ describe("handleTelegramAction", () => {
     ).rejects.toThrow(expectedMessage);
   });
 
+  it.each([[[{ text: "Yes", callback_data: "yes" }]], '[[{"text":"Yes","callback_data":"yes"}]]'])(
+    "rejects retired native button input before delivery",
+    async (buttons) => {
+      await expect(
+        handleTelegramAction(
+          { action: "sendMessage", to: "123456", content: "Choose", buttons },
+          telegramConfig({ capabilities: { inlineButtons: "all" } }),
+        ),
+      ).rejects.toThrow(/native "buttons" is unsupported.*Use presentation/);
+      expect(sendDurableMessageBatch).not.toHaveBeenCalled();
+    },
+  );
+
   it("allows inline buttons in DMs with tg: prefixed targets", async () => {
     await sendInlineButtonsMessage({
       to: "tg:5232990709",

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -47,6 +47,7 @@ import {
   resolveTelegramMessageMutationChatId,
   type TelegramMessageMutationContext,
 } from "./message-topic-binding.js";
+import { rejectTelegramNativeButtonParams } from "./native-button-params.js";
 import { resolveTelegramPollVisibility } from "./poll-visibility.js";
 import { resolveTelegramReactionLevel } from "./reaction-level.js";
 import {
@@ -414,6 +415,7 @@ export async function handleTelegramAction(
     toolContext?: TelegramMessageMutationContext["toolContext"];
   },
 ): Promise<AgentToolResult<unknown>> {
+  rejectTelegramNativeButtonParams(params);
   const { action, accountId } = {
     action: normalizeTelegramActionName(readStringParam(params, "action", { required: true })),
     accountId: readStringParam(params, "accountId"),

--- a/extensions/telegram/src/channel-actions.contract.test.ts
+++ b/extensions/telegram/src/channel-actions.contract.test.ts
@@ -316,4 +316,31 @@ describe("telegram actions contract", () => {
       }),
     ).resolves.toEqual({ location });
   });
+
+  it("rejects retired native buttons before prepared presentation delivery", async () => {
+    const prepareSendPayload = telegramPlugin.actions?.prepareSendPayload;
+
+    await expect(
+      prepareSendPayload?.({
+        ctx: {
+          channel: "telegram",
+          action: "send",
+          cfg: {} as OpenClawConfig,
+          params: { buttons: '[[{"text":"Yes","callback_data":"yes"}]]' },
+        },
+        to: "123456",
+        payload: {
+          text: "Choose",
+          presentation: {
+            blocks: [
+              {
+                type: "buttons",
+                buttons: [{ label: "Yes", action: { type: "callback", value: "yes" } }],
+              },
+            ],
+          },
+        },
+      }),
+    ).rejects.toThrow(/native "buttons" is unsupported.*Use presentation/);
+  });
 });

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -26,6 +26,7 @@ import {
   createTelegramPollExtraToolSchemas,
   createTelegramRichSendExtraToolSchemas,
 } from "./message-tool-schema.js";
+import { rejectTelegramNativeButtonParams } from "./native-button-params.js";
 
 const loadTelegramActionRuntime = createLazyRuntimeModule(() => import("./action-runtime.js"));
 
@@ -75,6 +76,7 @@ function prepareTelegramSendPayload({
   ctx,
   payload,
 }: Parameters<NonNullable<ChannelMessageActionAdapter["prepareSendPayload"]>>[0]) {
+  rejectTelegramNativeButtonParams(ctx.params);
   if (
     ctx.action !== "send" ||
     (!payload.presentation && !payload.location && payload.videoAsNote !== true)

--- a/extensions/telegram/src/native-button-params.ts
+++ b/extensions/telegram/src/native-button-params.ts
@@ -1,0 +1,8 @@
+export function rejectTelegramNativeButtonParams(params: Record<string, unknown>): void {
+  if (params.buttons === undefined) {
+    return;
+  }
+  throw new Error(
+    'Telegram native "buttons" is unsupported. Use presentation: {"blocks":[{"type":"buttons","buttons":[{"label":"Yes","action":{"type":"callback","value":"yes"}}]}]}.',
+  );
+}

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1361,8 +1361,10 @@ describe("buildAgentSystemPrompt", () => {
       },
     });
 
-    expect(prompt).toContain("buttons=[[{text,callback_data,style?}]]");
-    expect(prompt).toContain("style primary|success|danger");
+    expect(prompt).toContain('presentation={"blocks":[{"type":"buttons"');
+    expect(prompt).toContain(
+      '"label":"Yes","action":{"type":"callback","value":"yes"},"style":"primary"',
+    );
   });
 
   it("does not embed Telegram rich-text authoring guidance in core messaging", () => {
@@ -1449,7 +1451,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("`presentation` buttons/selects");
     expect(prompt).not.toContain("Inline buttons not enabled for slack");
     expect(prompt).not.toContain("slack.capabilities.inlineButtons");
-    expect(prompt).not.toContain("buttons=[[{text,callback_data,style?}]]");
+    expect(prompt).not.toContain('presentation={"blocks":[{"type":"buttons"');
   });
 
   it.each(["group", "channel"] as const)(

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -655,7 +655,7 @@ function buildMessagingSection(params: {
               : `- After visible \`message(send)\`, final ONLY ${SILENT_REPLY_TOKEN}.`,
           showGenericInlineButtonHint
             ? params.inlineButtonsEnabled
-              ? "- Inline buttons: `send` with `buttons=[[{text,callback_data,style?}]]`; style primary|success|danger."
+              ? '- Inline buttons: `send` with `presentation={"blocks":[{"type":"buttons","buttons":[{"label":"Yes","action":{"type":"callback","value":"yes"},"style":"primary"}]}]}`.'
               : params.runtimeChannel
                 ? `- Inline buttons OFF for ${params.runtimeChannel}; ask owner for ${params.runtimeChannel}.capabilities.inlineButtons=dm|group|all|allowlist.`
                 : ""


### PR DESCRIPTION
Fixes #117628

## Problem

Telegram's native top-level `buttons` message argument was intentionally retired in favor of typed `presentation`, but the system prompt and Telegram docs still taught the old syntax. Because unknown arguments can reach the Telegram action runtime, the old field was silently ignored and users received text without the requested keyboard.

## Root fix

- Point model guidance and Telegram docs to typed `presentation` buttons.
- Reject retired top-level `buttons` at the Telegram action owner before send/edit delivery, including JSON-string input.
- Return the canonical `presentation` shape in the tool error so the model can retry.
- Keep provider-native callback fields private; do not revive a second public button contract.

Compatibility decision: maintainers intentionally accept the fail-loud cutover. A recoverable tool error with the canonical retry shape is safer than silently delivering an incomplete text-only message.

Production runtime delta: +12 net lines. The shared owner-boundary guard covers direct and prepared delivery paths. Tests add 42 net lines. Docs add 10 net lines; the release-owned changelog is untouched.

## Verification

- Focused Vitest: 315/315 passed, including the exact `NO_REPLY` terminal-message regression suite.
- Distill: one canonical typed-presentation path; no compatibility stack.
- Greybeard: two constant-time property checks; no hot-path concern.
- Exact-head Autoreview: no P0/P1 findings, 0.94 confidence; TruffleHog clean.
- OpenClaw-org Blacksmith Testbox changed gate: passed ([run](https://github.com/openclaw/openclaw/actions/runs/31019453479)). The current head was then rebased over new `main`, including the `NO_REPLY` silence repair; exact-head focused tests, autoreview, Telegram E2E, and PR CI cover that integration.
- Exact head: `ee06db235d335791730e9e4c111f4832c39b4d3b`.

## Real Telegram user proof

An ephemeral Gateway and mock OpenAI provider drove a real dedicated Telegram QA user. The provider first called `message.send` with retired raw `buttons`, received the new recovery error, retried with typed `presentation`, then returned `NO_REPLY`. The user observed exactly one bot message, `PR118112 button proof`, with one primary `Confirm` inline button. No failure or `NO_REPLY` text was visible.

```json
{"status":"pass","head":"ee06db235d335791730e9e4c111f4832c39b4d3b","harness":{"ephemeralGateway":true,"mockOpenAi":true,"realTelegramUser":true},"providerRequests":3,"retiredInput":{"rejected":true,"deliveredMessages":0,"recoveryGuidance":"typed callback action"},"typedRetry":{"ok":true,"messageId":"48132","visibleMessages":1,"visibleText":"PR118112 button proof","inlineButtons":[{"label":"Confirm","action":"callback","style":"primary"}]},"visibleFailures":0,"visibleNoReply":0}
```
