### PR TITLE
feat(cron): auto-disable repeatedly failing recurring jobs

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -347,6 +347,8 @@ Failure notifications follow a separate destination path:
 
 Chat failure notifications include the run start time in the agent's configured user timezone. Webhook message text stays stable; integrations can read the same instant from the structured `runAtMs` field.
 
+Failure alerts are opt-in, but the scheduler also provides an unconditional safety backstop. A time-based recurring job is auto-disabled after 10 consecutive execution failures; a successful run resets that streak. Repeated schedule-computation failures auto-disable after 3 errors. The job records `state.autoDisabled.reason` as `consecutive-failures` or `schedule-errors`, and the owning agent receives a notification with the last error and recovery command. After fixing the cause, run `openclaw automations enable <jobId>`; enabling clears the recorded reason and failure streaks. Because disabled jobs are hidden by the default list, use `openclaw automations list --all` to inspect them.
+
 ### Output language
 
 Automation jobs do not infer a reply language from channel, locale, or previous messages. Put the language rule in the scheduled message or template:

--- a/packages/gateway-protocol/src/cron-validators.test.ts
+++ b/packages/gateway-protocol/src/cron-validators.test.ts
@@ -1,3 +1,4 @@
+import { Value } from "typebox/value";
 // Gateway Protocol tests cover cron validators behavior.
 import { describe, expect, it } from "vitest";
 import {
@@ -9,6 +10,7 @@ import {
   validateCronRunsParams,
   validateCronUpdateParams,
 } from "./index.js";
+import { CronJobSchema } from "./schema/cron.js";
 
 /**
  * Cron validator regressions for public scheduler RPC payloads.
@@ -43,6 +45,26 @@ function expectCases(
 describe("cron protocol validators", () => {
   it("accepts minimal add params", () => {
     expectCases(validateCronAddParams, true, [minimalAddParams]);
+  });
+
+  it("reports auto-disable state without accepting it in writable patches", () => {
+    const job = {
+      ...minimalAddParams,
+      id: "job-1",
+      enabled: false,
+      createdAtMs: 1,
+      updatedAtMs: 2,
+      state: {
+        consecutiveErrors: 10,
+        autoDisabled: {
+          reason: "consecutive-failures",
+          atMs: 2,
+          consecutiveErrors: 10,
+        },
+      },
+    };
+    expect(Value.Check(CronJobSchema, job)).toBe(true);
+    expect(validateCronUpdateParams(update({ state: job.state }))).toBe(false);
   });
 
   it("rejects client-authored scheduled authority provenance", () => {

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -430,6 +430,12 @@ const CronFailureNotificationDeliverySchema = closedObject({
   error: Type.Optional(Type.String()),
 });
 
+const CronAutoDisabledSchema = closedObject({
+  reason: Type.Union([Type.Literal("consecutive-failures"), Type.Literal("schedule-errors")]),
+  atMs: Type.Integer({ minimum: 0 }),
+  consecutiveErrors: Type.Integer({ minimum: 1 }),
+});
+
 /** Scheduler-maintained state for the latest run/delivery outcome. */
 export const CronJobStateSchema = closedObject({
   nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
@@ -444,6 +450,8 @@ export const CronJobStateSchema = closedObject({
   lastErrorReason: Type.Optional(CronFailoverReasonSchema),
   lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
   consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
+  // Report-only scheduler ownership fact; callers cannot patch this field.
+  autoDisabled: Type.Optional(CronAutoDisabledSchema),
   consecutiveSkipped: Type.Optional(Type.Integer({ minimum: 0 })),
   lastDelivered: Type.Optional(Type.Boolean()),
   lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -305,6 +305,51 @@ describe("printCronList", () => {
     expect(singleLine).not.toContain("(1x)");
   });
 
+  it("shows why the scheduler auto-disabled a job without changing JSON status", () => {
+    const runFailures = createBaseJob({
+      id: "auto-disabled-runs",
+      name: "Auto-disabled runs",
+      enabled: false,
+      state: {
+        consecutiveErrors: 10,
+        autoDisabled: {
+          reason: "consecutive-failures",
+          atMs: Date.now(),
+          consecutiveErrors: 10,
+        },
+      },
+    });
+    const scheduleErrors = createBaseJob({
+      id: "auto-disabled-schedule",
+      name: "Auto-disabled schedule",
+      enabled: false,
+      state: {
+        scheduleErrorCount: 3,
+        autoDisabled: {
+          reason: "schedule-errors",
+          atMs: Date.now(),
+          consecutiveErrors: 3,
+        },
+      },
+    });
+
+    const list = createRuntimeLogCapture();
+    printCronList([runFailures, scheduleErrors], list.runtime);
+    expectLogsToInclude(list.logs, "disabled (10x)");
+    expectLogsToInclude(list.logs, "disabled (schedule)");
+
+    const show = createRuntimeLogCapture();
+    printCronShow(runFailures, show.runtime);
+    expectLogsToInclude(show.logs, "status: disabled (10x)");
+
+    expect(enrichCronJsonWithStatus(runFailures)).toMatchObject({
+      status: "disabled",
+      state: {
+        autoDisabled: { reason: "consecutive-failures", consecutiveErrors: 10 },
+      },
+    });
+  });
+
   it("caps the failure count so the status column never overflows", () => {
     const { logs, runtime } = createRuntimeLogCapture();
     printCronList(

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -174,8 +174,7 @@ function computeStatus(job: CronJob): string {
 }
 
 // Human-facing decoration only: enrichCronJsonWithStatus() emits computeStatus()
-// verbatim as the --json `status` field, so the failure count must stay out of it.
-// consecutiveErrors resets to 0 on the next successful run, so the count is live.
+// verbatim as the --json `status` field, so failure and disable detail stays out of it.
 function decorateStatusWithFailures(status: string, consecutiveErrors: number | undefined): string {
   const failures = consecutiveErrors ?? 0;
   if (status !== "error" || failures <= 1) {
@@ -188,6 +187,11 @@ function decorateStatusWithFailures(status: string, consecutiveErrors: number | 
 
 function formatCronStatusForDisplay(job: CronJob): string {
   const state = job.state ?? {};
+  if (computeStatus(job) === "disabled" && state.autoDisabled) {
+    return state.autoDisabled.reason === "schedule-errors"
+      ? "disabled (schedule)"
+      : `disabled (${state.autoDisabled.consecutiveErrors}x)`;
+  }
   return decorateStatusWithFailures(computeStatus(job), state.consecutiveErrors);
 }
 
@@ -323,7 +327,7 @@ const CRON_NAME_PAD = 24;
 const CRON_SCHEDULE_PAD = 32;
 const CRON_NEXT_PAD = 10;
 const CRON_LAST_PAD = 10;
-const CRON_STATUS_PAD = 12;
+const CRON_STATUS_PAD = 19;
 const CRON_TARGET_PAD = 9;
 const CRON_DELIVERY_PAD = 64;
 const CRON_AGENT_PAD = 10;

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -732,6 +732,58 @@ describe("maybeRepairLegacyCronStore", () => {
 
       expectNoNoteContaining("runs in a row", "Cron");
     });
+
+    it("lists auto-disabled jobs with their recorded reasons and recovery commands", async () => {
+      const storePath = await makeTempStorePath();
+      await writeCurrentCronStore(storePath, [
+        createCurrentCronJob({
+          id: "run-failure-job",
+          name: "Run failure job",
+          enabled: false,
+          state: {
+            consecutiveErrors: 10,
+            autoDisabled: {
+              reason: "consecutive-failures",
+              atMs: Date.parse("2026-08-01T10:00:00.000Z"),
+              consecutiveErrors: 10,
+            },
+          },
+        }),
+        createCurrentCronJob({
+          id: "schedule-error-job",
+          name: "Schedule error job",
+          enabled: false,
+          state: {
+            scheduleErrorCount: 3,
+            autoDisabled: {
+              reason: "schedule-errors",
+              atMs: Date.parse("2026-08-01T11:00:00.000Z"),
+              consecutiveErrors: 3,
+            },
+          },
+        }),
+        createCurrentCronJob({
+          id: "disabled-one-shot",
+          enabled: false,
+          state: { lastRunStatus: "error", consecutiveErrors: 9 },
+        }),
+      ]);
+
+      await maybeRepairLegacyCronStore({
+        cfg: createCronConfig(storePath),
+        options: {},
+        prompter: makePrompter(true),
+      });
+
+      expectNoteContaining("2 automations are auto-disabled", "Cron");
+      expectNoteContaining("Run failure job (run-failure-job)", "Cron");
+      expectNoteContaining("recorded reason `consecutive-failures` after 10", "Cron");
+      expectNoteContaining("openclaw automations enable run-failure-job", "Cron");
+      expectNoteContaining("Schedule error job (schedule-error-job)", "Cron");
+      expectNoteContaining("recorded reason `schedule-errors` after 3", "Cron");
+      expectNoteContaining("openclaw automations enable schedule-error-job", "Cron");
+      expectNoNoteContaining("disabled-one-shot", "Cron");
+    });
   });
 
   it("repairs legacy cron store fields and migrates notify fallback to webhook delivery", async () => {

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -1,4 +1,5 @@
 // Doctor cron repair orchestration for legacy stores, run logs, payloads, and warnings.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { note } from "../../../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../../../cli/command-format.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
@@ -83,6 +84,44 @@ function countChronicallyFailingCronJobs(jobs: Array<Record<string, unknown>>): 
       consecutiveErrors >= CHRONIC_FAILURE_MIN_CONSECUTIVE_ERRORS
     );
   }).length;
+}
+
+type AutoDisabledCronJob = {
+  id: string;
+  name: string;
+  reason: "consecutive-failures" | "schedule-errors";
+  consecutiveErrors: number;
+};
+
+function collectAutoDisabledCronJobs(jobs: Array<Record<string, unknown>>): AutoDisabledCronJob[] {
+  const autoDisabledJobs: AutoDisabledCronJob[] = [];
+  for (const job of jobs) {
+    if (job.enabled !== false || typeof job.id !== "string") {
+      continue;
+    }
+    const state = job.state;
+    if (!isRecord(state)) {
+      continue;
+    }
+    const autoDisabled = state.autoDisabled;
+    if (!isRecord(autoDisabled)) {
+      continue;
+    }
+    if (
+      (autoDisabled.reason !== "consecutive-failures" &&
+        autoDisabled.reason !== "schedule-errors") ||
+      typeof autoDisabled.consecutiveErrors !== "number"
+    ) {
+      continue;
+    }
+    autoDisabledJobs.push({
+      id: job.id,
+      name: typeof job.name === "string" && job.name.trim() ? job.name.trim() : job.id,
+      reason: autoDisabled.reason,
+      consecutiveErrors: autoDisabled.consecutiveErrors,
+    });
+  }
+  return autoDisabledJobs;
 }
 
 const LEGACY_CRON_STORE_CHECK_ID = "core/doctor/legacy-cron-store";
@@ -403,6 +442,20 @@ export async function maybeRepairLegacyCronStore(params: {
         `${pluralize(chronicFailureCount, "automation")} ${chronicFailureCount === 1 ? "has" : "have"} failed ${CHRONIC_FAILURE_MIN_CONSECUTIVE_ERRORS}+ runs in a row (\`state.consecutiveErrors\`), so the scheduler only re-fires ${chronicFailureCount === 1 ? "it" : "them"} on error backoff.`,
         `- The count resets on the next successful run and also counts runs interrupted by a gateway restart, so a lasting streak means repeated task failures, repeatedly interrupted runs, or a mix. Failure alerts are opt-in, so this may be the only notice.`,
         `- Review with ${formatCliCommand("openclaw automations list")} or ${formatCliCommand("openclaw automations show <id>")}.`,
+      ].join("\n"),
+      "Cron",
+    );
+  }
+
+  const autoDisabledJobs = collectAutoDisabledCronJobs(rawJobs);
+  if (autoDisabledJobs.length > 0) {
+    note(
+      [
+        `${pluralize(autoDisabledJobs.length, "automation")} ${autoDisabledJobs.length === 1 ? "is" : "are"} auto-disabled after repeated failures.`,
+        ...autoDisabledJobs.map(
+          (job) =>
+            `- ${job.name} (${job.id}): recorded reason \`${job.reason}\` after ${job.consecutiveErrors} consecutive errors. Fix the cause, then re-enable with ${formatCliCommand(`openclaw automations enable ${job.id}`)}.`,
+        ),
       ].join("\n"),
       "Cron",
     );

--- a/src/cron/service/auto-disable.ts
+++ b/src/cron/service/auto-disable.ts
@@ -1,0 +1,108 @@
+/** Shared state and owner-notification policy for cron auto-disable transitions. */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
+import type { CronJob, CronJobState } from "../types.js";
+import { normalizeOptionalAgentId } from "./normalize.js";
+import type { CronServiceState } from "./state.js";
+
+type CronAutoDisableReason = NonNullable<CronJobState["autoDisabled"]>["reason"];
+
+export type DeferredAutoDisableNotifications = Array<() => void>;
+
+/**
+ * Run failures get more room than schedule errors (10 vs. 3) because provider
+ * and network errors are often transient, and restart-interrupted runs count too.
+ */
+const MAX_CONSECUTIVE_RUN_FAILURES = 10;
+
+function autoDisableReasonLabel(reason: CronAutoDisableReason): string {
+  return reason === "consecutive-failures" ? "run failures" : "schedule errors";
+}
+
+/** Records one canonical auto-disable fact and queues its owning-agent notification. */
+export function autoDisableCronJob(params: {
+  state: CronServiceState;
+  job: CronJob;
+  reason: CronAutoDisableReason;
+  atMs: number;
+  consecutiveErrors: number;
+  error: unknown;
+  deferredNotifications?: DeferredAutoDisableNotifications;
+}): boolean {
+  const { state, job } = params;
+  if (!job.enabled || job.state.autoDisabled) {
+    return false;
+  }
+
+  job.enabled = false;
+  job.state.nextRunAtMs = undefined;
+  job.state.autoDisabled = {
+    reason: params.reason,
+    atMs: params.atMs,
+    consecutiveErrors: params.consecutiveErrors,
+  };
+
+  const name = truncateUtf16Safe((job.name || job.id).replace(/\s+/g, " ").trim(), 120);
+  const error = truncateUtf16Safe(String(params.error).trim() || "unknown reason", 200);
+  const text = [
+    `⚠️ Automation "${name}" (${job.id}) was auto-disabled after ${params.consecutiveErrors} consecutive ${autoDisableReasonLabel(params.reason)}.`,
+    `Last error: ${error}`,
+    `Fix the underlying cause, then run \`openclaw automations enable ${job.id}\` to re-enable it.`,
+  ].join("\n");
+  const notify = () => {
+    const agentId =
+      normalizeOptionalAgentId(job.agentId) ??
+      normalizeOptionalAgentId(parseAgentSessionKey(job.sessionKey)?.agentId) ??
+      normalizeOptionalAgentId(state.deps.resolveDefaultAgentId?.()) ??
+      normalizeOptionalAgentId(state.deps.defaultAgentId);
+    const deliveryContext =
+      agentId || job.sessionKey
+        ? state.deps.resolveOriginDeliveryContext?.({
+            agentId,
+            sessionKey: job.sessionKey,
+          })
+        : undefined;
+    state.deps.enqueueSystemEvent(text, {
+      agentId,
+      sessionKey: job.sessionKey,
+      contextKey: `cron:${job.id}:auto-disabled`,
+      ...(deliveryContext ? { deliveryContext } : {}),
+    });
+    state.deps.requestHeartbeat({
+      source: "cron",
+      intent: "event",
+      reason: `cron:${job.id}:auto-disabled`,
+      agentId,
+      sessionKey: job.sessionKey,
+    });
+  };
+
+  if (params.deferredNotifications) {
+    params.deferredNotifications.push(notify);
+  } else {
+    notify();
+  }
+  return true;
+}
+
+/** Auto-disables only time-based recurring jobs once their run-error streak reaches the limit. */
+export function maybeAutoDisableCronJobAfterRunFailure(params: {
+  state: CronServiceState;
+  job: CronJob;
+  atMs: number;
+  error: unknown;
+  deferredNotifications?: DeferredAutoDisableNotifications;
+}): boolean {
+  const consecutiveErrors = params.job.state.consecutiveErrors ?? 0;
+  if (
+    (params.job.schedule.kind !== "cron" && params.job.schedule.kind !== "every") ||
+    consecutiveErrors < MAX_CONSECUTIVE_RUN_FAILURES
+  ) {
+    return false;
+  }
+  return autoDisableCronJob({
+    ...params,
+    reason: "consecutive-failures",
+    consecutiveErrors,
+  });
+}

--- a/src/cron/service/jobs-scheduling.ts
+++ b/src/cron/service/jobs-scheduling.ts
@@ -11,6 +11,7 @@ import {
 import { resolveCronStaggerMs } from "../stagger.js";
 import { createCronStreamSourceIdentity, resolveCronStreamBatching } from "../stream-schedule.js";
 import type { CronJob, CronSchedule } from "../types.js";
+import { autoDisableCronJob, type DeferredAutoDisableNotifications } from "./auto-disable.js";
 import { normalizePayloadToSystemText } from "./normalize.js";
 import { isQueuedCronRun, isQueuedForceCronRun } from "./run-admission.js";
 import type { CronServiceState } from "./state.js";
@@ -358,7 +359,7 @@ export function recordScheduleComputeError(params: {
   state: CronServiceState;
   job: CronJob;
   err: unknown;
-  deferredAutoDisableNotifications?: Array<() => void>;
+  deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
 }): boolean {
   const { state, job, err } = params;
   const errorCount = (job.state.scheduleErrorCount ?? 0) + 1;
@@ -369,33 +370,19 @@ export function recordScheduleComputeError(params: {
   job.state.lastError = `schedule error: ${errText}`;
 
   if (errorCount >= MAX_SCHEDULE_ERRORS) {
-    job.enabled = false;
+    autoDisableCronJob({
+      state,
+      job,
+      reason: "schedule-errors",
+      atMs: state.deps.nowMs(),
+      consecutiveErrors: errorCount,
+      error: errText,
+      deferredNotifications: params.deferredAutoDisableNotifications,
+    });
     state.deps.log.error(
       { jobId: job.id, name: job.name, errorCount, err: errText },
       "cron: auto-disabled job after repeated schedule errors",
     );
-
-    const notifyText = `⚠️ Automation "${job.name}" has been auto-disabled after ${errorCount} consecutive schedule errors. Last error: ${errText}`;
-    const notify = () => {
-      state.deps.enqueueSystemEvent(notifyText, {
-        agentId: job.agentId,
-        sessionKey: job.sessionKey,
-        contextKey: `cron:${job.id}:auto-disabled`,
-      });
-      state.deps.requestHeartbeat({
-        source: "cron",
-        intent: "event",
-        reason: `cron:${job.id}:auto-disabled`,
-        agentId: job.agentId,
-        sessionKey: job.sessionKey,
-      });
-    };
-    if (params.deferredAutoDisableNotifications) {
-      params.deferredAutoDisableNotifications.push(notify);
-    } else {
-      // Notify the user so the auto-disable is not silent (#28861).
-      notify();
-    }
   } else {
     state.deps.log.warn(
       { jobId: job.id, name: job.name, errorCount, err: errText },
@@ -552,7 +539,7 @@ function recomputeJobNextRunAtMs(params: {
   state: CronServiceState;
   job: CronJob;
   nowMs: number;
-  deferredAutoDisableNotifications?: Array<() => void>;
+  deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
 }) {
   let changed = false;
   try {
@@ -628,7 +615,7 @@ export function recomputeNextRunsForMaintenance(
     nowMs?: number;
     repairFutureCronNextRunAtMs?: boolean;
     preserveExpiredPacedNextRunJobId?: string;
-    deferredAutoDisableNotifications?: Array<() => void>;
+    deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
   },
 ): boolean {
   const recomputeExpired = opts?.recomputeExpired ?? false;

--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -136,6 +136,11 @@ describe("cron schedule error isolation", () => {
     // After 3rd error, job should be disabled
     expect(badJob.enabled).toBe(false);
     expect(badJob.state.scheduleErrorCount).toBe(3);
+    expect(badJob.state.autoDisabled).toEqual({
+      reason: "schedule-errors",
+      atMs: Date.now(),
+      consecutiveErrors: 3,
+    });
     expect(state.deps.log.error).toHaveBeenCalledWith(
       {
         jobId: "bad-job",
@@ -144,6 +149,10 @@ describe("cron schedule error isolation", () => {
         err: "TypeError: CronPattern: invalid configuration format ('garbage'), exactly five, six, or seven space separated parts are required.",
       },
       "cron: auto-disabled job after repeated schedule errors",
+    );
+    expect(state.deps.enqueueSystemEvent).toHaveBeenCalledWith(
+      expect.stringContaining("openclaw automations enable bad-job"),
+      expect.objectContaining({ contextKey: "cron:bad-job:auto-disabled" }),
     );
   });
 

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -384,7 +384,13 @@ export function applyJobPatch(
     // Runtime state patches may report execution progress, but the scheduler
     // alone owns the boundary that decides whether restart catch-up can run.
     delete statePatch.scheduleActivatedAtMs;
+    delete statePatch.autoDisabled;
     job.state = { ...job.state, ...statePatch };
+  }
+  if (patch.enabled === true) {
+    delete job.state.autoDisabled;
+    job.state.consecutiveErrors = 0;
+    job.state.scheduleErrorCount = 0;
   }
   if ("agentId" in patch) {
     job.agentId = normalizeOptionalAgentId((patch as { agentId?: unknown }).agentId);

--- a/src/cron/service/ops-lifecycle.ts
+++ b/src/cron/service/ops-lifecycle.ts
@@ -26,6 +26,7 @@ export async function start(state: CronServiceState) {
   const interruptedRuns: InterruptedStartupRun[] = [];
   const completedJobIdsToDelete = new Set<string>();
   let repairedAnyStartupRun = false;
+  const postPersistAutoDisableNotifications: Array<() => void> = [];
   await locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
     if (state.stopped) {
@@ -56,6 +57,7 @@ export async function start(state: CronServiceState) {
             entry: finalized.entry,
             ...(finalized.scriptResult ? { scriptResult: finalized.scriptResult } : {}),
             ...(finalized.triggerEval ? { triggerEval: finalized.triggerEval } : {}),
+            deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
           });
           // Skip only the old invocation; a distinct overdue replacement
           // must remain eligible for normal one-shot startup catch-up.
@@ -75,6 +77,7 @@ export async function start(state: CronServiceState) {
           taskRunId,
           runningAtMs,
           nowMs,
+          deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
         });
         if (interrupted.replacementAtMs === undefined) {
           interruptedJobIds.add(job.id);
@@ -87,7 +90,17 @@ export async function start(state: CronServiceState) {
       state.store.jobs = jobs.filter((job) => !completedJobIdsToDelete.has(job.id));
     }
     if (repairedAnyStartupRun || jobs.length > 0) {
-      await persist(state, repairedAnyStartupRun ? undefined : { stateOnly: true });
+      const persisted = await persist(
+        state,
+        repairedAnyStartupRun ? undefined : { stateOnly: true },
+      );
+      // Recovery alerts describe the repaired durable row, so never publish
+      // them until the startup write has committed successfully.
+      if (persisted) {
+        for (const notify of postPersistAutoDisableNotifications) {
+          notify();
+        }
+      }
     }
   });
 
@@ -107,9 +120,18 @@ export async function start(state: CronServiceState) {
     if (state.stopped) {
       return;
     }
-    const changed = recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+    const postPersistMaintenanceNotifications: Array<() => void> = [];
+    const changed = recomputeNextRunsForMaintenance(state, {
+      recomputeExpired: true,
+      deferredAutoDisableNotifications: postPersistMaintenanceNotifications,
+    });
     if (changed) {
-      await persist(state);
+      const persisted = await persist(state);
+      if (persisted) {
+        for (const notify of postPersistMaintenanceNotifications) {
+          notify();
+        }
+      }
     }
     for (const interrupted of interruptedRuns) {
       const job = state.store?.jobs.find((entry) => entry.id === interrupted.jobId);

--- a/src/cron/service/ops-run.ts
+++ b/src/cron/service/ops-run.ts
@@ -174,6 +174,7 @@ async function finishPreparedManualRun(
           : mode === "force"
             ? "force-preserve"
             : "advance";
+      const postPersistAutoDisableNotifications: Array<() => void> = [];
 
       let shouldDelete = false;
       if (coreResult.status === "ok" && coreResult.triggerEval?.fired === false) {
@@ -187,7 +188,11 @@ async function finishPreparedManualRun(
             endedAt,
             triggerEval: coreResult.triggerEval,
           },
-          { scheduleMode, triggerOwnership },
+          {
+            scheduleMode,
+            triggerOwnership,
+            deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+          },
         );
       } else {
         shouldDelete = applyJobResult(
@@ -204,6 +209,7 @@ async function finishPreparedManualRun(
             scheduleMode: scheduleMode === "force-preserve" ? "preserve" : "advance",
             scheduleOwnership,
             scheduleOwnershipAtMs: prepared.scheduleOwnershipAtMs,
+            deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
           },
         );
         applyTriggerRunResult(
@@ -287,13 +293,16 @@ async function finishPreparedManualRun(
       });
       recomputeNextRunsForMaintenance(state, {
         recomputeExpired: true,
+        deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
         ...(mode === "force"
           ? {
               preserveExpiredPacedNextRunJobId: jobId,
             }
           : {}),
       });
-      await persistOrRestore(state, rollbackSnapshot);
+      await persistOrRestore(state, rollbackSnapshot, {
+        postPersistAutoDisableNotifications,
+      });
       if (removedJob) {
         emit(state, { jobId: removedJob.id, action: "removed", job: removedJob });
       }

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -1355,6 +1355,54 @@ describe("cron service ops seam coverage", () => {
     expect(updated.enabled).toBe(false);
   });
 
+  it("clears auto-disable state and failure streaks when manually re-enabled", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-08-01T16:00:00.000Z");
+    await writeCronStoreSnapshot({
+      storePath,
+      jobs: [
+        {
+          id: "auto-disabled-recurring",
+          name: "auto-disabled recurring",
+          enabled: false,
+          createdAtMs: now - 60_000,
+          updatedAtMs: now - 60_000,
+          schedule: { kind: "cron", expr: "0 * * * *" },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "agentTurn", message: "do work" },
+          state: {
+            consecutiveErrors: 10,
+            scheduleErrorCount: 3,
+            autoDisabled: {
+              reason: "consecutive-failures",
+              atMs: now - 1_000,
+              consecutiveErrors: 10,
+            },
+          },
+        },
+      ],
+    });
+    const state = createOkIsolatedCronState({ storePath, now });
+
+    const updated = await update(state, "auto-disabled-recurring", { enabled: true });
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+
+    expect(updated).toMatchObject({
+      enabled: true,
+      state: { consecutiveErrors: 0, scheduleErrorCount: 0 },
+    });
+    expect(updated.state.autoDisabled).toBeUndefined();
+    const persisted = (await loadCronStore(storePath)).jobs[0];
+    expect(persisted).toMatchObject({
+      enabled: true,
+      state: { consecutiveErrors: 0, scheduleErrorCount: 0 },
+    });
+    expect(persisted?.state.autoDisabled).toBeUndefined();
+  });
+
   it("rejects enabling a pre-existing never-matching job", async () => {
     const { storePath } = await makeStorePath();
     const now = Date.parse("2026-06-09T00:00:00.000Z");

--- a/src/cron/service/startup-run-repair.auto-disable.test.ts
+++ b/src/cron/service/startup-run-repair.auto-disable.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CronJob } from "../types.js";
+import { markInterruptedStartupRun } from "./startup-run-repair.js";
+import { createCronServiceState } from "./state.js";
+
+describe("startup run repair auto-disable", () => {
+  it("records the tenth restart-interrupted recurring failure before notification", () => {
+    const runningAtMs = Date.parse("2026-08-01T16:00:00.000Z");
+    const nowMs = runningAtMs + 30_000;
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+    const state = createCronServiceState({
+      storePath: "/tmp/startup-run-repair-auto-disable.json",
+      cronEnabled: true,
+      log: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      nowMs: () => nowMs,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob: vi.fn(),
+    });
+    const job: CronJob = {
+      id: "restart-auto-disable",
+      name: "restart auto-disable",
+      enabled: true,
+      createdAtMs: runningAtMs - 60_000,
+      updatedAtMs: runningAtMs,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: runningAtMs - 60_000 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "do not replay" },
+      state: {
+        nextRunAtMs: runningAtMs,
+        runningAtMs,
+        consecutiveErrors: 9,
+      },
+    };
+    const deferredNotifications: Array<() => void> = [];
+
+    markInterruptedStartupRun({
+      state,
+      job,
+      runningAtMs,
+      nowMs,
+      deferredAutoDisableNotifications: deferredNotifications,
+    });
+
+    expect(job).toMatchObject({
+      enabled: false,
+      state: {
+        consecutiveErrors: 10,
+        autoDisabled: {
+          reason: "consecutive-failures",
+          atMs: nowMs,
+          consecutiveErrors: 10,
+        },
+      },
+    });
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(requestHeartbeat).not.toHaveBeenCalled();
+    expect(deferredNotifications).toHaveLength(1);
+
+    deferredNotifications[0]?.();
+    expect(enqueueSystemEvent).toHaveBeenCalledOnce();
+    expect(requestHeartbeat).toHaveBeenCalledOnce();
+  });
+});

--- a/src/cron/service/startup-run-repair.ts
+++ b/src/cron/service/startup-run-repair.ts
@@ -3,6 +3,10 @@ import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-
 import { parseAbsoluteTimeMs } from "../parse.js";
 import type { CronRunLogEntry } from "../run-log-types.js";
 import type { CronJob, CronRunStatus } from "../types.js";
+import {
+  type DeferredAutoDisableNotifications,
+  maybeAutoDisableCronJobAfterRunFailure,
+} from "./auto-disable.js";
 import type { CronServiceState } from "./state.js";
 import {
   applyJobResult,
@@ -54,6 +58,7 @@ export function markInterruptedStartupRun(params: {
   taskRunId?: string;
   runningAtMs: number;
   nowMs: number;
+  deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
 }): InterruptedStartupRun {
   const { job, runningAtMs, nowMs } = params;
   const replacementAtMs = resolveOneShotReplacementAtMs(job, runningAtMs);
@@ -89,6 +94,21 @@ export function markInterruptedStartupRun(params: {
   job.state.nextRunAtMs = replacementAtMs;
   job.updatedAtMs = nowMs;
 
+  if (
+    maybeAutoDisableCronJobAfterRunFailure({
+      state: params.state,
+      job,
+      atMs: nowMs,
+      error: STARTUP_INTERRUPTED_ERROR,
+      deferredNotifications: params.deferredAutoDisableNotifications,
+    })
+  ) {
+    params.state.deps.log.error(
+      { jobId: job.id, name: job.name, consecutiveErrors: job.state.consecutiveErrors },
+      "cron: auto-disabled interrupted job after consecutive run failures",
+    );
+  }
+
   if (job.schedule.kind === "at" && replacementAtMs === undefined) {
     job.enabled = false;
   }
@@ -109,6 +129,7 @@ export function restoreFinalizedStartupRun(params: {
   entry: CronRunLogEntry & { status: CronRunStatus };
   scriptResult?: { scriptStateChanged: true; scriptState?: unknown };
   triggerEval?: CronTriggerEvalOutcome;
+  deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
 }): { shouldDelete: boolean; replacementAtMs?: number } {
   const { state, job, runningAtMs, entry } = params;
   const startedAt = entry.runAtMs ?? runningAtMs;
@@ -122,7 +143,11 @@ export function restoreFinalizedStartupRun(params: {
       startedAt,
       endedAt: entry.ts,
     },
-    { replayFailureAlertAtMs: entry.ts, scheduleOwnership },
+    {
+      replayFailureAlertAtMs: entry.ts,
+      scheduleOwnership,
+      deferredAutoDisableNotifications: params.deferredAutoDisableNotifications,
+    },
   );
 
   // The finalized row captured post-run state before the stale cron store write.
@@ -134,7 +159,9 @@ export function restoreFinalizedStartupRun(params: {
   job.state.lastFailureNotificationDelivered = entry.failureNotificationDelivery?.delivered;
   job.state.lastFailureNotificationDeliveryStatus = entry.failureNotificationDelivery?.status;
   job.state.lastFailureNotificationDeliveryError = entry.failureNotificationDelivery?.error;
-  job.state.nextRunAtMs = replacementAtMs ?? entry.nextRunAtMs;
+  job.state.nextRunAtMs = job.state.autoDisabled
+    ? undefined
+    : (replacementAtMs ?? entry.nextRunAtMs);
   // The finalized ledger row owns the schedule decision made before the stale
   // store write. No next run means that one-shot was permanently disabled.
   if (

--- a/src/cron/service/timer-outcome-finalization.ts
+++ b/src/cron/service/timer-outcome-finalization.ts
@@ -134,8 +134,11 @@ export async function finalizeCompletedCronRunOutcomes(
 
       const rollbackSnapshot = snapshotStoreForRollback(state);
       const removedJobs: CronJob[] = [];
+      const postPersistAutoDisableNotifications: Array<() => void> = [];
       for (const outcome of finalizedOutcomes) {
-        const removedJob = applyOutcomeToStoredJob(state, outcome);
+        const removedJob = applyOutcomeToStoredJob(state, outcome, {
+          deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+        });
         if (removedJob) {
           removedJobs.push(removedJob);
         }
@@ -146,10 +149,17 @@ export async function finalizeCompletedCronRunOutcomes(
       recomputeNextRunsForMaintenance(
         state,
         opts?.repairFutureCronNextRunAtMs === false
-          ? { repairFutureCronNextRunAtMs: false }
-          : undefined,
+          ? {
+              repairFutureCronNextRunAtMs: false,
+              deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+            }
+          : { deferredAutoDisableNotifications: postPersistAutoDisableNotifications },
       );
-      await persistOrRestore(state, rollbackSnapshot);
+      // Auto-disable alerts describe durable state. Drain them only after the
+      // terminal write succeeds so a rolled-back run cannot publish a false transition.
+      await persistOrRestore(state, rollbackSnapshot, {
+        postPersistAutoDisableNotifications,
+      });
       finishPersistedQuietCronTaskRuns(state, finalizedOutcomes);
       for (const removedJob of removedJobs) {
         emit(state, { jobId: removedJob.id, action: "removed", job: removedJob });

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -8,6 +8,10 @@ import { computeNextRunAtMs } from "../schedule.js";
 import { createCronStreamSourceIdentity } from "../stream-schedule.js";
 import type { CronJob, CronRunStatus } from "../types.js";
 import {
+  type DeferredAutoDisableNotifications,
+  maybeAutoDisableCronJobAfterRunFailure,
+} from "./auto-disable.js";
+import {
   failureNotificationDeliveryFromJobState,
   maybeEmitFailureAlert,
   resolveFailureAlert,
@@ -77,6 +81,7 @@ export function applyJobResult(
     scheduleOwnershipAtMs?: number;
     // Startup replay restores alert cooldown bookkeeping without redelivery.
     replayFailureAlertAtMs?: number;
+    deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
   },
 ): boolean {
   const previousScheduleState = {
@@ -292,6 +297,28 @@ export function applyJobResult(
       job.state.nextRunAtMs = previousScheduleState.nextRunAtMs;
       job.state.pacedNextRunAtMs = previousScheduleState.pacedNextRunAtMs;
       job.state.forcePreservedNextRunAtMs = previousScheduleState.nextRunAtMs;
+    } else if (
+      result.status === "error" &&
+      isJobEnabled(job) &&
+      maybeAutoDisableCronJobAfterRunFailure({
+        state,
+        job,
+        atMs: result.endedAt,
+        error: result.error ?? "unknown run failure",
+        deferredNotifications: opts?.deferredAutoDisableNotifications,
+      })
+    ) {
+      // Keep this after the ownership and force-preserve gates: those paths
+      // restore schedule state and would otherwise silently undo the disable.
+      state.deps.log.error(
+        {
+          jobId: job.id,
+          name: job.name,
+          consecutiveErrors: job.state.consecutiveErrors,
+          error: result.error,
+        },
+        "cron: auto-disabled job after consecutive run failures",
+      );
     } else if (result.status === "error" && isJobEnabled(job)) {
       const retryDecision = resolveTransientCronRetryDecision({
         cronConfig: state.deps.cronConfig,
@@ -315,7 +342,12 @@ export function applyJobResult(
             // If the schedule expression/timezone throws (croner edge cases),
             // record the schedule error (auto-disables after repeated failures)
             // and fall back to backoff-only schedule so the state update is not lost.
-            recordScheduleComputeError({ state, job, err });
+            recordScheduleComputeError({
+              state,
+              job,
+              err,
+              deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
+            });
           }
           normalNextComputed = true;
         }
@@ -407,7 +439,12 @@ export function applyJobResult(
         // If the schedule expression/timezone throws (croner edge cases),
         // record the schedule error (auto-disables after repeated failures)
         // so a persistent throw doesn't cause a MIN_REFIRE_GAP_MS hot loop.
-        recordScheduleComputeError({ state, job, err });
+        recordScheduleComputeError({
+          state,
+          job,
+          err,
+          deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
+        });
       }
       if (job.schedule.kind === "cron") {
         // Safety net: ensure the next fire is at least MIN_REFIRE_GAP_MS
@@ -518,6 +555,7 @@ export function applyTriggerNoFireResult(
   opts?: {
     scheduleMode?: "advance" | "force-preserve" | "stale-preserve";
     triggerOwnership?: CronTriggerOwnership;
+    deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
   },
 ): void {
   const previousNextRunAtMs = job.state.nextRunAtMs;
@@ -557,13 +595,19 @@ export function applyTriggerNoFireResult(
     job.state.nextRunAtMs =
       naturalNext === undefined ? undefined : Math.max(naturalNext, result.endedAt + floorMs);
   } catch (err) {
-    recordScheduleComputeError({ state, job, err });
+    recordScheduleComputeError({
+      state,
+      job,
+      err,
+      deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
+    });
   }
 }
 
 export function applyOutcomeToStoredJob(
   state: CronServiceState,
   result: TimedCronRunOutcome,
+  opts?: { deferredAutoDisableNotifications?: DeferredAutoDisableNotifications },
 ): CronJob | undefined {
   const store = state.store;
   if (!store) {
@@ -579,7 +623,7 @@ export function applyOutcomeToStoredJob(
     }
     // A run may finish after its job disappears; finalize the admitted job
     // snapshot so operator history survives without reviving the stored job.
-    applyJobResult(state, result.job, result);
+    applyJobResult(state, result.job, result, { scheduleOwnership: "stale" });
     emitJobFinished(state, result.job, result, result.startedAt);
     state.deps.log.info(
       { jobId: result.jobId, status: result.status },
@@ -613,6 +657,7 @@ export function applyOutcomeToStoredJob(
       {
         scheduleMode: scheduleOwnership === "stale" ? "stale-preserve" : "advance",
         triggerOwnership,
+        deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
       },
     );
     job.state.startupCatchupAtMs = undefined;
@@ -624,7 +669,10 @@ export function applyOutcomeToStoredJob(
     return undefined;
   }
 
-  const shouldDelete = applyJobResult(state, job, result, { scheduleOwnership });
+  const shouldDelete = applyJobResult(state, job, result, {
+    scheduleOwnership,
+    deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
+  });
   applyTriggerRunResult(job, result, { scheduleOwnership, triggerOwnership });
   applyScriptRunResult(job, result, { triggerOwnership });
   job.state.startupCatchupAtMs = undefined;

--- a/src/cron/service/timer.batch-finalization.test.ts
+++ b/src/cron/service/timer.batch-finalization.test.ts
@@ -320,6 +320,163 @@ describe("cron batch outcome finalization", () => {
     }
   });
 
+  it("notifies the owning agent once after a recurring auto-disable is durable", async () => {
+    const store = fixtures.makeStorePath();
+    const dueAt = Date.parse("2026-08-01T15:00:00.000Z");
+    const job = createDueIsolatedJob({
+      id: "recurring-auto-disable-notification",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    job.name = "Recurring report";
+    job.schedule = { kind: "every", everyMs: 60_000, anchorMs: dueAt - 60_000 };
+    job.state.consecutiveErrors = 9;
+    job.state.runningAtMs = dueAt;
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const order: string[] = [];
+    const enqueueSystemEvent = vi.fn(
+      (
+        _text: string,
+        _opts?: {
+          agentId?: string;
+          sessionKey?: string;
+          contextKey?: string;
+          deliveryContext?: unknown;
+        },
+      ) => {
+        order.push("notify");
+      },
+    );
+    const requestHeartbeat = vi.fn(() => {
+      order.push("heartbeat");
+    });
+    const deliveryContext = { channel: "discord", to: "channel-1", accountId: "default" };
+    const resolveOriginDeliveryContext = vi.fn(() => deliveryContext);
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => dueAt + 10,
+      defaultAgentId: "main",
+      enqueueSystemEvent,
+      resolveOriginDeliveryContext,
+      requestHeartbeat,
+      runIsolatedAgentJob: vi.fn(),
+    });
+    const save = cronStoreModule.saveCronJobsStore;
+    const saveSpy = vi
+      .spyOn(cronStoreModule, "saveCronJobsStore")
+      .mockImplementation(async (...args) => {
+        if (args[1].jobs[0]?.state.autoDisabled) {
+          expect(enqueueSystemEvent).not.toHaveBeenCalled();
+          expect(requestHeartbeat).not.toHaveBeenCalled();
+          order.push("persist");
+        }
+        return await save(...args);
+      });
+
+    try {
+      await finalizeCompletedCronRunOutcomes(state, [
+        {
+          jobId: job.id,
+          job: structuredClone(job),
+          activeJobMarker: markCronJobActive(job.id),
+          status: "error",
+          error: "provider remained unavailable",
+          startedAt: dueAt,
+          endedAt: dueAt + 10,
+        },
+      ]);
+
+      expect(order).toEqual(["persist", "notify", "heartbeat"]);
+      expect(enqueueSystemEvent).toHaveBeenCalledOnce();
+      expect(enqueueSystemEvent).toHaveBeenCalledWith(
+        expect.stringContaining(`openclaw automations enable ${job.id}`),
+        {
+          agentId: "main",
+          sessionKey: undefined,
+          contextKey: `cron:${job.id}:auto-disabled`,
+          deliveryContext,
+        },
+      );
+      expect(enqueueSystemEvent.mock.calls[0]?.[0]).toContain("Recurring report");
+      expect(enqueueSystemEvent.mock.calls[0]?.[0]).toContain(job.id);
+      expect(enqueueSystemEvent.mock.calls[0]?.[0]).toContain("10 consecutive run failures");
+      expect(enqueueSystemEvent.mock.calls[0]?.[0]).toContain("provider remained unavailable");
+      expect(resolveOriginDeliveryContext).toHaveBeenCalledWith({
+        agentId: "main",
+        sessionKey: undefined,
+      });
+      expect(requestHeartbeat).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: `cron:${job.id}:auto-disabled`, agentId: "main" }),
+      );
+      expect((await loadCronStore(store.storePath)).jobs[0]).toMatchObject({
+        enabled: false,
+        state: {
+          consecutiveErrors: 10,
+          autoDisabled: {
+            reason: "consecutive-failures",
+            atMs: dueAt + 10,
+            consecutiveErrors: 10,
+          },
+        },
+      });
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  it("rolls back recurring auto-disable without notifying when persistence fails", async () => {
+    const store = fixtures.makeStorePath();
+    const dueAt = Date.parse("2026-08-01T15:05:00.000Z");
+    const job = createDueIsolatedJob({
+      id: "recurring-auto-disable-rollback",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    job.schedule = { kind: "every", everyMs: 60_000, anchorMs: dueAt - 60_000 };
+    job.state.consecutiveErrors = 9;
+    job.state.runningAtMs = dueAt;
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => dueAt + 10,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(),
+    });
+    const saveSpy = vi
+      .spyOn(cronStoreModule, "saveCronJobsStore")
+      .mockRejectedValueOnce(new Error("terminal write failed"));
+
+    try {
+      await expect(
+        finalizeCompletedCronRunOutcomes(state, [
+          {
+            jobId: job.id,
+            job: structuredClone(job),
+            activeJobMarker: markCronJobActive(job.id),
+            status: "error",
+            error: "tenth failure",
+            startedAt: dueAt,
+            endedAt: dueAt + 10,
+          },
+        ]),
+      ).rejects.toThrow("terminal write failed");
+      expect(state.deps.enqueueSystemEvent).not.toHaveBeenCalled();
+      expect(state.deps.requestHeartbeat).not.toHaveBeenCalled();
+      expect(state.store?.jobs[0]?.enabled).toBe(true);
+      expect(state.store?.jobs[0]?.state.autoDisabled).toBeUndefined();
+      expect((await loadCronStore(store.storePath)).jobs[0]?.enabled).toBe(true);
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
   it("clears retired setup-timeout markers without rewriting stopped-service state", async () => {
     const store = fixtures.makeStorePath();
     const dueAt = Date.parse("2026-02-06T10:05:01.250Z");

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -2819,6 +2819,141 @@ describe("cron service timer regressions", () => {
     },
   );
 
+  it("auto-disables a recurring job on its tenth consecutive run failure", () => {
+    const startedAt = Date.parse("2026-08-01T12:00:00.000Z");
+    const deferredNotifications: Array<() => void> = [];
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-consecutive-failure-threshold.json",
+      log: noopLogger,
+      nowMs: () => startedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "recurring-failure-threshold",
+      name: "recurring failure threshold",
+      scheduledAt: startedAt,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: startedAt },
+      payload: { kind: "agentTurn", message: "fail" },
+      state: { consecutiveErrors: 8 },
+    });
+
+    applyJobResult(
+      state,
+      job,
+      { status: "error", error: "ninth failure", startedAt, endedAt: startedAt + 10 },
+      { deferredAutoDisableNotifications: deferredNotifications },
+    );
+    expect(job.enabled).toBe(true);
+    expect(job.state.consecutiveErrors).toBe(9);
+    expect(job.state.autoDisabled).toBeUndefined();
+    expect(deferredNotifications).toHaveLength(0);
+
+    applyJobResult(
+      state,
+      job,
+      {
+        status: "error",
+        error: "tenth failure",
+        startedAt: startedAt + 60_000,
+        endedAt: startedAt + 60_010,
+      },
+      { deferredAutoDisableNotifications: deferredNotifications },
+    );
+    expect(job.enabled).toBe(false);
+    expect(job.state.nextRunAtMs).toBeUndefined();
+    expect(job.state.autoDisabled).toEqual({
+      reason: "consecutive-failures",
+      atMs: startedAt + 60_010,
+      consecutiveErrors: 10,
+    });
+    expect(deferredNotifications).toHaveLength(1);
+  });
+
+  it("resets the auto-disable streak after a successful recurring run", () => {
+    const startedAt = Date.parse("2026-08-01T13:00:00.000Z");
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-consecutive-failure-reset.json",
+      log: noopLogger,
+      nowMs: () => startedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "recurring-failure-reset",
+      name: "recurring failure reset",
+      scheduledAt: startedAt,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: startedAt },
+      payload: { kind: "agentTurn", message: "recover" },
+      state: {},
+    });
+    const apply = (status: "ok" | "error", run: number) =>
+      applyJobResult(
+        state,
+        job,
+        {
+          status,
+          ...(status === "error" ? { error: `failure ${run}` } : {}),
+          startedAt: startedAt + run * 60_000,
+          endedAt: startedAt + run * 60_000 + 10,
+        },
+        { deferredAutoDisableNotifications: [] },
+      );
+
+    for (let run = 0; run < 9; run += 1) {
+      apply("error", run);
+    }
+    apply("ok", 9);
+    for (let run = 10; run < 19; run += 1) {
+      apply("error", run);
+    }
+
+    expect(job.enabled).toBe(true);
+    expect(job.state.consecutiveErrors).toBe(9);
+    expect(job.state.autoDisabled).toBeUndefined();
+  });
+
+  it.each([
+    { name: "stale schedule", opts: { scheduleOwnership: "stale" as const } },
+    { name: "forced run", opts: { scheduleMode: "preserve" as const } },
+  ])("does not auto-disable after a $name failure", ({ opts }) => {
+    const startedAt = Date.parse("2026-08-01T14:00:00.000Z");
+    const deferredNotifications: Array<() => void> = [];
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: "/tmp/cron-non-owning-failure.json",
+      log: noopLogger,
+      nowMs: () => startedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: createDefaultIsolatedRunner(),
+    });
+    const job = createIsolatedRegressionJob({
+      id: "non-owning-recurring-failure",
+      name: "non-owning recurring failure",
+      scheduledAt: startedAt,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: startedAt },
+      payload: { kind: "agentTurn", message: "fail" },
+      state: { consecutiveErrors: 9, nextRunAtMs: startedAt + 60_000 },
+    });
+
+    applyJobResult(
+      state,
+      job,
+      { status: "error", error: "tenth failure", startedAt, endedAt: startedAt + 10 },
+      { ...opts, deferredAutoDisableNotifications: deferredNotifications },
+    );
+
+    expect(job.enabled).toBe(true);
+    expect(job.state.consecutiveErrors).toBe(10);
+    expect(job.state.autoDisabled).toBeUndefined();
+    expect(deferredNotifications).toHaveLength(0);
+  });
+
   it("keeps state updates when cron next-run computation throws after a successful run (#30905)", () => {
     const startedAt = Date.parse("2026-03-02T12:00:00.000Z");
     const endedAt = startedAt + 50;

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -552,6 +552,25 @@ describe("cron store", () => {
     await expectPathMissing(`${store.storePath}.bak`);
   });
 
+  it("round-trips the auto-disable reason through runtime state JSON", async () => {
+    const store = await makeStorePath();
+    const payload = makeStore("auto-disabled-job", false);
+    const job = expectDefined(payload.jobs[0], "payload.jobs[0] test invariant");
+    await saveCronStore(store.storePath, payload);
+
+    job.state = {
+      consecutiveErrors: 10,
+      autoDisabled: {
+        reason: "consecutive-failures",
+        atMs: job.updatedAtMs,
+        consecutiveErrors: 10,
+      },
+    };
+    await saveCronStore(store.storePath, payload, { stateOnly: true });
+
+    expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject(job.state);
+  });
+
   it("stores queued reservations separately from active run markers", async () => {
     const store = await makeStorePath();
     const payload = makeStore("job-queued-phase", true);

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -389,6 +389,12 @@ export type CronJobState = {
   lastDurationMs?: number;
   /** Number of consecutive execution errors (reset on success). Used for backoff. */
   consecutiveErrors?: number;
+  /** Durable explanation for a scheduler-owned automatic disable transition. */
+  autoDisabled?: {
+    reason: "consecutive-failures" | "schedule-errors";
+    atMs: number;
+    consecutiveErrors: number;
+  };
   /** Number of consecutive skipped executions (reset on success or error). */
   consecutiveSkipped?: number;
   /** Last failure alert timestamp (ms since epoch) for cooldown gating. */
@@ -487,7 +493,7 @@ export type CronStoreFile = {
 };
 
 type CronJobStateInput = Partial<
-  Omit<CronJobState, "scheduleActivatedAtMs" | "streamSourceIdentity">
+  Omit<CronJobState, "autoDisabled" | "scheduleActivatedAtMs" | "streamSourceIdentity">
 >;
 
 /** Create input accepted by cron APIs before id/timestamps/state are assigned. */

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -693,6 +693,11 @@ type CronJobState = {
   lastErrorReason?: string;
   lastDurationMs?: number;
   consecutiveErrors?: number;
+  autoDisabled?: {
+    reason: "consecutive-failures" | "schedule-errors";
+    atMs: number;
+    consecutiveErrors: number;
+  };
   lastDelivered?: boolean;
   lastDeliveryStatus?: CronDeliveryStatus;
   lastDeliveryError?: string;


### PR DESCRIPTION
## What Problem This Solves

Recurring automations could fail forever on the default configuration without a visible terminal outcome. Failure alerts are opt-in, so a permanently broken job could continue consuming scheduler work while only accumulating `state.consecutiveErrors`.

This completes the existing cron auto-disable family by stopping time-based recurring jobs after 10 consecutive execution failures, recording the reason durably, and notifying the owning agent with a recovery command.

Fixes #118089

## Why This Change Was Made

The scheduler already records the authoritative consecutive-error streak at run completion, so this change uses that O(1) state instead of reading retained run history. A shared auto-disable owner now records `state.autoDisabled` with a closed reason (`consecutive-failures` or `schedule-errors`), timestamp, and count. The field stays in `state_json`; there is no SQLite DDL, schema-version bump, mirrored column, config option, or protocol-version change.

Notifications are queued while state mutates and drained only after the corresponding durable write succeeds. That contract now covers scheduled completion, manual due completion, and startup recovery. The recurring threshold check remains after schedule-ownership and force-preserve gates, so stale, removed, and out-of-band force runs cannot disable the durable schedule. Manual enable clears the auto-disable record plus both execution and schedule-error streaks.

Source verification found three details beyond the initial issue sketch:

- Restart-interrupted runs increment `consecutiveErrors` in `startup-run-repair.ts`, not `timer-outcomes.ts`, so startup recovery also uses the canonical policy and post-persist notification queue.
- The prior schedule-error notification did not carry `deliveryContext` or a re-enable hint; both schedule and run-failure reasons now share the same owning-agent notifier.
- Cron job state is a closed Gateway response schema. `autoDisabled` was added as report-only state and intentionally omitted from writable patch/input schemas.

One-shot completion/exhaustion, `trigger.once`, and stream-source restart exhaustion remain separate. They represent completion or a different lifecycle owner, not the recurring time-schedule failure streak addressed here.

Production/UI/schema delta is +339/-46 lines (net +293), with +558 test lines and +2 docs lines. The production growth is the named capability plus its persistence, protocol, recovery, notification, and operator-visibility ownership boundaries.

## User Impact

- `every` and `cron` jobs auto-disable after 10 consecutive execution failures; successful runs reset the streak.
- Schedule-computation auto-disable now records the same structured reason (`schedule-errors`).
- The owner receives an unconditional post-persist system event containing job name/id, failure count, last-error snippet, and `openclaw automations enable <id>`.
- `automations list --all`, `automations show`, JSON output, and `openclaw doctor` expose why a job was auto-disabled.
- Re-enabling starts cleanly with failure counters reset instead of immediately retripping.

## Evidence

Focused Vitest proof:

- `node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts` — 62 passed
- `node scripts/run-vitest.mjs src/cron/service/timer.batch-finalization.test.ts` — 24 passed
- `node scripts/run-vitest.mjs src/cron/service/ops.test.ts` — 51 passed
- `node scripts/run-vitest.mjs src/cron/service/jobs.schedule-error-isolation.test.ts` — 8 passed
- `node scripts/run-vitest.mjs src/cron/store.test.ts` — 51 passed
- `node scripts/run-vitest.mjs src/commands/doctor/cron/index.test.ts` — 62 passed
- `node scripts/run-vitest.mjs src/cli/cron-cli/shared.test.ts` — 66 passed
- `node scripts/run-vitest.mjs packages/gateway-protocol/src/cron-validators.test.ts` — 26 passed
- `node scripts/run-vitest.mjs src/cron/service/startup-run-repair.auto-disable.test.ts` — 1 passed
- `node scripts/run-vitest.mjs src/cron/service.restart-catchup.test.ts` — 26 passed
- `node scripts/run-vitest.mjs src/cron/service.runs-one-shot-main-job-disables-it.test.ts` — 18 passed

Broader proof:

- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs --base 1704ea59182 --timed` — passed all core/core-test/UI/docs formatting, typecheck, lint, dead-code, architecture, database-first, and import-cycle lanes. The normal Crabbox route was unavailable due to the installed broker/provider state, so trusted-source policy used the local fallback against the immutable branch base.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm build` — passed; final build completed in 3m11.7s, including package surfaces and Control UI.
- `.agents/skills/autoreview/scripts/autoreview --mode local ...` — clean, no accepted/actionable findings (Codex `gpt-5.6-sol`, high reasoning).

Source-blind built-CLI/Gateway probing observed a real scheduled command failure, durable `consecutiveErrors: 1`, and the 30-second error backoff. The remaining threshold clauses were intentionally marked blocked because public schedule edits and `--due` runs could not bypass that backoff; the validator did not use force runs, source inspection, or direct SQLite mutation to manufacture ten scheduled outcomes.


---

## Built CLI/Gateway live proof (dist build, ephemeral gateway, isolated state dir, port 19872)

Full threshold → persisted disable → owner notification → re-enable loop, run against the built dist:

1. **Streak accumulation**: failing command job (`exit 7`), 10 consecutive manual `automations run --wait` failures → `consecutiveErrors: 10`, job still enabled. (Manual runs do not own the schedule slot, so they feed the streak but do not trip the disable — the trip is reserved for scheduler-owned outcomes.)
2. **Scheduled acceleration is blocked by design**: after the streak, error backoff floors `nextRunAtMs` to +60m (`DEFAULT_ERROR_BACKOFF_SCHEDULE_MS` cap), and a `cron.update` state patch cannot backdate it — so the trip was exercised through the other scheduler-owned failure path:
3. **Restart interruption (11th consecutive failure)**: started a `sleep 120` run, `kill -9` the gateway mid-run, restarted. Startup repair marked the run failed and tripped the threshold:
   ```json
   { "enabled": false, "ce": 11,
     "autoDisabled": { "reason": "consecutive-failures", "atMs": 1785696282658, "consecutiveErrors": 11 } }
   ```
   Structured log: `cron: marking interrupted running job failed on startup` → `cron: auto-disabled interrupted job after consecutive run failures` (`consecutiveErrors: 11`).
4. **CLI surface**: `automations list` renders the new status decoration: `disabled (11x)`.
5. **Owner notification delivered post-persist**: found verbatim in the owning agent's session transcript:
   > Automation "proof-fail" (caf09457-…) was auto-disabled after 11 consecutive run failures.
   > Last error: cron: job interrupted by gateway restart
   > Fix the underlying cause, then run `openclaw automations enable caf09457-…` to re-enable it.
6. **Manual re-enable reset**: `automations enable` → `{ "enabled": true, "consecutiveErrors": 0, "autoDisabled": null }`.

Ephemeral gateway + test job deleted after the run; no operator state touched.
