### PR TITLE
fix(whatsapp): preserve accepted delivery receipts and activity

### DIFF
--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -1,12 +1,16 @@
 // Whatsapp tests cover deliver reply plugin behavior.
-import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import type { WAMessage } from "baileys";
 import {
-  createMessageReceiptFromOutboundResults,
-  listMessageReceiptPlatformIds,
-} from "openclaw/plugin-sdk/channel-outbound";
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
+import { listMessageReceiptPlatformIds } from "openclaw/plugin-sdk/channel-outbound";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS } from "openclaw/plugin-sdk/media-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { createWebSendApi } from "../inbound/send-api.js";
+import { normalizeWhatsAppSendResult } from "../inbound/send-result.js";
 import { createAcceptedWhatsAppSendResult } from "../inbound/send-result.test-helper.js";
 import { createTestWebInboundMessage } from "../inbound/test-message.test-helper.js";
 import type { AdmittedWebInboundMessage } from "../inbound/types.js";
@@ -15,8 +19,19 @@ import { cacheInboundMessageMeta } from "../quoted-message.js";
 import { withWhatsAppSocketOperationTimeout } from "../socket-timing.js";
 
 const hoisted = vi.hoisted(() => ({
+  recordChannelActivity: vi.fn(),
   transcodeAudioBufferToOpus: vi.fn(),
 }));
+
+vi.mock("openclaw/plugin-sdk/channel-activity-runtime", async () => {
+  const actual = await vi.importActual<
+    typeof import("openclaw/plugin-sdk/channel-activity-runtime")
+  >("openclaw/plugin-sdk/channel-activity-runtime");
+  return {
+    ...actual,
+    recordChannelActivity: (...args: unknown[]) => hoisted.recordChannelActivity(...args),
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/media-runtime")>(
@@ -214,7 +229,8 @@ describe("deliverWebReply", () => {
 
   it("does not resend an accepted reply when its transport reports a disconnect afterward", async () => {
     const { msg, params } = createDelivery({ text: "already delivered" });
-    const acceptedFailure = createChannelPartialDeliveryError(new Error("connection closed"), {
+    const disconnect = new Error("connection closed");
+    const acceptedFailure = createChannelPartialDeliveryError(disconnect, {
       messageIds: ["reply-already-accepted"],
       visibleReplySent: true,
     });
@@ -224,7 +240,15 @@ describe("deliverWebReply", () => {
       deliverWebReply(params).catch((caught: unknown) => caught),
     );
 
-    expect(failure).toBe(acceptedFailure);
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("accepted reply was not promoted to a receipt-backed partial delivery");
+    }
+    expect(failure).not.toBe(acceptedFailure);
+    expect(failure.deliveryResult.messageIds).toEqual(["reply-already-accepted"]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual(["reply-already-accepted"]);
+    expect(failure).toHaveProperty("cause", disconnect);
+    expect(failure).toMatchObject({ sentBeforeError: true, visibleReplySent: true });
     expect(msg.platform.reply).toHaveBeenCalledOnce();
   });
 
@@ -255,6 +279,7 @@ describe("deliverWebReply", () => {
   });
 
   it("sends chunked text replies and logs a summary", async () => {
+    hoisted.recordChannelActivity.mockClear();
     const { msg, params } = createDelivery({ text: "aaaaaa" }, { textLimit: 3 });
 
     const delivery = await deliverWebReply(params);
@@ -270,27 +295,91 @@ describe("deliverWebReply", () => {
     expect(delivery.receipt.platformMessageIds).toEqual(["reply-sent-1"]);
     expect(delivery.receipt.parts[0]?.platformMessageId).toBe("reply-sent-1");
     expect(delivery.receipt.parts[0]?.kind).toBe("text");
+    expect(hoisted.recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
+      channel: "whatsapp",
+      accountId: "work",
+      direction: "outbound",
+    });
   });
 
-  it("reports text replies that Baileys did not accept", async () => {
+  it("retains an accepted auto-reply receipt when outbound activity bookkeeping fails", async () => {
+    hoisted.recordChannelActivity.mockClear();
+    const activityError = new Error("auto-reply activity bookkeeping disconnected");
+    hoisted.recordChannelActivity.mockImplementationOnce(() => {
+      throw activityError;
+    });
+    const { msg, params } = createDelivery({ text: "already accepted" });
+
+    const failure = await deliverWebReply(params).catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("accepted auto-reply receipt was discarded during activity bookkeeping");
+    }
+    expect(failure.deliveryResult.messageIds).toEqual(["reply-sent-1"]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual(["reply-sent-1"]);
+    expect(failure).toHaveProperty("cause", activityError);
+    expect(msg.platform.reply).toHaveBeenCalledOnce();
+    expect(hoisted.recordChannelActivity).toHaveBeenCalledOnce();
+  });
+
+  it("merges earlier accepted chunks with a nested accepted-chunk bookkeeping failure", async () => {
+    hoisted.recordChannelActivity.mockClear();
+    const bookkeepingError = new Error("second accepted chunk bookkeeping failed");
+    const firstChunk = normalizeWhatsAppSendResult(
+      { key: { id: "auto-reply-first-chunk" } } as WAMessage,
+      "text",
+    );
+    const secondChunk = normalizeWhatsAppSendResult(
+      { key: { id: "auto-reply-second-chunk" } } as WAMessage,
+      "text",
+    );
+    const { msg, params } = createDelivery({ text: "aaaaaa" }, { textLimit: 3 });
+    vi.mocked(msg.platform.reply)
+      .mockResolvedValueOnce(firstChunk)
+      .mockRejectedValueOnce(
+        createChannelPartialDeliveryError(bookkeepingError, {
+          messageIds: [secondChunk.messageId],
+          receipt: secondChunk.receipt,
+          visibleReplySent: true,
+        }),
+      );
+
+    const failure = await deliverWebReply(params).catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error(
+        "accepted auto-reply chunks were not composed after nested bookkeeping failed",
+      );
+    }
+    expect(failure.deliveryResult.messageIds).toEqual([
+      "auto-reply-first-chunk",
+      "auto-reply-second-chunk",
+    ]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual([
+      "auto-reply-first-chunk",
+      "auto-reply-second-chunk",
+    ]);
+    expect(failure).toHaveProperty("cause", bookkeepingError);
+    expect(msg.platform.reply).toHaveBeenCalledTimes(2);
+    expect(hoisted.recordChannelActivity).toHaveBeenCalledOnce();
+  });
+
+  it("rejects text replies that Baileys did not accept without recording outbound activity", async () => {
+    hoisted.recordChannelActivity.mockClear();
     const { msg, params } = createDelivery({ text: "hello" });
     vi.mocked(msg.platform.reply).mockResolvedValueOnce({
       ...createAcceptedWhatsAppSendResult("text", "unknown"),
-      receipt: createMessageReceiptFromOutboundResults({ kind: "text", results: [] }),
+      receipt: undefined,
       keys: [],
       providerAccepted: false,
     });
 
-    const delivery = await deliverWebReply(params);
+    await expect(deliverWebReply(params)).rejects.toBeInstanceOf(PlatformMessageNotDispatchedError);
 
-    expect(msg.platform.reply).toHaveBeenCalledTimes(1);
-    expect(delivery.receipt.platformMessageIds).toEqual([]);
-    expect(delivery.receipt.parts).toEqual([]);
-    expect(delivery.providerAccepted).toBe(false);
-    expect(typeof mockCallArg(replyLogger.warn, 0, 0, "replyLogger.warn")).toBe("object");
-    expect(mockCallArg(replyLogger.warn, 0, 1, "replyLogger.warn")).toBe(
-      "auto-reply text was not accepted by WhatsApp provider",
-    );
+    expect(msg.platform.reply).toHaveBeenCalledOnce();
+    expect(hoisted.recordChannelActivity).not.toHaveBeenCalled();
   });
 
   it("strips raw XML tool-call blocks before WhatsApp text delivery", async () => {
@@ -632,13 +721,24 @@ describe("deliverWebReply", () => {
     );
     vi.mocked(msg.platform.sendMedia).mockRejectedValueOnce(new Error("upload failed"));
 
-    await deliverWebReply(params);
+    const delivery = await deliverWebReply(params);
 
     // First media succeeded — no text reply for it.
     // Second media failed — user must be notified, not silently dropped.
+    expect(msg.platform.sendMedia).toHaveBeenCalledTimes(2);
     expect(msg.platform.reply).toHaveBeenCalledTimes(1);
     expect(replyText(msg)).toContain("⚠️ Media unavailable");
     expect(replyText(msg)).not.toContain("upload failed");
+    expect(delivery.receipt.platformMessageIds).toEqual(["media-first-ok", "reply-sent-1"]);
+    expect(hoisted.recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
+      channel: "whatsapp",
+      accountId: "work",
+      direction: "outbound",
+    });
+    expect(replyLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaUrl: "http://example.com/img2.jpg" }),
+      "failed to send web media reply",
+    );
   });
 
   it("sanitizes XML tool-call blocks for outbound sendPayload delivery", async () => {
@@ -729,6 +829,91 @@ describe("deliverWebReply", () => {
     expect(mockCallArg(msg.platform.sendMedia, 0, 1, "sendMedia")).toBeUndefined();
     expect(expectFirstSendMediaPayload(msg)).not.toHaveProperty("caption");
     expect(msg.platform.reply).toHaveBeenCalledWith("cap", undefined);
+  });
+
+  it("preserves accepted voice receipts without false media fallback after caption rejection", async () => {
+    hoisted.recordChannelActivity.mockClear();
+    const { msg, params } = createDelivery({
+      text: "caption",
+      mediaUrl: "http://example.com/accepted-voice.ogg",
+    });
+    mockLoadedMedia("aud", "audio/ogg", "audio");
+    vi.mocked(msg.platform.sendMedia).mockImplementationOnce(async () =>
+      normalizeWhatsAppSendResult(
+        { key: { id: "auto-reply-voice-accepted" } } as WAMessage,
+        "media",
+      ),
+    );
+    vi.mocked(msg.platform.reply).mockImplementationOnce(async () =>
+      normalizeWhatsAppSendResult(undefined, "text"),
+    );
+
+    const failure = await deliverWebReply(params).catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("accepted auto-reply voice receipt was discarded after caption rejection");
+    }
+    expect(failure.deliveryResult.visibleReplySent).toBe(true);
+    expect(failure.deliveryResult.messageIds).toEqual(["auto-reply-voice-accepted"]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual([
+      "auto-reply-voice-accepted",
+    ]);
+    expect(failure).toHaveProperty("cause", expect.any(PlatformMessageNotDispatchedError));
+    expect(msg.platform.sendMedia).toHaveBeenCalledOnce();
+    expect(msg.platform.reply).toHaveBeenCalledOnce();
+    expect(msg.platform.reply).toHaveBeenCalledWith("caption", undefined);
+    expect(hoisted.recordChannelActivity).toHaveBeenCalledOnce();
+    expect(hoisted.recordChannelActivity).toHaveBeenCalledWith({
+      channel: "whatsapp",
+      accountId: "work",
+      direction: "outbound",
+    });
+  });
+
+  it("keeps accepted media receipts when the inner sender throws during activity bookkeeping", async () => {
+    hoisted.recordChannelActivity.mockClear();
+    replyLogger.warn.mockClear();
+    const bookkeepingError = new Error("accepted media bookkeeping failed");
+    hoisted.recordChannelActivity.mockImplementationOnce(() => {
+      throw bookkeepingError;
+    });
+    const sendMessage = vi.fn(
+      async () => ({ key: { id: "auto-reply-nested-media" } }) as WAMessage,
+    );
+    const sendApi = createWebSendApi({
+      sock: {
+        sendMessage,
+        sendPresenceUpdate: vi.fn(async () => undefined),
+      },
+      defaultAccountId: "work",
+    });
+    const { msg, params } = createDelivery({
+      text: "caption",
+      mediaUrl: "http://example.com/nested-voice.ogg",
+    });
+    mockLoadedMedia("aud", "audio/ogg", "audio");
+    vi.mocked(msg.platform.sendMedia).mockImplementationOnce(async () =>
+      sendApi.sendMessage("+1555", "", Buffer.from("aud"), "audio/ogg"),
+    );
+
+    const failure = await deliverWebReply(params).catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("nested accepted media delivery was treated as a failed upload");
+    }
+    expect(failure.deliveryResult.messageIds).toEqual(["auto-reply-nested-media"]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual(["auto-reply-nested-media"]);
+    expect(failure).toHaveProperty("cause", bookkeepingError);
+    expect(msg.platform.sendMedia).toHaveBeenCalledOnce();
+    expect(msg.platform.reply).not.toHaveBeenCalled();
+    expect(replyLogger.warn).not.toHaveBeenCalled();
+    expect(hoisted.recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
+      channel: "whatsapp",
+      accountId: "work",
+      direction: "outbound",
+    });
   });
 
   it("transcodes mp3 audio media before sending a ptt voice note", async () => {

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -1,4 +1,5 @@
 // Whatsapp plugin module implements deliver reply behavior.
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -13,8 +14,15 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { requireWhatsAppInboundAdmission } from "../inbound/admission.js";
-import type { WhatsAppSendResult } from "../inbound/send-result.js";
-import { listWhatsAppSendResultMessageIds } from "../inbound/send-result.js";
+import {
+  listWhatsAppSendResultMessageIds,
+  mergeWhatsAppAcceptedSendError,
+  rememberWhatsAppAcceptedSend,
+  rememberWhatsAppPartialSend,
+  withWhatsAppLogicalDeliveryActivity,
+  type WhatsAppSendKind,
+  type WhatsAppSendResult,
+} from "../inbound/send-result.js";
 import type { AdmittedWebInboundMessage } from "../inbound/types.js";
 import { loadWebMedia } from "../media.js";
 import {
@@ -29,7 +37,7 @@ import { newConnectionId } from "../reconnect.js";
 import { formatError } from "../session.js";
 import { markdownToWhatsAppChunks } from "../text-runtime.js";
 import { whatsappOutboundLog } from "./loggers.js";
-import { elide, markWhatsAppVisibleDeliveryError } from "./util.js";
+import { elide } from "./util.js";
 
 export type WhatsAppReplyDeliveryResult = {
   results: WhatsAppSendResult[];
@@ -113,7 +121,7 @@ function createWhatsAppReplyDeliveryReceipt(
   });
 }
 
-export async function deliverWebReply(params: {
+type WhatsAppReplyDeliveryParams = {
   replyResult: ReplyPayload;
   normalizedReplyResult?: DeliverableWhatsAppOutboundPayload<ReplyPayload>;
   transport: WhatsAppReplyTransportContext;
@@ -128,18 +136,23 @@ export async function deliverWebReply(params: {
   connectionId?: string;
   skipLog?: boolean;
   tableMode?: MarkdownTableMode;
-}): Promise<WhatsAppReplyDeliveryResult> {
+};
+
+export async function deliverWebReply(
+  params: WhatsAppReplyDeliveryParams,
+): Promise<WhatsAppReplyDeliveryResult> {
+  return await withWhatsAppLogicalDeliveryActivity(() => deliverWebReplyInActivityScope(params));
+}
+
+async function deliverWebReplyInActivityScope(
+  params: WhatsAppReplyDeliveryParams,
+): Promise<WhatsAppReplyDeliveryResult> {
   const { replyResult, transport, maxMediaBytes, textLimit, replyLogger, connectionId, skipLog } =
     params;
   const conversationId = transport.conversationId;
   const isGroupConversation = transport.conversationKind === "group";
   const replyStarted = Date.now();
   const sendResults: WhatsAppSendResult[] = [];
-  const rememberSendResult = (result: WhatsAppSendResult | undefined) => {
-    if (result) {
-      sendResults.push(result);
-    }
-  };
   const finishDelivery = (): WhatsAppReplyDeliveryResult => {
     const receipt = createWhatsAppReplyDeliveryReceipt(sendResults);
     return {
@@ -147,6 +160,38 @@ export async function deliverWebReply(params: {
       receipt,
       providerAccepted: sendResults.some((result) => result.providerAccepted),
     };
+  };
+  const preserveAcceptedDeliveryError = (error: unknown, kind?: WhatsAppSendKind) => {
+    const sendKind = kind ?? sendResults[0]?.kind ?? "text";
+    if (isChannelPartialDeliveryError(error)) {
+      rememberWhatsAppPartialSend({
+        error,
+        kind: sendKind,
+        results: sendResults,
+      });
+    }
+    return mergeWhatsAppAcceptedSendError({
+      error,
+      kind: sendKind,
+      results: sendResults,
+    });
+  };
+  const rememberSendResult = (result: WhatsAppSendResult | undefined) => {
+    if (!result) {
+      return;
+    }
+    try {
+      rememberWhatsAppAcceptedSend({
+        accountId: transport.accountId,
+        result,
+        results: sendResults,
+      });
+    } catch (error: unknown) {
+      if (sendResults.some((accepted) => accepted.providerAccepted)) {
+        throw preserveAcceptedDeliveryError(error, result.kind);
+      }
+      throw error;
+    }
   };
   if (isReasoningReplyPayload(replyResult)) {
     whatsappOutboundLog.debug(`Suppressed reasoning payload to ${conversationId}`);
@@ -189,7 +234,7 @@ export async function deliverWebReply(params: {
     });
   };
 
-  const sendWithRetry = async <T>(fn: () => Promise<T>, label: string) => {
+  const sendWithRetry = async <T>(fn: () => Promise<T>, label: string, kind: WhatsAppSendKind) => {
     try {
       return await sendWhatsAppOutboundWithRetry({
         send: fn,
@@ -200,8 +245,11 @@ export async function deliverWebReply(params: {
         },
       });
     } catch (error: unknown) {
-      if (sendResults.some((result) => result.providerAccepted)) {
-        throw markWhatsAppVisibleDeliveryError(error);
+      if (
+        isChannelPartialDeliveryError(error) ||
+        sendResults.some((result) => result.providerAccepted)
+      ) {
+        throw preserveAcceptedDeliveryError(error, kind);
       }
       throw error;
     }
@@ -213,7 +261,7 @@ export async function deliverWebReply(params: {
     for (const [index, chunk] of textChunks.entries()) {
       const chunkStarted = Date.now();
       const quote = getQuote();
-      rememberSendResult(await sendWithRetry(() => transport.reply(chunk, quote), "text"));
+      rememberSendResult(await sendWithRetry(() => transport.reply(chunk, quote), "text", "text"));
       if (!skipLog) {
         const durationMs = Date.now() - chunkStarted;
         whatsappOutboundLog.debug(
@@ -245,10 +293,14 @@ export async function deliverWebReply(params: {
 
   // Media (with optional caption on first item)
   const leadingCaption = remainingText.shift() || "";
+  let acceptedIdsBeforeCurrentMedia = new Set<string>();
   await sendMediaWithLeadingCaption({
     mediaUrls: mediaList,
     caption: leadingCaption,
     send: async ({ mediaUrl, caption }) => {
+      acceptedIdsBeforeCurrentMedia = new Set(
+        sendResults.flatMap(listWhatsAppSendResultMessageIds),
+      );
       const media = await prepareWhatsAppOutboundMedia(
         await loadWebMedia(mediaUrl, {
           maxBytes: maxMediaBytes,
@@ -276,6 +328,7 @@ export async function deliverWebReply(params: {
                 quote,
               ),
             "media:image",
+            "media",
           ),
         );
       } else if (media.kind === "audio") {
@@ -292,11 +345,12 @@ export async function deliverWebReply(params: {
                 quote,
               ),
             "media:audio",
+            "media",
           ),
         );
         if (caption) {
           rememberSendResult(
-            await sendWithRetry(() => transport.reply(caption, quote), "media:audio-text"),
+            await sendWithRetry(() => transport.reply(caption, quote), "media:audio-text", "text"),
           );
         }
       } else if (media.kind === "video") {
@@ -313,6 +367,7 @@ export async function deliverWebReply(params: {
                 quote,
               ),
             "media:video",
+            "media",
           ),
         );
       } else {
@@ -330,6 +385,7 @@ export async function deliverWebReply(params: {
                 quote,
               ),
             "media:document",
+            "media",
           ),
         );
       }
@@ -352,6 +408,15 @@ export async function deliverWebReply(params: {
       );
     },
     onError: async ({ error, mediaUrl, caption, isFirst }) => {
+      const currentMediaWasAccepted = sendResults.some((result) =>
+        listWhatsAppSendResultMessageIds(result).some(
+          (messageId) => !acceptedIdsBeforeCurrentMedia.has(messageId),
+        ),
+      );
+      if (currentMediaWasAccepted) {
+        // Earlier accepted uploads do not make a genuinely rejected trailing upload successful.
+        throw preserveAcceptedDeliveryError(error);
+      }
       whatsappOutboundLog.error(
         `Failed sending web media to ${conversationId}: ${formatError(error)}`,
       );
@@ -364,6 +429,7 @@ export async function deliverWebReply(params: {
           await sendWithRetry(
             () => transport.reply("⚠️ Media unavailable.", getQuote()),
             "media:fallback-unavailable",
+            "text",
           ),
         );
         return;
@@ -376,14 +442,20 @@ export async function deliverWebReply(params: {
       }
       whatsappOutboundLog.warn(`Media skipped; sent text-only to ${conversationId}`);
       rememberSendResult(
-        await sendWithRetry(() => transport.reply(fallbackText, getQuote()), "media:fallback-text"),
+        await sendWithRetry(
+          () => transport.reply(fallbackText, getQuote()),
+          "media:fallback-text",
+          "text",
+        ),
       );
     },
   });
 
   // Remaining text chunks after media
   for (const chunk of remainingText) {
-    rememberSendResult(await sendWithRetry(() => transport.reply(chunk, getQuote()), "media:text"));
+    rememberSendResult(
+      await sendWithRetry(() => transport.reply(chunk, getQuote()), "media:text", "text"),
+    );
   }
   return finishDelivery();
 }

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.message-sent.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.message-sent.test.ts
@@ -1,6 +1,9 @@
 // WhatsApp tests prove native reply receipts reach the canonical sent-message observers.
+import type { WAMessage } from "baileys";
 import {
+  createChannelPartialDeliveryError,
   dispatchChannelInboundReply,
+  isChannelPartialDeliveryError,
   type ChannelInboundTurnPlan,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
@@ -14,9 +17,15 @@ import {
   resetGlobalHookRunner,
   type PluginHookRegistration,
 } from "openclaw/plugin-sdk/channel-test-helpers";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { clearInternalHooks, registerInternalHook } from "openclaw/plugin-sdk/hook-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createWebSendApi } from "../../inbound/send-api.js";
+import { normalizeWhatsAppSendResult } from "../../inbound/send-result.js";
 import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
+import { loadWebMedia } from "../../media.js";
+import { deliverWebReply } from "../deliver-reply.js";
 import {
   buildWhatsAppInboundTransportContext,
   createWhatsAppReplyPlan,
@@ -25,6 +34,20 @@ import {
 const sessionKey = "agent:main:whatsapp:direct:+1000";
 type InternalHookEvent = Parameters<Parameters<typeof registerInternalHook>[1]>[0];
 
+const recordChannelActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/channel-activity-runtime", async () => {
+  const actual = await vi.importActual<
+    typeof import("openclaw/plugin-sdk/channel-activity-runtime")
+  >("openclaw/plugin-sdk/channel-activity-runtime");
+  return {
+    ...actual,
+    recordChannelActivity: (...args: unknown[]) => recordChannelActivity(...args),
+  };
+});
+
+vi.mock("../../media.js", () => ({ loadWebMedia: vi.fn() }));
+
 function createReceipt(results: MessageReceiptSourceResult[]) {
   return createMessageReceiptFromOutboundResults({
     kind: "unknown",
@@ -32,7 +55,10 @@ function createReceipt(results: MessageReceiptSourceResult[]) {
   });
 }
 
-function createPlan(deliverReply: Parameters<typeof createWhatsAppReplyPlan>[0]["deliverReply"]) {
+function createPlan(
+  deliverReply: Parameters<typeof createWhatsAppReplyPlan>[0]["deliverReply"],
+  platform?: Pick<AdmittedWebInboundMessage["platform"], "reply" | "sendMedia">,
+) {
   const msg = createTestWebInboundMessage({
     event: { id: "wa-inbound-1" },
     payload: { body: "show me the result" },
@@ -40,6 +66,7 @@ function createPlan(deliverReply: Parameters<typeof createWhatsAppReplyPlan>[0][
       chatJid: "1000@s.whatsapp.net",
       recipientJid: "+2000",
       senderJid: "1000@s.whatsapp.net",
+      ...platform,
     },
     admission: {
       accountId: "default",
@@ -62,6 +89,12 @@ function createPlan(deliverReply: Parameters<typeof createWhatsAppReplyPlan>[0][
     AccountId: "default",
     ChatType: "direct",
     CommandAuthorized: false,
+  };
+  const replyLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
   };
   const plan = createWhatsAppReplyPlan({
     cfg: { channels: { whatsapp: {} } } as never,
@@ -91,12 +124,7 @@ function createPlan(deliverReply: Parameters<typeof createWhatsAppReplyPlan>[0][
       },
     },
     rememberSentText: vi.fn(),
-    replyLogger: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    } as never,
+    replyLogger: replyLogger as never,
     replyPipeline: {},
     replyResolver: (async () => undefined) as never,
     route: {
@@ -111,7 +139,47 @@ function createPlan(deliverReply: Parameters<typeof createWhatsAppReplyPlan>[0][
     shouldClearGroupHistory: false,
     transport: buildWhatsAppInboundTransportContext(msg),
   });
-  return { context, plan };
+  return { context, plan, replyLogger };
+}
+
+async function dispatchObservedPlatformReply(params: {
+  payload: { text: string; mediaUrls?: string[] };
+  platform: Pick<AdmittedWebInboundMessage["platform"], "reply" | "sendMedia">;
+}) {
+  const pluginHook = vi.fn();
+  const internalHook = vi.fn();
+  const registry = createEmptyPluginRegistry();
+  addTestHook({
+    registry,
+    pluginId: "whatsapp-message-sent-partial-test",
+    hookName: "message_sent",
+    handler: pluginHook as PluginHookRegistration["handler"],
+  });
+  initializeGlobalHookRunner(registry);
+  registerInternalHook("message:sent", internalHook);
+  const { context, plan, replyLogger } = createPlan(deliverWebReply, params.platform);
+  let deliveryResult: unknown;
+  const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async (dispatch) => {
+    dispatch.replyOptions?.onAgentRunStart?.("run-wa-partial");
+    deliveryResult = await dispatch.dispatcherOptions.deliver(params.payload, { kind: "final" });
+    return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+  });
+  const failure = await dispatchChannelInboundReply({
+    cfg: { channels: { whatsapp: {} } } as never,
+    channel: "whatsapp",
+    accountId: "default",
+    agentId: "main",
+    routeSessionKey: sessionKey,
+    storePath: "/tmp/whatsapp-message-sent-test.json",
+    ctxPayload: context,
+    recordInboundSession: async () => undefined,
+    dispatchReplyWithBufferedBlockDispatcher,
+    dispatcherOptions: plan.dispatcherOptions,
+    delivery: plan.delivery,
+    replyOptions: plan.replyOptions,
+    replyResolver: plan.replyResolver,
+  }).catch((caught: unknown) => caught);
+  return { deliveryResult, failure, internalHook, pluginHook, replyLogger };
 }
 
 afterEach(() => {
@@ -221,5 +289,469 @@ describe("WhatsApp canonical message_sent delivery", () => {
         : delivery.durable,
     ).toMatchObject({ to: "+1000" });
     expect(deliverReply).not.toHaveBeenCalled();
+  });
+
+  it("preserves accepted voice receipts through real dispatch after caption rejection", async () => {
+    recordChannelActivity.mockClear();
+    vi.mocked(loadWebMedia).mockResolvedValueOnce({
+      buffer: Buffer.from("voice"),
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    const sendMedia = vi.fn(async () =>
+      normalizeWhatsAppSendResult({ key: { id: "dispatch-voice-accepted" } } as WAMessage, "media"),
+    );
+    const reply = vi.fn(async () => normalizeWhatsAppSendResult(undefined, "text"));
+    const { plan } = createPlan(deliverWebReply, { reply, sendMedia });
+    const delivery = plan.delivery as ChannelInboundTurnPlan["delivery"];
+
+    const failure = await delivery
+      .deliver({ text: "caption", mediaUrls: ["/tmp/accepted-voice.ogg"] }, { kind: "final" })
+      .catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("inbound dispatch discarded the accepted native voice receipt");
+    }
+    expect(failure.deliveryResult).toMatchObject({
+      messageIds: ["dispatch-voice-accepted"],
+      receipt: { platformMessageIds: ["dispatch-voice-accepted"] },
+      visibleReplySent: true,
+    });
+    expect(failure).toHaveProperty("cause", expect.any(PlatformMessageNotDispatchedError));
+    expect(sendMedia).toHaveBeenCalledOnce();
+    expect(reply).toHaveBeenCalledExactlyOnceWith("caption", undefined);
+    expect(recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
+      channel: "whatsapp",
+      accountId: "default",
+      direction: "outbound",
+    });
+  });
+
+  it.each([
+    {
+      name: "a real producer-backed reply",
+      route: "reply" as const,
+      failDuplicateBookkeeping: false,
+    },
+    {
+      name: "a real producer-backed reply with duplicate bookkeeping armed to fail",
+      route: "reply" as const,
+      failDuplicateBookkeeping: true,
+    },
+    {
+      name: "a real producer-backed media send with duplicate bookkeeping armed to fail",
+      route: "media" as const,
+      failDuplicateBookkeeping: true,
+    },
+  ])("records activity exactly once through $name", async ({ route, failDuplicateBookkeeping }) => {
+    recordChannelActivity.mockReset();
+    if (failDuplicateBookkeeping) {
+      recordChannelActivity.mockImplementation(() => {
+        if (recordChannelActivity.mock.calls.length > 1) {
+          throw new Error("outer owner duplicated producer activity bookkeeping");
+        }
+      });
+    }
+    const messageId = `dispatch-producer-${route}${failDuplicateBookkeeping ? "-guarded" : ""}`;
+    const sendMessage = vi.fn(
+      async () =>
+        ({
+          key: {
+            id: messageId,
+            remoteJid: "1000@s.whatsapp.net",
+            fromMe: true,
+            participant: "observer@s.whatsapp.net",
+          },
+        }) as WAMessage,
+    );
+    const sendApi = createWebSendApi({
+      sock: {
+        sendMessage,
+        sendPresenceUpdate: vi.fn(async () => undefined),
+      },
+      defaultAccountId: "default",
+    });
+    const isMediaRoute = route === "media";
+    vi.mocked(loadWebMedia).mockResolvedValueOnce({
+      buffer: Buffer.from(isMediaRoute ? "video" : "image"),
+      contentType: isMediaRoute ? "video/mp4" : "image/jpeg",
+      kind: isMediaRoute ? "video" : "image",
+    });
+    const reply = isMediaRoute
+      ? vi.fn<AdmittedWebInboundMessage["platform"]["reply"]>()
+      : vi.fn<AdmittedWebInboundMessage["platform"]["reply"]>(async (text) =>
+          sendApi.sendMessage("+1000", text),
+        );
+    const sendMedia = isMediaRoute
+      ? vi.fn<AdmittedWebInboundMessage["platform"]["sendMedia"]>(async (payload) => {
+          if (!("video" in payload) || !Buffer.isBuffer(payload.video)) {
+            throw new Error("expected a real WhatsApp video payload");
+          }
+          return sendApi.sendMessage(
+            "+1000",
+            typeof payload.caption === "string" ? payload.caption : "",
+            payload.video,
+            typeof payload.mimetype === "string" ? payload.mimetype : "video/mp4",
+          );
+        })
+      : vi
+          .fn<AdmittedWebInboundMessage["platform"]["sendMedia"]>()
+          .mockRejectedValueOnce(new Error("unaccepted initial upload"));
+
+    const { deliveryResult, failure, internalHook, pluginHook, replyLogger } =
+      await dispatchObservedPlatformReply({
+        payload: {
+          text: "caption",
+          mediaUrls: [isMediaRoute ? "/tmp/producer-video.mp4" : "/tmp/producer-image.jpg"],
+        },
+        platform: { reply, sendMedia },
+      });
+
+    expect(failure).toMatchObject({
+      dispatched: true,
+      dispatchResult: { queuedFinal: true },
+    });
+    await vi.waitFor(() => {
+      expect(pluginHook).toHaveBeenCalledOnce();
+      expect(internalHook).toHaveBeenCalledOnce();
+    });
+    expect(pluginHook).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId, success: true }),
+      expect.objectContaining({ messageId }),
+    );
+    expect(deliveryResult).toMatchObject({
+      receipt: {
+        primaryPlatformMessageId: messageId,
+        platformMessageIds: [messageId],
+        raw: [
+          expect.objectContaining({
+            channel: "whatsapp",
+            messageId,
+            toJid: "1000@s.whatsapp.net",
+            meta: expect.objectContaining({
+              fromMe: true,
+              participant: "observer@s.whatsapp.net",
+              providerAccepted: true,
+            }),
+          }),
+        ],
+        parts: [
+          expect.objectContaining({
+            platformMessageId: messageId,
+            index: 0,
+            raw: expect.objectContaining({
+              toJid: "1000@s.whatsapp.net",
+              meta: expect.objectContaining({
+                fromMe: true,
+                participant: "observer@s.whatsapp.net",
+              }),
+            }),
+          }),
+        ],
+      },
+    });
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(sendMedia).toHaveBeenCalledOnce();
+    if (isMediaRoute) {
+      expect(reply).not.toHaveBeenCalled();
+      expect(replyLogger.warn).not.toHaveBeenCalled();
+    } else {
+      expect(reply).toHaveBeenCalledExactlyOnceWith("caption\n⚠️ Media failed.", undefined);
+    }
+    expect(recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
+      channel: "whatsapp",
+      accountId: "default",
+      direction: "outbound",
+    });
+    recordChannelActivity.mockReset();
+  });
+
+  it("shares one logical activity scope across real separately accepted voice and caption sends", async () => {
+    recordChannelActivity.mockReset();
+    recordChannelActivity.mockImplementation(() => {
+      if (recordChannelActivity.mock.calls.length > 1) {
+        throw new Error("caption producer incorrectly repeated logical activity bookkeeping");
+      }
+    });
+    vi.mocked(loadWebMedia).mockResolvedValueOnce({
+      buffer: Buffer.from("voice"),
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        key: {
+          id: "dispatch-scoped-voice",
+          remoteJid: "1000@s.whatsapp.net",
+          fromMe: true,
+        },
+      } as WAMessage)
+      .mockResolvedValueOnce({
+        key: {
+          id: "dispatch-scoped-caption",
+          remoteJid: "1000@s.whatsapp.net",
+          fromMe: true,
+        },
+      } as WAMessage);
+    const sendApi = createWebSendApi({
+      sock: {
+        sendMessage,
+        sendPresenceUpdate: vi.fn(async () => undefined),
+      },
+      defaultAccountId: "default",
+    });
+    const sendMedia = vi.fn<AdmittedWebInboundMessage["platform"]["sendMedia"]>(async (payload) => {
+      if (!("audio" in payload) || !Buffer.isBuffer(payload.audio)) {
+        throw new Error("expected a real WhatsApp voice payload");
+      }
+      return sendApi.sendMessage(
+        "+1000",
+        "",
+        payload.audio,
+        typeof payload.mimetype === "string" ? payload.mimetype : "audio/ogg",
+      );
+    });
+    const reply = vi.fn<AdmittedWebInboundMessage["platform"]["reply"]>(async (text) =>
+      sendApi.sendMessage("+1000", text),
+    );
+
+    const { deliveryResult, failure, internalHook, pluginHook, replyLogger } =
+      await dispatchObservedPlatformReply({
+        payload: { text: "voice caption", mediaUrls: ["/tmp/scoped-voice.ogg"] },
+        platform: { reply, sendMedia },
+      });
+
+    expect(failure).toMatchObject({
+      dispatched: true,
+      dispatchResult: { queuedFinal: true },
+    });
+    expect(deliveryResult).toMatchObject({
+      messageIds: ["dispatch-scoped-voice", "dispatch-scoped-caption"],
+      receipt: {
+        primaryPlatformMessageId: "dispatch-scoped-voice",
+        platformMessageIds: ["dispatch-scoped-voice", "dispatch-scoped-caption"],
+        parts: [
+          expect.objectContaining({
+            platformMessageId: "dispatch-scoped-voice",
+            raw: expect.objectContaining({ meta: expect.objectContaining({ kind: "media" }) }),
+          }),
+          expect.objectContaining({
+            platformMessageId: "dispatch-scoped-caption",
+            raw: expect.objectContaining({ meta: expect.objectContaining({ kind: "text" }) }),
+          }),
+        ],
+        raw: [
+          expect.objectContaining({
+            messageId: "dispatch-scoped-voice",
+            toJid: "1000@s.whatsapp.net",
+          }),
+          expect.objectContaining({
+            messageId: "dispatch-scoped-caption",
+            toJid: "1000@s.whatsapp.net",
+          }),
+        ],
+      },
+    });
+    await vi.waitFor(() => {
+      expect(pluginHook).toHaveBeenCalledOnce();
+      expect(internalHook).toHaveBeenCalledOnce();
+    });
+    expect(pluginHook).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "dispatch-scoped-voice", success: true }),
+      expect.objectContaining({ messageId: "dispatch-scoped-voice" }),
+    );
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMedia).toHaveBeenCalledOnce();
+    expect(reply).toHaveBeenCalledExactlyOnceWith("voice caption", undefined);
+    expect(replyLogger.warn).not.toHaveBeenCalled();
+    expect(recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
+      channel: "whatsapp",
+      accountId: "default",
+      direction: "outbound",
+    });
+    recordChannelActivity.mockReset();
+  });
+
+  it("keeps the first accepted chunk visible to observers when a later chunk throws a nested partial", async () => {
+    recordChannelActivity.mockClear();
+    const bookkeepingError = new Error("second accepted chunk bookkeeping failed");
+    vi.mocked(loadWebMedia).mockResolvedValueOnce({
+      buffer: Buffer.from("voice"),
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    const firstChunk = normalizeWhatsAppSendResult(
+      { key: { id: "dispatch-first-chunk" } } as WAMessage,
+      "media",
+    );
+    const secondChunk = normalizeWhatsAppSendResult(
+      { key: { id: "dispatch-second-chunk" } } as WAMessage,
+      "text",
+    );
+    const reply = vi.fn<AdmittedWebInboundMessage["platform"]["reply"]>().mockRejectedValueOnce(
+      createChannelPartialDeliveryError(bookkeepingError, {
+        messageIds: [secondChunk.messageId],
+        receipt: secondChunk.receipt,
+        visibleReplySent: true,
+      }),
+    );
+    const sendMedia = vi
+      .fn<AdmittedWebInboundMessage["platform"]["sendMedia"]>()
+      .mockResolvedValueOnce(firstChunk);
+
+    const { failure, internalHook, pluginHook } = await dispatchObservedPlatformReply({
+      payload: { text: "caption", mediaUrls: ["/tmp/accepted-first-voice.ogg"] },
+      platform: { reply, sendMedia },
+    });
+
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error(
+        "canonical dispatch dropped accepted WhatsApp chunks after nested bookkeeping",
+      );
+    }
+    expect(failure.deliveryResult.messageIds).toEqual([
+      "dispatch-first-chunk",
+      "dispatch-second-chunk",
+    ]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual([
+      "dispatch-first-chunk",
+      "dispatch-second-chunk",
+    ]);
+    expect(failure).toHaveProperty("cause", bookkeepingError);
+    await vi.waitFor(() => {
+      expect(pluginHook).toHaveBeenCalledOnce();
+      expect(internalHook).toHaveBeenCalledOnce();
+    });
+    expect(pluginHook).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "dispatch-first-chunk", success: false }),
+      expect.objectContaining({ messageId: "dispatch-first-chunk" }),
+    );
+    expect(sendMedia).toHaveBeenCalledOnce();
+    expect(reply).toHaveBeenCalledOnce();
+    expect(recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
+      channel: "whatsapp",
+      accountId: "default",
+      direction: "outbound",
+    });
+  });
+
+  it("warns about a genuinely rejected trailing upload without losing its earlier receipt", async () => {
+    recordChannelActivity.mockClear();
+    vi.mocked(loadWebMedia)
+      .mockResolvedValueOnce({
+        buffer: Buffer.from("first"),
+        contentType: "image/jpeg",
+        kind: "image",
+      })
+      .mockResolvedValueOnce({
+        buffer: Buffer.from("second"),
+        contentType: "image/jpeg",
+        kind: "image",
+      });
+    const sendMedia = vi
+      .fn<AdmittedWebInboundMessage["platform"]["sendMedia"]>()
+      .mockResolvedValueOnce(
+        normalizeWhatsAppSendResult(
+          { key: { id: "dispatch-accepted-first-media" } } as WAMessage,
+          "media",
+        ),
+      )
+      .mockRejectedValueOnce(new Error("trailing upload rejected"));
+    const reply = vi
+      .fn<AdmittedWebInboundMessage["platform"]["reply"]>()
+      .mockResolvedValueOnce(
+        normalizeWhatsAppSendResult(
+          { key: { id: "dispatch-trailing-media-warning" } } as WAMessage,
+          "text",
+        ),
+      );
+
+    const { failure, internalHook, pluginHook, replyLogger } = await dispatchObservedPlatformReply({
+      payload: {
+        text: "caption",
+        mediaUrls: ["/tmp/accepted-first.jpg", "/tmp/rejected-second.jpg"],
+      },
+      platform: { reply, sendMedia },
+    });
+
+    expect(failure).toMatchObject({
+      dispatched: true,
+      dispatchResult: { queuedFinal: true },
+    });
+    await vi.waitFor(() => {
+      expect(pluginHook).toHaveBeenCalledOnce();
+      expect(internalHook).toHaveBeenCalledOnce();
+    });
+    expect(pluginHook).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "dispatch-accepted-first-media", success: true }),
+      expect.objectContaining({ messageId: "dispatch-accepted-first-media" }),
+    );
+    expect(sendMedia).toHaveBeenCalledTimes(2);
+    expect(reply).toHaveBeenCalledExactlyOnceWith("⚠️ Media unavailable.", undefined);
+    expect(replyLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaUrl: "/tmp/rejected-second.jpg" }),
+      "failed to send web media reply",
+    );
+    expect(recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
+      channel: "whatsapp",
+      accountId: "default",
+      direction: "outbound",
+    });
+  });
+
+  it("preserves inner accepted media receipts and one activity attempt through full dispatch", async () => {
+    recordChannelActivity.mockClear();
+    const bookkeepingError = new Error("accepted dispatch media bookkeeping failed");
+    recordChannelActivity.mockImplementationOnce(() => {
+      throw bookkeepingError;
+    });
+    vi.mocked(loadWebMedia).mockResolvedValueOnce({
+      buffer: Buffer.from("voice"),
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    const sendApi = createWebSendApi({
+      sock: {
+        sendMessage: vi.fn(async () => ({ key: { id: "dispatch-nested-media" } }) as WAMessage),
+        sendPresenceUpdate: vi.fn(async () => undefined),
+      },
+      defaultAccountId: "default",
+    });
+    const sendMedia = vi.fn(async () =>
+      sendApi.sendMessage("+1000", "", Buffer.from("voice"), "audio/ogg"),
+    );
+    const reply = vi.fn<AdmittedWebInboundMessage["platform"]["reply"]>();
+
+    const { failure, internalHook, pluginHook, replyLogger } = await dispatchObservedPlatformReply({
+      payload: { text: "caption", mediaUrls: ["/tmp/accepted-nested-voice.ogg"] },
+      platform: { reply, sendMedia },
+    });
+
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("canonical dispatch treated accepted WhatsApp media as an upload failure");
+    }
+    expect(failure.deliveryResult.messageIds).toEqual(["dispatch-nested-media"]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual(["dispatch-nested-media"]);
+    expect(failure).toHaveProperty("cause", bookkeepingError);
+    await vi.waitFor(() => {
+      expect(pluginHook).toHaveBeenCalledOnce();
+      expect(internalHook).toHaveBeenCalledOnce();
+    });
+    expect(pluginHook).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "dispatch-nested-media", success: false }),
+      expect.objectContaining({ messageId: "dispatch-nested-media" }),
+    );
+    expect(sendMedia).toHaveBeenCalledOnce();
+    expect(reply).not.toHaveBeenCalled();
+    expect(replyLogger.warn).not.toHaveBeenCalled();
+    expect(recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
+      channel: "whatsapp",
+      accountId: "default",
+      direction: "outbound",
+    });
   });
 });

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -3,13 +3,17 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { AnyMessageContent, MiscMessageGenerationOptions, WAMessage } from "baileys";
-import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { listMessageReceiptPlatformIds } from "openclaw/plugin-sdk/channel-outbound";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { prepareWhatsAppOutboundMedia } from "../outbound-media-contract.js";
 import { resolveWhatsAppOutboundMentions } from "./outbound-mentions.js";
 import { createWebSendApi } from "./send-api.js";
-import type { WhatsAppSendResult } from "./send-result.js";
+import { normalizeWhatsAppSendResult, type WhatsAppSendResult } from "./send-result.js";
 
 const recordChannelActivity = vi.hoisted(() => vi.fn());
 const imageOps = vi.hoisted(() => ({
@@ -110,6 +114,15 @@ describe("createWebSendApi", () => {
 
   function expectSendResultFields(result: WhatsAppSendResult, fields: Record<string, unknown>) {
     expectRecordFields(requireRecord(result, "send result"), fields);
+  }
+
+  function expectOutboundActivityOnce(accountId = "main") {
+    expect(recordChannelActivity).toHaveBeenCalledOnce();
+    expect(recordChannelActivity).toHaveBeenCalledWith({
+      channel: "whatsapp",
+      accountId,
+      direction: "outbound",
+    });
   }
 
   it("uses sendOptions fileName for outbound documents", async () => {
@@ -471,6 +484,7 @@ describe("createWebSendApi", () => {
       "voice-1",
       "voice-text-1",
     ]);
+    expectOutboundActivityOnce();
   });
 
   it("preserves the accepted voice receipt when its visible caption send disconnects", async () => {
@@ -492,6 +506,64 @@ describe("createWebSendApi", () => {
     expect(failure.deliveryResult.messageIds).toEqual(["voice-accepted-1"]);
     expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual(["voice-accepted-1"]);
     expect(failure).toHaveProperty("cause", captionError);
+    expectOutboundActivityOnce();
+  });
+
+  it("composes accepted voice and caption receipts when the caption throws a nested partial", async () => {
+    const bookkeepingError = new Error("accepted voice caption bookkeeping failed");
+    const acceptedCaption = normalizeWhatsAppSendResult(
+      { key: { id: "nested-voice-caption" } } as WAMessage,
+      "text",
+    );
+    sendMessage.mockResolvedValueOnce({ key: { id: "nested-voice-media" } }).mockRejectedValueOnce(
+      createChannelPartialDeliveryError(bookkeepingError, {
+        messageIds: [acceptedCaption.messageId],
+        receipt: acceptedCaption.receipt,
+        visibleReplySent: true,
+      }),
+    );
+
+    const failure = await api
+      .sendMessage("+1555", "voice text", Buffer.from("voice"), "audio/ogg")
+      .catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("nested accepted voice-caption receipt replaced its earlier voice receipt");
+    }
+    expect(failure.deliveryResult.messageIds).toEqual([
+      "nested-voice-media",
+      "nested-voice-caption",
+    ]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual([
+      "nested-voice-media",
+      "nested-voice-caption",
+    ]);
+    expect(failure).toHaveProperty("cause", bookkeepingError);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expectOutboundActivityOnce();
+  });
+
+  it("preserves the accepted voice receipt when Baileys never accepts its caption", async () => {
+    sendMessage
+      .mockResolvedValueOnce({ key: { id: "voice-accepted-no-caption" } })
+      .mockResolvedValueOnce(undefined);
+
+    const failure = await api
+      .sendMessage("+1555", "voice text", Buffer.from("voice"), "audio/ogg")
+      .catch((caught: unknown) => caught);
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("accepted voice delivery was lost when Baileys rejected its caption");
+    }
+    expect(failure.deliveryResult.messageIds).toEqual(["voice-accepted-no-caption"]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual([
+      "voice-accepted-no-caption",
+    ]);
+    expect(failure).toHaveProperty("cause", expect.any(PlatformMessageNotDispatchedError));
+    expectOutboundActivityOnce();
   });
 
   it("preserves the accepted voice receipt when caption mention resolution fails", async () => {
@@ -514,6 +586,7 @@ describe("createWebSendApi", () => {
     }
     expect(failure.deliveryResult.messageIds).toEqual(["voice-accepted-2"]);
     expect(failure).toHaveProperty("cause", mentionError);
+    expectOutboundActivityOnce();
   });
 
   it.each([
@@ -543,13 +616,12 @@ describe("createWebSendApi", () => {
     expect(failure.deliveryResult.messageIds).toEqual([`${kind}-accepted`]);
     expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual([`${kind}-accepted`]);
     expect(failure).toHaveProperty("cause", activityError);
+    expectOutboundActivityOnce();
   });
 
-  it("retains both accepted voice receipts when later activity recording fails", async () => {
+  it("retains the first accepted voice receipt when immediate activity recording fails", async () => {
     const activityError = new Error("channel activity bookkeeping disconnected");
-    sendMessage
-      .mockResolvedValueOnce({ key: { id: "voice-accepted-3" } })
-      .mockResolvedValueOnce({ key: { id: "caption-accepted-3" } });
+    sendMessage.mockResolvedValueOnce({ key: { id: "voice-accepted-3" } });
     recordChannelActivity.mockImplementationOnce(() => {
       throw activityError;
     });
@@ -558,17 +630,15 @@ describe("createWebSendApi", () => {
       .sendMessage("+1555", "voice text", Buffer.from("voice"), "audio/ogg")
       .catch((caught: unknown) => caught);
 
-    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenCalledOnce();
     expect(isChannelPartialDeliveryError(failure)).toBe(true);
     if (!isChannelPartialDeliveryError(failure)) {
-      throw new Error("accepted voice and caption deliveries were lost");
+      throw new Error("accepted voice delivery was lost during immediate activity bookkeeping");
     }
-    expect(failure.deliveryResult.messageIds).toEqual(["voice-accepted-3", "caption-accepted-3"]);
-    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual([
-      "voice-accepted-3",
-      "caption-accepted-3",
-    ]);
+    expect(failure.deliveryResult.messageIds).toEqual(["voice-accepted-3"]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual(["voice-accepted-3"]);
     expect(failure).toHaveProperty("cause", activityError);
+    expectOutboundActivityOnce();
   });
 
   it("supports video media and gifPlayback option", async () => {
@@ -583,10 +653,13 @@ describe("createWebSendApi", () => {
     });
   });
 
-  it("falls back to unknown messageId if Baileys result does not expose key.id", async () => {
+  it("rejects Baileys results that do not expose an accepted message key", async () => {
     sendMessage.mockResolvedValueOnce({ key: {} as { id: string } });
-    const res = await api.sendMessage("+1555", "hello");
-    expect(res.messageId).toBe("unknown");
+
+    await expect(api.sendMessage("+1555", "hello")).rejects.toBeInstanceOf(
+      PlatformMessageNotDispatchedError,
+    );
+    expect(recordChannelActivity).not.toHaveBeenCalled();
   });
 
   it("sends polls and records outbound activity", async () => {
@@ -627,18 +700,40 @@ describe("createWebSendApi", () => {
     });
   });
 
-  it("reports provider-unaccepted sends when Baileys returns no message", async () => {
-    sendMessage.mockResolvedValueOnce(undefined);
-
-    const res = await api.sendMessage("+1555", "hello");
-
-    expectSendResultFields(res, {
+  it.each([
+    {
       kind: "text",
-      messageId: "unknown",
-      providerAccepted: false,
-    });
-    expect(res.receipt ? listMessageReceiptPlatformIds(res.receipt) : []).toStrictEqual([]);
-  });
+      send: (sendApi: ReturnType<typeof createWebSendApi>) => sendApi.sendMessage("+1555", "hello"),
+    },
+    {
+      kind: "image",
+      send: (sendApi: ReturnType<typeof createWebSendApi>) =>
+        sendApi.sendMessage("+1555", "image", Buffer.from("image"), "image/png"),
+    },
+    {
+      kind: "document",
+      send: (sendApi: ReturnType<typeof createWebSendApi>) =>
+        sendApi.sendMessage("+1555", "file", Buffer.from("file"), "application/pdf"),
+    },
+    {
+      kind: "voice",
+      send: (sendApi: ReturnType<typeof createWebSendApi>) =>
+        sendApi.sendMessage("+1555", "", Buffer.from("voice"), "audio/ogg"),
+    },
+    {
+      kind: "poll",
+      send: (sendApi: ReturnType<typeof createWebSendApi>) =>
+        sendApi.sendPoll("+1555", { question: "Q?", options: ["a", "b"] }),
+    },
+  ])(
+    "rejects an unaccepted Baileys $kind send without recording outbound activity",
+    async ({ send }) => {
+      sendMessage.mockResolvedValueOnce(undefined);
+
+      await expect(send(api)).rejects.toBeInstanceOf(PlatformMessageNotDispatchedError);
+      expect(recordChannelActivity).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps direct-chat reactions without a participant key", async () => {
     await api.sendReaction("+1555", "msg-2", "👍", false);

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -5,8 +5,6 @@ import type {
   WAMessage,
   WAPresence,
 } from "baileys";
-import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
-import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveWhatsAppDocumentFileName } from "../document-filename.js";
 import { addWhatsAppImagePreviewFields } from "../image-preview.js";
 import { isWhatsAppNewsletterJid } from "../normalize.js";
@@ -18,8 +16,9 @@ import {
 } from "./outbound-mentions.js";
 import {
   combineWhatsAppSendResults,
-  listWhatsAppSendResultMessageIds,
+  mergeWhatsAppAcceptedSendError,
   normalizeWhatsAppSendResult,
+  rememberWhatsAppAcceptedSend,
   type WhatsAppSendKind,
   type WhatsAppSendResult,
 } from "./send-result.js";
@@ -40,14 +39,6 @@ type StructuredLocationSend = {
 type StructuredStickerSendOptions = {
   mimetype?: string;
 };
-
-function recordWhatsAppOutbound(accountId: string) {
-  recordChannelActivity({
-    channel: "whatsapp",
-    accountId,
-    direction: "outbound",
-  });
-}
 
 function supportsForcedDocumentMediaType(mediaType: string): boolean {
   return mediaType.startsWith("image/") || mediaType.startsWith("video/");
@@ -95,21 +86,15 @@ export function createWebSendApi(params: {
     try {
       // Baileys resolves only after relay acceptance; capture that fact before any later work.
       await send((result, sendKind) => {
-        results.push(normalizeWhatsAppSendResult(result, sendKind));
+        rememberWhatsAppAcceptedSend({
+          accountId,
+          result: normalizeWhatsAppSendResult(result, sendKind),
+          results,
+        });
       });
-      recordWhatsAppOutbound(accountId);
       return combineWhatsAppSendResults(kind, results);
     } catch (error) {
-      const accepted = results.filter((result) => result.providerAccepted);
-      if (accepted.length === 0) {
-        throw error;
-      }
-      const delivered = combineWhatsAppSendResults(kind, accepted);
-      throw createChannelPartialDeliveryError(error, {
-        messageIds: listWhatsAppSendResultMessageIds(delivered),
-        receipt: delivered.receipt,
-        visibleReplySent: true,
-      });
+      throw mergeWhatsAppAcceptedSendError({ error, kind, results });
     }
   };
   const sendStructuredMessage = async (

--- a/extensions/whatsapp/src/inbound/send-result.test.ts
+++ b/extensions/whatsapp/src/inbound/send-result.test.ts
@@ -1,9 +1,44 @@
 // Whatsapp tests cover send result plugin behavior.
 import type { WAMessage } from "baileys";
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { describe, expect, it } from "vitest";
-import { combineWhatsAppSendResults, normalizeWhatsAppSendResult } from "./send-result.js";
+import {
+  combineWhatsAppSendResults,
+  mergeWhatsAppAcceptedSendError,
+  normalizeWhatsAppSendResult,
+  requireWhatsAppAcceptedSendResult,
+} from "./send-result.js";
 
 describe("WhatsApp send receipts", () => {
+  it.each([
+    { name: "no provider result", result: undefined },
+    { name: "no message key", result: { key: {} } as unknown as WAMessage },
+    { name: "a blank message key", result: { key: { id: "  " } } as unknown as WAMessage },
+  ])("rejects $name before fabricating a receipt", ({ result }) => {
+    expect(() => normalizeWhatsAppSendResult(result, "text")).toThrow(
+      PlatformMessageNotDispatchedError,
+    );
+  });
+
+  it("rejects listener results that claim an unauthenticated provider receipt", () => {
+    expect(() =>
+      requireWhatsAppAcceptedSendResult({
+        kind: "text",
+        messageId: "unknown",
+        keys: [],
+        providerAccepted: false,
+      }),
+    ).toThrow(PlatformMessageNotDispatchedError);
+  });
+
+  it("rejects empty send batches instead of fabricating an unknown receipt", () => {
+    expect(() => combineWhatsAppSendResults("text", [])).toThrow(PlatformMessageNotDispatchedError);
+  });
+
   it("attaches receipts to accepted provider sends", () => {
     const result = normalizeWhatsAppSendResult(
       {
@@ -49,6 +84,141 @@ describe("WhatsApp send receipts", () => {
         },
       ],
     });
+  });
+
+  it("enriches matching partial-delivery ids that do not yet carry their canonical receipt", () => {
+    const accepted = normalizeWhatsAppSendResult(
+      { key: { id: "receipt-enrichment", remoteJid: "123@s.whatsapp.net" } } as WAMessage,
+      "text",
+    );
+    const bookkeepingError = new Error("accepted result metadata was not attached");
+    const partial = createChannelPartialDeliveryError(bookkeepingError, {
+      messageIds: [accepted.messageId],
+      visibleReplySent: true,
+    });
+
+    const enriched = mergeWhatsAppAcceptedSendError({
+      error: partial,
+      kind: "text",
+      results: [accepted],
+    });
+
+    expect(isChannelPartialDeliveryError(enriched)).toBe(true);
+    if (!isChannelPartialDeliveryError(enriched)) {
+      throw new Error("matching partial-delivery ids suppressed missing receipt enrichment");
+    }
+    expect(enriched).not.toBe(partial);
+    expect(enriched.deliveryResult.receipt?.platformMessageIds).toEqual(["receipt-enrichment"]);
+    expect(enriched.deliveryResult.receipt?.parts[0]?.raw).toMatchObject({
+      channel: "whatsapp",
+      messageId: "receipt-enrichment",
+      toJid: "123@s.whatsapp.net",
+    });
+    expect(enriched).toHaveProperty("cause", bookkeepingError);
+    expect(enriched).toMatchObject({ sentBeforeError: true, visibleReplySent: true });
+  });
+
+  it("rebuilds matching nested receipts whose existing raw provider metadata is incomplete", () => {
+    const accepted = normalizeWhatsAppSendResult(
+      {
+        key: {
+          id: "receipt-raw-enrichment",
+          remoteJid: "123@s.whatsapp.net",
+          fromMe: true,
+          participant: "456@s.whatsapp.net",
+        },
+      } as WAMessage,
+      "text",
+    );
+    const providerReceipt = accepted.receipt;
+    if (!providerReceipt) {
+      throw new Error("accepted WhatsApp send did not expose its provider receipt");
+    }
+    accepted.receipt = {
+      ...providerReceipt,
+      threadId: "provider-thread",
+      replyToId: "provider-reply",
+      editToken: "provider-edit-token",
+      deleteToken: "provider-delete-token",
+      parts: providerReceipt.parts.map((part) =>
+        Object.assign({}, part, {
+          index: 7,
+          threadId: "provider-thread",
+          replyToId: "provider-reply",
+        }),
+      ),
+    };
+    const incompleteReceipt = {
+      ...accepted.receipt,
+      raw: [{ channel: "whatsapp", messageId: accepted.messageId }],
+      parts: accepted.receipt.parts.map((part) =>
+        Object.assign({}, part, {
+          raw: { channel: "whatsapp", messageId: part.platformMessageId },
+        }),
+      ),
+    };
+    const originalCause = new Error("provider bookkeeping failed after accepted delivery");
+    const partial = createChannelPartialDeliveryError(originalCause, {
+      messageIds: [accepted.messageId],
+      receipt: incompleteReceipt,
+      visibleReplySent: true,
+    });
+    const wrapped = createChannelPartialDeliveryError(partial, {
+      messageIds: [accepted.messageId],
+      receipt: incompleteReceipt,
+      visibleReplySent: true,
+    });
+
+    const enriched = mergeWhatsAppAcceptedSendError({
+      error: wrapped,
+      kind: "text",
+      results: [accepted],
+    });
+
+    expect(isChannelPartialDeliveryError(enriched)).toBe(true);
+    if (!isChannelPartialDeliveryError(enriched)) {
+      throw new Error("existing incomplete nested raw suppressed canonical receipt reconstruction");
+    }
+    expect(enriched).not.toBe(wrapped);
+    expect(enriched).toHaveProperty("cause", originalCause);
+    expect(enriched.deliveryResult.receipt).toMatchObject({
+      primaryPlatformMessageId: "receipt-raw-enrichment",
+      platformMessageIds: ["receipt-raw-enrichment"],
+      threadId: "provider-thread",
+      replyToId: "provider-reply",
+      editToken: "provider-edit-token",
+      deleteToken: "provider-delete-token",
+      raw: [
+        {
+          channel: "whatsapp",
+          messageId: "receipt-raw-enrichment",
+          toJid: "123@s.whatsapp.net",
+          meta: {
+            fromMe: true,
+            participant: "456@s.whatsapp.net",
+          },
+        },
+      ],
+      parts: [
+        {
+          platformMessageId: "receipt-raw-enrichment",
+          kind: "text",
+          index: 7,
+          threadId: "provider-thread",
+          replyToId: "provider-reply",
+          raw: {
+            channel: "whatsapp",
+            messageId: "receipt-raw-enrichment",
+            toJid: "123@s.whatsapp.net",
+            meta: {
+              fromMe: true,
+              participant: "456@s.whatsapp.net",
+            },
+          },
+        },
+      ],
+    });
+    expect(enriched).toMatchObject({ sentBeforeError: true, visibleReplySent: true });
   });
 
   it("combines receipts in provider send order", () => {

--- a/extensions/whatsapp/src/inbound/send-result.ts
+++ b/extensions/whatsapp/src/inbound/send-result.ts
@@ -1,5 +1,11 @@
 // Whatsapp plugin module implements send result behavior.
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { WAMessage, WAMessageKey } from "baileys";
+import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
 import {
   createMessageReceiptFromOutboundResults,
   listMessageReceiptPlatformIds,
@@ -7,6 +13,7 @@ import {
   type MessageReceiptPartKind,
   type MessageReceiptSourceResult,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 export type WhatsAppSendKind =
@@ -32,6 +39,20 @@ export type WhatsAppSendResult = {
   keys: WhatsAppSendKey[];
   providerAccepted: boolean;
 };
+
+// Producer-owned accounting follows the accepted object across nested owner boundaries.
+const activityAccountedWhatsAppSendResults = new WeakSet<WhatsAppSendResult>();
+const logicalWhatsAppDeliveryActivity = new AsyncLocalStorage<{
+  accountedAccountIds: Set<string>;
+}>();
+
+/** Keep all separately produced platform sends inside one logical reply accounting scope. */
+export async function withWhatsAppLogicalDeliveryActivity<T>(run: () => Promise<T>): Promise<T> {
+  if (logicalWhatsAppDeliveryActivity.getStore()) {
+    return await run();
+  }
+  return await logicalWhatsAppDeliveryActivity.run({ accountedAccountIds: new Set() }, run);
+}
 
 function resolveWhatsAppReceiptKind(kind: WhatsAppSendKind): MessageReceiptPartKind {
   if (kind === "media" || kind === "text") {
@@ -62,6 +83,92 @@ function createWhatsAppSendReceipt(
   });
 }
 
+function mergeWhatsAppReceiptSourceMetadata(
+  sources: readonly (MessageReceiptSourceResult | undefined)[],
+): MessageReceiptSourceResult | undefined {
+  const defined = sources.filter((source): source is MessageReceiptSourceResult => Boolean(source));
+  const preferred = defined[0];
+  if (!preferred) {
+    return undefined;
+  }
+  const merged = new Map<string, unknown>();
+  const meta = new Map<string, unknown>();
+  for (const source of defined.toReversed()) {
+    for (const [key, value] of Object.entries(source)) {
+      if (key !== "meta" && value !== undefined) {
+        merged.set(key, value);
+      }
+    }
+    for (const [key, value] of Object.entries(source.meta ?? {})) {
+      if (value !== undefined) {
+        meta.set(key, value);
+      }
+    }
+  }
+  const mergedSource = Object.assign({}, preferred, Object.fromEntries(merged));
+  if (meta.size > 0) {
+    mergedSource.meta = Object.fromEntries(meta);
+  } else {
+    delete mergedSource.meta;
+  }
+  return mergedSource;
+}
+
+function enrichWhatsAppDeliveryReceipt(params: {
+  receipt: MessageReceipt;
+  sources: readonly MessageReceipt[];
+}): MessageReceipt {
+  const seenPartIds = new Set<string>();
+  const parts = params.receipt.parts.flatMap((part) => {
+    if (seenPartIds.has(part.platformMessageId)) {
+      return [];
+    }
+    seenPartIds.add(part.platformMessageId);
+    const matchingParts = params.sources.flatMap((source) =>
+      source.parts.filter((candidate) => candidate.platformMessageId === part.platformMessageId),
+    );
+    const matchingRawSources = params.sources.flatMap(
+      (source) => source.raw?.filter((raw) => raw.messageId === part.platformMessageId) ?? [],
+    );
+    const raw = mergeWhatsAppReceiptSourceMetadata([
+      part.raw,
+      ...matchingParts.map((candidate) => candidate.raw),
+      ...matchingRawSources,
+    ]);
+    const threadId =
+      part.threadId ?? matchingParts.find((candidate) => candidate.threadId)?.threadId;
+    const replyToId =
+      part.replyToId ?? matchingParts.find((candidate) => candidate.replyToId)?.replyToId;
+    return [
+      {
+        ...part,
+        ...(threadId ? { threadId } : {}),
+        ...(replyToId ? { replyToId } : {}),
+        ...(raw ? { raw } : {}),
+      },
+    ];
+  });
+  const threadId =
+    params.receipt.threadId ?? params.sources.find((source) => source.threadId)?.threadId;
+  const replyToId =
+    params.receipt.replyToId ?? params.sources.find((source) => source.replyToId)?.replyToId;
+  const editToken =
+    params.receipt.editToken ?? params.sources.find((source) => source.editToken)?.editToken;
+  const deleteToken =
+    params.receipt.deleteToken ?? params.sources.find((source) => source.deleteToken)?.deleteToken;
+  return {
+    ...params.receipt,
+    parts,
+    raw: parts.map(
+      (part) => part.raw ?? { channel: "whatsapp", messageId: part.platformMessageId },
+    ),
+    ...(threadId ? { threadId } : {}),
+    ...(replyToId ? { replyToId } : {}),
+    ...(editToken ? { editToken } : {}),
+    ...(deleteToken ? { deleteToken } : {}),
+  };
+}
+
 function normalizeKey(key: WAMessageKey | undefined): WhatsAppSendKey | undefined {
   const id = typeof key?.id === "string" ? key.id.trim() : "";
   if (!id) {
@@ -75,19 +182,196 @@ function normalizeKey(key: WAMessageKey | undefined): WhatsAppSendKey | undefine
   };
 }
 
+function createWhatsAppProviderNotAcceptedError(kind: WhatsAppSendKind) {
+  const cause = new Error("Baileys returned no accepted message key.");
+  return new PlatformMessageNotDispatchedError(
+    `WhatsApp ${kind} send was not accepted by the provider: ${cause.message}`,
+    { cause },
+  );
+}
+
 export function normalizeWhatsAppSendResult(
   result: WAMessage | undefined,
   kind: WhatsAppSendKind,
 ): WhatsAppSendResult {
   const key = normalizeKey(result?.key);
-  const messageId = key?.id ?? "unknown";
+  if (!key) {
+    throw createWhatsAppProviderNotAcceptedError(kind);
+  }
   return {
     kind,
-    messageId,
-    receipt: createWhatsAppSendReceipt(kind, key ? [key] : []),
-    keys: key ? [key] : [],
-    providerAccepted: Boolean(key),
+    messageId: key.id,
+    receipt: createWhatsAppSendReceipt(kind, [key]),
+    keys: [key],
+    providerAccepted: true,
   };
+}
+
+/** Refuse synthetic ids from listener boundaries before callers create durable receipts. */
+export function requireWhatsAppAcceptedSendResult(result: WhatsAppSendResult): WhatsAppSendResult {
+  if (
+    result.providerAccepted &&
+    result.messageId !== "unknown" &&
+    result.keys.some((key) => key.id === result.messageId) &&
+    listWhatsAppSendResultMessageIds(result).includes(result.messageId)
+  ) {
+    return result;
+  }
+  throw createWhatsAppProviderNotAcceptedError(result.kind);
+}
+
+/** Persist accepted provider facts before account bookkeeping or later platform sends can fail. */
+export function rememberWhatsAppAcceptedSend(params: {
+  accountId: string;
+  result: WhatsAppSendResult;
+  results: WhatsAppSendResult[];
+}): WhatsAppSendResult {
+  const accepted = requireWhatsAppAcceptedSendResult(params.result);
+  params.results.push(accepted);
+  if (params.results.length === 1) {
+    const deliveryActivity = logicalWhatsAppDeliveryActivity.getStore();
+    const alreadyAccounted =
+      activityAccountedWhatsAppSendResults.has(accepted) ||
+      Boolean(deliveryActivity?.accountedAccountIds.has(params.accountId));
+    // Mark before bookkeeping: a thrown owner callback must not be retried by an outer adapter.
+    activityAccountedWhatsAppSendResults.add(accepted);
+    if (!alreadyAccounted) {
+      deliveryActivity?.accountedAccountIds.add(params.accountId);
+      recordChannelActivity({
+        channel: "whatsapp",
+        accountId: params.accountId,
+        direction: "outbound",
+      });
+    }
+  }
+  return accepted;
+}
+
+/** Nested owners already attempted activity accounting before exposing accepted delivery. */
+export function rememberWhatsAppPartialSend(params: {
+  error: unknown;
+  kind: WhatsAppSendKind;
+  results: WhatsAppSendResult[];
+}): boolean {
+  if (!isChannelPartialDeliveryError(params.error)) {
+    return false;
+  }
+  const delivery = params.error.deliveryResult;
+  const messageIds = uniqueStrings([
+    ...(delivery.receipt ? listMessageReceiptPlatformIds(delivery.receipt) : []),
+    ...normalizeStringEntries(delivery.messageIds ?? []),
+  ]).filter((messageId) => messageId !== "unknown");
+  const existingIds = new Set(params.results.flatMap(listWhatsAppSendResultMessageIds));
+  const acceptedIds = messageIds.filter((messageId) => !existingIds.has(messageId));
+  const messageId = acceptedIds[0];
+  if (!messageId) {
+    return false;
+  }
+  const receiptSources: Array<MessageReceiptSourceResult & { receipt?: MessageReceipt }> = [];
+  if (delivery.receipt) {
+    receiptSources.push({ channel: "whatsapp", messageId, receipt: delivery.receipt });
+  }
+  const receiptIds = new Set(
+    delivery.receipt ? listMessageReceiptPlatformIds(delivery.receipt) : [],
+  );
+  for (const acceptedId of acceptedIds) {
+    if (!receiptIds.has(acceptedId)) {
+      receiptSources.push({ channel: "whatsapp", messageId: acceptedId });
+    }
+  }
+  const receipt = createMessageReceiptFromOutboundResults({
+    kind: resolveWhatsAppReceiptKind(params.kind),
+    results: receiptSources,
+  });
+  const accepted = requireWhatsAppAcceptedSendResult({
+    kind: params.kind,
+    messageId,
+    receipt,
+    keys: acceptedIds.map((id) => ({ id })),
+    providerAccepted: true,
+  });
+  activityAccountedWhatsAppSendResults.add(accepted);
+  params.results.push(accepted);
+  return true;
+}
+
+/** Merge accepted local sends with nested partial receipts without inventing provider ids. */
+export function mergeWhatsAppAcceptedSendError(params: {
+  error: unknown;
+  kind: WhatsAppSendKind;
+  results: readonly WhatsAppSendResult[];
+}): unknown {
+  const nested = isChannelPartialDeliveryError(params.error)
+    ? params.error.deliveryResult
+    : undefined;
+  const receiptSources: Array<MessageReceiptSourceResult & { receipt?: MessageReceipt }> = [];
+  const recordedIds = new Set<string>();
+  for (const result of params.results) {
+    const resultIds = listWhatsAppSendResultMessageIds(result);
+    if (resultIds.every((messageId) => recordedIds.has(messageId))) {
+      continue;
+    }
+    receiptSources.push({
+      channel: "whatsapp",
+      messageId: result.messageId,
+      ...(result.receipt ? { receipt: result.receipt } : {}),
+    });
+    for (const messageId of resultIds) {
+      recordedIds.add(messageId);
+    }
+  }
+  const nestedIds = uniqueStrings([
+    ...(nested?.receipt ? listMessageReceiptPlatformIds(nested.receipt) : []),
+    ...normalizeStringEntries(nested?.messageIds ?? []),
+  ]).filter((messageId) => messageId !== "unknown");
+  const unrecordedNestedIds = nestedIds.filter((messageId) => !recordedIds.has(messageId));
+  const nestedMessageId = unrecordedNestedIds[0];
+  if (nested?.receipt && nestedMessageId) {
+    receiptSources.push({
+      channel: "whatsapp",
+      messageId: nestedMessageId,
+      receipt: nested.receipt,
+    });
+    for (const messageId of listMessageReceiptPlatformIds(nested.receipt)) {
+      recordedIds.add(messageId);
+    }
+  }
+  for (const messageId of unrecordedNestedIds) {
+    if (!recordedIds.has(messageId)) {
+      receiptSources.push({ channel: "whatsapp", messageId });
+    }
+  }
+  const receipt = enrichWhatsAppDeliveryReceipt({
+    receipt: createMessageReceiptFromOutboundResults({
+      kind: resolveWhatsAppReceiptKind(params.kind),
+      results: receiptSources,
+    }),
+    sources: [
+      ...params.results.flatMap((result) => (result.receipt ? [result.receipt] : [])),
+      ...(nested?.receipt ? [nested.receipt] : []),
+    ],
+  });
+  const messageIds = listMessageReceiptPlatformIds(receipt);
+  if (messageIds.length === 0) {
+    return params.error;
+  }
+  let cause: unknown = params.error;
+  const visitedPartialErrors = new Set<unknown>();
+  while (
+    isChannelPartialDeliveryError(cause) &&
+    cause instanceof Error &&
+    cause.cause !== undefined &&
+    !visitedPartialErrors.has(cause)
+  ) {
+    visitedPartialErrors.add(cause);
+    cause = cause.cause;
+  }
+  return createChannelPartialDeliveryError(cause, {
+    ...nested,
+    messageIds,
+    receipt,
+    visibleReplySent: true,
+  });
 }
 
 export function combineWhatsAppSendResults(
@@ -95,14 +379,22 @@ export function combineWhatsAppSendResults(
   results: readonly WhatsAppSendResult[],
 ): WhatsAppSendResult {
   const messageIds = uniqueStrings(results.flatMap(listWhatsAppSendResultMessageIds));
+  const messageId = messageIds[0];
+  if (!messageId) {
+    throw createWhatsAppProviderNotAcceptedError(kind);
+  }
   const keys = results.flatMap((result) => result.keys);
-  return {
+  const combined: WhatsAppSendResult = {
     kind,
-    messageId: messageIds[0] ?? "unknown",
+    messageId,
     receipt: createWhatsAppSendReceipt(kind, keys),
     keys,
     providerAccepted: results.some((result) => result.providerAccepted),
   };
+  if (results.some((result) => activityAccountedWhatsAppSendResults.has(result))) {
+    activityAccountedWhatsAppSendResults.add(combined);
+  }
+  return combined;
 }
 
 export function listWhatsAppSendResultMessageIds(result: WhatsAppSendResult): string[] {

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -6,7 +6,6 @@ import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { redactIdentifier } from "openclaw/plugin-sdk/logging-core";
-import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS } from "openclaw/plugin-sdk/media-runtime";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAcceptedWhatsAppSendResult } from "./inbound/send-result.test-helper.js";
 import type { ActiveWebListener } from "./inbound/types.js";
@@ -141,6 +140,43 @@ describe("web outbound", () => {
     expect(sendComposingTo).toHaveBeenCalledWith("+1555");
     expect(sendMessage).toHaveBeenCalledWith("+1555", "hi", undefined, undefined);
   });
+
+  it.each([
+    { kind: "text", mediaUrl: undefined, contentType: undefined },
+    { kind: "image", mediaUrl: "/tmp/pic.png", contentType: "image/png" },
+    { kind: "document", mediaUrl: "/tmp/report.pdf", contentType: "application/pdf" },
+    { kind: "voice", mediaUrl: "/tmp/voice.ogg", contentType: "audio/ogg" },
+  ])(
+    "rejects provider-unaccepted $kind sends without synthetic delivery progress",
+    async ({ kind, mediaUrl, contentType }) => {
+      if (mediaUrl) {
+        loadWebMediaMock.mockResolvedValueOnce({
+          buffer: Buffer.from(kind),
+          contentType,
+          kind: kind === "document" ? "document" : kind === "voice" ? "audio" : "image",
+        });
+      }
+      sendMessage.mockResolvedValueOnce({
+        kind: mediaUrl ? "media" : "text",
+        messageId: "unknown",
+        keys: [],
+        providerAccepted: false,
+      });
+      const onDeliveryResult = vi.fn();
+
+      await expect(
+        sendMessageWhatsApp("+1555", "hello", {
+          verbose: false,
+          cfg: WHATSAPP_TEST_CFG,
+          ...(mediaUrl ? { mediaUrl } : {}),
+          onDeliveryResult,
+        }),
+      ).rejects.toBeInstanceOf(PlatformMessageNotDispatchedError);
+
+      expect(sendMessage).toHaveBeenCalledOnce();
+      expect(onDeliveryResult).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     { name: "text", mediaUrl: undefined },
@@ -391,104 +427,6 @@ describe("web outbound", () => {
         /No active WhatsApp Web listener.*channels login.*account work/,
       ),
     });
-  });
-
-  it("maps audio to PTT with opus mime when ogg", async () => {
-    const buf = Buffer.from("audio");
-    loadWebMediaMock.mockResolvedValueOnce({
-      buffer: buf,
-      contentType: "audio/ogg",
-      kind: "audio",
-    });
-    await sendMessageWhatsApp("+1555", "voice note", {
-      verbose: false,
-      cfg: WHATSAPP_TEST_CFG,
-      mediaUrl: "/tmp/voice.ogg",
-    });
-    expect(sendMessage).toHaveBeenNthCalledWith(1, "+1555", "", buf, "audio/ogg; codecs=opus");
-    expect(sendMessage).toHaveBeenNthCalledWith(2, "+1555", "voice note", undefined, undefined);
-  });
-
-  it("normalizes MIME parameters before handing media to the socket transport", async () => {
-    const buf = Buffer.from("image");
-    loadWebMediaMock.mockResolvedValueOnce({
-      buffer: buf,
-      contentType: " Image/PNG; charset=binary ",
-    });
-
-    await sendMessageWhatsApp("+1555", "caption", {
-      verbose: false,
-      cfg: WHATSAPP_TEST_CFG,
-      mediaUrl: "/tmp/image.png",
-    });
-
-    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "caption", buf, "image/png");
-  });
-
-  it("reports the accepted voice send before a caption failure", async () => {
-    const buf = Buffer.from("audio");
-    loadWebMediaMock.mockResolvedValueOnce({
-      buffer: buf,
-      contentType: "audio/ogg",
-      kind: "audio",
-    });
-    sendMessage
-      .mockResolvedValueOnce(createAcceptedWhatsAppSendResult("media", "voice-accepted"))
-      .mockRejectedValueOnce(new Error("caption failed"));
-    const onDeliveryResult = vi.fn();
-
-    await expect(
-      sendMessageWhatsApp("+1555", "voice note", {
-        verbose: false,
-        cfg: WHATSAPP_TEST_CFG,
-        mediaUrl: "/tmp/voice.ogg",
-        onDeliveryResult,
-      }),
-    ).rejects.toThrow("caption failed");
-
-    expect(onDeliveryResult).toHaveBeenCalledOnce();
-    expect(onDeliveryResult).toHaveBeenCalledWith(
-      expect.objectContaining({ messageId: "voice-accepted" }),
-    );
-  });
-
-  it.each([
-    { name: "mp3", contentType: "audio/mpeg", fileName: "voice.mp3" },
-    { name: "m4a", contentType: "audio/mp4; codecs=mp4a.40.2", fileName: "voice.m4a" },
-    { name: "webm", contentType: "audio/webm", fileName: "voice.webm" },
-  ])("transcodes $name audio to Ogg Opus before sending a PTT voice note", async (media) => {
-    const buf = Buffer.from(media.name);
-    loadWebMediaMock.mockResolvedValueOnce({
-      buffer: buf,
-      contentType: media.contentType,
-      kind: "audio",
-      fileName: media.fileName,
-    });
-
-    await sendMessageWhatsApp("+1555", "voice note", {
-      verbose: false,
-      cfg: WHATSAPP_TEST_CFG,
-      mediaUrl: `/tmp/${media.fileName}`,
-    });
-
-    expect(hoisted.transcodeAudioBufferToOpus).toHaveBeenCalledWith({
-      audioBuffer: buf,
-      inputFileName: media.fileName,
-      tempPrefix: "whatsapp-voice-",
-      outputFileName: "voice.ogg",
-      maxDurationSeconds: MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS,
-      sampleRateHz: 48000,
-      channels: 1,
-      bitrate: "64k",
-    });
-    expect(sendMessage).toHaveBeenNthCalledWith(
-      1,
-      "+1555",
-      "",
-      Buffer.from("opus-output"),
-      "audio/ogg; codecs=opus",
-    );
-    expect(sendMessage).toHaveBeenNthCalledWith(2, "+1555", "voice note", undefined, undefined);
   });
 
   it("maps video with caption", async () => {
@@ -837,6 +775,25 @@ describe("web outbound", () => {
       durationSeconds: undefined,
       durationHours: undefined,
     });
+  });
+
+  it("rejects polls without an accepted provider message key", async () => {
+    sendPoll.mockResolvedValueOnce({
+      kind: "poll",
+      messageId: "unknown",
+      keys: [],
+      providerAccepted: false,
+    });
+
+    await expect(
+      sendPollWhatsApp(
+        "+1555",
+        { question: "Lunch?", options: ["Pizza", "Sushi"] },
+        { verbose: false, cfg: WHATSAPP_TEST_CFG },
+      ),
+    ).rejects.toBeInstanceOf(PlatformMessageNotDispatchedError);
+
+    expect(sendPoll).toHaveBeenCalledOnce();
   });
 
   it("returns the actual outbound poll key when Baileys resolves a LID target", async () => {

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -17,6 +17,12 @@ import {
 } from "./accounts.js";
 import { getWhatsAppConnectionController } from "./connection-controller-runtime-context.js";
 import { resolveWhatsAppDocumentFileName } from "./document-filename.js";
+import {
+  mergeWhatsAppAcceptedSendError,
+  requireWhatsAppAcceptedSendResult,
+  withWhatsAppLogicalDeliveryActivity,
+  type WhatsAppSendResult,
+} from "./inbound/send-result.js";
 import type { ActiveWebListener, ActiveWebSendOptions } from "./inbound/types.js";
 import { isWhatsAppNewsletterJid } from "./normalize.js";
 import {
@@ -154,6 +160,16 @@ export async function sendMessageWhatsApp(
     onDeliveryResult?: (result: { messageId: string; toJid: string }) => Promise<void> | void;
   },
 ): Promise<{ messageId: string; toJid: string }> {
+  return await withWhatsAppLogicalDeliveryActivity(() =>
+    sendMessageWhatsAppInActivityScope(to, body, options),
+  );
+}
+
+async function sendMessageWhatsAppInActivityScope(
+  to: string,
+  body: string,
+  options: Parameters<typeof sendMessageWhatsApp>[2],
+): Promise<{ messageId: string; toJid: string }> {
   let text = options.preserveLeadingWhitespace ? body : normalizeWhatsAppPayloadText(body);
   const jid = toWhatsappJid(to);
   const mediaUrls = resolveAdditiveWhatsAppMediaUrls(options);
@@ -200,6 +216,7 @@ export async function sendMessageWhatsApp(
     correlationId,
     to: redactedTo,
   });
+  const acceptedResults: WhatsAppSendResult[] = [];
   try {
     const redactedJid = redactIdentifier(jid);
     let mediaBuffer: Buffer | undefined;
@@ -267,10 +284,13 @@ export async function sendMessageWhatsApp(
             accountId,
           }
         : undefined;
-    const result = sendOptions
-      ? await active.sendMessage(to, text, mediaBuffer, mediaType, sendOptions)
-      : await active.sendMessage(to, text, mediaBuffer, mediaType);
-    const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
+    const result = requireWhatsAppAcceptedSendResult(
+      sendOptions
+        ? await active.sendMessage(to, text, mediaBuffer, mediaType, sendOptions)
+        : await active.sendMessage(to, text, mediaBuffer, mediaType),
+    );
+    acceptedResults.push(result);
+    const messageId = result.messageId;
     const sentRemoteJid = resolveActualSentRemoteJid(result, jid);
     const trailingTextChunks = [visibleTextAfterVoice, ...textChunks].filter(
       (chunk): chunk is string => Boolean(chunk),
@@ -280,11 +300,14 @@ export async function sendMessageWhatsApp(
       // cannot replay already-delivered media or text chunks.
       await options.onDeliveryResult?.({ messageId, toJid: sentRemoteJid });
       for (const trailingText of trailingTextChunks) {
-        const trailingResult = sendOptions
-          ? await active.sendMessage(to, trailingText, undefined, undefined, sendOptions)
-          : await active.sendMessage(to, trailingText, undefined, undefined);
+        const trailingResult = requireWhatsAppAcceptedSendResult(
+          sendOptions
+            ? await active.sendMessage(to, trailingText, undefined, undefined, sendOptions)
+            : await active.sendMessage(to, trailingText, undefined, undefined),
+        );
+        acceptedResults.push(trailingResult);
         await options.onDeliveryResult?.({
-          messageId: (trailingResult as { messageId?: string })?.messageId ?? "unknown",
+          messageId: trailingResult.messageId,
           toJid: resolveActualSentRemoteJid(trailingResult, jid),
         });
       }
@@ -297,7 +320,12 @@ export async function sendMessageWhatsApp(
     return { messageId, toJid: sentRemoteJid };
   } catch (err) {
     logger.error({ err: String(err), to: redactedTo, hasMedia }, "failed to send via web session");
-    throw err;
+    const firstAccepted = acceptedResults[0];
+    throw mergeWhatsAppAcceptedSendError({
+      error: err,
+      kind: firstAccepted?.kind ?? (hasMedia ? "media" : "text"),
+      results: acceptedResults,
+    });
   }
 }
 
@@ -401,8 +429,8 @@ export async function sendPollWhatsApp(
     if (!isWhatsAppNewsletterJid(jid)) {
       await active.assertSendReady?.(to);
     }
-    const result = await active.sendPoll(to, normalized);
-    const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
+    const result = requireWhatsAppAcceptedSendResult(await active.sendPoll(to, normalized));
+    const messageId = result.messageId;
     const durationMs = Date.now() - startedAt;
     outboundLog.info(`Sent poll ${messageId} -> ${redactedJid} (${durationMs}ms)`);
     logger.info({ jid: redactedJid, messageId }, "sent poll");

--- a/extensions/whatsapp/src/send.voice-delivery.test.ts
+++ b/extensions/whatsapp/src/send.voice-delivery.test.ts
@@ -1,0 +1,361 @@
+// WhatsApp tests cover provider-backed gateway voice delivery, captions, and accepted receipts.
+import type { WAMessage } from "baileys";
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS } from "openclaw/plugin-sdk/media-runtime";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createWebSendApi } from "./inbound/send-api.js";
+import { createAcceptedWhatsAppSendResult } from "./inbound/send-result.test-helper.js";
+import type { ActiveWebListener } from "./inbound/types.js";
+
+const hoisted = vi.hoisted(() => ({
+  loadOutboundMediaFromUrl: vi.fn(),
+  controllerListeners: new Map<string, ActiveWebListener>(),
+  transcodeAudioBufferToOpus: vi.fn(),
+}));
+const recordChannelActivity = vi.hoisted(() => vi.fn());
+const loadWebMediaMock = vi.fn();
+let sendMessageWhatsApp: typeof import("./send.js").sendMessageWhatsApp;
+const WHATSAPP_TEST_CFG: OpenClawConfig = { channels: { whatsapp: {} } };
+
+vi.mock("openclaw/plugin-sdk/channel-activity-runtime", async () => {
+  const actual = await vi.importActual<
+    typeof import("openclaw/plugin-sdk/channel-activity-runtime")
+  >("openclaw/plugin-sdk/channel-activity-runtime");
+  return {
+    ...actual,
+    recordChannelActivity: (...args: unknown[]) => recordChannelActivity(...args),
+  };
+});
+
+vi.mock("./connection-controller-runtime-context.js", async () => {
+  const actual = await vi.importActual<typeof import("./connection-controller-runtime-context.js")>(
+    "./connection-controller-runtime-context.js",
+  );
+  return {
+    ...actual,
+    getWhatsAppConnectionController: vi.fn((accountId: string) => {
+      const listener = hoisted.controllerListeners.get(accountId) ?? null;
+      return listener ? { getActiveListener: () => listener } : null;
+    }),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/outbound-media", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/outbound-media")>(
+    "openclaw/plugin-sdk/outbound-media",
+  );
+  return {
+    ...actual,
+    loadOutboundMediaFromUrl: hoisted.loadOutboundMediaFromUrl,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/media-runtime")>(
+    "openclaw/plugin-sdk/media-runtime",
+  );
+  return {
+    ...actual,
+    transcodeAudioBufferToOpus: hoisted.transcodeAudioBufferToOpus,
+  };
+});
+
+describe("WhatsApp gateway voice delivery", () => {
+  const sendComposingTo = vi.fn(async () => {});
+  const sendMessage = vi.fn(async () => createAcceptedWhatsAppSendResult("text", "msg123"));
+  const sendPoll = vi.fn(async () => createAcceptedWhatsAppSendResult("poll", "poll123"));
+  const sendReaction = vi.fn(async () =>
+    createAcceptedWhatsAppSendResult("reaction", "reaction123"),
+  );
+
+  beforeAll(async () => {
+    ({ sendMessageWhatsApp } = await import("./send.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.transcodeAudioBufferToOpus.mockReset().mockResolvedValue(Buffer.from("opus-output"));
+    hoisted.loadOutboundMediaFromUrl
+      .mockReset()
+      .mockImplementation(async (mediaUrl: string) => await loadWebMediaMock(mediaUrl));
+    hoisted.controllerListeners.clear();
+    hoisted.controllerListeners.set("default", {
+      sendComposingTo,
+      sendMessage,
+      sendPoll,
+      sendReaction,
+    });
+  });
+
+  afterEach(() => {
+    recordChannelActivity.mockReset();
+    hoisted.controllerListeners.clear();
+  });
+
+  it("maps audio to PTT with opus mime when ogg", async () => {
+    const buf = Buffer.from("audio");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    await sendMessageWhatsApp("+1555", "voice note", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/voice.ogg",
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(1, "+1555", "", buf, "audio/ogg; codecs=opus");
+    expect(sendMessage).toHaveBeenNthCalledWith(2, "+1555", "voice note", undefined, undefined);
+  });
+
+  it("shares one gateway activity scope across separately accepted producer voice and caption", async () => {
+    recordChannelActivity.mockReset();
+    recordChannelActivity.mockImplementation(() => {
+      if (recordChannelActivity.mock.calls.length > 1) {
+        throw new Error("gateway caption producer repeated logical delivery bookkeeping");
+      }
+    });
+    const voice = Buffer.from("gateway-voice");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: voice,
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    const providerSendMessage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        key: {
+          id: "gateway-scoped-voice",
+          remoteJid: "1555@s.whatsapp.net",
+          fromMe: true,
+        },
+      } as WAMessage)
+      .mockResolvedValueOnce({
+        key: {
+          id: "gateway-scoped-caption",
+          remoteJid: "1555@s.whatsapp.net",
+          fromMe: true,
+        },
+      } as WAMessage);
+    const sendApi = createWebSendApi({
+      sock: {
+        sendMessage: providerSendMessage,
+        sendPresenceUpdate: vi.fn(async () => undefined),
+      },
+      defaultAccountId: "default",
+    });
+    const listenerSendMessage = vi.fn<ActiveWebListener["sendMessage"]>(
+      async (to, text, mediaBuffer, mediaType, options) =>
+        await sendApi.sendMessage(to, text, mediaBuffer, mediaType, options),
+    );
+    hoisted.controllerListeners.set("default", {
+      sendComposingTo,
+      sendMessage: listenerSendMessage,
+      sendPoll,
+      sendReaction,
+    });
+    const onDeliveryResult = vi.fn();
+
+    const result = await sendMessageWhatsApp("+1555", "voice caption", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/gateway-voice.ogg",
+      onDeliveryResult,
+    });
+
+    expect(result).toEqual({
+      messageId: "gateway-scoped-voice",
+      toJid: "1555@s.whatsapp.net",
+    });
+    expect(providerSendMessage).toHaveBeenCalledTimes(2);
+    expect(providerSendMessage).toHaveBeenNthCalledWith(1, "1555@s.whatsapp.net", {
+      audio: voice,
+      ptt: true,
+      mimetype: "audio/ogg; codecs=opus",
+    });
+    expect(providerSendMessage).toHaveBeenNthCalledWith(2, "1555@s.whatsapp.net", {
+      text: "voice caption",
+    });
+    expect(listenerSendMessage).toHaveBeenCalledTimes(2);
+    expect(onDeliveryResult).toHaveBeenCalledTimes(2);
+    expect(onDeliveryResult).toHaveBeenNthCalledWith(1, {
+      messageId: "gateway-scoped-voice",
+      toJid: "1555@s.whatsapp.net",
+    });
+    expect(onDeliveryResult).toHaveBeenNthCalledWith(2, {
+      messageId: "gateway-scoped-caption",
+      toJid: "1555@s.whatsapp.net",
+    });
+    expect(recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
+      channel: "whatsapp",
+      accountId: "default",
+      direction: "outbound",
+    });
+    recordChannelActivity.mockReset();
+  });
+
+  it("normalizes MIME parameters before handing media to the socket transport", async () => {
+    const buf = Buffer.from("image");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: " Image/PNG; charset=binary ",
+    });
+
+    await sendMessageWhatsApp("+1555", "caption", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/image.png",
+    });
+
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "caption", buf, "image/png");
+  });
+
+  it("reports the accepted voice send before a caption failure", async () => {
+    const buf = Buffer.from("audio");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    sendMessage
+      .mockResolvedValueOnce(createAcceptedWhatsAppSendResult("media", "voice-accepted"))
+      .mockRejectedValueOnce(new Error("caption failed"));
+    const onDeliveryResult = vi.fn();
+
+    await expect(
+      sendMessageWhatsApp("+1555", "voice note", {
+        verbose: false,
+        cfg: WHATSAPP_TEST_CFG,
+        mediaUrl: "/tmp/voice.ogg",
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("caption failed");
+
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "voice-accepted" }),
+    );
+  });
+
+  it("retains the accepted voice receipt when its gateway caption has no provider key", async () => {
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: Buffer.from("audio"),
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    sendMessage
+      .mockResolvedValueOnce(createAcceptedWhatsAppSendResult("media", "gateway-voice-accepted"))
+      .mockResolvedValueOnce({
+        kind: "text",
+        messageId: "unknown",
+        keys: [],
+        providerAccepted: false,
+      });
+    const onDeliveryResult = vi.fn();
+
+    const failure = await sendMessageWhatsApp("+1555", "voice note", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/voice.ogg",
+      onDeliveryResult,
+    }).catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("accepted gateway voice delivery did not preserve its partial receipt");
+    }
+    expect(failure.deliveryResult.messageIds).toEqual(["gateway-voice-accepted"]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual(["gateway-voice-accepted"]);
+    expect(failure).toHaveProperty("cause", expect.any(PlatformMessageNotDispatchedError));
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "gateway-voice-accepted" }),
+    );
+  });
+
+  it("merges accepted gateway voice and nested accepted caption receipts", async () => {
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: Buffer.from("audio"),
+      contentType: "audio/ogg",
+      kind: "audio",
+    });
+    const bookkeepingError = new Error("accepted gateway caption bookkeeping failed");
+    const acceptedCaption = createAcceptedWhatsAppSendResult("text", "gateway-caption-accepted");
+    sendMessage
+      .mockResolvedValueOnce(createAcceptedWhatsAppSendResult("media", "gateway-voice-first"))
+      .mockRejectedValueOnce(
+        createChannelPartialDeliveryError(bookkeepingError, {
+          messageIds: [acceptedCaption.messageId],
+          receipt: acceptedCaption.receipt,
+          visibleReplySent: true,
+        }),
+      );
+
+    const failure = await sendMessageWhatsApp("+1555", "voice note", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/voice.ogg",
+    }).catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error(
+        "gateway discarded its first accepted voice receipt on nested caption failure",
+      );
+    }
+    expect(failure.deliveryResult.messageIds).toEqual([
+      "gateway-voice-first",
+      "gateway-caption-accepted",
+    ]);
+    expect(failure.deliveryResult.receipt?.platformMessageIds).toEqual([
+      "gateway-voice-first",
+      "gateway-caption-accepted",
+    ]);
+    expect(failure).toHaveProperty("cause", bookkeepingError);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    { name: "mp3", contentType: "audio/mpeg", fileName: "voice.mp3" },
+    { name: "m4a", contentType: "audio/mp4; codecs=mp4a.40.2", fileName: "voice.m4a" },
+    { name: "webm", contentType: "audio/webm", fileName: "voice.webm" },
+  ])("transcodes $name audio to Ogg Opus before sending a PTT voice note", async (media) => {
+    const buf = Buffer.from(media.name);
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: media.contentType,
+      kind: "audio",
+      fileName: media.fileName,
+    });
+
+    await sendMessageWhatsApp("+1555", "voice note", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: `/tmp/${media.fileName}`,
+    });
+
+    expect(hoisted.transcodeAudioBufferToOpus).toHaveBeenCalledWith({
+      audioBuffer: buf,
+      inputFileName: media.fileName,
+      tempPrefix: "whatsapp-voice-",
+      outputFileName: "voice.ogg",
+      maxDurationSeconds: MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS,
+      sampleRateHz: 48000,
+      channels: 1,
+      bitrate: "64k",
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(
+      1,
+      "+1555",
+      "",
+      Buffer.from("opus-output"),
+      "audio/ogg; codecs=opus",
+    );
+    expect(sendMessage).toHaveBeenNthCalledWith(2, "+1555", "voice note", undefined, undefined);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where WhatsApp users could receive an apparently successful delivery after the provider rejected a message, lose the receipt for an already-delivered multipart reply, or have a successful voice-and-caption reply corrupted by duplicate delivery bookkeeping.

## Why This Change Was Made

WhatsApp now determines provider acceptance at its transport owner, carries the actual provider receipt through the existing direct and native-reply lifecycles, and scopes activity bookkeeping to one logical delivery. Accepted partial results remain visible and are not replayed; rejected sends no longer masquerade as successful messages.

## User Impact

WhatsApp text, media, voice, captions, direct sends, Gateway sends, and native auto-replies now report their actual delivery outcome. Successful multipart replies keep their real receipts, account activity is recorded once, and rejected follow-up parts provide an honest partial-delivery result.

## Evidence

- Immutable candidate: `358adbdab793da5a7ed03fed90b85da485631db7`.
- Actual pinned transport dependency inspected: `baileys@7.0.0-rc13`.
- Authenticated parent-source regression: the actual Gateway/direct voice-and-caption path and the actual native-auto-reply/observer path both fail because the same accepted logical delivery records activity twice.
- Exact candidate: six affected WhatsApp provider, direct-send, Gateway, voice-delivery, native-reply, and observer suites pass **157/157 tests** on an isolated Blacksmith Testbox; nine existing voice tests were moved coherently into their owner-focused suite without dropping coverage.
- Four independent fresh nonauthor hostile reviews plus additional receipt/isolation reviewers found no remaining actionable issue.
- Full-branch `gpt-5.6-sol` high-reasoning P0–P3 autoreview: no findings; genuine TruffleHog secret scan: clean.
- Exact-head ten-file changed gate passed: formatting, max-lines ratchet, plugin SDK/package boundaries, production and test tsgo, full scoped oxlint, database-first guard, and zero runtime import cycles.
- Exact authenticated Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/30760673169. The lease was explicitly stopped and independently verified completed.
- Exact-head hosted CI and ClawSweeper review remain required before landing.


## Real behavior proof

Reviewed head: `358adbdab793da5a7ed03fed90b85da485631db7`
Parent: `fe81123fe80ba85a4223555c4fa6542a8e422c35`
Run: https://github.com/openclaw/openclaw/actions/runs/30760673169

### Installed pinned provider
```text
BAILEYS_DECLARED=7.0.0-rc13
BAILEYS_RESOLVED=/home/runner/_work/openclaw/openclaw/node_modules/baileys/package.json
BAILEYS_VERSION=7.0.0-rc13
```

### Provider contract
```text
node_modules/baileys/lib/Socket/messages-send.js:1053-1068,1128-1140
1053: sendMessage: async (jid, content, options = {}) => {
1068: const fullMsg = await generateWAMessage(jid, content, {
1128: await relayMessage(jid, fullMsg.message, {
1129: messageId: fullMsg.key.id,
1134: });
1140: return fullMsg;
node_modules/baileys/lib/Utils/messages.js:603-616
604: const messageJSON = {
605: key: {
606: remoteJid: jid,
607: fromMe: true,
608: id: options?.messageId || generateMessageIDV2()
614: status: WAMessageStatus.PENDING
616: return WAProto.WebMessageInfo.fromObject(messageJSON);
```
Baileys constructs fullMsg.key.id, awaits relayMessage with that message ID, and returns fullMsg only after relayMessage resolves. A relay rejection prevents the accepted result. This establishes provider-accepted relay submission, not end-device delivery or read confirmation.

### Parent red: actual gateway/direct voice + caption
```text
RED_GATEWAY_EXIT=1
Error: gateway caption producer repeated logical delivery bookkeeping
Caused by: Error: gateway caption producer repeated logical delivery bookkeeping
Test Files  1 failed (1)
Tests  1 failed | 8 skipped (9)
```

### Parent red: actual native auto-reply dispatch + observer
```text
RED_NATIVE_EXIT=1
+   "message": "caption producer incorrectly repeated logical activity bookkeeping",
+     "message": "caption producer incorrectly repeated logical activity bookkeeping",
Test Files  1 failed (1)
Tests  1 failed | 9 skipped (10)
TRUE_PARENT_RED_AUTHENTICATED=2
```

### Exact candidate green: six affected suites
```text
✓  extension-whatsapp  extensions/whatsapp/src/auto-reply/deliver-reply.test.ts (37 tests) 298ms
✓  extension-whatsapp  extensions/whatsapp/src/inbound/send-api.test.ts (51 tests) 21ms
✓  extension-whatsapp  extensions/whatsapp/src/send.test.ts (41 tests) 222ms
✓  extension-whatsapp  extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.message-sent.test.ts (10 tests) 20ms
✓  extension-whatsapp  extensions/whatsapp/src/send.voice-delivery.test.ts (9 tests) 16ms
✓  extension-whatsapp  extensions/whatsapp/src/inbound/send-result.test.ts (9 tests) 3ms
Test Files  6 passed (6)
Tests  157 passed (157)
```

### Exact candidate green: ten-file changed gate
```text
Import cycle check: 0 runtime value cycle(s).
WHATSAPP_TEN_FILE_PLUGIN_GATE_GREEN_EXIT=0
14.31s  ok         max-lines suppression ratchet
414ms  ok         format changed files
8.22s  ok         Plugin SDK API contract manifest
982ms  ok         plugin boundaries
33.27s  ok         typecheck extensions
56.63s  ok         typecheck extension tests
96.36s  ok         lint extension changed files
10.60s  ok         lint extension changed files
5.52s  ok         runtime import cycles
blacksmith run summary sync=delegated command=5m37.099s total=5m37.132s exit=0
```

Focused real gateway/direct-send and native auto-reply dispatch code paths with controlled provider responses; not a live WhatsApp-network delivery. Provider acceptance semantics were separately checked against installed pinned Baileys source.

### Redacted exact-head runtime verdict

```json
{
  "verdict": "PASS",
  "head": "358adbdab793da5a7ed03fed90b85da485631db7",
  "provider": {
    "package": "baileys",
    "pinned": "7.0.0-rc13",
    "installed": "7.0.0-rc13",
    "contract": "generate key -> await relayMessage(messageId:key.id) -> return fullMsg",
    "source": [
      "lib/Socket/messages-send.js:1053-1068",
      "lib/Socket/messages-send.js:1128-1140",
      "lib/Utils/messages.js:603-616"
    ]
  },
  "before": {
    "parent": "fe81123fe80ba85a4223555c4fa6542a8e422c35",
    "gateway": {
      "exit": 1,
      "error": "gateway caption producer repeated logical delivery bookkeeping"
    },
    "native": {
      "exit": 1,
      "error": "caption producer incorrectly repeated logical activity bookkeeping"
    },
    "authenticated_failures": 2
  },
  "after": {
    "test_files": 6,
    "tests_passed": 157,
    "changed_files": 10,
    "changed_gate_exit": 0,
    "prod_types": "PASS",
    "test_types": "PASS",
    "oxlint": "PASS",
    "max_lines": "PASS",
    "sdk_boundary": "PASS"
  },
  "run": "https://github.com/openclaw/openclaw/actions/runs/30760673169",
  "scope": "actual gateway and native dispatch paths with controlled provider results; not a live WhatsApp-network send"
}
```

## Rank-up moves addressed

1. **Expose a redacted exact-head Testbox transcript:** The actual parent failures, six after-fix suites, 157 passing tests, complete ten-file changed gate, and pinned provider source excerpts are reproduced above without private identifiers or credentials.
2. **Verify the Baileys acceptance contract:** The installed `baileys@7.0.0-rc13` source shows that `sendMessage` generates the message key, awaits `relayMessage`, and returns the accepted message only after relay submission succeeds; this is relay acceptance, not device/read delivery.
3. **Verify exact-head hosted CI:** All relevant exact-head production/test type, lint, packaging/SDK boundary, behavior, and hosted checks passed.
4. **Moving-main refresh:** No rebase is performed solely because main advanced: repository landing policy explicitly treats unrelated mainline drift as advisory, the exact reviewed head remains mergeable, and all exact-head hosted checks are green. The required `scripts/pr` maintainer workflow revalidates the current head and mergeability immediately before landing.

## Maintainer review

The repository owner explicitly delegated autonomous landing of low-risk, independently reviewed QA fixes. The acting maintainer reviewed the actual authenticated parent failures, exact-head after-fix transcript, pinned Baileys acceptance implementation, four independent nonauthor whole-owner approvals, clean genuine Sol/TruffleHog review, complete changed gate, and green hosted CI. Baileys relay acceptance is not represented as device delivery or a read receipt.
