### PR TITLE
fix(qa): reject quoted compaction write success

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
@@ -65,6 +65,14 @@ function readCompletedImageGenerationMediaPath(prompt: string): string | undefin
   return /^MEDIA:\s*([^\r\n]+)$/im.exec(completionEvent)?.[1]?.trim() || undefined;
 }
 
+export const QA_COMPACTION_RETRY_FINAL_MARKER = "Protocol note: replay unsafe after write.";
+
+export function isCanonicalCompactionRetryWriteResult(toolOutput: string): boolean {
+  return /^Successfully wrote \d+ bytes to compaction-retry-summary\.txt\.?$/i.test(
+    toolOutput.trim(),
+  );
+}
+
 export function buildAssistantText(input: ResponsesInputItem[], body: Record<string, unknown>) {
   const prompt = extractLastUserText(input);
   const latestRawUserText = extractAllUserTexts(input).at(-1) ?? "";
@@ -351,13 +359,8 @@ export function buildAssistantText(input: ResponsesInputItem[], body: Record<str
     (/compaction retry mutating tool check/i.test(allInputText) ||
       /compaction-retry-summary\.txt/i.test(toolOutput))
   ) {
-    if (
-      toolOutput.includes("Replay safety: unsafe after write.") ||
-      /compaction-retry-summary\.txt/i.test(toolOutput) ||
-      /successfully (?:wrote|replaced)/i.test(toolOutput) ||
-      /\bwrote\b.*\bcompaction-retry-summary\.txt\b/i.test(toolOutput)
-    ) {
-      return "Protocol note: replay unsafe after write.";
+    if (isCanonicalCompactionRetryWriteResult(toolOutput)) {
+      return QA_COMPACTION_RETRY_FINAL_MARKER;
     }
     return "";
   }

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -2240,14 +2240,48 @@ describe("qa mock openai server", () => {
         makeUserInput(
           "Compaction retry mutating tool check: read COMPACTION_RETRY_CONTEXT.md, then create compaction-retry-summary.txt and keep replay safety explicit.",
         ),
-        makeToolOutput("Successfully wrote 41 bytes to compaction-retry-summary.txt."),
+        makeToolOutput("Successfully wrote 41 bytes to compaction-retry-summary.txt"),
       ],
     });
     expect(finalReply.status).toBe(200);
     const finalPayload = (await finalReply.json()) as {
       output?: Array<{ content?: Array<{ text?: string }> }>;
     };
-    expect(finalPayload.output?.[0]?.content?.[0]?.text).toContain("replay unsafe after write");
+    expect(finalPayload.output?.[0]?.content?.[0]?.text).toBe(
+      "Protocol note: replay unsafe after write.",
+    );
+  });
+
+  it("finishes a compacted retry after the canonical successful write result", async () => {
+    const server = await startMockServer();
+
+    const finalReply = await postNonStreamingResponses(server, {
+      model: "gpt-5.6-luna",
+      input: [
+        makeToolOutput("Successfully wrote 41 bytes to compaction-retry-summary.txt"),
+        makeUserInput("Continue after compaction."),
+      ],
+    });
+
+    expect(finalReply.status).toBe(200);
+    expect(outputText(await finalReply.json())).toBe("Protocol note: replay unsafe after write.");
+  });
+
+  it("does not finish a compacted retry when failure text quotes the write success marker", async () => {
+    const server = await startMockServer();
+
+    const failedReply = await postNonStreamingResponses(server, {
+      model: "gpt-5.6-luna",
+      input: [
+        makeToolOutput(
+          'Write failed after reporting "Successfully wrote 41 bytes to compaction-retry-summary.txt."',
+        ),
+        makeUserInput("Continue after compaction."),
+      ],
+    });
+
+    expect(failedReply.status).toBe(200);
+    expect(outputText(await failedReply.json())).toBe("");
   });
 
   it("keeps compaction retry planning across continuation prompts", async () => {
@@ -2284,7 +2318,7 @@ describe("qa mock openai server", () => {
       model: "gpt-5.6-luna",
       input: [
         makeUserInput(prompt),
-        makeToolOutput("Successfully wrote 41 bytes to compaction-retry-summary.txt."),
+        makeToolOutput("Successfully wrote 41 bytes to compaction-retry-summary.txt"),
         makeUserInput("Continue after compaction."),
       ],
     });

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -9,7 +9,11 @@ import {
   listMockOpenAiServerModelIds,
 } from "../shared/mock-model-config.js";
 import { buildMessagesPayload } from "./mock-anthropic-messages.js";
-import { buildAssistantText } from "./mock-openai-assistant-text.js";
+import {
+  buildAssistantText,
+  isCanonicalCompactionRetryWriteResult,
+  QA_COMPACTION_RETRY_FINAL_MARKER,
+} from "./mock-openai-assistant-text.js";
 import {
   type ResponsesInputItem,
   type StreamEvent,
@@ -1346,6 +1350,9 @@ async function buildResponsesPayload(
     /compaction retry evidence/i.test(toolOutput) ||
     /compaction-retry-summary\.txt/i.test(toolOutput)
   ) {
+    if (isCanonicalCompactionRetryWriteResult(toolOutput)) {
+      return buildAssistantEvents(QA_COMPACTION_RETRY_FINAL_MARKER);
+    }
     if (!hasCompletedToolOutput) {
       return buildToolCallEventsWithArgs("read", { path: "COMPACTION_RETRY_CONTEXT.md" });
     }


### PR DESCRIPTION
## Problem

The QA compaction retry mock accepted any tool output containing the successful write marker. A failed result that quoted that marker could therefore be classified as success and let the release scenario false-pass.

## Solution

- require the exact canonical successful write result
- share the classifier across streaming and non-streaming mock responses
- keep continuation handling explicit
- cover direct success, continuation success, and quoted-failure rejection

## User impact

Release QA no longer reports a successful compaction side effect when the write actually failed.

## Verification

- Blacksmith Testbox: 3 passed, 199 skipped
- exact-head focused test: 3 passed, 199 skipped
- fresh branch autoreview: patch correct, 0.99
- `git diff --check`

AI-assisted: yes
