### PR TITLE
fix(agents): restore missing subagent replies after steering or yield

### DIFF
--- a/src/agents/openclaw-tools.registration.test.ts
+++ b/src/agents/openclaw-tools.registration.test.ts
@@ -520,6 +520,53 @@ describe("Swarm registration", () => {
   });
 });
 
+describe("sessions_yield completion ownership", () => {
+  const controllerSessionKey = "agent:main:telegram:default:direct:1234";
+
+  it.each([
+    ["the durable run owner", "agent:main:main", "agent:main:main"],
+    ["a trimmed durable run owner", "  agent:main:main  ", "agent:main:main"],
+    ["the controller when the run owner is blank", "   ", controllerSessionKey],
+    ["the controller when the run owner is absent", undefined, controllerSessionKey],
+  ] as const)("records yield intent against %s", async (_, runSessionKey, expectedSessionKey) => {
+    const registry = await import("./subagent-registry.js");
+    const markRequesterTurnYielded = vi
+      .spyOn(registry, "markRequesterTurnYielded")
+      .mockReturnValue(1);
+    const onYield = vi.fn(async () => undefined);
+
+    try {
+      const tool = expectToolNamed(
+        createTestOpenClawTools({
+          agentSessionKey: controllerSessionKey,
+          runSessionKey,
+          sessionId: "requester-session",
+          runId: "run-requester",
+          onYield,
+          disableMessageTool: true,
+          disablePluginTools: true,
+          wrapBeforeToolCallHook: false,
+        }),
+        "sessions_yield",
+      );
+
+      const result = await tool.execute("yield-requester", {});
+
+      expect(result.details).toMatchObject({ status: "yielded" });
+      expect(markRequesterTurnYielded).toHaveBeenCalledExactlyOnceWith({
+        requesterSessionKey: expectedSessionKey,
+        requesterTurnRunId: "run-requester",
+      });
+      expect(onYield).toHaveBeenCalledOnce();
+      expect(markRequesterTurnYielded.mock.invocationCallOrder[0]).toBeLessThan(
+        onYield.mock.invocationCallOrder[0]!,
+      );
+    } finally {
+      markRequesterTurnYielded.mockRestore();
+    }
+  });
+});
+
 function hasTool(tools: readonly { name: string }[], name: string): boolean {
   return tools.some((tool) => tool.name === name);
 }

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -296,7 +296,8 @@ export function createOpenClawTools(
           });
         };
   const taskKey = normalizeOptionalString(options?.runSessionKey ?? options?.agentSessionKey);
-  const { agentSessionKey: requesterSessionKey, runId: requesterTurnRunId } = options ?? {};
+  const requesterSessionKey = trimmedRunSessionKey || options?.agentSessionKey;
+  const requesterTurnRunId = options?.runId;
   const imageTool =
     options?.agentDir &&
     resolveImageToolFactoryAvailable({

--- a/src/agents/subagent-registry-restore.ts
+++ b/src/agents/subagent-registry-restore.ts
@@ -119,7 +119,7 @@ export function createSubagentRegistryRestorer(config: {
             requesterTurnRunId,
             requesterYielded: entries.every((entry) => entry.requesterTurnYielded === true),
             acceptedSessionSpawns: entries.map((entry) => ({
-              runId: entry.runId,
+              runId: entry.taskRunId ?? entry.runId,
               childSessionKey: entry.childSessionKey,
             })),
           });

--- a/src/agents/subagent-registry.persistence.resume.test.ts
+++ b/src/agents/subagent-registry.persistence.resume.test.ts
@@ -11,7 +11,10 @@ import {
   createSubagentRegistryTestDeps,
   writeSubagentSessionEntry,
 } from "./subagent-registry.persistence.test-support.js";
-import { saveSubagentRegistryToSqlite } from "./subagent-registry.store.sqlite.js";
+import {
+  loadSubagentRegistryFromSqlite,
+  saveSubagentRegistryToSqlite,
+} from "./subagent-registry.store.sqlite.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const { announceSpy } = vi.hoisted(() => ({
@@ -180,4 +183,77 @@ describe("subagent registry persistence resume", () => {
       );
     });
   });
+
+  it.each([false, true])(
+    "settles a restored steered requester turn (yielded: %s)",
+    async (requesterYielded) => {
+      tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+      const stateDir = tempStateDir;
+      const wakeRequester = vi.fn(async () => false);
+      mod.testing.setDepsForTest({
+        ...createSubagentRegistryTestDeps({
+          callGateway: vi.mocked(callGatewayModule.callGateway),
+          maybeWakeRequesterAfterAllChildrenSettled: wakeRequester,
+        }),
+      });
+
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const endedAt = Date.now();
+        const run: SubagentRunRecord = {
+          runId: "run-steered",
+          taskRunId: "run-original",
+          requesterTurnRunId: "run-requester",
+          ...(requesterYielded ? { requesterTurnYielded: true } : {}),
+          childSessionKey: "agent:main:subagent:steered",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "deliver the steered result",
+          cleanup: "keep",
+          createdAt: endedAt - 1_000,
+          endedReason: "subagent-complete",
+          execution: {
+            status: "terminal",
+            startedAt: endedAt - 500,
+            endedAt,
+            outcome: { status: "ok" },
+          },
+          expectsCompletionMessage: true,
+          completion: { required: true, resultText: "done", capturedAt: endedAt },
+          delivery: { status: "delivered", deliveredAt: endedAt },
+          cleanupHandled: true,
+          cleanupCompletedAt: endedAt,
+        };
+        saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+        await writeSubagentSessionEntry({
+          stateDir,
+          agentId: "main",
+          sessionKey: run.childSessionKey,
+          sessionId: "sess-steered",
+          defaultSessionId: "sess-steered",
+        });
+
+        mod.initSubagentRegistry();
+
+        const restored = mod.getSubagentRunByRunId(run.runId);
+        expect(restored).toMatchObject({ runId: run.runId, taskRunId: run.taskRunId });
+        expect(restored?.requesterTurnRunId).toBeUndefined();
+        expect(loadSubagentRegistryFromSqlite().get(run.runId)?.requesterTurnRunId).toBeUndefined();
+
+        if (requesterYielded) {
+          expect(restored?.requesterSettleWake).toMatchObject({
+            batchRunIds: [run.runId],
+            requesterYieldBatch: true,
+            afterRequesterYield: true,
+          });
+          await vi.waitFor(() => expect(wakeRequester).toHaveBeenCalledOnce(), {
+            timeout: 1_000,
+            interval: 10,
+          });
+        } else {
+          expect(restored?.requesterSettleWake).toBeUndefined();
+          expect(wakeRequester).not.toHaveBeenCalled();
+        }
+      });
+    },
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users waiting for a spawned agent could receive no final reply when a child was steered before Gateway restart, or when a sandboxed/controller session differed from the real completion-owner session.

## Why This Change Was Made

Requester completion is owned by the durable requester session and the original immutable child task identity. Restart restoration now reconstructs accepted children with their original task identity, and the yield hook marks the actual trimmed completion-owner session before ending the requester turn. Existing controller/policy identity and persisted schema remain unchanged.

## User Impact

Completed child-agent work reliably wakes the original requester after steering, restart, and sandboxed session projection. Normal sessions, whitespace/absent overrides, and non-yielded completion keep their existing behavior.

## Evidence

- Before: actual production settlement returned `settled=false`, made no persistence update, and scheduled no requester wake for a restored steered child; a controller/durable-owner split likewise marked zero children and lost the requester wake.
- After: both production-owner paths settle successfully; the yielded requester wakes exactly once and the durable requester-turn marker is cleared.
- Focused hosted Testbox proof: `pnpm test src/agents/openclaw-tools.registration.test.ts src/agents/subagent-registry.persistence.resume.test.ts src/agents/subagent-registry-requester-yield.test.ts` — **61/61 tests across three files passed**.
- Hosted runner: https://github.com/openclaw/openclaw/actions/runs/30760713254
- Added real SQLite restore regressions for yielded and non-yielded steered children, plus actual tool-factory coverage for distinct, trimmed, blank, and absent completion-owner sessions.
- Fresh independent `gpt-5.6-sol`/high autoreview: no actionable P0/P1 findings; confidence 0.93. TruffleHog clean.
- Production delta: **+1 line** across the two canonical owners; no schema, configuration, security, or permission changes.
- AI-assisted; independently reviewed and behaviorally reproduced.
