### PR TITLE
fix(qa): stop reporting failed suites and evaluations as passing

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -306,6 +306,8 @@ describe("qa cli runtime", () => {
     runQaCharacterEval.mockResolvedValue({
       reportPath: "/tmp/character-report.md",
       summaryPath: "/tmp/character-summary.json",
+      runs: [{ model: "qa/candidate", status: "pass" }],
+      judgments: [{ model: "qa/judge", rankings: [{ model: "qa/candidate", rank: 1 }] }],
     });
     runQaManualLane.mockResolvedValue({
       model: "openai/gpt-5.6-luna",
@@ -2625,6 +2627,54 @@ describe("qa cli runtime", () => {
       candidateConcurrency: undefined,
       judgeConcurrency: undefined,
     });
+  });
+
+  it("keeps a successful character eval exit status clear", async () => {
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runQaCharacterEvalCommand({ model: ["qa/candidate"] });
+
+      expect(process.exitCode).toBeUndefined();
+      expectWriteContains(stdoutWrite, "QA character eval report: /tmp/character-report.md");
+      expectWriteContains(stdoutWrite, "QA character eval summary: /tmp/character-summary.json");
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+  });
+
+  it.each([
+    {
+      label: "candidate failure",
+      runs: [{ model: "qa/candidate", status: "fail" }],
+      judgments: [{ model: "qa/judge", rankings: [{ model: "qa/candidate", rank: 1 }] }],
+      expectedVerdict: "QA character eval failed: 1 candidate(s), 0 judge(s).",
+    },
+    {
+      label: "judge failure",
+      runs: [{ model: "qa/candidate", status: "pass" }],
+      judgments: [{ model: "qa/judge", rankings: [], error: "judge unavailable" }],
+      expectedVerdict: "QA character eval failed: 0 candidate(s), 1 judge(s).",
+    },
+  ])("returns a failing exit code on $label without hiding artifacts", async (failure) => {
+    runQaCharacterEval.mockResolvedValueOnce({
+      reportPath: "/tmp/character-report.md",
+      summaryPath: "/tmp/character-summary.json",
+      runs: failure.runs,
+      judgments: failure.judgments,
+    });
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runQaCharacterEvalCommand({ model: ["qa/candidate"] });
+
+      expect(process.exitCode).toBe(1);
+      expectWriteContains(stderrWrite, failure.expectedVerdict);
+      expectWriteContains(stdoutWrite, "QA character eval report: /tmp/character-report.md");
+      expectWriteContains(stdoutWrite, "QA character eval summary: /tmp/character-summary.json");
+    } finally {
+      process.exitCode = priorExitCode;
+    }
   });
 
   it("rejects invalid character eval thinking levels", async () => {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -98,7 +98,10 @@ import {
   runQaSuiteWithInfraRetry,
 } from "./suite-launch.runtime.js";
 import { resolveQaSuiteScenarioChannel, resolveQaSuiteScenarioChannels } from "./suite-planning.js";
-import { readQaSuiteFailedOrSkippedScenarioCountFromFile } from "./suite-summary.js";
+import {
+  readQaSuiteFailedOrSkippedScenarioCountFromFile,
+  resolveQaReportOnlyOptionalScenarioNames as resolveQaReportOnlyOptionalScenarioNamesFromCatalog,
+} from "./suite-summary.js";
 import {
   buildTokenEfficiencyReport,
   renderTokenEfficiencyMarkdownReport,
@@ -815,22 +818,7 @@ function resolveQaReportOnlyOptionalScenarioNames(params: {
   if (params.explicitScenarioSelection || params.scenarioIds.length > 0) {
     return undefined;
   }
-  return new Set(
-    readQaScenarioPack()
-      .scenarios.filter((scenario) => {
-        if (scenario.execution.kind !== "flow") {
-          return false;
-        }
-        const toolCoverage = scenario.execution.config?.toolCoverage;
-        return (
-          typeof toolCoverage === "object" &&
-          toolCoverage !== null &&
-          "required" in toolCoverage &&
-          toolCoverage.required === false
-        );
-      })
-      .map((scenario) => scenario.title),
-  );
+  return resolveQaReportOnlyOptionalScenarioNamesFromCatalog(readQaScenarioPack().scenarios);
 }
 
 export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
@@ -1381,6 +1369,16 @@ export async function runQaCharacterEvalCommand(opts: {
   });
   process.stdout.write(`QA character eval report: ${result.reportPath}\n`);
   process.stdout.write(`QA character eval summary: ${result.summaryPath}\n`);
+  const failedCandidateCount = result.runs.filter((run) => run.status === "fail").length;
+  const failedJudgeCount = result.judgments.filter(
+    (judgment) => judgment.rankings.length === 0,
+  ).length;
+  if (failedCandidateCount > 0 || failedJudgeCount > 0) {
+    process.stderr.write(
+      `QA character eval failed: ${failedCandidateCount} candidate(s), ${failedJudgeCount} judge(s).\n`,
+    );
+    process.exitCode = 1;
+  }
 }
 
 export async function runQaManualLaneCommand(opts: {

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -343,6 +343,62 @@ async function createQaLabRepoRootFixture(params?: {
   return repoRoot;
 }
 
+type QaLabSuiteScenarioFixture = {
+  name: string;
+  status: "pass" | "fail" | "skip";
+  steps: unknown[];
+  details?: string;
+};
+
+async function createQaLabSuiteResultFixture(params?: {
+  scenarios?: QaLabSuiteScenarioFixture[];
+  watchUrl?: string;
+}) {
+  const outputDir = await mkdtemp(path.join(os.tmpdir(), "qa-lab-suite-result-"));
+  cleanups.push(async () => {
+    await rm(outputDir, { recursive: true, force: true });
+  });
+  const scenarios = params?.scenarios ?? [
+    { name: "Channel chat baseline", status: "pass" as const, steps: [] },
+  ];
+  const report = "# QA report\n";
+  const evidencePath = path.join(outputDir, "qa-evidence.json");
+  const reportPath = path.join(outputDir, "qa-suite-report.md");
+  const summaryPath = path.join(outputDir, "qa-suite-summary.json");
+  await Promise.all([
+    writeFile(
+      evidencePath,
+      JSON.stringify({
+        entries: scenarios.map((scenario) => ({ result: { status: scenario.status } })),
+      }),
+      "utf8",
+    ),
+    writeFile(reportPath, report, "utf8"),
+    writeFile(
+      summaryPath,
+      JSON.stringify({
+        counts: {
+          total: scenarios.length,
+          passed: scenarios.filter((scenario) => scenario.status === "pass").length,
+          failed: scenarios.filter((scenario) => scenario.status === "fail").length,
+          skipped: scenarios.filter((scenario) => scenario.status === "skip").length,
+        },
+        scenarios,
+      }),
+      "utf8",
+    ),
+  ]);
+  return {
+    evidencePath,
+    outputDir,
+    report,
+    reportPath,
+    scenarios,
+    summaryPath,
+    ...(params?.watchUrl ? { watchUrl: params.watchUrl } : {}),
+  };
+}
+
 describe("qa-lab server", () => {
   it("dispatches explicit mixed-kind selections through the suite planner", async () => {
     const lab = await startQaLabServerForTest();
@@ -351,14 +407,7 @@ describe("qa-lab server", () => {
     });
     suiteLaunchMock.runQaSuite.mockResolvedValue({
       executionKind: "suite",
-      result: {
-        evidencePath: "/tmp/qa-evidence.json",
-        outputDir: "/tmp/qa-output",
-        report: "# QA report\n",
-        reportPath: "/tmp/qa-report.md",
-        scenarios: [],
-        summaryPath: "/tmp/qa-summary.json",
-      },
+      result: await createQaLabSuiteResultFixture(),
     });
 
     const response = await fetch(`${lab.baseUrl}/api/scenario/suite`, {
@@ -431,6 +480,148 @@ describe("qa-lab server", () => {
     });
   });
 
+  it.each([
+    { label: "failed", status: "fail" as const },
+    { label: "skipped", status: "skip" as const },
+  ])(
+    "marks $label suite results failed while preserving generated artifacts",
+    async ({ status }) => {
+      const lab = await startQaLabServerForTest();
+      cleanups.push(async () => {
+        await lab.stop();
+      });
+      const result = await createQaLabSuiteResultFixture({
+        scenarios: [{ name: "Channel chat baseline", status, steps: [] }],
+      });
+      suiteLaunchMock.runQaSuite.mockResolvedValue({ executionKind: "flow", result });
+
+      const response = await fetch(`${lab.baseUrl}/api/scenario/suite`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          channelDriver: "crabline",
+          providerMode: "live-frontier",
+          scenarioIds: ["dm-chat-baseline"],
+        }),
+      });
+
+      expect(response.status).toBe(202);
+      await vi.waitFor(async () => {
+        const bootstrap = (await (await fetchWithRetry(`${lab.baseUrl}/api/bootstrap`)).json()) as {
+          latestReport: { outputPath: string; markdown: string };
+          runner: {
+            status: string;
+            error: string;
+            artifacts: {
+              outputDir: string;
+              evidencePath: string;
+              reportPath: string;
+              summaryPath: string;
+            };
+          };
+        };
+        expect(bootstrap.runner.status).toBe("failed");
+        expect(bootstrap.runner.error).toBe("QA suite reported 1 failed or skipped scenario(s).");
+        expect(bootstrap.runner.artifacts).toEqual(
+          expect.objectContaining({
+            outputDir: result.outputDir,
+            evidencePath: result.evidencePath,
+            reportPath: result.reportPath,
+            summaryPath: result.summaryPath,
+          }),
+        );
+        expect(bootstrap.latestReport).toEqual(
+          expect.objectContaining({ outputPath: result.reportPath, markdown: result.report }),
+        );
+      });
+    },
+  );
+
+  it.each([
+    {
+      label: "invalid",
+      summary: "{invalid-summary",
+      expectedError: "Could not parse QA summary JSON",
+    },
+    {
+      label: "empty",
+      summary: JSON.stringify({
+        counts: { total: 0, passed: 0, failed: 0, skipped: 0 },
+        scenarios: [],
+      }),
+      expectedError: "did not include any executed scenarios",
+    },
+  ])(
+    "fails closed on an $label suite summary while preserving artifacts",
+    async (invalidResult) => {
+      const lab = await startQaLabServerForTest();
+      cleanups.push(async () => {
+        await lab.stop();
+      });
+      const result = await createQaLabSuiteResultFixture();
+      await writeFile(result.summaryPath, invalidResult.summary, "utf8");
+      suiteLaunchMock.runQaSuite.mockResolvedValue({ executionKind: "flow", result });
+
+      const response = await fetch(`${lab.baseUrl}/api/scenario/suite`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          channelDriver: "crabline",
+          providerMode: "live-frontier",
+          scenarioIds: ["dm-chat-baseline"],
+        }),
+      });
+
+      expect(response.status).toBe(202);
+      await vi.waitFor(async () => {
+        const bootstrap = (await (await fetchWithRetry(`${lab.baseUrl}/api/bootstrap`)).json()) as {
+          runner: { status: string; error: string; artifacts: { summaryPath: string } };
+        };
+        expect(bootstrap.runner.status).toBe("failed");
+        expect(bootstrap.runner.error).toContain(invalidResult.expectedError);
+        expect(bootstrap.runner.artifacts.summaryPath).toBe(result.summaryPath);
+      });
+    },
+  );
+
+  it("keeps implicit suites green for catalog-verified report-only optional skips", async () => {
+    const lab = await startQaLabServerForTest();
+    cleanups.push(async () => {
+      await lab.stop();
+    });
+    const result = await createQaLabSuiteResultFixture({
+      scenarios: [
+        { name: "Channel chat baseline", status: "pass", steps: [] },
+        {
+          name: "Runtime tool fixture — image_generate",
+          status: "skip",
+          steps: [],
+          details: "image_generate mock provider report-only: tool unavailable",
+        },
+      ],
+    });
+    suiteLaunchMock.runQaSuite.mockResolvedValue({ executionKind: "flow", result });
+
+    const response = await fetch(`${lab.baseUrl}/api/scenario/suite`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        profile: "all",
+        channelDriver: "crabline",
+        providerMode: "live-frontier",
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    await vi.waitFor(async () => {
+      const bootstrap = (await (await fetchWithRetry(`${lab.baseUrl}/api/bootstrap`)).json()) as {
+        runner: { status: string; error: string | null };
+      };
+      expect(bootstrap.runner.status).toBe("completed");
+      expect(bootstrap.runner.error).toBeNull();
+    });
+  });
+
   it("keeps mock providers independent from real channel adapters", async () => {
     const lab = await startQaLabServerForTest();
     cleanups.push(async () => {
@@ -438,15 +629,7 @@ describe("qa-lab server", () => {
     });
     suiteLaunchMock.runQaSuite.mockResolvedValue({
       executionKind: "flow",
-      result: {
-        evidencePath: "/tmp/qa-evidence.json",
-        outputDir: "/tmp/qa-output",
-        report: "# QA report\n",
-        reportPath: "/tmp/qa-report.md",
-        scenarios: [],
-        summaryPath: "/tmp/qa-summary.json",
-        watchUrl: "http://runtime-watch.invalid",
-      },
+      result: await createQaLabSuiteResultFixture({ watchUrl: "http://runtime-watch.invalid" }),
     });
 
     const response = await fetch(`${lab.baseUrl}/api/scenario/suite`, {
@@ -509,14 +692,7 @@ describe("qa-lab server", () => {
     expect(suiteLaunchMock.runQaSuite).toHaveBeenCalledTimes(1);
     finishSuite?.({
       executionKind: "flow",
-      result: {
-        evidencePath: "/tmp/qa-evidence.json",
-        outputDir: "/tmp/qa-output",
-        report: "# QA report\n",
-        reportPath: "/tmp/qa-report.md",
-        scenarios: [],
-        summaryPath: "/tmp/qa-summary.json",
-      },
+      result: await createQaLabSuiteResultFixture(),
     });
     await vi.waitFor(async () => {
       const bootstrap = (await (await fetchWithRetry(`${lab.baseUrl}/api/bootstrap`)).json()) as {
@@ -550,15 +726,7 @@ describe("qa-lab server", () => {
     });
     suiteLaunchMock.runQaSuite.mockResolvedValue({
       executionKind: "flow",
-      result: {
-        evidencePath: "/tmp/qa-evidence.json",
-        outputDir: "/tmp/qa-output",
-        report: "# QA report\n",
-        reportPath: "/tmp/qa-report.md",
-        scenarios: [],
-        summaryPath: "/tmp/qa-summary.json",
-        watchUrl: lab.baseUrl,
-      },
+      result: await createQaLabSuiteResultFixture({ watchUrl: lab.baseUrl }),
     });
 
     const response = await fetch(`${lab.baseUrl}/api/scenario/suite`, {

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -60,6 +60,10 @@ import {
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
 import { readQaScorecardTaxonomyReport } from "./scorecard-taxonomy.js";
 import { runQaSelfCheckAgainstState, type QaSelfCheckResult } from "./self-check.js";
+import {
+  readQaSuiteFailedOrSkippedScenarioCountFromFile,
+  resolveQaReportOnlyOptionalScenarioNames,
+} from "./suite-summary.js";
 
 type QaLabBootstrapDefaults = {
   conversationKind: "direct" | "channel";
@@ -781,6 +785,8 @@ export async function startQaLabServer(
             error: null,
           };
           activeSuiteRun = (async () => {
+            // Keep generated artifacts visible when authenticated verdict validation fails.
+            let artifacts: ReturnType<typeof createIdleQaRunnerSnapshot>["artifacts"] = null;
             try {
               const [{ runQaSuite }, channelDriverSelection] = await Promise.all([
                 import("./suite-launch.runtime.js"),
@@ -813,28 +819,40 @@ export async function startQaLabServer(
               });
               const result = runtimeResult.result;
               const finishedAt = new Date().toISOString();
+              artifacts = {
+                outputDir: result.outputDir,
+                evidencePath: result.evidencePath,
+                reportPath: result.reportPath,
+                summaryPath: result.summaryPath,
+                watchUrl:
+                  "watchUrl" in result && typeof result.watchUrl === "string"
+                    ? result.watchUrl
+                    : (labHandle?.baseUrl ?? publicBaseUrl),
+              };
               latestReport = {
                 outputPath: result.reportPath,
                 markdown: result.report,
                 generatedAt: finishedAt,
               };
+              const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
+                result.summaryPath,
+                {
+                  optionalScenarioNames: plan.explicitScenarioSelection
+                    ? undefined
+                    : resolveQaReportOnlyOptionalScenarioNames(scenarioCatalog.scenarios),
+                },
+              );
               runnerSnapshot = {
-                status: "completed",
+                status: blockingScenarioCount > 0 ? "failed" : "completed",
                 selection,
                 plan,
                 startedAt,
                 finishedAt,
-                artifacts: {
-                  outputDir: result.outputDir,
-                  evidencePath: result.evidencePath,
-                  reportPath: result.reportPath,
-                  summaryPath: result.summaryPath,
-                  watchUrl:
-                    "watchUrl" in result && typeof result.watchUrl === "string"
-                      ? result.watchUrl
-                      : (labHandle?.baseUrl ?? publicBaseUrl),
-                },
-                error: null,
+                artifacts,
+                error:
+                  blockingScenarioCount > 0
+                    ? `QA suite reported ${blockingScenarioCount} failed or skipped scenario(s).`
+                    : null,
               };
             } catch (error) {
               const finishedAt = new Date().toISOString();
@@ -860,7 +878,7 @@ export async function startQaLabServer(
                 plan,
                 startedAt,
                 finishedAt,
-                artifacts: null,
+                artifacts,
                 error: message,
               };
             } finally {

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -6,6 +6,7 @@ import { QaSuiteArtifactError } from "./errors.js";
 import type { QaEvidenceSummaryJson, QaEvidenceTiming } from "./evidence-summary.js";
 import type { QaProviderMode } from "./model-selection.js";
 import type { RuntimeId, RuntimeParityResult } from "./runtime-parity.js";
+import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScorecardChannelDriver } from "./scorecard-taxonomy.js";
 
 type QaSuiteSummaryScenario = {
@@ -215,6 +216,23 @@ function isQaSuiteReportOnlyOptionalScenario(
     optionalScenarioNames?.has(scenario.name) === true &&
     typeof scenario.details === "string" &&
     scenario.details.includes("report-only")
+  );
+}
+
+export function resolveQaReportOnlyOptionalScenarioNames(
+  scenarios: readonly QaSeedScenarioWithSource[],
+): ReadonlySet<string> {
+  return new Set(
+    scenarios
+      .filter((scenario) => {
+        const toolCoverage = scenario.execution.config?.toolCoverage;
+        return (
+          scenario.execution.kind === "flow" &&
+          isRecord(toolCoverage) &&
+          toolCoverage.required === false
+        );
+      })
+      .map((scenario) => scenario.title),
   );
 }
 


### PR DESCRIPTION
## Summary

- Make QA Lab classify generated failed, skipped, malformed, and empty scenario summaries as failed instead of falsely reporting success.
- Preserve the generated report, summary, and evidence artifacts even when the dashboard verdict fails.
- Make character evaluations return a nonzero process status for failed candidates and unusable judges while still printing and retaining all reports.
- Reuse one canonical catalog-authenticated optional-scenario verdict policy across the dashboard and CLI.

## Root cause and owner boundary

The QA Lab control-plane runner previously treated any fulfilled suite execution as `completed` without inspecting its actual generated summary. Character evaluation likewise returned success after writing reports, even when candidate or judge results failed. The fix evaluates generated verdicts at their producer/control-plane ownership boundaries, preserves diagnostics, and avoids a dashboard-only display workaround. Production delta: **+34 lines** for the dashboard verdict owner, shared optional-policy owner, and CLI exit owner. No auth, provider config, public protocol, database schema, or migrations change.

## Real QA Lab Dashboard Proof

Exact source `842759f55aed1a950f9f43b8450ecac6d38fb2db` was built with private QA support on an isolated Blacksmith Testbox. The actual `pnpm openclaw qa ui` server received a real HTTP `/api/scenario/suite` request for a Telegram startup scenario with the mock provider and all live credentials unset:

```json
{
  "launchStatus": "running",
  "terminalStatus": "failed",
  "counts": { "total": 1, "passed": 0, "failed": 1, "skipped": 0 },
  "error": "QA suite reported 1 failed or skipped scenario(s).",
  "artifacts": {
    "reportPath": ".artifacts/qa-e2e/lab-2026-08-02-193010602Z-146dc33e/qa-suite-report.md",
    "summaryPath": ".artifacts/qa-e2e/lab-2026-08-02-193010602Z-146dc33e/qa-suite-summary.json",
    "evidencePath": ".artifacts/qa-e2e/lab-2026-08-02-193010602Z-146dc33e/qa-evidence.json"
  },
  "latestReportRetained": true
}
```

Full redacted HTTP/operator transcript: https://github.com/openclaw/openclaw/pull/118120#issuecomment-5159983659

## Real Character-Evaluation CLI Proof

The actual private QA CLI executed a deliberately missing candidate scenario and invalid judge with live credentials unset; it generated and printed real reports, then genuinely exited **1**:

```json
{
  "exitCode": 1,
  "candidateStatus": "fail",
  "candidateError": "unknown QA scenario id(s): qa-verdict-intentionally-missing",
  "judgeRankings": 0,
  "judgeError": "invalid QA bundled plugin id: qa!",
  "reportPath": ".artifacts/qa-e2e/qa-verdict-118120-character/character-eval-report.md",
  "summaryPath": ".artifacts/qa-e2e/qa-verdict-118120-character/character-eval-summary.json",
  "operatorPrintedArtifactPaths": true,
  "operatorPrintedFailureVerdict": true
}
```

Full redacted terminal/operator transcript: https://github.com/openclaw/openclaw/pull/118120#issuecomment-5159999560

## Additional Validation

- Final-source hosted focused suites: `node scripts/run-vitest.mjs extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/lab-server.test.ts extensions/qa-lab/src/suite-summary.test.ts` — **3 suites, 219/219 passing**.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30762645548 — **success**.
- Exact-head Workflow Sanity: https://github.com/openclaw/openclaw/actions/runs/30762645547 — **success**.
- Exact-head real behavior proof: https://github.com/openclaw/openclaw/actions/runs/30762644792 — **success**.
- Fresh complete production-owner structured review clean; final formatting-only Sol/high structured review clean, confidence **0.99**.
- Both explicit ClawSweeper rank-up requests are satisfied by the genuine dashboard and CLI transcripts above. No public provider calls, Telegram messages, live credentials, or operator gateway changes were required.
