### PR TITLE
test(plugin-sdk): canonicalize session lock fixture path

### DIFF
--- a/src/plugin-sdk/session-write-lock-runtime.test.ts
+++ b/src/plugin-sdk/session-write-lock-runtime.test.ts
@@ -236,7 +236,7 @@ describe("Plugin SDK session write-lock adapter", () => {
   });
 
   it("cancels contended infinite admission without affecting the owner", async () => {
-    const sessionFile = path.join(root, "session.jsonl");
+    const sessionFile = path.join(await fs.realpath(root), "session.jsonl");
     const held = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
     const lockPath = `${sessionFile}.lock`;
     const originalReadFile = fs.readFile.bind(fs);


### PR DESCRIPTION
## Summary

- stop the macOS Plugin SDK write-lock cancellation test from waiting 120 seconds on a path alias that can never match
- construct the session fixture from the temporary root's canonical filesystem identity
- leave the production cancellation and lock-manager paths unchanged

## Root cause and fix

macOS exposes the temporary directory lexically through `/var/...`, while the lock manager canonicalizes the same target to `/private/var/...`. The test's contention spy compared the canonical read against a noncanonical expected lock path, never observed contention, and waited until Vitest teardown removed the directory.

The fixture now resolves its temporary root before creating the session path, so the spy and the production lock manager refer to the same filesystem object. Production delta is 0 lines.

Closes https://github.com/openclaw/openclaw/issues/118118

## Proof

Exact candidate head: `a2d924716cb1de0a0613f69a0d0a806761c92df2`

- Current-main reproduction: the focused shard times out after 120 seconds with an unhandled `ENOENT` rejection
- `node scripts/run-vitest.mjs src/plugin-sdk/session-write-lock-runtime.test.ts` — 22 passed, 1 platform skip, in 1.37 seconds after final rebase
- stress loop — 20/20 focused shard runs passed
- `node scripts/check-changed.mjs -- src/plugin-sdk/session-write-lock-runtime.test.ts` — passed the core, extension, SDK-surface, typecheck, lint, storage, and import-cycle gates on Blacksmith Testbox `tbx_01kz1vk17gvmt79cy6fp2xq51j` ([run](https://github.com/openclaw/openclaw/actions/runs/30761088260))
- Codex autoreview — clean, no accepted/actionable findings, overall confidence 0.99

## Changelog

Not required: test-only reliability fix with no runtime behavior change.
