### PR TITLE
fix(channels): make status --channel all show every channel

### DIFF
--- a/src/cli/channels-status-cold-imports.test.ts
+++ b/src/cli/channels-status-cold-imports.test.ts
@@ -55,10 +55,19 @@ describe("routed channels status cold imports", () => {
     vi.clearAllMocks();
   });
 
-  it("keeps successful JSON routes out of config/plugin runtimes with and without probing", async () => {
+  it("keeps successful all-channel JSON routes cold with and without probing", async () => {
     for (const probe of [false, true]) {
       vi.clearAllMocks();
-      const argv = ["node", "openclaw", "channels", "status", "--json"];
+      const timeoutMs = probe ? 30000 : 10000;
+      const argv = [
+        "node",
+        "openclaw",
+        "channels",
+        "status",
+        "--json",
+        "--channel",
+        probe ? " ALL " : "all",
+      ];
       if (probe) {
         argv.push("--probe");
       }
@@ -66,6 +75,11 @@ describe("routed channels status cold imports", () => {
       await expect(tryRouteCli(argv)).resolves.toBe(true);
 
       expect(callGatewayMock).toHaveBeenCalledOnce();
+      expect(callGatewayMock).toHaveBeenCalledWith({
+        method: "channels.status",
+        params: { probe, timeoutMs },
+        timeoutMs,
+      });
       expect(runtime.writeJson).toHaveBeenCalledWith({ channelAccounts: {} }, 2);
       expect(loaded.modules).not.toContain("config-guard");
       expect(loaded.modules).not.toContain("channels-status-runtime");

--- a/src/commands/channels.status.command-flow.test.ts
+++ b/src/commands/channels.status.command-flow.test.ts
@@ -381,7 +381,7 @@ describe("channelsStatusCommand SecretRef fallback flow", () => {
     expect(payload.configuredChannels).toStrictEqual([]);
   });
 
-  it("includes explicitly configured channels in JSON config-only fallback", async () => {
+  it("treats all as no filter in JSON config-only fallback", async () => {
     mocks.callGateway.mockRejectedValue(new Error("gateway closed"));
     mocks.requireValidConfigSnapshot.mockResolvedValue({
       channels: { clickclack: { enabled: true } },
@@ -394,7 +394,7 @@ describe("channelsStatusCommand SecretRef fallback flow", () => {
     mocks.listConfiguredAnnounceChannelIdsForConfig.mockReturnValue(["clickclack"]);
     const { runtime, logs } = createCapturingTestRuntime();
 
-    await channelsStatusCommand({ json: true, probe: false }, runtime as never);
+    await channelsStatusCommand({ channel: "all", json: true, probe: false }, runtime as never);
 
     const payload = JSON.parse(logs.at(-1) ?? "{}");
     expect(payload.gatewayReachable).toBe(false);

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -1,5 +1,6 @@
 // Implements `openclaw channels status` with gateway status and config-only fallback.
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { parseTimeoutMsWithFallback } from "../../cli/parse-timeout.js";
 import { withProgress } from "../../cli/progress.js";
 import { callGateway } from "../../gateway/call.js";
@@ -32,6 +33,10 @@ export async function channelsStatusCommand(
   opts: ChannelsStatusOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
+  const args =
+    normalizeOptionalLowercaseString(opts.channel) === "all"
+      ? { ...opts, channel: undefined }
+      : opts;
   const timeoutMs = parseTimeoutMsWithFallback(opts.timeout, opts.probe ? 30_000 : 10_000, {
     invalidType: "error",
   });
@@ -52,8 +57,8 @@ export async function channelsStatusCommand(
           probe: Boolean(opts.probe),
           timeoutMs,
         };
-        if (opts.channel) {
-          params.channel = opts.channel;
+        if (args.channel) {
+          params.channel = args.channel;
         }
         return await callGateway({
           method: "channels.status",
@@ -72,6 +77,6 @@ export async function channelsStatusCommand(
     const safeError = formatChannelsStatusError(err);
     const gatewayAuthUnavailable = isGatewaySecretRefUnavailableError(err);
     const { renderChannelsStatusFallback } = await loadChannelsStatusRuntime();
-    await renderChannelsStatusFallback({ opts, runtime, safeError, gatewayAuthUnavailable });
+    await renderChannelsStatusFallback({ opts: args, runtime, safeError, gatewayAuthUnavailable });
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw channels status --channel all` would get `unknown channel: all` and fall back to an empty config-only result, even though the CLI help advertises `all` as a supported channel value.

## Why This Change Was Made

The shared status command now normalizes its channel argument once and translates the `all` sentinel into the existing unfiltered request shape before both the Gateway call and config-only fallback. Specific channel filters, the Gateway protocol, plugin discovery, and status payloads are unchanged.

This change was AI-assisted. I verified the owner boundary, kept the patch scoped to the status command, and reviewed the resulting diff and evidence.

## User Impact

Users can request status for every configured channel with `--channel all`, including case- and whitespace-normalized forms, without receiving a false unknown-channel or Gateway-unreachable result.

## Evidence

Before the fix, `openclaw channels status --channel all --probe --json` on the beta build returned `unknown channel: all` and entered config-only fallback. Inspection of current `main` confirmed the same literal `all` value was forwarded to the Gateway, where omission of `channel` is the established all-channel contract.

Regression coverage now exercises the real route-first CLI path with `all` and ` ALL `, asserting that the Gateway request omits `channel` while the cold-path imports stay lazy. The config-only command-flow test also verifies that `all` retains configured channels after a Gateway failure; existing tests continue to cover specific-channel forwarding and filtering.

### After-fix CLI proof

I downloaded the `dist-runtime-build` artifact from [exact-head CI run 30761642377](https://github.com/openclaw/openclaw/actions/runs/30761642377) (`headSha=e096241428c932dc19dbb6425555a93e425eed2e`, artifact SHA-256 `8A35807A85D6D13BE050149E61CBD2AF191BBDC16C7346932FF35A0040F0D768`) and ran its built CLI. The summaries below were generated from separately captured stdout/stderr; channel/account details from the live Gateway were reduced to counts and were not posted.

Live local Gateway:

```json
{
  "command": "openclaw channels status --channel all --json --timeout 5000",
  "exitCode": 0,
  "jsonParsed": true,
  "containsUnknownChannelError": false,
  "gatewayReachable": true,
  "channelGroups": 4,
  "accountGroups": 4
}
```

Config-only fallback, using an isolated state directory with dummy `discord` and `telegram` entries and an unused loopback port:

```json
{
  "command": "openclaw channels status --channel all --json --timeout 1000",
  "exitCode": 0,
  "jsonParsed": true,
  "containsUnknownChannelError": false,
  "gatewayReachable": false,
  "configOnly": true,
  "configuredChannels": ["discord", "telegram"]
}
```

Validation completed before push:

- `oxfmt --check` on all three changed files: passed
- `oxlint` on all three changed files: passed
- `git diff --check origin/main...HEAD`: passed
- repository `autoreview` with TruffleHog scan: clean, no actionable findings; correctness score 0.98
- exact-head pull-request CI: passed ([run 30762559928, attempt 2](https://github.com/openclaw/openclaw/actions/runs/30762559928/attempts/2)); 57 jobs passed, 13 were skipped by scope, and none failed

The linked worktree intentionally has no local dependency tree, and the configured Testbox clients are unavailable on this Windows host. I therefore relied on exact-head pull-request CI rather than installing or reconciling dependencies locally.


### Maintainer proof on refreshed head

- Exact merge-result artifact: `dist-runtime-build` from [run 30766853820](https://github.com/openclaw/openclaw/actions/runs/30766853820), SHA-256 `762f88929112c6cc65249daf2e5d17f47e356ea706bdd831619685b1d55e9452`.
- Artifact `build-info.json` identifies merge commit `a1272618bd17df80023f41bb1110b7d1ef402de4`, whose parents are live base `b35b8e286df028ec3998b17b7f73dd9b1c673975` and repaired head `e8a4661a443724b31efe9144811c401336bca978`.
- Reachable-Gateway run: exit 0, JSON parsed, Gateway status payload returned, and no `unknown channel: all` error.
- Isolated config-only fallback with one configured `clickclack` channel and an unused loopback Gateway: exit 0, JSON parsed, `gatewayReachable=false`, `configOnly=true`, `configuredChannels=["clickclack"]`, and no `unknown channel: all` error.
- Local structured autoreview on `e8a4661a443724b31efe9144811c401336bca978`: clean, no actionable findings, correctness confidence 0.99.
