### PR TITLE
fix(channels): stop fabricating message IDs from empty delivery receipts

### DIFF
--- a/src/channels/message/receipt.test.ts
+++ b/src/channels/message/receipt.test.ts
@@ -36,7 +36,7 @@ describe("createMessageReceiptFromOutboundResults", () => {
     ]);
   });
 
-  it("uses alternate platform ids when messageId is unavailable", () => {
+  it("uses legacy WhatsApp platform ids when no adapter receipt exists", () => {
     const receipt = createMessageReceiptFromOutboundResults({
       results: [{ channel: "whatsapp", messageId: "", toJid: "jid-1" }],
       sentAt: 123,
@@ -44,6 +44,47 @@ describe("createMessageReceiptFromOutboundResults", () => {
 
     expect(receipt.primaryPlatformMessageId).toBe("jid-1");
     expect(receipt.platformMessageIds).toEqual(["jid-1"]);
+  });
+
+  it.each([
+    {
+      label: "Synology Chat destination IDs",
+      result: { channel: "synology-chat", messageId: "", chatId: "42" },
+      receiptMetadata: { threadId: "42" },
+    },
+    {
+      label: "iMessage bridge placeholders",
+      result: { channel: "imessage", messageId: "ok" },
+      receiptMetadata: { replyToId: "source-1" },
+    },
+    {
+      label: "Slack suppression sentinels",
+      result: { channel: "slack", messageId: "suppressed", channelId: "" },
+      receiptMetadata: {},
+    },
+    {
+      label: "Twitch skip sentinels",
+      result: { channel: "twitch", messageId: "skipped" },
+      receiptMetadata: {},
+    },
+  ])("does not fabricate platform ids from $label", ({ result, receiptMetadata }) => {
+    const adapterReceipt = {
+      platformMessageIds: [],
+      parts: [],
+      sentAt: 123,
+      ...receiptMetadata,
+    };
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [{ ...result, receipt: adapterReceipt }],
+    });
+
+    expect(receipt).toMatchObject({
+      ...receiptMetadata,
+      platformMessageIds: [],
+      parts: [],
+      sentAt: 123,
+    });
+    expect(receipt.primaryPlatformMessageId).toBeUndefined();
   });
 
   it("preserves nested platform receipts before falling back to delivery ids", () => {

--- a/src/channels/message/receipt.ts
+++ b/src/channels/message/receipt.ts
@@ -26,15 +26,6 @@ function resolveReceiptMessageId(result: MessageReceiptInputResult): string | un
   );
 }
 
-function hasNestedReceiptData(receipt: MessageReceipt | undefined): receipt is MessageReceipt {
-  return Boolean(
-    receipt &&
-    (receipt.parts.length > 0 ||
-      receipt.platformMessageIds.length > 0 ||
-      receipt.primaryPlatformMessageId),
-  );
-}
-
 function appendUnique(values: string[], value: string | undefined): void {
   const normalized = value?.trim();
   if (normalized && !values.includes(normalized)) {
@@ -51,7 +42,7 @@ export function createMessageReceiptFromOutboundResults(params: {
   sentAt?: number;
 }): MessageReceipt {
   const parts = params.results.flatMap((result, resultIndex) => {
-    if (hasNestedReceiptData(result.receipt)) {
+    if (result.receipt) {
       if (result.receipt.parts.length === 0) {
         return result.receipt.platformMessageIds.map((platformMessageId, partIndex) => ({
           platformMessageId,
@@ -90,7 +81,7 @@ export function createMessageReceiptFromOutboundResults(params: {
   });
   const platformMessageIds: string[] = [];
   for (const result of params.results) {
-    if (hasNestedReceiptData(result.receipt)) {
+    if (result.receipt) {
       appendUnique(platformMessageIds, result.receipt.primaryPlatformMessageId);
       for (const platformMessageId of result.receipt.platformMessageIds) {
         appendUnique(platformMessageIds, platformMessageId);
@@ -102,9 +93,7 @@ export function createMessageReceiptFromOutboundResults(params: {
     }
     appendUnique(platformMessageIds, resolveReceiptMessageId(result));
   }
-  const firstNestedReceipt = params.results.find((result) =>
-    hasNestedReceiptData(result.receipt),
-  )?.receipt;
+  const firstNestedReceipt = params.results.find((result) => result.receipt)?.receipt;
   return {
     ...(platformMessageIds[0] ? { primaryPlatformMessageId: platformMessageIds[0] } : {}),
     platformMessageIds,

--- a/src/channels/message/send.test.ts
+++ b/src/channels/message/send.test.ts
@@ -301,6 +301,42 @@ describe("withDurableMessageSendContext", () => {
     ]);
   });
 
+  it("keeps acknowledged multipart sends without platform ids authoritative", async () => {
+    deliverOutboundPayloads.mockResolvedValueOnce(
+      [123, 456].map((sentAt) => ({
+        channel: "synology-chat",
+        messageId: "",
+        chatId: "42",
+        receipt: {
+          platformMessageIds: [],
+          parts: [],
+          threadId: "42",
+          sentAt,
+        },
+      })),
+    );
+    const onCommitReceipt = vi.fn();
+
+    const result = await sendDurableMessageBatch({
+      cfg,
+      channel: "synology-chat",
+      to: "42",
+      payloads: [{ text: "first" }, { text: "second" }],
+      onCommitReceipt,
+    });
+
+    expectBatchStatus(result, "sent");
+    expect(result.results).toHaveLength(2);
+    expect(result.receipt).toMatchObject({
+      platformMessageIds: [],
+      parts: [],
+      threadId: "42",
+      sentAt: 123,
+    });
+    expect(result.receipt.primaryPlatformMessageId).toBeUndefined();
+    expect(onCommitReceipt).toHaveBeenCalledWith(result.receipt);
+  });
+
   it("supports preview, edit, and delete send-context hooks", async () => {
     const receipt = {
       primaryPlatformMessageId: "preview-1",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where channel adapters that truthfully reported no platform message ID were assigned fabricated destination IDs or sentinel values, corrupting delivery receipts, multipart message correlation, and reply/thread metadata.

## Why This Change Was Made

An adapter-supplied receipt is authoritative even when its message-ID and part arrays are intentionally empty. The shared receipt owner now distinguishes an absent receipt from an explicit empty receipt, while retaining legacy ID inference only for integrations that provided no receipt at all.

## User Impact

Synology Chat, iMessage, Slack, and Twitch no longer claim nonexistent messages were sent under IDs such as a chat destination, `ok`, `suppressed`, or `skipped`. Real thread/reply metadata and multipart delivery facts remain accurate; older adapters without receipts preserve their existing behavior.

## Evidence

- Before: real source reconstructed `user1`, `ok`, `suppressed`, and `skipped` as platform message IDs despite the owning adapters explicitly returning empty receipts; two Synology sends collapsed into fabricated duplicate IDs.
- After: all four integrations retain empty authoritative ID sets; Synology multipart delivery remains successful without invented IDs; real thread/reply facts and legacy WhatsApp no-receipt ID fallback are preserved.
- Focused hosted Testbox proof: `pnpm test src/channels/message/receipt.test.ts src/channels/message/send.test.ts` — **28/28 tests across two suites passed**.
- Hosted runner: https://github.com/openclaw/openclaw/actions/runs/30760713254
- Additional actual-source execution covered all nine receipt cases and real two-part durable-send commitment.
- Fresh independent `gpt-5.6-sol`/high autoreview: no actionable P0/P1 findings; confidence 0.96. TruffleHog clean.
- Production delta: **11 fewer lines**; no schema, persistence, configuration, permission, or dependency changes. AI-assisted and independently reviewed.
