### PR TITLE
fix(matrix): retain every message ID and actual reply in multipart sends

### DIFF
--- a/extensions/matrix/src/channel.message-adapter.test.ts
+++ b/extensions/matrix/src/channel.message-adapter.test.ts
@@ -108,6 +108,45 @@ describe("matrix channel message adapter", () => {
     });
   });
 
+  it("keeps all owner-provided Matrix receipt parts across the message adapter boundary", async () => {
+    const receipt = {
+      primaryPlatformMessageId: "$image",
+      platformMessageIds: ["$image", "$overflow"],
+      parts: [
+        { platformMessageId: "$image", kind: "media" as const, index: 0, replyToId: "$reply" },
+        { platformMessageId: "$overflow", kind: "text" as const, index: 1 },
+      ],
+      replyToId: "$reply",
+      sentAt: 1,
+    };
+    mocks.sendMessageMatrix.mockResolvedValueOnce({
+      messageId: "$overflow",
+      roomId: "!room:example",
+      primaryMessageId: "$image",
+      receipt,
+      content: "image\noverflow",
+    });
+    const sendMedia = matrixPlugin.message?.send?.media;
+    if (!sendMedia) {
+      throw new Error("Expected Matrix message adapter media sender");
+    }
+
+    const result = await sendMedia({
+      cfg,
+      to: "room:!room:example",
+      text: "image\noverflow",
+      mediaUrl: "file:///tmp/photo.png",
+      replyToId: "$reply",
+      accountId: "default",
+    });
+
+    expect(result.messageId).toBe("$overflow");
+    expect(result.receipt).toBe(receipt);
+    expect(result.receipt.primaryPlatformMessageId).toBe("$image");
+    expect(result.receipt.platformMessageIds).toEqual(["$image", "$overflow"]);
+    expect(result.receipt.parts[1]).not.toHaveProperty("replyToId");
+  });
+
   it("routes the standard Matrix send action through canonical durable delivery", async () => {
     const prepareSendPayload = matrixPlugin.actions?.prepareSendPayload;
     if (!prepareSendPayload) {

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -595,6 +595,44 @@ describe("sendMessageMatrix media", () => {
     expect(content.url).toBe("mxc://example/file");
   });
 
+  it("records each media and overflow event with its actual kind and reply relation", async () => {
+    const { client, sendMessage } = makeClient();
+    resolveTextChunkLimitMock.mockReturnValue(6);
+    chunkMarkdownTextWithModeMock.mockImplementation((text: string) => text.split("|"));
+    sendMessage.mockReset().mockResolvedValueOnce("$image").mockResolvedValueOnce("$overflow");
+    const onDeliveryResult = vi.fn();
+
+    const result = await sendMessageMatrix("room:!room:example", "first|second", {
+      client,
+      cfg: {} as never,
+      mediaUrl: "file:///tmp/photo.png",
+      replyToId: "$reply",
+      onDeliveryResult,
+    });
+
+    expect(sentContent(sendMessage, 0)).toMatchObject({
+      msgtype: "m.image",
+      "m.relates_to": { "m.in_reply_to": { event_id: "$reply" } },
+    });
+    expect(sentContent(sendMessage, 1)).toMatchObject({ msgtype: "m.text" });
+    expect(sentContent(sendMessage, 1)).not.toHaveProperty("m.relates_to");
+    expect(result.messageId).toBe("$overflow");
+    expect(result.primaryMessageId).toBe("$image");
+    expect(result.receipt.platformMessageIds).toEqual(["$image", "$overflow"]);
+    expect(result.receipt.parts).toMatchObject([
+      { platformMessageId: "$image", kind: "media", index: 0, replyToId: "$reply" },
+      { platformMessageId: "$overflow", kind: "text", index: 1 },
+    ]);
+    expect(result.receipt.parts[1]).not.toHaveProperty("replyToId");
+    expect(
+      onDeliveryResult.mock.calls.map(([progress]) => progress.receipt.parts[0]),
+    ).toMatchObject([
+      { platformMessageId: "$image", kind: "media", replyToId: "$reply" },
+      { platformMessageId: "$overflow", kind: "text" },
+    ]);
+    expect(onDeliveryResult.mock.calls[1]?.[0]?.receipt.parts[0]).not.toHaveProperty("replyToId");
+  });
+
   it("uploads encrypted media with file payloads", async () => {
     const { client, sendMessage, uploadContent } = makeEncryptedMediaClient();
 
@@ -668,6 +706,7 @@ describe("sendMessageMatrix media", () => {
 
   it("keeps reply context on voice transcript follow-ups outside threads", async () => {
     const { client, sendMessage } = makeClient();
+    sendMessage.mockReset().mockResolvedValueOnce("$voice").mockResolvedValueOnce("$transcript");
     mediaKindFromMimeMock.mockReturnValue("audio");
     isVoiceCompatibleAudioMock.mockReturnValue(true);
     loadWebMediaMock.mockResolvedValueOnce({
@@ -677,7 +716,7 @@ describe("sendMessageMatrix media", () => {
       kind: "audio",
     });
 
-    await sendMessageMatrix("room:!room:example", "voice caption", {
+    const result = await sendMessageMatrix("room:!room:example", "voice caption", {
       client,
       cfg: {} as never,
       mediaUrl: "file:///tmp/clip.mp3",
@@ -691,6 +730,10 @@ describe("sendMessageMatrix media", () => {
     expect(requireRecord(transcriptContent["m.relates_to"], "relation")["m.in_reply_to"]).toEqual({
       event_id: "$reply",
     });
+    expect(result.receipt.parts).toMatchObject([
+      { platformMessageId: "$voice", kind: "voice", index: 0, replyToId: "$reply" },
+      { platformMessageId: "$transcript", kind: "text", index: 1, replyToId: "$reply" },
+    ]);
   });
 
   it("keeps regular audio payload when audioAsVoice media is incompatible", async () => {

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -64,23 +64,40 @@ type MatrixClientResolveOpts = {
   accountId?: string | null;
 };
 
-function createMatrixSendReceipt(params: {
-  roomId: string;
-  platformMessageIds: readonly string[];
+type MatrixReceiptEvent = {
+  messageId: string;
   kind: MessageReceiptPartKind;
   replyToId?: string;
+};
+
+function createMatrixSendReceipt(params: {
+  roomId: string;
+  events: readonly MatrixReceiptEvent[];
   threadId?: string | null;
 }) {
-  return createMessageReceiptFromOutboundResults({
-    kind: params.kind,
-    ...(params.replyToId ? { replyToId: params.replyToId } : {}),
+  const firstEvent = params.events[0];
+  const receipt = createMessageReceiptFromOutboundResults({
+    kind: firstEvent?.kind ?? "text",
+    ...(firstEvent?.replyToId ? { replyToId: firstEvent.replyToId } : {}),
     ...(params.threadId ? { threadId: params.threadId } : {}),
-    results: params.platformMessageIds.map((messageId) => ({
+    results: params.events.map(({ messageId }) => ({
       channel: "matrix",
       messageId,
       roomId: params.roomId,
     })),
   });
+  // Caption overflow is not a native reply; never copy the first event's relation onto later parts.
+  receipt.parts = receipt.parts.map((part, index) => {
+    const event = params.events[index]!;
+    const actualPart = { ...part, kind: event.kind };
+    if (event.replyToId) {
+      actualPart.replyToId = event.replyToId;
+    } else {
+      delete actualPart.replyToId;
+    }
+    return actualPart;
+  });
+  return receipt;
 }
 
 function isMatrixClient(value: MatrixClient | MatrixClientResolveOpts): value is MatrixClient {
@@ -332,7 +349,7 @@ export async function sendMessageMatrix(
         await opts.onPlatformSendDispatch?.();
         platformDispatchStarted = true;
       }
-      const platformMessageIds: string[] = [];
+      const acceptedEvents: MatrixReceiptEvent[] = [];
       const acceptedContents: string[] = [];
       let lastMessageId = "";
       for (const planned of plannedEvents) {
@@ -362,7 +379,14 @@ export async function sendMessageMatrix(
         if (!eventId) {
           continue;
         }
-        platformMessageIds.push(eventId);
+        // Media captions and text follow-ups can intentionally have different reply relations.
+        const eventReplyToId = planned.content["m.relates_to"]?.["m.in_reply_to"]?.event_id;
+        const acceptedEvent: MatrixReceiptEvent = {
+          messageId: eventId,
+          kind: planned.receiptKind,
+          ...(eventReplyToId ? { replyToId: eventReplyToId } : {}),
+        };
+        acceptedEvents.push(acceptedEvent);
         const visibleContent = planned.content.body ?? "";
         acceptedContents.push(visibleContent);
         await opts.onDeliveryResult?.({
@@ -371,9 +395,7 @@ export async function sendMessageMatrix(
           primaryMessageId: eventId,
           receipt: createMatrixSendReceipt({
             roomId,
-            platformMessageIds: [eventId],
-            kind: planned.receiptKind,
-            replyToId: opts.replyToId,
+            events: [acceptedEvent],
             threadId,
           }),
           content: visibleContent,
@@ -383,12 +405,10 @@ export async function sendMessageMatrix(
       return {
         messageId: lastMessageId || "unknown",
         roomId,
-        primaryMessageId: platformMessageIds[0] ?? (lastMessageId || "unknown"),
+        primaryMessageId: acceptedEvents[0]?.messageId ?? (lastMessageId || "unknown"),
         receipt: createMatrixSendReceipt({
           roomId,
-          platformMessageIds,
-          kind: plannedEvents[0]?.receiptKind ?? "text",
-          replyToId: opts.replyToId,
+          events: acceptedEvents,
           threadId,
         }),
         content: acceptedContents.join("\n"),
@@ -547,16 +567,16 @@ export async function sendSingleTextMessageMatrix(
         (content as Record<string, unknown>)[MSC4357_LIVE_KEY] = {};
       }
       const eventId = await client.sendMessage(resolvedRoom, content);
-      const platformMessageIds = eventId ? [eventId] : [];
+      const replyToId = content["m.relates_to"]?.["m.in_reply_to"]?.event_id;
       return {
         messageId: eventId ?? "unknown",
         roomId: resolvedRoom,
         primaryMessageId: eventId ?? "unknown",
         receipt: createMatrixSendReceipt({
           roomId: resolvedRoom,
-          platformMessageIds,
-          kind: "text",
-          replyToId: opts.replyToId,
+          events: eventId
+            ? [{ messageId: eventId, kind: "text", ...(replyToId ? { replyToId } : {}) }]
+            : [],
           threadId: normalizedThreadId,
         }),
         content: content.body,

--- a/extensions/matrix/src/outbound.test.ts
+++ b/extensions/matrix/src/outbound.test.ts
@@ -46,6 +46,24 @@ function mockOptions(
   return value as Record<string, unknown>;
 }
 
+function createMatrixReceipt(
+  parts: Array<{ messageId: string; kind: "text" | "media" | "voice"; replyToId?: string }>,
+) {
+  const firstPart = parts[0];
+  return {
+    primaryPlatformMessageId: firstPart?.messageId,
+    platformMessageIds: parts.map(({ messageId }) => messageId),
+    parts: parts.map(({ messageId, kind, replyToId }, index) => ({
+      platformMessageId: messageId,
+      kind,
+      index,
+      ...(replyToId ? { replyToId } : {}),
+    })),
+    ...(firstPart?.replyToId ? { replyToId: firstPart.replyToId } : {}),
+    sentAt: 1,
+  };
+}
+
 describe("matrixOutbound cfg threading", () => {
   beforeEach(() => {
     mocks.sendMessageMatrix.mockReset();
@@ -108,6 +126,44 @@ describe("matrixOutbound cfg threading", () => {
     expect(options.threadId).toBe("$thread");
     expect(options.replyToId).toBe("$reply");
   });
+
+  it.each(["sendText", "sendMedia"] as const)(
+    "preserves the complete Matrix sender result through %s",
+    async (method) => {
+      const receipt = createMatrixReceipt([
+        { messageId: "$first", kind: "media", replyToId: "$reply" },
+        { messageId: "$last", kind: "text" },
+      ]);
+      mocks.sendMessageMatrix.mockResolvedValueOnce({
+        messageId: "$last",
+        roomId: "!room:example",
+        primaryMessageId: "$first",
+        receipt,
+        content: "first\nlast",
+      });
+      const send = matrixOutbound[method];
+      if (!send) {
+        throw new Error(`matrixOutbound.${method} missing`);
+      }
+
+      const result = await send({
+        cfg: {} as OpenClawConfig,
+        to: "room:!room:example",
+        text: "first\nlast",
+        mediaUrl: "file:///tmp/photo.png",
+        accountId: "default",
+      });
+
+      expect(result).toMatchObject({
+        channel: "matrix",
+        messageId: "$last",
+        roomId: "!room:example",
+        primaryMessageId: "$first",
+        content: "first\nlast",
+      });
+      expect(result.receipt).toBe(receipt);
+    },
+  );
 
   it("passes resolved cfg to sendMessageMatrix for media sends", async () => {
     const cfg = {
@@ -471,6 +527,65 @@ describe("matrixOutbound cfg threading", () => {
       "file:///tmp/b.png",
     );
     expect(mockOptions(mocks.sendMessageMatrix, "sendMessageMatrix", 1).threadId).toBe("$thread");
+  });
+
+  it("combines media payload receipts without inventing replies on later events", async () => {
+    const firstReceipt = createMatrixReceipt([
+      { messageId: "$image", kind: "media", replyToId: "$reply" },
+      { messageId: "$caption-overflow", kind: "text" },
+    ]);
+    const secondReceipt = createMatrixReceipt([{ messageId: "$second-image", kind: "media" }]);
+    mocks.sendMessageMatrix
+      .mockResolvedValueOnce({
+        messageId: "$caption-overflow",
+        roomId: "!room:example",
+        primaryMessageId: "$image",
+        receipt: firstReceipt,
+        content: "caption\noverflow",
+      })
+      .mockResolvedValueOnce({
+        messageId: "$second-image",
+        roomId: "!room:example",
+        primaryMessageId: "$second-image",
+        receipt: secondReceipt,
+        content: "second image",
+      });
+
+    const result = await matrixOutbound.sendPayload!({
+      cfg: {} as OpenClawConfig,
+      to: "room:!room:example",
+      text: "caption",
+      payload: {
+        text: "caption",
+        mediaUrls: ["file:///tmp/a.png", "file:///tmp/b.png"],
+      },
+      accountId: "default",
+      replyToId: "$reply",
+      replyToIdSource: "implicit",
+      replyToMode: "first",
+    });
+
+    expect(mockOptions(mocks.sendMessageMatrix, "sendMessageMatrix", 0).replyToId).toBe("$reply");
+    expect(mockOptions(mocks.sendMessageMatrix, "sendMessageMatrix", 1).replyToId).toBeUndefined();
+    expect(result).toMatchObject({
+      channel: "matrix",
+      messageId: "$second-image",
+      primaryMessageId: "$image",
+      content: "caption\noverflow\nsecond image",
+    });
+    expect(result.receipt?.primaryPlatformMessageId).toBe("$image");
+    expect(result.receipt?.platformMessageIds).toEqual([
+      "$image",
+      "$caption-overflow",
+      "$second-image",
+    ]);
+    expect(result.receipt?.parts).toMatchObject([
+      { platformMessageId: "$image", kind: "media", index: 0, replyToId: "$reply" },
+      { platformMessageId: "$caption-overflow", kind: "text", index: 1 },
+      { platformMessageId: "$second-image", kind: "media", index: 2 },
+    ]);
+    expect(result.receipt?.parts[1]).not.toHaveProperty("replyToId");
+    expect(result.receipt?.parts[2]).not.toHaveProperty("replyToId");
   });
 
   it("sends mediaUrls with extraContent only on first item", async () => {

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -1,5 +1,9 @@
 // Matrix plugin module implements outbound behavior.
-import { createReplyToFanout } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  createMessageReceiptFromOutboundResults,
+  createReplyToFanout,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import {
   renderMessagePresentationFallbackText,
   type MessagePresentation,
@@ -104,7 +108,7 @@ function resolveMatrixDeliveryProgress(
 ) {
   return onDeliveryResult
     ? async (result: Awaited<ReturnType<typeof sendMessageMatrix>>) => {
-        await onDeliveryResult({ channel: "matrix", ...result });
+        await onDeliveryResult(attachChannelToResult("matrix", result));
       }
     : undefined;
 }
@@ -157,6 +161,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
     const urls = resolvePayloadMediaUrls(payload);
     const payloadText = resolveMatrixPayloadText(payload);
     if (urls.length > 0) {
+      const sentResults: Awaited<ReturnType<typeof sendMessageMatrix>>[] = [];
       const lastResult = await sendPayloadMediaSequence({
         text: payloadText,
         mediaUrls: urls,
@@ -174,13 +179,20 @@ export const matrixOutbound: ChannelOutboundAdapter = {
             extraContent: isFirst ? resolveMatrixExtraContent(payload) : undefined,
             onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
           }),
+        onResult: (result) => {
+          sentResults.push(result);
+        },
       });
       if (lastResult !== undefined) {
-        return {
-          channel: "matrix",
-          messageId: lastResult.messageId,
-          roomId: lastResult.roomId,
-        };
+        // One payload owns one receipt; keep every attachment and its original reply metadata.
+        const receipt = createMessageReceiptFromOutboundResults({ results: sentResults });
+        receipt.parts = receipt.parts.map((part, index) => ({ ...part, index }));
+        return attachChannelToResult("matrix", {
+          ...lastResult,
+          primaryMessageId: receipt.primaryPlatformMessageId,
+          receipt,
+          content: sentResults.map((result) => result.content).join("\n"),
+        });
       }
     }
     const result = await send(to, payloadText, {
@@ -195,11 +207,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       extraContent: resolveMatrixExtraContent(payload),
       onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
     });
-    return {
-      channel: "matrix",
-      messageId: result.messageId,
-      roomId: result.roomId,
-    };
+    return attachChannelToResult("matrix", result);
   },
   sendText: async ({
     cfg,
@@ -232,11 +240,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       onPlatformSendDispatch,
       onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
     });
-    return {
-      channel: "matrix",
-      messageId: result.messageId,
-      roomId: result.roomId,
-    };
+    return attachChannelToResult("matrix", result);
   },
   sendMedia: async ({
     cfg,
@@ -277,11 +281,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       onPlatformSendDispatch,
       onDeliveryResult: resolveMatrixDeliveryProgress(onDeliveryResult),
     });
-    return {
-      channel: "matrix",
-      messageId: result.messageId,
-      roomId: result.roomId,
-    };
+    return attachChannelToResult("matrix", result);
   },
   sendPoll: async ({ cfg, to, poll, threadId, accountId }) => {
     const resolvedThreadId = threadId !== undefined && threadId !== null ? threadId : undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix messages containing multiple chunks, attachments, captions, or voice transcripts lost their real message IDs and recorded incorrect message types or reply relationships.

## Why This Change Was Made

The Matrix sender now records each emitted event's actual type and native reply relationship. Matrix outbound adapters retain the sender's complete authoritative receipt, and multi-attachment delivery combines those receipts in real event order while preserving the existing final message ID.

## User Impact

Matrix conversations correctly account for every delivered text/image/audio event. Replies apply only to messages that actually replied, the first delivered event remains the primary message, later attachments remain discoverable, and ordinary single-message behavior is unchanged.

## Evidence

- Before: an actual PNG followed by overflow text produced wire events `[image reply, text nonreply]`, while public results reported only the last ID and incorrectly projected both events as replying media.
- After: actual sender, typed channel adapter, and multi-attachment fanout preserve every event ID, `[media,text]` kinds, `[reply,null]` reply facts, first primary ID, contiguous indices, and the final returned message ID.
- Focused hosted Testbox proof: `pnpm test extensions/matrix/src/matrix/send.test.ts extensions/matrix/src/outbound.test.ts extensions/matrix/src/channel.message-adapter.test.ts` — **96/96 tests across three suites passed**.
- Hosted runner: https://github.com/openclaw/openclaw/actions/runs/30760713254
- Additional actual runtime proof exercised a real PNG/shared file loader, Matrix message formatting, typed adapter, text chunking, voice, and first-only reply fanout.
- Fresh independent `gpt-5.6-sol`/high autoreview: no actionable P0/P1 findings; confidence 0.86. TruffleHog clean.
- Production delta: **+20 lines** for authoritative per-event and multi-attachment accounting. No SDK surface, configuration, permission, or persistent-state changes. AI-assisted and independently reviewed.
