### PR TITLE
fix(ios): preserve limited access when full upgrade fails

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -21811,7 +21811,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 156,
+      "line": 157,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Settings",
       "surface": "apple",
@@ -21819,7 +21819,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 264,
+      "line": 265,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Scan QR Code",
       "surface": "apple",
@@ -21827,7 +21827,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 286,
+      "line": 287,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset Onboarding?",
       "surface": "apple",
@@ -21835,7 +21835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 290,
+      "line": 291,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset",
       "surface": "apple",
@@ -21843,7 +21843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 298,
+      "line": 299,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This disconnects, clears saved gateway credentials, and reopens onboarding.",
       "surface": "apple",
@@ -21851,7 +21851,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 302,
+      "line": 303,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -21859,7 +21859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 311,
+      "line": 312,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -21867,7 +21867,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 320,
+      "line": 321,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Forget %@?",
       "surface": "apple",
@@ -21875,7 +21875,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 321,
+      "line": 322,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "gateway",
       "surface": "apple",
@@ -21883,7 +21883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 336,
+      "line": 337,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Forget Gateway",
       "surface": "apple",
@@ -21891,7 +21891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 342,
+      "line": 343,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -21899,7 +21899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 350,
+      "line": 351,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This removes saved credentials, device access, TLS trust, and cached chats for this gateway.",
       "surface": "apple",
@@ -21907,7 +21907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 404,
+      "line": 405,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Enable OpenClaw Hosted Push Relay?",
       "surface": "apple",
@@ -21915,7 +21915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 418,
+      "line": 419,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Continue",
       "surface": "apple",
@@ -21923,7 +21923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 426,
+      "line": 427,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Not Now",
       "surface": "apple",
@@ -22099,7 +22099,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 329,
+      "line": 330,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "TLS",
       "surface": "apple",
@@ -22107,7 +22107,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 329,
+      "line": 330,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "plain",
       "surface": "apple",
@@ -22115,7 +22115,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 332,
+      "line": 333,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup link loaded for %@:%@ (%@). Tap Connect to apply.",
       "surface": "apple",
@@ -22123,7 +22123,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 343,
+      "line": 344,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Paste a setup code to continue.",
       "surface": "apple",
@@ -22131,7 +22131,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 358,
+      "line": 359,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup code not recognized or uses an insecure ws:// gateway URL.",
       "surface": "apple",
@@ -22139,7 +22139,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 404,
+      "line": 417,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Opening QR scanner...",
       "surface": "apple",
@@ -22147,7 +22147,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 410,
+      "line": 423,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "QR loaded. Closing scanner...",
       "surface": "apple",
@@ -22155,7 +22155,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 440,
+      "line": 458,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Review demo mode enabled.",
       "surface": "apple",
@@ -22163,7 +22163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 491,
+      "line": 512,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Failed: host required",
       "surface": "apple",
@@ -22171,7 +22171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 499,
+      "line": 520,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Failed: invalid port",
       "surface": "apple",
@@ -22179,7 +22179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 557,
+      "line": 603,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Tailscale is off on this device. Turn it on, then try again.",
       "surface": "apple",
@@ -22187,7 +22187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 934,
+      "line": 980,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -22195,7 +22195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 935,
+      "line": 981,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -22203,7 +22203,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 936,
+      "line": 982,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Watch",
       "surface": "apple",
@@ -22211,7 +22211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 937,
+      "line": 983,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Approvals",
       "surface": "apple",
@@ -22219,7 +22219,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 938,
+      "line": 984,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permissions",
       "surface": "apple",
@@ -22227,7 +22227,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 939,
+      "line": 985,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Channels",
       "surface": "apple",
@@ -22235,7 +22235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 940,
+      "line": 986,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Skills",
       "surface": "apple",
@@ -22243,7 +22243,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 941,
+      "line": 987,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Voice & Talk",
       "surface": "apple",
@@ -22251,7 +22251,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 942,
+      "line": 988,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Diagnostics",
       "surface": "apple",
@@ -22259,7 +22259,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 943,
+      "line": 989,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Privacy",
       "surface": "apple",
@@ -22267,7 +22267,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 945,
+      "line": 991,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Licenses",
       "surface": "apple",
@@ -22275,7 +22275,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 946,
+      "line": 992,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "About",
       "surface": "apple",
@@ -22283,7 +22283,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 953,
+      "line": 999,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Preparing one-time setup…",
       "surface": "apple",
@@ -22291,7 +22291,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 958,
+      "line": 1004,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "surface": "apple",
@@ -22299,7 +22299,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 960,
+      "line": 1006,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
       "surface": "apple",
@@ -22307,7 +22307,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1050,
+      "line": 1096,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This gateway is on your tailnet. Turn on Tailscale on this device, then tap Connect.",
       "surface": "apple",
@@ -22315,7 +22315,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1057,
+      "line": 1103,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Pairing required. Run /pair approve in your OpenClaw chat, then connect again.",
       "surface": "apple",
@@ -22323,7 +22323,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1060,
+      "line": 1106,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Secure handshake failed. Check Tailscale, then connect again.",
       "surface": "apple",
@@ -22331,7 +22331,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1069,
+      "line": 1115,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connection timed out. Make sure Tailscale is connected, then try again.",
       "surface": "apple",
@@ -22339,7 +22339,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1073,
+      "line": 1119,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connected, but some controls are restricted for nodes. This is expected.",
       "surface": "apple",
@@ -22347,7 +22347,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1080,
+      "line": 1126,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup code applied. Connecting...",
       "surface": "apple",
@@ -22355,7 +22355,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1081,
+      "line": 1127,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checking gateway reachability...",
       "surface": "apple",
@@ -22363,7 +22363,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1082,
+      "line": 1128,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "QR loaded. Connecting to %@:%@...",
       "surface": "apple",
@@ -22371,7 +22371,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1145,
+      "line": 1191,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not loaded",
       "surface": "apple",
@@ -22379,7 +22379,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1148,
+      "line": 1194,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
@@ -22387,7 +22387,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1149,
+      "line": 1195,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -22395,7 +22395,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1156,
+      "line": 1202,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not active",
       "surface": "apple",
@@ -22403,7 +22403,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1192,
+      "line": 1238,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Review demo mode",
       "surface": "apple",
@@ -22411,7 +22411,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1195,
+      "line": 1241,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connected",
       "surface": "apple",
@@ -22419,7 +22419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1201,
+      "line": 1247,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "offline",
       "surface": "apple",
@@ -22427,7 +22427,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1201,
+      "line": 1247,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "online",
       "surface": "apple",
@@ -22435,7 +22435,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1219,
+      "line": 1265,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Live gateway requests are disabled in demo mode.",
       "surface": "apple",
@@ -22443,7 +22443,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1223,
+      "line": 1269,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Foreground approvals still appear while OpenClaw is connected.",
       "surface": "apple",
@@ -22451,7 +22451,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1226,
+      "line": 1272,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
@@ -22459,7 +22459,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1227,
+      "line": 1273,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -22467,7 +22467,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1231,
+      "line": 1277,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Demo mode only",
       "surface": "apple",
@@ -22475,7 +22475,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1238,
+      "line": 1284,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "loaded",
       "surface": "apple",
@@ -22483,7 +22483,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1239,
+      "line": 1285,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "missing",
       "surface": "apple",
@@ -22491,7 +22491,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1248,
+      "line": 1294,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Waiting for gateway",
       "surface": "apple",
@@ -22499,7 +22499,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1265,
+      "line": 1311,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "1 waiting",
       "surface": "apple",
@@ -22507,7 +22507,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1268,
+      "line": 1314,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "%@ waiting",
       "surface": "apple",
@@ -22515,7 +22515,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1279,
+      "line": 1325,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review gateway action",
       "surface": "apple",
@@ -22523,7 +22523,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1281,
+      "line": 1327,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Agent: %@",
       "surface": "apple",
@@ -22531,7 +22531,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1290,
+      "line": 1336,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
@@ -22539,7 +22539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1291,
+      "line": 1337,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
@@ -22547,7 +22547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1297,
+      "line": 1343,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
@@ -22555,7 +22555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1298,
+      "line": 1344,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
@@ -22563,7 +22563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1301,
+      "line": 1347,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
@@ -22571,7 +22571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1302,
+      "line": 1348,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
@@ -22579,7 +22579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1308,
+      "line": 1354,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk + Wake",
       "surface": "apple",
@@ -22587,7 +22587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1309,
+      "line": 1355,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk on",
       "surface": "apple",
@@ -22595,7 +22595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1310,
+      "line": 1356,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Wake on",
       "surface": "apple",
@@ -22603,7 +22603,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1311,
+      "line": 1357,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Off",
       "surface": "apple",
@@ -22611,7 +22611,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1315,
+      "line": 1361,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "demo",
       "surface": "apple",
@@ -22619,7 +22619,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1316,
+      "line": 1362,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "ready",
       "surface": "apple",
@@ -22627,7 +22627,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1317,
+      "line": 1363,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "check",
       "surface": "apple",
@@ -22635,7 +22635,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1318,
+      "line": 1364,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "partial",
       "surface": "apple",
@@ -22643,7 +22643,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1322,
+      "line": 1368,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "pending",
       "surface": "apple",
@@ -22651,7 +22651,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1324,
+      "line": 1370,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "pass",
       "surface": "apple",
@@ -22659,7 +22659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1335,
+      "line": 1381,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Requesting iOS location permission…",
       "surface": "apple",
@@ -22667,7 +22667,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1401,
+      "line": 1447,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This build uses OpenClaw's hosted push relay at %@ for notification delivery data.",
       "surface": "apple",
@@ -22675,7 +22675,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1405,
+      "line": 1451,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This build is not configured to use OpenClaw's hosted push relay.",
       "surface": "apple",
@@ -22683,7 +22683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1410,
+      "line": 1456,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Enabling this sends delivery data through OpenClaw's hosted push relay.",
       "surface": "apple",
@@ -26147,7 +26147,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4175,
+      "line": 4190,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -26155,7 +26155,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4176,
+      "line": 4191,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -26163,7 +26163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4891,
+      "line": 4984,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -26171,7 +26171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4892,
+      "line": 4985,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -26179,7 +26179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5247,
+      "line": 5340,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -26187,7 +26187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5247,
+      "line": 5340,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -26195,7 +26195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6417,
+      "line": 6510,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -26203,7 +26203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6479,
+      "line": 6572,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -26211,7 +26211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6479,
+      "line": 6572,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -26219,7 +26219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8838,
+      "line": 8931,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -26227,7 +26227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8838,
+      "line": 8931,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -26235,7 +26235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8844,
+      "line": 8937,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -26243,7 +26243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8845,
+      "line": 8938,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -26251,7 +26251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10215,
+      "line": 10308,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -26163,7 +26163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4984,
+      "line": 4990,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -26171,7 +26171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4985,
+      "line": 4991,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -26179,7 +26179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5340,
+      "line": 5346,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -26187,7 +26187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5340,
+      "line": 5346,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -26195,7 +26195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6510,
+      "line": 6516,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -26203,7 +26203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6572,
+      "line": 6578,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -26211,7 +26211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6572,
+      "line": 6578,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -26219,7 +26219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8931,
+      "line": 8937,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -26227,7 +26227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8931,
+      "line": 8937,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -26235,7 +26235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8937,
+      "line": 8943,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -26243,7 +26243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8938,
+      "line": 8944,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -26251,7 +26251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10308,
+      "line": 10314,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",

--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -62,6 +62,7 @@ struct SettingsProTab: View {
     @State var pendingManualAuthOverride: GatewayConnectionController.ManualAuthOverride?
     @State var scannerResultHandoff = QRScannerResultHandoff()
     @State var scannerScanID: UInt64 = 0
+    @State var preserveExistingGatewayAccessForScan = false
     @State var pendingTargetSuppression = GatewayPendingTargetSuppression()
     @State var defaultShareInstruction = ""
     @State var showQRScanner = false

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -320,6 +320,7 @@ extension SettingsProTab {
         // Only the root-selected Gateway destination may destructively claim a
         // setup link; other Settings views can remain mounted behind onboarding.
         self.showQRScanner = false
+        self.preserveExistingGatewayAccessForScan = false
         self.scannerResultHandoff.cancel()
         let lease = self.gatewayController.cancelPendingConnectionAttempts()
         self.pendingTargetSuppression.replace(owner: .setupLink, lease: lease)
@@ -366,7 +367,10 @@ extension SettingsProTab {
         return true
     }
 
-    func applyGatewayLink(_ link: GatewayConnectDeepLink) async {
+    func applyGatewayLink(
+        _ link: GatewayConnectDeepLink,
+        preservingExistingAccess requestedPreservation: Bool = false) async
+    {
         self.manualGatewayHost = link.host
         self.manualGatewayPort = link.port
         self.manualGatewayPortText = String(link.port)
@@ -374,13 +378,17 @@ extension SettingsProTab {
         let instanceId = GatewaySettingsStore.currentInstanceID()
         let setupAuth = GatewayConnectionController.ManualAuthOverride.setupAuth(from: link)
         self.gatewayCredentialFieldStableID = setupAuth.targetStableID
+        let preserveExistingAccess = requestedPreservation && setupAuth.hasBootstrapToken &&
+            self.hasStoredGatewayAccess(gatewayStableID: setupAuth.targetStableID)
+        self.preserveExistingGatewayAccessForScan = preserveExistingAccess
         if setupAuth.hasBootstrapToken {
             await GatewayOnboardingReset.prepareForBootstrapPairing(
                 appModel: self.appModel,
                 instanceId: instanceId,
-                gatewayStableID: setupAuth.targetStableID)
+                gatewayStableID: setupAuth.targetStableID,
+                preserveExistingAccess: preserveExistingAccess)
         }
-        if !instanceId.isEmpty {
+        if !instanceId.isEmpty, !preserveExistingAccess {
             GatewaySettingsStore.saveGatewayCredentials(
                 token: setupAuth.token,
                 bootstrapToken: setupAuth.bootstrapToken,
@@ -395,9 +403,14 @@ extension SettingsProTab {
     }
 
     func openGatewayQRScanner() {
+        self.openGatewayQRScanner(preservingExistingAccess: false)
+    }
+
+    func openGatewayQRScanner(preservingExistingAccess: Bool) {
         self.invalidateGatewaySetupAttempt()
         let lease = self.gatewayController.cancelPendingConnectionAttempts(suspendCurrentGateway: true)
         self.stagedGatewaySetupLink = nil
+        self.preserveExistingGatewayAccessForScan = preservingExistingAccess
         self.pendingTargetSuppression.replace(owner: .qrScanner, lease: lease)
         self.scannerScanID = self.scannerResultHandoff.beginScan()
         self.connectingGateway = nil
@@ -421,18 +434,23 @@ extension SettingsProTab {
             }
         }
         if delivery == nil {
+            self.preserveExistingGatewayAccessForScan = false
             self.pendingTargetSuppression.resumeAutoConnect(.qrScanner, controller: self.gatewayController)
         }
     }
 
     func handleScannedGatewayLink(_ link: GatewayConnectDeepLink) {
         self.showQRScanner = false
-        guard let attemptID = self.beginGatewaySetupAttempt() else { return }
+        guard let attemptID = self.beginGatewaySetupAttempt() else {
+            self.preserveExistingGatewayAccessForScan = false
+            return
+        }
         self.setupCode = ""
         Task { await self.connectAfterScannedGatewayLink(link, attemptID: attemptID) }
     }
 
     func handleScannedSetupCode(_ code: String) {
+        self.preserveExistingGatewayAccessForScan = false
         guard AppleReviewDemoMode.isSetupCode(code) else { return }
         self.showQRScanner = false
         self.setupCode = ""
@@ -455,12 +473,15 @@ extension SettingsProTab {
 
     func connectAfterScannedGatewayLink(_ parsedLink: GatewayConnectDeepLink, attemptID: UUID) async {
         defer {
+            self.preserveExistingGatewayAccessForScan = false
             self.finishGatewaySetupAttempt(attemptID)
             self.pendingTargetSuppression.resumeAutoConnect(.qrScanner, controller: self.gatewayController)
         }
         let link = await self.gatewayController.selectReachableSetupLink(parsedLink)
         guard self.setupAttemptID == attemptID else { return }
-        await self.applyGatewayLink(link)
+        await self.applyGatewayLink(
+            link,
+            preservingExistingAccess: self.preserveExistingGatewayAccessForScan)
         self.setupStatusText = String(
             format: String(localized: "QR loaded. Connecting to %@:%@..."),
             link.host,
@@ -508,7 +529,15 @@ extension SettingsProTab {
         let stableID = GatewayConnectionController.ManualAuthOverride.manualStableID(
             host: host,
             port: port)
+        let preservedSetupOverride = self.preserveExistingGatewayAccessForScan
+            ? self.pendingManualAuthOverride
+            : nil
         self.selectGatewayCredentialTarget(stableID, allowManualOverride: true)
+        if GatewayStableIdentifier.matches(preservedSetupOverride?.targetStableID, stableID) {
+            // Upgrade bootstrap credentials are intentionally memory-only so a crash or
+            // rejected handoff cannot replace the working Limited credential bundle.
+            self.pendingManualAuthOverride = preservedSetupOverride
+        }
         if GatewayStableIdentifier.matches(
             self.appModel.activeGatewayConnectConfig?.effectiveStableID,
             stableID),
@@ -530,7 +559,10 @@ extension SettingsProTab {
             password: fieldsMatchTarget ? self.gatewayPassword : nil,
             targetStableID: stableID)
         let instanceId = GatewaySettingsStore.currentInstanceID()
-        if !instanceId.isEmpty, fieldsMatchTarget || pendingOverride != nil {
+        if !instanceId.isEmpty,
+           !self.preserveExistingGatewayAccessForScan,
+           fieldsMatchTarget || pendingOverride != nil
+        {
             GatewaySettingsStore.saveGatewayCredentials(
                 token: authOverride?.token,
                 bootstrapToken: authOverride?.bootstrapToken,
@@ -547,6 +579,20 @@ extension SettingsProTab {
         // The controller now owns this attempt's immutable override. A later retry must reload
         // durable state so a spent bootstrap token cannot be resurrected from the live view.
         self.pendingManualAuthOverride = nil
+    }
+
+    private func hasStoredGatewayAccess(gatewayStableID: String) -> Bool {
+        guard let identity = DeviceIdentityStore.loadOrCreatePersisted() else { return false }
+        let authenticationOwnerID = GatewaySettingsStore.authenticationOwnerID(
+            routeStableID: gatewayStableID)
+        return DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "node",
+            gatewayID: authenticationOwnerID) != nil &&
+            DeviceAuthStore.loadToken(
+                deviceId: identity.deviceId,
+                role: "operator",
+                gatewayID: authenticationOwnerID) != nil
     }
 
     func preflightGateway(host: String) async -> Bool {

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -386,7 +386,7 @@ extension SettingsProTab {
                             .fixedSize(horizontal: false, vertical: true)
                     }
                     Button {
-                        self.openGatewayQRScanner()
+                        self.openGatewayQRScanner(preservingExistingAccess: true)
                     } label: {
                         Label("Scan Full-Access Code", systemImage: "qrcode.viewfinder")
                             .font(OpenClawType.body)

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -4494,8 +4494,8 @@ extension NodeAppModel {
             owner: .gateway,
             title: "Gateway update required",
             message: pauseReconnect
-                ? "This Gateway did not issue the access credentials this phone needs. Update the Gateway, then scan a new Full-Access code."
-                : "Full access was not issued. Your existing Limited connection was restored; update the Gateway, then scan a new Full-Access code.",
+                ? "This Gateway did not issue the access credentials this phone needs. Update the Gateway, then scan a new Full-Access code." // swiftlint:disable:this line_length
+                : "Full access was not issued. Your existing Limited connection was restored; update the Gateway, then scan a new Full-Access code.", // swiftlint:disable:this line_length
             actionLabel: "Copy update command",
             actionCommand: "openclaw update",
             retryable: false,

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -9,6 +9,17 @@ import SwiftUI
 import UIKit
 import UserNotifications
 
+private enum GatewayCredentialHandoffError: LocalizedError {
+    case deviceAuthPersistenceFailed(missingRoles: Set<String>)
+
+    var errorDescription: String? {
+        switch self {
+        case let .deviceAuthPersistenceFailed(missingRoles):
+            "Could not save device authentication for: \(missingRoles.sorted().joined(separator: ", "))"
+        }
+    }
+}
+
 private let clientDatabaseLogger = Logger(
     subsystem: "ai.openclawfoundation.app",
     category: "ClientDatabases")
@@ -482,6 +493,8 @@ final class NodeAppModel {
     @ObservationIgnored private var operatorTalkConnectionGeneration: UInt64 = 0
     @ObservationIgnored private var operatorTalkHydrationGeneration: UInt64?
     @ObservationIgnored private var credentialHandoffFailureGeneration: UInt64?
+    @ObservationIgnored private var credentialHandoffIncompleteGeneration: UInt64?
+    @ObservationIgnored private var credentialHandoffMissingRoles = Set<String>()
     @ObservationIgnored private(set) var gatewayConnectGeneration: UInt64 = 0
     private var forceOperatorTalkPermissionUpgradeRequest = false
     @ObservationIgnored private var talkPermissionUpgradeTask: Task<Void, Never>?
@@ -4069,6 +4082,8 @@ extension NodeAppModel {
             self.clearGatewayConnectionProblem()
         }
         self.credentialHandoffFailureGeneration = nil
+        self.credentialHandoffIncompleteGeneration = nil
+        self.credentialHandoffMissingRoles = []
         self.nodeGatewayTask?.cancel()
         self.operatorGatewayTask?.cancel()
         self.gatewayHealthMonitor.stop()
@@ -4291,15 +4306,29 @@ extension NodeAppModel {
     private func completeSuccessfulGatewayAuthHandoff(
         stableID: String,
         routeGeneration: UInt64,
-        issuedRoles: Set<String>,
+        handoff: GatewayDeviceAuthHandoff,
         nodeOptions: GatewayConnectOptions) throws -> GatewayConnectOptions?
     {
         guard self.isCurrentGatewayRoute(generation: routeGeneration, stableID: stableID) else { return nil }
 
         // Bootstrap authentication is single-use. Do not keep a consumed bootstrap
         // route alive unless both replacement sessions can authenticate from secure storage.
-        guard issuedRoles.isSuperset(of: ["node", "operator"]) else {
-            return nodeOptions.allowStoredDeviceAuth ? nodeOptions : nil
+        let requiredRoles: Set<String> = ["node", "operator"]
+        let missingOfferedRoles = requiredRoles.subtracting(handoff.offeredRoles)
+        if missingOfferedRoles.isEmpty {
+            guard handoff.persistedRoles.isSuperset(of: requiredRoles) else {
+                throw GatewayCredentialHandoffError.deviceAuthPersistenceFailed(
+                    missingRoles: requiredRoles.subtracting(handoff.persistedRoles))
+            }
+            self.credentialHandoffIncompleteGeneration = nil
+            self.credentialHandoffMissingRoles = []
+        } else {
+            let deviceAuthGatewayID = nodeOptions.deviceAuthGatewayID ?? stableID
+            guard self.hasStoredGatewayRoleToken("node", gatewayID: deviceAuthGatewayID),
+                  self.hasStoredGatewayRoleToken("operator", gatewayID: deviceAuthGatewayID)
+            else { return nil }
+            self.credentialHandoffIncompleteGeneration = routeGeneration
+            self.credentialHandoffMissingRoles = missingOfferedRoles
         }
         guard let config = activeGatewayConnectConfig,
               GatewayStableIdentifier.matches(config.effectiveStableID, stableID)
@@ -4364,14 +4393,14 @@ extension NodeAppModel {
         else {
             return nodeOptions
         }
-        let issuedRoles = await nodeGateway.currentIssuedDeviceAuthRoles()
+        let handoff = await nodeGateway.currentDeviceAuthHandoff()
         guard self.isCurrentGatewayRoute(generation: routeGeneration, stableID: stableID) else { return nil }
         let reconnectOptions: GatewayConnectOptions?
         do {
             reconnectOptions = try self.completeSuccessfulGatewayAuthHandoff(
                 stableID: stableID,
                 routeGeneration: routeGeneration,
-                issuedRoles: issuedRoles,
+                handoff: handoff,
                 nodeOptions: nodeOptions)
         } catch {
             await self.handleGatewayCredentialHandoffPersistenceFailure(
@@ -4381,9 +4410,10 @@ extension NodeAppModel {
             return nil
         }
         guard let reconnectOptions else {
-            await self.handleGatewayCredentialHandoffPersistenceFailure(
+            await self.handleGatewayCredentialHandoffRoleFailure(
                 stableID: stableID,
-                routeGeneration: routeGeneration)
+                routeGeneration: routeGeneration,
+                handoff: handoff)
             return nil
         }
         return reconnectOptions
@@ -4417,6 +4447,60 @@ extension NodeAppModel {
             retryable: true,
             pauseReconnect: true,
             technicalDetails: technicalDetails))
+    }
+
+    private func handleGatewayCredentialHandoffRoleFailure(
+        stableID: String,
+        routeGeneration: UInt64,
+        handoff: GatewayDeviceAuthHandoff) async
+    {
+        guard self.isCurrentGatewayRoute(generation: routeGeneration, stableID: stableID) else { return }
+        guard self.credentialHandoffFailureGeneration != routeGeneration else { return }
+        self.credentialHandoffFailureGeneration = routeGeneration
+        self.disableGatewayAutoReconnect()
+        self.nodeGatewayTask?.cancel()
+        self.nodeGatewayTask = nil
+        self.operatorGatewayTask?.cancel()
+        self.operatorGatewayTask = nil
+        await self.nodeGateway.disconnect()
+        await self.operatorGateway.disconnect()
+        guard self.isCurrentGatewayRoute(generation: routeGeneration, stableID: stableID) else { return }
+        self.applyGatewayAccessHandoffProblem(
+            handoff: handoff,
+            pauseReconnect: true)
+    }
+
+    private func applyGatewayAccessHandoffProblem(
+        handoff: GatewayDeviceAuthHandoff,
+        pauseReconnect: Bool)
+    {
+        let problem = self.gatewayAccessHandoffProblem(
+            handoff: handoff,
+            pauseReconnect: pauseReconnect)
+        GatewayDiagnostics.log(problem.technicalDetails ?? problem.message)
+        self.applyGatewayConnectionProblem(problem)
+    }
+
+    private func gatewayAccessHandoffProblem(
+        handoff: GatewayDeviceAuthHandoff,
+        pauseReconnect: Bool) -> GatewayConnectionProblem
+    {
+        let requiredRoles: Set<String> = ["node", "operator"]
+        let missingRoles = requiredRoles.subtracting(handoff.offeredRoles)
+        let technicalDetails = "Gateway access handoff incomplete; missing roles: " +
+            missingRoles.sorted().joined(separator: ", ") + "."
+        return GatewayConnectionProblem(
+            kind: .protocolMismatch,
+            owner: .gateway,
+            title: "Gateway update required",
+            message: pauseReconnect
+                ? "This Gateway did not issue the access credentials this phone needs. Update the Gateway, then scan a new Full-Access code."
+                : "Full access was not issued. Your existing Limited connection was restored; update the Gateway, then scan a new Full-Access code.",
+            actionLabel: "Copy update command",
+            actionCommand: "openclaw update",
+            retryable: false,
+            pauseReconnect: pauseReconnect,
+            technicalDetails: technicalDetails)
     }
 
     private func refreshBackgroundReconnectSuppressionIfNeeded(source: String) {
@@ -4556,18 +4640,19 @@ extension NodeAppModel {
             bootstrapToken: auth.bootstrapToken,
             password: auth.password)
         if usedBootstrapToken {
-            let issuedRoles = await nodeGateway.currentIssuedDeviceAuthRoles()
+            let handoff = await nodeGateway.currentDeviceAuthHandoff()
             guard self.isCurrentGatewayRoute(generation: routeGeneration, stableID: stableID) else { return }
             do {
                 guard try self.completeSuccessfulGatewayAuthHandoff(
                     stableID: stableID,
                     routeGeneration: routeGeneration,
-                    issuedRoles: issuedRoles,
+                    handoff: handoff,
                     nodeOptions: nodeOptions) != nil
                 else {
-                    await self.handleGatewayCredentialHandoffPersistenceFailure(
+                    await self.handleGatewayCredentialHandoffRoleFailure(
                         stableID: stableID,
-                        routeGeneration: routeGeneration)
+                        routeGeneration: routeGeneration,
+                        handoff: handoff)
                     return
                 }
             } catch {
@@ -4583,6 +4668,14 @@ extension NodeAppModel {
         self.gatewayStatusText = "Connected"
         self.gatewayServerName = url.host ?? "gateway"
         self.gatewayConnected = true
+        if self.credentialHandoffIncompleteGeneration == routeGeneration {
+            self.applyGatewayAccessHandoffProblem(
+                handoff: GatewayDeviceAuthHandoff(
+                    offeredRoles: Set(["node", "operator"])
+                        .subtracting(self.credentialHandoffMissingRoles),
+                    persistedRoles: []),
+                pauseReconnect: false)
+        }
         _ = GatewaySettingsStore.markGatewayConnected(
             stableID: stableID,
             atMs: Int(Date().timeIntervalSince1970 * 1000))
@@ -11195,7 +11288,36 @@ extension NodeAppModel {
         return try self.completeSuccessfulGatewayAuthHandoff(
             stableID: stableID,
             routeGeneration: self.gatewayRouteGeneration,
-            issuedRoles: issuedRoles,
+            handoff: GatewayDeviceAuthHandoff(
+                offeredRoles: issuedRoles,
+                persistedRoles: issuedRoles),
+            nodeOptions: nodeOptions)
+    }
+
+    func _test_gatewayAccessHandoffProblem(
+        offeredRoles: Set<String>,
+        persistedRoles: Set<String>,
+        pauseReconnect: Bool) -> GatewayConnectionProblem
+    {
+        self.gatewayAccessHandoffProblem(
+            handoff: GatewayDeviceAuthHandoff(
+                offeredRoles: offeredRoles,
+                persistedRoles: persistedRoles),
+            pauseReconnect: pauseReconnect)
+    }
+
+    func _test_completeSuccessfulGatewayAuthHandoff(
+        offeredRoles: Set<String>,
+        persistedRoles: Set<String>,
+        nodeOptions: GatewayConnectOptions) throws -> GatewayConnectOptions?
+    {
+        guard let stableID = activeGatewayConnectConfig?.effectiveStableID else { return nil }
+        return try self.completeSuccessfulGatewayAuthHandoff(
+            stableID: stableID,
+            routeGeneration: self.gatewayRouteGeneration,
+            handoff: GatewayDeviceAuthHandoff(
+                offeredRoles: offeredRoles,
+                persistedRoles: persistedRoles),
             nodeOptions: nodeOptions)
     }
 

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -4313,7 +4313,7 @@ extension NodeAppModel {
 
         // Bootstrap authentication is single-use. Do not keep a consumed bootstrap
         // route alive unless both replacement sessions can authenticate from secure storage.
-        let requiredRoles: Set<String> = ["node", "operator"]
+        let requiredRoles: Set = ["node", "operator"]
         let missingOfferedRoles = requiredRoles.subtracting(handoff.offeredRoles)
         if missingOfferedRoles.isEmpty {
             guard handoff.persistedRoles.isSuperset(of: requiredRoles) else {
@@ -4485,17 +4485,23 @@ extension NodeAppModel {
         handoff: GatewayDeviceAuthHandoff,
         pauseReconnect: Bool) -> GatewayConnectionProblem
     {
-        let requiredRoles: Set<String> = ["node", "operator"]
+        let requiredRoles: Set = ["node", "operator"]
         let missingRoles = requiredRoles.subtracting(handoff.offeredRoles)
         let technicalDetails = "Gateway access handoff incomplete; missing roles: " +
             missingRoles.sorted().joined(separator: ", ") + "."
+        let pausedMessage = """
+        This Gateway did not issue the access credentials this phone needs. \
+        Update the Gateway, then scan a new Full-Access code.
+        """
+        let restoredMessage = """
+        Full access was not issued. Your existing Limited connection was restored; \
+        update the Gateway, then scan a new Full-Access code.
+        """
         return GatewayConnectionProblem(
             kind: .protocolMismatch,
             owner: .gateway,
             title: "Gateway update required",
-            message: pauseReconnect
-                ? "This Gateway did not issue the access credentials this phone needs. Update the Gateway, then scan a new Full-Access code." // swiftlint:disable:this line_length
-                : "Full access was not issued. Your existing Limited connection was restored; update the Gateway, then scan a new Full-Access code.", // swiftlint:disable:this line_length
+            message: pauseReconnect ? pausedMessage : restoredMessage,
             actionLabel: "Copy update command",
             actionCommand: "openclaw update",
             retryable: false,

--- a/apps/ios/Sources/Onboarding/GatewayOnboardingReset.swift
+++ b/apps/ios/Sources/Onboarding/GatewayOnboardingReset.swift
@@ -18,7 +18,7 @@ enum GatewayOnboardingReset {
             // Gateway proves that replacement node and operator auth were issued.
             return true
         }
-        await self.prepare(
+        return await self.prepare(
             appModel: appModel,
             instanceId: instanceId,
             gatewayStableID: gatewayStableID,

--- a/apps/ios/Sources/Onboarding/GatewayOnboardingReset.swift
+++ b/apps/ios/Sources/Onboarding/GatewayOnboardingReset.swift
@@ -9,8 +9,15 @@ enum GatewayOnboardingReset {
         instanceId: String,
         gatewayStableID: String,
         disconnectGateway: Bool = true,
+        preserveExistingAccess: Bool = false,
         defaults: UserDefaults = .standard) async -> Bool
     {
+        if preserveExistingAccess {
+            // A same-target access upgrade uses the bootstrap token only for this
+            // connection attempt. Keep the working Limited route intact until the
+            // Gateway proves that replacement node and operator auth were issued.
+            return true
+        }
         await self.prepare(
             appModel: appModel,
             instanceId: instanceId,

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -1281,10 +1281,11 @@ private func waitUntil(
         defer { appModel.disconnectGateway() }
         appModel.applyGatewayConnectConfig(config)
 
-        let restoredOptions = try #require(appModel._test_completeSuccessfulGatewayAuthHandoff(
+        let incompleteOptions = try appModel._test_completeSuccessfulGatewayAuthHandoff(
             offeredRoles: ["node"],
             persistedRoles: ["node"],
-            nodeOptions: nodeOptions))
+            nodeOptions: nodeOptions)
+        let restoredOptions = try #require(incompleteOptions)
 
         #expect(restoredOptions.allowStoredDeviceAuth)
         #expect(appModel.activeGatewayConnectConfig?.bootstrapToken == nil)

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -1199,6 +1199,140 @@ private func waitUntil(
         #expect(GatewayTLSStore.loadFingerprint(stableID: gatewayB) == nil)
     }
 
+    @Test @MainActor func `access upgrade preserves the working target gateway`() async throws {
+        let temporaryState = try TemporaryOpenClawState()
+        defer { temporaryState.restore() }
+        let stableID = "manual|limited-gateway-\(UUID().uuidString)|443"
+        defer { GatewayTLSStore.clearFingerprint(stableID: stableID) }
+        let primaryIdentity = DeviceIdentityStore.loadOrCreate()
+        let shareIdentity = DeviceIdentityStore.loadOrCreate(profile: .shareExtension)
+        let authenticationOwnerID = GatewaySettingsStore.authenticationOwnerID(routeStableID: stableID)
+        for (identity, profile) in [
+            (primaryIdentity, GatewayDeviceIdentityProfile.primary),
+            (shareIdentity, GatewayDeviceIdentityProfile.shareExtension),
+        ] {
+            for role in ["node", "operator"] {
+                _ = DeviceAuthStore.storeToken(
+                    deviceId: identity.deviceId,
+                    role: role,
+                    token: "\(profile)-\(role)-token",
+                    gatewayID: authenticationOwnerID,
+                    profile: profile)
+            }
+        }
+        GatewayTLSStore.saveFingerprint("trusted-fingerprint", stableID: stableID)
+
+        let appModel = NodeAppModel()
+        let prepared = await GatewayOnboardingReset.prepareForBootstrapPairing(
+            appModel: appModel,
+            instanceId: "",
+            gatewayStableID: stableID,
+            disconnectGateway: false,
+            preserveExistingAccess: true)
+
+        #expect(prepared)
+        for (identity, profile) in [
+            (primaryIdentity, GatewayDeviceIdentityProfile.primary),
+            (shareIdentity, GatewayDeviceIdentityProfile.shareExtension),
+        ] {
+            for role in ["node", "operator"] {
+                #expect(DeviceAuthStore.loadToken(
+                    deviceId: identity.deviceId,
+                    role: role,
+                    gatewayID: authenticationOwnerID,
+                    profile: profile) != nil)
+            }
+        }
+        #expect(GatewayTLSStore.loadFingerprint(stableID: stableID) == "trusted-fingerprint")
+    }
+
+    @Test @MainActor func `incomplete access upgrade restores preserved limited auth`() throws {
+        let stableID = "manual|limited-gateway.example.com|443"
+        let instanceID = "limited-upgrade-\(UUID().uuidString)"
+        let temporaryState = try TemporaryOpenClawState(instanceID: instanceID)
+        defer { temporaryState.restore() }
+        let identity = DeviceIdentityStore.loadOrCreate()
+        for role in ["node", "operator"] {
+            _ = DeviceAuthStore.storeToken(
+                deviceId: identity.deviceId,
+                role: role,
+                token: "existing-\(role)-token",
+                gatewayID: stableID)
+        }
+        GatewaySettingsStore.saveGatewayCredentials(
+            token: "existing-shared-token",
+            bootstrapToken: nil,
+            password: nil,
+            gatewayStableID: stableID,
+            suppressStoredDeviceAuth: false,
+            instanceId: instanceID)
+        let nodeOptions = Self.makeNodeOptions(
+            allowStoredDeviceAuth: false,
+            deviceAuthGatewayID: stableID)
+        let config = try GatewayConnectConfig(
+            url: #require(URL(string: "wss://127.0.0.1:1")),
+            stableID: stableID,
+            tls: nil,
+            token: nil,
+            bootstrapToken: "one-time-bootstrap",
+            password: nil,
+            nodeOptions: nodeOptions)
+        let appModel = NodeAppModel()
+        defer { appModel.disconnectGateway() }
+        appModel.applyGatewayConnectConfig(config)
+
+        let restoredOptions = try #require(appModel._test_completeSuccessfulGatewayAuthHandoff(
+            offeredRoles: ["node"],
+            persistedRoles: ["node"],
+            nodeOptions: nodeOptions))
+
+        #expect(restoredOptions.allowStoredDeviceAuth)
+        #expect(appModel.activeGatewayConnectConfig?.bootstrapToken == nil)
+        #expect(appModel.activeGatewayConnectConfig?.nodeOptions.allowStoredDeviceAuth == true)
+        #expect(GatewaySettingsStore.loadGatewayCredentials(
+            instanceId: instanceID,
+            gatewayStableID: stableID).token == "existing-shared-token")
+        #expect(DeviceAuthStore.loadToken(
+            deviceId: identity.deviceId,
+            role: "operator",
+            gatewayID: stableID)?.token == "existing-operator-token")
+
+        let problem = appModel._test_gatewayAccessHandoffProblem(
+            offeredRoles: ["node"],
+            persistedRoles: ["node"],
+            pauseReconnect: false)
+        #expect(problem.kind == .protocolMismatch)
+        #expect(problem.owner == .gateway)
+        #expect(!problem.retryable)
+        #expect(!problem.pauseReconnect)
+        #expect(problem.message.contains("Limited connection was restored"))
+    }
+
+    @Test @MainActor func `offered auth that cannot persist remains an iphone failure`() throws {
+        let stableID = "manual|persistence-failure.example.com|443"
+        let nodeOptions = Self.makeNodeOptions(
+            allowStoredDeviceAuth: false,
+            deviceAuthGatewayID: stableID)
+        let config = try GatewayConnectConfig(
+            url: #require(URL(string: "wss://127.0.0.1:1")),
+            stableID: stableID,
+            tls: nil,
+            token: nil,
+            bootstrapToken: "one-time-bootstrap",
+            password: nil,
+            nodeOptions: nodeOptions)
+        let appModel = NodeAppModel()
+        defer { appModel.disconnectGateway() }
+        appModel.applyGatewayConnectConfig(config)
+
+        #expect(throws: Error.self) {
+            _ = try appModel._test_completeSuccessfulGatewayAuthHandoff(
+                offeredRoles: ["node", "operator"],
+                persistedRoles: ["node"],
+                nodeOptions: nodeOptions)
+        }
+    }
+
     @Test @MainActor func `explicit auth starts operator loop while stored auth is disabled`() throws {
         let stableID = "manual|gateway.example.com|443"
         let appModel = NodeAppModel()

--- a/apps/ios/Tests/RootTabsSourceGuardTests+GatewaySupport.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests+GatewaySupport.swift
@@ -82,6 +82,8 @@ extension RootTabsSourceGuardTests {
         #expect(sectionsSource.contains("This phone has limited Gateway access."))
         #expect(sectionsSource.contains("Use a secure wss:// or Tailscale Serve Gateway"))
         #expect(sectionsSource.contains("Label(\"Scan Full-Access Code\""))
+        #expect(sectionsSource.contains(
+            "self.openGatewayQRScanner(preservingExistingAccess: true)"))
         #expect(sectionsSource.contains("self.gatewayActions"))
         #expect(sectionsSource.contains("self.manualGatewayCard"))
         #expect(sectionsSource.contains("self.gatewaySetupCard"))

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -3,6 +3,10 @@ import Foundation
 import OpenClawProtocol
 import OSLog
 
+// This transport actor intentionally keeps socket ownership and connect-handshake
+// state together so generation guards remain auditable.
+// swiftlint:disable file_length
+
 /// Avoid ambiguity with the app's own AnyCodable type.
 private typealias ProtoAnyCodable = OpenClawProtocol.AnyCodable
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -913,7 +913,8 @@ extension GatewayChannelActor {
         role: String,
         deviceAuthGatewayID: String?,
         deviceIdentityProfile: GatewayDeviceIdentityProfile,
-        connectionGeneration: UInt64) async throws -> (
+        connectionGeneration: UInt64) async throws
+        -> (
             offeredRoles: Set<String>,
             persistedRoles: Set<String>,
             hello: HelloOk)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -6,6 +6,16 @@ import OSLog
 /// Avoid ambiguity with the app's own AnyCodable type.
 private typealias ProtoAnyCodable = OpenClawProtocol.AnyCodable
 
+public struct GatewayDeviceAuthHandoff: Equatable, Sendable {
+    public let offeredRoles: Set<String>
+    public let persistedRoles: Set<String>
+
+    public init(offeredRoles: Set<String> = [], persistedRoles: Set<String> = []) {
+        self.offeredRoles = offeredRoles
+        self.persistedRoles = persistedRoles
+    }
+}
+
 private func gatewayErrorDetails(_ error: ErrorShape?) -> [String: ProtoAnyCodable] {
     var details: [String: ProtoAnyCodable] = [:]
     if let nested = error?.details?.value as? [String: ProtoAnyCodable] {
@@ -94,7 +104,7 @@ public actor GatewayChannelActor {
     private var keepaliveTask: Task<Void, Never>?
     private var pendingDeviceTokenRetry = false
     private var deviceTokenRetryBudgetUsed = false
-    private var issuedDeviceAuthRoles = Set<String>()
+    private var deviceAuthHandoff = GatewayDeviceAuthHandoff()
     private var reconnectPausedForAuthFailure = false
     private let defaultRequestTimeoutMs: Double = 15000
     private let extraHeadersProvider: (@Sendable () -> [String: String])?
@@ -558,8 +568,10 @@ public actor GatewayChannelActor {
                 deviceAuthGatewayID: deviceAuthGatewayID,
                 deviceIdentityProfile: deviceIdentityProfile,
                 connectionGeneration: connectionGeneration)
-            self.issuedDeviceAuthRoles.formUnion(outcome.issuedRoles)
-            if outcome.issuedRoles.contains(role) {
+            self.deviceAuthHandoff = GatewayDeviceAuthHandoff(
+                offeredRoles: self.deviceAuthHandoff.offeredRoles.union(outcome.offeredRoles),
+                persistedRoles: self.deviceAuthHandoff.persistedRoles.union(outcome.persistedRoles))
+            if outcome.persistedRoles.contains(role) {
                 // Only a token persisted from this endpoint may unlock stored auth for its role.
                 self.connectOptions?.allowStoredDeviceAuth = true
             }
@@ -897,7 +909,10 @@ extension GatewayChannelActor {
         role: String,
         deviceAuthGatewayID: String?,
         deviceIdentityProfile: GatewayDeviceIdentityProfile,
-        connectionGeneration: UInt64) async throws -> (issuedRoles: Set<String>, hello: HelloOk)
+        connectionGeneration: UInt64) async throws -> (
+            offeredRoles: Set<String>,
+            persistedRoles: Set<String>,
+            hello: HelloOk)
     {
         if res.ok == false {
             let error = res.error
@@ -954,10 +969,12 @@ extension GatewayChannelActor {
             self.tickIntervalMs = Double(tick)
         }
         let auth = ok.auth
-        var issuedRoles = Set<String>()
+        var offeredRoles = Set<String>()
+        var persistedRoles = Set<String>()
         if let identity {
             if let deviceToken = auth["deviceToken"]?.value as? String {
                 let authRole = auth["role"]?.value as? String ?? role
+                offeredRoles.insert(authRole)
                 let scopes = (auth["scopes"]?.value as? [ProtoAnyCodable])?
                     .compactMap { $0.value as? String } ?? []
                 if self.persistIssuedDeviceToken(
@@ -969,7 +986,7 @@ extension GatewayChannelActor {
                     deviceAuthGatewayID: deviceAuthGatewayID,
                     deviceIdentityProfile: deviceIdentityProfile)
                 {
-                    issuedRoles.insert(authRole)
+                    persistedRoles.insert(authRole)
                 }
             }
             if self.shouldPersistBootstrapHandoffTokens(),
@@ -982,6 +999,7 @@ extension GatewayChannelActor {
                     else {
                         continue
                     }
+                    offeredRoles.insert(authRole)
                     let scopes = (rawEntry["scopes"]?.value as? [ProtoAnyCodable])?
                         .compactMap { $0.value as? String } ?? []
                     if self.persistBootstrapHandoffToken(
@@ -992,7 +1010,7 @@ extension GatewayChannelActor {
                         deviceAuthGatewayID: deviceAuthGatewayID,
                         deviceIdentityProfile: deviceIdentityProfile)
                     {
-                        issuedRoles.insert(authRole)
+                        persistedRoles.insert(authRole)
                     }
                 }
             }
@@ -1005,7 +1023,7 @@ extension GatewayChannelActor {
         {
             await self.connectSnapshotAdmissionHandler?(ok, connectionGeneration)
         }
-        return (issuedRoles, ok)
+        return (offeredRoles, persistedRoles, ok)
     }
 
     private func deliverPushIfCurrent(
@@ -1019,7 +1037,11 @@ extension GatewayChannelActor {
     }
 
     public func currentIssuedDeviceAuthRoles() -> Set<String> {
-        self.issuedDeviceAuthRoles
+        self.deviceAuthHandoff.persistedRoles
+    }
+
+    public func currentDeviceAuthHandoff() -> GatewayDeviceAuthHandoff {
+        self.deviceAuthHandoff
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -524,6 +524,11 @@ public actor GatewayNodeSession {
         return await channel.currentIssuedDeviceAuthRoles()
     }
 
+    public func currentDeviceAuthHandoff() async -> GatewayDeviceAuthHandoff {
+        guard let channel else { return GatewayDeviceAuthHandoff() }
+        return await channel.currentDeviceAuthHandoff()
+    }
+
     public func currentCanvasHostUrl() -> String? {
         self.pluginSurfaceUrls["canvas"]
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -519,6 +519,7 @@ public actor GatewayNodeSession {
         return self.executingLifecycleCallbackIDs.contains(id)
     }
 
+    // periphery:ignore - package tests verify credential handoff rollback without exposing mutable channel state.
     public func currentIssuedDeviceAuthRoles() async -> Set<String> {
         guard let channel else { return [] }
         return await channel.currentIssuedDeviceAuthRoles()

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -3332,6 +3332,9 @@ struct GatewayNodeSessionTests {
             "operator.write",
         ])
         #expect(await gateway.currentIssuedDeviceAuthRoles() == ["node", "operator"])
+        #expect(await gateway.currentDeviceAuthHandoff() == GatewayDeviceAuthHandoff(
+            offeredRoles: ["node", "operator"],
+            persistedRoles: ["node", "operator"]))
 
         await gateway.disconnect()
     }
@@ -3375,6 +3378,9 @@ struct GatewayNodeSessionTests {
             })
 
         #expect(await gateway.currentIssuedDeviceAuthRoles().isEmpty)
+        #expect(await gateway.currentDeviceAuthHandoff() == GatewayDeviceAuthHandoff(
+            offeredRoles: ["node"],
+            persistedRoles: []))
         await gateway.disconnect()
     }
 


### PR DESCRIPTION
Related: #108888

## What Problem This Solves

Fixes an issue where iPhone users upgrading an existing Limited Gateway connection to Full Access could see a misleading “Credential save failed” error and lose the working Limited connection when an older Gateway did not return both node and operator credentials.

## Why This Change Was Made

The Full-Access scanner now treats a same-target upgrade as a non-destructive attempt: it keeps the existing device tokens, TLS trust, cached data, and credential bundle, and uses the bootstrap token only in memory. The Apple connection layer separately records roles offered by the Gateway and roles persisted locally, so the app can distinguish an outdated/incomplete Gateway handoff from a real device storage failure.

When the Gateway omits a required role, iOS drops the one-time bootstrap credential and reconnects with the preserved Limited credentials. It reports a Gateway-owned, non-retryable update instruction instead of blaming iPhone credential storage. The Gateway's authorization and role ceilings are unchanged.

## User Impact

Users keep their existing Limited connection when a Full-Access upgrade is rejected or unsupported. After updating the Gateway, they can scan a fresh Full-Access code and try again without re-registering the phone from scratch.

## Evidence

- Added OpenClawKit coverage proving offered and persisted handoff roles remain distinguishable, including a simulated device-token write failure.
- Added iOS coverage for non-destructive upgrade preparation, Limited-auth recovery, Gateway-owned guidance, and the true persistence-failure boundary.
- Existing Gateway Full QR regression passed:
  `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts -t "full qr setup upgrades an existing limited mobile pairing"`
  (1 passed, 37 skipped.)
- Repository commit hooks completed successfully.
- iOS/Xcode tests were not runnable on this Windows host; macOS CI is required for the Apple build/test proof.
- `pnpm apple:i18n:check` is currently blocked by a pre-existing stale macOS `Localizable.xcstrings` baseline; this PR does not modify that catalog.
