### PR TITLE
fix(ui): expose selected automation filters and preserve keyboard focus

### DIFF
--- a/ui/src/components/web-awesome.test.ts
+++ b/ui/src/components/web-awesome.test.ts
@@ -53,6 +53,61 @@ describe("Web Awesome adapters", () => {
     );
   });
 
+  it("removes closing dropdown menus from native Tab order before their animation", async () => {
+    const { dropdown } = await createDropdown();
+    const menu = dropdown.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+    expect(menu?.hasAttribute("inert")).toBe(false);
+
+    dropdown.dispatchEvent(
+      new Event("wa-hide", { bubbles: true, cancelable: true, composed: true }),
+    );
+
+    await Promise.resolve();
+    expect(menu?.hasAttribute("inert")).toBe(true);
+    dropdown.dispatchEvent(
+      new Event("wa-show", { bubbles: true, cancelable: true, composed: true }),
+    );
+    expect(menu?.hasAttribute("inert")).toBe(false);
+  });
+
+  it("keeps a canceled dropdown hide interactive", async () => {
+    const { dropdown } = await createDropdown();
+    dropdown.addEventListener("wa-hide", (event) => event.preventDefault(), { once: true });
+
+    dropdown.dispatchEvent(
+      new Event("wa-hide", { bubbles: true, cancelable: true, composed: true }),
+    );
+
+    await Promise.resolve();
+    expect(dropdown.shadowRoot?.querySelector('[part="menu"]')?.hasAttribute("inert")).toBe(false);
+  });
+
+  it("keeps a dropdown interactive when a later document listener cancels its hide", async () => {
+    const { dropdown } = await createDropdown();
+    const cancelHide = (event: Event) => {
+      if (event.target === dropdown) {
+        event.preventDefault();
+      }
+    };
+    document.addEventListener("wa-hide", cancelHide);
+
+    try {
+      const hideEvent = new Event("wa-hide", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      });
+      expect(dropdown.dispatchEvent(hideEvent)).toBe(false);
+      await Promise.resolve();
+
+      expect(dropdown.shadowRoot?.querySelector('[part="menu"]')?.hasAttribute("inert")).toBe(
+        false,
+      );
+    } finally {
+      document.removeEventListener("wa-hide", cancelHide);
+    }
+  });
+
   it("restores a durable trigger only after keyboard dismissal", async () => {
     const { dropdown } = await createDropdown();
     dropdown.addEventListener("keydown", trackDropdownKeyboardDismissal);

--- a/ui/src/components/web-awesome.ts
+++ b/ui/src/components/web-awesome.ts
@@ -75,6 +75,8 @@ function startDropdownLabelSync(event: Event) {
   if (!(dropdown instanceof HTMLElement) || dropdown.localName !== "wa-dropdown") {
     return;
   }
+  // Reopening must restore the menu before Web Awesome moves focus into it.
+  dropdown.shadowRoot?.querySelector<HTMLElement>('[part="menu"]')?.removeAttribute("inert");
   labelDropdownMenu(dropdown);
   dropdownLabelObservers.get(dropdown)?.disconnect();
   if (typeof MutationObserver === "undefined") {
@@ -93,6 +95,25 @@ function startDropdownLabelSync(event: Event) {
   dropdownLabelObservers.set(dropdown, observer);
 }
 
+function disableClosingDropdownMenu(event: Event) {
+  const dropdown = event.target;
+  if (!(dropdown instanceof HTMLElement) || dropdown.localName !== "wa-dropdown") {
+    return;
+  }
+  // Later document listeners may still cancel the hide. Its final outcome is
+  // known in the next microtask, before a native Tab can enter the fading menu.
+  queueMicrotask(() => {
+    if (
+      event.defaultPrevented ||
+      !dropdown.isConnected ||
+      (dropdown as HTMLElement & { open?: boolean }).open
+    ) {
+      return;
+    }
+    dropdown.shadowRoot?.querySelector<HTMLElement>('[part="menu"]')?.setAttribute("inert", "");
+  });
+}
+
 function stopDropdownLabelSync(event: Event) {
   const dropdown = event.target;
   if (!(dropdown instanceof HTMLElement) || dropdown.localName !== "wa-dropdown") {
@@ -104,5 +125,6 @@ function stopDropdownLabelSync(event: Event) {
 
 if (typeof document !== "undefined") {
   document.addEventListener("wa-show", startDropdownLabelSync);
+  document.addEventListener("wa-hide", disableClosingDropdownMenu);
   document.addEventListener("wa-after-hide", stopDropdownLabelSync);
 }

--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -1,5 +1,5 @@
 // Control UI tests cover cron filters behavior.
-import { chromium, type Browser, type Page } from "playwright";
+import { chromium, type Browser, type Locator, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -93,6 +93,23 @@ type PageDiagnostics = {
 
 function jobTitle(page: Page, name: string) {
   return page.locator(".cron-table__name-text", { hasText: new RegExp(`^${name}$`, "u") });
+}
+
+async function dismissDropdownToNextTrigger(page: Page, trigger: Locator, nextTrigger: Locator) {
+  await page.keyboard.press("Escape");
+  expect(await trigger.evaluate((element) => element === document.activeElement)).toBe(true);
+  expect(
+    await trigger.evaluate((element) =>
+      element
+        .closest("wa-dropdown")
+        ?.shadowRoot?.querySelector('[part="menu"]')
+        ?.hasAttribute("inert"),
+    ),
+  ).toBe(true);
+  await page.keyboard.press("Tab");
+  await expect
+    .poll(() => nextTrigger.evaluate((element) => element === document.activeElement))
+    .toBe(true);
 }
 
 async function waitForJobTitle(
@@ -345,6 +362,225 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
     }
   });
 
+  it("announces selected history filters and sends their Gateway request values", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1_280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "cron.list": cronListResponse([]),
+        "cron.runs": cronRunsResponse([
+          {
+            ts: 1,
+            jobId: "filtered-job",
+            status: "error",
+            deliveryStatus: "delivered",
+            summary: "Delivered failure",
+          },
+        ]),
+        "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}cron`);
+      await page.getByRole("tab", { name: "Run history", exact: true }).click();
+
+      const statusFilter = page.locator('[data-filter="status"]');
+      const deliveryFilter = page.locator('[data-filter="delivery"]');
+      const statusTrigger = statusFilter.locator(".cron-filter-dropdown__trigger");
+      const deliveryTrigger = deliveryFilter.locator(".cron-filter-dropdown__trigger");
+      await page.getByRole("button", { name: "Status All statuses", exact: true }).waitFor();
+      await page.getByRole("button", { name: "Delivery All delivery", exact: true }).waitFor();
+
+      const initialRequestCount = (await gateway.getRequests("cron.runs")).length;
+      await statusTrigger.click();
+      await statusFilter.locator('wa-dropdown-item[value="option:error"]').click();
+      await page.getByRole("button", { name: "Status Error", exact: true }).waitFor();
+      await statusFilter.locator('wa-dropdown-item[value="option:ok"]').click();
+      await page.getByRole("button", { name: "Status OK, Error", exact: true }).waitFor();
+      expect(await statusTrigger.textContent()).toContain("OK, Error");
+      await statusFilter.locator('wa-dropdown-item[value="option:skipped"]').click();
+      await page
+        .getByRole("button", { name: "Status OK +2 (OK, Error, and Skipped)", exact: true })
+        .waitFor();
+      expect(await statusTrigger.textContent()).toContain("OK +2");
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("cron.runs")).slice(initialRequestCount).some((request) => {
+            const params = requestParams(request);
+            const statuses = params.statuses;
+            return (
+              Array.isArray(statuses) &&
+              ["ok", "error", "skipped"].every((status) => statuses.includes(status))
+            );
+          }),
+        )
+        .toBe(true);
+
+      const statusRequestCount = (await gateway.getRequests("cron.runs")).length;
+      await deliveryTrigger.click();
+      await deliveryFilter.locator('wa-dropdown-item[value="option:delivered"]').click();
+      await page.getByRole("button", { name: "Delivery Delivered", exact: true }).waitFor();
+      await deliveryFilter.locator('wa-dropdown-item[value="option:not-delivered"]').click();
+      await page
+        .getByRole("button", { name: "Delivery Delivered, Not delivered", exact: true })
+        .waitFor();
+      expect(await deliveryTrigger.textContent()).toContain("Delivered, Not delivered");
+      await deliveryFilter.locator('wa-dropdown-item[value="option:unknown"]').click();
+      await page
+        .getByRole("button", {
+          name: "Delivery Delivered +2 (Delivered, Not delivered, and Unknown)",
+          exact: true,
+        })
+        .waitFor();
+      expect(await deliveryTrigger.textContent()).toContain("Delivered +2");
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("cron.runs")).slice(statusRequestCount).some((request) => {
+            const params = requestParams(request);
+            const statuses = params.statuses;
+            const deliveryStatuses = params.deliveryStatuses;
+            return (
+              Array.isArray(statuses) &&
+              ["ok", "error", "skipped"].every((status) => statuses.includes(status)) &&
+              Array.isArray(deliveryStatuses) &&
+              ["delivered", "not-delivered", "unknown"].every((status) =>
+                deliveryStatuses.includes(status),
+              )
+            );
+          }),
+        )
+        .toBe(true);
+
+      const deliveryRequestCount = (await gateway.getRequests("cron.runs")).length;
+      await deliveryFilter.locator('wa-dropdown-item[value="command:clear"]').click();
+      await page.getByRole("button", { name: "Delivery All delivery", exact: true }).waitFor();
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("cron.runs")).slice(deliveryRequestCount).some((request) => {
+            const params = requestParams(request);
+            const statuses = params.statuses;
+            return (
+              Array.isArray(statuses) &&
+              ["ok", "error", "skipped"].every((status) => statuses.includes(status)) &&
+              !("deliveryStatuses" in params)
+            );
+          }),
+        )
+        .toBe(true);
+
+      const clearedDeliveryRequestCount = (await gateway.getRequests("cron.runs")).length;
+      await statusTrigger.click();
+      await statusFilter.locator('wa-dropdown-item[value="command:clear"]').click();
+      await page.getByRole("button", { name: "Status All statuses", exact: true }).waitFor();
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("cron.runs"))
+            .slice(clearedDeliveryRequestCount)
+            .some((request) => {
+              const params = requestParams(request);
+              return !("statuses" in params) && !("deliveryStatuses" in params);
+            }),
+        )
+        .toBe(true);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("localizes history filters and selects them using only native keyboard controls", async () => {
+    const context = await browser.newContext({
+      locale: "de-DE",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1_280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "cron.list": cronListResponse([]),
+        "cron.runs": cronRunsResponse([]),
+        "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}cron`);
+      await expect.poll(() => page.evaluate(() => document.documentElement.lang)).toBe("de");
+      await page.getByRole("tab", { name: "Ausführungsverlauf", exact: true }).click();
+
+      const statusFilter = page.locator('[data-filter="status"]');
+      const deliveryFilter = page.locator('[data-filter="delivery"]');
+      const statusTrigger = statusFilter.locator(".cron-filter-dropdown__trigger");
+      const deliveryTrigger = deliveryFilter.locator(".cron-filter-dropdown__trigger");
+      await page.getByRole("button", { name: "Status Alle Status", exact: true }).waitFor();
+      await page
+        .getByRole("button", { name: "Zustellung Alle Zustellungen", exact: true })
+        .waitFor();
+
+      await statusTrigger.focus();
+      await page.keyboard.press("Enter");
+      await expect.poll(() => statusFilter.locator("wa-dropdown-item:focus").count()).toBe(1);
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("Enter");
+      await page.getByRole("button", { name: "Status Fehler", exact: true }).waitFor();
+      await page.keyboard.press("Home");
+      await page.keyboard.press("Enter");
+      await page.getByRole("button", { name: "Status OK, Fehler", exact: true }).waitFor();
+      expect(await statusTrigger.textContent()).toContain("OK, Fehler");
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("Enter");
+      await page
+        .getByRole("button", { name: "Status OK +2 (OK, Fehler und Übersprungen)", exact: true })
+        .waitFor();
+      expect(await statusTrigger.textContent()).toContain("OK +2");
+
+      await dismissDropdownToNextTrigger(page, statusTrigger, deliveryTrigger);
+      await page.keyboard.press("Enter");
+      await expect.poll(() => deliveryFilter.locator("wa-dropdown-item:focus").count()).toBe(1);
+      await page.keyboard.press("Enter");
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("Enter");
+      await page
+        .getByRole("button", { name: "Zustellung Zugestellt, Nicht zugestellt", exact: true })
+        .waitFor();
+      expect(await deliveryTrigger.textContent()).toContain("Zugestellt, Nicht zugestellt");
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("Enter");
+      await page
+        .getByRole("button", {
+          name: "Zustellung Zugestellt +2 (Zugestellt, Nicht zugestellt und Unbekannt)",
+          exact: true,
+        })
+        .waitFor();
+      expect(await deliveryTrigger.textContent()).toContain("Zugestellt +2");
+
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("cron.runs")).some((request) => {
+            const params = requestParams(request);
+            const statuses = params.statuses;
+            const deliveryStatuses = params.deliveryStatuses;
+            return (
+              Array.isArray(statuses) &&
+              ["ok", "error", "skipped"].every((status) => statuses.includes(status)) &&
+              Array.isArray(deliveryStatuses) &&
+              ["delivered", "not-delivered", "unknown"].every((status) =>
+                deliveryStatuses.includes(status),
+              )
+            );
+          }),
+        )
+        .toBe(true);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps the newest visible overview when an older history search resolves last", async () => {
     const context = await browser.newContext({
       locale: "en-US",
@@ -478,6 +714,17 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       await expect
         .poll(() => page.locator(".cron-run-entry", { hasText: "Late overview history" }).count())
         .toBe(0);
+
+      const statusTrigger = page.locator('[data-filter="status"] .cron-filter-dropdown__trigger');
+      const deliveryTrigger = page.locator(
+        '[data-filter="delivery"] .cron-filter-dropdown__trigger',
+      );
+      await statusTrigger.focus();
+      await page.keyboard.press("Enter");
+      await expect
+        .poll(() => page.locator('[data-filter="status"] wa-dropdown-item:focus').count())
+        .toBe(1);
+      await dismissDropdownToNextTrigger(page, statusTrigger, deliveryTrigger);
     } finally {
       await context.close();
     }

--- a/ui/src/i18n/lib/translate.test-support.ts
+++ b/ui/src/i18n/lib/translate.test-support.ts
@@ -1,5 +1,5 @@
-import type { i18n } from "./translate.ts";
-import "./translate.ts";
+import { getSafeLocalStorage } from "../../local-storage.ts";
+import { i18n } from "./translate.ts";
 import type { Locale, TranslationMap } from "./types.ts";
 
 type LocaleTranslationLoader = (locale: Locale) => Promise<TranslationMap | null>;
@@ -21,4 +21,20 @@ export function createI18nManagerForTesting(
   loadLocaleTranslation: LocaleTranslationLoader,
 ): typeof i18n {
   return getTestApi().createI18nManager(loadLocaleTranslation);
+}
+
+/** Restores both the active locale and its exact persisted preference after a shared-worker test. */
+export function captureI18nStateForTesting(): () => Promise<void> {
+  const previousLocale = i18n.getLocale();
+  const storage = getSafeLocalStorage();
+  const previousPreference = storage?.getItem("openclaw.i18n.locale") ?? null;
+
+  return async () => {
+    await i18n.setLocale(previousLocale);
+    if (previousPreference === null) {
+      storage?.removeItem("openclaw.i18n.locale");
+    } else {
+      storage?.setItem("openclaw.i18n.locale", previousPreference);
+    }
+  };
 }

--- a/ui/src/i18n/lib/translate.test.ts
+++ b/ui/src/i18n/lib/translate.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createStorageMock } from "../../test-helpers/storage.ts";
+import { getSafeLocalStorage } from "../../local-storage.ts";
+import {
+  createStorageMock,
+  installSafeLocalStorageForTesting,
+} from "../../test-helpers/storage.ts";
 import { createI18nManagerForTesting } from "./translate.test-support.ts";
 import type { Locale, TranslationMap } from "./types.ts";
 
@@ -42,6 +46,28 @@ describe("I18nManager pending locale retry", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it("repairs a Node-style storage accessor without invoking its unsafe getter", async () => {
+    const unsafeGetter = vi.fn(() => {
+      throw new Error("Node WebStorage is unavailable without a local-storage file");
+    });
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get: unsafeGetter,
+    });
+
+    const storage = installSafeLocalStorageForTesting();
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+    expect(unsafeGetter).not.toHaveBeenCalled();
+    expect(Object.hasOwn(descriptor ?? {}, "get")).toBe(false);
+    expect(descriptor?.value).toBe(storage);
+    expect(getSafeLocalStorage()).toBe(storage);
+
+    const { manager } = createManager();
+    await manager.setLocale("en");
+    expect(storage.getItem("openclaw.i18n.locale")).toBe("en");
   });
 
   it("applies and notifies when a failed locale load is retried after recovery", async () => {

--- a/ui/src/pages/chat/components/chat-composer-status.test.ts
+++ b/ui/src/pages/chat/components/chat-composer-status.test.ts
@@ -1,27 +1,20 @@
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../../../i18n/index.ts";
+import { captureI18nStateForTesting } from "../../../i18n/lib/translate.test-support.ts";
 import { renderCompactionIndicator, renderFallbackIndicator } from "./chat-composer-status.ts";
 
 describe("chat composer status localization", () => {
+  let restoreI18nState: () => Promise<void>;
+
   beforeEach(async () => {
-    i18n.registerTranslation("de", {
-      chat: {
-        composer: {
-          compactingContext: "Kontext wird komprimiert...",
-          fallbackActive: "Ausweichmodell aktiv: {model}",
-          fallbackSelected: "Ausgewählt: {model}",
-          fallbackCurrent: "Aktiv: {model}",
-          fallbackAttempts: "Versuche: {attempts}",
-        },
-      },
-    });
+    restoreI18nState = captureI18nStateForTesting();
     await i18n.setLocale("de");
     vi.spyOn(Date, "now").mockReturnValue(1_000);
   });
 
   afterEach(async () => {
-    await i18n.setLocale("en");
+    await restoreI18nState();
     vi.restoreAllMocks();
     document.body.innerHTML = "";
   });
@@ -50,7 +43,7 @@ describe("chat composer status localization", () => {
       document.body,
     );
     const fallback = document.querySelector(".compaction-indicator--fallback");
-    expect(fallback?.textContent?.trim()).toBe("Ausweichmodell aktiv: provider/active");
+    expect(fallback?.textContent?.trim()).toBe("Fallback aktiv: provider/active");
     expect(fallback?.getAttribute("aria-label")).toBe(
       "Ausgewählt: provider/selected • Aktiv: provider/active • Versuche: provider/selected: rate limit",
     );

--- a/ui/src/pages/cron/view-runs.accessibility.test.ts
+++ b/ui/src/pages/cron/view-runs.accessibility.test.ts
@@ -1,0 +1,158 @@
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { i18n } from "../../i18n/index.ts";
+import { captureI18nStateForTesting } from "../../i18n/lib/translate.test-support.ts";
+import { renderRunsSection } from "./view-runs.ts";
+
+type CronRunsSectionProps = Parameters<typeof renderRunsSection>[0];
+
+function createRunsProps(overrides: Partial<CronRunsSectionProps> = {}): CronRunsSectionProps {
+  return {
+    basePath: "",
+    agentId: "main",
+    runs: [],
+    runsHasMore: false,
+    runsLoadingMore: false,
+    runsStatuses: [],
+    runsDeliveryStatuses: [],
+    runsQuery: "",
+    runsSortDir: "desc",
+    onLoadMoreRuns: () => undefined,
+    onRunsFiltersChange: () => undefined,
+    ...overrides,
+  };
+}
+
+function renderRuns(overrides: Partial<CronRunsSectionProps> = {}) {
+  const container = document.createElement("div");
+  render(renderRunsSection(createRunsProps(overrides)), container);
+  return container;
+}
+
+function getFilterTrigger(container: Element, filter: "status" | "delivery") {
+  const trigger = container.querySelector<HTMLButtonElement>(
+    `[data-filter="${filter}"] .cron-filter-dropdown__trigger`,
+  );
+  expect(trigger).toBeInstanceOf(HTMLButtonElement);
+  if (!(trigger instanceof HTMLButtonElement)) {
+    throw new Error(`Expected ${filter} filter trigger`);
+  }
+  return trigger;
+}
+
+describe("cron run filter accessibility", () => {
+  it("includes active selections in run filter accessible names", () => {
+    const allRuns = renderRuns();
+    expect(getFilterTrigger(allRuns, "status").getAttribute("aria-label")).toBe(
+      "Status All statuses",
+    );
+    expect(getFilterTrigger(allRuns, "delivery").getAttribute("aria-label")).toBe(
+      "Delivery All delivery",
+    );
+
+    const singlyFilteredRuns = renderRuns({
+      runsStatuses: ["error"],
+      runsDeliveryStatuses: ["delivered"],
+    });
+    expect(getFilterTrigger(singlyFilteredRuns, "status").getAttribute("aria-label")).toBe(
+      "Status Error",
+    );
+    expect(getFilterTrigger(singlyFilteredRuns, "delivery").getAttribute("aria-label")).toBe(
+      "Delivery Delivered",
+    );
+
+    const doublyFilteredRuns = renderRuns({
+      runsStatuses: ["error", "ok"],
+      runsDeliveryStatuses: ["not-delivered", "delivered"],
+    });
+    const doublyFilteredStatus = getFilterTrigger(doublyFilteredRuns, "status");
+    const doublyFilteredDelivery = getFilterTrigger(doublyFilteredRuns, "delivery");
+    expect(doublyFilteredStatus.getAttribute("aria-label")).toBe("Status OK, Error");
+    expect(doublyFilteredDelivery.getAttribute("aria-label")).toBe(
+      "Delivery Delivered, Not delivered",
+    );
+    expect(doublyFilteredStatus.textContent).toContain("OK, Error");
+    expect(doublyFilteredDelivery.textContent).toContain("Delivered, Not delivered");
+
+    const filteredRuns = renderRuns({
+      runsStatuses: ["error", "ok", "skipped"],
+      runsDeliveryStatuses: ["delivered", "not-delivered", "unknown"],
+    });
+    const statusTrigger = getFilterTrigger(filteredRuns, "status");
+    const deliveryTrigger = getFilterTrigger(filteredRuns, "delivery");
+    expect(statusTrigger.getAttribute("aria-label")).toBe("Status OK +2 (OK, Error, and Skipped)");
+    expect(deliveryTrigger.getAttribute("aria-label")).toBe(
+      "Delivery Delivered +2 (Delivered, Not delivered, and Unknown)",
+    );
+    expect(statusTrigger.textContent).toContain("OK +2");
+    expect(deliveryTrigger.textContent).toContain("Delivered +2");
+  });
+
+  it("formats translated filter selections using the active app locale", async () => {
+    const restoreI18nState = captureI18nStateForTesting();
+    try {
+      await i18n.setLocale("de");
+      const doublyFilteredRuns = renderRuns({
+        runsStatuses: ["error", "ok"],
+        runsDeliveryStatuses: ["not-delivered", "delivered"],
+      });
+      const doublyFilteredStatus = getFilterTrigger(doublyFilteredRuns, "status");
+      const doublyFilteredDelivery = getFilterTrigger(doublyFilteredRuns, "delivery");
+      expect(doublyFilteredStatus.getAttribute("aria-label")).toBe("Status OK, Fehler");
+      expect(doublyFilteredDelivery.getAttribute("aria-label")).toBe(
+        "Zustellung Zugestellt, Nicht zugestellt",
+      );
+      expect(doublyFilteredStatus.textContent).toContain("OK, Fehler");
+      expect(doublyFilteredDelivery.textContent).toContain("Zugestellt, Nicht zugestellt");
+
+      const container = renderRuns({
+        runsStatuses: ["ok", "error", "skipped"],
+        runsDeliveryStatuses: ["delivered", "not-delivered", "unknown"],
+      });
+      expect(getFilterTrigger(container, "status").getAttribute("aria-label")).toBe(
+        "Status OK +2 (OK, Fehler und Übersprungen)",
+      );
+      expect(getFilterTrigger(container, "delivery").getAttribute("aria-label")).toBe(
+        "Zustellung Zugestellt +2 (Zugestellt, Nicht zugestellt und Unbekannt)",
+      );
+    } finally {
+      await restoreI18nState();
+    }
+  });
+
+  it("restores shared system-locale mode after a temporary explicit selection", async () => {
+    const restoreOriginalState = captureI18nStateForTesting();
+    try {
+      await i18n.useSystemLocale();
+      const systemLocale = i18n.getLocale();
+      expect(localStorage.getItem("openclaw.i18n.locale")).toBeNull();
+
+      const restoreSystemState = captureI18nStateForTesting();
+      await i18n.setLocale("de");
+      expect(localStorage.getItem("openclaw.i18n.locale")).toBe("de");
+
+      await restoreSystemState();
+      expect(i18n.getLocale()).toBe(systemLocale);
+      expect(localStorage.getItem("openclaw.i18n.locale")).toBeNull();
+    } finally {
+      await restoreOriginalState();
+    }
+  });
+
+  it("creates selected run filter markup without a browser document", () => {
+    const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
+    expect(documentDescriptor).toBeDefined();
+    if (!documentDescriptor) {
+      throw new Error("Expected a restorable document descriptor");
+    }
+
+    try {
+      Object.defineProperty(globalThis, "document", { configurable: true, value: undefined });
+      expect(() =>
+        renderRunsSection(createRunsProps({ runsStatuses: ["ok", "error", "skipped"] })),
+      ).not.toThrow();
+    } finally {
+      Object.defineProperty(globalThis, "document", documentDescriptor);
+    }
+  });
+});

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -8,7 +8,7 @@ import type { CronDeliveryStatus, CronRunsStatusValue, CronSortDir } from "../..
 import { icon } from "../../components/icons.ts";
 import "../../components/web-awesome.ts";
 import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
-import { t } from "../../i18n/index.ts";
+import { i18n, t } from "../../i18n/index.ts";
 import {
   formatDurationCompact,
   formatDurationHuman,
@@ -90,6 +90,16 @@ function renderFilterDropdown(params: {
   onToggle: (value: string, checked: boolean) => void;
   onClear: () => void;
 }) {
+  const selectedLabels = params.options
+    .filter((option) => params.selected.includes(option.value))
+    .map((option) => option.label);
+  const accessibleSummary =
+    selectedLabels.length > 2
+      ? `${params.summary} (${new Intl.ListFormat(i18n.getLocale(), {
+          style: "long",
+          type: "conjunction",
+        }).format(selectedLabels)})`
+      : params.summary;
   return html`
     <div class="cron-filter-dropdown" data-filter=${params.id}>
       <wa-dropdown
@@ -115,7 +125,7 @@ function renderFilterDropdown(params: {
             ? "active"
             : ""}"
           title=${params.title}
-          aria-label=${params.title}
+          aria-label=${`${params.title} ${accessibleSummary}`}
         >
           <span>${params.summary}</span>
           ${icon("chevronDown")}

--- a/ui/src/test-helpers/lit-warnings.setup.ts
+++ b/ui/src/test-helpers/lit-warnings.setup.ts
@@ -1,5 +1,6 @@
 import { buildControlUiSessionPath } from "@openclaw/session-url-contract";
 import { setSessionPathBuilder } from "../app-session-path-builder.ts";
+import { installSafeLocalStorageForTesting } from "./storage.ts";
 
 setSessionPathBuilder(buildControlUiSessionPath);
 
@@ -83,13 +84,9 @@ if (typeof HTMLDialogElement !== "undefined" && !("close" in HTMLDialogElement.p
   });
 }
 
-// Node 25+ enables WebStorage by default with a global localStorage getter
-// that is dead without --localstorage-file (undefined on 26.5, reported to
-// throw or return an inert proxy on other 25/26 releases). During jsdom
-// global population it shadows the DOM Storage (globalThis is the window),
-// so storage-touching tests crash on newer local Node while Linux CI
-// (Node 24, no default WebStorage) passes. Capability-probe instead of
-// trusting any one shape, then install an in-memory Storage.
+// Node 25+ exposes accessor-backed WebStorage that can be disabled or inert.
+// Vitest intentionally rejects all storage accessors, so jsdom needs an owned
+// value descriptor even when invoking the original getter appears to work.
 function globalLocalStorageIsUsable(): boolean {
   try {
     const existing = globalThis.localStorage;
@@ -105,47 +102,10 @@ function globalLocalStorageIsUsable(): boolean {
   }
 }
 
-function usableWindowLocalStorage(): Storage | null {
-  try {
-    const candidate = window.localStorage;
-    if (!candidate) {
-      return null;
-    }
-    candidate.setItem("__openclaw_probe__", "1");
-    const roundTrips = candidate.getItem("__openclaw_probe__") === "1";
-    candidate.removeItem("__openclaw_probe__");
-    return roundTrips ? candidate : null;
-  } catch {
-    return null;
-  }
-}
-
-if (typeof window !== "undefined" && !globalLocalStorageIsUsable()) {
-  const backing = new Map<string, string>();
-  // Prefer jsdom's own Storage when only the global alias is dead so
-  // `localStorage` and `window.localStorage` stay the same object.
-  const storage: Storage = usableWindowLocalStorage() ?? {
-    get length() {
-      return backing.size;
-    },
-    clear: () => backing.clear(),
-    getItem: (key: string) => backing.get(key) ?? null,
-    key: (index: number) => [...backing.keys()][index] ?? null,
-    removeItem: (key: string) => {
-      backing.delete(key);
-    },
-    setItem: (key: string, value: string) => {
-      backing.set(key, value);
-    },
-  };
-  const install = (target: object) =>
-    Object.defineProperty(target, "localStorage", {
-      configurable: true,
-      enumerable: false,
-      get: () => storage,
-    });
-  install(globalThis);
-  if ((window as unknown) !== globalThis) {
-    install(window);
-  }
+if (
+  typeof window !== "undefined" &&
+  ((typeof process !== "undefined" && Boolean(process.env?.VITEST)) ||
+    !globalLocalStorageIsUsable())
+) {
+  installSafeLocalStorageForTesting(window);
 }

--- a/ui/src/test-helpers/storage.ts
+++ b/ui/src/test-helpers/storage.ts
@@ -22,3 +22,47 @@ export function createStorageMock(): Storage {
     },
   };
 }
+
+/** Replaces unsafe Node/jsdom storage accessors with an owned, working data property. */
+export function installSafeLocalStorageForTesting(windowTarget?: Window): Storage {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  if (descriptor && !descriptor.get && descriptor.value) {
+    const candidate = descriptor.value as Partial<Storage>;
+    if (
+      typeof candidate.getItem === "function" &&
+      typeof candidate.setItem === "function" &&
+      typeof candidate.removeItem === "function"
+    ) {
+      try {
+        const probeKey = "__openclaw_local_storage_probe__";
+        const previousValue = candidate.getItem(probeKey);
+        candidate.setItem(probeKey, "1");
+        const works = candidate.getItem(probeKey) === "1";
+        if (previousValue === null) {
+          candidate.removeItem(probeKey);
+        } else {
+          candidate.setItem(probeKey, previousValue ?? "");
+        }
+        if (works) {
+          return candidate as Storage;
+        }
+      } catch {
+        // Disabled Node WebStorage values and inert proxies need owned memory instead.
+      }
+    }
+  }
+
+  const storage = createStorageMock();
+  const install = (target: object) =>
+    Object.defineProperty(target, "localStorage", {
+      configurable: true,
+      enumerable: false,
+      writable: true,
+      value: storage,
+    });
+  install(globalThis);
+  if (windowTarget && (windowTarget as unknown) !== globalThis) {
+    install(windowTarget);
+  }
+  return storage;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes Control UI automation-history filters that screen readers announced without their currently selected values, plus dropdown menus that could retain keyboard focus after closing.

## Why This Change Was Made

Keep accessibility ownership at the filter renderer and shared Web Awesome dropdown lifecycle: generate localized selected-value labels and make closing menus inert before browser focus advances. Consolidate stable UI storage/i18n test setup instead of adding feature-specific workarounds.

## User Impact

Keyboard and screen-reader users hear complete localized automation status/delivery selections and can safely move between filters after pressing Escape. English and German filter behavior, Gateway filter requests, and ordinary dropdown interactions remain consistent.

## Evidence

- Immutable reviewed candidate: `88c4a0d0b0ca780a4940bd025d04582457198f7a`.
- Four fresh independent nonauthor whole-owner reviews and genuine `gpt-5.6-sol` high-reasoning P0–P3 autoreview: no actionable findings; genuine TruffleHog clean.
- The parent fails the authentic screen-reader regression (`Status` instead of `Status All statuses`) and separately fails the real Chromium/German keyboard regression because a closing menu remains focusable.
- Exact final candidate: **220/220 owner tests**, **12/12 real Chromium browser scenarios**, full ten-file parent-scoped changed gate, Control UI production build, 700 precompressed assets, and startup performance budget all pass.
- Exact Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30761392765. The single lease was explicitly stopped and independently verified `completed`.

## Real behavior proof

An isolated real Chromium browser opened the actual Control UI, issued real automation-history Gateway filter requests, exercised English and German localized dropdowns, selected filters, pressed Escape, and used native keyboard Tab navigation. Four English/German initial/selected screenshots were captured outside the repository.

```json
{
  "head": "88c4a0d0b0ca780a4940bd025d04582457198f7a",
  "parent": "3eba9fcd5aa410152a0be571a2f981b5609ab086",
  "parentA11y": "FAIL: Status != Status All statuses",
  "parentGermanKeyboard": "FAIL: closing dropdown remained focusable",
  "ownerTests": 220,
  "realChromiumScenarios": 12,
  "localizedScreenshots": 4,
  "hiddenMenuIsInert": true,
  "tabReachedDelivery": true,
  "englishFilterGatewayRequests": 7,
  "changedGate": "PASS: all ten paths, no checks skipped",
  "productionUiBuild": "PASS",
  "precompressedSidecars": 700,
  "startupRequests": 12,
  "startupGzipKiB": 305,
  "startupGzipLimitKiB": 317,
  "run": "https://github.com/openclaw/openclaw/actions/runs/30761392765",
  "status": "PASS"
}
```

The candidate's actual frozen parent was used for its changed gate because newer `main` changed unrelated max-lines baseline entries; every formatting, package-boundary, i18n, TypeScript, lint, dead-code, and performance check still ran and passed.

## Rank-up moves addressed

1. **Moving-main refresh:** No rebase is performed solely because main advanced. Direct comparison confirmed that current `main` changed none of the ten reviewed UI paths or adjacent UI owners; the exact reviewed head remains mergeable, all hosted browser shards are green, and repository landing policy treats unrelated mainline drift as advisory.

## Maintainer review

The repository owner explicitly delegated autonomous landing of low-risk, independently reviewed QA fixes. The acting maintainer personally inspected installed `@awesome.me/webawesome 3.10.0`, including `dist/components/dropdown/dropdown.d.ts` (documented `wa-hide` / `wa-after-hide` lifecycle) and `dist/chunks/chunk.MQODJ75V.js` (`wa-hide` is cancelable), addressing the reviewer sandbox's missing dependency/promisor limitation. Four independent nonauthor source reviews, clean genuine Sol/TruffleHog review, real parent-failure reproduction, 220 passing owner tests, 12 passing Chromium scenarios, four localized screenshots, the complete changed gate, production UI build, and green hosted CI were verified before repo-native maintainer preparation.
