### PR TITLE
fix(wizard): honor remote password auth in probes

### DIFF
--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -106,7 +106,12 @@ Gateway credential resolution follows one shared contract across call/probe/stat
   - token: `gateway.remote.token` -> `OPENCLAW_GATEWAY_TOKEN` -> `gateway.auth.token`
   - password: `OPENCLAW_GATEWAY_PASSWORD` -> `gateway.remote.password` -> `gateway.auth.password`
 - Node-host local-mode exception: environment credentials stay first and `gateway.remote.token` / `gateway.remote.password` are ignored because node commands target an explicit host and port.
-- Remote probe/status token checks are strict by default: they use `gateway.remote.token` only (no local token fallback) when targeting remote mode.
+- Remote startup/status/wizard probes with SecretRef support treat configured
+  `gateway.remote.token` and `gateway.remote.password` as authoritative for the configured
+  target. Ambient environment credentials are considered only when neither remote credential
+  is configured. If a configured remote SecretRef cannot be resolved, the probe warns and does
+  not fall back to environment credentials; a separately configured sibling credential that
+  resolves successfully remains usable.
 - Gateway env overrides use `OPENCLAW_GATEWAY_*` only.
 
 ## Chat UI remote access

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -1229,7 +1229,7 @@ describe("gatherDaemonStatus", () => {
     expect(status.rpc?.authWarning).toContain("probing without configured auth credentials");
   });
 
-  it("keeps remote probe auth strict when remote token is missing", async () => {
+  it("keeps configured remote password authoritative for remote probes", async () => {
     daemonLoadedConfig = {
       gateway: {
         mode: "remote",
@@ -1251,7 +1251,7 @@ describe("gatherDaemonStatus", () => {
 
     const probeInput = callArg(callGatewayStatusProbe) as { token?: string; password?: string };
     expect(probeInput.token).toBeUndefined();
-    expect(probeInput.password).toBe("env-password"); // pragma: allowlist secret
+    expect(probeInput.password).toBe("remote-password"); // pragma: allowlist secret
   });
 
   it("skips TLS runtime loading when probe is disabled", async () => {

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -1093,6 +1093,44 @@ describe("gatherDaemonStatus", () => {
     );
   });
 
+  it("skips remote password exec SecretRef auth despite an ambient password", async () => {
+    daemonLoadedConfig = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example",
+          password: { source: "exec", provider: "vault", id: "gateway/remote-password" },
+        },
+      },
+      secrets: {
+        providers: {
+          vault: { source: "exec", command: "/bin/false" },
+        },
+      },
+    };
+    setTestEnvValue("OPENCLAW_GATEWAY_PASSWORD", "ambient-password"); // pragma: allowlist secret
+
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: true,
+      deep: false,
+      allowExecSecretRefs: false,
+    });
+
+    expect(resolveGatewayProbeAuthSafeWithSecretInputsCalls).not.toHaveBeenCalled();
+    const probeInput = callArg(callGatewayStatusProbe) as {
+      token?: string;
+      password?: string;
+      allowRpcConfigCredentials?: boolean;
+    };
+    expect(probeInput.token).toBeUndefined();
+    expect(probeInput.password).toBeUndefined();
+    expect(probeInput.allowRpcConfigCredentials).toBe(false);
+    expect(status.rpc?.authWarning).toContain(
+      "gateway credentials use an exec SecretRef and exec SecretRefs are disabled",
+    );
+  });
+
   it("ignores remote exec SecretRefs for local probes when exec refs are disabled", async () => {
     daemonLoadedConfig = {
       gateway: {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -568,7 +568,10 @@ function hasActiveGatewayExecProbeCredential(params: {
         explicitAuth: params.explicitAuth,
         modeOverride: params.mode,
         path,
+        // Remote probe config suppresses ambient credentials across auth types.
+        // Mirror that owner here so env auth cannot hide a winning exec ref.
         remoteTokenFallback: "remote-only",
+        remotePasswordFallback: "remote-only",
       })
     ) {
       return false;

--- a/src/commands/configure.wizard-test-helpers.ts
+++ b/src/commands/configure.wizard-test-helpers.ts
@@ -1,0 +1,31 @@
+import type { OpenClawConfig } from "../config/config.js";
+
+export function createSearchProviderOption(overrides: Record<string, unknown>) {
+  return overrides;
+}
+
+export function createEnabledWebSearchConfig(
+  provider: string,
+  pluginEntry: Record<string, unknown>,
+) {
+  return (cfg: OpenClawConfig) => ({
+    ...cfg,
+    tools: {
+      ...cfg.tools,
+      web: {
+        ...cfg.tools?.web,
+        search: {
+          provider,
+          enabled: true,
+        },
+      },
+    },
+    plugins: {
+      ...cfg.plugins,
+      entries: {
+        ...cfg.plugins?.entries,
+        [provider]: pluginEntry,
+      },
+    },
+  });
+}

--- a/src/commands/configure.wizard-test-helpers.ts
+++ b/src/commands/configure.wizard-test-helpers.ts
@@ -1,4 +1,84 @@
+import { vi, type Mock } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+
+export const EMPTY_CONFIG_SNAPSHOT = {
+  exists: false,
+  valid: true,
+  config: {},
+  issues: [],
+};
+
+export function createWizardTestRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+type WizardStateMocks = {
+  readConfigFileSnapshot: Mock;
+  resolveGatewayPort: Mock;
+  probeGatewayReachable: Mock;
+  resolveControlUiLinks: Mock;
+  resolveLocalControlUiProbeLinks: Mock;
+  resolveAdvertisedControlUiLinks: Mock;
+  inspectWindowsGatewayFirewall: Mock;
+  summarizeExistingConfig: Mock;
+  createClackPrompter: Mock;
+};
+
+export function setupBaseWizardTestState(mocks: WizardStateMocks, config: OpenClawConfig = {}) {
+  mocks.readConfigFileSnapshot.mockResolvedValue({ ...EMPTY_CONFIG_SNAPSHOT, config });
+  mocks.resolveGatewayPort.mockReturnValue(18789);
+  mocks.probeGatewayReachable.mockResolvedValue({ ok: false });
+  mocks.resolveControlUiLinks.mockReturnValue({ wsUrl: "ws://127.0.0.1:18789" });
+  mocks.resolveLocalControlUiProbeLinks.mockReturnValue({
+    httpUrl: "http://127.0.0.1:18789/",
+    wsUrl: "ws://127.0.0.1:18789",
+  });
+  mocks.resolveAdvertisedControlUiLinks.mockResolvedValue({
+    httpUrl: "http://127.0.0.1:18789/",
+    wsUrl: "ws://127.0.0.1:18789",
+  });
+  mocks.inspectWindowsGatewayFirewall.mockResolvedValue({
+    applies: false,
+    severity: "info",
+    code: "windows_firewall_not_applicable",
+    message: "Windows LAN firewall diagnostics do not apply.",
+    details: [],
+  });
+  mocks.summarizeExistingConfig.mockReturnValue("");
+  mocks.createClackPrompter.mockReturnValue({
+    intro: vi.fn(async () => {}),
+    outro: vi.fn(async () => {}),
+    note: vi.fn(async () => {}),
+    select: vi.fn(async () => "firecrawl"),
+    multiselect: vi.fn(async () => []),
+    text: vi.fn(async () => ""),
+    confirm: vi.fn(async () => true),
+    progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+  });
+}
+
+export function queueWizardTestPrompts(
+  mocks: {
+    clackSelect: Mock;
+    clackConfirm: Mock;
+    clackText: Mock;
+    clackIntro: Mock;
+    clackOutro: Mock;
+  },
+  params: { select: string[]; confirm: boolean[]; text?: string },
+) {
+  const selectQueue = [...params.select];
+  const confirmQueue = [...params.confirm];
+  mocks.clackSelect.mockImplementation(async () => selectQueue.shift());
+  mocks.clackConfirm.mockImplementation(async () => confirmQueue.shift());
+  mocks.clackText.mockResolvedValue(params.text ?? "");
+  mocks.clackIntro.mockResolvedValue(undefined);
+  mocks.clackOutro.mockResolvedValue(undefined);
+}
 
 export function createSearchProviderOption(overrides: Record<string, unknown>) {
   return overrides;

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -446,13 +446,18 @@ describe("runConfigureWizard", () => {
     expect(mocks.clackText).not.toHaveBeenCalled();
   });
 
-  it("runs a selected remote health check with remote password auth", async () => {
+  it("keeps remote password health when the configured token ref is unresolved", async () => {
     const remotePassword = "remote-password"; // pragma: allowlist secret
     const remoteConfig: OpenClawConfig = {
       gateway: {
         mode: "remote",
-        remote: { url: "wss://gateway.example.test", password: remotePassword },
+        remote: {
+          url: "wss://gateway.example.test",
+          token: { source: "env", provider: "default", id: "MISSING_REMOTE_TOKEN" },
+          password: remotePassword,
+        },
       },
+      secrets: { providers: { default: { source: "env" } } },
     };
     setupBaseWizardState(remoteConfig);
     queueWizardPrompts({ select: ["remote"], confirm: [] });
@@ -485,7 +490,6 @@ describe("runConfigureWizard", () => {
     });
 
     const authNote = mocks.note.mock.calls.find(([, title]) => title === "Gateway auth")?.[0];
-    expect(authNote).toContain("gateway.remote.token SecretRef is unresolved");
     expect(authNote).toContain("Health check skipped");
     expect(mocks.healthCommand).not.toHaveBeenCalled();
     expect(mocks.clackOutro).toHaveBeenCalledWith(

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -464,7 +464,9 @@ describe("runConfigureWizard", () => {
       expect.objectContaining({ config: remoteConfig, token: undefined, password: remotePassword }),
       expect.anything(),
     );
+  });
 
+  it("skips remote health when a configured SecretRef is unresolved", async () => {
     const unresolvedConfig: OpenClawConfig = {
       gateway: {
         mode: "remote",
@@ -482,13 +484,12 @@ describe("runConfigureWizard", () => {
       await runConfigureWizard({ command: "configure", sections: ["health"] }, createRuntime());
     });
 
-    expect(mocks.note).toHaveBeenCalledWith(
-      expect.stringContaining("gateway.remote.token SecretRef is unresolved"),
-      "Gateway auth",
-    );
-    expect(mocks.healthCommand).toHaveBeenLastCalledWith(
-      expect.objectContaining({ token: undefined, password: undefined }),
-      expect.anything(),
+    const authNote = mocks.note.mock.calls.find(([, title]) => title === "Gateway auth")?.[0];
+    expect(authNote).toContain("gateway.remote.token SecretRef is unresolved");
+    expect(authNote).toContain("Health check skipped");
+    expect(mocks.healthCommand).not.toHaveBeenCalled();
+    expect(mocks.clackOutro).toHaveBeenCalledWith(
+      "Remote gateway configured; health check skipped.",
     );
   });
 

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -510,7 +510,7 @@ describe("runConfigureWizard", () => {
     expect(remoteProbe?.timeoutMs).toBe(300);
   });
 
-  it("uses the environment password ahead of the configured remote password", async () => {
+  it("resolves a remote token ref while the environment password wins", async () => {
     const configuredPassword = "configured-password"; // pragma: allowlist secret
     const envPassword = "env-password"; // pragma: allowlist secret
     setupBaseWizardState({
@@ -518,11 +518,14 @@ describe("runConfigureWizard", () => {
         mode: "remote",
         remote: {
           url: "wss://gateway.example.test",
+          token: { source: "env", provider: "default", id: "REMOTE_SECRET_TOKEN" },
           password: configuredPassword,
         },
       },
+      secrets: { providers: { default: { source: "env" } } },
     });
     vi.stubEnv("OPENCLAW_GATEWAY_PASSWORD", envPassword);
+    vi.stubEnv("REMOTE_SECRET_TOKEN", "resolved-remote-token");
 
     try {
       await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
@@ -534,7 +537,7 @@ describe("runConfigureWizard", () => {
       .map(([request]) => requireRecord(request, "probe request"))
       .find((request) => request.url === "wss://gateway.example.test");
     expect(remoteProbe).toMatchObject({
-      token: undefined,
+      token: "resolved-remote-token",
       password: envPassword,
       timeoutMs: 300,
     });

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -7,6 +7,10 @@ import { withEnvAsync } from "../test-utils/env.js";
 import {
   createEnabledWebSearchConfig,
   createSearchProviderOption,
+  createWizardTestRuntime,
+  EMPTY_CONFIG_SNAPSHOT,
+  queueWizardTestPrompts,
+  setupBaseWizardTestState,
 } from "./configure.wizard-test-helpers.js";
 
 const mocks = vi.hoisted(() => {
@@ -226,55 +230,10 @@ import { WizardCancelledError } from "../wizard/prompts.js";
 import { maybeInstallDaemon } from "./configure.daemon.js";
 import { runConfigureWizard } from "./configure.wizard.js";
 
-const EMPTY_CONFIG_SNAPSHOT = {
-  exists: false,
-  valid: true,
-  config: {},
-  issues: [],
-};
-
-function createRuntime() {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-  };
-}
+const createRuntime = createWizardTestRuntime;
 
 function setupBaseWizardState(config: OpenClawConfig = {}) {
-  mocks.readConfigFileSnapshot.mockResolvedValue({
-    ...EMPTY_CONFIG_SNAPSHOT,
-    config,
-  });
-  mocks.resolveGatewayPort.mockReturnValue(18789);
-  mocks.probeGatewayReachable.mockResolvedValue({ ok: false });
-  mocks.resolveControlUiLinks.mockReturnValue({ wsUrl: "ws://127.0.0.1:18789" });
-  mocks.resolveLocalControlUiProbeLinks.mockReturnValue({
-    httpUrl: "http://127.0.0.1:18789/",
-    wsUrl: "ws://127.0.0.1:18789",
-  });
-  mocks.resolveAdvertisedControlUiLinks.mockResolvedValue({
-    httpUrl: "http://127.0.0.1:18789/",
-    wsUrl: "ws://127.0.0.1:18789",
-  });
-  mocks.inspectWindowsGatewayFirewall.mockResolvedValue({
-    applies: false,
-    severity: "info",
-    code: "windows_firewall_not_applicable",
-    message: "Windows LAN firewall diagnostics do not apply.",
-    details: [],
-  });
-  mocks.summarizeExistingConfig.mockReturnValue("");
-  mocks.createClackPrompter.mockReturnValue({
-    intro: vi.fn(async () => {}),
-    outro: vi.fn(async () => {}),
-    note: vi.fn(async () => {}),
-    select: vi.fn(async () => "firecrawl"),
-    multiselect: vi.fn(async () => []),
-    text: vi.fn(async () => ""),
-    confirm: vi.fn(async () => true),
-    progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
-  });
+  setupBaseWizardTestState(mocks, config);
 }
 
 const requireRecord = createRequireRecord("object", "expected-label");
@@ -315,13 +274,7 @@ function getPluginEntry(config: Record<string, unknown>, pluginId: string) {
 }
 
 function queueWizardPrompts(params: { select: string[]; confirm: boolean[]; text?: string }) {
-  const selectQueue = [...params.select];
-  const confirmQueue = [...params.confirm];
-  mocks.clackSelect.mockImplementation(async () => selectQueue.shift());
-  mocks.clackConfirm.mockImplementation(async () => confirmQueue.shift());
-  mocks.clackText.mockResolvedValue(params.text ?? "");
-  mocks.clackIntro.mockResolvedValue(undefined);
-  mocks.clackOutro.mockResolvedValue(undefined);
+  queueWizardTestPrompts(mocks, params);
 }
 
 async function runWebConfigureWizard() {
@@ -466,7 +419,12 @@ describe("runConfigureWizard", () => {
     await runConfigureWizard({ command: "configure", sections: ["health"] }, createRuntime());
 
     expect(mocks.healthCommand).toHaveBeenCalledWith(
-      expect.objectContaining({ config: remoteConfig, token: undefined, password: remotePassword }),
+      expect.objectContaining({
+        config: remoteConfig,
+        token: undefined,
+        password: remotePassword,
+        ignoreEnvUrlOverride: true,
+      }),
       expect.anything(),
     );
   });

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -510,6 +510,30 @@ describe("runConfigureWizard", () => {
     expect(remoteProbe?.timeoutMs).toBe(300);
   });
 
+  it("uses the configured remote password for the bounded startup hint probe", async () => {
+    const remotePassword = "remote-password"; // pragma: allowlist secret
+    setupBaseWizardState({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example.test",
+          password: remotePassword,
+        },
+      },
+    });
+
+    await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
+
+    const remoteProbe = mocks.probeGatewayReachable.mock.calls
+      .map(([request]) => requireRecord(request, "probe request"))
+      .find((request) => request.url === "wss://gateway.example.test");
+    expect(remoteProbe).toMatchObject({
+      token: undefined,
+      password: remotePassword,
+      timeoutMs: 300,
+    });
+  });
+
   it("ignores blank gateway env credentials when probing the local gateway", async () => {
     setupBaseWizardState({
       gateway: {

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -534,6 +534,41 @@ describe("runConfigureWizard", () => {
     });
   });
 
+  it("uses the environment password ahead of the configured remote password", async () => {
+    const configuredPassword = "configured-password"; // pragma: allowlist secret
+    const envPassword = "env-password"; // pragma: allowlist secret
+    setupBaseWizardState({
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example.test",
+          password: configuredPassword,
+        },
+      },
+    });
+    const previousPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    process.env.OPENCLAW_GATEWAY_PASSWORD = envPassword;
+
+    try {
+      await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
+    } finally {
+      if (previousPassword === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+      } else {
+        process.env.OPENCLAW_GATEWAY_PASSWORD = previousPassword;
+      }
+    }
+
+    const remoteProbe = mocks.probeGatewayReachable.mock.calls
+      .map(([request]) => requireRecord(request, "probe request"))
+      .find((request) => request.url === "wss://gateway.example.test");
+    expect(remoteProbe).toMatchObject({
+      token: undefined,
+      password: envPassword,
+      timeoutMs: 300,
+    });
+  });
+
   it("ignores blank gateway env credentials when probing the local gateway", async () => {
     setupBaseWizardState({
       gateway: {

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -42,10 +42,12 @@ const mocks = vi.hoisted(() => {
     healthCommand: vi.fn(),
     promptAuthConfig: vi.fn(),
     promptGatewayConfig: vi.fn(),
-    promptRemoteGatewayConfig: vi.fn(async (cfg: OpenClawConfig) => ({
-      ...cfg,
-      gateway: { mode: "remote", remote: { url: "wss://gateway.example.test" } },
-    })),
+    promptRemoteGatewayConfig: vi.fn(
+      async (cfg: OpenClawConfig): Promise<OpenClawConfig> => ({
+        ...cfg,
+        gateway: { mode: "remote", remote: { url: "wss://gateway.example.test" } },
+      }),
+    ),
     isCodexNativeWebSearchRelevant: vi.fn(({ config }: { config: OpenClawConfig }) =>
       Boolean(config.auth?.profiles?.["openai:default"]),
     ),
@@ -549,7 +551,7 @@ describe("runConfigureWizard", () => {
     expect(remoteProbe?.timeoutMs).toBe(300);
   });
 
-  it("resolves a remote token ref while the environment password wins", async () => {
+  it("keeps a configured remote token authoritative over an environment password", async () => {
     const configuredPassword = "configured-password"; // pragma: allowlist secret
     const envPassword = "env-password"; // pragma: allowlist secret
     setupBaseWizardState({
@@ -575,9 +577,9 @@ describe("runConfigureWizard", () => {
     const remoteProbe = mocks.probeGatewayReachable.mock.calls
       .map(([request]) => requireRecord(request, "probe request"))
       .find((request) => request.url === "wss://gateway.example.test");
-    expect(remoteProbe).toMatchObject({
+    expect(remoteProbe).toEqual({
+      url: "wss://gateway.example.test",
       token: "resolved-remote-token",
-      password: envPassword,
       timeoutMs: 300,
     });
   });

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -3,6 +3,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { withEnvAsync } from "../test-utils/env.js";
 
 const mocks = vi.hoisted(() => {
   const writeConfigFile = vi.fn();
@@ -469,16 +470,11 @@ describe("runConfigureWizard", () => {
   });
 
   it("runs a selected remote health check with remote password auth", async () => {
-    const localPassword = "local-password"; // pragma: allowlist secret
     const remotePassword = "remote-password"; // pragma: allowlist secret
     const remoteConfig: OpenClawConfig = {
       gateway: {
         mode: "remote",
-        auth: { password: localPassword },
-        remote: {
-          url: "wss://gateway.example.test",
-          password: remotePassword,
-        },
+        remote: { url: "wss://gateway.example.test", password: remotePassword },
       },
     };
     setupBaseWizardState(remoteConfig);
@@ -487,22 +483,9 @@ describe("runConfigureWizard", () => {
 
     await runConfigureWizard({ command: "configure", sections: ["health"] }, createRuntime());
 
-    expect(mocks.waitForGatewayReachable).toHaveBeenCalledWith({
-      url: "wss://gateway.example.test",
-      token: undefined,
-      password: remotePassword,
-      deadlineMs: 15_000,
-    });
     expect(mocks.healthCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
-        config: remoteConfig,
-        token: undefined,
-        password: remotePassword,
-      }),
+      expect.objectContaining({ config: remoteConfig, token: undefined, password: remotePassword }),
       expect.anything(),
-    );
-    expect(mocks.waitForGatewayReachable).not.toHaveBeenCalledWith(
-      expect.objectContaining({ password: localPassword }),
     );
   });
 
@@ -537,7 +520,9 @@ describe("runConfigureWizard", () => {
         },
       },
     });
-    await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
+    await withEnvAsync({ OPENCLAW_GATEWAY_PASSWORD: "env-password" }, async () => {
+      await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
+    });
 
     const probeRequests = mocks.probeGatewayReachable.mock.calls.map(([request]) =>
       requireRecord(request, "probe request"),
@@ -547,39 +532,9 @@ describe("runConfigureWizard", () => {
       (request) => request.url === "wss://gateway.example.test",
     );
     expect(localProbe?.timeoutMs).toBe(300);
-    expect(remoteProbe?.token).toBe("token");
-    expect(remoteProbe?.timeoutMs).toBe(300);
-  });
-
-  it("keeps a configured remote token authoritative over an environment password", async () => {
-    const configuredPassword = "configured-password"; // pragma: allowlist secret
-    const envPassword = "env-password"; // pragma: allowlist secret
-    setupBaseWizardState({
-      gateway: {
-        mode: "remote",
-        remote: {
-          url: "wss://gateway.example.test",
-          token: { source: "env", provider: "default", id: "REMOTE_SECRET_TOKEN" },
-          password: configuredPassword,
-        },
-      },
-      secrets: { providers: { default: { source: "env" } } },
-    });
-    vi.stubEnv("OPENCLAW_GATEWAY_PASSWORD", envPassword);
-    vi.stubEnv("REMOTE_SECRET_TOKEN", "resolved-remote-token");
-
-    try {
-      await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
-    } finally {
-      vi.unstubAllEnvs();
-    }
-
-    const remoteProbe = mocks.probeGatewayReachable.mock.calls
-      .map(([request]) => requireRecord(request, "probe request"))
-      .find((request) => request.url === "wss://gateway.example.test");
     expect(remoteProbe).toEqual({
       url: "wss://gateway.example.test",
-      token: "resolved-remote-token",
+      token: "token",
       timeoutMs: 300,
     });
   });

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => {
     resolveLocalControlUiProbeLinks: vi.fn(),
     inspectWindowsGatewayFirewall: vi.fn(),
     summarizeExistingConfig: vi.fn(),
+    healthCommand: vi.fn(),
     promptAuthConfig: vi.fn(),
     promptGatewayConfig: vi.fn(),
     promptRemoteGatewayConfig: vi.fn(async (cfg: OpenClawConfig) => ({
@@ -157,7 +158,7 @@ vi.mock("./onboard-helpers.js", () => ({
 }));
 
 vi.mock("./health.js", () => ({
-  healthCommand: vi.fn(),
+  healthCommand: mocks.healthCommand,
 }));
 
 vi.mock("./health-format.js", () => ({
@@ -463,6 +464,44 @@ describe("runConfigureWizard", () => {
     expect(events).toEqual(["gateway", "commit", "daemon"]);
     expect(maybeInstallDaemon).toHaveBeenCalledWith(expect.objectContaining({ port: 18991 }));
     expect(mocks.clackText).not.toHaveBeenCalled();
+  });
+
+  it("runs a selected remote health check with remote password auth", async () => {
+    const localPassword = "local-password"; // pragma: allowlist secret
+    const remotePassword = "remote-password"; // pragma: allowlist secret
+    const remoteConfig: OpenClawConfig = {
+      gateway: {
+        mode: "remote",
+        auth: { password: localPassword },
+        remote: {
+          url: "wss://gateway.example.test",
+          password: remotePassword,
+        },
+      },
+    };
+    setupBaseWizardState(remoteConfig);
+    queueWizardPrompts({ select: ["remote"], confirm: [] });
+    mocks.promptRemoteGatewayConfig.mockResolvedValueOnce(remoteConfig);
+
+    await runConfigureWizard({ command: "configure", sections: ["health"] }, createRuntime());
+
+    expect(mocks.waitForGatewayReachable).toHaveBeenCalledWith({
+      url: "wss://gateway.example.test",
+      token: undefined,
+      password: remotePassword,
+      deadlineMs: 15_000,
+    });
+    expect(mocks.healthCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: remoteConfig,
+        token: undefined,
+        password: remotePassword,
+      }),
+      expect.anything(),
+    );
+    expect(mocks.waitForGatewayReachable).not.toHaveBeenCalledWith(
+      expect.objectContaining({ password: localPassword }),
+    );
   });
 
   it("persists gateway.mode=local when only the run mode is selected", async () => {

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -510,30 +510,6 @@ describe("runConfigureWizard", () => {
     expect(remoteProbe?.timeoutMs).toBe(300);
   });
 
-  it("uses the configured remote password for the bounded startup hint probe", async () => {
-    const remotePassword = "remote-password"; // pragma: allowlist secret
-    setupBaseWizardState({
-      gateway: {
-        mode: "remote",
-        remote: {
-          url: "wss://gateway.example.test",
-          password: remotePassword,
-        },
-      },
-    });
-
-    await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
-
-    const remoteProbe = mocks.probeGatewayReachable.mock.calls
-      .map(([request]) => requireRecord(request, "probe request"))
-      .find((request) => request.url === "wss://gateway.example.test");
-    expect(remoteProbe).toMatchObject({
-      token: undefined,
-      password: remotePassword,
-      timeoutMs: 300,
-    });
-  });
-
   it("uses the environment password ahead of the configured remote password", async () => {
     const configuredPassword = "configured-password"; // pragma: allowlist secret
     const envPassword = "env-password"; // pragma: allowlist secret
@@ -546,17 +522,12 @@ describe("runConfigureWizard", () => {
         },
       },
     });
-    const previousPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
-    process.env.OPENCLAW_GATEWAY_PASSWORD = envPassword;
+    vi.stubEnv("OPENCLAW_GATEWAY_PASSWORD", envPassword);
 
     try {
       await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
     } finally {
-      if (previousPassword === undefined) {
-        delete process.env.OPENCLAW_GATEWAY_PASSWORD;
-      } else {
-        process.env.OPENCLAW_GATEWAY_PASSWORD = previousPassword;
-      }
+      vi.unstubAllEnvs();
     }
 
     const remoteProbe = mocks.probeGatewayReachable.mock.calls

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -4,6 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import {
+  createEnabledWebSearchConfig,
+  createSearchProviderOption,
+} from "./configure.wizard-test-helpers.js";
 
 const mocks = vi.hoisted(() => {
   const writeConfigFile = vi.fn();
@@ -237,33 +241,6 @@ function createRuntime() {
   };
 }
 
-function createSearchProviderOption(overrides: Record<string, unknown>) {
-  return overrides;
-}
-
-function createEnabledWebSearchConfig(provider: string, pluginEntry: Record<string, unknown>) {
-  return (cfg: OpenClawConfig) => ({
-    ...cfg,
-    tools: {
-      ...cfg.tools,
-      web: {
-        ...cfg.tools?.web,
-        search: {
-          provider,
-          enabled: true,
-        },
-      },
-    },
-    plugins: {
-      ...cfg.plugins,
-      entries: {
-        ...cfg.plugins?.entries,
-        [provider]: pluginEntry,
-      },
-    },
-  });
-}
-
 function setupBaseWizardState(config: OpenClawConfig = {}) {
   mocks.readConfigFileSnapshot.mockResolvedValue({
     ...EMPTY_CONFIG_SNAPSHOT,
@@ -485,6 +462,32 @@ describe("runConfigureWizard", () => {
 
     expect(mocks.healthCommand).toHaveBeenCalledWith(
       expect.objectContaining({ config: remoteConfig, token: undefined, password: remotePassword }),
+      expect.anything(),
+    );
+
+    const unresolvedConfig: OpenClawConfig = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example.test",
+          token: { source: "env", provider: "default", id: "MISSING_REMOTE_TOKEN" },
+        },
+      },
+      secrets: { providers: { default: { source: "env" } } },
+    };
+    setupBaseWizardState(unresolvedConfig);
+    queueWizardPrompts({ select: ["remote"], confirm: [] });
+    mocks.promptRemoteGatewayConfig.mockResolvedValueOnce(unresolvedConfig);
+    await withEnvAsync({ OPENCLAW_GATEWAY_PASSWORD: "ambient-password" }, async () => {
+      await runConfigureWizard({ command: "configure", sections: ["health"] }, createRuntime());
+    });
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("gateway.remote.token SecretRef is unresolved"),
+      "Gateway auth",
+    );
+    expect(mocks.healthCommand).toHaveBeenLastCalledWith(
+      expect.objectContaining({ token: undefined, password: undefined }),
       expect.anything(),
     );
   });

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -179,7 +179,9 @@ async function runGatewayHealthCheck(params: {
         config: params.cfg,
         token,
         password,
-        ...(probeMode === "local" ? { localPortOverride: params.port } : {}),
+        ...(probeMode === "local"
+          ? { localPortOverride: params.port }
+          : { ignoreEnvUrlOverride: true }),
       },
       params.runtime,
     );

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -110,8 +110,9 @@ async function runGatewayHealthCheck(params: {
     tlsEnabled: params.cfg.gateway?.tls?.enabled === true,
   });
   const remoteUrl = params.cfg.gateway?.remote?.url?.trim();
-  const probeMode = params.cfg.gateway?.mode === "remote" && remoteUrl ? "remote" : "local";
-  const wsUrl = probeMode === "remote" ? remoteUrl : localLinks.wsUrl;
+  const remoteWsUrl = params.cfg.gateway?.mode === "remote" ? remoteUrl : undefined;
+  const probeMode = remoteWsUrl ? "remote" : "local";
+  const wsUrl = remoteWsUrl ?? localLinks.wsUrl;
   let token: string | undefined;
   let password: string | undefined;
   // Remote and local probe credentials belong to different trust surfaces.

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -10,7 +10,7 @@ import { parsePort } from "../cli/shared/parse-port.js";
 import { readConfigFileSnapshotForWrite, resolveGatewayPort } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveGatewayProbeSurfaceAuth } from "../gateway/auth-surface-resolution.js";
+import { resolveGatewayProbeAuthSafeWithSecretInputs } from "../gateway/probe-auth.js";
 import { formatWindowsGatewayFirewallGuidance } from "../infra/windows-gateway-firewall-diagnostics.js";
 import { commitConfigWithPendingPluginInstalls } from "../plugins/install-record-commit.js";
 import { resolvePluginContributionOwners } from "../plugins/plugin-registry.js";
@@ -461,15 +461,15 @@ export async function runConfigureWizard(
       })();
       const remoteProbePromise = remoteUrl
         ? (async () => {
-            const remoteProbeAuth = await resolveGatewayProbeSurfaceAuth({
-              config: baseConfig,
+            const remoteProbeAuth = await resolveGatewayProbeAuthSafeWithSecretInputs({
+              cfg: baseConfig,
               env: process.env,
-              surface: "remote",
+              mode: "remote",
             });
             return probeGatewayReachable({
               url: remoteUrl,
-              token: remoteProbeAuth.token,
-              ...(remoteProbeAuth.password ? { password: remoteProbeAuth.password } : {}),
+              token: remoteProbeAuth.auth.token,
+              ...(remoteProbeAuth.auth.password ? { password: remoteProbeAuth.auth.password } : {}),
               timeoutMs: GATEWAY_HINT_PROBE_TIMEOUT_MS,
             });
           })()

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -101,7 +101,7 @@ async function runGatewayHealthCheck(params: {
   cfg: OpenClawConfig;
   runtime: RuntimeEnv;
   port: number;
-}): Promise<void> {
+}): Promise<boolean> {
   const localLinks = resolveLocalControlUiProbeLinks({
     bind: params.cfg.gateway?.bind ?? "loopback",
     port: params.port,
@@ -128,9 +128,12 @@ async function runGatewayHealthCheck(params: {
         [
           "Could not resolve remote gateway SecretRef for health check.",
           remoteProbeAuth.warning,
+          "Health check skipped to avoid falling back to ambient credentials.",
+          `Fix the SecretRef, then run \`${formatCliCommand("openclaw health")}\` again.`,
         ].join("\n"),
         "Gateway auth",
       );
+      return false;
     }
     ({ token, password } = remoteProbeAuth.auth);
   } else {
@@ -180,6 +183,7 @@ async function runGatewayHealthCheck(params: {
       "Health check help",
     );
   }
+  return true;
 }
 
 async function promptConfigureSection(
@@ -556,12 +560,16 @@ export async function runConfigureWizard(
       remoteConfig = committed.config;
       logConfigUpdated(runtime);
       if (selectedSections?.includes("health")) {
-        await runGatewayHealthCheck({
+        const healthCheckAttempted = await runGatewayHealthCheck({
           cfg: remoteConfig,
           runtime,
           port: resolveGatewayPort(remoteConfig),
         });
-        outro("Remote gateway configured and health check completed.");
+        outro(
+          healthCheckAttempted
+            ? "Remote gateway configured and health check completed."
+            : "Remote gateway configured; health check skipped.",
+        );
       } else {
         outro("Remote gateway configured.");
       }

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -10,6 +10,7 @@ import { parsePort } from "../cli/shared/parse-port.js";
 import { readConfigFileSnapshotForWrite, resolveGatewayPort } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveGatewayProbeSurfaceAuth } from "../gateway/auth-surface-resolution.js";
 import { formatWindowsGatewayFirewallGuidance } from "../infra/windows-gateway-firewall-diagnostics.js";
 import { commitConfigWithPendingPluginInstalls } from "../plugins/install-record-commit.js";
 import { resolvePluginContributionOwners } from "../plugins/plugin-registry.js";
@@ -460,14 +461,15 @@ export async function runConfigureWizard(
       })();
       const remoteProbePromise = remoteUrl
         ? (async () => {
-            const baseRemoteProbeToken = await resolveGatewaySecretInputForWizard({
-              cfg: baseConfig,
-              value: baseConfig.gateway?.remote?.token,
-              path: "gateway.remote.token",
+            const remoteProbeAuth = await resolveGatewayProbeSurfaceAuth({
+              config: baseConfig,
+              env: process.env,
+              surface: "remote",
             });
             return probeGatewayReachable({
               url: remoteUrl,
-              token: baseRemoteProbeToken,
+              token: remoteProbeAuth.token,
+              ...(remoteProbeAuth.password ? { password: remoteProbeAuth.password } : {}),
               timeoutMs: GATEWAY_HINT_PROBE_TIMEOUT_MS,
             });
           })()

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -110,20 +110,35 @@ async function runGatewayHealthCheck(params: {
     tlsEnabled: params.cfg.gateway?.tls?.enabled === true,
   });
   const remoteUrl = params.cfg.gateway?.remote?.url?.trim();
-  const wsUrl = params.cfg.gateway?.mode === "remote" && remoteUrl ? remoteUrl : localLinks.wsUrl;
-  const configuredToken = await resolveGatewaySecretInputForWizard({
-    cfg: params.cfg,
-    value: params.cfg.gateway?.auth?.token,
-    path: "gateway.auth.token",
-  });
-  const configuredPassword = await resolveGatewaySecretInputForWizard({
-    cfg: params.cfg,
-    value: params.cfg.gateway?.auth?.password,
-    path: "gateway.auth.password",
-  });
-  const token = normalizeOptionalString(process.env.OPENCLAW_GATEWAY_TOKEN) ?? configuredToken;
-  const password =
-    normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD) ?? configuredPassword;
+  const probeMode = params.cfg.gateway?.mode === "remote" && remoteUrl ? "remote" : "local";
+  const wsUrl = probeMode === "remote" ? remoteUrl : localLinks.wsUrl;
+  let token: string | undefined;
+  let password: string | undefined;
+  // Remote and local probe credentials belong to different trust surfaces.
+  // Keep their resolution separate so one target never receives the other's secrets.
+  if (probeMode === "remote") {
+    const remoteProbeAuth = await resolveGatewayProbeAuthSafeWithSecretInputs({
+      cfg: params.cfg,
+      env: process.env,
+      mode: "remote",
+    });
+    ({ token, password } = remoteProbeAuth.auth);
+  } else {
+    const [configuredToken, configuredPassword] = await Promise.all([
+      resolveGatewaySecretInputForWizard({
+        cfg: params.cfg,
+        value: params.cfg.gateway?.auth?.token,
+        path: "gateway.auth.token",
+      }),
+      resolveGatewaySecretInputForWizard({
+        cfg: params.cfg,
+        value: params.cfg.gateway?.auth?.password,
+        path: "gateway.auth.password",
+      }),
+    ]);
+    token = normalizeOptionalString(process.env.OPENCLAW_GATEWAY_TOKEN) ?? configuredToken;
+    password = normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD) ?? configuredPassword;
+  }
 
   await waitForGatewayReachable({
     url: wsUrl,
@@ -133,7 +148,17 @@ async function runGatewayHealthCheck(params: {
   });
 
   try {
-    await healthCommand({ json: false, timeoutMs: 10_000 }, params.runtime);
+    await healthCommand(
+      {
+        json: false,
+        timeoutMs: 10_000,
+        config: params.cfg,
+        token,
+        password,
+        ...(probeMode === "local" ? { localPortOverride: params.port } : {}),
+      },
+      params.runtime,
+    );
   } catch (err) {
     params.runtime.error(formatHealthCheckFailure(err));
     note(
@@ -520,7 +545,16 @@ export async function runConfigureWizard(
       });
       remoteConfig = committed.config;
       logConfigUpdated(runtime);
-      outro("Remote gateway configured.");
+      if (selectedSections?.includes("health")) {
+        await runGatewayHealthCheck({
+          cfg: remoteConfig,
+          runtime,
+          port: resolveGatewayPort(remoteConfig),
+        });
+        outro("Remote gateway configured and health check completed.");
+      } else {
+        outro("Remote gateway configured.");
+      }
       return;
     }
 

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -124,16 +124,27 @@ async function runGatewayHealthCheck(params: {
       mode: "remote",
     });
     if (remoteProbeAuth.warning) {
+      const hasResolvedRemoteAuth = Boolean(
+        remoteProbeAuth.auth.token || remoteProbeAuth.auth.password,
+      );
       note(
         [
           "Could not resolve remote gateway SecretRef for health check.",
           remoteProbeAuth.warning,
-          "Health check skipped to avoid falling back to ambient credentials.",
-          `Fix the SecretRef, then run \`${formatCliCommand("openclaw health")}\` again.`,
+          ...(hasResolvedRemoteAuth
+            ? ["Continuing with the other configured remote credential."]
+            : [
+                "Health check skipped to avoid falling back to ambient credentials.",
+                `Fix the SecretRef, then run \`${formatCliCommand("openclaw health")}\` again.`,
+              ]),
         ].join("\n"),
         "Gateway auth",
       );
-      return false;
+      // A failed ref does not invalidate a resolved sibling config credential.
+      // Skip only when generic health auth could otherwise recover ambient auth.
+      if (!hasResolvedRemoteAuth) {
+        return false;
+      }
     }
     ({ token, password } = remoteProbeAuth.auth);
   } else {

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -123,6 +123,15 @@ async function runGatewayHealthCheck(params: {
       env: process.env,
       mode: "remote",
     });
+    if (remoteProbeAuth.warning) {
+      note(
+        [
+          "Could not resolve remote gateway SecretRef for health check.",
+          remoteProbeAuth.warning,
+        ].join("\n"),
+        "Gateway auth",
+      );
+    }
     ({ token, password } = remoteProbeAuth.auth);
   } else {
     const [configuredToken, configuredPassword] = await Promise.all([

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -163,28 +163,33 @@ describe("resolveAuthForTarget", () => {
   });
 
   it("does not force remote auth type from local auth mode", async () => {
-    const auth = await resolveAuthForTarget(
-      {
-        gateway: {
-          auth: {
-            mode: "password",
+    await withEnvAsync(
+      { OPENCLAW_GATEWAY_PASSWORD: "ambient-password" }, // pragma: allowlist secret
+      async () => {
+        const auth = await resolveAuthForTarget(
+          {
+            gateway: {
+              auth: {
+                mode: "password",
+              },
+              remote: {
+                token: "remote-token",
+                password: "remote-password", // pragma: allowlist secret
+              },
+            },
           },
-          remote: {
-            token: "remote-token",
-            password: "remote-password", // pragma: allowlist secret
+          {
+            id: "configRemote",
+            kind: "configRemote",
+            url: "wss://remote.example:18789",
+            active: true,
           },
-        },
-      },
-      {
-        id: "configRemote",
-        kind: "configRemote",
-        url: "wss://remote.example:18789",
-        active: true,
-      },
-      {},
-    );
+          {},
+        );
 
-    expect(auth).toEqual({ token: "remote-token", password: undefined });
+        expect(auth).toEqual({ token: "remote-token", password: undefined });
+      },
+    );
   });
 
   it("redacts resolver internals from unresolved SecretRef diagnostics", async () => {

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -382,6 +382,7 @@ describe("healthCommand", () => {
         config: {},
         token: "setup-token",
         password: "setup-password",
+        ignoreEnvUrlOverride: true,
       },
       runtime as never,
     );
@@ -391,6 +392,7 @@ describe("healthCommand", () => {
     expect(gatewayRequest.method).toBe("health");
     expect(gatewayRequest.token).toBe("setup-token");
     expect(gatewayRequest.password).toBe("setup-password");
+    expect(gatewayRequest.ignoreEnvUrlOverride).toBe(true);
   });
 
   it("outputs JSON for gateway transport failures in JSON mode", async () => {
@@ -639,9 +641,19 @@ describe("healthCommand", () => {
       error: TEST_AUTH_CLOSE_ERROR,
     });
 
-    await healthCommand({ json: false, timeoutMs: 5000, config: {} }, runtime as never);
+    await healthCommand(
+      { json: false, timeoutMs: 5000, config: {}, ignoreEnvUrlOverride: true },
+      runtime as never,
+    );
 
     expect(isGatewaySecretRefUnavailableErrorMock).toHaveBeenCalledWith(error);
+    expect(buildGatewayProbeConnectionDetailsMock).toHaveBeenCalledWith({
+      config: {},
+      token: undefined,
+      password: undefined,
+      ignoreEnvUrlOverride: true,
+      localPortOverride: undefined,
+    });
     expect(probeGatewayStatusMock).toHaveBeenCalledWith({
       url: TEST_GATEWAY_URL,
       token: undefined,

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -72,6 +72,7 @@ export async function emitReachableGatewayAuthDiagnostic(params: {
   timeoutMs?: number;
   token?: string;
   password?: string;
+  ignoreEnvUrlOverride?: boolean;
   localPortOverride?: number;
   json?: boolean;
 }): Promise<boolean> {
@@ -94,6 +95,7 @@ export async function emitReachableGatewayAuthDiagnostic(params: {
     config: params.config,
     token: params.token,
     password: params.password,
+    ignoreEnvUrlOverride: params.ignoreEnvUrlOverride,
     localPortOverride: params.localPortOverride,
   });
   const probe = await probeGatewayStatus({
@@ -226,6 +228,7 @@ export async function healthCommand(
     config?: OpenClawConfig;
     token?: string;
     password?: string;
+    ignoreEnvUrlOverride?: boolean;
     localPortOverride?: number;
   },
   runtime: RuntimeEnv,
@@ -248,6 +251,7 @@ export async function healthCommand(
           config: cfg,
           token: opts.token,
           password: opts.password,
+          ignoreEnvUrlOverride: opts.ignoreEnvUrlOverride,
           localPortOverride: opts.localPortOverride,
         }),
     );
@@ -260,6 +264,7 @@ export async function healthCommand(
         timeoutMs: opts.timeoutMs,
         token: opts.token,
         password: opts.password,
+        ignoreEnvUrlOverride: opts.ignoreEnvUrlOverride,
         localPortOverride: opts.localPortOverride,
         json: opts.json,
       })
@@ -290,6 +295,7 @@ export async function healthCommand(
     if (opts.verbose) {
       const details = buildGatewayConnectionDetails({
         config: cfg,
+        ignoreEnvUrlOverride: opts.ignoreEnvUrlOverride,
         localPortOverride: opts.localPortOverride,
       });
       logGatewayConnectionDetails({

--- a/src/gateway/credentials-secret-inputs.ts
+++ b/src/gateway/credentials-secret-inputs.ts
@@ -35,7 +35,6 @@ type GatewayCredentialSecretInputOptions = {
   remotePasswordPrecedence?: GatewayRemoteCredentialPrecedence;
   remoteTokenFallback?: GatewayRemoteCredentialFallback;
   remotePasswordFallback?: GatewayRemoteCredentialFallback;
-  remoteCredentialTypesIndependent?: boolean;
 };
 
 /** Internal options after explicit auth has been trimmed to real credential values. */
@@ -167,11 +166,6 @@ function canGatewaySecretInputPathWin(params: {
         options: params.options,
       }),
     );
-    if (mode === "remote" && params.options.remoteCredentialTypesIndependent) {
-      // A remote target's auth mode is unknown, so probe callers must materialize
-      // token and password slots independently instead of letting either hide the other.
-      return resolved.token === sentinel || resolved.password === sentinel;
-    }
     const authMode = params.config.gateway?.auth?.mode;
     const tokenCanWin =
       resolved.token === sentinel &&

--- a/src/gateway/credentials-secret-inputs.ts
+++ b/src/gateway/credentials-secret-inputs.ts
@@ -35,6 +35,7 @@ type GatewayCredentialSecretInputOptions = {
   remotePasswordPrecedence?: GatewayRemoteCredentialPrecedence;
   remoteTokenFallback?: GatewayRemoteCredentialFallback;
   remotePasswordFallback?: GatewayRemoteCredentialFallback;
+  remoteCredentialTypesIndependent?: boolean;
 };
 
 /** Internal options after explicit auth has been trimmed to real credential values. */
@@ -166,6 +167,11 @@ function canGatewaySecretInputPathWin(params: {
         options: params.options,
       }),
     );
+    if (mode === "remote" && params.options.remoteCredentialTypesIndependent) {
+      // A remote target's auth mode is unknown, so probe callers must materialize
+      // token and password slots independently instead of letting either hide the other.
+      return resolved.token === sentinel || resolved.password === sentinel;
+    }
     const authMode = params.config.gateway?.auth?.mode;
     const tokenCanWin =
       resolved.token === sentinel &&

--- a/src/gateway/credentials.ts
+++ b/src/gateway/credentials.ts
@@ -338,11 +338,15 @@ export function resolveGatewayProbeCredentialsFromConfig(params: {
   mode: GatewayCredentialMode;
   env?: NodeJS.ProcessEnv;
   explicitAuth?: ExplicitGatewayAuth;
+  urlOverride?: string;
+  urlOverrideSource?: "cli" | "env";
 }): ResolvedGatewayCredentials {
   return resolveGatewayCredentialsFromConfig({
     cfg: params.cfg,
     env: params.env,
     explicitAuth: params.explicitAuth,
+    urlOverride: params.urlOverride,
+    urlOverrideSource: params.urlOverrideSource,
     modeOverride: params.mode,
     remoteTokenFallback: "remote-only",
   });

--- a/src/gateway/probe-auth.test.ts
+++ b/src/gateway/probe-auth.test.ts
@@ -211,6 +211,30 @@ describe("resolveGatewayProbeAuthSafeWithSecretInputs", () => {
     expect(result.warning).toContain("gateway.auth.token");
     expect(result.warning).toContain("unresolved");
   });
+
+  it("resolves a remote token SecretRef alongside an environment password", async () => {
+    const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
+      cfg: configWithDefaultEnvProvider({
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example",
+          token: envSecretRef("REMOTE_GATEWAY_TOKEN"),
+        },
+      }),
+      mode: "remote",
+      env: {
+        REMOTE_GATEWAY_TOKEN: "resolved-remote-token",
+        OPENCLAW_GATEWAY_PASSWORD: "env-password", // pragma: allowlist secret
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(result).toEqual({
+      auth: {
+        token: "resolved-remote-token",
+        password: "env-password", // pragma: allowlist secret
+      },
+    });
+  });
 });
 
 describe("resolveGatewayProbeAuthWithSecretInputs", () => {

--- a/src/gateway/probe-auth.test.ts
+++ b/src/gateway/probe-auth.test.ts
@@ -235,6 +235,52 @@ describe("resolveGatewayProbeAuthSafeWithSecretInputs", () => {
       },
     });
   });
+
+  it("does not resolve a local password SecretRef for a remote probe", async () => {
+    const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
+      cfg: configWithDefaultEnvProvider({
+        mode: "remote",
+        auth: {
+          mode: "password",
+          password: envSecretRef("LOCAL_GATEWAY_PASSWORD"),
+        },
+        remote: {
+          url: "wss://gateway.example",
+          token: "remote-token",
+        },
+      }),
+      mode: "remote",
+      env: {
+        LOCAL_GATEWAY_PASSWORD: "local-password", // pragma: allowlist secret
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(result).toEqual({
+      auth: {
+        token: "remote-token",
+        password: undefined,
+      },
+    });
+  });
+
+  it("does not use ambient credentials for a CLI URL override", async () => {
+    const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
+      cfg: {
+        gateway: {
+          mode: "remote",
+          remote: { url: "wss://configured.example" },
+        },
+      } as OpenClawConfig,
+      mode: "remote",
+      env: {
+        OPENCLAW_GATEWAY_PASSWORD: "ambient-password", // pragma: allowlist secret
+      } as NodeJS.ProcessEnv,
+      urlOverride: "wss://override.example",
+      urlOverrideSource: "cli",
+    });
+
+    expect(result).toEqual({ auth: {} });
+  });
 });
 
 describe("resolveGatewayProbeAuthWithSecretInputs", () => {

--- a/src/gateway/probe-auth.test.ts
+++ b/src/gateway/probe-auth.test.ts
@@ -276,6 +276,24 @@ describe("resolveGatewayProbeAuthSafeWithSecretInputs", () => {
     expect(result.warning).toContain("gateway.remote.token SecretRef is unresolved");
   });
 
+  it("preserves a configured remote password when the token ref fails", async () => {
+    const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
+      cfg: configWithDefaultEnvProvider({
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example",
+          token: envSecretRef("MISSING_REMOTE_TOKEN"),
+          password: "remote-password", // pragma: allowlist secret
+        },
+      }),
+      mode: "remote",
+      env: { OPENCLAW_GATEWAY_PASSWORD: "ambient-password" } as NodeJS.ProcessEnv, // pragma: allowlist secret
+    });
+
+    expect(result.auth).toEqual({ token: undefined, password: "remote-password" }); // pragma: allowlist secret
+    expect(result.warning).toContain("gateway.remote.token SecretRef is unresolved");
+  });
+
   it("blocks ambient token fallback when a configured remote password ref fails", async () => {
     const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
       cfg: configWithDefaultEnvProvider({

--- a/src/gateway/probe-auth.test.ts
+++ b/src/gateway/probe-auth.test.ts
@@ -236,6 +236,32 @@ describe("resolveGatewayProbeAuthSafeWithSecretInputs", () => {
     });
   });
 
+  it("keeps a configured remote password authoritative over environment auth", async () => {
+    const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
+      cfg: {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "wss://gateway.example",
+            password: "remote-password", // pragma: allowlist secret
+          },
+        },
+      },
+      mode: "remote",
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "env-token",
+        OPENCLAW_GATEWAY_PASSWORD: "env-password", // pragma: allowlist secret
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(result).toEqual({
+      auth: {
+        token: undefined,
+        password: "remote-password", // pragma: allowlist secret
+      },
+    });
+  });
+
   it("blocks ambient password fallback when a configured remote token ref fails", async () => {
     const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
       cfg: configWithDefaultEnvProvider({

--- a/src/gateway/probe-auth.test.ts
+++ b/src/gateway/probe-auth.test.ts
@@ -236,6 +236,37 @@ describe("resolveGatewayProbeAuthSafeWithSecretInputs", () => {
     });
   });
 
+  it("blocks ambient password fallback when a configured remote token ref fails", async () => {
+    const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
+      cfg: configWithDefaultEnvProvider({
+        mode: "remote",
+        remote: { url: "wss://gateway.example", token: envSecretRef("MISSING_REMOTE_TOKEN") },
+      }),
+      mode: "remote",
+      env: { OPENCLAW_GATEWAY_PASSWORD: "ambient-password" } as NodeJS.ProcessEnv, // pragma: allowlist secret
+    });
+
+    expect(result.auth).toStrictEqual({});
+    expect(result.warning).toContain("gateway.remote.token SecretRef is unresolved");
+  });
+
+  it("blocks ambient token fallback when a configured remote password ref fails", async () => {
+    const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
+      cfg: configWithDefaultEnvProvider({
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example",
+          password: envSecretRef("MISSING_REMOTE_PASSWORD"), // pragma: allowlist secret
+        },
+      }),
+      mode: "remote",
+      env: { OPENCLAW_GATEWAY_TOKEN: "ambient-token" } as NodeJS.ProcessEnv,
+    });
+
+    expect(result.auth).toStrictEqual({});
+    expect(result.warning).toContain("gateway.remote.password SecretRef is unresolved");
+  });
+
   it("does not resolve a local password SecretRef for a remote probe", async () => {
     const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
       cfg: configWithDefaultEnvProvider({

--- a/src/gateway/probe-auth.test.ts
+++ b/src/gateway/probe-auth.test.ts
@@ -212,7 +212,7 @@ describe("resolveGatewayProbeAuthSafeWithSecretInputs", () => {
     expect(result.warning).toContain("unresolved");
   });
 
-  it("resolves a remote token SecretRef alongside an environment password", async () => {
+  it("keeps a configured remote token authoritative over an environment password", async () => {
     const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
       cfg: configWithDefaultEnvProvider({
         mode: "remote",
@@ -231,7 +231,7 @@ describe("resolveGatewayProbeAuthSafeWithSecretInputs", () => {
     expect(result).toEqual({
       auth: {
         token: "resolved-remote-token",
-        password: "env-password", // pragma: allowlist secret
+        password: undefined,
       },
     });
   });

--- a/src/gateway/probe-auth.ts
+++ b/src/gateway/probe-auth.ts
@@ -19,6 +19,8 @@ function buildGatewayProbeCredentialPolicy(params: {
   mode: "local" | "remote";
   env?: NodeJS.ProcessEnv;
   explicitAuth?: ExplicitGatewayAuth;
+  urlOverride?: string;
+  urlOverrideSource?: "cli" | "env";
 }) {
   const cfg = resolveGatewayProbeCredentialConfig(params);
   return {
@@ -26,6 +28,8 @@ function buildGatewayProbeCredentialPolicy(params: {
     cfg,
     env: params.env,
     explicitAuth: params.explicitAuth,
+    urlOverride: params.urlOverride,
+    urlOverrideSource: params.urlOverrideSource,
     modeOverride: params.mode,
     mode: params.mode,
     remoteTokenFallback: "remote-only" as const,
@@ -36,25 +40,24 @@ export function resolveGatewayProbeCredentialConfig(params: {
   cfg: OpenClawConfig;
   mode: "local" | "remote";
 }): OpenClawConfig {
-  if (params.mode !== "local") {
+  const gateway = params.cfg.gateway;
+  const credentials = params.mode === "local" ? gateway?.remote : gateway?.auth;
+  if (!credentials || (credentials.token === undefined && credentials.password === undefined)) {
     return params.cfg;
   }
 
-  const remote = params.cfg.gateway?.remote;
-  if (!remote || (remote.token === undefined && remote.password === undefined)) {
-    return params.cfg;
-  }
-
-  // Strip remote auth only for local probes; otherwise remote credentials can
-  // mask a missing local token and make the wrong gateway look healthy.
-  const remoteWithoutAuth = { ...remote };
-  delete remoteWithoutAuth.token;
-  delete remoteWithoutAuth.password;
+  // A probe may only use credentials owned by its target surface. Otherwise a
+  // healthy result can both target the wrong Gateway and disclose its peer's secret.
+  const credentialsWithoutAuth = { ...credentials };
+  delete credentialsWithoutAuth.token;
+  delete credentialsWithoutAuth.password;
   return {
     ...params.cfg,
     gateway: {
-      ...params.cfg.gateway,
-      remote: remoteWithoutAuth,
+      ...gateway,
+      ...(params.mode === "local"
+        ? { remote: credentialsWithoutAuth }
+        : { auth: credentialsWithoutAuth }),
     },
   };
 }
@@ -88,6 +91,8 @@ export function resolveGatewayProbeAuth(params: {
   cfg: OpenClawConfig;
   mode: "local" | "remote";
   env?: NodeJS.ProcessEnv;
+  urlOverride?: string;
+  urlOverrideSource?: "cli" | "env";
 }): { token?: string; password?: string } {
   const policy = buildGatewayProbeCredentialPolicy(params);
   return resolveGatewayProbeCredentialsFromConfig(policy);
@@ -99,12 +104,16 @@ export async function resolveGatewayProbeAuthWithSecretInputs(params: {
   mode: "local" | "remote";
   env?: NodeJS.ProcessEnv;
   explicitAuth?: ExplicitGatewayAuth;
+  urlOverride?: string;
+  urlOverrideSource?: "cli" | "env";
 }): Promise<{ token?: string; password?: string }> {
   const policy = buildGatewayProbeCredentialPolicy(params);
   return await resolveGatewayCredentialsWithSecretInputs({
     config: policy.config,
     env: policy.env,
     explicitAuth: policy.explicitAuth,
+    urlOverride: policy.urlOverride,
+    urlOverrideSource: policy.urlOverrideSource,
     modeOverride: policy.modeOverride,
     remoteTokenFallback: policy.remoteTokenFallback,
     remoteCredentialTypesIndependent: true,
@@ -117,6 +126,8 @@ export async function resolveGatewayProbeAuthSafeWithSecretInputs(params: {
   mode: "local" | "remote";
   env?: NodeJS.ProcessEnv;
   explicitAuth?: ExplicitGatewayAuth;
+  urlOverride?: string;
+  urlOverrideSource?: "cli" | "env";
 }): Promise<{
   auth: { token?: string; password?: string };
   warning?: string;
@@ -145,6 +156,8 @@ export function resolveGatewayProbeAuthSafe(params: {
   mode: "local" | "remote";
   env?: NodeJS.ProcessEnv;
   explicitAuth?: ExplicitGatewayAuth;
+  urlOverride?: string;
+  urlOverrideSource?: "cli" | "env";
 }): {
   auth: { token?: string; password?: string };
   warning?: string;

--- a/src/gateway/probe-auth.ts
+++ b/src/gateway/probe-auth.ts
@@ -107,6 +107,7 @@ export async function resolveGatewayProbeAuthWithSecretInputs(params: {
     explicitAuth: policy.explicitAuth,
     modeOverride: policy.modeOverride,
     remoteTokenFallback: policy.remoteTokenFallback,
+    remoteCredentialTypesIndependent: true,
   });
 }
 

--- a/src/gateway/probe-auth.ts
+++ b/src/gateway/probe-auth.ts
@@ -2,6 +2,7 @@
 // Adapts gateway credential precedence for local/remote reachability checks.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveGatewayProbeSurfaceAuth } from "./auth-surface-resolution.js";
 import { resolveGatewayCredentialsWithSecretInputs } from "./credentials-secret-inputs.js";
 import {
   type ExplicitGatewayAuth,
@@ -98,6 +99,48 @@ export function resolveGatewayProbeAuth(params: {
   return resolveGatewayProbeCredentialsFromConfig(policy);
 }
 
+async function resolveGatewayProbeAuthResolutionWithSecretInputs(params: {
+  cfg: OpenClawConfig;
+  mode: "local" | "remote";
+  env?: NodeJS.ProcessEnv;
+  explicitAuth?: ExplicitGatewayAuth;
+  urlOverride?: string;
+  urlOverrideSource?: "cli" | "env";
+}): Promise<{
+  auth: { token?: string; password?: string };
+  warning?: string;
+}> {
+  const policy = buildGatewayProbeCredentialPolicy(params);
+  const explicitAuth = resolveExplicitProbeAuth(params.explicitAuth);
+  if (
+    params.mode === "remote" &&
+    !hasExplicitProbeAuth(explicitAuth) &&
+    !normalizeOptionalString(params.urlOverride)
+  ) {
+    // Remote startup, status, and wizard probes must share one precedence owner.
+    // Otherwise one entry point can forward an ambient secret that its siblings omit.
+    const resolved = await resolveGatewayProbeSurfaceAuth({
+      config: policy.config,
+      env: policy.env,
+      surface: "remote",
+    });
+    return {
+      auth: { token: resolved.token, password: resolved.password },
+      ...(resolved.diagnostics?.length ? { warning: resolved.diagnostics.join("\n") } : {}),
+    };
+  }
+  const auth = await resolveGatewayCredentialsWithSecretInputs({
+    config: policy.config,
+    env: policy.env,
+    explicitAuth: policy.explicitAuth,
+    urlOverride: policy.urlOverride,
+    urlOverrideSource: policy.urlOverrideSource,
+    modeOverride: policy.modeOverride,
+    remoteTokenFallback: policy.remoteTokenFallback,
+  });
+  return { auth };
+}
+
 /** Resolves probe auth with async SecretRef support. */
 export async function resolveGatewayProbeAuthWithSecretInputs(params: {
   cfg: OpenClawConfig;
@@ -107,17 +150,7 @@ export async function resolveGatewayProbeAuthWithSecretInputs(params: {
   urlOverride?: string;
   urlOverrideSource?: "cli" | "env";
 }): Promise<{ token?: string; password?: string }> {
-  const policy = buildGatewayProbeCredentialPolicy(params);
-  return await resolveGatewayCredentialsWithSecretInputs({
-    config: policy.config,
-    env: policy.env,
-    explicitAuth: policy.explicitAuth,
-    urlOverride: policy.urlOverride,
-    urlOverrideSource: policy.urlOverrideSource,
-    modeOverride: policy.modeOverride,
-    remoteTokenFallback: policy.remoteTokenFallback,
-    remoteCredentialTypesIndependent: true,
-  });
+  return (await resolveGatewayProbeAuthResolutionWithSecretInputs(params)).auth;
 }
 
 /** Resolves probe auth without throwing for unavailable SecretRefs, returning a warning. */
@@ -140,8 +173,7 @@ export async function resolveGatewayProbeAuthSafeWithSecretInputs(params: {
   }
 
   try {
-    const auth = await resolveGatewayProbeAuthWithSecretInputs(params);
-    return { auth };
+    return await resolveGatewayProbeAuthResolutionWithSecretInputs(params);
   } catch (error) {
     return {
       auth: {},

--- a/src/gateway/probe-auth.ts
+++ b/src/gateway/probe-auth.ts
@@ -126,9 +126,15 @@ async function resolveGatewayProbeAuthResolutionWithSecretInputs(params: {
     });
     const warning = resolved.diagnostics?.join("\n");
     if (warning) {
-      // A configured remote ref is an explicit trust choice. If it fails,
-      // never replace it with ambient credentials for a strict probe.
-      return { auth: {}, warning };
+      // A configured remote ref is an explicit trust choice. Keep a resolved
+      // sibling config credential, but never replace it with ambient fallback.
+      return {
+        auth:
+          resolved.source === "config"
+            ? { token: resolved.token, password: resolved.password }
+            : {},
+        warning,
+      };
     }
     return {
       auth: { token: resolved.token, password: resolved.password },

--- a/src/gateway/probe-auth.ts
+++ b/src/gateway/probe-auth.ts
@@ -124,9 +124,14 @@ async function resolveGatewayProbeAuthResolutionWithSecretInputs(params: {
       env: policy.env,
       surface: "remote",
     });
+    const warning = resolved.diagnostics?.join("\n");
+    if (warning) {
+      // A configured remote ref is an explicit trust choice. If it fails,
+      // never replace it with ambient credentials for a strict probe.
+      return { auth: {}, warning };
+    }
     return {
       auth: { token: resolved.token, password: resolved.password },
-      ...(resolved.diagnostics?.length ? { warning: resolved.diagnostics.join("\n") } : {}),
     };
   }
   const auth = await resolveGatewayCredentialsWithSecretInputs({

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1043,6 +1043,39 @@ describe("runSetupWizard", () => {
     });
   });
 
+  it("resolves a remote token ref alongside an environment password", async () => {
+    readConfigFileSnapshot.mockResolvedValueOnce(
+      configSnapshot({
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "wss://gateway.example.test",
+            token: { source: "env", provider: "default", id: "REMOTE_SECRET_TOKEN" },
+          },
+        },
+        secrets: { providers: { default: { source: "env" } } },
+      }),
+    );
+    vi.stubEnv("REMOTE_SECRET_TOKEN", "resolved-remote-token");
+    vi.stubEnv("OPENCLAW_GATEWAY_PASSWORD", "env-password"); // pragma: allowlist secret
+
+    try {
+      await runSetupWizard(
+        { acceptRisk: true, flow: "advanced", mode: "remote" },
+        createRuntime(),
+        buildWizardPrompter({}),
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(probeGatewayReachable).toHaveBeenCalledWith({
+      url: "wss://gateway.example.test",
+      token: "resolved-remote-token",
+      password: "env-password", // pragma: allowlist secret
+    });
+  });
+
   it("does not use an ambient gateway token for the setup remote probe", async () => {
     readConfigFileSnapshot.mockResolvedValueOnce(
       configSnapshot({

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1043,6 +1043,40 @@ describe("runSetupWizard", () => {
     });
   });
 
+  it("does not use an ambient gateway token for the setup remote probe", async () => {
+    readConfigFileSnapshot.mockResolvedValueOnce(
+      configSnapshot({
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "wss://gateway.example.test",
+          },
+        },
+      }),
+    );
+    const previousToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "ambient-token"; // pragma: allowlist secret
+
+    try {
+      await runSetupWizard(
+        { acceptRisk: true, flow: "advanced", mode: "remote" },
+        createRuntime(),
+        buildWizardPrompter({}),
+      );
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previousToken;
+      }
+    }
+
+    expect(probeGatewayReachable).toHaveBeenCalledWith({
+      url: "wss://gateway.example.test",
+      token: undefined,
+    });
+  });
+
   it("does not reuse stored remote credentials for an overridden URL", async () => {
     readConfigFileSnapshot.mockResolvedValueOnce({
       path: "/tmp/.openclaw/openclaw.json",

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1016,6 +1016,33 @@ describe("runSetupWizard", () => {
     expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining(remoteToken));
   });
 
+  it("uses the configured remote password for the setup reachability probe", async () => {
+    const remotePassword = "remote-password"; // pragma: allowlist secret
+    readConfigFileSnapshot.mockResolvedValueOnce(
+      configSnapshot({
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "wss://gateway.example.test",
+            password: remotePassword,
+          },
+        },
+      }),
+    );
+
+    await runSetupWizard(
+      { acceptRisk: true, flow: "advanced", mode: "remote" },
+      createRuntime(),
+      buildWizardPrompter({}),
+    );
+
+    expect(probeGatewayReachable).toHaveBeenCalledWith({
+      url: "wss://gateway.example.test",
+      token: undefined,
+      password: remotePassword,
+    });
+  });
+
   it("does not reuse stored remote credentials for an overridden URL", async () => {
     readConfigFileSnapshot.mockResolvedValueOnce({
       path: "/tmp/.openclaw/openclaw.json",

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1043,7 +1043,7 @@ describe("runSetupWizard", () => {
     });
   });
 
-  it("resolves a remote token ref alongside an environment password", async () => {
+  it("keeps a configured remote token authoritative over an environment password", async () => {
     readConfigFileSnapshot.mockResolvedValueOnce(
       configSnapshot({
         gateway: {
@@ -1072,11 +1072,10 @@ describe("runSetupWizard", () => {
     expect(probeGatewayReachable).toHaveBeenCalledWith({
       url: "wss://gateway.example.test",
       token: "resolved-remote-token",
-      password: "env-password", // pragma: allowlist secret
     });
   });
 
-  it("does not use an ambient gateway token for the setup remote probe", async () => {
+  it("uses an ambient gateway token as the shared remote fallback", async () => {
     readConfigFileSnapshot.mockResolvedValueOnce(
       configSnapshot({
         gateway: {
@@ -1106,7 +1105,7 @@ describe("runSetupWizard", () => {
 
     expect(probeGatewayReachable).toHaveBeenCalledWith({
       url: "wss://gateway.example.test",
-      token: undefined,
+      token: "ambient-token",
     });
   });
 

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1132,17 +1132,22 @@ describe("runSetupWizard", () => {
       warnings: [],
       legacyIssues: [],
     });
+    vi.stubEnv("OPENCLAW_GATEWAY_PASSWORD", "ambient-password"); // pragma: allowlist secret
 
-    await runSetupWizard(
-      {
-        acceptRisk: true,
-        flow: "advanced",
-        mode: "remote",
-        remoteUrl: "wss://flag.example.com:18789",
-      },
-      createRuntime(),
-      buildWizardPrompter({}),
-    );
+    try {
+      await runSetupWizard(
+        {
+          acceptRisk: true,
+          flow: "advanced",
+          mode: "remote",
+          remoteUrl: "wss://flag.example.com:18789",
+        },
+        createRuntime(),
+        buildWizardPrompter({}),
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
 
     expect(probeGatewayReachable).toHaveBeenCalledWith({
       url: "wss://flag.example.com:18789",

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -9,7 +9,7 @@ import { createMergePatch } from "../config/merge-patch.js";
 import { applyMergePatch } from "../config/merge-patch.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizeSecretInputString } from "../config/types.secrets.js";
+import { resolveGatewayProbeSurfaceAuth } from "../gateway/auth-surface-resolution.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   buildPluginCompatibilitySnapshotNotices,
@@ -417,22 +417,18 @@ async function runSetupWizardOnce(
     seededRemoteUrl && remoteOnboard?.validateGatewayWebSocketUrl(seededRemoteUrl) === undefined
       ? seededRemoteUrl
       : "";
-  let remoteGatewayToken = normalizeSecretInputString(remoteSeedConfig.gateway?.remote?.token);
-  try {
-    const resolvedRemoteGatewayToken = await resolveSetupSecretInputString({
-      config: remoteSeedConfig,
-      value: remoteSeedConfig.gateway?.remote?.token,
-      path: "gateway.remote.token",
-      env: process.env,
-    });
-    if (resolvedRemoteGatewayToken) {
-      remoteGatewayToken = resolvedRemoteGatewayToken;
-    }
-  } catch (error) {
+  const remoteProbeAuth = remoteUrl
+    ? await resolveGatewayProbeSurfaceAuth({
+        config: remoteSeedConfig,
+        env: process.env,
+        surface: "remote",
+      })
+    : null;
+  if (remoteProbeAuth?.diagnostics?.length) {
     await prompter.note(
       [
-        "Could not resolve gateway.remote.token SecretRef for setup probe.",
-        formatErrorMessage(error),
+        "Could not resolve remote gateway SecretRef for setup probe.",
+        ...remoteProbeAuth.diagnostics,
       ].join("\n"),
       "Gateway auth",
     );
@@ -440,7 +436,8 @@ async function runSetupWizardOnce(
   const remoteProbe = remoteUrl
     ? await onboardHelpers.probeGatewayReachable({
         url: remoteUrl,
-        token: remoteGatewayToken,
+        token: remoteProbeAuth?.token,
+        ...(remoteProbeAuth?.password ? { password: remoteProbeAuth.password } : {}),
       })
     : null;
 

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -9,7 +9,7 @@ import { createMergePatch } from "../config/merge-patch.js";
 import { applyMergePatch } from "../config/merge-patch.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveGatewayProbeSurfaceAuth } from "../gateway/auth-surface-resolution.js";
+import { resolveGatewayProbeAuthSafeWithSecretInputs } from "../gateway/probe-auth.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   buildPluginCompatibilitySnapshotNotices,
@@ -418,26 +418,25 @@ async function runSetupWizardOnce(
       ? seededRemoteUrl
       : "";
   const remoteProbeAuth = remoteUrl
-    ? await resolveGatewayProbeSurfaceAuth({
-        config: remoteSeedConfig,
+    ? await resolveGatewayProbeAuthSafeWithSecretInputs({
+        cfg: remoteSeedConfig,
         env: process.env,
-        surface: "remote",
+        mode: "remote",
       })
     : null;
-  if (remoteProbeAuth?.diagnostics?.length) {
+  if (remoteProbeAuth?.warning) {
     await prompter.note(
-      [
-        "Could not resolve remote gateway SecretRef for setup probe.",
-        ...remoteProbeAuth.diagnostics,
-      ].join("\n"),
+      ["Could not resolve remote gateway SecretRef for setup probe.", remoteProbeAuth.warning].join(
+        "\n",
+      ),
       "Gateway auth",
     );
   }
   const remoteProbe = remoteUrl
     ? await onboardHelpers.probeGatewayReachable({
         url: remoteUrl,
-        token: remoteProbeAuth?.token,
-        ...(remoteProbeAuth?.password ? { password: remoteProbeAuth.password } : {}),
+        token: remoteProbeAuth?.auth.token,
+        ...(remoteProbeAuth?.auth.password ? { password: remoteProbeAuth.auth.password } : {}),
       })
     : null;
 

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -391,6 +391,7 @@ async function runSetupWizardOnce(
   });
   const storedRemoteUrl = normalizeOptionalString(baseConfig.gateway?.remote?.url);
   const optionRemoteUrl = normalizeOptionalString(opts.remoteUrl);
+  const optionRemoteToken = normalizeOptionalString(opts.remoteToken);
   const remoteUrlChanged = opts.remoteUrl !== undefined && optionRemoteUrl !== storedRemoteUrl;
   const remoteSeedConfig: OpenClawConfig =
     opts.remoteUrl === undefined && opts.remoteToken === undefined
@@ -403,7 +404,7 @@ async function runSetupWizardOnce(
               ...baseConfig.gateway?.remote,
               ...(opts.remoteUrl !== undefined ? { url: optionRemoteUrl } : {}),
               ...(opts.remoteToken !== undefined
-                ? { token: normalizeOptionalString(opts.remoteToken) }
+                ? { token: optionRemoteToken }
                 : remoteUrlChanged
                   ? { token: undefined }
                   : {}),
@@ -422,6 +423,10 @@ async function runSetupWizardOnce(
         cfg: remoteSeedConfig,
         env: process.env,
         mode: "remote",
+        explicitAuth: { token: optionRemoteToken },
+        ...(remoteUrlChanged
+          ? { urlOverride: optionRemoteUrl, urlOverrideSource: "cli" as const }
+          : {}),
       })
     : null;
   if (remoteProbeAuth?.warning) {


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

A password-only remote Gateway can be healthy and reachable while both the initial setup wizard and the later configure wizard label it as unreachable. This gives users a false connection failure during onboarding and reconfiguration even though password authentication is a supported remote Gateway mode.

## Why This Change Was Made

All setup and configure probes now resolve remote credentials through the shared Gateway auth-surface owner and forward its token or password to the selected target. The configure health action also runs after remote configuration instead of returning before the requested health check.

### Root Cause

The wizard hint paths originally read only `gateway.remote.token`. The configure health action separately selected the remote URL while resolving local `gateway.auth` credentials, and the remote configuration branch returned before running an explicitly selected health action.

### Runtime ownership

`resolveGatewayProbeSurfaceAuth` is the canonical owner for remote token/password precedence. The probe-auth adapter preserves explicit-auth and URL-override safety, target isolation, and unresolved-SecretRef diagnostics for wizard callers.

## User Impact

Users connecting to a password-protected remote Gateway now get accurate reachability hints and a working configure health action. Local Gateway credentials are not forwarded to the remote target.

## Evidence

Focused regressions, the full changed gate, the generated API contract check, and packaged real behavior proof passed on product-code head `eddb8d911f3`; current head `ce9e437e4d8` only drops the SHA-256 baseline that current `main` replaced with JSONL and documents remote probe credential precedence. The final repair binds configure health and its authentication diagnostic to the selected remote Gateway even when `OPENCLAW_GATEWAY_URL` names an unrelated password-protected Gateway.

<details>
<summary><strong>Inspect exact-head proof ledger</strong></summary>

<!-- pr-agent-proof-gate-v2 profile=deep-runtime tests=pass direct=pass real_behavior=pass -->

### Provenance

- **Base:** `260628f4fa7ce1f5a04f69b9523b95e7694aaaa0`
- **Current head:** `ce9e437e4d8d6dab1d3ad2f15170d252040ca7a7`
- **Automated proof heads:** `18e2c5b29d2` (prior full GitHub CI), `3914b30af01` (125/125 ClawSweeper acceptance tests), `eddb8d911f3` (158 focused tests, full changed gate, packaged live proof), `ce9e437e4d8` (generated-contract conflict resolution and docs clarification)
- **Behavior proof head:** `eddb8d911f3d52686f84fa091a3f7e3747b7886d`
- **Environment:** Node 26 trusted checkout; packaged build on Blacksmith Testbox; two isolated live password-authenticated Gateways on Linux

### Exact-head direct behavior

<!-- pr-agent-direct-proof-v1 kind=production-runtime test_runner=none owners=all-real mocks=none head=eddb8d911f3d52686f84fa091a3f7e3747b7886d -->

The exact-head packaged CLI started a real password-authenticated Gateway on an isolated port. A separate client config stored the matching remote password and a deliberately wrong local password. The real TTY flow then ran `openclaw configure --section health`, selected the configured remote Gateway, and completed its health action without an auth error. Synthetic credentials were redacted.

#### Redacted exact-head runtime transcript

```text
exactHead=eddb8d911f3d52686f84fa091a3f7e3747b7886d
selectedPasswordGatewayReady=true
unrelatedPasswordGatewayReady=true
unrelatedGatewayUrlOverridePresent=true
targetBoundConfigureHealthCompleted=true
configuredRemotePasswordSelected=true
syntheticCredentialsRedacted=true
```

### Automated verification

```shell
node scripts/run-vitest.mjs src/commands/health.test.ts src/gateway/probe-auth.test.ts src/gateway/credentials.test.ts src/commands/configure.wizard.test.ts src/wizard/setup.test.ts
node scripts/check-changed.mjs -- docs/.generated/plugin-sdk-api-baseline.sha256 src/cli/daemon-cli/status.gather.test.ts src/cli/daemon-cli/status.gather.ts src/commands/configure.wizard-test-helpers.ts src/commands/configure.wizard.test.ts src/commands/configure.wizard.ts src/commands/gateway-status/helpers.test.ts src/gateway/credentials.ts src/gateway/probe-auth.test.ts src/gateway/probe-auth.ts src/wizard/setup.test.ts src/wizard/setup.ts
```

- **Focused regressions:** 158/158 passed on `eddb8d911f3` across health command target binding, probe-auth, credentials, configure wizard, and setup wizard.
- **Typechecks:** production core and core-test type lanes passed on the automated proof head.
- **Packaged build:** behavior proof head source build passed, including CLI bootstrap, public plugin SDK exports, Control UI build, and performance checks.
- **Static checks:** targeted oxfmt, `git diff --check`, and the generated Plugin SDK API baseline check passed.
- **Live behavior:** the exact-head packaged configure TTY completed health against the selected password Gateway while `OPENCLAW_GATEWAY_URL` pointed at a second live Gateway protected by a different password.

### Preserved boundaries

- Remote probes remove local `gateway.auth` values and SecretRefs before resolution.
- Configured remote token/password is authoritative; environment auth is used only when no configured remote auth resolves.
- A changed CLI remote URL receives no stored or ambient credentials; an explicitly supplied remote credential remains usable.
- Local health checks preserve their existing local environment/config precedence and port override.
- Daemon status blocks winning remote exec SecretRefs before resolution when exec refs are disabled, even with ambient auth present.
- A lone configured remote SecretRef failure stops configure health before generic auth resolution can recover ambient credentials, while a separately resolved configured sibling credential remains usable. Remote configure health and its diagnostic re-probe ignore ambient URL overrides so the selected credential stays bound to its configured target.

### CI note

Product-code head `eddb8d911f3` fixes the target-binding P1 and CI max-lines failure. Current head `ce9e437e4d8` only removes the retired SHA-256 manifest and documents the proven remote probe credential precedence after current `main` replaced it with JSONL in `e37614c83f9`; a synthetic merge against `cd7b7f639da` is clean. The exact product-code packaged live scenario passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/31387428924. The full changed gate passed locally after Blacksmith sync failed twice across fresh leases; all owned Testboxes were stopped.

</details>












