### PR TITLE
fix(ui): surface session sharing errors without leaking across chats

### DIFF
--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -2,6 +2,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
+import { expect as expectBrowser } from "playwright/test";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -367,6 +368,49 @@ describeControlUiE2e("Control UI session ownership", () => {
       visibility: "shared",
     });
     expect(await gateway.getRequests("session.visibility.set")).toHaveLength(1);
+  });
+
+  it("keeps rejected visibility-only sharing changes visible after the menu closes", async () => {
+    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const sessions = draftSessionsList();
+    const ownerSession = sessions.sessions[0];
+    if (!ownerSession) {
+      throw new Error("expected owner draft fixture");
+    }
+    Object.assign(ownerSession, { sharingRole: "owner" });
+    const gateway = await installMockGateway(currentPage, {
+      sessionKey: "agent:main:ada",
+      allowedSessionVisibilities: ["shared", "draft"],
+      deferredMethods: ["session.visibility.set"],
+      featureMethods: ["chat.metadata", "chat.startup", "session.visibility.set"],
+      operatorScopes: ["operator.write"],
+      historyMessages: [{ role: "assistant", content: [{ type: "text", text: "Ready." }] }],
+      methodResponses: { "sessions.list": sessions },
+    });
+
+    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage.getByText("Ready.", { exact: true }).waitFor();
+    await currentPage.getByRole("button", { name: "Thread sharing" }).click();
+    const dropdown = currentPage.locator(".chat-pane__sharing-menu");
+    await expect.poll(() => dropdown.getAttribute("open")).not.toBeNull();
+    expect(await dropdown.locator(".chat-pane__sharing-title").count()).toBe(1);
+    await currentPage.getByText("Publish draft", { exact: true }).click();
+    await gateway.waitForRequest("session.visibility.set");
+    await expect.poll(() => dropdown.getAttribute("open")).toBeNull();
+    expect(await gateway.getRequests("session.members.list")).toHaveLength(0);
+
+    const message = "visibility change rejected";
+    await gateway.rejectDeferred("session.visibility.set", {
+      code: "INVALID_REQUEST",
+      message,
+    });
+    const alert = currentPage.getByRole("alert").filter({ hasText: message });
+    await expectBrowser(alert).toBeVisible();
+
+    await currentPage.getByRole("button", { name: "Thread sharing" }).click();
+    await expectBrowser(dropdown.locator(".chat-pane__sharing-status--error")).toBeVisible();
   });
 
   it("lets a read-scoped owner inspect sharing but blocks mutations", async () => {

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -468,7 +468,8 @@ export abstract class ChatPaneHeader extends ChatPaneContext {
     if (!this.state) {
       return;
     }
-    this.state.chatError = error instanceof Error ? error.message : String(error);
+    this.state.lastError = error instanceof Error ? error.message : String(error);
+    this.state.chatError = this.state.lastError;
     this.state.requestUpdate?.();
   }
 

--- a/ui/src/pages/chat/chat-pane-sharing.test.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.test.ts
@@ -388,6 +388,8 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
       expect(replacement.request).not.toHaveBeenCalled();
       expect(replacement.sessions.refreshReplacement).not.toHaveBeenCalled();
       expect(pane.sessionSharingStates.get(replacement.cacheKey)).toBe(replacement.sharingState);
+      expect(state.lastError).toBeNull();
+      expect(state.chatError).toBeNull();
     },
   );
 
@@ -435,8 +437,52 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
       expect(request).toHaveBeenCalledTimes(1);
       expect(sessions.refreshReplacement).not.toHaveBeenCalled();
       expect(pane.sessionSharingStates.get(cacheKey)).toBe(replacementState);
+      expect(state.lastError).toBeNull();
+      expect(state.chatError).toBeNull();
     },
   );
+
+  it("keeps a previous-session failure out of the newly selected session", async () => {
+    const response = createDeferred<unknown>();
+    const request = vi.fn((method: string) => {
+      if (method !== mutation.method) {
+        throw new Error(`unexpected request: ${method}`);
+      }
+      return response.promise;
+    });
+    const sessions = {
+      refreshReplacement: vi.fn(),
+    } as unknown as SessionCapability;
+    const { pane: testPane, state } = createSharingTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions,
+    });
+    const pane = testPane as SharingPane;
+    const previous = sessionRow();
+    const selected = {
+      ...sessionRow(),
+      key: "agent:main:selected",
+      sessionId: "session-selected",
+    };
+    state.sessionsResult = {
+      ...sharingSessionsResult(previous),
+      count: 2,
+      sessions: [previous, selected],
+    };
+    const pending = mutation.invoke(pane, previous);
+    state.sessionKey = selected.key;
+
+    response.reject(new Error(`${mutation.name} failed after session switch`));
+    await pending;
+
+    expect(pane.sessionSharingStates.get(pane.sessionSharingCacheKey(previous.key))).toMatchObject({
+      loading: false,
+      error: `Error: ${mutation.name} failed after session switch`,
+    });
+    expect(state.lastError).toBeNull();
+    expect(state.chatError).toBeNull();
+    expect(sessions.refreshReplacement).not.toHaveBeenCalled();
+  });
 
   it("preserves the current connection failure in the sharing cache", async () => {
     const request = vi.fn(async (method: string) => {
@@ -448,7 +494,7 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
     const sessions = {
       refreshReplacement: vi.fn(),
     } as unknown as SessionCapability;
-    const { pane: testPane } = createSharingTestChatPane({
+    const { pane: testPane, state } = createSharingTestChatPane({
       client: { request } as unknown as GatewayBrowserClient,
       sessions,
     });
@@ -461,6 +507,8 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
       loading: false,
       error: `Error: ${mutation.name} failed`,
     });
+    expect(state.lastError).toBe(`${mutation.name} failed`);
+    expect(state.chatError).toBe(state.lastError);
     expect(sessions.refreshReplacement).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/chat/chat-pane-sharing.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.ts
@@ -136,6 +136,19 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
     }
   }
 
+  protected publishSharingFailure(cacheKey: string, sessionKey: string, error: unknown): void {
+    this.setSessionSharingState(cacheKey, {
+      ...(this.sessionSharingStates.get(cacheKey) ?? { loading: false }),
+      loading: false,
+      error: String(error),
+    });
+    // Sharing errors stay with their session; the visible page slot belongs
+    // only to the selected session after same-connection navigation.
+    if (areUiSessionKeysEquivalent(this.state?.sessionKey, sessionKey)) {
+      this.publishHeaderError(error);
+    }
+  }
+
   protected async setSessionVisibility(
     row: GatewaySessionRow,
     visibility: SessionVisibility,
@@ -181,11 +194,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
       ) {
         return;
       }
-      this.setSessionSharingState(cacheKey, {
-        ...(this.sessionSharingStates.get(cacheKey) ?? { loading: false }),
-        loading: false,
-        error: String(error),
-      });
+      this.publishSharingFailure(cacheKey, currentRow.key, error);
     }
   }
 
@@ -238,11 +247,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
       ) {
         return;
       }
-      this.setSessionSharingState(cacheKey, {
-        ...(this.sessionSharingStates.get(cacheKey) ?? { loading: false }),
-        loading: false,
-        error: String(error),
-      });
+      this.publishSharingFailure(cacheKey, currentRow.key, error);
     }
   }
 

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -365,6 +365,7 @@ describe("chat pane header state", () => {
     } satisfies GatewaySessionRow;
     pane.handleHeaderMenuAction("reveal", session, "/src/openclaw", null);
     await vi.waitFor(() => expect(state.chatError).toBe("No desktop available."));
+    expect(state.lastError).toBe(state.chatError);
   });
 });
 

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -260,4 +260,34 @@ describe("chat session sharing menu", () => {
     expect(onOpen).toHaveBeenCalledOnce();
     expect(onVisibilityChange).toHaveBeenCalledWith("read-only");
   });
+
+  it.each([
+    { name: "visibility-only", membersAvailable: false },
+    { name: "member-enabled", membersAvailable: true },
+  ])("shows rejected sharing changes for $name Gateways", ({ membersAvailable }) => {
+    const root = mount(
+      renderChatSessionSharing({
+        session: {
+          key: "agent:main:main",
+          kind: "direct",
+          updatedAt: 1,
+          visibility: "shared",
+          sharingRole: "owner",
+        },
+        state: { loading: false, error: "Visibility update rejected" },
+        allowedVisibilities: ["shared", "read-only"],
+        membersAvailable,
+        onOpen: vi.fn(),
+        onVisibilityChange: vi.fn(),
+        onMemberChange: vi.fn(),
+      }),
+    );
+
+    expect(root.querySelector(".chat-pane__sharing-status--error")?.textContent).toContain(
+      "Visibility update rejected",
+    );
+    expect(root.querySelectorAll(".chat-pane__sharing-title")).toHaveLength(
+      membersAvailable ? 2 : 1,
+    );
+  });
 });

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -172,12 +172,12 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
                 : html`<div class="chat-pane__sharing-status">
                     ${t("chat.sessionSharing.noPeople")}
                   </div>`}
-            ${props.state?.error
-              ? html`<div class="chat-pane__sharing-status chat-pane__sharing-status--error">
-                  ${props.state.error}
-                </div>`
-              : nothing}
           `
+        : nothing}
+      ${props.state?.error
+        ? html`<div class="chat-pane__sharing-status chat-pane__sharing-status--error">
+            ${props.state.error}
+          </div>`
         : nothing}
     </wa-dropdown>
   `;


### PR DESCRIPTION
## Summary

- Preserve session-sharing mutation failures for visibility-only and member-enabled gateways instead of silently closing the menu with no visible result.
- Publish the error through the canonical chat header owner so an operator still sees it after Web Awesome closes the dropdown.
- Keep sharing errors scoped to their originating session; stale gateway connections, replaced sessions, and same-connection navigation from chat A to chat B cannot leak an old error into the active chat.
- Retain the session-local inline failure when the operator reopens the sharing menu.

## Root cause and owner boundary

The visibility-only sharing component discarded its error state, and successful connection-scope checks did not establish that the affected session was still the currently selected chat. Sharing failures now flow through one canonical owner that always caches the originating session's error but publishes the global chat header error only when that session remains active. The existing current-connection/current-row guards are preserved. Production delta: +6 lines across the owning chat header/sharing surfaces; no config, protocol, persistence, authorization, or security changes.

## Test plan / real behavior evidence

- Hosted Blacksmith Testbox: `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-session-sharing.test.ts ui/src/pages/chat/chat-pane-sharing.test.ts ui/src/pages/chat/chat-pane.test.ts` — **3 suites, 73/73 passing**, including both visibility and member failures after switching from chat A to chat B on the same live connection.
- Real Playwright **Chromium**, real Vite Control UI, and real websocket-backed gateway interaction: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-ownership.e2e.test.ts -t 'keeps rejected visibility-only sharing changes visible after the menu closes'` — **1/1 passing**. The browser selects visibility, waits for Web Awesome to close the menu, rejects the actual deferred sharing request, asserts the global `[role=alert]` is visible, reopens the menu, and asserts the originating session's inline sharing error is visible.
- Shared isolated Testbox lease / hosted backing run: https://github.com/openclaw/openclaw/actions/runs/30760713254
- Fresh full-patch `gpt-5.6-sol`, high-reasoning, P1-threshold structured review: **clean, confidence 0.96**.
- Canonical formatting and `git diff --check`: clean.

No public-channel message or live credentials are used or required.
