### PR TITLE
test(auto-reply): canonicalize session export expectations

### DIFF
--- a/src/auto-reply/reply/commands-export-session-file.test-support.ts
+++ b/src/auto-reply/reply/commands-export-session-file.test-support.ts
@@ -38,7 +38,7 @@ describe("writeSessionExportFile", () => {
     const result = await writeExport({ workspaceDir, requestedPath: targetPath });
 
     expect(result).toEqual({
-      absolutePath: path.join(workspaceDir, "exports", "session.html"),
+      absolutePath: path.join(await fs.realpath(workspaceDir), "exports", "session.html"),
       displayPath: path.join("exports", "session.html"),
     });
     expect(await fs.readFile(result.absolutePath, "utf-8")).toBe("new export");
@@ -86,7 +86,7 @@ describe("writeSessionExportFile", () => {
       const result = await writeExport({ workspaceDir: workspaceAlias, requestedPath });
 
       expect(result).toEqual({
-        absolutePath: path.join(workspaceDir, "exports", "session.html"),
+        absolutePath: path.join(await fs.realpath(workspaceDir), "exports", "session.html"),
         displayPath: path.join("exports", "session.html"),
       });
       expect(await fs.readFile(result.absolutePath, "utf-8")).toBe("new export");


### PR DESCRIPTION
## Summary

- align session-export test expectations with the canonical absolute path returned by the fs-safe `Root`
- restore relative, absolute, and symlinked-workspace cases on macOS
- leave production export policy and behavior unchanged

## Root cause and fix

macOS exposes temporary directories lexically as `/var/...`, while fs-safe resolves the workspace to its canonical `/private/var/...` identity before returning `absolutePath`. Three assertions built their expected path from the lexical fixture, so they failed despite writing and reading the correct file.

The expectations now resolve the fixture workspace before joining the export path. Production delta is 0 lines.

Closes https://github.com/openclaw/openclaw/issues/118137

## Proof

Exact candidate head: `57f32d62a9087c0a9c9ae60fe1eb9967a7096af6`

- Current-main reproduction: 3 failures across relative, absolute, and symlinked-workspace cases
- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-export-session.test.ts` — 34/34 passed after final rebase
- stress loop — 20/20 complete shard runs passed
- `node scripts/check-changed.mjs -- src/auto-reply/reply/commands-export-session-file.test-support.ts` — passed on Blacksmith Testbox `tbx_01kz1xjxsy9qcwp1q5a7hb12ky` ([run](https://github.com/openclaw/openclaw/actions/runs/30762404798))
- Codex autoreview — clean, no accepted/actionable findings, overall confidence 0.99

## Changelog

Not required: test-only reliability fix with no runtime behavior change.
