### PR TITLE
fix(agents): correlate Claude live turn results

### DIFF
--- a/src/agents/cli-runner/claude-live-session.background-tasks.test-support.ts
+++ b/src/agents/cli-runner/claude-live-session.background-tasks.test-support.ts
@@ -1,0 +1,159 @@
+import { vi } from "vitest";
+import type { getProcessSupervisor } from "../../process/supervisor/index.js";
+import { supervisorSpawnMock } from "../cli-runner.test-support.js";
+import { runClaudeLiveSessionTurn } from "./claude-live-session.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
+type SupervisorSpawnFn = ProcessSupervisor["spawn"];
+
+function buildPreparedCliRunContext(params: {
+  runId: string;
+  timeoutMs?: number;
+  sessionId?: string;
+  sessionKey?: string;
+  credentialFingerprint?: string;
+}): PreparedCliRunContext {
+  const backend = {
+    command: "claude",
+    args: ["-p", "--output-format", "stream-json"],
+    output: "jsonl" as const,
+    input: "stdin" as const,
+    modelArg: "--model",
+    sessionArgs: ["--session-id", "{sessionId}"],
+    sessionMode: "always" as const,
+    systemPromptFileArg: "--append-system-prompt-file",
+    systemPromptWhen: "first" as const,
+    serialize: true,
+    liveSession: "claude-stdio" as const,
+  };
+  return {
+    params: {
+      sessionId: params.sessionId ?? "s-bg",
+      sessionKey: params.sessionKey ?? "agent:main:bg",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "sonnet",
+      timeoutMs: params.timeoutMs ?? 60_000,
+      runId: params.runId,
+    },
+    started: Date.now(),
+    workspaceDir: "/tmp",
+    backendResolved: {
+      id: "claude-cli",
+      config: backend,
+      bundleMcp: true,
+      pluginId: "anthropic",
+    },
+    preparedBackend: {
+      backend,
+      env: {},
+      ...(params.credentialFingerprint
+        ? {
+            secretInput: {
+              fd: 3,
+              fingerprint: params.credentialFingerprint,
+              createData: () => Buffer.from("secret"),
+            },
+          }
+        : {}),
+    },
+    reusableCliSession: { mode: "none" },
+    hadSessionFile: false,
+    contextEngineConfig: {},
+    modelId: "sonnet",
+    normalizedModel: "sonnet",
+    systemPrompt: "You are a helpful assistant.",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    bootstrapPromptWarningLines: [],
+    authEpochVersion: 2,
+  };
+}
+
+function getProcessSupervisorForTest() {
+  return {
+    spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+      supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+    cancel: vi.fn(),
+    cancelScope: vi.fn(),
+    getRecord: vi.fn(),
+  };
+}
+
+export function installLiveStdoutDriver(params?: {
+  onWrite?: (stdout: (chunk: string) => void, input: string) => void;
+}): {
+  cancel: ReturnType<typeof vi.fn>;
+  stdout: { emit: (chunk: string) => void; waitReady: () => Promise<void> };
+} {
+  let stdoutListener: ((chunk: string) => void) | undefined;
+  const cancel = vi.fn();
+  let markReady: (() => void) | undefined;
+  const ready = new Promise<void>((resolve) => {
+    markReady = resolve;
+  });
+  const stdin = {
+    write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+      if (stdoutListener && params?.onWrite) {
+        params.onWrite(stdoutListener, data);
+      }
+      cb?.();
+      markReady?.();
+    }),
+    end: vi.fn(),
+  };
+  supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+    const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+    stdoutListener = input.onStdout;
+    return {
+      runId: "live-bg-run",
+      pid: 4242,
+      startedAtMs: Date.now(),
+      stdin,
+      wait: vi.fn(() => new Promise(() => {})),
+      cancel,
+    };
+  });
+  return {
+    cancel,
+    stdout: {
+      emit: (chunk: string) => {
+        stdoutListener?.(chunk);
+      },
+      waitReady: () => ready,
+    },
+  };
+}
+
+export function jsonl(lines: unknown[]): string {
+  return lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
+}
+
+export function startLiveTurn(params: {
+  runId: string;
+  timeoutMs?: number;
+  noOutputTimeoutMs?: number;
+  useResume?: boolean;
+  onPhase?: (phase: "send" | "resolve") => void;
+  credentialFingerprint?: string;
+}) {
+  const context = buildPreparedCliRunContext({
+    runId: params.runId,
+    timeoutMs: params.timeoutMs,
+    credentialFingerprint: params.credentialFingerprint,
+  });
+  return runClaudeLiveSessionTurn({
+    context,
+    args: context.preparedBackend.backend.args ?? [],
+    env: {},
+    prompt: "hi",
+    useResume: params.useResume ?? false,
+    noOutputTimeoutMs: params.noOutputTimeoutMs ?? 5_000,
+    getProcessSupervisor: getProcessSupervisorForTest,
+    onAssistantDelta: () => {},
+    onPhase: params.onPhase,
+    cleanup: async () => {},
+  });
+}

--- a/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
+++ b/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
@@ -10,24 +10,23 @@ import {
   resetDiagnosticRunActivityForTest,
   startDiagnosticRunActivityTracking,
 } from "../../logging/diagnostic-run-activity.js";
-import type { getProcessSupervisor } from "../../process/supervisor/index.js";
 import {
   restoreCliRunnerPrepareTestDeps,
   supervisorSpawnMock,
 } from "../cli-runner.test-support.js";
-import { runClaudeLiveSessionTurn } from "./claude-live-session.js";
+import {
+  installLiveStdoutDriver,
+  jsonl,
+  startLiveTurn,
+} from "./claude-live-session.background-tasks.test-support.js";
 import { resetClaudeLiveSessionsForTest } from "./claude-live-session.test-support.js";
 import { setCliRunnerExecuteTestDeps } from "./execute.test-support.js";
 import { writeCliSystemPromptFile } from "./helpers.js";
-import type { PreparedCliRunContext } from "./types.js";
 
 vi.mock("../../plugin-sdk/anthropic-cli.js", () => ({
   CLAUDE_CLI_BACKEND_ID: "claude-cli",
   isClaudeCliProvider: (providerId: string) => providerId === "claude-cli",
 }));
-
-type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
-type SupervisorSpawnFn = ProcessSupervisor["spawn"];
 
 beforeEach(() => {
   setDiagnosticsEnabledForProcess(true);
@@ -45,157 +44,6 @@ afterEach(() => {
   resetDiagnosticRunActivityForTest();
   resetClaudeLiveSessionsForTest();
 });
-
-function buildPreparedCliRunContext(params: {
-  runId: string;
-  timeoutMs?: number;
-  sessionId?: string;
-  sessionKey?: string;
-  credentialFingerprint?: string;
-}): PreparedCliRunContext {
-  const backend = {
-    command: "claude",
-    args: ["-p", "--output-format", "stream-json"],
-    output: "jsonl" as const,
-    input: "stdin" as const,
-    modelArg: "--model",
-    sessionArgs: ["--session-id", "{sessionId}"],
-    sessionMode: "always" as const,
-    systemPromptFileArg: "--append-system-prompt-file",
-    systemPromptWhen: "first" as const,
-    serialize: true,
-    liveSession: "claude-stdio" as const,
-  };
-  return {
-    params: {
-      sessionId: params.sessionId ?? "s-bg",
-      sessionKey: params.sessionKey ?? "agent:main:bg",
-      sessionFile: "/tmp/session.jsonl",
-      workspaceDir: "/tmp",
-      prompt: "hi",
-      provider: "claude-cli",
-      model: "sonnet",
-      timeoutMs: params.timeoutMs ?? 60_000,
-      runId: params.runId,
-    },
-    started: Date.now(),
-    workspaceDir: "/tmp",
-    backendResolved: {
-      id: "claude-cli",
-      config: backend,
-      bundleMcp: true,
-      pluginId: "anthropic",
-    },
-    preparedBackend: {
-      backend,
-      env: {},
-      ...(params.credentialFingerprint
-        ? {
-            secretInput: {
-              fd: 3,
-              fingerprint: params.credentialFingerprint,
-              createData: () => Buffer.from("secret"),
-            },
-          }
-        : {}),
-    },
-    reusableCliSession: { mode: "none" },
-    hadSessionFile: false,
-    contextEngineConfig: {},
-    modelId: "sonnet",
-    normalizedModel: "sonnet",
-    systemPrompt: "You are a helpful assistant.",
-    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
-    bootstrapPromptWarningLines: [],
-    authEpochVersion: 2,
-  };
-}
-
-function getProcessSupervisorForTest() {
-  return {
-    spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
-      supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
-    cancel: vi.fn(),
-    cancelScope: vi.fn(),
-    getRecord: vi.fn(),
-  };
-}
-
-function installLiveStdoutDriver(params?: {
-  onWrite?: (stdout: (chunk: string) => void) => void;
-}): {
-  cancel: ReturnType<typeof vi.fn>;
-  stdout: { emit: (chunk: string) => void; waitReady: () => Promise<void> };
-} {
-  let stdoutListener: ((chunk: string) => void) | undefined;
-  const cancel = vi.fn();
-  let markReady: (() => void) | undefined;
-  const ready = new Promise<void>((resolve) => {
-    markReady = resolve;
-  });
-  const stdin = {
-    write: vi.fn((_data: string, cb?: (err?: Error | null) => void) => {
-      if (stdoutListener && params?.onWrite) {
-        params.onWrite(stdoutListener);
-      }
-      cb?.();
-      markReady?.();
-    }),
-    end: vi.fn(),
-  };
-  supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
-    const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
-    stdoutListener = input.onStdout;
-    return {
-      runId: "live-bg-run",
-      pid: 4242,
-      startedAtMs: Date.now(),
-      stdin,
-      wait: vi.fn(() => new Promise(() => {})),
-      cancel,
-    };
-  });
-  return {
-    cancel,
-    stdout: {
-      emit: (chunk: string) => {
-        stdoutListener?.(chunk);
-      },
-      waitReady: () => ready,
-    },
-  };
-}
-
-function jsonl(lines: unknown[]): string {
-  return lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
-}
-
-function startLiveTurn(params: {
-  runId: string;
-  timeoutMs?: number;
-  noOutputTimeoutMs?: number;
-  useResume?: boolean;
-  onPhase?: (phase: "send" | "resolve") => void;
-  credentialFingerprint?: string;
-}) {
-  const context = buildPreparedCliRunContext({
-    runId: params.runId,
-    timeoutMs: params.timeoutMs,
-    credentialFingerprint: params.credentialFingerprint,
-  });
-  return runClaudeLiveSessionTurn({
-    context,
-    args: context.preparedBackend.backend.args ?? [],
-    env: {},
-    prompt: "hi",
-    useResume: params.useResume ?? false,
-    noOutputTimeoutMs: params.noOutputTimeoutMs ?? 5_000,
-    getProcessSupervisor: getProcessSupervisorForTest,
-    onAssistantDelta: () => {},
-    onPhase: params.onPhase,
-    cleanup: async () => {},
-  });
-}
 
 describe("claude live session provisional results", () => {
   it("reuses the same credential generation and restarts when it rotates", async () => {
@@ -359,6 +207,7 @@ describe("claude live session provisional results", () => {
             session_id: "live-bg",
             result: "Subagent finished: subagent final output",
             origin: { kind: "task-notification" },
+            user_message_uuid: "owned-background-notification",
           },
         ]),
       );
@@ -430,6 +279,111 @@ describe("claude live session provisional results", () => {
     });
     const result = await startLiveTurn({ runId: "run-bg-none" });
     expect(result.output.text).toBe("plain answer");
+    expect(driver.cancel).not.toHaveBeenCalled();
+  });
+
+  it("keeps an unowned task-notification result from consuming the current user turn", async () => {
+    let requestMessageUuid = "";
+    const driver = installLiveStdoutDriver({
+      onWrite: (_stdout, input) => {
+        const parsed = JSON.parse(input) as { uuid?: string };
+        requestMessageUuid = parsed.uuid ?? "";
+      },
+    });
+    const resultPromise = startLiveTurn({
+      runId: "run-orphaned-task-notification",
+      useResume: true,
+    });
+    await driver.stdout.waitReady();
+    expect(requestMessageUuid).not.toBe("");
+
+    driver.stdout.emit(
+      jsonl([
+        { type: "system", subtype: "init", session_id: "live-orphaned-notification" },
+        {
+          type: "user",
+          uuid: "queued-notification-message",
+          session_id: "live-orphaned-notification",
+          parent_tool_use_id: null,
+          message: { role: "user", content: "queued notification" },
+        },
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "live-orphaned-notification",
+          result: "",
+        },
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "live-orphaned-notification",
+          result: "",
+          origin: { kind: "task-notification" },
+        },
+      ]),
+    );
+
+    let settled = false;
+    void resultPromise.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    await waitForDiagnosticEventsDrained();
+    expect(
+      getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:bg" }).lastProgressReason,
+    ).toBe("cli_live:result_deferred_unowned_notification");
+
+    driver.stdout.emit(
+      jsonl([
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "live-orphaned-notification",
+          result: "",
+          user_message_uuid: "different-user-message",
+        },
+      ]),
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    driver.stdout.emit(
+      jsonl([
+        {
+          type: "user",
+          uuid: requestMessageUuid,
+          session_id: "live-orphaned-notification",
+          parent_tool_use_id: null,
+          message: { role: "user", content: "hi" },
+        },
+        {
+          type: "assistant",
+          session_id: "live-orphaned-notification",
+          message: {
+            model: "claude-fable-5",
+            role: "assistant",
+            content: [{ type: "text", text: "The actual user response." }],
+          },
+        },
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "live-orphaned-notification",
+          result: "The actual user response.",
+          origin: { kind: "human" },
+          user_message_uuid: requestMessageUuid,
+        },
+      ]),
+    );
+
+    const result = await resultPromise;
+    expect(result.output.text).toBe("The actual user response.");
     expect(driver.cancel).not.toHaveBeenCalled();
   });
 

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -75,6 +75,10 @@ type ManagedRun = Awaited<ReturnType<ProcessSupervisor["spawn"]>>;
 type ClaudeLiveTurn = {
   backend: CliBackendConfig;
   diagnosticRefs: ClaudeLiveDiagnosticRefs;
+  /** Correlates terminal results to the user message written for this turn. */
+  requestMessageUuid: string;
+  /** Tracks whether --replay-user-messages has reached this turn's stdin message. */
+  messageReplayState: "pending" | "unowned" | "acknowledged";
   /** Enclosing run abort signal; authoritative for tool terminal reason on turn failure. */
   abortSignal?: AbortSignal;
   outputLimits: ClaudeLiveOutputLimits;
@@ -92,6 +96,8 @@ type ClaudeLiveTurn = {
   useResume: boolean;
   /** True after any output other than init or the exact synthetic queue placeholder. */
   hasReplayUnsafeActivity: boolean;
+  /** This turn emitted an interim result while its own background work remained active. */
+  ownsBackgroundContinuation: boolean;
   /**
    * Claude consumed queued session notifications before processing this turn.
    * The following empty result is provisional; the same process can emit the
@@ -963,6 +969,49 @@ function isClaudeLiveSubstantiveAssistantProgress(parsed: Record<string, unknown
   );
 }
 
+function noteClaudeLiveUserMessageReplay(
+  turn: ClaudeLiveTurn,
+  parsed: Record<string, unknown>,
+): boolean {
+  if (
+    parsed.type !== "user" ||
+    typeof parsed.uuid !== "string" ||
+    !isRecord(parsed.message) ||
+    parsed.message.role !== "user" ||
+    typeof parsed.message.content !== "string"
+  ) {
+    return false;
+  }
+  if (parsed.uuid === turn.requestMessageUuid) {
+    turn.messageReplayState = "acknowledged";
+  } else if (turn.messageReplayState === "pending") {
+    turn.messageReplayState = "unowned";
+  }
+  return true;
+}
+
+function isClaudeLiveUnownedResult(turn: ClaudeLiveTurn, parsed: Record<string, unknown>): boolean {
+  if (parsed.type !== "result") {
+    return false;
+  }
+  const resultMessageUuid =
+    typeof parsed.user_message_uuid === "string" ? parsed.user_message_uuid.trim() : "";
+  if (resultMessageUuid === turn.requestMessageUuid) {
+    return false;
+  }
+  const taskNotificationOrigin =
+    isRecord(parsed.origin) && parsed.origin.kind === "task-notification";
+  if (taskNotificationOrigin && turn.ownsBackgroundContinuation) {
+    return false;
+  }
+  // Current Claude versions echo the triggering input UUID. Older origin-aware
+  // versions still identify queued task notifications without that field, and
+  // replay ordering identifies an older result before this input is acknowledged.
+  return (
+    taskNotificationOrigin || resultMessageUuid.length > 0 || turn.messageReplayState === "unowned"
+  );
+}
+
 function deferClaudeLiveSyntheticResult(
   session: ClaudeLiveSession,
   turn: ClaudeLiveTurn,
@@ -1398,10 +1447,15 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   if (!turn) {
     return;
   }
+  const userMessageReplay = noteClaudeLiveUserMessageReplay(turn, parsed);
+  const unownedResult = isClaudeLiveUnownedResult(turn, parsed);
+  const unownedUserMessageReplay = userMessageReplay && turn.messageReplayState === "unowned";
   if (
     !(
       (parsed.type === "system" && parsed.subtype === "init") ||
-      isClaudeLiveProvisionalSyntheticPlaceholder(parsed)
+      isClaudeLiveProvisionalSyntheticPlaceholder(parsed) ||
+      unownedUserMessageReplay ||
+      unownedResult
     )
   ) {
     turn.hasReplayUnsafeActivity = true;
@@ -1420,6 +1474,14 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
     return;
   }
   turn.rawLines.push(trimmed);
+  if (userMessageReplay) {
+    emitClaudeLiveProgress(turn, "cli_live:user_message_replayed");
+    return;
+  }
+  if (unownedResult) {
+    emitClaudeLiveProgress(turn, "cli_live:result_deferred_unowned_notification");
+    return;
+  }
   applyBackgroundTasksChanged(session, parsed);
   if (turn.allowSyntheticContinuationGrace && isClaudeLiveProvisionalSyntheticPlaceholder(parsed)) {
     turn.pendingSyntheticPlaceholder = true;
@@ -1466,6 +1528,7 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   // post-drain result. Other listed types (e.g. local_bash) do not hold it.
   if (session.outstandingBackgroundTaskIds.size > 0) {
     // An interim result is not terminal; background work returns the run to send.
+    turn.ownsBackgroundContinuation = true;
     turn.onPhase?.("send");
     emitClaudeLiveProgress(turn, "cli_live:result_deferred_background_tasks");
     return;
@@ -1569,9 +1632,10 @@ function handleClaudeExit(session: ClaudeLiveSession, exitCode: number | null): 
   );
 }
 
-function createClaudeUserInputMessage(content: string): string {
+function createClaudeUserInputMessage(content: string, uuid: string): string {
   return `${JSON.stringify({
     type: "user",
+    uuid,
     session_id: "",
     parent_tool_use_id: null,
     message: {
@@ -1701,6 +1765,7 @@ async function createClaudeLiveSession(params: {
 
 function createTurn(params: {
   context: PreparedCliRunContext;
+  requestMessageUuid: string;
   noOutputTimeoutMs: number;
   allowSyntheticContinuationGrace: boolean;
   useResume: boolean;
@@ -1725,6 +1790,8 @@ function createTurn(params: {
 }): ClaudeLiveTurn {
   const turn: ClaudeLiveTurn = {
     backend: params.context.preparedBackend.backend,
+    requestMessageUuid: params.requestMessageUuid,
+    messageReplayState: "pending",
     diagnosticRefs: {
       runId: params.context.params.runId,
       sessionId: params.context.params.sessionId,
@@ -1743,6 +1810,7 @@ function createTurn(params: {
     observedStdout: false,
     useResume: params.useResume,
     hasReplayUnsafeActivity: false,
+    ownsBackgroundContinuation: false,
     pendingSyntheticPlaceholder: false,
     allowSyntheticContinuationGrace: params.allowSyntheticContinuationGrace,
     deferredSyntheticOutput: null,
@@ -2189,9 +2257,11 @@ async function runSerializedClaudeLiveSessionTurn(
   liveSession.noOutputTimeoutMs = params.noOutputTimeoutMs;
   liveSession.stderr = "";
 
+  const requestMessageUuid = crypto.randomUUID();
   const outputPromise = new Promise<CliOutput>((resolve, reject) => {
     liveSession.currentTurn = createTurn({
       context: params.context,
+      requestMessageUuid,
       noOutputTimeoutMs: params.noOutputTimeoutMs,
       allowSyntheticContinuationGrace: params.useResume && createdSessionForTurn,
       useResume: params.useResume,
@@ -2235,7 +2305,7 @@ async function runSerializedClaudeLiveSessionTurn(
       abort();
     } else {
       try {
-        const requestPayload = createClaudeUserInputMessage(params.prompt);
+        const requestPayload = createClaudeUserInputMessage(params.prompt, requestMessageUuid);
         params.onRequestPayload?.(requestPayload);
         await Promise.race([writeTurnInput(liveSession, requestPayload), outputPromise]);
       } catch (error) {


### PR DESCRIPTION
## Summary

### High Level TLDR

A warm/resumed Claude CLI process can emit an older queued task-notification result before it starts the user's new message. OpenClaw treated that older empty result as the new turn's result, closed the process, and silently lost the user's message.

This stamps each stdin user message with a UUID and settles the turn only from its matching result. Older replayed messages and task-notification results remain attached to the live process until the current request is acknowledged and completed. Current-turn Agent/Workflow background completion remains supported.

Fixes #115228.

### Scope

- Owner: Claude CLI live-session request/result projection.
- Production delta: +73/-3 lines in one file.
- Tests: the existing background-task fixture was split through a test-only support module to stay below the repository line limit, then extended with the exact queue-drain ordering.
- No timeout, retry, Telegram-specific condition, config surface, persistence change, or generic empty-reply policy was added.

## What Problem This Solves

A reused Claude CLI process can drain an older queued task notification before handling the newly written user request. OpenClaw previously bound that older empty result to the new turn, terminated the process, and left the accepted user message with no visible response.

## Evidence

- Redacted live evidence before the patch: the resumed CLI turn ended with three raw frames, zero output bytes, and no queued channel reply; persisted ordering placed the older notification result before the current user-message replay.
- The new process-supervisor regression emits that exact ordering and proves the result promise remains unsettled until the current UUID is replayed and its matching result arrives.
- 108 focused tests pass, including supported current-turn background completion.
- A live Claude CLI 2.1.220 probe returned one terminal result with `request_uuid_echo_matches=1`, confirming the authoritative UUID contract used by the fix.

## Root Cause

### Before behavior

A resumed Claude CLI process accepted a new channel turn, then produced only three stream-json lines and zero output bytes. The persisted Claude ordering showed:

1. an older queued background task notification was replayed;
2. its empty terminal result arrived;
3. the actual user message was then replayed;
4. OpenClaw had already accepted the old result, closed the process, and the actual request was recorded as interrupted.

The channel therefore received no reply until the user sent another message. Identifiers and private channel details are intentionally omitted.

### Code and regression provenance

PR #69679 / commit `81ca7bc40b09` introduced warm Claude CLI sessions with `--replay-user-messages`. The live-session owner wrote an uncorrelated user payload and treated the first `type:"result"` frame as terminal for the current OpenClaw turn. That assumption fails when a reused Claude process drains queued work first.

The downstream group-silence behavior hid the empty successful result, but it did not create or own the request/result mismatch.

### Dependency contract

The official Anthropic SDK contract supports the correlation used here:

- `SDKUserMessage.uuid` is accepted (`@anthropic-ai/claude-agent-sdk@0.3.220/sdk.d.ts:4583-4618`).
- successful results expose `user_message_uuid` and `origin` (`sdk.d.ts:4290-4319`);
- `origin.kind` includes `task-notification` (`sdk.d.ts:4024-4058`).
- Anthropic documents `origin` specifically so consumers can distinguish user results from task-notification followups, and later added `user_message_uuid` for request correlation: [official changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/71c804dc8f4a61c1dca6fe10d4b95a6b65d1396b/CHANGELOG.md#L28-L32), [origin contract](https://github.com/anthropics/claude-agent-sdk-typescript/blob/71c804dc8f4a61c1dca6fe10d4b95a6b65d1396b/CHANGELOG.md#L452-L455).

This is an OpenClaw boundary-correlation defect. No evidence ties its introduction to a Claude CLI release; current Claude output merely exposes the pre-existing assumption.

## Exact change

- generate one UUID for each live stdin request and include it in the Claude user frame;
- consume `--replay-user-messages` acknowledgements to distinguish older queued input from the current input;
- defer results with a different UUID, a foreign `task-notification` origin, or markerless results that follow an older replay before current acknowledgement;
- keep an explicit current-turn background continuation eligible for its post-drain task-notification result;
- leave existing no-output and overall watchdogs authoritative.

## Real behavior proof

### Source-checkout protocol fixture

Command:

```sh
node scripts/run-vitest.mjs \
  src/agents/cli-runner/claude-live-session.background-tasks.test.ts \
  src/agents/cli-runner/claude-live-session-policy.test.ts \
  src/agents/cli-runner.reliability.test.ts
```

Copied result:

```text
Test Files  1 passed (1) — Tests 3 passed
Test Files  1 passed (1) — Tests 84 passed
Test Files  1 passed (1) — Tests 21 passed
[test] passed 3 Vitest shards
```

The regression fixture sends the real observed ordering: an older replayed user frame, a markerless empty result, a task-notification result, and a mismatched UUID result. The OpenClaw turn remains unsettled. It then sends the current UUID replay, assistant response, and matching result; the turn returns the actual response and does not cancel the live process.

The same fixture proves that a current turn which started supported background Agent/Workflow work still accepts its post-drain task-notification completion.

### Live Claude protocol contract

Environment: installed Claude CLI 2.1.220, fresh session UUID, harmless one-line prompt, no Gateway or channel.

Command shape:

```sh
printf '%s\n' "$uuid_stamped_user_frame" |
  claude -p --input-format stream-json --output-format stream-json \
    --verbose --replay-user-messages --session-id "$fresh_session_uuid"
```

Copied redacted result:

```json
{"result_count":1,"request_uuid_echo_matches":1,"nonempty_result_count":1,"origin_kinds":["absent"],"terminal_reasons":["completed"]}
```

Observed after behavior: current Claude echoes the stdin request UUID on its terminal result, providing a direct owner signal instead of a timing guess or fixed grace period.

## Verification

- 108 focused tests passed across three Vitest shards.
- `pnpm check:changed -- <three changed files>` passed all selected core/core-test type, lint, format, boundary, dead-export, import-cycle, database, and repository guards.
- Autoreview: clean, 0.98 correctness assessment; no accepted/actionable finding.
- `git diff --check`: clean.
- The remote changed-gate backend was unavailable because the Blacksmith Testbox authentication had expired. Per trusted-source fallback policy, the same changed gate ran locally and passed.

## What was not tested

- I did not inject an orphaned real background Agent notification into a production Telegram session; the process-supervisor fixture reproduces the exact Claude stream-json ordering at the live-session owner.
- I did not update or restart the live Gateway.
- The live Claude probe validates UUID echoing on a normal request, not a real orphaned background notification.
- An earlier contract-probe invocation omitted Claude's required `--verbose` flag and was rejected before model execution; the corrected exact shape above passed.

