### PR TITLE
test: avoid loading real plugins in schema facade test

### DIFF
--- a/src/plugin-sdk/bundled-channel-config-schema.test.ts
+++ b/src/plugin-sdk/bundled-channel-config-schema.test.ts
@@ -1,21 +1,20 @@
 import { describe, expect, it } from "vitest";
-// Bundled channel config schema tests cover lazy plugin-owned schema resolution.
-import { z } from "zod";
+// Keep the facade cold here; plugin suites own schema behavior and loader fixtures own resolution.
+import type { z } from "zod";
 import { IMessageConfigSchema, TelegramConfigSchema } from "./bundled-channel-config-schema.js";
 import type { OpenClawConfig } from "./config-contracts.js";
 
 describe("bundled channel config schema facade", () => {
-  it("resolves Telegram and iMessage schemas from bundled plugin public APIs", () => {
-    expect(TelegramConfigSchema.safeParse({ dmPolicy: "pairing" }).success).toBe(true);
-    expect(IMessageConfigSchema.safeParse({ dmPolicy: "pairing" }).success).toBe(true);
-
-    const extended = TelegramConfigSchema.safeExtend({ testOnly: z.literal(true) });
-    expect(extended.safeParse({ dmPolicy: "pairing", testOnly: true }).success).toBe(true);
-
+  it("exposes lazy Telegram and iMessage schemas with config-compatible output types", () => {
     type ChannelConfig = NonNullable<OpenClawConfig["channels"]>;
-    const telegramConfig: NonNullable<ChannelConfig["telegram"]> = TelegramConfigSchema.parse({});
-    const imessageConfig: NonNullable<ChannelConfig["imessage"]> = IMessageConfigSchema.parse({});
-    expect(telegramConfig).toBeDefined();
-    expect(imessageConfig).toBeDefined();
+    const telegramConfig: NonNullable<ChannelConfig["telegram"]> = {} as z.output<
+      typeof TelegramConfigSchema
+    >;
+    const imessageConfig: NonNullable<ChannelConfig["imessage"]> = {} as z.output<
+      typeof IMessageConfigSchema
+    >;
+
+    expect([TelegramConfigSchema, IMessageConfigSchema]).toHaveLength(2);
+    expect([telegramConfig, imessageConfig]).toEqual([{}, {}]);
   });
 });

--- a/src/plugin-sdk/facade-loader.test.ts
+++ b/src/plugin-sdk/facade-loader.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
 import {
   listImportedBundledPluginFacadeIds,
@@ -90,6 +91,33 @@ function createBundledPluginFixture(params: {
     "utf8",
   );
   return { bundledPluginsDir, pluginId, pluginRoot };
+}
+
+function createBundledChannelConfigFixtures(): string {
+  const bundledPluginsDir = path.join(
+    packageRoot,
+    "dist",
+    nextTrustedPluginId("openclaw-channel-config-fixtures-"),
+  );
+  trustedBundledPluginFixtureRoots.push(bundledPluginsDir);
+  for (const [pluginId, exportName] of [
+    ["telegram", "TelegramConfigSchema"],
+    ["imessage", "IMessageConfigSchema"],
+  ] as const) {
+    const pluginRoot = path.join(bundledPluginsDir, pluginId);
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    writeFixturePackageJson(pluginRoot, pluginId);
+    fs.writeFileSync(
+      path.join(pluginRoot, "config-api.js"),
+      [
+        'import { z } from "zod";',
+        `export const ${exportName} = z.object({ dmPolicy: z.literal("pairing").default("pairing") });`,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+  }
+  return bundledPluginsDir;
 }
 
 function createPackageSourcePluginFixture(params: {
@@ -187,6 +215,21 @@ afterEach(() => {
 });
 
 describe("plugin-sdk facade loader", () => {
+  it("resolves channel config facades lazily from generated plugin fixtures", async () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = createBundledChannelConfigFixtures();
+    const { IMessageConfigSchema, TelegramConfigSchema } =
+      await import("./bundled-channel-config-schema.js");
+
+    expect(listImportedBundledPluginFacadeIds()).toEqual([]);
+    expect(TelegramConfigSchema.safeParse({ dmPolicy: "pairing" }).success).toBe(true);
+    const extended = TelegramConfigSchema.safeExtend({ testOnly: z.literal(true) });
+    expect(extended.safeParse({ dmPolicy: "pairing", testOnly: true }).success).toBe(true);
+    expect(listImportedBundledPluginFacadeIds()).toEqual(["telegram"]);
+
+    expect(IMessageConfigSchema.safeParse({ dmPolicy: "pairing" }).success).toBe(true);
+    expect(listImportedBundledPluginFacadeIds()).toEqual(["imessage", "telegram"]);
+  });
+
   it("honors trusted bundled plugin dir overrides under the package root", () => {
     const pluginId = nextTrustedPluginId("openclaw-facade-loader-override-");
     const overrideA = createBundledPluginFixture({


### PR DESCRIPTION
## Summary

- keep the bundled channel schema facade test cold so it no longer source-transforms the full Telegram and iMessage plugins
- exercise the real lazy facade loader against generated, lightweight plugin fixtures
- preserve exact Telegram/iMessage export mapping, lazy-load order, caching, `safeExtend`, and `OpenClawConfig` output typing

## Performance

The target was the slowest file in `checks-node-compact-large-7` from [run 30761505614](https://github.com/openclaw/openclaw/actions/runs/30761505614):

- CI baseline: 47.053s
- same-machine `unit-fast` baseline: 89.24s total / 88.40s tests
- same-machine after: 685ms total / 2ms tests
- reduction: 99.2% total file duration, without changing shard configuration or test count

The unit-fast classifier still reports this file as `unitFast: true`, `forced: false`, with no stateful reasons.

## Proof

- `node scripts/run-vitest.mjs src/plugin-sdk/bundled-channel-config-schema.test.ts src/plugin-sdk/facade-loader.test.ts src/plugins/contracts/config-footprint-guardrails.test.ts` — 18/18 tests passed across the existing unit-fast, plugin-sdk, and contracts-plugin projects
- targeted `oxfmt`, `oxlint`, and `git diff --check` passed
- autoreview clean, no accepted/actionable findings

Production LOC delta: 0.
