### PR TITLE
test(gateway): isolate handler dependencies

### DIFF
--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -30,6 +30,35 @@ vi.mock("../../config/io.js", async () => {
   };
 });
 
+// This suite owns config patch/merge behavior, while plugin validation is covered by
+// config.plugin-validation.test.ts and validation.channel-metadata.test.ts.
+vi.mock("../../config/validation.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config/validation.js")>(
+    "../../config/validation.js",
+  );
+  return {
+    ...actual,
+    validateConfigObjectRawWithPlugins: vi.fn((config: OpenClawConfig) => ({
+      ok: true,
+      config,
+      warnings: [],
+    })),
+    validateConfigObjectWithPlugins: vi.fn((config: OpenClawConfig) => ({
+      ok: true,
+      config,
+      warnings: [],
+    })),
+  };
+});
+
+// Secret materialization has dedicated runtime suites; keep these handler tests on
+// their config-write boundary instead of loading every provider and plugin artifact.
+vi.mock("../../secrets/runtime.js", () => ({
+  prepareSecretsRuntimeSnapshot: vi.fn(async ({ config }: { config: OpenClawConfig }) => ({
+    config,
+  })),
+}));
+
 vi.mock("./config-write-flow.js", async () => {
   const actual =
     await vi.importActual<typeof import("./config-write-flow.js")>("./config-write-flow.js");

--- a/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
@@ -30,6 +30,20 @@ vi.mock("../../logging/subsystem.js", async () => {
   };
 });
 
+// Sticky-model tests own persistence policy; session-utils.test.ts owns the thinking
+// projection that otherwise materializes provider policy for every mutation here.
+vi.mock("../session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
+  return {
+    ...actual,
+    resolveGatewaySessionThinkingProjection: vi.fn(() => ({
+      agentRuntime: { id: "openclaw", source: "implicit" },
+      effectiveThinkingLevel: "off",
+      thinkingLevels: [],
+    })),
+  };
+});
+
 import { sessionMutationHandlers } from "./sessions-mutations.js";
 
 const cfg = {


### PR DESCRIPTION
## What Problem This Solves

Two gateway handler tests accidentally exercised unrelated integration work on every assertion:

- config patch/merge tests materialized plugin-aware validation and the secrets runtime;
- sticky-model persistence tests materialized provider thinking-policy artifacts.

That made two assertions take roughly 27–28 seconds each even though neither suite asserts those dependency outputs. This patch keeps the real handler, merge, normalization, persistence, and SQLite lifecycle paths while replacing only the orthogonal dependency results with deterministic test boundaries. Real plugin validation, secret materialization, and thinking projection remain covered in their owner suites.

No production code, Vitest config, worker count, or CI sharding changes.

## Evidence

Focused command:

```sh
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree \
OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
node scripts/run-vitest.mjs \
  src/gateway/server-methods/config.test.ts \
  src/gateway/server-methods/sessions-mutations.sticky-model.test.ts \
  --reporter=verbose
```

- Before: 32/32 passed; Vitest 47.04s; aggregate test time 59.43s.
- After fast-forward: 32/32 passed; Vitest 10.16s; aggregate test time 3.99s.
- The model normalization assertion fell from about 26.6s to 1ms.
- The cleared sticky-model assertion fell from about 28.0s to 494ms.
- Earlier full gateway-methods proof: 143 files and 2,801 tests passed.
- `git diff --check` passed.
- Codex autoreview reported no accepted/actionable findings.

The config suite still proves canonical model-ID normalization before map and ID-keyed array merge. The sticky suite still proves admin-only best-effort persistence, omission/null/default non-persistence, and SQLite handle cleanup before fixture deletion.
