### PR TITLE
fix(telegram): prevent stalled Bot API responses from blocking group messages

### DIFF
--- a/extensions/telegram/src/api-logging.ts
+++ b/extensions/telegram/src/api-logging.ts
@@ -8,14 +8,14 @@ type TelegramApiLogger = (message: string) => void;
 type TelegramApiLoggingParams<T> = {
   operation: string;
   fn: () => Promise<T>;
-  runtime?: RuntimeEnv;
+  runtime?: Pick<RuntimeEnv, "error">;
   logger?: TelegramApiLogger;
   shouldLog?: (err: unknown) => boolean;
 };
 
 const fallbackLogger = createSubsystemLogger("telegram/api");
 
-function resolveTelegramApiLogger(runtime?: RuntimeEnv, logger?: TelegramApiLogger) {
+function resolveTelegramApiLogger(runtime?: Pick<RuntimeEnv, "error">, logger?: TelegramApiLogger) {
   if (logger) {
     return logger;
   }

--- a/extensions/telegram/src/bot-handlers.message-events.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-events.runtime.ts
@@ -21,11 +21,34 @@ import { TelegramPairingStoreReadError } from "./bot/helpers.js";
 import type { TelegramContext, TelegramGetChat } from "./bot/types.js";
 import type { TelegramMessageDispatchReplayClaim } from "./message-dispatch-dedupe.js";
 
+type TelegramMessageHandlerParams = Pick<
+  RegisterTelegramHandlerParams,
+  "bot" | "shouldSkipUpdate"
+> & {
+  opts: Pick<RegisterTelegramHandlerParams["opts"], "botInfo">;
+  runtime: Pick<RegisterTelegramHandlerParams["runtime"], "error">;
+};
+
+type TelegramMessageHandlerRuntime = Pick<
+  TelegramHandlerMessageRuntime,
+  | "normalizePromptContextMinTimestampMs"
+  | "promptContextBoundaryOptions"
+  | "releaseDispatchDedupeClaims"
+  | "claimMessageDispatchDedupe"
+  | "buildSyntheticContext"
+  | "resolveTelegramSessionState"
+  | "resolvePromptContextAmbientWatermark"
+> & {
+  recordMessageForReplyChain: (
+    ...args: Parameters<TelegramHandlerMessageRuntime["recordMessageForReplyChain"]>
+  ) => Promise<unknown>;
+};
+
 export function registerTelegramMessageHandlers(
-  { bot, opts, runtime, shouldSkipUpdate }: RegisterTelegramHandlerParams,
-  messageRuntime: TelegramHandlerMessageRuntime,
-  authorizationRuntime: TelegramHandlerAuthorizationRuntime,
-  inboundRuntime: TelegramHandlerInboundRuntime,
+  { bot, opts, runtime, shouldSkipUpdate }: TelegramMessageHandlerParams,
+  messageRuntime: TelegramMessageHandlerRuntime,
+  authorizationRuntime: Pick<TelegramHandlerAuthorizationRuntime, "authorizeInboundMessage">,
+  inboundRuntime: Pick<TelegramHandlerInboundRuntime, "processInboundMessage">,
 ) {
   const {
     normalizePromptContextMinTimestampMs,

--- a/extensions/telegram/src/bot.fetch-abort.test.ts
+++ b/extensions/telegram/src/bot.fetch-abort.test.ts
@@ -72,6 +72,82 @@ describe("createTelegramBot fetch abort", () => {
     expect(observedSignal.aborted).toBe(true);
   });
 
+  it("keeps the getChat deadline active until its response body settles", async () => {
+    vi.useFakeTimers();
+    let observedSignal: AbortSignal | undefined;
+    let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      observedSignal = init?.signal ?? undefined;
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            bodyController = controller;
+            observedSignal?.addEventListener(
+              "abort",
+              () => controller.error(observedSignal?.reason),
+              { once: true },
+            );
+          },
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 },
+      );
+    });
+    const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy as typeof fetch);
+
+    const response = (await clientFetch(
+      "https://api.telegram.org/bot123456:ABC/getChat",
+    )) as Response;
+    const body = response.json();
+    void body.catch(() => undefined);
+
+    try {
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(observedSignal?.aborted).toBe(true);
+      await expect(body).rejects.toThrow("Telegram getchat timed out after 15000ms");
+    } finally {
+      if (!observedSignal?.aborted) {
+        bodyController?.error(new Error("test cleanup"));
+      }
+      await body.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["shutdown", "request"] as const)(
+    "keeps %s cancellation attached while a response body is being read",
+    async (cancellationSource) => {
+      let observedSignal: AbortSignal | undefined;
+      const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        observedSignal = init?.signal ?? undefined;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              observedSignal?.addEventListener(
+                "abort",
+                () => controller.error(observedSignal?.reason),
+                { once: true },
+              );
+            },
+          }),
+        );
+      });
+      const { clientFetch, shutdown } = createWrappedTelegramClientFetch(fetchSpy as typeof fetch);
+      const request = new AbortController();
+      const response = (await clientFetch("https://api.telegram.org/bot123456:ABC/getChat", {
+        signal: request.signal,
+      })) as Response;
+      const body = response.text();
+      void body.catch(() => undefined);
+
+      const cancellation = cancellationSource === "shutdown" ? shutdown : request;
+      cancellation.abort(new Error(`${cancellationSource} cancelled`));
+
+      expect(observedSignal?.aborted).toBe(true);
+      await expect(body).rejects.toThrow(`${cancellationSource} cancelled`);
+    },
+  );
+
   it("tags wrapped Telegram fetch failures with the Bot API method", async () => {
     const fetchError = Object.assign(new TypeError("fetch failed"), {
       cause: Object.assign(new Error("connect timeout"), {
@@ -257,9 +333,14 @@ describe("createTelegramBot fetch abort", () => {
 
   it("retries Telegram 421 responses after forcing transport fallback", async () => {
     const forceFallback = vi.fn(() => true);
+    const cancelMisdirectedBody = vi.fn();
     const fetchSpy = vi
       .fn()
-      .mockResolvedValueOnce(new Response("Misdirected Request", { status: 421 }))
+      .mockResolvedValueOnce(
+        new Response(new ReadableStream<Uint8Array>({ cancel: cancelMisdirectedBody }), {
+          status: 421,
+        }),
+      )
       .mockResolvedValueOnce(new Response("{}", { status: 200 }));
     const { clientFetch } = createWrappedTelegramClientFetchWithTransport({
       fetch: fetchSpy as typeof fetch,
@@ -272,6 +353,7 @@ describe("createTelegramBot fetch abort", () => {
     expect((result as Response).status).toBe(200);
     expect(forceFallback).toHaveBeenCalledWith("misdirected-request");
     expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(cancelMisdirectedBody).toHaveBeenCalledOnce();
   });
 
   it("retries Telegram 421 fetch errors after forcing transport fallback", async () => {

--- a/extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts
+++ b/extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts
@@ -1,0 +1,161 @@
+// Real grammY ingress and Bot API sockets: stalled forum metadata must not block delivery.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { Bot } from "grammy";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { registerTelegramMessageHandlers } from "./bot-handlers.message-events.runtime.js";
+import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
+import { resetTelegramForumFlagCacheForTest } from "./bot/helpers.js";
+import { asTelegramClientFetch, createTelegramClientFetch } from "./client-fetch.js";
+import * as telegramRequestTimeouts from "./request-timeouts.js";
+
+describe("Telegram supergroup ingress with a stalled Bot API response body", () => {
+  const liveSockets = new Set<Socket>();
+  let server: Server;
+  let apiRoot: string;
+  let getChatRequests = 0;
+  let closedSocketCount = 0;
+  let resolveGetChatHeaders: (() => void) | undefined;
+
+  beforeAll(async () => {
+    server = createServer((request, response) => {
+      if (!request.url?.endsWith("/getChat")) {
+        response.writeHead(404);
+        response.end();
+        return;
+      }
+      getChatRequests += 1;
+      response.writeHead(200, { "content-type": "application/json" });
+      response.write('{"ok":true,"result":{"id":-100364');
+      resolveGetChatHeaders?.();
+    });
+    server.on("connection", (socket) => {
+      liveSockets.add(socket);
+      socket.once("close", () => {
+        liveSockets.delete(socket);
+        closedSocketCount += 1;
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    apiRoot = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    vi.restoreAllMocks();
+    resetTelegramForumFlagCacheForTest();
+    for (const socket of liveSockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it("dispatches DMs immediately and the supergroup after cancelling its stalled socket", async () => {
+    const canonicalRequestTimeout = telegramRequestTimeouts.resolveTelegramRequestTimeoutMs;
+    vi.spyOn(telegramRequestTimeouts, "resolveTelegramRequestTimeoutMs").mockImplementation(
+      (method, configuredTimeoutSeconds) =>
+        method === "getchat" ? 100 : canonicalRequestTimeout(method, configuredTimeoutSeconds),
+    );
+    resetTelegramForumFlagCacheForTest();
+
+    const clientFetch = createTelegramClientFetch({
+      fetchImpl: asTelegramClientFetch(globalThis.fetch),
+    });
+    if (!clientFetch) {
+      throw new Error("expected production Telegram client fetch wrapper");
+    }
+    const botInfo = telegramBotInfoForTest;
+    const bot = new Bot("123456:integration-token", {
+      botInfo,
+      client: { apiRoot, fetch: asTelegramClientFetch(clientFetch) },
+    });
+    const dispatched = vi.fn<
+      Parameters<typeof registerTelegramMessageHandlers>[3]["processInboundMessage"]
+    >(async () => undefined);
+    const authorization = {
+      authorizeInboundMessage: vi.fn(async () => ({
+        allowed: true as const,
+        effectiveDmAllow: {},
+        context: {
+          cfg: {},
+          dmPolicy: "open" as const,
+          storeAllowFrom: [],
+          effectiveGroupAllow: {},
+        },
+      })),
+    } as unknown as Parameters<typeof registerTelegramMessageHandlers>[2];
+    const messageRuntime = {
+      normalizePromptContextMinTimestampMs: () => undefined,
+      promptContextBoundaryOptions: () => ({}),
+      releaseDispatchDedupeClaims: () => undefined,
+      claimMessageDispatchDedupe: async () => ({ process: true, claims: [] }),
+      buildSyntheticContext: (context: unknown) => context,
+      resolveTelegramSessionState: () => ({ sessionKey: "integration", storePath: "integration" }),
+      resolvePromptContextAmbientWatermark: () => undefined,
+      recordMessageForReplyChain: async () => undefined,
+    } as unknown as Parameters<typeof registerTelegramMessageHandlers>[1];
+
+    registerTelegramMessageHandlers(
+      {
+        bot,
+        opts: { botInfo },
+        runtime: { error: vi.fn() },
+        shouldSkipUpdate: () => false,
+      } as unknown as Parameters<typeof registerTelegramMessageHandlers>[0],
+      messageRuntime,
+      authorization,
+      { processInboundMessage: dispatched } as unknown as Parameters<
+        typeof registerTelegramMessageHandlers
+      >[3],
+    );
+
+    const headersReceived = new Promise<void>((resolve) => {
+      resolveGetChatHeaders = resolve;
+    });
+    const groupDelivery = bot.handleUpdate({
+      update_id: 1,
+      message: {
+        message_id: 11,
+        date: 1_700_000_000,
+        chat: { id: -100364, type: "supergroup", title: "Integration group" },
+        from: { id: 111, is_bot: false, first_name: "Group sender" },
+        text: "group message",
+      },
+    });
+    void groupDelivery.catch(() => undefined);
+    await headersReceived;
+
+    await bot.handleUpdate({
+      update_id: 2,
+      message: {
+        message_id: 22,
+        date: 1_700_000_001,
+        chat: { id: 222, type: "private", first_name: "DM sender" },
+        from: { id: 222, is_bot: false, first_name: "DM sender" },
+        text: "direct message",
+      },
+    });
+    expect(dispatched).toHaveBeenCalledTimes(1);
+    expect(dispatched.mock.calls[0]?.[0]).toMatchObject({ chatId: 222, isGroup: false });
+
+    const groupResult = await Promise.race([
+      groupDelivery.then(() => "dispatched" as const),
+      new Promise<"stalled">((resolve) => {
+        setTimeout(() => resolve("stalled"), 1_000);
+      }),
+    ]);
+
+    expect(groupResult).toBe("dispatched");
+    expect(dispatched).toHaveBeenCalledTimes(2);
+    expect(dispatched.mock.calls[1]?.[0]).toMatchObject({
+      chatId: -100364,
+      isGroup: true,
+      isForum: false,
+    });
+    expect(getChatRequests).toBe(1);
+    await vi.waitFor(() => expect(closedSocketCount).toBeGreaterThan(0));
+  });
+});

--- a/extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts
+++ b/extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts
@@ -75,28 +75,47 @@ describe("Telegram supergroup ingress with a stalled Bot API response body", () 
     const dispatched = vi.fn<
       Parameters<typeof registerTelegramMessageHandlers>[3]["processInboundMessage"]
     >(async () => undefined);
+    const emptyAllow = {
+      entries: [],
+      hasWildcard: false,
+      hasEntries: false,
+      invalidEntries: [],
+    };
     const authorization = {
       authorizeInboundMessage: vi.fn(async () => ({
         allowed: true as const,
-        effectiveDmAllow: {},
+        effectiveDmAllow: emptyAllow,
         context: {
           cfg: {},
+          telegramCfg: {},
+          allowFrom: [],
           dmPolicy: "open" as const,
           storeAllowFrom: [],
-          effectiveGroupAllow: {},
+          effectiveGroupAllow: emptyAllow,
+          hasGroupAllowOverride: false,
         },
       })),
-    } as unknown as Parameters<typeof registerTelegramMessageHandlers>[2];
+    } satisfies Parameters<typeof registerTelegramMessageHandlers>[2];
     const messageRuntime = {
       normalizePromptContextMinTimestampMs: () => undefined,
       promptContextBoundaryOptions: () => ({}),
       releaseDispatchDedupeClaims: () => undefined,
       claimMessageDispatchDedupe: async () => ({ process: true, claims: [] }),
-      buildSyntheticContext: (context: unknown) => context,
-      resolveTelegramSessionState: () => ({ sessionKey: "integration", storePath: "integration" }),
+      buildSyntheticContext: (context, message) => ({
+        message,
+        me: context.me,
+        getFile: context.getFile.bind(context),
+      }),
+      resolveTelegramSessionState: () => ({
+        agentId: "integration",
+        sessionEntry: undefined,
+        sessionKey: "integration",
+        storePath: "integration",
+        model: undefined,
+      }),
       resolvePromptContextAmbientWatermark: () => undefined,
       recordMessageForReplyChain: async () => undefined,
-    } as unknown as Parameters<typeof registerTelegramMessageHandlers>[1];
+    } satisfies Parameters<typeof registerTelegramMessageHandlers>[1];
 
     registerTelegramMessageHandlers(
       {
@@ -104,12 +123,10 @@ describe("Telegram supergroup ingress with a stalled Bot API response body", () 
         opts: { botInfo },
         runtime: { error: vi.fn() },
         shouldSkipUpdate: () => false,
-      } as unknown as Parameters<typeof registerTelegramMessageHandlers>[0],
+      } satisfies Parameters<typeof registerTelegramMessageHandlers>[0],
       messageRuntime,
       authorization,
-      { processInboundMessage: dispatched } as unknown as Parameters<
-        typeof registerTelegramMessageHandlers
-      >[3],
+      { processInboundMessage: dispatched },
     );
 
     const headersReceived = new Promise<void>((resolve) => {

--- a/extensions/telegram/src/client-fetch.ts
+++ b/extensions/telegram/src/client-fetch.ts
@@ -1,5 +1,6 @@
 // Telegram plugin module implements client fetch behavior.
 import type { ApiClientOptions } from "grammy";
+import { responseWithRelease } from "openclaw/plugin-sdk/fetch-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { TelegramTransport } from "./fetch.js";
 import { isTelegramMisdirectedRequestError, tagTelegramNetworkError } from "./network-errors.js";
@@ -11,7 +12,7 @@ type TelegramClientFetch = NonNullable<ApiClientOptions["fetch"]>;
 type TelegramCompatFetch = (
   input: TelegramFetchInput,
   init?: TelegramFetchInit,
-) => ReturnType<TelegramClientFetch>;
+) => Promise<Response>;
 type TelegramAbortSignalLike = {
   aborted: boolean;
   reason?: unknown;
@@ -179,17 +180,7 @@ export function createTelegramClientFetch(params: {
         requestTimeout.unref?.();
       }
 
-      try {
-        return await callFetch(input, {
-          ...init,
-          signal: controller.signal,
-        });
-      } catch (err) {
-        if (requestTimedOut && timeoutError) {
-          throw timeoutError;
-        }
-        throw err;
-      } finally {
+      const releaseRequest = async () => {
         if (requestTimeout) {
           clearTimeout(requestTimeout);
         }
@@ -197,12 +188,29 @@ export function createTelegramClientFetch(params: {
         if (requestSignal && onRequestAbort) {
           requestSignal.removeEventListener("abort", onRequestAbort);
         }
+      };
+
+      try {
+        const response = await callFetch(input, {
+          ...init,
+          signal: controller.signal,
+        });
+        // grammY consumes JSON after fetch resolves; keep its deadline and
+        // cancellation linked until the response body settles.
+        return responseWithRelease(response, releaseRequest);
+      } catch (err) {
+        await releaseRequest();
+        if (requestTimedOut && timeoutError) {
+          throw timeoutError;
+        }
+        throw err;
       }
     };
 
     try {
       const response = await runFetch();
       if (response.status === 421 && canForceTransportFallback("misdirected-request")) {
+        await response.body?.cancel().catch(() => undefined);
         return await runFetch();
       }
       return response;


### PR DESCRIPTION
Related: #100364

## What Problem This Solves

Fixes an issue where Telegram supergroup messages could remain stuck before agent dispatch while direct messages on the same bot continued normally when a Bot API `getChat` request returned headers but its response body never finished.

## Why This Change Was Made

The grammY client consumes response JSON after fetch resolves, but the Telegram transport previously removed its existing method timeout and shutdown/request cancellation listeners as soon as response headers arrived. Reuse the existing public Plugin SDK `responseWithRelease` owner so those protections remain active until the body completes, errors, or is cancelled. Explicitly cancel a discarded HTTP 421 response before the existing transport retry.

The handler and API logger now accept only the dependencies they consume. This keeps the integration regression fully typed without `as unknown` test bridges.

## User Impact

A stalled group/forum metadata lookup now releases at the existing Telegram request deadline and the supergroup message reaches the agent when its configured group authorization allows delivery; simultaneous DMs remain responsive. The same cancellation protection covers all Telegram Bot API response bodies without adding configuration or changing Telegram authorization policy.

## Evidence

- exact head: `ae487d2a0881cd44267b1c73f012ad12b2c81367`
- focused regression: `node scripts/run-vitest.mjs extensions/telegram/src/bot.fetch-abort.test.ts extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts --maxWorkers=1` — 2 files, 17 tests passed
- extension production types, extension test types, targeted Oxlint, formatting, and `git diff --check`: passed
- exact-head autoreview: clean; no P0/P1/P2 findings, 0.88 confidence
- production delta: +47/-16 across the transport and narrowed dependency contracts (+31 net); tests: +261/-1 (+260 net). Production growth records the exact handler/API logger ownership boundary so the real ingress regression stays typed.

### Injected stalled-body proof

The integration starts a real localhost HTTP server that returns Telegram JSON headers and a permanently incomplete body, runs a real grammY Bot through production OpenClaw Telegram message handlers, and proves:

- the DM dispatches immediately while the group `getChat` body is stalled
- the existing `getChat` deadline aborts the body and closes the socket
- the authorized supergroup dispatches after recovery
- request and shutdown cancellation remain attached through body consumption
- a discarded HTTP 421 response body is cancelled before retry

### Real Telegram userbot E2E

Ran from the exact PR worktree with the dedicated QA user, real Telegram, and deterministic mock provider; secrets and identities omitted.

Observed facts:

- userbot doctor: `ok: true`
- DM sent message id `334495744`; Telegram returned `OPENCLAW_E2E_PR118144_DM` as SUT message id `335544320` after 2.762s; one provider request
- group mention sent message id `50320113664`; Telegram returned `OPENCLAW_E2E_PR118144_GROUP` as SUT message id `50321162240` in forum topic 1 after 3.178s; one provider request
- raw TDLib updates recorded the DM typing lifecycle, group acknowledgement reaction, and both replies
- retained proof contains `events.ndjson`, `summary.json`, `gateway.log`, and `mock-openai-requests.ndjson` for both lanes

The live userbot proves normal exact-head Telegram transport behavior. Telegram's public service cannot be instructed to stall a response body; the real socket integration above proves that changed fault boundary. No Mantis result is used as evidence.

## Risk

The change retains existing request deadlines and cancellation semantics for longer: until the response body settles rather than only until headers arrive. It adds no configuration, persistence, schema, polling, or authorization change. The response wrapper is bounded per in-flight Bot API request and network latency dominates its allocation cost.
