### PR TITLE
fix(config): preserve secret ownership when configuration rows move

### DIFF
--- a/src/config/redact-snapshot.restore.test.ts
+++ b/src/config/redact-snapshot.restore.test.ts
@@ -251,6 +251,325 @@ describe("restoreRedactedValues", () => {
     ).toBe("user-provided-new-token-value");
   });
 
+  describe.each([
+    { name: "schema hints", hints: { "accounts[].token": { sensitive: true } } },
+    { name: "sensitive-path guessing", hints: undefined },
+  ])("stable array identities with $name", ({ hints }) => {
+    const original = {
+      accounts: [
+        { id: "alpha", token: "synthetic-alpha-token" },
+        { id: "bravo", token: "synthetic-bravo-token" },
+        { id: "charlie", token: "synthetic-charlie-token" },
+      ],
+    };
+
+    it.each([
+      { change: "deleting an earlier entry", ids: ["bravo", "charlie"] },
+      { change: "reordering the entries", ids: ["charlie", "alpha", "bravo"] },
+    ])("restores each owner's secret after $change", ({ ids }) => {
+      const incoming = {
+        accounts: ids.map((id) => ({ id, token: REDACTED_SENTINEL })),
+      };
+
+      const restored = restoreRedactedValues(incoming, original, hints);
+
+      expect(restored.accounts).toEqual(ids.map((id) => ({ id, token: `synthetic-${id}-token` })));
+    });
+
+    it("keeps a unique owner's secret when an unidentified sibling is deleted", () => {
+      const previous = {
+        accounts: [
+          { token: "synthetic-unidentified-token" },
+          { id: "bravo", token: "synthetic-bravo-token" },
+        ],
+      };
+      const incoming = {
+        accounts: [{ id: "bravo", token: REDACTED_SENTINEL }],
+      };
+
+      expect(restoreRedactedValues(incoming, previous, hints).accounts).toEqual([
+        { id: "bravo", token: "synthetic-bravo-token" },
+      ]);
+    });
+
+    it("keeps a unique owner's secret when ambiguous sibling identities are deleted", () => {
+      const previous = {
+        accounts: [
+          { id: "duplicate", token: "synthetic-first-duplicate-token" },
+          { id: "duplicate", token: "synthetic-second-duplicate-token" },
+          { id: "bravo", token: "synthetic-bravo-token" },
+        ],
+      };
+      const incoming = {
+        accounts: [{ id: "bravo", token: REDACTED_SENTINEL }],
+      };
+
+      expect(restoreRedactedValues(incoming, previous, hints).accounts).toEqual([
+        { id: "bravo", token: "synthetic-bravo-token" },
+      ]);
+    });
+
+    it("rejects a redacted secret for a new identity instead of borrowing its position", () => {
+      const result = restoreRedactedValues_orig(
+        { accounts: [{ id: "new-owner", token: REDACTED_SENTINEL }] },
+        original,
+        hints,
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).not.toContain("synthetic-alpha-token");
+    });
+
+    it("accepts a new identity when its secret was explicitly supplied", () => {
+      const restored = restoreRedactedValues(
+        { accounts: [{ id: "new-owner", token: "synthetic-new-token" }] },
+        original,
+        hints,
+      );
+
+      expect(restored.accounts).toEqual([{ id: "new-owner", token: "synthetic-new-token" }]);
+    });
+
+    it("matches prototype-shaped identities without inherited-key collisions", () => {
+      const previous = {
+        accounts: [
+          { id: "__proto__", token: "synthetic-prototype-token" },
+          { id: "constructor", token: "synthetic-constructor-token" },
+        ],
+      };
+      const incoming = {
+        accounts: [
+          { id: "constructor", token: REDACTED_SENTINEL },
+          { id: "__proto__", token: REDACTED_SENTINEL },
+        ],
+      };
+
+      expect(restoreRedactedValues(incoming, previous, hints).accounts).toEqual([
+        { id: "constructor", token: "synthetic-constructor-token" },
+        { id: "__proto__", token: "synthetic-prototype-token" },
+      ]);
+    });
+
+    it("keeps escaped environment identities positional after runtime substitution", () => {
+      const previous = {
+        accounts: [
+          { id: "${ACCOUNT_ID}", token: "synthetic-literal-token" },
+          { id: "bravo", token: "synthetic-bravo-token" },
+        ],
+      };
+      const incoming = {
+        accounts: [
+          { id: "$${ACCOUNT_ID}", token: REDACTED_SENTINEL },
+          { id: "bravo", token: REDACTED_SENTINEL },
+        ],
+      };
+
+      expect(restoreRedactedValues(incoming, previous, hints).accounts).toEqual([
+        { id: "$${ACCOUNT_ID}", token: "synthetic-literal-token" },
+        { id: "bravo", token: "synthetic-bravo-token" },
+      ]);
+    });
+
+    it("rejects moving an unidentified redacted entry onto an identified owner's position", () => {
+      const previous = {
+        accounts: [
+          { token: "synthetic-unidentified-token" },
+          { id: "bravo", token: "synthetic-bravo-token" },
+        ],
+      };
+      const incoming = {
+        accounts: [{ id: "bravo", token: REDACTED_SENTINEL }, { token: REDACTED_SENTINEL }],
+      };
+
+      const result = restoreRedactedValues_orig(incoming, previous, hints);
+
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).not.toContain("synthetic-bravo-token");
+    });
+
+    it.each([
+      {
+        reason: "original identities are duplicated",
+        previous: [
+          { id: "duplicate", token: "synthetic-first-token" },
+          { id: "duplicate", token: "synthetic-second-token" },
+        ],
+        incoming: [
+          { id: "duplicate", token: REDACTED_SENTINEL },
+          { id: "duplicate", token: REDACTED_SENTINEL },
+        ],
+      },
+      {
+        reason: "incoming identities are duplicated",
+        previous: [
+          { id: "alpha", token: "synthetic-first-token" },
+          { id: "bravo", token: "synthetic-second-token" },
+        ],
+        incoming: [
+          { id: "alpha", token: REDACTED_SENTINEL },
+          { id: "alpha", token: REDACTED_SENTINEL },
+        ],
+      },
+      {
+        reason: "an original identity is missing",
+        previous: [
+          { id: "alpha", token: "synthetic-first-token" },
+          { token: "synthetic-second-token" },
+        ],
+        incoming: [{ id: "alpha", token: REDACTED_SENTINEL }, { token: REDACTED_SENTINEL }],
+      },
+      {
+        reason: "an incoming identity is missing",
+        previous: [
+          { id: "alpha", token: "synthetic-first-token" },
+          { id: "bravo", token: "synthetic-second-token" },
+        ],
+        incoming: [{ id: "alpha", token: REDACTED_SENTINEL }, { token: REDACTED_SENTINEL }],
+      },
+      {
+        reason: "an identity is empty",
+        previous: [
+          { id: "", token: "synthetic-first-token" },
+          { id: "bravo", token: "synthetic-second-token" },
+        ],
+        incoming: [
+          { id: "", token: REDACTED_SENTINEL },
+          { id: "bravo", token: REDACTED_SENTINEL },
+        ],
+      },
+      {
+        reason: "an incoming identity is an unresolved environment placeholder",
+        previous: [
+          { id: "alpha", token: "synthetic-first-token" },
+          { id: "bravo", token: "synthetic-second-token" },
+        ],
+        incoming: [
+          { id: "${ACCOUNT_ID}", token: REDACTED_SENTINEL },
+          { id: "bravo", token: REDACTED_SENTINEL },
+        ],
+      },
+      {
+        reason: "an incoming identity contains an inline environment placeholder",
+        previous: [
+          { id: "account-alpha", token: "synthetic-first-token" },
+          { id: "bravo", token: "synthetic-second-token" },
+        ],
+        incoming: [
+          { id: "account-${ACCOUNT_ID}", token: REDACTED_SENTINEL },
+          { id: "bravo", token: REDACTED_SENTINEL },
+        ],
+      },
+    ])("keeps positional restoration when $reason", ({ previous, incoming }) => {
+      const restored = restoreRedactedValues({ accounts: incoming }, { accounts: previous }, hints);
+
+      expect(restored.accounts.map((entry) => entry.token)).toEqual([
+        "synthetic-first-token",
+        "synthetic-second-token",
+      ]);
+    });
+  });
+
+  it("matches stable identities independently at each nested array boundary", () => {
+    const hints: ConfigUiHints = {
+      "providers[].accounts[].token": { sensitive: true },
+    };
+    const original = {
+      providers: [
+        {
+          id: "provider-alpha",
+          accounts: [{ id: "account-one", token: "synthetic-alpha-one-token" }],
+        },
+        {
+          id: "provider-bravo",
+          accounts: [
+            { id: "account-one", token: "synthetic-bravo-one-token" },
+            { id: "account-two", token: "synthetic-bravo-two-token" },
+          ],
+        },
+      ],
+    };
+    const incoming = {
+      providers: [
+        {
+          id: "provider-bravo",
+          accounts: [
+            { id: "account-two", token: REDACTED_SENTINEL },
+            { id: "account-one", token: REDACTED_SENTINEL },
+          ],
+        },
+      ],
+    };
+
+    const restored = restoreRedactedValues(incoming, original, hints);
+
+    expect(restored.providers).toEqual([
+      {
+        id: "provider-bravo",
+        accounts: [
+          { id: "account-two", token: "synthetic-bravo-two-token" },
+          { id: "account-one", token: "synthetic-bravo-one-token" },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps positional restoration for arrays of scalar secrets", () => {
+    const hints: ConfigUiHints = { "apiKeys[]": { sensitive: true } };
+    const original = { apiKeys: ["synthetic-first-key", "synthetic-second-key"] };
+
+    const restored = restoreRedactedValues(
+      { apiKeys: [REDACTED_SENTINEL, REDACTED_SENTINEL] },
+      original,
+      hints,
+    );
+
+    expect(restored).toEqual(original);
+  });
+
+  it("does not treat a redacted identifier as a stable array identity", () => {
+    const hints: ConfigUiHints = {
+      "accounts[].id": { sensitive: true },
+      "accounts[].token": { sensitive: true },
+    };
+    const original = {
+      accounts: [
+        { id: "synthetic-first-id", token: "synthetic-first-token" },
+        { id: "synthetic-second-id", token: "synthetic-second-token" },
+      ],
+    };
+    const incoming = {
+      accounts: [
+        { id: REDACTED_SENTINEL, token: REDACTED_SENTINEL },
+        { id: REDACTED_SENTINEL, token: REDACTED_SENTINEL },
+      ],
+    };
+
+    expect(restoreRedactedValues(incoming, original, hints)).toEqual(original);
+  });
+
+  it("keeps reordered hook-mapping session keys redacted until identity-based restoration", () => {
+    const hints: ConfigUiHints = { "hooks.mappings[].sessionKey": { sensitive: true } };
+    const original = {
+      hooks: {
+        mappings: [
+          { id: "alpha", sessionKey: "synthetic-alpha-session" },
+          { id: "bravo", sessionKey: "synthetic-bravo-session" },
+        ],
+      },
+    };
+    const redacted = redactConfigSnapshot(makeSnapshot(original), hints);
+    const incoming = {
+      hooks: { mappings: [(redacted.config as typeof original).hooks.mappings[1]] },
+    };
+
+    expect(JSON.stringify(redacted)).not.toContain("synthetic-alpha-session");
+    expect(JSON.stringify(redacted)).not.toContain("synthetic-bravo-session");
+    expect(incoming.hooks.mappings[0]?.sessionKey).toBe(REDACTED_SENTINEL);
+    expect(restoreRedactedValues(incoming, original, hints).hooks.mappings).toEqual([
+      { id: "bravo", sessionKey: "synthetic-bravo-session" },
+    ]);
+  });
+
   it("restores redacted SecretRef ids for channels token paths", () => {
     const hints: ConfigUiHints = {
       "channels.discord.token": { sensitive: true },

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -8,6 +8,7 @@ import { isRecord as isObjectRecord } from "@openclaw/normalization-core/record-
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ConfigUiHints } from "../shared/config-ui-hints-types.js";
+import { containsEnvVarReference } from "./env-substitution.js";
 import {
   replaceSensitiveValuesInRaw,
   shouldFallbackToStructuredRawRedaction,
@@ -616,17 +617,84 @@ function maybeRestoreSecretRefId(params: {
   return { handled: true, value: { ...incomingObj, id: originalObj.id } };
 }
 
+type RedactedArrayIdentity = {
+  item: unknown;
+  index: number;
+  count: number;
+};
+
+function readRedactedArrayItemId(item: unknown): string | undefined {
+  if (!isObjectRecord(item) || !Object.hasOwn(item, "id")) {
+    return undefined;
+  }
+  const id = item.id;
+  // Authored env references and escapes differ from their resolved snapshot identities.
+  if (
+    typeof id !== "string" ||
+    id.length === 0 ||
+    id === REDACTED_SENTINEL ||
+    containsEnvVarReference(id) ||
+    id.includes("$${")
+  ) {
+    return undefined;
+  }
+  return id;
+}
+
+function indexRedactedArrayItemsById(items: unknown[]): Map<string, RedactedArrayIdentity> {
+  const itemsById = new Map<string, RedactedArrayIdentity>();
+  for (const [index, item] of items.entries()) {
+    const id = readRedactedArrayItemId(item);
+    if (id === undefined) {
+      continue;
+    }
+    const previous = itemsById.get(id);
+    if (previous) {
+      previous.count += 1;
+    } else {
+      itemsById.set(id, { item, index, count: 1 });
+    }
+  }
+  return itemsById;
+}
+
 function mapRedactedArray(params: {
   incoming: unknown[];
   original: unknown;
   path: string;
-  mapItem: (item: unknown, index: number, originalArray: unknown[]) => unknown;
+  mapItem: (item: unknown, originalItem: unknown) => unknown;
 }): unknown[] {
   const originalArray = Array.isArray(params.original) ? params.original : [];
   if (params.incoming.length < originalArray.length) {
     log.warn(`Redacted config array key ${params.path} has been truncated`);
   }
-  return params.incoming.map((item, index) => params.mapItem(item, index, originalArray));
+  const originalById = indexRedactedArrayItemsById(originalArray);
+  const incomingById = indexRedactedArrayItemsById(params.incoming);
+  const reservedOriginalIndexes = new Set<number>();
+  for (const [id, incomingIdentity] of incomingById) {
+    const originalIdentity = originalById.get(id);
+    if (incomingIdentity.count === 1 && originalIdentity?.count === 1) {
+      reservedOriginalIndexes.add(originalIdentity.index);
+    }
+  }
+  const hasUniqueOriginalIdentity = Array.from(originalById.values()).some(
+    (identity) => identity.count === 1,
+  );
+
+  return params.incoming.map((item, index) => {
+    const id = readRedactedArrayItemId(item);
+    const originalIdentity = id === undefined ? undefined : originalById.get(id);
+    const incomingIdentity = id === undefined ? undefined : incomingById.get(id);
+    if (incomingIdentity?.count === 1 && originalIdentity?.count === 1) {
+      return params.mapItem(item, originalIdentity.item);
+    }
+    if (incomingIdentity?.count === 1 && !originalIdentity && hasUniqueOriginalIdentity) {
+      return params.mapItem(item, undefined);
+    }
+    // Positional fallback must not reuse a secret already reserved for another identified entry.
+    const originalItem = reservedOriginalIndexes.has(index) ? undefined : originalArray[index];
+    return params.mapItem(item, originalItem);
+  });
 }
 
 function toObjectRecord(value: unknown): Record<string, unknown> {
@@ -649,18 +717,17 @@ function toRestoreArrayContext(
 
 function restoreArrayItemWithLookup(params: {
   item: unknown;
-  index: number;
-  originalArray: unknown[];
+  originalItem: unknown;
   lookup: Set<string>;
   path: string;
   hints: ConfigUiHints;
 }): unknown {
   if (params.item === REDACTED_SENTINEL) {
-    return params.originalArray[params.index];
+    return params.originalItem;
   }
   return restoreRedactedValuesWithLookup(
     params.item,
-    params.originalArray[params.index],
+    params.originalItem,
     params.lookup,
     params.path,
     params.hints,
@@ -669,8 +736,7 @@ function restoreArrayItemWithLookup(params: {
 
 function restoreArrayItemWithGuessing(params: {
   item: unknown;
-  index: number;
-  originalArray: unknown[];
+  originalItem: unknown;
   path: string;
   hints?: ConfigUiHints;
 }): unknown {
@@ -679,14 +745,9 @@ function restoreArrayItemWithGuessing(params: {
     isSensitivePath(params.path) &&
     params.item === REDACTED_SENTINEL
   ) {
-    return params.originalArray[params.index];
+    return params.originalItem;
   }
-  return restoreRedactedValuesGuessing(
-    params.item,
-    params.originalArray[params.index],
-    params.path,
-    params.hints,
-  );
+  return restoreRedactedValuesGuessing(params.item, params.originalItem, params.path, params.hints);
 }
 
 function restoreGuessingArray(
@@ -699,11 +760,10 @@ function restoreGuessingArray(
     incoming,
     original,
     path,
-    mapItem: (item, index, originalArray) =>
+    mapItem: (item, originalItem) =>
       restoreArrayItemWithGuessing({
         item,
-        index,
-        originalArray,
+        originalItem,
         path,
         hints,
       }),
@@ -780,10 +840,6 @@ function restoreRedactedValuesWithLookup(
 
   const arrayContext = toRestoreArrayContext(incoming, prefix);
   if (arrayContext) {
-    // Note: If the user removed an item in the middle of the array,
-    // we have no way of knowing which one. In this case, the last
-    // element(s) get(s) chopped off. Not good, so please don't put
-    // sensitive string array in the config...
     const { incoming: incomingArray, path } = arrayContext;
     if (!lookup.has(path)) {
       // Keep behavior symmetric with object fallback: if hints miss the path,
@@ -794,11 +850,10 @@ function restoreRedactedValuesWithLookup(
       incoming: incomingArray,
       original,
       path,
-      mapItem: (item, index, originalArray) =>
+      mapItem: (item, originalItem) =>
         restoreArrayItemWithLookup({
           item,
-          index,
-          originalArray,
+          originalItem,
           lookup,
           path,
           hints,
@@ -865,10 +920,6 @@ function restoreRedactedValuesGuessing(
 
   const arrayContext = toRestoreArrayContext(incoming, prefix);
   if (arrayContext) {
-    // Note: If the user removed an item in the middle of the array,
-    // we have no way of knowing which one. In this case, the last
-    // element(s) get(s) chopped off. Not good, so please don't put
-    // sensitive string array in the config...
     const { incoming: incomingArray, path } = arrayContext;
     return restoreGuessingArray(incomingArray, original, path, hints);
   }

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
+import { REDACTED_SENTINEL } from "../config/redact-snapshot.js";
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
 import {
   activateSecretsRuntimeSnapshot,
@@ -318,6 +319,66 @@ describe("gateway config methods", () => {
     expect(res.payload?.path).toBe(createConfigIO().configPath);
     requireConfigObject(res.payload?.config, "updated config");
   });
+
+  it.each([
+    { change: "deletes an earlier mapping", ids: ["bravo"], unidentifiedFirst: false },
+    { change: "reorders existing mappings", ids: ["bravo", "alpha"], unidentifiedFirst: false },
+    { change: "deletes an earlier unidentified mapping", ids: ["bravo"], unidentifiedFirst: true },
+  ])(
+    "keeps redacted hook secrets with their owner when config.set $change",
+    async ({ ids, unidentifiedFirst }) => {
+      const { resetConfigRuntimeState } = await import("../config/config.js");
+      const original = await getCurrentConfigObject();
+      const configured = structuredClone(original.config);
+      configured.hooks = {
+        ...requireConfigObject(configured.hooks ?? {}, "original hooks config"),
+        mappings: [
+          {
+            ...(unidentifiedFirst ? {} : { id: "alpha" }),
+            sessionKey: "synthetic-alpha-session",
+          },
+          { id: "bravo", sessionKey: "synthetic-bravo-session" },
+        ],
+      };
+
+      try {
+        await writeJsonFile(original.path, configured);
+        resetConfigRuntimeState();
+        const current = await getCurrentConfigObject();
+        const visibleHooks = requireConfigObject(current.config.hooks, "redacted hooks config");
+        const visibleMappings = visibleHooks.mappings as Array<{
+          id: string;
+          sessionKey: string;
+        }>;
+        expect(visibleMappings.map((mapping) => mapping.sessionKey)).toEqual([
+          REDACTED_SENTINEL,
+          REDACTED_SENTINEL,
+        ]);
+
+        const submitted = structuredClone(current.config);
+        const submittedHooks = requireConfigObject(submitted.hooks, "submitted hooks config");
+        submittedHooks.mappings = ids.map((id) =>
+          visibleMappings.find((mapping) => mapping.id === id),
+        );
+
+        const response = await sendConfigSet(configRawPayload(submitted, current.hash));
+
+        expect(response.error).toBeUndefined();
+        expect(response.ok).toBe(true);
+        expect(JSON.stringify(response.payload)).not.toContain("synthetic-alpha-session");
+        expect(JSON.stringify(response.payload)).not.toContain("synthetic-bravo-session");
+        const persisted = JSON.parse(await fs.readFile(original.path, "utf-8")) as {
+          hooks?: { mappings?: Array<{ id: string; sessionKey: string }> };
+        };
+        expect(persisted.hooks?.mappings).toEqual(
+          ids.map((id) => ({ id, sessionKey: `synthetic-${id}-session` })),
+        );
+      } finally {
+        await restoreConfigFileForTest(original);
+        resetConfigRuntimeState();
+      }
+    },
+  );
 
   it("rejects config.set when a stale snapshot drops an agent entry without changing disk", async () => {
     const { resetConfigRuntimeState } = await import("../config/config.js");


### PR DESCRIPTION
Closes #110658

## What Problem This Solves

Fixes an issue where editing configuration arrays in the Control UI could silently assign a deleted or reordered row secret to another row. The original report reproduced the corruption with agent entries; the same shipped and current defect also affects sensitive hook mapping session keys.

## Why This Change Was Made

Restore redacted values by each uniquely identifiable array item instead of its previous position. Keep positional behavior only for genuinely unidentifiable or ambiguous rows, reserve already-identified source rows so their secrets cannot be reused, and preserve authored environment-template identity behavior. This repairs the single shared configuration owner used by config set, apply, and patch without adding compatibility shims or exposing secrets.

## User Impact

Removing or reordering a configuration row no longer changes which secret belongs to the remaining row. Mixed arrays with optional IDs, duplicate IDs, nested arrays, scalar arrays, new rows, explicit new secrets, and environment-authored IDs retain safe behavior.

## Evidence

- Confirmed the same positional corruption on the latest shipped stable release, beta, and current main.
- Before the fix, owner regressions failed for deletion, reorder, mixed optional-ID arrays, and guessing/hinted restore paths; real Gateway WebSocket config.get/config.set calls persisted the wrong secret.
- After the fix: 103 focused configuration restore, redaction, and generated-schema regressions passed.
- Three real Gateway WebSocket-to-isolated-disk regressions passed for deletion, reorder, and deleting an optional-ID sibling.
- On a Linux Blacksmith Testbox, built the production Control UI, launched a real isolated Gateway, drove Chromium through Settings, and verified the submitted WebSocket payload remained redacted while the persisted remaining hook mapping retained its own original secret.
- Full Linux pnpm check:changed passed, including production/test typechecks, formatting, lint, import cycles, and boundary guards.
- A fresh independent xhigh reviewer found and helped correct the mixed-ID edge case before approving; fresh xhigh autoreview reported no actionable findings.