### PR TITLE
test(auto-reply): make usage watcher recovery deterministic

### DIFF
--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../logging/subsystem.js", () => ({
 }));
 
 const capturedWatchers = vi.hoisted(() => [] as Array<ReturnType<typeof import("node:fs").watch>>);
+const capturedWatchChanges = vi.hoisted(() => [] as Array<() => void>);
 
 vi.mock("node:fs", async (importOriginal) => {
   const orig = await importOriginal<typeof import("node:fs")>();
@@ -23,6 +24,9 @@ vi.mock("node:fs", async (importOriginal) => {
     watch: ((path: unknown, opts: unknown, cb: unknown) => {
       const w = origWatch(path as never, opts as never, cb as never);
       capturedWatchers.push(w);
+      capturedWatchChanges.push(() => {
+        (cb as (eventType: string, filename: null) => void)("change", null);
+      });
       return w;
     }) as typeof orig.watch,
   };
@@ -37,6 +41,7 @@ afterEach(() => {
   clearUsageBarTemplateCacheForTest();
   warnSpy.mockClear();
   capturedWatchers.splice(0);
+  capturedWatchChanges.splice(0);
   for (const fn of cleanups.splice(0)) {
     fn();
   }
@@ -203,7 +208,7 @@ describe("loadUsageBarTemplate", () => {
       });
     });
 
-    it("recovers after watcher error by clearing the dead watcher reference", async () => {
+    it("recovers after watcher error by clearing the dead watcher reference", () => {
       const path = tmpFile("t.json", JSON.stringify(tplA));
 
       // Load valid template → creates a watcher in the cache.
@@ -213,10 +218,7 @@ describe("loadUsageBarTemplate", () => {
       // Write invalid JSON to trigger the change handler, which sets
       // entry.template = undefined.
       writeFileSync(path, "{ not json");
-      // Wait for the watcher to deliver the change event.
-      await new Promise((r) => {
-        setTimeout(r, 200);
-      });
+      capturedWatchChanges[0]?.();
 
       // The template is now invalid — served as DEFAULT.
       expect(loadUsageBarTemplate(path)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);


### PR DESCRIPTION
## Summary

- remove a fixed 200 ms filesystem-watcher delay from the usage-template recovery test
- invoke the captured real change handler deterministically after updating the fixture
- preserve the watcher error and cache recovery behavior under test without changing runtime code

## Root cause and fix

The test waited for the operating system to deliver an `fs.watch` event within an arbitrary delay. That event is not deadline-bound, so the test frequently still saw cached template `A` and never reached the recovery behavior it intended to verify.

The existing `node:fs` mock now retains a trigger for the actual callback passed by production. The test writes invalid JSON, invokes that handler, verifies fallback, emits the watcher error, writes a valid template, and verifies recovery. Production delta is 0 lines.

Closes https://github.com/openclaw/openclaw/issues/118150

## Proof

Exact candidate head: `502923c1318f5bd88d3a4e99b0feb028504395be`

- Current-main reproduction: deterministic failure after the fixed 200 ms wait
- `node scripts/run-vitest.mjs src/auto-reply/usage-bar/template.test.ts` — 15/15 passed after final rebase
- stress loop — 50/50 complete shard runs passed
- `node scripts/check-changed.mjs -- src/auto-reply/usage-bar/template.test.ts` — passed on Blacksmith Testbox `tbx_01kz1zh1jm90c41atkc9n9gke3` ([run](https://github.com/openclaw/openclaw/actions/runs/30763675197))
- Codex autoreview — clean, no accepted/actionable findings, overall confidence 0.99

## Changelog

Not required: test-only reliability fix with no runtime behavior change.
