### PR TITLE
test(qa): consolidate runtime parity fixtures

### DIFF
--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -14,12 +14,8 @@ type QaParityReportScenario = QaParitySuiteSummary["scenarios"][number];
 
 function computeQaAgenticParityMetrics(summary: QaParitySuiteSummary) {
   const label = summary.run?.primaryProvider ?? "qa";
-  return buildQaAgenticParityComparison({
-    candidateLabel: label,
-    baselineLabel: label,
-    candidateSummary: summary,
-    baselineSummary: summary,
-  }).candidateMetrics;
+  return compareQaAgenticParity(summary, summary, { candidate: label, baseline: label })
+    .candidateMetrics;
 }
 
 const FULL_PARITY_PASS_SCENARIOS: QaParityReportScenario[] = [
@@ -43,12 +39,45 @@ function withScenarioOverride(name: string, override: Partial<QaParityReportScen
   );
 }
 
+function matchingRun(primaryProvider: "openai" | "anthropic") {
+  const primaryModel = primaryProvider === "openai" ? "gpt-5.6-luna" : "claude-opus-4-8";
+  return {
+    primaryProvider,
+    primaryModel: `${primaryProvider}/${primaryModel}`,
+    primaryModelName: primaryModel,
+  };
+}
+
+function parityPassSummary(primaryProvider?: "openai" | "anthropic"): QaParitySuiteSummary {
+  return {
+    scenarios: FULL_PARITY_PASS_SCENARIOS,
+    ...(primaryProvider ? { run: matchingRun(primaryProvider) } : {}),
+  };
+}
+
 function firstRuntimeParityScenario() {
   const scenario = makeRuntimeParitySummary().scenarios[0];
   if (!scenario) {
     throw new Error("missing runtime parity scenario fixture");
   }
   return scenario;
+}
+
+function compareQaAgenticParity(
+  candidateSummary: QaParitySuiteSummary,
+  baselineSummary: QaParitySuiteSummary,
+  {
+    candidate = "openai/gpt-5.6-luna",
+    baseline = "anthropic/claude-opus-4-8",
+  }: { candidate?: string; baseline?: string } = {},
+) {
+  return buildQaAgenticParityComparison({
+    candidateLabel: candidate,
+    baselineLabel: baseline,
+    candidateSummary,
+    baselineSummary,
+    comparedAt: "2026-04-11T00:00:00.000Z",
+  });
 }
 
 describe("qa agentic parity report", () => {
@@ -168,10 +197,8 @@ describe("qa agentic parity report", () => {
   });
 
   it("fails the parity gate when the candidate regresses against baseline", () => {
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: {
+    const comparison = compareQaAgenticParity(
+      {
         scenarios: [
           { name: "Approval turn tool followthrough", status: "pass" },
           {
@@ -184,7 +211,7 @@ describe("qa agentic parity report", () => {
           { name: "Image understanding from attachment", status: "pass" },
         ],
       },
-      baselineSummary: {
+      {
         scenarios: [
           { name: "Approval turn tool followthrough", status: "pass" },
           { name: "Compaction retry after mutating tool", status: "pass" },
@@ -193,8 +220,7 @@ describe("qa agentic parity report", () => {
           { name: "Image understanding from attachment", status: "pass" },
         ],
       },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    );
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
@@ -215,17 +241,14 @@ describe("qa agentic parity report", () => {
       passScenario("Image understanding from attachment"),
       passScenario("Extra non-parity lane"),
     ];
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: {
+    const comparison = compareQaAgenticParity(
+      {
         scenarios: baselineScenarios.filter(
           (scenario) => scenario.name !== "Extra non-parity lane",
         ),
       },
-      baselineSummary: { scenarios: baselineScenarios },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+      { scenarios: baselineScenarios },
+    );
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
@@ -234,17 +257,14 @@ describe("qa agentic parity report", () => {
   });
 
   it("reports each missing required parity scenario exactly once (no double-counting)", () => {
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: {
+    const comparison = compareQaAgenticParity(
+      {
         scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
       },
-      baselineSummary: {
+      {
         scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
       },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    );
 
     expect(comparison.pass).toBe(false);
     const missingScenario = "Image understanding from attachment";
@@ -276,13 +296,7 @@ describe("qa agentic parity report", () => {
       ],
     };
 
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: summaryWithExtras,
-      baselineSummary: scopedSummary,
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    const comparison = compareQaAgenticParity(summaryWithExtras, scopedSummary);
 
     // Extra lanes must not drag the candidate's completion rate below baseline
     // and must not generate unintended-stop or fake-success hits.
@@ -298,17 +312,14 @@ describe("qa agentic parity report", () => {
   });
 
   it("fails the parity gate when required parity scenarios are missing on both sides", () => {
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: {
+    const comparison = compareQaAgenticParity(
+      {
         scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
       },
-      baselineSummary: {
+      {
         scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
       },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    );
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
@@ -317,10 +328,8 @@ describe("qa agentic parity report", () => {
   });
 
   it("fails the parity gate when required parity scenarios are skipped", () => {
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: {
+    const comparison = compareQaAgenticParity(
+      {
         scenarios: [
           { name: "Approval turn tool followthrough", status: "pass" },
           { name: "Compaction retry after mutating tool", status: "skip" },
@@ -329,7 +338,7 @@ describe("qa agentic parity report", () => {
           { name: "Image understanding from attachment", status: "pass" },
         ],
       },
-      baselineSummary: {
+      {
         scenarios: [
           { name: "Approval turn tool followthrough", status: "pass" },
           { name: "Compaction retry after mutating tool", status: "skip" },
@@ -338,8 +347,7 @@ describe("qa agentic parity report", () => {
           { name: "Image understanding from attachment", status: "pass" },
         ],
       },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    );
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
@@ -358,13 +366,10 @@ describe("qa agentic parity report", () => {
     const scenariosWithBothFail = withScenarioOverride("Approval turn tool followthrough", {
       status: "fail",
     });
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: { scenarios: scenariosWithBothFail },
-      baselineSummary: { scenarios: scenariosWithBothFail },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    const comparison = compareQaAgenticParity(
+      { scenarios: scenariosWithBothFail },
+      { scenarios: scenariosWithBothFail },
+    );
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
@@ -386,13 +391,10 @@ describe("qa agentic parity report", () => {
     const candidateWithOneFail = withScenarioOverride("Approval turn tool followthrough", {
       status: "fail",
     });
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: { scenarios: candidateWithOneFail },
-      baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    const comparison = compareQaAgenticParity(
+      { scenarios: candidateWithOneFail },
+      { scenarios: FULL_PARITY_PASS_SCENARIOS },
+    );
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
@@ -403,19 +405,16 @@ describe("qa agentic parity report", () => {
   it("fails the parity gate when the baseline contains suspicious pass results", () => {
     // Cover the full second-wave pack on both sides so the suspicious-pass assertion
     // below is the isolated gate failure under test (no coverage-gap noise).
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: {
+    const comparison = compareQaAgenticParity(
+      {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
       },
-      baselineSummary: {
+      {
         scenarios: withScenarioOverride("Approval turn tool followthrough", {
           details: "timed out before it continued",
         }),
       },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    );
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toEqual([
@@ -587,19 +586,16 @@ status=done`,
     ];
 
     expect(() =>
-      buildQaAgenticParityComparison({
-        candidateLabel: "openai/gpt-5.6-luna",
-        baselineLabel: "anthropic/claude-opus-4-8",
-        candidateSummary: {
+      compareQaAgenticParity(
+        {
           scenarios: parityPassScenarios,
           run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-8" },
         },
-        baselineSummary: {
+        {
           scenarios: parityPassScenarios,
           run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-8" },
         },
-        comparedAt: "2026-04-11T00:00:00.000Z",
-      }),
+      ),
     ).toThrow("do not match --candidate-label");
   });
 
@@ -609,120 +605,60 @@ status=done`,
     ];
 
     expect(() =>
-      buildQaAgenticParityComparison({
-        candidateLabel: "openai/gpt-5.6-luna",
-        baselineLabel: "anthropic/claude-opus-4-8",
-        candidateSummary: {
+      compareQaAgenticParity(
+        {
           scenarios: parityPassScenarios,
           run: { primaryProvider: "openai" },
         },
-        baselineSummary: {
+        {
           scenarios: parityPassScenarios,
           run: { primaryProvider: "openai", primaryModel: "gpt-5.6-luna" },
         },
-        comparedAt: "2026-04-11T00:00:00.000Z",
-      }),
+      ),
     ).toThrow(
       /baseline summary run\.primaryProvider=openai and run\.primaryModel=gpt-5\.6-luna do not match --baseline-label/,
     );
   });
 
   it("accepts matching run.primaryProvider labels without throwing", () => {
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: {
-        scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: {
-          primaryProvider: "openai",
-          primaryModel: "openai/gpt-5.6-luna",
-          primaryModelName: "gpt-5.6-luna",
-        },
-      },
-      baselineSummary: {
-        scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: {
-          primaryProvider: "anthropic",
-          primaryModel: "anthropic/claude-opus-4-8",
-          primaryModelName: "claude-opus-4-8",
-        },
-      },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    const comparison = compareQaAgenticParity(
+      parityPassSummary("openai"),
+      parityPassSummary("anthropic"),
+    );
     expect(comparison.pass).toBe(true);
   });
 
   it("skips run.primaryProvider verification when the summary is missing a run block (legacy summaries)", () => {
     // Pre-PR-L summaries don't carry a `run` block. The gate must still
     // work against those, trusting the caller-supplied label.
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
-      baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    const comparison = compareQaAgenticParity(parityPassSummary(), parityPassSummary());
     expect(comparison.pass).toBe(true);
   });
 
   it("skips provider verification for arbitrary display labels when run metadata is present", () => {
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "GPT-5.6 Luna candidate",
-      baselineLabel: "Opus 4.8 baseline",
-      candidateSummary: {
-        scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: {
-          primaryProvider: "openai",
-          primaryModel: "openai/gpt-5.6-luna",
-          primaryModelName: "gpt-5.6-luna",
-        },
-      },
-      baselineSummary: {
-        scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: {
-          primaryProvider: "anthropic",
-          primaryModel: "anthropic/claude-opus-4-8",
-          primaryModelName: "claude-opus-4-8",
-        },
-      },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    const comparison = compareQaAgenticParity(
+      parityPassSummary("openai"),
+      parityPassSummary("anthropic"),
+      { candidate: "GPT-5.6 Luna candidate", baseline: "Opus 4.8 baseline" },
+    );
 
     expect(comparison.pass).toBe(true);
   });
 
   it("skips provider verification for mixed-case or decorated display labels", () => {
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "Candidate: GPT-5.6 Luna",
-      baselineLabel: "Opus 4.8 / baseline",
-      candidateSummary: {
-        scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: {
-          primaryProvider: "openai",
-          primaryModel: "openai/gpt-5.6-luna",
-          primaryModelName: "gpt-5.6-luna",
-        },
-      },
-      baselineSummary: {
-        scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: {
-          primaryProvider: "anthropic",
-          primaryModel: "anthropic/claude-opus-4-8",
-          primaryModelName: "claude-opus-4-8",
-        },
-      },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    const comparison = compareQaAgenticParity(
+      parityPassSummary("openai"),
+      parityPassSummary("anthropic"),
+      { candidate: "Candidate: GPT-5.6 Luna", baseline: "Opus 4.8 / baseline" },
+    );
 
     expect(comparison.pass).toBe(true);
   });
 
   it("throws when a structured label mismatches the recorded model even if the provider matches", () => {
     expect(() =>
-      buildQaAgenticParityComparison({
-        candidateLabel: "openai/gpt-5.6-luna",
-        baselineLabel: "anthropic/claude-opus-4-8",
-        candidateSummary: {
+      compareQaAgenticParity(
+        {
           scenarios: FULL_PARITY_PASS_SCENARIOS,
           run: {
             primaryProvider: "openai",
@@ -730,43 +666,19 @@ status=done`,
             primaryModelName: "gpt-5.6-luna-alt",
           },
         },
-        baselineSummary: {
-          scenarios: FULL_PARITY_PASS_SCENARIOS,
-          run: {
-            primaryProvider: "anthropic",
-            primaryModel: "anthropic/claude-opus-4-8",
-            primaryModelName: "claude-opus-4-8",
-          },
-        },
-        comparedAt: "2026-04-11T00:00:00.000Z",
-      }),
+        parityPassSummary("anthropic"),
+      ),
     ).toThrow(
       /candidate summary run\.primaryProvider=openai and run\.primaryModel=openai\/gpt-5\.6-luna-alt do not match --candidate-label=openai\/gpt-5\.6-luna/,
     );
   });
 
   it("accepts colon-delimited structured labels when provider and model both match", () => {
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai:gpt-5.6-luna",
-      baselineLabel: "anthropic:claude-opus-4-8",
-      candidateSummary: {
-        scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: {
-          primaryProvider: "openai",
-          primaryModel: "openai/gpt-5.6-luna",
-          primaryModelName: "gpt-5.6-luna",
-        },
-      },
-      baselineSummary: {
-        scenarios: FULL_PARITY_PASS_SCENARIOS,
-        run: {
-          primaryProvider: "anthropic",
-          primaryModel: "anthropic/claude-opus-4-8",
-          primaryModelName: "claude-opus-4-8",
-        },
-      },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    const comparison = compareQaAgenticParity(
+      parityPassSummary("openai"),
+      parityPassSummary("anthropic"),
+      { candidate: "openai:gpt-5.6-luna", baseline: "anthropic:claude-opus-4-8" },
+    );
 
     expect(comparison.pass).toBe(true);
   });
@@ -775,13 +687,7 @@ status=done`,
     // Cover the full parity pack on both sides so the pass
     // verdict is not disrupted by required-scenario coverage failures
     // added by the second-wave expansion.
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna",
-      baselineLabel: "anthropic/claude-opus-4-8",
-      candidateSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
-      baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    const comparison = compareQaAgenticParity(parityPassSummary(), parityPassSummary());
 
     const report = renderQaAgenticParityMarkdownReport(comparison);
 
@@ -799,13 +705,11 @@ status=done`,
     // another candidate) must see the labels in the rendered H1 instead of
     // the hardcoded "GPT-5.6 Luna / Opus 4.8" title that would otherwise confuse
     // readers of saved reports.
-    const comparison = buildQaAgenticParityComparison({
-      candidateLabel: "openai/gpt-5.6-luna-alt",
-      baselineLabel: "openai/gpt-5.6-luna",
-      candidateSummary: { scenarios: [] },
-      baselineSummary: { scenarios: [] },
-      comparedAt: "2026-04-11T00:00:00.000Z",
-    });
+    const comparison = compareQaAgenticParity(
+      { scenarios: [] },
+      { scenarios: [] },
+      { candidate: "openai/gpt-5.6-luna-alt", baseline: "openai/gpt-5.6-luna" },
+    );
     const report = renderQaAgenticParityMarkdownReport(comparison);
     expect(report).toContain(
       "# OpenClaw Agentic Parity Report — openai/gpt-5.6-luna-alt vs openai/gpt-5.6-luna",

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -84,6 +84,49 @@ function firstGatewayCall(
   return gatewayCall.mock.calls[0] as [string, unknown, unknown] | undefined;
 }
 
+const QA_CLI_ENV = {
+  repoRoot: "/repo",
+  gateway: {
+    tempRoot: "/tmp/runtime",
+    runtimeEnv: { PATH: "/usr/bin" },
+  },
+  primaryModel: "openai/gpt-5.6-luna",
+  alternateModel: "openai/gpt-5.6-luna-mini",
+  providerMode: "mock-openai",
+} as unknown as Parameters<typeof runQaCli>[0];
+
+const QA_CLI_JSON_ENV = {
+  ...QA_CLI_ENV,
+  gateway: { tempRoot: "/tmp/runtime", runtimeEnv: {} },
+} as unknown as Parameters<typeof runQaCli>[0];
+
+function startMockQaCli(params: {
+  args: string[];
+  child?: MockChildProcess;
+  env?: Parameters<typeof runQaCli>[0];
+  options?: Parameters<typeof runQaCli>[2];
+}) {
+  const child = params.child ?? createSpawnedProcess();
+  spawnMock.mockReturnValue(child);
+  return {
+    child,
+    pending: runQaCli(params.env ?? QA_CLI_ENV, params.args, params.options),
+  };
+}
+
+function createAgentPromptEnv(gatewayCall: ReturnType<typeof vi.fn>) {
+  return {
+    gateway: { call: gatewayCall },
+    transport: {
+      buildAgentDelivery: vi.fn(() => ({
+        channel: "qa-channel",
+        replyChannel: "reply-channel",
+        replyTo: "reply-target",
+      })),
+    },
+  } as never;
+}
+
 describe("qa suite runtime agent process helpers", () => {
   beforeEach(() => {
     spawnMock.mockReset();
@@ -95,22 +138,7 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("runs the qa cli through the resolved node executable", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
-        repoRoot: "/repo",
-        gateway: {
-          tempRoot: "/tmp/runtime",
-          runtimeEnv: { PATH: "/usr/bin" },
-        },
-        primaryModel: "openai/gpt-5.6-luna",
-        alternateModel: "openai/gpt-5.6-luna-mini",
-        providerMode: "mock-openai",
-      } as never,
-      ["qa", "suite"],
-    );
+    const { child, pending } = startMockQaCli({ args: ["qa", "suite"] });
 
     await waitForSpawnCount(1);
     child.stdout.emit("data", Buffer.from("ok\n"));
@@ -129,23 +157,10 @@ describe("qa suite runtime agent process helpers", () => {
   it("caps oversized qa cli timeout timers", async () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
-      const child = createSpawnedProcess();
-      spawnMock.mockReturnValue(child);
-
-      const pending = runQaCli(
-        {
-          repoRoot: "/repo",
-          gateway: {
-            tempRoot: "/tmp/runtime",
-            runtimeEnv: { PATH: "/usr/bin" },
-          },
-          primaryModel: "openai/gpt-5.6-luna",
-          alternateModel: "openai/gpt-5.6-luna-mini",
-          providerMode: "mock-openai",
-        } as never,
-        ["qa", "suite"],
-        { timeoutMs: Number.MAX_SAFE_INTEGER },
-      );
+      const { child, pending } = startMockQaCli({
+        args: ["qa", "suite"],
+        options: { timeoutMs: Number.MAX_SAFE_INTEGER },
+      });
 
       await waitForSpawnCount(1);
       expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
@@ -161,22 +176,11 @@ describe("qa suite runtime agent process helpers", () => {
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
     try {
       const child = createSpawnedProcess({ pid: 12345 });
-      spawnMock.mockReturnValue(child);
-
-      const pending = runQaCli(
-        {
-          repoRoot: "/repo",
-          gateway: {
-            tempRoot: "/tmp/runtime",
-            runtimeEnv: { PATH: "/usr/bin" },
-          },
-          primaryModel: "openai/gpt-5.6-luna",
-          alternateModel: "openai/gpt-5.6-luna-mini",
-          providerMode: "mock-openai",
-        } as never,
-        ["qa", "suite"],
-        { timeoutMs: 1 },
-      );
+      const { pending } = startMockQaCli({
+        args: ["qa", "suite"],
+        child,
+        options: { timeoutMs: 1 },
+      });
       const timeoutAssertion = expect(pending).rejects.toThrow(
         "qa cli timed out: openclaw qa suite",
       );
@@ -199,23 +203,12 @@ describe("qa suite runtime agent process helpers", () => {
     delete process.env.WINDIR;
     try {
       const child = createSpawnedProcess({ pid: 12345 });
-      spawnMock.mockReturnValue(child);
       spawnSyncMock.mockReturnValue({ status: 0 });
-
-      const pending = runQaCli(
-        {
-          repoRoot: "/repo",
-          gateway: {
-            tempRoot: "/tmp/runtime",
-            runtimeEnv: { PATH: "/usr/bin" },
-          },
-          primaryModel: "openai/gpt-5.6-luna",
-          alternateModel: "openai/gpt-5.6-luna-mini",
-          providerMode: "mock-openai",
-        } as never,
-        ["qa", "suite"],
-        { timeoutMs: 1 },
-      );
+      const { pending } = startMockQaCli({
+        args: ["qa", "suite"],
+        child,
+        options: { timeoutMs: 1 },
+      });
       const timeoutAssertion = expect(pending).rejects.toThrow(
         "qa cli timed out: openclaw qa suite",
       );
@@ -250,11 +243,8 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("merges isolated env overrides into qa cli runs", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
+    const { child, pending } = startMockQaCli({
+      env: {
         repoRoot: "/repo",
         gateway: {
           tempRoot: "/tmp/runtime",
@@ -264,14 +254,14 @@ describe("qa suite runtime agent process helpers", () => {
         alternateModel: "openai/gpt-5.6-luna-mini",
         providerMode: "mock-openai",
       } as never,
-      ["openclaw", "-m", "overview"],
-      {
+      args: ["openclaw", "-m", "overview"],
+      options: {
         env: {
           OPENCLAW_STATE_DIR: "/tmp/isolated-state",
           OPENCLAW_CONFIG_PATH: "/tmp/isolated-state/openclaw.json",
         },
       },
-    );
+    });
 
     await waitForSpawnCount(1);
     child.stdout.emit("data", Buffer.from("ok\n"));
@@ -293,23 +283,11 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("parses json qa cli output when requested", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
-        repoRoot: "/repo",
-        gateway: {
-          tempRoot: "/tmp/runtime",
-          runtimeEnv: {},
-        },
-        primaryModel: "openai/gpt-5.6-luna",
-        alternateModel: "openai/gpt-5.6-luna-mini",
-        providerMode: "mock-openai",
-      } as never,
-      ["memory", "search"],
-      { json: true },
-    );
+    const { child, pending } = startMockQaCli({
+      env: QA_CLI_JSON_ENV,
+      args: ["memory", "search"],
+      options: { json: true },
+    });
 
     await waitForSpawnCount(1);
     child.stdout.emit("data", Buffer.from('{"ok":true}\n'));
@@ -319,23 +297,11 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("parses json qa cli output after colored startup logs", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
-        repoRoot: "/repo",
-        gateway: {
-          tempRoot: "/tmp/runtime",
-          runtimeEnv: {},
-        },
-        primaryModel: "openai/gpt-5.6-luna",
-        alternateModel: "openai/gpt-5.6-luna-mini",
-        providerMode: "mock-openai",
-      } as never,
-      ["memory", "search", "--json"],
-      { json: true },
-    );
+    const { child, pending } = startMockQaCli({
+      env: QA_CLI_JSON_ENV,
+      args: ["memory", "search", "--json"],
+      options: { json: true },
+    });
 
     await waitForSpawnCount(1);
     child.stdout.emit(
@@ -350,23 +316,11 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("parses pretty json qa cli output after startup logs", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
-        repoRoot: "/repo",
-        gateway: {
-          tempRoot: "/tmp/runtime",
-          runtimeEnv: {},
-        },
-        primaryModel: "openai/gpt-5.6-luna",
-        alternateModel: "openai/gpt-5.6-luna-mini",
-        providerMode: "mock-openai",
-      } as never,
-      ["memory", "search", "--json"],
-      { json: true },
-    );
+    const { child, pending } = startMockQaCli({
+      env: QA_CLI_JSON_ENV,
+      args: ["memory", "search", "--json"],
+      options: { json: true },
+    });
 
     await waitForSpawnCount(1);
     child.stdout.emit(
@@ -381,23 +335,11 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("waits for stdio close before parsing qa cli stdout", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
-        repoRoot: "/repo",
-        gateway: {
-          tempRoot: "/tmp/runtime",
-          runtimeEnv: {},
-        },
-        primaryModel: "openai/gpt-5.6-luna",
-        alternateModel: "openai/gpt-5.6-luna-mini",
-        providerMode: "mock-openai",
-      } as never,
-      ["memory", "search", "--json"],
-      { json: true },
-    );
+    const { child, pending } = startMockQaCli({
+      env: QA_CLI_JSON_ENV,
+      args: ["memory", "search", "--json"],
+      options: { json: true },
+    });
 
     await waitForSpawnCount(1);
     child.emit("exit", 0);
@@ -408,23 +350,11 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("parses pretty json qa cli output before trailing stdout logs", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
-        repoRoot: "/repo",
-        gateway: {
-          tempRoot: "/tmp/runtime",
-          runtimeEnv: {},
-        },
-        primaryModel: "openai/gpt-5.6-luna",
-        alternateModel: "openai/gpt-5.6-luna-mini",
-        providerMode: "mock-openai",
-      } as never,
-      ["memory", "search", "--json"],
-      { json: true },
-    );
+    const { child, pending } = startMockQaCli({
+      env: QA_CLI_JSON_ENV,
+      args: ["memory", "search", "--json"],
+      options: { json: true },
+    });
 
     await waitForSpawnCount(1);
     child.stdout.emit(
@@ -439,23 +369,11 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("ignores diagnostic json fragments before the qa cli payload", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
-        repoRoot: "/repo",
-        gateway: {
-          tempRoot: "/tmp/runtime",
-          runtimeEnv: {},
-        },
-        primaryModel: "openai/gpt-5.6-luna",
-        alternateModel: "openai/gpt-5.6-luna-mini",
-        providerMode: "mock-openai",
-      } as never,
-      ["memory", "search", "--json"],
-      { json: true },
-    );
+    const { child, pending } = startMockQaCli({
+      env: QA_CLI_JSON_ENV,
+      args: ["memory", "search", "--json"],
+      options: { json: true },
+    });
 
     await waitForSpawnCount(1);
     child.stdout.emit(
@@ -470,23 +388,11 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("ignores leading json diagnostic records before the qa cli payload", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
-        repoRoot: "/repo",
-        gateway: {
-          tempRoot: "/tmp/runtime",
-          runtimeEnv: {},
-        },
-        primaryModel: "openai/gpt-5.6-luna",
-        alternateModel: "openai/gpt-5.6-luna-mini",
-        providerMode: "mock-openai",
-      } as never,
-      ["memory", "search", "--json"],
-      { json: true },
-    );
+    const { child, pending } = startMockQaCli({
+      env: QA_CLI_JSON_ENV,
+      args: ["memory", "search", "--json"],
+      options: { json: true },
+    });
 
     await waitForSpawnCount(1);
     child.stdout.emit(
@@ -501,23 +407,11 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("ignores trailing json diagnostic records after the qa cli payload", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
-        repoRoot: "/repo",
-        gateway: {
-          tempRoot: "/tmp/runtime",
-          runtimeEnv: {},
-        },
-        primaryModel: "openai/gpt-5.6-luna",
-        alternateModel: "openai/gpt-5.6-luna-mini",
-        providerMode: "mock-openai",
-      } as never,
-      ["memory", "search", "--json"],
-      { json: true },
-    );
+    const { child, pending } = startMockQaCli({
+      env: QA_CLI_JSON_ENV,
+      args: ["memory", "search", "--json"],
+      options: { json: true },
+    });
 
     await waitForSpawnCount(1);
     child.stdout.emit(
@@ -532,23 +426,11 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("rejects oversized qa cli stdout instead of parsing truncated output", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
-        repoRoot: "/repo",
-        gateway: {
-          tempRoot: "/tmp/runtime",
-          runtimeEnv: {},
-        },
-        primaryModel: "openai/gpt-5.6-luna",
-        alternateModel: "openai/gpt-5.6-luna-mini",
-        providerMode: "mock-openai",
-      } as never,
-      ["memory", "search", "--json"],
-      { json: true },
-    );
+    const { child, pending } = startMockQaCli({
+      env: QA_CLI_JSON_ENV,
+      args: ["memory", "search", "--json"],
+      options: { json: true },
+    });
 
     await waitForSpawnCount(1);
     child.stdout.emit("data", Buffer.alloc(QA_CHILD_STDOUT_MAX_BYTES + 1, "x"));
@@ -560,23 +442,11 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("keeps only a bounded qa cli stderr tail for failure diagnostics", async () => {
-    const child = createSpawnedProcess();
-    spawnMock.mockReturnValue(child);
-
-    const pending = runQaCli(
-      {
-        repoRoot: "/repo",
-        gateway: {
-          tempRoot: "/tmp/runtime",
-          runtimeEnv: {},
-        },
-        primaryModel: "openai/gpt-5.6-luna",
-        alternateModel: "openai/gpt-5.6-luna-mini",
-        providerMode: "mock-openai",
-      } as never,
-      ["memory", "search", "--json"],
-      { json: true },
-    );
+    const { child, pending } = startMockQaCli({
+      env: QA_CLI_JSON_ENV,
+      args: ["memory", "search", "--json"],
+      options: { json: true },
+    });
 
     await waitForSpawnCount(1);
     child.stderr.emit(
@@ -701,16 +571,7 @@ describe("qa suite runtime agent process helpers", () => {
       .fn()
       .mockResolvedValueOnce({ runId: "run-2" })
       .mockResolvedValueOnce({ status: "error", error: "boom" });
-    const env = {
-      gateway: { call: gatewayCall },
-      transport: {
-        buildAgentDelivery: vi.fn(() => ({
-          channel: "qa-channel",
-          replyChannel: "reply-channel",
-          replyTo: "reply-target",
-        })),
-      },
-    } as never;
+    const env = createAgentPromptEnv(gatewayCall);
 
     await expect(
       runAgentPrompt(env, {
@@ -725,16 +586,7 @@ describe("qa suite runtime agent process helpers", () => {
       .fn()
       .mockResolvedValueOnce({ runId: "run-completed" })
       .mockResolvedValueOnce({ status: "completed" });
-    const env = {
-      gateway: { call: gatewayCall },
-      transport: {
-        buildAgentDelivery: vi.fn(() => ({
-          channel: "qa-channel",
-          replyChannel: "reply-channel",
-          replyTo: "reply-target",
-        })),
-      },
-    } as never;
+    const env = createAgentPromptEnv(gatewayCall);
 
     await expect(
       runAgentPrompt(env, {
@@ -752,16 +604,7 @@ describe("qa suite runtime agent process helpers", () => {
       .fn()
       .mockResolvedValueOnce({ runId: "run-error-completed" })
       .mockResolvedValueOnce({ status: "error", error: "completed" });
-    const env = {
-      gateway: { call: gatewayCall },
-      transport: {
-        buildAgentDelivery: vi.fn(() => ({
-          channel: "qa-channel",
-          replyChannel: "reply-channel",
-          replyTo: "reply-target",
-        })),
-      },
-    } as never;
+    const env = createAgentPromptEnv(gatewayCall);
 
     await expect(
       runAgentPrompt(env, {
@@ -794,16 +637,7 @@ describe("qa suite runtime agent process helpers", () => {
           successfulToolCallCounts: { web_fetch: 1 },
           finalText: "",
         });
-      const env = {
-        gateway: { call: gatewayCall },
-        transport: {
-          buildAgentDelivery: vi.fn(() => ({
-            channel: "qa-channel",
-            replyChannel: "reply-channel",
-            replyTo: "reply-target",
-          })),
-        },
-      } as never;
+      const env = createAgentPromptEnv(gatewayCall);
 
       const pending = runAgentPrompt(env, {
         sessionKey: "session-transcript-evidence",
@@ -843,16 +677,7 @@ describe("qa suite runtime agent process helpers", () => {
           successfulToolCallCounts: {},
           finalText: "",
         });
-      const env = {
-        gateway: { call: gatewayCall },
-        transport: {
-          buildAgentDelivery: vi.fn(() => ({
-            channel: "qa-channel",
-            replyChannel: "reply-channel",
-            replyTo: "reply-target",
-          })),
-        },
-      } as never;
+      const env = createAgentPromptEnv(gatewayCall);
 
       const pending = runAgentPrompt(env, {
         sessionKey: "session-failed-tool-evidence",


### PR DESCRIPTION
## Summary

- centralize QA CLI child-process fixtures while preserving every timeout, abort, exit, JSON parsing, output-bound, and stderr-tail assertion
- centralize agent delivery and parity comparison fixtures while preserving provider/model label, transcript-evidence, and report assertions
- remove 271 test LOC with no production, private QA export, config, or schema changes

## Architecture / LOC

- Root cause: execution-owner setup was copied into each test, allowing mock env, delivery, and parity labels to drift independently.
- Owner: QA Lab runtime/parity test fixture layer.
- Canonical fix: one CLI launcher fixture, one agent-delivery fixture, and typed parity summary/comparison builders.
- Removed paths: repeated per-test CLI env/spawn setup, delivery envelopes, and comparison labels/timestamps.
- Production LOC delta: 0. Test LOC delta: +224 / -495 = **-271 net**.
- Preserved surface: 34 + 44 test declarations and 77 + 106 `expect(...)` calls exactly match `main`.

## Codex contract proof

Personally inspected the sibling Codex source before editing/reviewing the parity-backed tests:

- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:57-202` and `turn.rs:71-168` for thread/turn start and response contracts
- `codex-rs/app-server-protocol/src/protocol/v2/item.rs:227-298,844-860,990-1010` for item and command-execution status mapping
- `codex-rs/app-server-protocol/src/protocol/v2/model.rs:43-135`, `codex-rs/protocol/src/auth.rs:6-55`, and `codex-rs/protocol/src/openai_models.rs:204-247,370-430` for model/catalog/auth contracts
- `codex-rs/app-server/src/request_processors/{thread_processor.rs:981-1065,1386-1418,turn_processor.rs:476-619,catalog_processor.rs:255-305}` and account/message processors for runtime lifecycle behavior
- `codex-rs/exec/src/{exec_events.rs:8-166,event_processor_with_jsonl_output.rs:142-180,582-600}` for JSONL event projection

## Validation

- `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-runtime-agent-process.test.ts extensions/qa-lab/src/agentic-parity-report.test.ts` — 2 files, 78 tests passed (also repeated after rebase)
- Blacksmith Testbox `tbx_01kz1zazqx3gghsanm9vb2ee0z`: `pnpm test extensions/qa-lab` — 171 files, 2,207 tests passed
- Blacksmith Testbox: extension-test `tsgo` — passed
- Blacksmith Testbox: `pnpm check:changed` — passed, including formatting, dead-export scan, typecheck, and lint
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30763549763
- `git diff --check` — passed

No changelog entry: test-only refactor with no user-visible behavior change.