### PR TITLE
fix(sms): reject a zero SMS_TEXT_CHUNK_LIMIT instead of sending one text per character

### DIFF
--- a/extensions/sms/src/accounts.test.ts
+++ b/extensions/sms/src/accounts.test.ts
@@ -205,6 +205,18 @@ describe("SMS account config", () => {
     });
   });
 
+  it.each(["0", "00", " 0 ", "-1", "1.5", "unlimited", " "])(
+    "keeps the default text chunk limit when SMS_TEXT_CHUNK_LIMIT is %j",
+    (raw) => {
+      process.env.TWILIO_ACCOUNT_SID = "AC-env";
+      process.env.TWILIO_AUTH_TOKEN = "env-token";
+      process.env.TWILIO_PHONE_NUMBER = "+15550001111";
+      process.env.SMS_TEXT_CHUNK_LIMIT = raw;
+
+      expect(resolveSmsAccount({}).textChunkLimit).toBe(1500);
+    },
+  );
+
   it("coerces numeric allowFrom entries accepted by the config schema", () => {
     const parsed = parseSmsConfig({
       accountSid: "AC123",

--- a/extensions/sms/src/accounts.ts
+++ b/extensions/sms/src/accounts.ts
@@ -7,7 +7,7 @@ import {
   resolveAccountEntry,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/account-resolution";
-import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import {
   hasConfiguredSecretInput,
   normalizeResolvedSecretInputString,
@@ -41,7 +41,9 @@ function parseTextChunkLimit(raw: unknown): number {
     return raw;
   }
   if (typeof raw === "string" && /^\d+$/.test(raw.trim())) {
-    return parseStrictInteger(raw.trim()) ?? DEFAULT_TEXT_CHUNK_LIMIT;
+    // Positive like the numeric branch: a zero limit makes chunkSmsPlainText
+    // in send.ts emit one Twilio send per character.
+    return parseStrictPositiveInteger(raw.trim()) ?? DEFAULT_TEXT_CHUNK_LIMIT;
   }
   return DEFAULT_TEXT_CHUNK_LIMIT;
 }

--- a/extensions/sms/src/send.test.ts
+++ b/extensions/sms/src/send.test.ts
@@ -6,6 +6,7 @@ type SendModule = typeof import("./send.js");
 
 let sendSmsTextChunks: SendModule["sendSmsTextChunks"];
 let toSmsPlainText: SendModule["toSmsPlainText"];
+let resolveSmsAccount: (typeof import("./accounts.js"))["resolveSmsAccount"];
 
 const sendSmsViaTwilio = vi.hoisted(() => vi.fn(async ({ to }) => ({ sid: `SM-${to}`, to })));
 
@@ -16,10 +17,15 @@ beforeEach(async () => {
     sendSmsViaTwilio,
   }));
   ({ sendSmsTextChunks, toSmsPlainText } = await import("./send.js"));
+  ({ resolveSmsAccount } = await import("./accounts.js"));
 });
 
 afterEach(() => {
   vi.doUnmock("./twilio.js");
+  delete process.env.TWILIO_ACCOUNT_SID;
+  delete process.env.TWILIO_AUTH_TOKEN;
+  delete process.env.TWILIO_PHONE_NUMBER;
+  delete process.env.SMS_TEXT_CHUNK_LIMIT;
 });
 
 function createAccount(textChunkLimit: number): ResolvedSmsAccount {
@@ -52,6 +58,22 @@ describe("sendSmsTextChunks", () => {
     const texts = sendSmsViaTwilio.mock.calls.map(([call]) => call.text);
     expect(texts).toEqual(["alpha", " beta"]);
     expect(texts.join("")).toBe("alpha beta");
+  });
+
+  it("sends one message when an invalid zero SMS_TEXT_CHUNK_LIMIT falls back to the default limit", async () => {
+    process.env.TWILIO_ACCOUNT_SID = "AC-env";
+    process.env.TWILIO_AUTH_TOKEN = "env-token";
+    process.env.TWILIO_PHONE_NUMBER = "+15557654321";
+    process.env.SMS_TEXT_CHUNK_LIMIT = "0";
+
+    await sendSmsTextChunks({
+      account: resolveSmsAccount({}),
+      to: "+15551234567",
+      text: "alpha beta gamma",
+    });
+
+    expect(sendSmsViaTwilio).toHaveBeenCalledOnce();
+    expect(sendSmsViaTwilio.mock.calls[0]?.[0].text).toBe("alpha beta gamma");
   });
 
   it("labels transcript-role headers promoted to an SMS chunk boundary", async () => {


### PR DESCRIPTION
Closes #118156

AI-assisted: written with Claude Code (Opus 5). I understand what the change
does; the reasoning, the reproduction harness and the before/after capture are
in the Evidence section below.

## What Problem This Solves

Fixes an issue where operators who set `SMS_TEXT_CHUNK_LIMIT=0` would have one
SMS reply fanned out into a separate outbound message per sanitized character.
In the measured reproduction below, a 9,528-character reply produced **7,550
single-character Twilio send requests** — fewer than the character count because
`toSmsPlainText` normalizes whitespace before the chunker runs and empty chunks
are dropped. The run reported no error and no failed send. What the
reproduction establishes is the request fan-out; the resulting carrier charges
and delivery were not measured.

`SMS_TEXT_CHUNK_LIMIT` is the documented environment fallback for
`channels.sms.textChunkLimit` (`docs/channels/sms.md`, environment variable
table). The variable itself is documented; what is undocumented is that the
environment path accepts `0`. The same `0` written in `openclaw.json` is already
rejected — `SmsChannelConfigSchema` declares `z.number().int().positive()` — so
the two ways of configuring one field disagree, and only the environment path is
destructive.

## Why This Change Was Made

`parseTextChunkLimit` in `extensions/sms/src/accounts.ts` validates this field on
two paths and only guards one. The numeric branch requires `raw > 0`; the string
branch that the environment fallback uses ended in
`parseStrictInteger(raw.trim()) ?? DEFAULT_TEXT_CHUNK_LIMIT`, and `0 ?? 1500`
is `0`.

That `0` reaches the plugin's own chunker — `sendSmsTextChunks` calls
`chunkSmsPlainText(text, account.textChunkLimit)` and then issues one Twilio
request per returned chunk. The outbound-adapter path is not a backstop: the
limit core chunks with comes from the plugin's own
`resolveSmsTextChunkLimit` (`extensions/sms/src/channel.ts`), which evaluates
`account.textChunkLimit || fallbackLimit || 1500` and so quietly reads 1500,
while `sendSmsTextChunks` still receives the raw `0`.

This PR changes that one branch's parser to `parseStrictPositiveInteger`, so the
string path enforces the same positivity the numeric path and the schema already
require. Nothing else changes. On the string path the surrounding `/^\d+$/`
guard already rejected negative, fractional and non-numeric input, and it still
does; the numeric config path is unchanged and keeps its own
`Number.isSafeInteger(raw) && raw > 0` check. Every previously accepted value
resolves to the same number.

Out of scope: no startup warning for a rejected value (the other malformed
inputs covered by the test table already fall back silently, and changing that
is a separate topic), and no other channel — searching the tree for
environment-sourced chunk limits
(`grep -rn CHUNK_LIMIT --include=*.ts src/ extensions/ packages/ | grep process.env`)
returns only this one, so no sibling was found with the same gap.

## User Impact

A zero-valued `SMS_TEXT_CHUNK_LIMIT` — `0`, `00`, or the same with surrounding
whitespace — now falls back to the documented default of 1500 instead of
splitting every reply into one message per character. Those are the only inputs
whose behavior changes: negative, fractional and non-numeric values already fell
back, and every accepted positive limit still resolves to the same number.

## Evidence

### Real behavior proof

Behavior addressed: with `SMS_TEXT_CHUNK_LIMIT=0`, one assistant reply is sent
as one Twilio message per character of the sanitized text instead of one message
per chunk.

Real environment tested: Linux, Node v24.18.0. The harness drives production
source end to end — real plugin registry, the real bundled SMS plugin, the real
`resolveSmsAccount`, and the real outbound pipeline entered at
`deliverOutboundPayloadsInternal`. The only fake is `globalThis.fetch`, which
stands in for the Twilio endpoint and records each request body; it is tagged
`.mock`, which `isMockedFetch` (`src/infra/net/runtime-fetch.ts:80`) detects, so
`fetchWithSsrFGuard` skips DNS pinning (`fetch-guard.ts:580-586`) and calls the
stub directly (`fetch-guard.ts:648`) instead of resolving `api.twilio.com`.
No real Twilio account is involved: the harness sets placeholder `TWILIO_*`
values so account resolution succeeds. It fails closed — any non-Twilio URL, any
non-`POST`, or any path other than `/Messages.json` throws — so both runs
completing is itself evidence that no unexpected `fetch` request was made (it
observes `globalThis.fetch` only).

Exact steps or command run after this patch: the harness is not part of this
diff — it is the standalone script at the end of this description. Save it as
`sms-chunk-limit-zero.mts` at the checkout root and run the command below (it
also accepts `OPENCLAW_REPO_ROOT` if you keep it elsewhere).
`SMS_TEXT_CHUNK_LIMIT=0` is set inside the harness. Both runs below were taken
from the tree that is now head `27cf8f3b0188c3354a870dbb354ae0bc3014cdab`, one
commit on top of base `2970ccb53fb75a16b838f81ec1b0f0e9bfd81afa`; the working
tree was clean at commit time, so the captures describe the exact head being
submitted.

```
./node_modules/.bin/tsx sms-chunk-limit-zero.mts
```

Before evidence: `extensions/sms/src/accounts.ts` at base
`2970ccb53fb75a16b838f81ec1b0f0e9bfd81afa`

```
SMS_TEXT_CHUNK_LIMIT env: "0"
resolved account.textChunkLimit: 0
assistant reply length (chars): 9528
Twilio endpoint calls: 7550
distinct body lengths: [1]
first 6 message bodies (truncated to 44 chars): ["P","a","r","a","g","r"]
```

Evidence after fix: same harness, same command, this branch

```
SMS_TEXT_CHUNK_LIMIT env: "0"
resolved account.textChunkLimit: 1500
assistant reply length (chars): 9528
Twilio endpoint calls: 7
distinct body lengths: [1458,1468,628]
first 6 message bodies (truncated to 44 chars): ["Paragraph 0: the quick brown fox jumps over ","Paragraph 14: the quick brown fox jumps over","Paragraph 28: the quick brown fox jumps over","Paragraph 42: the quick brown fox jumps over","Paragraph 56: the quick brown fox jumps over","Paragraph 70: the quick brown fox jumps over"]
```

Observed result after fix: the rejected env value falls back to 1500, and the
same 9,528-character reply produces 7 send requests instead of 7,550. The before
capture shows every request body has length 1 and the first six are literally
`P`, `a`, `r`, `a`, `g`, `r`, so the recipient would receive per-character
texts — this is not just a counter changing. (7,550 rather than 9,528 because
`toSmsPlainText` normalizes whitespace before the chunker runs and empty chunks
are dropped.) `Twilio endpoint calls` counts `POST`s the plugin made to
`https://api.twilio.com/.../Messages.json`; the harness rejects anything else,
so the counter cannot absorb an unrelated request.

What was not tested: no live Twilio account, so carrier acceptance, billing
records, delivery, and handset rendering of the 7,550 messages are inferred from
the request count rather than observed. Nothing outside the SMS channel was
exercised.

Proof limitations or environment constraints: `globalThis.fetch` is faked at the
Twilio HTTPS boundary; everything below it is production code. The harness is
not part of this diff — it is reproduced in full below for reproducibility and
can be skipped when reading the change itself. The harness loads
plugin sources through `tsx` and the repo `tsconfig` paths, so it exercises
source rather than a built `dist`. The before/after pair differs only in
`extensions/sms/src/accounts.ts` — the harness never runs the test files, so the
two captures differ by exactly that one production file, restored with
`git checkout <base> -- <file>` and verified absent by grep before the before
run. The harness bytes are identical across both runs.

### Focused tests (supplemental)

`node scripts/run-vitest.mjs extensions/sms` → 12 files / 108 tests passed.

Reverting only `extensions/sms/src/accounts.ts` to the base commit fails every
new test, so they have teeth:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  |extensions| extensions/sms/src/accounts.test.ts > SMS account config > keeps the default text chunk limit when SMS_TEXT_CHUNK_LIMIT is "0"
 FAIL  |extensions| extensions/sms/src/accounts.test.ts > SMS account config > keeps the default text chunk limit when SMS_TEXT_CHUNK_LIMIT is "00"
 FAIL  |extensions| extensions/sms/src/accounts.test.ts > SMS account config > keeps the default text chunk limit when SMS_TEXT_CHUNK_LIMIT is " 0 "
AssertionError: expected +0 to be 1500 // Object.is equality
 FAIL  |extensions| extensions/sms/src/send.test.ts > sendSmsTextChunks > sends one message when an invalid zero SMS_TEXT_CHUNK_LIMIT falls back to the default limit
AssertionError: expected "vi.fn()" to be called once, but got 14 times
      Tests  4 failed | 21 passed (25)
```

<details>
<summary>Proof harness (<code>sms-chunk-limit-zero.mts</code>)</summary>

```ts
// Real-behavior proof: with SMS_TEXT_CHUNK_LIMIT=0, one assistant reply is
// sent as one Twilio message per character of the sanitized text.
//
// Everything below the Twilio HTTPS boundary is production source: the real
// plugin registry, the real bundled SMS plugin, the real account resolver, and
// the real core outbound delivery pipeline. Only `globalThis.fetch` is
// replaced; it is tagged `.mock` (detected by isMockedFetch,
// src/infra/net/runtime-fetch.ts:80) so the SSRF guard skips DNS pinning
// (fetch-guard.ts:580-586) and calls it directly (fetch-guard.ts:648).
// No real Twilio account is involved: placeholder TWILIO_* values only, and the
// stub throws on any non-Twilio URL so the run cannot silently reach the
// network.
//
// Place this file at the repository root and run:
//   ./node_modules/.bin/tsx sms-chunk-limit-zero.mts
// (or keep it elsewhere and point OPENCLAW_REPO_ROOT at the checkout root)

const rootInput = process.env.OPENCLAW_REPO_ROOT ?? "./";
const ROOT = rootInput.endsWith("/") ? rootInput : `${rootInput}/`;

// Documented operator surface: docs/channels/sms.md maps SMS_TEXT_CHUNK_LIMIT
// to channels.sms.textChunkLimit. The legacy parser accepted "0" here, which
// made the plugin chunk per character.
process.env.TWILIO_ACCOUNT_SID = "AC00000000000000000000000000000000";
process.env.TWILIO_AUTH_TOKEN = "harness-token";
process.env.TWILIO_PHONE_NUMBER = "+15550000000";
process.env.SMS_TEXT_CHUNK_LIMIT = "0";

const twilioBodies: string[] = [];
let sendCounter = 0;
const realFetch = globalThis.fetch;
const stubFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
  const url = String(input instanceof Request ? input.url : input);
  // Fail closed: this proof must not depend on any real network call.
  if (!url.startsWith("https://api.twilio.com/")) {
    throw new Error(`harness refused an unexpected request: ${url}`);
  }
  if (init?.method !== "POST" || !url.endsWith("/Messages.json")) {
    throw new Error(`unexpected Twilio call: ${init?.method} ${url}`);
  }
  twilioBodies.push(new URLSearchParams(String(init?.body ?? "")).get("Body") ?? "");
  sendCounter += 1;
  return new Response(
    JSON.stringify({
      sid: `SM${String(sendCounter).padStart(8, "0")}`,
      to: "+15551234567",
      from: "+15550000000",
      status: "queued",
    }),
    { status: 201, headers: { "content-type": "application/json" } },
  );
}) as typeof fetch & { mock: object };
stubFetch.mock = {};
globalThis.fetch = stubFetch;

const { smsPlugin } = await import(`${ROOT}extensions/sms/src/channel.js`);
const { resolveSmsAccount } = await import(`${ROOT}extensions/sms/src/accounts.js`);
const { createEmptyPluginRegistry } = await import(`${ROOT}src/plugins/registry-empty.js`);
const { setActivePluginRegistry } = await import(`${ROOT}src/plugins/runtime.js`);
const { deliverOutboundPayloadsInternal } = await import(`${ROOT}src/infra/outbound/deliver.js`);

const registry = createEmptyPluginRegistry();
registry.channels.push({ pluginId: "sms", source: "bundled", plugin: smsPlugin });
setActivePluginRegistry(registry);

const cfg = { channels: { sms: { enabled: true, dmPolicy: "open" } } };

console.log("SMS_TEXT_CHUNK_LIMIT env:", JSON.stringify(process.env.SMS_TEXT_CHUNK_LIMIT));
console.log("resolved account.textChunkLimit:", resolveSmsAccount(cfg).textChunkLimit);

const REPLY = Array.from(
  { length: 90 },
  (_, i) => `Paragraph ${i}: ${"the quick brown fox jumps over the lazy dog. ".repeat(2)}`,
).join("\n\n");

await deliverOutboundPayloadsInternal({
  cfg,
  channel: "sms",
  to: "+15551234567",
  payloads: [{ text: REPLY }],
} as never);

globalThis.fetch = realFetch;

console.log("assistant reply length (chars):", REPLY.length);
console.log("Twilio endpoint calls:", twilioBodies.length);
console.log(
  "distinct body lengths:",
  JSON.stringify([...new Set(twilioBodies.map((body) => body.length))]),
);
console.log(
  "first 6 message bodies (truncated to 44 chars):",
  JSON.stringify(twilioBodies.slice(0, 6).map((body) => body.slice(0, 44))),
);
```

</details>
