### PR TITLE
fix(cron): stop recording a job that produced nothing as a successful run

### DIFF
--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -368,8 +368,11 @@ export async function finalizeCronRun(params: {
     finalRunResult.meta?.terminalReplyKind === "silent-empty" ||
     isSilentReplyPayloadText(finalRunResult.meta?.finalAssistantRawText) ||
     isSilentReplyPayloadText(finalRunResult.meta?.finalAssistantVisibleText);
+  // Not gated on deliveryRequested: "the runner does not deliver" (mode none/webhook) must
+  // not also mean "nothing checks that the run produced anything". The remaining conditions
+  // already describe a run with no observable outcome — no payload, no committed send, no
+  // deliberate silence — which is a failure in every delivery mode (#113181).
   if (
-    prepared.deliveryRequested &&
     !hasFatalErrorPayload &&
     !sourceDeliveryOutcome.satisfiesSourceDelivery &&
     !hasCommittedTerminalProgress &&

--- a/src/cron/isolated-agent/run.meta-error-status.test.ts
+++ b/src/cron/isolated-agent/run.meta-error-status.test.ts
@@ -176,6 +176,46 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
     expect(result.delivered).toBe(false);
   });
 
+  // #113181: delivery.mode "none" only means the runner does not deliver. It must not
+  // also disable the no-outcome guard, or a run that sent nothing and produced nothing
+  // is recorded as a clean success and failureAlert can never fire.
+  it("marks a delivery-disabled run with no committed outcome as a cron error", async () => {
+    runWithModelFallbackMock.mockResolvedValueOnce({
+      result: {
+        payloads: [],
+        meta: {
+          agentMeta: { usage: { input: 10, output: 0 } },
+        },
+      },
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      attempts: [],
+    });
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: false,
+      mode: "none",
+      channel: "messagechat",
+      to: "test-target",
+    });
+    resolveCronPayloadOutcomeMock.mockReturnValue({
+      summary: undefined,
+      outputText: undefined,
+      synthesizedText: undefined,
+      deliveryPayload: undefined,
+      deliveryPayloads: [],
+      deliveryPayloadHasStructuredContent: false,
+      hasFatalErrorPayload: false,
+      hasFatalStructuredErrorPayload: false,
+      embeddedRunError: undefined,
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("cron isolated run completed without a final assistant payload");
+    expect(result.delivered).toBe(false);
+  });
+
   it("keeps explicit silent replies as successful cron completions", async () => {
     runWithModelFallbackMock.mockResolvedValueOnce({
       result: {


### PR DESCRIPTION
Related: #113181

## What Problem This Solves

Fixes an issue where a scheduled job with `delivery.mode` set to `none` or `webhook` could finish having produced nothing at all — no message, no reply, no recorded reason — and still be stored as a clean success.

OpenClaw already guards against this. A cron run that ends with no assistant payload, no committed message-tool send, and no deliberate silent reply is recorded as an error. But that guard only ran when the cron runner itself owned delivery. Jobs that deliver some other way skipped the check entirely and were saved as `status: "ok"`.

That matters because failure alerts key off run status. A job configured with `failureAlert` cannot fire on a run that never reports a failure, so the operator's only signal is noticing that the message never arrived.

## Why This Change Was Made

`delivery.mode: "none"` means "the runner does not deliver". It was also, by accident, switching off the check that anything happened at all.

`resolveCronDeliveryPlan` sets `requested: resolvedMode === "announce"` (`src/cron/delivery-plan.ts:103`), so `deliveryRequested` is false for every `none` and `webhook` job — with or without an explicit target. The no-outcome guard in `finalizeCronRun` was gated on that flag, so it could only ever fire for announce jobs.

The fix removes that one condition. The guard's remaining conditions already describe a run with no observable outcome — no payload, no committed send, no deliberate silence — and that is a failure whoever was supposed to deliver. Net change is one line of logic removed.

Scope, stated up front: this does not cover every case in #113181. A run whose agent tries to send, fails, and then writes an explanation into its own final text still reports `ok`, because it did produce a payload. Recording that case needs failed-send evidence carried out of the agent runner, which is a bigger change at a different owner boundary. Hence `Related:`, not `Closes:`.

## User Impact

A scheduled job that silently does nothing now reports an error instead of a success, so `failureAlert` fires and the run carries a reason. Jobs that deliver normally, send via the message tool, spawn a session, add a cron job, or return a deliberate silent reply are unaffected.

## Evidence

Focused proof, driving the real entry point `runCronIsolatedAgentTurn`:

```
node scripts/run-vitest.mjs src/cron/isolated-agent/run.meta-error-status.test.ts
```

New test: `marks a delivery-disabled run with no committed outcome as a cron error`.

Before, on unmodified `main`:

```
AssertionError: expected 'ok' to be 'error' // Object.is equality
Expected: "error"
Received: "ok"
 ❯ src/cron/isolated-agent/run.meta-error-status.test.ts:214:27
 Test Files  1 failed (1)
      Tests  1 failed | 15 passed (16)
```

After, whole `src/cron/isolated-agent/` suite:

```
 Test Files  39 passed (39)
      Tests  553 passed (553)
```

Wider regression sweep, `src/cron/` plus `src/infra/outbound/`:

```
 Test Files  284 passed (284)
      Tests  4403 passed (4403)
   Duration  646.56s
```

Typecheck and lint:

```
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental ...   # exit 0, no output
node scripts/run-oxlint.mjs src/cron/isolated-agent                 # exit 0, clean
```

Production diff is +4/−1 in one file; the four added lines are a comment recording why the gate is absent.

Limits:

- No live gateway or real channel run. Proof is the repo's own cron suite driving `runCronIsolatedAgentTurn` with the model and delivery boundaries mocked — the same shape as the two existing tests that pin this guard for announce jobs.
- The `webhook` half of the change is covered by the suite passing, not by a webhook-specific test. No existing test pinned webhook no-outcome behavior in either direction.

AI-assisted: prepared with AI assistance and reviewed by the author.
