### PR TITLE
refactor(memory): consolidate host process fixtures

### DIFF
--- a/packages/memory-host-sdk/src/host/embeddings-worker.lifecycle.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.lifecycle.test.ts
@@ -7,22 +7,77 @@ const accessMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
-  return {
-    ...actual,
-    fork: forkMock,
-  };
+  return { ...actual, fork: forkMock };
 });
 
 vi.mock("node:fs/promises", async () => {
   const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
-  return {
-    ...actual,
-    default: { ...actual, access: accessMock },
-    access: accessMock,
-  };
+  return { ...actual, default: { ...actual, access: accessMock }, access: accessMock };
 });
 
 import { createLocalEmbeddingWorkerProvider } from "./embeddings-worker.js";
+
+type WorkerMessage = { id: number; type?: string; text?: string };
+type WorkerReply = { id: number; ok: boolean; value?: number[]; error?: string };
+type MockWorkerChild = EventEmitter & {
+  connected: boolean;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  disconnect: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+};
+
+const LOCAL_PROVIDER_OPTIONS = {
+  config: {} as never,
+  provider: "local",
+  model: "",
+  fallback: "none",
+} as const;
+
+function createMockWorkerChild(
+  options: {
+    onKill?: (child: MockWorkerChild, signal: NodeJS.Signals) => boolean;
+    onMessage?: (message: WorkerMessage, child: MockWorkerChild) => WorkerReply | null;
+  } = {},
+): MockWorkerChild {
+  const child = Object.assign(new EventEmitter(), {
+    connected: true,
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    disconnect: vi.fn(),
+    kill: vi.fn(),
+    send: vi.fn(),
+  }) as MockWorkerChild;
+  child.disconnect.mockImplementation(() => {
+    child.connected = false;
+  });
+  child.kill.mockImplementation((signal: NodeJS.Signals = "SIGTERM") => {
+    if (options.onKill) {
+      return options.onKill(child, signal);
+    }
+    child.signalCode = signal;
+    queueMicrotask(() => child.emit("close", null, signal));
+    return true;
+  });
+  child.send.mockImplementation(
+    (message: WorkerMessage, callback: (err?: Error | null) => void) => {
+      callback();
+      const customReply = options.onMessage?.(message, child);
+      const reply = customReply === undefined ? { id: message.id, ok: true } : customReply;
+      if (reply) {
+        queueMicrotask(() => child.emit("message", reply));
+      }
+      return true;
+    },
+  );
+  return child;
+}
+
+function failWorkerKill(child: MockWorkerChild): boolean {
+  queueMicrotask(() => child.emit("error", new Error("kill failed")));
+  return false;
+}
 
 beforeEach(() => {
   forkMock.mockReset();
@@ -41,34 +96,13 @@ it("forks workers through a stable Homebrew Node path", async () => {
     }
     throw new Error("missing");
   });
-  const child = Object.assign(new EventEmitter(), {
-    connected: true,
-    exitCode: null as number | null,
-    signalCode: null as NodeJS.Signals | null,
-    disconnect: vi.fn(function (this: { connected: boolean }) {
-      this.connected = false;
-    }),
-    kill: vi.fn(function (this: EventEmitter, signal: NodeJS.Signals) {
-      queueMicrotask(() => this.emit("close", null, signal));
-      return true;
-    }),
-    send: vi.fn(function (
-      this: EventEmitter,
-      message: { id: number },
-      callback: (err?: Error | null) => void,
-    ) {
-      callback();
-      queueMicrotask(() => this.emit("message", { id: message.id, ok: true }));
-      return true;
-    }),
-  });
+  const child = createMockWorkerChild();
   forkMock.mockReturnValue(child);
 
   try {
-    const provider = await createLocalEmbeddingWorkerProvider(
-      { config: {} as never, provider: "local", model: "", fallback: "none" },
-      { workerScriptPath: "/mock/worker.cjs" },
-    );
+    const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+      workerScriptPath: "/mock/worker.cjs",
+    });
 
     expect(forkMock).toHaveBeenCalledWith(
       "/mock/worker.cjs",
@@ -86,48 +120,25 @@ it("forks workers through a stable Homebrew Node path", async () => {
 
 it("keeps an active worker alive when a queued embedding request is aborted", async () => {
   let completeActiveRequest: (() => void) | undefined;
-  const child = Object.assign(new EventEmitter(), {
-    connected: true,
-    exitCode: null as number | null,
-    signalCode: null as NodeJS.Signals | null,
-    disconnect: vi.fn(function (this: { connected: boolean }) {
-      this.connected = false;
-    }),
-    kill: vi.fn(function (
-      this: EventEmitter & { signalCode: NodeJS.Signals | null },
-      signal: NodeJS.Signals,
-    ) {
-      this.signalCode = signal;
-      queueMicrotask(() => this.emit("close", null, signal));
-      return true;
-    }),
-    send: vi.fn(function (
-      this: EventEmitter,
-      message: { id: number; type: string; text?: string },
-      callback: (err?: Error | null) => void,
-    ) {
-      callback();
+  const child = createMockWorkerChild({
+    onMessage: (message, emitter) => {
       if (message.type === "embedQuery" && message.text === "active") {
         completeActiveRequest = () => {
-          this.emit("message", { id: message.id, ok: true, value: [1, 0] });
+          emitter.emit("message", { id: message.id, ok: true, value: [1, 0] });
         };
-      } else {
-        queueMicrotask(() => {
-          this.emit("message", {
-            id: message.id,
-            ok: true,
-            ...(message.type === "embedQuery" ? { value: [0, 1] } : {}),
-          });
-        });
+        return null;
       }
-      return true;
-    }),
+      return {
+        id: message.id,
+        ok: true,
+        ...(message.type === "embedQuery" ? { value: [0, 1] } : {}),
+      };
+    },
   });
   forkMock.mockReturnValue(child);
-  const provider = await createLocalEmbeddingWorkerProvider(
-    { config: {} as never, provider: "local", model: "", fallback: "none" },
-    { workerScriptPath: "/mock/worker.cjs" },
-  );
+  const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+    workerScriptPath: "/mock/worker.cjs",
+  });
   const activeRequest = provider.embedQuery("active");
   await vi.waitFor(() => expect(completeActiveRequest).toBeDefined());
 
@@ -150,36 +161,11 @@ it("keeps an active worker alive when a queued embedding request is aborted", as
 });
 
 it("terminates a disconnected live worker without forking a replacement", async () => {
-  const child = Object.assign(new EventEmitter(), {
-    connected: true,
-    exitCode: null as number | null,
-    signalCode: null as NodeJS.Signals | null,
-    disconnect: vi.fn(function (this: { connected: boolean }) {
-      this.connected = false;
-    }),
-    kill: vi.fn(function (
-      this: EventEmitter & { signalCode: NodeJS.Signals | null },
-      signal: NodeJS.Signals,
-    ) {
-      this.signalCode = signal;
-      queueMicrotask(() => this.emit("close", null, signal));
-      return true;
-    }),
-    send: vi.fn(function (
-      this: EventEmitter,
-      message: { id: number },
-      callback: (err?: Error | null) => void,
-    ) {
-      callback();
-      queueMicrotask(() => this.emit("message", { id: message.id, ok: true }));
-      return true;
-    }),
-  });
+  const child = createMockWorkerChild();
   forkMock.mockReturnValue(child);
-  const provider = await createLocalEmbeddingWorkerProvider(
-    { config: {} as never, provider: "local", model: "", fallback: "none" },
-    { workerScriptPath: "/mock/worker.cjs" },
-  );
+  const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+    workerScriptPath: "/mock/worker.cjs",
+  });
   child.connected = false;
 
   await expect(provider.close?.()).resolves.toBeUndefined();
@@ -190,76 +176,29 @@ it("terminates a disconnected live worker without forking a replacement", async 
 });
 
 it("drains failed construction clients before forking another worker", async () => {
-  const failedChild = Object.assign(new EventEmitter(), {
-    connected: true,
-    exitCode: null as number | null,
-    signalCode: null as NodeJS.Signals | null,
-    disconnect: vi.fn(function (this: { connected: boolean }) {
-      this.connected = false;
-    }),
-    kill: vi.fn(function (this: EventEmitter, _signal?: NodeJS.Signals) {
-      queueMicrotask(() => this.emit("error", new Error("kill failed")));
-      return false;
-    }),
-    send: vi.fn(function (
-      this: EventEmitter,
-      message: { id: number; type: string },
-      callback: (err?: Error | null) => void,
-    ) {
-      callback();
-      queueMicrotask(() =>
-        this.emit(
-          "message",
-          message.type === "initialize"
-            ? { id: message.id, ok: false, error: "initialization failed" }
-            : { id: message.id, ok: true },
-        ),
-      );
-      return true;
-    }),
+  const failedChild = createMockWorkerChild({
+    onKill: failWorkerKill,
+    onMessage: (message) =>
+      message.type === "initialize"
+        ? { id: message.id, ok: false, error: "initialization failed" }
+        : { id: message.id, ok: true },
   });
-  const replacementChild = Object.assign(new EventEmitter(), {
-    connected: true,
-    exitCode: null as number | null,
-    signalCode: null as NodeJS.Signals | null,
-    disconnect: vi.fn(function (this: { connected: boolean }) {
-      this.connected = false;
-    }),
-    kill: vi.fn(function (
-      this: EventEmitter & { signalCode: NodeJS.Signals | null },
-      signal: NodeJS.Signals,
-    ) {
-      this.signalCode = signal;
-      queueMicrotask(() => this.emit("close", null, signal));
-      return true;
-    }),
-    send: vi.fn(function (
-      this: EventEmitter,
-      message: { id: number },
-      callback: (err?: Error | null) => void,
-    ) {
-      callback();
-      queueMicrotask(() => this.emit("message", { id: message.id, ok: true }));
-      return true;
-    }),
-  });
+  const replacementChild = createMockWorkerChild();
   forkMock.mockReturnValueOnce(failedChild).mockReturnValueOnce(replacementChild);
-  const options = { config: {} as never, provider: "local", model: "", fallback: "none" };
 
   await expect(
-    createLocalEmbeddingWorkerProvider(options, { workerScriptPath: "/mock/worker.cjs" }),
+    createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+      workerScriptPath: "/mock/worker.cjs",
+    }),
   ).rejects.toThrow("initialization failed");
   expect(forkMock).toHaveBeenCalledTimes(1);
 
-  failedChild.kill.mockImplementationOnce(function (
-    this: typeof failedChild,
-    signal: NodeJS.Signals = "SIGTERM",
-  ) {
-    this.signalCode = signal;
-    queueMicrotask(() => this.emit("close", null, signal));
+  failedChild.kill.mockImplementationOnce((signal: NodeJS.Signals = "SIGTERM") => {
+    failedChild.signalCode = signal;
+    queueMicrotask(() => failedChild.emit("close", null, signal));
     return true;
   });
-  const provider = await createLocalEmbeddingWorkerProvider(options, {
+  const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
     workerScriptPath: "/mock/worker.cjs",
   });
   expect(forkMock).toHaveBeenCalledTimes(2);
@@ -268,50 +207,25 @@ it("drains failed construction clients before forking another worker", async () 
 });
 
 it("retries failed construction cleanup without another provider creation", async () => {
-  const failedChild = Object.assign(new EventEmitter(), {
-    connected: true,
-    exitCode: null as number | null,
-    signalCode: null as NodeJS.Signals | null,
-    disconnect: vi.fn(function (this: { connected: boolean }) {
-      this.connected = false;
-    }),
-    kill: vi.fn(function (this: EventEmitter, _signal?: NodeJS.Signals) {
-      queueMicrotask(() => this.emit("error", new Error("kill failed")));
-      return false;
-    }),
-    send: vi.fn(function (
-      this: EventEmitter,
-      message: { id: number; type: string },
-      callback: (err?: Error | null) => void,
-    ) {
-      callback();
-      queueMicrotask(() =>
-        this.emit(
-          "message",
-          message.type === "initialize"
-            ? { id: message.id, ok: false, error: "initialization failed" }
-            : { id: message.id, ok: true },
-        ),
-      );
-      return true;
-    }),
+  const failedChild = createMockWorkerChild({
+    onKill: failWorkerKill,
+    onMessage: (message) =>
+      message.type === "initialize"
+        ? { id: message.id, ok: false, error: "initialization failed" }
+        : { id: message.id, ok: true },
   });
   forkMock.mockReturnValue(failedChild);
 
   await expect(
-    createLocalEmbeddingWorkerProvider(
-      { config: {} as never, provider: "local", model: "", fallback: "none" },
-      { workerScriptPath: "/mock/worker.cjs" },
-    ),
+    createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+      workerScriptPath: "/mock/worker.cjs",
+    }),
   ).rejects.toThrow("initialization failed");
   expect(forkMock).toHaveBeenCalledTimes(1);
 
-  failedChild.kill.mockImplementationOnce(function (
-    this: typeof failedChild,
-    signal: NodeJS.Signals = "SIGTERM",
-  ) {
-    this.signalCode = signal;
-    queueMicrotask(() => this.emit("close", null, signal));
+  failedChild.kill.mockImplementationOnce((signal: NodeJS.Signals = "SIGTERM") => {
+    failedChild.signalCode = signal;
+    queueMicrotask(() => failedChild.emit("close", null, signal));
     return true;
   });
   await vi.waitFor(() => expect(failedChild.kill).toHaveBeenCalledTimes(3), { timeout: 2_000 });
@@ -321,40 +235,16 @@ it("retries failed construction cleanup without another provider creation", asyn
 });
 
 it("retries failed provider close without another owner call", async () => {
-  const child = Object.assign(new EventEmitter(), {
-    connected: true,
-    exitCode: null as number | null,
-    signalCode: null as NodeJS.Signals | null,
-    disconnect: vi.fn(function (this: { connected: boolean }) {
-      this.connected = false;
-    }),
-    kill: vi.fn(function (this: EventEmitter, _signal?: NodeJS.Signals) {
-      queueMicrotask(() => this.emit("error", new Error("kill failed")));
-      return false;
-    }),
-    send: vi.fn(function (
-      this: EventEmitter,
-      message: { id: number },
-      callback: (err?: Error | null) => void,
-    ) {
-      callback();
-      queueMicrotask(() => this.emit("message", { id: message.id, ok: true }));
-      return true;
-    }),
-  });
+  const child = createMockWorkerChild({ onKill: failWorkerKill });
   forkMock.mockReturnValue(child);
-  const provider = await createLocalEmbeddingWorkerProvider(
-    { config: {} as never, provider: "local", model: "", fallback: "none" },
-    { workerScriptPath: "/mock/worker.cjs" },
-  );
+  const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+    workerScriptPath: "/mock/worker.cjs",
+  });
 
   await expect(provider.close?.()).rejects.toThrow("did not exit after SIGKILL");
-  child.kill.mockImplementationOnce(function (
-    this: typeof child,
-    signal: NodeJS.Signals = "SIGTERM",
-  ) {
-    this.signalCode = signal;
-    queueMicrotask(() => this.emit("close", null, signal));
+  child.kill.mockImplementationOnce((signal: NodeJS.Signals = "SIGTERM") => {
+    child.signalCode = signal;
+    queueMicrotask(() => child.emit("close", null, signal));
     return true;
   });
   await vi.waitFor(() => expect(child.kill).toHaveBeenCalledTimes(3), { timeout: 2_000 });

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -11,6 +11,12 @@ import { createLocalEmbeddingProviderInProcess, DEFAULT_LOCAL_MODEL } from "./em
 import { getLocalEmbeddingRuntimeFacts } from "./local-embedding-runtime-facts.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const LOCAL_PROVIDER_OPTIONS = {
+  config: {} as never,
+  provider: "local",
+  model: "",
+  fallback: "none",
+} as const;
 
 const nodeLlamaMock = vi.hoisted(() => ({
   importNodeLlamaCpp: vi.fn(),
@@ -125,12 +131,7 @@ describe("local embedding provider", () => {
   it("normalizes local embeddings and resolves the default local model", async () => {
     const runtime = mockLocalEmbeddingRuntime();
 
-    const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
-    });
+    const provider = await createLocalEmbeddingProviderInProcess(LOCAL_PROVIDER_OPTIONS);
 
     const embedding = await provider.embedQuery("test query");
     const magnitude = Math.sqrt(embedding.reduce((sum, value) => sum + value * value, 0));
@@ -155,10 +156,7 @@ describe("local embedding provider", () => {
   it("truncates local embeddings before normalizing them", async () => {
     mockLocalEmbeddingRuntime(new Float32Array([3, 4, 12]));
     const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
+      ...LOCAL_PROVIDER_OPTIONS,
       outputDimensionality: 2,
     });
 
@@ -176,10 +174,7 @@ describe("local embedding provider", () => {
       },
     });
     const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
+      ...LOCAL_PROVIDER_OPTIONS,
       outputDimensionality: 2,
     });
 
@@ -189,12 +184,7 @@ describe("local embedding provider", () => {
   it("passes default contextSize (4096) to createEmbeddingContext when not configured", async () => {
     const runtime = mockLocalEmbeddingRuntime();
 
-    const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
-    });
+    const provider = await createLocalEmbeddingProviderInProcess(LOCAL_PROVIDER_OPTIONS);
 
     await provider.embedQuery("context size default test");
 
@@ -217,10 +207,7 @@ describe("local embedding provider", () => {
     mockLocalEmbeddingRuntime();
 
     await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
+      ...LOCAL_PROVIDER_OPTIONS,
       local: {
         nodeLlamaCppImportUrl: "file:///plugins/llama-cpp/node-llama-cpp.js",
       } as never,
@@ -235,10 +222,7 @@ describe("local embedding provider", () => {
     const runtime = mockLocalEmbeddingRuntime();
 
     const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
+      ...LOCAL_PROVIDER_OPTIONS,
       local: { contextSize: 2048 },
     });
 
@@ -263,10 +247,7 @@ describe("local embedding provider", () => {
     const runtime = mockLocalEmbeddingRuntime();
 
     const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
+      ...LOCAL_PROVIDER_OPTIONS,
       local: { contextSize: "auto" },
     });
 
@@ -282,12 +263,7 @@ describe("local embedding provider", () => {
 
   it("reports selected backend, memory, offload, and requested context facts", async () => {
     mockLocalEmbeddingRuntime();
-    const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
-    });
+    const provider = await createLocalEmbeddingProviderInProcess(LOCAL_PROVIDER_OPTIONS);
 
     expect(getLocalEmbeddingRuntimeFacts(provider)).toBeUndefined();
     await provider.embedQuery("runtime facts");
@@ -320,12 +296,7 @@ describe("local embedding provider", () => {
   it("retains reliable runtime facts when model loading fails", async () => {
     const runtime = mockLocalEmbeddingRuntime();
     runtime.loadModel.mockRejectedValueOnce(new Error("GGUF load failed"));
-    const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
-    });
+    const provider = await createLocalEmbeddingProviderInProcess(LOCAL_PROVIDER_OPTIONS);
 
     await expect(provider.embedQuery("runtime failure")).rejects.toThrow("GGUF load failed");
 
@@ -346,10 +317,7 @@ describe("local embedding provider", () => {
     const runtime = mockLocalEmbeddingRuntime();
     runtime.getLlama.mockRejectedValueOnce(new Error("No compatible llama.cpp backend"));
     const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
+      ...LOCAL_PROVIDER_OPTIONS,
       local: {
         contextSize: 2048,
       },
@@ -395,12 +363,7 @@ describe("local embedding provider", () => {
       resolveModelFile: vi.fn(async () => "/resolved/model.gguf"),
       LlamaLogLevel: { error: 0 },
     } as never);
-    const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
-    });
+    const provider = await createLocalEmbeddingProviderInProcess(LOCAL_PROVIDER_OPTIONS);
 
     const batchPromise = provider.embedBatch(["first", "second"]);
     await expect.poll(() => calls.join(",")).toBe("first");
@@ -415,10 +378,7 @@ describe("local embedding provider", () => {
     const runtime = mockLocalEmbeddingRuntime(new Float32Array([1, 0]));
 
     const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
+      ...LOCAL_PROVIDER_OPTIONS,
       local: {
         modelPath: "  /models/embed.gguf  ",
         modelCacheDir: "  /cache/models  ",
@@ -441,12 +401,7 @@ describe("local embedding provider", () => {
   it("disposes cached local llama resources when closed", async () => {
     const runtime = mockLocalEmbeddingRuntime();
 
-    const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
-    });
+    const provider = await createLocalEmbeddingProviderInProcess(LOCAL_PROVIDER_OPTIONS);
 
     await provider.embedQuery("load local resources");
     await provider.close?.();
@@ -468,12 +423,7 @@ describe("local embedding provider", () => {
       resolveModelFile: vi.fn(async (modelPath: string) => `/resolved/${modelPath}`),
       LlamaLogLevel: { error: 0 },
     } as never);
-    const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
-    });
+    const provider = await createLocalEmbeddingProviderInProcess(LOCAL_PROVIDER_OPTIONS);
 
     const embedPromise = provider.embedQuery("pending init");
     await expect(provider.close?.()).resolves.toBeUndefined();
@@ -504,12 +454,7 @@ describe("local embedding provider", () => {
       }),
       LlamaLogLevel: { error: 0 },
     } as never);
-    const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
-    });
+    const provider = await createLocalEmbeddingProviderInProcess(LOCAL_PROVIDER_OPTIONS);
 
     const embedPromise = provider.embedQuery("pending model load");
     await loadModelStarted.promise;
@@ -548,12 +493,7 @@ describe("local embedding provider", () => {
       resolveModelFile: vi.fn(async () => "/resolved/model.gguf"),
       LlamaLogLevel: { error: 0 },
     } as never);
-    const provider = await createLocalEmbeddingProviderInProcess({
-      config: {} as never,
-      provider: "local",
-      model: "",
-      fallback: "none",
-    });
+    const provider = await createLocalEmbeddingProviderInProcess(LOCAL_PROVIDER_OPTIONS);
 
     const embedPromise = provider.embedQuery("pending context create");
     await createContextStarted.promise;
@@ -620,10 +560,7 @@ process.on("message", (message) => {
     );
     const provider = await createLocalEmbeddingWorkerProvider(
       {
-        config: {} as never,
-        provider: "local",
-        model: "",
-        fallback: "none",
+        ...LOCAL_PROVIDER_OPTIONS,
         outputDimensionality: 2,
       },
       {
@@ -668,10 +605,9 @@ process.on("message", (message) => {
 `,
       "utf8",
     );
-    const provider = await createLocalEmbeddingWorkerProvider(
-      { config: {} as never, provider: "local", model: "", fallback: "none" },
-      { workerScriptPath: workerScript },
-    );
+    const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+      workerScriptPath: workerScript,
+    });
 
     const firstClose = provider.close?.() ?? Promise.resolve();
     const secondClose = provider.close?.() ?? Promise.resolve();
@@ -706,10 +642,9 @@ process.on("message", (message) => {
 `,
       "utf8",
     );
-    const provider = await createLocalEmbeddingWorkerProvider(
-      { config: {} as never, provider: "local", model: "", fallback: "none" },
-      { workerScriptPath: workerScript },
-    );
+    const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+      workerScriptPath: workerScript,
+    });
     const controller = new AbortController();
     const embedPromise = provider.embedQuery("cancel me", { signal: controller.signal });
     await expect
@@ -750,10 +685,9 @@ process.on("message", (message) => {
 `,
       "utf8",
     );
-    const provider = await createLocalEmbeddingWorkerProvider(
-      { config: {} as never, provider: "local", model: "", fallback: "none" },
-      { workerScriptPath: workerScript },
-    );
+    const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+      workerScriptPath: workerScript,
+    });
 
     await expect(
       settleWithin(
@@ -786,10 +720,9 @@ process.on("message", (message) => {
       }),
     });
     forkMock.mockReturnValue(child);
-    const provider = await createLocalEmbeddingWorkerProvider(
-      { config: {} as never, provider: "local", model: "", fallback: "none" },
-      { workerScriptPath: "/mock/worker.cjs" },
-    );
+    const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+      workerScriptPath: "/mock/worker.cjs",
+    });
 
     const closeResult = await settleWithin(
       (provider.close?.() ?? Promise.resolve()).then(
@@ -831,10 +764,9 @@ process.on("message", (message) => {
       "utf8",
     );
     const warning = vi.spyOn(process, "emitWarning").mockImplementation(() => {});
-    const provider = await createLocalEmbeddingWorkerProvider(
-      { config: {} as never, provider: "local", model: "", fallback: "none" },
-      { workerScriptPath: workerScript },
-    );
+    const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+      workerScriptPath: workerScript,
+    });
 
     await expect(provider.close?.()).resolves.toBeUndefined();
 
@@ -873,15 +805,9 @@ process.on("message", (message) => {
 `,
       "utf8",
     );
-    const provider = await createLocalEmbeddingWorkerProvider(
-      {
-        config: {} as never,
-        provider: "local",
-        model: "",
-        fallback: "none",
-      },
-      { workerScriptPath: workerScript },
-    );
+    const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+      workerScriptPath: workerScript,
+    });
 
     const firstEmbedError = provider.embedQuery("first").then(
       () => undefined,
@@ -949,15 +875,9 @@ process.on("message", (message) => {
 `,
       "utf8",
     );
-    const provider = await createLocalEmbeddingWorkerProvider(
-      {
-        config: {} as never,
-        provider: "local",
-        model: "",
-        fallback: "none",
-      },
-      { workerScriptPath: workerScript },
-    );
+    const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+      workerScriptPath: workerScript,
+    });
 
     await expect(provider.embedQuery("hello")).rejects.toMatchObject({
       message: "CUDA model load failed",
@@ -1003,15 +923,9 @@ process.on("message", (message) => {
         "--inspect-port",
         "0",
       );
-      provider = await createLocalEmbeddingWorkerProvider(
-        {
-          config: {} as never,
-          provider: "local",
-          model: "",
-          fallback: "none",
-        },
-        { workerScriptPath: workerScript },
-      );
+      provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+        workerScriptPath: workerScript,
+      });
       await expect(provider.embedQuery("hello")).resolves.toEqual([0]);
     } finally {
       process.execArgv.splice(0, process.execArgv.length, ...originalExecArgv);
@@ -1037,15 +951,9 @@ process.on("message", (message) => {
     );
 
     try {
-      await createLocalEmbeddingWorkerProvider(
-        {
-          config: {} as never,
-          provider: "local",
-          model: "",
-          fallback: "none",
-        },
-        { workerScriptPath: workerScript },
-      );
+      await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+        workerScriptPath: workerScript,
+      });
       throw new Error("expected local embedding provider creation to fail");
     } catch (err) {
       expect(err).toBeInstanceOf(Error);
@@ -1070,15 +978,9 @@ process.on("message", (message) => {
 `,
       "utf8",
     );
-    const provider = await createLocalEmbeddingWorkerProvider(
-      {
-        config: {} as never,
-        provider: "local",
-        model: "",
-        fallback: "none",
-      },
-      { workerScriptPath: workerScript },
-    );
+    const provider = await createLocalEmbeddingWorkerProvider(LOCAL_PROVIDER_OPTIONS, {
+      workerScriptPath: workerScript,
+    });
 
     await expect(provider.embedQuery("hello")).rejects.toMatchObject({
       code: LOCAL_EMBEDDING_WORKER_ERROR_CODES.exited,

--- a/packages/memory-host-sdk/src/host/qmd-process.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.test.ts
@@ -84,6 +84,17 @@ function restoreEnvValue(key: string, value: string | undefined): void {
   process.env[key] = value;
 }
 
+function runQmdCommand(overrides: Partial<Parameters<typeof runCliCommand>[0]> = {}) {
+  return runCliCommand({
+    commandSummary: "qmd query test",
+    spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
+    env: process.env,
+    cwd: tempDir,
+    maxOutputChars: 10_000,
+    ...overrides,
+  });
+}
+
 beforeAll(async () => {
   fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-qmd-win-spawn-"));
   platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
@@ -410,13 +421,7 @@ describe("runCliCommand", () => {
     });
 
     try {
-      await runCliCommand({
-        commandSummary: "qmd query test",
-        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-        env: process.env,
-        cwd: tempDir,
-        maxOutputChars: 10_000,
-      });
+      await runQmdCommand();
       throw new Error("expected runCliCommand to reject");
     } catch (err) {
       expect(err).toBeInstanceOf(Error);
@@ -446,15 +451,7 @@ describe("runCliCommand", () => {
       return child;
     });
 
-    await expect(
-      runCliCommand({
-        commandSummary: "qmd query test",
-        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-        env: process.env,
-        cwd: tempDir,
-        maxOutputChars: 10_000,
-      }),
-    ).rejects.toMatchObject({
+    await expect(runQmdCommand()).rejects.toMatchObject({
       code: null,
       signal: "SIGABRT",
       stdout: "[]",
@@ -471,15 +468,7 @@ describe("runCliCommand", () => {
       return child;
     });
 
-    await expect(
-      runCliCommand({
-        commandSummary: "qmd query test",
-        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-        env: process.env,
-        cwd: tempDir,
-        maxOutputChars: 4,
-      }),
-    ).rejects.toThrow(/produced too much output/);
+    await expect(runQmdCommand({ maxOutputChars: 4 })).rejects.toThrow(/produced too much output/);
   });
 
   it("counts surrogate pairs as one character when capping failed command output", async () => {
@@ -492,15 +481,7 @@ describe("runCliCommand", () => {
       return child;
     });
 
-    await expect(
-      runCliCommand({
-        commandSummary: "qmd query test",
-        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-        env: process.env,
-        cwd: tempDir,
-        maxOutputChars: 2,
-      }),
-    ).rejects.toThrow(/🙂/);
+    await expect(runQmdCommand({ maxOutputChars: 2 })).rejects.toThrow(/🙂/);
   });
 
   it("caps oversized command timeouts before scheduling", async () => {
@@ -509,12 +490,7 @@ describe("runCliCommand", () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     spawnMock.mockReturnValueOnce(child);
 
-    void runCliCommand({
-      commandSummary: "qmd query test",
-      spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-      env: process.env,
-      cwd: tempDir,
-      maxOutputChars: 10_000,
+    void runQmdCommand({
       timeoutMs: Number.MAX_SAFE_INTEGER,
     }).catch(() => undefined);
 
@@ -529,12 +505,9 @@ describe("runCliCommand", () => {
     const controller = new AbortController();
 
     try {
-      const pending = runCliCommand({
+      const pending = runQmdCommand({
         commandSummary: "qmd query slow",
         spawnInvocation: { command: "qmd", argv: ["query", "slow", "--json"] },
-        env: process.env,
-        cwd: tempDir,
-        maxOutputChars: 10_000,
         timeoutMs: 60_000,
         signal: controller.signal,
       });
@@ -555,12 +528,7 @@ describe("runCliCommand", () => {
     controller.abort(new Error("memory_search timed out after 15s"));
 
     await expect(
-      runCliCommand({
-        commandSummary: "qmd query test",
-        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-        env: process.env,
-        cwd: tempDir,
-        maxOutputChars: 10_000,
+      runQmdCommand({
         signal: controller.signal,
       }),
     ).rejects.toThrow("memory_search timed out after 15s");
@@ -574,12 +542,7 @@ describe("runCliCommand", () => {
     spawnMock.mockReturnValueOnce(child);
 
     try {
-      const pending = runCliCommand({
-        commandSummary: "qmd query test",
-        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-        env: process.env,
-        cwd: tempDir,
-        maxOutputChars: 10_000,
+      const pending = runQmdCommand({
         timeoutMs: 1,
       });
       const timeoutAssertion = expect(pending).rejects.toThrow(
@@ -600,12 +563,7 @@ describe("runCliCommand", () => {
     const child = createMockChild({ pid: 12346 });
     spawnMock.mockReturnValueOnce(child);
 
-    const pending = runCliCommand({
-      commandSummary: "qmd query test",
-      spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-      env: process.env,
-      cwd: tempDir,
-      maxOutputChars: 10_000,
+    const pending = runQmdCommand({
       timeoutMs: 1,
     });
 
@@ -625,12 +583,7 @@ describe("runCliCommand", () => {
     spawnMock.mockReturnValueOnce(child);
     spawnMock.mockReturnValueOnce(taskkill);
 
-    const pending = runCliCommand({
-      commandSummary: "qmd query test",
-      spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-      env: process.env,
-      cwd: tempDir,
-      maxOutputChars: 10_000,
+    const pending = runQmdCommand({
       timeoutMs: 1,
     });
 
@@ -656,13 +609,7 @@ describe("runCliCommand", () => {
       spawnMock.mockReturnValueOnce(child);
       const streamError = new Error(`${streamName} EPIPE`);
 
-      const pending = runCliCommand({
-        commandSummary: "qmd query test",
-        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-        env: process.env,
-        cwd: tempDir,
-        maxOutputChars: 10_000,
-      });
+      const pending = runQmdCommand();
 
       child[streamName].emit("error", streamError);
 
@@ -679,13 +626,7 @@ describe("runCliCommand", () => {
     const child = createMockChild();
     spawnMock.mockReturnValueOnce(child);
 
-    const pending = runCliCommand({
-      commandSummary: "qmd query test",
-      spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-      env: process.env,
-      cwd: tempDir,
-      maxOutputChars: 10_000,
-    });
+    const pending = runQmdCommand();
 
     child.stdout.emit("error", new Error("stdout EPIPE"));
 


### PR DESCRIPTION
## What Problem This Solves

The memory-host embedding and QMD process tests repeated large option bags and hand-built worker child-process fixtures, making lifecycle and subprocess coverage harder to audit and maintain.

## Why This Change Was Made

Consolidates the repeated local-provider options, worker child behavior, failed-kill behavior, and QMD command defaults at the owning memory-host test boundary. Specialized event ordering, vector dimensions, abort/cleanup paths, POSIX/Windows termination behavior, timeouts, stream errors, and output caps remain explicit in each case.

No production code, public exports, configuration, schema, or i18n surface changes.

## User Impact

No user-visible behavior change. The same memory-host contracts are covered with 267 fewer test lines and a single canonical fixture shape.

## Evidence

- Diff: 3 test files, `+194/-461` (net `-267`); production LOC `0`.
- Parity: exact test names/order preserved; 59 declarations / 60 expanded cases and all 175 `expect` calls retained.
- Focused exact-head proof: 60/60 passed across embedding provider, worker lifecycle, and QMD process tests.
- Blacksmith Testbox exact-head proof: full `packages/memory-host-sdk` suite 136/136 passed, including real QMD subprocess coverage; `pnpm check:changed` passed; `pnpm build` passed.
- Remote proof: https://github.com/openclaw/openclaw/actions/runs/30763942412
- Dependency contracts inspected against `node-llama-cpp` v3.19.1 source and current QMD source.
