### PR TITLE
test(secrets): consolidate runtime fixtures

### DIFF
--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -9,35 +9,39 @@ import {
   resolveProviderAuthLookupMaps,
 } from "./provider-env-vars.js";
 
-type MockManifestRegistry = {
-  plugins: Array<{
-    id: string;
-    origin: string;
-    enabled?: boolean;
-    enabledByDefault?: boolean;
-    kind?: "memory" | "context-engine" | Array<"memory" | "context-engine">;
-    providers?: string[];
-    providerUsageAuthEnvVars?: Record<string, string[]>;
-    providerAuthAliases?: Record<string, string>;
-    setup?: {
-      requiresRuntime?: boolean;
-      providers?: Array<{
-        id: string;
-        envVars?: string[];
-        authEvidence?: Array<{
-          type: "local-file-with-env";
-          fileEnvVar?: string;
-          fallbackPaths?: string[];
-          requiresAnyEnv?: string[];
-          requiresAllEnv?: string[];
-          credentialMarker: string;
-          source?: string;
-        }>;
+type MockManifestPlugin = {
+  id: string;
+  origin: string;
+  enabled?: boolean;
+  enabledByDefault?: boolean;
+  kind?: "memory" | "context-engine" | Array<"memory" | "context-engine">;
+  providers?: string[];
+  providerUsageAuthEnvVars?: Record<string, string[]>;
+  providerAuthAliases?: Record<string, string>;
+  setup?: {
+    requiresRuntime?: boolean;
+    providers?: Array<{
+      id: string;
+      envVars?: string[];
+      authEvidence?: Array<{
+        type: "local-file-with-env";
+        fileEnvVar?: string;
+        fallbackPaths?: string[];
+        requiresAnyEnv?: string[];
+        requiresAllEnv?: string[];
+        credentialMarker: string;
+        source?: string;
       }>;
-    };
-  }>;
+    }>;
+  };
+};
+
+type MockManifestRegistry = {
+  plugins: MockManifestPlugin[];
   diagnostics: unknown[];
 };
+
+type MockSetupProvider = NonNullable<NonNullable<MockManifestPlugin["setup"]>["providers"]>[number];
 
 const pluginRegistryMocks = vi.hoisted(() => {
   const loadManifestRegistry = vi.fn<(...args: unknown[]) => MockManifestRegistry>(() => ({
@@ -51,17 +55,7 @@ const pluginRegistryMocks = vi.hoisted(() => {
     loadPluginRegistrySnapshot: vi.fn(() => ({ plugins: [] })),
     loadPluginMetadataSnapshot: vi.fn((params: unknown) => {
       const registry = loadManifestRegistry(params) ?? { plugins: [], diagnostics: [] };
-      return {
-        index: {
-          plugins: registry.plugins.map((plugin) => ({
-            pluginId: plugin.id,
-            origin: plugin.origin,
-            enabled: plugin.enabled ?? true,
-            enabledByDefault: plugin.enabledByDefault ?? true,
-          })),
-        },
-        plugins: registry.plugins,
-      };
+      return metadataSnapshot(...registry.plugins);
     }),
   };
 });
@@ -73,6 +67,63 @@ function requireLastMetadataSnapshotCall(): unknown[] {
     throw new Error("expected plugin metadata snapshot call");
   }
   return call;
+}
+
+function manifestRegistry(...plugins: MockManifestPlugin[]): MockManifestRegistry {
+  return { plugins, diagnostics: [] };
+}
+
+function setupPlugin(
+  id: string,
+  origin: string,
+  provider: MockSetupProvider,
+  extra: Omit<MockManifestPlugin, "id" | "origin" | "setup"> = {},
+): MockManifestPlugin {
+  return { id, origin, ...extra, setup: { providers: [provider] } };
+}
+
+function metadataSnapshot(...plugins: MockManifestPlugin[]) {
+  return {
+    index: {
+      plugins: plugins.map((plugin) => ({
+        pluginId: plugin.id,
+        origin: plugin.origin,
+        enabled: plugin.enabled ?? true,
+        enabledByDefault: plugin.enabledByDefault ?? true,
+      })),
+    },
+    plugins,
+  };
+}
+
+const LOAD_PATH_PROVIDER_PLUGIN = setupPlugin("load-path-provider", "global", {
+  id: "load-path-provider",
+  envVars: ["LOAD_PATH_PROVIDER_API_KEY"],
+});
+
+function useInstalledPlugins(...plugins: MockManifestPlugin[]): void {
+  pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue(
+    manifestRegistry(...plugins),
+  );
+}
+
+function useInstalledSetupPlugin(
+  id: string,
+  origin: string,
+  provider: MockSetupProvider,
+  extra?: Omit<MockManifestPlugin, "id" | "origin" | "setup">,
+): void {
+  useInstalledPlugins(setupPlugin(id, origin, provider, extra));
+}
+
+function useRegistryPlugins(...plugins: MockManifestPlugin[]): void {
+  pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue(
+    manifestRegistry(...plugins),
+  );
+}
+
+function useRegistrySetupPlugin(id: string, origin: string, provider: MockSetupProvider): void {
+  useRegistryPlugins(setupPlugin(id, origin, provider));
 }
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
@@ -97,10 +148,7 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
 describe("provider env vars dynamic manifest metadata", () => {
   beforeEach(() => {
     pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReset();
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [],
-      diagnostics: [],
-    });
+    useInstalledPlugins();
     pluginRegistryMocks.loadPluginRegistrySnapshot.mockReset();
     pluginRegistryMocks.loadPluginRegistrySnapshot.mockReturnValue({ plugins: [] });
     pluginRegistryMocks.getCurrentPluginMetadataSnapshot.mockReset();
@@ -109,21 +157,12 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("includes later-installed plugin env vars without a bundled generated map", () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "external-fireworks",
-          origin: "global",
-          setup: {
-            providers: [{ id: "fireworks", envVars: ["FIREWORKS_ALT_API_KEY"] }],
-          },
-          providerAuthAliases: {
-            "fireworks-plan": "fireworks",
-          },
-        },
-      ],
-      diagnostics: [],
-    });
+    useInstalledSetupPlugin(
+      "external-fireworks",
+      "global",
+      { id: "fireworks", envVars: ["FIREWORKS_ALT_API_KEY"] },
+      { providerAuthAliases: { "fireworks-plan": "fireworks" } },
+    );
 
     expect(getProviderEnvVars("fireworks", { config: {} })).toEqual(["FIREWORKS_ALT_API_KEY"]);
     expect(getProviderEnvVars("fireworks-plan", { config: {} })).toEqual(["FIREWORKS_ALT_API_KEY"]);
@@ -132,18 +171,13 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("scrubs provider usage credentials without making them inference auth candidates", () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "provider-billing",
-          origin: "global",
-          providers: ["provider-billing"],
-          providerUsageAuthEnvVars: {
-            "provider-billing": ["PROVIDER_BILLING_CREDENTIAL"],
-          },
-        },
-      ],
-      diagnostics: [],
+    useInstalledPlugins({
+      id: "provider-billing",
+      origin: "global",
+      providers: ["provider-billing"],
+      providerUsageAuthEnvVars: {
+        "provider-billing": ["PROVIDER_BILLING_CREDENTIAL"],
+      },
     });
 
     expect(listKnownProviderAuthEnvVarNames()).toContain("PROVIDER_BILLING_CREDENTIAL");
@@ -216,22 +250,9 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("includes setup provider env vars without loading setup runtime", () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "external-model-studio",
-          origin: "global",
-          setup: {
-            providers: [
-              {
-                id: "model-studio",
-                envVars: ["MODEL_STUDIO_API_KEY", "MODEL_STUDIO_API_KEY"],
-              },
-            ],
-          },
-        },
-      ],
-      diagnostics: [],
+    useInstalledSetupPlugin("external-model-studio", "global", {
+      id: "model-studio",
+      envVars: ["MODEL_STUDIO_API_KEY", "MODEL_STUDIO_API_KEY"],
     });
 
     expect(getProviderEnvVars("model-studio", { config: {} })).toEqual(["MODEL_STUDIO_API_KEY"]);
@@ -240,30 +261,17 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("includes setup provider auth evidence without loading setup runtime", () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
-      plugins: [
+    useRegistrySetupPlugin("external-cloud", "global", {
+      id: "external-cloud",
+      authEvidence: [
         {
-          id: "external-cloud",
-          origin: "global",
-          setup: {
-            providers: [
-              {
-                id: "external-cloud",
-                authEvidence: [
-                  {
-                    type: "local-file-with-env",
-                    fileEnvVar: "EXTERNAL_CLOUD_CREDENTIALS",
-                    requiresAllEnv: ["EXTERNAL_CLOUD_PROJECT"],
-                    credentialMarker: "external-cloud-local-credentials",
-                    source: "external cloud credentials",
-                  },
-                ],
-              },
-            ],
-          },
+          type: "local-file-with-env",
+          fileEnvVar: "EXTERNAL_CLOUD_CREDENTIALS",
+          requiresAllEnv: ["EXTERNAL_CLOUD_PROJECT"],
+          credentialMarker: "external-cloud-local-credentials",
+          source: "external cloud credentials",
         },
       ],
-      diagnostics: [],
     });
 
     expect(resolveProviderAuthLookupMaps().authEvidenceMap["external-cloud"]).toEqual([
@@ -280,38 +288,20 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("reuses the current compatible metadata snapshot for workspace auth evidence", () => {
-    pluginRegistryMocks.getCurrentPluginMetadataSnapshot.mockReturnValue({
-      index: {
-        plugins: [
-          {
-            pluginId: "external-cloud",
-            origin: "global",
-            enabled: true,
-            enabledByDefault: true,
-          },
-        ],
-      },
-      plugins: [
-        {
+    pluginRegistryMocks.getCurrentPluginMetadataSnapshot.mockReturnValue(
+      metadataSnapshot(
+        setupPlugin("external-cloud", "global", {
           id: "external-cloud",
-          origin: "global",
-          setup: {
-            providers: [
-              {
-                id: "external-cloud",
-                authEvidence: [
-                  {
-                    type: "local-file-with-env",
-                    fileEnvVar: "EXTERNAL_CLOUD_CREDENTIALS",
-                    credentialMarker: "external-cloud-local-credentials",
-                  },
-                ],
-              },
-            ],
-          },
-        },
-      ],
-    });
+          authEvidence: [
+            {
+              type: "local-file-with-env",
+              fileEnvVar: "EXTERNAL_CLOUD_CREDENTIALS",
+              credentialMarker: "external-cloud-local-credentials",
+            },
+          ],
+        }),
+      ),
+    );
 
     expect(
       resolveProviderAuthLookupMaps({
@@ -329,27 +319,7 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("does not reuse a load-path current snapshot for default provider env lookups", () => {
-    const staleSnapshot = {
-      index: {
-        plugins: [
-          {
-            pluginId: "load-path-provider",
-            origin: "global",
-            enabled: true,
-            enabledByDefault: true,
-          },
-        ],
-      },
-      plugins: [
-        {
-          id: "load-path-provider",
-          origin: "global",
-          setup: {
-            providers: [{ id: "load-path-provider", envVars: ["LOAD_PATH_PROVIDER_API_KEY"] }],
-          },
-        },
-      ],
-    };
+    const staleSnapshot = metadataSnapshot(LOAD_PATH_PROVIDER_PLUGIN);
     pluginRegistryMocks.getCurrentPluginMetadataSnapshot.mockImplementation(
       (params: { config?: unknown; requireDefaultDiscoveryContext?: boolean }) => {
         if (params.config || params.requireDefaultDiscoveryContext) {
@@ -371,28 +341,15 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("excludes untrusted workspace plugin auth evidence by default", () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
-      plugins: [
+    useRegistrySetupPlugin("workspace-cloud", "workspace", {
+      id: "workspace-cloud",
+      authEvidence: [
         {
-          id: "workspace-cloud",
-          origin: "workspace",
-          setup: {
-            providers: [
-              {
-                id: "workspace-cloud",
-                authEvidence: [
-                  {
-                    type: "local-file-with-env",
-                    fileEnvVar: "WORKSPACE_CLOUD_CREDENTIALS",
-                    credentialMarker: "workspace-cloud-local-credentials",
-                  },
-                ],
-              },
-            ],
-          },
+          type: "local-file-with-env",
+          fileEnvVar: "WORKSPACE_CLOUD_CREDENTIALS",
+          credentialMarker: "workspace-cloud-local-credentials",
         },
       ],
-      diagnostics: [],
     });
 
     expect(
@@ -401,28 +358,15 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("keeps explicitly trusted workspace plugin auth evidence", () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
-      plugins: [
+    useRegistrySetupPlugin("workspace-cloud", "workspace", {
+      id: "workspace-cloud",
+      authEvidence: [
         {
-          id: "workspace-cloud",
-          origin: "workspace",
-          setup: {
-            providers: [
-              {
-                id: "workspace-cloud",
-                authEvidence: [
-                  {
-                    type: "local-file-with-env",
-                    fileEnvVar: "WORKSPACE_CLOUD_CREDENTIALS",
-                    credentialMarker: "workspace-cloud-local-credentials",
-                  },
-                ],
-              },
-            ],
-          },
+          type: "local-file-with-env",
+          fileEnvVar: "WORKSPACE_CLOUD_CREDENTIALS",
+          credentialMarker: "workspace-cloud-local-credentials",
         },
       ],
-      diagnostics: [],
     });
 
     expect(
@@ -443,22 +387,9 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("deduplicates setup provider env vars in declaration order", () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "external-fireworks",
-          origin: "global",
-          setup: {
-            providers: [
-              {
-                id: "fireworks",
-                envVars: ["FIREWORKS_API_KEY", "FIREWORKS_SETUP_KEY", "FIREWORKS_API_KEY"],
-              },
-            ],
-          },
-        },
-      ],
-      diagnostics: [],
+    useInstalledSetupPlugin("external-fireworks", "global", {
+      id: "fireworks",
+      envVars: ["FIREWORKS_API_KEY", "FIREWORKS_SETUP_KEY", "FIREWORKS_API_KEY"],
     });
 
     expect(getProviderEnvVars("fireworks", { config: {} })).toEqual([
@@ -468,17 +399,9 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("keeps default provider env lookups lazy and cached", async () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "external-fireworks",
-          origin: "global",
-          setup: {
-            providers: [{ id: "fireworks", envVars: ["FIREWORKS_ALT_API_KEY"] }],
-          },
-        },
-      ],
-      diagnostics: [],
+    useInstalledSetupPlugin("external-fireworks", "global", {
+      id: "fireworks",
+      envVars: ["FIREWORKS_ALT_API_KEY"],
     });
 
     vi.resetModules();
@@ -496,17 +419,9 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("keeps workspace plugin env vars in default lookups", async () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "workspace-audio",
-          origin: "workspace",
-          setup: {
-            providers: [{ id: "whisperx", envVars: ["WHISPERX_API_KEY"] }],
-          },
-        },
-      ],
-      diagnostics: [],
+    useInstalledSetupPlugin("workspace-audio", "workspace", {
+      id: "whisperx",
+      envVars: ["WHISPERX_API_KEY"],
     });
 
     vi.resetModules();
@@ -517,26 +432,21 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("excludes untrusted workspace plugin env vars when requested", async () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "workspace-audio",
-          origin: "workspace",
-          setup: {
-            providers: [
-              {
-                id: "whisperx",
-                envVars: ["AWS_SECRET_ACCESS_KEY"],
-              },
-              {
-                id: "workspace-setup",
-                envVars: ["WORKSPACE_SETUP_SECRET"],
-              },
-            ],
+    useInstalledPlugins({
+      id: "workspace-audio",
+      origin: "workspace",
+      setup: {
+        providers: [
+          {
+            id: "whisperx",
+            envVars: ["AWS_SECRET_ACCESS_KEY"],
           },
-        },
-      ],
-      diagnostics: [],
+          {
+            id: "workspace-setup",
+            envVars: ["WORKSPACE_SETUP_SECRET"],
+          },
+        ],
+      },
     });
 
     const mod = await import("./provider-env-vars.js");
@@ -568,17 +478,9 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("keeps explicitly trusted workspace plugin env vars when requested", async () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "workspace-audio",
-          origin: "workspace",
-          setup: {
-            providers: [{ id: "whisperx", envVars: ["WHISPERX_API_KEY"] }],
-          },
-        },
-      ],
-      diagnostics: [],
+    useInstalledSetupPlugin("workspace-audio", "workspace", {
+      id: "whisperx",
+      envVars: ["WHISPERX_API_KEY"],
     });
 
     const mod = await import("./provider-env-vars.js");
@@ -596,17 +498,9 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("does not trust arbitrary workspace plugin ids from the context engine slot", async () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "workspace-audio",
-          origin: "workspace",
-          setup: {
-            providers: [{ id: "whisperx", envVars: ["AWS_SECRET_ACCESS_KEY"] }],
-          },
-        },
-      ],
-      diagnostics: [],
+    useInstalledSetupPlugin("workspace-audio", "workspace", {
+      id: "whisperx",
+      envVars: ["AWS_SECRET_ACCESS_KEY"],
     });
 
     const mod = await import("./provider-env-vars.js");
@@ -626,19 +520,12 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("keeps selected workspace context engine env vars when requested", async () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "workspace-engine",
-          origin: "workspace",
-          kind: "context-engine",
-          setup: {
-            providers: [{ id: "whisperx", envVars: ["WHISPERX_API_KEY"] }],
-          },
-        },
-      ],
-      diagnostics: [],
-    });
+    useInstalledSetupPlugin(
+      "workspace-engine",
+      "workspace",
+      { id: "whisperx", envVars: ["WHISPERX_API_KEY"] },
+      { kind: "context-engine" },
+    );
 
     const mod = await import("./provider-env-vars.js");
 
@@ -657,21 +544,12 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("only loads plugin metadata snapshot once when resolving env var candidates, avoiding duplicate snapshot loads", () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "external-fireworks",
-          origin: "global",
-          setup: {
-            providers: [{ id: "fireworks", envVars: ["FIREWORKS_ALT_API_KEY"] }],
-          },
-          providerAuthAliases: {
-            "fireworks-plan": "fireworks",
-          },
-        },
-      ],
-      diagnostics: [],
-    });
+    useInstalledSetupPlugin(
+      "external-fireworks",
+      "global",
+      { id: "fireworks", envVars: ["FIREWORKS_ALT_API_KEY"] },
+      { providerAuthAliases: { "fireworks-plan": "fireworks" } },
+    );
 
     pluginRegistryMocks.loadPluginMetadataSnapshot.mockClear();
 
@@ -682,41 +560,38 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("resolves alias, env, and evidence lookup maps from one metadata snapshot", () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "external-fireworks",
-          origin: "global",
-          providerAuthAliases: {
-            "fireworks-plan": "fireworks",
-          },
-          setup: {
-            providers: [
-              {
-                id: "fireworks",
-                envVars: ["FIREWORKS_ALT_API_KEY"],
-                authEvidence: [
-                  {
-                    type: "local-file-with-env",
-                    fileEnvVar: "FIREWORKS_CREDENTIALS",
-                    credentialMarker: "fireworks-local-credentials",
-                  },
-                ],
-              },
-            ],
-          },
+    useInstalledPlugins(
+      {
+        id: "external-fireworks",
+        origin: "global",
+        providerAuthAliases: {
+          "fireworks-plan": "fireworks",
         },
-        {
-          id: "legacy-setup-owner",
-          origin: "global",
-          providers: ["legacy-cloud"],
-          providerAuthAliases: {
-            "legacy-cloud-plan": "legacy-cloud",
-          },
+        setup: {
+          providers: [
+            {
+              id: "fireworks",
+              envVars: ["FIREWORKS_ALT_API_KEY"],
+              authEvidence: [
+                {
+                  type: "local-file-with-env",
+                  fileEnvVar: "FIREWORKS_CREDENTIALS",
+                  credentialMarker: "fireworks-local-credentials",
+                },
+              ],
+            },
+          ],
         },
-      ],
-      diagnostics: [],
-    });
+      },
+      {
+        id: "legacy-setup-owner",
+        origin: "global",
+        providers: ["legacy-cloud"],
+        providerAuthAliases: {
+          "legacy-cloud-plan": "legacy-cloud",
+        },
+      },
+    );
 
     const lookupMaps = resolveProviderAuthLookupMaps({ config: {} });
 
@@ -739,19 +614,14 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("excludes disabled plugin setup fallback refs from runtime auth lookup maps", () => {
-    pluginRegistryMocks.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
-      plugins: [
-        {
-          id: "disabled-setup-owner",
-          origin: "global",
-          enabled: false,
-          providers: ["disabled-cloud"],
-          providerAuthAliases: {
-            "disabled-cloud-plan": "disabled-cloud",
-          },
-        },
-      ],
-      diagnostics: [],
+    useInstalledPlugins({
+      id: "disabled-setup-owner",
+      origin: "global",
+      enabled: false,
+      providers: ["disabled-cloud"],
+      providerAuthAliases: {
+        "disabled-cloud-plan": "disabled-cloud",
+      },
     });
 
     const lookupMaps = resolveProviderAuthLookupMaps({ config: {} });
@@ -761,27 +631,7 @@ describe("provider env vars dynamic manifest metadata", () => {
   });
 
   it("does not reuse a load-path current snapshot for default provider env lookups without parameters", () => {
-    const staleSnapshot = {
-      index: {
-        plugins: [
-          {
-            pluginId: "load-path-provider",
-            origin: "global",
-            enabled: true,
-            enabledByDefault: true,
-          },
-        ],
-      },
-      plugins: [
-        {
-          id: "load-path-provider",
-          origin: "global",
-          setup: {
-            providers: [{ id: "load-path-provider", envVars: ["LOAD_PATH_PROVIDER_API_KEY"] }],
-          },
-        },
-      ],
-    };
+    const staleSnapshot = metadataSnapshot(LOAD_PATH_PROVIDER_PLUGIN);
     pluginRegistryMocks.getCurrentPluginMetadataSnapshot.mockImplementation(
       (params: { config?: unknown; requireDefaultDiscoveryContext?: boolean }) => {
         if (params.config || params.requireDefaultDiscoveryContext) {

--- a/src/secrets/runtime-config-collectors-plugins.test.ts
+++ b/src/secrets/runtime-config-collectors-plugins.test.ts
@@ -3,11 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { PluginOrigin } from "../plugins/types.js";
 import { collectPluginConfigAssignments } from "./runtime-config-collectors-plugins.js";
-import {
-  createResolverContext,
-  type ResolverContext,
-  type SecretDefaults,
-} from "./runtime-shared.js";
+import { createResolverContext, type ResolverContext } from "./runtime-shared.js";
 
 const { loadPluginManifestRegistryForPluginRegistryMock } = vi.hoisted(() => ({
   loadPluginManifestRegistryForPluginRegistryMock: vi.fn(),
@@ -54,36 +50,52 @@ function requireAssignment(context: ResolverContext, index: number): RuntimeConf
   return assignment;
 }
 
-function createAcpxMcpSecretConfig(params: {
-  plugins?: Record<string, unknown>;
-  entry?: Record<string, unknown>;
-}): OpenClawConfig {
+function createPluginConfig(
+  pluginId: string,
+  config: Record<string, unknown>,
+  entry: Record<string, unknown> = { enabled: true },
+  plugins: Record<string, unknown> = {},
+): OpenClawConfig {
   return asConfig({
     plugins: {
-      ...params.plugins,
-      entries: {
-        acpx: {
-          ...params.entry,
-          config: {
-            mcpServers: {
-              s1: { command: "node", env: { K: envRef("K") } },
-            },
-          },
-        },
-      },
+      ...plugins,
+      entries: { [pluginId]: { ...entry, config } },
     },
   });
 }
 
-function collectAcpxConfigAssignments(config: OpenClawConfig): ResolverContext {
+function createAcpxMcpSecretConfig(params: {
+  plugins?: Record<string, unknown>;
+  entry?: Record<string, unknown>;
+}): OpenClawConfig {
+  return createPluginConfig(
+    "acpx",
+    {
+      mcpServers: {
+        s1: { command: "node", env: { K: envRef("K") } },
+      },
+    },
+    params.entry ?? {},
+    params.plugins,
+  );
+}
+
+function collectAssignments(
+  config: OpenClawConfig,
+  origins: Array<[string, PluginOrigin]>,
+): ResolverContext {
   const context = makeContext(config);
   collectPluginConfigAssignments({
     config,
     defaults: undefined,
     context,
-    loadablePluginOrigins: loadablePluginOrigins([["acpx", "bundled"]]),
+    loadablePluginOrigins: loadablePluginOrigins(origins),
   });
   return context;
+}
+
+function collectAcpxConfigAssignments(config: OpenClawConfig): ResolverContext {
+  return collectAssignments(config, [["acpx", "bundled"]]);
 }
 
 function expectInactiveAcpxConfig(config: OpenClawConfig): void {
@@ -123,36 +135,19 @@ describe("collectPluginConfigAssignments", () => {
   });
 
   it("collects SecretRef assignments from active acpx MCP server env vars", () => {
-    const config = asConfig({
-      plugins: {
-        entries: {
-          acpx: {
-            enabled: true,
-            config: {
-              mcpServers: {
-                github: {
-                  command: "npx",
-                  args: ["-y", "@modelcontextprotocol/server-github"],
-                  env: {
-                    GITHUB_TOKEN: envRef("GITHUB_TOKEN"),
-                    PLAIN_VAR: "plain-value",
-                  },
-                },
-              },
-            },
+    const config = createPluginConfig("acpx", {
+      mcpServers: {
+        github: {
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-github"],
+          env: {
+            GITHUB_TOKEN: envRef("GITHUB_TOKEN"),
+            PLAIN_VAR: "plain-value",
           },
         },
       },
     });
-    const context = makeContext(config);
-    const defaults: SecretDefaults = undefined;
-
-    collectPluginConfigAssignments({
-      config,
-      defaults,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([["acpx", "bundled"]]),
-    });
+    const context = collectAcpxConfigAssignments(config);
 
     expect(context.assignments).toHaveLength(1);
     const assignment = requireAssignment(context, 0);
@@ -161,33 +156,17 @@ describe("collectPluginConfigAssignments", () => {
   });
 
   it("resolves assignments via apply callback", () => {
-    const config = asConfig({
-      plugins: {
-        entries: {
-          acpx: {
-            enabled: true,
-            config: {
-              mcpServers: {
-                mcp1: {
-                  command: "node",
-                  env: {
-                    API_KEY: envRef("MY_API_KEY"),
-                  },
-                },
-              },
-            },
+    const config = createPluginConfig("acpx", {
+      mcpServers: {
+        mcp1: {
+          command: "node",
+          env: {
+            API_KEY: envRef("MY_API_KEY"),
           },
         },
       },
     });
-    const context = makeContext(config);
-
-    collectPluginConfigAssignments({
-      config,
-      defaults: undefined,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([["acpx", "bundled"]]),
-    });
+    const context = collectAcpxConfigAssignments(config);
 
     expect(context.assignments).toHaveLength(1);
     requireAssignment(context, 0).apply("resolved-key-value");
@@ -221,29 +200,10 @@ describe("collectPluginConfigAssignments", () => {
       ],
       diagnostics: [],
     });
-    const config = asConfig({
-      plugins: {
-        entries: {
-          "array-plugin": {
-            enabled: true,
-            config: {
-              servers: [
-                { env: { API_KEY: envRef("FIRST") } },
-                { env: { API_KEY: envRef("SECOND") } },
-              ],
-            },
-          },
-        },
-      },
+    const config = createPluginConfig("array-plugin", {
+      servers: [{ env: { API_KEY: envRef("FIRST") } }, { env: { API_KEY: envRef("SECOND") } }],
     });
-    const context = makeContext(config);
-
-    collectPluginConfigAssignments({
-      config,
-      defaults: undefined,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([["array-plugin", "config"]]),
-    });
+    const context = collectAssignments(config, [["array-plugin", "config"]]);
 
     const assignment = context.assignments.find((entry) =>
       entry.path.endsWith("servers[1].env.API_KEY"),
@@ -286,17 +246,10 @@ describe("collectPluginConfigAssignments", () => {
         },
       },
     });
-    const context = makeContext(config);
-
-    collectPluginConfigAssignments({
-      config,
-      defaults: undefined,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([
-        ["acpx", "bundled"],
-        ["other", "config"],
-      ]),
-    });
+    const context = collectAssignments(config, [
+      ["acpx", "bundled"],
+      ["other", "config"],
+    ]);
 
     expect(context.assignments).toHaveLength(3);
     const paths = context.assignments.map((a) => a.path).toSorted();
@@ -317,28 +270,14 @@ describe("collectPluginConfigAssignments", () => {
         },
       },
     });
-    const context = makeContext(config);
-
-    collectPluginConfigAssignments({
-      config,
-      defaults: undefined,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([]),
-    });
+    const context = collectAssignments(config, []);
 
     expect(context.assignments).toHaveLength(0);
   });
 
   it("skips when no plugins.entries at all", () => {
     const config = asConfig({});
-    const context = makeContext(config);
-
-    collectPluginConfigAssignments({
-      config,
-      defaults: undefined,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([]),
-    });
+    const context = collectAssignments(config, []);
 
     expect(context.assignments).toHaveLength(0);
   });
@@ -382,78 +321,39 @@ describe("collectPluginConfigAssignments", () => {
     const config = createAcpxMcpSecretConfig({
       plugins: { allow: ["acpx"] },
     });
-    const context = makeContext(config);
-
-    collectPluginConfigAssignments({
-      config,
-      defaults: undefined,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([["acpx", "config"]]),
-    });
+    const context = collectAssignments(config, [["acpx", "config"]]);
 
     expect(context.assignments).toHaveLength(1);
   });
 
   it("ignores plain string env values", () => {
-    const config = asConfig({
-      plugins: {
-        entries: {
-          acpx: {
-            enabled: true,
-            config: {
-              mcpServers: {
-                s1: {
-                  command: "node",
-                  env: { PLAIN: "hello", ALSO_PLAIN: "world" },
-                },
-              },
-            },
-          },
+    const config = createPluginConfig("acpx", {
+      mcpServers: {
+        s1: {
+          command: "node",
+          env: { PLAIN: "hello", ALSO_PLAIN: "world" },
         },
       },
     });
-    const context = makeContext(config);
-
-    collectPluginConfigAssignments({
-      config,
-      defaults: undefined,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([["acpx", "bundled"]]),
-    });
+    const context = collectAcpxConfigAssignments(config);
 
     expect(context.assignments).toHaveLength(0);
   });
 
   it("collects inline env-template refs while leaving normal strings literal", () => {
-    const config = asConfig({
-      plugins: {
-        entries: {
-          acpx: {
-            enabled: true,
-            config: {
-              mcpServers: {
-                s1: {
-                  command: "node",
-                  env: {
-                    INLINE: "${INLINE_KEY}",
-                    SECOND: "${SECOND_KEY}",
-                    LITERAL: "hello",
-                  },
-                },
-              },
-            },
+    const config = createPluginConfig("acpx", {
+      mcpServers: {
+        s1: {
+          command: "node",
+          env: {
+            INLINE: "${INLINE_KEY}",
+            SECOND: "${SECOND_KEY}",
+            LITERAL: "hello",
           },
         },
       },
     });
-    const context = makeContext(config);
-
-    collectPluginConfigAssignments({
-      config,
-      defaults: undefined,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([["acpx", "bundled"]]),
-    });
+    const context = collectAcpxConfigAssignments(config);
 
     expect(context.assignments).toHaveLength(2);
     expect(requireAssignment(context, 0).path).toBe(
@@ -465,28 +365,12 @@ describe("collectPluginConfigAssignments", () => {
   });
 
   it("skips stale acpx entries not in loadablePluginOrigins", () => {
-    const config = asConfig({
-      plugins: {
-        entries: {
-          acpx: {
-            enabled: true,
-            config: {
-              mcpServers: {
-                s1: { command: "node", env: { K1: envRef("K1") } },
-              },
-            },
-          },
-        },
+    const config = createPluginConfig("acpx", {
+      mcpServers: {
+        s1: { command: "node", env: { K1: envRef("K1") } },
       },
     });
-    const context = makeContext(config);
-
-    collectPluginConfigAssignments({
-      config,
-      defaults: undefined,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([]),
-    });
+    const context = collectAssignments(config, []);
 
     expect(context.assignments).toHaveLength(0);
     expect(
@@ -499,28 +383,12 @@ describe("collectPluginConfigAssignments", () => {
   });
 
   it("ignores non-acpx plugin mcpServers surfaces", () => {
-    const config = asConfig({
-      plugins: {
-        entries: {
-          other: {
-            enabled: true,
-            config: {
-              mcpServers: {
-                s1: { command: "node", env: { K1: envRef("K1") } },
-              },
-            },
-          },
-        },
+    const config = createPluginConfig("other", {
+      mcpServers: {
+        s1: { command: "node", env: { K1: envRef("K1") } },
       },
     });
-    const context = makeContext(config);
-
-    collectPluginConfigAssignments({
-      config,
-      defaults: undefined,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([["other", "config"]]),
-    });
+    const context = collectAssignments(config, [["other", "config"]]);
 
     expect(context.assignments).toHaveLength(0);
   });
@@ -542,31 +410,15 @@ describe("collectPluginConfigAssignments", () => {
       ],
       diagnostics: [],
     });
-    const config = asConfig({
-      plugins: {
-        entries: {
-          other: {
-            enabled: true,
-            config: {
-              service: {
-                tokens: {
-                  primary: envRef("PRIMARY_TOKEN"),
-                  secondary: "${SECONDARY_TOKEN}",
-                },
-              },
-            },
-          },
+    const config = createPluginConfig("other", {
+      service: {
+        tokens: {
+          primary: envRef("PRIMARY_TOKEN"),
+          secondary: "${SECONDARY_TOKEN}",
         },
       },
     });
-    const context = makeContext(config);
-
-    collectPluginConfigAssignments({
-      config,
-      defaults: undefined,
-      context,
-      loadablePluginOrigins: loadablePluginOrigins([["other", "config"]]),
-    });
+    const context = collectAssignments(config, [["other", "config"]]);
 
     expect(context.assignments.map((assignment) => assignment.path).toSorted()).toEqual([
       "plugins.entries.other.config.service.tokens.primary",

--- a/src/secrets/runtime-degradation-attribution.test.ts
+++ b/src/secrets/runtime-degradation-attribution.test.ts
@@ -18,6 +18,77 @@ const EMPTY_LOADABLE_PLUGIN_ORIGINS = new Map();
 const { prepareSecretsRuntimeSnapshot } = setupSecretsRuntimeSnapshotTestHooks();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+type RuntimeConfig = ReturnType<typeof asConfig>;
+type RuntimeSnapshot = Awaited<ReturnType<typeof prepareSecretsRuntimeSnapshot>>;
+type PrepareOverrides = Omit<
+  Parameters<typeof prepareSecretsRuntimeSnapshot>[0],
+  "config" | "includeAuthStoreRefs" | "loadablePluginOrigins"
+>;
+
+function prepare(config: RuntimeConfig, overrides: PrepareOverrides = {}) {
+  return prepareSecretsRuntimeSnapshot({
+    config,
+    ...overrides,
+    includeAuthStoreRefs: false,
+    loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
+  });
+}
+
+async function captureFailure(config: RuntimeConfig, overrides: PrepareOverrides = {}) {
+  return await prepare(config, overrides).catch((failure: unknown) => failure);
+}
+
+function activate(snapshot: RuntimeSnapshot): void {
+  activateSecretsRuntimeSnapshotState({
+    snapshot,
+    refreshContext: null,
+    refreshHandler: null,
+  });
+}
+
+function attachAuthOwner(params: {
+  snapshot: RuntimeSnapshot;
+  agentDir: string;
+  profileId: string;
+  ref: SecretRef;
+  refKey: string;
+  sourceConfig?: RuntimeConfig;
+  contractDigest?: string;
+  append?: boolean;
+}): string {
+  const ownerId = resolveAuthProfileSecretOwnerId(params);
+  if (params.sourceConfig) {
+    params.snapshot.sourceConfig = params.sourceConfig;
+    params.snapshot.config = params.sourceConfig;
+  }
+  params.snapshot.authStores = [
+    {
+      agentDir: params.agentDir,
+      store: {
+        version: 1,
+        profiles: {
+          [params.profileId]: {
+            type: "api_key",
+            provider: "openai",
+            key: "dummy",
+            keyRef: params.ref,
+          },
+        },
+      },
+    },
+  ];
+  const owner = {
+    ownerKind: "account" as const,
+    ownerId,
+    refKeys: [params.refKey],
+    ...(params.contractDigest ? { contractDigest: params.contractDigest } : {}),
+  };
+  params.snapshot.secretOwners = params.append
+    ? [...(params.snapshot.secretOwners ?? []), owner]
+    : [owner];
+  return ownerId;
+}
+
 const TTS_REF = {
   source: "env",
   provider: "default",
@@ -26,8 +97,8 @@ const TTS_REF = {
 
 describe("secrets runtime degraded-owner attribution", () => {
   it("fails closed for missing TTS SecretRefs outside cold-start isolation", async () => {
-    const error = await prepareSecretsRuntimeSnapshot({
-      config: asConfig({
+    const error = await captureFailure(
+      asConfig({
         models: {
           providers: {
             example: {
@@ -43,12 +114,7 @@ describe("secrets runtime degraded-owner attribution", () => {
           },
         },
       }),
-      env: { CURRENT_PROVIDER_REF: "resolved" },
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    }).then(
-      () => undefined,
-      (failure: unknown) => failure,
+      { env: { CURRENT_PROVIDER_REF: "resolved" } },
     );
 
     expect(error).toBeInstanceOf(Error);
@@ -74,24 +140,12 @@ describe("secrets runtime degraded-owner attribution", () => {
     const config = (ref: SecretRef) =>
       asConfig({ tts: { providers: { elevenlabs: { apiKey: ref } } } });
     const ref = (id: string): SecretRef => ({ source: "env", provider: "default", id });
-    const active = await prepareSecretsRuntimeSnapshot({
-      config: config(ref("CURRENT_REF")),
+    const active = await prepare(config(ref("CURRENT_REF")), {
       env: { CURRENT_REF: "resolved" },
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
     });
-    activateSecretsRuntimeSnapshotState({
-      snapshot: active,
-      refreshContext: null,
-      refreshHandler: null,
-    });
+    activate(active);
 
-    const error = await prepareSecretsRuntimeSnapshot({
-      config: config(ref(candidateId)),
-      env: {},
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    }).catch((failure: unknown) => failure);
+    const error = await captureFailure(config(ref(candidateId)), { env: {} });
 
     expect(listSecretResolutionErrorOwners(error)).toEqual([
       expect.objectContaining({
@@ -133,24 +187,12 @@ describe("secrets runtime degraded-owner attribution", () => {
           },
         },
       });
-    const active = await prepareSecretsRuntimeSnapshot({
-      config: config("WEB_TOOL_REF"),
+    const active = await prepare(config("WEB_TOOL_REF"), {
       env: { WEB_TOOL_REF: "resolved" },
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
     });
-    activateSecretsRuntimeSnapshotState({
-      snapshot: active,
-      refreshContext: null,
-      refreshHandler: null,
-    });
+    activate(active);
 
-    const error = await prepareSecretsRuntimeSnapshot({
-      config: config(candidateId),
-      env: {},
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    }).catch((failure: unknown) => failure);
+    const error = await captureFailure(config(candidateId), { env: {} });
 
     const owners = listSecretResolutionErrorOwners(error);
     expect(owners).toEqual(
@@ -184,8 +226,8 @@ describe("secrets runtime degraded-owner attribution", () => {
     await fs.writeFile(healthyPath, JSON.stringify({ shared: "healthy" }), "utf8");
     await fs.chmod(healthyPath, 0o600);
     const sharedId = "/shared";
-    const error = await prepareSecretsRuntimeSnapshot({
-      config: asConfig({
+    const error = await captureFailure(
+      asConfig({
         secrets: {
           providers: {
             missing: {
@@ -213,9 +255,7 @@ describe("secrets runtime degraded-owner attribution", () => {
           },
         },
       }),
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    }).catch((failure: unknown) => failure);
+    );
 
     expect(error).toBeInstanceOf(Error);
     expect(listSecretResolutionErrorOwners(error)).toEqual([
@@ -253,68 +293,35 @@ describe("secrets runtime degraded-owner attribution", () => {
     });
     const agentDir = path.join(root, "agent");
     const profileId = "openai:provider-failure";
-    const accountOwnerId = resolveAuthProfileSecretOwnerId({
+    const active = await prepare(asConfig({}));
+    const accountOwnerId = attachAuthOwner({
+      snapshot: active,
       agentDir,
       profileId,
-    });
-    const active = await prepareSecretsRuntimeSnapshot({
-      config: asConfig({}),
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    });
-    active.sourceConfig = config;
-    active.config = config;
-    active.authStores = [
-      {
-        agentDir,
-        store: {
-          version: 1,
-          profiles: {
-            [profileId]: {
-              type: "api_key",
-              provider: "openai",
-              key: "dummy",
-              keyRef: activeRef,
-            },
-          },
-        },
-      },
-    ];
-    active.secretOwners = [
-      {
-        ownerKind: "account",
-        ownerId: accountOwnerId,
-        refKeys: ["file:missing:/active"],
-        contractDigest: combineSecretOwnerContractDigests([
-          digestSecretOwnerContract(
-            canonicalizeSecretRefsForOwnerContract(
-              {
-                profile: {
-                  type: "api_key",
-                  provider: "openai",
-                  key: "dummy",
-                  keyRef: activeRef,
-                },
-                providerId: "openai",
-                configuredProvider: undefined,
+      ref: activeRef,
+      refKey: "file:missing:/active",
+      sourceConfig: config,
+      contractDigest: combineSecretOwnerContractDigests([
+        digestSecretOwnerContract(
+          canonicalizeSecretRefsForOwnerContract(
+            {
+              profile: {
+                type: "api_key",
+                provider: "openai",
+                key: "dummy",
+                keyRef: activeRef,
               },
-              undefined,
-            ),
+              providerId: "openai",
+              configuredProvider: undefined,
+            },
+            undefined,
           ),
-        ]),
-      },
-    ];
-    activateSecretsRuntimeSnapshotState({
-      snapshot: active,
-      refreshContext: null,
-      refreshHandler: null,
+        ),
+      ]),
     });
+    activate(active);
 
-    const error = await prepareSecretsRuntimeSnapshot({
-      config,
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    }).catch((failure: unknown) => failure);
+    const error = await captureFailure(config);
 
     expect(listSecretResolutionErrorOwners(error)).toEqual(
       expect.arrayContaining([
@@ -334,10 +341,6 @@ describe("secrets runtime degraded-owner attribution", () => {
     const sharedRef = { source: "env" as const, provider: "default", id: "SHARED_API_KEY" };
     const authAgentDir = "/tmp/shared-secret-co-owner";
     const authProfileId = "openai:shared";
-    const authOwnerId = resolveAuthProfileSecretOwnerId({
-      agentDir: authAgentDir,
-      profileId: authProfileId,
-    });
     const config = asConfig({
       models: {
         providers: {
@@ -355,45 +358,18 @@ describe("secrets runtime degraded-owner attribution", () => {
         },
       },
     });
-    const active = await prepareSecretsRuntimeSnapshot({
-      config,
-      env: { SHARED_API_KEY: "dummy" },
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    });
-    active.authStores = [
-      {
-        agentDir: authAgentDir,
-        store: {
-          version: 1,
-          profiles: {
-            [authProfileId]: {
-              type: "api_key",
-              provider: "openai",
-              key: "dummy",
-              keyRef: sharedRef,
-            },
-          },
-        },
-      },
-    ];
-    active.secretOwners?.push({
-      ownerKind: "account",
-      ownerId: authOwnerId,
-      refKeys: ["env:default:SHARED_API_KEY"],
-    });
-    activateSecretsRuntimeSnapshotState({
+    const active = await prepare(config, { env: { SHARED_API_KEY: "dummy" } });
+    const authOwnerId = attachAuthOwner({
       snapshot: active,
-      refreshContext: null,
-      refreshHandler: null,
+      agentDir: authAgentDir,
+      profileId: authProfileId,
+      ref: sharedRef,
+      refKey: "env:default:SHARED_API_KEY",
+      append: true,
     });
+    activate(active);
 
-    const error = await prepareSecretsRuntimeSnapshot({
-      config,
-      env: {},
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    }).catch((failure: unknown) => failure);
+    const error = await captureFailure(config, { env: {} });
 
     expect(listSecretResolutionErrorOwners(error)).toEqual(
       expect.arrayContaining([
@@ -445,23 +421,11 @@ describe("secrets runtime degraded-owner attribution", () => {
         },
       },
     });
-    const active = await prepareSecretsRuntimeSnapshot({
-      config,
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    });
-    activateSecretsRuntimeSnapshotState({
-      snapshot: active,
-      refreshContext: null,
-      refreshHandler: null,
-    });
+    const active = await prepare(config);
+    activate(active);
     await fs.writeFile(secretsPath, JSON.stringify({ shared: { invalid: true } }), "utf8");
 
-    const error = await prepareSecretsRuntimeSnapshot({
-      config,
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    }).catch((failure: unknown) => failure);
+    const error = await captureFailure(config);
 
     expect(listSecretResolutionErrorOwners(error)).toEqual(
       expect.arrayContaining([
@@ -506,23 +470,11 @@ describe("secrets runtime degraded-owner attribution", () => {
         },
       },
     });
-    const active = await prepareSecretsRuntimeSnapshot({
-      config,
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    });
-    activateSecretsRuntimeSnapshotState({
-      snapshot: active,
-      refreshContext: null,
-      refreshHandler: null,
-    });
+    const active = await prepare(config);
+    activate(active);
     await fs.writeFile(secretsPath, JSON.stringify({ shared: { invalid: true } }), "utf8");
 
-    const error = await prepareSecretsRuntimeSnapshot({
-      config,
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    }).catch((failure: unknown) => failure);
+    const error = await captureFailure(config);
 
     expect(listSecretResolutionErrorOwners(error)).toEqual(
       expect.arrayContaining([
@@ -585,53 +537,21 @@ describe("secrets runtime degraded-owner attribution", () => {
     });
     const authAgentDir = "/tmp/invalid-value-auth-co-owner";
     const authProfileId = "openai:invalid-value";
-    const authOwnerId = resolveAuthProfileSecretOwnerId({
+    const active = await prepare(asConfig({}));
+    const authOwnerId = attachAuthOwner({
+      snapshot: active,
       agentDir: authAgentDir,
       profileId: authProfileId,
+      ref,
+      refKey: "file:ttsfile:/providers/elevenlabs/apiKey",
+      sourceConfig: config,
     });
-    const active = await prepareSecretsRuntimeSnapshot({
-      config: asConfig({}),
-      includeAuthStoreRefs: false,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    });
-    active.sourceConfig = config;
-    active.config = config;
-    active.authStores = [
-      {
-        agentDir: authAgentDir,
-        store: {
-          version: 1,
-          profiles: {
-            [authProfileId]: {
-              type: "api_key",
-              provider: "openai",
-              key: "dummy",
-              keyRef: ref,
-            },
-          },
-        },
-      },
-    ];
-    active.secretOwners = [
-      {
-        ownerKind: "account",
-        ownerId: authOwnerId,
-        refKeys: ["file:ttsfile:/providers/elevenlabs/apiKey"],
-      },
-    ];
-    activateSecretsRuntimeSnapshotState({
-      snapshot: active,
-      refreshContext: null,
-      refreshHandler: null,
-    });
+    activate(active);
 
-    const error = await prepareSecretsRuntimeSnapshot({
-      config,
+    const error = await captureFailure(config, {
       env: {},
-      includeAuthStoreRefs: false,
       allowUnavailableSecretOwners: true,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    }).catch((failure: unknown) => failure);
+    });
 
     expect(error).toBeInstanceOf(Error);
     expect(String(error)).toContain(
@@ -667,8 +587,8 @@ describe("secrets runtime degraded-owner attribution", () => {
     await fs.writeFile(secretsPath, JSON.stringify({ shared: { invalid: true } }), "utf8");
     await fs.chmod(secretsPath, 0o600);
     const sharedRef = { source: "file" as const, provider: "shared", id: "/shared" };
-    const error = await prepareSecretsRuntimeSnapshot({
-      config: asConfig({
+    const error = await captureFailure(
+      asConfig({
         secrets: {
           providers: {
             shared: { source: "file", path: secretsPath, mode: "json" },
@@ -692,11 +612,11 @@ describe("secrets runtime degraded-owner attribution", () => {
           },
         },
       }),
-      env: { HEALTHY_SKILL_KEY: "healthy-skill-key" },
-      includeAuthStoreRefs: false,
-      allowUnavailableSecretOwners: true,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    }).catch((failure: unknown) => failure);
+      {
+        env: { HEALTHY_SKILL_KEY: "healthy-skill-key" },
+        allowUnavailableSecretOwners: true,
+      },
+    );
 
     expect(error).toBeInstanceOf(Error);
     const owners = listSecretResolutionErrorOwners(error);
@@ -721,8 +641,8 @@ describe("secrets runtime degraded-owner attribution", () => {
   });
 
   it("still fails required gateway auth SecretRefs when env is missing", async () => {
-    const error = await prepareSecretsRuntimeSnapshot({
-      config: asConfig({
+    const error = await captureFailure(
+      asConfig({
         gateway: {
           auth: {
             mode: "token",
@@ -730,11 +650,8 @@ describe("secrets runtime degraded-owner attribution", () => {
           },
         },
       }),
-      env: {},
-      includeAuthStoreRefs: false,
-      allowUnavailableSecretOwners: true,
-      loadablePluginOrigins: EMPTY_LOADABLE_PLUGIN_ORIGINS,
-    }).catch((failure: unknown) => failure);
+      { env: {}, allowUnavailableSecretOwners: true },
+    );
 
     expect(String(error)).toContain(
       'Environment variable "GATEWAY_TOKEN_REF" is missing or empty.',


### PR DESCRIPTION
## Summary

- centralize repeated provider metadata and plugin SecretRef fixtures
- centralize repeated degradation preparation, owner, and failure-capture setup
- preserve every test title, dynamic case table, ordered matcher input, env restore, plugin isolation, attribution fallback, and credential-privacy assertion

## Architecture / safety

The repetition lived entirely in test setup. Production ownership remains unchanged in `src/secrets/provider-env-vars.ts`, `src/secrets/runtime-config-collectors-plugins.ts`, `src/secrets/runtime-owner-assignments.ts`, `src/secrets/runtime-degraded-state.ts`, and `src/secrets/runtime-state.ts`.

The canonical fix is typed, test-local fixture builders. No production abstraction, config/default/schema surface, compatibility path, provider behavior, or runtime state changed. Connected repeated registry/snapshot, collector invocation, preparation, activation, auth-owner, and failure-capture literals were removed.

Production LOC delta: **0**  
Test/total delta: **+447/-828, net -381 LOC**

## Parity

- 49 static test declarations / 52 expanded runtime cases preserved
- all titles and both dynamic case matrices preserved
- all 93 ordered `expect(...)` inputs and matcher chains preserved
- frozen diff SHA-256: `2bd07d7f38c4009466715b288d061ff4da85e0f614308cbe0c74612c211e6a57`
- `git diff --check`: clean

## Proof

- focused local: 3 files, **52/52 passed**
- Blacksmith Testbox focused: 3 files, **52/52 passed**
- Blacksmith Testbox broad: **5 shards passed**, including `src/secrets` (**69 files, 713 tests**) plus sandbox env sanitization and provider/auth/plugin-trust selections
- Blacksmith Testbox changed gate: `pnpm check:changed` passed (format, Knip, core-test tsgo, changed-file lint, plugin boundaries, dependency guards)
- Testbox execution: https://github.com/openclaw/openclaw/actions/runs/30763444162 (commands exited 0 before the owned lease was stopped; stopping the lease cancelled the remaining orchestration shell)
- live collision delta: no exact-path overlap among all **109 open PRs updated since reservation**, including paginated >100-file PRs

## Codex dependency contract

Personally inspected sibling Codex at `ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff`:

- auth modes: `../codex/codex-rs/protocol/src/auth.rs:6-55`
- provider env-backed auth and missing/blank `env_key` rejection: `../codex/codex-rs/model-provider-info/src/lib.rs:118-302`
- auth normalization and explicit env-key behavior: `../codex/codex-rs/login/src/auth/manager.rs:71-89`, `../codex/codex-rs/login/src/auth/manager.rs:418-525`
- provider bearer and first-party auth boundary: `../codex/codex-rs/model-provider/src/auth.rs:267-278`, `../codex/codex-rs/model-provider/src/provider.rs:155-320`
- session auth/env telemetry boundary: `../codex/codex-rs/core/src/session/session.rs:832-855`
- default secret-shaped env exclusion: `../codex/codex-rs/protocol/src/shell_environment.rs:1-110`
- auth storage/privacy and presence-only telemetry: `../codex/codex-rs/login/src/auth/storage.rs:38-60`, `../codex/codex-rs/login/src/auth_env_telemetry.rs:1-50`

## Independent review

Two direct xhigh security/Codex reviewers independently returned **CLEAN** on the exact frozen diff. They confirmed plugin trust/enablement, mock hoisting, input identity/order, SecretRef collection, env isolation, last-known-good digest rules, fail-closed gateway behavior, degradation attribution, redaction/credential privacy, and best-fix ownership.
