### PR TITLE
refactor: consolidate heartbeat runner test fixtures

### DIFF
--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -68,11 +68,36 @@ function createHeartbeatTelegramConfig(): OpenClawConfig {
   } as unknown as OpenClawConfig;
 }
 
-async function seedHeartbeatTelegramSession(storePath: string, cfg: OpenClawConfig) {
+async function seedHeartbeatTelegramSession(
+  storePath: string,
+  cfg: OpenClawConfig,
+  entry: Partial<Parameters<typeof seedMainSessionStore>[2]> = {},
+) {
   return seedMainSessionStore(storePath, cfg, {
     lastChannel: "telegram",
     lastProvider: "telegram",
     lastTo: "123",
+    ...entry,
+  });
+}
+
+type HeartbeatRunOverrides = Omit<Parameters<typeof runHeartbeatOnce>[0], "cfg" | "deps">;
+
+function runHeartbeat(
+  cfg: OpenClawConfig,
+  replySpy: HeartbeatDeps["getReplyFromConfig"],
+  overrides: HeartbeatRunOverrides = {},
+  deps: Partial<HeartbeatDeps> = {},
+) {
+  return runHeartbeatOnce({
+    cfg,
+    ...overrides,
+    deps: {
+      getQueueSize: vi.fn((_lane?: string) => 0),
+      nowMs: () => Date.now(),
+      getReplyFromConfig: replySpy,
+      ...deps,
+    } as HeartbeatDeps,
   });
 }
 
@@ -97,10 +122,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
         const cfg = createHeartbeatTelegramConfig();
         cfg.session = { store: storePath };
-        await seedMainSessionStore(storePath, cfg, {
-          lastChannel: "telegram",
-          lastProvider: "telegram",
-          lastTo: "123",
+        await seedHeartbeatTelegramSession(storePath, cfg, {
           status: "running",
           abortedLastRun: true,
           mainRestartRecovery: {
@@ -110,15 +132,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
           },
         });
 
-        const result = await runHeartbeatOnce({
-          cfg,
-          intent,
-          deps: {
-            getQueueSize: vi.fn((_lane?: string) => 0),
-            nowMs: () => Date.now(),
-            getReplyFromConfig: replySpy,
-          } as HeartbeatDeps,
-        });
+        const result = await runHeartbeat(cfg, replySpy, { intent });
 
         expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
         expect(replySpy).not.toHaveBeenCalled();
@@ -130,10 +144,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
     await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
       const cfg = createHeartbeatTelegramConfig();
       cfg.session = { store: storePath };
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: "123",
+      await seedHeartbeatTelegramSession(storePath, cfg, {
         status: "running",
         abortedLastRun: false,
         mainRestartRecovery: {
@@ -147,15 +158,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
         },
       });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        intent: "immediate",
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy, { intent: "immediate" });
 
       expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
       expect(replySpy).not.toHaveBeenCalled();
@@ -171,10 +174,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
         const cfg = createHeartbeatTelegramConfig();
         cfg.session = { store: storePath };
-        await seedMainSessionStore(storePath, cfg, {
-          lastChannel: "telegram",
-          lastProvider: "telegram",
-          lastTo: "123",
+        await seedHeartbeatTelegramSession(storePath, cfg, {
           status: "running",
           abortedLastRun: false,
           restartRecoveryDeliveryRunId: "restart-recovery-run",
@@ -186,15 +186,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
           ],
         });
 
-        const result = await runHeartbeatOnce({
-          cfg,
-          intent,
-          deps: {
-            getQueueSize: vi.fn((_lane?: string) => 0),
-            nowMs: () => Date.now(),
-            getReplyFromConfig: replySpy,
-          } as HeartbeatDeps,
-        });
+        const result = await runHeartbeat(cfg, replySpy, { intent });
 
         expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
         expect(replySpy).not.toHaveBeenCalled();
@@ -206,10 +198,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
     await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
       const cfg = createHeartbeatTelegramConfig();
       cfg.session = { store: storePath };
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: "123",
+      await seedHeartbeatTelegramSession(storePath, cfg, {
         status: "running",
         abortedLastRun: false,
         restartRecoveryDeliveryRunId: "restart-recovery-run",
@@ -222,15 +211,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       });
       replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        intent: "manual",
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy, { intent: "manual" });
 
       expect(result.status).toBe("ran");
       expect(replySpy).toHaveBeenCalledOnce();
@@ -256,10 +237,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
     await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
       const cfg = createHeartbeatTelegramConfig();
       cfg.session = { store: storePath };
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: "123",
+      await seedHeartbeatTelegramSession(storePath, cfg, {
         status: "running",
         abortedLastRun: false,
         restartRecoveryDeliveryRunId: "restart-recovery-run",
@@ -275,15 +253,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       });
       replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        intent: "scheduled",
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy, { intent: "scheduled" });
 
       expect(result.status).toBe("ran");
       expect(replySpy).toHaveBeenCalledOnce();
@@ -296,14 +266,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       await seedHeartbeatTelegramSession(storePath, cfg);
       markCronJobActive("local-model-report");
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy);
 
       expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS });
       expect(replySpy).not.toHaveBeenCalled();
@@ -315,14 +278,14 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       const cfg = createHeartbeatTelegramConfig();
       await seedHeartbeatTelegramSession(storePath, cfg);
 
-      const result = await runHeartbeatOnce({
+      const result = await runHeartbeat(
         cfg,
-        deps: {
+        replySpy,
+        {},
+        {
           getQueueSize: vi.fn((lane?: string) => (lane === CommandLane.Cron ? 1 : 0)),
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+        },
+      );
 
       expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS });
       expect(replySpy).not.toHaveBeenCalled();
@@ -339,15 +302,15 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       cfg.agents!.defaults!.heartbeat = { every: "30m" };
       await seedHeartbeatTelegramSession(storePath, cfg);
 
-      const result = await runHeartbeatOnce({
+      const result = await runHeartbeat(
         cfg,
-        deps: {
+        replySpy,
+        {},
+        {
           getQueueSize: vi.fn((lane?: string) => (lane === CommandLane.Subagent ? 1 : 0)),
           getCommandLaneSnapshots: vi.fn(() => []),
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+        },
+      );
 
       expect(result.status).not.toBe("skipped");
     });
@@ -360,15 +323,14 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       await seedHeartbeatTelegramSession(storePath, cfg);
       const nestedSessionLane = resolveNestedAgentLaneForSession("agent:main:telegram:123");
 
-      const result = await runHeartbeatOnce({
+      const result = await runHeartbeat(
         cfg,
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
+        replySpy,
+        {},
+        {
           getCommandLaneSnapshots: vi.fn(() => [createBusyLaneSnapshot(nestedSessionLane)]),
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+        },
+      );
 
       expect(result.status).toBe("ran");
       expect(replySpy).toHaveBeenCalledTimes(1);
@@ -384,15 +346,14 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       await seedHeartbeatTelegramSession(storePath, cfg);
       const nestedSessionLane = resolveNestedAgentLaneForSession("agent:other:telegram:123");
 
-      const result = await runHeartbeatOnce({
+      const result = await runHeartbeat(
         cfg,
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
+        replySpy,
+        {},
+        {
           getCommandLaneSnapshots: vi.fn(() => [createBusyLaneSnapshot(nestedSessionLane)]),
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+        },
+      );
 
       expect(result.status).not.toBe("skipped");
     });
@@ -418,14 +379,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
         return 0;
       });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: {
-          getQueueSize,
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy, {}, { getQueueSize });
 
       expect(result.status).toBe("skipped");
       if (result.status === "skipped") {
@@ -441,15 +395,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       const sessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
       const isReplyRunActive = vi.fn((key: string) => key === sessionKey);
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
-          isReplyRunActive,
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy, {}, { isReplyRunActive });
 
       expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
       expect(isReplyRunActive).toHaveBeenCalledWith(sessionKey);
@@ -465,15 +411,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
         "agent:main:telegram:group:-1003966283270:topic:547",
       ]);
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
-          listActiveReplyRunSessionKeys,
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy, {}, { listActiveReplyRunSessionKeys });
 
       expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
       expect(listActiveReplyRunSessionKeys).toHaveBeenCalledOnce();
@@ -488,15 +426,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       const listActiveReplyRunSessionKeys = vi.fn(() => ["legacy-session-key"]);
       replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
-          listActiveReplyRunSessionKeys,
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy, {}, { listActiveReplyRunSessionKeys });
 
       expect(result.status).toBe("ran");
       expect(listActiveReplyRunSessionKeys).toHaveBeenCalledOnce();
@@ -513,16 +443,12 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       ]);
       replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
 
-      const result = await runHeartbeatOnce({
+      const result = await runHeartbeat(
         cfg,
-        intent: "immediate",
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
-          listActiveReplyRunSessionKeys,
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+        replySpy,
+        { intent: "immediate" },
+        { listActiveReplyRunSessionKeys },
+      );
 
       expect(result.status).toBe("ran");
       expect(replySpy).toHaveBeenCalledOnce();
@@ -541,14 +467,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       operation.setPhase("running");
 
       try {
-        const result = await runHeartbeatOnce({
-          cfg,
-          deps: {
-            getQueueSize: vi.fn((_lane?: string) => 0),
-            nowMs: () => Date.now(),
-            getReplyFromConfig: replySpy,
-          } as HeartbeatDeps,
-        });
+        const result = await runHeartbeat(cfg, replySpy);
 
         expect(result.status).toBe("skipped");
         if (result.status === "skipped") {
@@ -582,14 +501,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       });
 
       try {
-        const result = await runHeartbeatOnce({
-          cfg,
-          deps: {
-            getQueueSize: vi.fn((_lane?: string) => 0),
-            nowMs: () => Date.now(),
-            getReplyFromConfig: replySpy,
-          } as HeartbeatDeps,
-        });
+        const result = await runHeartbeat(cfg, replySpy);
 
         expect(result.status).toBe("ran");
         expect(replySpy).toHaveBeenCalledOnce();
@@ -613,14 +525,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       operation.setPhase("running");
 
       try {
-        const result = await runHeartbeatOnce({
-          cfg,
-          deps: {
-            getQueueSize: vi.fn((_lane?: string) => 0),
-            nowMs: () => Date.now(),
-            getReplyFromConfig: replySpy,
-          } as HeartbeatDeps,
-        });
+        const result = await runHeartbeat(cfg, replySpy);
 
         expect(result.status).toBe("skipped");
         if (result.status === "skipped") {
@@ -637,8 +542,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
     await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
       const cfg = createHeartbeatTelegramConfig();
       cfg.session = { store: storePath };
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
+      await seedHeartbeatTelegramSession(storePath, cfg, {
         lastProvider: "heartbeat",
         lastTo: "heartbeat",
         updatedAt: Date.now(),
@@ -650,14 +554,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       });
       replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy);
 
       expect(result.status).toBe("ran");
       expect(replySpy).toHaveBeenCalledTimes(1);
@@ -669,8 +566,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       const cfg = createHeartbeatTelegramConfig();
       cfg.session = { store: storePath };
       cfg.agents!.defaults!.heartbeat = { every: "30m" };
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
+      await seedHeartbeatTelegramSession(storePath, cfg, {
         lastProvider: "heartbeat",
         lastTo: "heartbeat",
         updatedAt: Date.now(),
@@ -682,14 +578,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       });
       replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy);
 
       expect(result.status).toBe("ran");
       expect(replySpy).toHaveBeenCalledTimes(1);
@@ -704,9 +593,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
         every: "30m",
         target: "telegram",
       };
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
+      await seedHeartbeatTelegramSession(storePath, cfg, {
         lastTo: "default-heartbeat-target",
         updatedAt: Date.now() - 60_000,
         pendingFinalDelivery: {
@@ -718,15 +605,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "default" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: {
-          getQueueSize: vi.fn((_lane?: string) => 0),
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-          telegram: sendTelegram,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy, {}, { telegram: sendTelegram });
 
       expect(result.status).toBe("ran");
       expect(replySpy).toHaveBeenCalledOnce();
@@ -749,14 +628,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
         text: "HEARTBEAT_OK",
       });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: {
-          getQueueSize,
-          nowMs: () => Date.now(),
-          getReplyFromConfig: replySpy,
-        } as HeartbeatDeps,
-      });
+      const result = await runHeartbeat(cfg, replySpy, {}, { getQueueSize });
 
       expect(replySpy).toHaveBeenCalled();
       expect(result.status).toBe("ran");

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -120,6 +120,32 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     };
   }
 
+  function seedTelegramSession(
+    storePath: string,
+    cfg: OpenClawConfig,
+    entry: Partial<Parameters<typeof seedMainSessionStore>[2]> = {},
+  ) {
+    return seedMainSessionStore(storePath, cfg, {
+      lastChannel: "telegram",
+      lastProvider: "telegram",
+      lastTo: TELEGRAM_GROUP,
+      ...entry,
+    });
+  }
+
+  function runHeartbeat(
+    cfg: OpenClawConfig,
+    replySpy: HeartbeatDeps["getReplyFromConfig"],
+    sendTelegram: ReturnType<typeof vi.fn>,
+    overrides: Omit<Parameters<typeof runHeartbeatOnce>[0], "cfg" | "deps"> = {},
+  ) {
+    return runHeartbeatOnce({
+      cfg,
+      ...overrides,
+      deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+    });
+  }
+
   function expectTelegramSend(
     sendTelegram: ReturnType<typeof vi.fn>,
     params: { text: string; cfg: OpenClawConfig; silent?: boolean },
@@ -177,18 +203,11 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   async function runWithToolResponse(response: HeartbeatToolResponse) {
     return await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       replySpy.mockResolvedValue(createHeartbeatToolResponsePayload(response));
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, sendTelegram);
 
       return { result, sendTelegram, replySpy, cfg };
     });
@@ -210,18 +229,11 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   async function runPlainFallbackReply(text: string, options: { showOk?: boolean } = {}) {
     return await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath, showOk: options.showOk });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       replySpy.mockResolvedValue({ text });
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, sendTelegram);
 
       return { result, sendTelegram, replySpy, cfg };
     });
@@ -242,12 +254,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     return await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath, ...params.config });
       await params.beforeSeed?.({ tmpDir, storePath, cfg });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-        ...params.session,
-      });
+      await seedTelegramSession(storePath, cfg, params.session);
       replySpy.mockResolvedValue(
         createHeartbeatToolResponsePayload({
           outcome: "no_change",
@@ -257,11 +264,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       );
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      await runHeartbeatOnce({
-        cfg,
-        tasks: params.tasks,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      await runHeartbeat(cfg, replySpy, sendTelegram, { tasks: params.tasks });
 
       return {
         calledCtx: replyContext(replySpy),
@@ -299,11 +302,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });
       const jobId = await seedHeartbeatScratchForTest({ content: "old scratch" });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       const reply = createHeartbeatToolResponsePayload({
         outcome: "progress",
         notify: false,
@@ -313,11 +312,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       expect(JSON.stringify(reply)).not.toContain("new private scratch");
       replySpy.mockResolvedValue(reply);
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        source: "manual",
-        deps: createDeps({ sendTelegram: vi.fn(), getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, vi.fn(), { source: "manual" });
 
       expect(result.status).toBe("ran");
       expect(readCronJobScratchState(resolveCronJobsStorePath(), jobId).scratch?.content).toBe(
@@ -336,11 +331,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
         throw new Error("Expected seeded heartbeat monitor");
       }
       deleteCronJobScratch(cronStorePath, monitor.jobId);
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       replySpy.mockImplementation(async () => {
         await saveCronJobsStore(cronStorePath, { version: 1, jobs: [] });
         return createHeartbeatToolResponsePayload({
@@ -351,11 +342,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
         });
       });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        source: "manual",
-        deps: createDeps({ sendTelegram: vi.fn(), getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, vi.fn(), { source: "manual" });
 
       expect(result.status).toBe("ran");
       expect(readCronJobScratchState(cronStorePath, monitor.jobId)).toEqual({
@@ -368,11 +355,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       vi.stubEnv("OPENCLAW_STATE_DIR", tmpDir);
       const cfg = createConfig({ tmpDir, storePath });
-      const sessionKey = await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      const sessionKey = await seedTelegramSession(storePath, cfg);
       replySpy.mockResolvedValue(
         createHeartbeatToolResponsePayload({
           outcome: "progress",
@@ -382,11 +365,9 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
         }),
       );
 
-      await runHeartbeatOnce({
-        cfg,
+      await runHeartbeat(cfg, replySpy, vi.fn(), {
         source: "manual",
         reason: "operator check",
-        deps: createDeps({ sendTelegram: vi.fn(), getReplyFromConfig: replySpy }),
       });
 
       expect(
@@ -425,11 +406,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   it("reports a quiet terminal tool failure without external delivery for target none", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath, target: "none" });
-      const sessionKey = await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      const sessionKey = await seedTelegramSession(storePath, cfg);
       enqueueSystemEvent("exec finished: delivery probe completed", { sessionKey });
       replySpy.mockResolvedValue(
         createTerminalToolFailureReply({
@@ -440,10 +417,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       );
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, sendTelegram);
 
       expect(result).toEqual({ status: "failed", reason: "agent-tool-failure" });
       expect(sendTelegram).not.toHaveBeenCalled();
@@ -460,11 +434,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   it("does not deliver a suppressed quiet terminal failure to an explicit target", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       replySpy.mockResolvedValue(
         createTerminalToolFailureReply({
           outcome: "no_change",
@@ -474,10 +444,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       );
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, sendTelegram);
 
       expect(result).toEqual({ status: "failed", reason: "agent-tool-failure" });
       expect(sendTelegram).not.toHaveBeenCalled();
@@ -493,11 +460,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   it("delivers a terminal tool warning without recording successful delivery bookkeeping", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });
-      const sessionKey = await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      const sessionKey = await seedTelegramSession(storePath, cfg);
       const warning = "⚠️ Message failed";
       replySpy.mockResolvedValue(
         createTerminalToolFailureReply(
@@ -511,10 +474,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       );
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, sendTelegram);
       const sessionStore = readSessionStoreForTest<{
         lastHeartbeatText?: string;
       }>(storePath);
@@ -536,11 +496,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       const cfg = createConfig({ tmpDir, storePath });
       const warning = "⚠️ Message failed";
       const pendingText = `Original exec completion\n\n${warning}`;
-      const sessionKey = await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      const sessionKey = await seedTelegramSession(storePath, cfg);
       replySpy.mockImplementation(async () => {
         await patchSessionEntry(
           { storePath, sessionKey },
@@ -584,11 +540,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });
       const warning = "⚠️ Message failed";
-      const sessionKey = await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      const sessionKey = await seedTelegramSession(storePath, cfg);
       replySpy.mockImplementation(async () => {
         await patchSessionEntry(
           { storePath, sessionKey },
@@ -626,11 +578,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   it("keeps terminal failure status when its warning delivery fails", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       replySpy.mockResolvedValue(
         createTerminalToolFailureReply(
           { outcome: "blocked", notify: true, summary: "Message delivery was denied." },
@@ -656,11 +604,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   it("preserves media when delivering a plain terminal failure reply", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       const mediaUrl = "https://example.test/failure.png";
       replySpy.mockResolvedValue(
         setReplyPayloadMetadata(
@@ -751,21 +695,13 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   ])("keeps a heartbeat's unmarked final private under $name", async (policy) => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath, ...policy });
-      await seedMainSessionStore(storePath, cfg, {
-        chatType: policy.chatType,
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg, { chatType: policy.chatType });
       replySpy.mockResolvedValue({
         text: "Private heartbeat reasoning with HEARTBEAT_OK inside the sentence.",
       });
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, sendTelegram);
 
       expect(result.status).toBe("ran");
       expect(replyOptions(replySpy).sourceReplyDeliveryMode).toBe("message_tool_only");
@@ -781,19 +717,12 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   it("keeps marked operator notices visible in message-tool heartbeat mode", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath, visibleReplies: "message_tool" });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       const notice = "The configured model backend needs operator attention.";
       replySpy.mockResolvedValue(markReplyPayloadForSourceSuppressionDelivery({ text: notice }));
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, sendTelegram);
 
       expect(result.status).toBe("ran");
       expectTelegramSend(sendTelegram, { text: notice, cfg });
@@ -803,19 +732,12 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   it("keeps ordinary heartbeat finals visible under automatic reply policy", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath, visibleReplies: "automatic" });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       const text = "The heartbeat found a deployment requiring your attention.";
       replySpy.mockResolvedValue({ text });
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, sendTelegram);
 
       expect(result.status).toBe("ran");
       expectTelegramSend(sendTelegram, { text, cfg });
@@ -864,12 +786,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   it("delivers Codex runtime failure notices during Codex heartbeat message-tool mode", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-        agentHarnessId: "codex",
-      });
+      await seedTelegramSession(storePath, cfg, { agentHarnessId: "codex" });
       const usageLimitMessage =
         "⚠️ You've reached your Codex subscription usage limit. Next reset in 42 minutes (2026-05-04T21:34:00.000Z). Run /codex account for current usage details.";
       replySpy.mockResolvedValue(
@@ -880,10 +797,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       );
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, sendTelegram);
 
       const calledOpts = replyOptions(replySpy);
       expect(result.status).toBe("ran");
@@ -898,11 +812,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   it("rewrites foreground generic runner failure payloads before heartbeat delivery", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       replySpy.mockResolvedValue(
         markReplyPayloadForSourceSuppressionDelivery({
           text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
@@ -910,10 +820,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       );
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, sendTelegram);
 
       expect(result.status).toBe("ran");
       expectTelegramSend(sendTelegram, {
@@ -933,11 +840,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   it("suppresses internal stream-error fallback placeholders before heartbeat delivery", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       replySpy.mockResolvedValue(
         markReplyPayloadForSourceSuppressionDelivery({
           text: `${STREAM_ERROR_FALLBACK_TEXT}\n${STREAM_ERROR_FALLBACK_TEXT}`,
@@ -945,10 +848,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       );
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      const result = await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      const result = await runHeartbeat(cfg, replySpy, sendTelegram);
 
       expect(result.status).toBe("ran");
       expect(sendTelegram).not.toHaveBeenCalled();
@@ -1020,11 +920,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   it("keeps the legacy heartbeat ok prompt outside heartbeat response tool mode", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath, visibleReplies: "automatic" });
-      await seedMainSessionStore(storePath, cfg, {
-        lastChannel: "telegram",
-        lastProvider: "telegram",
-        lastTo: TELEGRAM_GROUP,
-      });
+      await seedTelegramSession(storePath, cfg);
       replySpy.mockResolvedValue(
         createHeartbeatToolResponsePayload({
           outcome: "no_change",
@@ -1034,10 +930,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       );
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
-      await runHeartbeatOnce({
-        cfg,
-        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
-      });
+      await runHeartbeat(cfg, replySpy, sendTelegram);
 
       const calledCtx = replyContext(replySpy);
       const calledOpts = replyOptions(replySpy);


### PR DESCRIPTION
## What Problem This Solves

Heartbeat runner coverage repeated complete session and dependency fixtures across 55 declarations. That made test-specific queue, recovery, terminal-delivery, and runtime-selection state harder to distinguish and left 235 avoidable lines to maintain.

## Why This Change Was Made

This introduces file-local typed seed/run helpers in the two heartbeat owner tests. Canonical Telegram route and runner dependency defaults live in one place; every case-specific override remains explicit and caller-wins.

This is test-only: production, config/default, timer, schema, protocol, and public API behavior are unchanged. No compatibility path or runtime fallback is added or removed.

## User Impact

No user-visible behavior changes. The existing heartbeat safety coverage is smaller and clearer while continuing to guard busy-session suppression, recorded intentional non-outcomes, marked tool visibility, pending-final delivery, scratch persistence, isolated sessions, cancellation, terminal failures, and Codex runtime routing.

## Evidence

- Delta: `+142/-377`, net `-235` test and total LOC; production LOC `0`.
- Exact surface preserved: 55 static declarations, 60 expanded cases, 118 `expect` calls, identical titles/tables, and no changed `it`/`expect` source lines.
- Local focused proof: 2 files, 60/60 passed.
- Final Blacksmith Testbox: `tbx_01kz1zyajnck116mx1hxrfj7mk`, [Actions run 30763949160](https://github.com/openclaw/openclaw/actions/runs/30763949160), exit 0. All four broad `src/infra`, `src/cron`, `src/config/sessions`, and heartbeat tool-response shards passed; full `check:changed`, core-test typecheck, and changed-file lint passed.
- Two independent `gpt-5.6-sol` xhigh reviews: CLEAN. A reviewer found the initial seed-helper parameter needed `Partial<...>`; that was fixed, then focused and full remote proof were repeated on the final sources.
- `git diff --check`: clean.
- Current `origin/main` has no touched-path drift from this branch base.
- Collision proof: frozen 2,161-open-PR census plus all 33 large-PR tail pages, then 143 updated open PRs across two replacement pages through `2026-08-02T19:55:14.981Z`; oversized #98201 fully paged at 213 files. Exact matches for both paths: zero.

Architectural review followed `runHeartbeatOnce` through queue/recovery/session ownership, delivery normalization, pending-final persistence, scratch CAS ownership, cron callers, and runtime selection. The canonical fix is confined to each test owner; a shared cross-file fixture or heavier table-driving would widen coupling or hide high-risk terminal/recovery cases.

Codex dependency contracts were personally inspected at sibling commit `ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff`, including model/provider thread inputs and resolved outputs (`../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:57`, `:171`, `:325`, `:404`), runtime override/response ownership (`../codex/codex-rs/app-server/src/request_processors/thread_processor.rs:981`, `:1386`), provider auth construction (`../codex/codex-rs/model-provider/src/provider.rs:155`, `:231`), auth modes (`../codex/codex-rs/protocol/src/auth.rs:6`), and typed usage-limit projection (`../codex/codex-rs/protocol/src/error.rs:415`, `:617`).
