### PR TITLE
test(ui): consolidate terminal connection fixtures

### DIFF
--- a/ui/src/components/terminal/terminal-connection.test.ts
+++ b/ui/src/components/terminal/terminal-connection.test.ts
@@ -13,6 +13,30 @@ const TERMINAL_OPEN_WATCHDOG_MS = 35_000;
 // Idle window elapses, then one probe times out: the interval after which a probe resolves failed.
 const IDLE_PLUS_PROBE_MS = TERMINAL_LIVENESS_IDLE_MS + TERMINAL_LIVENESS_PROBE_TIMEOUT_MS;
 
+type TerminalSink = Parameters<TerminalConnection["open"]>[1];
+type TerminalOpenParams = Parameters<TerminalConnection["open"]>[0];
+type TestSessionResult = {
+  sessionId: string;
+  agentId: string;
+  shell: string;
+  cwd: string;
+  confined: boolean;
+  buffer?: string;
+  seq?: number;
+  title?: string;
+};
+
+function sessionResult(overrides: Partial<TestSessionResult> = {}): TestSessionResult {
+  return {
+    sessionId: "s1",
+    agentId: "main",
+    shell: "/bin/zsh",
+    cwd: "/work",
+    confined: false,
+    ...overrides,
+  };
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -41,13 +65,7 @@ function makeFakeClient() {
     nextResponse: unknown;
   } = {
     requests,
-    nextResponse: {
-      sessionId: "s1",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
-    },
+    nextResponse: sessionResult(),
     forceReconnects,
     inboundActivitySeq: 0,
     request: <T>(method: string, params?: unknown, options?: { timeoutMs?: number | null }) => {
@@ -71,6 +89,65 @@ function makeFakeClient() {
     listenerCount: () => listeners.size,
   };
   return client;
+}
+
+type FakeClient = ReturnType<typeof makeFakeClient>;
+
+function makeHarness() {
+  const client = makeFakeClient();
+  return { client, conn: new TerminalConnection(client) };
+}
+
+function testSink(overrides: Partial<TerminalSink> = {}): TerminalSink {
+  return { onData: () => {}, onExit: () => {}, ...overrides };
+}
+
+function openSession(
+  conn: TerminalConnection,
+  overrides: Partial<TerminalSink> = {},
+  params: Partial<TerminalOpenParams> = {},
+) {
+  return conn.open({ cols: 80, rows: 24, ...params }, testSink(overrides));
+}
+
+function emitData(client: FakeClient, seq: number, data: string, sessionId = "s1"): void {
+  client.emit("terminal.data", { sessionId, seq, data });
+}
+
+function emitExit(
+  client: FakeClient,
+  info: { exitCode: number | null; signal: number | null; reason?: string },
+  sessionId = "s1",
+): void {
+  client.emit("terminal.exit", { sessionId, ...info });
+}
+
+function deferRequest<T>(
+  client: FakeClient,
+  method: string,
+  pending: ReturnType<typeof deferred<T>>,
+): void {
+  const baseRequest = client.request.bind(client);
+  client.request = (<R>(
+    candidate: string,
+    params?: unknown,
+    options?: { timeoutMs?: number | null },
+  ): Promise<R> => {
+    if (candidate === method) {
+      client.requests.push({ method: candidate, params, ...(options ? { options } : {}) });
+      return pending.promise as unknown as Promise<R>;
+    }
+    return baseRequest<R>(candidate, params, options);
+  }) as typeof client.request;
+}
+
+async function withFakeTimers(run: () => Promise<void>): Promise<void> {
+  vi.useFakeTimers();
+  try {
+    await run();
+  } finally {
+    vi.useRealTimers();
+  }
 }
 
 function setLivenessProbeOutcomes(
@@ -100,13 +177,9 @@ function setLivenessProbeOutcomes(
 
 describe("TerminalConnection", () => {
   it("opens a session and routes its data to the registered sink", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
-    const result = await conn.open(
-      { cols: 80, rows: 24 },
-      { onData: (d) => data.push(d), onExit: () => {} },
-    );
+    const result = await openSession(conn, { onData: (chunk) => data.push(chunk) });
 
     expect(result.sessionId).toBe("s1");
     expect(client.requests[0]).toEqual({
@@ -115,18 +188,17 @@ describe("TerminalConnection", () => {
       options: { timeoutMs: TERMINAL_OPEN_WATCHDOG_MS },
     });
 
-    client.emit("terminal.data", { sessionId: "s1", seq: 5, data: "hello" });
-    client.emit("terminal.data", { sessionId: "s1", seq: 6, data: "!" });
+    emitData(client, 5, "hello");
+    emitData(client, 6, "!");
     expect(data).toEqual(["hello", "!"]);
   });
 
   it("accepts a coalesced frame whose seq marks the chunk end", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
-    await conn.open({ cols: 80, rows: 24 }, { onData: (d) => data.push(d), onExit: () => {} });
+    await openSession(conn, { onData: (dataChunk) => data.push(dataChunk) });
 
-    client.emit("terminal.data", { sessionId: "s1", seq: 6, data: "abcdef" });
+    emitData(client, 6, "abcdef");
 
     expect(data).toEqual(["abcdef"]);
     expect(client.requests.filter((request) => request.method === "terminal.attach")).toHaveLength(
@@ -135,13 +207,12 @@ describe("TerminalConnection", () => {
   });
 
   it("keeps shipped protocol-4 counter jumps diagnostic-only during version skew", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
-    await conn.open({ cols: 80, rows: 24 }, { onData: (d) => data.push(d), onExit: () => {} });
+    await openSession(conn, { onData: (dataChunk) => data.push(dataChunk) });
 
-    client.emit("terminal.data", { sessionId: "s1", seq: 0, data: "hello" });
-    client.emit("terminal.data", { sessionId: "s1", seq: 7, data: "world" });
+    emitData(client, 0, "hello");
+    emitData(client, 7, "world");
 
     expect(data).toEqual(["hello", "world"]);
     expect(client.requests.filter((request) => request.method === "terminal.attach")).toHaveLength(
@@ -150,57 +221,23 @@ describe("TerminalConnection", () => {
   });
 
   it("does not combine a legacy recovery snapshot with indistinguishable queued frames", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
     const replays: string[] = [];
     const exits: unknown[] = [];
-    const recovery = deferred<{
-      sessionId: string;
-      agentId: string;
-      shell: string;
-      cwd: string;
-      confined: boolean;
-      buffer: string;
-    }>();
-    await conn.open(
-      { cols: 80, rows: 24 },
-      {
-        onData: (chunk) => data.push(chunk),
-        onReplay: (snapshot) => replays.push(snapshot),
-        onExit: (info) => exits.push(info),
-      },
-    );
-    const baseRequest = client.request.bind(client);
-    client.request = ((
-      method: string,
-      params: unknown,
-      options?: { timeoutMs?: number | null },
-    ) => {
-      if (method === "terminal.attach") {
-        client.requests.push({ method, params });
-        return recovery.promise;
-      }
-      return baseRequest(method, params, options);
-    }) as typeof client.request;
+    const recovery = deferred<TestSessionResult>();
+    await openSession(conn, {
+      onData: (chunk) => data.push(chunk),
+      onReplay: (snapshot) => replays.push(snapshot),
+      onExit: (info) => exits.push(info),
+    });
+    deferRequest(client, "terminal.attach", recovery);
 
     // A non-zero first counter is ambiguous until attach reveals an old peer.
-    client.emit("terminal.data", { sessionId: "s1", seq: 7, data: "first" });
-    client.emit("terminal.data", { sessionId: "s1", seq: 8, data: "second" });
-    client.emit("terminal.exit", {
-      sessionId: "s1",
-      exitCode: null,
-      signal: null,
-      reason: "detached",
-    });
-    recovery.resolve({
-      sessionId: "s1",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
-      buffer: "legacy snapshot containing first",
-    });
+    emitData(client, 7, "first");
+    emitData(client, 8, "second");
+    emitExit(client, { exitCode: null, signal: null, reason: "detached" });
+    recovery.resolve(sessionResult({ buffer: "legacy snapshot containing first" }));
 
     await vi.waitFor(() => expect(data).toEqual(["first", "second"]));
     expect(replays).toEqual([]);
@@ -211,55 +248,23 @@ describe("TerminalConnection", () => {
   });
 
   it("repairs a sequence gap with one authoritative attach replay", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
     const replays: Array<{ snapshot: string; newlyObservedFrom: number }> = [];
-    const recovery = deferred<{
-      sessionId: string;
-      agentId: string;
-      shell: string;
-      cwd: string;
-      confined: boolean;
-      buffer: string;
-      seq: number;
-    }>();
-    await conn.open(
-      { cols: 80, rows: 24 },
-      {
-        onData: (chunk) => data.push(chunk),
-        onReplay: (snapshot, newlyObservedFrom) => replays.push({ snapshot, newlyObservedFrom }),
-        onExit: () => {},
-      },
-    );
-    const baseRequest = client.request.bind(client);
-    client.request = ((
-      method: string,
-      params: unknown,
-      options?: { timeoutMs?: number | null },
-    ) => {
-      if (method === "terminal.attach") {
-        client.requests.push({ method, params });
-        return recovery.promise;
-      }
-      return baseRequest(method, params, options);
-    }) as typeof client.request;
+    const recovery = deferred<TestSessionResult>();
+    await openSession(conn, {
+      onData: (chunk) => data.push(chunk),
+      onReplay: (snapshot, newlyObservedFrom) => replays.push({ snapshot, newlyObservedFrom }),
+    });
+    deferRequest(client, "terminal.attach", recovery);
 
-    client.emit("terminal.data", { sessionId: "s1", seq: 5, data: "hello" });
+    emitData(client, 5, "hello");
     // startOfChunk=7, but expected=5. The missing bytes are already in the ring.
-    client.emit("terminal.data", { sessionId: "s1", seq: 12, data: "world" });
+    emitData(client, 12, "world");
     // This frame races before the server takes its attach snapshot. It must be
     // covered by replay, not rendered twice or treated as another gap.
-    client.emit("terminal.data", { sessionId: "s1", seq: 19, data: "covered" });
-    recovery.resolve({
-      sessionId: "s1",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
-      buffer: "hello??worldcovered",
-      seq: 19,
-    });
+    emitData(client, 19, "covered");
+    recovery.resolve(sessionResult({ buffer: "hello??worldcovered", seq: 19 }));
 
     await vi.waitFor(() =>
       expect(replays).toEqual([{ snapshot: "hello??worldcovered", newlyObservedFrom: 5 }]),
@@ -269,30 +274,18 @@ describe("TerminalConnection", () => {
       1,
     );
 
-    client.emit("terminal.data", { sessionId: "s1", seq: 20, data: "!" });
+    emitData(client, 20, "!");
     expect(data).toEqual(["hello", "!"]);
   });
 
   it("never appends a recovery snapshot when the sink cannot reset", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
-    await conn.open(
-      { cols: 80, rows: 24 },
-      { onData: (chunk) => data.push(chunk), onExit: () => {} },
-    );
-    client.nextResponse = {
-      sessionId: "s1",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
-      buffer: "authoritative snapshot",
-      seq: 12,
-    };
+    await openSession(conn, { onData: (chunk) => data.push(chunk) });
+    client.nextResponse = sessionResult({ buffer: "authoritative snapshot", seq: 12 });
 
-    client.emit("terminal.data", { sessionId: "s1", seq: 5, data: "hello" });
-    client.emit("terminal.data", { sessionId: "s1", seq: 12, data: "world" });
+    emitData(client, 5, "hello");
+    emitData(client, 12, "world");
 
     await vi.waitFor(() =>
       expect(client.forceReconnects).toEqual(["terminal replay reset unavailable"]),
@@ -301,50 +294,23 @@ describe("TerminalConnection", () => {
   });
 
   it("serializes a terminal exit behind an in-flight gap replay", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
     const replays: string[] = [];
     const exits: unknown[] = [];
-    const recovery = deferred<{
-      sessionId: string;
-      agentId: string;
-      shell: string;
-      cwd: string;
-      confined: boolean;
-      buffer: string;
-      seq: number;
-    }>();
-    await conn.open(
-      { cols: 80, rows: 24 },
-      {
-        onData: (chunk) => data.push(chunk),
-        onReplay: (snapshot) => replays.push(snapshot),
-        onExit: (info) => exits.push(info),
-      },
-    );
-    const baseRequest = client.request.bind(client);
-    client.request = ((method: string, params: unknown) => {
-      if (method === "terminal.attach") {
-        client.requests.push({ method, params });
-        return recovery.promise;
-      }
-      return baseRequest(method, params);
-    }) as typeof client.request;
-
-    client.emit("terminal.data", { sessionId: "s1", seq: 5, data: "hello" });
-    client.emit("terminal.data", { sessionId: "s1", seq: 12, data: "world" });
-    client.emit("terminal.exit", { sessionId: "s1", exitCode: 0, signal: null });
-    expect(exits).toEqual([]);
-    recovery.resolve({
-      sessionId: "s1",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
-      buffer: "complete output",
-      seq: 12,
+    const recovery = deferred<TestSessionResult>();
+    await openSession(conn, {
+      onData: (chunk) => data.push(chunk),
+      onReplay: (snapshot) => replays.push(snapshot),
+      onExit: (info) => exits.push(info),
     });
+    deferRequest(client, "terminal.attach", recovery);
+
+    emitData(client, 5, "hello");
+    emitData(client, 12, "world");
+    emitExit(client, { exitCode: 0, signal: null });
+    expect(exits).toEqual([]);
+    recovery.resolve(sessionResult({ buffer: "complete output", seq: 12 }));
 
     await vi.waitFor(() => expect(exits).toHaveLength(1));
     expect(data).toEqual(["hello"]);
@@ -353,89 +319,46 @@ describe("TerminalConnection", () => {
   });
 
   it("discards a detached exit that predates a successful recovery rebind", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
     const replays: string[] = [];
     const exits: unknown[] = [];
-    const recovery = deferred<{
-      sessionId: string;
-      agentId: string;
-      shell: string;
-      cwd: string;
-      confined: boolean;
-      buffer: string;
-      seq: number;
-    }>();
-    await conn.open(
-      { cols: 80, rows: 24 },
-      {
-        onData: (chunk) => data.push(chunk),
-        onReplay: (snapshot) => replays.push(snapshot),
-        onExit: (info) => exits.push(info),
-      },
-    );
-    const baseRequest = client.request.bind(client);
-    client.request = ((method: string, params: unknown) => {
-      if (method === "terminal.attach") {
-        client.requests.push({ method, params });
-        return recovery.promise;
-      }
-      return baseRequest(method, params);
-    }) as typeof client.request;
+    const recovery = deferred<TestSessionResult>();
+    await openSession(conn, {
+      onData: (chunk) => data.push(chunk),
+      onReplay: (snapshot) => replays.push(snapshot),
+      onExit: (info) => exits.push(info),
+    });
+    deferRequest(client, "terminal.attach", recovery);
 
-    client.emit("terminal.data", { sessionId: "s1", seq: 5, data: "hello" });
-    client.emit("terminal.data", { sessionId: "s1", seq: 12, data: "world" });
-    client.emit("terminal.exit", {
-      sessionId: "s1",
-      exitCode: null,
-      signal: null,
-      reason: "detached",
-    });
-    recovery.resolve({
-      sessionId: "s1",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
-      buffer: "complete output",
-      seq: 12,
-    });
+    emitData(client, 5, "hello");
+    emitData(client, 12, "world");
+    emitExit(client, { exitCode: null, signal: null, reason: "detached" });
+    recovery.resolve(sessionResult({ buffer: "complete output", seq: 12 }));
 
     await vi.waitFor(() => expect(replays).toEqual(["complete output"]));
-    client.emit("terminal.data", { sessionId: "s1", seq: 13, data: "!" });
+    emitData(client, 13, "!");
     expect(data).toEqual(["hello", "!"]);
     expect(exits).toEqual([]);
     expect(conn.size).toBe(1);
   });
 
   it("delivers the received tail and exit when recovery loses the finished session", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
     const exits: unknown[] = [];
     const recovery = deferred<never>();
-    await conn.open(
-      { cols: 80, rows: 24 },
-      {
-        onData: (chunk) => data.push(chunk),
-        onReplay: () => {},
-        onExit: (info) => exits.push(info),
-      },
-    );
-    const baseRequest = client.request.bind(client);
-    client.request = ((method: string, params: unknown) => {
-      if (method === "terminal.attach") {
-        client.requests.push({ method, params });
-        return recovery.promise;
-      }
-      return baseRequest(method, params);
-    }) as typeof client.request;
+    await openSession(conn, {
+      onData: (chunk) => data.push(chunk),
+      onReplay: () => {},
+      onExit: (info) => exits.push(info),
+    });
+    deferRequest(client, "terminal.attach", recovery);
 
-    client.emit("terminal.data", { sessionId: "s1", seq: 5, data: "hello" });
-    client.emit("terminal.data", { sessionId: "s1", seq: 12, data: "world" });
-    client.emit("terminal.data", { sessionId: "s1", seq: 13, data: "!" });
-    client.emit("terminal.exit", { sessionId: "s1", exitCode: 0, signal: null });
+    emitData(client, 5, "hello");
+    emitData(client, 12, "world");
+    emitData(client, 13, "!");
+    emitExit(client, { exitCode: 0, signal: null });
     recovery.reject(new Error("unknown terminal session"));
 
     await vi.waitFor(() => expect(exits).toHaveLength(1));
@@ -445,24 +368,9 @@ describe("TerminalConnection", () => {
   });
 
   it("keeps a queued exit behind recovery started while flushing early events", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
-    const openResult = deferred<{
-      sessionId: string;
-      agentId: string;
-      shell: string;
-      cwd: string;
-      confined: boolean;
-    }>();
-    const recovery = deferred<{
-      sessionId: string;
-      agentId: string;
-      shell: string;
-      cwd: string;
-      confined: boolean;
-      buffer: string;
-      seq: number;
-    }>();
+    const { client, conn } = makeHarness();
+    const openResult = deferred<TestSessionResult>();
+    const recovery = deferred<TestSessionResult>();
     client.request = ((method: string, params: unknown) => {
       client.requests.push({ method, params });
       return method === "terminal.open" ? openResult.promise : recovery.promise;
@@ -470,35 +378,18 @@ describe("TerminalConnection", () => {
     const replays: string[] = [];
     const exits: unknown[] = [];
 
-    const opening = conn.open(
-      { cols: 80, rows: 24 },
-      {
-        onData: () => {},
-        onReplay: (snapshot) => replays.push(snapshot),
-        onExit: (info) => exits.push(info),
-      },
-    );
-    client.emit("terminal.data", { sessionId: "s1", seq: 7, data: "first" });
-    client.emit("terminal.exit", { sessionId: "s1", exitCode: 0, signal: null });
-    openResult.resolve({
-      sessionId: "s1",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
+    const opening = openSession(conn, {
+      onData: () => {},
+      onReplay: (snapshot) => replays.push(snapshot),
+      onExit: (info) => exits.push(info),
     });
+    emitData(client, 7, "first");
+    emitExit(client, { exitCode: 0, signal: null });
+    openResult.resolve(sessionResult());
     await opening;
     expect(exits).toEqual([]);
 
-    recovery.resolve({
-      sessionId: "s1",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
-      buffer: "complete output",
-      seq: 7,
-    });
+    recovery.resolve(sessionResult({ buffer: "complete output", seq: 7 }));
 
     await vi.waitFor(() => expect(exits).toHaveLength(1));
     expect(replays).toEqual(["complete output"]);
@@ -506,12 +397,8 @@ describe("TerminalConnection", () => {
   });
 
   it("forwards the selected agent when opening a session", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
-    await conn.open(
-      { agentId: "ops", cols: 100, rows: 30 },
-      { onData: () => {}, onExit: () => {} },
-    );
+    const { client, conn } = makeHarness();
+    await openSession(conn, {}, { agentId: "ops", cols: 100, rows: 30 });
 
     expect(client.requests[0]).toEqual({
       method: "terminal.open",
@@ -521,7 +408,7 @@ describe("TerminalConnection", () => {
   });
 
   it("maps the Gateway's request-scoped terminal open deadline", async () => {
-    const client = makeFakeClient();
+    const { client, conn } = makeHarness();
     client.request = <T>(
       method: string,
       params?: unknown,
@@ -530,17 +417,13 @@ describe("TerminalConnection", () => {
       client.requests.push({ method, params, ...(options ? { options } : {}) });
       return Promise.reject(new Error("terminal open timed out")) as Promise<T>;
     };
-    const conn = new TerminalConnection(client);
-
-    await expect(
-      conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} }),
-    ).rejects.toBeInstanceOf(TerminalOpenTimeoutError);
+    await expect(openSession(conn)).rejects.toBeInstanceOf(TerminalOpenTimeoutError);
     expect(client.requests[0]?.options).toEqual({ timeoutMs: TERMINAL_OPEN_WATCHDOG_MS });
     expect(client.forceReconnects).toEqual([]);
   });
 
   it("reconnects when the browser watchdog cannot receive the Gateway deadline", async () => {
-    const client = makeFakeClient();
+    const { client, conn } = makeHarness();
     client.request = <T>(
       method: string,
       params?: unknown,
@@ -551,30 +434,15 @@ describe("TerminalConnection", () => {
         new Error(`gateway request timed out after ${options?.timeoutMs}ms: ${method}`),
       ) as Promise<T>;
     };
-    const conn = new TerminalConnection(client);
-
-    await expect(
-      conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} }),
-    ).rejects.toBeInstanceOf(TerminalOpenTimeoutError);
+    await expect(openSession(conn)).rejects.toBeInstanceOf(TerminalOpenTimeoutError);
     expect(client.forceReconnects).toEqual(["terminal open watchdog timeout"]);
   });
 
   it("forwards a typed catalog reference and preserves the returned title", async () => {
-    const client = makeFakeClient();
-    client.nextResponse = {
-      sessionId: "s1",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
-      title: "codex resume 0d5c…",
-    };
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
+    client.nextResponse = sessionResult({ title: "codex resume 0d5c…" });
     const catalog = { catalogId: "codex", hostId: "node:mac", threadId: "thread" };
-    const result = await conn.open(
-      { cols: 100, rows: 30, catalog },
-      { onData: () => {}, onExit: () => {} },
-    );
+    const result = await openSession(conn, {}, { cols: 100, rows: 30, catalog });
 
     expect(client.requests[0]).toEqual({
       method: "terminal.open",
@@ -585,25 +453,18 @@ describe("TerminalConnection", () => {
   });
 
   it("does not deliver data to the wrong session", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
-    await conn.open({ cols: 80, rows: 24 }, { onData: (d) => data.push(d), onExit: () => {} });
-    client.emit("terminal.data", { sessionId: "other", seq: 0, data: "nope" });
+    await openSession(conn, { onData: (dataChunk) => data.push(dataChunk) });
+    emitData(client, 0, "nope", "other");
     expect(data).toEqual([]);
   });
 
   it("delivers exit info to the owning session", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     let exit: unknown;
-    await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: (info) => (exit = info) });
-    client.emit("terminal.exit", {
-      sessionId: "s1",
-      exitCode: 0,
-      signal: null,
-      reason: "process_exit",
-    });
+    await openSession(conn, { onExit: (info) => (exit = info) });
+    emitExit(client, { exitCode: 0, signal: null, reason: "process_exit" });
     expect(exit).toEqual({ exitCode: 0, signal: null, reason: "process_exit", error: undefined });
     // The connection drops its own sink on exit so nothing leaks.
     expect(conn.size).toBe(0);
@@ -611,9 +472,8 @@ describe("TerminalConnection", () => {
   });
 
   it("sends input, resize, and close RPCs", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
-    await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} });
+    const { client, conn } = makeHarness();
+    await openSession(conn);
     await conn.input("s1", "ls\n");
     await conn.resize("s1", 120, 40);
     await conn.close("s1");
@@ -626,80 +486,38 @@ describe("TerminalConnection", () => {
   });
 
   it("buffers output that races ahead of sink registration and replays it in order", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
     // Hold the open response so data can arrive before the sink registers.
-    let resolveOpen: (() => void) | undefined;
-    client.request = ((method: string, params: unknown) => {
-      client.requests.push({ method, params });
-      if (method === "terminal.open") {
-        return new Promise<unknown>((resolve) => {
-          resolveOpen = () =>
-            resolve({
-              sessionId: "s1",
-              agentId: "main",
-              shell: "/bin/zsh",
-              cwd: "/work",
-              confined: false,
-            });
-        });
-      }
-      return Promise.resolve({});
-    }) as typeof client.request;
-
-    const openPromise = conn.open(
-      { cols: 80, rows: 24 },
-      { onData: (d) => data.push(d), onExit: () => {} },
-    );
+    const opening = deferred<TestSessionResult>();
+    deferRequest(client, "terminal.open", opening);
+    const openPromise = openSession(conn, { onData: (chunk) => data.push(chunk) });
     // Server streams the shell prompt before the client has a sink for s1.
-    client.emit("terminal.data", { sessionId: "s1", seq: 6, data: "prompt" });
-    client.emit("terminal.data", { sessionId: "s1", seq: 8, data: "$ " });
+    emitData(client, 6, "prompt");
+    emitData(client, 8, "$ ");
     expect(data).toEqual([]); // buffered, not dropped
 
-    resolveOpen?.();
+    opening.resolve(sessionResult());
     await openPromise;
     expect(data).toEqual(["prompt", "$ "]); // replayed in arrival order on registration
   });
 
   it("buffers an instant exit that races ahead of registration", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
     let exit: unknown;
-    let resolveOpen: (() => void) | undefined;
-    client.request = ((method: string, params: unknown) => {
-      client.requests.push({ method, params });
-      if (method === "terminal.open") {
-        return new Promise<unknown>((resolve) => {
-          resolveOpen = () =>
-            resolve({
-              sessionId: "s1",
-              agentId: "main",
-              shell: "/bad/shell",
-              cwd: "/work",
-              confined: false,
-            });
-        });
-      }
-      return Promise.resolve({});
-    }) as typeof client.request;
-
-    const openPromise = conn.open(
-      { cols: 80, rows: 24 },
-      { onData: (d) => data.push(d), onExit: (info) => (exit = info) },
-    );
-    // A shell that fails to exec exits before the client has a sink.
-    client.emit("terminal.data", { sessionId: "s1", seq: 4, data: "boom" });
-    client.emit("terminal.exit", {
-      sessionId: "s1",
-      exitCode: 127,
-      signal: null,
-      reason: "process_exit",
+    const opening = deferred<TestSessionResult>();
+    deferRequest(client, "terminal.open", opening);
+    const openPromise = openSession(conn, {
+      onData: (chunk) => data.push(chunk),
+      onExit: (info) => (exit = info),
     });
+    // A shell that fails to exec exits before the client has a sink.
+    emitData(client, 4, "boom");
+    emitExit(client, { exitCode: 127, signal: null, reason: "process_exit" });
     expect(exit).toBeUndefined();
 
-    resolveOpen?.();
+    opening.resolve(sessionResult({ shell: "/bad/shell" }));
     await openPromise;
     expect(data).toEqual(["boom"]);
     expect(exit).toEqual({ exitCode: 127, signal: null, reason: "process_exit", error: undefined });
@@ -709,9 +527,8 @@ describe("TerminalConnection", () => {
   });
 
   it("unsubscribes from the event stream once no sessions remain", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
-    await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} });
+    const { client, conn } = makeHarness();
+    await openSession(conn);
     expect(client.listenerCount()).toBe(1);
     await conn.close("s1");
     expect(client.listenerCount()).toBe(0);
@@ -719,17 +536,14 @@ describe("TerminalConnection", () => {
   });
 
   it("drops the listener when an open fails so failures do not leak subscriptions", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     client.request = ((method: string, params: unknown) => {
       client.requests.push({ method, params });
       // Rejected open: sandboxed agent, disabled terminal, missing PTY, etc.
       return Promise.reject(new Error("terminal open refused"));
     }) as typeof client.request;
 
-    await expect(
-      conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} }),
-    ).rejects.toThrow("terminal open refused");
+    await expect(openSession(conn)).rejects.toThrow("terminal open refused");
     // The failed open subscribed but never registered a sink; repeated failures
     // across reconnects must not accumulate listeners on the gateway client.
     expect(conn.size).toBe(0);
@@ -737,70 +551,39 @@ describe("TerminalConnection", () => {
   });
 
   it("keeps the listener while an open is in flight even if every session closes", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
-    await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} });
+    const { client, conn } = makeHarness();
+    await openSession(conn);
 
     // Second open held in flight while the only registered session closes.
-    let resolveOpen: (() => void) | undefined;
-    client.request = ((method: string, params: unknown) => {
-      client.requests.push({ method, params });
-      if (method === "terminal.open") {
-        return new Promise<unknown>((resolve) => {
-          resolveOpen = () =>
-            resolve({
-              sessionId: "s2",
-              agentId: "main",
-              shell: "/bin/zsh",
-              cwd: "/work",
-              confined: false,
-            });
-        });
-      }
-      return Promise.resolve({});
-    }) as typeof client.request;
+    const opening = deferred<TestSessionResult>();
+    deferRequest(client, "terminal.open", opening);
     const data: string[] = [];
-    const openPromise = conn.open(
-      { cols: 80, rows: 24 },
-      { onData: (d) => data.push(d), onExit: () => {} },
-    );
+    const openPromise = openSession(conn, { onData: (chunk) => data.push(chunk) });
 
     await conn.close("s1");
     // The in-flight open must keep the subscription so s2's early output
     // is buffered instead of silently lost.
     expect(client.listenerCount()).toBe(1);
-    client.emit("terminal.data", { sessionId: "s2", seq: 5, data: "early" });
+    emitData(client, 5, "early", "s2");
 
-    resolveOpen?.();
+    opening.resolve(sessionResult({ sessionId: "s2" }));
     await openPromise;
     expect(data).toEqual(["early"]);
   });
 
   it("drops the final exit the server emits while a close RPC is in flight", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
-    await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} });
+    const { client, conn } = makeHarness();
+    await openSession(conn);
     // A second session keeps the event subscription alive across the close.
-    client.nextResponse = {
-      sessionId: "s2",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
-    };
-    await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} });
+    client.nextResponse = sessionResult({ sessionId: "s2" });
+    await openSession(conn);
 
     // The server finalizes the session (emitting terminal.exit) before it
     // responds to terminal.close, so the event arrives with no sink.
     const baseRequest = client.request.bind(client);
     client.request = ((method: string, params: unknown) => {
       if (method === "terminal.close") {
-        client.emit("terminal.exit", {
-          sessionId: "s1",
-          exitCode: null,
-          signal: null,
-          reason: "closed",
-        });
+        emitExit(client, { exitCode: null, signal: null, reason: "closed" });
       }
       return baseRequest(method, params);
     }) as typeof client.request;
@@ -808,60 +591,29 @@ describe("TerminalConnection", () => {
 
     // If that exit were buffered, reusing the id would replay it into the new
     // session's sink and instantly mark a live tab as exited.
-    client.nextResponse = {
-      sessionId: "s1",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
-    };
+    client.nextResponse = sessionResult();
     let staleExit = false;
-    await conn.open(
-      { cols: 80, rows: 24 },
-      {
-        onData: () => {},
-        onExit: () => {
-          staleExit = true;
-        },
+    await openSession(conn, {
+      onExit: () => {
+        staleExit = true;
       },
-    );
+    });
     expect(staleExit).toBe(false);
     expect(conn.size).toBe(2);
   });
 
   it("attach replays the buffer before events that raced ahead, then resumes live", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
-    let resolveAttach: (() => void) | undefined;
-    client.request = ((method: string, params: unknown) => {
-      client.requests.push({ method, params });
-      if (method === "terminal.attach") {
-        return new Promise<unknown>((resolve) => {
-          resolveAttach = () =>
-            resolve({
-              sessionId: "s1",
-              agentId: "main",
-              shell: "/bin/zsh",
-              cwd: "/work",
-              confined: false,
-              buffer: "replayed history",
-              seq: 16,
-            });
-        });
-      }
-      return Promise.resolve({});
-    }) as typeof client.request;
+    const attached = deferred<TestSessionResult>();
+    deferRequest(client, "terminal.attach", attached);
 
-    const attachPromise = conn.attach("s1", {
-      onData: (d) => data.push(d),
-      onExit: () => {},
-    });
+    const attachPromise = conn.attach("s1", testSink({ onData: (chunk) => data.push(chunk) }));
     // Post-snapshot bytes the server emits between rebind and the response.
-    client.emit("terminal.data", { sessionId: "s1", seq: 21, data: " tail" });
+    emitData(client, 21, " tail");
     expect(data).toEqual([]);
 
-    resolveAttach?.();
+    attached.resolve(sessionResult({ buffer: "replayed history", seq: 16 }));
     const result = await attachPromise;
     expect(result.buffer).toBe("replayed history");
     expect(client.requests[0]).toEqual({
@@ -869,53 +621,28 @@ describe("TerminalConnection", () => {
       params: { sessionId: "s1" },
     });
     // Buffer first, then the raced event, then live data.
-    client.emit("terminal.data", { sessionId: "s1", seq: 26, data: " live" });
+    emitData(client, 26, " live");
     expect(data).toEqual(["replayed history", " tail", " live"]);
   });
 
   it("discards a detached exit that predates successful session adoption", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const replays: string[] = [];
     const data: string[] = [];
     const exits: unknown[] = [];
-    const attached = deferred<{
-      sessionId: string;
-      agentId: string;
-      shell: string;
-      cwd: string;
-      confined: boolean;
-      buffer: string;
-      seq: number;
-    }>();
-    client.request = ((method: string, params: unknown) => {
-      client.requests.push({ method, params });
-      return attached.promise;
-    }) as typeof client.request;
+    const attached = deferred<TestSessionResult>();
+    deferRequest(client, "terminal.attach", attached);
 
     const attachPromise = conn.attach("s1", {
       onData: (chunk) => data.push(chunk),
       onReplay: (snapshot) => replays.push(snapshot),
       onExit: (info) => exits.push(info),
     });
-    client.emit("terminal.exit", {
-      sessionId: "s1",
-      exitCode: null,
-      signal: null,
-      reason: "detached",
-    });
-    attached.resolve({
-      sessionId: "s1",
-      agentId: "main",
-      shell: "/bin/zsh",
-      cwd: "/work",
-      confined: false,
-      buffer: "snapshot",
-      seq: 8,
-    });
+    emitExit(client, { exitCode: null, signal: null, reason: "detached" });
+    attached.resolve(sessionResult({ buffer: "snapshot", seq: 8 }));
 
     await attachPromise;
-    client.emit("terminal.data", { sessionId: "s1", seq: 9, data: "!" });
+    emitData(client, 9, "!");
     expect(replays).toEqual(["snapshot"]);
     expect(data).toEqual(["!"]);
     expect(exits).toEqual([]);
@@ -923,34 +650,17 @@ describe("TerminalConnection", () => {
   });
 
   it("preserves output that races an older gateway replay with no offset", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const data: string[] = [];
-    let resolveAttach: (() => void) | undefined;
-    client.request = ((method: string, params: unknown) => {
-      client.requests.push({ method, params });
-      return new Promise<unknown>((resolve) => {
-        resolveAttach = () =>
-          resolve({
-            sessionId: "s1",
-            agentId: "main",
-            shell: "/bin/zsh",
-            cwd: "/work",
-            confined: false,
-            buffer: "legacy replay",
-          });
-      });
-    }) as typeof client.request;
+    const attached = deferred<TestSessionResult>();
+    deferRequest(client, "terminal.attach", attached);
 
-    const attachPromise = conn.attach("s1", {
-      onData: (chunk) => data.push(chunk),
-      onExit: () => {},
-    });
-    client.emit("terminal.data", { sessionId: "s1", seq: 41, data: "raced" });
-    resolveAttach?.();
+    const attachPromise = conn.attach("s1", testSink({ onData: (chunk) => data.push(chunk) }));
+    emitData(client, 41, "raced");
+    attached.resolve(sessionResult({ buffer: "legacy replay" }));
     await attachPromise;
-    client.emit("terminal.data", { sessionId: "s1", seq: 42, data: "live" });
-    client.emit("terminal.data", { sessionId: "s1", seq: 43, data: "more" });
+    emitData(client, 42, "live");
+    emitData(client, 43, "more");
 
     expect(data).toEqual(["legacy replay", "raced", "live", "more"]);
     expect(client.requests.filter((request) => request.method === "terminal.attach")).toHaveLength(
@@ -959,24 +669,20 @@ describe("TerminalConnection", () => {
   });
 
   it("drops the listener when an attach fails so failures do not leak subscriptions", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     client.request = ((method: string, params: unknown) => {
       client.requests.push({ method, params });
       // Expired/unknown session after the detach grace period.
       return Promise.reject(new Error("unknown terminal session"));
     }) as typeof client.request;
 
-    await expect(conn.attach("gone", { onData: () => {}, onExit: () => {} })).rejects.toThrow(
-      "unknown terminal session",
-    );
+    await expect(conn.attach("gone", testSink())).rejects.toThrow("unknown terminal session");
     expect(conn.size).toBe(0);
     expect(client.listenerCount()).toBe(0);
   });
 
   it("lists attachable sessions and tolerates a missing sessions field", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
+    const { client, conn } = makeHarness();
     const info = {
       sessionId: "s1",
       agentId: "main",
@@ -992,13 +698,11 @@ describe("TerminalConnection", () => {
     expect(await conn.list()).toEqual([]);
   });
 
-  it("keeps the socket after one failed liveness probe and retries on a short backoff", async () => {
-    vi.useFakeTimers();
-    try {
-      const client = makeFakeClient();
+  it("keeps the socket after one failed liveness probe and retries on a short backoff", () =>
+    withFakeTimers(async () => {
+      const { client, conn } = makeHarness();
       setLivenessProbeOutcomes(client, ["timeout"]);
-      const conn = new TerminalConnection(client);
-      await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} });
+      await openSession(conn);
       const probes = () =>
         client.requests.filter((request) => request.method === "terminal.list").length;
 
@@ -1009,18 +713,13 @@ describe("TerminalConnection", () => {
       await vi.advanceTimersByTimeAsync(TERMINAL_LIVENESS_FAILURE_RETRY_MS);
       expect(probes()).toBe(2);
       conn.dispose();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+    }));
 
-  it("forces exactly one reconnect after two consecutive failed liveness probes", async () => {
-    vi.useFakeTimers();
-    try {
-      const client = makeFakeClient();
+  it("forces exactly one reconnect after two consecutive failed liveness probes", () =>
+    withFakeTimers(async () => {
+      const { client, conn } = makeHarness();
       setLivenessProbeOutcomes(client, ["timeout", "timeout"]);
-      const conn = new TerminalConnection(client);
-      await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} });
+      await openSession(conn);
 
       await vi.advanceTimersByTimeAsync(IDLE_PLUS_PROBE_MS);
       expect(client.forceReconnects).toEqual([]);
@@ -1029,18 +728,13 @@ describe("TerminalConnection", () => {
       );
       expect(client.forceReconnects).toEqual(["terminal liveness timeout"]);
       conn.dispose();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+    }));
 
-  it("resets liveness failures after a successful probe", async () => {
-    vi.useFakeTimers();
-    try {
-      const client = makeFakeClient();
+  it("resets liveness failures after a successful probe", () =>
+    withFakeTimers(async () => {
+      const { client, conn } = makeHarness();
       setLivenessProbeOutcomes(client, ["timeout", "success", "timeout"]);
-      const conn = new TerminalConnection(client);
-      await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} });
+      await openSession(conn);
 
       // Probes: timeout (fail), success (clears the streak), timeout (fail again).
       await vi.advanceTimersByTimeAsync(IDLE_PLUS_PROBE_MS);
@@ -1048,18 +742,13 @@ describe("TerminalConnection", () => {
       // The middle success reset the streak, so the later lone failure cannot reconnect.
       expect(client.forceReconnects).toEqual([]);
       conn.dispose();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+    }));
 
-  it("keeps the socket when other inbound traffic arrives during a failed probe", async () => {
-    vi.useFakeTimers();
-    try {
-      const client = makeFakeClient();
+  it("keeps the socket when other inbound traffic arrives during a failed probe", () =>
+    withFakeTimers(async () => {
+      const { client, conn } = makeHarness();
       setLivenessProbeOutcomes(client, ["timeout", "timeout"]);
-      const conn = new TerminalConnection(client);
-      await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} });
+      await openSession(conn);
 
       await vi.advanceTimersByTimeAsync(TERMINAL_LIVENESS_IDLE_MS);
       // A frame delivered mid-probe proves the socket alive, so the probe timeout is not counted.
@@ -1068,18 +757,13 @@ describe("TerminalConnection", () => {
 
       expect(client.forceReconnects).toEqual([]);
       conn.dispose();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+    }));
 
-  it("restarts the full idle window when inbound traffic arrives during the retry backoff", async () => {
-    vi.useFakeTimers();
-    try {
-      const client = makeFakeClient();
+  it("restarts the full idle window when inbound traffic arrives during the retry backoff", () =>
+    withFakeTimers(async () => {
+      const { client, conn } = makeHarness();
       setLivenessProbeOutcomes(client, ["timeout", "timeout"]);
-      const conn = new TerminalConnection(client);
-      await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} });
+      await openSession(conn);
 
       const probeCount = () =>
         client.requests.filter((request) => request.method === "terminal.list").length;
@@ -1097,15 +781,11 @@ describe("TerminalConnection", () => {
       expect(probeCount()).toBe(1);
       expect(client.forceReconnects).toEqual([]);
       conn.dispose();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+    }));
 
   it("dispose() drops the gateway subscription and clears buffered state", async () => {
-    const client = makeFakeClient();
-    const conn = new TerminalConnection(client);
-    await conn.open({ cols: 80, rows: 24 }, { onData: () => {}, onExit: () => {} });
+    const { client, conn } = makeHarness();
+    await openSession(conn);
     expect(client.listenerCount()).toBe(1);
     // Panel teardown (disconnect/disable) discards the connection.
     conn.dispose();


### PR DESCRIPTION
## Summary

- Consolidate repeated terminal-connection test scaffolding into typed local fixtures.
- Preserve all 34 test titles and order, all 92 `expect` calls, and the websocket/session/auth lifecycle coverage.
- Remove 320 net test LOC (`+277/-597`) with production LOC delta 0.

## Root cause and owner boundary

`terminal-connection.test.ts` repeated the same session result, sink, terminal event, deferred RPC, and fake-timer scaffolding across the terminal connection lifecycle matrix. The test file owns this scaffolding; production ownership remains in `TerminalConnection`, the terminal panel session controller, and gateway terminal methods/session management.

The canonical cleanup is a small set of typed local fixtures (`sessionResult`, `makeHarness`, `testSink`, `openSession`, terminal event emitters, deferred request wiring, and `withFakeTimers`). Removed paths are repeated inline test setup only; no runtime, UI, config, i18n, schema, or protocol path changes.

## Parity and sibling coverage

- 34/34 test declarations and order unchanged.
- 92/92 `expect` calls unchanged; the four non-text-identical matcher expressions are exact fixture substitutions.
- Preserves open/attach request options, early-event buffering, sequence replay/gap recovery, exit/detach/rebind ordering, session adoption, subscription cleanup, open watchdog behavior, liveness retries, and timer restoration.
- Reviewed against terminal connection, terminal panel session controller, browser gateway client, protocol schema, gateway terminal methods, and terminal session manager.

## Verification

- Final SHA focused: `node scripts/run-vitest.mjs ui/src/components/terminal/terminal-connection.test.ts` — 34/34 passed.
- Final SHA Blacksmith Testbox `check:changed` — formatting, dead-export scan, UI i18n, core-test tsgo, and changed-file lint all passed; lease `tbx_01kz20g928zp5cqw6zxbzvdhga`.
- Identical runtime test diff before the final type-boundary cast/rebase: full Control UI config — 521 files passed, 6 skipped; 7,666 tests passed, 33 skipped.
- Identical runtime test diff before the final type-boundary cast/rebase: mocked real-Chromium UI E2E — 136 files, 474 tests passed, including terminal catalog timeout/reconnect/readiness, upload, embedded restore, runtime reuse, and repaint coverage.
- `git diff --check` passed.
- Two direct xhigh reviewers independently returned CLEAN and judged this the best coherent cleanup for the touched surface.

## Collision and LOC

The frozen exhaustive open-PR census reported zero exact-path collisions. A final live delta rechecked all 139 PRs updated since `2026-08-02T18:30:00Z`, including paginated file lists: zero collisions and zero API errors.

Production LOC: **0**  
Test LOC: **-320**  
Total LOC: **-320**
