### PR TITLE
test(android): consolidate gateway security fixtures

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -158,66 +158,30 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun doesNotConnectOperatorSessionWhenOnlyBootstrapAuthExists() {
-    assertFalse(
-      resolveOperatorSessionConnectAuth(
-        NodeRuntime.GatewayConnectAuth(token = "", bootstrapToken = "bootstrap-1", password = ""),
-        storedOperatorToken = "",
-      ) != null,
-    )
-    assertFalse(
-      resolveOperatorSessionConnectAuth(
-        NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap-1", password = null),
-        storedOperatorToken = null,
-      ) != null,
-    )
+    assertFalse(operatorAuth(auth(token = "", bootstrapToken = "bootstrap-1", password = ""), "") != null)
+    assertFalse(operatorAuth(auth(bootstrapToken = "bootstrap-1")) != null)
   }
 
   @Test
   fun connectsOperatorSessionWhenSharedPasswordOrStoredAuthExists() {
-    assertTrue(
-      resolveOperatorSessionConnectAuth(
-        NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = "bootstrap-1", password = null),
-        storedOperatorToken = null,
-      ) != null,
-    )
-    assertTrue(
-      resolveOperatorSessionConnectAuth(
-        NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap-1", password = "shared-password"),
-        storedOperatorToken = null,
-      ) != null,
-    )
-    assertTrue(
-      resolveOperatorSessionConnectAuth(
-        NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap-1", password = null),
-        storedOperatorToken = "stored-token",
-      ) != null,
-    )
-    assertTrue(
-      resolveOperatorSessionConnectAuth(
-        NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "", password = null),
-        storedOperatorToken = null,
-      ) != null,
-    )
+    assertTrue(operatorAuth(auth(token = "shared-token", bootstrapToken = "bootstrap-1")) != null)
+    assertTrue(operatorAuth(auth(bootstrapToken = "bootstrap-1", password = "shared-password")) != null)
+    assertTrue(operatorAuth(auth(bootstrapToken = "bootstrap-1"), "stored-token") != null)
+    assertTrue(operatorAuth(auth(bootstrapToken = "")) != null)
   }
 
   @Test
   fun resolveOperatorSessionConnectAuthUsesStoredTokenPathAfterBootstrapHandoff() {
     val resolved =
-      resolveOperatorSessionConnectAuth(
-        auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap-1", password = null),
-        storedOperatorToken = "stored-token",
-      )
+      operatorAuth(auth(bootstrapToken = "bootstrap-1"), "stored-token")
 
-    assertEquals(NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = null, password = null), resolved)
+    assertEquals(auth(), resolved)
   }
 
   @Test
   fun resolveOperatorSessionConnectAuthIgnoresBootstrapWhenNoStoredOperatorTokenExists() {
     val resolved =
-      resolveOperatorSessionConnectAuth(
-        auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap-1", password = null),
-        storedOperatorToken = null,
-      )
+      operatorAuth(auth(bootstrapToken = "bootstrap-1"))
 
     assertNull(resolved)
   }
@@ -225,24 +189,18 @@ class GatewayBootstrapAuthTest {
   @Test
   fun resolveOperatorSessionConnectAuthUsesNoAuthWhenGatewayHasNoAuth() {
     val resolved =
-      resolveOperatorSessionConnectAuth(
-        auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = null, password = null),
-        storedOperatorToken = null,
-      )
+      operatorAuth(auth())
 
-    assertEquals(NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = null, password = null), resolved)
+    assertEquals(auth(), resolved)
   }
 
   @Test
   fun resolveOperatorSessionConnectAuthPrefersExplicitSharedAuth() {
     val resolved =
-      resolveOperatorSessionConnectAuth(
-        auth = NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = "bootstrap-1", password = "shared-password"),
-        storedOperatorToken = "stored-token",
-      )
+      operatorAuth(auth(token = "shared-token", bootstrapToken = "bootstrap-1", password = "shared-password"), "stored-token")
 
     assertEquals(
-      NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
+      auth(token = "shared-token"),
       resolved,
     )
   }
@@ -251,12 +209,12 @@ class GatewayBootstrapAuthTest {
   fun resolveGatewayControlPageAuthFallsBackToStoredOperatorToken() {
     val resolved =
       resolveGatewayControlPageAuth(
-        auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap-1", password = null),
+        auth = auth(bootstrapToken = "bootstrap-1"),
         storedOperatorToken = " stored-token ",
       )
 
     assertEquals(
-      NodeRuntime.GatewayConnectAuth(token = "stored-token", bootstrapToken = null, password = null),
+      auth(token = "stored-token"),
       resolved,
     )
   }
@@ -264,26 +222,16 @@ class GatewayBootstrapAuthTest {
   @Test
   fun resolveGatewayControlPageAuthPrefersExplicitSharedAuth() {
     assertEquals(
-      NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
+      auth(token = "shared-token"),
       resolveGatewayControlPageAuth(
-        auth =
-          NodeRuntime.GatewayConnectAuth(
-            token = " shared-token ",
-            bootstrapToken = "bootstrap-1",
-            password = "shared-password",
-          ),
+        auth = auth(token = " shared-token ", bootstrapToken = "bootstrap-1", password = "shared-password"),
         storedOperatorToken = "stored-token",
       ),
     )
     assertEquals(
-      NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = null, password = "shared-password"),
+      auth(password = "shared-password"),
       resolveGatewayControlPageAuth(
-        auth =
-          NodeRuntime.GatewayConnectAuth(
-            token = null,
-            bootstrapToken = "bootstrap-1",
-            password = " shared-password ",
-          ),
+        auth = auth(bootstrapToken = "bootstrap-1", password = " shared-password "),
         storedOperatorToken = "stored-token",
       ),
     )
@@ -344,36 +292,14 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun operatorSessionUsesStoredDeviceTokenOnlyWithoutExplicitSharedAuth() {
-    assertTrue(
-      operatorSessionUsesStoredDeviceToken(
-        auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap-1", password = null),
-        storedOperatorToken = "stored-token",
-      ),
-    )
-    assertFalse(
-      operatorSessionUsesStoredDeviceToken(
-        auth = NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
-        storedOperatorToken = "stored-token",
-      ),
-    )
-    assertFalse(
-      operatorSessionUsesStoredDeviceToken(
-        auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = null, password = "password"),
-        storedOperatorToken = "stored-token",
-      ),
-    )
+    assertTrue(usesStoredOperatorToken(auth(bootstrapToken = "bootstrap-1")))
+    assertFalse(usesStoredOperatorToken(auth(token = "shared-token")))
+    assertFalse(usesStoredOperatorToken(auth(password = "password")))
   }
 
   @Test
   fun nodeConnectStartsOperatorAfterBootstrapHandoffWhenOperatorWasConnecting() {
-    val app = RuntimeEnvironment.getApplication()
-    val securePrefs =
-      app.getSharedPreferences(
-        "openclaw.node.secure.test.${UUID.randomUUID()}",
-        android.content.Context.MODE_PRIVATE,
-      )
-    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-    val runtime = NodeRuntime(app, prefs)
+    val (app, prefs, runtime) = gatewayFixture()
     val deviceId = DeviceIdentityStore.withPrefs(app, prefs).loadOrCreate().deviceId
     val endpoint = GatewayEndpoint.manual(host = "127.0.0.1", port = 18789)
     DeviceAuthStore(prefs).saveToken(endpoint.stableId, deviceId, "operator", "bootstrap-operator-token")
@@ -382,7 +308,7 @@ class GatewayBootstrapAuthTest {
     invokeMaybeStartOperatorSessionAfterNodeConnect(
       runtime = runtime,
       endpoint = endpoint,
-      auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "setup-bootstrap-token", password = null),
+      auth = auth(bootstrapToken = "setup-bootstrap-token"),
     )
 
     val desired = desiredConnection(runtime, "operatorSession")
@@ -392,25 +318,14 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun resolveGatewayConnectAuth_prefersExplicitSetupAuthOverStoredPrefs() {
-    val app = RuntimeEnvironment.getApplication()
-    val securePrefs =
-      app.getSharedPreferences(
-        "openclaw.node.secure.test.${UUID.randomUUID()}",
-        android.content.Context.MODE_PRIVATE,
-      )
-    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+    val (_, prefs, runtime) = gatewayFixture()
     val endpoint = GatewayEndpoint.manual("gateway.example", 18789)
     prefs.saveGatewayCredentials(endpoint.stableId, token = "stale-shared-token", password = "stale-password")
-    val runtime = NodeRuntime(app, prefs)
 
     val auth =
       runtime.resolveGatewayConnectAuth(
         endpoint,
-        NodeRuntime.GatewayConnectAuth(
-          token = null,
-          bootstrapToken = "setup-bootstrap-token",
-          password = null,
-        ),
+        auth(bootstrapToken = "setup-bootstrap-token"),
       )
 
     assertNull(auth.token)
@@ -421,27 +336,11 @@ class GatewayBootstrapAuthTest {
   @Test
   fun acceptGatewayTrustPrompt_preservesExplicitSetupAuth() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      val securePrefs =
-        app.getSharedPreferences(
-          "openclaw.node.secure.test.${UUID.randomUUID()}",
-          android.content.Context.MODE_PRIVATE,
-        )
-      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+      val (_, prefs, runtime) =
+        gatewayFixture { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = "ab".repeat(32)) }
       val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
       prefs.saveGatewayCredentials(endpoint.stableId, token = "stale-shared-token", password = "stale-password")
-      val runtime =
-        NodeRuntime(
-          app,
-          prefs,
-          tlsFingerprintProbe = { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = "ab".repeat(32)) },
-        )
-      val explicitAuth =
-        NodeRuntime.GatewayConnectAuth(
-          token = null,
-          bootstrapToken = "setup-bootstrap-token",
-          password = null,
-        )
+      val explicitAuth = auth(bootstrapToken = "setup-bootstrap-token")
 
       runtime.connect(endpoint, explicitAuth)
       val prompt = waitForGatewayTrustPrompt(runtime)
@@ -458,27 +357,16 @@ class GatewayBootstrapAuthTest {
   @Test
   fun connect_promptsBeforeReplacingChangedTlsFingerprint() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      val securePrefs =
-        app.getSharedPreferences(
-          "openclaw.node.secure.test.${UUID.randomUUID()}",
-          android.content.Context.MODE_PRIVATE,
-        )
-      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+      val (_, prefs, runtime) =
+        gatewayFixture { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = "bb".repeat(32), systemTrusted = true) }
       val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
       val oldFingerprint = "aa".repeat(32)
       val newFingerprint = "bb".repeat(32)
       prefs.saveGatewayTlsFingerprint(endpoint.stableId, oldFingerprint)
-      val runtime =
-        NodeRuntime(
-          app,
-          prefs,
-          tlsFingerprintProbe = { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = newFingerprint, systemTrusted = true) },
-        )
 
       runtime.connect(
         endpoint,
-        NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
+        auth(token = "shared-token"),
       )
 
       val prompt = waitForGatewayTrustPrompt(runtime)
@@ -493,7 +381,7 @@ class GatewayBootstrapAuthTest {
 
       runtime.connect(
         endpoint,
-        NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
+        auth(token = "shared-token"),
       )
       waitForGatewayTrustPrompt(runtime)
       runtime.acceptGatewayTrustPrompt()
@@ -503,24 +391,13 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun connect_systemTrustedCandidateWithoutStoredPinUsesPlatformTrust() {
-    val app = RuntimeEnvironment.getApplication()
-    val securePrefs =
-      app.getSharedPreferences(
-        "openclaw.node.secure.test.${UUID.randomUUID()}",
-        android.content.Context.MODE_PRIVATE,
-      )
-    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+    val (_, prefs, runtime) =
+      gatewayFixture { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = "bb".repeat(32), systemTrusted = true) }
     val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
-    val runtime =
-      NodeRuntime(
-        app,
-        prefs,
-        tlsFingerprintProbe = { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = "bb".repeat(32), systemTrusted = true) },
-      )
 
     runtime.connect(
       endpoint,
-      NodeRuntime.GatewayConnectAuth(token = "test-token-placeholder", bootstrapToken = null, password = null),
+      auth(token = "test-token-placeholder"),
     )
 
     val desired = waitForDesiredConnection(runtime, "nodeSession")
@@ -533,27 +410,16 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun connect_systemTrustedChangedPinSwitchClearsPinAndUsesPlatformTrust() {
-    val app = RuntimeEnvironment.getApplication()
-    val securePrefs =
-      app.getSharedPreferences(
-        "openclaw.node.secure.test.${UUID.randomUUID()}",
-        android.content.Context.MODE_PRIVATE,
-      )
-    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-    val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
     val oldFingerprint = "aa".repeat(32)
     val newFingerprint = "bb".repeat(32)
+    val (_, prefs, runtime) =
+      gatewayFixture { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = newFingerprint, systemTrusted = true) }
+    val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
     prefs.saveGatewayTlsFingerprint(endpoint.stableId, oldFingerprint)
-    val runtime =
-      NodeRuntime(
-        app,
-        prefs,
-        tlsFingerprintProbe = { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = newFingerprint, systemTrusted = true) },
-      )
 
     runtime.connect(
       endpoint,
-      NodeRuntime.GatewayConnectAuth(token = "test-token-placeholder", bootstrapToken = null, password = null),
+      auth(token = "test-token-placeholder"),
     )
 
     val prompt = waitForGatewayTrustPrompt(runtime)
@@ -571,27 +437,16 @@ class GatewayBootstrapAuthTest {
   @Test
   fun connect_ignoresStaleTlsProbeAfterDisconnect() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      val securePrefs =
-        app.getSharedPreferences(
-          "openclaw.node.secure.test.${UUID.randomUUID()}",
-          android.content.Context.MODE_PRIVATE,
-        )
-      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-      val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
       val fingerprint = "aa".repeat(32)
-      prefs.saveGatewayTlsFingerprint(endpoint.stableId, fingerprint)
       val probeStarted = CompletableDeferred<Unit>()
       val probeResult = CompletableDeferred<GatewayTlsProbeResult>()
-      val runtime =
-        NodeRuntime(
-          app,
-          prefs,
-          tlsFingerprintProbe = { _, _ ->
-            probeStarted.complete(Unit)
-            probeResult.await()
-          },
-        )
+      val (_, prefs, runtime) =
+        gatewayFixture { _, _ ->
+          probeStarted.complete(Unit)
+          probeResult.await()
+        }
+      val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
+      prefs.saveGatewayTlsFingerprint(endpoint.stableId, fingerprint)
       val runtimeScope = readField<CoroutineScope>(runtime, "scope")
       val existingJobs =
         runtimeScope.coroutineContext[Job]
@@ -601,7 +456,7 @@ class GatewayBootstrapAuthTest {
 
       runtime.connect(
         endpoint,
-        NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
+        auth(token = "shared-token"),
       )
       probeStarted.await()
       val probeJob =
@@ -623,25 +478,14 @@ class GatewayBootstrapAuthTest {
   @Test
   fun forgetGatewayCancelsInFlightTlsProbeBeforePurgingAuth() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      val securePrefs =
-        app.getSharedPreferences(
-          "openclaw.node.secure.test.${UUID.randomUUID()}",
-          android.content.Context.MODE_PRIVATE,
-        )
-      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-      val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
       val probeStarted = CompletableDeferred<Unit>()
       val probeResult = CompletableDeferred<GatewayTlsProbeResult>()
-      val runtime =
-        NodeRuntime(
-          app,
-          prefs,
-          tlsFingerprintProbe = { _, _ ->
-            probeStarted.complete(Unit)
-            probeResult.await()
-          },
-        )
+      val (_, prefs, runtime) =
+        gatewayFixture { _, _ ->
+          probeStarted.complete(Unit)
+          probeResult.await()
+        }
+      val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
       prefs.gatewayRegistry.upsert(
         GatewayRegistryEntry(
           stableId = endpoint.stableId,
@@ -675,7 +519,7 @@ class GatewayBootstrapAuthTest {
 
     runtime.connect(
       GatewayEndpoint.manual(host = "127.0.0.1", port = 18789),
-      NodeRuntime.GatewayConnectAuth(token = "initial-token", bootstrapToken = null, password = null),
+      auth(token = "initial-token"),
     )
     runtime.disconnect()
     assertNull(desiredConnection(runtime, "nodeSession"))
@@ -765,22 +609,12 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun connect_showsSecureEndpointGuidanceWhenTlsProbeFails() {
-    val app = RuntimeEnvironment.getApplication()
-    val runtime =
-      NodeRuntime(
-        app,
-        SecurePrefs(
-          app,
-          app.getSharedPreferences("openclaw.node.secure.test.${UUID.randomUUID()}", android.content.Context.MODE_PRIVATE),
-        ),
-        tlsFingerprintProbe = { _, _ ->
-          GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.TLS_UNAVAILABLE)
-        },
-      )
+    val (_, _, runtime) =
+      gatewayFixture { _, _ -> GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.TLS_UNAVAILABLE) }
 
     runtime.connect(
       GatewayEndpoint.manual(host = "gateway.example", port = 18789),
-      NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
+      auth(token = "shared-token"),
     )
 
     assertEquals(
@@ -794,23 +628,13 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun connect_enforcesAcceptedManualFingerprintAfterTlsProbeFailure() {
-    val app = RuntimeEnvironment.getApplication()
-    val prefs =
-      SecurePrefs(
-        app,
-        app.getSharedPreferences("openclaw.node.secure.test.${UUID.randomUUID()}", android.content.Context.MODE_PRIVATE),
-      )
-    val runtime =
-      NodeRuntime(
-        app,
-        prefs,
-        tlsFingerprintProbe = { _, _ -> GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.TLS_UNAVAILABLE) },
-      )
+    val (_, prefs, runtime) =
+      gatewayFixture { _, _ -> GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.TLS_UNAVAILABLE) }
     val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
 
     runtime.connect(
       endpoint,
-      NodeRuntime.GatewayConnectAuth(token = "test-token-placeholder", bootstrapToken = null, password = null),
+      auth(token = "test-token-placeholder"),
     )
     waitForGatewayTrustPrompt(runtime)
     val manualFingerprint = "cd".repeat(32)
@@ -824,22 +648,12 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun connect_showsTlsTimeoutGuidanceWhenFingerprintProbeTimesOut() {
-    val app = RuntimeEnvironment.getApplication()
-    val runtime =
-      NodeRuntime(
-        app,
-        SecurePrefs(
-          app,
-          app.getSharedPreferences("openclaw.node.secure.test.${UUID.randomUUID()}", android.content.Context.MODE_PRIVATE),
-        ),
-        tlsFingerprintProbe = { _, _ ->
-          GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.TLS_HANDSHAKE_TIMEOUT)
-        },
-      )
+    val (_, _, runtime) =
+      gatewayFixture { _, _ -> GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.TLS_HANDSHAKE_TIMEOUT) }
 
     runtime.connect(
       GatewayEndpoint.manual(host = "gateway.example", port = 18789),
-      NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
+      auth(token = "shared-token"),
     )
 
     assertEquals(
@@ -854,14 +668,7 @@ class GatewayBootstrapAuthTest {
   @Test
   fun resetGatewaySetupAuth_clearsOnlyTargetGatewayCredentialsAndDeviceTokens() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      val securePrefs =
-        app.getSharedPreferences(
-          "openclaw.node.secure.test.${UUID.randomUUID()}",
-          android.content.Context.MODE_PRIVATE,
-        )
-      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-      val runtime = NodeRuntime(app, prefs)
+      val (app, prefs, runtime) = gatewayFixture()
       val deviceId = DeviceIdentityStore.withPrefs(app, prefs).loadOrCreate().deviceId
       val authStore = DeviceAuthStore(prefs)
       val target = GatewayEndpoint.manual("target.example", 18789).stableId
@@ -883,12 +690,7 @@ class GatewayBootstrapAuthTest {
   fun resetGatewaySetupAuthClearsInjectedTranscriptStore() =
     runBlocking {
       val app = RuntimeEnvironment.getApplication()
-      val securePrefs =
-        app.getSharedPreferences(
-          "openclaw.node.secure.test.${UUID.randomUUID()}",
-          android.content.Context.MODE_PRIVATE,
-        )
-      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+      val prefs = testPrefs(app)
       val transcriptCache = RecordingTranscriptCache()
       val runtime = NodeRuntime(app, prefs, transcriptCache)
       val target = GatewayEndpoint.manual("target.example", 18789).stableId
@@ -900,14 +702,7 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun switchToUndiscoveredGatewayKeepsCurrentConnectionAndActiveGateway() {
-    val app = RuntimeEnvironment.getApplication()
-    val securePrefs =
-      app.getSharedPreferences(
-        "openclaw.node.secure.test.${UUID.randomUUID()}",
-        android.content.Context.MODE_PRIVATE,
-      )
-    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-    val runtime = NodeRuntime(app, prefs)
+    val (_, prefs, runtime) = gatewayFixture()
     neutralizeColdStartAutoConnect(runtime)
     val current = GatewayEndpoint.manual("127.0.0.1", 18789)
     val missingStableId = "bonjour-missing"
@@ -942,14 +737,9 @@ class GatewayBootstrapAuthTest {
   fun gatewayConnectDoesNotHoldAuthMonitorWhileWaitingForSessionLifecycle() =
     runBlocking {
       val app = RuntimeEnvironment.getApplication()
-      val securePrefs =
-        app.getSharedPreferences(
-          "openclaw.node.secure.test.${UUID.randomUUID()}",
-          android.content.Context.MODE_PRIVATE,
-        )
-      val runtime = NodeRuntime(app, SecurePrefs(app, securePrefsOverride = securePrefs))
+      val runtime = NodeRuntime(app, testPrefs(app))
       val endpoint = GatewayEndpoint.manual("127.0.0.1", 18789)
-      val auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap", password = null)
+      val auth = auth(bootstrapToken = "bootstrap")
       val nodeSession = readField<GatewaySession>(runtime, "nodeSession")
       val lifecycleLock = readField<Any>(nodeSession, "lifecycleLock")
       val connectWithAuth =
@@ -1009,12 +799,7 @@ class GatewayBootstrapAuthTest {
   fun restoredManualMicWithoutRecordAudioClearsStalePreference() {
     val app = RuntimeEnvironment.getApplication()
     shadowOf(app).denyPermissions(Manifest.permission.RECORD_AUDIO)
-    val securePrefs =
-      app.getSharedPreferences(
-        "openclaw.node.secure.test.${UUID.randomUUID()}",
-        android.content.Context.MODE_PRIVATE,
-      )
-    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+    val prefs = testPrefs(app)
     prefs.setVoiceMicEnabled(true)
 
     val runtime = NodeRuntime(app, prefs)
@@ -1027,8 +812,7 @@ class GatewayBootstrapAuthTest {
   @Test
   fun revokedRecordAudioPermissionStopsGatewayPttBeforeMicStart() {
     val app = RuntimeEnvironment.getApplication()
-    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-    val runtime = createTestRuntime(app)
+    val runtime = createVoiceRuntime(app)
     val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
     writeField(talkMode, "activePttCaptureId", "capture-1")
     talkMode.ttsOnAllResponses = true
@@ -1048,9 +832,7 @@ class GatewayBootstrapAuthTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   fun voiceNoteMicOwnershipBlocksLocalVoiceAndGatewayPtt() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = createTestRuntime(app)
+      val runtime = createVoiceRuntime()
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
       Dispatchers.setMain(Dispatchers.Unconfined)
       try {
@@ -1074,9 +856,7 @@ class GatewayBootstrapAuthTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   fun dictationMicOwnershipBlocksLocalVoiceAndGatewayPtt() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = createTestRuntime(app)
+      val runtime = createVoiceRuntime()
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
       Dispatchers.setMain(Dispatchers.Unconfined)
       try {
@@ -1100,9 +880,7 @@ class GatewayBootstrapAuthTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   fun talkPttStart_cleansPreparedCaptureWhenBeginFails() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = createTestRuntime(app)
+      val runtime = createVoiceRuntime()
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
       Dispatchers.setMain(Dispatchers.Unconfined)
       try {
@@ -1121,9 +899,7 @@ class GatewayBootstrapAuthTest {
   @Test
   fun talkPttStart_rejectsNewCaptureWhenBackgrounded() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = createTestRuntime(app)
+      val runtime = createVoiceRuntime()
       runtime.setForeground(false)
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
 
@@ -1137,9 +913,7 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun staleTalkPttCleanupPreservesNewerManualMicOwnership() {
-    val app = RuntimeEnvironment.getApplication()
-    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-    val runtime = createTestRuntime(app)
+    val runtime = createVoiceRuntime()
     val ownershipEpoch = readField<AtomicLong>(runtime, "voiceCaptureOwnershipEpoch")
     ownershipEpoch.set(41L)
 
@@ -1155,9 +929,7 @@ class GatewayBootstrapAuthTest {
   @Test
   fun talkPttOnceRetryReturnsBusyWithoutPreparingCapture() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = createTestRuntime(app)
+      val runtime = createVoiceRuntime()
       val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
       writeField(talkMode, "activePttCaptureId", "capture-1")
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
@@ -1179,9 +951,7 @@ class GatewayBootstrapAuthTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   fun talkPttOnceRechecksFinishingTurnAfterPreparationWait() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = createTestRuntime(app)
+      val runtime = createVoiceRuntime()
       val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
       val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
@@ -1206,9 +976,7 @@ class GatewayBootstrapAuthTest {
   @Test
   fun talkPttStartRejectsFinishingTurnWithoutPreparingCapture() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = createTestRuntime(app)
+      val runtime = createVoiceRuntime()
       val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
       writeField(talkMode, "finishingPttCaptureId", "capture-1")
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
@@ -1230,9 +998,7 @@ class GatewayBootstrapAuthTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   fun pttStartQueuedAfterCancelUsesNewCommandEpoch() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = createTestRuntime(app)
+      val runtime = createVoiceRuntime()
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
       val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
       Dispatchers.setMain(Dispatchers.Unconfined)
@@ -1259,9 +1025,7 @@ class GatewayBootstrapAuthTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   fun pttStartWaitingForPreparationIsInvalidatedByCancel() =
     runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = createTestRuntime(app)
+      val runtime = createVoiceRuntime()
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
       val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
       Dispatchers.setMain(Dispatchers.Unconfined)
@@ -1286,9 +1050,7 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun sameManualMicModeReassertsCaptureAndInvalidatesPendingPtt() {
-    val app = RuntimeEnvironment.getApplication()
-    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-    val runtime = createTestRuntime(app)
+    val runtime = createVoiceRuntime()
     runtime.setMicEnabled(true)
     val commandEpoch = readField<AtomicLong>(runtime, "talkPttCommandEpoch")
     val epochBeforeReassertion = commandEpoch.get()
@@ -1307,9 +1069,7 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun sameTalkModeReassertionStopsManualMicCapture() {
-    val app = RuntimeEnvironment.getApplication()
-    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-    val runtime = createTestRuntime(app)
+    val runtime = createVoiceRuntime()
     readField<CoroutineScope>(runtime, "scope").coroutineContext[Job]?.cancel()
     runtime.setTalkModeEnabled(true)
     val micCapture = readField<Lazy<MicCaptureManager>>(runtime, "micCapture\$delegate").value
@@ -1325,8 +1085,7 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun backgroundingStopsTalkModeCapture() {
-    val app = RuntimeEnvironment.getApplication()
-    val runtime = createTestRuntime(app)
+    val runtime = createTestRuntime(RuntimeEnvironment.getApplication())
     val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
     readField<MutableStateFlow<VoiceCaptureMode>>(runtime, "_voiceCaptureMode").value = VoiceCaptureMode.TalkMode
     readField<MutableStateFlow<Boolean>>(talkMode, "_isEnabled").value = true
@@ -1347,9 +1106,7 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun backgroundingStopsGatewayPttWhenVoiceModeIsOff() {
-    val app = RuntimeEnvironment.getApplication()
-    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-    val runtime = createTestRuntime(app)
+    val runtime = createVoiceRuntime()
     val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
     writeField(talkMode, "activePttCaptureId", "capture-1")
     readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value = true
@@ -1390,12 +1147,7 @@ class GatewayBootstrapAuthTest {
   // discovery collector can never observe an auto-connectable active gateway.
   private fun createNeutralizedRuntime(): Pair<NodeRuntime, SecurePrefs> {
     val app = RuntimeEnvironment.getApplication()
-    val securePrefs =
-      app.getSharedPreferences(
-        "openclaw.node.secure.test.${UUID.randomUUID()}",
-        android.content.Context.MODE_PRIVATE,
-      )
-    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+    val prefs = testPrefs(app)
     val runtime = NodeRuntime(app, prefs)
     neutralizeColdStartAutoConnect(runtime)
     return runtime to prefs
@@ -1443,14 +1195,53 @@ class GatewayBootstrapAuthTest {
     error("Expected pending gateway trust prompt")
   }
 
-  private fun createTestRuntime(app: android.app.Application): NodeRuntime {
-    val securePrefs =
+  private fun createTestRuntime(app: android.app.Application): NodeRuntime = NodeRuntime(app, testPrefs(app))
+
+  private fun createVoiceRuntime(
+    app: android.app.Application = RuntimeEnvironment.getApplication(),
+  ): NodeRuntime {
+    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+    return createTestRuntime(app)
+  }
+
+  private fun testPrefs(app: android.app.Application): SecurePrefs =
+    SecurePrefs(
+      app,
       app.getSharedPreferences(
         "openclaw.node.secure.test.${UUID.randomUUID()}",
         android.content.Context.MODE_PRIVATE,
-      )
-    return NodeRuntime(app, SecurePrefs(app, securePrefsOverride = securePrefs))
+      ),
+    )
+
+  private data class GatewayFixture(
+    val app: android.app.Application,
+    val prefs: SecurePrefs,
+    val runtime: NodeRuntime,
+  )
+
+  private fun gatewayFixture(
+    tlsFingerprintProbe: (suspend (String, Int) -> GatewayTlsProbeResult)? = null,
+  ): GatewayFixture {
+    val app: android.app.Application = RuntimeEnvironment.getApplication()
+    val prefs = testPrefs(app)
+    val runtime =
+      tlsFingerprintProbe?.let { NodeRuntime(app, prefs, tlsFingerprintProbe = it) }
+        ?: NodeRuntime(app, prefs)
+    return GatewayFixture(app, prefs, runtime)
   }
+
+  private fun auth(
+    token: String? = null,
+    bootstrapToken: String? = null,
+    password: String? = null,
+  ): NodeRuntime.GatewayConnectAuth = NodeRuntime.GatewayConnectAuth(token, bootstrapToken, password)
+
+  private fun operatorAuth(
+    auth: NodeRuntime.GatewayConnectAuth,
+    storedToken: String? = null,
+  ): NodeRuntime.GatewayConnectAuth? = resolveOperatorSessionConnectAuth(auth, storedToken)
+
+  private fun usesStoredOperatorToken(auth: NodeRuntime.GatewayConnectAuth): Boolean = operatorSessionUsesStoredDeviceToken(auth, "stored-token")
 
   private fun waitForStatusText(runtime: NodeRuntime): String {
     repeat(50) {
@@ -1510,18 +1301,7 @@ class GatewayBootstrapAuthTest {
     name: String,
     value: Any?,
   ) {
-    var type: Class<*>? = target.javaClass
-    while (type != null) {
-      try {
-        val field: Field = type.getDeclaredField(name)
-        field.isAccessible = true
-        field.set(target, value)
-        return
-      } catch (_: NoSuchFieldException) {
-        type = type.superclass
-      }
-    }
-    error("Field $name not found on ${target.javaClass.name}")
+    findTestField(target, name).set(target, value)
   }
 
   private fun waitForDesiredBootstrapToken(
@@ -1543,18 +1323,8 @@ class GatewayBootstrapAuthTest {
     target: Any,
     name: String,
   ): T {
-    var type: Class<*>? = target.javaClass
-    while (type != null) {
-      try {
-        val field: Field = type.getDeclaredField(name)
-        field.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        return field.get(target) as T
-      } catch (_: NoSuchFieldException) {
-        type = type.superclass
-      }
-    }
-    error("Field $name not found on ${target.javaClass.name}")
+    @Suppress("UNCHECKED_CAST")
+    return findTestField(target, name).get(target) as T
   }
 
   private class RecordingTranscriptCache : ChatTranscriptCache {
@@ -1602,4 +1372,19 @@ class GatewayBootstrapAuthTest {
       clearedGatewayIds += gatewayId
     }
   }
+}
+
+internal fun findTestField(
+  target: Any,
+  name: String,
+): Field {
+  var type: Class<*>? = target.javaClass
+  while (type != null) {
+    try {
+      return type.getDeclaredField(name).apply { isAccessible = true }
+    } catch (_: NoSuchFieldException) {
+      type = type.superclass
+    }
+  }
+  error("Field $name not found on ${target.javaClass.name}")
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayExecApprovalRuntimeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayExecApprovalRuntimeTest.kt
@@ -27,7 +27,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import java.lang.reflect.Field
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -47,9 +46,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun anotherSurfaceWinnerClosesLocalCardFromCanonicalResolveResult() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime()
       val requests = mutableListOf<Pair<String, String?>>()
       runtime.gatewayDataRequestOverrideForTests = { _, method, params ->
         requests += method to params
@@ -71,16 +68,14 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun exactApprovalIdsCannotCrossTargetThroughKotlinWhitespaceNormalization() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
       val controlPrefixedId = "\u001Capproval-1"
-      seedApprovals(
-        runtime,
-        listOf(
-          approvalSummary(id = controlPrefixedId, commandText = "echo selected"),
-          approvalSummary(id = "approval-1", commandText = "echo other"),
-        ),
-      )
+      val runtime =
+        twoApprovalRuntime(
+          firstCommand = "echo selected",
+          secondCommand = "echo other",
+          firstId = controlPrefixedId,
+          secondId = "approval-1",
+        )
       val requestParams = CompletableDeferred<String>()
       val requestCount = AtomicInteger()
       runtime.gatewayDataRequestOverrideForTests = { _, method, params ->
@@ -116,8 +111,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun approvalEventsPreserveExactStringIdsAndRejectNonStrings() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
+      val runtime = connectedRuntime()
       val controlPrefixedId = "\u001Capproval-1"
       val requestedIds = mutableListOf<String>()
       val methods = mutableListOf<String>()
@@ -153,9 +147,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun malformedOrMismatchedWriteResultFreezesThenUsesCanonicalReadback() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime()
       val methods = mutableListOf<String>()
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         methods += method
@@ -180,9 +172,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun unknownWriteOutcomeStaysFrozenAndReconcilesAfterReconnect() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime()
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         when (method) {
           "approval.resolve", "approval.get" -> throw GatewayRequestOutcomeUnknown("disconnected")
@@ -222,9 +212,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun cancelledApprovalRefreshPreservesOwnerStateWithoutPublishingFailure() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime()
       val requestStarted = CompletableDeferred<Unit>()
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         check(method == "exec.approval.list")
@@ -245,9 +233,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun reconnectListHydrationPublishesTerminalForRetainedUnknownWrite() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime()
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         when (method) {
           "approval.resolve", "approval.get" -> throw GatewayRequestOutcomeUnknown("disconnected")
@@ -284,9 +270,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun reconnectKeepsInFlightWriteDisabledBeforeRetiredWaiterFails() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime()
       val resolveStarted = CompletableDeferred<Unit>()
       val releaseUnknownOutcome = CompletableDeferred<Unit>()
       val pendingReadCompleted = CompletableDeferred<Unit>()
@@ -345,9 +329,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun fullRefreshCannotUnlockApprovalWhileResolveRequestIsInFlight() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime()
       val resolveStarted = CompletableDeferred<Unit>()
       val releaseResolve = CompletableDeferred<Unit>()
       val refreshReadCompleted = CompletableDeferred<Unit>()
@@ -390,15 +372,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun unknownWriteInvalidatesRefreshSnapshotBuiltWhileRequestWasInFlight() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApprovals(
-        runtime,
-        listOf(
-          approvalSummary(id = "approval-1", commandText = "echo selected"),
-          approvalSummary(id = "approval-2", commandText = "echo retained"),
-        ),
-      )
+      val runtime = twoApprovalRuntime("echo selected", "echo retained")
       val resolveStarted = CompletableDeferred<Unit>()
       val releaseUnknownOutcome = CompletableDeferred<Unit>()
       val retainedReadStarted = CompletableDeferred<Unit>()
@@ -469,9 +443,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun canonicalPendingReadbackInvalidatesConcurrentStaleRefresh() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime()
       val pendingReadStarted = CompletableDeferred<Unit>()
       val staleRefreshReadStarted = CompletableDeferred<Unit>()
       val releasePendingRead = CompletableDeferred<Unit>()
@@ -531,9 +503,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun legacyUnknownWriteUnlocksAfterReconnectProvesApprovalStillPending() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, legacyMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime(legacyMethods)
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         when (method) {
           "exec.approval.resolve", "exec.approval.get" -> throw GatewayRequestOutcomeUnknown("disconnected")
@@ -594,9 +564,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun legacySuccessUsesNeutralWinnerAttribution() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, legacyMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime(legacyMethods)
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         check(method == "exec.approval.resolve")
         """{"ok":true}"""
@@ -611,9 +579,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun resolutionEventWinsRaceAgainstLateLocalResponse() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime()
       val resolveStarted = CompletableDeferred<Unit>()
       val releaseResolve = CompletableDeferred<Unit>()
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
@@ -646,15 +612,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun legacyResolutionEventWinsBeforeLateResponseAndListFailure() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, legacyMethods)
-      seedApprovals(
-        runtime,
-        listOf(
-          approvalSummary(id = "approval-1", commandText = "echo selected"),
-          approvalSummary(id = "approval-2", commandText = "echo retained"),
-        ),
-      )
+      val runtime = twoApprovalRuntime("echo selected", "echo retained", legacyMethods)
       val methods = mutableListOf<String>()
       val resolveStarted = CompletableDeferred<Unit>()
       val releaseResolve = CompletableDeferred<Unit>()
@@ -667,12 +625,7 @@ class GatewayExecApprovalRuntimeTest {
             """{"ok":true}"""
           }
           "exec.approval.list", "exec.approval.get" ->
-            throw GatewayRequestRejected(
-              GatewaySession.ErrorShape(
-                code = "UNAVAILABLE",
-                message = "$method failed",
-              ),
-            )
+            throw rejected("UNAVAILABLE", "$method failed")
           else -> error("unexpected method $method")
         }
       }
@@ -704,15 +657,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun legacyAlreadyResolvedRejectionRetiresExactCardWithoutEvent() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, legacyMethods)
-      seedApprovals(
-        runtime,
-        listOf(
-          approvalSummary(id = "approval-1", commandText = "echo selected"),
-          approvalSummary(id = "approval-2", commandText = "echo retryable"),
-        ),
-      )
+      val runtime = twoApprovalRuntime("echo selected", "echo retryable", legacyMethods)
       val resolvedIds = mutableListOf<String>()
       runtime.gatewayDataRequestOverrideForTests = { _, method, params ->
         check(method == "exec.approval.resolve")
@@ -724,13 +669,7 @@ class GatewayExecApprovalRuntimeTest {
             ?: error("missing approval id")
         resolvedIds += id
         val reason = if (id == "approval-1") "APPROVAL_ALREADY_RESOLVED" else "OTHER_REJECTION"
-        throw GatewayRequestRejected(
-          GatewaySession.ErrorShape(
-            code = "INVALID_REQUEST",
-            message = "approval rejected",
-            details = gatewayErrorDetails(reason),
-          ),
-        )
+        throw rejected("INVALID_REQUEST", "approval rejected", reason)
       }
 
       runtime.resolveExecApproval("approval-1", "allow-once")
@@ -755,9 +694,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun legacyAlreadyResolvedRacingMethodsEpochBumpReconcilesWrite() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, legacyMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime(legacyMethods)
       val resolveStarted = CompletableDeferred<Unit>()
       val releaseResolve = CompletableDeferred<Unit>()
       val methods = mutableListOf<String>()
@@ -767,13 +704,7 @@ class GatewayExecApprovalRuntimeTest {
           "exec.approval.resolve" -> {
             resolveStarted.complete(Unit)
             releaseResolve.await()
-            throw GatewayRequestRejected(
-              GatewaySession.ErrorShape(
-                code = "INVALID_REQUEST",
-                message = "approval rejected",
-                details = gatewayErrorDetails("APPROVAL_ALREADY_RESOLVED"),
-              ),
-            )
+            throw rejected("INVALID_REQUEST", "approval rejected", "APPROVAL_ALREADY_RESOLVED")
           }
           "exec.approval.get" -> legacyGet()
           else -> error("unexpected method $method")
@@ -802,15 +733,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun terminalNoticeSurvivesRefreshUntilUserDismissal() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApprovals(
-        runtime,
-        listOf(
-          approvalSummary(id = "approval-1", commandText = "echo losing"),
-          approvalSummary(id = "approval-2", commandText = "echo retained"),
-        ),
-      )
+      val runtime = twoApprovalRuntime("echo losing", "echo retained")
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         check(method == "approval.resolve")
         unifiedResolve(applied = false, status = "denied", decision = "deny")
@@ -846,24 +769,14 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun unrelatedApprovalWriteKeepsUnacknowledgedTerminalNotice() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApprovals(
-        runtime,
-        listOf(
-          approvalSummary(id = "approval-1", commandText = "echo losing"),
-          approvalSummary(id = "approval-2", commandText = "echo unrelated"),
-        ),
-      )
+      val runtime = twoApprovalRuntime("echo losing", "echo unrelated")
       runtime.gatewayDataRequestOverrideForTests = { _, method, params ->
         check(method == "approval.resolve")
         val request = Json.parseToJsonElement(requireNotNull(params)).jsonObject
         when (val id = request["id"]?.jsonPrimitive?.content) {
           "approval-1" -> unifiedResolve(applied = false, status = "denied", decision = "deny")
           "approval-2" ->
-            throw GatewayRequestRejected(
-              GatewaySession.ErrorShape(code = "UNAVAILABLE", message = "resolve failed"),
-            )
+            throw rejected("UNAVAILABLE", "resolve failed")
           else -> error("unexpected approval id $id")
         }
       }
@@ -890,15 +803,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun staleDismissLeavesReplacementNoticeVisible() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApprovals(
-        runtime,
-        listOf(
-          approvalSummary(id = "approval-1", commandText = "echo first"),
-          approvalSummary(id = "approval-2", commandText = "echo second"),
-        ),
-      )
+      val runtime = twoApprovalRuntime("echo first", "echo second")
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         when (method) {
           "approval.resolve" -> unifiedResolve(applied = false, status = "denied", decision = "deny")
@@ -932,9 +837,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun staleDismissCannotClearStructurallyEqualReplacementNotice() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime()
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         when (method) {
           "approval.resolve" -> unifiedResolve(applied = false, status = "denied", decision = "deny")
@@ -971,11 +874,10 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun oldGatewayUsesOnlyShippedExecMethods() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(
-        runtime,
-        setOf("exec.approval.list", "exec.approval.get", "exec.approval.resolve"),
-      )
+      val runtime =
+        connectedRuntime(
+          setOf("exec.approval.list", "exec.approval.get", "exec.approval.resolve"),
+        )
       val methods = mutableListOf<String>()
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         methods += method
@@ -1007,9 +909,8 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun partialCanonicalCatalogCannotMixWithLegacyApprovalMethods() =
     runBlocking {
-      val runtime = createTestRuntime()
       val mixedMethods = legacyMethods + "approval.get"
-      seedConnectedRuntime(runtime, mixedMethods)
+      val runtime = connectedRuntime(mixedMethods)
       val methods = mutableListOf<String>()
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         methods += method
@@ -1042,8 +943,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun canonicalUnknownReadFailsClosedWithoutLegacyDowngrade() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, allApprovalMethods)
+      val runtime = connectedRuntime(allApprovalMethods)
       val methods = mutableListOf<String>()
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         methods += method
@@ -1051,12 +951,7 @@ class GatewayExecApprovalRuntimeTest {
           "exec.approval.list" ->
             """[{"id":"approval-1","createdAtMs":100,"expiresAtMs":4000000000000}]"""
           "approval.get" ->
-            throw GatewayRequestRejected(
-              GatewaySession.ErrorShape(
-                code = "INVALID_REQUEST",
-                message = "unknown method: approval.get",
-              ),
-            )
+            throw rejected("INVALID_REQUEST", "unknown method: approval.get")
           "exec.approval.get" -> error("canonical hello must never downgrade")
           else -> error("unexpected method $method")
         }
@@ -1076,20 +971,13 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun canonicalUnknownResolveFailsClosedWithoutLegacyDowngrade() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, allApprovalMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime(allApprovalMethods)
       val methods = mutableListOf<String>()
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
         methods += method
         when (method) {
           "approval.resolve" ->
-            throw GatewayRequestRejected(
-              GatewaySession.ErrorShape(
-                code = "INVALID_REQUEST",
-                message = "unknown method: approval.resolve",
-              ),
-            )
+            throw rejected("INVALID_REQUEST", "unknown method: approval.resolve")
           "exec.approval.resolve" -> error("canonical hello must never downgrade")
           else -> error("unexpected method $method")
         }
@@ -1110,9 +998,7 @@ class GatewayExecApprovalRuntimeTest {
   @Test
   fun staleCanonicalRejectionFromRetiredSocketCannotAffectReplacementCatalog() =
     runBlocking {
-      val runtime = createTestRuntime()
-      seedConnectedRuntime(runtime, unifiedMethods)
-      seedApproval(runtime)
+      val runtime = approvalRuntime()
       val firstResolveStarted = CompletableDeferred<Unit>()
       val releaseFirstResolve = CompletableDeferred<Unit>()
       val methods = mutableListOf<String>()
@@ -1125,12 +1011,7 @@ class GatewayExecApprovalRuntimeTest {
             if (unifiedResolveCalls == 1) {
               firstResolveStarted.complete(Unit)
               releaseFirstResolve.await()
-              throw GatewayRequestRejected(
-                GatewaySession.ErrorShape(
-                  code = "INVALID_REQUEST",
-                  message = "unknown method: approval.resolve",
-                ),
-              )
+              throw rejected("INVALID_REQUEST", "unknown method: approval.resolve")
             }
             unifiedResolve(applied = true, status = "denied", decision = "deny")
           }
@@ -1163,6 +1044,28 @@ class GatewayExecApprovalRuntimeTest {
       )
     return NodeRuntime(app, SecurePrefs(app, securePrefsOverride = securePrefs))
   }
+
+  private fun connectedRuntime(methods: Set<String> = unifiedMethods): NodeRuntime = createTestRuntime().also { seedConnectedRuntime(it, methods) }
+
+  private fun approvalRuntime(
+    methods: Set<String> = unifiedMethods,
+    approvals: List<GatewayExecApprovalSummary> = listOf(approvalSummary()),
+  ): NodeRuntime = connectedRuntime(methods).also { seedApprovals(it, approvals) }
+
+  private fun twoApprovalRuntime(
+    firstCommand: String,
+    secondCommand: String,
+    methods: Set<String> = unifiedMethods,
+    firstId: String = "approval-1",
+    secondId: String = "approval-2",
+  ): NodeRuntime =
+    approvalRuntime(
+      methods,
+      listOf(
+        approvalSummary(id = firstId, commandText = firstCommand),
+        approvalSummary(id = secondId, commandText = secondCommand),
+      ),
+    )
 
   private fun seedConnectedRuntime(
     runtime: NodeRuntime,
@@ -1246,7 +1149,7 @@ class GatewayExecApprovalRuntimeTest {
     name: String,
     value: Any?,
   ) {
-    findField(target, name).set(target, value)
+    findTestField(target, name).set(target, value)
   }
 
   private fun <T> readField(
@@ -1254,22 +1157,7 @@ class GatewayExecApprovalRuntimeTest {
     name: String,
   ): T {
     @Suppress("UNCHECKED_CAST")
-    return findField(target, name).get(target) as T
-  }
-
-  private fun findField(
-    target: Any,
-    name: String,
-  ): Field {
-    var type: Class<*>? = target.javaClass
-    while (type != null) {
-      try {
-        return type.getDeclaredField(name).apply { isAccessible = true }
-      } catch (_: NoSuchFieldException) {
-        type = type.superclass
-      }
-    }
-    error("Field $name not found on ${target.javaClass.name}")
+    return findTestField(target, name).get(target) as T
   }
 
   private fun unifiedResolve(
@@ -1340,6 +1228,12 @@ class GatewayExecApprovalRuntimeTest {
       recommendedNextStep = null,
       reason = reason,
     )
+
+  private fun rejected(
+    code: String,
+    message: String,
+    reason: String? = null,
+  ): GatewayRequestRejected = GatewayRequestRejected(GatewaySession.ErrorShape(code, message, reason?.let(::gatewayErrorDetails)))
 
   private val unifiedMethods = setOf("approval.get", "approval.resolve", "exec.approval.list")
   private val legacyMethods = setOf("exec.approval.list", "exec.approval.get", "exec.approval.resolve")


### PR DESCRIPTION
## Summary

- centralize fresh Android gateway runtime, preferences, TLS-probe, auth, voice, approval, rejection, and reflection fixtures
- remove repeated setup while retaining all 79 named security/lifecycle tests and every assertion call
- keep production, config, protocol, schema, dependencies, and user-visible behavior unchanged

## Repair shape

Root cause: these two gateway security suites repeatedly rebuilt the same UUID-isolated `SecurePrefs`/`NodeRuntime`, approval catalog, exception, microphone-permission, and superclass-reflection setup. The duplication obscured the security-specific inputs and made fixes easy to apply unevenly.

Architectural owner: the test fixtures in `GatewayBootstrapAuthTest.kt` and `GatewayExecApprovalRuntimeTest.kt`. Production ownership remains in `NodeRuntime`, `GatewaySession`, `GatewayTls`, `SecurePrefs`, and `DeviceAuthStore`.

Canonical fix: local deterministic fixture helpers preserve create -> connect/catalog seed -> approval seed ordering, use a fresh preferences namespace/runtime per invocation, and leave concrete assertions in each named case. Removed paths are duplicated test setup only; no runtime fallback or compatibility path changed.

## Size and parity

- production LOC: `0`
- tests/total: `+219/-540`, net `-321`
- tests: exact `53 + 26 = 79` names retained
- assertion calls: exact per-file parity across `assertEquals`, `assertFalse`, `assertNotEquals`, `assertNotNull`, `assertNull`, and `assertTrue`
- reviewed diff SHA-256: `2bbc636c39036e3b534918012aabbe69725f602757793245381b56a7baa77980`

## Security/lifecycle coverage retained

- bootstrap-only isolation and stored operator-token handoff
- explicit shared auth preference and operator/admin scope behavior
- TLS trust prompt, pin replacement, manual fingerprint, timeout, and stale-probe fencing
- pairing/credential/token/transcript reset ownership
- canonical versus legacy approval methods, fail-closed routing, unknown write reconciliation, stale socket/epoch fencing, and notice lifecycle
- coroutine cancellation/connect ordering and microphone ownership races

## Proof

Blacksmith Testbox lease `tbx_01kz1ywkx530x4em7v8yy9gxza`:

- `:app:ktlintCheck`: passed
- focused `GatewayBootstrapAuthTest` + `GatewayExecApprovalRuntimeTest`: passed in Play and third-party flavors
- adjacent pairing, approval parsing/state, secure preferences, device auth, TLS, and gateway-session ring: 142 tests passed per flavor
- repository `pnpm check:changed -- <two files>` gate: passed
- synthetic merge against current `origin/main`: clean; no Android files changed on main since the proven base

One combined adjacent run hit Robolectric's `FileSystemAlreadyExistsException` while loading native fonts across consecutive flavor tasks in one reused Gradle daemon. Third-party passed immediately in isolation; Play then passed all 142 with a fresh single-use daemon. The focused both-flavor run had already passed.

Two independent xhigh reviewers returned CLEAN and judged this the canonical bounded fix. Their only residual note is the intentional package-level test-helper relationship for superclass reflection; both flavors compile and exercise the complete test source set.

Final collision census through `2026-08-02T19:55:14.981Z`: 143 updated open PRs fully paged, including the 213-file oversized tail; exact matches for both reserved paths were zero.

No changelog: test-only refactor with no user-visible behavior change.
