### PR TITLE
test(android): compact chat recovery fixtures

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
@@ -22,34 +21,76 @@ import org.junit.Test
  * refetches chat.history and re-adopts the run the gateway still reports in flight
  * (`inFlightRun`), matching the reconnect snapshot contract the TUI consumes.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class ChatControllerReconnectRestoreTest {
-  private val json = Json { ignoreUnknownKeys = true }
+  private val json = chatControllerTestJson
+  private val ChatController.messageTexts: List<String?>
+    get() = messages.value.map { it.content.single().text }
 
   // The controller runs on backgroundScope: while a restored run stays in flight the
   // pending-run watchdog keeps re-arming, so its timer must be cancelled by runTest
   // instead of counting as an uncompleted test coroutine.
-  private fun TestScope.newController(gateway: ScriptedGateway): ChatController = ChatController(scope = backgroundScope, json = json, requestGateway = gateway::request)
+  private fun TestScope.newController(gateway: ScriptedGateway): ChatController = backgroundScope.createChatController(requestGateway = gateway::request)
 
   private fun TestScope.newScopedController(gateway: ScriptedGateway): ChatController =
-    ChatController(
-      scope = backgroundScope,
-      json = json,
+    backgroundScope.createChatController(
       requestGateway = gateway::request,
       requestGatewayForGateway = { _, method, paramsJson -> gateway.request(method, paramsJson) },
       cacheScope = { ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 1) },
     )
 
+  private fun TestScope.loadController(gateway: ScriptedGateway): ChatController =
+    newController(gateway).also {
+      it.load("main")
+      runCurrent()
+    }
+
+  private fun TestScope.loadController(
+    gateway: ScriptedGateway,
+    history: String,
+  ): ChatController {
+    gateway.respondWith("chat.history", history)
+    return loadController(gateway)
+  }
+
+  private fun TestScope.recoverSeqGap(controller: ChatController) {
+    controller.handleGatewayEvent("seqGap", null)
+    runCurrent()
+  }
+
+  private fun TestScope.connect(controller: ChatController) {
+    controller.onGatewayConnected()
+    runCurrent()
+  }
+
+  private fun TestScope.reconnect(controller: ChatController) {
+    controller.onDisconnected("Reconnecting…")
+    connect(controller)
+  }
+
+  private fun TestScope.advanceRecoveryRetry() {
+    advanceTimeBy(750)
+    runCurrent()
+  }
+
+  private fun history(
+    messages: List<ReplayHistoryMessage>,
+    inFlightRun: Pair<String, String>? = null,
+    inFlightPlan: ChatPlanSnapshot? = null,
+    hasActiveRun: Boolean? = inFlightRun?.let { true },
+    activeRunIds: List<String>? = inFlightRun?.let { listOf(it.first) },
+  ): String = historyResponse("session-1", messages, inFlightRun, inFlightPlan, hasActiveRun, activeRunIds)
+
   private val userTurn = ReplayHistoryMessage("user", "keep working", 1_000)
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun connectedRefreshUpsertsDeviceSessionBeforeLoadingHistory() =
     runTest {
       val sessionKey = "agent:main:node-device"
       val gateway = ScriptedGateway(json)
       gateway.respondWith("sessions.describe", """{"session":null}""")
       gateway.respondWith("sessions.patch", """{"ok":true,"key":"$sessionKey"}""")
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       val controller = newScopedController(gateway)
 
       controller.load("agent:main:custom")
@@ -72,14 +113,13 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun connectedRefreshContinuesWhenSessionAdoptionFails() =
     runTest {
       val sessionKey = "agent:main:node-device"
       val gateway = ScriptedGateway(json)
       gateway.respondWith("sessions.describe", """{"session":null}""")
       gateway.respond("sessions.patch") { error("patch unavailable") }
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       val controller = newScopedController(gateway)
 
       controller.prepareMainSessionKey(sessionKey)
@@ -93,7 +133,6 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun connectedRefreshLabelsExistingSessionWithoutRecreatingIt() =
     runTest {
       val sessionKey = "agent:main:node-device"
@@ -119,7 +158,6 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun agentSelectionAcknowledgesUnreadDeviceSession() =
     runTest {
       val sessionKey = "agent:main:node-device"
@@ -129,7 +167,7 @@ class ChatControllerReconnectRestoreTest {
         """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}""",
       )
       gateway.respondWith("sessions.patch", """{"ok":true,"key":"$sessionKey"}""")
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       val controller = newScopedController(gateway)
       controller.handleGatewayEvent(
         "sessions.changed",
@@ -150,7 +188,6 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectRevalidatesWithoutOverwritingExistingLabel() =
     runTest {
       val sessionKey = "agent:main:node-device"
@@ -169,7 +206,7 @@ class ChatControllerReconnectRestoreTest {
             ?.content
         """{"ok":true,"key":"$sessionKey"}"""
       }
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       val controller = newScopedController(gateway)
       val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
 
@@ -195,7 +232,6 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun agentSwitchWaitsForTheLatestSessionAdoption() =
     runTest {
       val firstDescribe = CompletableDeferred<String>()
@@ -218,7 +254,7 @@ class ChatControllerReconnectRestoreTest {
             ?.content
         """{"ok":true,"key":"$key"}"""
       }
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       val controller = newScopedController(gateway)
 
       controller.prepareAndSelectMainSessionKey("agent:first:node-device")
@@ -258,7 +294,6 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectRecoveryWaitsForSessionReadiness() =
     runTest {
       val sessionKey = "agent:main:node-device"
@@ -272,7 +307,7 @@ class ChatControllerReconnectRestoreTest {
           """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}"""
         }
       }
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       val controller = newScopedController(gateway)
       val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
 
@@ -295,7 +330,6 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectCancelsStaleAdoptionAndRetriesOnTheNewTransport() =
     runTest {
       val sessionKey = "agent:main:node-device"
@@ -310,7 +344,7 @@ class ChatControllerReconnectRestoreTest {
           """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}"""
         }
       }
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       val controller = newScopedController(gateway)
       val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
 
@@ -329,7 +363,6 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectUpsertsSessionDeletedWhileDisconnected() =
     runTest {
       val sessionKey = "agent:main:node-device"
@@ -346,7 +379,7 @@ class ChatControllerReconnectRestoreTest {
         sessionExists = true
         """{"ok":true,"key":"$sessionKey"}"""
       }
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       val controller = newScopedController(gateway)
       val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
 
@@ -363,23 +396,18 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectAdoptsInFlightRunAndConsumesLiveEvents() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", listOf(userTurn)))
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway, history(listOf(userTurn)))
       assertEquals(0, controller.pendingRunCount.value)
 
       controller.onDisconnected("Reconnecting…")
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "partial reply"),
+        history(listOf(userTurn), inFlightRun = "run-active" to "partial reply"),
       )
-      controller.onGatewayConnected()
-      runCurrent()
+      connect(controller)
 
       assertEquals(1, controller.pendingRunCount.value)
       assertEquals("partial reply", controller.streamingAssistantText.value)
@@ -393,8 +421,7 @@ class ChatControllerReconnectRestoreTest {
       assertEquals("partial reply more", controller.streamingAssistantText.value)
       gateway.respondWith(
         "chat.history",
-        historyResponse(
-          "session-1",
+        history(
           listOf(userTurn, ReplayHistoryMessage("assistant", "partial reply more", 2_000)),
         ),
       )
@@ -410,19 +437,14 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectRestoresInFlightPlanSnapshot() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway, history(emptyList()))
 
       gateway.respondWith(
         "chat.history",
-        historyResponse(
-          "session-1",
+        history(
           emptyList(),
           inFlightRun = "run-active" to "working",
           inFlightPlan =
@@ -436,9 +458,7 @@ class ChatControllerReconnectRestoreTest {
             ),
         ),
       )
-      controller.onDisconnected("Reconnecting…")
-      controller.onGatewayConnected()
-      runCurrent()
+      reconnect(controller)
 
       assertEquals(
         listOf(
@@ -450,7 +470,6 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun historyPlanReconciliationContract() =
     runTest {
       val retainedSteps = listOf(ChatPlanStep("Retained", ChatPlanStepStatus.InProgress))
@@ -469,8 +488,7 @@ class ChatControllerReconnectRestoreTest {
           Case(
             name = "replace",
             history =
-              historyResponse(
-                "session-1",
+              history(
                 emptyList(),
                 inFlightRun = "run-retained" to "working",
                 inFlightPlan =
@@ -483,8 +501,7 @@ class ChatControllerReconnectRestoreTest {
           Case(
             name = "legacy-preserve",
             history =
-              historyResponse(
-                "session-1",
+              history(
                 emptyList(),
                 inFlightRun = "run-retained" to "working",
               ),
@@ -493,8 +510,7 @@ class ChatControllerReconnectRestoreTest {
           Case(
             name = "superseded",
             history =
-              historyResponse(
-                "session-1",
+              history(
                 emptyList(),
                 inFlightRun = "run-next" to "next",
                 inFlightPlan =
@@ -507,8 +523,7 @@ class ChatControllerReconnectRestoreTest {
           Case(
             name = "active-preserve",
             history =
-              historyResponse(
-                "session-1",
+              history(
                 emptyList(),
                 hasActiveRun = true,
                 activeRunIds = listOf("run-retained"),
@@ -518,8 +533,7 @@ class ChatControllerReconnectRestoreTest {
           Case(
             name = "terminal-clear",
             history =
-              historyResponse(
-                "session-1",
+              history(
                 emptyList(),
                 hasActiveRun = false,
                 activeRunIds = emptyList(),
@@ -529,8 +543,7 @@ class ChatControllerReconnectRestoreTest {
           Case(
             name = "no-evidence-preserve",
             history =
-              historyResponse(
-                "session-1",
+              history(
                 emptyList(),
                 hasActiveRun = null,
                 activeRunIds = null,
@@ -540,8 +553,7 @@ class ChatControllerReconnectRestoreTest {
           Case(
             name = "stale-response-does-not-clobber-newer-live-plan",
             history =
-              historyResponse(
-                "session-1",
+              history(
                 emptyList(),
                 hasActiveRun = false,
                 activeRunIds = emptyList(),
@@ -552,8 +564,7 @@ class ChatControllerReconnectRestoreTest {
           Case(
             name = "stale-previous-run-snapshot-does-not-clobber-newer-live-plan",
             history =
-              historyResponse(
-                "session-1",
+              history(
                 emptyList(),
                 inFlightRun = "run-previous" to "stale",
                 inFlightPlan = ChatPlanSnapshot(steps = emptyList()),
@@ -563,7 +574,7 @@ class ChatControllerReconnectRestoreTest {
           ),
           Case(
             name = "snapshot-for-newer-owned-run-is-accepted",
-            history = historyResponse("session-1", emptyList()),
+            history = history(emptyList()),
             expectedSteps = listOf(ChatPlanStep("Matching snapshot", ChatPlanStepStatus.Completed)),
             staleAfterLivePlan = true,
             snapshotForNewLiveRun =
@@ -574,8 +585,7 @@ class ChatControllerReconnectRestoreTest {
           Case(
             name = "explicit-empty-clears",
             history =
-              historyResponse(
-                "session-1",
+              history(
                 emptyList(),
                 inFlightRun = "run-retained" to "working",
                 inFlightPlan = ChatPlanSnapshot(steps = emptyList()),
@@ -584,7 +594,7 @@ class ChatControllerReconnectRestoreTest {
           ),
           Case(
             name = "gateway-scope-change-clears",
-            history = historyResponse("session-1", emptyList()),
+            history = history(emptyList()),
             expectedSteps = emptyList(),
             gatewayScopeChange = true,
           ),
@@ -593,12 +603,11 @@ class ChatControllerReconnectRestoreTest {
       for (testCase in cases) {
         val gateway = ScriptedGateway(json)
         if (testCase.staleAfterLivePlan) {
-          gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+          gateway.respondWith("chat.history", history(emptyList()))
         } else {
           gateway.respondWith(
             "chat.history",
-            historyResponse(
-              "session-1",
+            history(
               emptyList(),
               inFlightRun = "run-retained" to "working",
               inFlightPlan = ChatPlanSnapshot(steps = retainedSteps),
@@ -628,8 +637,7 @@ class ChatControllerReconnectRestoreTest {
           )
           releaseHistory.complete(
             testCase.snapshotForNewLiveRun?.let { plan ->
-              historyResponse(
-                "session-1",
+              history(
                 emptyList(),
                 inFlightRun = runId to "matching",
                 inFlightPlan = plan,
@@ -653,20 +661,15 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectWithoutInFlightRunStaysClean() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", listOf(userTurn)))
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway, history(listOf(userTurn)))
       val historyCallsAfterLoad = gateway.callCount("chat.history")
       val metadataCallsAfterLoad = gateway.callCount("chat.metadata")
 
       controller.onDisconnected("Offline")
-      controller.onGatewayConnected()
-      runCurrent()
+      connect(controller)
 
       // Reconnect refetched history once and restored nothing.
       assertEquals(historyCallsAfterLoad + 1, gateway.callCount("chat.history"))
@@ -679,20 +682,14 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectStaysUnhealthyUntilRecoveryHistoryApplies() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway, history(emptyList()))
 
       val recoveryHistory = CompletableDeferred<String>()
       gateway.respond("chat.history") { recoveryHistory.await() }
-      controller.onDisconnected("Reconnecting…")
-      controller.onGatewayConnected()
-      runCurrent()
+      reconnect(controller)
 
       assertFalse(controller.healthOk.value)
       val healthCallsDuringRecovery = gateway.callCount("health")
@@ -703,23 +700,20 @@ class ChatControllerReconnectRestoreTest {
       assertEquals(healthCallsDuringRecovery, gateway.callCount("health"))
       assertEquals(historyCallsDuringRecovery + 1, gateway.callCount("chat.history"))
 
-      recoveryHistory.complete(historyResponse("session-1", emptyList()))
+      recoveryHistory.complete(history(emptyList()))
       runCurrent()
       assertTrue(controller.healthOk.value)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun newerSameGenerationHistoryRequestCompletesReconnectHealth() =
     runTest {
       val gateway = ScriptedGateway(json)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "working"),
+        history(listOf(userTurn), inFlightRun = "run-active" to "working"),
       )
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       val reconnectHistoryStarted = CompletableDeferred<Unit>()
       val releaseReconnectHistory = CompletableDeferred<String>()
@@ -730,16 +724,13 @@ class ChatControllerReconnectRestoreTest {
           reconnectHistoryStarted.complete(Unit)
           releaseReconnectHistory.await()
         } else {
-          historyResponse(
-            "session-1",
+          history(
             listOf(userTurn, ReplayHistoryMessage("assistant", "done", 2_000)),
           )
         }
       }
 
-      controller.onDisconnected("Reconnecting…")
-      controller.onGatewayConnected()
-      runCurrent()
+      reconnect(controller)
       reconnectHistoryStarted.await()
       assertFalse(controller.healthOk.value)
 
@@ -750,25 +741,22 @@ class ChatControllerReconnectRestoreTest {
       runCurrent()
 
       assertTrue(controller.healthOk.value)
-      assertEquals(listOf("keep working", "done"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("keep working", "done"), controller.messageTexts)
 
-      releaseReconnectHistory.complete(historyResponse("session-1", emptyList()))
+      releaseReconnectHistory.complete(history(emptyList()))
       runCurrent()
       assertTrue(controller.healthOk.value)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun recoveredPendingRunRefreshesHistoryBeforeTimingOut() =
     runTest {
       val gateway = ScriptedGateway(json)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "working"),
+        history(listOf(userTurn), inFlightRun = "run-active" to "working"),
       )
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
       assertEquals(1, controller.pendingRunCount.value)
       controller.handleGatewayEvent(
         "agent",
@@ -777,8 +765,7 @@ class ChatControllerReconnectRestoreTest {
 
       gateway.respondWith(
         "chat.history",
-        historyResponse(
-          "session-1",
+        history(
           listOf(userTurn, ReplayHistoryMessage("assistant", "completed while offline", 2_000)),
         ),
       )
@@ -786,27 +773,21 @@ class ChatControllerReconnectRestoreTest {
       runCurrent()
 
       assertEquals(0, controller.pendingRunCount.value)
-      assertEquals(
-        listOf("keep working", "completed while offline"),
-        controller.messages.value.map { it.content.single().text },
-      )
+      assertEquals(listOf("keep working", "completed while offline"), controller.messageTexts)
       assertNull(controller.errorText.value)
       assertNull(controller.streamingAssistantText.value)
       assertTrue(controller.pendingToolCalls.value.isEmpty())
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun recoveredPendingRunStopsWatchdogWhenRefreshFails() =
     runTest {
       val gateway = ScriptedGateway(json)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "working"),
+        history(listOf(userTurn), inFlightRun = "run-active" to "working"),
       )
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
       assertEquals(1, controller.pendingRunCount.value)
 
       gateway.respond("chat.history") { error("history unavailable") }
@@ -823,17 +804,14 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun newerRecoverySnapshotCanSupersedePendingRunWatchdogRefresh() =
     runTest {
       val gateway = ScriptedGateway(json)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "working"),
+        history(listOf(userTurn), inFlightRun = "run-active" to "working"),
       )
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       val watchdogRefreshStarted = CompletableDeferred<Unit>()
       val releaseWatchdogRefresh = CompletableDeferred<String>()
@@ -858,7 +836,7 @@ class ChatControllerReconnectRestoreTest {
       runCurrent()
       newerRefreshStarted.await()
       releaseWatchdogRefresh.complete(
-        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "stale working"),
+        history(listOf(userTurn), inFlightRun = "run-active" to "stale working"),
       )
       runCurrent()
 
@@ -867,7 +845,7 @@ class ChatControllerReconnectRestoreTest {
       assertNull(controller.errorText.value)
 
       releaseNewerRefresh.complete(
-        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "still working"),
+        history(listOf(userTurn), inFlightRun = "run-active" to "still working"),
       )
       runCurrent()
 
@@ -878,21 +856,17 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun explicitRefreshClearsPriorHistoryError() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway, history(emptyList()))
 
       gateway.respond("chat.history") { error("history unavailable") }
       controller.refresh()
       runCurrent()
       assertEquals("history unavailable", controller.errorText.value)
 
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       controller.refresh()
       assertNull(controller.errorText.value)
       runCurrent()
@@ -900,14 +874,10 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun disconnectInvalidatesLateHistoryError() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway, history(emptyList()))
 
       val pendingHistory = CompletableDeferred<String>()
       gateway.respond("chat.history") { pendingHistory.await() }
@@ -918,7 +888,7 @@ class ChatControllerReconnectRestoreTest {
       runCurrent()
       assertNull(controller.errorText.value)
 
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       controller.onGatewayConnected()
       assertNull(controller.errorText.value)
       runCurrent()
@@ -926,15 +896,12 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun disconnectInvalidatesOlderHistorySnapshotBeforeOwnershipRestore() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
       assertTrue(controller.sendMessageAwaitAcceptance("keep ownership", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
 
@@ -943,30 +910,25 @@ class ChatControllerReconnectRestoreTest {
       controller.refresh()
       runCurrent()
       controller.onDisconnected("Reconnecting…")
-      staleHistory.complete(historyResponse("session-1", emptyList()))
+      staleHistory.complete(history(emptyList()))
       runCurrent()
 
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", emptyList(), inFlightRun = runId to "working"),
+        history(emptyList(), inFlightRun = runId to "working"),
       )
-      controller.onGatewayConnected()
-      runCurrent()
+      connect(controller)
 
       assertEquals(1, controller.pendingRunCount.value)
       assertEquals("working", controller.streamingAssistantText.value)
-      assertEquals(listOf("keep ownership"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("keep ownership"), controller.messageTexts)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun disconnectAfterGatewayAcceptancePreservesSendWhenAckIsLost() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway, history(emptyList()))
 
       val sendStarted = CompletableDeferred<Unit>()
       val releaseSend = CompletableDeferred<String>()
@@ -987,39 +949,30 @@ class ChatControllerReconnectRestoreTest {
       controller.onDisconnected("Reconnecting…")
       releaseSend.completeExceptionally(GatewayRequestOutcomeUnknown("socket closed before ACK"))
       assertTrue(sendResult.await())
-      assertEquals(listOf("accepted before drop"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("accepted before drop"), controller.messageTexts)
       assertNull(controller.errorText.value)
 
       gateway.respondWith(
         "chat.history",
-        historyResponse(
-          "session-1",
+        history(
           listOf(
             ReplayHistoryMessage("user", "accepted before drop", 1_000, idempotencyKey = "$runId:user"),
             ReplayHistoryMessage("assistant", "completed once", 2_000),
           ),
         ),
       )
-      controller.onGatewayConnected()
-      runCurrent()
+      connect(controller)
 
       assertEquals(0, controller.pendingRunCount.value)
-      assertEquals(
-        listOf("accepted before drop", "completed once"),
-        controller.messages.value.map { it.content.single().text },
-      )
+      assertEquals(listOf("accepted before drop", "completed once"), controller.messageTexts)
       assertNull(controller.errorText.value)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun lostAckAdoptsCanonicalRunWhilePreservingClientHistoryIdentity() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway, history(emptyList()))
 
       gateway.respond("chat.send") { throw GatewayRequestOutcomeUnknown("ACK lost") }
       var clientRunId: String? = null
@@ -1034,10 +987,9 @@ class ChatControllerReconnectRestoreTest {
             .jsonPrimitive
             .content
         if (recoveryHistoryCalls == 1) {
-          historyResponse("session-1", emptyList())
+          history(emptyList())
         } else {
-          historyResponse(
-            "session-1",
+          history(
             listOf(ReplayHistoryMessage("user", "canonical recovery", 1_000, idempotencyKey = "$clientRunId:user")),
             inFlightRun = "canonical-run" to "working",
           )
@@ -1049,8 +1001,7 @@ class ChatControllerReconnectRestoreTest {
       assertEquals(1, controller.pendingRunCount.value)
       assertNull(controller.streamingAssistantText.value)
 
-      advanceTimeBy(750)
-      runCurrent()
+      advanceRecoveryRetry()
 
       assertEquals(1, controller.pendingRunCount.value)
       assertEquals("working", controller.streamingAssistantText.value)
@@ -1068,17 +1019,14 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun repeatedReconnectsDoNotDuplicateRunOrRows() =
     runTest {
       val gateway = ScriptedGateway(json)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "partial"),
+        history(listOf(userTurn), inFlightRun = "run-active" to "partial"),
       )
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
       assertEquals(1, controller.pendingRunCount.value)
 
       repeat(2) {
@@ -1094,55 +1042,46 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectKeepsOptimisticUserWhileHistoryPersistenceLags() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("survive reconnect", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
       controller.onDisconnected("Reconnecting…")
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", emptyList(), inFlightRun = runId to "working"),
+        history(emptyList(), inFlightRun = runId to "working"),
       )
-      controller.onGatewayConnected()
-      runCurrent()
+      connect(controller)
 
       assertEquals(1, controller.pendingRunCount.value)
       assertEquals("working", controller.streamingAssistantText.value)
-      assertEquals(listOf("survive reconnect"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("survive reconnect"), controller.messageTexts)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectStaleSnapshotCannotReplaceDisconnectedLocalRun() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("local work", "off", emptyList()))
       val localRunId = requireNotNull(gateway.lastRunId)
       controller.onDisconnected("Reconnecting…")
       gateway.respondWith(
         "chat.history",
-        historyResponse(
-          "session-1",
+        history(
           listOf(ReplayHistoryMessage("user", "local work", 1_000, idempotencyKey = "$localRunId:user")),
           inFlightRun = "run-stale" to "old text",
         ),
       )
-      controller.onGatewayConnected()
-      runCurrent()
+      connect(controller)
 
       assertEquals(1, controller.pendingRunCount.value)
       assertNull(controller.streamingAssistantText.value)
@@ -1167,27 +1106,23 @@ class ChatControllerReconnectRestoreTest {
       assertEquals("ours", controller.streamingAssistantText.value)
       assertTrue(controller.pendingToolCalls.value.isEmpty())
       assertNull(controller.errorText.value)
-      assertEquals(listOf("local work"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("local work"), controller.messageTexts)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectRetiresPersistedLocalRunBeforeAdoptingOtherRun() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("local work", "off", emptyList()))
       val localRunId = requireNotNull(gateway.lastRunId)
       controller.onDisconnected("Reconnecting…")
       gateway.respondWith(
         "chat.history",
-        historyResponse(
-          "session-1",
+        history(
           listOf(
             ReplayHistoryMessage("user", "local work", 1_000, idempotencyKey = "$localRunId:user"),
             ReplayHistoryMessage("assistant", "local done", 2_000),
@@ -1195,12 +1130,11 @@ class ChatControllerReconnectRestoreTest {
           inFlightRun = "run-other" to "other working",
         ),
       )
-      controller.onGatewayConnected()
-      runCurrent()
+      connect(controller)
 
       assertEquals(1, controller.pendingRunCount.value)
       assertEquals("other working", controller.streamingAssistantText.value)
-      assertEquals(listOf("local work", "local done"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("local work", "local done"), controller.messageTexts)
       controller.handleGatewayEvent(
         "chat",
         chatDeltaPayload("main", localRunId, 1, "stale", "stale local"),
@@ -1209,27 +1143,23 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectReplacesPreviouslyAdoptedRunWithAuthoritativeSnapshotRun() =
     runTest {
       val gateway = ScriptedGateway(json)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", emptyList(), inFlightRun = "run-a" to "old work"),
+        history(emptyList(), inFlightRun = "run-a" to "old work"),
       )
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
       assertEquals(1, controller.pendingRunCount.value)
       assertEquals("old work", controller.streamingAssistantText.value)
 
       controller.onDisconnected("Reconnecting…")
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", emptyList(), inFlightRun = "run-b" to "current work"),
+        history(emptyList(), inFlightRun = "run-b" to "current work"),
       )
-      controller.onGatewayConnected()
-      runCurrent()
+      connect(controller)
 
       assertEquals(1, controller.pendingRunCount.value)
       assertEquals("current work", controller.streamingAssistantText.value)
@@ -1240,67 +1170,57 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun seqGapKeepsOptimisticUserWhileHistoryPersistenceLags() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("survive gap", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", emptyList(), inFlightRun = runId to "working"),
+        history(emptyList(), inFlightRun = runId to "working"),
       )
-      controller.handleGatewayEvent("seqGap", null)
-      runCurrent()
+      recoverSeqGap(controller)
 
       assertEquals(1, controller.pendingRunCount.value)
       assertEquals("working", controller.streamingAssistantText.value)
-      assertEquals(listOf("survive gap"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("survive gap"), controller.messageTexts)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun sameSessionRefreshKeepsOptimisticRunOwnership() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("survive refresh", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", emptyList(), inFlightRun = runId to "working"),
+        history(emptyList(), inFlightRun = runId to "working"),
       )
       controller.refresh()
       runCurrent()
 
       assertEquals(1, controller.pendingRunCount.value)
       assertEquals("working", controller.streamingAssistantText.value)
-      assertEquals(listOf("survive refresh"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("survive refresh"), controller.messageTexts)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun sameSessionRefreshClearsTransientUiForResolvedRun() =
     runTest {
       val gateway = ScriptedGateway(json)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "partial"),
+        history(listOf(userTurn), inFlightRun = "run-active" to "partial"),
       )
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
       controller.handleGatewayEvent(
         "agent",
         """{"sessionKey":"main","runId":"run-active","seq":2,"ts":10,"stream":"tool","data":{"phase":"start","name":"exec","toolCallId":"tool-1"}}""",
@@ -1310,8 +1230,7 @@ class ChatControllerReconnectRestoreTest {
 
       gateway.respondWith(
         "chat.history",
-        historyResponse(
-          "session-1",
+        history(
           listOf(userTurn, ReplayHistoryMessage("assistant", "complete", 2_000)),
         ),
       )
@@ -1321,89 +1240,74 @@ class ChatControllerReconnectRestoreTest {
       assertEquals(0, controller.pendingRunCount.value)
       assertNull(controller.streamingAssistantText.value)
       assertTrue(controller.pendingToolCalls.value.isEmpty())
-      assertEquals(listOf("keep working", "complete"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("keep working", "complete"), controller.messageTexts)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun seqGapMissingRunClearsPendingButKeepsOptimisticUser() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("finished during gap", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
-      controller.handleGatewayEvent("seqGap", null)
-      runCurrent()
+      gateway.respondWith("chat.history", history(emptyList()))
+      recoverSeqGap(controller)
 
       assertEquals(0, controller.pendingRunCount.value)
       assertNull(controller.streamingAssistantText.value)
-      assertEquals(listOf("finished during gap"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("finished during gap"), controller.messageTexts)
 
       gateway.respondWith(
         "chat.history",
-        historyResponse(
-          "session-1",
+        history(
           listOf(
             ReplayHistoryMessage("user", "finished during gap", 1_000, idempotencyKey = "$runId:user"),
             ReplayHistoryMessage("assistant", "done", 2_000),
           ),
         ),
       )
-      advanceTimeBy(750)
-      runCurrent()
+      advanceRecoveryRetry()
 
-      assertEquals(listOf("finished during gap", "done"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("finished during gap", "done"), controller.messageTexts)
       assertNull(controller.errorText.value)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun recoveryRetriesWhenUserPersistsBeforeAssistantReply() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("await reply", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
       val persistedUser = ReplayHistoryMessage("user", "await reply", 1_000, idempotencyKey = "$runId:user")
-      gateway.respondWith("chat.history", historyResponse("session-1", listOf(persistedUser)))
-      controller.handleGatewayEvent("seqGap", null)
-      runCurrent()
-      assertEquals(listOf("await reply"), controller.messages.value.map { it.content.single().text })
+      gateway.respondWith("chat.history", history(listOf(persistedUser)))
+      recoverSeqGap(controller)
+      assertEquals(listOf("await reply"), controller.messageTexts)
 
       gateway.respondWith(
         "chat.history",
-        historyResponse(
-          "session-1",
+        history(
           listOf(persistedUser, ReplayHistoryMessage("assistant", "done", 2_000)),
         ),
       )
-      advanceTimeBy(750)
-      runCurrent()
+      advanceRecoveryRetry()
 
-      assertEquals(listOf("await reply", "done"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("await reply", "done"), controller.messageTexts)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun recoveryPerformsFinalRefreshWhenAssistantPersistsAfterFirstRetry() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("late reply", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
@@ -1411,8 +1315,7 @@ class ChatControllerReconnectRestoreTest {
       var historyCall = 0
       gateway.respond("chat.history") {
         historyCall += 1
-        historyResponse(
-          "session-1",
+        history(
           if (historyCall < 3) {
             listOf(persistedUser)
           } else {
@@ -1421,33 +1324,28 @@ class ChatControllerReconnectRestoreTest {
         )
       }
 
-      controller.handleGatewayEvent("seqGap", null)
-      runCurrent()
-      advanceTimeBy(750)
-      runCurrent()
-      assertEquals(listOf("late reply"), controller.messages.value.map { it.content.single().text })
+      recoverSeqGap(controller)
+      advanceRecoveryRetry()
+      assertEquals(listOf("late reply"), controller.messageTexts)
 
       advanceTimeBy(119_250)
       runCurrent()
-      assertEquals(listOf("late reply", "eventually done"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("late reply", "eventually done"), controller.messageTexts)
       assertNull(controller.errorText.value)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun newerRunReconciliationKeepsOlderUnresolvedReply() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("first", "off", emptyList()))
       val firstRunId = requireNotNull(gateway.lastRunId)
       val firstUser = ReplayHistoryMessage("user", "first", 1_000, idempotencyKey = "$firstRunId:user")
-      gateway.respondWith("chat.history", historyResponse("session-1", listOf(firstUser)))
+      gateway.respondWith("chat.history", history(listOf(firstUser)))
       controller.handleGatewayEvent(
         "chat",
         chatTerminalPayload("main", firstRunId, seq = 2, assistantText = "first done"),
@@ -1464,7 +1362,7 @@ class ChatControllerReconnectRestoreTest {
       val secondReply = ReplayHistoryMessage("assistant", "second done", 3_000)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", listOf(firstUser, secondUser, secondReply)),
+        history(listOf(firstUser, secondUser, secondReply)),
       )
       controller.handleGatewayEvent("chat", chatTerminalPayload("main", firstRunId, seq = 3, state = "error"))
       runCurrent()
@@ -1475,12 +1373,11 @@ class ChatControllerReconnectRestoreTest {
         chatTerminalPayload("main", secondRunId, seq = 2, assistantText = "second done"),
       )
       runCurrent()
-      assertEquals(listOf("first", "second", "second done"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("first", "second", "second done"), controller.messageTexts)
 
       gateway.respondWith(
         "chat.history",
-        historyResponse(
-          "session-1",
+        history(
           listOf(
             firstUser,
             ReplayHistoryMessage("assistant", "first done", 1_500),
@@ -1489,26 +1386,19 @@ class ChatControllerReconnectRestoreTest {
           ),
         ),
       )
-      advanceTimeBy(750)
-      runCurrent()
+      advanceRecoveryRetry()
 
-      assertEquals(
-        listOf("first", "first done", "second", "second done"),
-        controller.messages.value.map { it.content.single().text },
-      )
+      assertEquals(listOf("first", "first done", "second", "second done"), controller.messageTexts)
       assertNull(controller.errorText.value)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun newerRefreshCarriesUnresolvedReplyReconciliation() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("carry reply", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
@@ -1516,8 +1406,7 @@ class ChatControllerReconnectRestoreTest {
       var historyCall = 0
       gateway.respond("chat.history") {
         historyCall += 1
-        historyResponse(
-          "session-1",
+        history(
           if (historyCall < 4) {
             listOf(persistedUser)
           } else {
@@ -1526,29 +1415,23 @@ class ChatControllerReconnectRestoreTest {
         )
       }
 
-      controller.handleGatewayEvent("seqGap", null)
-      runCurrent()
-      advanceTimeBy(750)
-      runCurrent()
+      recoverSeqGap(controller)
+      advanceRecoveryRetry()
       controller.refresh()
       runCurrent()
-      advanceTimeBy(750)
-      runCurrent()
+      advanceRecoveryRetry()
 
-      assertEquals(listOf("carry reply", "carried done"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("carry reply", "carried done"), controller.messageTexts)
       assertNull(controller.errorText.value)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun successfulRecoveryRetryClearsHistoryError() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("recover error", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
@@ -1558,8 +1441,7 @@ class ChatControllerReconnectRestoreTest {
         if (historyCall == 1) {
           error("history unavailable")
         }
-        historyResponse(
-          "session-1",
+        history(
           listOf(
             ReplayHistoryMessage("user", "recover error", 1_000, idempotencyKey = "$runId:user"),
             ReplayHistoryMessage("assistant", "recovered", 2_000),
@@ -1567,34 +1449,28 @@ class ChatControllerReconnectRestoreTest {
         )
       }
 
-      controller.handleGatewayEvent("seqGap", null)
-      runCurrent()
+      recoverSeqGap(controller)
       assertEquals("history unavailable", controller.errorText.value)
-      advanceTimeBy(750)
-      runCurrent()
+      advanceRecoveryRetry()
 
       assertNull(controller.errorText.value)
-      assertEquals(listOf("recover error", "recovered"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("recover error", "recovered"), controller.messageTexts)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectFailureStillExpiresUnconfirmedUser() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("never persisted", "off", emptyList()))
       controller.onDisconnected("Reconnecting…")
       gateway.respond("chat.history") { error("history unavailable") }
-      controller.onGatewayConnected()
-      runCurrent()
+      connect(controller)
 
-      assertEquals(listOf("never persisted"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("never persisted"), controller.messageTexts)
 
       advanceTimeBy(120_000)
       runCurrent()
@@ -1604,15 +1480,12 @@ class ChatControllerReconnectRestoreTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun lateTerminalAfterTimeoutRefreshesHistoryWithoutClearingNewerRun() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("slow first", "off", emptyList()))
       val firstRunId = requireNotNull(gateway.lastRunId)
@@ -1628,8 +1501,7 @@ class ChatControllerReconnectRestoreTest {
       )
       gateway.respondWith(
         "chat.history",
-        historyResponse(
-          "session-1",
+        history(
           listOf(
             ReplayHistoryMessage("user", "slow first", 1_000, idempotencyKey = "$firstRunId:user"),
             ReplayHistoryMessage("assistant", "slow done", 2_000),
@@ -1646,22 +1518,16 @@ class ChatControllerReconnectRestoreTest {
       assertEquals(1, controller.pendingRunCount.value)
       assertEquals("new reply", controller.streamingAssistantText.value)
       assertNull(controller.errorText.value)
-      assertEquals(
-        listOf("slow first", "slow done", "newer work"),
-        controller.messages.value.map { it.content.single().text },
-      )
+      assertEquals(listOf("slow first", "slow done", "newer work"), controller.messageTexts)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun staleRecoveryCompletionCannotCancelNewerReconciliation() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
       assertTrue(controller.sendMessageAwaitAcceptance("ordered recovery", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
 
@@ -1675,10 +1541,9 @@ class ChatControllerReconnectRestoreTest {
             firstRecoveryStarted.complete(Unit)
             releaseFirstRecovery.await()
           }
-          2 -> historyResponse("session-1", emptyList())
+          2 -> history(emptyList())
           else ->
-            historyResponse(
-              "session-1",
+            history(
               listOf(
                 ReplayHistoryMessage("user", "ordered recovery", 1_000, idempotencyKey = "$runId:user"),
                 ReplayHistoryMessage("assistant", "done", 2_000),
@@ -1687,36 +1552,29 @@ class ChatControllerReconnectRestoreTest {
         }
       }
 
-      controller.handleGatewayEvent("seqGap", null)
-      runCurrent()
+      recoverSeqGap(controller)
       firstRecoveryStarted.await()
-      controller.handleGatewayEvent("seqGap", null)
+      recoverSeqGap(controller)
+      releaseFirstRecovery.complete(history(emptyList()))
       runCurrent()
-      releaseFirstRecovery.complete(historyResponse("session-1", emptyList()))
-      runCurrent()
-      advanceTimeBy(750)
-      runCurrent()
+      advanceRecoveryRetry()
 
-      assertEquals(listOf("ordered recovery", "done"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("ordered recovery", "done"), controller.messageTexts)
       assertNull(controller.errorText.value)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun olderSameGenerationRetryCannotOverwriteTerminalHistory() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
       assertTrue(controller.sendMessageAwaitAcceptance("ordered result", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
 
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
-      controller.handleGatewayEvent("seqGap", null)
-      runCurrent()
+      gateway.respondWith("chat.history", history(emptyList()))
+      recoverSeqGap(controller)
 
       val retryStarted = CompletableDeferred<Unit>()
       val releaseRetry = CompletableDeferred<String>()
@@ -1727,8 +1585,7 @@ class ChatControllerReconnectRestoreTest {
           retryStarted.complete(Unit)
           releaseRetry.await()
         } else {
-          historyResponse(
-            "session-1",
+          history(
             listOf(
               ReplayHistoryMessage("user", "ordered result", 1_000, idempotencyKey = "$runId:user"),
               ReplayHistoryMessage("assistant", "done", 2_000),
@@ -1736,30 +1593,26 @@ class ChatControllerReconnectRestoreTest {
           )
         }
       }
-      advanceTimeBy(750)
-      runCurrent()
+      advanceRecoveryRetry()
       retryStarted.await()
       controller.handleGatewayEvent(
         "chat",
         chatTerminalPayload("main", runId, seq = 2, assistantText = "done"),
       )
       runCurrent()
-      releaseRetry.complete(historyResponse("session-1", emptyList()))
+      releaseRetry.complete(history(emptyList()))
       runCurrent()
 
-      assertEquals(listOf("ordered result", "done"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("ordered result", "done"), controller.messageTexts)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun newerSameGenerationHistoryCompletionSuppressesOlderFailureAndClearsLoading() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
       assertTrue(controller.sendMessageAwaitAcceptance("ordered loading", "off", emptyList()))
       val runId = requireNotNull(gateway.lastRunId)
 
@@ -1772,8 +1625,7 @@ class ChatControllerReconnectRestoreTest {
           recoveryStarted.complete(Unit)
           releaseRecovery.await()
         } else {
-          historyResponse(
-            "session-1",
+          history(
             listOf(
               ReplayHistoryMessage("user", "ordered loading", 1_000, idempotencyKey = "$runId:user"),
               ReplayHistoryMessage("assistant", "done", 2_000),
@@ -1782,8 +1634,7 @@ class ChatControllerReconnectRestoreTest {
         }
       }
 
-      controller.handleGatewayEvent("seqGap", null)
-      runCurrent()
+      recoverSeqGap(controller)
       recoveryStarted.await()
       assertTrue(controller.historyLoading.value)
       controller.handleGatewayEvent(
@@ -1793,34 +1644,30 @@ class ChatControllerReconnectRestoreTest {
       runCurrent()
 
       assertFalse(controller.historyLoading.value)
-      assertEquals(listOf("ordered loading", "done"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("ordered loading", "done"), controller.messageTexts)
 
       releaseRecovery.completeExceptionally(IllegalStateException("older history failed"))
       runCurrent()
       assertFalse(controller.historyLoading.value)
-      assertEquals(listOf("ordered loading", "done"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("ordered loading", "done"), controller.messageTexts)
       assertNull(controller.errorText.value)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun seqGapStaleSnapshotCannotReplaceLocallyOwnedRun() =
     runTest {
       val gateway = ScriptedGateway(json)
-      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondWith("chat.history", history(emptyList()))
       gateway.respondChatSend(status = "started")
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
 
       assertTrue(controller.sendMessageAwaitAcceptance("new work", "off", emptyList()))
       val localRunId = requireNotNull(gateway.lastRunId)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", emptyList(), inFlightRun = "run-stale" to "old text"),
+        history(emptyList(), inFlightRun = "run-stale" to "old text"),
       )
-      controller.handleGatewayEvent("seqGap", null)
-      runCurrent()
+      recoverSeqGap(controller)
 
       assertEquals(1, controller.pendingRunCount.value)
       assertNull(controller.streamingAssistantText.value)
@@ -1829,25 +1676,21 @@ class ChatControllerReconnectRestoreTest {
         chatDeltaPayload("main", localRunId, 1, "ours", "ours"),
       )
       assertEquals("ours", controller.streamingAssistantText.value)
-      assertEquals(listOf("new work"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("new work"), controller.messageTexts)
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun seqGapRefetchesHistoryAndRestoresInFlightRun() =
     runTest {
       val gateway = ScriptedGateway(json)
       gateway.respondWith(
         "chat.history",
-        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "still going"),
+        history(listOf(userTurn), inFlightRun = "run-active" to "still going"),
       )
-      val controller = newController(gateway)
-      controller.load("main")
-      runCurrent()
+      val controller = loadController(gateway)
       assertEquals(1, controller.pendingRunCount.value)
 
-      controller.handleGatewayEvent("seqGap", null)
-      runCurrent()
+      recoverSeqGap(controller)
 
       assertEquals(1, controller.pendingRunCount.value)
       assertEquals("still going", controller.streamingAssistantText.value)

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatQuestionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatQuestionTest.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
@@ -26,7 +25,12 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ChatQuestionTest {
+  private val json = chatControllerTestJson
+  private val ChatController.onlyQuestion: ChatQuestionPrompt
+    get() = questions.value.single()
+
   private val question =
     Question(
       questionId = "meal",
@@ -116,31 +120,23 @@ class ChatQuestionTest {
   }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun staleQuestionListCannotOverwriteNewerEvent() =
     runTest {
       val listStarted = CompletableDeferred<Unit>()
       val listResponse = CompletableDeferred<String>()
-      val json = Json { ignoreUnknownKeys = true }
       var listCallCount = 0
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            if (method == "question.list") {
-              listCallCount += 1
-              if (listCallCount == 1) {
-                listStarted.complete(Unit)
-                listResponse.await()
-              } else {
-                json.encodeToString(QuestionListResult(listOf(record(id = "ask_new"))))
-              }
+        createScriptedChatController {
+          respond("question.list") {
+            listCallCount += 1
+            if (listCallCount == 1) {
+              listStarted.complete(Unit)
+              listResponse.await()
             } else {
-              "{}"
+              json.encodeToString(QuestionListResult(listOf(record(id = "ask_new"))))
             }
-          },
-        )
+          }
+        }
 
       controller.handleGatewayEvent("health", null)
       runCurrent()
@@ -153,34 +149,27 @@ class ChatQuestionTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun structuredMissingQuestionScopeClearsStaleCards() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            if (method == "question.list") {
-              throw GatewayRequestRejected(
-                GatewaySession.ErrorShape(
-                  code = "FORBIDDEN",
-                  message = "permission denied",
-                  details =
-                    GatewayErrorDetails(
-                      code = "MISSING_SCOPE",
-                      missingScope = "operator.questions",
-                      requiredScopes = listOf("operator.questions"),
-                      canRetryWithDeviceToken = false,
-                      recommendedNextStep = null,
-                    ),
-                ),
-              )
-            }
-            "{}"
-          },
-        )
+        createScriptedChatController {
+          respond("question.list") {
+            throw GatewayRequestRejected(
+              GatewaySession.ErrorShape(
+                code = "FORBIDDEN",
+                message = "permission denied",
+                details =
+                  GatewayErrorDetails(
+                    code = "MISSING_SCOPE",
+                    missingScope = "operator.questions",
+                    requiredScopes = listOf("operator.questions"),
+                    canRetryWithDeviceToken = false,
+                    recommendedNextStep = null,
+                  ),
+              ),
+            )
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(record(id = "ask_stale")))
       controller.handleGatewayEvent("health", null)
@@ -190,28 +179,19 @@ class ChatQuestionTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun pendingRefreshPreservesSubmissionLock() =
     runTest {
       val resolveStarted = CompletableDeferred<Unit>()
       val resolveResponse = CompletableDeferred<String>()
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = Long.MAX_VALUE)
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            when (method) {
-              "question.list" -> json.encodeToString(QuestionListResult(listOf(pending.copy(createdAtMs = 2_000))))
-              "question.resolve" -> {
-                resolveStarted.complete(Unit)
-                resolveResponse.await()
-              }
-              else -> "{}"
-            }
-          },
-        )
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(listOf(pending.copy(createdAtMs = 2_000)))))
+          respond("question.resolve") {
+            resolveStarted.complete(Unit)
+            resolveResponse.await()
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       controller.resolveQuestion(pending.id, mapOf("meal" to listOf("Pizza")))
@@ -220,95 +200,60 @@ class ChatQuestionTest {
       controller.handleGatewayEvent("health", null)
       runCurrent()
 
-      assertEquals(
-        ChatQuestionStatus.Submitting,
-        controller.questions.value
-          .single()
-          .status(nowMs = 3_000),
-      )
-      assertFalse(
-        controller.questions.value
-          .single()
-          .answeredLocally,
-      )
+      assertEquals(ChatQuestionStatus.Submitting, controller.onlyQuestion.status(nowMs = 3_000))
+      assertFalse(controller.onlyQuestion.answeredLocally)
       resolveResponse.complete("{}")
       advanceUntilIdle()
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun replayedPendingEventCannotReopenResolvedQuestion() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = Long.MAX_VALUE)
-      val controller = ChatController(scope = this, json = json, requestGateway = { _, _ -> "{}" })
+      val controller = createChatController()
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       controller.handleGatewayEvent("question.resolved", """{"id":"ask_123","status":"answered"}""")
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
 
-      assertEquals(
-        ChatQuestionStatus.AnsweredElsewhere,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.AnsweredElsewhere, controller.onlyQuestion.status())
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun pendingListRecordCannotReopenResolvedQuestion() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = Long.MAX_VALUE)
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            if (method == "question.list") json.encodeToString(QuestionListResult(listOf(pending))) else "{}"
-          },
-        )
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(listOf(pending))))
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       controller.handleGatewayEvent("question.resolved", """{"id":"ask_123","status":"cancelled"}""")
       controller.handleGatewayEvent("health", null)
       advanceUntilIdle()
 
-      assertEquals(
-        ChatQuestionStatus.Cancelled,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.Cancelled, controller.onlyQuestion.status())
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun resolvedEventReconcilesAfterDiscardingOlderList() =
     runTest {
       val firstListStarted = CompletableDeferred<Unit>()
       val firstListResponse = CompletableDeferred<String>()
-      val json = Json { ignoreUnknownKeys = true }
       var listCallCount = 0
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            if (method != "question.list") {
-              "{}"
+        createScriptedChatController {
+          respond("question.list") {
+            listCallCount += 1
+            if (listCallCount == 1) {
+              firstListStarted.complete(Unit)
+              firstListResponse.await()
             } else {
-              listCallCount += 1
-              if (listCallCount == 1) {
-                firstListStarted.complete(Unit)
-                firstListResponse.await()
-              } else {
-                json.encodeToString(QuestionListResult(listOf(record(id = "ask_other"))))
-              }
+              json.encodeToString(QuestionListResult(listOf(record(id = "ask_other"))))
             }
-          },
-        )
+          }
+        }
 
       controller.handleGatewayEvent("health", null)
       runCurrent()
@@ -325,17 +270,13 @@ class ChatQuestionTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun questionListRetainsResolvedSummaryPermanently() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(id = "ask_done", expiresAtMs = Long.MAX_VALUE)
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { _, _ -> json.encodeToString(QuestionListResult(emptyList())) },
-        )
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(emptyList())))
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       controller.handleGatewayEvent(
@@ -345,12 +286,7 @@ class ChatQuestionTest {
       runCurrent()
 
       assertEquals(listOf("ask_done"), controller.questions.value.map { it.record.id })
-      assertEquals(
-        ChatQuestionStatus.AnsweredElsewhere,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.AnsweredElsewhere, controller.onlyQuestion.status())
 
       advanceTimeBy(60_000)
       runCurrent()
@@ -359,51 +295,35 @@ class ChatQuestionTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun locallyExpiredQuestionRemainsAsSummary() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
-      val controller = ChatController(scope = this, json = json, requestGateway = { _, _ -> "{}" })
+      val controller = createChatController()
       val pending = record(expiresAtMs = 1_000)
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       advanceUntilIdle()
 
-      assertEquals(
-        ChatQuestionStatus.Expired,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.Expired, controller.onlyQuestion.status())
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun localExpiryReconcilesMissedRemoteAnswer() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = System.currentTimeMillis() + 1_000)
       val answered = pending.copy(status = "answered")
       var listCalls = 0
       var getCalls = 0
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            when (method) {
-              "question.list" -> {
-                listCalls += 1
-                json.encodeToString(QuestionListResult(if (listCalls == 1) listOf(pending) else emptyList()))
-              }
-              "question.get" -> {
-                getCalls += 1
-                json.encodeToString(QuestionGetResult(answered))
-              }
-              else -> "{}"
-            }
-          },
-        )
+        createScriptedChatController {
+          respond("question.list") {
+            listCalls += 1
+            json.encodeToString(QuestionListResult(if (listCalls == 1) listOf(pending) else emptyList()))
+          }
+          respond("question.get") {
+            getCalls += 1
+            json.encodeToString(QuestionGetResult(answered))
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       runCurrent()
@@ -412,19 +332,12 @@ class ChatQuestionTest {
 
       assertEquals(2, listCalls)
       assertEquals(1, getCalls)
-      assertEquals(
-        ChatQuestionStatus.AnsweredElsewhere,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.AnsweredElsewhere, controller.onlyQuestion.status())
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun missingPendingQuestionUsesPerIdGetFallback() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = Long.MAX_VALUE)
       val answered =
         pending.copy(
@@ -433,20 +346,13 @@ class ChatQuestionTest {
         )
       var getParams: String? = null
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, params ->
-            when (method) {
-              "question.list" -> json.encodeToString(QuestionListResult(emptyList()))
-              "question.get" -> {
-                getParams = params
-                json.encodeToString(QuestionGetResult(answered))
-              }
-              else -> "{}"
-            }
-          },
-        )
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(emptyList())))
+          respond("question.get") { params ->
+            getParams = params
+            json.encodeToString(QuestionGetResult(answered))
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       advanceUntilIdle()
@@ -461,25 +367,16 @@ class ChatQuestionTest {
       )
       assertEquals(
         listOf("Tacos"),
-        controller.questions.value
-          .single()
-          .record.answers
+        controller.onlyQuestion.record.answers
           ?.answers
           ?.get("meal"),
       )
-      assertEquals(
-        ChatQuestionStatus.AnsweredElsewhere,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.AnsweredElsewhere, controller.onlyQuestion.status())
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun successfulRefreshRecordsApplyWhenAnotherFallbackFails() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val listedPending = record(id = "ask_listed")
       val recoveredPending = record(id = "ask_recovered")
       val failingPending = record(id = "ask_failing")
@@ -495,51 +392,44 @@ class ChatQuestionTest {
       val getCalls = mutableMapOf<String, Int>()
       var fallbackFailed = false
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, params ->
-            when (method) {
-              "question.list" -> {
-                val records =
-                  if (!fallbackFailed) {
-                    listOf(listedAnswered, newlyMissingPending)
-                  } else {
-                    listOf(listedAnswered)
-                  }
-                json.encodeToString(QuestionListResult(records))
+        createScriptedChatController {
+          respond("question.list") {
+            val records =
+              if (!fallbackFailed) {
+                listOf(listedAnswered, newlyMissingPending)
+              } else {
+                listOf(listedAnswered)
               }
-              "question.get" -> {
-                val id =
-                  json
-                    .parseToJsonElement(checkNotNull(params))
-                    .jsonObject
-                    .getValue("id")
-                    .jsonPrimitive
-                    .content
-                getCalls[id] = getCalls.getOrDefault(id, 0) + 1
-                when (id) {
-                  recoveredPending.id ->
-                    json.encodeToString(
-                      QuestionGetResult(
-                        if (getCalls.getValue(id) == 1) recoveredPending else recoveredAnswered,
-                      ),
-                    )
-                  newlyMissingPending.id -> json.encodeToString(QuestionGetResult(newlyMissingAnswered))
-                  failingPending.id -> {
-                    if (getCalls.getValue(id) == 1) {
-                      fallbackFailed = true
-                      error("temporary question.get failure")
-                    }
-                    json.encodeToString(QuestionGetResult(failingAnswered))
-                  }
-                  else -> error("unexpected question id")
+            json.encodeToString(QuestionListResult(records))
+          }
+          respond("question.get") { params ->
+            val id =
+              json
+                .parseToJsonElement(checkNotNull(params))
+                .jsonObject
+                .getValue("id")
+                .jsonPrimitive
+                .content
+            getCalls[id] = getCalls.getOrDefault(id, 0) + 1
+            when (id) {
+              recoveredPending.id ->
+                json.encodeToString(
+                  QuestionGetResult(
+                    if (getCalls.getValue(id) == 1) recoveredPending else recoveredAnswered,
+                  ),
+                )
+              newlyMissingPending.id -> json.encodeToString(QuestionGetResult(newlyMissingAnswered))
+              failingPending.id -> {
+                if (getCalls.getValue(id) == 1) {
+                  fallbackFailed = true
+                  error("temporary question.get failure")
                 }
+                json.encodeToString(QuestionGetResult(failingAnswered))
               }
-              else -> "{}"
+              else -> error("unexpected question id")
             }
-          },
-        )
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(listedPending))
       controller.handleGatewayEvent("question.requested", json.encodeToString(recoveredPending))
@@ -582,10 +472,8 @@ class ChatQuestionTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun questionGetRetryResetsExhaustedBudgetAfterAnotherQuestionChanges() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val recovering = record(id = "ask_recovering")
       val unrelated = record(id = "ask_unrelated")
       val recovered = recovering.copy(status = "answered")
@@ -593,26 +481,19 @@ class ChatQuestionTest {
       val finalGetStarted = CompletableDeferred<Unit>()
       val releaseFinalGet = CompletableDeferred<Unit>()
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            when (method) {
-              "question.list" -> json.encodeToString(QuestionListResult(listOf(unrelated)))
-              "question.get" -> {
-                getCalls += 1
-                if (getCalls < 4) error("temporary question.get failure")
-                if (getCalls == 4) {
-                  finalGetStarted.complete(Unit)
-                  releaseFinalGet.await()
-                }
-                json.encodeToString(QuestionGetResult(recovered))
-              }
-              "question.resolve" -> "{}"
-              else -> "{}"
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(listOf(unrelated))))
+          respond("question.get") {
+            getCalls += 1
+            if (getCalls < 4) error("temporary question.get failure")
+            if (getCalls == 4) {
+              finalGetStarted.complete(Unit)
+              releaseFinalGet.await()
             }
-          },
-        )
+            json.encodeToString(QuestionGetResult(recovered))
+          }
+          respond("question.resolve", "{}")
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(recovering))
       controller.handleGatewayEvent("question.requested", json.encodeToString(unrelated))
@@ -645,31 +526,22 @@ class ChatQuestionTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun questionGetRetryResetsBudgetWhenRevisionChangesDuringFinalBackoff() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val recovering = record(id = "ask_recovering")
       val unrelated = record(id = "ask_unrelated")
       val recovered = recovering.copy(status = "answered")
       var getCalls = 0
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            when (method) {
-              "question.list" -> json.encodeToString(QuestionListResult(listOf(unrelated)))
-              "question.get" -> {
-                getCalls += 1
-                if (getCalls < 5) error("temporary question.get failure")
-                json.encodeToString(QuestionGetResult(recovered))
-              }
-              "question.resolve" -> "{}"
-              else -> "{}"
-            }
-          },
-        )
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(listOf(unrelated))))
+          respond("question.get") {
+            getCalls += 1
+            if (getCalls < 5) error("temporary question.get failure")
+            json.encodeToString(QuestionGetResult(recovered))
+          }
+          respond("question.resolve", "{}")
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(recovering))
       controller.handleGatewayEvent("question.requested", json.encodeToString(unrelated))
@@ -698,10 +570,8 @@ class ChatQuestionTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun locallyExpiredMissingQuestionUsesPerIdGetFallback() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = 0)
       val answered =
         pending.copy(
@@ -710,20 +580,13 @@ class ChatQuestionTest {
         )
       var getCalls = 0
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            when (method) {
-              "question.list" -> json.encodeToString(QuestionListResult(emptyList()))
-              "question.get" -> {
-                getCalls += 1
-                json.encodeToString(QuestionGetResult(answered))
-              }
-              else -> "{}"
-            }
-          },
-        )
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(emptyList())))
+          respond("question.get") {
+            getCalls += 1
+            json.encodeToString(QuestionGetResult(answered))
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       runCurrent()
@@ -731,43 +594,27 @@ class ChatQuestionTest {
       assertEquals(1, getCalls)
       assertEquals(
         listOf("Tacos"),
-        controller.questions.value
-          .single()
-          .record.answers
+        controller.onlyQuestion.record.answers
           ?.answers
           ?.get("meal"),
       )
-      assertEquals(
-        ChatQuestionStatus.AnsweredElsewhere,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.AnsweredElsewhere, controller.onlyQuestion.status())
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun missingQuestionGetRetriesAfterOneTwoAndFourSeconds() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = Long.MAX_VALUE)
       var getCalls = 0
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            when (method) {
-              "question.list" -> json.encodeToString(QuestionListResult(emptyList()))
-              "question.get" -> {
-                getCalls += 1
-                if (getCalls < 4) error("temporary question.get failure")
-                json.encodeToString(QuestionGetResult(pending))
-              }
-              else -> "{}"
-            }
-          },
-        )
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(emptyList())))
+          respond("question.get") {
+            getCalls += 1
+            if (getCalls < 4) error("temporary question.get failure")
+            json.encodeToString(QuestionGetResult(pending))
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       runCurrent()
@@ -787,86 +634,57 @@ class ChatQuestionTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun missingQuestionNotFoundHasUnknownTerminalOutcome() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = Long.MAX_VALUE)
       var getCalls = 0
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            when (method) {
-              "question.list" -> json.encodeToString(QuestionListResult(emptyList()))
-              "question.get" ->
-                run {
-                  getCalls += 1
-                  throw GatewayRequestRejected(
-                    GatewaySession.ErrorShape(
-                      code = "INVALID_REQUEST",
-                      message = "question not found",
-                      details =
-                        GatewayErrorDetails(
-                          code = null,
-                          reason = "QUESTION_NOT_FOUND",
-                          canRetryWithDeviceToken = false,
-                          recommendedNextStep = null,
-                        ),
-                    ),
-                  )
-                }
-              else -> "{}"
-            }
-          },
-        )
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(emptyList())))
+          respond("question.get") {
+            getCalls += 1
+            throw GatewayRequestRejected(
+              GatewaySession.ErrorShape(
+                code = "INVALID_REQUEST",
+                message = "question not found",
+                details =
+                  GatewayErrorDetails(
+                    code = null,
+                    reason = "QUESTION_NOT_FOUND",
+                    canRetryWithDeviceToken = false,
+                    recommendedNextStep = null,
+                  ),
+              ),
+            )
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       advanceUntilIdle()
 
-      assertEquals(
-        ChatQuestionStatus.Unavailable,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.Unavailable, controller.onlyQuestion.status())
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       controller.handleGatewayEvent("health", null)
       advanceUntilIdle()
 
       assertEquals(1, getCalls)
-      assertEquals(
-        ChatQuestionStatus.Unavailable,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.Unavailable, controller.onlyQuestion.status())
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun skipUsesCancelResolutionAndKeepsSkippedSummary() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = Long.MAX_VALUE)
       var resolveParams: String? = null
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, params ->
-            when (method) {
-              "question.list" -> json.encodeToString(QuestionListResult(listOf(pending)))
-              "question.resolve" -> {
-                resolveParams = params
-                "{}"
-              }
-              else -> "{}"
-            }
-          },
-        )
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(listOf(pending))))
+          respond("question.resolve") { params ->
+            resolveParams = params
+            "{}"
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       controller.skipQuestion(pending.id)
@@ -876,37 +694,23 @@ class ChatQuestionTest {
       assertEquals("ask_123", params["id"]?.jsonPrimitive?.content)
       assertTrue(params["cancel"]?.jsonPrimitive?.content?.toBoolean() == true)
       assertFalse("answers" in params)
-      assertEquals(
-        ChatQuestionStatus.Cancelled,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.Cancelled, controller.onlyQuestion.status())
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun skipClaimExposesSkippingProgress() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = Long.MAX_VALUE)
       val resolveStarted = CompletableDeferred<Unit>()
       val releaseResolve = CompletableDeferred<Unit>()
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            when (method) {
-              "question.resolve" -> {
-                resolveStarted.complete(Unit)
-                releaseResolve.await()
-                "{}"
-              }
-              else -> "{}"
-            }
-          },
-        )
+        createScriptedChatController {
+          respond("question.resolve") {
+            resolveStarted.complete(Unit)
+            releaseResolve.await()
+            "{}"
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       controller.skipQuestion(pending.id)
@@ -928,31 +732,22 @@ class ChatQuestionTest {
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun answerClaimBlocksCompetingSkip() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = Long.MAX_VALUE)
       val requestStarted = CompletableDeferred<Unit>()
       val releaseRequest = CompletableDeferred<Unit>()
       val resolveParams = mutableListOf<String>()
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, params ->
-            when (method) {
-              "question.list" -> json.encodeToString(QuestionListResult(listOf(pending)))
-              "question.resolve" -> {
-                resolveParams.add(checkNotNull(params))
-                requestStarted.complete(Unit)
-                releaseRequest.await()
-                "{}"
-              }
-              else -> "{}"
-            }
-          },
-        )
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(listOf(pending))))
+          respond("question.resolve") { params ->
+            resolveParams.add(checkNotNull(params))
+            requestStarted.complete(Unit)
+            releaseRequest.await()
+            "{}"
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       controller.resolveQuestion(pending.id, mapOf("meal" to listOf("Pizza")))
@@ -964,55 +759,43 @@ class ChatQuestionTest {
 
       assertEquals(1, resolveParams.size)
       assertFalse("cancel" in resolveParams.single())
-      assertEquals(
-        ChatQuestionStatus.Answered,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.Answered, controller.onlyQuestion.status())
     }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
   fun successfulAnswerOverridesUnavailableRecoveryRace() =
     runTest {
-      val json = Json { ignoreUnknownKeys = true }
       val pending = record(expiresAtMs = Long.MAX_VALUE)
       val resolveStarted = CompletableDeferred<Unit>()
       val releaseResolve = CompletableDeferred<Unit>()
       val controller =
-        ChatController(
-          scope = this,
-          json = json,
-          requestGateway = { method, _ ->
-            when (method) {
-              "question.list" ->
-                json.encodeToString(
-                  QuestionListResult(if (resolveStarted.isCompleted) emptyList() else listOf(pending)),
-                )
-              "question.get" ->
-                throw GatewayRequestRejected(
-                  GatewaySession.ErrorShape(
-                    code = "INVALID_REQUEST",
-                    message = "question not found",
-                    details =
-                      GatewayErrorDetails(
-                        code = null,
-                        reason = "QUESTION_NOT_FOUND",
-                        canRetryWithDeviceToken = false,
-                        recommendedNextStep = null,
-                      ),
+        createScriptedChatController {
+          respond("question.list") {
+            json.encodeToString(
+              QuestionListResult(if (resolveStarted.isCompleted) emptyList() else listOf(pending)),
+            )
+          }
+          respond("question.get") {
+            throw GatewayRequestRejected(
+              GatewaySession.ErrorShape(
+                code = "INVALID_REQUEST",
+                message = "question not found",
+                details =
+                  GatewayErrorDetails(
+                    code = null,
+                    reason = "QUESTION_NOT_FOUND",
+                    canRetryWithDeviceToken = false,
+                    recommendedNextStep = null,
                   ),
-                )
-              "question.resolve" -> {
-                resolveStarted.complete(Unit)
-                releaseResolve.await()
-                "{}"
-              }
-              else -> "{}"
-            }
-          },
-        )
+              ),
+            )
+          }
+          respond("question.resolve") {
+            resolveStarted.complete(Unit)
+            releaseResolve.await()
+            "{}"
+          }
+        }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       runCurrent()
@@ -1021,22 +804,12 @@ class ChatQuestionTest {
       resolveStarted.await()
       controller.handleGatewayEvent("health", null)
       runCurrent()
-      assertEquals(
-        ChatQuestionStatus.Unavailable,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.Unavailable, controller.onlyQuestion.status())
 
       releaseResolve.complete(Unit)
       advanceUntilIdle()
 
-      assertEquals(
-        ChatQuestionStatus.Answered,
-        controller.questions.value
-          .single()
-          .status(),
-      )
+      assertEquals(ChatQuestionStatus.Answered, controller.onlyQuestion.status())
     }
 
   private fun record(


### PR DESCRIPTION
## What Problem This Solves

The Android chat reconnect and question suites duplicated controller construction, gateway wiring, scripted requests, history fixtures, and scheduler-drain sequences. That boilerplate obscured the recovery ownership and made timing-sensitive tests harder to audit.

## Why This Change Was Made

The Android chat test owner already has a canonical ChatReplayHarness. This refactor reuses its controller and scripted-request fixtures, then keeps only small local helpers for the exact reconnect/history sequences owned by these suites.

Root cause: these tests predated the shared harness consolidation and retained parallel fixture construction. The canonical fix removes those direct constructors and repeated scheduling/history boilerplate without changing production behavior or test contracts.

## User Impact

None. This is test-only cleanup: production, config, i18n, generated, and schema deltas are all zero.

## Evidence

- Exact scope: two Android chat test files, +462/-846, net -384 test LOC; production delta 0.
- Structural parity: 70/70 test names, 288/288 assertion calls, and all 11 named plan-reconciliation cases preserved.
- Scheduler/behavior parity independently reviewed: reconnect ordering, session/auth adoption, seq-gap recovery, optimistic runs, 750 ms retry, 120 s watchdog, question 1/2/4 s retry, submission locking, and answer/cancel races unchanged.
- Blacksmith Testbox tbx_01kz1zgrxt9z9ty6ccx27rn21f: focused Play + ThirdParty suites green (70 tests per flavor); full Play green (2,052 tests); full ThirdParty green (2,183 tests); Android ktlint and pnpm check:changed green.
- Hydration/proof run: https://github.com/openclaw/openclaw/actions/runs/30763669304
- Two independent gpt-5.6-sol xhigh final reviews: CLEAN.
