### PR TITLE
test(discord): deduplicate draft process fixtures

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.draft-reasoning.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-reasoning.test.ts
@@ -18,6 +18,41 @@ import {
 
 registerDiscordProcessTestLifecycle();
 
+type ReasoningProgressPayload = {
+  text: string;
+  isReasoningSnapshot?: boolean;
+  requiresReasoningProgressOptIn?: boolean;
+};
+
+async function runReasoningProgressDraft(
+  payloads: Array<string | ReasoningProgressPayload>,
+  progress: {
+    label?: string | false;
+    maxLineChars?: number;
+    thinking?: boolean;
+  } = { label: "Clawing...", thinking: true },
+) {
+  const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
+  const draftStream = createMockDraftStreamForTest();
+
+  dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+    await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+    for (const payload of payloads) {
+      await params?.replyOptions?.onReasoningStream?.(
+        typeof payload === "string" ? { text: payload } : payload,
+      );
+    }
+    await elapseProgressDraftStartDelay();
+    return createNoQueuedDispatchResult();
+  });
+
+  const ctx = await createAutomaticSourceDeliveryContext({
+    discordConfig: { streaming: { mode: "progress", progress } },
+  });
+  await runProcessDiscordMessage(ctx);
+  return draftStream;
+}
+
 describe("processDiscordMessage draft streaming reasoning", () => {
   it("skips empty apply_patch starts and renders the patch summary", async () => {
     const draftStream = createMockDraftStreamForTest();
@@ -125,31 +160,12 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("accumulates reasoning deltas in Discord progress drafts", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      for (const text of ["Considering", " plugin", " installation", "!"]) {
-        await params?.replyOptions?.onReasoningStream?.({ text });
-      }
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            thinking: true,
-          },
-        },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runReasoningProgressDraft([
+      "Considering",
+      " plugin",
+      " installation",
+      "!",
+    ]);
 
     expect(draftStream.update).toHaveBeenCalledWith(
       "Clawing...\n\n🛠️ Exec\n🧠 _Considering plugin installation!_",
@@ -159,30 +175,7 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("preserves raw reasoning content that starts with Thinking", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params?.replyOptions?.onReasoningStream?.({ text: "Thinking" });
-      await params?.replyOptions?.onReasoningStream?.({ text: " through the install plan" });
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            thinking: true,
-          },
-        },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runReasoningProgressDraft(["Thinking", " through the install plan"]);
 
     expect(draftStream.update).toHaveBeenCalledWith(
       "Clawing...\n\n🛠️ Exec\n🧠 _Thinking through the install plan_",
@@ -190,29 +183,7 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("preserves raw reasoning content that starts with Thinking colon", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params?.replyOptions?.onReasoningStream?.({ text: "Thinking: compare install paths" });
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            thinking: true,
-          },
-        },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runReasoningProgressDraft(["Thinking: compare install paths"]);
 
     expect(draftStream.update).toHaveBeenCalledWith(
       "Clawing...\n\n🛠️ Exec\n🧠 _Thinking: compare install paths_",
@@ -220,29 +191,7 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("preserves raw reasoning content that starts with Reasoning colon", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params?.replyOptions?.onReasoningStream?.({ text: "Reasoning: compare install paths" });
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            thinking: true,
-          },
-        },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runReasoningProgressDraft(["Reasoning: compare install paths"]);
 
     expect(draftStream.update).toHaveBeenCalledWith(
       "Clawing...\n\n🛠️ Exec\n🧠 _Reasoning: compare install paths_",
@@ -250,31 +199,7 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("strips legacy Reasoning newline wrappers from progress snapshots", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params?.replyOptions?.onReasoningStream?.({
-        text: "Reasoning:\ncompare install paths",
-      });
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            thinking: true,
-          },
-        },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runReasoningProgressDraft(["Reasoning:\ncompare install paths"]);
 
     expect(draftStream.update).toHaveBeenCalledWith(
       "Clawing...\n\n🛠️ Exec\n🧠 _compare install paths_",
@@ -282,31 +207,7 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("strips legacy Thinking ellipsis display wrappers from progress snapshots", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params?.replyOptions?.onReasoningStream?.({
-        text: "Thinking...\n\n_compare install paths_",
-      });
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            thinking: true,
-          },
-        },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runReasoningProgressDraft(["Thinking...\n\n_compare install paths_"]);
 
     expect(draftStream.update).toHaveBeenCalledWith(
       "Clawing...\n\n🛠️ Exec\n🧠 _compare install paths_",
@@ -314,29 +215,7 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("preserves raw reasoning content that starts with a Thinking line", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params?.replyOptions?.onReasoningStream?.({ text: "Thinking\nthrough the plan" });
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            thinking: true,
-          },
-        },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runReasoningProgressDraft(["Thinking\nthrough the plan"]);
 
     expect(draftStream.update).toHaveBeenCalledWith(
       "Clawing...\n\n🛠️ Exec\n🧠 _Thinking through the plan_",
@@ -344,30 +223,7 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("appends raw reasoning chunks that start with Thinking", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params?.replyOptions?.onReasoningStream?.({ text: "I was " });
-      await params?.replyOptions?.onReasoningStream?.({ text: "Thinking about the plan" });
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            thinking: true,
-          },
-        },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runReasoningProgressDraft(["I was ", "Thinking about the plan"]);
 
     expect(draftStream.update).toHaveBeenCalledWith(
       "Clawing...\n\n🛠️ Exec\n🧠 _I was Thinking about the plan_",
@@ -375,30 +231,7 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("appends raw reasoning chunks that start with Thinking ellipsis", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params?.replyOptions?.onReasoningStream?.({ text: "I was " });
-      await params?.replyOptions?.onReasoningStream?.({ text: "Thinking... through the plan" });
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            thinking: true,
-          },
-        },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runReasoningProgressDraft(["I was ", "Thinking... through the plan"]);
 
     expect(draftStream.update).toHaveBeenCalledWith(
       "Clawing...\n\n🛠️ Exec\n🧠 _I was Thinking... through the plan_",
@@ -406,30 +239,10 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("appends raw reasoning chunks that start with Reasoning colon", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params?.replyOptions?.onReasoningStream?.({ text: "I was " });
-      await params?.replyOptions?.onReasoningStream?.({ text: "Reasoning: through edge cases" });
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            thinking: true,
-          },
-        },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runReasoningProgressDraft([
+      "I was ",
+      "Reasoning: through edge cases",
+    ]);
 
     expect(draftStream.update).toHaveBeenCalledWith(
       "Clawing...\n\n🛠️ Exec\n🧠 _I was Reasoning: through edge cases_",
@@ -437,32 +250,10 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("keeps reasoning italics balanced when progress lines truncate", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params?.replyOptions?.onReasoningStream?.({
-        text: "Thinking through a very detailed installation plan with many steps",
-      });
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            maxLineChars: 36,
-            thinking: true,
-          },
-        },
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runReasoningProgressDraft(
+      ["Thinking through a very detailed installation plan with many steps"],
+      { label: "Clawing...", maxLineChars: 36, thinking: true },
+    );
 
     const lastUpdate = draftStream.update.mock.calls.at(-1)?.[0];
     const reasoningLine = lastUpdate?.split("\n").at(-1);
@@ -472,36 +263,16 @@ describe("processDiscordMessage draft streaming reasoning", () => {
   });
 
   it("replaces reasoning snapshots instead of appending duplicates", async () => {
-    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
-    const draftStream = createMockDraftStreamForTest();
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await params?.replyOptions?.onReasoningStream?.({
+    const draftStream = await runReasoningProgressDraft([
+      {
         text: "Checking ",
         isReasoningSnapshot: true,
-      });
-      await params?.replyOptions?.onReasoningStream?.({
+      },
+      {
         text: "Reading \n\nChecking ",
         isReasoningSnapshot: true,
-      });
-      await elapseProgressDraftStartDelay();
-      return createNoQueuedDispatchResult();
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: {
-        streaming: {
-          mode: "progress",
-          progress: {
-            label: "Clawing...",
-            thinking: true,
-          },
-        },
       },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    ]);
 
     expect(draftStream.update.mock.calls.at(-1)?.[0]).toContain("_Reading Checking_");
     const updates = draftStream.update.mock.calls.map((call) => call[0]);

--- a/extensions/discord/src/monitor/message-handler.process.draft-recovery.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-recovery.test.ts
@@ -31,6 +31,27 @@ import {
 
 registerDiscordProcessTestLifecycle();
 
+type AutomaticDeliveryOverrides = Parameters<typeof createAutomaticSourceDeliveryContext>[0];
+type FinalReplyPayload = Parameters<DispatchInboundParams["dispatcher"]["sendFinalReply"]>[0];
+
+async function runFinalReplyScenario(
+  payload: FinalReplyPayload,
+  overrides: AutomaticDeliveryOverrides = {},
+) {
+  const draftStream = createMockDraftStreamForTest();
+  dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+    await params?.dispatcher.sendFinalReply(payload);
+    return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+  });
+
+  const ctx = await createAutomaticSourceDeliveryContext({
+    discordConfig: { streaming: { mode: "partial" }, maxLinesPerMessage: 5 },
+    ...overrides,
+  });
+  await runProcessDiscordMessage(ctx);
+  return draftStream;
+}
+
 describe("processDiscordMessage draft streaming recovery", () => {
   it("falls back to standard send when final needs multiple chunks", async () => {
     await runSingleChunkFinalScenario({ streaming: { mode: "partial" }, maxLinesPerMessage: 1 });
@@ -104,26 +125,21 @@ describe("processDiscordMessage draft streaming recovery", () => {
 
   it("uses root discord maxLinesPerMessage for fresh final delivery when runtime config omits it", async () => {
     const longReply = Array.from({ length: 20 }, (_value, index) => `Line ${index + 1}`).join("\n");
-    const draftStream = createMockDraftStreamForTest();
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.dispatcher.sendFinalReply({ text: longReply });
-      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      cfg: {
-        messages: { ackReaction: "👀" },
-        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
-        channels: {
-          discord: {
-            maxLinesPerMessage: 120,
+    const draftStream = await runFinalReplyScenario(
+      { text: longReply },
+      {
+        cfg: {
+          messages: { ackReaction: "👀" },
+          session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+          channels: {
+            discord: {
+              maxLinesPerMessage: 120,
+            },
           },
         },
+        discordConfig: { streaming: { mode: "partial" } },
       },
-      discordConfig: { streaming: { mode: "partial" } },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    );
 
     expect(editMessageDiscord).not.toHaveBeenCalled();
     expectFreshFinalText(longReply);
@@ -132,41 +148,22 @@ describe("processDiscordMessage draft streaming recovery", () => {
   });
 
   it("falls back to standard delivery for explicit reply-tag finals", async () => {
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.dispatcher.sendFinalReply({
-        text: "[[reply_to_current]] Hello\nWorld",
-        replyToId: "m-explicit-1",
-        replyToTag: true,
-        replyToCurrent: true,
-      });
-      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    await runFinalReplyScenario({
+      text: "[[reply_to_current]] Hello\nWorld",
+      replyToId: "m-explicit-1",
+      replyToTag: true,
+      replyToCurrent: true,
     });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: { streaming: { mode: "partial" }, maxLinesPerMessage: 5 },
-    });
-
-    await runProcessDiscordMessage(ctx);
 
     expect(editMessageDiscord).not.toHaveBeenCalled();
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
   it("does not flush draft previews for media finals before normal delivery", async () => {
-    const draftStream = createMockDraftStreamForTest();
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.dispatcher.sendFinalReply({
-        text: "Photo",
-        mediaUrl: "https://example.com/a.png",
-      } as never);
-      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: { streaming: { mode: "partial" }, maxLinesPerMessage: 5 },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runFinalReplyScenario({
+      text: "Photo",
+      mediaUrl: "https://example.com/a.png",
+    } as never);
 
     expect(draftStream.flush).not.toHaveBeenCalled();
     expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
@@ -176,23 +173,15 @@ describe("processDiscordMessage draft streaming recovery", () => {
   });
 
   it("sends a fresh visible TTS supplement final and clears the preview", async () => {
-    const draftStream = createMockDraftStreamForTest();
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.dispatcher.sendFinalReply({
+    const draftStream = await runFinalReplyScenario(
+      {
         mediaUrl: "https://example.com/tts.mp3",
         audioAsVoice: true,
         spokenText: "Spoken answer",
         ttsSupplement: { spokenText: "Spoken answer" },
-      } as never);
-      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: { streaming: { mode: "partial" }, maxLinesPerMessage: 5 },
-      replyToMode: "first",
-    });
-
-    await runProcessDiscordMessage(ctx);
+      } as never,
+      { replyToMode: "first" },
+    );
 
     expect(draftStream.flush).not.toHaveBeenCalled();
     expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
@@ -214,22 +203,12 @@ describe("processDiscordMessage draft streaming recovery", () => {
   });
 
   it("sends fresh visible text for TTS supplement finals", async () => {
-    const draftStream = createMockDraftStreamForTest();
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.dispatcher.sendFinalReply({
-        mediaUrl: "https://example.com/tts.mp3",
-        audioAsVoice: true,
-        spokenText: "Spoken answer",
-        ttsSupplement: { spokenText: "Spoken answer" },
-      } as never);
-      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: { streaming: { mode: "partial" }, maxLinesPerMessage: 5 },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runFinalReplyScenario({
+      mediaUrl: "https://example.com/tts.mp3",
+      audioAsVoice: true,
+      spokenText: "Spoken answer",
+      ttsSupplement: { spokenText: "Spoken answer" },
+    } as never);
 
     expect(draftStream.flush).not.toHaveBeenCalled();
     expect(draftStream.discardPending).toHaveBeenCalled();
@@ -251,24 +230,15 @@ describe("processDiscordMessage draft streaming recovery", () => {
 
   it("keeps already-delivered TTS supplement fallback audio-only", async () => {
     editMessageDiscord.mockRejectedValueOnce(new Error("edit failed"));
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.dispatcher.sendFinalReply({
-        mediaUrl: "https://example.com/tts.mp3",
-        audioAsVoice: true,
+    await runFinalReplyScenario({
+      mediaUrl: "https://example.com/tts.mp3",
+      audioAsVoice: true,
+      spokenText: "Spoken answer",
+      ttsSupplement: {
         spokenText: "Spoken answer",
-        ttsSupplement: {
-          spokenText: "Spoken answer",
-          visibleTextAlreadyDelivered: true,
-        },
-      } as never);
-      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: { streaming: { mode: "partial" }, maxLinesPerMessage: 5 },
-    });
-
-    await runProcessDiscordMessage(ctx);
+        visibleTextAlreadyDelivered: true,
+      },
+    } as never);
 
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
     expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
@@ -287,20 +257,10 @@ describe("processDiscordMessage draft streaming recovery", () => {
   });
 
   it("does not flush draft previews for error finals before normal delivery", async () => {
-    const draftStream = createMockDraftStreamForTest();
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      await params?.dispatcher.sendFinalReply({
-        text: "Something failed",
-        isError: true,
-      } as never);
-      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
-    });
-
-    const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: { streaming: { mode: "partial" }, maxLinesPerMessage: 5 },
-    });
-
-    await runProcessDiscordMessage(ctx);
+    const draftStream = await runFinalReplyScenario({
+      text: "Something failed",
+      isError: true,
+    } as never);
 
     expect(draftStream.flush).not.toHaveBeenCalled();
     expect(draftStream.discardPending).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## What Problem This Solves

Discord draft-process coverage repeated the same dispatch, progress-stream, draft allocation, and final-delivery fixture plumbing across reasoning and recovery cases. That repetition made the scenario-specific invariants harder to review and maintain while adding 269 avoidable test lines.

This is a maintainer-requested cleanup in the coordinated LOC-reduction campaign.

## Why This Change Was Made

Introduce two local, typed scenario helpers in the existing owner test files. Every named test and assertion remains independent and unchanged; the helpers only centralize identical fixture setup for reasoning progress and single-final delivery.

No production, config, API, schema, dependency, i18n, or Discord behavior changes.

## User Impact

No user-visible behavior changes. Maintainers get smaller, clearer coverage for Discord reasoning streams, draft lifecycle, transcript recovery, reply tags, media/TTS/error finals, and delivery fallback behavior.

## Evidence

- Delta: 127 additions, 396 deletions; net -269 test LOC; production delta 0.
- Exact parity: 44 named cases and 103 assertion sites preserved (reasoning 21/29; recovery 23/74).
- Focused: 44/44 passed with `node scripts/run-vitest.mjs` on both changed files.
- Full Discord Testbox: 209/209 files and 2,489/2,489 tests passed on `tbx_01kz1za390r2ptwb78e2z5vkf5` ([hydration run](https://github.com/openclaw/openclaw/actions/runs/30763531906)).
- Remote `pnpm check:changed`: passed, including formatting, extension-test typecheck, lint (0 warnings/errors), boundary/dependency/dead-export guards.
- Structured autoreview: clean, no accepted/actionable findings; TruffleHog clean.
- Two independent xhigh reviewers: CLEAN; both verified the full ingress/process/draft/recovery owner boundary and pinned `discord-api-types@0.38.52` contracts.
- Immediate collision census: zero exact-path matches through 2026-08-02T20:04:11.173Z, including all updated open PRs and fully paged oversized tails.
- Latest-main synthetic merge: clean; target files unchanged since the reviewed base.

AI-assisted: yes. I understand the changed fixture and production owner paths and verified the behavior directly.
