### PR TITLE
feat(signal): link first account from setup QR

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -37,13 +37,16 @@ Bare plugin specs try ClawHub first, then npm fallback. Force a source with `ope
     ```bash
     openclaw channels add
     ```
-    The wizard detects whether `signal-cli` is on `PATH` and, when missing, offers to install it: downloads the official native GraalVM build on Linux x86-64, or installs via Homebrew on macOS and other architectures. It then prompts for the bot number and `signal-cli` path.
+    The wizard detects whether `signal-cli` is on `PATH` and, when missing, offers to install it: downloads the official native GraalVM build on Linux x86-64, or installs via Homebrew on macOS and other architectures.
+
+    A hosted setup client with QR support can link the first managed-native Signal account directly. Scan the displayed QR in Signal; setup records the linked number without another number prompt. CLI setup, additional accounts, relinking, external daemons, and containers keep the manual flow below.
 
     For non-interactive setup, `openclaw channels add --channel signal` also accepts `--signal-number <e164>` for the bot phone number, plus `--http-host <host>` and `--http-port <port>` for the Signal daemon endpoint (default `127.0.0.1:8080`).
 
   </Step>
   <Step title="Link or register the account">
-    - **QR link (fastest):** `signal-cli link -n "OpenClaw"`, then scan with Signal. See [Path A](#setup-path-a-link-existing-signal-account-qr).
+    - **Hosted QR link (fastest):** if setup displayed a QR and confirmed the account, continue to verification.
+    - **Manual QR link:** otherwise run `signal-cli link -n "OpenClaw"`, then scan with Signal. See [Path A](#setup-path-a-link-existing-signal-account-qr).
     - **SMS registration:** dedicated number with captcha + SMS verification. See [Path B](#setup-path-b-register-dedicated-bot-number-sms-linux).
 
   </Step>
@@ -91,9 +94,10 @@ Multi-account support: use `channels.signal.accounts` with per-account config an
 
 ## Setup path A: link existing Signal account (QR)
 
-1. Install `signal-cli` (JVM or native build), or let `openclaw channels add` install it for you.
-2. Link a bot account: `signal-cli link -n "OpenClaw"`, then scan the QR in Signal.
-3. Configure Signal and start the gateway.
+1. Install `signal-cli` (JVM or native build), or let setup install it for you.
+2. In a hosted setup client that displays the first-account QR, scan it in Signal under **Settings > Linked devices**, then continue.
+3. For CLI setup, additional accounts, relinking, external daemons, or containers, run `signal-cli link -n "OpenClaw"` and scan the terminal QR instead.
+4. Configure Signal and start the gateway.
 
 ## Setup path B: register dedicated bot number (SMS, Linux)
 

--- a/extensions/signal/src/daemon-lifecycle.ts
+++ b/extensions/signal/src/daemon-lifecycle.ts
@@ -1,4 +1,38 @@
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
+import { signalCheck } from "./client-adapter.js";
 import { formatSignalDaemonExit, type SignalDaemonHandle } from "./daemon.js";
+
+export async function waitForSignalDaemonReady(params: {
+  baseUrl: string;
+  abortSignal?: AbortSignal;
+  timeoutMs: number;
+  logAfterMs: number;
+  logIntervalMs?: number;
+  runtime: RuntimeEnv;
+  waitForTransportReadyFn?: typeof waitForTransportReady;
+}): Promise<void> {
+  const waitForTransportReadyFn = params.waitForTransportReadyFn ?? waitForTransportReady;
+  await waitForTransportReadyFn({
+    label: "signal daemon",
+    timeoutMs: params.timeoutMs,
+    logAfterMs: params.logAfterMs,
+    logIntervalMs: params.logIntervalMs,
+    pollIntervalMs: 150,
+    abortSignal: params.abortSignal,
+    runtime: params.runtime,
+    check: async () => {
+      const res = await signalCheck(params.baseUrl, 1000);
+      if (res.ok) {
+        return { ok: true };
+      }
+      return {
+        ok: false,
+        error: res.error ?? (res.status ? `HTTP ${res.status}` : "unreachable"),
+      };
+    },
+  });
+}
 
 export function createSignalDaemonLifecycle(params: { abortSignal?: AbortSignal }) {
   let daemonHandle: SignalDaemonHandle | null = null;

--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -48,6 +48,7 @@ describe("spawnSignalDaemon", () => {
       configPath: "~/.openclaw/signal-cli",
       httpHost: "127.0.0.1",
       httpPort: 8080,
+      receiveMode: "manual",
     });
 
     expect(spawnMock).toHaveBeenCalledWith(
@@ -59,6 +60,8 @@ describe("spawnSignalDaemon", () => {
         "--http",
         "127.0.0.1:8080",
         "--no-receive-stdout",
+        "--receive-mode",
+        "manual",
       ],
       { stdio: ["ignore", "pipe", "pipe"] },
     );

--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { spawnSignalDaemon } from "./daemon.js";
+import { spawnSignalDaemon, spawnSignalJsonRpcProcess } from "./daemon.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 
@@ -14,12 +14,14 @@ function createMockChild() {
   const child = new EventEmitter() as EventEmitter & {
     pid: number;
     killed: boolean;
+    stdin: PassThrough;
     stdout: PassThrough;
     stderr: PassThrough;
     kill: ReturnType<typeof vi.fn>;
   };
   child.pid = 1234;
   child.killed = false;
+  child.stdin = new PassThrough();
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
   child.kill = vi.fn(() => true);
@@ -36,12 +38,34 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  child.stdin.end();
   child.stdout.end();
   child.stderr.end();
   child.removeAllListeners();
 });
 
 describe("spawnSignalDaemon", () => {
+  it("owns setup JSON-RPC through the child pipes", () => {
+    const process = spawnSignalJsonRpcProcess({
+      cliPath: "signal-cli",
+      configPath: "~/.openclaw/signal-cli",
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "signal-cli",
+      [
+        "--config",
+        path.join(os.homedir(), ".openclaw/signal-cli"),
+        "jsonRpc",
+        "--receive-mode",
+        "manual",
+      ],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+    expect(process.stdin).toBe(child.stdin);
+    expect(process.stdout).toBe(child.stdout);
+  });
+
   it("expands home-relative configPath before passing it to signal-cli", () => {
     spawnSignalDaemon({
       cliPath: "signal-cli",

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -27,7 +27,7 @@ export type SignalDaemonHandle = {
 
 const SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS = 1_500;
 
-export type SignalDaemonExitEvent = {
+type SignalDaemonExitEvent = {
   source: "process" | "spawn-error";
   code: number | null;
   signal: NodeJS.Signals | null;

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -27,10 +27,15 @@ export type SignalDaemonHandle = {
 
 const SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS = 1_500;
 
-type SignalDaemonExitEvent = {
+export type SignalDaemonExitEvent = {
   source: "process" | "spawn-error";
   code: number | null;
   signal: NodeJS.Signals | null;
+};
+
+export type SignalJsonRpcProcess = SignalDaemonHandle & {
+  stdin: NodeJS.WritableStream;
+  stdout: NodeJS.ReadableStream;
 };
 
 export function formatSignalDaemonExit(exit: SignalDaemonExitEvent): string {
@@ -121,15 +126,14 @@ function buildDaemonArgs(opts: SignalDaemonOpts): string[] {
   return args;
 }
 
-export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
-  const args = buildDaemonArgs(opts);
-  // The executable is operator-selected or setup-discovered signal-cli.
-  // Runtime message content only flows through the daemon HTTP API, not argv.
-  const child = spawn(opts.cliPath, args, {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  const log = opts.runtime?.log ?? (() => {});
-  const error = opts.runtime?.error ?? (() => {});
+function bindSignalProcess(params: {
+  child: ReturnType<typeof spawn>;
+  runtime?: RuntimeEnv;
+  bindStdout: boolean;
+}): SignalDaemonHandle {
+  const { child } = params;
+  const log = params.runtime?.log ?? (() => {});
+  const error = params.runtime?.error ?? (() => {});
   let exited = false;
   let settledExit = false;
   let stopPromise: Promise<void> | undefined;
@@ -146,7 +150,9 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
     resolveExit(value);
   };
 
-  bindSignalCliOutput({ stream: child.stdout, log, error });
+  if (params.bindStdout) {
+    bindSignalCliOutput({ stream: child.stdout, log, error });
+  }
   bindSignalCliOutput({ stream: child.stderr, log, error });
   child.once("exit", (code, signal) => {
     settleExit({
@@ -215,4 +221,31 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
       return stopPromise;
     },
   };
+}
+
+export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
+  // The executable is operator-selected or setup-discovered signal-cli.
+  // Runtime message content only flows through the daemon HTTP API, not argv.
+  const child = spawn(opts.cliPath, buildDaemonArgs(opts), {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return bindSignalProcess({ child, runtime: opts.runtime, bindStdout: true });
+}
+
+export function spawnSignalJsonRpcProcess(opts: {
+  cliPath: string;
+  configPath?: string;
+  runtime?: RuntimeEnv;
+}): SignalJsonRpcProcess {
+  const args: string[] = [];
+  if (opts.configPath?.trim()) {
+    args.push("--config", resolveSignalCliConfigPath(opts.configPath));
+  }
+  args.push("jsonRpc", "--receive-mode", "manual");
+  const child = spawn(opts.cliPath, args, { stdio: ["pipe", "pipe", "pipe"] });
+  const handle = bindSignalProcess({ child, runtime: opts.runtime, bindStdout: false });
+  if (!child.stdin || !child.stdout) {
+    throw new Error("signal-cli jsonRpc pipes unavailable");
+  }
+  return { ...handle, stdin: child.stdin, stdout: child.stdout };
 }

--- a/extensions/signal/src/link-rpc.test.ts
+++ b/extensions/signal/src/link-rpc.test.ts
@@ -2,7 +2,7 @@
 import { once } from "node:events";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SignalDaemonExitEvent, SignalJsonRpcProcess } from "./daemon.js";
+import type { SignalJsonRpcProcess } from "./daemon.js";
 import { createSignalLinkRpcClient } from "./link-rpc.js";
 
 const mocks = vi.hoisted(() => ({ spawn: vi.fn() }));
@@ -15,8 +15,9 @@ vi.mock("./daemon.js", async (importOriginal) => ({
 function createProcess() {
   const stdin = new PassThrough();
   const stdout = new PassThrough();
-  let resolveExit!: (exit: SignalDaemonExitEvent) => void;
-  const exited = new Promise<SignalDaemonExitEvent>((resolve) => {
+  type ExitEvent = Awaited<SignalJsonRpcProcess["exited"]>;
+  let resolveExit!: (exit: ExitEvent) => void;
+  const exited = new Promise<ExitEvent>((resolve) => {
     resolveExit = resolve;
   });
   const process: SignalJsonRpcProcess = {

--- a/extensions/signal/src/link-rpc.test.ts
+++ b/extensions/signal/src/link-rpc.test.ts
@@ -1,0 +1,104 @@
+// Signal link RPC tests cover child-owned JSON-line request routing.
+import { once } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SignalDaemonExitEvent, SignalJsonRpcProcess } from "./daemon.js";
+import { createSignalLinkRpcClient } from "./link-rpc.js";
+
+const mocks = vi.hoisted(() => ({ spawn: vi.fn() }));
+
+vi.mock("./daemon.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./daemon.js")>()),
+  spawnSignalJsonRpcProcess: mocks.spawn,
+}));
+
+function createProcess() {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  let resolveExit!: (exit: SignalDaemonExitEvent) => void;
+  const exited = new Promise<SignalDaemonExitEvent>((resolve) => {
+    resolveExit = resolve;
+  });
+  const process: SignalJsonRpcProcess = {
+    stdin,
+    stdout,
+    exited,
+    isExited: () => false,
+    stop: vi.fn(async () => {}),
+  };
+  return { process, resolveExit };
+}
+
+let fixture: ReturnType<typeof createProcess>;
+
+beforeEach(() => {
+  fixture = createProcess();
+  mocks.spawn.mockReset().mockReturnValue(fixture.process);
+});
+
+afterEach(() => {
+  (fixture.process.stdin as PassThrough).end();
+  (fixture.process.stdout as PassThrough).end();
+});
+
+describe("SignalLinkRpcClient", () => {
+  it("routes a response through the owned child pipes", async () => {
+    const client = createSignalLinkRpcClient({
+      cliPath: "signal-cli",
+      configPath: "/tmp/signal",
+    });
+    const written = once(fixture.process.stdin, "data");
+    const response = client.request("startLink", undefined, { maxResponseBytes: 1024 });
+    const [chunk] = await written;
+    const request = JSON.parse(String(chunk)) as { id: string; method: string };
+
+    expect(request.method).toBe("startLink");
+    fixture.process.stdout.emit(
+      "data",
+      `${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { deviceLinkUri: "sgnl://linkdevice?uuid=test" } })}\n`,
+    );
+
+    await expect(response).resolves.toEqual({
+      deviceLinkUri: "sgnl://linkdevice?uuid=test",
+    });
+    expect(mocks.spawn).toHaveBeenCalledWith({
+      cliPath: "signal-cli",
+      configPath: "/tmp/signal",
+    });
+    await client.stop();
+    expect(fixture.process.stop).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a pending request when the owned child exits", async () => {
+    const client = createSignalLinkRpcClient({ cliPath: "signal-cli" });
+    const response = client.request("listAccounts");
+
+    fixture.resolveExit({ source: "process", code: 1, signal: null });
+
+    await expect(response).rejects.toThrow("signal daemon exited");
+  });
+
+  it("rejects a pending request when the child closes stdin", async () => {
+    const client = createSignalLinkRpcClient({ cliPath: "signal-cli" });
+    const response = client.request("listAccounts");
+
+    fixture.process.stdin.emit("error", new Error("write EPIPE"));
+
+    await expect(response).rejects.toThrow("write EPIPE");
+  });
+
+  it("rejects an oversized response before parsing it", async () => {
+    const client = createSignalLinkRpcClient({ cliPath: "signal-cli" });
+    const written = once(fixture.process.stdin, "data");
+    const response = client.request("listAccounts", undefined, { maxResponseBytes: 64 });
+    const [chunk] = await written;
+    const request = JSON.parse(String(chunk)) as { id: string };
+
+    fixture.process.stdout.emit(
+      "data",
+      `${JSON.stringify({ id: request.id, result: "x".repeat(128) })}\n`,
+    );
+
+    await expect(response).rejects.toThrow("response exceeded size limit");
+  });
+});

--- a/extensions/signal/src/link-rpc.ts
+++ b/extensions/signal/src/link-rpc.ts
@@ -1,0 +1,165 @@
+// Setup-only signal-cli JSON-RPC transport bound to one child process.
+import { createInterface } from "node:readline";
+import { generateSecureUuid } from "openclaw/plugin-sdk/core";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { SignalRpcOptions } from "./client.js";
+import {
+  formatSignalDaemonExit,
+  spawnSignalJsonRpcProcess,
+  type SignalJsonRpcProcess,
+} from "./daemon.js";
+
+type PendingRequest = {
+  id: string;
+  maxResponseBytes: number;
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export type SignalLinkRpcClient = {
+  request: <T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: Pick<SignalRpcOptions, "timeoutMs" | "maxResponseBytes">,
+  ) => Promise<T>;
+  stop: () => Promise<void>;
+};
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 16 * 1024;
+
+class SignalLinkRpcProcessClient implements SignalLinkRpcClient {
+  private readonly lines;
+  private pending: PendingRequest | undefined;
+  private terminalError: Error | undefined;
+
+  constructor(
+    private readonly process: SignalJsonRpcProcess,
+    private readonly abortSignal?: AbortSignal,
+  ) {
+    this.lines = createInterface({ input: process.stdout });
+    this.lines.on("line", this.handleLine);
+    process.stdin.on("error", this.fail);
+    process.stdout.on("error", this.fail);
+    void process.exited.then((exit) => this.fail(new Error(formatSignalDaemonExit(exit))));
+    abortSignal?.addEventListener("abort", this.onAbort, { once: true });
+  }
+
+  async request<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: Pick<SignalRpcOptions, "timeoutMs" | "maxResponseBytes">,
+  ): Promise<T> {
+    if (this.terminalError) {
+      throw this.terminalError;
+    }
+    if (this.pending) {
+      throw new Error("signal-cli link RPC request already in flight");
+    }
+    this.abortSignal?.throwIfAborted();
+    const id = generateSecureUuid();
+    const timeoutMs = this.positiveInteger(options?.timeoutMs, DEFAULT_TIMEOUT_MS);
+    const maxResponseBytes = this.positiveInteger(
+      options?.maxResponseBytes,
+      DEFAULT_MAX_RESPONSE_BYTES,
+    );
+    const response = new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending = undefined;
+        reject(new Error(`signal-cli jsonRpc timeout (${method})`));
+      }, timeoutMs);
+      timer.unref?.();
+      this.pending = {
+        id,
+        maxResponseBytes,
+        resolve: (value) => resolve(value as T),
+        reject,
+        timer,
+      };
+    });
+    try {
+      this.process.stdin.write(
+        `${JSON.stringify({ jsonrpc: "2.0", method, params, id })}\n`,
+        (error?: Error | null) => {
+          if (error) {
+            this.fail(error);
+          }
+        },
+      );
+    } catch (error) {
+      this.fail(error instanceof Error ? error : new Error(String(error)));
+    }
+    return await response;
+  }
+
+  async stop(): Promise<void> {
+    this.abortSignal?.removeEventListener("abort", this.onAbort);
+    this.lines.close();
+    await this.process.stop();
+  }
+
+  private positiveInteger(value: number | undefined, fallback: number): number {
+    return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : fallback;
+  }
+
+  private readonly onAbort = () => void this.process.stop();
+
+  private readonly handleLine = (line: string) => {
+    const pending = this.pending;
+    if (!pending || !line.trim()) {
+      return;
+    }
+    if (Buffer.byteLength(line) > pending.maxResponseBytes) {
+      this.fail(new Error("signal-cli jsonRpc response exceeded size limit"));
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      this.fail(new Error("signal-cli jsonRpc returned malformed JSON"));
+      return;
+    }
+    if (!isRecord(parsed) || String(parsed.id ?? "") !== pending.id) {
+      return;
+    }
+    this.pending = undefined;
+    clearTimeout(pending.timer);
+    if (isRecord(parsed.error)) {
+      const code = typeof parsed.error.code === "number" ? ` ${parsed.error.code}` : "";
+      const message =
+        typeof parsed.error.message === "string"
+          ? parsed.error.message.slice(0, 512)
+          : "request failed";
+      pending.reject(new Error(`signal-cli jsonRpc${code}: ${message}`));
+    } else if (Object.hasOwn(parsed, "result")) {
+      pending.resolve(parsed.result);
+    } else {
+      pending.reject(new Error("signal-cli jsonRpc returned an invalid response"));
+    }
+  };
+
+  private readonly fail = (error: Error) => {
+    if (this.terminalError) {
+      return;
+    }
+    this.terminalError = error;
+    const pending = this.pending;
+    this.pending = undefined;
+    if (pending) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    void this.process.stop();
+  };
+}
+
+export function createSignalLinkRpcClient(options: {
+  cliPath: string;
+  configPath?: string;
+  abortSignal?: AbortSignal;
+}): SignalLinkRpcClient {
+  const { abortSignal, ...processOptions } = options;
+  return new SignalLinkRpcProcessClient(spawnSignalJsonRpcProcess(processOptions), abortSignal);
+}

--- a/extensions/signal/src/link-rpc.ts
+++ b/extensions/signal/src/link-rpc.ts
@@ -121,7 +121,7 @@ class SignalLinkRpcProcessClient implements SignalLinkRpcClient {
       this.fail(new Error("signal-cli jsonRpc returned malformed JSON"));
       return;
     }
-    if (!isRecord(parsed) || String(parsed.id ?? "") !== pending.id) {
+    if (!isRecord(parsed) || typeof parsed.id !== "string" || parsed.id !== pending.id) {
       return;
     }
     this.pending = undefined;

--- a/extensions/signal/src/link-rpc.ts
+++ b/extensions/signal/src/link-rpc.ts
@@ -18,11 +18,11 @@ type PendingRequest = {
 };
 
 export type SignalLinkRpcClient = {
-  request: <T = unknown>(
+  request: (
     method: string,
     params?: Record<string, unknown>,
     options?: Pick<SignalRpcOptions, "timeoutMs" | "maxResponseBytes">,
-  ) => Promise<T>;
+  ) => Promise<unknown>;
   stop: () => Promise<void>;
 };
 
@@ -46,11 +46,11 @@ class SignalLinkRpcProcessClient implements SignalLinkRpcClient {
     abortSignal?.addEventListener("abort", this.onAbort, { once: true });
   }
 
-  async request<T = unknown>(
+  async request(
     method: string,
     params?: Record<string, unknown>,
     options?: Pick<SignalRpcOptions, "timeoutMs" | "maxResponseBytes">,
-  ): Promise<T> {
+  ): Promise<unknown> {
     if (this.terminalError) {
       throw this.terminalError;
     }
@@ -64,7 +64,7 @@ class SignalLinkRpcProcessClient implements SignalLinkRpcClient {
       options?.maxResponseBytes,
       DEFAULT_MAX_RESPONSE_BYTES,
     );
-    const response = new Promise<T>((resolve, reject) => {
+    const response = new Promise<unknown>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending = undefined;
         reject(new Error(`signal-cli jsonRpc timeout (${method})`));
@@ -73,7 +73,7 @@ class SignalLinkRpcProcessClient implements SignalLinkRpcClient {
       this.pending = {
         id,
         maxResponseBytes,
-        resolve: (value) => resolve(value as T),
+        resolve,
         reject,
         timer,
       };

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -46,9 +46,9 @@ import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runti
 import { resolveSignalAccount, resolveSignalReplyToMode } from "./accounts.js";
 import { isSignalNativeApprovalHandlerConfigured } from "./approval-native.js";
 import { addSignalApprovalReactionHintToStructuredPayload } from "./approval-reactions.js";
-import { signalRpcRequest, signalCheck } from "./client-adapter.js";
+import { signalRpcRequest } from "./client-adapter.js";
 import type { SignalTransportKind } from "./client-adapter.js";
-import { createSignalDaemonLifecycle } from "./daemon-lifecycle.js";
+import { createSignalDaemonLifecycle, waitForSignalDaemonReady } from "./daemon-lifecycle.js";
 import { spawnSignalDaemon, type SignalDaemonHandle } from "./daemon.js";
 import { isSignalSenderAllowed, type resolveSignalSender } from "./identity.js";
 import { createSignalEventHandler } from "./monitor/event-handler.js";
@@ -192,37 +192,6 @@ function buildSignalReactionSystemEventText(params: {
   const base = `Signal reaction added: ${params.emojiLabel} by ${params.actorLabel} msg ${params.messageId}`;
   const withTarget = params.targetLabel ? `${base} from ${params.targetLabel}` : base;
   return params.groupLabel ? `${withTarget} in ${params.groupLabel}` : withTarget;
-}
-
-async function waitForSignalDaemonReady(params: {
-  baseUrl: string;
-  abortSignal?: AbortSignal;
-  timeoutMs: number;
-  logAfterMs: number;
-  logIntervalMs?: number;
-  runtime: RuntimeEnv;
-  waitForTransportReadyFn?: typeof waitForTransportReady;
-}): Promise<void> {
-  const waitForTransportReadyFn = params.waitForTransportReadyFn ?? waitForTransportReady;
-  await waitForTransportReadyFn({
-    label: "signal daemon",
-    timeoutMs: params.timeoutMs,
-    logAfterMs: params.logAfterMs,
-    logIntervalMs: params.logIntervalMs,
-    pollIntervalMs: 150,
-    abortSignal: params.abortSignal,
-    runtime: params.runtime,
-    check: async () => {
-      const res = await signalCheck(params.baseUrl, 1000);
-      if (res.ok) {
-        return { ok: true };
-      }
-      return {
-        ok: false,
-        error: res.error ?? (res.status ? `HTTP ${res.status}` : "unreachable"),
-      };
-    },
-  });
 }
 
 const SIGNAL_ATTACHMENT_RPC_RESPONSE_HEADROOM_BYTES = 64 * 1024;

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -40,6 +40,7 @@ import { normalizeSignalTransportHost, normalizeSignalTransportUrl } from "./tra
 const t = createSetupTranslator();
 
 const channel = "signal" as const;
+export const SIGNAL_LINK_COMPLETED_CREDENTIAL = "signalLinkCompleted";
 
 const signalSetupFields = {
   signalNumber: {
@@ -297,6 +298,9 @@ export const signalNumberTextInput: ChannelSetupWizardTextInput = {
   validate: ({ value }) =>
     normalizeSignalAccountInput(value) ? undefined : INVALID_SIGNAL_ACCOUNT_ERROR,
   normalizeValue: ({ value }) => normalizeSignalAccountInput(value) ?? value,
+  shouldPrompt: ({ credentialValues }) =>
+    credentialValues[SIGNAL_LINK_COMPLETED_CREDENTIAL] !== "true",
+  applyCurrentValue: true,
 };
 
 export const signalCompletionNote = {
@@ -307,6 +311,8 @@ export const signalCompletionNote = {
     `Then run: ${formatCliCommand("openclaw gateway call channels.status --params '{\"probe\":true}'")}`,
     `Docs: ${formatDocsLink("/signal", "signal")}`,
   ],
+  shouldShow: ({ credentialValues }: { credentialValues: Record<string, string | undefined> }) =>
+    credentialValues[SIGNAL_LINK_COMPLETED_CREDENTIAL] !== "true",
 };
 
 const signalSetupAdapterBase = createPatchedAccountSetupAdapter<SignalSetupInput>({

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -186,6 +186,26 @@ describe("Signal hosted setup linking", () => {
     expect(result?.credentialValues?.signalNumber).toBe("+15555550125");
   });
 
+  it("rejects stale hosted authority before starting device linking", async () => {
+    const guardError = new Error("verified inference changed");
+    const beforePersistentEffect = vi.fn(async () => {
+      throw guardError;
+    });
+    const prompt = createPrompter();
+
+    await expect(
+      prepareSignal({
+        prompter: prompt.prompter,
+        beforePersistentEffect,
+      }),
+    ).rejects.toBe(guardError);
+
+    expect(beforePersistentEffect).toHaveBeenCalledOnce();
+    expect(mocks.spawnDaemon).not.toHaveBeenCalled();
+    expect(mocks.rpc).not.toHaveBeenCalled();
+    expect(prompt.qrCode).not.toHaveBeenCalled();
+  });
+
   it.each([
     { label: "without QR support", includeSignal: true, includeQr: false, cfg: {} },
     { label: "without hosted cancellation", includeSignal: false, includeQr: true, cfg: {} },

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -1,0 +1,286 @@
+// Signal setup tests cover hosted first-account linking and manual fallbacks.
+import type { OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk/setup";
+import { WizardCancelledError } from "openclaw/plugin-sdk/setup";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SIGNAL_LINK_COMPLETED_CREDENTIAL } from "./setup-core.js";
+import { signalSetupWizard } from "./setup-surface.js";
+
+const mocks = vi.hoisted(() => ({
+  detectBinary: vi.fn(),
+  installSignalCli: vi.fn(),
+  rpc: vi.fn(),
+  spawnDaemon: vi.fn(),
+  waitReady: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/setup-tools", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/setup-tools")>()),
+  detectBinary: mocks.detectBinary,
+}));
+vi.mock("./client.js", () => ({ signalRpcRequest: mocks.rpc }));
+vi.mock("./daemon.js", () => ({ spawnSignalDaemon: mocks.spawnDaemon }));
+vi.mock("./daemon-lifecycle.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./daemon-lifecycle.js")>()),
+  waitForSignalDaemonReady: mocks.waitReady,
+}));
+vi.mock("./install-signal-cli.js", () => ({ installSignalCli: mocks.installSignalCli }));
+
+type PrepareParams = Parameters<NonNullable<typeof signalSetupWizard.prepare>>[0];
+
+function createPrompter(
+  params: {
+    confirm?: boolean;
+    qrCode?: (value: Parameters<NonNullable<WizardPrompter["qrCode"]>>[0]) => Promise<unknown>;
+    selectedAccount?: string;
+  } = {},
+) {
+  const note = vi.fn(async () => {});
+  const select = vi.fn(async () => params.selectedAccount ?? "+15555550123");
+  const qrCode = params.qrCode
+    ? vi.fn(params.qrCode)
+    : vi.fn(async (value: Parameters<NonNullable<WizardPrompter["qrCode"]>>[0]) => value.settled);
+  return {
+    note,
+    qrCode,
+    select,
+    prompter: {
+      confirm: vi.fn(async () => params.confirm ?? false),
+      note,
+      qrCode,
+      select,
+    } as unknown as WizardPrompter,
+  };
+}
+
+function createDaemonHandle() {
+  return {
+    exited: new Promise<never>(() => {}),
+    isExited: () => false,
+    stop: vi.fn(async () => {}),
+  };
+}
+
+async function prepareSignal(params: {
+  cfg?: OpenClawConfig;
+  prompter?: WizardPrompter;
+  signal?: AbortSignal;
+  includeSignal?: boolean;
+  beforePersistentEffect?: () => Promise<void>;
+}) {
+  const prepare = signalSetupWizard.prepare;
+  if (!prepare) {
+    throw new Error("expected Signal setup prepare hook");
+  }
+  const options: NonNullable<PrepareParams["options"]> = {
+    allowSignalInstall: true,
+    ...(params.includeSignal === false
+      ? {}
+      : { signal: params.signal ?? new AbortController().signal }),
+    ...(params.beforePersistentEffect
+      ? { beforePersistentEffect: params.beforePersistentEffect }
+      : {}),
+  };
+  return await prepare({
+    cfg: params.cfg ?? {},
+    accountId: "default",
+    credentialValues: {},
+    runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    prompter: params.prompter ?? createPrompter().prompter,
+    options,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.detectBinary.mockResolvedValue(true);
+  mocks.installSignalCli.mockResolvedValue({ ok: true, cliPath: "/tools/signal-cli" });
+  mocks.spawnDaemon.mockImplementation(() => createDaemonHandle());
+  mocks.waitReady.mockResolvedValue(undefined);
+});
+
+describe("Signal hosted setup linking", () => {
+  it("links the first managed-native account through one owned multi-account daemon", async () => {
+    const events: string[] = [];
+    const deviceLinkUri = "sgnl://linkdevice?uuid=test&pub_key=test";
+    mocks.rpc.mockImplementation(async (method: string) => {
+      events.push(method);
+      if (method === "listAccounts") {
+        return [];
+      }
+      if (method === "startLink") {
+        return { deviceLinkUri };
+      }
+      if (method === "finishLink") {
+        return { number: "+15555550123" };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const prompt = createPrompter({
+      qrCode: async (value) => {
+        events.push("qrCode");
+        return await value.settled;
+      },
+    });
+
+    const result = await prepareSignal({
+      prompter: prompt.prompter,
+    });
+
+    expect(mocks.spawnDaemon).toHaveBeenCalledWith({
+      cliPath: "signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+      receiveMode: "manual",
+    });
+    expect(mocks.spawnDaemon.mock.calls[0]?.[0]).not.toHaveProperty("account");
+    expect(events).toEqual(["listAccounts", "startLink", "finishLink", "qrCode"]);
+    expect(prompt.qrCode).toHaveBeenCalledWith({
+      title: "Link Signal",
+      message: "In Signal, open Settings → Linked devices and scan this QR code.",
+      text: deviceLinkUri,
+      expiresInMs: 120_000,
+      settled: expect.any(Promise),
+    });
+    expect(result?.credentialValues).toEqual({
+      signalNumber: "+15555550123",
+      [SIGNAL_LINK_COMPLETED_CREDENTIAL]: "true",
+    });
+    expect(mocks.spawnDaemon.mock.results[0]?.value.stop).toHaveBeenCalledOnce();
+
+    const numberInput = signalSetupWizard.textInputs?.find(
+      (input) => input.inputKey === "signalNumber",
+    );
+    expect(numberInput?.applyCurrentValue).toBe(true);
+    expect(
+      await numberInput?.shouldPrompt?.({
+        cfg: {},
+        accountId: "default",
+        credentialValues: result?.credentialValues ?? {},
+        currentValue: "+15555550123",
+      }),
+    ).toBe(false);
+    expect(
+      await signalSetupWizard.completionNote?.shouldShow?.({
+        cfg: {},
+        accountId: "default",
+        credentialValues: result?.credentialValues ?? {},
+      }),
+    ).toBe(false);
+  });
+
+  it("reuses a selected local signal-cli account without starting another link", async () => {
+    mocks.rpc.mockResolvedValueOnce([{ number: "+15555550125" }, { number: "+15555550123" }]);
+    const prompt = createPrompter({ selectedAccount: "+15555550125" });
+
+    const result = await prepareSignal({ prompter: prompt.prompter });
+
+    expect(prompt.select).toHaveBeenCalledWith({
+      message: "Choose the Signal account for OpenClaw",
+      options: [
+        { label: "+15555550123", value: "+15555550123" },
+        { label: "+15555550125", value: "+15555550125" },
+      ],
+    });
+    expect(mocks.rpc).toHaveBeenCalledTimes(1);
+    expect(prompt.qrCode).not.toHaveBeenCalled();
+    expect(result?.credentialValues?.signalNumber).toBe("+15555550125");
+  });
+
+  it.each([
+    { label: "without QR support", includeSignal: true, includeQr: false, cfg: {} },
+    { label: "without hosted cancellation", includeSignal: false, includeQr: true, cfg: {} },
+    {
+      label: "for an already configured account",
+      includeSignal: true,
+      includeQr: true,
+      cfg: { channels: { signal: { account: "+15555550123" } } } as OpenClawConfig,
+    },
+    {
+      label: "for an external daemon",
+      includeSignal: true,
+      includeQr: true,
+      cfg: {
+        channels: {
+          signal: {
+            transport: { kind: "external-native", url: "http://127.0.0.1:8080" },
+          },
+        },
+      } as OpenClawConfig,
+    },
+  ])("keeps the manual setup flow $label", async ({ includeSignal, includeQr, cfg }) => {
+    const prompt = createPrompter();
+    const prompter = includeQr
+      ? prompt.prompter
+      : ({ ...prompt.prompter, qrCode: undefined } as WizardPrompter);
+
+    const result = await prepareSignal({
+      cfg,
+      prompter,
+      includeSignal,
+    });
+
+    expect(mocks.spawnDaemon).not.toHaveBeenCalled();
+    expect(result?.credentialValues?.signalNumber).toBeUndefined();
+    expect(
+      await signalSetupWizard.completionNote?.shouldShow?.({
+        cfg,
+        accountId: "default",
+        credentialValues: result?.credentialValues ?? {},
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "invalid start URI",
+      responses: [[], { deviceLinkUri: "https://example.invalid/private-token" }],
+    },
+    {
+      label: "invalid finish number",
+      responses: [
+        [],
+        { deviceLinkUri: "sgnl://linkdevice?uuid=private-token&pub_key=test" },
+        { number: "private-number" },
+      ],
+    },
+  ])("falls back without exposing dependency data for an $label", async ({ responses }) => {
+    for (const response of responses) {
+      mocks.rpc.mockResolvedValueOnce(response);
+    }
+    const prompt = createPrompter();
+
+    const result = await prepareSignal({ prompter: prompt.prompter });
+
+    const notes = prompt.note.mock.calls.flat().map(String).join("\n");
+    expect(result).toBeUndefined();
+    expect(notes).toContain("Automatic Signal linking could not complete");
+    expect(notes).not.toContain("private-token");
+    expect(notes).not.toContain("private-number");
+    expect(mocks.spawnDaemon.mock.results[0]?.value.stop).toHaveBeenCalledOnce();
+  });
+
+  it("aborts linking and reaps its daemon without showing a dependency failure", async () => {
+    const controller = new AbortController();
+    mocks.rpc
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ deviceLinkUri: "sgnl://linkdevice?uuid=test&pub_key=test" })
+      .mockReturnValueOnce(new Promise<never>(() => {}));
+    const prompt = createPrompter({
+      qrCode: async () => {
+        controller.abort(new WizardCancelledError());
+        throw new WizardCancelledError();
+      },
+    });
+
+    await expect(
+      prepareSignal({
+        prompter: prompt.prompter,
+        signal: controller.signal,
+        beforePersistentEffect: vi.fn(async () => {}),
+      }),
+    ).rejects.toBeInstanceOf(WizardCancelledError);
+
+    expect(prompt.note).not.toHaveBeenCalled();
+    expect(mocks.spawnDaemon.mock.results[0]?.value.stop).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/signal/src/setup-surface.test.ts
+++ b/extensions/signal/src/setup-surface.test.ts
@@ -8,22 +8,17 @@ import { signalSetupWizard } from "./setup-surface.js";
 const mocks = vi.hoisted(() => ({
   detectBinary: vi.fn(),
   installSignalCli: vi.fn(),
+  createLinkClient: vi.fn(),
+  linkStop: vi.fn(async () => {}),
   rpc: vi.fn(),
-  spawnDaemon: vi.fn(),
-  waitReady: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/setup-tools", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/setup-tools")>()),
   detectBinary: mocks.detectBinary,
 }));
-vi.mock("./client.js", () => ({ signalRpcRequest: mocks.rpc }));
-vi.mock("./daemon.js", () => ({ spawnSignalDaemon: mocks.spawnDaemon }));
-vi.mock("./daemon-lifecycle.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./daemon-lifecycle.js")>()),
-  waitForSignalDaemonReady: mocks.waitReady,
-}));
 vi.mock("./install-signal-cli.js", () => ({ installSignalCli: mocks.installSignalCli }));
+vi.mock("./link-rpc.js", () => ({ createSignalLinkRpcClient: mocks.createLinkClient }));
 
 type PrepareParams = Parameters<NonNullable<typeof signalSetupWizard.prepare>>[0];
 
@@ -49,14 +44,6 @@ function createPrompter(
       qrCode,
       select,
     } as unknown as WizardPrompter,
-  };
-}
-
-function createDaemonHandle() {
-  return {
-    exited: new Promise<never>(() => {}),
-    isExited: () => false,
-    stop: vi.fn(async () => {}),
   };
 }
 
@@ -94,8 +81,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.detectBinary.mockResolvedValue(true);
   mocks.installSignalCli.mockResolvedValue({ ok: true, cliPath: "/tools/signal-cli" });
-  mocks.spawnDaemon.mockImplementation(() => createDaemonHandle());
-  mocks.waitReady.mockResolvedValue(undefined);
+  mocks.createLinkClient.mockImplementation(() => ({
+    request: mocks.rpc,
+    stop: mocks.linkStop,
+  }));
 });
 
 describe("Signal hosted setup linking", () => {
@@ -126,13 +115,10 @@ describe("Signal hosted setup linking", () => {
       prompter: prompt.prompter,
     });
 
-    expect(mocks.spawnDaemon).toHaveBeenCalledWith({
+    expect(mocks.createLinkClient).toHaveBeenCalledWith({
       cliPath: "signal-cli",
-      httpHost: "127.0.0.1",
-      httpPort: 8080,
-      receiveMode: "manual",
+      abortSignal: expect.any(AbortSignal),
     });
-    expect(mocks.spawnDaemon.mock.calls[0]?.[0]).not.toHaveProperty("account");
     expect(events).toEqual(["listAccounts", "startLink", "finishLink", "qrCode"]);
     expect(prompt.qrCode).toHaveBeenCalledWith({
       title: "Link Signal",
@@ -145,7 +131,7 @@ describe("Signal hosted setup linking", () => {
       signalNumber: "+15555550123",
       [SIGNAL_LINK_COMPLETED_CREDENTIAL]: "true",
     });
-    expect(mocks.spawnDaemon.mock.results[0]?.value.stop).toHaveBeenCalledOnce();
+    expect(mocks.linkStop).toHaveBeenCalledOnce();
 
     const numberInput = signalSetupWizard.textInputs?.find(
       (input) => input.inputKey === "signalNumber",
@@ -201,7 +187,7 @@ describe("Signal hosted setup linking", () => {
     ).rejects.toBe(guardError);
 
     expect(beforePersistentEffect).toHaveBeenCalledOnce();
-    expect(mocks.spawnDaemon).not.toHaveBeenCalled();
+    expect(mocks.createLinkClient).not.toHaveBeenCalled();
     expect(mocks.rpc).not.toHaveBeenCalled();
     expect(prompt.qrCode).not.toHaveBeenCalled();
   });
@@ -239,7 +225,7 @@ describe("Signal hosted setup linking", () => {
       includeSignal,
     });
 
-    expect(mocks.spawnDaemon).not.toHaveBeenCalled();
+    expect(mocks.createLinkClient).not.toHaveBeenCalled();
     expect(result?.credentialValues?.signalNumber).toBeUndefined();
     expect(
       await signalSetupWizard.completionNote?.shouldShow?.({
@@ -276,7 +262,7 @@ describe("Signal hosted setup linking", () => {
     expect(notes).toContain("Automatic Signal linking could not complete");
     expect(notes).not.toContain("private-token");
     expect(notes).not.toContain("private-number");
-    expect(mocks.spawnDaemon.mock.results[0]?.value.stop).toHaveBeenCalledOnce();
+    expect(mocks.linkStop).toHaveBeenCalledOnce();
   });
 
   it("aborts linking and reaps its daemon without showing a dependency failure", async () => {
@@ -301,6 +287,6 @@ describe("Signal hosted setup linking", () => {
     ).rejects.toBeInstanceOf(WizardCancelledError);
 
     expect(prompt.note).not.toHaveBeenCalled();
-    expect(mocks.spawnDaemon.mock.results[0]?.value.stop).toHaveBeenCalledOnce();
+    expect(mocks.linkStop).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/signal/src/setup-surface.ts
+++ b/extensions/signal/src/setup-surface.ts
@@ -12,10 +12,8 @@ import {
 import { detectBinary, formatCliCommand } from "openclaw/plugin-sdk/setup-tools";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { listSignalAccountIds, resolveSignalAccount } from "./accounts.js";
-import { signalRpcRequest } from "./client.js";
-import { createSignalDaemonLifecycle, waitForSignalDaemonReady } from "./daemon-lifecycle.js";
-import { spawnSignalDaemon } from "./daemon.js";
 import { installSignalCli } from "./install-signal-cli.js";
+import { createSignalLinkRpcClient, type SignalLinkRpcClient } from "./link-rpc.js";
 import {
   createSignalCliPathTextInput,
   normalizeSignalAccountInput,
@@ -135,38 +133,25 @@ async function prepareManagedSignalLink(params: {
 
   await params.options?.beforePersistentEffect?.();
   signal.throwIfAborted();
-  const lifecycle = createSignalDaemonLifecycle({ abortSignal: signal });
-  const onAbort = () => void lifecycle.stop();
-  signal.addEventListener("abort", onAbort, { once: true });
+  let linkClient: SignalLinkRpcClient | undefined;
   try {
     let accounts: string[];
     let deviceLinkUri: string | undefined;
     try {
-      const daemon = spawnSignalDaemon({
+      linkClient = createSignalLinkRpcClient({
         cliPath: params.cliPath,
         ...(transport.configPath ? { configPath: transport.configPath } : {}),
-        httpHost: transport.httpHost,
-        httpPort: transport.httpPort,
-        receiveMode: "manual",
-      });
-      lifecycle.attach(daemon);
-      await waitForSignalDaemonReady({
-        baseUrl: transport.baseUrl,
-        abortSignal: lifecycle.abortSignal,
-        timeoutMs: transport.startupTimeoutMs,
-        logAfterMs: transport.startupTimeoutMs,
-        runtime: { ...params.runtime, log: () => {}, error: () => {} },
+        abortSignal: signal,
       });
       accounts = parseSignalAccounts(
-        await signalRpcRequest("listAccounts", undefined, {
-          baseUrl: transport.baseUrl,
+        await linkClient.request("listAccounts", undefined, {
+          timeoutMs: transport.startupTimeoutMs,
           maxResponseBytes: SIGNAL_LINK_RPC_MAX_BYTES,
         }),
       );
       if (accounts.length === 0) {
         deviceLinkUri = parseSignalLinkUri(
-          await signalRpcRequest("startLink", undefined, {
-            baseUrl: transport.baseUrl,
+          await linkClient.request("startLink", undefined, {
             timeoutMs: 35_000,
             maxResponseBytes: SIGNAL_LINK_RPC_MAX_BYTES,
           }),
@@ -195,15 +180,16 @@ async function prepareManagedSignalLink(params: {
 
     signal.throwIfAborted();
     try {
-      const settled = signalRpcRequest(
-        "finishLink",
-        { deviceLinkUri, deviceName: "OpenClaw" },
-        {
-          baseUrl: transport.baseUrl,
-          timeoutMs: SIGNAL_LINK_EXPIRES_IN_MS + 5_000,
-          maxResponseBytes: SIGNAL_LINK_RPC_MAX_BYTES,
-        },
-      ).then(parseLinkedSignalNumber);
+      const settled = linkClient
+        .request(
+          "finishLink",
+          { deviceLinkUri, deviceName: "OpenClaw" },
+          {
+            timeoutMs: SIGNAL_LINK_EXPIRES_IN_MS + 5_000,
+            maxResponseBytes: SIGNAL_LINK_RPC_MAX_BYTES,
+          },
+        )
+        .then(parseLinkedSignalNumber);
       return await params.prompter.qrCode({
         title: "Link Signal",
         message: "In Signal, open Settings → Linked devices and scan this QR code.",
@@ -219,8 +205,7 @@ async function prepareManagedSignalLink(params: {
       return undefined;
     }
   } finally {
-    signal.removeEventListener("abort", onAbort);
-    await lifecycle.stop();
+    await linkClient?.stop();
   }
 }
 

--- a/extensions/signal/src/setup-surface.ts
+++ b/extensions/signal/src/setup-surface.ts
@@ -112,7 +112,7 @@ async function prepareManagedSignalLink(params: {
   accountId: string;
   runtime: RuntimeEnv;
   prompter: WizardPrompter;
-  options?: { signal?: AbortSignal };
+  options?: { signal?: AbortSignal; beforePersistentEffect?: () => Promise<void> };
   cliPath: string;
 }): Promise<string | undefined> {
   const signal = params.options?.signal;
@@ -133,6 +133,7 @@ async function prepareManagedSignalLink(params: {
     return undefined;
   }
 
+  await params.options?.beforePersistentEffect?.();
   signal.throwIfAborted();
   const lifecycle = createSignalDaemonLifecycle({ abortSignal: signal });
   const onAbort = () => void lifecycle.stop();

--- a/extensions/signal/src/setup-surface.ts
+++ b/extensions/signal/src/setup-surface.ts
@@ -1,15 +1,25 @@
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 // Signal plugin module implements setup surface behavior.
 import {
   createSetupTranslator,
   createDetectedBinaryStatus,
   setSetupChannelEnabled,
   type ChannelSetupWizard,
+  type OpenClawConfig,
+  type WizardPrompter,
+  WizardCancelledError,
 } from "openclaw/plugin-sdk/setup";
-import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
+import { detectBinary, formatCliCommand } from "openclaw/plugin-sdk/setup-tools";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { listSignalAccountIds, resolveSignalAccount } from "./accounts.js";
+import { signalRpcRequest } from "./client.js";
+import { createSignalDaemonLifecycle, waitForSignalDaemonReady } from "./daemon-lifecycle.js";
+import { spawnSignalDaemon } from "./daemon.js";
 import { installSignalCli } from "./install-signal-cli.js";
 import {
   createSignalCliPathTextInput,
+  normalizeSignalAccountInput,
+  SIGNAL_LINK_COMPLETED_CREDENTIAL,
   signalCompletionNote,
   signalDmPolicy,
   signalNumberTextInput,
@@ -18,6 +28,9 @@ import {
 const t = createSetupTranslator();
 
 const channel = "signal" as const;
+const SIGNAL_LINK_URI_MAX_LENGTH = 4096;
+const SIGNAL_LINK_RPC_MAX_BYTES = 16 * 1024;
+const SIGNAL_LINK_EXPIRES_IN_MS = 120_000;
 const configuredLabel = t("wizard.channels.statusConfigured");
 const unconfiguredLabel = t("wizard.channels.statusNeedsSetup");
 const managedStatus = createDetectedBinaryStatus({
@@ -42,6 +55,173 @@ const managedStatus = createDetectedBinaryStatus({
   },
   detectBinary,
 });
+
+function parseSignalAccounts(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length > 100) {
+    throw new Error("invalid Signal account list");
+  }
+  return [
+    ...new Set(
+      value.map((entry) => {
+        const rawNumber = isRecord(entry) ? entry.number : undefined;
+        const number =
+          typeof rawNumber === "string" ? normalizeSignalAccountInput(rawNumber) : null;
+        if (!number) {
+          throw new Error("invalid Signal account");
+        }
+        return number;
+      }),
+    ),
+  ].toSorted();
+}
+
+function parseSignalLinkUri(value: unknown): string {
+  const rawUri = isRecord(value) ? value.deviceLinkUri : undefined;
+  const uri = typeof rawUri === "string" ? rawUri.trim() : "";
+  if (!uri || uri !== rawUri || uri.length > SIGNAL_LINK_URI_MAX_LENGTH) {
+    throw new Error("invalid Signal device link URI");
+  }
+  const parsed = new URL(uri);
+  if (parsed.protocol !== "sgnl:" || parsed.hostname !== "linkdevice") {
+    throw new Error("invalid Signal device link URI");
+  }
+  return uri;
+}
+
+function parseLinkedSignalNumber(value: unknown): string {
+  const rawNumber = isRecord(value) ? value.number : undefined;
+  const number = typeof rawNumber === "string" ? normalizeSignalAccountInput(rawNumber) : null;
+  if (!number) {
+    throw new Error("invalid linked Signal account");
+  }
+  return number;
+}
+
+async function noteSignalLinkFallback(prompter: WizardPrompter) {
+  await prompter.note(
+    [
+      "Automatic Signal linking could not complete. Continue with the account number, then link it manually:",
+      formatCliCommand('signal-cli link -n "OpenClaw"'),
+    ].join("\n"),
+    "Signal",
+  );
+}
+
+async function prepareManagedSignalLink(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  runtime: RuntimeEnv;
+  prompter: WizardPrompter;
+  options?: { signal?: AbortSignal };
+  cliPath: string;
+}): Promise<string | undefined> {
+  const signal = params.options?.signal;
+  if (
+    !signal ||
+    !params.prompter.qrCode ||
+    listSignalAccountIds(params.cfg).some(
+      (accountId) => resolveSignalAccount({ cfg: params.cfg, accountId }).configured,
+    )
+  ) {
+    return undefined;
+  }
+  const transport = resolveSignalAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  }).transport;
+  if (transport.kind !== "managed-native") {
+    return undefined;
+  }
+
+  signal.throwIfAborted();
+  const lifecycle = createSignalDaemonLifecycle({ abortSignal: signal });
+  const onAbort = () => void lifecycle.stop();
+  signal.addEventListener("abort", onAbort, { once: true });
+  try {
+    let accounts: string[];
+    let deviceLinkUri: string | undefined;
+    try {
+      const daemon = spawnSignalDaemon({
+        cliPath: params.cliPath,
+        ...(transport.configPath ? { configPath: transport.configPath } : {}),
+        httpHost: transport.httpHost,
+        httpPort: transport.httpPort,
+        receiveMode: "manual",
+      });
+      lifecycle.attach(daemon);
+      await waitForSignalDaemonReady({
+        baseUrl: transport.baseUrl,
+        abortSignal: lifecycle.abortSignal,
+        timeoutMs: transport.startupTimeoutMs,
+        logAfterMs: transport.startupTimeoutMs,
+        runtime: { ...params.runtime, log: () => {}, error: () => {} },
+      });
+      accounts = parseSignalAccounts(
+        await signalRpcRequest("listAccounts", undefined, {
+          baseUrl: transport.baseUrl,
+          maxResponseBytes: SIGNAL_LINK_RPC_MAX_BYTES,
+        }),
+      );
+      if (accounts.length === 0) {
+        deviceLinkUri = parseSignalLinkUri(
+          await signalRpcRequest("startLink", undefined, {
+            baseUrl: transport.baseUrl,
+            timeoutMs: 35_000,
+            maxResponseBytes: SIGNAL_LINK_RPC_MAX_BYTES,
+          }),
+        );
+      }
+    } catch {
+      if (signal.aborted) {
+        throw new WizardCancelledError();
+      }
+      await noteSignalLinkFallback(params.prompter);
+      return undefined;
+    }
+
+    if (accounts.length > 0) {
+      return accounts.length === 1
+        ? accounts[0]
+        : await params.prompter.select({
+            message: "Choose the Signal account for OpenClaw",
+            options: accounts.map((number) => ({ value: number, label: number })),
+          });
+    }
+    if (!deviceLinkUri) {
+      await noteSignalLinkFallback(params.prompter);
+      return undefined;
+    }
+
+    signal.throwIfAborted();
+    try {
+      const settled = signalRpcRequest(
+        "finishLink",
+        { deviceLinkUri, deviceName: "OpenClaw" },
+        {
+          baseUrl: transport.baseUrl,
+          timeoutMs: SIGNAL_LINK_EXPIRES_IN_MS + 5_000,
+          maxResponseBytes: SIGNAL_LINK_RPC_MAX_BYTES,
+        },
+      ).then(parseLinkedSignalNumber);
+      return await params.prompter.qrCode({
+        title: "Link Signal",
+        message: "In Signal, open Settings → Linked devices and scan this QR code.",
+        text: deviceLinkUri,
+        expiresInMs: SIGNAL_LINK_EXPIRES_IN_MS,
+        settled,
+      });
+    } catch {
+      if (signal.aborted) {
+        throw new WizardCancelledError();
+      }
+      await noteSignalLinkFallback(params.prompter);
+      return undefined;
+    }
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    await lifecycle.stop();
+  }
+}
 
 export const signalSetupWizard: ChannelSetupWizard = {
   channel,
@@ -74,36 +254,57 @@ export const signalSetupWizard: ChannelSetupWizard = {
     if (transport.kind !== "managed-native") {
       return undefined;
     }
-    const currentCliPath =
+    let cliPath =
       (typeof credentialValues.cliPath === "string" ? credentialValues.cliPath : undefined) ??
       (transport.kind === "managed-native" ? transport.cliPath : undefined) ??
       "signal-cli";
-    const cliDetected = await detectBinary(currentCliPath);
+    const cliDetected = await detectBinary(cliPath);
     const wantsInstall = await prompter.confirm({
       message: cliDetected ? t("wizard.signal.reinstallPrompt") : t("wizard.signal.installPrompt"),
       initialValue: !cliDetected,
     });
-    if (!wantsInstall) {
+    if (!wantsInstall && !cliDetected) {
       return undefined;
     }
-    try {
-      await options?.beforePersistentEffect?.();
-      const result = await installSignalCli(runtime);
-      if (result.ok && result.cliPath) {
-        await prompter.note(`Installed signal-cli at ${result.cliPath}`, "Signal");
-        return {
-          credentialValues: {
-            cliPath: result.cliPath,
-          },
-        };
+    const preparedCredentialValues: Record<string, string> = {};
+    if (wantsInstall) {
+      try {
+        await options?.beforePersistentEffect?.();
+        const result = await installSignalCli(runtime);
+        if (result.ok && result.cliPath) {
+          cliPath = result.cliPath;
+          preparedCredentialValues.cliPath = cliPath;
+          await prompter.note(`Installed signal-cli at ${cliPath}`, "Signal");
+        } else if (!result.ok) {
+          await prompter.note(
+            "signal-cli installation failed. Install it manually and retry setup.",
+            "Signal",
+          );
+          return undefined;
+        }
+      } catch {
+        await prompter.note(
+          "signal-cli installation failed. Install it manually and retry setup.",
+          "Signal",
+        );
+        return undefined;
       }
-      if (!result.ok) {
-        await prompter.note(result.error ?? "signal-cli install failed.", "Signal");
-      }
-    } catch (error) {
-      await prompter.note(`signal-cli install failed: ${String(error)}`, "Signal");
     }
-    return undefined;
+    const linkedNumber = await prepareManagedSignalLink({
+      cfg,
+      accountId,
+      runtime,
+      prompter,
+      options,
+      cliPath,
+    });
+    if (linkedNumber) {
+      preparedCredentialValues.signalNumber = linkedNumber;
+      preparedCredentialValues[SIGNAL_LINK_COMPLETED_CREDENTIAL] = "true";
+    }
+    return Object.keys(preparedCredentialValues).length > 0
+      ? { credentialValues: preparedCredentialValues }
+      : undefined;
   },
   credentials: [],
   textInputs: [


### PR DESCRIPTION
## What Problem This Solves

First-time Signal setup currently sends operators to a separate manual `signal-cli link` command even though the plugin already owns a structured JSON-RPC daemon and the hosted wizard can now present short-lived QR steps safely.

## Why This Change Was Made

Signal now uses the dependency-owned structured linking contract:

- Call `startLink` through the existing Signal JSON-RPC client.
- Present the returned device URI through the generic `WizardPrompter.qrCode` seam from #119341.
- Call `finishLink`, normalize the linked account, and persist only the successful result.
- Reuse the existing daemon lifecycle and cleanup path instead of spawning `signal-cli link` and scraping human stdout.
- Limit automatic linking to the first managed-native account. Existing, additional, or unsupported account layouts keep the documented manual path.

This is part 2 of 2 and depends only on #119341. #114098 remains independent Signal setup-validation work.

## User Impact

An operator configuring Signal for the first time can scan the QR code in the hosted setup wizard and continue automatically after association. Failure and cancellation remain visible and bounded; raw link values are not written to wizard notes or transcripts.

## Evidence

- Exact head: `30d9eaed0265d1471d9f8440e8fe951307e98565`, with #119341 as its only parent layer.
- Focused Signal setup/linking tests, extension and extension-test typechecks, targeted lint, Docs MDX, diff checks, and autoreview passed.
- Upstream signal-cli `startLink`/`finishLink` source and JSON-RPC contract were inspected directly.
- Production LOC: +263/-53 (net +210). Tests: +289. Docs: +9/-5.
- Live account-link proof was not available on this host because `signal-cli` and an authenticated test account are absent; exact-head CI remains required.

![Synthetic Signal setup QR proof](https://github.com/user-attachments/assets/8e2b2e66-0d5d-4aab-9f29-710759af467b)

[Interaction video](https://github.com/user-attachments/assets/f0161fe4-3b87-4e89-ae66-d2a362410bb6)
