### PR TITLE
fix(memory): keep QMD running when filesystem watches fail

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager-lifecycle.ts
+++ b/extensions/memory-core/src/memory/qmd-manager-lifecycle.ts
@@ -48,6 +48,10 @@ export abstract class QmdManagerLifecycle extends QmdManagerSync {
     watcher.on("add", markDirty);
     watcher.on("change", markDirty);
     watcher.on("unlink", markDirty);
+    watcher.on("error", (err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      qmdManagerLog.warn(`qmd watcher error: ${message}`);
+    });
     watcher.once("ready", () => {
       this.warnIfWatchPressure(countChokidarWatchedEntries(watcher));
       qmdManagerLog.info(

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1325,6 +1325,31 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("logs qmd watcher errors instead of throwing", async () => {
+    configureQmd(
+      { update: { interval: "0s", debounceMs: 0, onBoot: false } },
+      {
+        search: {
+          provider: "openai",
+          model: "mock-embed",
+          store: { vector: { enabled: false } },
+          sync: { watch: true, onSessionStart: false, onSearch: false },
+        },
+      },
+    );
+
+    const { manager } = await createManager({ mode: "full" });
+    expect(watchMock).toHaveBeenCalledTimes(1);
+    const watcher = watchMock.mock.results[0]?.value as EventEmitter;
+
+    expect(() => {
+      watcher.emit("error", new Error("ENOSPC: watcher limit reached"));
+    }).not.toThrow();
+    expectMockMessageContains(logWarnMock, "qmd watcher error: ENOSPC: watcher limit reached");
+
+    await manager.close();
+  });
+
   it("runs qmd sync when watched collection files change", async () => {
     vi.useFakeTimers();
     configureQmd(


### PR DESCRIPTION
Related: #118093

## What Problem This Solves

Fixes an issue where operators using QMD memory could lose the owning process
when the filesystem watcher emits an error such as a rejected or exhausted
watch.

This is a same-repository replacement for #118093. The code and authored commit
are identical; the replacement exists because fork PR changed-test jobs are
forced onto 4-vCPU GitHub runners whose 300-second no-output watchdog
deterministically kills unrelated long-running memory integration tests.

## Why This Change Was Made

The QMD lifecycle now owns the watcher's `error` event beside its existing
change and shutdown listeners. It logs the concrete failure and preserves the
existing sync, search, and close behavior, matching the sibling memory watcher
policy without adding restart, fallback, config, or persistence behavior.

Original contribution and commit author: WhatsSkiLL (@IWhatsskill), #118093.
AI-assisted maintainer review and landing preparation: yes.

## User Impact

QMD watcher failures are visible as warnings instead of surfacing as unhandled
events that can terminate the process. Manual memory operations and orderly
shutdown remain available.

## Evidence

- Current-main baseline repro: emitting the QMD watcher error throws because no
  lifecycle listener exists.
- Exact head: `fa5f6af5e536e084f67f50d6895cb776b6d28c32`.
- Focused regression: 1 passed; verifies the error does not throw, is logged,
  and the manager closes cleanly.
- Exact missing fork-lane target:
  `extensions/memory-wiki/src/agent-vault-isolation.test.ts` passed 1/1 in
  248.86s with the focused repo harness.
- Blacksmith Testbox: 303 tests passed across the touched Memory Core surface:
  https://github.com/openclaw/openclaw/actions/runs/30760772648
- Blacksmith changed gate passed:
  https://github.com/openclaw/openclaw/actions/runs/30761108214
- Fork CI watchdog evidence:
  https://github.com/openclaw/openclaw/actions/runs/30762387611
  (`memory/index.test.ts` and `agent-vault-isolation.test.ts` each exceeded the
  fork lane's 300-second no-output watchdog twice; neither file is changed).
- Independent identical watchdog failure:
  https://github.com/openclaw/openclaw/actions/runs/30707714999
- Autoreview: no findings; patch correct, confidence 0.99.
- ClawSweeper reviewed this exact commit with no findings:
  https://github.com/openclaw/openclaw/pull/118093#issuecomment-5159617489
- `git diff --check`: clean.
- Current-main touched-file drift: none.
- Current-main merge-tree: clean.
