### PR TITLE
refactor(policy): consolidate doctor test fixtures

### DIFF
--- a/extensions/policy/src/doctor/register.base.test-utils.ts
+++ b/extensions/policy/src/doctor/register.base.test-utils.ts
@@ -26,29 +26,37 @@ import {
   describe0AfterEach1,
 } from "./register.test-harness.js";
 
+async function writePolicyFixture(...json: Parameters<typeof JSON.stringify>): Promise<string> {
+  const [policy] = json;
+  const configPath = join(workspaceDir, "openclaw.jsonc");
+  await fs.writeFile(configPath, "{}", "utf-8");
+  await fs.writeFile(
+    join(workspaceDir, "policy.jsonc"),
+    typeof policy === "string" ? policy : JSON.stringify(...json),
+    "utf-8",
+  );
+  return configPath;
+}
+
+async function runPolicyChecksFixture(policy: unknown) {
+  return runPolicyChecks(ctx(await writePolicyFixture(policy), cfgWithPolicy()));
+}
+
 describe("registerPolicyDoctorChecks", () => {
   beforeEach(describe0BeforeEach0);
 
   afterEach(describe0AfterEach1);
 
   it("allows scoped overrides that are stricter than top-level policy", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        tools: { exec: { allowHosts: ["sandbox", "node"] } },
-        scopes: {
-          sebby: {
-            agentIds: ["sebby"],
-            tools: { exec: { allowHosts: ["sandbox"] } },
-          },
+    const result = await runPolicyChecksFixture({
+      tools: { exec: { allowHosts: ["sandbox", "node"] } },
+      scopes: {
+        sebby: {
+          agentIds: ["sebby"],
+          tools: { exec: { allowHosts: ["sandbox"] } },
         },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyChecks(ctx(configPath, cfgWithPolicy()));
+      },
+    });
 
     expect(result.findings).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ checkId: "policy/policy-jsonc-invalid" })]),
@@ -56,23 +64,15 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("allows scoped allowlists when an empty top-level allowlist is disabled", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        tools: { exec: { allowHosts: [] } },
-        scopes: {
-          sebby: {
-            agentIds: ["sebby"],
-            tools: { exec: { allowHosts: ["sandbox"] } },
-          },
+    const result = await runPolicyChecksFixture({
+      tools: { exec: { allowHosts: [] } },
+      scopes: {
+        sebby: {
+          agentIds: ["sebby"],
+          tools: { exec: { allowHosts: ["sandbox"] } },
         },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyChecks(ctx(configPath, cfgWithPolicy()));
+      },
+    });
 
     expect(result.findings).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ checkId: "policy/policy-jsonc-invalid" })]),
@@ -80,23 +80,15 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("allows scoped denyTools groups that cover top-level required denies", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        tools: { denyTools: ["exec"] },
-        scopes: {
-          sebby: {
-            agentIds: ["sebby"],
-            tools: { denyTools: ["group:runtime"] },
-          },
+    const result = await runPolicyChecksFixture({
+      tools: { denyTools: ["exec"] },
+      scopes: {
+        sebby: {
+          agentIds: ["sebby"],
+          tools: { denyTools: ["group:runtime"] },
         },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyChecks(ctx(configPath, cfgWithPolicy()));
+      },
+    });
 
     expect(result.findings).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ checkId: "policy/policy-jsonc-invalid" })]),
@@ -104,23 +96,15 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("allows scoped sandbox container requirements that match top-level policy", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        sandbox: { containers: { denyHostNetwork: true } },
-        scopes: {
-          sebby: {
-            agentIds: ["sebby"],
-            sandbox: { containers: { denyHostNetwork: true } },
-          },
+    const result = await runPolicyChecksFixture({
+      sandbox: { containers: { denyHostNetwork: true } },
+      scopes: {
+        sebby: {
+          agentIds: ["sebby"],
+          sandbox: { containers: { denyHostNetwork: true } },
         },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyChecks(ctx(configPath, cfgWithPolicy()));
+      },
+    });
 
     expect(result.findings).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ checkId: "policy/policy-jsonc-invalid" })]),
@@ -128,23 +112,15 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("rejects scoped sandbox container policies weaker than top-level requirements", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        sandbox: { containers: { denyHostNetwork: true } },
-        scopes: {
-          sebby: {
-            agentIds: ["sebby"],
-            sandbox: { containers: { denyHostNetwork: false } },
-          },
+    const result = await runPolicyChecksFixture({
+      sandbox: { containers: { denyHostNetwork: true } },
+      scopes: {
+        sebby: {
+          agentIds: ["sebby"],
+          sandbox: { containers: { denyHostNetwork: false } },
         },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyChecks(ctx(configPath, cfgWithPolicy()));
+      },
+    });
 
     expect(result.findings).toEqual(
       expect.arrayContaining([
@@ -157,23 +133,15 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("rejects scoped overrides that are weaker than top-level policy", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        tools: { exec: { allowHosts: ["sandbox"] } },
-        scopes: {
-          sebby: {
-            agentIds: ["sebby"],
-            tools: { exec: { allowHosts: ["sandbox", "node"] } },
-          },
+    const result = await runPolicyChecksFixture({
+      tools: { exec: { allowHosts: ["sandbox"] } },
+      scopes: {
+        sebby: {
+          agentIds: ["sebby"],
+          tools: { exec: { allowHosts: ["sandbox", "node"] } },
         },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyChecks(ctx(configPath, cfgWithPolicy()));
+      },
+    });
 
     expect(result.findings).toEqual(
       expect.arrayContaining([
@@ -186,26 +154,18 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("allows overlapping scoped fields when later scopes are stricter", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          team: {
-            agentIds: ["sebby"],
-            tools: { exec: { allowHosts: ["sandbox", "node"] } },
-          },
-          lockdown: {
-            agentIds: ["sebby"],
-            tools: { exec: { allowHosts: ["sandbox"] } },
-          },
+    const result = await runPolicyChecksFixture({
+      scopes: {
+        team: {
+          agentIds: ["sebby"],
+          tools: { exec: { allowHosts: ["sandbox", "node"] } },
         },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyChecks(ctx(configPath, cfgWithPolicy()));
+        lockdown: {
+          agentIds: ["sebby"],
+          tools: { exec: { allowHosts: ["sandbox"] } },
+        },
+      },
+    });
 
     expect(result.findings).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ checkId: "policy/policy-jsonc-invalid" })]),
@@ -213,26 +173,18 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("rejects overlapping scoped fields when later scopes are weaker", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          lockdown: {
-            agentIds: ["sebby"],
-            tools: { exec: { allowHosts: ["sandbox"] } },
-          },
-          team: {
-            agentIds: ["sebby"],
-            tools: { exec: { allowHosts: ["sandbox", "node"] } },
-          },
+    const result = await runPolicyChecksFixture({
+      scopes: {
+        lockdown: {
+          agentIds: ["sebby"],
+          tools: { exec: { allowHosts: ["sandbox"] } },
         },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyChecks(ctx(configPath, cfgWithPolicy()));
+        team: {
+          agentIds: ["sebby"],
+          tools: { exec: { allowHosts: ["sandbox", "node"] } },
+        },
+      },
+    });
 
     expect(result.findings).toEqual(
       expect.arrayContaining([
@@ -359,11 +311,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports invalid policy files as errors", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), "{ channels: ", "utf-8");
-
-    const result = await runPolicyChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runPolicyChecksFixture("{ channels: ");
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -375,15 +323,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports malformed channel deny rules as policy errors", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ channels: { denyRules: [{ when: {} }] } }),
-      "utf-8",
-    );
-
-    const result = await runPolicyChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runPolicyChecksFixture({ channels: { denyRules: [{ when: {} }] } });
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -750,11 +690,7 @@ describe("registerPolicyDoctorChecks", () => {
     ["auth array", { auth: [] }, "oc://policy.jsonc/auth"],
     ["auth profiles array", { auth: { profiles: [] } }, "oc://policy.jsonc/auth/profiles"],
   ])("reports malformed policy shape for %s", async (_label, policy, target) => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
-
-    const result = await runPolicyChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runPolicyChecksFixture(policy);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -942,13 +878,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports a policy hash mismatch when expectedHash is configured", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ channels: { denyRules: [] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ channels: { denyRules: [] } });
 
     const result = await runPolicyChecks(
       ctx(configPath, cfgWithPolicy({ expectedHash: "sha256:not-the-policy" })),
@@ -964,21 +894,15 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not emit repairable channel findings when the policy hash is not accepted", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ expectedHash: "sha256:not-the-policy", workspaceRepairs: true }),
       channels: { telegram: { enabled: true } },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        channels: {
-          denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      channels: {
+        denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
+      },
+    });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
 
@@ -988,10 +912,8 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("accepts a policy file that matches the configured expectedHash", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const policy = { channels: { denyRules: [] } };
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    const configPath = await writePolicyFixture(policy);
 
     const result = await runPolicyChecks(
       ctx(configPath, cfgWithPolicy({ expectedHash: policyDocumentHash(policy) })),
@@ -1001,13 +923,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports an attestation mismatch when expectedAttestationHash is configured", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ channels: { denyRules: [] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ channels: { denyRules: [] } });
 
     const result = await runPolicyChecks(
       ctx(configPath, cfgWithPolicy({ expectedAttestationHash: "sha256:not-current" })),
@@ -1023,13 +939,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports policy validation errors before attestation drift", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ channels: { denyRules: [{ when: {} }] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ channels: { denyRules: [{ when: {} }] } });
 
     const result = await runPolicyChecks(
       ctx(configPath, cfgWithPolicy({ expectedAttestationHash: "sha256:not-current" })),
@@ -1044,21 +954,15 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not emit repairable channel findings when the accepted attestation changed", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ expectedAttestationHash: "sha256:not-current", workspaceRepairs: true }),
       channels: { telegram: { enabled: true } },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        channels: {
-          denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      channels: {
+        denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
+      },
+    });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
 
@@ -1068,7 +972,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("accepts a policy check that matches the configured expectedAttestationHash", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const policy = { channels: { denyRules: [] } };
     const policyHash = policyDocumentHash(policy);
     const acceptedAttestationHash = createPolicyAttestation({
@@ -1091,8 +994,7 @@ describe("registerPolicyDoctorChecks", () => {
       ),
       findings: [],
     }).attestationHash;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    const configPath = await writePolicyFixture(policy);
 
     const result = await runPolicyChecks(
       ctx(configPath, cfgWithPolicy({ expectedAttestationHash: acceptedAttestationHash })),
@@ -1102,7 +1004,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not include unrelated AGENTS.md tool evidence in channel-only attestations", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const policy = { channels: { denyRules: [] } };
     const policyHash = policyDocumentHash(policy);
     const acceptedAttestationHash = createPolicyAttestation({
@@ -1125,8 +1026,7 @@ describe("registerPolicyDoctorChecks", () => {
       ),
       findings: [],
     }).attestationHash;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    const configPath = await writePolicyFixture(policy);
     await fs.writeFile(join(workspaceDir, "AGENTS.md"), "## Tools\n\n### deploy\n", "utf-8");
 
     const result = await runPolicyChecks(
@@ -1137,7 +1037,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not include unrelated secret or auth evidence in channel-only attestations", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const policy = { channels: { denyRules: [] } };
     const policyHash = policyDocumentHash(policy);
     const acceptedAttestationHash = createPolicyAttestation({
@@ -1184,8 +1083,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    const configPath = await writePolicyFixture(policy);
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
 
@@ -1210,7 +1108,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("includes global and per-agent alsoAllow in tool posture attestations", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const policy = { tools: { profiles: { allow: ["messaging"] } } };
     const baselineConfig = {
       tools: { profile: "messaging" },
@@ -1243,8 +1140,7 @@ describe("registerPolicyDoctorChecks", () => {
         ],
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    const configPath = await writePolicyFixture(policy);
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
@@ -1275,30 +1171,24 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports configured channels denied by policy", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       channels: { telegram: { enabled: true } },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify(
-        {
-          channels: {
-            denyRules: [
-              {
-                id: "no-telegram",
-                when: { provider: "telegram" },
-                reason: "Telegram is not approved for this workspace.",
-              },
-            ],
-          },
+    const configPath = await writePolicyFixture(
+      {
+        channels: {
+          denyRules: [
+            {
+              id: "no-telegram",
+              when: { provider: "telegram" },
+              reason: "Telegram is not approved for this workspace.",
+            },
+          ],
         },
-        null,
-        2,
-      ),
-      "utf-8",
+      },
+      null,
+      2,
     );
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
@@ -1321,24 +1211,18 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("repairs denied enabled channels by disabling them when workspace repairs are enabled", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       channels: { telegram: { enabled: true } },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify(
-        {
-          channels: {
-            denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
-          },
+    const configPath = await writePolicyFixture(
+      {
+        channels: {
+          denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
         },
-        null,
-        2,
-      ),
-      "utf-8",
+      },
+      null,
+      2,
     );
 
     const result = await runDeniedChannelRepair(repairCtx(configPath, cfg));
@@ -1349,24 +1233,18 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not repair denied channels without workspace repair opt-in", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: false }),
       channels: { telegram: { enabled: true } },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify(
-        {
-          channels: {
-            denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
-          },
+    const configPath = await writePolicyFixture(
+      {
+        channels: {
+          denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
         },
-        null,
-        2,
-      ),
-      "utf-8",
+      },
+      null,
+      2,
     );
 
     const result = await runDeniedChannelRepair(repairCtx(configPath, cfg));
@@ -1379,25 +1257,19 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not let policy.jsonc enable workspace repairs", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       channels: { telegram: { enabled: true } },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify(
-        {
-          workspaceRepairs: true,
-          channels: {
-            denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
-          },
+    const configPath = await writePolicyFixture(
+      {
+        workspaceRepairs: true,
+        channels: {
+          denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
         },
-        null,
-        2,
-      ),
-      "utf-8",
+      },
+      null,
+      2,
     );
 
     const result = await runDeniedChannelRepair(repairCtx(configPath, cfg));
@@ -1410,17 +1282,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("dry-runs automatic policy narrowing repairs without mutating config", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       tools: { elevated: { enabled: true } },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { elevated: { allow: false } } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ tools: { elevated: { allow: false } } });
 
     const result = await runPolicyRepairCheck("policy/tools-elevated-enabled", {
       ...repairCtx(configPath, cfg),
@@ -1434,17 +1300,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not repair automatic policy narrowing config without workspace repair opt-in", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       tools: { elevated: { enabled: true } },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { elevated: { allow: false } } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ tools: { elevated: { allow: false } } });
 
     const result = await runPolicyRepairCheck(
       "policy/tools-elevated-enabled",
@@ -1461,7 +1321,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not over-apply scoped elevated policy findings globally", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       agents: {
@@ -1473,19 +1332,14 @@ describe("registerPolicyDoctorChecks", () => {
         ],
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          reviewer: {
-            agentIds: ["reviewer"],
-            tools: { elevated: { allow: false } },
-          },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        reviewer: {
+          agentIds: ["reviewer"],
+          tools: { elevated: { allow: false } },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
     const result = await runPolicyRepairCheck(
       "policy/tools-elevated-enabled",
@@ -1502,7 +1356,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("skips scoped elevated repairs that inherit shared global tools config", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       tools: { elevated: { enabled: true } },
@@ -1510,19 +1363,14 @@ describe("registerPolicyDoctorChecks", () => {
         list: [{ id: "reviewer" }],
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          reviewer: {
-            agentIds: ["reviewer"],
-            tools: { elevated: { allow: false } },
-          },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        reviewer: {
+          agentIds: ["reviewer"],
+          tools: { elevated: { allow: false } },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
     const result = await runPolicyRepairCheck(
       "policy/tools-elevated-enabled",
@@ -1539,7 +1387,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("repairs automatic policy narrowing config findings", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       tools: { elevated: { enabled: true } },
@@ -1552,21 +1399,16 @@ describe("registerPolicyDoctorChecks", () => {
       },
       diagnostics: { otel: { enabled: true, captureContent: true } },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        tools: { elevated: { allow: false } },
-        gateway: {
-          controlUi: { allowInsecure: false },
-          remote: { allow: false },
-        },
-        dataHandling: {
-          telemetry: { denyContentCapture: true },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      tools: { elevated: { allow: false } },
+      gateway: {
+        controlUi: { allowInsecure: false },
+        remote: { allow: false },
+      },
+      dataHandling: {
+        telemetry: { denyContentCapture: true },
+      },
+    });
 
     const elevated = await runPolicyRepairCheck(
       "policy/tools-elevated-enabled",
@@ -1611,7 +1453,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("repairs denied gateway HTTP endpoint findings", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       gateway: {
@@ -1630,19 +1471,14 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        gateway: {
-          http: {
-            denyEndpoints: ["chatCompletions", "responses"],
-            requireUrlAllowlists: true,
-          },
+    const configPath = await writePolicyFixture({
+      gateway: {
+        http: {
+          denyEndpoints: ["chatCompletions", "responses"],
+          requireUrlAllowlists: true,
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
     const result = await runPolicyRepairCheck(
       "policy/gateway-http-endpoint-enabled",
@@ -1669,17 +1505,13 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("previews review-required gateway bind repair without mutating config", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       gateway: { bind: "lan" },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ gateway: { exposure: { allowNonLoopbackBind: false } } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      gateway: { exposure: { allowNonLoopbackBind: false } },
+    });
 
     const result = await runPolicyRepairCheck(
       "policy/gateway-non-loopback-bind",
@@ -1707,17 +1539,13 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("previews review-required custom gateway bind repair without mutating config", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       gateway: { bind: "custom", customBindHost: "10.0.0.4" },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ gateway: { exposure: { allowNonLoopbackBind: false } } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      gateway: { exposure: { allowNonLoopbackBind: false } },
+    });
 
     const result = await runPolicyRepairCheck(
       "policy/gateway-non-loopback-bind",
@@ -1752,17 +1580,13 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("previews review-required gateway node command repairs without mutating config", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       gateway: { nodes: { commands: { deny: ["mcp.help"] } } },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ gateway: { nodes: { denyCommands: ["mcp.help", "system.run"] } } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      gateway: { nodes: { denyCommands: ["mcp.help", "system.run"] } },
+    });
 
     const result = await runPolicyRepairCheck(
       "policy/gateway-node-command-denied",
@@ -1790,7 +1614,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("repairs automatic channel ingress narrowing findings", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       channels: {
@@ -1807,19 +1630,14 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          channels: {
-            denyOpenGroups: true,
-            requireMentionInGroups: true,
-          },
+    const configPath = await writePolicyFixture({
+      ingress: {
+        channels: {
+          denyOpenGroups: true,
+          requireMentionInGroups: true,
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
     const openGroups = await runPolicyRepairCheck(
       "policy/ingress-open-groups-denied",
@@ -1854,7 +1672,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("repairs quoted channel ingress paths without splitting slash segments", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       channels: {
@@ -1863,18 +1680,13 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          channels: {
-            requireMentionInGroups: true,
-          },
+    const configPath = await writePolicyFixture({
+      ingress: {
+        channels: {
+          requireMentionInGroups: true,
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
     const result = await runPolicyRepairCheck(
       "policy/ingress-group-mention-required",
@@ -1896,7 +1708,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("skips scoped channel ingress repairs that would mutate inherited defaults", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       channels: {
@@ -1904,23 +1715,18 @@ describe("registerPolicyDoctorChecks", () => {
         telegram: {},
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          telegram: {
-            channelIds: ["telegram"],
-            ingress: {
-              channels: {
-                denyOpenGroups: true,
-              },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        telegram: {
+          channelIds: ["telegram"],
+          ingress: {
+            channels: {
+              denyOpenGroups: true,
             },
           },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
     const result = await runPolicyRepairCheck(
       "policy/ingress-open-groups-denied",
@@ -1945,23 +1751,17 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not repair channel ingress config without workspace repair opt-in", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       channels: { telegram: { groupPolicy: "open" } },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          channels: {
-            denyOpenGroups: true,
-          },
+    const configPath = await writePolicyFixture({
+      ingress: {
+        channels: {
+          denyOpenGroups: true,
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
     const result = await runPolicyRepairCheck(
       "policy/ingress-open-groups-denied",
@@ -1978,17 +1778,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("dry-runs required tool deny repairs without mutating config", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       tools: { deny: ["read"] },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { denyTools: ["exec", "write"] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ tools: { denyTools: ["exec", "write"] } });
 
     const result = await runPolicyRepairCheck("policy/tools-required-deny-missing", {
       ...repairCtx(configPath, cfg),

--- a/extensions/policy/src/doctor/register.gateway-data-and-approvals.test-utils.ts
+++ b/extensions/policy/src/doctor/register.gateway-data-and-approvals.test-utils.ts
@@ -15,13 +15,37 @@ import {
   describe0AfterEach1,
 } from "./register.test-harness.js";
 
+async function writePolicyFixture(...json: Parameters<typeof JSON.stringify>): Promise<string> {
+  const [policy] = json;
+  const configPath = join(workspaceDir, "openclaw.jsonc");
+  await fs.writeFile(configPath, "{}", "utf-8");
+  await fs.writeFile(
+    join(workspaceDir, "policy.jsonc"),
+    typeof policy === "string" ? policy : JSON.stringify(...json),
+    "utf-8",
+  );
+  return configPath;
+}
+
+function writeExecApprovalsPolicyFixture(execApprovals: object): Promise<string> {
+  return writePolicyFixture({ execApprovals });
+}
+
+function writeDataHandlingPolicyFixture(dataHandling: object): Promise<string> {
+  return writePolicyFixture({ dataHandling });
+}
+
+function runRegisteredPolicyDoctor(configPath: string, cfg: OpenClawConfig) {
+  registerPolicyDoctorChecks();
+  return runDoctorLintChecks(ctx(configPath, cfg));
+}
+
 describe("registerPolicyDoctorChecks", () => {
   beforeEach(describe0BeforeEach0);
 
   afterEach(describe0AfterEach1);
 
   it("does not report Responses URL fetching when it is disabled", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       gateway: {
@@ -36,27 +60,20 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        gateway: {
-          http: {
-            requireUrlAllowlists: true,
-          },
+    const configPath = await writePolicyFixture({
+      gateway: {
+        http: {
+          requireUrlAllowlists: true,
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const result = await runRegisteredPolicyDoctor(configPath, cfg);
 
     expect(result.findings).toEqual([]);
   });
 
   it("reports auth profiles missing required metadata or using unapproved modes", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       auth: {
@@ -66,19 +83,13 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        auth: {
-          profiles: { requireMetadata: ["provider", "mode"], allowModes: ["api_key", "token"] },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      auth: {
+        profiles: { requireMetadata: ["provider", "mode"], allowModes: ["api_key", "token"] },
+      },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const result = await runRegisteredPolicyDoctor(configPath, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -97,29 +108,20 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports data-handling conformance findings from config posture", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       diagnostics: { otel: { enabled: true, captureContent: true } },
       session: { maintenance: { mode: "warn" } },
       memory: { backend: "qmd", qmd: { sessions: { enabled: true } } },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        dataHandling: {
-          sensitiveLogging: { requireRedaction: true },
-          telemetry: { denyContentCapture: true },
-          retention: { requireSessionMaintenance: true },
-          memory: { denySessionTranscriptIndexing: true },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeDataHandlingPolicyFixture({
+      sensitiveLogging: { requireRedaction: true },
+      telemetry: { denyContentCapture: true },
+      retention: { requireSessionMaintenance: true },
+      memory: { denySessionTranscriptIndexing: true },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const result = await runRegisteredPolicyDoctor(configPath, cfg);
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
 
     expect(evidence.dataHandling).toEqual(
@@ -168,24 +170,15 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("treats omitted session maintenance mode as enforce for retention conformance", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       session: {},
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        dataHandling: {
-          retention: { requireSessionMaintenance: true },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeDataHandlingPolicyFixture({
+      retention: { requireSessionMaintenance: true },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const result = await runRegisteredPolicyDoctor(configPath, cfg);
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
 
     expect(evidence.dataHandling).toEqual(
@@ -202,26 +195,20 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not treat disabled telemetry capture as content capture", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       diagnostics: { otel: { captureContent: false } },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ dataHandling: { telemetry: { denyContentCapture: true } } }),
-      "utf-8",
-    );
+    const configPath = await writeDataHandlingPolicyFixture({
+      telemetry: { denyContentCapture: true },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const result = await runRegisteredPolicyDoctor(configPath, cfg);
 
     expect(result.findings).toEqual([]);
   });
 
   it("does not report inert telemetry capture config", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       diagnostics: {
@@ -229,36 +216,27 @@ describe("registerPolicyDoctorChecks", () => {
         otel: { enabled: true, captureContent: true },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ dataHandling: { telemetry: { denyContentCapture: true } } }),
-      "utf-8",
-    );
+    const configPath = await writeDataHandlingPolicyFixture({
+      telemetry: { denyContentCapture: true },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const result = await runRegisteredPolicyDoctor(configPath, cfg);
 
     expect(result.findings).toEqual([]);
   });
 
   it("reports OTEL log body content capture without trace export", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       diagnostics: {
         otel: { enabled: true, traces: false, logs: true, captureContent: true },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ dataHandling: { telemetry: { denyContentCapture: true } } }),
-      "utf-8",
-    );
+    const configPath = await writeDataHandlingPolicyFixture({
+      telemetry: { denyContentCapture: true },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const result = await runRegisteredPolicyDoctor(configPath, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -269,7 +247,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("supports agent-scoped session transcript memory conformance", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       memory: {
@@ -283,22 +260,16 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["sebby"],
-            dataHandling: { memory: { denySessionTranscriptIndexing: true } },
-          },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["sebby"],
+          dataHandling: { memory: { denySessionTranscriptIndexing: true } },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const result = await runRegisteredPolicyDoctor(configPath, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -311,29 +282,22 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("applies agent-scoped data-handling memory claims to inherited default posture", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       memory: {
         search: { rememberAcrossConversations: true, sources: ["sessions"] },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["release"],
-            dataHandling: { memory: { denySessionTranscriptIndexing: true } },
-          },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["release"],
+          dataHandling: { memory: { denySessionTranscriptIndexing: true } },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const result = await runRegisteredPolicyDoctor(configPath, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -346,7 +310,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not report inert memory transcript indexing config", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       memory: {
@@ -358,37 +321,22 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        dataHandling: { memory: { denySessionTranscriptIndexing: true } },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeDataHandlingPolicyFixture({
+      memory: { denySessionTranscriptIndexing: true },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const result = await runRegisteredPolicyDoctor(configPath, cfg);
 
     expect(result.findings).toEqual([]);
   });
 
   it("reports malformed data-handling policy sections", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        dataHandling: {
-          sensitiveLogging: true,
-          memory: [],
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeDataHandlingPolicyFixture({
+      sensitiveLogging: true,
+      memory: [],
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual(
       expect.arrayContaining([
@@ -405,23 +353,16 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("rejects scoped data-handling rules that cannot be agent-scoped", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["sebby"],
-            dataHandling: { telemetry: { denyContentCapture: true } },
-          },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["sebby"],
+          dataHandling: { telemetry: { denyContentCapture: true } },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -432,23 +373,16 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("rejects malformed scoped data-handling memory rules", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["sebby"],
-            dataHandling: { memory: { denySessionTranscriptIndexing: "true" } },
-          },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["sebby"],
+          dataHandling: { memory: { denySessionTranscriptIndexing: "true" } },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -460,22 +394,14 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports exec approvals file conformance findings", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        execApprovals: {
-          requireFile: true,
-          defaults: { allowSecurity: ["deny"] },
-          agents: {
-            allowSecurity: ["allowlist"],
-            allowlist: { expected: ["deploy", "doctor"] },
-          },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({
+      requireFile: true,
+      defaults: { allowSecurity: ["deny"] },
+      agents: {
+        allowSecurity: ["allowlist"],
+        allowlist: { expected: ["deploy", "doctor"] },
+      },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({
@@ -496,8 +422,7 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual(
       expect.arrayContaining([
@@ -528,19 +453,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("compares exec approval allowlist entries with argPattern", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        execApprovals: {
-          agents: {
-            allowlist: { expected: [{ pattern: "deploy", argPattern: "^--prod$" }] },
-          },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({
+      agents: {
+        allowlist: { expected: [{ pattern: "deploy", argPattern: "^--prod$" }] },
+      },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({
@@ -550,8 +467,7 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -569,21 +485,16 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("checks inherited default security for global exec approval agent rules", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ execApprovals: { agents: { allowSecurity: ["allowlist"] } } }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({
+      agents: { allowSecurity: ["allowlist"] },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({ version: 1, defaults: { security: "full" } }),
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -595,21 +506,16 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports inherited autoAllowSkills when policy requires manual exec allowlists", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ execApprovals: { agents: { allowAutoAllowSkills: false } } }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({
+      agents: { allowAutoAllowSkills: false },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({ version: 1, defaults: { autoAllowSkills: true } }),
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -621,13 +527,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("uses wildcard security for global exec approval agents that only add allowlist entries", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ execApprovals: { agents: { allowSecurity: ["deny"] } } }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({
+      agents: { allowSecurity: ["deny"] },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({
@@ -641,20 +543,15 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([]);
   });
 
   it("checks default-inherited global exec approval agents when explicit agents exist", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ execApprovals: { agents: { allowSecurity: ["allowlist"] } } }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({
+      agents: { allowSecurity: ["allowlist"] },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({
@@ -665,8 +562,7 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -678,25 +574,19 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("applies scoped exec approvals only to selected agents", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["sebby"],
-            execApprovals: {
-              agents: {
-                allowSecurity: ["allowlist"],
-                allowlist: { expected: ["deploy", "doctor"] },
-              },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["sebby"],
+          execApprovals: {
+            agents: {
+              allowSecurity: ["allowlist"],
+              allowlist: { expected: ["deploy", "doctor"] },
             },
           },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({
@@ -716,8 +606,7 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual(
       expect.arrayContaining([
@@ -747,20 +636,14 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not inherit wildcard security when exact agent security is malformed", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["sebby"],
-            execApprovals: { agents: { allowSecurity: ["deny"] } },
-          },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["sebby"],
+          execApprovals: { agents: { allowSecurity: ["deny"] } },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({
@@ -774,52 +657,39 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([]);
   });
 
   it("uses runtime defaults for malformed exec approval mode fields", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ execApprovals: { defaults: { allowSecurity: ["full"] } } }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({
+      defaults: { allowSecurity: ["full"] },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({ version: 1, defaults: { security: "bogus" } }),
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([]);
   });
 
   it("requires exec approvals artifacts for scoped exec approval rules", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["sebby", "buddy"],
-            execApprovals: {
-              agents: { allowSecurity: ["allowlist"] },
-            },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["sebby", "buddy"],
+          execApprovals: {
+            agents: { allowSecurity: ["allowlist"] },
           },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -831,26 +701,19 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("rejects invalid exec approvals artifacts for scoped exec approval rules", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["sebby", "buddy"],
-            execApprovals: {
-              agents: { allowSecurity: ["allowlist"] },
-            },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["sebby", "buddy"],
+          execApprovals: {
+            agents: { allowSecurity: ["allowlist"] },
           },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
     await fs.writeFile(join(workspaceDir, "exec-approvals.json"), "{", "utf-8");
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -862,40 +725,27 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not require exec approvals artifacts for requireFile false alone", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ execApprovals: { requireFile: false } }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({ requireFile: false });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([]);
   });
 
   it("applies wildcard exec approvals to scoped agents", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["sebby"],
-            execApprovals: {
-              agents: {
-                allowSecurity: ["allowlist"],
-                allowlist: { expected: ["deploy"] },
-              },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["sebby"],
+          execApprovals: {
+            agents: {
+              allowSecurity: ["allowlist"],
+              allowlist: { expected: ["deploy"] },
             },
           },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({
@@ -914,8 +764,7 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual(
       expect.arrayContaining([
@@ -935,22 +784,16 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("applies wildcard autoAllowSkills posture to scoped exec approvals", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["sebby"],
-            execApprovals: {
-              agents: { allowAutoAllowSkills: false },
-            },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["sebby"],
+          execApprovals: {
+            agents: { allowAutoAllowSkills: false },
           },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({
@@ -963,8 +806,7 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -982,22 +824,16 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("applies inherited default autoAllowSkills posture to scoped exec approvals", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["sebby"],
-            execApprovals: {
-              agents: { allowAutoAllowSkills: false },
-            },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["sebby"],
+          execApprovals: {
+            agents: { allowAutoAllowSkills: false },
           },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({
@@ -1010,8 +846,7 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -1024,25 +859,19 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("evaluates legacy default exec approvals for scoped main policies", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          restricted: {
-            agentIds: ["main"],
-            execApprovals: {
-              agents: {
-                allowSecurity: ["deny"],
-                allowlist: { expected: ["legacy", "doctor"] },
-              },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        restricted: {
+          agentIds: ["main"],
+          execApprovals: {
+            agents: {
+              allowSecurity: ["deny"],
+              allowlist: { expected: ["legacy", "doctor"] },
             },
           },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({
@@ -1058,8 +887,7 @@ describe("registerPolicyDoctorChecks", () => {
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -1072,17 +900,13 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("uses OPENCLAW_HOME for the default exec approvals artifact path", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const openclawHome = join(workspaceDir, "home");
     const approvalsDir = join(openclawHome, ".openclaw");
     const previousOpenClawHome = process.env.OPENCLAW_HOME;
     await fs.mkdir(approvalsDir, { recursive: true });
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ execApprovals: { defaults: { allowSecurity: ["deny"] } } }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({
+      defaults: { allowSecurity: ["deny"] },
+    });
     await fs.writeFile(
       join(approvalsDir, "exec-approvals.json"),
       JSON.stringify({ version: 1, defaults: { security: "full" } }),
@@ -1091,8 +915,7 @@ describe("registerPolicyDoctorChecks", () => {
 
     process.env.OPENCLAW_HOME = openclawHome;
     try {
-      registerPolicyDoctorChecks();
-      const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+      const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
       expect(result.findings).toEqual([
         expect.objectContaining({
@@ -1110,15 +933,11 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("uses OPENCLAW_STATE_DIR for the exec approvals artifact path", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const stateDir = join(workspaceDir, "state");
     await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ execApprovals: { defaults: { allowSecurity: ["deny"] } } }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({
+      defaults: { allowSecurity: ["deny"] },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({ version: 1, defaults: { security: "deny" } }),
@@ -1132,8 +951,7 @@ describe("registerPolicyDoctorChecks", () => {
 
     process.env.OPENCLAW_STATE_DIR = stateDir;
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -1144,24 +962,15 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("rejects unsupported exec approval allowlist requirement keys", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        execApprovals: {
-          agents: {
-            allowlist: {
-              expected: [{ pattern: "deploy", argpattern: "^--prod$" }],
-            },
-          },
+    const configPath = await writeExecApprovalsPolicyFixture({
+      agents: {
+        allowlist: {
+          expected: [{ pattern: "deploy", argpattern: "^--prod$" }],
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual(
       expect.arrayContaining([
@@ -1174,16 +983,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("targets the missing exec approvals artifact when required", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ execApprovals: { requireFile: true } }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({ requireFile: true });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -1195,23 +997,17 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("rejects required versionless exec approvals artifacts", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        execApprovals: { requireFile: true, defaults: { allowSecurity: ["deny"] } },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeExecApprovalsPolicyFixture({
+      requireFile: true,
+      defaults: { allowSecurity: ["deny"] },
+    });
     await fs.writeFile(
       join(workspaceDir, "exec-approvals.json"),
       JSON.stringify({ defaults: { security: "deny" } }),
       "utf-8",
     );
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -1222,22 +1018,15 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports malformed secrets policy values before applying secrets checks", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        secrets: {
-          requireManagedProviders: "yes",
-          denySources: "exec",
-          allowInsecureProviders: "false",
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      secrets: {
+        requireManagedProviders: "yes",
+        denySources: "exec",
+        allowInsecureProviders: "false",
+      },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual(
       expect.arrayContaining([
@@ -1258,7 +1047,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("keeps secret conformance checks active when auth policy shape is invalid", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       models: {
@@ -1269,24 +1057,18 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        secrets: {
-          requireManagedProviders: true,
+    const configPath = await writePolicyFixture({
+      secrets: {
+        requireManagedProviders: true,
+      },
+      auth: {
+        profiles: {
+          allowModes: "token",
         },
-        auth: {
-          profiles: {
-            allowModes: "token",
-          },
-        },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const result = await runRegisteredPolicyDoctor(configPath, cfg);
 
     expect(result.findings).toEqual(
       expect.arrayContaining([
@@ -1303,16 +1085,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports blank secrets deny source policy entries", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ secrets: { denySources: ["exec", " "] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ secrets: { denySources: ["exec", " "] } });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -1323,23 +1098,16 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports malformed auth profile policy values", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        auth: {
-          profiles: {
-            requireMetadata: ["provider", ""],
-            allowModes: ["api_key", "unsupported"],
-          },
+    const configPath = await writePolicyFixture({
+      auth: {
+        profiles: {
+          requireMetadata: ["provider", ""],
+          allowModes: ["api_key", "unsupported"],
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual(
       expect.arrayContaining([
@@ -1356,16 +1124,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports non-array auth mode allowlists", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ auth: { profiles: { allowModes: "token" } } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ auth: { profiles: { allowModes: "token" } } });
 
-    registerPolicyDoctorChecks();
-    const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()));
+    const result = await runRegisteredPolicyDoctor(configPath, cfgWithPolicy());
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -1376,7 +1137,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("allows private-network SSRF settings when policy permits them", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       browser: {
@@ -1385,16 +1145,11 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        network: {
-          privateNetwork: { allow: true },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      network: {
+        privateNetwork: { allow: true },
+      },
+    });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
 
@@ -1402,7 +1157,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not enable model checks from a network-only policy block", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ enabled: undefined }),
       models: {
@@ -1411,16 +1165,11 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        network: {
-          privateNetwork: { allow: false },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      network: {
+        privateNetwork: { allow: false },
+      },
+    });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
 
@@ -1428,13 +1177,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports unknown governed tool sensitivity metadata", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { requireMetadata: ["sensitivity"] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ tools: { requireMetadata: ["sensitivity"] } });
     await fs.writeFile(
       join(workspaceDir, "AGENTS.md"),
       "## Tools\n\n### deploy risk:critical sensitivity:secret\n",

--- a/extensions/policy/src/doctor/register.models-and-mcp.test-utils.ts
+++ b/extensions/policy/src/doctor/register.models-and-mcp.test-utils.ts
@@ -22,13 +22,40 @@ const scanPolicyMcpServers = (cfg: object) =>
 const scanPolicyIngress = (cfg: object) =>
   collectPolicyEvidence(cfg as Record<string, unknown>).ingress ?? [];
 
+async function writePolicyFixture(...json: Parameters<typeof JSON.stringify>): Promise<string> {
+  const [policy] = json;
+  const configPath = join(workspaceDir, "openclaw.jsonc");
+  await fs.writeFile(configPath, "{}", "utf-8");
+  await fs.writeFile(
+    join(workspaceDir, "policy.jsonc"),
+    typeof policy === "string" ? policy : JSON.stringify(...json),
+    "utf-8",
+  );
+  return configPath;
+}
+
+function writeModelPolicyFixture(providers: object): Promise<string> {
+  return writePolicyFixture({ models: { providers } });
+}
+
+async function runModelPolicyFixture(providers: object, cfg: OpenClawConfig) {
+  return runPolicyDoctorLint(ctx(await writeModelPolicyFixture(providers), cfg));
+}
+
+function writeMcpPolicyFixture(servers: object): Promise<string> {
+  return writePolicyFixture({ mcp: { servers } });
+}
+
+function writeIngressPolicyFixture(ingress: object): Promise<string> {
+  return writePolicyFixture({ ingress });
+}
+
 describe("registerPolicyDoctorChecks", () => {
   beforeEach(describe0BeforeEach0);
 
   afterEach(describe0AfterEach1);
 
   it("repairs required agent workspace deny tool findings", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       agents: {
@@ -40,19 +67,14 @@ describe("registerPolicyDoctorChecks", () => {
         ],
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          reviewer: {
-            agentIds: ["reviewer"],
-            agents: { workspace: { denyTools: ["exec", "write", "edit"] } },
-          },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        reviewer: {
+          agentIds: ["reviewer"],
+          agents: { workspace: { denyTools: ["exec", "write", "edit"] } },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
     const result = await runPolicyRepairCheck(
       "policy/agents-tool-not-denied",
@@ -72,7 +94,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("skips scoped required deny repairs that would mutate root tools deny", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),
       tools: { deny: ["exec"] },
@@ -80,19 +101,14 @@ describe("registerPolicyDoctorChecks", () => {
         list: [{ id: "reviewer" }],
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          reviewer: {
-            agentIds: ["reviewer"],
-            tools: { denyTools: ["exec", "write"] },
-          },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        reviewer: {
+          agentIds: ["reviewer"],
+          tools: { denyTools: ["exec", "write"] },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
     const result = await runPolicyRepairCheck(
       "policy/tools-required-deny-missing",
@@ -125,30 +141,24 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not report denied providers for disabled channels", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       channels: { telegram: { enabled: false } },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify(
-        {
-          channels: {
-            denyRules: [
-              {
-                id: "no-telegram",
-                when: { provider: "telegram" },
-                reason: "Telegram is not approved for this workspace.",
-              },
-            ],
-          },
+    const configPath = await writePolicyFixture(
+      {
+        channels: {
+          denyRules: [
+            {
+              id: "no-telegram",
+              when: { provider: "telegram" },
+              reason: "Telegram is not approved for this workspace.",
+            },
+          ],
         },
-        null,
-        2,
-      ),
-      "utf-8",
+      },
+      null,
+      2,
     );
 
     await expect(runPolicyChecks(ctx(configPath, cfg))).resolves.toMatchObject({
@@ -157,7 +167,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not run policy checks for empty category namespaces", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       channels: { telegram: { enabled: true } },
@@ -165,12 +174,13 @@ describe("registerPolicyDoctorChecks", () => {
       models: { providers: { openrouter: {} } },
       browser: { ssrfPolicy: { dangerouslyAllowPrivateNetwork: true } },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ channels: {}, mcp: {}, models: {}, network: {}, tools: {} }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      channels: {},
+      mcp: {},
+      models: {},
+      network: {},
+      tools: {},
+    });
     await fs.writeFile(join(workspaceDir, "AGENTS.md"), "## Tools\n\n### deploy\n", "utf-8");
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
@@ -179,13 +189,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports invalid requireMetadata policy entries", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { requireMetadata: ["risk", "unsupported"] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      tools: { requireMetadata: ["risk", "unsupported"] },
+    });
     await fs.writeFile(join(workspaceDir, "AGENTS.md"), "## Tools\n\n### deploy\n", "utf-8");
 
     const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()), {
@@ -203,13 +209,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports blank requireMetadata policy entries", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { requireMetadata: ["risk", " "] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ tools: { requireMetadata: ["risk", " "] } });
 
     const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()), {
       checks: registerChecks(),
@@ -251,13 +251,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports governed tools missing risk and sensitivity metadata", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { requireMetadata: ["risk", "sensitivity", "owner"] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      tools: { requireMetadata: ["risk", "sensitivity", "owner"] },
+    });
     await fs.writeFile(join(workspaceDir, "AGENTS.md"), "## Tools\n\n### deploy\n", "utf-8");
 
     const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()), {
@@ -290,13 +286,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("blocks governed tool evaluation until TOOLS.md is migrated into AGENTS.md", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { requireMetadata: ["risk"] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ tools: { requireMetadata: ["risk"] } });
     await fs.writeFile(join(workspaceDir, "TOOLS.md"), "### deploy\n", "utf-8");
 
     const beforeMigration = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()), {
@@ -330,13 +320,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("runs required metadata checks for a tool literally named tools", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { requireMetadata: ["risk", "sensitivity", "owner"] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      tools: { requireMetadata: ["risk", "sensitivity", "owner"] },
+    });
     await fs.writeFile(
       join(workspaceDir, "AGENTS.md"),
       "# Tools\n\n## Local notes\n\n- SSH: prod-host\n\n## tools risk: high\n",
@@ -363,13 +349,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not capture an unrelated nested Tools section as governed evidence", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { requireMetadata: ["risk", "sensitivity", "owner"] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      tools: { requireMetadata: ["risk", "sensitivity", "owner"] },
+    });
     await fs.writeFile(
       join(workspaceDir, "AGENTS.md"),
       "## Build\n\n### Tools\n\n- npm: install dependencies\n",
@@ -384,13 +366,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports governed bullet tools missing required metadata", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { requireMetadata: ["risk", "sensitivity", "owner"] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      tools: { requireMetadata: ["risk", "sensitivity", "owner"] },
+    });
     await fs.writeFile(join(workspaceDir, "AGENTS.md"), "## Tools\n\n- deploy: deploys\n", "utf-8");
 
     const result = await runDoctorLintChecks(ctx(configPath, cfgWithPolicy()), {
@@ -420,13 +398,9 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("accepts governed tool metadata declared on following lines", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { requireMetadata: ["risk", "sensitivity", "owner"] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({
+      tools: { requireMetadata: ["risk", "sensitivity", "owner"] },
+    });
     await fs.writeFile(
       join(workspaceDir, "AGENTS.md"),
       [
@@ -480,13 +454,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports unknown governed tool risk metadata", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ tools: { requireMetadata: ["risk"] } }),
-      "utf-8",
-    );
+    const configPath = await writePolicyFixture({ tools: { requireMetadata: ["risk"] } });
     await fs.writeFile(
       join(workspaceDir, "AGENTS.md"),
       "## Tools\n\n### deploy risk:critcal\n",
@@ -508,7 +476,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports model providers denied by policy", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       models: {
@@ -525,18 +492,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        models: {
-          providers: { deny: ["openrouter"] },
-        },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+    const result = await runModelPolicyFixture({ deny: ["openrouter"] }, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -555,7 +511,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("compares canonical model provider refs for deny policy checks", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       models: {
@@ -569,18 +524,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        models: {
-          providers: { deny: ["openrouter", "amazon-bedrock"] },
-        },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+    const result = await runModelPolicyFixture({ deny: ["openrouter", "amazon-bedrock"] }, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -593,7 +537,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("compares canonical model provider refs for allow policy checks", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       models: {
@@ -607,18 +550,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        models: {
-          providers: { allow: ["openrouter", "amazon-bedrock"] },
-        },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+    const result = await runModelPolicyFixture({ allow: ["openrouter", "amazon-bedrock"] }, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -631,7 +563,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports model refs outside the policy allowlist", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       agents: {
@@ -643,18 +574,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        models: {
-          providers: { allow: ["openai"] },
-        },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+    const result = await runModelPolicyFixture({ allow: ["openai"] }, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -667,7 +587,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports model allowlist keys outside the policy allowlist", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       agents: {
@@ -678,18 +597,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        models: {
-          providers: { allow: ["openai"] },
-        },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+    const result = await runModelPolicyFixture({ allow: ["openai"] }, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -702,7 +610,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports per-agent model allowlist keys outside the policy allowlist", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       agents: {
@@ -716,18 +623,7 @@ describe("registerPolicyDoctorChecks", () => {
         ],
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        models: {
-          providers: { allow: ["openai"] },
-        },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+    const result = await runModelPolicyFixture({ allow: ["openai"] }, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -740,7 +636,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports configured model providers outside the policy allowlist", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       models: {
@@ -749,18 +644,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        models: {
-          providers: { allow: ["openai"] },
-        },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+    const result = await runModelPolicyFixture({ allow: ["openai"] }, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -773,7 +657,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports non-default agent model refs outside the policy allowlist", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       agents: {
@@ -785,18 +668,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        models: {
-          providers: { allow: ["openai"] },
-        },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+    const result = await runModelPolicyFixture({ allow: ["openai"] }, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -809,7 +681,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports per-agent model refs outside the policy allowlist", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       agents: {
@@ -821,18 +692,7 @@ describe("registerPolicyDoctorChecks", () => {
         ],
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        models: {
-          providers: { deny: ["openrouter"] },
-        },
-      }),
-      "utf-8",
-    );
-
-    const result = await runPolicyDoctorLint(ctx(configPath, cfg));
+    const result = await runModelPolicyFixture({ deny: ["openrouter"] }, cfg);
 
     expect(result.findings).toEqual([
       expect.objectContaining({
@@ -845,17 +705,7 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not enable tool metadata checks from a model-only policy block", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        models: {
-          providers: { allow: ["openai"] },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeModelPolicyFixture({ allow: ["openai"] });
     await fs.writeFile(join(workspaceDir, "AGENTS.md"), "## Tools\n\n### deploy\n", "utf-8");
 
     const result = await runPolicyDoctorLint(
@@ -866,7 +716,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports MCP servers denied by policy", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       mcp: {
@@ -878,16 +727,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        mcp: {
-          servers: { deny: ["untrusted"] },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeMcpPolicyFixture({ deny: ["untrusted"] });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
 
@@ -902,7 +742,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("preserves MCP server casing for deny rules", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       mcp: {
@@ -914,16 +753,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        mcp: {
-          servers: { deny: ["DocsServer"] },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeMcpPolicyFixture({ deny: ["DocsServer"] });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
 
@@ -938,7 +768,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports MCP servers outside the policy allowlist", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       mcp: {
@@ -954,16 +783,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        mcp: {
-          servers: { allow: ["docs"] },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeMcpPolicyFixture({ allow: ["docs"] });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
 
@@ -978,7 +798,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("preserves MCP server casing for allowlists", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       mcp: {
@@ -990,16 +809,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        mcp: {
-          servers: { allow: ["DocsServer"] },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeMcpPolicyFixture({ allow: ["DocsServer"] });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
 
@@ -1046,7 +856,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not enable model checks from an MCP-only policy block", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy({ enabled: undefined }),
       models: {
@@ -1055,16 +864,7 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        mcp: {
-          servers: { allow: ["docs"] },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeMcpPolicyFixture({ allow: ["docs"] });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
 
@@ -1072,7 +872,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("reports ingress channel access conformance findings", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       session: { dmScope: "main" },
@@ -1087,21 +886,14 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          session: { requireDmScope: "per-channel-peer" },
-          channels: {
-            allowDmPolicies: ["pairing", "allowlist", "disabled"],
-            denyOpenGroups: true,
-            requireMentionInGroups: true,
-          },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeIngressPolicyFixture({
+      session: { requireDmScope: "per-channel-peer" },
+      channels: {
+        allowDmPolicies: ["pairing", "allowlist", "disabled"],
+        denyOpenGroups: true,
+        requireMentionInGroups: true,
+      },
+    });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
 
@@ -1137,21 +929,13 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("normalizes mixed-case session DM scope before checking ingress policy", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       session: { dmScope: "Per-Channel-Peer" },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          session: { requireDmScope: "per-channel-peer" },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeIngressPolicyFixture({
+      session: { requireDmScope: "per-channel-peer" },
+    });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
 
@@ -1165,7 +949,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("applies channel-scoped ingress claims to matching channel posture", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       session: { dmScope: "main" },
@@ -1179,28 +962,23 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          session: { requireDmScope: "per-channel-peer" },
-        },
-        scopes: {
-          telegramIngress: {
-            channelIds: ["telegram"],
-            ingress: {
-              channels: {
-                allowDmPolicies: ["pairing"],
-                denyOpenGroups: true,
-                requireMentionInGroups: true,
-              },
+    const configPath = await writePolicyFixture({
+      ingress: {
+        session: { requireDmScope: "per-channel-peer" },
+      },
+      scopes: {
+        telegramIngress: {
+          channelIds: ["telegram"],
+          ingress: {
+            channels: {
+              allowDmPolicies: ["pairing"],
+              denyOpenGroups: true,
+              requireMentionInGroups: true,
             },
           },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
 
@@ -1228,7 +1006,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not apply channel-scoped ingress claims from invalid scopes", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       channels: {
@@ -1239,26 +1016,21 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        scopes: {
-          telegramIngress: {
-            channelIds: ["telegram"],
-            agents: {},
-            ingress: {
-              channels: {
-                allowDmPolicies: ["pairing"],
-                denyOpenGroups: true,
-                requireMentionInGroups: true,
-              },
+    const configPath = await writePolicyFixture({
+      scopes: {
+        telegramIngress: {
+          channelIds: ["telegram"],
+          agents: {},
+          ingress: {
+            channels: {
+              allowDmPolicies: ["pairing"],
+              denyOpenGroups: true,
+              requireMentionInGroups: true,
             },
           },
         },
-      }),
-      "utf-8",
-    );
+      },
+    });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
 
@@ -1280,7 +1052,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not treat wildcard groupPolicy as channel ingress posture", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       channels: {
@@ -1298,19 +1069,12 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          channels: {
-            denyOpenGroups: true,
-            requireMentionInGroups: true,
-          },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeIngressPolicyFixture({
+      channels: {
+        denyOpenGroups: true,
+        requireMentionInGroups: true,
+      },
+    });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
@@ -1333,7 +1097,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("honors wildcard mention ingress for channel posture", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       channels: {
@@ -1348,18 +1111,11 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          channels: {
-            requireMentionInGroups: true,
-          },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeIngressPolicyFixture({
+      channels: {
+        requireMentionInGroups: true,
+      },
+    });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
@@ -1381,7 +1137,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("honors strict channel group policy defaults", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       channels: {
@@ -1393,18 +1148,11 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          channels: {
-            denyOpenGroups: true,
-          },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeIngressPolicyFixture({
+      channels: {
+        denyOpenGroups: true,
+      },
+    });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
@@ -1428,7 +1176,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("treats disabled nested DM config as disabled ingress", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       channels: {
@@ -1439,18 +1186,11 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          channels: {
-            allowDmPolicies: ["disabled"],
-          },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeIngressPolicyFixture({
+      channels: {
+        allowDmPolicies: ["disabled"],
+      },
+    });
 
     const result = await runPolicyChecks(ctx(configPath, cfg));
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
@@ -1570,7 +1310,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("uses effective ingress defaults when policy governs omitted fields", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       session: { dmScope: "per-channel-peer" },
@@ -1578,21 +1317,14 @@ describe("registerPolicyDoctorChecks", () => {
         qqbot: {},
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          session: { requireDmScope: "per-channel-peer" },
-          channels: {
-            allowDmPolicies: ["pairing", "allowlist", "disabled"],
-            denyOpenGroups: true,
-            requireMentionInGroups: true,
-          },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeIngressPolicyFixture({
+      session: { requireDmScope: "per-channel-peer" },
+      channels: {
+        allowDmPolicies: ["pairing", "allowlist", "disabled"],
+        denyOpenGroups: true,
+        requireMentionInGroups: true,
+      },
+    });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
 
@@ -1605,7 +1337,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("infers allowlist group posture from configured groups", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       session: { dmScope: "per-channel-peer" },
@@ -1618,20 +1349,13 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          channels: {
-            allowDmPolicies: ["pairing"],
-            denyOpenGroups: true,
-            requireMentionInGroups: true,
-          },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeIngressPolicyFixture({
+      channels: {
+        allowDmPolicies: ["pairing"],
+        denyOpenGroups: true,
+        requireMentionInGroups: true,
+      },
+    });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
@@ -1654,7 +1378,6 @@ describe("registerPolicyDoctorChecks", () => {
   });
 
   it("does not infer allowlist posture from Slack channel entries", async () => {
-    const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
       ...cfgWithPolicy(),
       session: { dmScope: "per-channel-peer" },
@@ -1667,18 +1390,11 @@ describe("registerPolicyDoctorChecks", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    await fs.writeFile(configPath, "{}", "utf-8");
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        ingress: {
-          channels: {
-            denyOpenGroups: true,
-          },
-        },
-      }),
-      "utf-8",
-    );
+    const configPath = await writeIngressPolicyFixture({
+      channels: {
+        denyOpenGroups: true,
+      },
+    });
 
     const result = await runPolicyDoctorLint(ctx(configPath, cfg));
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);


### PR DESCRIPTION
## What Problem This Solves

Policy doctor coverage had accumulated hundreds of repeated lines for temporary config and policy files, doctor registration, and check execution. That repetition made the security-sensitive cases harder to compare and maintain even though the underlying behavior was identical.

## Why This Change Was Made

This consolidates the repeated setup into file-local fixture helpers owned by the three existing Policy doctor test modules. The helpers preserve sequential config-before-policy writes, raw malformed fixtures, pretty-printed JSON bytes, and the existing registration/check boundaries; no production, config, schema, default, API, or i18n surface changes.

Architecturally, the test fixture layer owns the duplication. The canonical fix removes duplicate config/policy writes and registration/check ceremony while leaving the Policy doctor implementation and all assertions at their current owners.

## User Impact

No runtime behavior changes. Maintainers get the same 300-case Policy doctor safety net with 747 fewer test-support lines and clearer case-specific inputs and expectations.

## Evidence

- Exact parity census: 131 test declarations and 235 `expect(...)` call sites before and after.
- Local focused proof: `node scripts/run-vitest.mjs extensions/policy/src/doctor/register.test.ts --reporter=verbose` — 300/300 passed.
- Blacksmith Testbox broad proof: the complete `extensions/policy` suite plus every MCP- and security-named test across core, plugins, UI, and E2E — all 30 Vitest shards passed.
- Blacksmith Testbox changed gate: `pnpm check:changed` passed, including formatting, extension production/test typechecks, lint, dead-code, plugin-boundary, database-first, and import-cycle checks.
- Diff: +668/-1,415, net -747 test LOC; production delta 0.
- Collision audit: exhaustive open-PR census and all >100-file tails found zero matches for the three changed paths.

The dependency contract was checked directly in sibling Codex source: MCP server configuration and transport shapes in `../codex/codex-rs/config/src/mcp_types.rs:124-225,324-480`; authentication state and persistence in `../codex/codex-rs/protocol/src/auth.rs:6-55` and `../codex/codex-rs/login/src/auth/manager.rs:248-458`; model/catalog behavior in `../codex/codex-rs/app-server-protocol/src/protocol/v2/model.rs:40-135`, `../codex/codex-rs/app-server/src/request_processors/catalog_processor.rs:159-305`, and `../codex/codex-rs/model-provider-info/src/lib.rs:86-285,332-507`; MCP lifecycle behavior in `../codex/codex-rs/core/src/session/mcp.rs:89-218,581-635` and `../codex/codex-rs/core/src/session/session.rs:721-755,1241-1270`.
