### PR TITLE
test(plugins): canonicalize native resolver fixtures

### DIFF
--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -112,7 +112,7 @@ function createInternalCoreAliasFixture(prefix: string): {
   root: string;
   sourcePath: string;
 } {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
   const { loaderModulePath } = writeFakeOpenClawPackage(root);
   const sourcePath = writeInternalCorePackageSource(root, "markdown-core", "code-spans.ts");
   const coreSourceParent = path.join(root, "src", "host-probe.js");


### PR DESCRIPTION
## Summary

- canonicalize the shared Plugin SDK native-resolver fixture root on macOS
- restore shared-cache, host-isolation, and lifecycle-invalidation assertions
- leave production resolver and cache behavior unchanged

## Root cause and fix

The test fixture retained the lexical `/var/...` path returned by `mkdtemp`, while the production resolver canonicalizes the loader package root to `/private/var/...` before scanning internal package aliases. Three spy expectations therefore compared different spellings of the same source files.

The fixture now resolves its temporary root once before creating the fake package. Production delta is 0 lines.

Closes https://github.com/openclaw/openclaw/issues/118172

## Proof

Exact candidate head: `48714e7eb80e2e3b21545d8354912c0c32ea799e`

- Current-main reproduction: 3 failures in shared-host, isolated-host, and lifecycle-invalidation cases
- `node scripts/run-vitest.mjs src/plugins/plugin-sdk-native-resolver.test.ts` — 15/15 passed after final rebase
- stress loop — 30/30 complete shard runs passed
- `node scripts/check-changed.mjs -- src/plugins/plugin-sdk-native-resolver.test.ts` — passed on Blacksmith Testbox `tbx_01kz217pdg6671tfqv64fw9trm` ([run](https://github.com/openclaw/openclaw/actions/runs/30764790791))
- Codex autoreview — clean, no accepted/actionable findings, overall confidence 0.99
- exact-head hosted CI — green ([run](https://github.com/openclaw/openclaw/actions/runs/30765135390))

### macOS before/after terminal proof

Host: Darwin, macOS 27.0. Only the random per-user temporary-directory component is redacted below.

The candidate and current `origin/main` are byte-identical in the resolver surface except for this fixture line. Restoring the exact current-main line on the candidate checkout reproduces the defect:

```text
$ node -e 'const fs=require("node:fs"),os=require("node:os"); console.log(JSON.stringify({platform:process.platform,tmpdir:os.tmpdir(),realTmpdir:fs.realpathSync(os.tmpdir())}))'
{"platform":"darwin","tmpdir":"/var/folders/<macos-user-temp>/T","realTmpdir":"/private/var/folders/<macos-user-temp>/T"}

$ node scripts/run-vitest.mjs src/plugins/plugin-sdk-native-resolver.test.ts
FAIL  src/plugins/plugin-sdk-native-resolver.test.ts > shares one internal core alias scan across importers from the same host package
expected: /var/folders/<macos-user-temp>/T/.../packages/markdown-core/src/code-spans.ts
received: /private/var/folders/<macos-user-temp>/T/.../packages/markdown-core/src/code-spans.ts

FAIL  src/plugins/plugin-sdk-native-resolver.test.ts > keeps internal core alias registration isolated between host modules
FAIL  src/plugins/plugin-sdk-native-resolver.test.ts > rescans internal core aliases after plugin metadata lifecycle invalidation
Test Files  1 failed (1)
Tests       3 failed | 12 passed (15)
```

Restoring the candidate line on the same checkout and host fixes all three path-identity assertions:

```text
$ node scripts/run-vitest.mjs src/plugins/plugin-sdk-native-resolver.test.ts
Test Files  1 passed (1)
Tests       15 passed (15)
[test] passed 1 Vitest shard in 2.74s
```

## Changelog

Not required: test-only reliability fix with no runtime behavior change.
