### PR TITLE
refactor(android): share Wear transport test fixtures

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeChannelRegistryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeChannelRegistryTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -29,12 +30,18 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class WearRealtimeChannelRegistryTest {
+  private val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
+  private val transport = FakeChannelTransport()
+  private val registry = WearRealtimeChannelRegistry(scope, transport)
+
+  @After
+  fun cancelScope() {
+    scope.cancel()
+  }
+
   @Test
   fun `replacement stops displaced owner once before its finalizer`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val stoppedOwners = mutableListOf<WearRealtimeAttemptOwner>()
       val stopTalk: suspend (WearRealtimeAttemptOwner) -> Unit = { owner ->
         synchronized(stoppedOwners) { stoppedOwners += owner }
@@ -42,7 +49,7 @@ class WearRealtimeChannelRegistryTest {
       val first = FakeChannel("watch-a", "channel-a", "attempt-a")
       val second = FakeChannel("watch-a", "channel-b", "attempt-b")
 
-      try {
+      run {
         registry.accept(first, appendAudio = { _, _ -> }, stopTalk = stopTalk)
         transport.awaitOpened(first)
         val firstClaim = checkNotNull(registry.claim("watch-a", "attempt-a"))
@@ -84,17 +91,12 @@ class WearRealtimeChannelRegistryTest {
 
         registry.close(retryOwner)
         assertEquals(listOf(firstOwner, retryOwner), synchronized(stoppedOwners) { stoppedOwners.toList() })
-      } finally {
-        scope.cancel()
       }
     }
 
   @Test
   fun `replacement claim waits for owner retirement but not delayed gateway close`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val closeStarted = CompletableDeferred<Unit>()
       val releaseClose = CompletableDeferred<Unit>()
       val closeFinished = CompletableDeferred<Unit>()
@@ -161,16 +163,12 @@ class WearRealtimeChannelRegistryTest {
         registry.close(checkNotNull(secondOwner))
       } finally {
         releaseClose.complete(Unit)
-        scope.cancel()
       }
     }
 
   @Test
   fun `reader retirement blocks replacement claim until owner stops`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val stopStarted = CompletableDeferred<Unit>()
       val releaseStop = CompletableDeferred<Unit>()
       val first = FakeChannel("watch-a", "channel-a", "attempt-a")
@@ -198,16 +196,12 @@ class WearRealtimeChannelRegistryTest {
         registry.close(replacementOwner)
       } finally {
         releaseStop.complete(Unit)
-        scope.cancel()
       }
     }
 
   @Test
   fun `rapid replacements preserve transitive owner retirement`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val stopStarted = CompletableDeferred<Unit>()
       val releaseStop = CompletableDeferred<Unit>()
       val first = FakeChannel("watch-a", "channel-a", "attempt-a")
@@ -237,16 +231,12 @@ class WearRealtimeChannelRegistryTest {
         registry.close(newestOwner)
       } finally {
         releaseStop.complete(Unit)
-        scope.cancel()
       }
     }
 
   @Test
   fun `delayed unclaimed channel cannot retire the active attempt`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val stoppedOwners = mutableListOf<WearRealtimeAttemptOwner>()
       val stopTalk: suspend (WearRealtimeAttemptOwner) -> Unit = { owner ->
         synchronized(stoppedOwners) { stoppedOwners += owner }
@@ -254,7 +244,7 @@ class WearRealtimeChannelRegistryTest {
       val active = FakeChannel("watch-a", "channel-b", "attempt-b")
       val delayed = FakeChannel("watch-a", "channel-a", "attempt-a")
 
-      try {
+      run {
         registry.accept(active, appendAudio = { _, _ -> }, stopTalk = stopTalk)
         transport.awaitOpened(active)
         val activeClaim = checkNotNull(registry.claim("watch-a", "attempt-b"))
@@ -269,17 +259,12 @@ class WearRealtimeChannelRegistryTest {
         assertFalse(repeated.newlyAcquired)
         assertSame(activeClaim.owner, repeated.owner)
         registry.close(activeClaim.owner)
-      } finally {
-        scope.cancel()
       }
     }
 
   @Test
   fun `same path reconnect inherits the active attempt owner`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val stoppedOwners = mutableListOf<WearRealtimeAttemptOwner>()
       val stopTalk: suspend (WearRealtimeAttemptOwner) -> Unit = { owner ->
         synchronized(stoppedOwners) { stoppedOwners += owner }
@@ -287,7 +272,7 @@ class WearRealtimeChannelRegistryTest {
       val active = FakeChannel("watch-a", "channel-a", "attempt-a")
       val reconnect = FakeChannel("watch-a", "channel-a-reconnect", "attempt-a")
 
-      try {
+      run {
         registry.accept(active, appendAudio = { _, _ -> }, stopTalk = stopTalk)
         transport.awaitOpened(active)
         val owner = checkNotNull(registry.claim("watch-a", "attempt-a")).owner
@@ -305,17 +290,12 @@ class WearRealtimeChannelRegistryTest {
         assertTrue(registry.isCurrent(owner))
         assertTrue(synchronized(stoppedOwners) { stoppedOwners.isEmpty() })
         registry.close(owner)
-      } finally {
-        scope.cancel()
       }
     }
 
   @Test
   fun `same path reconnect waits for an in flight frame before retiring its channel`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val active = FakeChannel("watch-a", "channel-a", "attempt-a")
       val reconnect = FakeChannel("watch-a", "channel-a-reconnect", "attempt-a")
       val releaseWrite = transport.holdWrite(active)
@@ -346,19 +326,15 @@ class WearRealtimeChannelRegistryTest {
         registry.close(owner)
       } finally {
         releaseWrite.countDown()
-        scope.cancel()
       }
     }
 
   @Test
   fun `missing stale claim does not block a valid attempt on the same watch`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val current = FakeChannel("watch-a", "channel-b", "attempt-b")
 
-      try {
+      run {
         registry.accept(current, appendAudio = { _, _ -> }, stopTalk = {})
         transport.awaitOpened(current)
         val missingClaim = async { registry.claim("watch-a", "attempt-a") }
@@ -371,17 +347,12 @@ class WearRealtimeChannelRegistryTest {
         assertFalse(missingClaim.isCompleted)
         missingClaim.cancel()
         registry.close(currentOwner)
-      } finally {
-        scope.cancel()
       }
     }
 
   @Test
   fun `replacement claim bounds a stalled owner stop callback`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val first = FakeChannel("watch-a", "channel-a", "attempt-a")
       val second = FakeChannel("watch-a", "channel-b", "attempt-b")
       val stopStarted = CompletableDeferred<Unit>()
@@ -411,15 +382,12 @@ class WearRealtimeChannelRegistryTest {
         registry.close(replacement)
       } finally {
         releaseStop.complete(Unit)
-        scope.cancel()
       }
     }
 
   @Test
   fun `retirement timeout keeps transport cleanup running`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
       val registry =
         WearRealtimeChannelRegistry(
           scope = scope,
@@ -441,15 +409,12 @@ class WearRealtimeChannelRegistryTest {
         withTimeout(1_000L) { transport.awaitClosed(channel) }
       } finally {
         releaseClose.complete(Unit)
-        scope.cancel()
       }
     }
 
   @Test
   fun `old path reconnect cannot inherit an owner reserved for retirement`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
       val registry =
         WearRealtimeChannelRegistry(
           scope = scope,
@@ -488,15 +453,12 @@ class WearRealtimeChannelRegistryTest {
         registry.close(replacementOwner)
       } finally {
         releaseStop.complete(Unit)
-        scope.cancel()
       }
     }
 
   @Test
   fun `promotion reserved before discovery timeout commits after bounded cleanup`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
       val registry =
         WearRealtimeChannelRegistry(
           scope = scope,
@@ -530,15 +492,12 @@ class WearRealtimeChannelRegistryTest {
         registry.close(replacementOwner)
       } finally {
         releaseReplacement.complete(Unit)
-        scope.cancel()
       }
     }
 
   @Test
   fun `claim keeps polling after an unclaimed channel expires`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
       val registry =
         WearRealtimeChannelRegistry(
           scope = scope,
@@ -549,7 +508,7 @@ class WearRealtimeChannelRegistryTest {
       val expired = FakeChannel("watch-a", "channel-a-expired", "attempt-a")
       val replacement = FakeChannel("watch-a", "channel-a-replacement", "attempt-a")
 
-      try {
+      run {
         registry.accept(expired, appendAudio = { _, _ -> }, stopTalk = {})
         transport.awaitOpened(expired)
         withTimeout(1_000L) { transport.awaitClosed(expired) }
@@ -563,17 +522,12 @@ class WearRealtimeChannelRegistryTest {
         val owner = checkNotNull(withTimeout(1_000L) { claim.await() }).owner
         assertTrue(registry.isCurrent(owner))
         registry.close(owner)
-      } finally {
-        scope.cancel()
       }
     }
 
   @Test
   fun `older polling claim cannot replace a newer active attempt`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val stoppedOwners = mutableListOf<WearRealtimeAttemptOwner>()
       val stopTalk: suspend (WearRealtimeAttemptOwner) -> Unit = { owner ->
         synchronized(stoppedOwners) { stoppedOwners += owner }
@@ -581,7 +535,7 @@ class WearRealtimeChannelRegistryTest {
       val newer = FakeChannel("watch-a", "channel-b", "attempt-b")
       val delayedOlder = FakeChannel("watch-a", "channel-a", "attempt-a")
 
-      try {
+      run {
         val olderClaim = async { registry.claim("watch-a", "attempt-a") }
         delay(100L)
         registry.accept(newer, appendAudio = { _, _ -> }, stopTalk = stopTalk)
@@ -595,17 +549,12 @@ class WearRealtimeChannelRegistryTest {
         assertTrue(registry.isCurrent(newerOwner))
         assertTrue(synchronized(stoppedOwners) { stoppedOwners.isEmpty() })
         registry.close(newerOwner)
-      } finally {
-        scope.cancel()
       }
     }
 
   @Test
   fun `newer waiting channel survives an older promotion`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val stopStarted = CompletableDeferred<Unit>()
       val releaseStop = CompletableDeferred<Unit>()
       val first = FakeChannel("watch-a", "channel-a", "attempt-a")
@@ -638,16 +587,12 @@ class WearRealtimeChannelRegistryTest {
         registry.close(thirdOwner)
       } finally {
         releaseStop.complete(Unit)
-        scope.cancel()
       }
     }
 
   @Test
   fun `same path reconnect replaces a reserved channel before promotion`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val stopStarted = CompletableDeferred<Unit>()
       val releaseStop = CompletableDeferred<Unit>()
       val active = FakeChannel("watch-a", "channel-a", "attempt-a")
@@ -687,16 +632,12 @@ class WearRealtimeChannelRegistryTest {
         registry.close(owner)
       } finally {
         releaseStop.complete(Unit)
-        scope.cancel()
       }
     }
 
   @Test
   fun `latest reconnect wins while an older promotion candidate retires`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val stopStarted = CompletableDeferred<Unit>()
       val releaseStop = CompletableDeferred<Unit>()
       val active = FakeChannel("watch-a", "channel-a", "attempt-a")
@@ -742,15 +683,12 @@ class WearRealtimeChannelRegistryTest {
       } finally {
         releaseStop.complete(Unit)
         releaseReservedClose.complete(Unit)
-        scope.cancel()
       }
     }
 
   @Test
   fun `cancelled promotion retires its reserved channel before retry`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
       val registry =
         WearRealtimeChannelRegistry(
           scope = scope,
@@ -770,7 +708,7 @@ class WearRealtimeChannelRegistryTest {
         }
       }
 
-      try {
+      run {
         registry.accept(first, appendAudio = { _, _ -> }, stopTalk = stopTalk)
         transport.awaitOpened(first)
         checkNotNull(registry.claim("watch-a", "attempt-a"))
@@ -786,20 +724,15 @@ class WearRealtimeChannelRegistryTest {
         transport.awaitOpened(retry)
         val retryOwner = checkNotNull(withTimeout(1_000L) { registry.claim("watch-a", "attempt-b") }).owner
         registry.close(retryOwner)
-      } finally {
-        scope.cancel()
       }
     }
 
   @Test
   fun `pending channel does not read pcm before promotion`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val channel = FakeChannel("watch-a", "channel-a", "attempt-a")
 
-      try {
+      run {
         registry.accept(channel, appendAudio = { _, _ -> }, stopTalk = {})
         transport.awaitOpened(channel)
         delay(100L)
@@ -810,17 +743,12 @@ class WearRealtimeChannelRegistryTest {
           while (!transport.hasStartedReading(channel)) yield()
         }
         registry.close(owner)
-      } finally {
-        scope.cancel()
       }
     }
 
   @Test
   fun `older channel setup cannot displace a newer published channel`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val first = FakeChannel("watch-a", "channel-a", "attempt-a")
       val second = FakeChannel("watch-a", "channel-b", "attempt-b")
       val releaseFirst = transport.holdOpen(first)
@@ -841,16 +769,12 @@ class WearRealtimeChannelRegistryTest {
         registry.close(secondOwner)
       } finally {
         releaseFirst.complete(Unit)
-        scope.cancel()
       }
     }
 
   @Test
   fun `legacy channel replacement binds the new attempt instead of inheriting the old owner`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
-      val registry = WearRealtimeChannelRegistry(scope, transport)
       val stoppedOwners = mutableListOf<WearRealtimeAttemptOwner>()
       val first =
         FakeChannel(
@@ -867,7 +791,7 @@ class WearRealtimeChannelRegistryTest {
           pathOverride = WearProtocol.LEGACY_REALTIME_AUDIO_CHANNEL_PATH,
         )
 
-      try {
+      run {
         registry.accept(first, appendAudio = { _, _ -> }, stopTalk = { stoppedOwners += it })
         transport.awaitOpened(first)
         val firstOwner =
@@ -894,16 +818,12 @@ class WearRealtimeChannelRegistryTest {
         assertTrue(secondOwner.channelGeneration > firstOwner.channelGeneration)
         assertEquals(listOf(firstOwner), stoppedOwners)
         registry.close(secondOwner)
-      } finally {
-        scope.cancel()
       }
     }
 
   @Test
   fun `staged channel limits reject excess connections before opening streams`() =
     runBlocking {
-      val scope = kotlinx.coroutines.CoroutineScope(SupervisorJob() + Dispatchers.IO)
-      val transport = FakeChannelTransport()
       val registry =
         WearRealtimeChannelRegistry(
           scope = scope,
@@ -916,7 +836,7 @@ class WearRealtimeChannelRegistryTest {
       val secondNode = FakeChannel("watch-b", "second-node", "attempt-c")
       val globalExcess = FakeChannel("watch-c", "global-excess", "attempt-d")
 
-      try {
+      run {
         registry.accept(first, appendAudio = { _, _ -> }, stopTalk = {})
         transport.awaitOpened(first)
 
@@ -932,8 +852,6 @@ class WearRealtimeChannelRegistryTest {
         transport.awaitClosed(globalExcess)
         assertFalse(transport.wasOpened(globalExcess))
         assertEquals(1, transport.closeCount(globalExcess))
-      } finally {
-        scope.cancel()
       }
     }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
@@ -4,9 +4,11 @@ import ai.openclaw.app.gateway.GatewayRequestRejected
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.wear.shared.WearProtocol
 import ai.openclaw.wear.shared.WearRealtimeAudioFrameType
+import ai.openclaw.wear.shared.WearRealtimeTalkSnapshot
 import ai.openclaw.wear.shared.WearRealtimeTalkStatus
 import android.util.Base64
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
@@ -42,25 +44,16 @@ class WearRealtimeTalkControllerTest {
     runTest {
       var gatewayCalls = 0
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { _, _, _ ->
             gatewayCalls += 1
             """{"relaySessionId":"relay-late"}"""
           },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
         )
 
       assertTrue(controller.stop("watch-a", "attempt-a"))
       assertFalse(
-        controller.start(
-          nodeId = "watch-a",
-          sessionKey = "session-a",
-          attemptId = "attempt-a",
-          language = "de",
-        ),
+        controller.start("watch-a", "session-a", "attempt-a", "de"),
       )
       assertEquals(0, gatewayCalls)
     }
@@ -69,12 +62,8 @@ class WearRealtimeTalkControllerTest {
   fun `partial scoped stop rejects when no active owner can match`() =
     runTest {
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { _, _, _ -> """{"relaySessionId":"relay-late"}""" },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
         )
 
       assertFalse(controller.stop(nodeId = "watch-a"))
@@ -89,12 +78,8 @@ class WearRealtimeTalkControllerTest {
       val forcedChannelCloses = mutableListOf<String>()
       lateinit var controller: WearRealtimeTalkController
       controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { _, _, _ -> """{"ok":true}""" },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
           onSnapshot = { snapshot ->
             if (snapshot.status == WearRealtimeTalkStatus.CONNECTING) controller.abort()
           },
@@ -102,12 +87,7 @@ class WearRealtimeTalkControllerTest {
         )
 
       assertFalse(
-        controller.start(
-          nodeId = "watch-a",
-          sessionKey = "session-a",
-          attemptId = "attempt-a",
-          language = "de",
-        ),
+        controller.start("watch-a", "session-a", "attempt-a", "de"),
       )
       assertEquals(listOf("watch-a"), forcedChannelCloses)
       assertEquals(WearRealtimeTalkStatus.OFF, controller.snapshot.value.status)
@@ -123,8 +103,7 @@ class WearRealtimeTalkControllerTest {
       val gatewayMethods = mutableListOf<String>()
       val forcedChannelCloses = mutableListOf<String>()
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
+        testTalkController(
           isConnected = { connected },
           requestGateway = { method, _, _ ->
             gatewayMethods += method
@@ -135,19 +114,12 @@ class WearRealtimeTalkControllerTest {
               """{"ok":true}"""
             }
           },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
           onForceCloseWatchChannel = { owner -> forcedChannelCloses += owner.nodeId },
         )
 
       val startResult =
         async {
-          controller.start(
-            nodeId = "watch-a",
-            sessionKey = "session-a",
-            attemptId = "attempt-a",
-            language = "de",
-          )
+          controller.start("watch-a", "session-a", "attempt-a", "de")
         }
       createStarted.await()
       connected = false
@@ -166,44 +138,18 @@ class WearRealtimeTalkControllerTest {
     runTest {
       val forcedChannelCloses = mutableListOf<String>()
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
-          requestGateway = { method, _, _ ->
-            if (method == "talk.session.create") {
-              """{"relaySessionId":"relay-1"}"""
-            } else {
-              """{"ok":true}"""
-            }
-          },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
+        testTalkController(
           onForceCloseWatchChannel = { owner -> forcedChannelCloses += owner.nodeId },
         )
 
       assertTrue(
-        controller.start(
-          nodeId = "watch-a",
-          sessionKey = "session-a",
-          attemptId = "attempt-a",
-          language = "de",
-        ),
+        controller.start("watch-a", "session-a", "attempt-a", "de"),
       )
       assertFalse(
-        controller.start(
-          nodeId = "watch-b",
-          sessionKey = "session-a",
-          attemptId = "attempt-b",
-          language = "de",
-        ),
+        controller.start("watch-b", "session-a", "attempt-b", "de"),
       )
       assertFalse(
-        controller.start(
-          nodeId = "watch-a",
-          sessionKey = "session-b",
-          attemptId = "attempt-b",
-          language = "de",
-        ),
+        controller.start("watch-a", "session-b", "attempt-b", "de"),
       )
 
       assertFalse(controller.stop("watch-b"))
@@ -218,9 +164,7 @@ class WearRealtimeTalkControllerTest {
       var staleAppendError: ((String) -> Unit)? = null
       var createCount = 0
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { method, _, _ ->
             if (method == "talk.session.create") {
               createCount += 1
@@ -232,7 +176,6 @@ class WearRealtimeTalkControllerTest {
           sendGatewayFrame = { _, _, _, onError ->
             if (staleAppendError == null) staleAppendError = onError
           },
-          sendWatchFrame = { _, _, _ -> },
         )
 
       assertTrue(controller.start("watch-a", "session-a", "attempt-a", "de"))
@@ -256,9 +199,7 @@ class WearRealtimeTalkControllerTest {
       val releaseOutput = CompletableDeferred<Unit>()
       var createCount = 0
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { method, _, _ ->
             if (method == "talk.session.create") {
               createCount += 1
@@ -267,7 +208,6 @@ class WearRealtimeTalkControllerTest {
               """{"ok":true}"""
             }
           },
-          sendGatewayFrame = { _, _, _, _ -> },
           sendWatchFrame = { _, _, _ ->
             outputStarted.complete(Unit)
             withContext(NonCancellable) {
@@ -305,9 +245,7 @@ class WearRealtimeTalkControllerTest {
     runTest {
       var createCount = 0
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { method, _, _ ->
             if (method == "talk.session.create") {
               createCount += 1
@@ -316,8 +254,6 @@ class WearRealtimeTalkControllerTest {
               """{"ok":true}"""
             }
           },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
         )
       val staleOwner = WearRealtimeAttemptOwner("watch-a", "attempt-a", 1L)
       val replacementOwner = WearRealtimeAttemptOwner("watch-a", "attempt-b", 2L)
@@ -345,9 +281,7 @@ class WearRealtimeTalkControllerTest {
       val gatewayMethods = mutableListOf<String>()
       var createCount = 0
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { method, _, _ ->
             gatewayMethods += method
             if (method == "talk.session.create") {
@@ -357,8 +291,6 @@ class WearRealtimeTalkControllerTest {
               """{"ok":true}"""
             }
           },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
         )
       val staleOwner = WearRealtimeAttemptOwner("watch-a", "attempt-a", 1L)
       val replacementOwner = WearRealtimeAttemptOwner("watch-a", "attempt-b", 2L)
@@ -409,9 +341,7 @@ class WearRealtimeTalkControllerTest {
       val oldToolResponse = CompletableDeferred<String>()
       var createCount = 0
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { method, _, _ ->
             gatewayMethods += method
             when (method) {
@@ -426,8 +356,6 @@ class WearRealtimeTalkControllerTest {
               else -> """{"ok":true}"""
             }
           },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
         )
       val staleOwner = WearRealtimeAttemptOwner("watch-a", "attempt-a", 1L)
       val replacementOwner = WearRealtimeAttemptOwner("watch-a", "attempt-b", 2L)
@@ -475,9 +403,7 @@ class WearRealtimeTalkControllerTest {
     runTest {
       val createParams = mutableListOf<String?>()
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { method, params, _ ->
             if (method != "talk.session.create") {
               """{"ok":true}"""
@@ -495,17 +421,10 @@ class WearRealtimeTalkControllerTest {
               """{"relaySessionId":"relay-legacy"}"""
             }
           },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
         )
 
       assertTrue(
-        controller.start(
-          nodeId = "watch-a",
-          sessionKey = "session-a",
-          attemptId = "attempt-a",
-          language = "de",
-        ),
+        controller.start("watch-a", "session-a", "attempt-a", "de"),
       )
 
       assertEquals(2, createParams.size)
@@ -521,9 +440,7 @@ class WearRealtimeTalkControllerTest {
     runTest {
       var createAttempts = 0
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { method, _, _ ->
             if (method == "talk.session.create") {
               createAttempts += 1
@@ -536,17 +453,10 @@ class WearRealtimeTalkControllerTest {
             }
             """{"ok":true}"""
           },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
         )
 
       assertFalse(
-        controller.start(
-          nodeId = "watch-a",
-          sessionKey = "session-a",
-          attemptId = "attempt-a",
-          language = "de",
-        ),
+        controller.start("watch-a", "session-a", "attempt-a", "de"),
       )
       assertEquals(1, createAttempts)
     }
@@ -556,9 +466,7 @@ class WearRealtimeTalkControllerTest {
     runTest {
       val gatewayCalls = mutableListOf<Pair<String, String?>>()
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { method, params, _ ->
             gatewayCalls += method to params
             when (method) {
@@ -567,16 +475,9 @@ class WearRealtimeTalkControllerTest {
               else -> """{"ok":true}"""
             }
           },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
         )
       assertTrue(
-        controller.start(
-          nodeId = "watch-a",
-          sessionKey = "session-a",
-          attemptId = "attempt-a",
-          language = "de",
-        ),
+        controller.start("watch-a", "session-a", "attempt-a", "de"),
       )
 
       controller.handleGatewayEvent(
@@ -646,9 +547,7 @@ class WearRealtimeTalkControllerTest {
       val toolCallResponse = CompletableDeferred<String>()
       val submittedResults = mutableListOf<String>()
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { method, params, _ ->
             when (method) {
               "talk.session.create" -> """{"relaySessionId":"relay-1"}"""
@@ -660,16 +559,9 @@ class WearRealtimeTalkControllerTest {
               else -> """{"ok":true}"""
             }
           },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
         )
       assertTrue(
-        controller.start(
-          nodeId = "watch-a",
-          sessionKey = "session-a",
-          attemptId = "attempt-a",
-          language = null,
-        ),
+        controller.start("watch-a", "session-a", "attempt-a", null),
       )
 
       controller.handleGatewayEvent(
@@ -701,9 +593,7 @@ class WearRealtimeTalkControllerTest {
     runTest {
       val gatewayCalls = mutableListOf<Pair<String, String?>>()
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { method, params, _ ->
             gatewayCalls += method to params
             when (method) {
@@ -712,16 +602,9 @@ class WearRealtimeTalkControllerTest {
               else -> """{"ok":true}"""
             }
           },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
         )
       assertTrue(
-        controller.start(
-          nodeId = "watch-a",
-          sessionKey = "session-a",
-          attemptId = "attempt-a",
-          language = null,
-        ),
+        controller.start("watch-a", "session-a", "attempt-a", null),
       )
 
       controller.handleGatewayEvent(
@@ -754,26 +637,11 @@ class WearRealtimeTalkControllerTest {
     runTest {
       val output = mutableListOf<Pair<WearRealtimeAudioFrameType, ByteArray>>()
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
-          requestGateway = { method, _, _ ->
-            if (method == "talk.session.create") {
-              """{"relaySessionId":"relay-1"}"""
-            } else {
-              """{"ok":true}"""
-            }
-          },
-          sendGatewayFrame = { _, _, _, _ -> },
+        testTalkController(
           sendWatchFrame = { _, type, payload -> output += type to payload },
         )
       assertTrue(
-        controller.start(
-          nodeId = "watch-a",
-          sessionKey = "session-a",
-          attemptId = "attempt-a",
-          language = "de",
-        ),
+        controller.start("watch-a", "session-a", "attempt-a", "de"),
       )
       val audio =
         ByteArray(WearProtocol.MAX_REALTIME_AUDIO_FRAME_BYTES * 2 + 8) { index ->
@@ -821,17 +689,7 @@ class WearRealtimeTalkControllerTest {
     runTest {
       val output = mutableListOf<ByteArray>()
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
-          requestGateway = { method, _, _ ->
-            if (method == "talk.session.create") {
-              """{"relaySessionId":"relay-1"}"""
-            } else {
-              """{"ok":true}"""
-            }
-          },
-          sendGatewayFrame = { _, _, _, _ -> },
+        testTalkController(
           sendWatchFrame = { _, type, payload ->
             if (type == WearRealtimeAudioFrameType.OUTPUT_PCM) output += payload
           },
@@ -866,13 +724,7 @@ class WearRealtimeTalkControllerTest {
       val output = mutableListOf<ByteArray>()
       lateinit var controller: WearRealtimeTalkController
       controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
-          requestGateway = { method, _, _ ->
-            if (method == "talk.session.create") """{"relaySessionId":"relay-1"}""" else """{"ok":true}"""
-          },
-          sendGatewayFrame = { _, _, _, _ -> },
+        testTalkController(
           sendWatchFrame = { _, type, payload ->
             if (type == WearRealtimeAudioFrameType.OUTPUT_PCM) {
               output += payload
@@ -906,13 +758,7 @@ class WearRealtimeTalkControllerTest {
       val releaseOutput = CompletableDeferred<Unit>()
       val forcedChannelCloses = mutableListOf<String>()
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
-          requestGateway = { method, _, _ ->
-            if (method == "talk.session.create") """{"relaySessionId":"relay-1"}""" else """{"ok":true}"""
-          },
-          sendGatewayFrame = { _, _, _, _ -> },
+        testTalkController(
           sendWatchFrame = { _, type, _ ->
             if (type == WearRealtimeAudioFrameType.OUTPUT_PCM) {
               outputStarted.complete(Unit)
@@ -947,18 +793,7 @@ class WearRealtimeTalkControllerTest {
     runTest {
       val forcedChannelCloses = mutableListOf<String>()
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
-          requestGateway = { method, _, _ ->
-            if (method == "talk.session.create") {
-              """{"relaySessionId":"relay-1"}"""
-            } else {
-              """{"ok":true}"""
-            }
-          },
-          sendGatewayFrame = { _, _, _, _ -> },
-          sendWatchFrame = { _, _, _ -> },
+        testTalkController(
           onForceCloseWatchChannel = { forcedChannelCloses += it.nodeId },
         )
       assertTrue(controller.start("watch-a", "session-a", "attempt-a", "de"))
@@ -978,9 +813,7 @@ class WearRealtimeTalkControllerTest {
       val gatewayMethods = mutableListOf<String>()
       val forcedChannelCloses = mutableListOf<String>()
       val controller =
-        WearRealtimeTalkController(
-          scope = this,
-          isConnected = { true },
+        testTalkController(
           requestGateway = { method, _, _ ->
             gatewayMethods += method
             if (method == "talk.session.create") {
@@ -989,17 +822,11 @@ class WearRealtimeTalkControllerTest {
               """{"ok":true}"""
             }
           },
-          sendGatewayFrame = { _, _, _, _ -> },
           sendWatchFrame = { _, _, _ -> error("wear link down") },
           onForceCloseWatchChannel = { owner -> forcedChannelCloses += owner.nodeId },
         )
       assertTrue(
-        controller.start(
-          nodeId = "watch-a",
-          sessionKey = "session-a",
-          attemptId = "attempt-a",
-          language = "de",
-        ),
+        controller.start("watch-a", "session-a", "attempt-a", "de"),
       )
 
       controller.handleGatewayEvent(
@@ -1020,6 +847,26 @@ class WearRealtimeTalkControllerTest {
       assertEquals(listOf("watch-a"), forcedChannelCloses)
     }
 }
+
+private fun CoroutineScope.testTalkController(
+  isConnected: () -> Boolean = { true },
+  requestGateway: suspend (String, String?, Long) -> String = { method, _, _ ->
+    if (method == "talk.session.create") """{"relaySessionId":"relay-1"}""" else """{"ok":true}"""
+  },
+  sendGatewayFrame: suspend (String, String?, Long, (String) -> Unit) -> Unit = { _, _, _, _ -> },
+  sendWatchFrame: suspend (WearRealtimeAttemptOwner, WearRealtimeAudioFrameType, ByteArray) -> Unit = { _, _, _ -> },
+  onSnapshot: (WearRealtimeTalkSnapshot) -> Unit = {},
+  onForceCloseWatchChannel: (WearRealtimeAttemptOwner) -> Unit = {},
+): WearRealtimeTalkController =
+  WearRealtimeTalkController(
+    scope = this,
+    isConnected = isConnected,
+    requestGateway = requestGateway,
+    sendGatewayFrame = sendGatewayFrame,
+    sendWatchFrame = sendWatchFrame,
+    onSnapshot = onSnapshot,
+    onForceCloseWatchChannel = onForceCloseWatchChannel,
+  )
 
 private suspend fun WearRealtimeTalkController.start(
   nodeId: String,

--- a/apps/android/wear/src/test/java/ai/openclaw/wear/WearProxyClientTest.kt
+++ b/apps/android/wear/src/test/java/ai/openclaw/wear/WearProxyClientTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
@@ -35,29 +36,19 @@ class WearProxyClientTest {
       lateinit var client: WearProxyClient
       var sentNode: String? = null
       client =
-        WearProxyClient.createForTests(
-          nodeResolver = WearNodeResolver { "phone-nearby" },
-          transport =
-            WearMessageTransport { nodeId, path, data ->
-              sentNode = nodeId
-              assertEquals(WearProtocol.REQUEST_PATH, path)
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              val response =
-                WearProtocolCodec.encode(
-                  WearMessage.Response(
-                    requestId = request.requestId,
-                    ok = true,
-                    result = buildJsonObject { put("connected", JsonPrimitive(true)) },
-                    eventStreamId = "stream-1",
-                    eventSequence = 12,
-                  ),
-                )
-              client.handleMessage(
-                sourceNodeId = "phone-nearby",
-                path = WearProtocol.RESPONSE_PATH,
-                data = response,
-              )
-            },
+        testProxyClient(
+          nodeResolver = { "phone-nearby" },
+          transport = { nodeId, path, data ->
+            sentNode = nodeId
+            assertEquals(WearProtocol.REQUEST_PATH, path)
+            client.respond(
+              sourceNodeId = "phone-nearby",
+              requestData = data,
+              result = buildJsonObject { put("connected", JsonPrimitive(true)) },
+              eventStreamId = "stream-1",
+              eventSequence = 12,
+            )
+          },
         )
 
       val response = client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, expectedNodeId = null)
@@ -81,25 +72,15 @@ class WearProxyClientTest {
     runTest {
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver = WearNodeResolver { "phone-nearby" },
-          transport =
-            WearMessageTransport { _, _, data ->
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              val response =
-                WearProtocolCodec.encode(
-                  WearMessage.Response(
-                    requestId = request.requestId,
-                    ok = true,
-                    result = buildJsonObject { put("connected", JsonPrimitive(true)) },
-                  ),
-                )
-              client.handleMessage(
-                sourceNodeId = "phone-nearby",
-                path = WearProtocol.RESPONSE_PATH,
-                data = response,
-              )
-            },
+        testProxyClient(
+          nodeResolver = { "phone-nearby" },
+          transport = { _, _, data ->
+            client.respond(
+              sourceNodeId = "phone-nearby",
+              requestData = data,
+              result = buildJsonObject { put("connected", JsonPrimitive(true)) },
+            )
+          },
         )
 
       val response = client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, expectedNodeId = null)
@@ -118,15 +99,14 @@ class WearProxyClientTest {
       var preferredNode = "phone-1"
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver = WearNodeResolver { preferredNode },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              val response = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true))
-              client.handleMessage("wrong-phone", WearProtocol.RESPONSE_PATH, response)
-              client.handleMessage(nodeId, WearProtocol.RESPONSE_PATH, response)
-            },
+        testProxyClient(
+          nodeResolver = { preferredNode },
+          transport = { nodeId, _, data ->
+            val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+            val response = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true))
+            client.handleMessage("wrong-phone", WearProtocol.RESPONSE_PATH, response)
+            client.handleMessage(nodeId, WearProtocol.RESPONSE_PATH, response)
+          },
         )
 
       client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, expectedNodeId = null)
@@ -147,12 +127,11 @@ class WearProxyClientTest {
       lateinit var client: WearProxyClient
       lateinit var request: WearMessage.Request
       client =
-        WearProxyClient.createForTests(
-          nodeResolver = WearNodeResolver { "phone-1" },
-          transport =
-            WearMessageTransport { _, _, data ->
-              request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-            },
+        testProxyClient(
+          nodeResolver = { "phone-1" },
+          transport = { _, _, data ->
+            request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+          },
         )
 
       client.updatePreferredPhoneNodeId("phone-1")
@@ -180,22 +159,15 @@ class WearProxyClientTest {
       var discoveries = 0
       var sentNode: String? = null
       client =
-        WearProxyClient.createForTests(
-          nodeResolver =
-            WearNodeResolver {
-              discoveries += 1
-              "different-phone"
-            },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              sentNode = nodeId
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              client.handleMessage(
-                sourceNodeId = nodeId,
-                path = WearProtocol.RESPONSE_PATH,
-                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-              )
-            },
+        testProxyClient(
+          nodeResolver = {
+            discoveries += 1
+            "different-phone"
+          },
+          transport = { nodeId, _, data ->
+            sentNode = nodeId
+            client.respond(nodeId, data)
+          },
         )
 
       val result = client.request(WearRpcMethod.ChatAbort, buildJsonObject {}, expectedNodeId = "state-phone")
@@ -210,17 +182,11 @@ class WearProxyClientTest {
     runTest {
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver = WearNodeResolver { "preferred-phone" },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              client.handleMessage(
-                sourceNodeId = nodeId,
-                path = WearProtocol.RESPONSE_PATH,
-                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-              )
-            },
+        testProxyClient(
+          nodeResolver = { "preferred-phone" },
+          transport = { nodeId, _, data ->
+            client.respond(nodeId, data)
+          },
         )
 
       client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, expectedNodeId = null)
@@ -238,22 +204,15 @@ class WearProxyClientTest {
       var discoveries = 0
       val sentNodes = mutableListOf<String>()
       client =
-        WearProxyClient.createForTests(
-          nodeResolver =
-            WearNodeResolver {
-              discoveries += 1
-              "resolver-phone"
-            },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              sentNodes += nodeId
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              client.handleMessage(
-                sourceNodeId = nodeId,
-                path = WearProtocol.RESPONSE_PATH,
-                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-              )
-            },
+        testProxyClient(
+          nodeResolver = {
+            discoveries += 1
+            "resolver-phone"
+          },
+          transport = { nodeId, _, data ->
+            sentNodes += nodeId
+            client.respond(nodeId, data)
+          },
         )
       val changed = async { client.preferredPhoneChanges.first() }
       runCurrent()
@@ -282,9 +241,9 @@ class WearProxyClientTest {
     runTest {
       var sends = 0
       val client =
-        WearProxyClient.createForTests(
-          nodeResolver = WearNodeResolver { "phone-current" },
-          transport = WearMessageTransport { _, _, _ -> sends += 1 },
+        testProxyClient(
+          nodeResolver = { "phone-current" },
+          transport = { _, _, _ -> sends += 1 },
         )
 
       val stale =
@@ -306,9 +265,9 @@ class WearProxyClientTest {
     runTest {
       var sends = 0
       val client =
-        WearProxyClient.createForTests(
-          nodeResolver = WearNodeResolver { null },
-          transport = WearMessageTransport { _, _, _ -> sends += 1 },
+        testProxyClient(
+          nodeResolver = { null },
+          transport = { _, _, _ -> sends += 1 },
         )
 
       var code: String? = null
@@ -326,9 +285,9 @@ class WearProxyClientTest {
   fun discoveryTaskCancellationUsesConnectivityError() =
     runTest {
       val client =
-        WearProxyClient.createForTests(
-          nodeResolver = WearNodeResolver { throw CancellationException("task canceled") },
-          transport = WearMessageTransport { _, _, _ -> error("must not send") },
+        testProxyClient(
+          nodeResolver = { throw CancellationException("task canceled") },
+          transport = { _, _, _ -> error("must not send") },
         )
 
       val failure = runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) }.exceptionOrNull()
@@ -340,9 +299,9 @@ class WearProxyClientTest {
   fun sendTaskCancellationUsesConnectivityError() =
     runTest {
       val client =
-        WearProxyClient.createForTests(
-          nodeResolver = WearNodeResolver { "phone-nearby" },
-          transport = WearMessageTransport { _, _, _ -> throw CancellationException("task canceled") },
+        testProxyClient(
+          nodeResolver = { "phone-nearby" },
+          transport = { _, _, _ -> throw CancellationException("task canceled") },
         )
 
       val failure = runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) }.exceptionOrNull()
@@ -357,22 +316,15 @@ class WearProxyClientTest {
       var respond = false
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver =
-            WearNodeResolver {
-              discoveries += 1
-              "resolver-phone"
-            },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              if (!respond) awaitCancellation()
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              client.handleMessage(
-                sourceNodeId = nodeId,
-                path = WearProtocol.RESPONSE_PATH,
-                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-              )
-            },
+        testProxyClient(
+          nodeResolver = {
+            discoveries += 1
+            "resolver-phone"
+          },
+          transport = { nodeId, _, data ->
+            if (!respond) awaitCancellation()
+            client.respond(nodeId, data)
+          },
         )
       client.updatePreferredPhoneNodeId("phone-current")
 
@@ -398,24 +350,17 @@ class WearProxyClientTest {
       val sentNodes = mutableListOf<String>()
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver =
-            WearNodeResolver {
-              discoveries += 1
-              resolvedNode
-            },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              sends += 1
-              sentNodes += nodeId
-              if (sends == 1) error("stale node")
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              client.handleMessage(
-                sourceNodeId = nodeId,
-                path = WearProtocol.RESPONSE_PATH,
-                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-              )
-            },
+        testProxyClient(
+          nodeResolver = {
+            discoveries += 1
+            resolvedNode
+          },
+          transport = { nodeId, _, data ->
+            sends += 1
+            sentNodes += nodeId
+            if (sends == 1) error("stale node")
+            client.respond(nodeId, data)
+          },
         )
 
       val first = runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) }.exceptionOrNull()
@@ -436,24 +381,17 @@ class WearProxyClientTest {
       var sends = 0
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver =
-            WearNodeResolver {
-              discoveries += 1
-              resolvedNode
-            },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              sends += 1
-              if (sends > 1) {
-                val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-                client.handleMessage(
-                  sourceNodeId = nodeId,
-                  path = WearProtocol.RESPONSE_PATH,
-                  data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-                )
-              }
-            },
+        testProxyClient(
+          nodeResolver = {
+            discoveries += 1
+            resolvedNode
+          },
+          transport = { nodeId, _, data ->
+            sends += 1
+            if (sends > 1) {
+              client.respond(nodeId, data)
+            }
+          },
         )
 
       val first = runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) }.exceptionOrNull()
@@ -472,26 +410,19 @@ class WearProxyClientTest {
       var sends = 0
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver =
-            WearNodeResolver {
-              discoveries += 1
-              "resolver-phone"
-            },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              sends += 1
-              if (sends == 1) {
-                client.updatePreferredPhoneNodeId(nodeId)
-                error("stale send")
-              }
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              client.handleMessage(
-                sourceNodeId = nodeId,
-                path = WearProtocol.RESPONSE_PATH,
-                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-              )
-            },
+        testProxyClient(
+          nodeResolver = {
+            discoveries += 1
+            "resolver-phone"
+          },
+          transport = { nodeId, _, data ->
+            sends += 1
+            if (sends == 1) {
+              client.updatePreferredPhoneNodeId(nodeId)
+              error("stale send")
+            }
+            client.respond(nodeId, data)
+          },
         )
       client.updatePreferredPhoneNodeId("phone-current")
 
@@ -510,26 +441,19 @@ class WearProxyClientTest {
       var sends = 0
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver =
-            WearNodeResolver {
-              discoveries += 1
-              "resolver-phone"
-            },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              sends += 1
-              if (sends == 1) {
-                client.updatePreferredPhoneNodeId(nodeId)
-              } else {
-                val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-                client.handleMessage(
-                  sourceNodeId = nodeId,
-                  path = WearProtocol.RESPONSE_PATH,
-                  data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-                )
-              }
-            },
+        testProxyClient(
+          nodeResolver = {
+            discoveries += 1
+            "resolver-phone"
+          },
+          transport = { nodeId, _, data ->
+            sends += 1
+            if (sends == 1) {
+              client.updatePreferredPhoneNodeId(nodeId)
+            } else {
+              client.respond(nodeId, data)
+            }
+          },
         )
       client.updatePreferredPhoneNodeId("phone-current")
 
@@ -548,24 +472,17 @@ class WearProxyClientTest {
       var sends = 0
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver =
-            WearNodeResolver {
-              discoveries += 1
-              "resolver-phone"
-            },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              sends += 1
-              if (sends > 1) {
-                val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-                client.handleMessage(
-                  sourceNodeId = nodeId,
-                  path = WearProtocol.RESPONSE_PATH,
-                  data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-                )
-              }
-            },
+        testProxyClient(
+          nodeResolver = {
+            discoveries += 1
+            "resolver-phone"
+          },
+          transport = { nodeId, _, data ->
+            sends += 1
+            if (sends > 1) {
+              client.respond(nodeId, data)
+            }
+          },
         )
       client.updatePreferredPhoneNodeId("phone-current")
 
@@ -588,24 +505,22 @@ class WearProxyClientTest {
       val requests = mutableListOf<WearMessage.Request>()
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver =
-            WearNodeResolver {
-              discoveries += 1
-              "resolver-phone"
-            },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              requests += request
-              if (respond) {
-                client.handleMessage(
-                  sourceNodeId = nodeId,
-                  path = WearProtocol.RESPONSE_PATH,
-                  data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-                )
-              }
-            },
+        testProxyClient(
+          nodeResolver = {
+            discoveries += 1
+            "resolver-phone"
+          },
+          transport = { nodeId, _, data ->
+            val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
+            requests += request
+            if (respond) {
+              client.handleMessage(
+                sourceNodeId = nodeId,
+                path = WearProtocol.RESPONSE_PATH,
+                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
+              )
+            }
+          },
         )
       client.updatePreferredPhoneNodeId("phone-current")
 
@@ -635,21 +550,14 @@ class WearProxyClientTest {
       var discoveries = 0
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver =
-            WearNodeResolver {
-              discoveries += 1
-              "phone-reachable"
-            },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              client.handleMessage(
-                sourceNodeId = nodeId,
-                path = WearProtocol.RESPONSE_PATH,
-                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-              )
-            },
+        testProxyClient(
+          nodeResolver = {
+            discoveries += 1
+            "phone-reachable"
+          },
+          transport = { nodeId, _, data ->
+            client.respond(nodeId, data)
+          },
         )
       client.updatePreferredPhoneNodeId("phone-stale")
 
@@ -670,27 +578,20 @@ class WearProxyClientTest {
       val sentNodes = mutableListOf<String>()
       lateinit var client: WearProxyClient
       client =
-        WearProxyClient.createForTests(
-          nodeResolver =
-            WearNodeResolver {
-              val result = resolvedNode
-              discoveries += 1
-              if (discoveries == 1) {
-                discoveryStarted.complete(Unit)
-                releaseDiscovery.await()
-              }
-              result
-            },
-          transport =
-            WearMessageTransport { nodeId, _, data ->
-              sentNodes += nodeId
-              val request = (WearProtocolCodec.decode(data) as WearDecodeResult.Success).message as WearMessage.Request
-              client.handleMessage(
-                sourceNodeId = nodeId,
-                path = WearProtocol.RESPONSE_PATH,
-                data = WearProtocolCodec.encode(WearMessage.Response(requestId = request.requestId, ok = true)),
-              )
-            },
+        testProxyClient(
+          nodeResolver = {
+            val result = resolvedNode
+            discoveries += 1
+            if (discoveries == 1) {
+              discoveryStarted.complete(Unit)
+              releaseDiscovery.await()
+            }
+            result
+          },
+          transport = { nodeId, _, data ->
+            sentNodes += nodeId
+            client.respond(nodeId, data)
+          },
         )
 
       val first = async { runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) } }
@@ -907,9 +808,9 @@ class WearProxyClientTest {
   fun requestDeadlineIncludesPhoneDiscovery() =
     runTest {
       val client =
-        WearProxyClient.createForTests(
-          nodeResolver = WearNodeResolver { awaitCancellation() },
-          transport = WearMessageTransport { _, _, _ -> error("must not send") },
+        testProxyClient(
+          nodeResolver = { awaitCancellation() },
+          transport = { _, _, _ -> error("must not send") },
         )
 
       val failure =
@@ -925,13 +826,46 @@ class WearProxyClientTest {
   fun discoveryFailureUsesConnectivityError() =
     runTest {
       val client =
-        WearProxyClient.createForTests(
-          nodeResolver = WearNodeResolver { error("Play services failed") },
-          transport = WearMessageTransport { _, _, _ -> error("must not send") },
+        testProxyClient(
+          nodeResolver = { error("Play services failed") },
+          transport = { _, _, _ -> error("must not send") },
         )
 
       val failure = runCatching { client.request(WearRpcMethod.ProxyStatus, buildJsonObject {}, null) }.exceptionOrNull()
 
       assertEquals("phone_unavailable", (failure as WearProxyException).code)
     }
+}
+
+private fun testProxyClient(
+  nodeResolver: suspend () -> String?,
+  transport: suspend (String, String, ByteArray) -> Unit,
+): WearProxyClient =
+  WearProxyClient.createForTests(
+    nodeResolver = WearNodeResolver(nodeResolver),
+    transport = WearMessageTransport(transport),
+  )
+
+private suspend fun WearProxyClient.respond(
+  sourceNodeId: String,
+  requestData: ByteArray,
+  result: JsonElement? = null,
+  eventStreamId: String? = null,
+  eventSequence: Long? = null,
+) {
+  val request = (WearProtocolCodec.decode(requestData) as WearDecodeResult.Success).message as WearMessage.Request
+  handleMessage(
+    sourceNodeId = sourceNodeId,
+    path = WearProtocol.RESPONSE_PATH,
+    data =
+      WearProtocolCodec.encode(
+        WearMessage.Response(
+          requestId = request.requestId,
+          ok = true,
+          result = result,
+          eventStreamId = eventStreamId,
+          eventSequence = eventSequence,
+        ),
+      ),
+  )
 }


### PR DESCRIPTION
## What Problem This Solves

The Wear transport suites repeated controller, registry, coroutine-scope, node-resolution, and response-correlation setup across 79 lifecycle-sensitive tests. That duplication made future test changes noisier and increased the chance that sibling scenarios would drift apart.

## Why This Change Was Made

This maintainer-requested cleanup gives each suite one canonical fixture boundary while leaving every scenario, assertion, cancellation gate, source-node check, and cleanup finalizer in place. It removes 301 net test lines across three files with zero production, configuration, protocol, schema, or user-visible changes.

## User Impact

No user-visible behavior changes. Android and Wear maintainers get smaller fixtures while preserving all existing transport, pairing, cancellation, stale-owner, and privacy coverage.

AI-assisted: yes. I reviewed the production owners, callers, history, kotlinx-coroutines 1.11 contracts, and Play Services Wearable 20.0.1 contracts before changing the fixtures.

## Evidence

- Exact parity against the base: 79 test titles and 287 assertion calls unchanged
  - Talk controller: 22 tests / 111 assertions
  - Channel registry: 22 tests / 64 assertions
  - Proxy client: 35 tests / 112 assertions
- Blacksmith Testbox full Android matrix: `BUILD SUCCESSFUL` (292 tasks)
  - Play and third-party phone unit tests
  - Wear and Wear-shared unit tests
  - Play and third-party APK assembly and Android lint
  - Wear, Wear-shared, and benchmark assembly/lint
  - app, Wear, Wear-shared, and benchmark ktlint
- Remote `node scripts/check-changed.mjs --timed -- <three paths>`: passed
- `git diff --check`: passed
- Two independent xhigh reviews: behavior-clean; exact lifecycle/privacy parity confirmed
- Structured autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings
