### PR TITLE
fix(agents): stop messaging dedupe from dropping final replies that quote a short tool send

### DIFF
--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -1104,6 +1104,17 @@ describe("isMessagingToolDuplicate", () => {
       sentTexts: ["Hello, this is a test message!"],
       expected: false,
     },
+    {
+      input:
+        "Checking the deploy logs now. The deploy failed because the migration step timed out after 300 seconds while the database was mid-vacuum, which held the lock the migration needed. I re-ran the deploy after the vacuum finished and it completed cleanly. All services are healthy and the new version is serving traffic.",
+      sentTexts: ["Checking the deploy logs now."],
+      expected: false,
+    },
+    {
+      input: "Checking the deploy logs now. All good!",
+      sentTexts: ["Checking the deploy logs now."],
+      expected: true,
+    },
   ])("returns $expected for duplicate check", ({ input, sentTexts, expected }) => {
     expect(isMessagingToolDuplicate(input, sentTexts)).toBe(expected);
   });

--- a/src/agents/embedded-agent-helpers/messaging-dedupe.ts
+++ b/src/agents/embedded-agent-helpers/messaging-dedupe.ts
@@ -4,7 +4,7 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
 const MIN_DUPLICATE_TEXT_LENGTH = 10;
-const MIN_REVERSE_SUBSTRING_DUPLICATE_RATIO = 0.5;
+const MIN_SUBSTRING_DUPLICATE_RATIO = 0.5;
 
 /**
  * Normalize text for duplicate comparison.
@@ -36,11 +36,11 @@ export function isMessagingToolDuplicateNormalized(
       return false;
     }
     if (normalized.includes(normalizedSent)) {
-      return true;
+      return normalizedSent.length >= normalized.length * MIN_SUBSTRING_DUPLICATE_RATIO;
     }
     return (
       normalizedSent.includes(normalized) &&
-      normalized.length >= normalizedSent.length * MIN_REVERSE_SUBSTRING_DUPLICATE_RATIO
+      normalized.length >= normalizedSent.length * MIN_SUBSTRING_DUPLICATE_RATIO
     );
   });
 }


### PR DESCRIPTION
## What Problem This Solves

When an agent posts a short interim update through the message tool (for example "Checking the deploy logs now.") and then restates that line at the start of its final answer, the messaging dedupe filter classifies the entire final reply as a duplicate and drops it. With block streaming off (the default), the final payload set is the only delivery of the answer, so the user receives the 29 character interim line and never sees the full reply. The text survives only in the session transcript, which a channel-only user cannot access.

Root cause is in `src/agents/embedded-agent-helpers/messaging-dedupe.ts`. The forward substring check treats any reply that contains a prior tool send as a duplicate with no length floor:

```ts
if (normalized.includes(normalizedSent)) {
  return true;
}
return (
  normalizedSent.includes(normalized) &&
  normalized.length >= normalizedSent.length * MIN_REVERSE_SUBSTRING_DUPLICATE_RATIO
);
```

The reverse direction already carries a deliberate 0.5 length ratio floor, so proportionality was reasoned about and then omitted in the forward direction. A 29 character send suppresses a 316 character reply at a 0.09 overlap ratio.

## Why This Change Was Made

Apply the same 0.5 ratio floor to the forward direction, so a reply is deduped only when the prior send covers at least half of it:

```ts
if (normalized.includes(normalizedSent)) {
  return normalizedSent.length >= normalized.length * MIN_SUBSTRING_DUPLICATE_RATIO;
}
```

This is the right boundary because every dedupe consumer routes through `isMessagingToolDuplicateNormalized`: the final payload filter (`src/auto-reply/reply/reply-payloads-dedupe.ts` via `agent-runner-payloads.ts`), the follow-up delivery filter (`src/auto-reply/reply/followup-delivery-payloads.ts`), and both streamed chunk suppression sites (`src/agents/embedded-agent-subscribe.ts`, `src/agents/embedded-agent-subscribe.handlers.messages.ts`). One fix in the shared predicate covers all of them; no sibling call site needs its own change.

Intended dedupe behavior is preserved: exact restatements (ratio 1), narrations like `I sent the message: "..."` (ratio 0.58, pinned by the existing test), and short suffix additions such as the sent text plus "All good!" (ratio 0.74) are still suppressed. Only replies with substantial content beyond the tool send are now delivered.

Closest prior art: #97513 (closed, trailing acks after tool sends) and #54061 (closed, whole-turn inline text suppression). Neither touches the substring direction asymmetry.

## User Impact

Final answers on Telegram, WhatsApp, Signal, Slack, and every other channel are no longer silently withheld when they open with or quote a short interim update the agent already sent. This was a silent failure: the user saw only the interim line with no indication anything was dropped.

## Evidence

Driving the real reply payload assembly (`buildReplyPayloads` in `src/auto-reply/reply/agent-runner-payloads.ts`, the production function the agent runner uses to build the final delivery set) with a Telegram routed turn: one 316 character final assistant reply that opens with a 29 character message-tool send recorded for the same route. No seams were replaced; the route matching, dedupe decision, and filtering are the production code paths.

Before (pristine main a8b114b3f31):

```
interim tool send: "Checking the deploy logs now." (29 chars)
final assistant reply chars: 316
delivered payload count: 0
delivered chars: 0
unique final-answer content delivered: false
```

After (this patch, identical inputs):

```
interim tool send: "Checking the deploy logs now." (29 chars)
final assistant reply chars: 316
delivered payload count: 1
delivered chars: 316
unique final-answer content delivered: true
```

Verification:

- New regression cases in `src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts`: the long reply quoting a short send must be delivered, and a short restatement plus "All good!" must still dedupe. The suite fails on pristine main (1 failed, 113 passed) and passes with the patch (114 passed).
- Adjacent suites pass: `src/auto-reply/reply/agent-runner-payloads.test.ts`, `src/auto-reply/reply/reply-payloads.test.ts`, `src/agents/embedded-agent-subscribe.handlers.messages.test.ts`.
- `scripts/run-oxlint.mjs` and `oxfmt --check` clean on both changed files.
- Not tested locally: tsgo typecheck lanes (left to CI) and a live channel send; the proof drives the payload assembly seam rather than a live Telegram bot.
