### PR TITLE
fix(agents): queued runs lose execution context under sustained load

### DIFF
--- a/src/agents/embedded-agent-runner/run/lane-controller.queue-liveness.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.queue-liveness.test.ts
@@ -1,0 +1,492 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  getAgentEventLifecycleGeneration,
+  resetAgentEventsForTest,
+  rotateAgentEventLifecycleGeneration,
+} from "../../../infra/agent-events.js";
+import {
+  getAgentRunContext,
+  readAgentRunIndexVersion,
+  registerAgentRunContext,
+  sweepStaleRunContexts,
+} from "../../../infra/agent-run-registry.js";
+import {
+  clearCommandLane,
+  getCommandLaneSnapshot,
+  setCommandLaneConcurrency,
+} from "../../../process/command-queue.js";
+import { resetCommandQueueStateForTest } from "../../../process/command-queue.test-support.js";
+import { createDeferred } from "../../../shared/deferred.js";
+import { installSessionPlacementAdmissionProvider } from "../../session-placement-admission.js";
+import type { EmbeddedAgentRunResult } from "../types.js";
+import { createEmbeddedRunLaneController } from "./lane-controller.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+
+const CONTEXT_TTL_MS = 30 * 60 * 1000;
+const SESSION_LANE = "queued-run-context-session";
+const GLOBAL_LANE = "queued-run-context-global";
+
+function createRunController(overrides: Partial<RunEmbeddedAgentParams> = {}) {
+  let lifecycleGeneration = getAgentEventLifecycleGeneration();
+  let params: RunEmbeddedAgentParams & { sessionFile: string } = {
+    lifecycleGeneration,
+    prompt: "queued run",
+    runId: "healthy-queued-run",
+    sessionFile: "/tmp/queued-run.jsonl",
+    sessionId: "queued-session",
+    timeoutMs: 60_000,
+    workspaceDir: "/tmp",
+    ...overrides,
+  };
+  const controller = createEmbeddedRunLaneController({
+    getLifecycleGeneration: () => lifecycleGeneration,
+    getParams: () => params,
+    globalLane: GLOBAL_LANE,
+    initialQueuedLifecycleGeneration: lifecycleGeneration,
+    sessionLane: SESSION_LANE,
+    setLifecycleGeneration: (updated) => {
+      lifecycleGeneration = updated;
+    },
+    setParams: (updated) => {
+      params = updated;
+    },
+  });
+  return { controller, params };
+}
+
+async function waitForQueuedLane(lane: string): Promise<void> {
+  for (let turn = 0; turn < 10 && getCommandLaneSnapshot(lane).queuedCount === 0; turn++) {
+    await Promise.resolve();
+  }
+  expect(getCommandLaneSnapshot(lane).queuedCount).toBe(1);
+}
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+  resetCommandQueueStateForTest();
+});
+
+afterEach(() => {
+  resetAgentEventsForTest();
+  resetCommandQueueStateForTest();
+  vi.restoreAllMocks();
+});
+
+describe("queued embedded run context liveness", () => {
+  test.each([
+    { blockedLane: SESSION_LANE, queue: "session" },
+    { blockedLane: GLOBAL_LANE, queue: "global" },
+  ])(
+    "retains a healthy run past the context TTL while the $queue lane is full",
+    async ({ blockedLane }) => {
+      const registeredAt = 1_000;
+      const admissionAt = registeredAt + CONTEXT_TTL_MS + 1;
+      const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+      const lifecycleGeneration = getAgentEventLifecycleGeneration();
+      const { controller, params } = createRunController();
+
+      registerAgentRunContext(params.runId, {
+        agentId: "main",
+        isControlUiVisible: false,
+        lifecycleGeneration,
+        registeredAt,
+        sessionKey: "agent:main:subagent:queued",
+      });
+      registerAgentRunContext("abandoned-run", {
+        lifecycleGeneration,
+        registeredAt,
+        sessionKey: "agent:main:subagent:abandoned",
+      });
+      setCommandLaneConcurrency(blockedLane, 0);
+
+      const run = controller.enqueueSession(() =>
+        controller.enqueueGlobal(async () => ({}) as EmbeddedAgentRunResult),
+      );
+
+      try {
+        await waitForQueuedLane(blockedLane);
+
+        clock.mockReturnValue(admissionAt);
+        expect(sweepStaleRunContexts()).toBe(1);
+        expect(getAgentRunContext("abandoned-run")).toBeUndefined();
+        expect(getAgentRunContext(params.runId)).toMatchObject({ lifecycleGeneration });
+
+        setCommandLaneConcurrency(blockedLane, 1);
+        await run;
+        expect(getAgentRunContext(params.runId)).toMatchObject({
+          agentId: "main",
+          isControlUiVisible: false,
+          lastActiveAt: admissionAt,
+          registeredAt,
+          sessionKey: "agent:main:subagent:queued",
+        });
+
+        clock.mockReturnValue(admissionAt + CONTEXT_TTL_MS);
+        expect(sweepStaleRunContexts()).toBe(0);
+
+        clock.mockReturnValue(admissionAt + CONTEXT_TTL_MS + 1);
+        expect(sweepStaleRunContexts()).toBe(1);
+        expect(getAgentRunContext(params.runId)).toBeUndefined();
+      } finally {
+        setCommandLaneConcurrency(blockedLane, 1);
+        await run.catch(() => {});
+      }
+    },
+  );
+
+  test("retains context past the TTL while worker placement admission is pending", async () => {
+    const registeredAt = 1_000;
+    const admissionAt = registeredAt + CONTEXT_TTL_MS + 1;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+    const { controller, params } = createRunController();
+    registerAgentRunContext(params.runId, {
+      agentId: "main",
+      isControlUiVisible: false,
+      lifecycleGeneration: params.lifecycleGeneration,
+      registeredAt,
+      sessionKey: "agent:main:subagent:queued",
+    });
+
+    let admitPlacement: (() => void) | undefined;
+    let markPlacementEntered: (() => void) | undefined;
+    const placementAdmission = new Promise<void>((resolve) => {
+      admitPlacement = resolve;
+    });
+    const placementEntered = new Promise<void>((resolve) => {
+      markPlacementEntered = resolve;
+    });
+    const uninstallPlacement = installSessionPlacementAdmissionProvider({
+      executeLocalTurn: async (_claim, runLocal) => await runLocal(),
+      executeTurn: async (_claim, _params, runLocal) => {
+        markPlacementEntered?.();
+        await placementAdmission;
+        return await runLocal();
+      },
+    });
+    const run = controller.enqueueSession(() =>
+      controller.enqueueGlobal(async () => ({}) as EmbeddedAgentRunResult),
+    );
+
+    try {
+      await placementEntered;
+      expect(getCommandLaneSnapshot(GLOBAL_LANE).activeCount).toBe(1);
+
+      clock.mockReturnValue(admissionAt);
+      expect(sweepStaleRunContexts()).toBe(0);
+      expect(getAgentRunContext(params.runId)).toMatchObject({
+        agentId: "main",
+        isControlUiVisible: false,
+        registeredAt,
+        sessionKey: "agent:main:subagent:queued",
+      });
+
+      admitPlacement?.();
+      await run;
+      expect(getAgentRunContext(params.runId)).toMatchObject({
+        agentId: "main",
+        isControlUiVisible: false,
+        lastActiveAt: admissionAt,
+        registeredAt,
+        sessionKey: "agent:main:subagent:queued",
+      });
+
+      clock.mockReturnValue(admissionAt + CONTEXT_TTL_MS + 1);
+      expect(sweepStaleRunContexts()).toBe(1);
+      expect(getAgentRunContext(params.runId)).toBeUndefined();
+    } finally {
+      admitPlacement?.();
+      uninstallPlacement();
+      await run.catch(() => {});
+    }
+  });
+
+  test("releases remote queue ownership at worker admission, not after worker completion", async () => {
+    const registeredAt = 1_000;
+    const admissionAt = registeredAt + CONTEXT_TTL_MS + 1;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+    const { controller, params } = createRunController();
+    registerAgentRunContext(params.runId, {
+      lifecycleGeneration: params.lifecycleGeneration,
+      registeredAt,
+      sessionKey: "agent:main:subagent:queued",
+    });
+    const versionBeforeQueue = readAgentRunIndexVersion();
+
+    const placementEntered = createDeferred();
+    const placementAdmitted = createDeferred();
+    const remoteStarted = createDeferred();
+    const remoteFinished = createDeferred();
+    const localTurn = vi.fn(async () => ({}) as EmbeddedAgentRunResult);
+    const uninstallPlacement = installSessionPlacementAdmissionProvider({
+      executeLocalTurn: async (_claim, runLocal) => await runLocal(),
+      executeTurn: async (_claim, _params, _runLocal, onAdmitted) => {
+        placementEntered.resolve();
+        await placementAdmitted.promise;
+        onAdmitted?.();
+        remoteStarted.resolve();
+        await remoteFinished.promise;
+        return { meta: { durationMs: 1 } };
+      },
+    });
+    const run = controller.enqueueSession(() => controller.enqueueGlobal(localTurn));
+
+    try {
+      await placementEntered.promise;
+      expect(readAgentRunIndexVersion()).toBe(versionBeforeQueue);
+      clock.mockReturnValue(admissionAt);
+      expect(sweepStaleRunContexts()).toBe(0);
+      expect(getAgentRunContext(params.runId)).toBeDefined();
+
+      placementAdmitted.resolve();
+      await remoteStarted.promise;
+      expect(getAgentRunContext(params.runId)?.lastActiveAt).toBe(admissionAt);
+      expect(readAgentRunIndexVersion()).toBe(versionBeforeQueue + 1);
+      expect(localTurn).not.toHaveBeenCalled();
+
+      clock.mockReturnValue(admissionAt + CONTEXT_TTL_MS + 1);
+      expect(sweepStaleRunContexts()).toBe(1);
+      expect(getAgentRunContext(params.runId)).toBeUndefined();
+      expect(getCommandLaneSnapshot(GLOBAL_LANE).activeCount).toBe(1);
+
+      remoteFinished.resolve();
+      await run;
+    } finally {
+      placementAdmitted.resolve();
+      remoteFinished.resolve();
+      uninstallPlacement();
+      await run.catch(() => {});
+    }
+  });
+
+  test.each([
+    { blockedLane: SESSION_LANE, queue: "session" },
+    { blockedLane: GLOBAL_LANE, queue: "global" },
+  ])(
+    "releases $queue queue ownership immediately when a waiting run is aborted",
+    async ({ blockedLane }) => {
+      const registeredAt = 1_000;
+      const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+      const abort = new AbortController();
+      const { controller, params } = createRunController({ abortSignal: abort.signal });
+      registerAgentRunContext(params.runId, {
+        lifecycleGeneration: params.lifecycleGeneration,
+        registeredAt,
+      });
+      setCommandLaneConcurrency(blockedLane, 0);
+      const run = controller.enqueueSession(() =>
+        controller.enqueueGlobal(async () => ({}) as EmbeddedAgentRunResult),
+      );
+
+      try {
+        await waitForQueuedLane(blockedLane);
+        clock.mockReturnValue(registeredAt + CONTEXT_TTL_MS + 1);
+        expect(sweepStaleRunContexts()).toBe(0);
+
+        abort.abort(new Error("queued run canceled"));
+        expect(getCommandLaneSnapshot(blockedLane).queuedCount).toBe(1);
+        expect(sweepStaleRunContexts()).toBe(1);
+        expect(getAgentRunContext(params.runId)).toBeUndefined();
+
+        setCommandLaneConcurrency(blockedLane, 1);
+        await expect(run).rejects.toThrow("queued run canceled");
+      } finally {
+        setCommandLaneConcurrency(blockedLane, 1);
+        await run.catch(() => {});
+      }
+    },
+  );
+
+  test.each([
+    { blockedLane: SESSION_LANE, queue: "session" },
+    { blockedLane: GLOBAL_LANE, queue: "global" },
+  ])(
+    "releases $queue queue ownership when pending lane work is cleared",
+    async ({ blockedLane }) => {
+      const registeredAt = 1_000;
+      const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+      const { controller, params } = createRunController();
+      registerAgentRunContext(params.runId, {
+        lifecycleGeneration: params.lifecycleGeneration,
+        registeredAt,
+      });
+      setCommandLaneConcurrency(blockedLane, 0);
+      const run = controller.enqueueSession(() =>
+        controller.enqueueGlobal(async () => ({}) as EmbeddedAgentRunResult),
+      );
+
+      await waitForQueuedLane(blockedLane);
+      clock.mockReturnValue(registeredAt + CONTEXT_TTL_MS + 1);
+      expect(sweepStaleRunContexts()).toBe(0);
+
+      expect(clearCommandLane(blockedLane)).toBe(1);
+      await expect(run).rejects.toThrow();
+      expect(sweepStaleRunContexts()).toBe(1);
+      expect(getAgentRunContext(params.runId)).toBeUndefined();
+    },
+  );
+
+  test("releases ownership when a custom queue rejects admission synchronously", () => {
+    const registeredAt = 1_000;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+    const { controller, params } = createRunController({
+      enqueue: () => {
+        throw new Error("custom lane rejected admission");
+      },
+    });
+    registerAgentRunContext(params.runId, {
+      lifecycleGeneration: params.lifecycleGeneration,
+      registeredAt,
+    });
+
+    expect(() =>
+      controller.enqueueSession(() =>
+        controller.enqueueGlobal(async () => ({}) as EmbeddedAgentRunResult),
+      ),
+    ).toThrow("custom lane rejected admission");
+
+    clock.mockReturnValue(registeredAt + CONTEXT_TTL_MS + 1);
+    expect(sweepStaleRunContexts()).toBe(1);
+    expect(getAgentRunContext(params.runId)).toBeUndefined();
+  });
+
+  test.each(["local", "remote"] as const)(
+    "rebinds queued foreground %s work after its retired context expires",
+    async (execution) => {
+      const registeredAt = 1_000;
+      const admissionAt = registeredAt + CONTEXT_TTL_MS + 1;
+      const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+      const { controller, params } = createRunController({ trigger: "user" });
+      registerAgentRunContext(params.runId, {
+        lifecycleGeneration: params.lifecycleGeneration,
+        registeredAt,
+      });
+      const localTurn = vi.fn(async () => ({}) as EmbeddedAgentRunResult);
+      const uninstallPlacement =
+        execution === "remote"
+          ? installSessionPlacementAdmissionProvider({
+              executeLocalTurn: async (_claim, runLocal) => await runLocal(),
+              executeTurn: async (_claim, _params, _runLocal, onAdmitted) => {
+                onAdmitted?.();
+                return { meta: { durationMs: 1 } };
+              },
+            })
+          : undefined;
+      setCommandLaneConcurrency(GLOBAL_LANE, 0);
+      const run = controller.enqueueSession(() => controller.enqueueGlobal(localTurn));
+
+      try {
+        await waitForQueuedLane(GLOBAL_LANE);
+        clock.mockReturnValue(admissionAt);
+        expect(sweepStaleRunContexts()).toBe(0);
+
+        const replacementGeneration = rotateAgentEventLifecycleGeneration();
+        expect(sweepStaleRunContexts()).toBe(1);
+        expect(getAgentRunContext(params.runId)).toBeUndefined();
+        const versionBeforeAdmission = readAgentRunIndexVersion();
+
+        setCommandLaneConcurrency(GLOBAL_LANE, 1);
+        await run;
+        expect(getAgentRunContext(params.runId)).toMatchObject({
+          lifecycleGeneration: replacementGeneration,
+          lastActiveAt: admissionAt,
+          sessionId: params.sessionId,
+        });
+        expect(readAgentRunIndexVersion()).toBe(versionBeforeAdmission + 1);
+        expect(localTurn).toHaveBeenCalledTimes(execution === "local" ? 1 : 0);
+
+        clock.mockReturnValue(admissionAt + CONTEXT_TTL_MS);
+        expect(sweepStaleRunContexts()).toBe(0);
+      } finally {
+        setCommandLaneConcurrency(GLOBAL_LANE, 1);
+        uninstallPlacement?.();
+        await run.catch(() => {});
+      }
+    },
+  );
+
+  test.each(["local", "remote"] as const)(
+    "rejects %s execution when its lifecycle rotates during placement admission",
+    async (execution) => {
+      const registeredAt = 1_000;
+      const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+      const { controller, params } = createRunController({ trigger: "user" });
+      registerAgentRunContext(params.runId, {
+        lifecycleGeneration: params.lifecycleGeneration,
+        registeredAt,
+        sessionKey: "agent:main:original",
+      });
+      const placementEntered = createDeferred();
+      const resumePlacement = createDeferred();
+      const localTurn = vi.fn(async () => ({}) as EmbeddedAgentRunResult);
+      const uninstallPlacement = installSessionPlacementAdmissionProvider({
+        executeLocalTurn: async (_claim, runLocal) => await runLocal(),
+        executeTurn: async (_claim, _params, runLocal, onAdmitted) => {
+          placementEntered.resolve();
+          await resumePlacement.promise;
+          if (execution === "remote") {
+            onAdmitted?.();
+            return { meta: { durationMs: 1 } };
+          }
+          return await runLocal();
+        },
+      });
+      const run = controller.enqueueSession(() => controller.enqueueGlobal(localTurn));
+
+      try {
+        await placementEntered.promise;
+        clock.mockReturnValue(registeredAt + CONTEXT_TTL_MS + 1);
+        const replacementGeneration = rotateAgentEventLifecycleGeneration();
+        expect(sweepStaleRunContexts()).toBe(1);
+        registerAgentRunContext(params.runId, {
+          lifecycleGeneration: replacementGeneration,
+          registeredAt: Date.now(),
+          sessionId: "replacement-session",
+          sessionKey: "agent:main:replacement",
+        });
+        const versionBeforeRejectedAdmission = readAgentRunIndexVersion();
+
+        resumePlacement.resolve();
+        await expect(run).rejects.toThrow("stale gateway lifecycle");
+        expect(getAgentRunContext(params.runId)).toMatchObject({
+          lifecycleGeneration: replacementGeneration,
+          sessionId: "replacement-session",
+          sessionKey: "agent:main:replacement",
+        });
+        expect(readAgentRunIndexVersion()).toBe(versionBeforeRejectedAdmission);
+        expect(localTurn).not.toHaveBeenCalled();
+      } finally {
+        resumePlacement.resolve();
+        uninstallPlacement();
+        await run.catch(() => {});
+      }
+    },
+  );
+
+  test("rejects queued background work from a retired lifecycle", async () => {
+    const registeredAt = 1_000;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+    const { controller, params } = createRunController({ trigger: "cron" });
+    registerAgentRunContext(params.runId, {
+      lifecycleGeneration: params.lifecycleGeneration,
+      registeredAt,
+    });
+    setCommandLaneConcurrency(GLOBAL_LANE, 0);
+    const run = controller.enqueueSession(() =>
+      controller.enqueueGlobal(async () => ({}) as EmbeddedAgentRunResult),
+    );
+
+    try {
+      await waitForQueuedLane(GLOBAL_LANE);
+      rotateAgentEventLifecycleGeneration();
+      clock.mockReturnValue(registeredAt + CONTEXT_TTL_MS + 1);
+      expect(sweepStaleRunContexts()).toBe(1);
+
+      setCommandLaneConcurrency(GLOBAL_LANE, 1);
+      await expect(run).rejects.toThrow("stale gateway lifecycle");
+      expect(getAgentRunContext(params.runId)).toBeUndefined();
+    } finally {
+      setCommandLaneConcurrency(GLOBAL_LANE, 1);
+      await run.catch(() => {});
+    }
+  });
+});

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -3,7 +3,11 @@ import {
   getAgentEventLifecycleGeneration,
   withAgentRunLifecycleGeneration,
 } from "../../../infra/agent-events.js";
-import { claimAgentRunContext, getAgentRunContext } from "../../../infra/agent-run-registry.js";
+import {
+  claimAgentRunContext,
+  getAgentRunContext,
+  retainQueuedAgentRunContext,
+} from "../../../infra/agent-run-registry.js";
 import { enqueueCommandInLane, getCommandLaneSnapshot } from "../../../process/command-queue.js";
 import type { CommandQueueEnqueueOptions } from "../../../process/command-queue.types.js";
 import { withSessionPlacementTurnAdmission } from "../../session-placement-admission.js";
@@ -40,6 +44,17 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
   const laneTaskAbortController = new AbortController();
   const laneTaskReleaseController = new AbortController();
   let laneTaskProgressAtMs = Date.now();
+  let releaseQueuedRunContext: ReturnType<typeof retainQueuedAgentRunContext>;
+  let queuedRunAbortSignal: AbortSignal | undefined;
+
+  const releaseQueuedContext = (outcome: "admitted" | "abandoned") => {
+    queuedRunAbortSignal?.removeEventListener("abort", abandonQueuedContext);
+    queuedRunAbortSignal = undefined;
+    releaseQueuedRunContext?.(outcome);
+  };
+  const abandonQueuedContext = () => {
+    releaseQueuedContext("abandoned");
+  };
 
   const noteLaneTaskProgress = () => {
     laneTaskProgressAtMs = Date.now();
@@ -147,14 +162,19 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
             runId: params.runId,
           },
           params,
+          task,
           () => {
+            throwIfAborted();
+            assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+            releaseQueuedContext("admitted");
+            // Queue-stage rotation may rebind, but placement admitted into a retired runtime must fail.
             claimAgentRunContext(params.runId, {
               ...existingContext,
               sessionKey: params.sessionKey ?? existingContext?.sessionKey,
               sessionId: params.sessionId ?? existingContext?.sessionId,
               lifecycleGeneration,
+              lastActiveAt: Date.now(),
             });
-            return task();
           },
         ),
       );
@@ -177,15 +197,38 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
       return task();
     };
     const params = options.getParams();
-    if (params.enqueue) {
-      return params.enqueue(taskWithLaneAdmission, withRunLaneWait(sessionOpts));
-    }
-    noteLaneWaitIfBusy(options.sessionLane);
-    return enqueueCommandInLane(
-      options.sessionLane,
-      taskWithLaneAdmission,
-      withRunLaneWait(sessionOpts),
+    // Session admission, deferred maintenance, and global admission share one queue owner.
+    releaseQueuedRunContext = retainQueuedAgentRunContext(
+      params.runId,
+      options.getLifecycleGeneration(),
     );
+    if (releaseQueuedRunContext && params.abortSignal) {
+      if (params.abortSignal.aborted) {
+        releaseQueuedContext("abandoned");
+      } else {
+        queuedRunAbortSignal = params.abortSignal;
+        queuedRunAbortSignal.addEventListener("abort", abandonQueuedContext, { once: true });
+      }
+    }
+    let queuedRun: Promise<T>;
+    try {
+      if (params.enqueue) {
+        queuedRun = params.enqueue(taskWithLaneAdmission, withRunLaneWait(sessionOpts));
+      } else {
+        noteLaneWaitIfBusy(options.sessionLane);
+        queuedRun = enqueueCommandInLane(
+          options.sessionLane,
+          taskWithLaneAdmission,
+          withRunLaneWait(sessionOpts),
+        );
+      }
+    } catch (error) {
+      releaseQueuedContext("abandoned");
+      throw error;
+    }
+    return queuedRun.finally(() => {
+      releaseQueuedContext("abandoned");
+    });
   };
 
   return {

--- a/src/agents/session-placement-admission.test.ts
+++ b/src/agents/session-placement-admission.test.ts
@@ -62,18 +62,26 @@ describe("local turn placement admission", () => {
         events.push("turn");
         return { meta: { durationMs: 1 } };
       },
+      () => events.push("admitted"),
     );
 
     expect(result.meta.durationMs).toBe(1);
-    expect(events).toEqual(["claim", "turn", "release"]);
+    expect(events).toEqual(["claim", "admitted", "turn", "release"]);
   });
 
   it("does not start a local turn when the provider routes remotely", async () => {
     const turn = vi.fn(async () => ({ meta: { durationMs: 1 } }));
-    const executeTurn = vi.fn<SessionPlacementAdmissionProvider["executeTurn"]>(async () => ({
-      payloads: [{ text: "remote" }],
-      meta: { durationMs: 2 },
-    }));
+    const onAdmitted = vi.fn();
+    const executeTurn = vi.fn<SessionPlacementAdmissionProvider["executeTurn"]>(
+      async (_claim, _params, _runLocal, admitTurn) => {
+        admitTurn?.();
+        admitTurn?.();
+        return {
+          payloads: [{ text: "remote" }],
+          meta: { durationMs: 2 },
+        };
+      },
+    );
     uninstallProvider = installSessionPlacementAdmissionProvider({
       executeLocalTurn,
       executeTurn,
@@ -83,11 +91,51 @@ describe("local turn placement admission", () => {
       { sessionId: "session-2", runId: "run-2" },
       { ...turnParams, sessionId: "session-2", runId: "run-2" },
       turn,
+      onAdmitted,
     );
     expect(result.payloads).toEqual([{ text: "remote" }]);
     expect(executeTurn).toHaveBeenCalledOnce();
     expect(executeTurn.mock.calls[0]?.[0]).toEqual({ sessionId: "session-2", runId: "run-2" });
+    expect(onAdmitted).toHaveBeenCalledOnce();
     expect(turn).not.toHaveBeenCalled();
+  });
+
+  it("admits a provider-free local turn exactly once before execution", async () => {
+    const events: string[] = [];
+    await withSessionPlacementTurnAdmission(
+      { sessionId: "session-direct", runId: "run-direct" },
+      { ...turnParams, sessionId: "session-direct", runId: "run-direct" },
+      async () => {
+        events.push("turn");
+        return { meta: { durationMs: 1 } };
+      },
+      () => events.push("admitted"),
+    );
+
+    expect(events).toEqual(["admitted", "turn"]);
+  });
+
+  it("admits once when a provider signals before calling the local turn", async () => {
+    const events: string[] = [];
+    uninstallProvider = installSessionPlacementAdmissionProvider({
+      executeLocalTurn,
+      executeTurn: async (_claim, _params, runLocal, admitTurn) => {
+        admitTurn?.();
+        return await runLocal();
+      },
+    });
+
+    await withSessionPlacementTurnAdmission(
+      { sessionId: "session-once", runId: "run-once" },
+      { ...turnParams, sessionId: "session-once", runId: "run-once" },
+      async () => {
+        events.push("turn");
+        return { meta: { durationMs: 1 } };
+      },
+      () => events.push("admitted"),
+    );
+
+    expect(events).toEqual(["admitted", "turn"]);
   });
 
   it("does not resurrect a replaced provider during uninstall", async () => {

--- a/src/agents/session-placement-admission.ts
+++ b/src/agents/session-placement-admission.ts
@@ -17,6 +17,7 @@ export type SessionPlacementAdmissionProvider = {
     claim: LocalTurnPlacementClaim,
     params: SessionPlacementTurnParams,
     runLocal: () => Promise<EmbeddedAgentRunResult>,
+    onAdmitted?: () => void,
   ) => Promise<EmbeddedAgentRunResult>;
 };
 
@@ -62,12 +63,27 @@ export async function withSessionPlacementTurnAdmission(
   claim: LocalTurnPlacementClaim,
   params: SessionPlacementTurnParams,
   task: () => Promise<EmbeddedAgentRunResult>,
+  onAdmitted?: () => void,
 ): Promise<EmbeddedAgentRunResult> {
+  let admitted = false;
+  const admitTurn = () => {
+    if (admitted) {
+      return;
+    }
+    admitted = true;
+    onAdmitted?.();
+  };
+  // Providers may execute locally or remotely; both must release queue ownership
+  // only when their actual execution path has acquired its placement claim.
+  const runAdmittedLocalTurn = () => {
+    admitTurn();
+    return task();
+  };
   const provider = state.provider;
   if (!provider) {
-    return await task();
+    return await runAdmittedLocalTurn();
   }
-  return await provider.executeTurn(claim, params, task);
+  return await provider.executeTurn(claim, params, runAdmittedLocalTurn, admitTurn);
 }
 
 export async function withLocalSessionPlacementTurnAdmission<T>(

--- a/src/gateway/worker-environments/worker-turn-launcher.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmbeddedRunLaneController } from "../../agents/embedded-agent-runner/run/lane-controller.js";
+import { installSessionPlacementAdmissionProvider } from "../../agents/session-placement-admission.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
 import {
   makeAgentAssistantMessage,
@@ -11,8 +13,19 @@ import {
 import { upsertSessionEntry } from "../../config/sessions/session-accessor.js";
 import {
   type AgentEventPayload,
+  getAgentEventLifecycleGeneration,
   onAgentEvent as subscribeAgentEvent,
+  rotateAgentEventLifecycleGeneration,
 } from "../../infra/agent-events.js";
+import {
+  clearAgentRunContext,
+  getAgentRunContext,
+  readAgentRunIndexVersion,
+  registerAgentRunContext,
+  retainQueuedAgentRunContext,
+  sweepStaleRunContexts,
+} from "../../infra/agent-run-registry.js";
+import { getCommandLaneSnapshot, setCommandLaneConcurrency } from "../../process/command-queue.js";
 import { runCommandWithTimeout, type SpawnResult } from "../../process/exec.js";
 import { createDeferred } from "../../shared/deferred.js";
 import {
@@ -1791,6 +1804,21 @@ describe("worker turn launcher", () => {
   it("redispatches a reclaimed placement before launching the worker turn", async () => {
     const reclaimed = seedReclaimedPlacement();
     const runId = "run-reclaimed-worker";
+    const contextTtlMs = 30 * 60 * 1000;
+    const registeredAt = Date.now();
+    const admissionAt = registeredAt + contextTtlMs + 1;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      registeredAt,
+      sessionKey: SESSION_KEY,
+    });
+    const releaseQueuedContext = retainQueuedAgentRunContext(runId, lifecycleGeneration);
+    const redispatchEntered = createDeferred();
+    const resumeRedispatch = createDeferred();
+    const workerStarted = createDeferred();
+    const resumeWorker = createDeferred();
     let redispatchCalls = 0;
     const redispatchReclaimed: NonNullable<
       WorkerTurnLauncherOptions["redispatchReclaimed"]
@@ -1798,6 +1826,8 @@ describe("worker turn launcher", () => {
       redispatchCalls += 1;
       expect(placement).toEqual(reclaimed);
       expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
+      redispatchEntered.resolve();
+      await resumeRedispatch.promise;
       seedActivePlacement();
       const active = placements.get(SESSION_ID);
       if (active?.state !== "active") {
@@ -1806,6 +1836,8 @@ describe("worker turn launcher", () => {
       return active;
     };
     const runWorkspaceCommand = vi.fn(async (): Promise<SpawnResult> => {
+      workerStarted.resolve();
+      await resumeWorker.promise;
       expect(placements.get(SESSION_ID)).toMatchObject({
         state: "active",
         turnClaim: { owner: "worker", runId },
@@ -1874,15 +1906,53 @@ describe("worker turn launcher", () => {
       redispatchReclaimed,
     });
     const runLocal = vi.fn(async () => ({ meta: { durationMs: 1 } }));
+    const onAdmitted = vi.fn(() => {
+      expect(placements.get(SESSION_ID)).toMatchObject({
+        state: "active",
+        turnClaim: { owner: "worker", runId },
+      });
+      releaseQueuedContext?.("admitted");
+    });
     const events: AgentEventPayload[] = [];
     const unsubscribe = subscribeAgentEvent((event) => events.push(event));
-    const result = await provider
-      .executeTurn(
-        { sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main", runId },
-        turn(runId),
-        runLocal,
-      )
-      .finally(unsubscribe);
+    const pending = provider.executeTurn(
+      { sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main", runId },
+      turn(runId),
+      runLocal,
+      onAdmitted,
+    );
+    const result = await (async () => {
+      try {
+        await redispatchEntered.promise;
+        clock.mockReturnValue(admissionAt);
+        expect(sweepStaleRunContexts()).toBe(0);
+        expect(getAgentRunContext(runId)).toMatchObject({ lifecycleGeneration, registeredAt });
+        expect(onAdmitted).not.toHaveBeenCalled();
+
+        resumeRedispatch.resolve();
+        await workerStarted.promise;
+        expect(onAdmitted).toHaveBeenCalledOnce();
+        expect(getAgentRunContext(runId)?.lastActiveAt).toBe(admissionAt);
+        expect(runLocal).not.toHaveBeenCalled();
+
+        clock.mockReturnValue(admissionAt + contextTtlMs + 1);
+        expect(sweepStaleRunContexts()).toBe(1);
+        expect(getAgentRunContext(runId)).toBeUndefined();
+        expect(placements.get(SESSION_ID)?.turnClaim).toMatchObject({ owner: "worker", runId });
+
+        clock.mockReturnValue(admissionAt);
+        resumeWorker.resolve();
+        return await pending;
+      } finally {
+        resumeRedispatch.resolve();
+        resumeWorker.resolve();
+        await pending.catch(() => {});
+        unsubscribe();
+        releaseQueuedContext?.("abandoned");
+        clearAgentRunContext(runId);
+        clock.mockRestore();
+      }
+    })();
 
     expect(events).toContainEqual(
       expect.objectContaining({
@@ -1898,6 +1968,190 @@ describe("worker turn launcher", () => {
     expect(runWorkspaceCommand).toHaveBeenCalledOnce();
     expect(runLocal).not.toHaveBeenCalled();
     expect(placements.get(SESSION_ID)).toMatchObject({ state: "active", turnClaim: null });
+  });
+
+  it("releases a claimed worker turn when its admission callback fails", async () => {
+    seedActivePlacement();
+    const environments = unusedEnvironments();
+    const provider = createWorkerSessionTurnPlacementProvider({ environments, placements });
+    const runId = "run-admission-failed";
+    const runLocal = vi.fn(async () => ({ meta: { durationMs: 1 } }));
+    const onAdmitted = vi.fn(() => {
+      expect(placements.get(SESSION_ID)?.turnClaim).toMatchObject({ owner: "worker", runId });
+      throw new Error("worker admission callback failed");
+    });
+
+    await expect(
+      provider.executeTurn(
+        { sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main", runId },
+        turn(runId),
+        runLocal,
+        onAdmitted,
+      ),
+    ).rejects.toThrow("worker admission callback failed");
+
+    expect(onAdmitted).toHaveBeenCalledOnce();
+    expect(runLocal).not.toHaveBeenCalled();
+    expect(environments.startTunnel).not.toHaveBeenCalled();
+    expect(placements.get(SESSION_ID)).toMatchObject({ state: "active", turnClaim: null });
+  });
+
+  it("reclaims a rotated foreground run before an actual remote worker starts", async () => {
+    seedActivePlacement();
+    const runId = "run-rotated-worker";
+    const sessionLane = `session:${runId}`;
+    const globalLane = `global:${runId}`;
+    const registeredAt = Date.now();
+    const admissionAt = registeredAt + 30 * 60 * 1000 + 1;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+    let lifecycleGeneration = getAgentEventLifecycleGeneration();
+    let params = { ...turn(runId), lifecycleGeneration, trigger: "user" as const };
+    registerAgentRunContext(runId, { lifecycleGeneration, registeredAt, sessionKey: SESSION_KEY });
+
+    const remoteStarted = createDeferred();
+    const finishRemote = createDeferred();
+    const environments = unusedEnvironments();
+    environments.get = vi.fn(() => attachedEnvironment());
+    const provider = createWorkerSessionTurnPlacementProvider({
+      environments,
+      placements,
+      workspaceOperations: {
+        async run<T>(_environmentId: string, _operation: () => Promise<T>): Promise<T> {
+          remoteStarted.resolve();
+          await finishRemote.promise;
+          throw new Error("remote lifecycle proof completed");
+        },
+      },
+    });
+    const uninstallPlacement = installSessionPlacementAdmissionProvider(provider);
+    const controller = createEmbeddedRunLaneController({
+      getLifecycleGeneration: () => lifecycleGeneration,
+      getParams: () => params,
+      globalLane,
+      initialQueuedLifecycleGeneration: lifecycleGeneration,
+      sessionLane,
+      setLifecycleGeneration: (generation) => {
+        lifecycleGeneration = generation;
+      },
+      setParams: (next) => {
+        params = next;
+      },
+    });
+    const runLocal = vi.fn(async () => ({ meta: { durationMs: 1 } }));
+    setCommandLaneConcurrency(globalLane, 0);
+    const pending = controller.enqueueSession(() => controller.enqueueGlobal(runLocal));
+
+    try {
+      for (
+        let attempt = 0;
+        attempt < 10 && getCommandLaneSnapshot(globalLane).queuedCount === 0;
+        attempt++
+      ) {
+        await Promise.resolve();
+      }
+      expect(getCommandLaneSnapshot(globalLane).queuedCount).toBe(1);
+
+      clock.mockReturnValue(admissionAt);
+      const replacementGeneration = rotateAgentEventLifecycleGeneration();
+      expect(sweepStaleRunContexts()).toBe(1);
+      expect(getAgentRunContext(runId)).toBeUndefined();
+      const versionBeforeAdmission = readAgentRunIndexVersion();
+
+      setCommandLaneConcurrency(globalLane, 1);
+      await remoteStarted.promise;
+      expect(getAgentRunContext(runId)).toMatchObject({
+        lifecycleGeneration: replacementGeneration,
+        lastActiveAt: admissionAt,
+        sessionId: SESSION_ID,
+        sessionKey: SESSION_KEY,
+      });
+      expect(readAgentRunIndexVersion()).toBe(versionBeforeAdmission + 1);
+      expect(placements.get(SESSION_ID)?.turnClaim).toMatchObject({ owner: "worker", runId });
+      expect(runLocal).not.toHaveBeenCalled();
+
+      finishRemote.resolve();
+      await expect(pending).rejects.toThrow("remote lifecycle proof completed");
+      expect(placements.get(SESSION_ID)).toMatchObject({ state: "active", turnClaim: null });
+    } finally {
+      setCommandLaneConcurrency(globalLane, 1);
+      finishRemote.resolve();
+      uninstallPlacement();
+      await pending.catch(() => {});
+      clearAgentRunContext(runId);
+      clock.mockRestore();
+    }
+  });
+
+  it("rejects an actual worker turn when its lifecycle rotates during placement admission", async () => {
+    seedActivePlacement();
+    const runId = "run-worker-rotated-during-admission";
+    const registeredAt = Date.now();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(registeredAt);
+    let lifecycleGeneration = getAgentEventLifecycleGeneration();
+    let params = { ...turn(runId), lifecycleGeneration, trigger: "user" as const };
+    registerAgentRunContext(runId, { lifecycleGeneration, registeredAt, sessionKey: SESSION_KEY });
+
+    const workspaceResolutionStarted = createDeferred();
+    const resumeWorkspaceResolution = createDeferred();
+    const environments = unusedEnvironments();
+    const provider = createWorkerSessionTurnPlacementProvider({
+      environments,
+      placements,
+      resolveWorkspacePath: async () => {
+        workspaceResolutionStarted.resolve();
+        await resumeWorkspaceResolution.promise;
+        return root;
+      },
+    });
+    const uninstallPlacement = installSessionPlacementAdmissionProvider(provider);
+    const controller = createEmbeddedRunLaneController({
+      getLifecycleGeneration: () => lifecycleGeneration,
+      getParams: () => params,
+      globalLane: `global:${runId}`,
+      initialQueuedLifecycleGeneration: lifecycleGeneration,
+      sessionLane: `session:${runId}`,
+      setLifecycleGeneration: (generation) => {
+        lifecycleGeneration = generation;
+      },
+      setParams: (next) => {
+        params = next;
+      },
+    });
+    const runLocal = vi.fn(async () => ({ meta: { durationMs: 1 } }));
+    const pending = controller.enqueueSession(() => controller.enqueueGlobal(runLocal));
+
+    try {
+      await workspaceResolutionStarted.promise;
+      clock.mockReturnValue(registeredAt + 30 * 60 * 1000 + 1);
+      const replacementGeneration = rotateAgentEventLifecycleGeneration();
+      expect(sweepStaleRunContexts()).toBe(1);
+      registerAgentRunContext(runId, {
+        lifecycleGeneration: replacementGeneration,
+        registeredAt: Date.now(),
+        sessionId: "replacement-session",
+        sessionKey: "agent:main:replacement",
+      });
+      const versionBeforeRejectedAdmission = readAgentRunIndexVersion();
+
+      resumeWorkspaceResolution.resolve();
+      await expect(pending).rejects.toThrow("stale gateway lifecycle");
+      expect(getAgentRunContext(runId)).toMatchObject({
+        lifecycleGeneration: replacementGeneration,
+        sessionId: "replacement-session",
+        sessionKey: "agent:main:replacement",
+      });
+      expect(readAgentRunIndexVersion()).toBe(versionBeforeRejectedAdmission);
+      expect(placements.get(SESSION_ID)).toMatchObject({ state: "active", turnClaim: null });
+      expect(environments.get).not.toHaveBeenCalled();
+      expect(environments.startTunnel).not.toHaveBeenCalled();
+      expect(runLocal).not.toHaveBeenCalled();
+    } finally {
+      resumeWorkspaceResolution.resolve();
+      uninstallPlacement();
+      await pending.catch(() => {});
+      clearAgentRunContext(runId);
+      clock.mockRestore();
+    }
   });
 
   it("rejects a reclaimed placement when redispatch is unavailable", async () => {

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -572,7 +572,7 @@ export function createWorkerSessionTurnPlacementProvider(
       }
       return await executeLocalTurn({ claim, placements: options.placements, runLocal });
     },
-    async executeTurn(claim, turn, runLocal) {
+    async executeTurn(claim, turn, runLocal, onAdmitted) {
       const current = options.placements.get(claim.sessionId);
       if (
         !current &&
@@ -613,6 +613,8 @@ export function createWorkerSessionTurnPlacementProvider(
       const turnClaim = admitted.turnClaim;
       let handedOff = false;
       try {
+        // Remote turns never invoke runLocal; release queue protection only after their claim.
+        onAdmitted?.();
         const result = await executeWorkerTurn({
           environments: options.environments,
           onHandoff: () => {

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -24,6 +24,7 @@ import {
   readAgentRunIndexVersion,
   registerAgentRunContext,
   releaseAgentRunContext,
+  retainQueuedAgentRunContext,
   sweepStaleRunContexts,
 } from "./agent-run-registry.js";
 import { emitAgentRunStatusEvent } from "./agent-run-status-events.js";
@@ -1011,6 +1012,109 @@ describe("agent-events sequencing", () => {
       { runId: "run-stale", seq: 1 },
       { runId: "run-active", seq: 2 },
     ]);
+  });
+
+  test("protects only active queue leases while stale tracked and abandoned owners expire", () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(100);
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext("queued-run", { lifecycleGeneration, registeredAt: 100 });
+    registerAgentRunContext("abandoned-run", { lifecycleGeneration, registeredAt: 100 });
+    claimAgentRunContext(
+      "tracked-worker-run",
+      { lifecycleGeneration, registeredAt: 100 },
+      { exclusive: true, ownsContext: true, trackOwner: true },
+    );
+    const versionBeforeLease = readAgentRunIndexVersion();
+
+    const firstLease = retainQueuedAgentRunContext("queued-run", lifecycleGeneration);
+    const secondLease = retainQueuedAgentRunContext("queued-run", lifecycleGeneration);
+    expect(firstLease).toBeTypeOf("function");
+    expect(secondLease).toBeTypeOf("function");
+    expect(retainQueuedAgentRunContext("missing-run", lifecycleGeneration)).toBeUndefined();
+    expect(retainQueuedAgentRunContext("queued-run", "stale-generation")).toBeUndefined();
+    expect(readAgentRunIndexVersion()).toBe(versionBeforeLease);
+
+    clock.mockReturnValue(1_000);
+    expect(sweepStaleRunContexts(500)).toBe(2);
+    expect(readAgentRunIndexVersion()).toBeGreaterThan(versionBeforeLease);
+    expect(getAgentRunContext("queued-run")).toBeDefined();
+    expect(getAgentRunContext("abandoned-run")).toBeUndefined();
+    expect(getAgentRunContext("tracked-worker-run")).toBeUndefined();
+
+    const versionAfterSweep = readAgentRunIndexVersion();
+    firstLease?.("admitted");
+    firstLease?.("abandoned");
+    expect(getAgentRunContext("queued-run")?.lastActiveAt).toBe(1_000);
+    expect(readAgentRunIndexVersion()).toBe(versionAfterSweep);
+
+    clock.mockReturnValue(1_501);
+    expect(sweepStaleRunContexts(500)).toBe(0);
+    expect(readAgentRunIndexVersion()).toBe(versionAfterSweep);
+    secondLease?.("abandoned");
+    expect(readAgentRunIndexVersion()).toBe(versionAfterSweep);
+    expect(sweepStaleRunContexts(500)).toBe(1);
+    expect(readAgentRunIndexVersion()).toBeGreaterThan(versionAfterSweep);
+    expect(getAgentRunContext("queued-run")).toBeUndefined();
+    clock.mockRestore();
+  });
+
+  test("never protects a retired lifecycle or refreshes a recycled run context", () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(100);
+    const originalGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext("recycled-run", {
+      lifecycleGeneration: originalGeneration,
+      registeredAt: 100,
+    });
+    const releaseOriginalLease = retainQueuedAgentRunContext("recycled-run", originalGeneration);
+
+    clock.mockReturnValue(1_000);
+    expect(sweepStaleRunContexts(500)).toBe(0);
+
+    const replacementGeneration = rotateAgentEventLifecycleGeneration();
+    expect(sweepStaleRunContexts(500)).toBe(1);
+    claimAgentRunContext("recycled-run", {
+      lifecycleGeneration: replacementGeneration,
+      registeredAt: 100,
+    });
+
+    releaseOriginalLease?.("admitted");
+    expect(getAgentRunContext("recycled-run")).toMatchObject({
+      lifecycleGeneration: replacementGeneration,
+      registeredAt: 100,
+    });
+    expect(getAgentRunContext("recycled-run")?.lastActiveAt).toBeUndefined();
+    expect(sweepStaleRunContexts(500)).toBe(1);
+    clock.mockRestore();
+  });
+
+  test("shares queue leases across duplicate modules without leaking through test resets", async () => {
+    const first = await importAgentEventsModule(`queued-first-${Date.now()}`);
+    const second = await importAgentEventsModule(`queued-second-${Date.now()}`);
+    const clock = vi.spyOn(Date, "now").mockReturnValue(100);
+    const lifecycleGeneration = first.events.getAgentEventLifecycleGeneration();
+    first.registry.registerAgentRunContext("duplicate-module-run", {
+      lifecycleGeneration,
+      registeredAt: 100,
+    });
+    const releaseOriginalLease = second.registry.retainQueuedAgentRunContext(
+      "duplicate-module-run",
+      lifecycleGeneration,
+    );
+
+    clock.mockReturnValue(1_000);
+    expect(first.registry.sweepStaleRunContexts(500)).toBe(0);
+
+    first.events.resetAgentEventsForTest();
+    first.registry.registerAgentRunContext("duplicate-module-run", {
+      lifecycleGeneration,
+      registeredAt: 100,
+    });
+    releaseOriginalLease?.("admitted");
+
+    expect(first.registry.getAgentRunContext("duplicate-module-run")?.lastActiveAt).toBeUndefined();
+    expect(first.registry.sweepStaleRunContexts(500)).toBe(1);
+    first.events.resetAgentEventsForTest();
+    clock.mockRestore();
   });
 });
 

--- a/src/infra/agent-run-registry.ts
+++ b/src/infra/agent-run-registry.ts
@@ -42,6 +42,7 @@ type AgentRunContextOwnership = {
 type AgentRunRegistryState = {
   contexts: Map<string, AgentRunContext>;
   owners: Map<string, AgentRunContextOwnership>;
+  queuedRunContextLeases?: WeakMap<AgentRunContext, number>;
   lifecycleGeneration: string;
   sequenceResetHandler?: (runId: string) => void;
   version: number;
@@ -256,6 +257,49 @@ export function getAgentRunContext(runId: string): AgentRunContext | undefined {
   return getAgentRunRegistryState().contexts.get(runId);
 }
 
+/** Holds an existing run context only while its current execution awaits lane admission. */
+export function retainQueuedAgentRunContext(
+  runId: string,
+  lifecycleGeneration: string,
+): ((outcome: "admitted" | "abandoned") => void) | undefined {
+  const state = getAgentRunRegistryState();
+  const context = state.contexts.get(runId);
+  if (
+    !context ||
+    context.lifecycleGeneration !== lifecycleGeneration ||
+    state.lifecycleGeneration !== lifecycleGeneration
+  ) {
+    return undefined;
+  }
+
+  const leases = (state.queuedRunContextLeases ??= new WeakMap<AgentRunContext, number>());
+  leases.set(context, (leases.get(context) ?? 0) + 1);
+  let released = false;
+
+  return (outcome) => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const remaining = (leases.get(context) ?? 0) - 1;
+    if (remaining > 0) {
+      leases.set(context, remaining);
+    } else {
+      leases.delete(context);
+    }
+
+    // A recycled run id or rotated lifecycle must not inherit the old queue's activity.
+    if (
+      outcome === "admitted" &&
+      state.contexts.get(runId) === context &&
+      context.lifecycleGeneration === lifecycleGeneration &&
+      state.lifecycleGeneration === lifecycleGeneration
+    ) {
+      context.lastActiveAt = Date.now();
+    }
+  };
+}
+
 export function getAgentRunContextOwnership(runId: string): AgentRunContextOwnership | undefined {
   return getAgentRunRegistryState().owners.get(runId);
 }
@@ -444,6 +488,13 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
   const now = Date.now();
   let swept = 0;
   for (const [runId, context] of state.contexts) {
+    // Queue capacity waits are live ownership, but never protect a retired lifecycle.
+    if (
+      context.lifecycleGeneration === state.lifecycleGeneration &&
+      (state.queuedRunContextLeases?.get(context) ?? 0) > 0
+    ) {
+      continue;
+    }
     // Use lastActiveAt (refreshed on every event) to avoid sweeping active runs.
     // Fall back to registeredAt, then treat missing timestamps as infinitely old.
     const lastSeen = context.lastActiveAt ?? context.registeredAt;
@@ -468,6 +519,7 @@ export function resetAgentRunRegistryForTest(): void {
   resetAgentRunUsageForTest();
   state.contexts.clear();
   state.owners.clear();
+  state.queuedRunContextLeases = undefined;
   if (hadRunContexts) {
     bumpAgentRunIndexVersion();
   }


### PR DESCRIPTION
Closes #112614

## What Problem This Solves

Fixes an issue where healthy agent runs waiting behind a saturated session or global execution queue could lose their active execution context after thirty minutes, before they had ever started.

## Why This Change Was Made

The run-context owner now holds a generation-scoped, identity-bound lease only while a real execution is awaiting lane admission. Admission restarts inactivity accounting without replacing original routing metadata; aborts, queue clearing, synchronous rejection, lifecycle replacement, and genuinely stale contexts still release normally. This resolves the complete queue lifecycle at the shared ownership boundary instead of extending TTLs globally or treating every queued record as permanently live. Related earlier unmerged exploration: #112877.

## User Impact

Sustained legitimate agent fan-out no longer falsely terminates healthy queued work, triggers duplicate retries, or drops execution routing. Abandoned and retired runs remain eligible for normal cleanup.

## Evidence

- Reproduced both actual production queue paths RED: hold either the session lane or global lane beyond the real 30-minute TTL, sweep, and observe healthy context deletion before admission.
- GREEN on the rebased head: `node scripts/run-vitest.mjs src/infra/agent-events.test.ts src/agents/embedded-agent-runner/run/lane-controller.queue-liveness.test.ts src/agents/embedded-agent-runner/run/lane-controller.group-wait.test.ts` — 3 real production-owner/queue test files, 58 tests passed.
- Regression coverage independently proves session and global waits, admission-time activity reset, abandoned cleanup, immediate abort release, queue clearing, synchronous queue rejection, lifecycle rotation, run-id reuse, and preserved original routing metadata.
- Fresh independent xhigh review approved; mandatory fresh structured xhigh autoreview returned no accepted or actionable findings.

## Exact-Head Production Queue Runtime Trace

Executed the real embedded-run lane controller, real session/global command queues, real registered run-context sweeper, and real lifecycle event router together on the exact pushed head. Both queues were truly saturated beyond the 30-minute inactivity threshold using a deterministic clock; the trace also independently proves immediate abandonment cleanup in both lanes.

```json
{
  "head": "bb7ba0c39d683405a43c5caca33e9146df3409fe",
  "execution": "actual embedded lane controller -> actual session/global command queues -> actual context sweeper and event routing",
  "inactivityTtlMs": 1800000,
  "sessionLane": {
    "elapsedMs": 1800001,
    "queued": 1,
    "capacity": 0,
    "sweptUnleasedContexts": 1,
    "queuedContextSurvived": true,
    "routingSessionKey": "agent:main:subagent:redacted-proof"
  },
  "globalLane": {
    "elapsedSinceRegistrationMs": 3600002,
    "queued": 1,
    "capacity": 0,
    "queuedContextSurvived": true,
    "routingSessionKey": "agent:main:subagent:redacted-proof"
  },
  "admitted": {
    "contextLastActiveAtMs": 3601002,
    "routedGatewayLifecycleEvent": {
      "stream": "lifecycle",
      "sessionKey": "agent:main:subagent:redacted-proof",
      "sessionId": "proof-session",
      "agentId": "main",
      "controlUiVisible": false
    }
  },
  "postAdmissionCleanup": {
    "expiryElapsedMs": 1800001,
    "sweptExpiredContexts": 1,
    "contextRemoved": true
  },
  "sessionLaneAbandoned": {
    "queued": 1,
    "sweptImmediatelyAfterAbort": 1,
    "contextRemoved": true
  },
  "globalLaneAbandoned": {
    "queued": 1,
    "sweptImmediatelyAfterAbort": 1,
    "contextRemoved": true
  }
}
```

Required exact-head `openclaw/ci-gate`: SUCCESS. No touched production-owner path changed on current main; behind-main drift alone is advisory under the maintainer workflow.

### Current-main canonical owner and real remote-worker proof

Current main moved run-context ownership from the old event facade into `src/infra/agent-run-registry.ts`; this branch was rebuilt against that newer architecture instead of restoring the obsolete owner or merging around the conflict. Queue ownership now lives directly in the canonical registry, and one internal placement-admission callback protects both local turns and real remote workers through potentially long environment redispatch.

A real production command-queue/event-bus trace held the session lane for **1,800,001 ms** and then the global lane through **3,600,002 ms**. The exact hidden session route survived both waits, an unleased stale sibling still expired, queue leases did not invalidate the sessions-list projection index, actual admission refreshed activity, and cancellation immediately released either lane. A real worker placement backed by its durable SQLite owner verified long reclaimed-environment redispatch, exactly-once remote admission, proper active-run expiry, durable-claim cleanup after errors, allowed queued foreground lifecycle rotation, and fail-closed rejection when the runtime rotates during placement.

Fresh verification of exact head `213c9585f65d461c8cc1f1ebfaec368bb3584486`: **115/115 tests across complete worker, registry, event, session-list cache, placement, and lane suites**; full unbypassed `pnpm check:changed` green; fresh independent xhigh P0-P2 autoreview clean. The event facade remains untouched; no new permanent helper or compatibility alias is introduced.
