### PR TITLE
refactor(migrate-hermes): consolidate migration test fixtures

### DIFF
--- a/extensions/migrate-hermes/config.test.ts
+++ b/extensions/migrate-hermes/config.test.ts
@@ -26,6 +26,16 @@ function modelProviderValues(
   );
 }
 
+async function makeHermesPaths(sourceName = "hermes") {
+  const root = await makeTempRoot();
+  return {
+    root,
+    source: path.join(root, sourceName),
+    workspaceDir: path.join(root, "workspace"),
+    stateDir: path.join(root, "state"),
+  };
+}
+
 describe("Hermes migration config mapping", () => {
   afterEach(async () => {
     vi.unstubAllEnvs();
@@ -33,10 +43,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("plans provider, MCP, skill, and memory plugin config as plugin-owned items", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { source, workspaceDir, stateDir } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       [
@@ -135,10 +142,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("applies mapped config items through the migration runtime config writer", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { source, workspaceDir, stateDir } = await makeHermesPaths();
     const config = {
       agents: { defaults: { workspace: workspaceDir } },
     } as OpenClawConfig;
@@ -188,10 +192,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("drops prototype-bearing provider, MCP, and skill keys during apply", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { source, workspaceDir, stateDir } = await makeHermesPaths();
     const config = {
       agents: { defaults: { workspace: workspaceDir } },
     } as OpenClawConfig;
@@ -240,10 +241,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("uses the provider runtime for CLI-applied config items", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { source, workspaceDir, stateDir } = await makeHermesPaths();
     const config: Record<string, unknown> = {
       agents: { defaults: { workspace: workspaceDir } },
     };
@@ -273,10 +271,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("omits MCP credentials without explicit secret consent", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { source, workspaceDir, stateDir } = await makeHermesPaths();
     const config: Record<string, unknown> = {};
     const envKey = ["TO", "KEN"].join("");
     await writeFile(
@@ -295,10 +290,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("translates current Hermes model-scoped providers and MCP semantics", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { source, workspaceDir, stateDir } = await makeHermesPaths();
     const tlsFieldName = ["client", "cert"].join("_");
     const tlsPaths = ["placeholder", "placeholder"];
     const oauthConfig = {
@@ -423,8 +415,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("resolves provider endpoint refs and preserves supported request options", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     const endpointEnv = ["ACME", "BASE", "URL"].join("_");
     const headerEnv = ["ACME", "HEADER"].join("_");
     await writeFile(
@@ -504,8 +495,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("reports unresolved provider endpoint environment references", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       "providers:\n  acme:\n    api: ${MISSING_ACME_URL}\n    models: [acme-one]\n",
@@ -524,8 +514,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("infers Hermes provider protocols from provider and endpoint contracts", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       [
@@ -574,8 +563,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("matches Hermes transport precedence for named and plain custom providers", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       [
@@ -608,8 +596,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("keeps built-in Hermes provider overrides on OpenClaw's canonical provider IDs", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       [
@@ -660,9 +647,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("isolates model provider conflicts", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
+    const { root, source, workspaceDir } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       [
@@ -749,8 +734,7 @@ describe("Hermes migration config mapping", () => {
   ])(
     "imports $envName as the selected $sourceProvider endpoint",
     async ({ sourceProvider, envName, envValue, targetProvider, expectedApi, expectedBaseUrl }) => {
-      const root = await makeTempRoot();
-      const source = path.join(root, "hermes");
+      const { root, source } = await makeHermesPaths();
       await writeFile(
         path.join(source, "config.yaml"),
         ["model:", `  provider: ${sourceProvider}`, "  default: imported-model", ""].join("\n"),
@@ -779,8 +763,7 @@ describe("Hermes migration config mapping", () => {
   );
 
   it("preserves the standard Alibaba endpoint instead of the coding-plan default", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       "model:\n  provider: alibaba\n  default: qwen-plus\n",
@@ -801,8 +784,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("resolves MCP environment references with source dotenv precedence and secret consent", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     const mcpEnvName = ["MCP", "VALUE"].join("_");
     const mcpUrlName = ["MCP", "URL"].join("_");
     const dottedEnvName = ["mcp", "value"].join(".");
@@ -885,8 +867,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("imports a model-scoped endpoint even when Hermes names a built-in provider", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       [
@@ -924,8 +905,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("preserves an explicit Hermes provider name before applying built-in aliases", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       [
@@ -956,8 +936,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("keeps current providers entries ahead of matching legacy custom providers", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     const envVar = ["CURRENT", "ACME", "TOKEN"].join("_");
     const legacyEnvVar = ["LEGACY", "ACME", "TOKEN"].join("_");
     await writeFile(
@@ -1011,8 +990,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("does not let a custom entry shadow a canonical Hermes provider", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       [
@@ -1045,8 +1023,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("preserves the Hermes Moonshot China endpoint while aligning provider auth", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       "model:\n  provider: kimi-coding-cn\n  default: kimi-k2.5\n",
@@ -1067,8 +1044,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("maps the Hermes MiniMax China route to OpenClaw's canonical provider", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       "model:\n  provider: minimax-cn\n  default: MiniMax-M2.7\n",
@@ -1096,8 +1072,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("maps the native Kimi Coding endpoint to Anthropic Messages", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { root, source } = await makeHermesPaths();
     await writeFile(
       path.join(source, "config.yaml"),
       [
@@ -1137,10 +1112,7 @@ describe("Hermes migration config mapping", () => {
   });
 
   it("continues independent items after one late config conflict", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { source, workspaceDir, stateDir } = await makeHermesPaths();
     const config: Record<string, unknown> = {};
     await writeFile(
       path.join(source, "config.yaml"),

--- a/extensions/migrate-hermes/secrets.test.ts
+++ b/extensions/migrate-hermes/secrets.test.ts
@@ -18,7 +18,7 @@ import { buildHermesMigrationProvider } from "./provider.js";
 import {
   cleanupTempRoots,
   makeConfigRuntime,
-  makeContext,
+  makeContext as makeProviderContext,
   makeTempRoot,
   writeFile,
 } from "./test/provider-helpers.js";
@@ -57,6 +57,32 @@ function fakeJwt(payload: Record<string, unknown>): string {
 const HERMES_ACCESS_FIELD = ["access", "token"].join("_");
 const HERMES_REFRESH_FIELD = ["refresh", "token"].join("_");
 
+async function makeHermesSecretFixture(sourceName = "hermes") {
+  const root = await makeTempRoot();
+  const source = path.join(root, sourceName);
+  const workspaceDir = path.join(root, "workspace");
+  const stateDir = path.join(root, "state");
+  const reportDir = path.join(root, "report");
+  const agentDir = path.join(stateDir, "agents", "main", "agent");
+  const config = { agents: { defaults: { workspace: workspaceDir } } } as OpenClawConfig;
+  const runtime = makeConfigRuntime(config);
+  const provider = buildHermesMigrationProvider();
+  const secretContext = (overrides: Partial<Parameters<typeof makeProviderContext>[0]> = {}) =>
+    makeProviderContext({ source, stateDir, workspaceDir, includeSecrets: true, ...overrides });
+  return {
+    root,
+    source,
+    workspaceDir,
+    stateDir,
+    reportDir,
+    agentDir,
+    config,
+    runtime,
+    provider,
+    secretContext,
+  };
+}
+
 describe("Hermes migration secret items", () => {
   afterEach(async () => {
     vi.unstubAllEnvs();
@@ -64,10 +90,8 @@ describe("Hermes migration secret items", () => {
   });
 
   it("uses configured agentDir for secret planning and imports without runtime helpers", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { root, source, workspaceDir, stateDir, secretContext, provider } =
+      await makeHermesSecretFixture();
     const customAgentDir = path.join(root, "custom-agent");
     await writeFile(path.join(source, ".env"), "OPENAI_API_KEY=sk-hermes\n");
     const config = {
@@ -84,15 +108,9 @@ describe("Hermes migration secret items", () => {
         ],
       },
     } as OpenClawConfig;
-
-    const provider = buildHermesMigrationProvider();
     const plan = await provider.plan(
-      makeContext({
-        source,
-        stateDir,
-        workspaceDir,
+      secretContext({
         config,
-        includeSecrets: true,
       }),
     );
 
@@ -115,12 +133,8 @@ describe("Hermes migration secret items", () => {
     ]);
 
     const result = await provider.apply(
-      makeContext({
-        source,
-        stateDir,
-        workspaceDir,
+      secretContext({
         config,
-        includeSecrets: true,
         overwrite: true,
         reportDir: path.join(root, "report"),
       }),
@@ -138,19 +152,14 @@ describe("Hermes migration secret items", () => {
   });
 
   it("parses current Hermes dotenv syntax and legacy Kimi credentials", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { source, secretContext } = await makeHermesSecretFixture();
     const kimiEnv = ["KIMI", "CODING", "API", "KEY"].join("_");
     const openaiEnv = ["OPENAI", "API", "KEY"].join("_");
     await writeFile(
       path.join(source, ".env"),
       `\uFEFFexport ${kimiEnv} = placeholder\nexport ${openaiEnv}='redacted'\n`,
     );
-    const plan = await buildHermesMigrationProvider().plan(
-      makeContext({ source, stateDir, workspaceDir, includeSecrets: true }),
-    );
+    const plan = await buildHermesMigrationProvider().plan(secretContext());
     expect(plan.items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -166,19 +175,11 @@ describe("Hermes migration secret items", () => {
   });
 
   it("imports the current Hermes MiniMax China credential", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { source, secretContext } = await makeHermesSecretFixture();
     const envVar = ["MINIMAX", "CN", "API", "KEY"].join("_");
     await writeFile(path.join(source, ".env"), `${envVar}=placeholder\n`);
 
-    const plan = await buildHermesMigrationProvider().plan(
-      makeContext({
-        source,
-        stateDir: path.join(root, "state"),
-        workspaceDir: path.join(root, "workspace"),
-        includeSecrets: true,
-      }),
-    );
+    const plan = await buildHermesMigrationProvider().plan(secretContext());
 
     expect(plan.items).toEqual(
       expect.arrayContaining([
@@ -191,8 +192,7 @@ describe("Hermes migration secret items", () => {
   });
 
   it("imports the selected provider credential without an endpoint override", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { source, secretContext } = await makeHermesSecretFixture();
     const envVar = ["STEPFUN", "API", "KEY"].join("_");
     await writeFile(
       path.join(source, "config.yaml"),
@@ -200,14 +200,7 @@ describe("Hermes migration secret items", () => {
     );
     await writeFile(path.join(source, ".env"), `${envVar}=placeholder\n`);
 
-    const plan = await buildHermesMigrationProvider().plan(
-      makeContext({
-        source,
-        stateDir: path.join(root, "state"),
-        workspaceDir: path.join(root, "workspace"),
-        includeSecrets: true,
-      }),
-    );
+    const plan = await buildHermesMigrationProvider().plan(secretContext());
 
     expect(plan.items).toEqual(
       expect.arrayContaining([
@@ -220,8 +213,7 @@ describe("Hermes migration secret items", () => {
   });
 
   it("keeps legacy Moonshot model routing and credentials aligned", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { source, secretContext } = await makeHermesSecretFixture();
     const envVar = ["MOONSHOT", "API", "KEY"].join("_");
     await writeFile(
       path.join(source, "config.yaml"),
@@ -229,14 +221,7 @@ describe("Hermes migration secret items", () => {
     );
     await writeFile(path.join(source, ".env"), `${envVar}=placeholder\n`);
 
-    const plan = await buildHermesMigrationProvider().plan(
-      makeContext({
-        source,
-        stateDir: path.join(root, "state"),
-        workspaceDir: path.join(root, "workspace"),
-        includeSecrets: true,
-      }),
-    );
+    const plan = await buildHermesMigrationProvider().plan(secretContext());
 
     expect(plan.items.find((item) => item.id === "config:default-model")?.details?.model).toBe(
       "moonshot/kimi-k2.5",
@@ -255,8 +240,7 @@ describe("Hermes migration secret items", () => {
     ["sk-kimi-placeholder", "kimi"],
     ["legacy-moonshot-placeholder", "moonshot"],
   ])("aligns KIMI_API_KEY with its effective %s route", async (apiKey, expectedProvider) => {
-    const root = await makeTempRoot();
-    const source = path.join(root, expectedProvider);
+    const { source, secretContext } = await makeHermesSecretFixture(expectedProvider);
     const envVar = ["KIMI", "API", "KEY"].join("_");
     await writeFile(
       path.join(source, "config.yaml"),
@@ -264,14 +248,7 @@ describe("Hermes migration secret items", () => {
     );
     await writeFile(path.join(source, ".env"), `${envVar}=${apiKey}\n`);
 
-    const plan = await buildHermesMigrationProvider().plan(
-      makeContext({
-        source,
-        stateDir: path.join(root, "state"),
-        workspaceDir: path.join(root, "workspace"),
-        includeSecrets: true,
-      }),
-    );
+    const plan = await buildHermesMigrationProvider().plan(secretContext());
 
     expect(plan.items.find((item) => item.id === "config:default-model")?.details?.model).toBe(
       `${expectedProvider}/kimi-k2.5`,
@@ -287,10 +264,7 @@ describe("Hermes migration secret items", () => {
   });
 
   it("imports a configured provider key_env as matching OpenClaw provider auth", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { source, stateDir, secretContext, config, runtime } = await makeHermesSecretFixture();
     const value = ["custom", "provider", "placeholder"].join("-");
     const envVar = ["ACME", "TOKEN"].join("_");
     await writeFile(
@@ -308,17 +282,10 @@ describe("Hermes migration secret items", () => {
       ].join("\n"),
     );
     await writeFile(path.join(source, ".env"), `${envVar}=${value}\n`);
-    const config = { agents: { defaults: { workspace: workspaceDir } } } as OpenClawConfig;
-    const runtime = makeConfigRuntime(config);
-
     const result = await buildHermesMigrationProvider({ runtime }).apply(
-      makeContext({
-        source,
-        stateDir,
-        workspaceDir,
+      secretContext({
         config,
         runtime,
-        includeSecrets: true,
         overwrite: true,
       }),
     );
@@ -346,8 +313,7 @@ describe("Hermes migration secret items", () => {
   });
 
   it("binds the host-gated OpenAI key fallback to a model-scoped endpoint", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { source, secretContext } = await makeHermesSecretFixture();
     const envVar = ["OPENAI", "API", "KEY"].join("_");
     await writeFile(
       path.join(source, "config.yaml"),
@@ -361,14 +327,7 @@ describe("Hermes migration secret items", () => {
     );
     await writeFile(path.join(source, ".env"), `${envVar}=placeholder\n`);
 
-    const plan = await buildHermesMigrationProvider().plan(
-      makeContext({
-        source,
-        stateDir: path.join(root, "state"),
-        workspaceDir: path.join(root, "workspace"),
-        includeSecrets: true,
-      }),
-    );
+    const plan = await buildHermesMigrationProvider().plan(secretContext());
 
     const secretItems = plan.items.filter((item) => item.kind === "secret");
     expect(secretItems).toHaveLength(1);
@@ -378,8 +337,7 @@ describe("Hermes migration secret items", () => {
   });
 
   it("keeps an env-backed custom endpoint and its OpenAI key on one provider", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
+    const { source, secretContext } = await makeHermesSecretFixture();
     const keyEnv = ["OPENAI", "API", "KEY"].join("_");
     const baseUrlEnv = ["OPENAI", "BASE", "URL"].join("_");
     await writeFile(
@@ -391,14 +349,7 @@ describe("Hermes migration secret items", () => {
       `${keyEnv}=placeholder\n${baseUrlEnv}=https://private.example.test/v1\n`,
     );
 
-    const plan = await buildHermesMigrationProvider().plan(
-      makeContext({
-        source,
-        stateDir: path.join(root, "state"),
-        workspaceDir: path.join(root, "workspace"),
-        includeSecrets: true,
-      }),
-    );
+    const plan = await buildHermesMigrationProvider().plan(secretContext());
 
     const providers = Object.assign(
       {},
@@ -415,11 +366,7 @@ describe("Hermes migration secret items", () => {
   });
 
   it("imports current Hermes singleton and pooled OpenAI OAuth accounts", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const config = { agents: { defaults: { workspace: workspaceDir } } } as OpenClawConfig;
+    const { source, stateDir, secretContext, config, runtime } = await makeHermesSecretFixture();
     const accountOne = fakeJwt({
       "https://api.openai.com/auth": { chatgpt_account_id: "acct_one" },
       "https://api.openai.com/profile": { email: "one@example.test" },
@@ -456,16 +403,11 @@ describe("Hermes migration secret items", () => {
         },
       }),
     );
-    const runtime = makeConfigRuntime(config);
     const provider = buildHermesMigrationProvider({ runtime });
     const result = await provider.apply(
-      makeContext({
-        source,
-        stateDir,
-        workspaceDir,
+      secretContext({
         config,
         runtime,
-        includeSecrets: true,
         overwrite: true,
       }),
     );
@@ -482,10 +424,7 @@ describe("Hermes migration secret items", () => {
   });
 
   it("imports manual Hermes API-key pool entries and skips borrowed references", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { source, stateDir, secretContext, config, runtime } = await makeHermesSecretFixture();
     const firstValue = "openrouter-one";
     const secondValue = "openrouter-two";
     const borrowedValue = "borrowed-value";
@@ -525,16 +464,10 @@ describe("Hermes migration secret items", () => {
         },
       }),
     );
-    const config = { agents: { defaults: { workspace: workspaceDir } } } as OpenClawConfig;
-    const runtime = makeConfigRuntime(config);
     const result = await buildHermesMigrationProvider({ runtime }).apply(
-      makeContext({
-        source,
-        stateDir,
-        workspaceDir,
+      secretContext({
         config,
         runtime,
-        includeSecrets: true,
         overwrite: true,
       }),
     );
@@ -556,10 +489,9 @@ describe("Hermes migration secret items", () => {
   });
 
   it("uses per-provider global API-key pool fallback for an active profile", async () => {
-    const root = await makeTempRoot();
+    const { root, secretContext, config, runtime } = await makeHermesSecretFixture();
     const hermesRoot = path.join(root, ".hermes");
     const source = path.join(hermesRoot, "profiles", "coder");
-    const workspaceDir = path.join(root, "workspace");
     const stateDir = path.join(root, "state");
     const globalOpenRouterValue = ["global", "openrouter", "placeholder"].join("-");
     const globalGeminiValue = ["global", "gemini", "placeholder"].join("-");
@@ -606,17 +538,11 @@ describe("Hermes migration secret items", () => {
     );
     vi.stubEnv("HOME", root);
     vi.stubEnv("HERMES_HOME", "");
-    const config = { agents: { defaults: { workspace: workspaceDir } } } as OpenClawConfig;
-    const runtime = makeConfigRuntime(config);
-
     const result = await buildHermesMigrationProvider({ runtime }).apply(
-      makeContext({
+      secretContext({
         source: "",
-        stateDir,
-        workspaceDir,
         config,
         runtime,
-        includeSecrets: true,
         overwrite: true,
       }),
     );
@@ -644,12 +570,8 @@ describe("Hermes migration secret items", () => {
   });
 
   it("reports API key import when config update fails after profile write", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const reportDir = path.join(root, "report");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { source, workspaceDir, secretContext, reportDir, agentDir, provider } =
+      await makeHermesSecretFixture();
     await writeFile(path.join(source, ".env"), "OPENAI_API_KEY=sk-hermes\n");
     const config = {
       agents: {
@@ -666,14 +588,8 @@ describe("Hermes migration secret items", () => {
         },
       },
     } as unknown as MigrationProviderContext["runtime"];
-
-    const provider = buildHermesMigrationProvider();
-    const ctx = makeContext({
-      source,
-      stateDir,
-      workspaceDir,
+    const ctx = secretContext({
       config,
-      includeSecrets: true,
       reportDir,
       runtime,
     });
@@ -701,11 +617,7 @@ describe("Hermes migration secret items", () => {
   });
 
   it("keeps secret conflict checks read-only during planning", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { source, secretContext, agentDir, provider } = await makeHermesSecretFixture();
     await writeFile(path.join(source, ".env"), "OPENAI_API_KEY=sk-hermes\n");
     const existingStore: AuthProfileStore = {
       version: 1,
@@ -719,9 +631,7 @@ describe("Hermes migration secret items", () => {
     };
     writeAuthProfileStore(agentDir, existingStore);
     const beforePlanStore = readAuthProfileStore(agentDir);
-
-    const provider = buildHermesMigrationProvider();
-    await provider.plan(makeContext({ source, stateDir, workspaceDir, includeSecrets: true }));
+    await provider.plan(secretContext());
 
     expect(readAuthProfileStore(agentDir)).toEqual(beforePlanStore);
     // Canonical profiles stay in SQLite; planning must not recreate the retired JSON sidecar.
@@ -729,20 +639,10 @@ describe("Hermes migration secret items", () => {
   });
 
   it("reports late-created auth profiles as conflicts without overwriting", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const reportDir = path.join(root, "report");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { source, secretContext, reportDir, agentDir, provider } =
+      await makeHermesSecretFixture();
     await writeFile(path.join(source, ".env"), "OPENAI_API_KEY=sk-hermes\n");
-
-    const provider = buildHermesMigrationProvider();
-    const ctx = makeContext({
-      source,
-      stateDir,
-      workspaceDir,
-      includeSecrets: true,
+    const ctx = secretContext({
       reportDir,
     });
     const plan = await provider.plan(ctx);
@@ -788,11 +688,8 @@ describe("Hermes migration secret items", () => {
   });
 
   it("reports API key config auth profile conflicts during planning", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { source, workspaceDir, secretContext, agentDir, provider } =
+      await makeHermesSecretFixture();
     await writeFile(path.join(source, ".env"), "OPENAI_API_KEY=sk-hermes\n");
     const config = {
       agents: {
@@ -809,14 +706,8 @@ describe("Hermes migration secret items", () => {
         },
       },
     } as OpenClawConfig;
-
-    const provider = buildHermesMigrationProvider();
-    const ctx = makeContext({
-      source,
-      stateDir,
-      workspaceDir,
+    const ctx = secretContext({
       config,
-      includeSecrets: true,
     });
     const plan = await provider.plan(ctx);
 
@@ -835,11 +726,8 @@ describe("Hermes migration secret items", () => {
   });
 
   it("reports late-created API key config auth profile conflicts before writing", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { source, workspaceDir, secretContext, agentDir, provider } =
+      await makeHermesSecretFixture();
     await writeFile(path.join(source, ".env"), "OPENAI_API_KEY=sk-hermes\n");
     const config = {
       agents: {
@@ -848,14 +736,8 @@ describe("Hermes migration secret items", () => {
         },
       },
     } as OpenClawConfig;
-
-    const provider = buildHermesMigrationProvider();
-    const ctx = makeContext({
-      source,
-      stateDir,
-      workspaceDir,
+    const ctx = secretContext({
       config,
-      includeSecrets: true,
       runtime: makeConfigRuntime(config),
     });
     const plan = await provider.plan(ctx);
@@ -882,12 +764,8 @@ describe("Hermes migration secret items", () => {
   });
 
   it("imports supported Hermes provider env credentials including OpenCode and GitHub Copilot", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const reportDir = path.join(root, "report");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { source, workspaceDir, secretContext, reportDir, agentDir, provider } =
+      await makeHermesSecretFixture();
     await writeFile(
       path.join(source, ".env"),
       ["OPENCODE_ZEN_API_KEY=opencode-key", "COPILOT_GITHUB_TOKEN=gho-copilot-token", ""].join(
@@ -901,14 +779,8 @@ describe("Hermes migration secret items", () => {
         },
       },
     } as OpenClawConfig;
-
-    const provider = buildHermesMigrationProvider();
-    const ctx = makeContext({
-      source,
-      stateDir,
-      workspaceDir,
+    const ctx = secretContext({
       config,
-      includeSecrets: true,
       reportDir,
       runtime: makeConfigRuntime(config),
     });
@@ -981,20 +853,10 @@ describe("Hermes migration secret items", () => {
   });
 
   it("does not import web-search-only Perplexity env credentials as model auth profiles", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const reportDir = path.join(root, "report");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { source, secretContext, reportDir, agentDir, provider } =
+      await makeHermesSecretFixture();
     await writeFile(path.join(source, ".env"), "PERPLEXITY_API_KEY=pplx-hermes\n");
-
-    const provider = buildHermesMigrationProvider();
-    const ctx = makeContext({
-      source,
-      stateDir,
-      workspaceDir,
-      includeSecrets: true,
+    const ctx = secretContext({
       reportDir,
     });
     const plan = await provider.plan(ctx);
@@ -1008,12 +870,8 @@ describe("Hermes migration secret items", () => {
   });
 
   it("imports supported OpenCode auth store credentials next to the Hermes home", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, ".hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const reportDir = path.join(root, "report");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { root, source, workspaceDir, secretContext, reportDir, agentDir, provider } =
+      await makeHermesSecretFixture(".hermes");
     await writeFile(path.join(source, "config.yaml"), "model: opencode/kimi-k2.5\n");
     await writeFile(
       path.join(root, ".local", "share", "opencode", "auth.json"),
@@ -1041,14 +899,8 @@ describe("Hermes migration secret items", () => {
         },
       },
     } as OpenClawConfig;
-
-    const provider = buildHermesMigrationProvider();
-    const ctx = makeContext({
-      source,
-      stateDir,
-      workspaceDir,
+    const ctx = secretContext({
       config,
-      includeSecrets: true,
       reportDir,
       runtime: makeConfigRuntime(config),
     });
@@ -1119,12 +971,8 @@ describe("Hermes migration secret items", () => {
   });
 
   it("skips OpenCode GitHub Copilot enterprise credentials until endpoint routing is supported", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, ".hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const reportDir = path.join(root, "report");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { root, source, workspaceDir, secretContext, reportDir, agentDir, provider } =
+      await makeHermesSecretFixture(".hermes");
     await writeFile(path.join(source, "config.yaml"), "model: github-copilot/gpt-5.4\n");
     await writeFile(
       path.join(root, ".local", "share", "opencode", "auth.json"),
@@ -1145,14 +993,8 @@ describe("Hermes migration secret items", () => {
         },
       },
     } as OpenClawConfig;
-
-    const provider = buildHermesMigrationProvider();
-    const ctx = makeContext({
-      source,
-      stateDir,
-      workspaceDir,
+    const ctx = secretContext({
       config,
-      includeSecrets: true,
       reportDir,
       runtime: makeConfigRuntime(config),
     });
@@ -1169,12 +1011,8 @@ describe("Hermes migration secret items", () => {
   });
 
   it("prefers OpenCode auth from XDG_DATA_HOME when it belongs to the migrated home", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, ".hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const reportDir = path.join(root, "report");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { root, source, workspaceDir, secretContext, reportDir, agentDir } =
+      await makeHermesSecretFixture(".hermes");
     const xdgDataHome = path.join(root, "xdg-data");
     const previousXdgDataHome = process.env.XDG_DATA_HOME;
     await writeFile(path.join(source, "config.yaml"), "model: opencode/kimi-k2.5\n");
@@ -1207,12 +1045,8 @@ describe("Hermes migration secret items", () => {
     try {
       process.env.XDG_DATA_HOME = xdgDataHome;
       const provider = buildHermesMigrationProvider();
-      const ctx = makeContext({
-        source,
-        stateDir,
-        workspaceDir,
+      const ctx = secretContext({
         config,
-        includeSecrets: true,
         reportDir,
         runtime: makeConfigRuntime(config),
       });
@@ -1249,12 +1083,8 @@ describe("Hermes migration secret items", () => {
   });
 
   it("imports OpenCode OpenAI OAuth credentials as OpenAI auth", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, ".hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const reportDir = path.join(root, "report");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { root, source, workspaceDir, secretContext, reportDir, agentDir, provider } =
+      await makeHermesSecretFixture(".hermes");
     const accessToken = fakeJwt({
       exp: Math.floor(Date.now() / 1000) + 3600,
       "https://api.openai.com/profile": { email: "opencode-openai@example.test" },
@@ -1282,14 +1112,8 @@ describe("Hermes migration secret items", () => {
         },
       },
     } as OpenClawConfig;
-
-    const provider = buildHermesMigrationProvider();
-    const ctx = makeContext({
-      source,
-      stateDir,
-      workspaceDir,
+    const ctx = secretContext({
       config,
-      includeSecrets: true,
       reportDir,
       runtime: makeConfigRuntime(config),
     });
@@ -1331,12 +1155,8 @@ describe("Hermes migration secret items", () => {
   });
 
   it("does not apply a planned OpenCode OpenAI OAuth credential after the source token changes", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, ".hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const reportDir = path.join(root, "report");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { root, source, secretContext, reportDir, agentDir, provider } =
+      await makeHermesSecretFixture(".hermes");
     const opencodeAuthPath = path.join(root, ".local", "share", "opencode", "auth.json");
     await writeFile(path.join(source, "auth.json"), "{}");
     await writeFile(
@@ -1349,13 +1169,7 @@ describe("Hermes migration secret items", () => {
         },
       }),
     );
-
-    const provider = buildHermesMigrationProvider();
-    const ctx = makeContext({
-      source,
-      stateDir,
-      workspaceDir,
-      includeSecrets: true,
+    const ctx = secretContext({
       reportDir,
     });
     const plan = await provider.plan(ctx);
@@ -1396,10 +1210,7 @@ describe("Hermes migration secret items", () => {
   });
 
   it("reports OpenCode OpenAI OAuth config auth profile conflicts during planning", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
+    const { root, source, workspaceDir, secretContext, provider } = await makeHermesSecretFixture();
     const accessToken = fakeJwt({
       exp: Math.floor(Date.now() / 1000) + 3600,
       "https://api.openai.com/profile": { email: "codex@example.test" },
@@ -1434,15 +1245,9 @@ describe("Hermes migration secret items", () => {
         },
       }),
     );
-
-    const provider = buildHermesMigrationProvider();
     const plan = await provider.plan(
-      makeContext({
-        source,
-        stateDir,
-        workspaceDir,
+      secretContext({
         config,
-        includeSecrets: true,
       }),
     );
     const authItem = plan.items.find((item) => item.id === "auth:openai");
@@ -1459,12 +1264,8 @@ describe("Hermes migration secret items", () => {
   });
 
   it("does not collapse OpenCode OpenAI OAuth accounts that share an email", async () => {
-    const root = await makeTempRoot();
-    const source = path.join(root, "hermes");
-    const workspaceDir = path.join(root, "workspace");
-    const stateDir = path.join(root, "state");
-    const reportDir = path.join(root, "report");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const { root, source, workspaceDir, secretContext, reportDir, agentDir, provider } =
+      await makeHermesSecretFixture();
     const sharedEmail = "shared@example.com";
     const accessToken = fakeJwt({
       exp: Math.floor(Date.now() / 1000) + 3600,
@@ -1510,14 +1311,8 @@ describe("Hermes migration secret items", () => {
         },
       },
     });
-
-    const provider = buildHermesMigrationProvider();
-    const ctx = makeContext({
-      source,
-      stateDir,
-      workspaceDir,
+    const ctx = secretContext({
       config,
-      includeSecrets: true,
       reportDir,
       runtime: makeConfigRuntime(config),
     });


### PR DESCRIPTION
## What Problem This Solves

The Hermes migration config and credential suites repeated temporary-root, canonical path, migration context, runtime, provider, report, and agent-store setup across nearly every scenario. That duplication made security-sensitive migration cases harder to compare and maintain.

## Why This Change Was Made

This maintainer-requested cleanup introduces suite-local fixtures: a path-only helper for config mapping and an explicitly secret-enabled context helper for credential migration. The helpers preserve per-test overrides and keep config-versus-secret semantics separate; production code and public behavior are unchanged.

## User Impact

No user-visible behavior changes. Maintainers get the same migration coverage with 233 fewer test lines and less duplicated setup around auth, conflict, revalidation, and provider-routing scenarios.

## Evidence

- Scope: two test files only; `+126/-359`, net `-233`; production/config/default/schema/docs delta `0`.
- Exact AST parity against `main`:
  - config: 23 declarations, 27 expanded cases, 99 ordered assertions
  - secrets: 26 declarations, 27 expanded cases, 77 ordered assertions
  - title, table-row, and assertion hashes match exactly
- Focused local proof: 54/54 passed.
- Blacksmith Testbox `tbx_01kz1z3h9rnb1d0p048g1skz02`:
  - full `extensions/migrate-hermes`: 102/102 passed
  - adjacent migration/doctor/secret suites: 96/96 passed
  - `pnpm check:changed`: passed, including ratchets, formatting, extension-test typecheck, and lint
- Two independent xhigh reviews: clean; both judged the suite-local fixture shape the best fix after full owner/caller/history review and fresh direct Codex source inspection.
- Direct Codex contract checks covered `codex-rs/protocol/src/auth.rs`, `codex-rs/login/src/auth/manager.rs`, `codex-rs/model-provider-info/src/lib.rs`, and core session/thread startup. Canonical provider identity remains `openai`; legacy `openai-codex` remains migration input only.
- Central collision audit through 2026-08-02T20:13:15Z: zero open-PR overlap for either changed path.

AI-assisted: yes. I reviewed the production migration/auth ownership chain, understand the helper boundaries, and validated the final tree through focused, adjacent, remote, structural-parity, and independent-review gates.
