### PR TITLE
fix(ollama): avoid loading idle models during guided setup

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -31,6 +31,7 @@ const ensureOllamaModelPulledMock = vi.hoisted(() => vi.fn(async () => {}));
 const checkOllamaCloudAuthMock = vi.hoisted(() => vi.fn());
 const configureOllamaNonInteractiveMock = vi.hoisted(() => vi.fn());
 const fetchOllamaModelsMock = vi.hoisted(() => vi.fn());
+const fetchLoadedOllamaModelNamesMock = vi.hoisted(() => vi.fn());
 const buildOllamaProviderMock = vi.hoisted(() => vi.fn());
 const queryOllamaModelShowInfoMock = vi.hoisted(() => vi.fn());
 const resolveConfiguredSecretInputStringMock = vi.hoisted(() => vi.fn());
@@ -69,6 +70,11 @@ vi.mock("./api.js", () => ({
   buildOllamaModelDefinition: buildOllamaModelDefinitionMock,
 }));
 
+vi.mock("./src/provider-models.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./src/provider-models.js")>()),
+  fetchLoadedOllamaModelNames: fetchLoadedOllamaModelNamesMock,
+}));
+
 vi.mock("openclaw/plugin-sdk/secret-input-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/secret-input-runtime")>();
   return {
@@ -100,6 +106,11 @@ beforeEach(() => {
   checkOllamaCloudAuthMock.mockResolvedValue({ signedIn: true });
   configureOllamaNonInteractiveMock.mockReset();
   fetchOllamaModelsMock.mockReset();
+  fetchLoadedOllamaModelNamesMock.mockReset();
+  fetchLoadedOllamaModelNamesMock.mockResolvedValue({
+    reachable: true,
+    models: ["qwen-tool", "qwen3.5:4b", "llama3.3:70b", "nomic-embed-text", "unknown-tools"],
+  });
   buildOllamaProviderMock.mockReset();
   queryOllamaModelShowInfoMock.mockReset();
   resolveConfiguredSecretInputStringMock.mockClear();
@@ -483,7 +494,7 @@ describe("ollama plugin", () => {
     expect(result.defaultModel).toBeUndefined();
   });
 
-  it("discovers and prepares an installed tool-capable model without pulling it", async () => {
+  it("discovers and prepares a loaded tool-capable model without pulling it", async () => {
     const provider = registerProvider();
     const guided = provider.auth[0].appGuidedSetup;
     buildOllamaProviderMock.mockResolvedValue({
@@ -532,7 +543,74 @@ describe("ollama plugin", () => {
     expect(ensureOllamaModelPulledMock).not.toHaveBeenCalled();
   });
 
-  it("prefers the strongest tool-calling family among installed models", async () => {
+  it("does not auto-detect installed models that are not loaded", async () => {
+    const provider = registerProvider();
+    fetchLoadedOllamaModelNamesMock.mockResolvedValue({ reachable: true, models: [] });
+
+    await expect(
+      provider.auth[0].appGuidedSetup?.detect({ config: {}, env: {} }),
+    ).resolves.toBeNull();
+
+    expect(buildOllamaProviderMock).not.toHaveBeenCalled();
+    expect(queryOllamaModelShowInfoMock).not.toHaveBeenCalled();
+  });
+
+  it("selects only from loaded models when stronger installed models are idle", async () => {
+    const provider = registerProvider();
+    fetchLoadedOllamaModelNamesMock.mockResolvedValue({
+      reachable: true,
+      models: ["llama3.3:70b"],
+    });
+    buildOllamaProviderMock.mockResolvedValue({
+      baseUrl: "http://127.0.0.1:11434",
+      api: "ollama",
+      models: [
+        { id: "llama3.3:70b", name: "llama3.3:70b", compat: { supportsTools: true } },
+        { id: "qwen3.5:4b", name: "qwen3.5:4b", compat: { supportsTools: true } },
+      ],
+    });
+
+    await expect(provider.auth[0].appGuidedSetup?.detect({ config: {}, env: {} })).resolves.toEqual(
+      {
+        modelRef: "ollama/llama3.3:70b",
+        detail: "llama3.3:70b at http://127.0.0.1:11434",
+      },
+    );
+    expect(queryOllamaModelShowInfoMock).toHaveBeenCalledTimes(1);
+    expect(queryOllamaModelShowInfoMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:11434",
+      "llama3.3:70b",
+      undefined,
+    );
+  });
+
+  it("rechecks loaded state before preparing the detected route", async () => {
+    const provider = registerProvider();
+    buildOllamaProviderMock.mockResolvedValue({
+      baseUrl: "http://127.0.0.1:11434",
+      api: "ollama",
+      models: [{ id: "qwen-tool", name: "qwen-tool", compat: { supportsTools: true } }],
+    });
+
+    await expect(provider.auth[0].appGuidedSetup?.detect({ config: {}, env: {} })).resolves.toEqual(
+      {
+        modelRef: "ollama/qwen-tool",
+        detail: "qwen-tool at http://127.0.0.1:11434",
+      },
+    );
+    fetchLoadedOllamaModelNamesMock.mockResolvedValue({ reachable: true, models: [] });
+
+    await expect(
+      provider.auth[0].appGuidedSetup?.prepare({
+        config: {},
+        env: {},
+        modelRef: "ollama/qwen-tool",
+      }),
+    ).resolves.toBeNull();
+    expect(buildOllamaProviderMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers the strongest tool-calling family among loaded models", async () => {
     const provider = registerProvider();
     buildOllamaProviderMock.mockResolvedValue({
       baseUrl: "http://127.0.0.1:11434",
@@ -625,6 +703,10 @@ describe("ollama plugin", () => {
       "https://ollama.example.com",
       expect.objectContaining(providerAccess),
     );
+    expect(fetchLoadedOllamaModelNamesMock).toHaveBeenCalledWith(
+      "https://ollama.example.com",
+      providerAccess,
+    );
   });
 
   it("keeps environment-backed Ollama access for the completion proposal", async () => {
@@ -677,6 +759,7 @@ describe("ollama plugin", () => {
       | { apiKey?: string; quiet?: boolean }
       | undefined;
     expect(options?.apiKey).toBeUndefined();
+    expect(fetchLoadedOllamaModelNamesMock).toHaveBeenCalledWith("http://127.0.0.1:11434", {});
   });
 
   it("honors the Ollama discovery opt-out during app-guided detection", async () => {
@@ -690,6 +773,7 @@ describe("ollama plugin", () => {
         env: {},
       }),
     ).resolves.toBeNull();
+    expect(fetchLoadedOllamaModelNamesMock).not.toHaveBeenCalled();
     expect(buildOllamaProviderMock).not.toHaveBeenCalled();
   });
 

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -78,8 +78,10 @@ import {
   buildDefaultOllamaCloudModelDefinition,
   capLocalOllamaModelContext,
   capLocalOllamaProviderContext,
+  fetchLoadedOllamaModelNames,
   isOllamaCloudModel,
 } from "./src/provider-models.js";
+import { findAvailableOllamaModelName } from "./src/setup-model-selection.js";
 import {
   OLLAMA_INCOMPLETE_STREAM_ERROR,
   createConfiguredOllamaCompatStreamWrapper,
@@ -239,12 +241,23 @@ async function discoverAppGuidedOllamaModel(ctx: ProviderAppGuidedSetupContext) 
   });
   const accessValue = await resolveAppGuidedOllamaApiKey(ctx, existing);
   const discoveryAccess = accessValue ? { apiKey: accessValue } : {};
-  const provider = await buildOllamaProvider(readProviderBaseUrl(existing), {
+  const baseUrl = resolveOllamaApiBase(readProviderBaseUrl(existing));
+  // App-guided setup must not turn an installed-but-idle model into a surprise
+  // memory allocation. Only /api/ps owns the currently resident model set.
+  const loaded = await fetchLoadedOllamaModelNames(baseUrl, discoveryAccess);
+  if (!loaded.reachable || loaded.models.length === 0) {
+    return null;
+  }
+  const provider = await buildOllamaProvider(baseUrl, {
     quiet: true,
     ...discoveryAccess,
   });
   const toolModels =
-    provider.models?.filter((candidate) => candidate.compat?.supportsTools === true) ?? [];
+    provider.models?.filter(
+      (candidate) =>
+        candidate.compat?.supportsTools === true &&
+        findAvailableOllamaModelName(candidate.id, loaded.models) !== undefined,
+    ) ?? [];
   // Automatic setup needs measured /api/show facts. The catalog fallback is
   // intentionally optimistic for manual use and must not qualify a weak route.
   let model: ModelDefinitionConfig | undefined;

--- a/extensions/ollama/src/node-inference.ts
+++ b/extensions/ollama/src/node-inference.ts
@@ -24,6 +24,7 @@ import {
   buildOllamaBaseUrlSsrFPolicy,
   enrichOllamaCompletionModels,
   enrichOllamaModelsWithContext,
+  fetchLoadedOllamaModelNames,
   fetchOllamaModels,
   isOllamaCloudModel,
   resolveOllamaApiBase,
@@ -156,32 +157,6 @@ async function requestOllamaJson<T>(params: {
   }
 }
 
-async function fetchLoadedModelNames(baseUrl: string, signal?: AbortSignal): Promise<Set<string>> {
-  try {
-    const data = await requestOllamaJson<{ models?: Array<{ name?: unknown; model?: unknown }> }>({
-      baseUrl,
-      path: "/api/ps",
-      timeoutMs: 5000,
-      ...(signal ? { signal } : {}),
-    });
-    return new Set(
-      (data.models ?? [])
-        .map((model) =>
-          typeof model.name === "string"
-            ? model.name.trim()
-            : typeof model.model === "string"
-              ? model.model.trim()
-              : "",
-        )
-        .filter(Boolean),
-    );
-  } catch {
-    throwIfOllamaRequestAborted(signal);
-    // Model discovery still works against Ollama versions without /api/ps.
-    return new Set();
-  }
-}
-
 async function discoverOllamaNodeModels(
   baseUrl = OLLAMA_DEFAULT_BASE_URL,
   signal?: AbortSignal,
@@ -194,7 +169,9 @@ async function discoverOllamaNodeModels(
   const localModels = discovered.models.filter(
     (model) => !model.remote_host?.trim() && !isOllamaCloudModel(model.name),
   );
-  const loadedNames = await fetchLoadedModelNames(apiBase, signal);
+  const loaded = await fetchLoadedOllamaModelNames(apiBase, signal ? { signal } : undefined);
+  // Model discovery still works against Ollama versions without /api/ps.
+  const loadedNames = new Set(loaded.models);
   // Probe loaded models before the bounded catalog can hide already-runnable node models.
   const prioritizedModels = localModels.toSorted(
     (left, right) => Number(loadedNames.has(right.name)) - Number(loadedNames.has(left.name)),

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -10,6 +10,7 @@ import {
   buildOllamaModelDefinition,
   capLocalOllamaProviderContext,
   enrichOllamaModelsWithContext,
+  fetchLoadedOllamaModelNames,
   isOllamaCloudModel,
   fetchOllamaModels,
   queryOllamaModelShowInfo,
@@ -159,6 +160,26 @@ describe("ollama provider models", () => {
       }),
     ]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reads loaded models from /api/ps with remote auth", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      expect(requestUrl(input)).toBe("https://ollama.example.com/api/ps");
+      expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer private-key");
+      return jsonResponse({
+        models: [{ name: "qwen3.5:4b" }, { model: "llama3.3:70b" }, { name: "   " }, {}],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchLoadedOllamaModelNames("https://ollama.example.com/v1", {
+        apiKey: "private-key",
+      }),
+    ).resolves.toEqual({
+      reachable: true,
+      models: ["qwen3.5:4b", "llama3.3:70b"],
+    });
   });
 
   it("discovers a chat model after 200 embedding-only catalog entries", async () => {
@@ -532,6 +553,18 @@ describe("ollama provider models", () => {
       models: [],
     });
     expect(tagsResponse.wasCanceled()).toBe(true);
+
+    const psResponse = cancelTrackedResponse("process listing unavailable", { status: 503 });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => psResponse.response),
+    );
+
+    await expect(fetchLoadedOllamaModelNames("http://127.0.0.1:11434")).resolves.toEqual({
+      reachable: true,
+      models: [],
+    });
+    expect(psResponse.wasCanceled()).toBe(true);
 
     const showResponse = cancelTrackedResponse("model unavailable", { status: 503 });
     vi.stubGlobal(

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -34,6 +34,11 @@ export type OllamaTagsResponse = {
   models?: OllamaTagModel[];
 };
 
+export type OllamaRunningModel = {
+  name?: unknown;
+  model?: unknown;
+};
+
 export type OllamaModelWithContext = OllamaTagModel & {
   contextWindow?: number;
   capabilities?: string[];
@@ -420,25 +425,29 @@ type OllamaModelsFetchDeps = {
   lookupFn?: LookupFn;
 };
 
-export async function fetchOllamaModels(
-  baseUrl: string,
-  opts?: OllamaModelRequestOptions,
-  deps?: OllamaModelsFetchDeps,
-): Promise<{ reachable: boolean; models: OllamaTagModel[] }> {
+async function fetchOllamaModelRows<T>(params: {
+  baseUrl: string;
+  endpoint: "ps" | "tags";
+  opts?: OllamaModelRequestOptions;
+  deps?: OllamaModelsFetchDeps;
+}): Promise<{ reachable: boolean; models: T[] }> {
   try {
-    const apiBase = resolveOllamaApiBase(baseUrl);
+    const apiBase = resolveOllamaApiBase(params.baseUrl);
+    const auditContext = `ollama-provider-models.${params.endpoint}`;
     const { response, release } = await fetchWithSsrFGuard({
-      url: `${apiBase}/api/tags`,
+      url: `${apiBase}/api/${params.endpoint}`,
       init: {
-        headers: opts?.apiKey ? { Authorization: `Bearer ${opts.apiKey}` } : undefined,
+        headers: params.opts?.apiKey
+          ? { Authorization: `Bearer ${params.opts.apiKey}` }
+          : undefined,
       },
       // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
-      timeoutMs: Math.min(opts?.timeoutMs ?? OLLAMA_TAGS_TIMEOUT_MS, OLLAMA_TAGS_TIMEOUT_MS),
-      ...(opts?.signal ? { signal: opts.signal } : {}),
+      timeoutMs: Math.min(params.opts?.timeoutMs ?? OLLAMA_TAGS_TIMEOUT_MS, OLLAMA_TAGS_TIMEOUT_MS),
+      ...(params.opts?.signal ? { signal: params.opts.signal } : {}),
       policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
-      auditContext: "ollama-provider-models.tags",
-      ...(deps?.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
-      ...(deps?.lookupFn ? { lookupFn: deps.lookupFn } : {}),
+      auditContext,
+      ...(params.deps?.fetchImpl ? { fetchImpl: params.deps.fetchImpl } : {}),
+      ...(params.deps?.lookupFn ? { lookupFn: params.deps.lookupFn } : {}),
     });
     try {
       if (!response.ok) {
@@ -447,19 +456,58 @@ export async function fetchOllamaModels(
         void response.body?.cancel().catch(() => undefined);
         return { reachable: true, models: [] };
       }
-      const data = await readProviderJsonResponse<OllamaTagsResponse>(
-        response,
-        "ollama-provider-models.tags",
-      );
-      const models = (data.models ?? []).filter((m) => m.name);
+      const data = await readProviderJsonResponse<{ models?: T[] }>(response, auditContext);
+      const models = Array.isArray(data.models) ? data.models : [];
       return { reachable: true, models };
     } finally {
       await release();
     }
   } catch {
-    throwIfOllamaRequestAborted(opts?.signal);
+    throwIfOllamaRequestAborted(params.opts?.signal);
     return { reachable: false, models: [] };
   }
+}
+
+export async function fetchOllamaModels(
+  baseUrl: string,
+  opts?: OllamaModelRequestOptions,
+  deps?: OllamaModelsFetchDeps,
+): Promise<{ reachable: boolean; models: OllamaTagModel[] }> {
+  const result = await fetchOllamaModelRows<OllamaTagModel>({
+    baseUrl,
+    endpoint: "tags",
+    opts,
+    deps,
+  });
+  return {
+    reachable: result.reachable,
+    models: result.models.filter((model) => model.name),
+  };
+}
+
+export async function fetchLoadedOllamaModelNames(
+  baseUrl: string,
+  opts?: OllamaModelRequestOptions,
+  deps?: OllamaModelsFetchDeps,
+): Promise<{ reachable: boolean; models: string[] }> {
+  const result = await fetchOllamaModelRows<OllamaRunningModel>({
+    baseUrl,
+    endpoint: "ps",
+    opts,
+    deps,
+  });
+  return {
+    reachable: result.reachable,
+    models: result.models
+      .map((model) =>
+        typeof model.name === "string"
+          ? model.name.trim()
+          : typeof model.model === "string"
+            ? model.model.trim()
+            : "",
+      )
+      .filter(Boolean),
+  };
 }
 
 export async function buildOllamaProvider(

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -34,10 +34,12 @@ export type OllamaTagsResponse = {
   models?: OllamaTagModel[];
 };
 
-export type OllamaRunningModel = {
+type OllamaRunningModel = {
   name?: unknown;
   model?: unknown;
 };
+
+type OllamaModelRow = OllamaTagModel | OllamaRunningModel;
 
 export type OllamaModelWithContext = OllamaTagModel & {
   contextWindow?: number;
@@ -425,12 +427,12 @@ type OllamaModelsFetchDeps = {
   lookupFn?: LookupFn;
 };
 
-async function fetchOllamaModelRows<T>(params: {
+async function fetchOllamaModelRows(params: {
   baseUrl: string;
   endpoint: "ps" | "tags";
   opts?: OllamaModelRequestOptions;
   deps?: OllamaModelsFetchDeps;
-}): Promise<{ reachable: boolean; models: T[] }> {
+}): Promise<{ reachable: boolean; models: OllamaModelRow[] }> {
   try {
     const apiBase = resolveOllamaApiBase(params.baseUrl);
     const auditContext = `ollama-provider-models.${params.endpoint}`;
@@ -456,7 +458,10 @@ async function fetchOllamaModelRows<T>(params: {
         void response.body?.cancel().catch(() => undefined);
         return { reachable: true, models: [] };
       }
-      const data = await readProviderJsonResponse<{ models?: T[] }>(response, auditContext);
+      const data = await readProviderJsonResponse<{ models?: OllamaModelRow[] }>(
+        response,
+        auditContext,
+      );
       const models = Array.isArray(data.models) ? data.models : [];
       return { reachable: true, models };
     } finally {
@@ -473,7 +478,7 @@ export async function fetchOllamaModels(
   opts?: OllamaModelRequestOptions,
   deps?: OllamaModelsFetchDeps,
 ): Promise<{ reachable: boolean; models: OllamaTagModel[] }> {
-  const result = await fetchOllamaModelRows<OllamaTagModel>({
+  const result = await fetchOllamaModelRows({
     baseUrl,
     endpoint: "tags",
     opts,
@@ -481,7 +486,9 @@ export async function fetchOllamaModels(
   });
   return {
     reachable: result.reachable,
-    models: result.models.filter((model) => model.name),
+    models: result.models.filter(
+      (model): model is OllamaTagModel => typeof model.name === "string" && Boolean(model.name),
+    ),
   };
 }
 
@@ -490,7 +497,7 @@ export async function fetchLoadedOllamaModelNames(
   opts?: OllamaModelRequestOptions,
   deps?: OllamaModelsFetchDeps,
 ): Promise<{ reachable: boolean; models: string[] }> {
-  const result = await fetchOllamaModelRows<OllamaRunningModel>({
+  const result = await fetchOllamaModelRows({
     baseUrl,
     endpoint: "ps",
     opts,
@@ -502,7 +509,7 @@ export async function fetchLoadedOllamaModelNames(
       .map((model) =>
         typeof model.name === "string"
           ? model.name.trim()
-          : typeof model.model === "string"
+          : "model" in model && typeof model.model === "string"
             ? model.model.trim()
             : "",
       )


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where app-guided Ollama setup could propose an installed but idle model, then wake it during verification and unexpectedly allocate several gigabytes of memory.

## Why This Change Was Made

Automatic setup now treats Ollama's `/api/ps` response as the authoritative resident-model set, filters the installed catalog to that set, and rechecks residency before persisting the route. Interactive setup, explicit pulls, runtime catalogs, and paired-node inference remain unchanged.

## User Impact

Users can keep multiple Ollama models installed without setup loading an idle model behind their back. When no suitable model is already resident, OpenClaw leaves Ollama in the explicit local-model setup flow instead of guessing.

## Evidence

- Live Ollama 0.32.5:
  - installed `qwen3:0.6b`, zero resident models: app-guided detection returned no candidate
  - loaded only `qwen3:0.6b`: detection and prepare resolved `ollama/qwen3:0.6b`
  - unloaded after proof: `/api/ps` returned an empty model list
- LM Studio remained at zero loaded instances throughout the live proof.
- `175` focused Ollama provider, node-inference, abort, deadline, SSRF, and response-body tests passed.
- Chromium model-setup recovery flow passed and captured all review screenshots.
- Autoreview: clean, no actionable findings, correctness confidence `0.98`.
- `git diff --check`: clean.
- Static lint is blocked before the changed files by the existing `packages/terminal-core/src/ansi.ts:194` declaration error on current `main`.

### Screenshots

**Configured Models surface**

![Ollama configured on the Models surface](https://github.com/user-attachments/assets/9df897d0-f7de-484d-afcc-067791d3a338)

**Ollama local setup**

![Ollama local setup mode selection](https://github.com/user-attachments/assets/2f48b2b5-1348-452f-beb1-7bbd10badd1f)

**Verified connection**

![Ollama connection verified with a start chatting action](https://github.com/user-attachments/assets/59e63b40-65e5-4629-80f4-d25291e80768)

AI-assisted: yes.
