### PR TITLE
test(system-agent): fixture CLI backend policy

### DIFF
--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../agents/auth-profiles/oauth-test-utils.js";
 import { upsertAuthProfileWithLock } from "../agents/auth-profiles/profiles.js";
 import { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js";
+import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import {
   fingerprintAuthProfileCredential,
   fingerprintResolvedProviderAuth,
@@ -136,6 +137,29 @@ beforeAll(async () => {
   pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(
     materializedMainRuntimeConfig,
   );
+  cliBackendsTesting.setDepsForTest({
+    resolvePluginSetupCliBackend: () => undefined,
+    resolvePluginSetupRegistry: () => ({ cliBackends: [] }) as never,
+    resolveRuntimeCliBackends: () => [
+      {
+        id: "claude-cli",
+        pluginId: "anthropic",
+        modelProvider: "anthropic",
+        bundleMcp: true,
+        bundleMcpMode: "claude-config-file",
+        config: { command: "claude" },
+        sideQuestionToolMode: "disabled",
+      },
+      {
+        id: "google-gemini-cli",
+        pluginId: "google",
+        modelProvider: "google",
+        bundleMcp: false,
+        config: { command: "gemini" },
+        nativeToolMode: "none",
+      },
+    ],
+  });
   await suiteTempRootTracker.setup();
 });
 
@@ -143,6 +167,7 @@ afterAll(async () => {
   try {
     await suiteTempRootTracker.cleanup();
   } finally {
+    cliBackendsTesting.resetDepsForTest();
     pluginMetadataSnapshot?.restore();
   }
 });


### PR DESCRIPTION
## Summary

- keep `setup-inference.test.ts` on deterministic contract-level Claude and Gemini CLI backend fixtures
- avoid cold-loading complete generated setup plugins merely to resolve CLI auth-forwarding and tool-free policy
- preserve all 122 setup, persistence, owner-drift, Codex, auth, and verification assertions

No production code, worker count, test configuration, or sharding changes.

## Performance

- baseline focused file: 76.73s Vitest duration, 67.93s test bodies, 1.61GB max RSS
- rebased result: 54.59s Vitest duration, 51.66s test bodies, 1.06GB max RSS
- improvement: 28.9% Vitest wall, 24.0% test bodies, 33.8% peak RSS

The former 15–18s first-success outlier now completes in roughly 150ms because CLI policy comes from the same dependency seam used by the CLI backend owner tests.

## Proof

- `node scripts/run-vitest.mjs src/system-agent/setup-inference.test.ts` — 122/122 passed after rebasing onto current `main`
- `git diff --check` and repository formatter passed
- autoreview clean with no accepted/actionable findings

Test-only change; no changelog entry.
