### PR TITLE
test(ui): run runtime-free suites in Node

### DIFF
--- a/ui/src/app/gateway-readiness.test.ts
+++ b/ui/src/app/gateway-readiness.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { waitForGatewayClient } from "./gateway-readiness.ts";

--- a/ui/src/app/user-profile.test.ts
+++ b/ui/src/app/user-profile.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   readPresenceEntries,

--- a/ui/src/components/config-form-array-identity.test.ts
+++ b/ui/src/components/config-form-array-identity.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   appendArrayRowIdentities,

--- a/ui/src/components/config-form-copy-on-write.test.ts
+++ b/ui/src/components/config-form-copy-on-write.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { copyWithPathPatch } from "./config-form-copy-on-write.ts";
 

--- a/ui/src/lib/gateway-connection-lifecycle.test.ts
+++ b/ui/src/lib/gateway-connection-lifecycle.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { createGatewayConnectionLifecycle } from "./gateway-connection-lifecycle.ts";

--- a/ui/src/lib/gateway-retry.test.ts
+++ b/ui/src/lib/gateway-retry.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createGatewayRetryOwner } from "./gateway-retry.ts";
 

--- a/ui/src/lib/observer-digest.test.ts
+++ b/ui/src/lib/observer-digest.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { SessionObserverDigest } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import {

--- a/ui/src/lib/sessions/child-session-data.test.ts
+++ b/ui/src/lib/sessions/child-session-data.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { fetchChildSessionRows } from "./child-session-data.ts";

--- a/ui/src/lib/sessions/tool-overrides.test.ts
+++ b/ui/src/lib/sessions/tool-overrides.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   countSessionToolOverrides,

--- a/ui/src/pages/channels/nostr-profile-ops.test.ts
+++ b/ui/src/pages/channels/nostr-profile-ops.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { importNostrProfile, putNostrProfile } from "./nostr-profile-ops.ts";
 

--- a/ui/src/pages/chat/chat-observer.test.ts
+++ b/ui/src/pages/chat/chat-observer.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { sendSessionObserverVisibility } from "./chat-observer.ts";

--- a/ui/src/pages/chat/components/chat-audio-waveform.test.ts
+++ b/ui/src/pages/chat/components/chat-audio-waveform.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
   cacheAndRetainChatAudioBlob,

--- a/ui/src/styles/base-theme-contrast.node.test.ts
+++ b/ui/src/styles/base-theme-contrast.node.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/ui/src/styles/base-theme-tokens.node.test.ts
+++ b/ui/src/styles/base-theme-tokens.node.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/ui/src/styles/theme-contrast.test.ts
+++ b/ui/src/styles/theme-contrast.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
## Summary

- run 15 UI tests with Node instead of jsdom after auditing their complete runtime import closures
- keep all files in the existing UI test project and shard; only the per-file Vitest environment changes
- exclude DOM-dependent candidates such as keyboard shortcut tests

The 15 files and all 13 local runtime dependencies use only Node built-ins, Vitest, type-only imports, or Node-supported web APIs. None imports Lit, WebAwesome, DOM globals, dynamic modules, or browser-only runtime packages.

## Performance

- jsdom baseline: 1.20s warm Vitest / 1.68s wrapper / 11.55s aggregate environment setup
- rebased Node proof: 452ms Vitest / 815ms wrapper / 1ms environment setup
- focused improvement: about 62% Vitest duration and effectively all jsdom environment cost

## Proof

- all 15 files / 65 tests passed after rebasing onto current `main`
- complete transitive runtime closure audited for all 28 test and dependency files
- `oxfmt` and `git diff --check` passed
- autoreview clean with no accepted/actionable findings

Test-only change; no changelog entry.
