### PR TITLE
test(agents): fixture CLI attempt backends

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -24,6 +24,7 @@ import { registerGeneratedMediaTaskActivity } from "../../tasks/generated-media-
 import { resetGeneratedMediaTaskActivityForTests } from "../../tasks/task-runtime.test-helpers.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
 import { saveAuthProfileStore } from "../auth-profiles/store.js";
+import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent.js";
 import { FailoverError } from "../failover-error.js";
 import { attachToolAllowlistIntersection } from "../tool-policy.js";
@@ -608,6 +609,24 @@ describe("CLI attempt execution", () => {
     providerAuthAliasMocks.resolveProviderAuthAliasMap.mockClear();
     providerAuthAliasMocks.resolveProviderIdForAuth.mockClear();
     sessionWriteLockMocks.acquireSessionWriteLock.mockClear();
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: () => undefined,
+      resolvePluginSetupRegistry: () => ({ cliBackends: [] }) as never,
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          pluginId: "anthropic",
+          config: { command: "claude", forkArg: "--fork-session" },
+        },
+        {
+          id: "google-gemini-cli",
+          modelProvider: "google",
+          pluginId: "google",
+          config: { command: "gemini" },
+        },
+      ],
+    });
   });
 
   async function writeSessionStoreSeed(sessionStore: Record<string, SessionEntry>): Promise<void> {
@@ -648,9 +667,10 @@ describe("CLI attempt execution", () => {
 
   afterEach(async () => {
     vi.useRealTimers();
+    cliBackendsTesting.resetDepsForTest();
+    closeOpenClawAgentDatabasesForTest();
     homeEnvSnapshot?.restore();
     homeEnvSnapshot = undefined;
-    closeOpenClawAgentDatabasesForTest();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary

- use deterministic contract-level Claude and Gemini CLI backend fixtures in the CLI attempt execution suite
- avoid cold-loading complete bundled setup plugins for orchestration tests that do not assert plugin discovery
- close agent database handles before restoring the test environment, preserving fixture ownership order

All 112 orchestration assertions remain unchanged. No production code, test configuration, worker count, or sharding changes.

## Performance

- baseline full file: 45.07s Vitest / 32.13s test bodies
- rebased result: 29.99s Vitest / 16.91s test bodies
- improvement: 33.5% Vitest duration and 47.4% test-body time
- targeted cold case group: 61.37s to 12.09s in the original comparison

## Proof

- `src/agents/command/attempt-execution.cli.test.ts` — 112/112 passed after rebasing onto current `main`
- targeted `oxfmt`, `oxlint`, and `git diff --check` passed
- autoreview clean with no accepted/actionable findings

Test-only change; no changelog entry.
