### PR TITLE
fix(cron): deliver failure alerts only after persistence

### DIFF
--- a/src/cron/service/auto-disable.ts
+++ b/src/cron/service/auto-disable.ts
@@ -3,11 +3,9 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import type { CronJob, CronJobState } from "../types.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
-import type { CronServiceState } from "./state.js";
+import type { CronServiceState, DeferredCronNotifications } from "./state.js";
 
 type CronAutoDisableReason = NonNullable<CronJobState["autoDisabled"]>["reason"];
-
-export type DeferredAutoDisableNotifications = Array<() => void>;
 
 /**
  * Run failures get more room than schedule errors (10 vs. 3) because provider
@@ -27,7 +25,7 @@ export function autoDisableCronJob(params: {
   atMs: number;
   consecutiveErrors: number;
   error: unknown;
-  deferredNotifications?: DeferredAutoDisableNotifications;
+  deferredNotifications?: DeferredCronNotifications;
 }): boolean {
   const { state, job } = params;
   if (!job.enabled || job.state.autoDisabled) {
@@ -91,7 +89,7 @@ export function maybeAutoDisableCronJobAfterRunFailure(params: {
   job: CronJob;
   atMs: number;
   error: unknown;
-  deferredNotifications?: DeferredAutoDisableNotifications;
+  deferredNotifications?: DeferredCronNotifications;
 }): boolean {
   const consecutiveErrors = params.job.state.consecutiveErrors ?? 0;
   if (

--- a/src/cron/service/failure-alerts.account-routing.test.ts
+++ b/src/cron/service/failure-alerts.account-routing.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import type { CronJob } from "../types.js";
 import { resolveFailureAlert } from "./failure-alerts.js";
-import { createCronServiceState } from "./state.js";
+import { createCronServiceState, type DeferredCronNotifications } from "./state.js";
 import { applyJobResult } from "./timer.js";
 
 describe("cron failure alert account routing", () => {
@@ -278,16 +278,24 @@ describe("cron failure alert account routing", () => {
       delivery: { mode: "announce", channel: "telegram", to: "telegram:19098680" },
       state: {},
     };
+    const deferredNotifications: DeferredCronNotifications = [];
 
-    applyJobResult(state, job, {
-      status: "error",
-      error: "provider unavailable",
-      startedAt: runAtMs,
-      endedAt,
-    });
+    applyJobResult(
+      state,
+      job,
+      {
+        status: "error",
+        error: "provider unavailable",
+        startedAt: runAtMs,
+        endedAt,
+      },
+      { deferredNotifications },
+    );
 
-    expect(sendCronFailureAlert).toHaveBeenCalledWith(expect.objectContaining({ runAtMs }));
     expect(job.state.lastFailureAlertAtMs).toBe(endedAt);
+    expect(sendCronFailureAlert).not.toHaveBeenCalled();
+    deferredNotifications[0]?.();
+    expect(sendCronFailureAlert).toHaveBeenCalledWith(expect.objectContaining({ runAtMs }));
   });
 
   it.each([
@@ -334,14 +342,22 @@ describe("cron failure alert account routing", () => {
       ...(failureAlert ? { failureAlert } : {}),
       state: {},
     };
+    const deferredNotifications: DeferredCronNotifications = [];
 
-    applyJobResult(state, job, {
-      status: "error",
-      error: "provider unavailable",
-      startedAt: 1,
-      endedAt: 2,
-    });
+    applyJobResult(
+      state,
+      job,
+      {
+        status: "error",
+        error: "provider unavailable",
+        startedAt: 1,
+        endedAt: 2,
+      },
+      { deferredNotifications },
+    );
 
+    expect(sendCronFailureAlert).not.toHaveBeenCalled();
+    deferredNotifications[0]?.();
     expect(sendCronFailureAlert).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "expectedChannel" in testCase ? testCase.expectedChannel : "telegram",

--- a/src/cron/service/failure-alerts.persistence.test.ts
+++ b/src/cron/service/failure-alerts.persistence.test.ts
@@ -1,0 +1,219 @@
+// Failure alerts must describe only cron outcomes that survived durable persistence.
+import { describe, expect, it, vi } from "vitest";
+import {
+  createDueIsolatedJob,
+  noopLogger,
+  setupCronRegressionFixtures,
+} from "../../../test/helpers/cron/service-regression-fixtures.js";
+import { markCronJobActive } from "../active-jobs.js";
+import * as cronStoreModule from "../store.js";
+import { loadCronStore, saveCronStore } from "../store.js";
+import type { CronJob, CronRunStatus } from "../types.js";
+import { createCronServiceState } from "./state.js";
+import { finalizeCompletedCronRunOutcomes } from "./timer-outcome-finalization.js";
+
+const fixtures = setupCronRegressionFixtures({
+  prefix: "cron-failure-alert-persistence-",
+});
+
+type SendCronFailureAlert = NonNullable<
+  Parameters<typeof createCronServiceState>[0]["sendCronFailureAlert"]
+>;
+
+function createAlertJob(params: { id: string; dueAt: number; includeSkipped?: boolean }): CronJob {
+  const job = createDueIsolatedJob({
+    id: params.id,
+    nowMs: params.dueAt,
+    nextRunAtMs: params.dueAt,
+  });
+  job.schedule = { kind: "every", everyMs: 60_000, anchorMs: params.dueAt - 60_000 };
+  job.failureAlert = {
+    after: 1,
+    cooldownMs: 60_000,
+    ...(params.includeSkipped ? { includeSkipped: true } : {}),
+  };
+  job.state.runningAtMs = params.dueAt;
+  return job;
+}
+
+function createAlertState(params: {
+  storePath: string;
+  nowMs: () => number;
+  sendCronFailureAlert: SendCronFailureAlert;
+}) {
+  return createCronServiceState({
+    cronEnabled: true,
+    storePath: params.storePath,
+    log: noopLogger,
+    nowMs: params.nowMs,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeat: vi.fn(),
+    sendCronFailureAlert: params.sendCronFailureAlert,
+    runIsolatedAgentJob: vi.fn(),
+  });
+}
+
+async function finalizeAlertOutcome(params: {
+  state: ReturnType<typeof createCronServiceState>;
+  job: CronJob;
+  status: Extract<CronRunStatus, "error" | "skipped">;
+  error: string;
+  startedAt: number;
+  endedAt: number;
+}) {
+  await finalizeCompletedCronRunOutcomes(params.state, [
+    {
+      jobId: params.job.id,
+      job: structuredClone(params.job),
+      activeJobMarker: markCronJobActive(params.job.id),
+      status: params.status,
+      error: params.error,
+      startedAt: params.startedAt,
+      endedAt: params.endedAt,
+    },
+  ]);
+}
+
+describe("cron failure alert persistence", () => {
+  it.each([
+    { status: "error", includeSkipped: false },
+    { status: "skipped", includeSkipped: true },
+  ] as const)("delivers a $status alert once after the outcome is durable", async (testCase) => {
+    const store = fixtures.makeStorePath();
+    const dueAt = Date.parse("2026-08-01T14:50:00.000Z");
+    const endedAt = dueAt + 10;
+    const job = createAlertJob({
+      id: `${testCase.status}-alert-after-persist`,
+      dueAt,
+      includeSkipped: testCase.includeSkipped,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const order: string[] = [];
+    const sendCronFailureAlert = vi.fn(async () => {
+      order.push("alert");
+    });
+    const state = createAlertState({
+      storePath: store.storePath,
+      nowMs: () => endedAt,
+      sendCronFailureAlert,
+    });
+    const save = cronStoreModule.saveCronJobsStore;
+    const saveSpy = vi
+      .spyOn(cronStoreModule, "saveCronJobsStore")
+      .mockImplementation(async (...args) => {
+        if (args[1].jobs[0]?.state.lastFailureAlertAtMs === endedAt) {
+          expect(sendCronFailureAlert).not.toHaveBeenCalled();
+          await save(...args);
+          order.push("persist");
+          return;
+        }
+        await save(...args);
+      });
+
+    try {
+      await finalizeAlertOutcome({
+        state,
+        job,
+        status: testCase.status,
+        error: testCase.status === "error" ? "provider unavailable" : "disabled",
+        startedAt: dueAt,
+        endedAt,
+      });
+
+      expect(order).toEqual(["persist", "alert"]);
+      expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+      expect((await loadCronStore(store.storePath)).jobs[0]?.state.lastFailureAlertAtMs).toBe(
+        endedAt,
+      );
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  it("rolls back the cooldown without delivery when persistence fails", async () => {
+    const store = fixtures.makeStorePath();
+    const dueAt = Date.parse("2026-08-01T14:55:00.000Z");
+    const job = createAlertJob({ id: "failure-alert-persist-rollback", dueAt });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const state = createAlertState({
+      storePath: store.storePath,
+      nowMs: () => dueAt + 10,
+      sendCronFailureAlert,
+    });
+    const saveSpy = vi
+      .spyOn(cronStoreModule, "saveCronJobsStore")
+      .mockRejectedValueOnce(new Error("terminal write failed"));
+
+    try {
+      await expect(
+        finalizeAlertOutcome({
+          state,
+          job,
+          status: "error",
+          error: "provider unavailable",
+          startedAt: dueAt,
+          endedAt: dueAt + 10,
+        }),
+      ).rejects.toThrow("terminal write failed");
+
+      expect(sendCronFailureAlert).not.toHaveBeenCalled();
+      expect(state.store?.jobs[0]?.state.lastFailureAlertAtMs).toBeUndefined();
+      expect(
+        (await loadCronStore(store.storePath)).jobs[0]?.state.lastFailureAlertAtMs,
+      ).toBeUndefined();
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  it("persists the cooldown atomically and suppresses a second alert", async () => {
+    const store = fixtures.makeStorePath();
+    const dueAt = Date.parse("2026-08-01T14:58:00.000Z");
+    const firstAlertAt = dueAt + 10;
+    const job = createAlertJob({ id: "failure-alert-cooldown-persisted", dueAt });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    let now = firstAlertAt;
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const state = createAlertState({
+      storePath: store.storePath,
+      nowMs: () => now,
+      sendCronFailureAlert,
+    });
+
+    await finalizeAlertOutcome({
+      state,
+      job,
+      status: "error",
+      error: "first failure",
+      startedAt: dueAt,
+      endedAt: firstAlertAt,
+    });
+    expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+    expect((await loadCronStore(store.storePath)).jobs[0]?.state.lastFailureAlertAtMs).toBe(
+      firstAlertAt,
+    );
+
+    now += 30_000;
+    const currentJob = state.store?.jobs[0];
+    if (!currentJob) {
+      throw new Error("expected persisted cron job");
+    }
+    await finalizeAlertOutcome({
+      state,
+      job: currentJob,
+      status: "error",
+      error: "second failure",
+      startedAt: now,
+      endedAt: now + 10,
+    });
+
+    expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+    expect((await loadCronStore(store.storePath)).jobs[0]).toMatchObject({
+      state: { consecutiveErrors: 2, lastFailureAlertAtMs: firstAlertAt },
+    });
+  });
+});

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -8,7 +8,7 @@ import {
   stripTargetProviderPrefix,
 } from "../../infra/outbound/channel-target-prefix.js";
 import type { CronFailureNotificationDelivery, CronJob, CronMessageChannel } from "../types.js";
-import type { CronServiceState } from "./state.js";
+import type { CronServiceState, DeferredCronNotifications } from "./state.js";
 
 const DEFAULT_FAILURE_ALERT_AFTER = 2;
 const DEFAULT_FAILURE_ALERT_COOLDOWN_MS = 60 * 60_000; // 1 hour
@@ -228,9 +228,11 @@ export function maybeEmitFailureAlert(
     consecutiveCount: number;
     delivery?: "emit" | "record-only";
     occurredAtMs?: number;
+    deferredNotifications?: DeferredCronNotifications;
   },
 ) {
-  if (!params.alertConfig || params.consecutiveCount < params.alertConfig.after) {
+  const alertConfig = params.alertConfig;
+  if (!alertConfig || params.consecutiveCount < alertConfig.after) {
     return;
   }
   if (
@@ -252,24 +254,33 @@ export function maybeEmitFailureAlert(
   // Cooldown is stored on job state so process restarts and service reloads do
   // not spam operators with repeated alerts for the same failing job.
   const inCooldown =
-    typeof lastAlert === "number" && now - lastAlert < Math.max(0, params.alertConfig.cooldownMs);
+    typeof lastAlert === "number" && now - lastAlert < Math.max(0, alertConfig.cooldownMs);
   if (inCooldown) {
     return;
   }
-  if (params.delivery !== "record-only") {
+  params.job.state.lastFailureAlertAtMs = now;
+  if (params.delivery === "record-only") {
+    return;
+  }
+
+  const job = structuredClone(params.job);
+  const notify = () =>
     emitFailureAlert(state, {
-      job: params.job,
+      job,
       error: params.error,
       errorReason: params.errorReason,
       runAtMs: params.runAtMs,
       consecutiveErrors: params.consecutiveCount,
-      channel: params.alertConfig.channel,
-      to: params.alertConfig.to,
-      mode: params.alertConfig.mode,
-      accountId: params.alertConfig.accountId,
-      threadId: params.alertConfig.threadId,
+      channel: alertConfig.channel,
+      to: alertConfig.to,
+      mode: alertConfig.mode,
+      accountId: alertConfig.accountId,
+      threadId: alertConfig.threadId,
       status: params.status,
     });
+  if (params.deferredNotifications) {
+    params.deferredNotifications.push(notify);
+  } else {
+    notify();
   }
-  params.job.state.lastFailureAlertAtMs = now;
 }

--- a/src/cron/service/jobs-scheduling.ts
+++ b/src/cron/service/jobs-scheduling.ts
@@ -11,10 +11,10 @@ import {
 import { resolveCronStaggerMs } from "../stagger.js";
 import { createCronStreamSourceIdentity, resolveCronStreamBatching } from "../stream-schedule.js";
 import type { CronJob, CronSchedule } from "../types.js";
-import { autoDisableCronJob, type DeferredAutoDisableNotifications } from "./auto-disable.js";
+import { autoDisableCronJob } from "./auto-disable.js";
 import { normalizePayloadToSystemText } from "./normalize.js";
 import { isQueuedCronRun, isQueuedForceCronRun } from "./run-admission.js";
-import type { CronServiceState } from "./state.js";
+import type { CronServiceState, DeferredCronNotifications } from "./state.js";
 
 const STUCK_RUN_MS = 2 * 60 * 60 * 1000;
 const STAGGER_OFFSET_CACHE_MAX = 4096;
@@ -359,7 +359,7 @@ export function recordScheduleComputeError(params: {
   state: CronServiceState;
   job: CronJob;
   err: unknown;
-  deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
+  deferredNotifications?: DeferredCronNotifications;
 }): boolean {
   const { state, job, err } = params;
   const errorCount = (job.state.scheduleErrorCount ?? 0) + 1;
@@ -377,7 +377,7 @@ export function recordScheduleComputeError(params: {
       atMs: state.deps.nowMs(),
       consecutiveErrors: errorCount,
       error: errText,
-      deferredNotifications: params.deferredAutoDisableNotifications,
+      deferredNotifications: params.deferredNotifications,
     });
     state.deps.log.error(
       { jobId: job.id, name: job.name, errorCount, err: errText },
@@ -539,7 +539,7 @@ function recomputeJobNextRunAtMs(params: {
   state: CronServiceState;
   job: CronJob;
   nowMs: number;
-  deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
+  deferredNotifications?: DeferredCronNotifications;
 }) {
   let changed = false;
   try {
@@ -572,7 +572,7 @@ function recomputeJobNextRunAtMs(params: {
         state: params.state,
         job: params.job,
         err,
-        deferredAutoDisableNotifications: params.deferredAutoDisableNotifications,
+        deferredNotifications: params.deferredNotifications,
       })
     ) {
       changed = true;
@@ -615,7 +615,7 @@ export function recomputeNextRunsForMaintenance(
     nowMs?: number;
     repairFutureCronNextRunAtMs?: boolean;
     preserveExpiredPacedNextRunJobId?: string;
-    deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
+    deferredNotifications?: DeferredCronNotifications;
   },
 ): boolean {
   const recomputeExpired = opts?.recomputeExpired ?? false;
@@ -625,7 +625,7 @@ export function recomputeNextRunsForMaintenance(
       state,
       job,
       nowMs,
-      deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
+      deferredNotifications: opts?.deferredNotifications,
     });
   return walkSchedulableJobs(
     state,

--- a/src/cron/service/ops-lifecycle.ts
+++ b/src/cron/service/ops-lifecycle.ts
@@ -9,7 +9,7 @@ import {
   restoreFinalizedStartupRun,
   STARTUP_INTERRUPTED_ERROR,
 } from "./startup-run-repair.js";
-import type { CronServiceState } from "./state.js";
+import type { CronServiceState, DeferredCronNotifications } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
 import { tryFindCronTaskRunIdForRecovery, tryFindFinalizedCronTaskRun } from "./task-runs.js";
 import { armTimer, runMissedJobs, stopTimer } from "./timer.js";
@@ -26,7 +26,7 @@ export async function start(state: CronServiceState) {
   const interruptedRuns: InterruptedStartupRun[] = [];
   const completedJobIdsToDelete = new Set<string>();
   let repairedAnyStartupRun = false;
-  const postPersistAutoDisableNotifications: Array<() => void> = [];
+  const postPersistNotifications: DeferredCronNotifications = [];
   await locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
     if (state.stopped) {
@@ -57,7 +57,7 @@ export async function start(state: CronServiceState) {
             entry: finalized.entry,
             ...(finalized.scriptResult ? { scriptResult: finalized.scriptResult } : {}),
             ...(finalized.triggerEval ? { triggerEval: finalized.triggerEval } : {}),
-            deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+            deferredNotifications: postPersistNotifications,
           });
           // Skip only the old invocation; a distinct overdue replacement
           // must remain eligible for normal one-shot startup catch-up.
@@ -77,7 +77,7 @@ export async function start(state: CronServiceState) {
           taskRunId,
           runningAtMs,
           nowMs,
-          deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+          deferredNotifications: postPersistNotifications,
         });
         if (interrupted.replacementAtMs === undefined) {
           interruptedJobIds.add(job.id);
@@ -94,10 +94,10 @@ export async function start(state: CronServiceState) {
         state,
         repairedAnyStartupRun ? undefined : { stateOnly: true },
       );
-      // Recovery alerts describe the repaired durable row, so never publish
-      // them until the startup write has committed successfully.
+      // Recovery notifications describe repaired durable rows, so never
+      // publish them until the startup write has committed successfully.
       if (persisted) {
-        for (const notify of postPersistAutoDisableNotifications) {
+        for (const notify of postPersistNotifications) {
           notify();
         }
       }
@@ -120,10 +120,10 @@ export async function start(state: CronServiceState) {
     if (state.stopped) {
       return;
     }
-    const postPersistMaintenanceNotifications: Array<() => void> = [];
+    const postPersistMaintenanceNotifications: DeferredCronNotifications = [];
     const changed = recomputeNextRunsForMaintenance(state, {
       recomputeExpired: true,
-      deferredAutoDisableNotifications: postPersistMaintenanceNotifications,
+      deferredNotifications: postPersistMaintenanceNotifications,
     });
     if (changed) {
       const persisted = await persist(state);

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -35,6 +35,7 @@ import type {
   CronServiceState,
   CronUpdateOptions,
   CronUpdatePrecondition,
+  DeferredCronNotifications,
 } from "./state.js";
 import { emit } from "./state.js";
 import {
@@ -276,15 +277,15 @@ export async function add(state: CronServiceState, input: CronJobCreate, opts?: 
     });
     state.store?.jobs.push(job);
 
-    // Auto-disable notifications describe durable state, so publish them only
+    // Mutation notifications describe durable state, so publish them only
     // after the write succeeds instead of leaking a rolled-back transition.
-    const postPersistAutoDisableNotifications: Array<() => void> = [];
+    const postPersistNotifications: DeferredCronNotifications = [];
     recomputeNextRunsForMaintenance(state, {
-      deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+      deferredNotifications: postPersistNotifications,
     });
 
     await persistOrRestore(state, snapshot, {
-      postPersistAutoDisableNotifications,
+      postPersistNotifications,
       suppressScheduledJobId: job.id,
     });
     armTimer(state);
@@ -428,13 +429,13 @@ export async function remove(
     state.store.jobs = state.store.jobs.filter((j) => j.id !== id);
     const removed = (state.store.jobs.length ?? 0) !== before;
 
-    const postPersistAutoDisableNotifications: Array<() => void> = [];
+    const postPersistNotifications: DeferredCronNotifications = [];
     recomputeNextRunsForMaintenance(state, {
-      deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+      deferredNotifications: postPersistNotifications,
     });
 
     await persistOrRestore(state, snapshot, {
-      postPersistAutoDisableNotifications,
+      postPersistNotifications,
       suppressScheduledJobId: id,
     });
     if (removed) {

--- a/src/cron/service/ops-read.ts
+++ b/src/cron/service/ops-read.ts
@@ -23,7 +23,7 @@ import {
   resolveCurrentDefaultAgentId,
   resolveEffectiveJobAgentId,
 } from "./ops-shared.js";
-import type { CronServiceState } from "./state.js";
+import type { CronServiceState, DeferredCronNotifications } from "./state.js";
 import { emit } from "./state.js";
 import { ensureLoaded, persistOrRestore, snapshotStoreForRollback } from "./store.js";
 import { applyJobResult, armTimer } from "./timer.js";
@@ -110,6 +110,7 @@ export async function recordExternalFailure(
       return;
     }
     const snapshot = snapshotStoreForRollback(state);
+    const postPersistNotifications: DeferredCronNotifications = [];
     const now = state.deps.nowMs();
     const sourceIdentity = job.state.streamSourceIdentity;
     Object.assign(job.state, statePatch);
@@ -117,13 +118,18 @@ export async function recordExternalFailure(
     // Source restarts are counted separately, but terminal exhaustion should
     // enter the same alert/history path as a fifth consecutive payload error.
     job.state.consecutiveErrors = Math.max(job.state.consecutiveErrors ?? 0, 4);
-    applyJobResult(state, job, {
-      status: "error",
-      error,
-      executionStarted: false,
-      startedAt: now,
-      endedAt: now,
-    });
+    applyJobResult(
+      state,
+      job,
+      {
+        status: "error",
+        error,
+        executionStarted: false,
+        startedAt: now,
+        endedAt: now,
+      },
+      { deferredNotifications: postPersistNotifications },
+    );
     // Stream schedules are event-driven; applyJobResult's generic recurring
     // backoff must never turn source failure into a time-due payload run.
     job.state.nextRunAtMs = undefined;
@@ -137,7 +143,7 @@ export async function recordExternalFailure(
       durationMs: 0,
       failureNotificationDelivery: failureNotificationDeliveryFromJobState(job),
     });
-    await persistOrRestore(state, snapshot);
+    await persistOrRestore(state, snapshot, { postPersistNotifications });
     armTimer(state);
   });
 }

--- a/src/cron/service/ops-run-preparation.ts
+++ b/src/cron/service/ops-run-preparation.ts
@@ -22,7 +22,7 @@ import {
   reserveQueuedCronRun,
   updateQueuedCronRunReservationMarker,
 } from "./run-admission.js";
-import type { CronEvent, CronServiceState } from "./state.js";
+import type { CronEvent, CronServiceState, DeferredCronNotifications } from "./state.js";
 import { emit } from "./state.js";
 import {
   ensureLoaded,
@@ -151,6 +151,7 @@ async function skipInvalidPersistedManualRun(params: {
   error: unknown;
 }) {
   const rollbackSnapshot = snapshotStoreForRollback(params.state);
+  const postPersistNotifications: DeferredCronNotifications = [];
   const endedAt = params.state.deps.nowMs();
   const errorText = normalizeCronRunErrorText(params.error);
   const diagnostics = createCronRunDiagnosticsFromError("cron-preflight", errorText, {
@@ -167,7 +168,10 @@ async function skipInvalidPersistedManualRun(params: {
       startedAt: endedAt,
       endedAt,
     },
-    { scheduleMode: params.mode === "force" ? "preserve" : "advance" },
+    {
+      scheduleMode: params.mode === "force" ? "preserve" : "advance",
+      deferredNotifications: postPersistNotifications,
+    },
   );
 
   emitCronRunFinished(
@@ -192,13 +196,14 @@ async function skipInvalidPersistedManualRun(params: {
 
   recomputeNextRunsForMaintenance(params.state, {
     recomputeExpired: true,
+    deferredNotifications: postPersistNotifications,
     ...(params.mode === "force"
       ? {
           preserveExpiredPacedNextRunJobId: params.job.id,
         }
       : {}),
   });
-  await persistOrRestore(params.state, rollbackSnapshot);
+  await persistOrRestore(params.state, rollbackSnapshot, { postPersistNotifications });
   armTimer(params.state);
 }
 

--- a/src/cron/service/ops-run.ts
+++ b/src/cron/service/ops-run.ts
@@ -20,7 +20,7 @@ import {
 import { clearManualCronJobActive, maybeNotifyManualIsolatedSetupTimeout } from "./ops-shared.js";
 import { releaseQueuedCronRun, runWithCronAdmission } from "./run-admission.js";
 import { mergeManualRunSnapshotAfterReload } from "./startup-run-repair.js";
-import type { CronServiceState, CronWakeMode } from "./state.js";
+import type { CronServiceState, CronWakeMode, DeferredCronNotifications } from "./state.js";
 import { emit } from "./state.js";
 import { ensureLoaded, persistOrRestore, snapshotStoreForRollback } from "./store.js";
 import { tryFinishCronTaskRunWithoutHistory } from "./task-runs.js";
@@ -174,7 +174,7 @@ async function finishPreparedManualRun(
           : mode === "force"
             ? "force-preserve"
             : "advance";
-      const postPersistAutoDisableNotifications: Array<() => void> = [];
+      const postPersistNotifications: DeferredCronNotifications = [];
 
       let shouldDelete = false;
       if (coreResult.status === "ok" && coreResult.triggerEval?.fired === false) {
@@ -191,7 +191,7 @@ async function finishPreparedManualRun(
           {
             scheduleMode,
             triggerOwnership,
-            deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+            deferredNotifications: postPersistNotifications,
           },
         );
       } else {
@@ -209,7 +209,7 @@ async function finishPreparedManualRun(
             scheduleMode: scheduleMode === "force-preserve" ? "preserve" : "advance",
             scheduleOwnership,
             scheduleOwnershipAtMs: prepared.scheduleOwnershipAtMs,
-            deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+            deferredNotifications: postPersistNotifications,
           },
         );
         applyTriggerRunResult(
@@ -293,7 +293,7 @@ async function finishPreparedManualRun(
       });
       recomputeNextRunsForMaintenance(state, {
         recomputeExpired: true,
-        deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+        deferredNotifications: postPersistNotifications,
         ...(mode === "force"
           ? {
               preserveExpiredPacedNextRunJobId: jobId,
@@ -301,7 +301,7 @@ async function finishPreparedManualRun(
           : {}),
       });
       await persistOrRestore(state, rollbackSnapshot, {
-        postPersistAutoDisableNotifications,
+        postPersistNotifications,
       });
       if (removedJob) {
         emit(state, { jobId: removedJob.id, action: "removed", job: removedJob });

--- a/src/cron/service/startup-run-repair.auto-disable.test.ts
+++ b/src/cron/service/startup-run-repair.auto-disable.test.ts
@@ -46,7 +46,7 @@ describe("startup run repair auto-disable", () => {
       job,
       runningAtMs,
       nowMs,
-      deferredAutoDisableNotifications: deferredNotifications,
+      deferredNotifications,
     });
 
     expect(job).toMatchObject({

--- a/src/cron/service/startup-run-repair.ts
+++ b/src/cron/service/startup-run-repair.ts
@@ -3,11 +3,8 @@ import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-
 import { parseAbsoluteTimeMs } from "../parse.js";
 import type { CronRunLogEntry } from "../run-log-types.js";
 import type { CronJob, CronRunStatus } from "../types.js";
-import {
-  type DeferredAutoDisableNotifications,
-  maybeAutoDisableCronJobAfterRunFailure,
-} from "./auto-disable.js";
-import type { CronServiceState } from "./state.js";
+import { maybeAutoDisableCronJobAfterRunFailure } from "./auto-disable.js";
+import type { CronServiceState, DeferredCronNotifications } from "./state.js";
 import {
   applyJobResult,
   applyScriptRunResult,
@@ -58,7 +55,7 @@ export function markInterruptedStartupRun(params: {
   taskRunId?: string;
   runningAtMs: number;
   nowMs: number;
-  deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
+  deferredNotifications?: DeferredCronNotifications;
 }): InterruptedStartupRun {
   const { job, runningAtMs, nowMs } = params;
   const replacementAtMs = resolveOneShotReplacementAtMs(job, runningAtMs);
@@ -100,7 +97,7 @@ export function markInterruptedStartupRun(params: {
       job,
       atMs: nowMs,
       error: STARTUP_INTERRUPTED_ERROR,
-      deferredNotifications: params.deferredAutoDisableNotifications,
+      deferredNotifications: params.deferredNotifications,
     })
   ) {
     params.state.deps.log.error(
@@ -129,7 +126,7 @@ export function restoreFinalizedStartupRun(params: {
   entry: CronRunLogEntry & { status: CronRunStatus };
   scriptResult?: { scriptStateChanged: true; scriptState?: unknown };
   triggerEval?: CronTriggerEvalOutcome;
-  deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
+  deferredNotifications?: DeferredCronNotifications;
 }): { shouldDelete: boolean; replacementAtMs?: number } {
   const { state, job, runningAtMs, entry } = params;
   const startedAt = entry.runAtMs ?? runningAtMs;
@@ -146,7 +143,7 @@ export function restoreFinalizedStartupRun(params: {
     {
       replayFailureAlertAtMs: entry.ts,
       scheduleOwnership,
-      deferredAutoDisableNotifications: params.deferredAutoDisableNotifications,
+      deferredNotifications: params.deferredNotifications,
     },
   );
 

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -66,6 +66,9 @@ export type CronSystemEventEnqueueResult =
       remove?: () => boolean | void;
     };
 
+/** Notifications queued by cron mutations until their state is durable. */
+export type DeferredCronNotifications = Array<() => void>;
+
 /** Dependency injection surface for the cron service runtime. */
 export type CronServiceDeps = {
   nowMs?: () => number;

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -12,7 +12,7 @@ import {
 } from "../store.js";
 import type { CronJob, CronStoreFile } from "../types.js";
 import { recomputeNextRuns } from "./jobs.js";
-import { emit, type CronServiceState } from "./state.js";
+import { emit, type CronServiceState, type DeferredCronNotifications } from "./state.js";
 
 const loadedCronStoreRevisions = new WeakMap<CronServiceState, number>();
 
@@ -310,7 +310,7 @@ export async function persistOrRestore(
   state: CronServiceState,
   snapshot: CronRollbackSnapshot,
   opts: {
-    postPersistAutoDisableNotifications?: Array<() => void>;
+    postPersistNotifications?: DeferredCronNotifications;
     suppressScheduledJobId?: string;
   } = {},
 ) {
@@ -329,7 +329,9 @@ export async function persistOrRestore(
     state.durableNextRunAtMsByJobId = snapshot.durableNextRunAtMsByJobId;
     throw err;
   }
-  for (const notify of opts.postPersistAutoDisableNotifications ?? []) {
+  // Queued notifications must not describe speculative cron state that a
+  // failed write rolls back before the service lock is released.
+  for (const notify of opts.postPersistNotifications ?? []) {
     notify();
   }
 }

--- a/src/cron/service/timer-outcome-finalization.ts
+++ b/src/cron/service/timer-outcome-finalization.ts
@@ -5,7 +5,7 @@ import type { CronJob } from "../types.js";
 import { recomputeNextRunsForMaintenance } from "./jobs.js";
 import { locked } from "./locked.js";
 import { clearQueuedCronRunReservationMarker, releaseQueuedCronRun } from "./run-admission.js";
-import { emit, type CronServiceState } from "./state.js";
+import { emit, type CronServiceState, type DeferredCronNotifications } from "./state.js";
 import { ensureLoaded, persistOrRestore, snapshotStoreForRollback } from "./store.js";
 import { tryFinishCronTaskRunWithoutHistory } from "./task-runs.js";
 import type { TimedCronRunOutcome } from "./timer-execution-timeout.js";
@@ -134,10 +134,10 @@ export async function finalizeCompletedCronRunOutcomes(
 
       const rollbackSnapshot = snapshotStoreForRollback(state);
       const removedJobs: CronJob[] = [];
-      const postPersistAutoDisableNotifications: Array<() => void> = [];
+      const postPersistNotifications: DeferredCronNotifications = [];
       for (const outcome of finalizedOutcomes) {
         const removedJob = applyOutcomeToStoredJob(state, outcome, {
-          deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+          deferredNotifications: postPersistNotifications,
         });
         if (removedJob) {
           removedJobs.push(removedJob);
@@ -151,14 +151,14 @@ export async function finalizeCompletedCronRunOutcomes(
         opts?.repairFutureCronNextRunAtMs === false
           ? {
               repairFutureCronNextRunAtMs: false,
-              deferredAutoDisableNotifications: postPersistAutoDisableNotifications,
+              deferredNotifications: postPersistNotifications,
             }
-          : { deferredAutoDisableNotifications: postPersistAutoDisableNotifications },
+          : { deferredNotifications: postPersistNotifications },
       );
-      // Auto-disable alerts describe durable state. Drain them only after the
-      // terminal write succeeds so a rolled-back run cannot publish a false transition.
+      // Run notifications describe durable state. Drain them only after the
+      // terminal write succeeds so rollback cannot publish a false outcome.
       await persistOrRestore(state, rollbackSnapshot, {
-        postPersistAutoDisableNotifications,
+        postPersistNotifications,
       });
       finishPersistedQuietCronTaskRuns(state, finalizedOutcomes);
       for (const removedJob of removedJobs) {

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -7,10 +7,7 @@ import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { computeNextRunAtMs } from "../schedule.js";
 import { createCronStreamSourceIdentity } from "../stream-schedule.js";
 import type { CronJob, CronRunStatus } from "../types.js";
-import {
-  type DeferredAutoDisableNotifications,
-  maybeAutoDisableCronJobAfterRunFailure,
-} from "./auto-disable.js";
+import { maybeAutoDisableCronJobAfterRunFailure } from "./auto-disable.js";
 import {
   failureNotificationDeliveryFromJobState,
   maybeEmitFailureAlert,
@@ -23,7 +20,7 @@ import {
   isJobEnabled,
   recordScheduleComputeError,
 } from "./jobs.js";
-import { type CronServiceState, emit } from "./state.js";
+import { type CronServiceState, type DeferredCronNotifications, emit } from "./state.js";
 import { tryFinishCronTaskRun, tryFinishCronTaskRunWithoutHistory } from "./task-runs.js";
 import {
   type CronJobRunResult,
@@ -81,7 +78,7 @@ export function applyJobResult(
     scheduleOwnershipAtMs?: number;
     // Startup replay restores alert cooldown bookkeeping without redelivery.
     replayFailureAlertAtMs?: number;
-    deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
+    deferredNotifications?: DeferredCronNotifications;
   },
 ): boolean {
   const previousScheduleState = {
@@ -157,6 +154,7 @@ export function applyJobResult(
       ...(opts?.replayFailureAlertAtMs !== undefined
         ? { delivery: "record-only" as const, occurredAtMs: opts.replayFailureAlertAtMs }
         : {}),
+      deferredNotifications: opts?.deferredNotifications,
     });
   } else if (result.status === "skipped") {
     job.state.consecutiveErrors = 0;
@@ -172,6 +170,7 @@ export function applyJobResult(
         ...(opts?.replayFailureAlertAtMs !== undefined
           ? { delivery: "record-only" as const, occurredAtMs: opts.replayFailureAlertAtMs }
           : {}),
+        deferredNotifications: opts?.deferredNotifications,
       });
     } else {
       job.state.lastFailureAlertAtMs = undefined;
@@ -305,7 +304,7 @@ export function applyJobResult(
         job,
         atMs: result.endedAt,
         error: result.error ?? "unknown run failure",
-        deferredNotifications: opts?.deferredAutoDisableNotifications,
+        deferredNotifications: opts?.deferredNotifications,
       })
     ) {
       // Keep this after the ownership and force-preserve gates: those paths
@@ -346,7 +345,7 @@ export function applyJobResult(
               state,
               job,
               err,
-              deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
+              deferredNotifications: opts?.deferredNotifications,
             });
           }
           normalNextComputed = true;
@@ -443,7 +442,7 @@ export function applyJobResult(
           state,
           job,
           err,
-          deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
+          deferredNotifications: opts?.deferredNotifications,
         });
       }
       if (job.schedule.kind === "cron") {
@@ -555,7 +554,7 @@ export function applyTriggerNoFireResult(
   opts?: {
     scheduleMode?: "advance" | "force-preserve" | "stale-preserve";
     triggerOwnership?: CronTriggerOwnership;
-    deferredAutoDisableNotifications?: DeferredAutoDisableNotifications;
+    deferredNotifications?: DeferredCronNotifications;
   },
 ): void {
   const previousNextRunAtMs = job.state.nextRunAtMs;
@@ -599,7 +598,7 @@ export function applyTriggerNoFireResult(
       state,
       job,
       err,
-      deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
+      deferredNotifications: opts?.deferredNotifications,
     });
   }
 }
@@ -607,7 +606,7 @@ export function applyTriggerNoFireResult(
 export function applyOutcomeToStoredJob(
   state: CronServiceState,
   result: TimedCronRunOutcome,
-  opts?: { deferredAutoDisableNotifications?: DeferredAutoDisableNotifications },
+  opts?: { deferredNotifications?: DeferredCronNotifications },
 ): CronJob | undefined {
   const store = state.store;
   if (!store) {
@@ -623,7 +622,10 @@ export function applyOutcomeToStoredJob(
     }
     // A run may finish after its job disappears; finalize the admitted job
     // snapshot so operator history survives without reviving the stored job.
-    applyJobResult(state, result.job, result, { scheduleOwnership: "stale" });
+    applyJobResult(state, result.job, result, {
+      scheduleOwnership: "stale",
+      deferredNotifications: opts?.deferredNotifications,
+    });
     emitJobFinished(state, result.job, result, result.startedAt);
     state.deps.log.info(
       { jobId: result.jobId, status: result.status },
@@ -657,7 +659,7 @@ export function applyOutcomeToStoredJob(
       {
         scheduleMode: scheduleOwnership === "stale" ? "stale-preserve" : "advance",
         triggerOwnership,
-        deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
+        deferredNotifications: opts?.deferredNotifications,
       },
     );
     job.state.startupCatchupAtMs = undefined;
@@ -671,7 +673,7 @@ export function applyOutcomeToStoredJob(
 
   const shouldDelete = applyJobResult(state, job, result, {
     scheduleOwnership,
-    deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
+    deferredNotifications: opts?.deferredNotifications,
   });
   applyTriggerRunResult(job, result, { scheduleOwnership, triggerOwnership });
   applyScriptRunResult(job, result, { triggerOwnership });

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -2844,7 +2844,7 @@ describe("cron service timer regressions", () => {
       state,
       job,
       { status: "error", error: "ninth failure", startedAt, endedAt: startedAt + 10 },
-      { deferredAutoDisableNotifications: deferredNotifications },
+      { deferredNotifications },
     );
     expect(job.enabled).toBe(true);
     expect(job.state.consecutiveErrors).toBe(9);
@@ -2860,7 +2860,7 @@ describe("cron service timer regressions", () => {
         startedAt: startedAt + 60_000,
         endedAt: startedAt + 60_010,
       },
-      { deferredAutoDisableNotifications: deferredNotifications },
+      { deferredNotifications },
     );
     expect(job.enabled).toBe(false);
     expect(job.state.nextRunAtMs).toBeUndefined();
@@ -2901,7 +2901,7 @@ describe("cron service timer regressions", () => {
           startedAt: startedAt + run * 60_000,
           endedAt: startedAt + run * 60_000 + 10,
         },
-        { deferredAutoDisableNotifications: [] },
+        { deferredNotifications: [] },
       );
 
     for (let run = 0; run < 9; run += 1) {
@@ -2945,7 +2945,7 @@ describe("cron service timer regressions", () => {
       state,
       job,
       { status: "error", error: "tenth failure", startedAt, endedAt: startedAt + 10 },
-      { ...opts, deferredAutoDisableNotifications: deferredNotifications },
+      { ...opts, deferredNotifications },
     );
 
     expect(job.enabled).toBe(true);


### PR DESCRIPTION
Fixes #118187

AI-assisted with Codex. I reviewed the implementation and validation results.

## What Problem This Solves

Fixes an issue where cron failure alerts could reach operators before the failed run outcome was durably stored. If that store write then failed, OpenClaw rolled back the run state and alert cooldown while the alert had already escaped, allowing premature and potentially duplicate alerts.

## Why This Change Was Made

Failure-alert policy resolution, threshold/cooldown checks, and `lastFailureAlertAtMs` recording now stay inside the run-outcome mutation. Actual announce, webhook, system-event, and heartbeat delivery is queued with a by-value job/route snapshot and drained only after persistence succeeds. Record-only startup replay remains delivery-free.

The existing auto-disable-specific deferred plumbing is renamed to the generic `DeferredCronNotifications`, `deferredNotifications`, and `postPersistNotifications` vocabulary because it now owns both alert families. The researched issue context said the list already reached every completion caller, but current source had three gaps: external stream failures, invalid persisted manual-run skips, and removed-job finalization. This change threads the generic queue through all three so error and opted-in skipped alerts share the same durability boundary.

Alert thresholds, cooldown duration, text, routing, account/topic inheritance, best-effort and failure-destination suppression, and opt-in behavior are unchanged.

## User Impact

Cron failure alerts now describe only run outcomes that survived persistence. A failed cron store write sends no alert and restores the prior cooldown state; after a successful write, the persisted cooldown still suppresses repeated delivery as before.

## Evidence

- `pnpm install` — passed; lockfile unchanged and workspace dependencies installed.
- `node scripts/run-vitest.mjs src/cron/service/failure-alerts.persistence.test.ts src/cron/service.failure-alert.test.ts src/cron/service/failure-alerts.account-routing.test.ts src/cron/store/failure-alert-codec.test.ts src/cron/service/timer.batch-finalization.test.ts src/cron/service/timer.regression.test.ts src/cron/service/ops.test.ts src/cron/service/startup-run-repair.auto-disable.test.ts src/cron/service.stream-validation.test.ts` — 9 files passed, 202 tests passed.
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs` — passed all selected core/core-test formatting, guards, production/test typechecks, lint, dead-code, boundary, database, and import-cycle lanes. The normal wrapper first attempted Testbox, but the configured Crabbox provider doctor was unavailable, so trusted-source validation used the repository-documented local fallback.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --prompt 'Review scope: GitHub issue #118187. Preserve all cron failure-alert semantics while moving delivery post-persist; verify all production completion paths, rollback/cooldown atomicity, by-value routing capture, record-only replay, and the complete DeferredCronNotifications rename. Treat unrelated changes as out of scope.' --stream-engine-output` — clean; no accepted/actionable findings.

The new boundary coverage proves strict `[persist, alert]` order for error and `includeSkipped` alerts, no delivery plus cooldown rollback on persist failure, and persisted cooldown dedupe after a successful write. Existing auto-disable ordering and rollback coverage remains green.


---

## Built CLI/Gateway live proof (dist build, ephemeral gateway :19873, isolated state dir)

Global config `cron.failureAlert: { enabled: true, after: 2, cooldownMs: 3600000 }`, failing command job (`exit N`), three consecutive manual `automations run --wait` failures:

- **Announce mode (no channel configured)**: alert decision fired at run 2 — `lastFailureAlertAtMs` recorded on the job and **stable through run 3** (cooldown suppression live); the delivery outcome was recorded as a fact (`lastFailureNotificationDelivered: false`, `status: "not-delivered"`) instead of vanishing.
- **Webhook mode** (`mode: "webhook"`, loopback listener): structured log shows `cron: failure alert webhook blocked by SSRF guard` for the job — stamped by the **deferred post-persist delivery closure** executing after run finalization (the guard sits inside the delivery path). Exactly **1** alert attempt across 3 failures (`grep -c` on the structured log): decision once at run 2, cooldown-suppressed at run 3. Loopback rejection is the guard working as designed; delivery success ordering is owned by the persistence tests (`[persist, alert]`, delivered-once, rollback-no-delivery).

Ephemeral gateway, listener, and proof jobs deleted after the run; no operator state touched.
