### PR TITLE
fix(googlechat): remove typing placeholders after silent or failed replies

### DIFF
--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -5,7 +5,7 @@ import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { deleteGoogleChatMessage, sendGoogleChatMessage, updateGoogleChatMessage } from "./api.js";
 import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
 
-export type GoogleChatTypingMessage =
+type GoogleChatTypingMessage =
   | {
       placement: "top-level";
       name: string;

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -17,6 +17,10 @@ export type GoogleChatTypingMessage =
       deliveredThreadName: string;
     };
 
+export type GoogleChatTypingMessageLease = {
+  current?: GoogleChatTypingMessage;
+};
+
 export function createGoogleChatTypingMessage(params: {
   messageName: string;
   requestedThreadName?: string;
@@ -35,6 +39,27 @@ export function createGoogleChatTypingMessage(params: {
   };
 }
 
+export async function cleanupGoogleChatTypingMessage(params: {
+  account: ResolvedGoogleChatAccount;
+  runtime: GoogleChatRuntimeEnv;
+  typingMessageLease: GoogleChatTypingMessageLease;
+}): Promise<void> {
+  const typingMessage = params.typingMessageLease.current;
+  if (!typingMessage) {
+    return;
+  }
+
+  try {
+    await deleteGoogleChatMessage({
+      account: params.account,
+      messageName: typingMessage.name,
+    });
+    params.typingMessageLease.current = undefined;
+  } catch (error) {
+    params.runtime.error?.(`Google Chat typing cleanup failed: ${String(error)}`);
+  }
+}
+
 export async function deliverGoogleChatReply(params: {
   payload: {
     text?: string;
@@ -48,12 +73,11 @@ export async function deliverGoogleChatReply(params: {
   core: GoogleChatCoreRuntime;
   config: OpenClawConfig;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
-  typingMessage?: GoogleChatTypingMessage;
+  typingMessageLease?: GoogleChatTypingMessageLease;
 }): Promise<void> {
   const { payload, account, spaceId, runtime, core, config, statusSink } = params;
-  // Clear this whenever the typing message is deleted or unavailable; otherwise
-  // text delivery can keep retrying a dead message and drop content.
-  let typingMessage = params.typingMessage;
+  const typingMessageLease = params.typingMessageLease;
+  let typingMessage = typingMessageLease?.current;
   const replyThreadName = payload.replyToId?.trim() || undefined;
   const reply = resolveSendableOutboundReplyParts(payload);
   const text = reply.text;
@@ -69,10 +93,8 @@ export async function deliverGoogleChatReply(params: {
   if (typingMessage && !typingMatchesReply) {
     // Typing starts before reply directives are resolved. Never edit a placeholder
     // from one thread into a final reply targeted at another conversation surface.
-    try {
-      await deleteGoogleChatMessage({ account, messageName: typingMessage.name });
-    } catch (err) {
-      runtime.error?.(`Google Chat typing cleanup failed: ${String(err)}`);
+    if (typingMessageLease) {
+      await cleanupGoogleChatTypingMessage({ account, runtime, typingMessageLease });
     }
     typingMessage = undefined;
   } else if (typingMessage?.placement === "thread") {
@@ -88,12 +110,8 @@ export async function deliverGoogleChatReply(params: {
   }
 
   if (reply.hasMedia && !reply.hasText) {
-    try {
-      if (typingMessage) {
-        await deleteGoogleChatMessage({ account, messageName: typingMessage.name });
-      }
-    } catch (err) {
-      runtime.error?.(`Google Chat typing cleanup failed: ${String(err)}`);
+    if (typingMessage && typingMessageLease) {
+      await cleanupGoogleChatTypingMessage({ account, runtime, typingMessageLease });
     }
     throw new Error(
       "Google Chat outbound attachments require user OAuth and no text fallback is available.",
@@ -132,6 +150,10 @@ export async function deliverGoogleChatReply(params: {
           messageName: typingMessage.name,
           text: chunk,
         });
+        // The placeholder is now a real reply; a later chunk failure must not delete it.
+        if (typingMessageLease) {
+          typingMessageLease.current = undefined;
+        }
       } catch (err) {
         // The typing placeholder may already be gone; resend the chunk as a new
         // message below. Only the resend failing counts as a delivery failure.

--- a/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery-failure.test.ts
@@ -158,11 +158,13 @@ async function runDelivery(params: {
       ...(params.statusSink ? { statusSink: params.statusSink } : {}),
       ...(params.withTypingMessage
         ? {
-            typingMessage: {
-              placement: "thread",
-              name: "spaces/AAA/messages/typing",
-              requestedThreadName: "spaces/AAA/threads/root",
-              deliveredThreadName: "spaces/AAA/threads/root",
+            typingMessageLease: {
+              current: {
+                placement: "thread" as const,
+                name: "spaces/AAA/messages/typing",
+                requestedThreadName: "spaces/AAA/threads/root",
+                deliveredThreadName: "spaces/AAA/threads/root",
+              },
             },
           }
         : {}),

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -2,6 +2,7 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import type { GoogleChatTypingMessageLease } from "./monitor-reply-delivery.js";
 import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
 
 const mocks = vi.hoisted(() => ({
@@ -49,6 +50,17 @@ function createRuntime() {
   } satisfies GoogleChatRuntimeEnv;
 }
 
+function createTypingMessageLease(): GoogleChatTypingMessageLease {
+  return {
+    current: {
+      placement: "thread",
+      name: "spaces/AAA/messages/typing",
+      requestedThreadName: "spaces/AAA/threads/root",
+      deliveredThreadName: "spaces/AAA/threads/root",
+    },
+  };
+}
+
 let createGoogleChatTypingMessage: typeof import("./monitor-reply-delivery.js").createGoogleChatTypingMessage;
 let deliverGoogleChatReply: typeof import("./monitor-reply-delivery.js").deliverGoogleChatReply;
 
@@ -68,6 +80,7 @@ describe("Google Chat reply delivery", () => {
     const core = createCore({ chunks: ["first chunk", "second chunk"] });
     const runtime = createRuntime();
     const statusSink = vi.fn();
+    const typingMessageLease = createTypingMessageLease();
     mocks.updateGoogleChatMessage.mockRejectedValueOnce(new Error("message not found"));
     mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/fallback" });
 
@@ -79,12 +92,7 @@ describe("Google Chat reply delivery", () => {
       core,
       config,
       statusSink,
-      typingMessage: {
-        placement: "thread",
-        name: "spaces/AAA/messages/typing",
-        requestedThreadName: "spaces/AAA/threads/root",
-        deliveredThreadName: "spaces/AAA/threads/root",
-      },
+      typingMessageLease,
     });
 
     expect(mocks.updateGoogleChatMessage).toHaveBeenCalledWith({
@@ -109,6 +117,7 @@ describe("Google Chat reply delivery", () => {
     expect(runtime.error).toHaveBeenCalledWith(
       "Google Chat message send failed: Error: message not found",
     );
+    expect(typingMessageLease.current?.name).toBe("spaces/AAA/messages/typing");
   });
 
   it("continues later chunks in the provider fallback thread", async () => {
@@ -150,6 +159,13 @@ describe("Google Chat reply delivery", () => {
   it("continues after a fallback typing placeholder in its delivered thread", async () => {
     const core = createCore({ chunks: ["first chunk", "second chunk"] });
     const runtime = createRuntime();
+    const typingMessageLease = {
+      current: createGoogleChatTypingMessage({
+        messageName: "spaces/AAA/messages/typing",
+        requestedThreadName: "spaces/AAA/threads/requested",
+        deliveredThreadName: "spaces/AAA/threads/fallback",
+      }),
+    } satisfies GoogleChatTypingMessageLease;
     mocks.sendGoogleChatMessage.mockResolvedValueOnce({
       messageName: "spaces/AAA/messages/second",
       threadName: "spaces/AAA/threads/fallback",
@@ -162,11 +178,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
-      typingMessage: createGoogleChatTypingMessage({
-        messageName: "spaces/AAA/messages/typing",
-        requestedThreadName: "spaces/AAA/threads/requested",
-        deliveredThreadName: "spaces/AAA/threads/fallback",
-      }),
+      typingMessageLease,
     });
 
     expect(mocks.updateGoogleChatMessage).toHaveBeenCalledWith({
@@ -181,6 +193,7 @@ describe("Google Chat reply delivery", () => {
       text: "second chunk",
       thread: "spaces/AAA/threads/fallback",
     });
+    expect(typingMessageLease.current).toBeUndefined();
   });
 
   it("keeps the requested thread when the provider omits thread metadata", async () => {
@@ -250,9 +263,38 @@ describe("Google Chat reply delivery", () => {
     expect(mocks.sendGoogleChatMessage).toHaveBeenCalledTimes(2);
   });
 
+  it("disarms a successfully edited typing message before a later chunk fails", async () => {
+    const core = createCore({ chunks: ["first chunk", "second chunk"] });
+    const runtime = createRuntime();
+    const typingMessageLease = createTypingMessageLease();
+    const sendError = new Error("API 500");
+    mocks.sendGoogleChatMessage.mockRejectedValueOnce(sendError);
+
+    await expect(
+      deliverGoogleChatReply({
+        payload: { text: "two chunks", replyToId: "spaces/AAA/threads/root" },
+        account,
+        spaceId: "spaces/AAA",
+        runtime,
+        core,
+        config,
+        typingMessageLease,
+      }),
+    ).rejects.toBe(sendError);
+
+    expect(mocks.updateGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      messageName: "spaces/AAA/messages/typing",
+      text: "first chunk",
+    });
+    expect(typingMessageLease.current).toBeUndefined();
+    expect(mocks.deleteGoogleChatMessage).not.toHaveBeenCalled();
+  });
+
   it("rejects when the fallback resend after a typing update failure also fails", async () => {
     const core = createCore({ chunks: ["only chunk"] });
     const runtime = createRuntime();
+    const typingMessageLease = createTypingMessageLease();
     const fallbackError = new Error("quota exceeded");
     mocks.updateGoogleChatMessage.mockRejectedValueOnce(new Error("message not found"));
     mocks.sendGoogleChatMessage.mockRejectedValueOnce(fallbackError);
@@ -265,21 +307,18 @@ describe("Google Chat reply delivery", () => {
         runtime,
         core,
         config,
-        typingMessage: {
-          placement: "thread",
-          name: "spaces/AAA/messages/typing",
-          requestedThreadName: "spaces/AAA/threads/root",
-          deliveredThreadName: "spaces/AAA/threads/root",
-        },
+        typingMessageLease,
       }),
     ).rejects.toBe(fallbackError);
 
     expect(mocks.sendGoogleChatMessage).toHaveBeenCalledTimes(1);
+    expect(typingMessageLease.current?.name).toBe("spaces/AAA/messages/typing");
   });
 
   it("replaces a typing message when the final reply target changed", async () => {
     const core = createCore();
     const runtime = createRuntime();
+    const typingMessageLease = createTypingMessageLease();
     mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/reply" });
 
     await deliverGoogleChatReply({
@@ -289,12 +328,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
-      typingMessage: {
-        placement: "thread",
-        name: "spaces/AAA/messages/typing",
-        requestedThreadName: "spaces/AAA/threads/root",
-        deliveredThreadName: "spaces/AAA/threads/root",
-      },
+      typingMessageLease,
     });
 
     expect(mocks.deleteGoogleChatMessage).toHaveBeenCalledWith({
@@ -308,6 +342,37 @@ describe("Google Chat reply delivery", () => {
       text: "top-level reply",
       thread: undefined,
     });
+    expect(typingMessageLease.current).toBeUndefined();
+  });
+
+  it("retains ownership when cleanup for a changed reply target fails", async () => {
+    const core = createCore();
+    const runtime = createRuntime();
+    const typingMessageLease = createTypingMessageLease();
+    mocks.deleteGoogleChatMessage.mockRejectedValueOnce(new Error("cleanup unavailable"));
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/reply" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "top-level reply" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      typingMessageLease,
+    });
+
+    expect(typingMessageLease.current?.name).toBe("spaces/AAA/messages/typing");
+    expect(mocks.updateGoogleChatMessage).not.toHaveBeenCalled();
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "top-level reply",
+      thread: undefined,
+    });
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Google Chat typing cleanup failed: Error: cleanup unavailable",
+    );
   });
 
   it("uses text fallback without loading outbound media", async () => {
@@ -315,6 +380,7 @@ describe("Google Chat reply delivery", () => {
       media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "reply.png" },
     });
     const runtime = createRuntime();
+    const typingMessageLease = createTypingMessageLease();
 
     await deliverGoogleChatReply({
       payload: {
@@ -327,12 +393,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
-      typingMessage: {
-        placement: "thread",
-        name: "spaces/AAA/messages/typing",
-        requestedThreadName: "spaces/AAA/threads/root",
-        deliveredThreadName: "spaces/AAA/threads/root",
-      },
+      typingMessageLease,
     });
 
     expect(mocks.updateGoogleChatMessage).toHaveBeenCalledWith({
@@ -346,11 +407,13 @@ describe("Google Chat reply delivery", () => {
     expect(runtime.error).toHaveBeenCalledWith(
       "Google Chat outbound attachments require user OAuth and are not supported by this service-account channel; sending text fallback only.",
     );
+    expect(typingMessageLease.current).toBeUndefined();
   });
 
   it("cleans up typing and rejects media-only replies without provider upload access", async () => {
     const core = createCore();
     const runtime = createRuntime();
+    const typingMessageLease = createTypingMessageLease();
 
     await expect(
       deliverGoogleChatReply({
@@ -363,12 +426,7 @@ describe("Google Chat reply delivery", () => {
         runtime,
         core,
         config,
-        typingMessage: {
-          placement: "thread",
-          name: "spaces/AAA/messages/typing",
-          requestedThreadName: "spaces/AAA/threads/root",
-          deliveredThreadName: "spaces/AAA/threads/root",
-        },
+        typingMessageLease,
       }),
     ).rejects.toThrow(
       "Google Chat outbound attachments require user OAuth and no text fallback is available.",
@@ -381,5 +439,35 @@ describe("Google Chat reply delivery", () => {
     expect(core.channel.media.readRemoteMediaBuffer).not.toHaveBeenCalled();
     expect(mocks.updateGoogleChatMessage).not.toHaveBeenCalled();
     expect(mocks.sendGoogleChatMessage).not.toHaveBeenCalled();
+    expect(typingMessageLease.current).toBeUndefined();
+  });
+
+  it("retains a media-only typing message when its immediate cleanup fails", async () => {
+    const core = createCore();
+    const runtime = createRuntime();
+    const typingMessageLease = createTypingMessageLease();
+    mocks.deleteGoogleChatMessage.mockRejectedValueOnce(new Error("cleanup unavailable"));
+
+    await expect(
+      deliverGoogleChatReply({
+        payload: {
+          mediaUrl: "https://example.invalid/reply.png",
+          replyToId: "spaces/AAA/threads/root",
+        },
+        account,
+        spaceId: "spaces/AAA",
+        runtime,
+        core,
+        config,
+        typingMessageLease,
+      }),
+    ).rejects.toThrow(
+      "Google Chat outbound attachments require user OAuth and no text fallback is available.",
+    );
+
+    expect(typingMessageLease.current?.name).toBe("spaces/AAA/messages/typing");
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Google Chat typing cleanup failed: Error: cleanup unavailable",
+    );
   });
 });

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -21,9 +21,10 @@ import {
   type GoogleChatIngressLifecycle,
 } from "./monitor-ingress.js";
 import {
+  cleanupGoogleChatTypingMessage,
   createGoogleChatTypingMessage,
   deliverGoogleChatReply,
-  type GoogleChatTypingMessage,
+  type GoogleChatTypingMessageLease,
 } from "./monitor-reply-delivery.js";
 import {
   registerGoogleChatWebhookTarget,
@@ -363,7 +364,7 @@ async function processMessageWithPipeline(params: {
     );
     typingIndicator = "message";
   }
-  let typingMessage: GoogleChatTypingMessage | undefined;
+  const typingMessageLease: GoogleChatTypingMessageLease = {};
   const typingMessageThreadName =
     account.config.replyToMode && account.config.replyToMode !== "off"
       ? replyThreadName
@@ -384,7 +385,7 @@ async function processMessageWithPipeline(params: {
         thread: typingMessageThreadName,
       });
       if (result?.messageName) {
-        typingMessage = createGoogleChatTypingMessage({
+        typingMessageLease.current = createGoogleChatTypingMessage({
           messageName: result.messageName,
           requestedThreadName: typingMessageThreadName,
           deliveredThreadName: result.threadName,
@@ -395,66 +396,74 @@ async function processMessageWithPipeline(params: {
     }
   }
 
-  await core.channel.inbound.run({
-    channel: "googlechat",
-    accountId: route.accountId,
-    raw: message,
-    ...(turnAdoptionLifecycle ? { turnAdoptionLifecycle } : {}),
-    adapter: {
-      ingest: () => ({
-        id: message.name ?? spaceId,
-        timestamp: timestampMs,
-        rawText: rawBody,
-        textForAgent: rawBody,
-        textForCommands: rawBody,
-        raw: message,
-      }),
-      resolveTurn: () => ({
-        cfg: config,
-        channel: "googlechat",
-        accountId: route.accountId,
-        route: { agentId: route.agentId, sessionKey: route.sessionKey },
-        ctxPayload,
-        delivery: {
-          durable: (payload, info) =>
-            resolveGoogleChatDurableReplyOptions({
-              payload,
-              infoKind: info.kind,
-              spaceId,
-              hasTypingMessage: Boolean(typingMessage),
-            }),
-          deliver: async (payload) => {
-            await deliverGoogleChatReply({
-              payload,
-              account,
-              spaceId,
-              runtime,
-              core,
-              config,
-              statusSink,
-              typingMessage,
-            });
-            // Only use typing message for first delivery
-            typingMessage = undefined;
+  // Failed placeholder edits still need cleanup, but only the first reply may reuse them.
+  let typingMessageAvailableForReply = Boolean(typingMessageLease.current);
+  try {
+    await core.channel.inbound.run({
+      channel: "googlechat",
+      accountId: route.accountId,
+      raw: message,
+      ...(turnAdoptionLifecycle ? { turnAdoptionLifecycle } : {}),
+      adapter: {
+        ingest: () => ({
+          id: message.name ?? spaceId,
+          timestamp: timestampMs,
+          rawText: rawBody,
+          textForAgent: rawBody,
+          textForCommands: rawBody,
+          raw: message,
+        }),
+        resolveTurn: () => ({
+          cfg: config,
+          channel: "googlechat",
+          accountId: route.accountId,
+          route: { agentId: route.agentId, sessionKey: route.sessionKey },
+          ctxPayload,
+          delivery: {
+            durable: (payload, info) =>
+              resolveGoogleChatDurableReplyOptions({
+                payload,
+                infoKind: info.kind,
+                spaceId,
+                hasTypingMessage:
+                  typingMessageAvailableForReply && Boolean(typingMessageLease.current),
+              }),
+            deliver: async (payload) => {
+              await deliverGoogleChatReply({
+                payload,
+                account,
+                spaceId,
+                runtime,
+                core,
+                config,
+                statusSink,
+                ...(typingMessageAvailableForReply && typingMessageLease.current
+                  ? { typingMessageLease }
+                  : {}),
+              });
+              typingMessageAvailableForReply = false;
+            },
+            onDelivered: () => {
+              statusSink?.({ lastOutboundAt: Date.now() });
+            },
+            onError: (err, info) => {
+              runtime.error?.(
+                `[${account.accountId}] Google Chat ${info.kind} reply failed: ${String(err)}`,
+              );
+            },
           },
-          onDelivered: () => {
-            statusSink?.({ lastOutboundAt: Date.now() });
+          replyPipeline: {},
+          record: {
+            onRecordError: (err) => {
+              runtime.error?.(`googlechat: failed updating session meta: ${String(err)}`);
+            },
           },
-          onError: (err, info) => {
-            runtime.error?.(
-              `[${account.accountId}] Google Chat ${info.kind} reply failed: ${String(err)}`,
-            );
-          },
-        },
-        replyPipeline: {},
-        record: {
-          onRecordError: (err) => {
-            runtime.error?.(`googlechat: failed updating session meta: ${String(err)}`);
-          },
-        },
-      }),
-    },
-  });
+        }),
+      },
+    });
+  } finally {
+    await cleanupGoogleChatTypingMessage({ account, runtime, typingMessageLease });
+  }
 }
 
 async function downloadAttachment(

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -43,6 +43,10 @@ import type { GoogleChatAttachment, GoogleChatEvent } from "./types.js";
 
 setGoogleChatWebhookEventProcessor(processGoogleChatEvent);
 
+type GoogleChatTurnAdoptionLifecycle = NonNullable<
+  Parameters<GoogleChatCoreRuntime["channel"]["inbound"]["run"]>[0]["turnAdoptionLifecycle"]
+>;
+
 function logVerbose(core: GoogleChatCoreRuntime, runtime: GoogleChatRuntimeEnv, message: string) {
   if (core.logging.shouldLogVerbose()) {
     runtime.log?.(`[googlechat] ${message}`);
@@ -398,12 +402,41 @@ async function processMessageWithPipeline(params: {
 
   // Failed placeholder edits still need cleanup, but only the first reply may reuse them.
   let typingMessageAvailableForReply = Boolean(typingMessageLease.current);
+  let typingCleanupOwner: "handler" | "deferred-turn" = "handler";
+  let typingCleanup: Promise<void> | undefined;
+  const settleTypingMessage = () => {
+    typingCleanup ??= cleanupGoogleChatTypingMessage({ account, runtime, typingMessageLease });
+    return typingCleanup;
+  };
+  const ingressLifecycle = turnAdoptionLifecycle as GoogleChatTurnAdoptionLifecycle | undefined;
+  const typingTurnLifecycle =
+    ingressLifecycle && typingMessageLease.current
+      ? ({
+          ...ingressLifecycle,
+          onDeferred: () => {
+            const accepted = ingressLifecycle.onDeferred?.();
+            if (accepted !== false) {
+              // Deferred reply ownership outlives inbound.run; terminal queue settlement
+              // must own the placeholder so a later reply can still promote it.
+              typingCleanupOwner = "deferred-turn";
+            }
+            return accepted;
+          },
+          onSettled: () => {
+            try {
+              ingressLifecycle.onSettled?.();
+            } finally {
+              void settleTypingMessage();
+            }
+          },
+        } satisfies GoogleChatTurnAdoptionLifecycle)
+      : turnAdoptionLifecycle;
   try {
     await core.channel.inbound.run({
       channel: "googlechat",
       accountId: route.accountId,
       raw: message,
-      ...(turnAdoptionLifecycle ? { turnAdoptionLifecycle } : {}),
+      ...(typingTurnLifecycle ? { turnAdoptionLifecycle: typingTurnLifecycle } : {}),
       adapter: {
         ingest: () => ({
           id: message.name ?? spaceId,
@@ -462,7 +495,9 @@ async function processMessageWithPipeline(params: {
       },
     });
   } finally {
-    await cleanupGoogleChatTypingMessage({ account, runtime, typingMessageLease });
+    if (typingCleanupOwner === "handler") {
+      await settleTypingMessage();
+    }
   }
 }
 

--- a/extensions/googlechat/src/monitor.typing-cleanup.integration.test.ts
+++ b/extensions/googlechat/src/monitor.typing-cleanup.integration.test.ts
@@ -1,0 +1,456 @@
+// Exercise typing ownership from a real inbound webhook through authenticated Chat HTTP.
+import { generateKeyPairSync } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { createReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
+import { withServer } from "openclaw/plugin-sdk/test-env";
+import {
+  createFixedWindowRateLimiter,
+  createWebhookInFlightLimiter,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+} from "openclaw/plugin-sdk/webhook-ingress";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import { sendGoogleChatMessage } from "./api.js";
+import type { GoogleChatCoreRuntime, WebhookTarget } from "./monitor-types.js";
+import { createGoogleChatWebhookRequestHandler } from "./monitor-webhook.js";
+import "./monitor.js";
+import type { GoogleChatEvent } from "./types.js";
+
+const monitorMocks = vi.hoisted(() => ({
+  processEvent: undefined as
+    | ((event: GoogleChatEvent, target: WebhookTarget) => Promise<void>)
+    | undefined,
+  verifyGoogleChatRequest: vi.fn(async () => ({ ok: true as const })),
+}));
+
+vi.mock("./auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./auth.js")>()),
+  verifyGoogleChatRequest: monitorMocks.verifyGoogleChatRequest,
+}));
+
+vi.mock("./monitor-access.js", () => ({
+  applyGoogleChatInboundAccessPolicy: vi.fn(async () => ({
+    ok: true,
+    commandAuthorized: undefined,
+    effectiveWasMentioned: undefined,
+    groupBotLoopProtection: undefined,
+    groupSystemPrompt: undefined,
+  })),
+}));
+
+vi.mock("./monitor-routing.js", () => ({
+  registerGoogleChatWebhookTarget: vi.fn(),
+  setGoogleChatWebhookEventProcessor: vi.fn(
+    (processEvent: (event: GoogleChatEvent, target: WebhookTarget) => Promise<void>) => {
+      monitorMocks.processEvent = processEvent;
+    },
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>()),
+  resolveChannelInboundRouteEnvelope: ({ accountId }: { accountId: string }) => ({
+    route: { agentId: "agent-1", accountId, sessionKey: "googlechat-session-1" },
+    buildEnvelope: ({ body }: { body: string }) => body,
+  }),
+}));
+
+const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const proofAccessToken = "ya29.googlechat-typing-integration-token";
+const typingResource = "spaces/AAA/messages/typing";
+const incomingResource = "spaces/AAA/messages/inbound";
+
+type TurnMode =
+  | "silent"
+  | "visible"
+  | "turn-error"
+  | "later-chunk-error"
+  | "message-tool-only"
+  | "fallback-then-final";
+
+type ChatRequest = {
+  method: string;
+  pathname: string;
+  text?: string;
+  authorization?: string;
+  status: number;
+};
+
+type StubOptions = {
+  deleteStatus?: number;
+  failPatch?: boolean;
+  failSecondChunk?: boolean;
+};
+
+function createGoogleStub(options: StubOptions = {}) {
+  const requests: ChatRequest[] = [];
+  const tokenAssertions: string[] = [];
+  const handler = (request: IncomingMessage, response: ServerResponse) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      const url = new URL(request.url ?? "/", "http://stub.invalid");
+      const body = Buffer.concat(chunks).toString("utf8");
+      const json = (status: number, value: unknown) => {
+        response.statusCode = status;
+        response.setHeader("Content-Type", "application/json");
+        response.end(JSON.stringify(value));
+      };
+
+      if (request.method === "POST" && url.pathname === "/token") {
+        tokenAssertions.push(new URLSearchParams(body).get("assertion") ?? "");
+        json(200, { access_token: proofAccessToken, token_type: "Bearer", expires_in: 3600 });
+        return;
+      }
+
+      const payload = body ? (JSON.parse(body) as { text?: string }) : {};
+      const failingPatch = options.failPatch && request.method === "PATCH";
+      const failingSecondChunk = options.failSecondChunk && payload.text === "Second visible chunk";
+      const status =
+        request.method === "DELETE"
+          ? (options.deleteStatus ?? 204)
+          : failingPatch || failingSecondChunk
+            ? 500
+            : 200;
+      requests.push({
+        method: request.method ?? "",
+        pathname: url.pathname,
+        text: payload.text,
+        authorization: request.headers.authorization,
+        status,
+      });
+
+      if (status === 204) {
+        response.writeHead(204);
+        response.end();
+        return;
+      }
+      if (status >= 400) {
+        json(status, { error: { message: "stub: Google Chat transport unavailable" } });
+        return;
+      }
+      const name =
+        request.method === "POST" && payload.text === "_OpenClaw is typing..._"
+          ? typingResource
+          : request.method === "PATCH"
+            ? typingResource
+            : "spaces/AAA/messages/message-tool";
+      json(status, { name });
+    });
+  };
+  return { handler, requests, tokenAssertions };
+}
+
+function rerouteGoogleFetch() {
+  const realFetch = globalThis.fetch;
+  let googleBaseUrl = "";
+  const redirectedFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const rawUrl = input instanceof Request ? input.url : String(input);
+    const url = new URL(rawUrl);
+    if (url.hostname === "chat.googleapis.com" || url.hostname === "oauth2.googleapis.com") {
+      if (!googleBaseUrl) {
+        throw new Error("Google Chat integration stub is not listening");
+      }
+      return await realFetch(`${googleBaseUrl}${url.pathname}${url.search}`, init);
+    }
+    return await realFetch(input, init);
+  });
+  // The guarded transport recognizes Vitest mocks and skips external DNS while preserving host policy.
+  vi.stubGlobal("fetch", redirectedFetch);
+  return { pointAt: (baseUrl: string) => (googleBaseUrl = baseUrl) };
+}
+
+function createAccount(id: string): ResolvedGoogleChatAccount {
+  return {
+    accountId: `typing-cleanup-${id}`,
+    enabled: true,
+    credentialSource: "inline",
+    credentials: {
+      type: "service_account",
+      client_email: "stub-bot@stub-project.iam.gserviceaccount.com",
+      private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+      auth_uri: "https://accounts.google.com/o/oauth2/auth",
+      token_uri: "https://oauth2.googleapis.com/token",
+      auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
+      client_x509_cert_url:
+        "https://www.googleapis.com/robot/v1/metadata/x509/stub-bot%40stub-project.iam.gserviceaccount.com",
+    },
+    config: { typingIndicator: "message" },
+  };
+}
+
+type TurnArgs = {
+  adapter: {
+    resolveTurn: () => {
+      delivery: {
+        durable: (
+          payload: { text?: string },
+          info: { kind: "tool" | "block" | "final" },
+        ) => false | { to: string; replyToId?: string | null; threadId?: string };
+        deliver: (payload: { text?: string }) => Promise<void>;
+        onDelivered: () => void;
+        onError: (error: unknown, info: { kind: "tool" | "block" | "final" }) => void;
+      };
+    };
+  };
+};
+
+function createCore(mode: TurnMode, account: ResolvedGoogleChatAccount) {
+  const dispatch = {
+    accepted: undefined as boolean | undefined,
+    durableDecisions: [] as Array<
+      false | { to: string; replyToId?: string | null; threadId?: string }
+    >,
+    failed: 0,
+  };
+  const run = vi.fn(async ({ adapter }: TurnArgs) => {
+    if (mode === "turn-error") {
+      throw new Error("stub: model turn failed");
+    }
+    const { delivery } = adapter.resolveTurn();
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload, info) => {
+        dispatch.durableDecisions.push(delivery.durable(payload, info));
+        await delivery.deliver(payload);
+        delivery.onDelivered();
+      },
+      onError: delivery.onError,
+    });
+    try {
+      if (mode === "message-tool-only") {
+        await sendGoogleChatMessage({
+          account,
+          space: "spaces/AAA",
+          text: "Visible message tool answer",
+        });
+      }
+      if (mode === "fallback-then-final") {
+        dispatcher.sendBlockReply({ text: "First assistant answer" });
+        dispatch.accepted = dispatcher.sendFinalReply({ text: "Second assistant answer" });
+      } else {
+        const silent = mode === "silent" || mode === "message-tool-only";
+        dispatch.accepted = dispatcher.sendFinalReply({
+          text: silent ? "NO_REPLY" : "Visible assistant answer",
+        });
+      }
+    } finally {
+      dispatcher.markComplete();
+      await dispatcher.waitForIdle();
+      dispatch.failed = dispatcher.getFailedCounts().final;
+    }
+  });
+  const core = {
+    logging: { shouldLogVerbose: () => false },
+    channel: {
+      inbound: { buildContext: (payload: unknown) => payload, run },
+      text: {
+        resolveChunkMode: () => "markdown",
+        chunkMarkdownTextWithMode: (text: string) =>
+          mode === "later-chunk-error" ? ["First visible chunk", "Second visible chunk"] : [text],
+      },
+    },
+  } as unknown as GoogleChatCoreRuntime;
+  return { core, dispatch, run };
+}
+
+async function runWebhookTurn(params: { mode: TurnMode; id: string; stub?: StubOptions }) {
+  const account = createAccount(params.id);
+  const errors: string[] = [];
+  const runtime = { error: (message: string) => errors.push(message), log: vi.fn() };
+  const { core, dispatch, run } = createCore(params.mode, account);
+  const google = createGoogleStub(params.stub);
+  const fetchRouting = rerouteGoogleFetch();
+  let webhookStatus = 0;
+  let durableHeader: string | null = null;
+
+  await withServer(google.handler, async (googleBaseUrl) => {
+    fetchRouting.pointAt(googleBaseUrl);
+    const target: WebhookTarget = {
+      account,
+      config: {} as OpenClawConfig,
+      runtime,
+      core,
+      path: "/googlechat",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+      mediaMaxMb: 10,
+      ingress: {
+        receive: async (raw) => {
+          if (!monitorMocks.processEvent) {
+            throw new Error("Google Chat production event processor was not registered");
+          }
+          // Durable persistence is outside the typing owner; replay the admitted event immediately.
+          await monitorMocks.processEvent(raw as GoogleChatEvent, target);
+          return { kind: "durable" as const };
+        },
+      },
+    };
+    const handler = createGoogleChatWebhookRequestHandler({
+      webhookTargets: new Map([[target.path, [target]]]),
+      webhookRateLimiter: createFixedWindowRateLimiter(WEBHOOK_RATE_LIMIT_DEFAULTS),
+      webhookInFlightLimiter: createWebhookInFlightLimiter(),
+      processEvent: async (event, eventTarget) => {
+        await monitorMocks.processEvent?.(event, eventTarget);
+      },
+    });
+
+    await withServer(
+      (request, response) => void handler(request, response),
+      async (webhookUrl) => {
+        const response = await fetch(`${webhookUrl}/googlechat`, {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer inbound-google-chat-webhook-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            type: "MESSAGE",
+            space: { name: "spaces/AAA", type: "DM" },
+            message: {
+              name: incomingResource,
+              text: "Hello from the real Google Chat webhook",
+              sender: { name: "users/alice", displayName: "Alice", type: "HUMAN" },
+            },
+          } satisfies GoogleChatEvent),
+        });
+        webhookStatus = response.status;
+        durableHeader = response.headers.get("x-openclaw-delivery-accepted");
+        await response.text();
+      },
+    );
+  });
+
+  return { ...google, account, dispatch, durableHeader, errors, run, webhookStatus };
+}
+
+function requestShape(requests: ChatRequest[]) {
+  return requests.map(({ method, pathname, text }) => ({
+    method,
+    pathname,
+    ...(text === undefined ? {} : { text }),
+  }));
+}
+
+describe("Google Chat typing placeholder ownership through real HTTP", () => {
+  beforeEach(() => {
+    monitorMocks.verifyGoogleChatRequest.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("deletes only the bot typing placeholder when the real dispatcher suppresses NO_REPLY", async () => {
+    const result = await runWebhookTurn({ mode: "silent", id: "silent" });
+
+    expect(result.webhookStatus).toBe(200);
+    expect(result.durableHeader).toBe("durable");
+    expect(monitorMocks.verifyGoogleChatRequest).toHaveBeenCalledWith({
+      bearer: "inbound-google-chat-webhook-token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+      expectedAddOnPrincipal: undefined,
+    });
+    expect(result.run).toHaveBeenCalledOnce();
+    expect(result.dispatch.accepted).toBe(false);
+    expect(result.tokenAssertions).toHaveLength(1);
+    expect(result.tokenAssertions[0]?.split(".")).toHaveLength(3);
+    expect(requestShape(result.requests)).toEqual([
+      { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "_OpenClaw is typing..._" },
+      { method: "DELETE", pathname: `/v1/${typingResource}` },
+    ]);
+    expect(
+      result.requests.every(({ authorization }) => authorization === `Bearer ${proofAccessToken}`),
+    ).toBe(true);
+    expect(result.requests.some(({ pathname }) => pathname.includes(incomingResource))).toBe(false);
+  });
+
+  it("edits a typing placeholder into the visible reply without deleting it", async () => {
+    const result = await runWebhookTurn({ mode: "visible", id: "visible" });
+
+    expect(result.webhookStatus).toBe(200);
+    expect(result.dispatch.accepted).toBe(true);
+    expect(requestShape(result.requests)).toEqual([
+      { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "_OpenClaw is typing..._" },
+      { method: "PATCH", pathname: `/v1/${typingResource}`, text: "Visible assistant answer" },
+    ]);
+  });
+
+  it("cleans up the typing placeholder when the model turn fails", async () => {
+    const result = await runWebhookTurn({ mode: "turn-error", id: "turn-error" });
+
+    expect(result.webhookStatus).toBe(503);
+    expect(requestShape(result.requests)).toEqual([
+      { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "_OpenClaw is typing..._" },
+      { method: "DELETE", pathname: `/v1/${typingResource}` },
+    ]);
+    expect(result.errors.some((message) => message.includes("stub: model turn failed"))).toBe(true);
+  });
+
+  it("never deletes a placeholder already converted into visible text when a later chunk fails", async () => {
+    const result = await runWebhookTurn({
+      mode: "later-chunk-error",
+      id: "later-chunk-error",
+      stub: { failSecondChunk: true },
+    });
+
+    expect(result.webhookStatus).toBe(200);
+    expect(result.dispatch.failed).toBe(1);
+    expect(requestShape(result.requests)).toEqual([
+      { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "_OpenClaw is typing..._" },
+      { method: "PATCH", pathname: `/v1/${typingResource}`, text: "First visible chunk" },
+      { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "Second visible chunk" },
+    ]);
+    expect(result.errors.some((message) => message.includes("Google Chat API 500"))).toBe(true);
+  });
+
+  it("does not reuse a failed typing placeholder for a later durable final reply", async () => {
+    const result = await runWebhookTurn({
+      mode: "fallback-then-final",
+      id: "fallback-then-final",
+      stub: { failPatch: true },
+    });
+
+    expect(result.webhookStatus).toBe(200);
+    expect(result.dispatch.durableDecisions).toEqual([
+      false,
+      { to: "spaces/AAA", replyToId: null },
+    ]);
+    expect(requestShape(result.requests)).toEqual([
+      { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "_OpenClaw is typing..._" },
+      { method: "PATCH", pathname: `/v1/${typingResource}`, text: "First assistant answer" },
+      { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "First assistant answer" },
+      { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "Second assistant answer" },
+      { method: "DELETE", pathname: `/v1/${typingResource}` },
+    ]);
+  });
+
+  it("keeps a silent turn successful when typing cleanup itself fails", async () => {
+    const result = await runWebhookTurn({
+      mode: "silent",
+      id: "delete-failure",
+      stub: { deleteStatus: 500 },
+    });
+
+    expect(result.webhookStatus).toBe(200);
+    expect(result.requests.at(-1)).toEqual(
+      expect.objectContaining({ method: "DELETE", pathname: `/v1/${typingResource}`, status: 500 }),
+    );
+    expect(
+      result.errors.some((message) => message.includes("Google Chat typing cleanup failed")),
+    ).toBe(true);
+  });
+
+  it("removes typing without removing a visible message-tool-only answer", async () => {
+    const result = await runWebhookTurn({ mode: "message-tool-only", id: "message-tool-only" });
+
+    expect(result.webhookStatus).toBe(200);
+    expect(result.dispatch.accepted).toBe(false);
+    expect(requestShape(result.requests)).toEqual([
+      { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "_OpenClaw is typing..._" },
+      { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "Visible message tool answer" },
+      { method: "DELETE", pathname: `/v1/${typingResource}` },
+    ]);
+  });
+});

--- a/extensions/googlechat/src/monitor.typing-cleanup.integration.test.ts
+++ b/extensions/googlechat/src/monitor.typing-cleanup.integration.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { sendGoogleChatMessage } from "./api.js";
+import type { GoogleChatIngressLifecycle } from "./monitor-ingress.js";
 import type { GoogleChatCoreRuntime, WebhookTarget } from "./monitor-types.js";
 import { createGoogleChatWebhookRequestHandler } from "./monitor-webhook.js";
 import "./monitor.js";
@@ -19,7 +20,11 @@ import type { GoogleChatEvent } from "./types.js";
 
 const monitorMocks = vi.hoisted(() => ({
   processEvent: undefined as
-    | ((event: GoogleChatEvent, target: WebhookTarget) => Promise<void>)
+    | ((
+        event: GoogleChatEvent,
+        target: WebhookTarget,
+        lifecycle?: GoogleChatIngressLifecycle,
+      ) => Promise<void>)
     | undefined,
   verifyGoogleChatRequest: vi.fn(async () => ({ ok: true as const })),
 }));
@@ -64,6 +69,9 @@ const incomingResource = "spaces/AAA/messages/inbound";
 type TurnMode =
   | "silent"
   | "visible"
+  | "deferred-visible"
+  | "deferred-silent"
+  | "deferred-abandoned"
   | "turn-error"
   | "later-chunk-error"
   | "message-tool-only"
@@ -181,6 +189,9 @@ function createAccount(id: string): ResolvedGoogleChatAccount {
 }
 
 type TurnArgs = {
+  turnAdoptionLifecycle?: GoogleChatIngressLifecycle & {
+    onSettled?: () => void;
+  };
   adapter: {
     resolveTurn: () => {
       delivery: {
@@ -203,42 +214,63 @@ function createCore(mode: TurnMode, account: ResolvedGoogleChatAccount) {
       false | { to: string; replyToId?: string | null; threadId?: string }
     >,
     failed: 0,
+    resumeDeferred: undefined as (() => Promise<void>) | undefined,
   };
-  const run = vi.fn(async ({ adapter }: TurnArgs) => {
+  const run = vi.fn(async ({ adapter, turnAdoptionLifecycle }: TurnArgs) => {
     if (mode === "turn-error") {
       throw new Error("stub: model turn failed");
     }
     const { delivery } = adapter.resolveTurn();
-    const dispatcher = createReplyDispatcher({
-      deliver: async (payload, info) => {
-        dispatch.durableDecisions.push(delivery.durable(payload, info));
-        await delivery.deliver(payload);
-        delivery.onDelivered();
-      },
-      onError: delivery.onError,
-    });
-    try {
-      if (mode === "message-tool-only") {
-        await sendGoogleChatMessage({
-          account,
-          space: "spaces/AAA",
-          text: "Visible message tool answer",
-        });
+    const dispatchReply = async () => {
+      const dispatcher = createReplyDispatcher({
+        deliver: async (payload, info) => {
+          dispatch.durableDecisions.push(delivery.durable(payload, info));
+          await delivery.deliver(payload);
+          delivery.onDelivered();
+        },
+        onError: delivery.onError,
+      });
+      try {
+        if (mode === "message-tool-only") {
+          await sendGoogleChatMessage({
+            account,
+            space: "spaces/AAA",
+            text: "Visible message tool answer",
+          });
+        }
+        if (mode === "fallback-then-final") {
+          dispatcher.sendBlockReply({ text: "First assistant answer" });
+          dispatch.accepted = dispatcher.sendFinalReply({ text: "Second assistant answer" });
+        } else {
+          const silent =
+            mode === "silent" || mode === "deferred-silent" || mode === "message-tool-only";
+          dispatch.accepted = dispatcher.sendFinalReply({
+            text: silent ? "NO_REPLY" : "Visible assistant answer",
+          });
+        }
+      } finally {
+        dispatcher.markComplete();
+        await dispatcher.waitForIdle();
+        dispatch.failed = dispatcher.getFailedCounts().final;
       }
-      if (mode === "fallback-then-final") {
-        dispatcher.sendBlockReply({ text: "First assistant answer" });
-        dispatch.accepted = dispatcher.sendFinalReply({ text: "Second assistant answer" });
-      } else {
-        const silent = mode === "silent" || mode === "message-tool-only";
-        dispatch.accepted = dispatcher.sendFinalReply({
-          text: silent ? "NO_REPLY" : "Visible assistant answer",
-        });
-      }
-    } finally {
-      dispatcher.markComplete();
-      await dispatcher.waitForIdle();
-      dispatch.failed = dispatcher.getFailedCounts().final;
+    };
+    if (mode.startsWith("deferred-")) {
+      turnAdoptionLifecycle?.onDeferred();
+      dispatch.resumeDeferred = async () => {
+        try {
+          if (mode === "deferred-abandoned") {
+            await turnAdoptionLifecycle?.onAbandoned();
+          } else {
+            await turnAdoptionLifecycle?.onAdopted();
+            await dispatchReply();
+          }
+        } finally {
+          turnAdoptionLifecycle?.onSettled?.();
+        }
+      };
+      return;
     }
+    await dispatchReply();
   });
   const core = {
     logging: { shouldLogVerbose: () => false },
@@ -254,13 +286,29 @@ function createCore(mode: TurnMode, account: ResolvedGoogleChatAccount) {
   return { core, dispatch, run };
 }
 
-async function runWebhookTurn(params: { mode: TurnMode; id: string; stub?: StubOptions }) {
+async function runWebhookTurn(params: {
+  mode: TurnMode;
+  id: string;
+  stub?: StubOptions;
+  afterAccepted?: (state: {
+    requests: ChatRequest[];
+    resumeDeferred: () => Promise<void>;
+  }) => Promise<void>;
+}) {
   const account = createAccount(params.id);
   const errors: string[] = [];
   const runtime = { error: (message: string) => errors.push(message), log: vi.fn() };
   const { core, dispatch, run } = createCore(params.mode, account);
   const google = createGoogleStub(params.stub);
   const fetchRouting = rerouteGoogleFetch();
+  const ingressLifecycle: GoogleChatIngressLifecycle & { onSettled: ReturnType<typeof vi.fn> } = {
+    admission: "exclusive",
+    abortSignal: new AbortController().signal,
+    onAdopted: vi.fn(async () => {}),
+    onDeferred: vi.fn(),
+    onAbandoned: vi.fn(async () => {}),
+    onSettled: vi.fn(),
+  };
   let webhookStatus = 0;
   let durableHeader: string | null = null;
 
@@ -281,7 +329,11 @@ async function runWebhookTurn(params: { mode: TurnMode; id: string; stub?: StubO
             throw new Error("Google Chat production event processor was not registered");
           }
           // Durable persistence is outside the typing owner; replay the admitted event immediately.
-          await monitorMocks.processEvent(raw as GoogleChatEvent, target);
+          await monitorMocks.processEvent(
+            raw as GoogleChatEvent,
+            target,
+            params.mode.startsWith("deferred-") ? ingressLifecycle : undefined,
+          );
           return { kind: "durable" as const };
         },
       },
@@ -317,11 +369,29 @@ async function runWebhookTurn(params: { mode: TurnMode; id: string; stub?: StubO
         webhookStatus = response.status;
         durableHeader = response.headers.get("x-openclaw-delivery-accepted");
         await response.text();
+        if (params.afterAccepted) {
+          if (!dispatch.resumeDeferred) {
+            throw new Error("Deferred Google Chat turn was not captured");
+          }
+          await params.afterAccepted({
+            requests: google.requests,
+            resumeDeferred: dispatch.resumeDeferred,
+          });
+        }
       },
     );
   });
 
-  return { ...google, account, dispatch, durableHeader, errors, run, webhookStatus };
+  return {
+    ...google,
+    account,
+    dispatch,
+    durableHeader,
+    errors,
+    ingressLifecycle,
+    run,
+    webhookStatus,
+  };
 }
 
 function requestShape(requests: ChatRequest[]) {
@@ -371,6 +441,85 @@ describe("Google Chat typing placeholder ownership through real HTTP", () => {
 
     expect(result.webhookStatus).toBe(200);
     expect(result.dispatch.accepted).toBe(true);
+    expect(requestShape(result.requests)).toEqual([
+      { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "_OpenClaw is typing..._" },
+      { method: "PATCH", pathname: `/v1/${typingResource}`, text: "Visible assistant answer" },
+    ]);
+  });
+
+  it("deletes queued typing only after a deferred silent turn settles", async () => {
+    const result = await runWebhookTurn({
+      mode: "deferred-silent",
+      id: "deferred-silent",
+      afterAccepted: async ({ requests, resumeDeferred }) => {
+        expect(requestShape(requests)).toEqual([
+          { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "_OpenClaw is typing..._" },
+        ]);
+        await resumeDeferred();
+        await vi.waitFor(() => {
+          expect(requestShape(requests)).toEqual([
+            {
+              method: "POST",
+              pathname: "/v1/spaces/AAA/messages",
+              text: "_OpenClaw is typing..._",
+            },
+            { method: "DELETE", pathname: `/v1/${typingResource}` },
+          ]);
+        });
+      },
+    });
+
+    expect(result.webhookStatus).toBe(200);
+    expect(result.dispatch.accepted).toBe(false);
+    expect(result.ingressLifecycle.onAdopted).toHaveBeenCalledOnce();
+    expect(result.ingressLifecycle.onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("deletes queued typing when deferred ownership is abandoned without a reply", async () => {
+    const result = await runWebhookTurn({
+      mode: "deferred-abandoned",
+      id: "deferred-abandoned",
+      afterAccepted: async ({ requests, resumeDeferred }) => {
+        expect(requestShape(requests)).toEqual([
+          { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "_OpenClaw is typing..._" },
+        ]);
+        await resumeDeferred();
+        await vi.waitFor(() => {
+          expect(requestShape(requests)).toEqual([
+            {
+              method: "POST",
+              pathname: "/v1/spaces/AAA/messages",
+              text: "_OpenClaw is typing..._",
+            },
+            { method: "DELETE", pathname: `/v1/${typingResource}` },
+          ]);
+        });
+      },
+    });
+
+    expect(result.webhookStatus).toBe(200);
+    expect(result.ingressLifecycle.onAdopted).not.toHaveBeenCalled();
+    expect(result.ingressLifecycle.onAbandoned).toHaveBeenCalledOnce();
+    expect(result.ingressLifecycle.onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a queued typing placeholder until the deferred turn delivers its visible reply", async () => {
+    const result = await runWebhookTurn({
+      mode: "deferred-visible",
+      id: "deferred-visible",
+      afterAccepted: async ({ requests, resumeDeferred }) => {
+        expect(requestShape(requests)).toEqual([
+          { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "_OpenClaw is typing..._" },
+        ]);
+        await resumeDeferred();
+      },
+    });
+
+    expect(result.webhookStatus).toBe(200);
+    expect(result.dispatch.accepted).toBe(true);
+    expect(result.ingressLifecycle.onDeferred).toHaveBeenCalledOnce();
+    expect(result.ingressLifecycle.onAdopted).toHaveBeenCalledOnce();
+    expect(result.ingressLifecycle.onSettled).toHaveBeenCalledOnce();
     expect(requestShape(result.requests)).toEqual([
       { method: "POST", pathname: "/v1/spaces/AAA/messages", text: "_OpenClaw is typing..._" },
       { method: "PATCH", pathname: `/v1/${typingResource}`, text: "Visible assistant answer" },


### PR DESCRIPTION
Closes #39843

## What Problem This Solves

Fixes an issue where Google Chat could permanently display a typing placeholder after an agent produced NO_REPLY, reacted without sending text, failed during its turn, or sent its response through a message tool.

## Why This Change Was Made

The Google Chat plugin now owns the temporary message for the entire inbound turn through one explicit lease and an outer cleanup boundary. Successful visible edits immediately transfer ownership to the delivered reply; later failures never delete real messages. Failed placeholder updates remain eligible for cleanup without being reused for later durable replies.

The original contributor MumuTW identified this problem in #39891 and is credited in the commit.

## User Impact

Temporary Google Chat typing indicators disappear after silent, canceled, failed, or tool-only turns while legitimate visible replies remain intact.

## Evidence

- Reproduced missing cleanup RED using the actual production Google Chat webhook handler, core reply dispatcher, a real RSA-signed service-account JWT/token exchange, and authenticated localhost Google Chat HTTP endpoints.
- Seven full production-path scenarios now verify silent NO_REPLY, model failure, message-tool-only delivery, failed cleanup, successful placeholder edits, later chunk failures, and failed-edit fallback with a durable final reply.
- Five focused files passed 49 tests, including existing Google Chat transport and reply delivery regressions.
- Fresh independent xhigh review caught and corrected a genuine first-reply ownership regression; mandatory fresh structured xhigh autoreview passed clean.
- No live Google Chat credentials were available; authenticated local production-protocol execution covered the complete owned webhook, OAuth, POST/PATCH/DELETE flow.

### Deferred-turn lifecycle correction and remaining proof boundary

A fresh independent xhigh P0-P2 review found that the original inbound-handler cleanup could run before an adopted deferred turn settled. The latest commit transfers placeholder ownership to the canonical `turnAdoptionLifecycle.onSettled`, preserves the original lifecycle callbacks, and verifies deferred visible, silent, and abandoned turns through the authenticated localhost webhook/OAuth/Google-Chat-shaped HTTP path. Five focused files now pass 52 tests; an independent run passed 41 tests and fresh xhigh autoreview reported no accepted findings.

**This is authenticated localhost protocol integration, not a real external Google Chat workspace/API call.** The existing authorized QA live lanes cover Telegram, Discord, Matrix, Slack, and WhatsApp but do not include Google Chat, and no authorized Google Chat credentials are configured. Keep this PR open until a maintainer can provide real external Google Chat after-fix evidence; do not treat the localhost proof as live channel verification.
