### PR TITLE
fix(auth): retain the selected account when migrating Codex sessions

### DIFF
--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -1,6 +1,7 @@
 // Doctor flat auth-profile tests cover legacy flat profile repair and persisted auth-profile loading.
 import fs from "node:fs";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
 import {
@@ -13,12 +14,19 @@ import {
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import { clearAgentHarnesses, registerAgentHarness } from "../agents/harness/registry.js";
+import {
+  listSessionEntriesReadOnly,
+  loadSessionEntry,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { buildStatusText } from "../status/status-text.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -29,6 +37,7 @@ import {
   maybeRepairOpenAICodexAuthConfig,
 } from "./doctor-auth-flat-profiles.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
+import { maybeRepairCodexSessionRoutes } from "./doctor/shared/codex-route-session-repair.js";
 
 const states: OpenClawTestState[] = [];
 
@@ -61,6 +70,74 @@ async function makeTestState(): Promise<OpenClawTestState> {
   });
   states.push(state);
   return state;
+}
+
+async function expectSelectedCodexAccountStatus(params: {
+  cfg: OpenClawConfig;
+  state: OpenClawTestState;
+  sessionKey: string;
+  storePath: string;
+}): Promise<void> {
+  const usageProfileIds: Array<string | undefined> = [];
+  registerAgentHarness(
+    {
+      id: "codex",
+      label: "Codex",
+      autoSelection: { providerIds: ["openai"] },
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt: async () => {
+        throw new Error("not used in doctor migration status proof");
+      },
+      fetchUsageSnapshot: async (context) => {
+        usageProfileIds.push(context.authProfileId);
+        const selectedProfile = context.authProfileId ?? "openai:peter";
+        const credential = loadPersistedAuthProfileStore(params.state.agentDir())?.profiles[
+          selectedProfile
+        ];
+        return {
+          provider: "openai",
+          displayName: "OpenAI",
+          windows: [
+            {
+              label: "Week",
+              usedPercent:
+                credential?.type === "oauth" && credential.accountId === "kate-account" ? 25 : 80,
+            },
+          ],
+        };
+      },
+    },
+    { ownerPluginId: "codex" },
+  );
+  try {
+    const status = await buildStatusText({
+      cfg: params.cfg,
+      sessionEntry: loadSessionEntry({
+        storePath: params.storePath,
+        sessionKey: params.sessionKey,
+        env: params.state.env,
+      }),
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      statusChannel: "telegram",
+      provider: "openai",
+      model: "gpt-5.5",
+      resolvedHarness: "codex",
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      modelAuthOverride: "oauth",
+      activeModelAuthOverride: "oauth",
+      skipDefaultTaskLookup: true,
+    });
+    expect(usageProfileIds).toEqual(["openai:chatgpt-default"]);
+    expect(status).toContain("Week 75% left");
+    expect(status).not.toContain("Week 20% left");
+  } finally {
+    clearAgentHarnesses();
+  }
 }
 
 async function writeLegacyAuthProfilesJson(
@@ -1802,6 +1879,644 @@ describe("legacy OpenAI auth profiles through the canonical migration owner", ()
         }),
       ),
     ).toEqual([["openai-codex:default", "openai:chatgpt-default"]]);
+  });
+
+  it("keeps existing SQLite accounts when planning legacy Codex profile collisions", async () => {
+    const state = await makeTestState();
+    await state.writeAuthProfiles({
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "oauth",
+          provider: "openai",
+          access: "peter-access",
+          refresh: "peter-refresh",
+          expires: 9_999_999_999_999,
+          accountId: "peter-account",
+        },
+      },
+    });
+    await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "kate-access",
+          refresh: "kate-refresh",
+          expires: 9_999_999_999_999,
+          accountId: "kate-account",
+        },
+      },
+    });
+
+    const profileIdMap = collectOpenAICodexAuthProfileStoreIdMap({ cfg: {}, env: state.env });
+    expect(profileIdMap.get("openai-codex:default")).toBe("openai:chatgpt-default");
+    await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      env: state.env,
+      prompter: makePrompter(true),
+      openAICodexAuthProfileIdMap: profileIdMap,
+    });
+    expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles).toMatchObject({
+      "openai:default": { accountId: "peter-account" },
+      "openai:chatgpt-default": { accountId: "kate-account" },
+    });
+  });
+
+  it("migrates config-only legacy OAuth accounts and their selected SQLite session", async () => {
+    const state = await makeTestState();
+    const storePath = path.join(state.sessionsDir(), "sessions.json");
+    const sessionKey = "agent:main:main";
+    const legacyConfig = {
+      auth: {
+        profiles: {
+          "openai:default": {
+            provider: "openai",
+            mode: "api_key",
+            key: "existing-api-key",
+          },
+          "openai-codex:default": {
+            provider: "openai-codex",
+            mode: "oauth",
+            access: "kate-access",
+            refresh: "kate-refresh",
+            expires: 9_999_999_999_999,
+            accountId: "kate-account",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await replaceSessionEntry(
+      { storePath, sessionKey, env: state.env },
+      {
+        sessionId: "config-only-selected-session",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "user",
+      },
+    );
+
+    const profileIdMap = collectOpenAICodexAuthProfileStoreIdMap({
+      cfg: legacyConfig,
+      env: state.env,
+    });
+    expect(profileIdMap.get("openai-codex:default")).toBe("openai:chatgpt-default");
+    const cfg = maybeRepairOpenAICodexAuthConfig(legacyConfig, { profileIdMap }).config;
+    await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg,
+      env: state.env,
+      prompter: makePrompter(true),
+      openAICodexAuthProfileIdMap: profileIdMap,
+    });
+    await maybeRepairCodexSessionRoutes({
+      cfg,
+      env: state.env,
+      shouldRepair: true,
+      authProfileIdMap: profileIdMap,
+    });
+
+    expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles).toMatchObject({
+      "openai:default": { type: "api_key" },
+      "openai:chatgpt-default": { type: "oauth", accountId: "kate-account" },
+    });
+    expect(loadSessionEntry({ storePath, sessionKey, env: state.env })).toMatchObject({
+      authProfileOverride: "openai:chatgpt-default",
+      authProfileOverrideSource: "user",
+    });
+  });
+
+  it("does not rebind unresolved sidecar accounts when another Codex account migrates", async () => {
+    const state = await makeTestState();
+    const storePath = path.join(state.sessionsDir(), "sessions.json");
+    const readySessionKey = "agent:main:main";
+    const pendingSessionKey = "agent:main:telegram:default:direct:5550100111";
+    await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai-codex:ready": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "ready-access",
+          refresh: "ready-refresh",
+          expires: 9_999_999_999_999,
+          accountId: "ready-account",
+        },
+        "openai-codex:pending": {
+          type: "oauth",
+          provider: "openai-codex",
+          accountId: "pending-account",
+          oauthRef: {
+            id: "0123456789abcdef0123456789abcdef",
+            provider: "openai-codex",
+          },
+        },
+      },
+    });
+    for (const [sessionKey, profileId] of [
+      [readySessionKey, "openai-codex:ready"],
+      [pendingSessionKey, "openai-codex:pending"],
+    ] as const) {
+      await replaceSessionEntry(
+        { storePath, sessionKey, env: state.env },
+        {
+          sessionId: `session-${profileId}`,
+          updatedAt: Date.now(),
+          authProfileOverride: profileId,
+          authProfileOverrideSource: "user",
+        },
+      );
+    }
+
+    const profileIdMap = collectOpenAICodexAuthProfileStoreIdMap({ cfg: {}, env: state.env });
+    const migration = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      env: state.env,
+      prompter: makePrompter(true),
+      openAICodexAuthProfileIdMap: profileIdMap,
+    });
+    expect(migration.changes.length).toBeGreaterThan(0);
+    expect(migration.warnings).toEqual([expect.stringContaining("legacy OAuth sidecar profile")]);
+    const result = await maybeRepairCodexSessionRoutes({
+      cfg: {},
+      env: state.env,
+      shouldRepair: true,
+      authProfileIdMap: profileIdMap,
+    });
+
+    expect(result.repairedSessions).toBe(1);
+    expect(
+      loadSessionEntry({ storePath, sessionKey: readySessionKey, env: state.env }),
+    ).toMatchObject({
+      authProfileOverride: "openai:ready",
+    });
+    expect(
+      loadSessionEntry({ storePath, sessionKey: pendingSessionKey, env: state.env }),
+    ).toMatchObject({
+      authProfileOverride: "openai-codex:pending",
+      authProfileOverrideSource: "user",
+    });
+  });
+
+  it("repairs an already-migrated selected account from its verified auth archive", async () => {
+    const state = await makeTestState();
+    const storePath = path.join(state.sessionsDir(), "sessions.json");
+    const sessionKey = "agent:main:main";
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "existing-api-key",
+        },
+        "openai-codex:default": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "kate-access",
+          refresh: "kate-refresh",
+          expires: 9_999_999_999_999,
+          accountId: "kate-account",
+          email: "kate@example.com",
+        },
+        "openai-codex:peter": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "peter-access",
+          refresh: "peter-refresh",
+          expires: 9_999_999_999_999,
+          accountId: "peter-account",
+          email: "peter@example.com",
+        },
+      },
+    });
+    await replaceSessionEntry(
+      { storePath, sessionKey, env: state.env },
+      {
+        sessionId: "already-migrated-selected-session",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "user",
+      },
+    );
+
+    const originalMap = collectOpenAICodexAuthProfileStoreIdMap({ cfg: {}, env: state.env });
+    await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      env: state.env,
+      prompter: makePrompter(true),
+      openAICodexAuthProfileIdMap: originalMap,
+    });
+    expect(fs.existsSync(authPath)).toBe(false);
+    expect(loadSessionEntry({ storePath, sessionKey, env: state.env })).toMatchObject({
+      authProfileOverride: "openai-codex:default",
+    });
+
+    const recoveredMap = collectOpenAICodexAuthProfileStoreIdMap({ cfg: {}, env: state.env });
+    expect(recoveredMap.get("openai-codex:default")).toBe("openai:chatgpt-default");
+    const repair = await maybeRepairCodexSessionRoutes({
+      cfg: {},
+      env: state.env,
+      shouldRepair: true,
+      authProfileIdMap: recoveredMap,
+    });
+
+    expect(repair.repairedSessions).toBe(1);
+    expect(loadSessionEntry({ storePath, sessionKey, env: state.env })).toMatchObject({
+      authProfileOverride: "openai:chatgpt-default",
+      authProfileOverrideSource: "user",
+    });
+    expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles).toMatchObject({
+      "openai:default": { type: "api_key" },
+      "openai:chatgpt-default": { accountId: "kate-account" },
+      "openai:peter": { accountId: "peter-account" },
+    });
+    await expectSelectedCodexAccountStatus({ cfg: {}, state, sessionKey, storePath });
+  });
+
+  it("rejects tampered auth archives instead of guessing a migrated account", async () => {
+    const state = await makeTestState();
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "kate-access",
+          refresh: "kate-refresh",
+          expires: 9_999_999_999_999,
+          accountId: "kate-account",
+        },
+      },
+    });
+    await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      env: state.env,
+      prompter: makePrompter(true),
+    });
+    const [archivePath] = listMigratedArchives(authPath);
+    fs.appendFileSync(archivePath!, "\n");
+
+    expect(collectOpenAICodexAuthProfileStoreIdMap({ cfg: {}, env: state.env }).size).toBe(0);
+  });
+
+  it("leaves archived profile mapping unresolved when account identity is ambiguous", async () => {
+    const state = await makeTestState();
+    const sharedAccount = {
+      type: "oauth",
+      provider: "openai-codex",
+      access: "shared-access",
+      refresh: "shared-refresh",
+      expires: 9_999_999_999_999,
+      accountId: "shared-account",
+    };
+    await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai-codex:default": sharedAccount,
+        "openai-codex:copy": { ...sharedAccount },
+      },
+    });
+    await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      env: state.env,
+      prompter: makePrompter(true),
+    });
+
+    expect(collectOpenAICodexAuthProfileStoreIdMap({ cfg: {}, env: state.env }).size).toBe(0);
+  });
+
+  it("keeps failed agent accounts separate while repairing verified and inherited main accounts", async () => {
+    const state = await makeTestState();
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "failed" },
+          { id: "inherited" },
+          { id: "dedup" },
+        ],
+      },
+    };
+    const sharedCredential = {
+      type: "oauth",
+      provider: "openai-codex",
+      access: "shared-access",
+      refresh: "shared-refresh",
+      expires: 9_999_999_999_999,
+      accountId: "shared-main-account",
+    };
+    await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: { "openai-codex:shared": sharedCredential },
+    });
+    await writeLegacyAuthProfilesJson(
+      state,
+      {
+        version: 1,
+        profiles: {
+          "openai-codex:shared": {
+            type: "oauth",
+            provider: "openai-codex",
+            accountId: "failed-different-account",
+            oauthRef: {
+              id: "0123456789abcdef0123456789abcdef",
+              provider: "openai-codex",
+            },
+          },
+        },
+      },
+      "failed",
+    );
+    await writeLegacyAuthProfilesJson(
+      state,
+      {
+        version: 1,
+        profiles: {
+          "openai-codex:shared": { ...sharedCredential },
+          "openai-codex:pending": {
+            type: "oauth",
+            provider: "openai-codex",
+            accountId: "dedup-pending-account",
+            oauthRef: {
+              id: "fedcba9876543210fedcba9876543210",
+              provider: "openai-codex",
+            },
+          },
+        },
+      },
+      "dedup",
+    );
+    for (const agentId of ["main", "failed", "inherited", "dedup"]) {
+      await replaceSessionEntry(
+        {
+          storePath: path.join(state.sessionsDir(agentId), "sessions.json"),
+          sessionKey: `agent:${agentId}:main`,
+          env: state.env,
+        },
+        {
+          sessionId: `${agentId}-session`,
+          updatedAt: Date.now(),
+          authProfileOverride: "openai-codex:shared",
+          authProfileOverrideSource: "user",
+        },
+      );
+    }
+
+    const profileIdMap = collectOpenAICodexAuthProfileStoreIdMap({ cfg, env: state.env });
+    const migration = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg,
+      env: state.env,
+      prompter: makePrompter(true),
+      openAICodexAuthProfileIdMap: profileIdMap,
+    });
+    expect(migration.warnings.length).toBeGreaterThan(0);
+    expect(loadPersistedAuthProfileStore(state.agentDir("dedup"))?.profiles).not.toHaveProperty(
+      "openai:shared",
+    );
+
+    const repair = await maybeRepairCodexSessionRoutes({
+      cfg,
+      env: state.env,
+      shouldRepair: true,
+      authProfileIdMap: profileIdMap,
+    });
+    expect(repair.repairedSessions).toBe(3);
+    for (const agentId of ["main", "inherited", "dedup"]) {
+      expect(
+        loadSessionEntry({
+          storePath: path.join(state.sessionsDir(agentId), "sessions.json"),
+          sessionKey: `agent:${agentId}:main`,
+          env: state.env,
+        }),
+      ).toMatchObject({
+        authProfileOverride: "openai:shared",
+        authProfileOverrideSource: "user",
+      });
+    }
+    expect(
+      loadSessionEntry({
+        storePath: path.join(state.sessionsDir("failed"), "sessions.json"),
+        sessionKey: "agent:failed:main",
+        env: state.env,
+      }),
+    ).toMatchObject({
+      authProfileOverride: "openai-codex:shared",
+      authProfileOverrideSource: "user",
+    });
+  });
+
+  it("previews noncanonical SQLite sessions without mutating or requiring canonical migration", async () => {
+    const state = await makeTestState();
+    const storePath = path.join(state.sessionsDir(), "sessions.json");
+    const sessionKey = "agent:main:main";
+    await replaceSessionEntry(
+      { storePath, sessionKey, env: state.env },
+      {
+        sessionId: "noncanonical-preview-session",
+        updatedAt: Date.now(),
+        modelProvider: "openai-codex",
+        model: "gpt-5.5",
+      },
+    );
+    closeOpenClawAgentDatabasesForTest();
+    const sqlitePath = path.join(state.agentDir(), "openclaw-agent.sqlite");
+    const database = new DatabaseSync(sqlitePath);
+    database
+      .prepare("UPDATE session_nodes SET entry_valid = 0 WHERE session_key = ?")
+      .run(sessionKey);
+    database.close();
+    expect(() =>
+      listSessionEntriesReadOnly({ storePath, agentId: "main", env: state.env }),
+    ).toThrow("invalid persisted session row requires repair");
+
+    const preview = await maybeRepairCodexSessionRoutes({
+      cfg: {},
+      env: state.env,
+      shouldRepair: false,
+    });
+
+    expect(preview).toMatchObject({
+      scannedStores: 1,
+      repairedStores: 0,
+      repairedSessions: 0,
+      changes: [],
+    });
+    expect(preview.warnings.join("\n")).toContain("Affected sessions: 1.");
+    const verifier = new DatabaseSync(sqlitePath, { readOnly: true });
+    try {
+      expect(
+        verifier
+          .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+          .get(sessionKey),
+      ).toEqual({ entry_valid: 0 });
+    } finally {
+      verifier.close();
+    }
+  });
+
+  it("preserves the selected Codex account across auth migration, SQLite sessions, and status", async () => {
+    const state = await makeTestState();
+    const storePath = path.join(state.sessionsDir(), "sessions.json");
+    const sessionKey = "agent:main:main";
+    const sessionUpdatedAt = Date.now();
+    const legacyConfig = {
+      auth: {
+        profiles: {
+          "openai:default": { provider: "openai", mode: "api_key" },
+          "openai-codex:peter": {
+            provider: "openai-codex",
+            mode: "oauth",
+            email: "peter@example.com",
+          },
+          "openai-codex:default": {
+            provider: "openai-codex",
+            mode: "oauth",
+            email: "kate@example.com",
+          },
+        },
+        order: {
+          openai: ["openai:default"],
+          "openai-codex": ["openai-codex:peter", "openai-codex:default"],
+        },
+      },
+      agents: { defaults: { agentRuntime: { id: "codex" } } },
+    } as OpenClawConfig;
+    await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "test-openai-api-key",
+        },
+        "openai-codex:peter": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "peter-access",
+          refresh: "peter-refresh",
+          expires: 9_999_999_999_999,
+          accountId: "peter-account",
+          email: "peter@example.com",
+        },
+        "openai-codex:default": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "kate-access",
+          refresh: "kate-refresh",
+          expires: 9_999_999_999_999,
+          accountId: "kate-account",
+          email: "kate@example.com",
+        },
+      },
+      order: {
+        openai: ["openai:default"],
+        "openai-codex": ["openai-codex:peter", "openai-codex:default"],
+      },
+    });
+    await replaceSessionEntry(
+      { storePath, sessionKey, env: state.env },
+      {
+        sessionId: "selected-kate-session",
+        updatedAt: sessionUpdatedAt,
+        modelProvider: "openai",
+        model: "gpt-5.5",
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "user",
+        agentRuntimeOverride: "codex",
+      },
+    );
+    const peterSessionKey = "agent:main:telegram:default:direct:5550100999";
+    await replaceSessionEntry(
+      { storePath, sessionKey: peterSessionKey, env: state.env },
+      {
+        sessionId: "selected-peter-session",
+        updatedAt: sessionUpdatedAt + 1,
+        modelProvider: "openai",
+        model: "gpt-5.5",
+        authProfileOverride: "openai-codex:peter",
+        authProfileOverrideSource: "auto",
+      },
+    );
+    expect(
+      loadSessionEntry({ storePath, sessionKey: peterSessionKey, env: state.env }),
+    ).toMatchObject({ authProfileOverride: "openai-codex:peter" });
+    const missingProfileSessionKey = "agent:main:discord:default:direct:5550100888";
+    await replaceSessionEntry(
+      { storePath, sessionKey: missingProfileSessionKey, env: state.env },
+      {
+        sessionId: "missing-profile-session",
+        updatedAt: sessionUpdatedAt + 2,
+        modelProvider: "openai",
+        model: "gpt-5.5",
+        authProfileOverride: "openai-codex:missing",
+        authProfileOverrideSource: "user",
+      },
+    );
+    expect(fs.existsSync(storePath)).toBe(false);
+
+    const profileIdMap = collectOpenAICodexAuthProfileStoreIdMap({
+      cfg: legacyConfig,
+      env: state.env,
+    });
+    expect(profileIdMap.get("openai-codex:default")).toBe("openai:chatgpt-default");
+    expect(profileIdMap.get("openai-codex:peter")).toBe("openai:peter");
+    const cfg = maybeRepairOpenAICodexAuthConfig(legacyConfig, { profileIdMap }).config;
+    const migration = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg,
+      env: state.env,
+      prompter: makePrompter(true),
+      openAICodexAuthProfileIdMap: profileIdMap,
+    });
+    expect(migration.warnings).toEqual([]);
+    expect(loadPersistedAuthProfileStore(state.agentDir())?.order?.openai).toEqual([
+      "openai:peter",
+      "openai:chatgpt-default",
+      "openai:default",
+    ]);
+
+    const repairParams = {
+      cfg,
+      env: state.env,
+      authProfileIdMap: profileIdMap,
+    };
+    expect(
+      listSessionEntriesReadOnly({ storePath, agentId: "main", env: state.env }).map(
+        ({ entry }) => entry.authProfileOverride,
+      ),
+    ).toEqual(expect.arrayContaining(["openai-codex:default", "openai-codex:peter"]));
+    const preview = await maybeRepairCodexSessionRoutes({ ...repairParams, shouldRepair: false });
+    expect(preview.repairedSessions).toBe(0);
+    expect(preview.warnings.join("\n")).toContain("Affected sessions: 2.");
+
+    const sessionRepair = await maybeRepairCodexSessionRoutes({
+      ...repairParams,
+      shouldRepair: true,
+    });
+    expect(sessionRepair.repairedSessions).toBe(2);
+    const selectedSession = loadSessionEntry({ storePath, sessionKey, env: state.env });
+    expect(selectedSession).toMatchObject({
+      authProfileOverride: "openai:chatgpt-default",
+      authProfileOverrideSource: "user",
+    });
+    expect(
+      loadSessionEntry({ storePath, sessionKey: peterSessionKey, env: state.env }),
+    ).toMatchObject({
+      authProfileOverride: "openai:peter",
+      authProfileOverrideSource: "auto",
+    });
+    expect(
+      loadSessionEntry({ storePath, sessionKey: missingProfileSessionKey, env: state.env }),
+    ).toMatchObject({
+      authProfileOverride: "openai-codex:missing",
+      authProfileOverrideSource: "user",
+      updatedAt: sessionUpdatedAt + 2,
+    });
+    await expect(
+      maybeRepairCodexSessionRoutes({ ...repairParams, shouldRepair: true }),
+    ).resolves.toMatchObject({ repairedSessions: 0, changes: [] });
+
+    await expectSelectedCodexAccountStatus({ cfg, state, sessionKey, storePath });
   });
 
   it("renames legacy OpenAI Codex auth profiles while archiving the untouched source", async () => {

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -10,8 +10,13 @@ import { resolveAgentDir, resolveDefaultAgentDir, listAgentIds } from "../agents
 import { AUTH_STORE_VERSION } from "../agents/auth-profiles/constants.js";
 import {
   clearAuthProfileMigrationDiagnostics,
+  listLegacyAuthProfileArchives,
   resolveLegacyOAuthPath,
 } from "../agents/auth-profiles/legacy-source-diagnostic.js";
+import {
+  areOAuthCredentialsEquivalent,
+  hasMatchingOAuthIdentity,
+} from "../agents/auth-profiles/oauth-shared.js";
 import {
   applyLegacyAuthStore,
   coerceLegacyAuthStore,
@@ -45,6 +50,7 @@ import type { AuthProfileConfig } from "../config/types.auth.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { loadJsonFile } from "../infra/json-file.js";
+import { readLegacyMigrationReceipt } from "../infra/state-migrations.receipts.js";
 import type { OpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { shortenHomePath } from "../utils.js";
 import {
@@ -974,6 +980,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   prompter: Pick<DoctorPrompter, "confirmAutoFix">;
   now?: () => number;
   env?: NodeJS.ProcessEnv;
+  openAICodexAuthProfileIdMap?: ReadonlyMap<string, string>;
   deps?: {
     loadPersistedAuthProfileStore?: typeof loadPersistedAuthProfileStore;
   };
@@ -1053,7 +1060,11 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
     return result;
   }
 
-  const openAIProfileIdMap = collectOpenAICodexAuthProfileStoreIdMap({ cfg: params.cfg, env });
+  // Config, credential import, and session repair must share one collision
+  // decision; archived legacy JSON cannot recreate it after migration.
+  const openAIProfileIdMap =
+    params.openAICodexAuthProfileIdMap ??
+    collectOpenAICodexAuthProfileStoreIdMap({ cfg: params.cfg, env });
   for (const candidate of detected) {
     let releaseSources: (() => void) | undefined;
     try {
@@ -1761,7 +1772,100 @@ function canonicalizeLegacyOpenAIAuthStore(
     : null;
 }
 
-/** Collects deterministic legacy-to-canonical OpenAI profile ids across all agent stores. */
+function recoverArchivedOpenAICodexAuthProfileIdMap(params: {
+  candidates: readonly AuthProfileRepairCandidate[];
+  env: NodeJS.ProcessEnv;
+}): Map<string, string> {
+  const recovered = new Map<string, string>();
+  const ambiguous = new Set<string>();
+  const agentDirs = params.candidates.flatMap((candidate) =>
+    candidate.agentDir ? [candidate.agentDir] : [],
+  );
+  const archives = listLegacyAuthProfileArchives({ agentDirs, env: params.env }).filter(
+    (archive) => archive.kind === "auth-profiles",
+  );
+  for (const candidate of params.candidates) {
+    const canonicalProfiles = loadPersistedAuthProfileStore(candidate.agentDir)?.profiles;
+    if (!canonicalProfiles) {
+      continue;
+    }
+    for (const archive of archives.filter((entry) =>
+      entry.path.startsWith(`${candidate.authPath}.migrated-`),
+    )) {
+      try {
+        const sourceBytes = fs.readFileSync(archive.path);
+        const sourceSha256 = createHash("sha256").update(sourceBytes).digest("hex");
+        const sourceKey = `auth-profile-v2:${createHash("sha256")
+          .update(`${path.resolve(candidate.authPath)}\0${sourceSha256}`)
+          .digest("hex")}`;
+        const receipt = readLegacyMigrationReceipt(sourceKey, params.env);
+        if (!receipt?.removedSource || receipt.sourceSha256 !== sourceSha256) {
+          continue;
+        }
+        const report = JSON.parse(receipt.reportJson) as unknown;
+        if (
+          !isRecord(report) ||
+          report.format !== "auth-profile-json-to-sqlite-v2" ||
+          report.completionStatus !== "completed" ||
+          report.targetTable !== "auth_profile_store" ||
+          typeof report.archivePath !== "string" ||
+          path.resolve(report.archivePath) !== path.resolve(archive.path) ||
+          typeof report.targetDatabasePath !== "string" ||
+          path.resolve(report.targetDatabasePath) !==
+            path.resolve(resolveAuthProfileDatabasePath(candidate.agentDir)) ||
+          !isRecord(report.expectedProfileSha256)
+        ) {
+          continue;
+        }
+        const archivedStore = JSON.parse(sourceBytes.toString("utf8")) as unknown;
+        if (!isRecord(archivedStore) || !isRecord(archivedStore.profiles)) {
+          continue;
+        }
+        for (const [legacyProfileId, rawCredential] of Object.entries(archivedStore.profiles)) {
+          if (!isLegacyOpenAICodexProfileId(legacyProfileId) || !isRecord(rawCredential)) {
+            continue;
+          }
+          const archivedCredential = parseLegacyCredentialEntry(
+            { ...rawCredential, provider: "openai" },
+            "openai",
+          );
+          if (archivedCredential?.type !== "oauth") {
+            continue;
+          }
+          const matches = Object.entries(report.expectedProfileSha256).flatMap(
+            ([canonicalProfileId, expectedSha256]) => {
+              const credential = canonicalProfiles[canonicalProfileId];
+              return typeof expectedSha256 === "string" &&
+                credential?.type === "oauth" &&
+                credential.provider === "openai" &&
+                (hasMatchingOAuthIdentity(archivedCredential, credential) ||
+                  areOAuthCredentialsEquivalent(archivedCredential, credential))
+                ? [canonicalProfileId]
+                : [];
+            },
+          );
+          if (matches.length !== 1) {
+            continue;
+          }
+          const canonicalProfileId = matches[0]!;
+          const previous = recovered.get(legacyProfileId);
+          if (previous && previous !== canonicalProfileId) {
+            recovered.delete(legacyProfileId);
+            ambiguous.add(legacyProfileId);
+          } else if (!ambiguous.has(legacyProfileId)) {
+            recovered.set(legacyProfileId, canonicalProfileId);
+          }
+        }
+      } catch {
+        // Archives without a matching verified receipt or parseable identity
+        // cannot prove account ownership; leave their session pins untouched.
+      }
+    }
+  }
+  return recovered;
+}
+
+/** Collects collision-safe OpenAI profile ids across config, SQLite, and legacy agent stores. */
 export function collectOpenAICodexAuthProfileStoreIdMap(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -1770,7 +1874,19 @@ export function collectOpenAICodexAuthProfileStoreIdMap(params: {
   const occupiedProfileIds = new Set<string>();
   const legacyProfileIds = new Set<string>();
   const profileIdMap = new Map<string, string>();
-  for (const candidate of listAuthProfileRepairCandidates(params.cfg, env)) {
+  const candidates = listAuthProfileRepairCandidates(params.cfg, env);
+  const addProfileIds = (profileIds: Iterable<string>): void => {
+    for (const profileId of profileIds) {
+      if (isLegacyOpenAICodexProfileId(profileId)) {
+        legacyProfileIds.add(profileId);
+      } else {
+        occupiedProfileIds.add(profileId);
+      }
+    }
+  };
+  addProfileIds(Object.keys(params.cfg.auth?.profiles ?? {}));
+  for (const candidate of candidates) {
+    addProfileIds(Object.keys(loadPersistedAuthProfileStore(candidate.agentDir)?.profiles ?? {}));
     if (!fs.existsSync(candidate.authPath)) {
       continue;
     }
@@ -1778,16 +1894,18 @@ export function collectOpenAICodexAuthProfileStoreIdMap(params: {
     if (!isRecord(raw) || !isRecord(raw.profiles)) {
       continue;
     }
-    for (const profileId of Object.keys(raw.profiles)) {
-      if (isLegacyOpenAICodexProfileId(profileId)) {
-        legacyProfileIds.add(profileId);
-      } else {
-        occupiedProfileIds.add(profileId);
-      }
-    }
+    addProfileIds(Object.keys(raw.profiles));
   }
   for (const profileId of [...legacyProfileIds].toSorted((a, b) => a.localeCompare(b))) {
     profileIdMap.set(profileId, allocateOpenAIProfileId(profileId, occupiedProfileIds));
+  }
+  for (const [legacyProfileId, canonicalProfileId] of recoverArchivedOpenAICodexAuthProfileIdMap({
+    candidates,
+    env,
+  })) {
+    if (!profileIdMap.has(legacyProfileId)) {
+      profileIdMap.set(legacyProfileId, canonicalProfileId);
+    }
   }
   return profileIdMap;
 }

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1953,6 +1953,28 @@ describe("doctor config flow", () => {
     });
   });
 
+  it("keeps the Codex session auth migration plan outside persisted config", async () => {
+    const openAICodexAuthProfileIdMap = new Map([
+      ["openai-codex:default", "openai:chatgpt-default"],
+    ]);
+    runDoctorRepairSequenceMock.mockImplementation(async (params: { state: unknown }) => ({
+      state: params.state,
+      changeNotes: [],
+      warningNotes: [],
+      authProfilesRepaired: false,
+      openAICodexAuthProfileIdMap,
+    }));
+
+    const result = await runDoctorConfigWithInput({
+      config: {},
+      repair: true,
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(result.openAICodexAuthProfileIdMap).toBe(openAICodexAuthProfileIdMap);
+    expect(result.cfg).not.toHaveProperty("openAICodexAuthProfileIdMap");
+  });
+
   it("does not refresh gateway before writing a config-only auth repair", async () => {
     runDoctorRepairSequenceMock.mockImplementation(
       async (params: {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -164,6 +164,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   };
   const explicitSetPaths: string[][] = [];
   let shouldRepairCronCodexModelRefsAfterConfigWrite = false;
+  let openAICodexAuthProfileIdMap: ReadonlyMap<string, string> | undefined;
   const doctorFixCommand = formatCliCommand("openclaw doctor --fix");
   const applyConfigMutation = (
     mutation: DoctorConfigMutationResult & { warnings?: string[] },
@@ -410,6 +411,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       blockedCodexProviderPlan,
     });
     state = repairSequence.state;
+    openAICodexAuthProfileIdMap = repairSequence.openAICodexAuthProfileIdMap;
     if (repairSequence.authProfilesRepaired) {
       await refreshGatewayAuthStateAfterAuthProfileRepair();
     }
@@ -520,5 +522,6 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     ...(blockedCodexProviderPlan.blockedModelIdentities.length > 0
       ? { blockedCodexModelIdentities: blockedCodexProviderPlan.blockedModelIdentities }
       : {}),
+    ...(openAICodexAuthProfileIdMap?.size ? { openAICodexAuthProfileIdMap } : {}),
   };
 }

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   applyPluginAutoEnable: vi.fn(),
   materializePluginAutoEnableCandidates: vi.fn(),
   collectChannelDoctorCompatibilityMutations: vi.fn(),
+  collectOpenAICodexAuthProfileStoreIdMap: vi.fn(),
   ensureAuthProfileStore: vi.fn(),
   evaluateStoredCredentialEligibility: vi.fn(),
   getInstalledPluginRecord: vi.fn(),
@@ -48,7 +49,7 @@ vi.mock("../../infra/state-migrations.onboarding-recommendations.js", () => ({
 }));
 
 vi.mock("../doctor-auth-flat-profiles.js", () => ({
-  collectOpenAICodexAuthProfileStoreIdMap: vi.fn(() => new Map()),
+  collectOpenAICodexAuthProfileStoreIdMap: mocks.collectOpenAICodexAuthProfileStoreIdMap,
   maybeMigrateAuthProfileJsonStoresToSqlite: mocks.maybeMigrateAuthProfileJsonStoresToSqlite,
   maybeRepairOpenAICodexAuthConfig: mocks.maybeRepairOpenAICodexAuthConfig,
 }));
@@ -255,6 +256,7 @@ describe("doctor repair sequencing", () => {
       changes: [],
       warnings: [],
     });
+    mocks.collectOpenAICodexAuthProfileStoreIdMap.mockReturnValue(new Map());
     mocks.maybeMigrateAuthProfileJsonStoresToSqlite.mockResolvedValue({
       detected: [],
       changes: [],
@@ -320,6 +322,37 @@ describe("doctor repair sequencing", () => {
     });
     expect(result.changeNotes).toContain("Migrated onboarding recommendation state.");
     expect(result.warningNotes).toContain("Migration warning.");
+  });
+
+  it("retains the exact auth profile map after import for later session-owner repair", async () => {
+    const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-doctor-test" };
+    const candidate = {} as OpenClawConfig;
+    const profileIdMap = new Map([["openai-codex:default", "openai:chatgpt-default"]]);
+    mocks.collectOpenAICodexAuthProfileStoreIdMap.mockReturnValue(profileIdMap);
+    mocks.maybeMigrateAuthProfileJsonStoresToSqlite.mockResolvedValue({
+      detected: ["auth-profiles.json"],
+      changes: ["Migrated auth profile JSON into SQLite."],
+      warnings: [],
+    });
+    const result = await runDoctorRepairSequence({
+      state: { cfg: candidate, candidate, pendingChanges: false, fixHints: [] },
+      doctorFixCommand: "openclaw doctor --fix",
+      env,
+    });
+
+    expect(mocks.maybeRepairOpenAICodexAuthConfig).toHaveBeenCalledWith(candidate, {
+      profileIdMap,
+    });
+    expect(mocks.maybeMigrateAuthProfileJsonStoresToSqlite).toHaveBeenCalledWith({
+      cfg: candidate,
+      env,
+      prompter: expect.objectContaining({ confirmAutoFix: expect.any(Function) }),
+      openAICodexAuthProfileIdMap: profileIdMap,
+    });
+    expect(result.openAICodexAuthProfileIdMap).toBe(profileIdMap);
+    expect(mocks.maybeRepairOpenAICodexAuthConfig.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.maybeMigrateAuthProfileJsonStoresToSqlite.mock.invocationCallOrder[0]!,
+    );
   });
 
   it("sanitizes ordered plugin repair changes, warnings, notices, and migration notes", async () => {

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -57,6 +57,7 @@ export async function runDoctorRepairSequence(params: {
   changeNotes: string[];
   warningNotes: string[];
   authProfilesRepaired: boolean;
+  openAICodexAuthProfileIdMap?: ReadonlyMap<string, string>;
 }> {
   let state = params.state;
   const changeNotes: string[] = [];
@@ -141,12 +142,15 @@ export async function runDoctorRepairSequence(params: {
     changes: codexRouteRepair.changes,
     warnings: codexRouteRepair.warnings,
   });
+  // Auth JSON is archived below; retain its exact collision-aware profile map
+  // so durable session selections can follow the same account after import.
+  const openAICodexAuthProfileIdMap = collectOpenAICodexAuthProfileStoreIdMap({
+    cfg: state.candidate,
+    env,
+  });
   applyMutation(
     maybeRepairOpenAICodexAuthConfig(state.candidate, {
-      profileIdMap: collectOpenAICodexAuthProfileStoreIdMap({
-        cfg: state.candidate,
-        env,
-      }),
+      profileIdMap: openAICodexAuthProfileIdMap,
     }),
   );
   applyMutation(
@@ -252,6 +256,7 @@ export async function runDoctorRepairSequence(params: {
     cfg: state.candidate,
     prompter: { confirmAutoFix: async () => true },
     env,
+    openAICodexAuthProfileIdMap,
   });
   if (authProfileSqliteMigration.configChanged) {
     state = applyDoctorConfigMutation({
@@ -274,5 +279,11 @@ export async function runDoctorRepairSequence(params: {
     staleOAuthShadowRepair.changes.length > 0 ||
     authProfileSqliteMigration.changes.length > 0;
 
-  return { state, changeNotes, warningNotes, authProfilesRepaired };
+  return {
+    state,
+    changeNotes,
+    warningNotes,
+    authProfilesRepaired,
+    ...(openAICodexAuthProfileIdMap.size > 0 ? { openAICodexAuthProfileIdMap } : {}),
+  };
 }

--- a/src/commands/doctor/shared/codex-route-session-repair.test-support.ts
+++ b/src/commands/doctor/shared/codex-route-session-repair.test-support.ts
@@ -8,6 +8,7 @@ type TestApi = {
     store: Record<string, SessionEntry>;
     now?: number;
     blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>;
+    authProfileIdMap?: ReadonlyMap<string, string>;
   }): SessionRouteRepairResult;
 };
 

--- a/src/commands/doctor/shared/codex-route-session-repair.ts
+++ b/src/commands/doctor/shared/codex-route-session-repair.ts
@@ -1,13 +1,31 @@
 import fs from "node:fs";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString as normalizeString } from "@openclaw/normalization-core/string-coerce";
+import { resolveAgentDir } from "../../../agents/agent-scope.js";
+import {
+  areOAuthCredentialsEquivalent,
+  hasMatchingOAuthIdentity,
+} from "../../../agents/auth-profiles/oauth-shared.js";
+import {
+  loadPersistedAuthProfileStore,
+  parseLegacyCredentialEntry,
+} from "../../../agents/auth-profiles/persisted.js";
+import { resolveSharedMainAuthAgentDir } from "../../../agents/auth-profiles/shared-main-dir.js";
+import {
+  applySessionEntryReplacements,
+  listSessionEntriesForCanonicalRepair,
+  listSessionEntriesReadOnly,
+} from "../../../config/sessions/session-accessor.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "../../../config/sessions/targets.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { loadJsonFile } from "../../../infra/json-file.js";
 import {
   loadLegacySessionStore,
   updateLegacySessionStore,
 } from "../../../infra/state-migrations.legacy-session-store.js";
 import { isValidAgentHarnessSessionStoreEntry } from "../../../sessions/agent-harness-session-key.js";
+import { resolveLegacyAuthProfilesPath } from "../../doctor-auth-legacy-paths.js";
 import {
   isOpenAICodexAuthProfileRef,
   isBlockedLegacyCodexModelPair,
@@ -170,6 +188,7 @@ function repairCodexSessionStoreRoutes(params: {
   store: Record<string, SessionEntry>;
   now?: number;
   blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>;
+  authProfileIdMap?: ReadonlyMap<string, string>;
 }): SessionRouteRepairResult {
   const now = params.now ?? Date.now();
   const sessionKeys: string[] = [];
@@ -205,7 +224,23 @@ function repairCodexSessionStoreRoutes(params: {
     const changedRuntimePins = changedModelRoute
       ? preserveRepairedSessionRuntimeIntent(entry)
       : false;
-    if (!changedModelRoute && !changedFallbackNotice && !changedRuntimePins) {
+    // Providerless route repair first needs the legacy profile prefix; only the
+    // auth migration owner's exact collision-aware map may rewrite its identity.
+    const mappedAuthProfileId =
+      typeof entry.authProfileOverride === "string"
+        ? params.authProfileIdMap?.get(entry.authProfileOverride)
+        : undefined;
+    const changedAuthProfile =
+      mappedAuthProfileId !== undefined && mappedAuthProfileId !== entry.authProfileOverride;
+    if (changedAuthProfile) {
+      entry.authProfileOverride = mappedAuthProfileId;
+    }
+    if (
+      !changedModelRoute &&
+      !changedFallbackNotice &&
+      !changedRuntimePins &&
+      !changedAuthProfile
+    ) {
       continue;
     }
     entry.updatedAt = now;
@@ -226,6 +261,7 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
 function scanCodexSessionStoreRoutes(
   store: Record<string, SessionEntry>,
   blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>,
+  authProfileIdMap?: ReadonlyMap<string, string>,
 ): string[] {
   return Object.entries(store).flatMap(([sessionKey, entry]) => {
     if (!entry || isValidAgentHarnessSessionStoreEntry(sessionKey, entry)) {
@@ -277,9 +313,70 @@ function scanCodexSessionStoreRoutes(
           normalizeString(entry.authProfileOverride)?.split(":", 1)[0],
           entry.modelOverride,
         )) ||
+      (typeof entry.authProfileOverride === "string" &&
+        authProfileIdMap?.has(entry.authProfileOverride)) ||
       hasRewritableFallbackNotice;
     return hasLegacyRoute ? [sessionKey] : [];
   });
+}
+
+function resolveVerifiedSessionAuthProfileIdMap(params: {
+  agentId: string;
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  authProfileIdMap: ReadonlyMap<string, string> | undefined;
+}): ReadonlyMap<string, string> | undefined {
+  if (!params.authProfileIdMap || params.authProfileIdMap.size === 0) {
+    return params.authProfileIdMap;
+  }
+  const agentDir = resolveAgentDir(params.cfg, params.agentId, params.env);
+  const localProfiles = loadPersistedAuthProfileStore(agentDir)?.profiles ?? {};
+  const mainProfiles =
+    loadPersistedAuthProfileStore(resolveSharedMainAuthAgentDir(params.env))?.profiles ?? {};
+  const localLegacyAuthPath = resolveLegacyAuthProfilesPath(agentDir);
+  const localLegacySourceExists = fs.existsSync(localLegacyAuthPath);
+  const localLegacySource = localLegacySourceExists ? loadJsonFile(localLegacyAuthPath) : null;
+  const localLegacyProfiles =
+    isRecord(localLegacySource) && isRecord(localLegacySource.profiles)
+      ? localLegacySource.profiles
+      : undefined;
+
+  return new Map(
+    [...params.authProfileIdMap].filter(([legacyProfileId, canonicalProfileId]) => {
+      const localCredential = localProfiles[canonicalProfileId];
+      if (localCredential) {
+        return normalizeString(localCredential.provider) === "openai";
+      }
+      // A failed local import still owns its account. Never replace it with a
+      // same-named main credential; inheritance is safe only without that source.
+      const inheritedCredential = mainProfiles[canonicalProfileId];
+      if (localLegacySourceExists) {
+        if (!localLegacyProfiles) {
+          return false;
+        }
+        const legacyCredential = localLegacyProfiles[legacyProfileId];
+        if (legacyCredential !== undefined) {
+          if (!isRecord(legacyCredential)) {
+            return false;
+          }
+          const canonicalLegacyCredential = parseLegacyCredentialEntry(
+            { ...legacyCredential, provider: "openai" },
+            "openai",
+          );
+          // A retained mixed-sidecar source still contains successful entries.
+          // Permit deduped main inheritance only when exact account identity matches.
+          return (
+            canonicalLegacyCredential?.type === "oauth" &&
+            inheritedCredential?.type === "oauth" &&
+            inheritedCredential.provider === "openai" &&
+            (hasMatchingOAuthIdentity(canonicalLegacyCredential, inheritedCredential) ||
+              areOAuthCredentialsEquivalent(canonicalLegacyCredential, inheritedCredential))
+          );
+        }
+      }
+      return normalizeString(inheritedCredential?.provider) === "openai";
+    }),
+  );
 }
 
 /** Scan or repair all configured agent session stores that still contain legacy Codex routes. */
@@ -289,20 +386,62 @@ export async function maybeRepairCodexSessionRoutes(params: {
   shouldRepair: boolean;
   codexRuntimeReady?: boolean;
   blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>;
+  authProfileIdMap?: ReadonlyMap<string, string>;
 }): Promise<CodexSessionRouteRepairSummary> {
-  const targets = resolveAllAgentSessionStoreTargetsSync(params.cfg, {
-    env: params.env ?? process.env,
-  }).filter((target) => fs.existsSync(target.storePath));
+  const env = params.env ?? process.env;
+  const targets = resolveAllAgentSessionStoreTargetsSync(params.cfg, { env }).flatMap((target) => {
+    const sessionScope = {
+      storePath: target.storePath,
+      agentId: target.agentId,
+      env,
+    };
+    // Preview cannot canonicalize legacy rows; its doctor-only inventory must
+    // remain readable without weakening strict post-migration repair writes.
+    const sqliteEntries = params.shouldRepair
+      ? listSessionEntriesReadOnly(sessionScope)
+      : listSessionEntriesForCanonicalRepair(sessionScope);
+    const hasLegacyStore = fs.existsSync(target.storePath);
+    return sqliteEntries.length > 0 || hasLegacyStore
+      ? [
+          {
+            ...target,
+            sqliteEntries,
+            hasLegacyStore,
+            authProfileIdMap: resolveVerifiedSessionAuthProfileIdMap({
+              agentId: target.agentId,
+              cfg: params.cfg,
+              env,
+              authProfileIdMap: params.authProfileIdMap,
+            }),
+          },
+        ]
+      : [];
+  });
   if (targets.length === 0) {
     return emptyRepairSummary();
   }
   if (!params.shouldRepair) {
     const stale = targets.flatMap((target) => {
-      const sessionKeys = scanCodexSessionStoreRoutes(
-        loadLegacySessionStore(target.storePath),
-        params.blockedModelIdentities,
+      const sqliteStore = Object.fromEntries(
+        target.sqliteEntries.map(({ sessionKey, entry }) => [sessionKey, entry]),
       );
-      return sessionKeys.map((sessionKey) => `${target.agentId}:${sessionKey}`);
+      const sessionKeys = new Set(
+        scanCodexSessionStoreRoutes(
+          sqliteStore,
+          params.blockedModelIdentities,
+          target.authProfileIdMap,
+        ),
+      );
+      if (target.hasLegacyStore) {
+        for (const sessionKey of scanCodexSessionStoreRoutes(
+          loadLegacySessionStore(target.storePath),
+          params.blockedModelIdentities,
+          target.authProfileIdMap,
+        )) {
+          sessionKeys.add(sessionKey);
+        }
+      }
+      return Array.from(sessionKeys, (sessionKey) => `${target.agentId}:${sessionKey}`);
     });
     return {
       scannedStores: targets.length,
@@ -324,27 +463,70 @@ export async function maybeRepairCodexSessionRoutes(params: {
   let repairedStores = 0;
   let repairedSessions = 0;
   for (const target of targets) {
-    const staleSessionKeys = scanCodexSessionStoreRoutes(
-      loadLegacySessionStore(target.storePath),
+    const repairedSessionKeys = new Set<string>();
+    const sqliteStore = Object.fromEntries(
+      target.sqliteEntries.map(({ sessionKey, entry }) => [sessionKey, entry]),
+    );
+    const staleSqliteSessionKeys = scanCodexSessionStoreRoutes(
+      sqliteStore,
       params.blockedModelIdentities,
+      target.authProfileIdMap,
     );
-    if (staleSessionKeys.length === 0) {
-      continue;
+    if (staleSqliteSessionKeys.length > 0) {
+      const result = await applySessionEntryReplacements({
+        agentId: target.agentId,
+        storePath: target.storePath,
+        sessionKeys: staleSqliteSessionKeys,
+        skipMaintenance: true,
+        update: (entries) => {
+          const store = Object.fromEntries(
+            entries.map(({ sessionKey, entry }) => [sessionKey, entry]),
+          );
+          const repair = repairCodexSessionStoreRoutes({
+            store,
+            blockedModelIdentities: params.blockedModelIdentities,
+            authProfileIdMap: target.authProfileIdMap,
+          });
+          return {
+            result: repair,
+            replacements: repair.sessionKeys.map((sessionKey) => ({
+              sessionKey,
+              entry: store[sessionKey]!,
+            })),
+          };
+        },
+      });
+      for (const sessionKey of result.sessionKeys) {
+        repairedSessionKeys.add(sessionKey);
+      }
     }
-    const result = await updateLegacySessionStore(
-      target.storePath,
-      (store) =>
-        repairCodexSessionStoreRoutes({
-          store,
-          blockedModelIdentities: params.blockedModelIdentities,
-        }),
-      { skipMaintenance: true },
-    );
-    if (!result.changed) {
-      continue;
+
+    if (target.hasLegacyStore) {
+      const staleLegacySessionKeys = scanCodexSessionStoreRoutes(
+        loadLegacySessionStore(target.storePath),
+        params.blockedModelIdentities,
+        target.authProfileIdMap,
+      );
+      if (staleLegacySessionKeys.length > 0) {
+        const result = await updateLegacySessionStore(
+          target.storePath,
+          (store) =>
+            repairCodexSessionStoreRoutes({
+              store,
+              blockedModelIdentities: params.blockedModelIdentities,
+              authProfileIdMap: target.authProfileIdMap,
+            }),
+          { skipMaintenance: true },
+        );
+        for (const sessionKey of result.sessionKeys) {
+          repairedSessionKeys.add(sessionKey);
+        }
+      }
     }
-    repairedStores += 1;
-    repairedSessions += result.sessionKeys.length;
+    if (repairedSessionKeys.size > 0) {
+      repairedStores += 1;
+      repairedSessions += repairedSessionKeys.size;
+    }
   }
   return {
     scannedStores: targets.length,

--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -3030,7 +3030,7 @@ describe("collectCodexRouteWarnings", () => {
     ]);
   });
 
-  it("repairs persisted session route refs, clears stale runtime pins, and preserves auth pins", () => {
+  it("repairs persisted session routes while preserving selected auth accounts", () => {
     const store: Record<string, SessionEntry> = {
       main: {
         sessionId: "s1",
@@ -3058,6 +3058,7 @@ describe("collectCodexRouteWarnings", () => {
     const result = repairCodexSessionStoreRoutes({
       store,
       now: 123,
+      authProfileIdMap: new Map([["openai-codex:default", "openai:chatgpt-default"]]),
     });
 
     expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
@@ -3071,7 +3072,7 @@ describe("collectCodexRouteWarnings", () => {
       expectDefined(store.main, "store.main test invariant").modelOverrideRouteResolution,
     ).toBe("resolved");
     expect(expectDefined(store.main, "store.main test invariant").authProfileOverride).toBe(
-      "openai-codex:default",
+      "openai:chatgpt-default",
     );
     expect(expectDefined(store.main, "store.main test invariant").authProfileOverrideSource).toBe(
       "auto",
@@ -3086,6 +3087,57 @@ describe("collectCodexRouteWarnings", () => {
     expect(expectDefined(store.main, "store.main test invariant").fallbackNotice).toBeUndefined();
     expect(expectDefined(store.other, "store.other test invariant").updatedAt).toBe(2);
     expect(expectDefined(store.other, "store.other test invariant").agentHarnessId).toBe("codex");
+  });
+
+  it("rewrites only exactly mapped auth pins on otherwise canonical sessions", () => {
+    const store: Record<string, SessionEntry> = {
+      selected: {
+        sessionId: "selected",
+        updatedAt: 1,
+        modelProvider: "openai",
+        model: "gpt-5.5",
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "user",
+        authProfileOverrideCompactionCount: 3,
+      },
+      unknown: {
+        sessionId: "unknown",
+        updatedAt: 2,
+        authProfileOverride: "openai-codex:missing",
+        authProfileOverrideSource: "user",
+      },
+      canonical: {
+        sessionId: "canonical",
+        updatedAt: 3,
+        authProfileOverride: "openai:default",
+        authProfileOverrideSource: "auto",
+      },
+    };
+    const authProfileIdMap = new Map([["openai-codex:default", "openai:chatgpt-default"]]);
+
+    expect(repairCodexSessionStoreRoutes({ store, now: 123, authProfileIdMap })).toEqual({
+      changed: true,
+      sessionKeys: ["selected"],
+    });
+    expect(store.selected).toMatchObject({
+      updatedAt: 123,
+      authProfileOverride: "openai:chatgpt-default",
+      authProfileOverrideSource: "user",
+      authProfileOverrideCompactionCount: 3,
+    });
+    expect(store.unknown).toMatchObject({
+      updatedAt: 2,
+      authProfileOverride: "openai-codex:missing",
+    });
+    expect(store.canonical).toMatchObject({
+      updatedAt: 3,
+      authProfileOverride: "openai:default",
+    });
+    expect(repairCodexSessionStoreRoutes({ store, now: 456, authProfileIdMap })).toEqual({
+      changed: false,
+      sessionKeys: [],
+    });
+    expect(store.selected?.updatedAt).toBe(123);
   });
 
   it("repairs shipped codex namespace session route refs", () => {
@@ -3521,6 +3573,7 @@ describe("collectCodexRouteWarnings", () => {
     const result = repairCodexSessionStoreRoutes({
       store,
       now: 123,
+      authProfileIdMap: new Map([["openai-codex:default", "openai:chatgpt-default"]]),
     });
 
     expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
@@ -3532,7 +3585,7 @@ describe("collectCodexRouteWarnings", () => {
       expectDefined(store.main, "store.main test invariant").modelOverrideRouteResolution,
     ).toBe("resolved");
     expect(expectDefined(store.main, "store.main test invariant").authProfileOverride).toBe(
-      "openai-codex:default",
+      "openai:chatgpt-default",
     );
     expect(expectDefined(store.main, "store.main test invariant").authProfileOverrideSource).toBe(
       "auto",

--- a/src/flows/doctor-health-contribution-runners.state.codex.test.ts
+++ b/src/flows/doctor-health-contribution-runners.state.codex.test.ts
@@ -15,6 +15,41 @@ vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note: mocks.note,
 }));
 
+function createDoctorHealthContext(params: {
+  cfg: DoctorHealthFlowContext["cfg"];
+  env: NodeJS.ProcessEnv;
+  shouldRepair: boolean;
+  configResult?: Omit<DoctorHealthFlowContext["configResult"], "cfg">;
+}): DoctorHealthFlowContext {
+  const { cfg, env, shouldRepair, configResult } = params;
+  return {
+    runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    options: {},
+    prompter: {
+      confirm: vi.fn(async () => shouldRepair),
+      confirmAutoFix: vi.fn(async () => shouldRepair),
+      confirmAggressiveAutoFix: vi.fn(async () => shouldRepair),
+      confirmRuntimeRepair: vi.fn(async () => shouldRepair),
+      select: vi.fn(async (_params, fallback) => fallback),
+      shouldRepair,
+      shouldForce: false,
+      repairMode: {
+        shouldRepair,
+        shouldForce: false,
+        nonInteractive: true,
+        canPrompt: false,
+        updateInProgress: false,
+      },
+    },
+    configResult: { cfg, ...configResult },
+    cfg,
+    cfgForPersistence: cfg,
+    sourceConfigValid: true,
+    configPath: "/tmp/openclaw-doctor-session-owner/openclaw.json",
+    env,
+  };
+}
+
 describe("Codex session doctor health owner", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -31,16 +66,15 @@ describe("Codex session doctor health owner", () => {
     const authProfileIdMap = new Map([["openai-codex:default", "openai:chatgpt-default"]]);
     const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-doctor-session-owner" };
     const cfg = {};
-    const ctx = {
+    const ctx = createDoctorHealthContext({
       cfg,
       env,
-      prompter: { shouldRepair: true },
+      shouldRepair: true,
       configResult: {
-        cfg,
         openAICodexAuthProfileIdMap: authProfileIdMap,
         blockedCodexModelIdentities: ["codex\0gpt-5.6-sol"],
       },
-    } as DoctorHealthFlowContext;
+    });
 
     await runCodexSessionRouteHealth(ctx);
 
@@ -55,12 +89,11 @@ describe("Codex session doctor health owner", () => {
 
   it("keeps preview mode read-only without inventing an auth migration map", async () => {
     const cfg = {};
-    const ctx = {
+    const ctx = createDoctorHealthContext({
       cfg,
       env: {},
-      prompter: { shouldRepair: false },
-      configResult: { cfg },
-    } as DoctorHealthFlowContext;
+      shouldRepair: false,
+    });
 
     await runCodexSessionRouteHealth(ctx);
 

--- a/src/flows/doctor-health-contribution-runners.state.codex.test.ts
+++ b/src/flows/doctor-health-contribution-runners.state.codex.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runCodexSessionRouteHealth } from "./doctor-health-contribution-runners.state.js";
+import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
+
+const mocks = vi.hoisted(() => ({
+  maybeRepairCodexSessionRoutes: vi.fn(),
+  note: vi.fn(),
+}));
+
+vi.mock("../commands/doctor/shared/codex-route-warnings.js", () => ({
+  maybeRepairCodexSessionRoutes: mocks.maybeRepairCodexSessionRoutes,
+}));
+
+vi.mock("../../packages/terminal-core/src/note.js", () => ({
+  note: mocks.note,
+}));
+
+describe("Codex session doctor health owner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.maybeRepairCodexSessionRoutes.mockResolvedValue({
+      scannedStores: 1,
+      repairedStores: 1,
+      repairedSessions: 1,
+      changes: [],
+      warnings: [],
+    });
+  });
+
+  it("applies the exact ephemeral auth map after earlier session migration owners", async () => {
+    const authProfileIdMap = new Map([["openai-codex:default", "openai:chatgpt-default"]]);
+    const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-doctor-session-owner" };
+    const cfg = {};
+    const ctx = {
+      cfg,
+      env,
+      prompter: { shouldRepair: true },
+      configResult: {
+        cfg,
+        openAICodexAuthProfileIdMap: authProfileIdMap,
+        blockedCodexModelIdentities: ["codex\0gpt-5.6-sol"],
+      },
+    } as DoctorHealthFlowContext;
+
+    await runCodexSessionRouteHealth(ctx);
+
+    expect(mocks.maybeRepairCodexSessionRoutes).toHaveBeenCalledWith({
+      cfg,
+      env,
+      shouldRepair: true,
+      authProfileIdMap,
+      blockedModelIdentities: new Set(["codex\0gpt-5.6-sol"]),
+    });
+  });
+
+  it("keeps preview mode read-only without inventing an auth migration map", async () => {
+    const cfg = {};
+    const ctx = {
+      cfg,
+      env: {},
+      prompter: { shouldRepair: false },
+      configResult: { cfg },
+    } as DoctorHealthFlowContext;
+
+    await runCodexSessionRouteHealth(ctx);
+
+    expect(mocks.maybeRepairCodexSessionRoutes).toHaveBeenCalledWith({
+      cfg,
+      env: {},
+      shouldRepair: false,
+    });
+  });
+});

--- a/src/flows/doctor-health-contribution-runners.state.ts
+++ b/src/flows/doctor-health-contribution-runners.state.ts
@@ -103,6 +103,9 @@ export async function runCodexSessionRouteHealth(ctx: DoctorHealthFlowContext): 
     ...(ctx.configResult.blockedCodexModelIdentities?.length
       ? { blockedModelIdentities: new Set(ctx.configResult.blockedCodexModelIdentities) }
       : {}),
+    ...(ctx.configResult.openAICodexAuthProfileIdMap?.size
+      ? { authProfileIdMap: ctx.configResult.openAICodexAuthProfileIdMap }
+      : {}),
   });
   if (result.changes.length > 0) {
     note(result.changes.join("\n"), "Doctor changes");

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -21,6 +21,8 @@ type DoctorConfigResult = {
   shouldRepairCronCodexModelRefsAfterConfigWrite?: boolean;
   retiredPhoneControlStateCleanupPending?: boolean;
   blockedCodexModelIdentities?: readonly string[];
+  /** Ephemeral doctor-only auth rename plan; never part of persisted config. */
+  openAICodexAuthProfileIdMap?: ReadonlyMap<string, string>;
 };
 
 export type DoctorHealthFlowContext = {

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -305,7 +305,9 @@ describe("node host MCP manager", () => {
       { endless: { command: "endless" }, healthy: { command: "healthy" } },
       {
         createClient: (serverName) => (serverName === "endless" ? endless : healthy),
-        resolveTransport: () => transport,
+        // Prove the page ceiling without loaded CI accidentally hitting the
+        // catalog deadline; timeout behavior has its own dedicated coverage.
+        resolveTransport: () => ({ ...transport, requestTimeoutMs: 1_000 }),
         warn,
       },
     );


### PR DESCRIPTION
Closes #58498

## What Problem This Solves

Fixes an issue where upgrading or repairing an installation with multiple ChatGPT OAuth accounts could silently switch an existing session to the wrong account. Session status and rate-limit usage then belonged to a different person even though the user had explicitly selected another account.

## Why This Change Was Made

Doctor now derives one collision-safe account migration plan across configuration, existing SQLite credentials, and legacy credential files, and carries that exact ephemeral plan to the existing late session-repair owner. Already-affected installations are repaired by reconstructing account identity only from authentic archived credentials with verified migration receipts and an unambiguous matching OAuth account. Ambiguous, tampered, unresolved, unrelated-agent, and incomplete migrations fail closed.

The sibling Codex source was directly inspected: codex-rs/app-server-protocol/src/protocol/common.rs confirms account/rateLimits/read has no account selector, and codex-rs/app-server/src/request_processors/account_processor.rs obtains rate limits from its selected AuthManager account. Correct host-side account selection is therefore required rather than attempting to pass an unsupported account argument.

## User Impact

Existing and newly upgraded multi-account installations retain the chosen ChatGPT account through doctor repair, including installations already affected by an earlier migration. Session status and quota reporting again reflect the intended user.

## Evidence

- Reproduced the complete account-selection failure RED using actual legacy OAuth credentials, real SQLite session/auth stores, canonical doctor migration, and the actual status rendering path.
- Fresh migration and already-migrated archived-installation cases both now show the selected Kate account with 75 percent quota instead of the unrelated Peter account with 20 percent quota.
- Independent xhigh review verified 16 focused regressions across five owner files: existing SQLite profile collisions, config-only credentials, unresolved sidecars, receipt/archive tampering, ambiguous identities, four-agent isolation and inherited credentials, late canonical session migration ordering, read-only malformed-session preview, and idempotence.
- Mandatory fresh structured xhigh autoreview passed with no accepted or actionable findings.
- No runtime legacy aliases, raw SQL runtime writes, SQLite schema version change, or persisted temporary migration map.

## Final-Head CI and Account Proof

- Actual doctor migration through real SQLite credentials and session stores renders `Week 75% left` for the selected account and explicitly rejects the unrelated account output `Week 20% left` (`src/commands/doctor-auth-flat-profiles.test.ts:113`, `:135-137`).
- Dedicated Blacksmith Testbox remote `corepack pnpm check:test-types`: PASS across core, plugin, and root test-type projects.
- Same isolated remote box: `corepack pnpm test src/flows/doctor-health-contribution-runners.state.codex.test.ts src/node-host/mcp.test.ts`: 2 files, 19 tests PASS.
- Fresh independent xhigh autoreview including P0, P1, and P2: no actionable findings.
- Direct sibling Codex upstream contract inspection: `codex-rs/app-server-protocol/src/protocol/v2/account.rs:20`, `:184`, `:269`; `codex-rs/app-server-protocol/src/protocol/common.rs:1192`; `codex-rs/app-server/src/request_processors/account_processor.rs:1010`; `codex-rs/login/src/auth/manager.rs:520`, `:2115`; and `codex-rs/login/src/token_data.rs:11`.

## Unrelated Mainline CI Repair

The existing MCP pagination ceiling test could exhaust its unrelated 50 ms wall-clock deadline under loaded CI before reaching its required 128-page ceiling. This PR isolates that single test with a 1,000 ms request deadline and retains the separate explicit 50 ms deadline regression unchanged. This repairs the independently reproduced existing-main CI failure without changing production behavior.

## Exact-Head Redacted Operator-Visible Transcript

Executed both committed scenarios against actual doctor migration, isolated temporary SQLite credentials/session stores, authenticated account selection, and the actual status renderer. A process-local read-only observer prints only the safe quota substring; no OAuth credentials are exposed.

```text
[actual /status][already-migrated verified archive repair] Week 75% left
[negative assertion][already-migrated verified archive repair] wrong-account Week 20% left: absent (PASS)
PASS repairs an already-migrated selected account from its verified auth archive

[actual /status][fresh auth and SQLite session migration] Week 75% left
[negative assertion][fresh auth and SQLite session migration] wrong-account Week 20% left: absent (PASS)
PASS preserves the selected Codex account across auth migration, SQLite sessions, and status

Test Files  1 passed (1)
Tests       2 passed | 47 skipped (49)
```

Direct Codex contract reverified: `codex-rs/app-server-protocol/src/protocol/common.rs:1058` has no account selector for rate-limit reads; `codex-rs/app-server/src/request_processors/account_processor.rs:1033` uses the current authenticated account; `codex-rs/login/src/auth/manager.rs:2029` and `:2115` enforce account-matched reload.