### PR TITLE
docs(config): preserve macOS remote field provenance

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -267,9 +267,9 @@ export type GatewayTailscaleConfig = {
 export type GatewayRemoteConfig = {
   /** Remote Gateway WebSocket URL (ws:// or wss://). */
   url?: string;
-  /** Transport for macOS remote connections (ssh tunnel or direct WS). */
+  /** macOS app-only transport (SSH tunnel or direct WS); core validates/preserves but does not read it. */
   transport?: "ssh" | "direct";
-  /** Gateway port on the remote SSH host. Defaults to 18789. */
+  /** macOS app-only remote SSH port (default 18789); core validates/preserves but does not read it. */
   remotePort?: number;
   /** Token for remote auth (when the gateway requires token auth). */
   token?: SecretInput;
@@ -281,7 +281,7 @@ export type GatewayRemoteConfig = {
   sshTarget?: string;
   /** SSH identity file path for tunneling remote Gateway. */
   sshIdentity?: string;
-  /** macOS SSH host-key policy. Defaults to strict; openssh delegates to effective SSH config. */
+  /** macOS app-only; core validates/preserves but does not read it. Defaults to strict; see docs/platforms/mac/remote.md. */
   sshHostKeyPolicy?: "strict" | "openssh";
 };
 


### PR DESCRIPTION
## What Problem This Solves

Prevents dead-config cleanup from removing three `gateway.remote` settings whose runtime consumers live in the macOS app rather than core TypeScript.

## Why This Change Was Made

Documents the native ownership boundary directly on `transport`, `remotePort`, and `sshHostKeyPolicy`. Core validates and preserves these fields, while the macOS app consumes them. This is AI-assisted maintainer-commissioned cleanup work.

## User Impact

No runtime behavior changes. Future cleanup can distinguish intentionally native-consumed configuration from genuinely unused core configuration.

## Evidence

- `oxfmt src/config/types.gateway.ts` — passed using the canonical checkout binary
- `git diff --check` — passed
- `node scripts/check-changed.mjs --dry-run` — classified the change as core production and produced the expected CI plan
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings
- Production LOC: +3/-3 (net 0); tests: +0/-0

No focused tests were run because the diff changes comments only. Exact-head hosted CI passed: https://github.com/openclaw/openclaw/actions/runs/30768465299
