### PR TITLE
test(macos): consolidate onboarding probe fixtures

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingConfiguredGatewayProbeTests.swift
@@ -38,7 +38,7 @@ private actor OnboardingProbeEndpoint {
     }
 }
 
-private actor OnboardingProbeRequestGate {
+private actor OnboardingProbeGate {
     private var started = false
     private var released = false
     private var startWaiters: [CheckedContinuation<Void, Never>] = []
@@ -71,10 +71,7 @@ private actor OnboardingProbeRequestGate {
 private actor OnboardingProbeConfigReadGate {
     private let blockedRead: Int
     private var readCount = 0
-    private var blocked = false
-    private var released = false
-    private var blockedWaiters: [CheckedContinuation<Void, Never>] = []
-    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private let gate = OnboardingProbeGate()
 
     init(blockedRead: Int) {
         self.blockedRead = blockedRead
@@ -83,29 +80,17 @@ private actor OnboardingProbeConfigReadGate {
     func snapshotToken() async -> String {
         self.readCount += 1
         if self.readCount == self.blockedRead {
-            self.blocked = true
-            self.blockedWaiters.forEach { $0.resume() }
-            self.blockedWaiters.removeAll()
-            if !self.released {
-                await withCheckedContinuation { continuation in
-                    self.releaseWaiters.append(continuation)
-                }
-            }
+            await self.gate.wait()
         }
         return "route-a"
     }
 
     func waitUntilBlocked() async {
-        guard !self.blocked else { return }
-        await withCheckedContinuation { continuation in
-            self.blockedWaiters.append(continuation)
-        }
+        await self.gate.waitUntilStarted()
     }
 
-    func release() {
-        self.released = true
-        self.releaseWaiters.forEach { $0.resume() }
-        self.releaseWaiters.removeAll()
+    func release() async {
+        await self.gate.release()
     }
 }
 
@@ -113,10 +98,7 @@ private actor OnboardingEndpointRevisionGate {
     private let stale: GatewayConnection.EndpointSnapshot
     private let current: GatewayConnection.EndpointSnapshot
     private var reads = 0
-    private var staleReadStarted = false
-    private var released = false
-    private var startWaiters: [CheckedContinuation<Void, Never>] = []
-    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private let gate = OnboardingProbeGate()
 
     init(staleURL: URL, currentURL: URL) {
         self.stale = GatewayConnection.EndpointSnapshot(
@@ -132,28 +114,16 @@ private actor OnboardingEndpointRevisionGate {
     func snapshot() async -> GatewayConnection.EndpointSnapshot {
         self.reads += 1
         guard self.reads == 1 else { return self.current }
-        self.staleReadStarted = true
-        self.startWaiters.forEach { $0.resume() }
-        self.startWaiters.removeAll()
-        if !self.released {
-            await withCheckedContinuation { continuation in
-                self.releaseWaiters.append(continuation)
-            }
-        }
+        await self.gate.wait()
         return self.stale
     }
 
     func waitUntilStaleReadStarted() async {
-        guard !self.staleReadStarted else { return }
-        await withCheckedContinuation { continuation in
-            self.startWaiters.append(continuation)
-        }
+        await self.gate.waitUntilStarted()
     }
 
-    func releaseStaleRead() {
-        self.released = true
-        self.releaseWaiters.forEach { $0.resume() }
-        self.releaseWaiters.removeAll()
+    func releaseStaleRead() async {
+        await self.gate.release()
     }
 }
 
@@ -172,33 +142,104 @@ private func onboardingAgentsResponse(
         """
     }
     return Data(
-        """
-        {
-          "type": "res",
-          "id": "\(id)",
-          "ok": true,
-          "payload": {
-            "defaultId": "\(defaultAgentID)",
-            "mainKey": "main",
-            "scope": "per-sender",
-            "agents": [
-              \(agentsJSON)
-            ]
-          }
-        }
-        """.utf8)
+        #"{"type":"res","id":"\#(id)","ok":true,"payload":{"defaultId":"\#(defaultAgentID)","mainKey":"main","scope":"per-sender","agents":[\#(agentsJSON)]}}"#
+            .utf8)
 }
 
 private func onboardingProbeErrorResponse(id: String) -> Data {
-    Data(
-        """
-        {
-          "type": "res",
-          "id": "\(id)",
-          "ok": false,
-          "error": { "code": "UNAVAILABLE", "message": "temporary failure" }
-        }
-        """.utf8)
+    Data(#"{"type":"res","id":"\#(id)","ok":false,"error":{"code":"UNAVAILABLE","message":"temporary failure"}}"#.utf8)
+}
+
+private enum OnboardingProbeReply: Sendable {
+    case agents(defaultAgentID: String, model: String?)
+    case error
+    case failure
+    case none
+
+    static let configured = Self.agents(defaultAgentID: "main", model: "openai/gpt-5.5")
+}
+
+private func onboardingProbeTaskFactory(
+    reply: OnboardingProbeReply = .configured,
+    beforeReply: (@Sendable () async -> Void)? = nil) -> GatewayTestWebSocketSession.TaskFactory
+{
+    {
+        GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
+            guard sendIndex > 0 else { return }
+            switch reply {
+            case let .agents(defaultAgentID, model):
+                guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
+                await beforeReply?()
+                task.emitReceiveSuccess(.data(onboardingAgentsResponse(
+                    id: id,
+                    defaultAgentID: defaultAgentID,
+                    model: model)))
+            case .error:
+                guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
+                await beforeReply?()
+                task.emitReceiveSuccess(.data(onboardingProbeErrorResponse(id: id)))
+            case .failure:
+                await beforeReply?()
+                task.emitReceiveFailure()
+            case .none:
+                break
+            }
+        })
+    }
+}
+
+private func onboardingProbeAuthFailureTaskFactory() -> GatewayTestWebSocketSession.TaskFactory {
+    {
+        GatewayTestWebSocketTask(receiveHook: { task, receiveIndex in
+            if receiveIndex == 0 {
+                return .data(GatewayWebSocketTestSupport.connectChallengeData())
+            }
+            return .data(GatewayWebSocketTestSupport.connectAuthFailureData(
+                id: task.snapshotConnectRequestID() ?? "connect",
+                detailCode: GatewayConnectAuthDetailCode.authTokenMissing.rawValue))
+        })
+    }
+}
+
+@MainActor
+private struct OnboardingProbeFixture {
+    let session: GatewayTestWebSocketSession
+    let probe: OnboardingConfiguredGatewayProbe
+}
+
+@MainActor
+private func onboardingProbeFixture(
+    url: URL,
+    timeoutMs: Double = 15000,
+    tokenProvider: @escaping @Sendable () async -> String? = { nil },
+    reply: OnboardingProbeReply = .configured,
+    beforeReply: (@Sendable () async -> Void)? = nil,
+    taskFactory: GatewayTestWebSocketSession.TaskFactory? = nil) -> OnboardingProbeFixture
+{
+    let session = GatewayTestWebSocketSession(
+        taskFactory: taskFactory ?? onboardingProbeTaskFactory(reply: reply, beforeReply: beforeReply))
+    let gateway = GatewayConnection(
+        configProvider: {
+            await (url: url, token: tokenProvider(), password: nil)
+        },
+        sessionBox: WebSocketSessionBox(session: session))
+    return OnboardingProbeFixture(
+        session: session,
+        probe: OnboardingConfiguredGatewayProbe(gateway: gateway, timeoutMs: timeoutMs))
+}
+
+@MainActor
+private func onboardingProbeFixture(
+    endpointProvider: @escaping GatewayConnection.EndpointProvider,
+    reply: OnboardingProbeReply = .configured) -> OnboardingProbeFixture
+{
+    let session = GatewayTestWebSocketSession(taskFactory: onboardingProbeTaskFactory(reply: reply))
+    let gateway = GatewayConnection(
+        endpointProvider: endpointProvider,
+        sessionBox: WebSocketSessionBox(session: session))
+    return OnboardingProbeFixture(
+        session: session,
+        probe: OnboardingConfiguredGatewayProbe(gateway: gateway))
 }
 
 @MainActor
@@ -228,22 +269,12 @@ private func isMissing(_ outcome: OnboardingConfiguredGatewayProbe.Outcome) -> B
 @MainActor
 struct OnboardingConfiguredGatewayProbeTests {
     @Test func `reachable gateway uses its configured default agent model`() async throws {
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                task.emitReceiveSuccess(.data(onboardingAgentsResponse(
-                    id: id,
-                    defaultAgentID: "work",
-                    model: "openai/gpt-5.5")))
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let fixture = onboardingProbeFixture(
+            url: url,
+            reply: .agents(defaultAgentID: "work", model: "openai/gpt-5.5"))
+        let session = fixture.session
+        let probe = fixture.probe
 
         #expect(await configuredModel(runOnboardingProbe(probe, connectionMode: .remote)) == "openai/gpt-5.5")
         #expect(session.snapshotMakeCount() == 1)
@@ -251,57 +282,30 @@ struct OnboardingConfiguredGatewayProbeTests {
     }
 
     @Test func `gateway without a default agent model stays in onboarding`() async throws {
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: id, model: nil)))
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let probe = onboardingProbeFixture(
+            url: url,
+            reply: .agents(defaultAgentID: "main", model: nil)).probe
 
         #expect(await isMissing(runOnboardingProbe(probe, connectionMode: .local)))
     }
 
     @Test func `gateway with a blank default agent model stays in onboarding`() async throws {
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: id, model: "   ")))
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let probe = onboardingProbeFixture(
+            url: url,
+            reply: .agents(defaultAgentID: "main", model: "   ")).probe
 
         #expect(await isMissing(runOnboardingProbe(probe, connectionMode: .local)))
     }
 
     @Test func `remote gateway auth failure stays classified`() async throws {
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(receiveHook: { task, receiveIndex in
-                if receiveIndex == 0 {
-                    return .data(GatewayWebSocketTestSupport.connectChallengeData())
-                }
-                return .data(GatewayWebSocketTestSupport.connectAuthFailureData(
-                    id: task.snapshotConnectRequestID() ?? "connect",
-                    detailCode: GatewayConnectAuthDetailCode.authTokenMissing.rawValue))
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let fixture = onboardingProbeFixture(
+            url: url,
+            taskFactory: onboardingProbeAuthFailureTaskFactory())
+        let session = fixture.session
+        let probe = fixture.probe
 
         let outcome = await runOnboardingProbe(probe, connectionMode: .remote)
 
@@ -310,17 +314,8 @@ struct OnboardingConfiguredGatewayProbeTests {
     }
 
     @Test func `current route read failure is unavailable rather than missing`() async throws {
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, _, sendIndex in
-                guard sendIndex > 0 else { return }
-                task.emitReceiveFailure(URLError(.networkConnectionLost))
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let probe = onboardingProbeFixture(url: url, reply: .failure).probe
 
         let outcome = await runOnboardingProbe(probe, connectionMode: .remote)
         #expect({
@@ -332,14 +327,8 @@ struct OnboardingConfiguredGatewayProbeTests {
     }
 
     @Test func `current route timeout is unavailable rather than missing`() async throws {
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { _, _, _ in })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway, timeoutMs: 1)
+        let probe = onboardingProbeFixture(url: url, timeoutMs: 1, reply: .none).probe
 
         let outcome = await runOnboardingProbe(probe, connectionMode: .remote)
         #expect({
@@ -352,24 +341,12 @@ struct OnboardingConfiguredGatewayProbeTests {
 
     @Test func `route replacement supersedes an in-flight configured model result`() async throws {
         let config = OnboardingProbeGatewayConfig()
-        let gate = OnboardingProbeRequestGate()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                await gate.wait()
-                task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: id)))
-            })
-        })
+        let gate = OnboardingProbeGate()
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: {
-                let token = await config.snapshotToken()
-                return (url: url, token: token, password: nil)
-            },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let probe = onboardingProbeFixture(
+            url: url,
+            tokenProvider: { await config.snapshotToken() },
+            beforeReply: { await gate.wait() }).probe
 
         let attempt = probe.beginProbe()
         let result = Task { await probe.probe(connectionMode: .remote, attempt: attempt) }
@@ -382,22 +359,10 @@ struct OnboardingConfiguredGatewayProbeTests {
 
     @Test func `configured result remains bound to its captured effective route`() async throws {
         let config = OnboardingProbeGatewayConfig()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: id)))
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: {
-                let token = await config.snapshotToken()
-                return (url: url, token: token, password: nil)
-            },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let probe = onboardingProbeFixture(
+            url: url,
+            tokenProvider: { await config.snapshotToken() }).probe
         let attempt = probe.beginProbe()
         let outcome = await probe.probe(
             connectionMode: .remote,
@@ -418,18 +383,9 @@ struct OnboardingConfiguredGatewayProbeTests {
     @Test func `ssh gateway replacement cannot reuse same loopback websocket`() async throws {
         let url = try #require(URL(string: "ws://127.0.0.1:18789"))
         let endpoint = OnboardingProbeEndpoint(url: url)
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: id)))
-            })
-        })
-        let gateway = GatewayConnection(
-            endpointProvider: { await endpoint.snapshot() },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let fixture = onboardingProbeFixture(endpointProvider: { await endpoint.snapshot() })
+        let session = fixture.session
+        let probe = fixture.probe
 
         let firstAttempt = probe.beginProbe()
         let first = await probe.probe(
@@ -483,22 +439,12 @@ struct OnboardingConfiguredGatewayProbeTests {
 
     @Test func `invalidation during final success route validation supersedes result`() async throws {
         let configGate = OnboardingProbeConfigReadGate(blockedRead: 4)
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: id)))
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: {
-                let token = await configGate.snapshotToken()
-                return (url: url, token: token, password: nil)
-            },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let fixture = onboardingProbeFixture(
+            url: url,
+            tokenProvider: { await configGate.snapshotToken() })
+        let session = fixture.session
+        let probe = fixture.probe
 
         let attempt = probe.beginProbe()
         let result = Task { await probe.probe(connectionMode: .remote, attempt: attempt) }
@@ -512,22 +458,13 @@ struct OnboardingConfiguredGatewayProbeTests {
 
     @Test func `invalidation during final error route validation supersedes result`() async throws {
         let configGate = OnboardingProbeConfigReadGate(blockedRead: 3)
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                task.emitReceiveSuccess(.data(onboardingProbeErrorResponse(id: id)))
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: {
-                let token = await configGate.snapshotToken()
-                return (url: url, token: token, password: nil)
-            },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let fixture = onboardingProbeFixture(
+            url: url,
+            tokenProvider: { await configGate.snapshotToken() },
+            reply: .error)
+        let session = fixture.session
+        let probe = fixture.probe
 
         let attempt = probe.beginProbe()
         let result = Task { await probe.probe(connectionMode: .remote, attempt: attempt) }
@@ -541,22 +478,13 @@ struct OnboardingConfiguredGatewayProbeTests {
 
     @Test func `route replacement supersedes an in-flight probe failure`() async throws {
         let config = OnboardingProbeGatewayConfig()
-        let gate = OnboardingProbeRequestGate()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, _, sendIndex in
-                guard sendIndex > 0 else { return }
-                await gate.wait()
-                task.emitReceiveFailure()
-            })
-        })
+        let gate = OnboardingProbeGate()
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: {
-                let token = await config.snapshotToken()
-                return (url: url, token: token, password: nil)
-            },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let probe = onboardingProbeFixture(
+            url: url,
+            tokenProvider: { await config.snapshotToken() },
+            reply: .failure,
+            beforeReply: { await gate.wait() }).probe
 
         let attempt = probe.beginProbe()
         let result = Task { await probe.probe(connectionMode: .remote, attempt: attempt) }
@@ -568,21 +496,10 @@ struct OnboardingConfiguredGatewayProbeTests {
     }
 
     @Test func `snapshot during active probe is delivered after probe completion`() async throws {
-        let gate = OnboardingProbeRequestGate()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                await gate.wait()
-                task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: id)))
-            })
-        })
+        let gate = OnboardingProbeGate()
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let fixture = onboardingProbeFixture(url: url, beforeReply: { await gate.wait() })
+        let probe = fixture.probe
         var reconnectCount = 0
         let reconnectConsumer = Task {
             await probe.consumeReconnects { reconnectCount += 1 }
@@ -609,21 +526,9 @@ struct OnboardingConfiguredGatewayProbeTests {
     }
 
     @Test func `invalidated onboarding probe cannot complete the replacement selection`() async throws {
-        let gate = OnboardingProbeRequestGate()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                await gate.wait()
-                task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: id)))
-            })
-        })
+        let gate = OnboardingProbeGate()
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let probe = onboardingProbeFixture(url: url, beforeReply: { await gate.wait() }).probe
 
         let attempt = probe.beginProbe()
         let result = Task { await probe.probe(connectionMode: .remote, attempt: attempt) }
@@ -635,19 +540,8 @@ struct OnboardingConfiguredGatewayProbeTests {
     }
 
     @Test func `newer queued probe stays current when older task starts last`() async throws {
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                task.emitReceiveSuccess(.data(onboardingAgentsResponse(id: id)))
-            })
-        })
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let probe = onboardingProbeFixture(url: url).probe
 
         let older = probe.beginProbe()
         let newer = probe.beginProbe()
@@ -660,10 +554,7 @@ struct OnboardingConfiguredGatewayProbeTests {
 
     @Test func `invalidation before queued probe starts supersedes it`() async throws {
         let url = try #require(URL(string: "ws://example.invalid"))
-        let gateway = GatewayConnection(
-            configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: GatewayTestWebSocketSession()))
-        let probe = OnboardingConfiguredGatewayProbe(gateway: gateway)
+        let probe = onboardingProbeFixture(url: url).probe
         let attempt = probe.beginProbe()
 
         probe.invalidate()


### PR DESCRIPTION
## Summary

- consolidate repeated onboarding probe session, gateway, reply, and gate scaffolding into suite-local typed fixtures
- preserve all 17 test cases, titles, assertions, authentication behavior, request ordering, and route-invalidation coverage
- keep production code and behavior unchanged

## Architectural scope

- Root cause: this test suite rebuilt the same websocket session, `GatewayConnection`, configured reply, failure reply, and continuation-gate mechanics in each test.
- Owner: suite-local test fixtures in `OnboardingConfiguredGatewayProbeTests.swift`.
- Canonical fix: one typed reply enum, one task factory, two gateway fixture builders, and one reusable actor gate.
- Removed paths: per-test transport/session/gateway factories and two duplicate continuation-gate implementations.
- Sibling/runtime scope: no production, configuration, schema, protocol, SDK, docs, or UI change.

## LOC

- Production: +0/-0
- Tests: +159/-268
- Net: -109 LOC

## Parity

- Exact reviewed head: `b25e97fa5300a55c88bae6906cbf1294f9dfb4a0`.
- 17/17 test declarations preserved in order.
- 33 `#expect`, 18 `#require`, and 3 `Issue.record` lines preserved byte-for-byte.
- Connect handshake, `sendIndex > 0`, request-ID validation/routing, auth failure, read failure, timeout, endpoint revision, and invalidation ordering remain covered.
- Success/error replies validate the application request ID before opening a test gate; failure replies retain gate-before-failure ordering.

## Proof

- [Exact-head CI run 30769120948](https://github.com/openclaw/openclaw/actions/runs/30769120948): passed, including `openclaw/ci-gate`, `macos-node`, and native `macos-swift`.
- [Native Blacksmith macOS job 91553204312](https://github.com/openclaw/openclaw/actions/runs/30769120948/job/91553204312): passed.
  - OpenClawKit: 1,316 tests in 101 suites passed.
  - macOS: 1,600 tests in 177 suites passed.
  - `OnboardingConfiguredGatewayProbeTests` compiled and passed in both executions (6.307s and 5.484s). The aggregate first attempt retried after an unrelated `MacNodeHostWorkerTests` flake; the target suite was green before and after the retry, and the complete retry passed.
- Exact-head delegated changed gate: Blacksmith Testbox `tbx_01kz27yj1370zfy1wzy46mahx6`, [Actions run 30769184539](https://github.com/openclaw/openclaw/actions/runs/30769184539), exit 0.
- Static local proof: Swift parser, SwiftFormat lint, and `git diff --check` passed.
- Two independent xhigh reviews: CLEAN on the exact head.
  - Architecture review found and verified the fix for pre-gate request-ID validation order.
  - Concurrency review verified actor reentrancy, continuation publication, auth sequencing, read barriers, endpoint revision races, timeout/failure semantics, and fixture lifetime.
- Central all-open-PR collision scan: SELF-ONLY, zero external exact-path collisions through 2026-08-02T22:05:53.074Z.

## ClawSweeper rank-up moves

- Posted exact-head native macOS suite evidence above.
- Completed exact-head native `macos-swift` and `macos-node` checks successfully.
- Complete source comparison was independently performed by two xhigh reviewers; both returned CLEAN after the request-order repair.
