### PR TITLE
test(cli): compact container target fixtures

### DIFF
--- a/src/cli/container-target.test.ts
+++ b/src/cli/container-target.test.ts
@@ -1,4 +1,5 @@
 // Container target tests cover CLI container target parsing and validation.
+import type { spawnSync as nodeSpawnSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
 import {
   maybeRunCliInContainer,
@@ -15,6 +16,77 @@ function requireSpawnCall(
     throw new Error(`Expected spawnSync call ${index}`);
   }
   return call as [string, string[], unknown?];
+}
+
+type SpawnResult = {
+  status: number | null;
+  stdout?: string;
+  signal?: NodeJS.Signals;
+};
+type SpawnMock = ReturnType<typeof vi.fn> & typeof nodeSpawnSync;
+
+const runningContainer = { status: 0, stdout: "true\n" };
+const missingContainer = { status: 1, stdout: "" };
+const successfulExec = { status: 0, stdout: "" };
+const probeOptions = { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 };
+
+function mockSpawn(...results: SpawnResult[]): SpawnMock {
+  const spawnSync = vi.fn();
+  for (const result of results) {
+    spawnSync.mockReturnValueOnce(result);
+  }
+  return spawnSync as SpawnMock;
+}
+
+function expectRuntimeProbe(
+  spawnSync: SpawnMock,
+  index: number,
+  runtime: "podman" | "docker",
+  container = "demo",
+): void {
+  expect(spawnSync).toHaveBeenNthCalledWith(
+    index,
+    runtime,
+    ["inspect", "--format", "{{.State.Running}}", container],
+    probeOptions,
+  );
+}
+
+function expectContainerExec(
+  spawnSync: SpawnMock,
+  params: {
+    runtime?: "podman" | "docker";
+    argv?: string[];
+    container?: string;
+    index?: number;
+    tty?: boolean;
+    proxyUrl?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): void {
+  const runtime = params.runtime ?? "podman";
+  const envFlag = runtime === "docker" ? "-e" : "--env";
+  expect(spawnSync).toHaveBeenNthCalledWith(
+    params.index ?? 3,
+    runtime,
+    [
+      "exec",
+      "-i",
+      ...(params.tty ? ["-t"] : []),
+      envFlag,
+      `OPENCLAW_CONTAINER_HINT=${params.container ?? "demo"}`,
+      envFlag,
+      "OPENCLAW_CLI_CONTAINER_BYPASS=1",
+      ...(params.proxyUrl ? [envFlag, `OPENCLAW_PROXY_URL=${params.proxyUrl}`] : []),
+      params.container ?? "demo",
+      "openclaw",
+      ...(params.argv ?? ["status"]),
+    ],
+    {
+      stdio: "inherit",
+      env: { ...params.env, OPENCLAW_CONTAINER: "" },
+    },
+  );
 }
 
 describe("parseCliContainerArgs", () => {
@@ -129,11 +201,10 @@ describe("maybeRunCliInContainer", () => {
     { signal: "SIGINT" as const, exitCode: 130 },
     { signal: "SIGTERM" as const, exitCode: 143 },
   ])("preserves exit code $exitCode when the container child exits from $signal", (testCase) => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({ status: 0, stdout: "true\n" })
-      .mockReturnValueOnce({ status: 1, stdout: "" })
-      .mockReturnValueOnce({ status: null, signal: testCase.signal });
+    const spawnSync = mockSpawn(runningContainer, missingContainer, {
+      status: null,
+      signal: testCase.signal,
+    });
 
     expect(
       maybeRunCliInContainer(["node", "openclaw", "status"], {
@@ -147,20 +218,7 @@ describe("maybeRunCliInContainer", () => {
   });
 
   it("uses OPENCLAW_CONTAINER when the flag is absent", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(runningContainer, missingContainer, successfulExec);
 
     expect(
       maybeRunCliInContainer(["node", "openclaw", "status"], {
@@ -172,44 +230,11 @@ describe("maybeRunCliInContainer", () => {
       exitCode: 0,
     });
 
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      3,
-      "podman",
-      [
-        "exec",
-        "-i",
-        "--env",
-        "OPENCLAW_CONTAINER_HINT=demo",
-        "--env",
-        "OPENCLAW_CLI_CONTAINER_BYPASS=1",
-        "demo",
-        "openclaw",
-        "status",
-      ],
-      {
-        stdio: "inherit",
-        env: {
-          OPENCLAW_CONTAINER: "",
-        },
-      },
-    );
+    expectContainerExec(spawnSync);
   });
 
   it("clears inherited host routing and gateway env before execing into the child CLI", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(runningContainer, missingContainer, successfulExec);
 
     maybeRunCliInContainer(["node", "openclaw", "status"], {
       env: {
@@ -223,44 +248,11 @@ describe("maybeRunCliInContainer", () => {
       spawnSync,
     });
 
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      3,
-      "podman",
-      [
-        "exec",
-        "-i",
-        "--env",
-        "OPENCLAW_CONTAINER_HINT=demo",
-        "--env",
-        "OPENCLAW_CLI_CONTAINER_BYPASS=1",
-        "demo",
-        "openclaw",
-        "status",
-      ],
-      {
-        stdio: "inherit",
-        env: {
-          OPENCLAW_CONTAINER: "",
-        },
-      },
-    );
+    expectContainerExec(spawnSync);
   });
 
   it("passes the proxy URL env fallback into the child container CLI", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(runningContainer, missingContainer, successfulExec);
 
     maybeRunCliInContainer(["node", "openclaw", "status"], {
       env: {
@@ -270,30 +262,10 @@ describe("maybeRunCliInContainer", () => {
       spawnSync,
     });
 
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      3,
-      "podman",
-      [
-        "exec",
-        "-i",
-        "--env",
-        "OPENCLAW_CONTAINER_HINT=demo",
-        "--env",
-        "OPENCLAW_CLI_CONTAINER_BYPASS=1",
-        "--env",
-        "OPENCLAW_PROXY_URL=http://proxy.internal:3128",
-        "demo",
-        "openclaw",
-        "status",
-      ],
-      {
-        stdio: "inherit",
-        env: {
-          OPENCLAW_CONTAINER: "",
-          OPENCLAW_PROXY_URL: " http://proxy.internal:3128 ",
-        },
-      },
-    );
+    expectContainerExec(spawnSync, {
+      proxyUrl: "http://proxy.internal:3128",
+      env: { OPENCLAW_PROXY_URL: " http://proxy.internal:3128 " },
+    });
   });
 
   it.each([
@@ -304,16 +276,7 @@ describe("maybeRunCliInContainer", () => {
     "http://[::1]:3128",
     "http://[::ffff:127.0.0.1]:3128",
   ])("fails before forwarding loopback proxy URL %s into a child container CLI", (proxyUrl) => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(runningContainer, missingContainer);
 
     expect(() =>
       maybeRunCliInContainer(["node", "openclaw", "status"], {
@@ -329,16 +292,7 @@ describe("maybeRunCliInContainer", () => {
   });
 
   it("redacts proxy URL credentials and URL suffixes before rejecting loopback container proxy forwarding", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(runningContainer, missingContainer);
 
     let message = "";
     try {
@@ -365,20 +319,7 @@ describe("maybeRunCliInContainer", () => {
   });
 
   it("allows explicitly overridden loopback proxy URL forwarding into a child container CLI", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(runningContainer, missingContainer, successfulExec);
 
     maybeRunCliInContainer(["node", "openclaw", "status"], {
       env: {
@@ -398,20 +339,7 @@ describe("maybeRunCliInContainer", () => {
   });
 
   it("executes through podman when the named container is running", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(runningContainer, missingContainer, successfulExec);
 
     expect(
       maybeRunCliInContainer(["node", "openclaw", "--container", "demo", "status"], {
@@ -423,48 +351,12 @@ describe("maybeRunCliInContainer", () => {
       exitCode: 0,
     });
 
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      1,
-      "podman",
-      ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
-    );
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      3,
-      "podman",
-      [
-        "exec",
-        "-i",
-        "--env",
-        "OPENCLAW_CONTAINER_HINT=demo",
-        "--env",
-        "OPENCLAW_CLI_CONTAINER_BYPASS=1",
-        "demo",
-        "openclaw",
-        "status",
-      ],
-      {
-        stdio: "inherit",
-        env: { OPENCLAW_CONTAINER: "" },
-      },
-    );
+    expectRuntimeProbe(spawnSync, 1, "podman");
+    expectContainerExec(spawnSync);
   });
 
   it("falls back to docker when podman does not have the container", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(missingContainer, runningContainer, successfulExec);
 
     expect(
       maybeRunCliInContainer(["node", "openclaw", "--container", "demo", "health"], {
@@ -476,52 +368,16 @@ describe("maybeRunCliInContainer", () => {
       exitCode: 0,
     });
 
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      2,
-      "docker",
-      ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
-    );
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      3,
-      "docker",
-      [
-        "exec",
-        "-i",
-        "-e",
-        "OPENCLAW_CONTAINER_HINT=demo",
-        "-e",
-        "OPENCLAW_CLI_CONTAINER_BYPASS=1",
-        "demo",
-        "openclaw",
-        "health",
-      ],
-      {
-        stdio: "inherit",
-        env: { USER: "openclaw", OPENCLAW_CONTAINER: "" },
-      },
-    );
+    expectRuntimeProbe(spawnSync, 2, "docker");
+    expectContainerExec(spawnSync, {
+      runtime: "docker",
+      argv: ["health"],
+      env: { USER: "openclaw" },
+    });
   });
 
   it("checks docker after podman and before failing", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(missingContainer, runningContainer, successfulExec, successfulExec);
 
     expect(
       maybeRunCliInContainer(["node", "openclaw", "--container", "demo", "status"], {
@@ -533,51 +389,14 @@ describe("maybeRunCliInContainer", () => {
       exitCode: 0,
     });
 
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      1,
-      "podman",
-      ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
-    );
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      2,
-      "docker",
-      ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
-    );
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      3,
-      "docker",
-      [
-        "exec",
-        "-i",
-        "-e",
-        "OPENCLAW_CONTAINER_HINT=demo",
-        "-e",
-        "OPENCLAW_CLI_CONTAINER_BYPASS=1",
-        "demo",
-        "openclaw",
-        "status",
-      ],
-      {
-        stdio: "inherit",
-        env: { USER: "somalley", OPENCLAW_CONTAINER: "" },
-      },
-    );
+    expectRuntimeProbe(spawnSync, 1, "podman");
+    expectRuntimeProbe(spawnSync, 2, "docker");
+    expectContainerExec(spawnSync, { runtime: "docker", env: { USER: "somalley" } });
     expect(spawnSync).toHaveBeenCalledTimes(3);
   });
 
   it("does not try any sudo podman fallback for regular users", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(missingContainer, missingContainer);
 
     expect(() =>
       maybeRunCliInContainer(["node", "openclaw", "--container", "demo", "status"], {
@@ -587,35 +406,12 @@ describe("maybeRunCliInContainer", () => {
     ).toThrow('No running container matched "demo" under podman or docker.');
 
     expect(spawnSync).toHaveBeenCalledTimes(2);
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      1,
-      "podman",
-      ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
-    );
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      2,
-      "docker",
-      ["inspect", "--format", "{{.State.Running}}", "demo"],
-      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
-    );
+    expectRuntimeProbe(spawnSync, 1, "podman");
+    expectRuntimeProbe(spawnSync, 2, "docker");
   });
 
   it("rejects ambiguous matches across runtimes", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(runningContainer, runningContainer, missingContainer);
 
     expect(() =>
       maybeRunCliInContainer(["node", "openclaw", "--container", "demo", "status"], {
@@ -628,20 +424,7 @@ describe("maybeRunCliInContainer", () => {
   });
 
   it("allocates a tty for interactive terminal sessions", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(runningContainer, missingContainer, successfulExec);
 
     maybeRunCliInContainer(["node", "openclaw", "--container", "demo", "setup"], {
       env: {},
@@ -650,43 +433,11 @@ describe("maybeRunCliInContainer", () => {
       stdoutIsTTY: true,
     });
 
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      3,
-      "podman",
-      [
-        "exec",
-        "-i",
-        "-t",
-        "--env",
-        "OPENCLAW_CONTAINER_HINT=demo",
-        "--env",
-        "OPENCLAW_CLI_CONTAINER_BYPASS=1",
-        "demo",
-        "openclaw",
-        "setup",
-      ],
-      {
-        stdio: "inherit",
-        env: { OPENCLAW_CONTAINER: "" },
-      },
-    );
+    expectContainerExec(spawnSync, { argv: ["setup"], tty: true });
   });
 
   it("prefers --container over OPENCLAW_CONTAINER", () => {
-    const spawnSync = vi
-      .fn()
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "true\n",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: "",
-      });
+    const spawnSync = mockSpawn(runningContainer, missingContainer, successfulExec);
 
     expect(
       maybeRunCliInContainer(["node", "openclaw", "--container", "flag-demo", "health"], {
@@ -698,19 +449,11 @@ describe("maybeRunCliInContainer", () => {
       exitCode: 0,
     });
 
-    expect(spawnSync).toHaveBeenNthCalledWith(
-      1,
-      "podman",
-      ["inspect", "--format", "{{.State.Running}}", "flag-demo"],
-      { encoding: "utf8", killSignal: "SIGKILL", timeout: 10_000 },
-    );
+    expectRuntimeProbe(spawnSync, 1, "podman", "flag-demo");
   });
 
   it("throws when the named container is not running", () => {
-    const spawnSync = vi.fn().mockReturnValue({
-      status: 1,
-      stdout: "",
-    });
+    const spawnSync = mockSpawn(missingContainer, missingContainer);
 
     expect(() =>
       maybeRunCliInContainer(["node", "openclaw", "--container", "demo", "status"], {
@@ -732,10 +475,7 @@ describe("maybeRunCliInContainer", () => {
   });
 
   it("blocks updater commands from running inside the container", () => {
-    const spawnSync = vi.fn().mockReturnValue({
-      status: 0,
-      stdout: "true\n",
-    });
+    const spawnSync = mockSpawn(runningContainer);
 
     expect(() =>
       maybeRunCliInContainer(["node", "openclaw", "--container", "demo", "update"], {
@@ -749,10 +489,7 @@ describe("maybeRunCliInContainer", () => {
   });
 
   it("blocks update after interleaved root flags", () => {
-    const spawnSync = vi.fn().mockReturnValue({
-      status: 0,
-      stdout: "true\n",
-    });
+    const spawnSync = mockSpawn(runningContainer);
 
     expect(() =>
       maybeRunCliInContainer(["node", "openclaw", "--container", "demo", "--no-color", "update"], {
@@ -766,10 +503,7 @@ describe("maybeRunCliInContainer", () => {
   });
 
   it("blocks the --update shorthand from running inside the container", () => {
-    const spawnSync = vi.fn().mockReturnValue({
-      status: 0,
-      stdout: "true\n",
-    });
+    const spawnSync = mockSpawn(runningContainer);
 
     expect(() =>
       maybeRunCliInContainer(["node", "openclaw", "--container", "demo", "--update"], {


### PR DESCRIPTION
## What Problem This Solves

The CLI container-target suite repeated the same Podman/Docker probe results, exec argument arrays, timeout options, and child-environment expectations across its scenarios. That duplication obscured the security-sensitive differences each test actually owns.

## Why This Change Was Made

This keeps the production owner unchanged and canonicalizes its test fixtures locally: three named subprocess results, one runtime-probe expectation, and one parameterized container-exec expectation. Individual tests still own their flags, environment, runtime choice, command arguments, and outcome assertions.

Root cause: the suite accumulated literal copies as container routing, proxy policy, bounded probes, and signal propagation were added. The canonical fix removes those copies at the test owner rather than adding a production abstraction.

## User Impact

None. This is test-only cleanup. Production, public CLI flags, config, environment surfaces, docs, generated files, and schemas are unchanged.

## Evidence

- Exact scope: src/cli/container-target.test.ts only, +114/-380, net -266 test LOC; production delta 0.
- Structural parity: 28/28 declaration names in identical order, 34/34 expanded tests, and 55/55 effective ordered assertions.
- Semantic parity independently reviewed for Podman/Docker selection and ambiguity, probe timeout options, exec argument ordering, gateway/profile/auth env stripping, proxy forwarding and redaction, TTY allocation, bypass/update rejection, and SIGINT/SIGTERM exit propagation.
- Blacksmith Testbox tbx_01kz25azf0z1whep39hhasqd1y: focused suite 34/34 green; direct importing siblings 211/211 green; targeted formatting and pnpm check:changed green.
- Hydration/proof run: https://github.com/openclaw/openclaw/actions/runs/30767497948
- Two independent gpt-5.6-sol xhigh final reviews: CLEAN.
- Final exact-path collision audit: zero open-PR matches through 2026-08-02T21:21:18.473Z.
