### PR TITLE
refactor(imessage): consolidate monitor test fixtures

### DIFF
--- a/extensions/imessage/src/monitor.gating.test-support.ts
+++ b/extensions/imessage/src/monitor.gating.test-support.ts
@@ -6,6 +6,7 @@ import type { IMessagePayload } from "./monitor/types.js";
 import { loadFreshIMessageReplyCacheForTest } from "./test-support/runtime.js";
 
 type InboundProcessingModule = typeof import("./monitor/inbound-processing.js");
+type DecisionParams = Parameters<InboundProcessingModule["resolveIMessageInboundDecision"]>[0];
 let buildIMessageInboundContext: InboundProcessingModule["buildIMessageInboundContext"];
 let resolveIMessageInboundDecision: InboundProcessingModule["resolveIMessageInboundDecision"];
 
@@ -32,38 +33,27 @@ async function resolve(params: {
   storeAllowFrom?: string[];
 }) {
   const cfg = params.cfg ?? baseCfg();
-  const groupHistories = new Map();
-  return resolveIMessageInboundDecision({
+  return resolveDecision({
     cfg,
-    accountId: "default",
     message: params.message,
-    opts: {},
-    messageText: (params.message.text ?? "").trim(),
-    bodyText: (params.message.text ?? "").trim(),
-    allowFrom: ["*"],
-    groupAllowFrom: [],
     groupPolicy: cfg.channels?.imessage?.groupPolicy ?? "open",
     dmPolicy: cfg.channels?.imessage?.dmPolicy ?? "pairing",
     storeAllowFrom: params.storeAllowFrom ?? [],
-    historyLimit: 0,
-    groupHistories,
   });
 }
 
-async function resolveDispatchDecision(params: {
+async function resolveDecision(params: {
   cfg: OpenClawConfig;
   message: IMessagePayload;
-  groupHistories?: Parameters<
-    InboundProcessingModule["resolveIMessageInboundDecision"]
-  >[0]["groupHistories"];
+  groupHistories?: DecisionParams["groupHistories"];
   allowFrom?: string[];
   groupAllowFrom?: string[];
   allowLegacyConversationAllowFromForGroup?: boolean;
-  groupPolicy?: "open" | "allowlist" | "disabled";
-  dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
+  groupPolicy?: string;
+  dmPolicy?: string;
+  storeAllowFrom?: string[];
 }) {
-  const groupHistories = params.groupHistories ?? new Map();
-  const decision = await resolveIMessageInboundDecision({
+  return resolveIMessageInboundDecision({
     cfg: params.cfg,
     accountId: "default",
     message: params.message,
@@ -75,10 +65,15 @@ async function resolveDispatchDecision(params: {
     allowLegacyConversationAllowFromForGroup: params.allowLegacyConversationAllowFromForGroup,
     groupPolicy: params.groupPolicy ?? "open",
     dmPolicy: params.dmPolicy ?? "open",
-    storeAllowFrom: [],
+    storeAllowFrom: params.storeAllowFrom ?? [],
     historyLimit: 0,
-    groupHistories,
+    groupHistories: params.groupHistories ?? new Map(),
   });
+}
+
+async function resolveDispatchDecision(params: Parameters<typeof resolveDecision>[0]) {
+  const groupHistories = params.groupHistories ?? new Map();
+  const decision = await resolveDecision({ ...params, groupHistories });
   expect(decision.kind).toBe("dispatch");
   if (decision.kind !== "dispatch") {
     throw new Error("expected dispatch decision");
@@ -89,9 +84,12 @@ async function resolveDispatchDecision(params: {
 async function buildDispatchContextPayload(params: {
   cfg: OpenClawConfig;
   message: IMessagePayload;
+  allowFrom?: string[];
+  groupAllowFrom?: string[];
+  groupPolicy?: string;
 }) {
   const { cfg, message } = params;
-  const { decision, groupHistories } = await resolveDispatchDecision({ cfg, message });
+  const { decision, groupHistories } = await resolveDispatchDecision(params);
 
   const { ctxPayload } = await buildIMessageInboundContext({
     cfg,
@@ -239,19 +237,12 @@ describe("imessage monitor gating + envelope builders", () => {
       reply_to_text: "blocked quote",
       reply_to_sender: "+15559998888",
     };
-    const { decision, groupHistories } = await resolveDispatchDecision({
+    const ctxPayload = await buildDispatchContextPayload({
       cfg,
       message,
       allowFrom: ["*"],
       groupAllowFrom: ["+15550001111"],
       groupPolicy: "allowlist",
-    });
-    const { ctxPayload } = await buildIMessageInboundContext({
-      cfg,
-      decision,
-      message,
-      historyLimit: 0,
-      groupHistories,
     });
 
     expect(ctxPayload.ReplyToId).toBeUndefined();
@@ -278,19 +269,12 @@ describe("imessage monitor gating + envelope builders", () => {
       reply_to_text: "quoted context",
       reply_to_sender: "+15559998888",
     };
-    const { decision, groupHistories } = await resolveDispatchDecision({
+    const ctxPayload = await buildDispatchContextPayload({
       cfg,
       message,
       allowFrom: ["*"],
       groupAllowFrom: ["chat_id:55"],
       groupPolicy: "allowlist",
-    });
-    const { ctxPayload } = await buildIMessageInboundContext({
-      cfg,
-      decision,
-      message,
-      historyLimit: 0,
-      groupHistories,
     });
 
     expect(ctxPayload.ReplyToId).toBe("9001");
@@ -323,19 +307,12 @@ describe("imessage monitor gating + envelope builders", () => {
       reply_to_text: "own quoted context",
       reply_to_sender: "+15559998888",
     };
-    const { decision, groupHistories } = await resolveDispatchDecision({
+    const ctxPayload = await buildDispatchContextPayload({
       cfg,
       message,
       allowFrom: ["*"],
       groupAllowFrom: ["accessGroup:oncall"],
       groupPolicy: "allowlist",
-    });
-    const { ctxPayload } = await buildIMessageInboundContext({
-      cfg,
-      decision,
-      message,
-      historyLimit: 0,
-      groupHistories,
     });
 
     expect(ctxPayload.ReplyToId).toBe("9002");
@@ -362,19 +339,12 @@ describe("imessage monitor gating + envelope builders", () => {
       reply_to_text: "quoted context",
       reply_to_sender: "+15559998888",
     };
-    const { decision, groupHistories } = await resolveDispatchDecision({
+    const ctxPayload = await buildDispatchContextPayload({
       cfg,
       message,
       allowFrom: ["*"],
       groupAllowFrom: ["+15550001111"],
       groupPolicy: "allowlist",
-    });
-    const { ctxPayload } = await buildIMessageInboundContext({
-      cfg,
-      decision,
-      message,
-      historyLimit: 0,
-      groupHistories,
     });
 
     expect(ctxPayload.ReplyToId).toBe("9001");
@@ -409,10 +379,8 @@ describe("imessage monitor gating + envelope builders", () => {
     cfg.messages.groupChat ??= {};
     cfg.messages.groupChat.mentionPatterns = [];
 
-    const groupHistories = new Map();
-    const decision = await resolveIMessageInboundDecision({
+    const decision = await resolveDecision({
       cfg,
-      accountId: "default",
       message: {
         id: 12,
         chat_id: 777,
@@ -421,16 +389,8 @@ describe("imessage monitor gating + envelope builders", () => {
         text: "hello group",
         is_group: true,
       },
-      opts: {},
-      messageText: "hello group",
-      bodyText: "hello group",
-      allowFrom: ["*"],
-      groupAllowFrom: [],
       groupPolicy: "open",
       dmPolicy: "open",
-      storeAllowFrom: [],
-      historyLimit: 0,
-      groupHistories,
     });
     expect(decision.kind).toBe("dispatch");
   });
@@ -441,10 +401,8 @@ describe("imessage monitor gating + envelope builders", () => {
     cfg.channels.imessage ??= {};
     cfg.channels.imessage.groups = { "99": { requireMention: false } };
 
-    const groupHistories = new Map();
-    const decision = await resolveIMessageInboundDecision({
+    const decision = await resolveDecision({
       cfg,
-      accountId: "default",
       message: {
         id: 13,
         chat_id: 123,
@@ -453,16 +411,8 @@ describe("imessage monitor gating + envelope builders", () => {
         text: "@openclaw hello",
         is_group: true,
       },
-      opts: {},
-      messageText: "@openclaw hello",
-      bodyText: "@openclaw hello",
-      allowFrom: ["*"],
-      groupAllowFrom: [],
       groupPolicy: "open",
       dmPolicy: "open",
-      storeAllowFrom: [],
-      historyLimit: 0,
-      groupHistories,
     });
     expect(decision.kind).toBe("drop");
   });
@@ -474,9 +424,8 @@ describe("imessage monitor gating + envelope builders", () => {
     cfg.channels.imessage.groupPolicy = "allowlist";
 
     const groupHistories = new Map();
-    const denied = await resolveIMessageInboundDecision({
+    const denied = await resolveDecision({
       cfg,
-      accountId: "default",
       message: {
         id: 3,
         chat_id: 202,
@@ -485,22 +434,17 @@ describe("imessage monitor gating + envelope builders", () => {
         text: "@openclaw hi",
         is_group: true,
       },
-      opts: {},
-      messageText: "@openclaw hi",
-      bodyText: "@openclaw hi",
       allowFrom: ["*"],
       groupAllowFrom: ["chat_id:101"],
       groupPolicy: "allowlist",
       dmPolicy: "pairing",
       storeAllowFrom: ["+15550003333"],
-      historyLimit: 0,
       groupHistories,
     });
     expect(denied.kind).toBe("drop");
 
-    const allowed = await resolveIMessageInboundDecision({
+    const allowed = await resolveDecision({
       cfg,
-      accountId: "default",
       message: {
         id: 33,
         chat_id: 101,
@@ -509,15 +453,11 @@ describe("imessage monitor gating + envelope builders", () => {
         text: "@openclaw ok",
         is_group: true,
       },
-      opts: {},
-      messageText: "@openclaw ok",
-      bodyText: "@openclaw ok",
       allowFrom: ["*"],
       groupAllowFrom: ["chat_id:101"],
       groupPolicy: "allowlist",
       dmPolicy: "pairing",
       storeAllowFrom: ["+15550003333"],
-      historyLimit: 0,
       groupHistories,
     });
     expect(allowed.kind).toBe("dispatch");
@@ -554,9 +494,8 @@ describe("imessage monitor gating + envelope builders", () => {
     cfg.channels.imessage ??= {};
     cfg.channels.imessage.groupPolicy = "allowlist";
 
-    const decision = await resolveIMessageInboundDecision({
+    const decision = await resolveDecision({
       cfg,
-      accountId: "default",
       message: {
         id: 38,
         chat_id: 101,
@@ -565,16 +504,10 @@ describe("imessage monitor gating + envelope builders", () => {
         text: "@openclaw ok",
         is_group: true,
       },
-      opts: {},
-      messageText: "@openclaw ok",
-      bodyText: "@openclaw ok",
       allowFrom: ["chat_id:101"],
       groupAllowFrom: [],
       groupPolicy: "allowlist",
       dmPolicy: "pairing",
-      storeAllowFrom: [],
-      historyLimit: 0,
-      groupHistories: new Map(),
     });
 
     expect(decision).toEqual({
@@ -589,9 +522,8 @@ describe("imessage monitor gating + envelope builders", () => {
     cfg.channels.imessage ??= {};
     cfg.channels.imessage.groupPolicy = "allowlist";
 
-    const decision = await resolveIMessageInboundDecision({
+    const decision = await resolveDecision({
       cfg,
-      accountId: "default",
       message: {
         id: 37,
         chat_id: 101,
@@ -600,16 +532,10 @@ describe("imessage monitor gating + envelope builders", () => {
         text: "@openclaw ok",
         is_group: true,
       },
-      opts: {},
-      messageText: "@openclaw ok",
-      bodyText: "@openclaw ok",
       allowFrom: ["chat_id:101"],
       groupAllowFrom: ["+15550004444"],
       groupPolicy: "allowlist",
       dmPolicy: "pairing",
-      storeAllowFrom: [],
-      historyLimit: 0,
-      groupHistories: new Map(),
     });
 
     expect(decision).toEqual({ kind: "drop", reason: "not in groupAllowFrom" });
@@ -621,9 +547,8 @@ describe("imessage monitor gating + envelope builders", () => {
     cfg.channels.imessage ??= {};
     cfg.channels.imessage.groupPolicy = "allowlist";
 
-    const decision = await resolveIMessageInboundDecision({
+    const decision = await resolveDecision({
       cfg,
-      accountId: "default",
       message: {
         id: 34,
         chat_id: 101,
@@ -632,16 +557,10 @@ describe("imessage monitor gating + envelope builders", () => {
         text: "/status",
         is_group: true,
       },
-      opts: {},
-      messageText: "/status",
-      bodyText: "/status",
       allowFrom: [],
       groupAllowFrom: ["chat_id:101"],
       groupPolicy: "allowlist",
       dmPolicy: "pairing",
-      storeAllowFrom: [],
-      historyLimit: 0,
-      groupHistories: new Map(),
     });
 
     expect(decision).toEqual({ kind: "drop", reason: "control command (unauthorized)" });
@@ -653,9 +572,8 @@ describe("imessage monitor gating + envelope builders", () => {
     cfg.channels.imessage ??= {};
     cfg.channels.imessage.groupPolicy = "allowlist";
 
-    const decision = await resolveIMessageInboundDecision({
+    const decision = await resolveDecision({
       cfg,
-      accountId: "default",
       message: {
         id: 36,
         chat_id: 101,
@@ -664,17 +582,11 @@ describe("imessage monitor gating + envelope builders", () => {
         text: "/status",
         is_group: true,
       },
-      opts: {},
-      messageText: "/status",
-      bodyText: "/status",
       allowFrom: ["chat_id:101"],
       groupAllowFrom: [],
       allowLegacyConversationAllowFromForGroup: true,
       groupPolicy: "allowlist",
       dmPolicy: "pairing",
-      storeAllowFrom: [],
-      historyLimit: 0,
-      groupHistories: new Map(),
     });
 
     expect(decision).toEqual({ kind: "drop", reason: "control command (unauthorized)" });
@@ -686,10 +598,8 @@ describe("imessage monitor gating + envelope builders", () => {
     cfg.channels.imessage ??= {};
     cfg.channels.imessage.groupPolicy = "disabled";
 
-    const groupHistories = new Map();
-    const decision = await resolveIMessageInboundDecision({
+    const decision = await resolveDecision({
       cfg,
-      accountId: "default",
       message: {
         id: 10,
         chat_id: 303,
@@ -698,16 +608,8 @@ describe("imessage monitor gating + envelope builders", () => {
         text: "@openclaw hi",
         is_group: true,
       },
-      opts: {},
-      messageText: "@openclaw hi",
-      bodyText: "@openclaw hi",
-      allowFrom: ["*"],
-      groupAllowFrom: [],
       groupPolicy: "disabled",
       dmPolicy: "open",
-      storeAllowFrom: [],
-      historyLimit: 0,
-      groupHistories,
     });
     expect(decision.kind).toBe("drop");
   });

--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -11,6 +11,10 @@ let rememberIMessageReplyCache: ReplyCacheModule["rememberIMessageReplyCache"];
 let buildIMessageInboundContext: InboundProcessingModule["buildIMessageInboundContext"];
 let resolveIMessageReactionContext: InboundProcessingModule["resolveIMessageReactionContext"];
 let resolveIMessageInboundDecision: InboundProcessingModule["resolveIMessageInboundDecision"];
+const cfg = {} as OpenClawConfig;
+type InboundDecisionParams = Parameters<
+  InboundProcessingModule["resolveIMessageInboundDecision"]
+>[0];
 
 beforeAll(async () => {
   ({ rememberIMessageReplyCache } = await loadFreshIMessageReplyCacheForTest());
@@ -18,61 +22,49 @@ beforeAll(async () => {
     await import("./inbound-processing.js"));
 });
 
+function createInboundDecisionParams(
+  overrides: Omit<Partial<InboundDecisionParams>, "message"> & {
+    message?: Partial<InboundDecisionParams["message"]>;
+  } = {},
+): InboundDecisionParams {
+  const { message: messageOverrides, ...restOverrides } = overrides;
+  const message = {
+    id: 42,
+    sender: "+15555550123",
+    text: "ok",
+    is_from_me: false,
+    is_group: false,
+    ...messageOverrides,
+  };
+  const messageText = restOverrides.messageText ?? message.text ?? "";
+  const bodyText = restOverrides.bodyText ?? messageText;
+  return {
+    cfg,
+    accountId: "default",
+    opts: undefined,
+    allowFrom: ["*"],
+    groupAllowFrom: [],
+    groupPolicy: "open",
+    dmPolicy: "open",
+    storeAllowFrom: [],
+    historyLimit: 0,
+    groupHistories: new Map(),
+    echoCache: undefined,
+    selfChatCache: undefined,
+    isKnownFromMeMessageId: () => false,
+    logVerbose: undefined,
+    ...restOverrides,
+    message,
+    messageText,
+    bodyText,
+  };
+}
+
+function resolveDecision(overrides: Parameters<typeof createInboundDecisionParams>[0] = {}) {
+  return resolveIMessageInboundDecision(createInboundDecisionParams(overrides));
+}
+
 describe("resolveIMessageInboundDecision echo detection", () => {
-  const cfg = {} as OpenClawConfig;
-  type InboundDecisionParams = Parameters<
-    InboundProcessingModule["resolveIMessageInboundDecision"]
-  >[0];
-
-  function createInboundDecisionParams(
-    overrides: Omit<Partial<InboundDecisionParams>, "message"> & {
-      message?: Partial<InboundDecisionParams["message"]>;
-    } = {},
-  ): InboundDecisionParams {
-    const { message: messageOverrides, ...restOverrides } = overrides;
-    const message = {
-      id: 42,
-      sender: "+15555550123",
-      text: "ok",
-      is_from_me: false,
-      is_group: false,
-      ...messageOverrides,
-    };
-    const messageText = restOverrides.messageText ?? message.text ?? "";
-    const bodyText = restOverrides.bodyText ?? messageText;
-    const baseParams: Omit<InboundDecisionParams, "message" | "messageText" | "bodyText"> = {
-      cfg,
-      accountId: "default",
-      opts: undefined,
-      allowFrom: ["*"],
-      groupAllowFrom: [],
-      groupPolicy: "open",
-      dmPolicy: "open",
-      storeAllowFrom: [],
-      historyLimit: 0,
-      groupHistories: new Map(),
-      echoCache: undefined,
-      selfChatCache: undefined,
-      isKnownFromMeMessageId: () => false,
-      logVerbose: undefined,
-    };
-    return {
-      ...baseParams,
-      ...restOverrides,
-      message,
-      messageText,
-      bodyText,
-    };
-  }
-
-  function resolveDecision(
-    overrides: Omit<Partial<InboundDecisionParams>, "message"> & {
-      message?: Partial<InboundDecisionParams["message"]>;
-    } = {},
-  ) {
-    return resolveIMessageInboundDecision(createInboundDecisionParams(overrides));
-  }
-
   it("drops inbound messages when outbound message id matches echo cache", async () => {
     const echoHas = vi.fn((_scope: string, lookup: { text?: string; messageId?: string }) => {
       return lookup.messageId === "42";
@@ -741,31 +733,15 @@ describe("resolveIMessageReactionContext", () => {
 
 describe("buildIMessageInboundContext", () => {
   it("keeps numeric row id and provider GUID separately for action tooling", async () => {
-    const decision = await resolveIMessageInboundDecision({
-      cfg: {} as OpenClawConfig,
-      accountId: "default",
-      message: {
-        id: 12345,
-        guid: "p:0/GUID-current",
-        sender: "+15555550123",
-        text: "Hello",
-        is_from_me: false,
-        is_group: false,
-      },
-      opts: undefined,
-      messageText: "Hello",
-      bodyText: "Hello",
-      allowFrom: ["*"],
-      groupAllowFrom: [],
-      groupPolicy: "open",
-      dmPolicy: "open",
-      storeAllowFrom: [],
-      historyLimit: 0,
-      groupHistories: new Map(),
-      echoCache: undefined,
-      selfChatCache: undefined,
-      logVerbose: undefined,
-    });
+    const message = {
+      id: 12345,
+      guid: "p:0/GUID-current",
+      sender: "+15555550123",
+      text: "Hello",
+      is_from_me: false,
+      is_group: false,
+    };
+    const decision = await resolveDecision({ message });
     expect(decision.kind).toBe("dispatch");
     if (decision.kind !== "dispatch") {
       return;
@@ -774,14 +750,7 @@ describe("buildIMessageInboundContext", () => {
     const { ctxPayload } = await buildIMessageInboundContext({
       cfg: {} as OpenClawConfig,
       decision,
-      message: {
-        id: 12345,
-        guid: "p:0/GUID-current",
-        sender: "+15555550123",
-        text: "Hello",
-        is_from_me: false,
-        is_group: false,
-      },
+      message,
       historyLimit: 0,
       groupHistories: new Map(),
     });
@@ -792,31 +761,15 @@ describe("buildIMessageInboundContext", () => {
   });
 
   it("keeps generated media notices out of command input", async () => {
-    const decision = await resolveIMessageInboundDecision({
-      cfg: {} as OpenClawConfig,
-      accountId: "default",
-      message: {
-        id: 12347,
-        guid: "p:0/GUID-media-failure",
-        sender: "+15555550123",
-        text: "/reset",
-        is_from_me: false,
-        is_group: false,
-      },
-      opts: undefined,
-      messageText: "/reset",
-      bodyText: "/reset",
-      allowFrom: ["*"],
-      groupAllowFrom: [],
-      groupPolicy: "open",
-      dmPolicy: "open",
-      storeAllowFrom: [],
-      historyLimit: 0,
-      groupHistories: new Map(),
-      echoCache: undefined,
-      selfChatCache: undefined,
-      logVerbose: undefined,
-    });
+    const message = {
+      id: 12347,
+      guid: "p:0/GUID-media-failure",
+      sender: "+15555550123",
+      text: "/reset",
+      is_from_me: false,
+      is_group: false,
+    };
+    const decision = await resolveDecision({ message });
     expect(decision.kind).toBe("dispatch");
     if (decision.kind !== "dispatch") {
       return;
@@ -828,14 +781,7 @@ describe("buildIMessageInboundContext", () => {
         ...decision,
         agentBodyText: "/reset\n\n[imessage attachment unavailable]",
       },
-      message: {
-        id: 12347,
-        guid: "p:0/GUID-media-failure",
-        sender: "+15555550123",
-        text: "/reset",
-        is_from_me: false,
-        is_group: false,
-      },
+      message,
       historyLimit: 0,
       groupHistories: new Map(),
     });
@@ -847,31 +793,15 @@ describe("buildIMessageInboundContext", () => {
   });
 
   it("prepends direct-message history when supplied", async () => {
-    const decision = await resolveIMessageInboundDecision({
-      cfg: {} as OpenClawConfig,
-      accountId: "default",
-      message: {
-        id: 12346,
-        guid: "p:0/GUID-current-history",
-        sender: "+15555550123",
-        text: "current",
-        is_from_me: false,
-        is_group: false,
-      },
-      opts: undefined,
-      messageText: "current",
-      bodyText: "current",
-      allowFrom: ["*"],
-      groupAllowFrom: [],
-      groupPolicy: "open",
-      dmPolicy: "open",
-      storeAllowFrom: [],
-      historyLimit: 0,
-      groupHistories: new Map(),
-      echoCache: undefined,
-      selfChatCache: undefined,
-      logVerbose: undefined,
-    });
+    const message = {
+      id: 12346,
+      guid: "p:0/GUID-current-history",
+      sender: "+15555550123",
+      text: "current",
+      is_from_me: false,
+      is_group: false,
+    };
+    const decision = await resolveDecision({ message });
     expect(decision.kind).toBe("dispatch");
     if (decision.kind !== "dispatch") {
       return;
@@ -880,14 +810,7 @@ describe("buildIMessageInboundContext", () => {
     const { ctxPayload, inboundHistory } = await buildIMessageInboundContext({
       cfg: {} as OpenClawConfig,
       decision,
-      message: {
-        id: 12346,
-        guid: "p:0/GUID-current-history",
-        sender: "+15555550123",
-        text: "current",
-        is_from_me: false,
-        is_group: false,
-      },
+      message,
       historyLimit: 0,
       groupHistories: new Map(),
       dmHistory: {
@@ -904,7 +827,6 @@ describe("buildIMessageInboundContext", () => {
 });
 
 describe("resolveIMessageInboundDecision command auth", () => {
-  const cfg = {} as OpenClawConfig;
   const resolveDmCommandDecision = (params: {
     messageId: number;
     storeAllowFrom: string[];
@@ -912,9 +834,7 @@ describe("resolveIMessageInboundDecision command auth", () => {
     allowFrom?: string[];
     text?: string;
   }) =>
-    resolveIMessageInboundDecision({
-      cfg,
-      accountId: "default",
+    resolveDecision({
       message: {
         id: params.messageId,
         sender: "+15555550123",
@@ -922,18 +842,9 @@ describe("resolveIMessageInboundDecision command auth", () => {
         is_from_me: false,
         is_group: false,
       },
-      opts: undefined,
-      messageText: params.text ?? "/status",
-      bodyText: params.text ?? "/status",
       allowFrom: params.allowFrom ?? [],
-      groupAllowFrom: [],
-      groupPolicy: "open",
       dmPolicy: params.dmPolicy ?? "open",
       storeAllowFrom: params.storeAllowFrom,
-      historyLimit: 0,
-      groupHistories: new Map(),
-      echoCache: undefined,
-      logVerbose: undefined,
     });
 
   it("does not auto-authorize DM commands in open mode without allowlists", async () => {

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -11,6 +11,9 @@ import { rememberPersistedIMessageEcho } from "./persisted-echo-cache.js";
 import { createSelfChatCache } from "./self-chat-cache.js";
 
 const IMAGE_MEDIA_FACT = { contentType: "image/png", kind: "image" } as const;
+const SELF_CHAT_HANDLE = "+15551234567";
+const SELF_CHAT_SCOPE = `default:imessage:${SELF_CHAT_HANDLE}`;
+const DEFAULT_FAKE_TIME = "2026-03-24T12:00:00Z";
 
 /**
  * Self-chat dedupe regression tests for #47830.
@@ -73,6 +76,31 @@ function createParams(
   };
 }
 
+async function resolveDecision(
+  overrides: Parameters<typeof createParams>[0] = {},
+): ReturnType<typeof resolveIMessageInboundDecision> {
+  return resolveIMessageInboundDecision(createParams(overrides));
+}
+
+function selfChatMessage(
+  overrides: Partial<InboundDecisionParams["message"]> = {},
+): InboundDecisionParams["message"] {
+  const sender = overrides.sender ?? SELF_CHAT_HANDLE;
+  return {
+    sender,
+    chat_identifier: sender,
+    destination_caller_id: sender,
+    is_from_me: true,
+    is_group: false,
+    ...overrides,
+  };
+}
+
+function useFakeTimersAt(iso = DEFAULT_FAKE_TIME): void {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(iso));
+}
+
 describe("echo cache — message ID type canary (#47830)", () => {
   // Tests the implicit contract that outbound GUIDs (e.g. "p:0/abc-def-123")
   // never match inbound SQLite row IDs (e.g. "200"). If iMessage ever changes
@@ -123,8 +151,7 @@ describe("echo cache — backward compat for channels without messageId", () => 
   // on either side. Critical for backward compat with channels that don't
   // populate messageId.
   it("text-only remember/has works within TTL", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
     const scope = "default:imessage:+15555550123";
@@ -136,8 +163,7 @@ describe("echo cache — backward compat for channels without messageId", () => 
   });
 
   it("text-only has returns false after TTL expiry", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
     const scope = "default:imessage:+15555550123";
@@ -149,8 +175,7 @@ describe("echo cache — backward compat for channels without messageId", () => 
   });
 
   it("text-only has returns false for different text", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
     const scope = "default:imessage:+15555550123";
@@ -168,33 +193,23 @@ describe("self-chat dedupe — #47830", () => {
   });
 
   it("does NOT drop a user message that matches recently-sent agent text (self-chat scope collision)", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
 
     // Agent sends "Hello" to self-chat target +15551234567
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
     echoCache.remember(scope, { text: "Hello", messageId: "agent-msg-1" });
 
     // 2 seconds later, user sends "Hello" to themselves (different message id)
     vi.advanceTimersByTime(2000);
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 200,
-          sender: "+15551234567",
-          text: "Hello",
-          is_from_me: false,
-        },
-        messageText: "Hello",
-        bodyText: "Hello",
-        echoCache,
-        selfChatCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: { id: 200, sender: SELF_CHAT_HANDLE, text: "Hello", is_from_me: false },
+      echoCache,
+      selfChatCache,
+    });
 
     // BUG: Before fix, this was "drop" reason "echo" — user message silently lost.
     // After fix: message-id mismatch means this is NOT an echo.
@@ -204,70 +219,54 @@ describe("self-chat dedupe — #47830", () => {
   });
 
   it("DOES drop genuine agent echo (same message id reflected back)", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
 
     // Agent sends "Hello" to target
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
     echoCache.remember(scope, { text: "Hello", messageId: "agent-msg-1" });
 
     // 1 second later, iMessage reflects it back with same message id
     vi.advanceTimersByTime(1000);
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: "agent-msg-1" as unknown as number,
-          sender: "+15551234567",
-          text: "Hello",
-          is_from_me: false,
-        },
-        messageText: "Hello",
-        bodyText: "Hello",
-        echoCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: {
+        id: "agent-msg-1" as unknown as number,
+        sender: SELF_CHAT_HANDLE,
+        text: "Hello",
+        is_from_me: false,
+      },
+      echoCache,
+    });
 
     expect(decision).toEqual({ kind: "drop", reason: "echo" });
   });
 
   it("does NOT drop different-text messages even within TTL", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
 
     // Agent sends "Hello"
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
     echoCache.remember(scope, { text: "Hello", messageId: "agent-msg-1" });
 
     vi.advanceTimersByTime(1000);
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 201,
-          sender: "+15551234567",
-          text: "Goodbye",
-          is_from_me: false,
-        },
-        messageText: "Goodbye",
-        bodyText: "Goodbye",
-        echoCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: { id: 201, sender: SELF_CHAT_HANDLE, text: "Goodbye", is_from_me: false },
+      echoCache,
+    });
 
     expect(decision.kind).toBe("dispatch");
   });
 
   it("does NOT drop user messages that match a chunk of a multi-chunk agent reply", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
 
     // Agent sends a multi-chunk reply: "Part one", "Part two", "Part three"
     echoCache.remember(scope, { text: "Part one", messageId: "agent-chunk-1" });
@@ -277,27 +276,17 @@ describe("self-chat dedupe — #47830", () => {
     vi.advanceTimersByTime(2000);
 
     // User sends "Part two" (matches chunk 2 text, but different message id)
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 300,
-          sender: "+15551234567",
-          text: "Part two",
-          is_from_me: false,
-        },
-        messageText: "Part two",
-        bodyText: "Part two",
-        echoCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: { id: 300, sender: SELF_CHAT_HANDLE, text: "Part two", is_from_me: false },
+      echoCache,
+    });
 
     // Should NOT be dropped — different message id means not an echo
     expect(decision.kind).toBe("dispatch");
   });
 
   it("drops echo after text TTL expiry (4s TTL: expired at 5s)", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
     const scope = "default:imessage:+15555550123";
@@ -314,11 +303,10 @@ describe("self-chat dedupe — #47830", () => {
 
   // Safe failure mode: TTL expiry causes duplicate delivery (noisy), never message loss (lossy)
   it("does NOT catch echo after TTL expiry — safe failure mode is duplicate delivery", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
 
     // Agent sends "Delayed echo test"
     echoCache.remember(scope, { text: "Delayed echo test", messageId: "agent-msg-delayed" });
@@ -334,8 +322,7 @@ describe("self-chat dedupe — #47830", () => {
   });
 
   it("still drops text echo within 4s TTL window", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
     const scope = "default:imessage:+15555550123";
@@ -359,23 +346,11 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 123703,
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          destination_caller_id: "+15551234567",
-          text: "Hello this is a test message",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "Hello this is a test message",
-        bodyText: "Hello this is a test message",
-        echoCache,
-        selfChatCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: selfChatMessage({ id: 123703, text: "Hello this is a test message" }),
+      echoCache,
+      selfChatCache,
+    });
 
     expect(decision.kind).toBe("dispatch");
   });
@@ -384,23 +359,15 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 123704,
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          destination_caller_id: "",
-          text: "Hello this is a test message",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "Hello this is a test message",
-        bodyText: "Hello this is a test message",
-        echoCache,
-        selfChatCache,
+    const decision = await resolveDecision({
+      message: selfChatMessage({
+        id: 123704,
+        destination_caller_id: "",
+        text: "Hello this is a test message",
       }),
-    );
+      echoCache,
+      selfChatCache,
+    });
 
     expect(decision).toEqual({ kind: "drop", reason: "from me" });
   });
@@ -409,266 +376,174 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 123705,
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          destination_caller_id: "me@icloud.com",
-          participants: ["+15551234567", "me@icloud.com"],
-          text: "Hello from a normal DM row",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "Hello from a normal DM row",
-        bodyText: "Hello from a normal DM row",
-        echoCache,
-        selfChatCache,
+    const decision = await resolveDecision({
+      message: selfChatMessage({
+        id: 123705,
+        destination_caller_id: "me@icloud.com",
+        participants: [SELF_CHAT_HANDLE, "me@icloud.com"],
+        text: "Hello from a normal DM row",
       }),
-    );
+      echoCache,
+      selfChatCache,
+    });
 
     expect(decision).toEqual({ kind: "drop", reason: "from me" });
   });
 
   it("drops agent reply echo in self-chat (is_from_me=true, echo cache text match)", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
 
     // Agent sends "Hi there!" to self-chat
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
     echoCache.remember(scope, { text: "Hi there!", messageId: "p:0/GUID-abc-def" });
 
     // 1 second later, iMessage delivers the agent reply as is_from_me=true
     // with a SQLite row ID (never matches the GUID)
     vi.advanceTimersByTime(1000);
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 123706,
-          guid: "p:0/GUID-abc-def",
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          destination_caller_id: "+15551234567",
-          text: "Hi there!",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "Hi there!",
-        bodyText: "Hi there!",
-        echoCache,
-        selfChatCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: selfChatMessage({ id: 123706, guid: "p:0/GUID-abc-def", text: "Hi there!" }),
+      echoCache,
+      selfChatCache,
+    });
 
     // Agent echo — should be dropped
     expect(decision).toEqual({ kind: "drop", reason: "agent echo in self-chat" });
   });
 
   it("drops attachment-only agent echo in self-chat via its media fact", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
     echoCache.remember(scope, { media: IMAGE_MEDIA_FACT, messageId: "p:0/GUID-media" });
     vi.advanceTimersByTime(1000);
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 123707,
-          guid: "p:0/GUID-media",
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          destination_caller_id: "+15551234567",
-          text: "",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "",
-        bodyText: "",
-        mediaFacts: [IMAGE_MEDIA_FACT],
-        echoCache,
-        selfChatCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: selfChatMessage({ id: 123707, guid: "p:0/GUID-media", text: "" }),
+      mediaFacts: [IMAGE_MEDIA_FACT],
+      echoCache,
+      selfChatCache,
+    });
 
     expect(decision).toEqual({ kind: "drop", reason: "agent echo in self-chat" });
   });
 
   it("drops self-chat echo when outbound cache stored numeric id but inbound also carries a guid", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
 
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
     echoCache.remember(scope, { text: "Numeric id echo", messageId: "123709" });
 
     vi.advanceTimersByTime(1000);
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 123709,
-          guid: "p:0/GUID-different-shape",
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          destination_caller_id: "+15551234567",
-          text: "Numeric id echo",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "Numeric id echo",
-        bodyText: "Numeric id echo",
-        echoCache,
-        selfChatCache,
+    const decision = await resolveDecision({
+      message: selfChatMessage({
+        id: 123709,
+        guid: "p:0/GUID-different-shape",
+        text: "Numeric id echo",
       }),
-    );
+      echoCache,
+      selfChatCache,
+    });
 
     expect(decision).toEqual({ kind: "drop", reason: "agent echo in self-chat" });
   });
 
   it("does not drop a real self-chat image just because a recent agent image had the same fact", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
 
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
     echoCache.remember(scope, { media: IMAGE_MEDIA_FACT, messageId: "p:0/GUID-agent-image" });
 
     vi.advanceTimersByTime(1000);
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 123708,
-          guid: "p:0/GUID-user-image",
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          destination_caller_id: "+15551234567",
-          text: "",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "",
-        bodyText: "",
-        mediaFacts: [IMAGE_MEDIA_FACT],
-        echoCache,
-        selfChatCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: selfChatMessage({ id: 123708, guid: "p:0/GUID-user-image", text: "" }),
+      mediaFacts: [IMAGE_MEDIA_FACT],
+      echoCache,
+      selfChatCache,
+    });
 
     expect(decision.kind).toBe("dispatch");
   });
 
   it("drops is_from_me=false reflection via selfChatCache (existing behavior preserved)", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const selfChatCache = createSelfChatCache();
     const createdAt = "2026-03-24T12:00:00.000Z";
 
     // Step 1: is_from_me=true copy arrives (real user message) → processed, selfChatCache populated
-    const first = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 123703,
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          destination_caller_id: "+15551234567",
-          text: "Hello",
-          created_at: createdAt,
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "Hello",
-        bodyText: "Hello",
-        selfChatCache,
-      }),
-    );
+    const first = await resolveDecision({
+      message: selfChatMessage({ id: 123703, text: "Hello", created_at: createdAt }),
+      selfChatCache,
+    });
     expect(first.kind).toBe("dispatch");
 
     // Step 2: is_from_me=false reflection arrives 2s later with same text+createdAt
     vi.advanceTimersByTime(2200);
-    const second = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 123704,
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          text: "Hello",
-          created_at: createdAt,
-          is_from_me: false,
-          is_group: false,
-        },
-        messageText: "Hello",
-        bodyText: "Hello",
-        selfChatCache,
-      }),
-    );
+    const second = await resolveDecision({
+      message: {
+        id: 123704,
+        sender: SELF_CHAT_HANDLE,
+        chat_identifier: SELF_CHAT_HANDLE,
+        text: "Hello",
+        created_at: createdAt,
+        is_from_me: false,
+        is_group: false,
+      },
+      selfChatCache,
+    });
     // Reflection correctly dropped
     expect(second).toEqual({ kind: "drop", reason: "self-chat echo" });
   });
 
   it("drops is_from_me=false self-chat reflection with sub-second created_at skew", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-10T05:34:00Z"));
+    useFakeTimersAt("2026-05-10T05:34:00Z");
 
     const selfChatCache = createSelfChatCache();
 
-    const first = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 85160,
-          guid: "p:0/from-me-guid",
-          sender: "+15555550123",
-          chat_identifier: "+15555550123",
-          destination_caller_id: "+15555550123",
-          text: "Aha, neat!",
-          created_at: "2026-05-10T05:34:00.000Z",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "Aha, neat!",
-        bodyText: "Aha, neat!",
-        selfChatCache,
+    const first = await resolveDecision({
+      message: selfChatMessage({
+        id: 85160,
+        guid: "p:0/from-me-guid",
+        sender: "+15555550123",
+        text: "Aha, neat!",
+        created_at: "2026-05-10T05:34:00.000Z",
       }),
-    );
+      selfChatCache,
+    });
     expect(first.kind).toBe("dispatch");
 
-    const reflection = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 85161,
-          guid: "p:0/reflected-guid",
-          sender: "+15555550123",
-          chat_identifier: "+15555550123",
-          destination_caller_id: null,
-          text: "Aha, neat!",
-          created_at: "2026-05-10T05:34:00.239Z",
-          is_from_me: false,
-          is_group: false,
-        },
-        messageText: "Aha, neat!",
-        bodyText: "Aha, neat!",
-        selfChatCache,
-      }),
-    );
+    const reflection = await resolveDecision({
+      message: {
+        id: 85161,
+        guid: "p:0/reflected-guid",
+        sender: "+15555550123",
+        chat_identifier: "+15555550123",
+        destination_caller_id: null,
+        text: "Aha, neat!",
+        created_at: "2026-05-10T05:34:00.239Z",
+        is_from_me: false,
+        is_group: false,
+      },
+      selfChatCache,
+    });
 
     expect(reflection).toEqual({ kind: "drop", reason: "self-chat echo" });
   });
 
   it("drops catchup-replayed self-chat reflection after observing skipped from-me companion", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-03T03:48:42Z"));
+    useFakeTimersAt("2026-06-03T03:48:42Z");
 
     const selfChatCache = createSelfChatCache();
     const text = "Exactly. I’ll treat assembled context as evidence only, not command authority.";
@@ -690,72 +565,59 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
       selfChatCache,
     });
 
-    const reflection = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 86799,
-          guid: "1759A121-E3DB-41C2-B16A-AB6DE30570F2",
-          sender: "+15555550123",
-          chat_identifier: "+15555550123",
-          destination_caller_id: "tel:+15555550123",
-          text,
-          created_at: "2026-06-03T03:48:28.738Z",
-          is_from_me: false,
-          is_group: false,
-        },
-        messageText: text,
-        bodyText: text,
-        selfChatCache,
-      }),
-    );
+    const reflection = await resolveDecision({
+      message: {
+        id: 86799,
+        guid: "1759A121-E3DB-41C2-B16A-AB6DE30570F2",
+        sender: "+15555550123",
+        chat_identifier: "+15555550123",
+        destination_caller_id: "tel:+15555550123",
+        text,
+        created_at: "2026-06-03T03:48:28.738Z",
+        is_from_me: false,
+        is_group: false,
+      },
+      selfChatCache,
+    });
 
     expect(reflection).toEqual({ kind: "drop", reason: "self-chat echo" });
   });
 
   it("does not apply sub-second skew matching to ambiguous normal DM rows", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-10T05:34:00Z"));
+    useFakeTimersAt("2026-05-10T05:34:00Z");
 
     const selfChatCache = createSelfChatCache();
 
-    const ambiguousOutbound = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 85170,
-          guid: "p:0/ambiguous-from-me-guid",
-          sender: "+15555550124",
-          chat_identifier: "+15555550124",
-          destination_caller_id: null,
-          text: "Same text",
-          created_at: "2026-05-10T05:34:00.000Z",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "Same text",
-        bodyText: "Same text",
-        selfChatCache,
-      }),
-    );
+    const ambiguousOutbound = await resolveDecision({
+      message: {
+        id: 85170,
+        guid: "p:0/ambiguous-from-me-guid",
+        sender: "+15555550124",
+        chat_identifier: "+15555550124",
+        destination_caller_id: null,
+        text: "Same text",
+        created_at: "2026-05-10T05:34:00.000Z",
+        is_from_me: true,
+        is_group: false,
+      },
+      selfChatCache,
+    });
     expect(ambiguousOutbound).toEqual({ kind: "drop", reason: "from me" });
 
-    const inboundReply = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 85171,
-          guid: "p:0/real-inbound-guid",
-          sender: "+15555550124",
-          chat_identifier: "+15555550124",
-          destination_caller_id: null,
-          text: "Same text",
-          created_at: "2026-05-10T05:34:00.239Z",
-          is_from_me: false,
-          is_group: false,
-        },
-        messageText: "Same text",
-        bodyText: "Same text",
-        selfChatCache,
-      }),
-    );
+    const inboundReply = await resolveDecision({
+      message: {
+        id: 85171,
+        guid: "p:0/real-inbound-guid",
+        sender: "+15555550124",
+        chat_identifier: "+15555550124",
+        destination_caller_id: null,
+        text: "Same text",
+        created_at: "2026-05-10T05:34:00.239Z",
+        is_from_me: false,
+        is_group: false,
+      },
+      selfChatCache,
+    });
 
     expect(inboundReply.kind).toBe("dispatch");
   });
@@ -763,68 +625,55 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
   it("drops outbound DM when sender matches chat_identifier but destination_caller_id is absent (#63980)", async () => {
     const selfChatCache = createSelfChatCache();
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 10003,
-          sender: "+15550008888",
-          chat_identifier: "+15550008888",
-          text: "outbound",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "outbound",
-        bodyText: "outbound",
-        selfChatCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: {
+        id: 10003,
+        sender: "+15550008888",
+        chat_identifier: "+15550008888",
+        text: "outbound",
+        is_from_me: true,
+        is_group: false,
+      },
+      selfChatCache,
+    });
 
     expect(decision).toEqual({ kind: "drop", reason: "from me" });
   });
 
   it("drops reflected inbound when destination_caller_id is absent (#63980)", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const selfChatCache = createSelfChatCache();
     const createdAt = "2026-03-24T12:00:00.000Z";
 
-    const outbound = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 10003,
-          sender: "+15550008888",
-          chat_identifier: "+15550008888",
-          text: "outbound",
-          created_at: createdAt,
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "outbound",
-        bodyText: "outbound",
-        selfChatCache,
-      }),
-    );
+    const outbound = await resolveDecision({
+      message: {
+        id: 10003,
+        sender: "+15550008888",
+        chat_identifier: "+15550008888",
+        text: "outbound",
+        created_at: createdAt,
+        is_from_me: true,
+        is_group: false,
+      },
+      selfChatCache,
+    });
     expect(outbound).toEqual({ kind: "drop", reason: "from me" });
 
     vi.advanceTimersByTime(2200);
 
-    const reflection = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 10004,
-          sender: "+15550008888",
-          chat_identifier: "+15550008888",
-          text: "outbound",
-          created_at: createdAt,
-          is_from_me: false,
-          is_group: false,
-        },
-        messageText: "outbound",
-        bodyText: "outbound",
-        selfChatCache,
-      }),
-    );
+    const reflection = await resolveDecision({
+      message: {
+        id: 10004,
+        sender: "+15550008888",
+        chat_identifier: "+15550008888",
+        text: "outbound",
+        created_at: createdAt,
+        is_from_me: false,
+        is_group: false,
+      },
+      selfChatCache,
+    });
 
     expect(reflection).toEqual({ kind: "drop", reason: "self-chat echo" });
   });
@@ -834,21 +683,17 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
 
     // Normal DM with is_from_me=true: sender may be the local handle and
     // chat_identifier the other party (they differ), so this is NOT self-chat.
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 9999,
-          sender: "+15551234567", // local user sent this
-          chat_identifier: "+15555550123", // sent TO this other person
-          text: "Hello",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "Hello",
-        bodyText: "Hello",
-        selfChatCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: {
+        id: 9999,
+        sender: "+15551234567", // local user sent this
+        chat_identifier: "+15555550123", // sent TO this other person
+        text: "Hello",
+        is_from_me: true,
+        is_group: false,
+      },
+      selfChatCache,
+    });
 
     expect(decision).toEqual({ kind: "drop", reason: "from me" });
   });
@@ -857,38 +702,33 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
 
-    echoCache.remember("default:imessage:+15551234567", {
+    echoCache.remember(SELF_CHAT_SCOPE, {
       text: "Clean outbound text",
       messageId: "p:0/GUID-outbound",
     });
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 10001,
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          destination_caller_id: "+15550001111",
-          text: "�\u0001corrupted stored text",
-          is_from_me: true,
-          is_group: false,
-        },
-        messageText: "�\u0001corrupted stored text",
-        bodyText: "�\u0001corrupted stored text",
-        echoCache,
-        selfChatCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: {
+        id: 10001,
+        sender: "+15551234567",
+        chat_identifier: "+15551234567",
+        destination_caller_id: "+15550001111",
+        text: "�\u0001corrupted stored text",
+        is_from_me: true,
+        is_group: false,
+      },
+      echoCache,
+      selfChatCache,
+    });
 
     expect(decision).toEqual({ kind: "drop", reason: "from me" });
   });
 
   it("echo cache text matching works with skipIdShortCircuit=true", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
     echoCache.remember(scope, { text: "Cached reply", messageId: "p:0/some-guid" });
 
     vi.advanceTimersByTime(1000);
@@ -906,7 +746,7 @@ describe("echo cache — text fallback for null-id inbound messages", () => {
   it("does not drop normal DM text from a pending pre-send marker", async () => {
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
     rememberPersistedIMessageEcho({
       scope,
       text: "same pending text",
@@ -914,23 +754,19 @@ describe("echo cache — text fallback for null-id inbound messages", () => {
       pending: true,
     });
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 12001,
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          destination_caller_id: "+15550001111",
-          text: "same pending text",
-          is_from_me: false,
-          is_group: false,
-        },
-        messageText: "same pending text",
-        bodyText: "same pending text",
-        echoCache,
-        selfChatCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: {
+        id: 12001,
+        sender: "+15551234567",
+        chat_identifier: "+15551234567",
+        destination_caller_id: "+15550001111",
+        text: "same pending text",
+        is_from_me: false,
+        is_group: false,
+      },
+      echoCache,
+      selfChatCache,
+    });
 
     expect(decision.kind).toBe("dispatch");
   });
@@ -938,7 +774,7 @@ describe("echo cache — text fallback for null-id inbound messages", () => {
   it("drops self-chat reflected text from a pending pre-send marker", async () => {
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
     rememberPersistedIMessageEcho({
       scope,
       text: "pending self-chat reply",
@@ -946,55 +782,46 @@ describe("echo cache — text fallback for null-id inbound messages", () => {
       pending: true,
     });
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: 12002,
-          sender: "+15551234567",
-          chat_identifier: "+15551234567",
-          destination_caller_id: "tel:+15551234567",
-          text: "pending self-chat reply",
-          is_from_me: false,
-          is_group: false,
-        },
-        messageText: "pending self-chat reply",
-        bodyText: "pending self-chat reply",
-        echoCache,
-        selfChatCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: {
+        id: 12002,
+        sender: "+15551234567",
+        chat_identifier: "+15551234567",
+        destination_caller_id: "tel:+15551234567",
+        text: "pending self-chat reply",
+        is_from_me: false,
+        is_group: false,
+      },
+      echoCache,
+      selfChatCache,
+    });
 
     expect(decision).toEqual({ kind: "drop", reason: "echo" });
   });
 
   it("still identifies echo via text when inbound message has id: null", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+    useFakeTimersAt();
 
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
 
     // Agent sends "Sounds good" — no messageId available (edge case)
-    const scope = "default:imessage:+15551234567";
+    const scope = SELF_CHAT_SCOPE;
     echoCache.remember(scope, { text: "Sounds good" });
 
     // 1 second later, inbound reflection arrives with id: null
     vi.advanceTimersByTime(1000);
 
-    const decision = await resolveIMessageInboundDecision(
-      createParams({
-        message: {
-          id: null as unknown as number,
-          sender: "+15551234567",
-          text: "Sounds good",
-          is_from_me: false,
-        },
-        messageText: "Sounds good",
-        bodyText: "Sounds good",
-        echoCache,
-        selfChatCache,
-      }),
-    );
+    const decision = await resolveDecision({
+      message: {
+        id: null as unknown as number,
+        sender: "+15551234567",
+        text: "Sounds good",
+        is_from_me: false,
+      },
+      echoCache,
+      selfChatCache,
+    });
 
     // With id: null, the text-based fallback path is still active and should
     // correctly identify this as an echo.


### PR DESCRIPTION
## What Problem This Solves

The iMessage monitor regression suites repeated large inbound-decision, context, timer, and self-chat message fixtures. That duplication made security-sensitive self-chat and echo-deduplication coverage harder to compare and maintain.

This refactor was explicitly requested by a maintainer as part of the coordinated LOC-reduction campaign. It is AI-assisted.

## Why This Change Was Made

The tests now use suite-local canonical builders for inbound decisions, dispatch contexts, fake time, and true self-chat payloads. Distinct production states remain explicit: normal DMs, ambiguous missing destinations, true self-chat, GUID/ROWID mismatches, persisted pending echoes, media-only echoes, and created-at skew.

No production source, runtime behavior, configuration, schema, docs, or generated files changed. The three test files change by +417/-777 lines, net -360.

## User Impact

No user-visible behavior changes. Developers retain the same 86 named cases and 170 ordered assertions with less duplicated setup.

## Evidence

- Exact AST parity against the base: titles/assertions remain 20/45, 32/85, and 34/40; ordered title and assertion hashes are unchanged.
- Focused local proof: 3 files, 325/325 tests passed.
- Blacksmith Testbox `tbx_01kz26j8vdskq55csg032edmzv`: full iMessage suite, 52/52 files and 1,034/1,034 tests passed ([run](https://github.com/openclaw/openclaw/actions/runs/30768307404)).
- The same Testbox lease passed `pnpm check:changed`, including extension-test typecheck, lint, formatting, boundary, dependency, and dead-export gates.
- `git diff --check` and targeted `oxfmt` passed.
- Fresh xhigh autoreview returned no findings at exact head `08a661099a9e2b7cf5a20096ecebfc9b44d5421c`.
- Upstream `imsg` source was checked for the watch payload, stable GUID/ROWID fields, and `destination_caller_id` self-chat discriminator.
