### PR TITLE
refactor(codex): compact plugin inventory test fixtures

### DIFF
--- a/extensions/codex/src/app-server/plugin-inventory.test.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.test.ts
@@ -12,41 +12,20 @@ import type { v2 } from "./protocol.js";
 
 describe("Codex plugin inventory", () => {
   it("returns enabled migrated curated plugins with stable owned app ids", async () => {
-    const appCache = new CodexAppInventoryCache();
-    await appCache.refreshNow({
-      key: "runtime",
-      nowMs: 0,
-      request: async (method, params) =>
-        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
-    });
+    const appCache = await cachedApps(appInfo("google-calendar-app", true));
     const calls: string[] = [];
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            "google-calendar": {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
-            slack: {
-              enabled: false,
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "slack",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        "google-calendar": curatedPlugin("google-calendar"),
+        slack: curatedPlugin("slack", { enabled: false }),
+      }),
       appCache,
       appCacheKey: "runtime",
       nowMs: 1,
       request: async (method, params) => {
         calls.push(method);
         if (method === "plugin/installed") {
-          return pluginInstalled([
-            pluginSummary("google-calendar", { installed: true, enabled: true }),
-            pluginSummary("slack", { installed: true, enabled: true }),
-          ]);
+          return pluginInstalled([activePlugin("google-calendar"), activePlugin("slack")]);
         }
         if (method === "plugin/read") {
           expect(params).toEqual({
@@ -82,17 +61,7 @@ describe("Codex plugin inventory", () => {
     const metadataCache = new CodexPluginMetadataCache();
     const calls: Array<{ method: string; params: unknown }> = [];
     const params = {
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            github: {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "github",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({ github: curatedPlugin("github") }),
       appCacheKey: "runtime",
       configCwd: "/repo/project",
       metadataCache,
@@ -100,7 +69,7 @@ describe("Codex plugin inventory", () => {
       request: async (method: string, requestParams?: unknown) => {
         calls.push({ method, params: requestParams });
         if (method === "plugin/installed") {
-          return pluginInstalled([pluginSummary("github", { installed: true, enabled: true })]);
+          return pluginInstalled([activePlugin("github")]);
         }
         throw new Error(`unexpected request ${method}`);
       },
@@ -117,17 +86,7 @@ describe("Codex plugin inventory", () => {
   it("reads the curated catalog only for an explicitly requested missing plugin", async () => {
     const calls: Array<{ method: string; params: unknown }> = [];
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            calendar: {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "calendar",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({ calendar: curatedPlugin("calendar") }),
       readPluginDetails: false,
       request: async (method, params) => {
         calls.push({ method, params });
@@ -152,19 +111,11 @@ describe("Codex plugin inventory", () => {
   });
 
   it("matches namespaced curated plugin ids by normalized path segment", async () => {
-    const appCache = new CodexAppInventoryCache();
-    await appCache.refreshNow({
-      key: "runtime",
-      nowMs: 0,
-      request: async (method, params) =>
-        codexAppInventoryResponse(method, [appInfo("github-app", true)], params),
-    });
+    const appCache = await cachedApps(appInfo("github-app", true));
 
     const listed = pluginList([
-      pluginSummary("openai-curated/github", {
+      activePlugin("openai-curated/github", {
         name: "GitHub",
-        installed: true,
-        enabled: true,
       }),
     ]);
     expect(findOpenAiCuratedPluginSummary(listed, "github")?.summary.id).toBe(
@@ -172,17 +123,7 @@ describe("Codex plugin inventory", () => {
     );
 
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            github: {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "github",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({ github: curatedPlugin("github") }),
       appCache,
       appCacheKey: "runtime",
       nowMs: 1,
@@ -215,18 +156,10 @@ describe("Codex plugin inventory", () => {
   });
 
   it("accepts the remote curated marketplace wire name", async () => {
-    const appCache = new CodexAppInventoryCache();
-    await appCache.refreshNow({
-      key: "runtime",
-      nowMs: 0,
-      request: async (method, params) =>
-        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
-    });
-    const remoteSummary = pluginSummary("google-calendar@openai-curated-remote", {
+    const appCache = await cachedApps(appInfo("google-calendar-app", true));
+    const remoteSummary = activePlugin("google-calendar@openai-curated-remote", {
       name: "google-calendar",
       remotePluginId: "plugin_connector_google_calendar",
-      installed: true,
-      enabled: true,
     });
     const localListed = pluginList([pluginSummary("github")]);
     const listed = {
@@ -243,17 +176,9 @@ describe("Codex plugin inventory", () => {
     } satisfies v2.PluginListResponse;
 
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            "google-calendar": {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        "google-calendar": curatedPlugin("google-calendar"),
+      }),
       appCache,
       appCacheKey: "runtime",
       nowMs: 1,
@@ -278,13 +203,7 @@ describe("Codex plugin inventory", () => {
   });
 
   it("accepts the API-key curated marketplace wire name", async () => {
-    const appCache = new CodexAppInventoryCache();
-    await appCache.refreshNow({
-      key: "runtime",
-      nowMs: 0,
-      request: async (method, params) =>
-        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
-    });
+    const appCache = await cachedApps(appInfo("google-calendar-app", true));
     const listed = {
       marketplaces: [
         {
@@ -292,10 +211,8 @@ describe("Codex plugin inventory", () => {
           path: "/codex-home/.tmp/plugins/.agents/plugins/api_marketplace.json",
           interface: null,
           plugins: [
-            pluginSummary("google-calendar@openai-api-curated", {
+            activePlugin("google-calendar@openai-api-curated", {
               name: "google-calendar",
-              installed: true,
-              enabled: true,
             }),
           ],
         },
@@ -304,17 +221,9 @@ describe("Codex plugin inventory", () => {
     } satisfies v2.PluginInstalledResponse;
 
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            "google-calendar": {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        "google-calendar": curatedPlugin("google-calendar"),
+      }),
       appCache,
       appCacheKey: "runtime",
       nowMs: 1,
@@ -341,26 +250,16 @@ describe("Codex plugin inventory", () => {
   it("fails closed when an installed remote curated plugin omits its opaque id", async () => {
     const calls: string[] = [];
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            "google-calendar": {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        "google-calendar": curatedPlugin("google-calendar"),
+      }),
       request: async (method) => {
         calls.push(method);
         if (method === "plugin/installed") {
           return pluginInstalled(
             [
-              pluginSummary("google-calendar@openai-curated-remote", {
+              activePlugin("google-calendar@openai-curated-remote", {
                 name: "google-calendar",
-                installed: true,
-                enabled: true,
               }),
             ],
             { name: "openai-curated-remote", path: null },
@@ -378,33 +277,17 @@ describe("Codex plugin inventory", () => {
   });
 
   it("resolves an installed workspace plugin from the one canonical installed snapshot", async () => {
-    const appCache = new CodexAppInventoryCache();
-    await appCache.refreshNow({
-      key: "runtime",
-      nowMs: 0,
-      request: async (method, params) =>
-        codexAppInventoryResponse(method, [appInfo("workspace-data-app", true)], params),
-    });
+    const appCache = await cachedApps(appInfo("workspace-data-app", true));
     const calls: Array<{ method: string; params: unknown }> = [];
-    const exactSummary = pluginSummary("workspace-data@workspace-directory", {
+    const exactSummary = activePlugin("workspace-data@workspace-directory", {
       name: "Workspace Data",
       remotePluginId: "plugin_workspace_data",
-      installed: true,
-      enabled: true,
     });
 
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            workspaceData: {
-              marketplaceName: CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
-              pluginName: "workspace-data@workspace-directory",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        workspaceData: workspacePlugin("workspace-data@workspace-directory"),
+      }),
       appCache,
       appCacheKey: "runtime",
       nowMs: 1,
@@ -413,11 +296,9 @@ describe("Codex plugin inventory", () => {
         if (method === "plugin/installed") {
           return pluginInstalled(
             [
-              pluginSummary("other-workspace-data@workspace-directory", {
+              activePlugin("other-workspace-data@workspace-directory", {
                 name: "Workspace Data",
                 remotePluginId: "wrong-workspace-data-id",
-                installed: true,
-                enabled: true,
               }),
               exactSummary,
             ],
@@ -448,22 +329,12 @@ describe("Codex plugin inventory", () => {
   it("uses only the cached installed snapshot for an installed curated plugin", async () => {
     const calls: unknown[] = [];
     await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            github: {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "github",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({ github: curatedPlugin("github") }),
       readPluginDetails: false,
       request: async (method, params) => {
         if (method === "plugin/installed") {
           calls.push(params);
-          return pluginInstalled([pluginSummary("github", { installed: true, enabled: true })]);
+          return pluginInstalled([activePlugin("github")]);
         }
         throw new Error(`unexpected request ${method}`);
       },
@@ -475,26 +346,16 @@ describe("Codex plugin inventory", () => {
   it("fails closed before plugin/read when a workspace summary lacks remotePluginId", async () => {
     const calls: string[] = [];
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            workspaceData: {
-              marketplaceName: CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
-              pluginName: "workspace-data@workspace-directory",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        workspaceData: workspacePlugin("workspace-data@workspace-directory"),
+      }),
       request: async (method) => {
         calls.push(method);
         if (method === "plugin/installed") {
           return pluginInstalled(
             [
-              pluginSummary("workspace-data@workspace-directory", {
+              activePlugin("workspace-data@workspace-directory", {
                 name: "Workspace Data",
-                installed: true,
-                enabled: true,
               }),
             ],
             { name: CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME, path: null },
@@ -513,27 +374,16 @@ describe("Codex plugin inventory", () => {
 
   it("keeps curated records when a configured workspace marketplace is missing", async () => {
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            github: {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "github",
-            },
-            workspaceData: {
-              marketplaceName: CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
-              pluginName: "workspace-data@workspace-directory",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        github: curatedPlugin("github"),
+        workspaceData: workspacePlugin("workspace-data@workspace-directory"),
+      }),
       readPluginDetails: false,
       request: async (method) => {
         if (method !== "plugin/installed") {
           throw new Error(`unexpected request ${method}`);
         }
-        return pluginInstalled([pluginSummary("github", { installed: true, enabled: true })]);
+        return pluginInstalled([activePlugin("github")]);
       },
     });
 
@@ -549,32 +399,18 @@ describe("Codex plugin inventory", () => {
   it("diagnoses every missing workspace owner from the canonical installed snapshot", async () => {
     const calls: Array<{ method: string; params: unknown }> = [];
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            github: {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "github",
-            },
-            workspaceData: {
-              marketplaceName: CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
-              pluginName: "workspace-data@workspace-directory",
-            },
-            workspaceMetrics: {
-              marketplaceName: CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
-              pluginName: "workspace-metrics@workspace-directory",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        github: curatedPlugin("github"),
+        workspaceData: workspacePlugin("workspace-data@workspace-directory"),
+        workspaceMetrics: workspacePlugin("workspace-metrics@workspace-directory"),
+      }),
       readPluginDetails: false,
       request: async (method, params) => {
         calls.push({ method, params });
         if (method !== "plugin/installed") {
           throw new Error(`unexpected request ${method}`);
         }
-        return pluginInstalled([pluginSummary("github", { installed: true, enabled: true })]);
+        return pluginInstalled([activePlugin("github")]);
       },
     });
 
@@ -604,17 +440,9 @@ describe("Codex plugin inventory", () => {
     const failure = new Error("plugin/installed transport closed");
     await expect(
       readCodexPluginInventory({
-        pluginConfig: {
-          codexPlugins: {
-            enabled: true,
-            plugins: {
-              workspaceData: {
-                marketplaceName: CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
-                pluginName: "workspace-data@workspace-directory",
-              },
-            },
-          },
-        },
+        pluginConfig: pluginConfig({
+          workspaceData: workspacePlugin("workspace-data@workspace-directory"),
+        }),
         readPluginDetails: false,
         request: async (method) => {
           if (method === "plugin/installed") {
@@ -627,32 +455,17 @@ describe("Codex plugin inventory", () => {
   });
 
   it("fails closed when plugin detail apps are absent from app inventory", async () => {
-    const appCache = new CodexAppInventoryCache();
-    await appCache.refreshNow({
-      key: "runtime",
-      nowMs: 0,
-      request: async (method, params) => codexAppInventoryResponse(method, [], params),
-    });
+    const appCache = await cachedApps();
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            "google-calendar": {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        "google-calendar": curatedPlugin("google-calendar"),
+      }),
       appCache,
       appCacheKey: "runtime",
       nowMs: 1,
       request: async (method) => {
         if (method === "plugin/installed") {
-          return pluginInstalled([
-            pluginSummary("google-calendar", { installed: true, enabled: true }),
-          ]);
+          return pluginInstalled([activePlugin("google-calendar")]);
         }
         if (method === "plugin/read") {
           return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
@@ -677,34 +490,19 @@ describe("Codex plugin inventory", () => {
   });
 
   it("keeps an authorized disabled plugin app distinct from an authentication failure", async () => {
-    const appCache = new CodexAppInventoryCache();
     const disabledApp = { ...appInfo("google-calendar-app", true), isEnabled: false };
-    await appCache.refreshNow({
-      key: "runtime",
-      nowMs: 0,
-      request: async (method, params) => codexAppInventoryResponse(method, [disabledApp], params),
-    });
+    const appCache = await cachedApps(disabledApp);
 
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            "google-calendar": {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        "google-calendar": curatedPlugin("google-calendar"),
+      }),
       appCache,
       appCacheKey: "runtime",
       nowMs: 1,
       request: async (method) => {
         if (method === "plugin/installed") {
-          return pluginInstalled([
-            pluginSummary("google-calendar", { installed: true, enabled: true }),
-          ]);
+          return pluginInstalled([activePlugin("google-calendar")]);
         }
         if (method === "plugin/read") {
           return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
@@ -727,30 +525,15 @@ describe("Codex plugin inventory", () => {
   });
 
   it("marks display-name-only app matches ambiguous instead of exposing app ids", async () => {
-    const appCache = new CodexAppInventoryCache();
-    await appCache.refreshNow({
-      key: "runtime",
-      nowMs: 0,
-      request: async (method, params) =>
-        codexAppInventoryResponse(
-          method,
-          [{ ...appInfo("calendar-app", true), pluginDisplayNames: ["Google Calendar"] }],
-          params,
-        ),
+    const appCache = await cachedApps({
+      ...appInfo("calendar-app", true),
+      pluginDisplayNames: ["Google Calendar"],
     });
 
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            "google-calendar": {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        "google-calendar": curatedPlugin("google-calendar"),
+      }),
       appCache,
       appCacheKey: "runtime",
       nowMs: 1,
@@ -758,10 +541,8 @@ describe("Codex plugin inventory", () => {
       request: async (method) => {
         if (method === "plugin/installed") {
           return pluginInstalled([
-            pluginSummary("google-calendar", {
+            activePlugin("google-calendar", {
               name: "Google Calendar",
-              installed: true,
-              enabled: true,
             }),
           ]);
         }
@@ -779,17 +560,9 @@ describe("Codex plugin inventory", () => {
   it("fails closed when the app inventory cache is missing", async () => {
     const appCache = new CodexAppInventoryCache();
     const inventory = await readCodexPluginInventory({
-      pluginConfig: {
-        codexPlugins: {
-          enabled: true,
-          plugins: {
-            "google-calendar": {
-              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-              pluginName: "google-calendar",
-            },
-          },
-        },
-      },
+      pluginConfig: pluginConfig({
+        "google-calendar": curatedPlugin("google-calendar"),
+      }),
       appCache,
       appCacheKey: "runtime",
       request: async (method) => {
@@ -797,9 +570,7 @@ describe("Codex plugin inventory", () => {
           return codexAppInventoryResponse(method, []);
         }
         if (method === "plugin/installed") {
-          return pluginInstalled([
-            pluginSummary("google-calendar", { installed: true, enabled: true }),
-          ]);
+          return pluginInstalled([activePlugin("google-calendar")]);
         }
         if (method === "plugin/read") {
           return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
@@ -816,6 +587,36 @@ describe("Codex plugin inventory", () => {
     ]);
   });
 });
+
+type ConfiguredPlugin = {
+  enabled?: boolean;
+  marketplaceName:
+    | typeof CODEX_PLUGINS_MARKETPLACE_NAME
+    | typeof CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME;
+  pluginName: string;
+};
+
+function pluginConfig(plugins: Record<string, ConfiguredPlugin>) {
+  return { codexPlugins: { enabled: true, plugins } };
+}
+
+function curatedPlugin(pluginName: string, options: { enabled?: boolean } = {}): ConfiguredPlugin {
+  return { marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME, pluginName, ...options };
+}
+
+function workspacePlugin(pluginName: string): ConfiguredPlugin {
+  return { marketplaceName: CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME, pluginName };
+}
+
+async function cachedApps(...apps: v2.AppInfo[]): Promise<CodexAppInventoryCache> {
+  const cache = new CodexAppInventoryCache();
+  await cache.refreshNow({
+    key: "runtime",
+    nowMs: 0,
+    request: async (method, params) => codexAppInventoryResponse(method, apps, params),
+  });
+  return cache;
+}
 
 function asPluginInstalled(listed: v2.PluginListResponse): v2.PluginInstalledResponse {
   const { featuredPluginIds: _featuredPluginIds, ...installed } = listed;
@@ -862,6 +663,10 @@ function pluginSummary(id: string, overrides: Partial<v2.PluginSummary> = {}): v
   };
 }
 
+function activePlugin(id: string, overrides: Partial<v2.PluginSummary> = {}): v2.PluginSummary {
+  return pluginSummary(id, { installed: true, enabled: true, ...overrides });
+}
+
 function pluginDetail(
   pluginName: string,
   apps: v2.AppSummary[],
@@ -874,7 +679,7 @@ function pluginDetail(
         marketplace.marketplacePath === undefined
           ? "/marketplaces/openai-curated"
           : marketplace.marketplacePath,
-      summary: pluginSummary(pluginName, { installed: true, enabled: true }),
+      summary: activePlugin(pluginName),
       description: null,
       skills: [],
       apps,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The Codex plugin-inventory test repeated full plugin policy, app-cache, and active-summary fixtures in each case. That duplication made the installed-snapshot, marketplace-gating, and app-ownership assertions harder to audit.

## Why This Change Was Made

Consolidates those repeated facts into small file-local builders while keeping the production owner and every test case unchanged. The single-file change removes 195 test LOC (+108/-303) with zero production LOC or behavior change.

## User Impact

No user-visible behavior changes. Maintainers get a smaller plugin inventory suite whose scenario-specific wire facts and assertions are easier to review.

## Evidence

- Exact head: `c1da9f3116480b72429094475006981dfe8f4901`
- AST parity: all 17 ordered test names and all 65 ordered matcher chains/expected arguments are identical to base.
- Blacksmith Testbox `tbx_01kz2699ksm2v8bp75zv350a3h` ([run](https://github.com/openclaw/openclaw/actions/runs/30768124929)):
  - untouched baseline target: 17/17
  - exact-head target: 17/17
  - sibling plugin/app/MCP suites: 124/124
  - `pnpm check:changed`: passed; extension-test typecheck and lint completed with zero warnings/errors
- `git diff --check`: passed.
- Central collision audit: clear for `extensions/codex/src/app-server/plugin-inventory.test.ts` through 2026-08-02T21:53:30.462Z.

Direct sibling Codex contract inspection at `ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff`:

- `codex-rs/app-server-protocol/src/protocol/v2/plugin.rs:129-190,607-707` — list/installed params and responses; availability, installed/enabled, opaque remote id, apps, and MCP fields.
- `codex-rs/app-server/src/request_processors/plugins.rs:554-606,810-885,1012-1049,1122-1164,1203-1207` — feature/workspace gates, installed snapshot, detail lookup, app/MCP ownership.
- `codex-rs/app-server-protocol/src/protocol/v2/mcp.rs:36-78` and `codex-rs/app-server/src/request_processors/mcp_processor.rs:305-388` — thread-scoped MCP detail, deterministic server ordering, and pagination.
- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:24-27,128-134` — thread dynamic-tool contract remains separate and untouched.
- `codex-rs/model-provider-info/src/lib.rs:35-38,244-262,332-367` — canonical provider remains `openai` across ChatGPT and API endpoints.
