### PR TITLE
fix(googlechat): retire expired approval-card actions

### DIFF
--- a/extensions/googlechat/src/approval-card-click.test.ts
+++ b/extensions/googlechat/src/approval-card-click.test.ts
@@ -2,6 +2,7 @@ import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildGoogleChatApprovalActionParameters,
+  getGoogleChatApprovalCardBinding,
   registerGoogleChatApprovalCardBinding,
   unregisterGoogleChatApprovalCardBindings,
 } from "./approval-card-actions.js";
@@ -130,6 +131,8 @@ describe("maybeHandleGoogleChatApprovalCardClick", () => {
       "token-common",
       "token-loser",
       "token-retry",
+      "token-stale-direct",
+      "token-stale-nested",
       "token-update-retry",
       "token-url",
     ]);
@@ -370,6 +373,54 @@ describe("maybeHandleGoogleChatApprovalCardClick", () => {
     ).resolves.toBe(true);
 
     expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      label: "direct approval-not-found gateway code",
+      token: "token-stale-direct",
+      error: Object.assign(new Error("approval is gone"), {
+        gatewayCode: "APPROVAL_NOT_FOUND",
+      }),
+    },
+    {
+      label: "approval-not-found gateway detail",
+      token: "token-stale-nested",
+      error: Object.assign(new Error("invalid approval request"), {
+        gatewayCode: "INVALID_REQUEST",
+        details: { reason: "APPROVAL_NOT_FOUND" },
+      }),
+    },
+  ])("consumes stale card tokens for $label and ignores later clicks", async ({ token, error }) => {
+    registerGoogleChatApprovalCardBinding({
+      token,
+      accountId: "default",
+      approvalId: "approval-stale",
+      approvalKind: "exec",
+      decision: "allow-once",
+      allowedDecisions: ["allow-once", "deny"],
+      spaceName: "spaces/AAA",
+      messageName: "spaces/AAA/messages/msg-1",
+      expiresAtMs: Date.now() + 60_000,
+    });
+    resolveApprovalOverGateway.mockRejectedValueOnce(error);
+    const target = createTarget();
+    const event = createCardClickEvent(token);
+
+    await expect(maybeHandleGoogleChatApprovalCardClick({ event, target })).resolves.toBe(true);
+
+    expect(getGoogleChatApprovalCardBinding(token)).toBeNull();
+    expect(target.runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("approval expired or no longer exists"),
+    );
+
+    await expect(maybeHandleGoogleChatApprovalCardClick({ event, target })).resolves.toBe(true);
+
+    expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
+    expect(updateGoogleChatMessage).not.toHaveBeenCalled();
+    expect(target.runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("unknown or expired card token"),
+    );
   });
 
   it("reports the canonical winner when another surface resolves first", async () => {

--- a/extensions/googlechat/src/approval-card-click.ts
+++ b/extensions/googlechat/src/approval-card-click.ts
@@ -2,6 +2,7 @@ import {
   resolveApprovalOverGateway,
   type ApprovalResolveResult,
 } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import { updateGoogleChatMessage } from "./api.js";
 import { googleChatApprovalAuth } from "./approval-auth.js";
 import {
@@ -94,6 +95,12 @@ export async function maybeHandleGoogleChatApprovalCardClick(params: {
       cardsV2: buildGoogleChatCanonicalApprovalTerminalCards(result),
     });
   } catch (error) {
+    if (isApprovalNotFoundError(error)) {
+      // Missing approvals cannot recover; retire the card instead of rearming its token.
+      completeGoogleChatApprovalCardBinding(token);
+      logIgnored(params.target, `approval expired or no longer exists id=${consumed.approvalId}`);
+      return true;
+    }
     releaseGoogleChatApprovalCardBinding(token);
     throw error;
   }


### PR DESCRIPTION
Closes #98432

## What Problem This Solves

Fixes an issue where clicking an expired or already-resolved Google Chat approval card repeatedly retried a missing gateway approval. The card action token was incorrectly made retryable even when the gateway had conclusively reported that the approval no longer exists.

## Why This Change Was Made

The Google Chat card-action owner now uses the existing public Plugin SDK approval-not-found classifier already shared by sibling transports. It consumes only the claimed terminal card token, logs the stale approval, and returns handled. Transient gateway failures and card-update failures still release their token and remain retryable. Authorization, action routing, gateway contracts, and plugin configuration are unchanged.

## User Impact

Expired approval cards stop generating repeated failed gateway requests. Valid approvals, simultaneous decisions, unauthorized actors, transient retries, and later card updates keep their existing behavior.

## Evidence

- Reproduced the exact reported production card lifecycle before the fix: clicking the same token twice retried the missing approval twice.
- Added real same-token double-click regressions for both canonical gateway error representations: direct APPROVAL_NOT_FOUND and nested INVALID_REQUEST/details.reason=APPROVAL_NOT_FOUND. Both failed before the fix and pass afterward.
- Current Google Chat approval-card owner suite: 10 tests pass, including existing authorization, canonical-winner, transient retry, and card-update retry behavior.
- Fresh independent reviewer ran all Google Chat card/action and shared approval-error suites: 3 files, 23 tests pass.
- Fresh independent xhigh autoreview explicitly included priorities P0 through P2 and reported no actionable findings.
- Exact previous issue-focused contributor PRs are closed; the remaining open plugin-cancellation draft owns a different issue and does not modify this card-click handler.

## Exact-Head Inspectable Runtime Verdict

Executed the actual Google Chat card-click handler and actual opaque-token lifecycle with a controlled mock Gateway resolver, matching the requested channel mock-gateway proof. Each case submits the identical authorized CARD_CLICKED event twice on the exact final head.

```json
{"head":"dccf4be16bd6961d5b38f20e0dfe3cfe17cd5c7d","direct":{"first":{"handled":true},"second":{"handled":true},"resolverCalls":1,"bindingConsumed":true},"nested":{"first":{"handled":true},"second":{"handled":true},"resolverCalls":1,"bindingConsumed":true},"transient":{"first":{"error":"gateway unavailable"},"second":{"error":"gateway unavailable"},"resolverCalls":2,"bindingConsumed":false}}
```

Direct and nested terminal gateway errors are each resolved exactly once and permanently consume the token; transient gateway failures retain the token and remain retryable. No Google OAuth credentials or external network calls are used.