### PR TITLE
test(system-agent): reuse shared verified binding

### DIFF
--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -53,6 +53,7 @@ const mocks = vi.hoisted(() => ({
   runSetupMemoryImportStep: vi.fn(),
   writeWizardConfigFile: vi.fn(),
   runCollectedChannelOnboardingPostWriteHooks: vi.fn(async () => {}),
+  sharedVerifiedInference: undefined as SystemAgentVerifiedInferenceBinding | undefined,
 }));
 
 type MemoryImportStepParams = Parameters<typeof runSetupMemoryImportStep>[0];
@@ -93,6 +94,23 @@ vi.mock("../plugins/providers.js", async (importOriginal) => ({
   resolveOwningPluginIdsForModelRefs: vi.fn(() => []),
   resolveOwningPluginIdsForProviderRef: vi.fn(() => []),
 }));
+
+vi.mock("./verified-inference.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./verified-inference.js")>();
+  return {
+    ...actual,
+    resolveSystemAgentVerifiedInferenceRoute: (
+      ...args: Parameters<typeof actual.resolveSystemAgentVerifiedInferenceRoute>
+    ) => {
+      // Most cases own chat state, not inference ownership. Explicit bindings
+      // still run the real resolver so every drift and apply-boundary test stays end-to-end.
+      if (args[0] === mocks.sharedVerifiedInference) {
+        return Promise.resolve(args[0].execution);
+      }
+      return actual.resolveSystemAgentVerifiedInferenceRoute(...args);
+    },
+  };
+});
 
 const tempDirs: string[] = [];
 
@@ -311,6 +329,7 @@ beforeAll(async () => {
     sharedVerifiedInferenceConfig,
   );
   sharedVerifiedInference = fixture.binding;
+  mocks.sharedVerifiedInference = fixture.binding;
   sharedVerifiedInferenceDeps = fixture.deps;
   mocks.readConfigFileSnapshot.mockResolvedValue(
     configSnapshot(structuredClone(sharedVerifiedInferenceConfig)) as never,
@@ -1357,11 +1376,13 @@ describe("SystemAgentChatEngine", () => {
         },
       },
     };
+    const verifiedInference = await createAmbientVerifiedBinding(baseConfig);
     // The route flips between the final turn's entry gate and the
     // persistent-apply recheck; only the apply boundary can catch it.
     let baseReadsRemaining = Number.POSITIVE_INFINITY;
     const engine = new SystemAgentChatEngine({
       surface: "gateway",
+      verifiedInference,
       runAgentTurn: async () => null,
       planWithAssistant: async () => null,
       deps: {


### PR DESCRIPTION
## Summary

- reuse the suite's already verified shared inference binding for chat-state and wizard cases
- delegate every explicit binding to the real verified-route resolver so auth, route-drift, and apply-boundary tests remain end-to-end
- convert the Gateway persistent-apply boundary regression to an explicit ambient binding

No production code, test configuration, worker count, or sharding changes.

## Performance

- chat-engine baseline: 110.26s Vitest / 103.88s test bodies
- patched chat-engine: 30.50s Vitest / 27.97s test bodies
- improvement: 72.3% Vitest duration and 73.1% test-body time

The suite made 144 `engine.handle()` calls; most own chat state rather than inference ownership, yet each repeatedly projected the same verified route.

## Proof

- chat-engine: 92/92 passed
- verified-inference owner: 35/35 passed
- rebased combined run: 127/127 passed in 33.96s Vitest duration
- targeted `oxfmt`, `oxlint`, and `git diff --check` passed
- autoreview clean with no accepted/actionable findings

Test-only change; no changelog entry.
