### PR TITLE
test(agents): fixture harness provider discovery

### DIFF
--- a/src/agents/harness/registry.test.ts
+++ b/src/agents/harness/registry.test.ts
@@ -14,10 +14,23 @@ import {
 import { selectAgentHarness } from "./selection.js";
 import type { AgentHarness } from "./types.js";
 
+const resolveProviderRefOwnership = vi.hoisted(() => vi.fn(() => ({ status: "unowned" as const })));
+
+// Registry tests exercise selection handoff; provider owner/route tests own the real artifacts,
+// which would cold-load bundled plugin surfaces for this synthetic provider config.
+vi.mock("../../plugins/providers.js", () => ({
+  resolveProviderRefOwnership,
+}));
+vi.mock("../../plugins/provider-model-routes.js", () => ({
+  resolveProviderModelCatalogId: () => null,
+  resolveProviderModelRoutes: () => null,
+}));
+
 const originalRuntime = process.env.OPENCLAW_AGENT_RUNTIME;
 
 beforeEach(() => {
   clearAgentHarnesses();
+  resolveProviderRefOwnership.mockClear();
 });
 
 afterEach(() => {
@@ -204,13 +217,18 @@ describe("agent harness registry", () => {
     registerAgentHarness(makeHarness("custom", { providers: ["anthropic"] }), {
       ownerPluginId: "plugin-a",
     });
+    const config = providerRuntimeConfig("anthropic", "custom");
 
     expect(
       selectAgentHarness({
         provider: "anthropic",
         modelId: "sonnet-4.6",
-        config: providerRuntimeConfig("anthropic", "custom"),
+        config,
       }).id,
     ).toBe("custom");
+    expect(resolveProviderRefOwnership).toHaveBeenCalledWith({
+      provider: "anthropic",
+      config,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- keep the harness registry suite on deterministic provider ownership and route-artifact seams
- preserve the registry-to-selection handoff and assert the exact provider/config ownership call
- leave real ownership classification and route discovery in their dedicated provider owner suites

No production code, test configuration, worker count, or sharding changes.

## Performance

- registry baseline: 31.67s Vitest / 27.68s test bodies / 1.87GB RSS
- patched registry: 3.93s Vitest / 10ms test bodies / 945MB RSS
- improvement: 87.6% Vitest duration, effectively all test-body overhead, and 49.5% RSS

The slow registry assertion used a synthetic provider config but accidentally cold-loaded every plugin metadata artifact through ownership and route discovery.

## Proof

- [inspectable reviewed-head terminal proof](https://github.com/openclaw/openclaw/pull/118228#issuecomment-5160569824): registry/selection 114/114 and provider owners/routes 82/82 passed with duration and RSS
- exact-head CI is green
- targeted `oxfmt`, `oxlint`, and `git diff --check` passed
- autoreview clean with no accepted/actionable findings

Test-only change; no changelog entry.
