### PR TITLE
test(macos): consolidate Codex catalog fixtures

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -6,10 +6,21 @@ import Testing
 
 @Suite(.serialized)
 struct MacNodeCodexThreadCatalogTests {
-    private struct FakeCodex {
-        var directory: URL
-        var executable: URL
-        var capture: URL
+    private final class FakeCodex: Sendable {
+        let directory: URL
+        let executable: URL
+        var capture: URL {
+            URL(fileURLWithPath: self.executable.path + ".requests")
+        }
+
+        init(directory: URL, executable: URL) {
+            self.directory = directory
+            self.executable = executable
+        }
+
+        deinit {
+            try? FileManager.default.removeItem(at: self.directory)
+        }
     }
 
     private func makeFakeCodex(_ script: String) throws -> FakeCodex {
@@ -19,10 +30,108 @@ struct MacNodeCodexThreadCatalogTests {
         let executable = directory.appendingPathComponent("codex")
         try script.write(to: executable, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
-        return FakeCodex(
-            directory: directory,
-            executable: executable,
-            capture: URL(fileURLWithPath: executable.path + ".requests"))
+        return FakeCodex(directory: directory, executable: executable)
+    }
+
+    private func makeAppServer(
+        preamble: String = "",
+        initializeResult: String = "{}",
+        captureHandshake: Bool = false,
+        body: String) throws -> FakeCodex
+    {
+        let captureCommand = captureHandshake ? "printf" : ":"
+        return try self.makeFakeCodex(#"""
+        #!/bin/sh
+        \#(preamble)
+        IFS= read -r initialize || exit 2
+        \#(captureCommand) '%s\n' "$initialize" >> "${0}.requests"
+        id=$(printf '%s\n' "$initialize" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
+        printf '{"id":%s,"result":\#(initializeResult)}\n' "$id"
+        IFS= read -r initialized || exit 3
+        \#(captureCommand) '%s\n' "$initialized" >> "${0}.requests"
+        \#(body)
+        """#)
+    }
+
+    private func makeEmptyListServer(
+        tracksLaunches: Bool = false,
+        terminatesOnSignal: Bool = false,
+        captureHandshake: Bool = false,
+        exitsAfterResponse: Bool = false) throws -> FakeCodex
+    {
+        var preamble: [String] = []
+        if tracksLaunches {
+            preamble.append(#"""
+            count=0
+            [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
+            printf '%s\n' "$((count + 1))" > "${0}.processes"
+            """#)
+        }
+        if terminatesOnSignal {
+            preamble.append(#"trap 'touch "${0}.terminated"; exit 0' TERM"#)
+        }
+        let body = exitsAfterResponse ? #"""
+        IFS= read -r request || exit 4
+        id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
+        printf '{"id":%s,"result":{"data":[]}}\n' "$id"
+        """# : #"""
+        while IFS= read -r request; do
+          printf '%s\n' "$request" >> "${0}.requests"
+          id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
+          printf '{"id":%s,"result":{"data":[],"nextCursor":null,"backwardsCursor":null}}\n' "$id"
+        done
+        """#
+        return try self.makeAppServer(
+            preamble: preamble.joined(separator: "\n"),
+            captureHandshake: captureHandshake,
+            body: body)
+    }
+
+    private func makeBlockedFirstRequestServer() throws -> FakeCodex {
+        try self.makeAppServer(
+            preamble: #"""
+            count=0
+            [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
+            count=$((count + 1))
+            printf '%s\n' "$count" > "${0}.processes"
+            """#,
+            body: #"""
+            IFS= read -r request || exit 4
+            if [ "$count" = 1 ]; then
+              touch "${0}.request-started"
+              sleep 5
+              exit 0
+            fi
+            id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
+            printf '{"id":%s,"result":{"data":[]}}\n' "$id"
+            """#)
+    }
+
+    private func codexRoot(
+        config: Any = ["supervision": ["enabled": true]],
+        entryKey: String = "codex",
+        enabled: Bool? = true,
+        pluginPolicy: [String: Any] = [:]) -> [String: Any]
+    {
+        var entry: [String: Any] = ["config": config]
+        if let enabled {
+            entry["enabled"] = enabled
+        }
+        var plugins = pluginPolicy
+        plugins["entries"] = [entryKey: entry]
+        return ["plugins": plugins]
+    }
+
+    private func codexRoot(
+        appServer: [String: Any],
+        pluginPolicy: [String: Any] = [:]) -> [String: Any]
+    {
+        self.codexRoot(
+            config: [
+                "supervision": ["enabled": true],
+                "appServer": appServer,
+            ],
+            pluginPolicy: pluginPolicy)
     }
 
     private func listResponseJSON(
@@ -30,11 +139,7 @@ struct MacNodeCodexThreadCatalogTests {
         names: [String],
         nextCursor: String?) throws -> String
     {
-        let encodedNextCursor: Any = if let nextCursor {
-            nextCursor
-        } else {
-            NSNull()
-        }
+        let encodedNextCursor: Any = nextCursor.map { $0 as Any } ?? NSNull()
         let threads: [[String: Any]] = names.enumerated().map { index, name in
             [
                 "id": "thread-\(name)-\(index)",
@@ -189,38 +294,30 @@ struct MacNodeCodexThreadCatalogTests {
         let clearEnvSentinel = "OPENCLAW_CODEX_CATALOG_CLEAR_ENV_SENTINEL"
         _ = setenv(clearEnvSentinel, "present", 1)
         defer { _ = unsetenv(clearEnvSentinel) }
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        [ "$1" = "custom-app-server" ] || exit 10
-        [ "$2" = "--stdio" ] || exit 11
-        [ -z "${OPENCLAW_CODEX_CATALOG_CLEAR_ENV_SENTINEL+x}" ] || exit 12
-        IFS= read -r initialize || exit 2
-        printf '%s\n' '{"id":1,"result":{}}'
-        IFS= read -r initialized || exit 3
-        IFS= read -r list || exit 4
-        printf '%s\n' '{"id":2,"result":{"data":[],"nextCursor":null,"backwardsCursor":null}}'
-        sleep 1
-        """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
-        let root: [String: Any] = [
-            "plugins": [
-                "entries": [
-                    " codex ": [
-                        "enabled": true,
-                        "config": [
-                            "supervision": ["enabled": true],
-                            "appServer": [
-                                "transport": "stdio",
-                                "homeScope": "user",
-                                "command": fake.executable.path,
-                                "args": #"custom-app-server "--stdio" workspace\ path "C:\\Codex" 'literal\slash' tail\"#,
-                                "clearEnv": [" \(clearEnvSentinel) ", ""],
-                            ],
-                        ],
-                    ],
+        let fake = try makeAppServer(
+            preamble: #"""
+            [ "$1" = "custom-app-server" ] || exit 10
+            [ "$2" = "--stdio" ] || exit 11
+            [ -z "${OPENCLAW_CODEX_CATALOG_CLEAR_ENV_SENTINEL+x}" ] || exit 12
+            """#,
+            body: #"""
+            IFS= read -r list || exit 4
+            printf '%s\n' '{"id":2,"result":{"data":[],"nextCursor":null,"backwardsCursor":null}}'
+            sleep 1
+            """#)
+        defer { withExtendedLifetime(fake) {} }
+        let root = self.codexRoot(
+            config: [
+                "supervision": ["enabled": true],
+                "appServer": [
+                    "transport": "stdio",
+                    "homeScope": "user",
+                    "command": fake.executable.path,
+                    "args": #"custom-app-server "--stdio" workspace\ path "C:\\Codex" 'literal\slash' tail\"#,
+                    "clearEnv": [" \(clearEnvSentinel) ", ""],
                 ],
             ],
-        ]
+            entryKey: " codex ")
 
         let resolved = try MacNodeCodexThreadCatalog.resolveInvocation(
             root: root,
@@ -254,10 +351,6 @@ struct MacNodeCodexThreadCatalogTests {
     @Test func `uses official environment command and argument fallbacks`() throws {
         let fake = try makeFakeCodex("#!/bin/sh\nexit 0\n")
         let chatGPTApp = try makeFakeCodex("#!/bin/sh\nexit 0\n")
-        defer {
-            try? FileManager.default.removeItem(at: fake.directory)
-            try? FileManager.default.removeItem(at: chatGPTApp.directory)
-        }
         let missing = fake.directory.appendingPathComponent("missing").path
 
         let resolved = try MacNodeCodexThreadCatalog.resolveInvocation(
@@ -281,21 +374,9 @@ struct MacNodeCodexThreadCatalogTests {
     @Test func `configured command stays ahead of an installed ChatGPT app`() throws {
         let configured = try makeFakeCodex("#!/bin/sh\nexit 0\n")
         let chatGPTApp = try makeFakeCodex("#!/bin/sh\nexit 0\n")
-        defer {
-            try? FileManager.default.removeItem(at: configured.directory)
-            try? FileManager.default.removeItem(at: chatGPTApp.directory)
-        }
-        let root: [String: Any] = [
-            "plugins": [
-                "entries": [
-                    "codex": [
-                        "config": [
-                            "appServer": ["command": configured.executable.path],
-                        ],
-                    ],
-                ],
-            ],
-        ]
+        let root = self.codexRoot(
+            config: ["appServer": ["command": configured.executable.path]],
+            enabled: nil)
 
         let resolved = try MacNodeCodexThreadCatalog.resolveInvocation(
             root: root,
@@ -307,18 +388,9 @@ struct MacNodeCodexThreadCatalogTests {
 
     @Test func `blank configured command falls back to the environment command`() throws {
         let fallback = try makeFakeCodex("#!/bin/sh\nexit 0\n")
-        defer { try? FileManager.default.removeItem(at: fallback.directory) }
-        let root: [String: Any] = [
-            "plugins": [
-                "entries": [
-                    "codex": [
-                        "config": [
-                            "appServer": ["command": "  \n "],
-                        ],
-                    ],
-                ],
-            ],
-        ]
+        let root = self.codexRoot(
+            config: ["appServer": ["command": "  \n "]],
+            enabled: nil)
 
         let resolved = try MacNodeCodexThreadCatalog.resolveInvocation(
             root: root,
@@ -330,108 +402,98 @@ struct MacNodeCodexThreadCatalogTests {
 
     @Test func `complete official plugin config remains eligible for the catalog`() throws {
         let app = try makeFakeCodex("#!/bin/sh\nexit 0\n")
-        defer { try? FileManager.default.removeItem(at: app.directory) }
-        let root: [String: Any] = [
-            "plugins": [
-                "entries": [
-                    "codex": [
-                        "enabled": true,
-                        "config": [
-                            "codexDynamicToolsLoading": "direct",
-                            "codexDynamicToolsExclude": ["private_tool"],
-                            "discovery": ["enabled": true, "timeoutMs": 1000],
-                            "computerUse": [
-                                "enabled": false,
-                                "autoInstall": false,
-                                "marketplaceDiscoveryTimeoutMs": 1000,
-                                "marketplaceSource": "source",
-                                "marketplacePath": "path",
-                                "marketplaceName": "marketplace",
-                                "pluginName": "plugin",
-                                "mcpServerName": "server",
-                            ],
-                            // The TypeScript parser treats this subtree independently.
-                            "codexPlugins": 42,
-                            "supervision": [
-                                "enabled": true,
-                                "allowRawTranscripts": false,
-                                "allowWriteControls": false,
-                                "endpoints": [
-                                    [
-                                        "id": "local",
-                                        "label": "Local",
-                                        "transport": "stdio-proxy",
-                                        "command": "codex",
-                                        "args": ["app-server"],
-                                        "cwd": "/tmp",
-                                    ],
-                                    [
-                                        "id": "remote",
-                                        "label": "Remote",
-                                        "transport": "websocket",
-                                        "url": "wss://codex.example.test",
-                                        "authTokenEnv": "CODEX_TOKEN",
-                                    ],
-                                ],
-                            ],
-                            "appServer": [
-                                "mode": "guardian",
-                                "transport": "stdio",
-                                "homeScope": "user",
-                                "command": app.executable.path,
-                                "args": ["app-server", "--listen", "stdio://"],
-                                "url": "",
-                                "authToken": [
-                                    "source": "env",
-                                    "provider": "default",
-                                    "id": "CODEX_TOKEN",
-                                ],
-                                "headers": [
-                                    "x-file": [
-                                        "source": "file",
-                                        "provider": "mounted-json",
-                                        "id": "/codex/token~1value",
-                                    ],
-                                    "x-exec": [
-                                        "source": "exec",
-                                        "provider": "vault",
-                                        "id": "codex/token#value",
-                                    ],
-                                ],
-                                "clearEnv": ["OPENAI_API_KEY"],
-                                "remoteWorkspaceRoot": "/workspaces",
-                                "codeModeOnly": true,
-                                "requestTimeoutMs": 1000,
-                                "turnCompletionIdleTimeoutMs": 1000,
-                                "postToolRawAssistantCompletionIdleTimeoutMs": 1000,
-                                "approvalPolicy": "on-failure",
-                                "sandbox": "workspace-write",
-                                "approvalsReviewer": "user",
-                                "serviceTier": "priority",
-                                "networkProxy": [
-                                    "enabled": true,
-                                    "profileName": "openclaw",
-                                    "baseProfile": "workspace",
-                                    "mode": "limited",
-                                    "domains": ["example.test": "allow"],
-                                    "unixSockets": ["/tmp/service.sock": "allow"],
-                                    "proxyUrl": "http://127.0.0.1:8080",
-                                    "socksUrl": "socks5://127.0.0.1:1080",
-                                    "enableSocks5": true,
-                                    "enableSocks5Udp": false,
-                                    "allowUpstreamProxy": false,
-                                    "allowLocalBinding": false,
-                                    "dangerouslyAllowNonLoopbackProxy": false,
-                                    "dangerouslyAllowAllUnixSockets": false,
-                                ],
-                                "defaultWorkspaceDir": "",
-                                "experimental": ["sandboxExecServer": false],
-                            ],
-                        ],
+        let root = self.codexRoot(config: [
+            "codexDynamicToolsLoading": "direct",
+            "codexDynamicToolsExclude": ["private_tool"],
+            "discovery": ["enabled": true, "timeoutMs": 1000],
+            "computerUse": [
+                "enabled": false,
+                "autoInstall": false,
+                "marketplaceDiscoveryTimeoutMs": 1000,
+                "marketplaceSource": "source",
+                "marketplacePath": "path",
+                "marketplaceName": "marketplace",
+                "pluginName": "plugin",
+                "mcpServerName": "server",
+            ],
+            // The TypeScript parser treats this subtree independently.
+            "codexPlugins": 42,
+            "supervision": [
+                "enabled": true,
+                "allowRawTranscripts": false,
+                "allowWriteControls": false,
+                "endpoints": [
+                    [
+                        "id": "local",
+                        "label": "Local",
+                        "transport": "stdio-proxy",
+                        "command": "codex",
+                        "args": ["app-server"],
+                        "cwd": "/tmp",
+                    ],
+                    [
+                        "id": "remote",
+                        "label": "Remote",
+                        "transport": "websocket",
+                        "url": "wss://codex.example.test",
+                        "authTokenEnv": "CODEX_TOKEN",
                     ],
                 ],
             ],
-        ]
+            "appServer": [
+                "mode": "guardian",
+                "transport": "stdio",
+                "homeScope": "user",
+                "command": app.executable.path,
+                "args": ["app-server", "--listen", "stdio://"],
+                "url": "",
+                "authToken": [
+                    "source": "env",
+                    "provider": "default",
+                    "id": "CODEX_TOKEN",
+                ],
+                "headers": [
+                    "x-file": [
+                        "source": "file",
+                        "provider": "mounted-json",
+                        "id": "/codex/token~1value",
+                    ],
+                    "x-exec": [
+                        "source": "exec",
+                        "provider": "vault",
+                        "id": "codex/token#value",
+                    ],
+                ],
+                "clearEnv": ["OPENAI_API_KEY"],
+                "remoteWorkspaceRoot": "/workspaces",
+                "codeModeOnly": true,
+                "requestTimeoutMs": 1000,
+                "turnCompletionIdleTimeoutMs": 1000,
+                "postToolRawAssistantCompletionIdleTimeoutMs": 1000,
+                "approvalPolicy": "on-failure",
+                "sandbox": "workspace-write",
+                "approvalsReviewer": "user",
+                "serviceTier": "priority",
+                "networkProxy": [
+                    "enabled": true,
+                    "profileName": "openclaw",
+                    "baseProfile": "workspace",
+                    "mode": "limited",
+                    "domains": ["example.test": "allow"],
+                    "unixSockets": ["/tmp/service.sock": "allow"],
+                    "proxyUrl": "http://127.0.0.1:8080",
+                    "socksUrl": "socks5://127.0.0.1:1080",
+                    "enableSocks5": true,
+                    "enableSocks5Udp": false,
+                    "allowUpstreamProxy": false,
+                    "allowLocalBinding": false,
+                    "dangerouslyAllowNonLoopbackProxy": false,
+                    "dangerouslyAllowAllUnixSockets": false,
+                ],
+                "defaultWorkspaceDir": "",
+                "experimental": ["sandboxExecServer": false],
+            ],
+        ])
 
         #expect(MacNodeCodexThreadCatalog.shouldAdvertise(root: root))
         let invocation = try MacNodeCodexThreadCatalog.resolveInvocation(root: root, searchPaths: [])
@@ -441,7 +503,6 @@ struct MacNodeCodexThreadCatalogTests {
 
     @Test func `malformed or unknown official plugin config fails closed`() throws {
         let app = try makeFakeCodex("#!/bin/sh\nexit 0\n")
-        defer { try? FileManager.default.removeItem(at: app.directory) }
         var malformedConfigs: [Any] = [
             "enabled",
             ["supervision": ["enabled": true], "unknown": true] as [String: Any],
@@ -498,16 +559,7 @@ struct MacNodeCodexThreadCatalogTests {
         })
 
         for config in malformedConfigs {
-            let root: [String: Any] = [
-                "plugins": [
-                    "entries": [
-                        "codex": [
-                            "enabled": true,
-                            "config": config,
-                        ],
-                    ],
-                ],
-            ]
+            let root = self.codexRoot(config: config)
 
             #expect(!MacNodeCodexThreadCatalog.shouldAdvertise(root: root))
             #expect(throws: MacNodeCodexThreadCatalog.CatalogError.invalidAppServerConfiguration) {
@@ -520,45 +572,19 @@ struct MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `list authorizes and resolves one config snapshot`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        IFS= read -r initialize || exit 2
-        printf '%s\n' '{"id":1,"result":{}}'
-        IFS= read -r initialized || exit 3
+        let fake = try makeAppServer(body: #"""
         IFS= read -r list || exit 4
         printf '%s\n' '{"id":2,"result":{"data":[]}}'
         sleep 1
         """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
-        let enabled: [String: Any] = [
-            "plugins": [
-                "entries": [
-                    "codex": [
-                        "enabled": true,
-                        "config": [
-                            "supervision": ["enabled": true],
-                            "appServer": [
-                                "transport": "stdio",
-                                "homeScope": "user",
-                                "command": fake.executable.path,
-                                "args": ["app-server", "--listen", "stdio://"],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ]
-        let revoked: [String: Any] = [
-            "plugins": [
-                "deny": ["codex"],
-                "entries": [
-                    "codex": [
-                        "enabled": true,
-                        "config": ["supervision": ["enabled": true]],
-                    ],
-                ],
-            ],
-        ]
+        defer { withExtendedLifetime(fake) {} }
+        let enabled = self.codexRoot(appServer: [
+            "transport": "stdio",
+            "homeScope": "user",
+            "command": fake.executable.path,
+            "args": ["app-server", "--listen", "stdio://"],
+        ])
+        let revoked = self.codexRoot(pluginPolicy: ["deny": ["codex"]])
         var loadCount = 0
 
         let payload = try await MacNodeCodexThreadCatalog.list(paramsJSON: nil) {
@@ -573,40 +599,17 @@ struct MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `does not advertise when the plugin allowlist excludes Codex`() {
-        let root: [String: Any] = [
-            "plugins": [
-                "allow": ["discord"],
-                "entries": [
-                    "codex": [
-                        "enabled": true,
-                        "config": ["supervision": ["enabled": true]],
-                    ],
-                ],
-            ],
-        ]
+        let root = self.codexRoot(pluginPolicy: ["allow": ["discord"]])
 
         #expect(!MacNodeCodexThreadCatalog.shouldAdvertise(root: root))
     }
 
     @Test func `rejects agent home scope instead of exposing the user Codex home`() throws {
         let app = try makeFakeCodex("#!/bin/sh\nexit 0\n")
-        defer { try? FileManager.default.removeItem(at: app.directory) }
-        let root: [String: Any] = [
-            "plugins": [
-                "entries": [
-                    "codex": [
-                        "enabled": true,
-                        "config": [
-                            "supervision": ["enabled": true],
-                            "appServer": [
-                                "transport": "stdio",
-                                "homeScope": "agent",
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ]
+        let root = self.codexRoot(appServer: [
+            "transport": "stdio",
+            "homeScope": "agent",
+        ])
 
         #expect(!MacNodeCodexThreadCatalog.shouldAdvertise(root: root))
         #expect(throws: MacNodeCodexThreadCatalog.CatalogError.unsupportedAppServerHomeScope) {
@@ -620,29 +623,13 @@ struct MacNodeCodexThreadCatalogTests {
     @Test func `rejects configured non-stdio transports instead of spawning a local fallback`() throws {
         let app = try makeFakeCodex("#!/bin/sh\nexit 0\n")
         let pathCLI = try makeFakeCodex("#!/bin/sh\nexit 0\n")
-        defer {
-            try? FileManager.default.removeItem(at: app.directory)
-            try? FileManager.default.removeItem(at: pathCLI.directory)
-        }
 
         for transport in ["websocket", "unix"] {
-            let root: [String: Any] = [
-                "plugins": [
-                    "entries": [
-                        "codex": [
-                            "enabled": true,
-                            "config": [
-                                "supervision": ["enabled": true],
-                                "appServer": [
-                                    "transport": transport,
-                                    "command": "/must/not/win",
-                                    "args": ["must-not-win"],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ]
+            let root = self.codexRoot(appServer: [
+                "transport": transport,
+                "command": "/must/not/win",
+                "args": ["must-not-win"],
+            ])
 
             #expect(!MacNodeCodexThreadCatalog.shouldAdvertise(root: root))
             #expect(throws: MacNodeCodexThreadCatalog.CatalogError.unsupportedAppServerTransport) {
@@ -657,10 +644,6 @@ struct MacNodeCodexThreadCatalogTests {
     @Test func `finds a Codex app installed in the user Applications directory`() throws {
         let userApp = try makeFakeCodex("#!/bin/sh\nexit 0\n")
         let pathCLI = try makeFakeCodex("#!/bin/sh\nexit 0\n")
-        defer {
-            try? FileManager.default.removeItem(at: userApp.directory)
-            try? FileManager.default.removeItem(at: pathCLI.directory)
-        }
 
         let resolved = try MacNodeCodexThreadCatalog.resolveInvocation(
             root: [:],
@@ -677,10 +660,6 @@ struct MacNodeCodexThreadCatalogTests {
     @Test func `finds a Codex Beta app when stable app bundles are absent`() throws {
         let betaApp = try makeFakeCodex("#!/bin/sh\nexit 0\n")
         let pathCLI = try makeFakeCodex("#!/bin/sh\nexit 0\n")
-        defer {
-            try? FileManager.default.removeItem(at: betaApp.directory)
-            try? FileManager.default.removeItem(at: pathCLI.directory)
-        }
 
         let missing = betaApp.directory.appendingPathComponent("missing").path
         let resolved = try MacNodeCodexThreadCatalog.resolveInvocation(
@@ -700,10 +679,6 @@ struct MacNodeCodexThreadCatalogTests {
     @Test func `finds ChatGPT app in the user Applications directory`() throws {
         let chatGPTApp = try makeFakeCodex("#!/bin/sh\nexit 0\n")
         let pathCLI = try makeFakeCodex("#!/bin/sh\nexit 0\n")
-        defer {
-            try? FileManager.default.removeItem(at: chatGPTApp.directory)
-            try? FileManager.default.removeItem(at: pathCLI.directory)
-        }
         let missing = chatGPTApp.directory.appendingPathComponent("missing").path
 
         let resolved = try MacNodeCodexThreadCatalog.resolveInvocation(
@@ -723,11 +698,6 @@ struct MacNodeCodexThreadCatalogTests {
         let chatGPTApp = try makeFakeCodex("#!/bin/sh\nexit 0\n")
         let codexApp = try makeFakeCodex("#!/bin/sh\nexit 0\n")
         let codexBetaApp = try makeFakeCodex("#!/bin/sh\nexit 0\n")
-        defer {
-            try? FileManager.default.removeItem(at: chatGPTApp.directory)
-            try? FileManager.default.removeItem(at: codexApp.directory)
-            try? FileManager.default.removeItem(at: codexBetaApp.directory)
-        }
         let missing = chatGPTApp.directory.appendingPathComponent("missing").path
 
         let resolved = try MacNodeCodexThreadCatalog.resolveInvocation(
@@ -744,26 +714,20 @@ struct MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `fake App Server receives handshake and bounded list request`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        capture="${0}.requests"
-        IFS= read -r initialize || exit 2
-        printf '%s\n' "$initialize" > "$capture"
-        printf '%s' '{"id":1,"result":{"codexHome":"/Users/private/.codex",'
-        printf '%s\n' '"platformFamily":"unix","platformOs":"macos","userAgent":"fake"}}'
-        IFS= read -r initialized || exit 3
-        printf '%s\n' "$initialized" >> "$capture"
-        IFS= read -r list || exit 4
-        printf '%s\n' "$list" >> "$capture"
-        printf '%s' '{"id":2,"result":{"data":[{"id":"thread-1","sessionId":"session-1",'
-        printf '%s' '"name":"One","preview":"private transcript","cwd":"/work",'
-        printf '%s' '"status":{"type":"notLoaded"},"source":{"custom":"chatgpt"},'
-        printf '%s' '"path":"/private/rollout.jsonl","turns":[]},{"id":"thread-2",'
-        printf '%s' '"name":"Two","preview":"One","cwd":"/other",'
-        printf '%s\n' '"status":{"type":"notLoaded"}}],"nextCursor":null,"backwardsCursor":"back/+=="}}'
-        sleep 1
-        """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
+        let fake = try makeAppServer(
+            initializeResult: #"{"codexHome":"/Users/private/.codex","platformFamily":"unix","platformOs":"macos","userAgent":"fake"}"#,
+            captureHandshake: true,
+            body: #"""
+            IFS= read -r list || exit 4
+            printf '%s\n' "$list" >> "${0}.requests"
+            printf '%s' '{"id":2,"result":{"data":[{"id":"thread-1","sessionId":"session-1",'
+            printf '%s' '"name":"One","preview":"private transcript","cwd":"/work",'
+            printf '%s' '"status":{"type":"notLoaded"},"source":{"custom":"chatgpt"},'
+            printf '%s' '"path":"/private/rollout.jsonl","turns":[]},{"id":"thread-2",'
+            printf '%s' '"name":"Two","preview":"One","cwd":"/other",'
+            printf '%s\n' '"status":{"type":"notLoaded"}}],"nextCursor":null,"backwardsCursor":"back/+=="}}'
+            sleep 1
+            """#)
 
         let payload = try await MacNodeCodexThreadCatalog.list(
             paramsJSON: #"{"cursor":" cursor ","limit":25,"searchTerm":" oNe ","cwd":" /work "}"#,
@@ -801,41 +765,14 @@ struct MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `Mac node runtime reuses its owned App Server across invokes`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        count=0
-        [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
-        printf '%s\n' "$((count + 1))" > "${0}.processes"
-        IFS= read -r initialize || exit 2
-        printf '%s\n' "$initialize" >> "${0}.requests"
-        id=$(printf '%s\n' "$initialize" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{}}\n' "$id"
-        IFS= read -r initialized || exit 3
-        printf '%s\n' "$initialized" >> "${0}.requests"
-        while IFS= read -r request; do
-          printf '%s\n' "$request" >> "${0}.requests"
-          id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-          printf '{"id":%s,"result":{"data":[],"nextCursor":null,"backwardsCursor":null}}\n' "$id"
-        done
-        """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
-        let root: [String: Any] = [
-            "plugins": [
-                "entries": [
-                    "codex": [
-                        "enabled": true,
-                        "config": [
-                            "supervision": ["enabled": true],
-                            "appServer": [
-                                "transport": "stdio",
-                                "homeScope": "user",
-                                "command": fake.executable.path,
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ]
+        let fake = try makeEmptyListServer(
+            tracksLaunches: true,
+            captureHandshake: true)
+        let root = self.codexRoot(appServer: [
+            "transport": "stdio",
+            "homeScope": "user",
+            "command": fake.executable.path,
+        ])
         let client = MacNodeCodexThreadCatalogClient(
             idleTimeoutSeconds: 10,
             loadRoot: { root })
@@ -869,28 +806,15 @@ struct MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `reads one paginated transcript turn page from App Server`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        capture="${0}.requests"
-        counter="${0}.counter"
-        count=0
-        [ ! -f "$counter" ] || count=$(cat "$counter")
-        count=$((count + 1))
-        printf '%s\n' "$count" > "$counter"
-        IFS= read -r initialize || exit 2
-        printf '%s\n' "$initialize" >> "$capture"
-        printf '%s\n' '{"id":1,"result":{}}'
-        IFS= read -r initialized || exit 3
-        printf '%s\n' "$initialized" >> "$capture"
+        let fake = try makeAppServer(captureHandshake: true, body: #"""
         IFS= read -r list || exit 4
-        printf '%s\n' "$list" >> "$capture"
+        printf '%s\n' "$list" >> "${0}.requests"
         printf '%s\n' '{"id":2,"result":{"data":[{"id":"thread-1","name":"Task","status":{"type":"notLoaded"}}],"nextCursor":null,"backwardsCursor":null}}'
         IFS= read -r turns || exit 5
-        printf '%s\n' "$turns" >> "$capture"
+        printf '%s\n' "$turns" >> "${0}.requests"
         printf '%s\n' '{"id":3,"result":{"data":[{"id":"turn-1","items":[{"id":"item-1","type":"agentMessage","text":"full answer"}]}],"nextCursor":"turns-2","backwardsCursor":null}}'
         sleep 1
         """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
 
         let payload = try await MacNodeCodexThreadCatalog.turns(
             paramsJSON: #"{"threadId":" thread-1 ","cursor":" turns-1 ","limit":25}"#,
@@ -932,11 +856,7 @@ struct MacNodeCodexThreadCatalogTests {
             id: 4,
             names: ["Target two", "Target three"],
             nextCursor: "cursor-3")
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        IFS= read -r initialize || exit 2
-        printf '%s\n' '{"id":1,"result":{}}'
-        IFS= read -r initialized || exit 3
+        let fake = try makeAppServer(body: #"""
         count=0
         while IFS= read -r list; do
           count=$((count + 1))
@@ -949,7 +869,6 @@ struct MacNodeCodexThreadCatalogTests {
           esac
         done
         """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
 
         let payload = try await MacNodeCodexThreadCatalog.list(
             paramsJSON: #"{"limit":3,"searchTerm":"target"}"#,
@@ -987,11 +906,7 @@ struct MacNodeCodexThreadCatalogTests {
                 names: names,
                 nextCursor: "cursor-\(page)")
         }
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        IFS= read -r initialize || exit 2
-        printf '%s\n' '{"id":1,"result":{}}'
-        IFS= read -r initialized || exit 3
+        let fake = try makeAppServer(body: #"""
         count=0
         while IFS= read -r list; do
           count=$((count + 1))
@@ -1005,7 +920,6 @@ struct MacNodeCodexThreadCatalogTests {
           esac
         done
         """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
 
         let payload = try await MacNodeCodexThreadCatalog.list(
             paramsJSON: #"{"limit":40,"searchTerm":"target"}"#,
@@ -1029,11 +943,7 @@ struct MacNodeCodexThreadCatalogTests {
     @Test func `title search stops a native cursor cycle`() async throws {
         let first = try listResponseJSON(id: 2, names: ["Other one"], nextCursor: "same")
         let second = try listResponseJSON(id: 3, names: ["Other two"], nextCursor: "same")
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        IFS= read -r initialize || exit 2
-        printf '%s\n' '{"id":1,"result":{}}'
-        IFS= read -r initialized || exit 3
+        let fake = try makeAppServer(body: #"""
         count=0
         while IFS= read -r list; do
           count=$((count + 1))
@@ -1045,7 +955,6 @@ struct MacNodeCodexThreadCatalogTests {
           esac
         done
         """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
 
         let payload = try await MacNodeCodexThreadCatalog.list(
             paramsJSON: #"{"limit":40,"searchTerm":"target"}"#,
@@ -1061,39 +970,10 @@ struct MacNodeCodexThreadCatalogTests {
 
 extension MacNodeCodexThreadCatalogTests {
     @Test func `restarts the lifecycle client when the resolved invocation changes`() async throws {
-        let first = try makeFakeCodex(#"""
-        #!/bin/sh
-        count=0
-        [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
-        printf '%s\n' "$((count + 1))" > "${0}.processes"
-        trap 'touch "${0}.terminated"; exit 0' TERM
-        IFS= read -r initialize || exit 2
-        id=$(printf '%s\n' "$initialize" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{}}\n' "$id"
-        IFS= read -r initialized || exit 3
-        while IFS= read -r request; do
-          id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-          printf '{"id":%s,"result":{"data":[]}}\n' "$id"
-        done
-        """#)
-        let second = try makeFakeCodex(#"""
-        #!/bin/sh
-        count=0
-        [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
-        printf '%s\n' "$((count + 1))" > "${0}.processes"
-        IFS= read -r initialize || exit 2
-        id=$(printf '%s\n' "$initialize" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{}}\n' "$id"
-        IFS= read -r initialized || exit 3
-        while IFS= read -r request; do
-          id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-          printf '{"id":%s,"result":{"data":[]}}\n' "$id"
-        done
-        """#)
-        defer {
-            try? FileManager.default.removeItem(at: first.directory)
-            try? FileManager.default.removeItem(at: second.directory)
-        }
+        let first = try makeEmptyListServer(
+            tracksLaunches: true,
+            terminatesOnSignal: true)
+        let second = try makeEmptyListServer(tracksLaunches: true)
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 10)
 
         _ = try await self.requestEmptyList(client: client, executable: first.executable)
@@ -1109,20 +989,9 @@ extension MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `restarts the lifecycle client after the child exits`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        count=0
-        [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
-        printf '%s\n' "$((count + 1))" > "${0}.processes"
-        IFS= read -r initialize || exit 2
-        id=$(printf '%s\n' "$initialize" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{}}\n' "$id"
-        IFS= read -r initialized || exit 3
-        IFS= read -r request || exit 4
-        id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{"data":[]}}\n' "$id"
-        """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
+        let fake = try makeEmptyListServer(
+            tracksLaunches: true,
+            exitsAfterResponse: true)
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 10)
 
         _ = try await self.requestEmptyList(client: client, executable: fake.executable)
@@ -1135,19 +1004,7 @@ extension MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `shuts down an idle lifecycle client`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        trap 'touch "${0}.terminated"; exit 0' TERM
-        IFS= read -r initialize || exit 2
-        id=$(printf '%s\n' "$initialize" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{}}\n' "$id"
-        IFS= read -r initialized || exit 3
-        while IFS= read -r request; do
-          id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-          printf '{"id":%s,"result":{"data":[]}}\n' "$id"
-        done
-        """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
+        let fake = try makeEmptyListServer(terminatesOnSignal: true)
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 0.05)
 
         _ = try await self.requestEmptyList(client: client, executable: fake.executable)
@@ -1158,19 +1015,7 @@ extension MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `client deinit terminates its owned child`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        trap 'touch "${0}.terminated"; exit 0' TERM
-        IFS= read -r initialize || exit 2
-        id=$(printf '%s\n' "$initialize" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{}}\n' "$id"
-        IFS= read -r initialized || exit 3
-        while IFS= read -r request; do
-          id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-          printf '{"id":%s,"result":{"data":[]}}\n' "$id"
-        done
-        """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
+        let fake = try makeEmptyListServer(terminatesOnSignal: true)
         var client: CodexAppServerThreadClient? = CodexAppServerThreadClient(
             idleTimeoutSeconds: 10)
 
@@ -1184,26 +1029,23 @@ extension MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `oversized idle output resets the lifecycle client`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        count=0
-        [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
-        count=$((count + 1))
-        printf '%s\n' "$count" > "${0}.processes"
-        IFS= read -r initialize || exit 2
-        id=$(printf '%s\n' "$initialize" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{}}\n' "$id"
-        IFS= read -r initialized || exit 3
-        while IFS= read -r request; do
-          id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-          printf '{"id":%s,"result":{"data":[]}}\n' "$id"
-          if [ "$count" = 1 ]; then
-            sleep 0.1
-            printf '%512s\n' x
-          fi
-        done
-        """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
+        let fake = try makeAppServer(
+            preamble: #"""
+            count=0
+            [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
+            count=$((count + 1))
+            printf '%s\n' "$count" > "${0}.processes"
+            """#,
+            body: #"""
+            while IFS= read -r request; do
+              id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
+              printf '{"id":%s,"result":{"data":[]}}\n' "$id"
+              if [ "$count" = 1 ]; then
+                sleep 0.1
+                printf '%512s\n' x
+              fi
+            done
+            """#)
         let client = CodexAppServerThreadClient(
             idleTimeoutSeconds: 10,
             idleReadLimit: 128)
@@ -1224,26 +1066,7 @@ extension MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `timeout restarts the client without dropping the next request`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        count=0
-        [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
-        count=$((count + 1))
-        printf '%s\n' "$count" > "${0}.processes"
-        IFS= read -r initialize || exit 2
-        id=$(printf '%s\n' "$initialize" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{}}\n' "$id"
-        IFS= read -r initialized || exit 3
-        IFS= read -r request || exit 4
-        if [ "$count" = 1 ]; then
-          touch "${0}.request-started"
-          sleep 5
-          exit 0
-        fi
-        id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{"data":[]}}\n' "$id"
-        """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
+        let fake = try makeBlockedFirstRequestServer()
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 10)
 
         let first = Task {
@@ -1269,17 +1092,11 @@ extension MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `queued request consumes its wall-clock deadline`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        IFS= read -r initialize || exit 2
-        id=$(printf '%s\n' "$initialize" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{}}\n' "$id"
-        IFS= read -r initialized || exit 3
+        let fake = try makeAppServer(body: #"""
         IFS= read -r request || exit 4
         touch "${0}.request-started"
         sleep 5
         """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 10)
 
         let first = Task {
@@ -1307,26 +1124,7 @@ extension MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `cancellation restarts the client without dropping the next request`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        count=0
-        [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
-        count=$((count + 1))
-        printf '%s\n' "$count" > "${0}.processes"
-        IFS= read -r initialize || exit 2
-        id=$(printf '%s\n' "$initialize" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{}}\n' "$id"
-        IFS= read -r initialized || exit 3
-        IFS= read -r request || exit 4
-        if [ "$count" = 1 ]; then
-          touch "${0}.request-started"
-          sleep 5
-          exit 0
-        fi
-        id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf '{"id":%s,"result":{"data":[]}}\n' "$id"
-        """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
+        let fake = try makeBlockedFirstRequestServer()
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 10)
         let first = Task {
             try await self.requestEmptyList(
@@ -1366,18 +1164,14 @@ extension MacNodeCodexThreadCatalogTests {
         ])
         let response = try #require(String(data: responseData, encoding: .utf8))
         #expect(response.utf8.count > 64 * 1024)
-        let fake = try makeFakeCodex("""
-        #!/bin/sh
-        IFS= read -r initialize || exit 2
-        printf '%s\n' '{"id":1,"result":{}}'
-        IFS= read -r initialized || exit 3
+        let fake = try makeAppServer(body: #"""
         IFS= read -r list || exit 4
-        printf '%s\n' '\(response)'
+        printf '%s\n' '\#(response)'
         # Keep stdout open until the client closes stdin; completion must come
         # from draining the full JSONL frame, never from observing process EOF.
         IFS= read -r keep_open || exit 0
-        """)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
+        """#)
+        defer { withExtendedLifetime(fake) {} }
 
         let payload = try await MacNodeCodexThreadCatalog.list(
             paramsJSON: #"{"limit":50}"#,
@@ -1403,15 +1197,11 @@ extension MacNodeCodexThreadCatalogTests {
         ])
         let response = try #require(String(data: responseData, encoding: .utf8))
         #expect(response.utf8.count > 256 * 1024)
-        let fake = try makeFakeCodex("""
-        #!/bin/sh
-        IFS= read -r initialize || exit 2
-        printf '%s\n' '{"id":1,"result":{}}'
-        IFS= read -r initialized || exit 3
+        let fake = try makeAppServer(body: #"""
         IFS= read -r list || exit 4
-        printf '%s\n' '\(response)'
-        """)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
+        printf '%s\n' '\#(response)'
+        """#)
+        defer { withExtendedLifetime(fake) {} }
 
         let payload = try await MacNodeCodexThreadCatalog.list(
             paramsJSON: #"{"limit":100}"#,
@@ -1423,18 +1213,14 @@ extension MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `accepts coalesced JSONL frames within the per-frame limit`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        IFS= read -r initialize || exit 2
-        printf '%s\n' '{"id":1,"result":{}}'
-        IFS= read -r initialized || exit 3
+        let fake = try makeAppServer(body: #"""
         IFS= read -r list || exit 4
         printf '%s\n%s\n' \
           '{"method":"thread/started","params":{"padding":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}' \
           '{"id":2,"result":{"data":[]}}'
         sleep 1
         """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
+        defer { withExtendedLifetime(fake) {} }
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 10)
 
         let result = try await self.requestEmptyList(
@@ -1447,11 +1233,7 @@ extension MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `uses the active request frame limit after advancing the queue`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        IFS= read -r initialize || exit 2
-        printf '%s\n' '{"id":1,"result":{}}'
-        IFS= read -r initialized || exit 3
+        let fake = try makeAppServer(body: #"""
         IFS= read -r first || exit 4
         first_id=$(printf '%s\n' "$first" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
         touch "${0}.first-started"
@@ -1463,7 +1245,6 @@ extension MacNodeCodexThreadCatalogTests {
         printf '{"id":%s,"result":{"data":[],"padding":"%s"}}\n' "$second_id" "$padding"
         sleep 1
         """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 10)
 
         let first = Task {
@@ -1521,7 +1302,7 @@ extension MacNodeCodexThreadCatalogTests {
         printf '%512s\n' x
         sleep 1
         """#)
-        defer { try? FileManager.default.removeItem(at: oversized.directory) }
+        defer { withExtendedLifetime(oversized) {} }
         do {
             _ = try await MacNodeCodexThreadCatalog.list(
                 paramsJSON: nil,
@@ -1537,7 +1318,7 @@ extension MacNodeCodexThreadCatalogTests {
         IFS= read -r initialize || exit 2
         sleep 1
         """#)
-        defer { try? FileManager.default.removeItem(at: stalled.directory) }
+        defer { withExtendedLifetime(stalled) {} }
         do {
             _ = try await MacNodeCodexThreadCatalog.list(
                 paramsJSON: nil,
@@ -1550,16 +1331,14 @@ extension MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `App Server error details stay on node`() async throws {
-        let fake = try makeFakeCodex(#"""
-        #!/bin/sh
-        IFS= read -r initialize || exit 2
-        printf '%s\n' '{"id":1,"result":{"codexHome":"/private"}}'
-        IFS= read -r initialized || exit 3
-        IFS= read -r list || exit 4
-        printf '%s\n' '{"id":2,"error":{"code":-32000,"message":"private /Users/secret/path"}}'
-        sleep 1
-        """#)
-        defer { try? FileManager.default.removeItem(at: fake.directory) }
+        let fake = try makeAppServer(
+            initializeResult: #"{"codexHome":"/private"}"#,
+            body: #"""
+            IFS= read -r list || exit 4
+            printf '%s\n' '{"id":2,"error":{"code":-32000,"message":"private /Users/secret/path"}}'
+            sleep 1
+            """#)
+        defer { withExtendedLifetime(fake) {} }
 
         do {
             _ = try await MacNodeCodexThreadCatalog.list(


### PR DESCRIPTION
## Summary

Consolidate repeated macOS Codex App Server test scaffolding into fixture owners without changing production behavior or the test contract.

- make an immutable, checked-`Sendable` `FakeCodex` own its temporary directory lifetime
- centralize initialize/initialized JSONL handshakes and reusable empty-list, blocked-request, and plugin-config fixtures
- remove repeated inline process lifecycle scripts, cleanup blocks, and nested config envelopes

## Architecture and scope

Root cause: this suite repeated protocol handshakes, process lifecycle setup, cleanup ownership, and official-plugin config envelopes in individual tests. That made equivalent fixtures drift and left a 1,575-line test file dominated by setup.

The owning boundary is the test fixture layer in `MacNodeCodexThreadCatalogTests.swift`. The canonical repair keeps each behavior-specific script body at its test while moving only invariant handshake, lifecycle, config-envelope, and temp-directory ownership into suite helpers. Direct async calls that receive only a copied executable path explicitly keep the fixture owner alive through scope, so its `deinit` cleanup cannot unlink the executable before the child launches. Handshake capture remains opt-in; non-capturing fixtures use a shell no-op so title-search request logs remain list-only.

Removed paths: repeated initialize/initialized readers and response writers, repeated launch counters/signal traps, repeated timeout/cancellation first-request servers, repeated plugin entry envelopes, and manual temp-directory cleanup.

Production LOC delta: **0**. Test LOC: **1,575 → 1,354 (net −221)**; diff is +333/−554 in one test file.

## Contract proof

Before editing, I personally inspected the sibling Codex implementation and protocol:

- `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:311-475` (resume parameters, precedence, response), `:653-663` (archive contract), and `:1193-1347` (list filters/defaults/pagination)
- `../codex/codex-rs/app-server/src/request_processors/thread_processor.rs:195-215,481-540,735-742` (filter normalization and public entry points), `:1464-1542` (archive), `:2005-2102,4501-4613` (list), and `:3039-3795` (resume/live reattach/history load)

Both independent xhigh reviewers also personally inspected the sibling Codex checkout on the exact frozen head. Their direct citations additionally covered `protocol/v1.rs:27-74`, `protocol/common.rs:474-479,628-633,677-682,2575-2585`, `protocol/v2/thread.rs:1193-1252,1334-1347,1501-1533`, `initialize_processor.rs:44-154`, and `thread_processor.rs:519-540,735-742,1464-1542,2005-2103,2493-2535,3039-3225,3380-3410,3458-3716,4501-4585`.

The fixture handshake remains `initialize` → `initialized`; list responses retain Codex's `data`/cursor shape. Test declarations and assertion sites are unchanged byte-for-byte and in the same order: **38/38 `@Test` declarations** and **211/211 combined `@Test`/`#expect`/`#require`/`Issue.record` lines**.

Security/owner behavior stays asserted in the same tests: plugin allow/deny and fail-closed config parsing, remote capability authorization, non-archived interactive filtering, and stripping private transcript/path/git metadata and App Server error detail at the node boundary.

## Validation

Exact head: `915c3cd768b4c0cfc474e1b58512661abf5a249f`. Frozen diff SHA-256: `9751fe8df21c611ee57a0ce554540a4527249c72e1326cee73618c74e7b892e5`.

- Native Blacksmith macOS: [run 30770484096 / macos-swift](https://github.com/openclaw/openclaw/actions/runs/30770484096/job/91556746499) passed. It compiled and passed `MacNodeCodexThreadCatalogTests` in 3.460s, sibling `MacNodeClaudeSessionCatalogTests` in 0.788s, and all 1,600 tests in 177 suites.
- [macos-node](https://github.com/openclaw/openclaw/actions/runs/30770484096/job/91556746472) passed.
- Hosted exact-head [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/30770484096/job/91557439490) passed.
- Exact-head `node scripts/check-changed.mjs -- apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift` passed through fresh Blacksmith Testbox [run 30770964127](https://github.com/openclaw/openclaw/actions/runs/30770964127): all routed checks, 218 relevant tests (37 skipped), and the native schema guard.
- `swiftformat --lint apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift --config config/swiftformat`, `swiftc -parse`, and `git diff --check` passed.
- Exact test-title/assertion trace diff against `origin/main` is empty. Independent hashes for the ordered declaration and assertion traces also match base.
- Two independent xhigh reviews on the frozen head passed with no findings and personal direct Codex inspection.
- Final race-closed collision audit found this PR self-only on the target file and zero external open-PR matches after 365 updates, four pages, all seven oversized tails, and a closing race pass.

The first native macOS run proved the new reference fixture needed checked `Sendable` conformance before tests could compile. The first fresh-head review then caught an over-broad handshake capture that would have polluted list-only request logs. Both findings are repaired and all evidence above is from the final exact head.

ClawSweeper's latest rank-up moves are satisfied: completed inspectable exact-head native macOS proof is linked above, and three reviewers (author plus both independent xhigh reviewers) directly inspected and cited the sibling Codex protocol/processor source. No re-review round trip is required by repository policy.
