### PR TITLE
refactor: adopt canonical async serialization

### DIFF
--- a/src/agents/subagent-registry-helpers.test.ts
+++ b/src/agents/subagent-registry-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   logAnnounceGiveUp,
   reconcileOrphanedRestoredRuns,
   reconcileOrphanedRun,
+  resolveAnnounceRetryDelayMs,
   resolveSubagentArchiveAtMs,
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
@@ -29,6 +30,14 @@ function createRunEntry(overrides: Partial<SubagentRunRecord> = {}): SubagentRun
     ...overrides,
   };
 }
+
+describe("resolveAnnounceRetryDelayMs", () => {
+  it("preserves the exact retry schedule through attempt 10", () => {
+    expect(
+      Array.from({ length: 10 }, (_, index) => resolveAnnounceRetryDelayMs(index + 1)),
+    ).toEqual([1_000, 2_000, 4_000, 8_000, 8_000, 8_000, 8_000, 8_000, 8_000, 8_000]);
+  });
+});
 
 describe("capFrozenResultText", () => {
   it("preserves a valid UTF-8 prefix within the frozen-result byte budget", () => {

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -11,6 +11,7 @@ import { getRuntimeConfig } from "../config/config.js";
 import { resolveAgentIdFromSessionKey, resolveStorePath } from "../config/sessions.js";
 import { patchSessionEntry } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { computeBackoff } from "../infra/backoff.js";
 import { defaultRuntime } from "../runtime.js";
 import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
 import { getDeliveryAttemptCount, getDeliveryLastError } from "./subagent-delivery-state.js";
@@ -33,6 +34,13 @@ const MAX_ANNOUNCE_RETRY_DELAY_MS = 8_000;
 export const MAX_ANNOUNCE_RETRY_COUNT = 3;
 export const ANNOUNCE_EXPIRY_MS = 5 * 60_000;
 export const ANNOUNCE_COMPLETION_HARD_EXPIRY_MS = 30 * 60_000;
+
+const ANNOUNCE_RETRY_BACKOFF = {
+  initialMs: MIN_ANNOUNCE_RETRY_DELAY_MS,
+  maxMs: MAX_ANNOUNCE_RETRY_DELAY_MS,
+  factor: 2,
+  jitter: 0,
+};
 
 const FROZEN_RESULT_TEXT_MAX_BYTES = 100 * 1024;
 
@@ -57,11 +65,8 @@ export function capFrozenResultText(resultText: string): string {
 
 /** Computes bounded exponential backoff for subagent announce retries. */
 export function resolveAnnounceRetryDelayMs(retryCount: number) {
-  const boundedRetryCount = Math.max(0, Math.min(retryCount, 10));
   // retryCount is "attempts already made", so retry #1 waits 1s, then 2s, 4s...
-  const backoffExponent = Math.max(0, boundedRetryCount - 1);
-  const baseDelay = MIN_ANNOUNCE_RETRY_DELAY_MS * 2 ** backoffExponent;
-  return Math.min(baseDelay, MAX_ANNOUNCE_RETRY_DELAY_MS);
+  return computeBackoff(ANNOUNCE_RETRY_BACKOFF, Math.max(0, Math.min(retryCount, 10)));
 }
 
 function formatAnnounceGiveUpLogField(value: string): string {

--- a/src/auto-reply/reply/queue/recent-message-ids.ts
+++ b/src/auto-reply/reply/queue/recent-message-ids.ts
@@ -1,14 +1,9 @@
 // Recent-queue message-id dedupe shared by enqueue admission and abandonment release.
-import { pruneMapToMaxSize } from "../../../infra/map-size.js";
+import { resolveGlobalDedupeCache } from "../../../infra/dedupe.js";
 import { resolveGlobalSingleton } from "../../../shared/global-singleton.js";
 
 const RECENT_QUEUE_MESSAGE_ID_TTL_MS = 5 * 60 * 1000;
 const RECENT_QUEUE_MESSAGE_ID_MAX_SIZE = 10_000;
-
-type RecentQueueMessageIdRecord = {
-  ownerToken: object;
-  recordedAt: number;
-};
 
 type RecentQueueMessageIdOwnership = {
   key: string;
@@ -19,9 +14,12 @@ type RecentQueueMessageIdOwnership = {
  * Keep queued message-id dedupe shared across bundled chunks so redeliveries
  * are rejected no matter which chunk receives the enqueue call.
  */
-const RECENT_QUEUE_MESSAGE_IDS = resolveGlobalSingleton(
+const RECENT_QUEUE_MESSAGE_IDS = resolveGlobalDedupeCache(
   Symbol.for("openclaw.recentQueueMessageIdOwners"),
-  () => new Map<string, RecentQueueMessageIdRecord>(),
+  {
+    ttlMs: RECENT_QUEUE_MESSAGE_ID_TTL_MS,
+    maxSize: RECENT_QUEUE_MESSAGE_ID_MAX_SIZE,
+  },
 );
 
 /** Chunk-shared identity→key association so abandonment can free the entry. */
@@ -43,26 +41,8 @@ function resolveDedupeIdentity(run: DedupeOwnedRun): object {
   return run.turnAdoptionLifecycle ?? run;
 }
 
-function pruneRecentQueueMessageIds(now: number): void {
-  const cutoff = now - RECENT_QUEUE_MESSAGE_ID_TTL_MS;
-  for (const [key, record] of RECENT_QUEUE_MESSAGE_IDS) {
-    if (record.recordedAt <= cutoff) {
-      RECENT_QUEUE_MESSAGE_IDS.delete(key);
-    }
-  }
-  pruneMapToMaxSize(RECENT_QUEUE_MESSAGE_IDS, RECENT_QUEUE_MESSAGE_ID_MAX_SIZE);
-}
-
 export function peekRecentQueueMessageId(key: string, now = Date.now()): boolean {
-  const record = RECENT_QUEUE_MESSAGE_IDS.get(key);
-  if (!record) {
-    return false;
-  }
-  if (now - record.recordedAt >= RECENT_QUEUE_MESSAGE_ID_TTL_MS) {
-    RECENT_QUEUE_MESSAGE_IDS.delete(key);
-    return false;
-  }
-  return true;
+  return RECENT_QUEUE_MESSAGE_IDS.peek(key, now);
 }
 
 export function recordRecentQueueMessageId(
@@ -73,8 +53,7 @@ export function recordRecentQueueMessageId(
   const ownerToken = {};
   DEDUPE_IDENTITY_OWNERSHIPS.set(resolveDedupeIdentity(run), { key, ownerToken });
   RECENT_QUEUE_MESSAGE_IDS.delete(key);
-  RECENT_QUEUE_MESSAGE_IDS.set(key, { ownerToken, recordedAt: now });
-  pruneRecentQueueMessageIds(now);
+  RECENT_QUEUE_MESSAGE_IDS.check(key, now, ownerToken);
 }
 
 /**
@@ -91,9 +70,7 @@ export function releaseRecentQueueMessageId(run: DedupeOwnedRun): void {
   DEDUPE_IDENTITY_OWNERSHIPS.delete(identity);
   // The key may have expired and been re-recorded by a newer same-ID run.
   // Only the lifecycle that installed the current owner may release it.
-  if (RECENT_QUEUE_MESSAGE_IDS.get(ownership.key)?.ownerToken === ownership.ownerToken) {
-    RECENT_QUEUE_MESSAGE_IDS.delete(ownership.key);
-  }
+  RECENT_QUEUE_MESSAGE_IDS.delete(ownership.key, ownership.ownerToken);
 }
 
 export function resetRecentQueuedMessageIdDedupe(): void {

--- a/src/channels/message/ingress-retry-policy.test.ts
+++ b/src/channels/message/ingress-retry-policy.test.ts
@@ -11,6 +11,34 @@ import {
 describe("ingress retry policy", () => {
   it.each([
     {
+      name: "default cap",
+      config: undefined,
+      expected: [1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 64_000, 128_000, 180_000, 180_000],
+    },
+    {
+      name: "independent exponent cap",
+      config: { baseMs: 1_000, maxMs: 1_000_000 },
+      expected: [1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 64_000, 128_000, 256_000, 256_000],
+    },
+  ])("preserves the exact retry schedule through attempt 10: $name", ({ config, expected }) => {
+    expect(
+      expected.map((_, index) =>
+        resolveIngressRetryDelayMs(
+          {
+            receivedAt: 0,
+            attempts: index + 1,
+            lastAttemptAt: 0,
+            lastError: "boom",
+          },
+          config,
+          0,
+        ),
+      ),
+    ).toEqual(expected);
+  });
+
+  it.each([
+    {
       name: "no prior error → immediate",
       event: { receivedAt: 0, attempts: 2 },
       now: 10_000,

--- a/src/channels/message/ingress-retry-policy.ts
+++ b/src/channels/message/ingress-retry-policy.ts
@@ -3,6 +3,7 @@
  *
  * Channel-specific non-retryable classification stays out of core; pass it in.
  */
+import { computeBackoff } from "../../infra/backoff.js";
 
 export const DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS = 8;
 export const DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS = 24 * 60 * 60 * 1000;
@@ -66,8 +67,10 @@ export function resolveIngressRetryDelayMs(
   if (!event.lastError || event.lastAttemptAt === undefined || attempts <= 0) {
     return 0;
   }
-  const exponent = Math.min(attempts - 1, 8);
-  const delayMs = Math.min(maxMs, baseMs * 2 ** exponent);
+  const delayMs = computeBackoff(
+    { initialMs: baseMs, maxMs, factor: 2, jitter: 0 },
+    Math.min(attempts, 9),
+  );
   return Math.max(0, event.lastAttemptAt + delayMs - now);
 }
 

--- a/src/gateway/node-reapproval-coordinator.ts
+++ b/src/gateway/node-reapproval-coordinator.ts
@@ -8,6 +8,7 @@ import {
   type NodePairingSupersededRequest,
   type RequestNodePairingResult,
 } from "../infra/node-pairing.js";
+import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 import { createDeferred, type Deferred } from "../shared/deferred.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_NODE_REAPPROVAL,
@@ -15,7 +16,8 @@ import {
   createAuthRateLimiter,
   type RateLimitConfig,
 } from "./auth-rate-limit.js";
-import { withSerializedKeyedAttempt } from "./rate-limit-attempt-serialization.js";
+
+const pendingNodeReapprovalAttempts = new KeyedAsyncQueue();
 
 type ReapprovalRequestParams = {
   input: NodePairingRequestInput;
@@ -125,44 +127,38 @@ export function createNodeReapprovalCoordinator(
     state: NodeRequestState,
     request: QueuedRequest,
   ): void => {
-    void withSerializedKeyedAttempt({
-      key: `node-reapproval:${nodeId}`,
-      run: async () => {
-        try {
-          request.deferred.resolve(await executeRequest(request.params));
-        } catch (error) {
-          request.deferred.reject(error);
-        } finally {
-          finishActiveRequest(nodeId, state, request.fingerprint);
-        }
-      },
+    void pendingNodeReapprovalAttempts.enqueue(`node-reapproval:${nodeId}`, async () => {
+      try {
+        request.deferred.resolve(await executeRequest(request.params));
+      } catch (error) {
+        request.deferred.reject(error);
+      } finally {
+        finishActiveRequest(nodeId, state, request.fingerprint);
+      }
     });
   };
 
   const startQueuedRequest = (nodeId: string, state: NodeRequestState): void => {
-    void withSerializedKeyedAttempt({
-      key: `node-reapproval:${nodeId}`,
-      run: async () => {
-        const queued = state.queued;
-        if (!queued) {
-          return;
+    void pendingNodeReapprovalAttempts.enqueue(`node-reapproval:${nodeId}`, async () => {
+      const queued = state.queued;
+      if (!queued) {
+        return;
+      }
+      state.queued = undefined;
+      state.activeFingerprint = queued.fingerprint;
+      try {
+        queued.deferred.resolve(await executeRequest(queued.params));
+        for (const follower of queued.followers) {
+          follower.resolve(null);
         }
-        state.queued = undefined;
-        state.activeFingerprint = queued.fingerprint;
-        try {
-          queued.deferred.resolve(await executeRequest(queued.params));
-          for (const follower of queued.followers) {
-            follower.resolve(null);
-          }
-        } catch (error) {
-          queued.deferred.reject(error);
-          for (const follower of queued.followers) {
-            follower.reject(error);
-          }
-        } finally {
-          finishActiveRequest(nodeId, state, queued.fingerprint);
+      } catch (error) {
+        queued.deferred.reject(error);
+        for (const follower of queued.followers) {
+          follower.reject(error);
         }
-      },
+      } finally {
+        finishActiveRequest(nodeId, state, queued.fingerprint);
+      }
     });
   };
 
@@ -207,10 +203,10 @@ export function createNodeReapprovalCoordinator(
       return deferred.promise;
     },
     async finalizeCleanup(claim) {
-      return await withSerializedKeyedAttempt({
-        key: `node-reapproval:${claim.nodeId}`,
-        run: async () => await finalizeNodePairingCleanupClaim(claim),
-      });
+      return await pendingNodeReapprovalAttempts.enqueue(
+        `node-reapproval:${claim.nodeId}`,
+        async () => await finalizeNodePairingCleanupClaim(claim),
+      );
     },
     dispose() {
       disposed = true;

--- a/src/gateway/rate-limit-attempt-serialization.ts
+++ b/src/gateway/rate-limit-attempt-serialization.ts
@@ -13,22 +13,11 @@ function buildSerializationKey(ip: string | undefined, scope: string | undefined
   return `${normalizeScope(scope)}:${normalizeRateLimitClientIp(ip)}`;
 }
 
-/** Runs one attempt after prior work for the same stable key finishes. */
-export async function withSerializedKeyedAttempt<T>(params: {
-  key: string;
-  run: () => Promise<T>;
-}): Promise<T> {
-  return await pendingAttempts.enqueue(params.key, params.run);
-}
-
 /** Runs one rate-limit attempt after prior attempts for the same IP/scope finish. */
 export async function withSerializedRateLimitAttempt<T>(params: {
   ip: string | undefined;
   scope: string | undefined;
   run: () => Promise<T>;
 }): Promise<T> {
-  return await withSerializedKeyedAttempt({
-    key: buildSerializationKey(params.ip, params.scope),
-    run: params.run,
-  });
+  return await pendingAttempts.enqueue(buildSerializationKey(params.ip, params.scope), params.run);
 }

--- a/src/infra/dedupe.test.ts
+++ b/src/infra/dedupe.test.ts
@@ -60,4 +60,29 @@ describe("createDedupeCache", () => {
     expect(cache.size()).toBe(0);
     expect(cache.peek("a", 300)).toBe(false);
   });
+
+  it("releases an owned entry only for its current owner", () => {
+    const cache = createDedupeCache({ ttlMs: 1_000, maxSize: 10 });
+    const staleOwner = {};
+    const currentOwner = {};
+
+    cache.check("a", 100, staleOwner);
+    cache.delete("a");
+    cache.check("a", 200, currentOwner);
+    cache.delete("a", staleOwner);
+    expect(cache.peek("a", 300)).toBe(true);
+    expect(cache.check("a", 300)).toBe(true);
+
+    cache.delete("a", currentOwner);
+    expect(cache.peek("a", 400)).toBe(false);
+  });
+
+  it("prunes other entries at the exact TTL boundary", () => {
+    const cache = createDedupeCache({ ttlMs: 1_000, maxSize: 10 });
+
+    cache.check("expired", 100);
+    cache.check("current", 1_100);
+
+    expect(cache.size()).toBe(1);
+  });
 });

--- a/src/infra/dedupe.ts
+++ b/src/infra/dedupe.ts
@@ -71,7 +71,7 @@ export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
   };
 
   return {
-    check: (key, now = Date.now(), ownerToken) => {
+    check: (key, now = Date.now(), ownerToken = undefined) => {
       if (!key) {
         return false;
       }

--- a/src/infra/dedupe.ts
+++ b/src/infra/dedupe.ts
@@ -5,11 +5,11 @@ import { pruneMapToMaxSize } from "./map-size.js";
 
 /** Small in-memory TTL/LRU-style cache for replay and duplicate suppression. */
 export type DedupeCache = {
-  /** Returns true for a recent duplicate; records the key when it was not present. */
-  check: (key: string | undefined | null, now?: number) => boolean;
+  /** Returns true for a recent duplicate; records the key and optional owner when absent. */
+  check: (key: string | undefined | null, now?: number, ownerToken?: object) => boolean;
   /** Returns true for a recent duplicate without refreshing or recording the key. */
   peek: (key: string | undefined | null, now?: number) => boolean;
-  delete: (key: string | undefined | null) => void;
+  delete: (key: string | undefined | null, ownerToken?: object) => void;
   clear: () => void;
   size: () => number;
 };
@@ -27,18 +27,22 @@ export { resolveNonNegativeIntegerOption as resolveDedupeNonNegativeInteger };
 export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
   const ttlMs = resolveNonNegativeIntegerOption(options.ttlMs, 0);
   const maxSize = resolveNonNegativeIntegerOption(options.maxSize, 0);
-  const cache = new Map<string, number>();
+  const cache = new Map<string, { ownerToken?: object; recordedAt: number }>();
+
+  const record = (key: string, recordedAt: number, ownerToken?: object) => {
+    cache.delete(key);
+    cache.set(key, { recordedAt, ...(ownerToken ? { ownerToken } : {}) });
+  };
 
   const touch = (key: string, now: number) => {
-    cache.delete(key);
-    cache.set(key, now);
+    record(key, now, cache.get(key)?.ownerToken);
   };
 
   const prune = (now: number) => {
     const cutoff = ttlMs > 0 ? now - ttlMs : undefined;
     if (cutoff !== undefined) {
-      for (const [entryKey, entryTs] of cache) {
-        if (entryTs < cutoff) {
+      for (const [entryKey, entry] of cache) {
+        if (entry.recordedAt <= cutoff) {
           cache.delete(entryKey);
         }
       }
@@ -52,10 +56,10 @@ export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
 
   const hasUnexpired = (key: string, now: number, touchOnRead: boolean): boolean => {
     const existing = cache.get(key);
-    if (existing === undefined) {
+    if (!existing) {
       return false;
     }
-    if (ttlMs > 0 && now - existing >= ttlMs) {
+    if (ttlMs > 0 && now - existing.recordedAt >= ttlMs) {
       cache.delete(key);
       return false;
     }
@@ -67,14 +71,14 @@ export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
   };
 
   return {
-    check: (key, now = Date.now()) => {
+    check: (key, now = Date.now(), ownerToken) => {
       if (!key) {
         return false;
       }
       if (hasUnexpired(key, now, true)) {
         return true;
       }
-      touch(key, now);
+      record(key, now, ownerToken);
       prune(now);
       return false;
     },
@@ -84,8 +88,11 @@ export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
       }
       return hasUnexpired(key, now, false);
     },
-    delete: (key) => {
+    delete: (key, ownerToken) => {
       if (!key) {
+        return;
+      }
+      if (ownerToken && cache.get(key)?.ownerToken !== ownerToken) {
         return;
       }
       cache.delete(key);

--- a/src/infra/dedupe.ts
+++ b/src/infra/dedupe.ts
@@ -71,15 +71,16 @@ export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
   };
 
   return {
-    check: (key, now = Date.now(), ownerToken = undefined) => {
+    check: (key, now, ownerToken) => {
       if (!key) {
         return false;
       }
-      if (hasUnexpired(key, now, true)) {
+      const checkedAt = now ?? Date.now();
+      if (hasUnexpired(key, checkedAt, true)) {
         return true;
       }
-      record(key, now, ownerToken);
-      prune(now);
+      record(key, checkedAt, ownerToken);
+      prune(checkedAt);
       return false;
     },
     peek: (key, now = Date.now()) => {

--- a/src/meeting-bot/session-transcript-store.ts
+++ b/src/meeting-bot/session-transcript-store.ts
@@ -1,3 +1,4 @@
+import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 import type {
   MeetingSessionRecord,
   MeetingTranscriptLine,
@@ -69,7 +70,7 @@ export class MeetingTranscriptDeliveryError extends Error {
 
 export class MeetingSessionTranscriptStore<TSession extends MeetingSessionRecord> {
   readonly #transcripts = new Map<string, RetainedTranscriptSnapshot>();
-  readonly #captures = new Map<string, Promise<void>>();
+  readonly #captures = new KeyedAsyncQueue();
   readonly #finalizing = new Set<string>();
   readonly #pendingLines = new Map<string, PendingTranscriptLine[]>();
   readonly #retired = new Set<string>();
@@ -162,93 +163,91 @@ export class MeetingSessionTranscriptStore<TSession extends MeetingSessionRecord
   ): Promise<void> {
     // Live reads, periodic notes, and finalization share this per-session chain.
     // Keep cursor reads inside it so overlapping snapshots cannot deliver twice.
-    const previous = this.#captures.get(session.id) ?? Promise.resolve();
-    const capture = previous
-      .catch(() => {})
-      .then(async () => {
-        let pendingError: MeetingTranscriptDeliveryError | undefined;
-        try {
-          await this.#flushPending(session);
-        } catch (error) {
-          if (pendingOnly) {
-            throw error;
-          }
-          pendingError = error as MeetingTranscriptDeliveryError;
-        }
-        if (pendingOnly) {
-          return;
-        }
-        if (
-          !this.options.isBrowserSession(session) ||
-          (requireTranscribeMode && !this.options.isTranscribeSession(session)) ||
-          !this.options.hasBrowserTab(session)
-        ) {
-          if (pendingError) {
-            throw pendingError;
-          }
-          return;
-        }
-        let snapshot: MeetingTranscriptSnapshot | undefined;
-        try {
-          snapshot = await this.options.capture(session, options);
-        } catch (error) {
-          if (pendingError) {
-            throw new MeetingTranscriptDeliveryError(pendingError.cause ?? pendingError, error);
-          }
-          throw error;
-        }
-        if (snapshot) {
-          if (this.options.isTranscribeSession(session)) {
-            this.#merge(session.id, snapshot);
-          }
-          const pending = this.#pendingLines.get(session.id);
-          const cursor = pending?.at(-1)?.cursor ?? this.#streamCursors.get(session.id);
-          const delta = this.#snapshotDelta(cursor, snapshot);
-          if (pendingError) {
-            if (delta.lines.length > 0) {
-              this.#queuePending(session.id, snapshot, delta, 0, delta.prefixKeys, true);
-            } else if (delta.commitEmpty) {
-              this.#queuePendingCursor(session.id, {
-                pageEpoch: snapshot.epoch,
-                pageNextIndex: snapshot.droppedLines + snapshot.lines.length,
-                tailKeys: delta.prefixKeys,
-              });
-            }
-            throw pendingError;
-          }
-          let tailKeys = [...delta.prefixKeys];
-          for (const [index, line] of delta.lines.entries()) {
-            try {
-              await this.options.onLines?.(session, [line]);
-            } catch (error) {
-              this.#queuePending(session.id, snapshot, delta, index, tailKeys);
-              throw new MeetingTranscriptDeliveryError(error);
-            }
-            tailKeys = [...tailKeys, transcriptLineKey(line)].slice(-TRANSCRIPT_CURSOR_TAIL);
-            this.#streamCursors.set(session.id, {
-              pageEpoch: snapshot.epoch,
-              pageNextIndex: delta.startIndex + index + 1,
-              tailKeys,
-            });
-          }
-          if (delta.lines.length === 0 && delta.commitEmpty) {
-            this.#streamCursors.set(session.id, {
-              pageEpoch: snapshot.epoch,
-              pageNextIndex: snapshot.droppedLines + snapshot.lines.length,
-              tailKeys: delta.prefixKeys,
-            });
-          }
-        } else if (pendingError) {
-          throw pendingError;
-        }
-      });
-    this.#captures.set(session.id, capture);
+    await this.#captures.enqueue(session.id, async () => {
+      await this.#captureTask(session, options, requireTranscribeMode, pendingOnly);
+    });
+  }
+
+  async #captureTask(
+    session: TSession,
+    options: { finalize?: boolean },
+    requireTranscribeMode: boolean,
+    pendingOnly: boolean,
+  ): Promise<void> {
+    let pendingError: MeetingTranscriptDeliveryError | undefined;
     try {
-      await capture;
-    } finally {
-      if (this.#captures.get(session.id) === capture) {
-        this.#captures.delete(session.id);
+      await this.#flushPending(session);
+    } catch (error) {
+      if (pendingOnly) {
+        throw error;
       }
+      pendingError = error as MeetingTranscriptDeliveryError;
+    }
+    if (pendingOnly) {
+      return;
+    }
+    if (
+      !this.options.isBrowserSession(session) ||
+      (requireTranscribeMode && !this.options.isTranscribeSession(session)) ||
+      !this.options.hasBrowserTab(session)
+    ) {
+      if (pendingError) {
+        throw pendingError;
+      }
+      return;
+    }
+    let snapshot: MeetingTranscriptSnapshot | undefined;
+    try {
+      snapshot = await this.options.capture(session, options);
+    } catch (error) {
+      if (pendingError) {
+        throw new MeetingTranscriptDeliveryError(pendingError.cause ?? pendingError, error);
+      }
+      throw error;
+    }
+    if (snapshot) {
+      if (this.options.isTranscribeSession(session)) {
+        this.#merge(session.id, snapshot);
+      }
+      const pending = this.#pendingLines.get(session.id);
+      const cursor = pending?.at(-1)?.cursor ?? this.#streamCursors.get(session.id);
+      const delta = this.#snapshotDelta(cursor, snapshot);
+      if (pendingError) {
+        if (delta.lines.length > 0) {
+          this.#queuePending(session.id, snapshot, delta, 0, delta.prefixKeys, true);
+        } else if (delta.commitEmpty) {
+          this.#queuePendingCursor(session.id, {
+            pageEpoch: snapshot.epoch,
+            pageNextIndex: snapshot.droppedLines + snapshot.lines.length,
+            tailKeys: delta.prefixKeys,
+          });
+        }
+        throw pendingError;
+      }
+      let tailKeys = [...delta.prefixKeys];
+      for (const [index, line] of delta.lines.entries()) {
+        try {
+          await this.options.onLines?.(session, [line]);
+        } catch (error) {
+          this.#queuePending(session.id, snapshot, delta, index, tailKeys);
+          throw new MeetingTranscriptDeliveryError(error);
+        }
+        tailKeys = [...tailKeys, transcriptLineKey(line)].slice(-TRANSCRIPT_CURSOR_TAIL);
+        this.#streamCursors.set(session.id, {
+          pageEpoch: snapshot.epoch,
+          pageNextIndex: delta.startIndex + index + 1,
+          tailKeys,
+        });
+      }
+      if (delta.lines.length === 0 && delta.commitEmpty) {
+        this.#streamCursors.set(session.id, {
+          pageEpoch: snapshot.epoch,
+          pageNextIndex: snapshot.droppedLines + snapshot.lines.length,
+          tailKeys: delta.prefixKeys,
+        });
+      }
+    } else if (pendingError) {
+      throw pendingError;
     }
   }
 

--- a/src/meeting-bot/transcripts-bridge.runtime.ts
+++ b/src/meeting-bot/transcripts-bridge.runtime.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
+import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 import { resolveTranscriptsConfig } from "../transcripts/config.js";
 import type {
   TranscriptSessionDescriptor,
@@ -99,42 +100,8 @@ export function createMeetingDurableTranscriptBridge<
   const captures = new Map<string, ActiveCapture<TSession>>();
   const pendingSubscribers = new Map<string, { agentId: string; meetingSessionId: string }>();
   const subscribers = new Map<string, Subscriber>();
-  const lifecycleTasks = new Map<string, Promise<void>>();
-  const tasks = new Map<string, Promise<void>>();
-
-  const runSerial = async <T>(sessionId: string, task: () => Promise<T>): Promise<T> => {
-    const previous = tasks.get(sessionId) ?? Promise.resolve();
-    const result = previous.catch(() => {}).then(task);
-    const settled = result.then(
-      () => undefined,
-      () => undefined,
-    );
-    tasks.set(sessionId, settled);
-    try {
-      return await result;
-    } finally {
-      if (tasks.get(sessionId) === settled) {
-        tasks.delete(sessionId);
-      }
-    }
-  };
-
-  const runLifecycle = async <T>(sessionId: string, task: () => Promise<T>): Promise<T> => {
-    const previous = lifecycleTasks.get(sessionId) ?? Promise.resolve();
-    const result = previous.catch(() => {}).then(task);
-    const settled = result.then(
-      () => undefined,
-      () => undefined,
-    );
-    lifecycleTasks.set(sessionId, settled);
-    try {
-      return await result;
-    } finally {
-      if (lifecycleTasks.get(sessionId) === settled) {
-        lifecycleTasks.delete(sessionId);
-      }
-    }
-  };
+  const lifecycleTasks = new KeyedAsyncQueue();
+  const tasks = new KeyedAsyncQueue();
 
   const reportCaptureError = (sessionId: string, error: unknown) => {
     params.logger.debug?.(
@@ -168,7 +135,7 @@ export function createMeetingDurableTranscriptBridge<
   return {
     enabled: config.enabled,
     async start(session, capture) {
-      await runLifecycle(session.id, async () => {
+      await lifecycleTasks.enqueue(session.id, async () => {
         if (!config.enabled || captures.has(session.id)) {
           return;
         }
@@ -246,7 +213,7 @@ export function createMeetingDurableTranscriptBridge<
       if (!active || lines.length === 0) {
         return;
       }
-      await runSerial(session.id, async () => {
+      await tasks.enqueue(session.id, async () => {
         for (const line of lines) {
           const sequence = active.utteranceCount;
           const utterance = utteranceFromLine({
@@ -292,7 +259,7 @@ export function createMeetingDurableTranscriptBridge<
       });
     },
     async stop(session, finalCapture) {
-      const active = await runLifecycle(session.id, async () => {
+      const active = await lifecycleTasks.enqueue(session.id, async () => {
         const current = captures.get(session.id);
         if (!current) {
           return undefined;
@@ -362,7 +329,7 @@ export function createMeetingDurableTranscriptBridge<
           : {}),
       };
       try {
-        await runSerial(session.id, async () => {
+        await tasks.enqueue(session.id, async () => {
           await store.writeSession(stopped);
           const utterances = await store.readUtterancesForSession(stopped, {
             maxUtterances: config.maxUtterances,
@@ -415,7 +382,7 @@ export function createMeetingDurableTranscriptBridge<
         meetingSessionId: session.id,
       });
       try {
-        await runSerial(session.id, async () => {
+        await tasks.enqueue(session.id, async () => {
           if (captures.get(session.id) !== active || active.closing) {
             return;
           }
@@ -468,7 +435,7 @@ export function createMeetingDurableTranscriptBridge<
       if (request.source.agentId !== owner.agentId) {
         return { ok: false, error: "transcripts session belongs to another agent" };
       }
-      return await runSerial(owner.meetingSessionId, async () => {
+      return await tasks.enqueue(owner.meetingSessionId, async () => {
         const current = subscribers.get(request.sessionId);
         if (!current) {
           return { ok: true, sessionId: request.sessionId, stoppedAt: new Date().toISOString() };

--- a/src/plugins/session-conversation-binding.ts
+++ b/src/plugins/session-conversation-binding.ts
@@ -5,6 +5,7 @@ import {
   unbindConversationBindingRecord,
 } from "../bindings/records.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 import { bindConversationNow, buildPluginBindingIdentity } from "./conversation-binding.js";
 import type {
@@ -17,7 +18,7 @@ const log = createSubsystemLogger("plugins/binding");
 // Serializes bind+finalize+rollback per session so a failing older attempt
 // can never unbind or restore over a newer successful one (all session binds
 // go through this in-process seam).
-const pluginSessionBindTails = new Map<string, Promise<void>>();
+const pluginSessionBindQueue = new KeyedAsyncQueue();
 
 /** Binds a plugin-owned runtime to one authenticated Control UI session. */
 export async function bindPluginSessionConversation(params: {
@@ -32,22 +33,9 @@ export async function bindPluginSessionConversation(params: {
   if (!sessionKey) {
     throw new Error("session key is required for a plugin session binding");
   }
-  const previousTail = pluginSessionBindTails.get(sessionKey) ?? Promise.resolve();
-  const operation = previousTail.then(() =>
+  return await pluginSessionBindQueue.enqueue(sessionKey, async () =>
     bindPluginSessionConversationExclusive({ ...params, sessionKey }),
   );
-  const tail = operation.then(
-    () => undefined,
-    () => undefined,
-  );
-  pluginSessionBindTails.set(sessionKey, tail);
-  try {
-    return await operation;
-  } finally {
-    if (pluginSessionBindTails.get(sessionKey) === tail) {
-      pluginSessionBindTails.delete(sessionKey);
-    }
-  }
 }
 
 async function bindPluginSessionConversationExclusive(params: {


### PR DESCRIPTION
## What Problem This Solves

Several runtime owners independently reimplemented the same per-key promise-tail queue, exponential retry arithmetic, and bounded message-id dedupe behavior. Those copies duplicated cleanup and error-isolation policy and made future fixes easy to apply unevenly.

## Why This Change Was Made

This consolidates the exact per-key chains in meeting transcripts and plugin session binding onto `KeyedAsyncQueue`, and removes the zero-value Gateway keyed-attempt passthrough. Retry delay arithmetic now uses the canonical `computeBackoff` policy while retaining the ingress exponent-8 ceiling and subagent retry-count clamp.

Recent queue message IDs now use the shared `DedupeCache` for TTL/LRU storage. The queue-specific lifecycle WeakMap, fresh owner tokens, clone-surviving identity, guarded abandonment release, chunk-global singletons, and last-recorder-wins re-entrancy remain intact.

The public dedupe signature gains optional owner-token arguments but no new export, entrypoint, config, protocol, or storage surface. The existing Plugin SDK API baseline check accepts the additive optional parameters without regeneration.

## User Impact

No user-visible behavior changes. Per-session and per-node work remains serialized with unrelated keys running concurrently; retry delays remain numerically identical through attempts 1–10; abandoned ingress runs remain retryable without allowing stale owners to release newer dedupe claims.

Production code is 68 lines smaller. Tests add 62 lines of schedule, owner-token, and exact-TTL-boundary coverage.

## Evidence

- `oxfmt <12 touched files>` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `node scripts/run-vitest.mjs src/plugin-sdk/keyed-async-queue.test.ts src/infra/dedupe.test.ts src/channels/message/ingress-retry-policy.test.ts src/agents/subagent-registry-helpers.test.ts` — passed: 3 shards, 38 tests.
- `node scripts/run-vitest.mjs src/infra/dedupe.test.ts` after the exact-boundary adjustment — passed: 1 shard, 7 tests.
- Affected meeting/binding/queue/gateway test batch was attempted twice but never started; both attempts timed out waiting 10 minutes for active fleet-owned local test locks. Hosted CI ran the compact Node matrix successfully.
- `node scripts/check-changed.mjs` selected remote proof but could not start because no configured Crabbox provider was ready. Hosted CI supplied the changed-surface proof.
- Targeted local oxlint later stopped before linting this patch on an unrelated package-boundary type error in `packages/terminal-core/src/ansi.ts`; hosted `check-lint` passed on the exact head.
- Final autoreview: Codex `gpt-5.6-sol`, high reasoning — clean, no accepted/actionable findings, patch correctness 0.99.
- Exact-head CI run 30769949489 — green; `openclaw/ci-gate`, `check-lint`, `check-prod-types`, `check-test-types`, Plugin SDK API baseline, build artifacts, Node shards, contract shards, and security checks passed.
