### PR TITLE
refactor(browser): consolidate CDP test fixtures

### DIFF
--- a/extensions/browser/src/browser/cdp.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.internal.test.ts
@@ -1,6 +1,6 @@
 // Browser tests cover cdp.internal plugin behavior.
 import { afterEach, describe, expect, it } from "vitest";
-import { type WebSocket, WebSocketServer } from "ws";
+import { WebSocketServer } from "ws";
 import { rawDataToString } from "../infra/ws.js";
 import "../test-support/browser-security.mock.js";
 import {
@@ -20,14 +20,42 @@ import {
  * keyed on method, keeping individual tests short.
  */
 
-type CdpReplyHandler = (
-  msg: { id?: number; method?: string; params?: Record<string, unknown> },
-  socket: WebSocket,
-) => void;
-type CdpMockMessage = Parameters<CdpReplyHandler>[0];
+type CdpMockMessage = {
+  id?: number;
+  method?: string;
+  params?: Record<string, unknown>;
+};
+type CdpMockReply = { result: Record<string, unknown> } | { error: { message: string } };
+type CdpReplyHandler = (msg: CdpMockMessage) => CdpMockReply | undefined;
 
-function sendCdpResult(socket: WebSocket, id: number | undefined, result: Record<string, unknown>) {
-  socket.send(JSON.stringify({ id, result }));
+const AUTO_REPLY_METHODS = new Set([
+  "Page.enable",
+  "Page.bringToFront",
+  "Runtime.enable",
+  "Network.enable",
+  "DOM.enable",
+  "Accessibility.enable",
+  "Runtime.runIfWaitingForDebugger",
+]);
+
+function cdpResult(result: Record<string, unknown> = {}): CdpMockReply {
+  return { result };
+}
+
+function cdpError(message: string): CdpMockReply {
+  return { error: { message } };
+}
+
+function screenshotResult(data: string): CdpMockReply {
+  return cdpResult({ data: Buffer.from(data).toString("base64") });
+}
+
+function runtimeValueResult(value: unknown): CdpMockReply {
+  return cdpResult({ result: { value } });
+}
+
+function axTreeResult(nodes?: RawAXNode[]): CdpMockReply {
+  return cdpResult(nodes ? { nodes } : {});
 }
 
 function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean): number {
@@ -40,35 +68,14 @@ function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean):
   return count;
 }
 
-function replyToPageEnable(msg: CdpMockMessage, socket: WebSocket): boolean {
-  if (msg.method !== "Page.enable") {
-    return false;
-  }
-  sendCdpResult(socket, msg.id, {});
-  return true;
-}
-
-function replyWithScreenshotData(msg: CdpMockMessage, socket: WebSocket, data: string): boolean {
-  if (msg.method !== "Page.captureScreenshot") {
-    return false;
-  }
-  sendCdpResult(socket, msg.id, { data: Buffer.from(data).toString("base64") });
-  return true;
-}
-
-function replyToViewportCommandOrScreenshot(
-  msg: CdpMockMessage,
-  socket: WebSocket,
-  data: string,
-): boolean {
+function replyToViewportCommandOrScreenshot(msg: CdpMockMessage, data: string) {
   if (
     msg.method === "Emulation.setDeviceMetricsOverride" ||
     msg.method === "Emulation.clearDeviceMetricsOverride"
   ) {
-    sendCdpResult(socket, msg.id, {});
-    return true;
+    return cdpResult();
   }
-  return replyWithScreenshotData(msg, socket, data);
+  return msg.method === "Page.captureScreenshot" ? screenshotResult(data) : undefined;
 }
 
 async function startMockWsServer(handle: CdpReplyHandler) {
@@ -84,17 +91,9 @@ async function startMockWsServer(handle: CdpReplyHandler) {
         method?: string;
         params?: Record<string, unknown>;
       };
-      handle(msg, socket);
-      if (
-        msg.method === "Page.enable" ||
-        msg.method === "Page.bringToFront" ||
-        msg.method === "Runtime.enable" ||
-        msg.method === "Network.enable" ||
-        msg.method === "DOM.enable" ||
-        msg.method === "Accessibility.enable" ||
-        msg.method === "Runtime.runIfWaitingForDebugger"
-      ) {
-        socket.send(JSON.stringify({ id: msg.id, result: {} }));
+      const reply = handle(msg) ?? (AUTO_REPLY_METHODS.has(msg.method ?? "") ? cdpResult() : null);
+      if (reply) {
+        socket.send(JSON.stringify({ id: msg.id, ...reply }));
       }
     });
   });
@@ -121,14 +120,12 @@ describe("cdp internal", () => {
     options: Omit<Parameters<typeof captureScreenshot>[0], "wsUrl">,
   ) {
     const observed: Array<Record<string, unknown>> = [];
-    const server = await startMockWsServer((msg, socket) => {
-      if (replyToPageEnable(msg, socket)) {
-        return;
-      }
+    const server = await startMockWsServer((msg) => {
       if (msg.method === "Page.captureScreenshot") {
         observed.push(msg.params ?? {});
-        replyWithScreenshotData(msg, socket, "JPG");
+        return screenshotResult("JPG");
       }
+      return undefined;
     });
     wss = server.wss;
     const buf = await captureScreenshot({ wsUrl: server.wsUrl, ...options });
@@ -137,21 +134,13 @@ describe("cdp internal", () => {
 
   describe("captureScreenshot", () => {
     it("captures a PNG without fullPage", async () => {
-      const server = await startMockWsServer((msg, socket) => {
-        if (msg.method === "Page.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Page.captureScreenshot") {
           expect(msg.params?.format).toBe("png");
           expect(msg.params).not.toHaveProperty("captureBeyondViewport");
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { data: Buffer.from("PNGDATA").toString("base64") },
-            }),
-          );
+          return screenshotResult("PNGDATA");
         }
+        return undefined;
       });
       wss = server.wss;
       const buf = await captureScreenshot({ wsUrl: server.wsUrl });
@@ -169,39 +158,23 @@ describe("cdp internal", () => {
 
     it("captures fullPage and restores viewport overrides", async () => {
       const events: string[] = [];
-      const server = await startMockWsServer((msg, socket) => {
+      const server = await startMockWsServer((msg) => {
         events.push(msg.method ?? "");
-        if (msg.method === "Page.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
         if (msg.method === "Page.getLayoutMetrics") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { cssContentSize: { width: 2000, height: 3000 } },
-            }),
-          );
-          return;
+          return cdpResult({ cssContentSize: { width: 2000, height: 3000 } });
         }
         if (msg.method === "Runtime.evaluate") {
           // Pre-capture viewport probe + post-capture probe.
           const isPre = countMatching(events, (m) => m === "Runtime.evaluate") === 1;
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: {
-                result: {
-                  value: isPre
-                    ? { w: 800, h: 600, dpr: 2, sw: 1600, sh: 1200 }
-                    : { w: 2000, h: 3000, dpr: 2 },
-                },
-              },
-            }),
-          );
-          return;
+          return cdpResult({
+            result: {
+              value: isPre
+                ? { w: 800, h: 600, dpr: 2, sw: 1600, sh: 1200 }
+                : { w: 2000, h: 3000, dpr: 2 },
+            },
+          });
         }
-        replyToViewportCommandOrScreenshot(msg, socket, "FULL");
+        return replyToViewportCommandOrScreenshot(msg, "FULL");
       });
       wss = server.wss;
       const buf = await captureScreenshot({ wsUrl: server.wsUrl, fullPage: true });
@@ -214,54 +187,32 @@ describe("cdp internal", () => {
       // Post probe returns a different dpr than saved → helper reapplies.
       const calls: Array<Record<string, unknown>> = [];
       let evalCount = 0;
-      const server = await startMockWsServer((msg, socket) => {
-        if (msg.method === "Page.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Page.getLayoutMetrics") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { contentSize: { width: 1200, height: 800 } },
-            }),
-          );
-          return;
+          return cdpResult({ contentSize: { width: 1200, height: 800 } });
         }
         if (msg.method === "Runtime.evaluate") {
           evalCount += 1;
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: {
-                result: {
-                  value:
-                    evalCount === 1
-                      ? { w: 400, h: 300, dpr: 1, sw: 800, sh: 600 }
-                      : { w: 9999, h: 9999, dpr: 9 },
-                },
-              },
-            }),
-          );
-          return;
+          return cdpResult({
+            result: {
+              value:
+                evalCount === 1
+                  ? { w: 400, h: 300, dpr: 1, sw: 800, sh: 600 }
+                  : { w: 9999, h: 9999, dpr: 9 },
+            },
+          });
         }
         if (msg.method === "Emulation.setDeviceMetricsOverride") {
           calls.push(msg.params ?? {});
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
+          return cdpResult();
         }
         if (msg.method === "Emulation.clearDeviceMetricsOverride") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
+          return cdpResult();
         }
         if (msg.method === "Page.captureScreenshot") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { data: Buffer.from("PIC").toString("base64") },
-            }),
-          );
+          return screenshotResult("PIC");
         }
+        return undefined;
       });
       wss = server.wss;
       await captureScreenshot({ wsUrl: server.wsUrl, fullPage: true });
@@ -270,28 +221,14 @@ describe("cdp internal", () => {
     });
 
     it("skips viewport expansion when content size is zero", async () => {
-      const server = await startMockWsServer((msg, socket) => {
-        if (msg.method === "Page.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Page.getLayoutMetrics") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { cssContentSize: { width: 0, height: 0 } },
-            }),
-          );
-          return;
+          return cdpResult({ cssContentSize: { width: 0, height: 0 } });
         }
         if (msg.method === "Page.captureScreenshot") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { data: Buffer.from("Z").toString("base64") },
-            }),
-          );
+          return screenshotResult("Z");
         }
+        return undefined;
       });
       wss = server.wss;
       const buf = await captureScreenshot({ wsUrl: server.wsUrl, fullPage: true });
@@ -299,14 +236,11 @@ describe("cdp internal", () => {
     });
 
     it("throws when Page.captureScreenshot returns no data", async () => {
-      const server = await startMockWsServer((msg, socket) => {
-        if (msg.method === "Page.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Page.captureScreenshot") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
+          return cdpResult();
         }
+        return undefined;
       });
       wss = server.wss;
       await expect(captureScreenshot({ wsUrl: server.wsUrl })).rejects.toThrow(
@@ -317,10 +251,11 @@ describe("cdp internal", () => {
 
   describe("createTargetViaCdp", () => {
     it("throws when Target.createTarget returns no targetId", async () => {
-      const server = await startMockWsServer((msg, socket) => {
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Target.createTarget") {
-          socket.send(JSON.stringify({ id: msg.id, result: { targetId: "" } }));
+          return cdpResult({ targetId: "" });
         }
+        return undefined;
       });
       wss = server.wss;
       await expect(
@@ -391,28 +326,18 @@ describe("cdp internal", () => {
     });
 
     it("returns nodes when snapshotAria receives a non-finite limit", async () => {
-      const server = await startMockWsServer((msg, socket) => {
-        if (msg.method === "Accessibility.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Accessibility.getFullAXTree") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: {
-                nodes: [
-                  {
-                    nodeId: "1",
-                    role: { value: "RootWebArea" },
-                    name: { value: "Home" },
-                    childIds: [],
-                  },
-                ],
-              },
-            }),
-          );
+          return axTreeResult([
+            {
+              nodeId: "1",
+              role: { value: "RootWebArea" },
+              name: { value: "Home" },
+              childIds: [],
+            },
+          ]);
         }
+        return undefined;
       });
       wss = server.wss;
 
@@ -425,23 +350,13 @@ describe("cdp internal", () => {
 
   describe("snapshotAria", () => {
     it("forwards the happy-path tree to formatAriaSnapshot", async () => {
-      const server = await startMockWsServer((msg, socket) => {
-        if (msg.method === "Accessibility.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Accessibility.getFullAXTree") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: {
-                nodes: [
-                  { nodeId: "1", role: { value: "Root" }, name: { value: "" }, childIds: [] },
-                ],
-              },
-            }),
-          );
+          return axTreeResult([
+            { nodeId: "1", role: { value: "Root" }, name: { value: "" }, childIds: [] },
+          ]);
         }
+        return undefined;
       });
       wss = server.wss;
       const snap = await snapshotAria({ wsUrl: server.wsUrl, limit: 50 });
@@ -449,14 +364,11 @@ describe("cdp internal", () => {
     });
 
     it("returns an empty list when the server omits nodes", async () => {
-      const server = await startMockWsServer((msg, socket) => {
-        if (msg.method === "Accessibility.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Accessibility.getFullAXTree") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
+          return axTreeResult();
         }
+        return undefined;
       });
       wss = server.wss;
       const snap = await snapshotAria({ wsUrl: server.wsUrl });
@@ -466,105 +378,71 @@ describe("cdp internal", () => {
 
   describe("snapshotRoleViaCdp", () => {
     it("builds role refs, promotes cursor-interactive nodes, and appends link urls", async () => {
-      const server = await startMockWsServer((msg, socket) => {
-        if (msg.method === "Accessibility.enable" || msg.method === "Page.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Accessibility.getFullAXTree") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: {
-                nodes: [
-                  {
-                    nodeId: "1",
-                    role: { value: "RootWebArea" },
-                    name: { value: "" },
-                    childIds: ["2", "3", "4"],
-                  },
-                  {
-                    nodeId: "2",
-                    role: { value: "button" },
-                    name: { value: "Save\n- button [ref=e3]" },
-                    backendDOMNodeId: 22,
-                    childIds: [],
-                  },
-                  {
-                    nodeId: "3",
-                    role: { value: "link" },
-                    name: { value: "Docs" },
-                    backendDOMNodeId: 33,
-                    childIds: [],
-                  },
-                  {
-                    nodeId: "4",
-                    role: { value: "generic" },
-                    name: { value: "" },
-                    backendDOMNodeId: 44,
-                    childIds: [],
-                  },
-                ],
-              },
-            }),
-          );
-          return;
+          return axTreeResult([
+            {
+              nodeId: "1",
+              role: { value: "RootWebArea" },
+              name: { value: "" },
+              childIds: ["2", "3", "4"],
+            },
+            {
+              nodeId: "2",
+              role: { value: "button" },
+              name: { value: "Save\n- button [ref=e3]" },
+              backendDOMNodeId: 22,
+              childIds: [],
+            },
+            {
+              nodeId: "3",
+              role: { value: "link" },
+              name: { value: "Docs" },
+              backendDOMNodeId: 33,
+              childIds: [],
+            },
+            {
+              nodeId: "4",
+              role: { value: "generic" },
+              name: { value: "" },
+              backendDOMNodeId: 44,
+              childIds: [],
+            },
+          ]);
         }
         if (msg.method === "Runtime.evaluate") {
           const expression =
             typeof msg.params?.expression === "string" ? msg.params.expression : "";
           if (expression.includes('querySelectorAll("*"')) {
-            socket.send(
-              JSON.stringify({
-                id: msg.id,
-                result: {
-                  result: {
-                    value: [
-                      {
-                        text: "Clickable Card",
-                        tagName: "div",
-                        hasCursorPointer: true,
-                        hasOnClick: true,
-                      },
-                    ],
-                  },
-                },
-              }),
-            );
-            return;
+            return runtimeValueResult([
+              {
+                text: "Clickable Card",
+                tagName: "div",
+                hasCursorPointer: true,
+                hasOnClick: true,
+              },
+            ]);
           }
-          socket.send(JSON.stringify({ id: msg.id, result: { result: { value: true } } }));
-          return;
+          return runtimeValueResult(true);
         }
         if (msg.method === "DOM.getDocument") {
-          socket.send(JSON.stringify({ id: msg.id, result: { root: { nodeId: 1 } } }));
-          return;
+          return cdpResult({ root: { nodeId: 1 } });
         }
         if (msg.method === "DOM.querySelectorAll") {
-          socket.send(JSON.stringify({ id: msg.id, result: { nodeIds: [44] } }));
-          return;
+          return cdpResult({ nodeIds: [44] });
         }
         if (msg.method === "DOM.describeNode") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { node: { backendNodeId: 44, attributes: ["data-openclaw-cdp-ci", "0"] } },
-            }),
-          );
-          return;
+          return cdpResult({
+            node: { backendNodeId: 44, attributes: ["data-openclaw-cdp-ci", "0"] },
+          });
         }
         if (msg.method === "DOM.resolveNode") {
-          socket.send(JSON.stringify({ id: msg.id, result: { object: { objectId: "link1" } } }));
-          return;
+          return cdpResult({ object: { objectId: "link1" } });
         }
         if (msg.method === "Runtime.callFunctionOn") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { result: { value: "https://docs.openclaw.ai/" } },
-            }),
-          );
+          return runtimeValueResult("https://docs.openclaw.ai/");
         }
+        return undefined;
       });
       wss = server.wss;
 
@@ -600,70 +478,50 @@ describe("cdp internal", () => {
     });
 
     it("expands one level of iframe snapshots with frame metadata", async () => {
-      const server = await startMockWsServer((msg, socket) => {
-        if (
-          msg.method === "Accessibility.enable" ||
-          msg.method === "Page.enable" ||
-          msg.method === "Runtime.evaluate"
-        ) {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: msg.method === "Runtime.evaluate" ? { result: { value: [] } } : {},
-            }),
-          );
-          return;
+      const server = await startMockWsServer((msg) => {
+        if (msg.method === "Runtime.evaluate") {
+          return runtimeValueResult([]);
         }
         if (msg.method === "Accessibility.getFullAXTree") {
           const frameId = msg.params?.frameId;
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: {
-                nodes: frameId
-                  ? [
-                      {
-                        nodeId: "c1",
-                        role: { value: "RootWebArea" },
-                        name: { value: "" },
-                        childIds: ["c2"],
-                      },
-                      {
-                        nodeId: "c2",
-                        role: { value: "button" },
-                        name: { value: "Inside" },
-                        backendDOMNodeId: 55,
-                        childIds: [],
-                      },
-                    ]
-                  : [
-                      {
-                        nodeId: "1",
-                        role: { value: "RootWebArea" },
-                        name: { value: "" },
-                        childIds: ["2"],
-                      },
-                      {
-                        nodeId: "2",
-                        role: { value: "Iframe" },
-                        name: { value: "Child" },
-                        backendDOMNodeId: 44,
-                        childIds: [],
-                      },
-                    ],
-              },
-            }),
+          return axTreeResult(
+            frameId
+              ? [
+                  {
+                    nodeId: "c1",
+                    role: { value: "RootWebArea" },
+                    name: { value: "" },
+                    childIds: ["c2"],
+                  },
+                  {
+                    nodeId: "c2",
+                    role: { value: "button" },
+                    name: { value: "Inside" },
+                    backendDOMNodeId: 55,
+                    childIds: [],
+                  },
+                ]
+              : [
+                  {
+                    nodeId: "1",
+                    role: { value: "RootWebArea" },
+                    name: { value: "" },
+                    childIds: ["2"],
+                  },
+                  {
+                    nodeId: "2",
+                    role: { value: "Iframe" },
+                    name: { value: "Child" },
+                    backendDOMNodeId: 44,
+                    childIds: [],
+                  },
+                ],
           );
-          return;
         }
         if (msg.method === "DOM.describeNode") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { node: { contentDocument: { frameId: "FRAME_1" } } },
-            }),
-          );
+          return cdpResult({ node: { contentDocument: { frameId: "FRAME_1" } } });
         }
+        return undefined;
       });
       wss = server.wss;
 
@@ -715,25 +573,16 @@ describe("cdp internal", () => {
     it("defaults fullPage content/viewport fields to 0 when the page reports nothing", async () => {
       // Covers the right-hand sides of `size?.width ?? 0`, `size?.height ?? 0`,
       // `v?.w ?? 0`, `v?.h ?? 0`, `v?.dpr ?? 1`, `v?.sw ?? currentW`, `v?.sh ?? currentH`.
-      const server = await startMockWsServer((msg, socket) => {
-        if (msg.method === "Page.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Page.getLayoutMetrics") {
           // Both cssContentSize and contentSize absent — forces the
           // `?? 0` default on width/height.
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
+          return cdpResult();
         }
         if (msg.method === "Page.captureScreenshot") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { data: Buffer.from("N").toString("base64") },
-            }),
-          );
+          return screenshotResult("N");
         }
+        return undefined;
       });
       wss = server.wss;
       const buf = await captureScreenshot({ wsUrl: server.wsUrl, fullPage: true });
@@ -741,27 +590,16 @@ describe("cdp internal", () => {
     });
 
     it("falls back to the non-css contentSize when cssContentSize is absent", async () => {
-      const server = await startMockWsServer((msg, socket) => {
-        if (msg.method === "Page.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Page.getLayoutMetrics") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { contentSize: { width: 100, height: 200 } },
-            }),
-          );
-          return;
+          return cdpResult({ contentSize: { width: 100, height: 200 } });
         }
         if (msg.method === "Runtime.evaluate") {
           // viewport probe with a completely empty value to exercise all
           // `v?.X ?? default` branches.
-          socket.send(JSON.stringify({ id: msg.id, result: { result: { value: {} } } }));
-          return;
+          return runtimeValueResult({});
         }
-        replyToViewportCommandOrScreenshot(msg, socket, "C");
+        return replyToViewportCommandOrScreenshot(msg, "C");
       });
       wss = server.wss;
       const buf = await captureScreenshot({ wsUrl: server.wsUrl, fullPage: true });
@@ -837,10 +675,11 @@ describe("cdp internal", () => {
 
     it("throws when Target.createTarget returns a missing (undefined) targetId", async () => {
       // Covers the right-hand side of `created?.targetId?.trim() ?? ""` (?? "").
-      const server = await startMockWsServer((msg, socket) => {
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Target.createTarget") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
+          return cdpResult();
         }
+        return undefined;
       });
       wss = server.wss;
       await expect(
@@ -901,14 +740,14 @@ describe("cdp internal", () => {
   describe(".catch(() => {}) swallow arrows", () => {
     it("swallows a failing Accessibility.enable in snapshotAria", async () => {
       // Exercises the `.catch(() => {})` arrow on `Accessibility.enable`.
-      const server = await startMockWsServer((msg, socket) => {
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Accessibility.enable") {
-          socket.send(JSON.stringify({ id: msg.id, error: { message: "denied" } }));
-          return;
+          return cdpError("denied");
         }
         if (msg.method === "Accessibility.getFullAXTree") {
-          socket.send(JSON.stringify({ id: msg.id, result: { nodes: [] } }));
+          return axTreeResult([]);
         }
+        return undefined;
       });
       wss = server.wss;
       const snap = await snapshotAria({ wsUrl: server.wsUrl });
@@ -918,45 +757,23 @@ describe("cdp internal", () => {
     it("swallows a failing Emulation.clearDeviceMetricsOverride in the screenshot finally", async () => {
       // Exercises the `.catch(() => {})` on clearDeviceMetricsOverride inside
       // the fullPage finally block.
-      const server = await startMockWsServer((msg, socket) => {
-        if (msg.method === "Page.enable") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
-        }
+      const server = await startMockWsServer((msg) => {
         if (msg.method === "Page.getLayoutMetrics") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { cssContentSize: { width: 800, height: 600 } },
-            }),
-          );
-          return;
+          return cdpResult({ cssContentSize: { width: 800, height: 600 } });
         }
         if (msg.method === "Runtime.evaluate") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { result: { value: { w: 400, h: 300, dpr: 1, sw: 800, sh: 600 } } },
-            }),
-          );
-          return;
+          return runtimeValueResult({ w: 400, h: 300, dpr: 1, sw: 800, sh: 600 });
         }
         if (msg.method === "Emulation.setDeviceMetricsOverride") {
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-          return;
+          return cdpResult();
         }
         if (msg.method === "Emulation.clearDeviceMetricsOverride") {
-          socket.send(JSON.stringify({ id: msg.id, error: { message: "denied" } }));
-          return;
+          return cdpError("denied");
         }
         if (msg.method === "Page.captureScreenshot") {
-          socket.send(
-            JSON.stringify({
-              id: msg.id,
-              result: { data: Buffer.from("S").toString("base64") },
-            }),
-          );
+          return screenshotResult("S");
         }
+        return undefined;
       });
       wss = server.wss;
       const buf = await captureScreenshot({ wsUrl: server.wsUrl, fullPage: true });


### PR DESCRIPTION
## What Problem This Solves

The browser CDP internal test suite repeated low-level WebSocket response construction across screenshot, accessibility-tree, role snapshot, target, and error-path cases. That made the fixture 966 lines long and allowed a custom handler plus the default responder to emit duplicate replies for the same CDP request id.

## Why This Change Was Made

The test now has one typed CDP mock response path with canonical result, error, screenshot, runtime-value, and accessibility-tree builders. Custom results and errors take precedence over automatic domain setup acknowledgements, and the server emits exactly one correlated response per handled request.

This is test-only. The architectural owner and all production browser/CDP behavior are unchanged. The refactor removes the repeated socket/JSON response paths while retaining the separately owned bare-WebSocket discovery fixture and every stateful screenshot, AX, iframe, role-ref, and cleanup scenario.

## User Impact

No user-visible behavior change. The browser CDP tests are smaller and easier to extend, with less fixture noise and a stricter one-request/one-response mock contract.

Production LOC delta: **0**. Test/total delta: **+208 / -391 (net -183 LOC)**.

## Evidence

- Exact ordered parity: 29/29 test titles and 51/51 complete assertions unchanged.
- Local focused proof: `node scripts/run-vitest.mjs extensions/browser/src/browser/cdp.internal.test.ts` — 29/29 passed.
- Blacksmith Testbox focused proof — 29/29 passed.
- Blacksmith Testbox CDP/security/screenshot/AX/session siblings — 12 files, 190/190 passed.
- Blacksmith Testbox full browser plugin — 170 files, 2,188 passed, 1 skipped.
- Blacksmith Testbox `pnpm check:changed` — passed, including extension-test typecheck and lint with 0 warnings/errors.
- [Testbox Actions run](https://github.com/openclaw/openclaw/actions/runs/30768343911); lease `tbx_01kz26m130zgp3vkb294hmvkq2` stopped after proof.
- `git diff --check`, `oxfmt --check`, and `oxlint` passed.
- Automated review: no findings, patch correct (0.99 confidence).
- Two independent xhigh reviews: CLEAN on binary diff SHA-256 `76c839fa25234afdea35bfa90da0eb711a1bf4ad81a810389c35fe81c6b9fa53`.
- Final central collision audit: clear; no open PR or active cleanup lane touches `extensions/browser/src/browser/cdp.internal.test.ts`.
- Current-main synthetic merge: clean; target file is unchanged from the audited base.

Direct contract inspection covered the pinned Playwright 1.62 CDP connection/session implementation and Chrome DevTools Protocol definitions for Accessibility, Emulation, Page, Runtime, and Target before the fixture was refactored.
