### PR TITLE
fix: canonicalize single-flight promise caching

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -72,6 +72,7 @@ const TRANSIENT_WORKSPACE_READ_ERRNOS = new Set([-11, -4]);
 const TRANSIENT_WORKSPACE_READ_MESSAGE = /Unknown system error -(?:11|4)\b/i;
 
 const workspaceTemplateCache = new Map<string, Promise<string>>();
+// Git availability is process-stable; cache the probe result, including failure, until restart.
 let gitAvailabilityPromise: Promise<boolean> | null = null;
 
 // File content cache keyed by stable file identity to avoid stale reads.

--- a/src/cli/deps.test.ts
+++ b/src/cli/deps.test.ts
@@ -106,4 +106,24 @@ describe("createDefaultDeps", () => {
     expect(runtimeFactories.discord).toHaveBeenCalledTimes(1);
     expect(sendFns.discord).toHaveBeenCalledTimes(2);
   });
+
+  it("retries a channel runtime after a transient load failure", async () => {
+    runtimeFactories.telegram.mockImplementationOnce(() => {
+      throw new Error("transient channel load");
+    });
+    const createDefaultDeps = await loadCreateDefaultDeps("module-retry");
+    const deps = createDefaultDeps();
+    const sendTelegram = deps.telegram as (...args: unknown[]) => Promise<unknown>;
+
+    await expect(sendTelegram("chat", "first", { verbose: false })).rejects.toThrow(
+      "transient channel load",
+    );
+    await expect(sendTelegram("chat", "second", { verbose: false })).resolves.toEqual({
+      messageId: "t1",
+      chatId: "telegram:1",
+    });
+
+    expect(runtimeFactories.telegram).toHaveBeenCalledTimes(2);
+    expect(sendFns.telegram).toHaveBeenCalledOnce();
+  });
 });

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -1,6 +1,6 @@
 // Default CLI dependency surface with lazy outbound channel send adapters.
 import { normalizeChannelId } from "../channels/registry.js";
-import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import type { CliDeps } from "./deps.types.js";
 import { CLI_OUTBOUND_SEND_FACTORY } from "./outbound-send-mapping.js";
 
@@ -60,14 +60,13 @@ function createLazySender(
   channelId: string,
   loader: () => Promise<RuntimeSendModule>,
 ): (...args: unknown[]) => Promise<unknown> {
-  const loadRuntimeSend = createLazyRuntimeSurface(loader, ({ runtimeSend }) => runtimeSend);
   return async (...args: unknown[]) => {
-    let cached = senderCache.get(channelId);
-    if (!cached) {
-      cached = loadRuntimeSend();
-      senderCache.set(channelId, cached);
-    }
-    const runtimeSend = await cached;
+    const runtimeSend = await getOrCreatePromise(
+      senderCache,
+      channelId,
+      async () => (await loader()).runtimeSend,
+      { cacheRejections: false },
+    );
     return await runtimeSend.sendMessage(...args);
   };
 }

--- a/src/config/doc-baseline.ts
+++ b/src/config/doc-baseline.ts
@@ -105,6 +105,7 @@ const DEFAULT_CHANNEL_OUTPUT = "docs/.generated/config-baseline.channel.json";
 const DEFAULT_PLUGIN_OUTPUT = "docs/.generated/config-baseline.plugin.json";
 const DEFAULT_HASH_OUTPUT = "docs/.generated/config-baseline.sha256";
 const DEFAULT_COUNTS_OUTPUT = "docs/.generated/config-baseline.counts.json";
+// A successful schema snapshot is process-stable; failures clear below so tooling can retry.
 let cachedConfigDocBaselinePromise: Promise<ConfigDocBaseline> | null = null;
 const uiHintIndexCache = new WeakMap<
   ConfigSchemaResponse["uiHints"],

--- a/src/gateway/control-ui-static.ts
+++ b/src/gateway/control-ui-static.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import { brotliCompress, constants as zlibConstants, gzip } from "node:zlib";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 
 const CONTROL_UI_IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
 const CONTROL_UI_HTML_COMPRESSION_CACHE_MAX_ENTRIES = 4;
@@ -296,13 +297,12 @@ function cachedCompressedControlUiHtml(
   // Index HTML is process-stable for a configured root. Keep its few rewritten
   // variants single-flight and bounded so unauthenticated requests cannot fan
   // out zlib work; large hashed assets use build-time sidecars instead.
-  const compression = compressControlUiBody(Buffer.from(body), encoding);
-  controlUiHtmlCompressionCache.set(key, compression);
-  void compression.catch(() => {
-    if (controlUiHtmlCompressionCache.get(key) === compression) {
-      controlUiHtmlCompressionCache.delete(key);
-    }
-  });
+  const compression = getOrCreatePromise(
+    controlUiHtmlCompressionCache,
+    key,
+    () => compressControlUiBody(Buffer.from(body), encoding),
+    { cacheRejections: false },
+  );
   while (controlUiHtmlCompressionCache.size > CONTROL_UI_HTML_COMPRESSION_CACHE_MAX_ENTRIES) {
     const oldestKey = controlUiHtmlCompressionCache.keys().next().value;
     if (oldestKey === undefined) {

--- a/src/gateway/dashboard-session-title.ts
+++ b/src/gateway/dashboard-session-title.ts
@@ -9,6 +9,7 @@ import { updateSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 
 type DashboardSessionTitleModelEntry = Pick<
   SessionEntry,
@@ -179,39 +180,39 @@ export async function maybeGenerateSessionTitle(params: {
   if (existing) {
     return { kind: "in-flight", settled: existing };
   }
-  const request = (async () => {
-    const displayName = await generateDashboardSessionTitle({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      entry: params.entry,
-      userMessage: sourceText,
-    });
-    if (!displayName) {
-      return false;
-    }
-
-    let persisted = false;
-    await updateSessionEntry(
-      {
+  const request = getOrCreatePromise(
+    sessionTitleRequests,
+    requestKey,
+    async () => {
+      const displayName = await generateDashboardSessionTitle({
+        cfg: params.cfg,
         agentId: params.agentId,
-        sessionKey: params.sessionKey,
-        storePath: params.storePath,
-      },
-      (current) => {
-        if (current.sessionId !== params.sessionId || hasExplicitSessionName(current)) {
-          return null;
-        }
-        persisted = true;
-        return { displayName };
-      },
-      { requireWriteSuccess: true },
-    );
-    return persisted;
-  })();
-  sessionTitleRequests.set(requestKey, request);
-  try {
-    return (await request) ? { kind: "persisted" } : { kind: "skipped" };
-  } finally {
-    sessionTitleRequests.delete(requestKey);
-  }
+        entry: params.entry,
+        userMessage: sourceText,
+      });
+      if (!displayName) {
+        return false;
+      }
+
+      let persisted = false;
+      await updateSessionEntry(
+        {
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          storePath: params.storePath,
+        },
+        (current) => {
+          if (current.sessionId !== params.sessionId || hasExplicitSessionName(current)) {
+            return null;
+          }
+          persisted = true;
+          return { displayName };
+        },
+        { requireWriteSuccess: true },
+      );
+      return persisted;
+    },
+    { evictOnSettled: true },
+  );
+  return (await request) ? { kind: "persisted" } : { kind: "skipped" };
 }

--- a/src/gateway/mcp-app-reconstruction.ts
+++ b/src/gateway/mcp-app-reconstruction.ts
@@ -11,6 +11,7 @@ import {
 } from "../agents/mcp-ui-resource.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { visitSessionMessagesAsync } from "./session-transcript-readers.js";
 import { loadSessionEntryReadOnly } from "./session-utils.js";
 
@@ -345,15 +346,7 @@ export async function restoreMcpAppView(params: {
 }): Promise<ReconstructionResult | undefined> {
   const key = `${params.sessionKey}\0${params.viewId}`;
   const inFlight = getRestoreInFlight();
-  const existing = inFlight.get(key);
-  if (existing) {
-    return await existing;
-  }
-  const pending = restoreMcpAppViewOnce(params).finally(() => {
-    if (inFlight.get(key) === pending) {
-      inFlight.delete(key);
-    }
+  return await getOrCreatePromise(inFlight, key, () => restoreMcpAppViewOnce(params), {
+    evictOnSettled: true,
   });
-  inFlight.set(key, pending);
-  return await pending;
 }

--- a/src/gateway/node-pairing-ssh-verify.ts
+++ b/src/gateway/node-pairing-ssh-verify.ts
@@ -8,6 +8,7 @@ import net from "node:net";
 import os from "node:os";
 import type { GatewayNodePairingConfig } from "../config/types.gateway.js";
 import { normalizeDevicePublicKeyBase64Url } from "../infra/device-identity.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { isLoopbackAddress, isPrivateOrLoopbackAddress, isTrustedProxyAddress } from "./net.js";
 import {
   isEligibleFreshNodePairingRequest,
@@ -238,9 +239,6 @@ export function startNodePairingSshVerify(params: {
     return { ok: true, user: params.plan.policy.user, host: params.plan.host };
   })();
 
-  const tracked = done.finally(() => {
-    inFlightByKey.delete(key);
-  });
-  inFlightByKey.set(key, tracked);
+  const tracked = getOrCreatePromise(inFlightByKey, key, () => done, { evictOnSettled: true });
   return { done: tracked, alreadyInFlight: false };
 }

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { sweepStaleRunContexts } from "../infra/agent-events.js";
 import { pruneOrphanedDeliveryQueueMedia } from "../infra/outbound/delivery-queue-media-spool.js";
 import { cleanOldMedia } from "../media/store.js";
+import { createLazyPromiseLoader } from "../shared/lazy-promise.js";
 import { startSkillCuratorMaintenance } from "../skills/workshop/curator.js";
 import {
   abortTrackedChatRunById,
@@ -135,24 +136,21 @@ export function startGatewayMaintenanceTimers(params: {
   // the general media TTL sweep is disabled.
   const runDeliveryQueueMediaGc =
     params.runDeliveryQueueMediaGc ?? (() => pruneOrphanedDeliveryQueueMedia());
-  let deliveryQueueMediaGcInFlight: Promise<void> | null = null;
   let deliveryQueueMediaGcStartedAtMs = 0;
-  const performDeliveryQueueMediaGc = () => {
-    if (deliveryQueueMediaGcInFlight) {
-      return deliveryQueueMediaGcInFlight;
+  const deliveryQueueMediaGcLoader = createLazyPromiseLoader(async () => {
+    try {
+      await runDeliveryQueueMediaGc();
+    } catch (error) {
+      params.logHealth.error(`delivery queue media cleanup failed: ${formatError(error)}`);
+    } finally {
+      deliveryQueueMediaGcLoader.clear();
     }
-    deliveryQueueMediaGcStartedAtMs = Date.now();
-    deliveryQueueMediaGcInFlight = Promise.resolve()
-      .then(async () => {
-        await runDeliveryQueueMediaGc();
-      })
-      .catch((err: unknown) => {
-        params.logHealth.error(`delivery queue media cleanup failed: ${formatError(err)}`);
-      })
-      .finally(() => {
-        deliveryQueueMediaGcInFlight = null;
-      });
-    return deliveryQueueMediaGcInFlight;
+  });
+  const performDeliveryQueueMediaGc = () => {
+    if (!deliveryQueueMediaGcLoader.peek()) {
+      deliveryQueueMediaGcStartedAtMs = Date.now();
+    }
+    return deliveryQueueMediaGcLoader.load();
   };
   void performDeliveryQueueMediaGc();
 

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -30,6 +30,7 @@ import { redactConfigObject } from "../../config/redact-snapshot.js";
 import { fetchClawHubSkillDetail } from "../../infra/clawhub.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { getOrCreatePromise } from "../../shared/lazy-promise.js";
 import { updateSkillConfigEntry } from "../../skills/config/mutations.js";
 import { collectSkillBins } from "../../skills/discovery/bins.js";
 import { buildWorkspaceSkillStatus } from "../../skills/discovery/status.js";
@@ -91,20 +92,9 @@ function installClawHubSkillDeduped(params: ClawHubInstallParams): Promise<ClawH
     params.force ?? false,
     params.acknowledgeClawHubRisk ?? false,
   ]);
-  const active = clawHubInstallsInFlight.get(key);
-  if (active) {
-    return active;
-  }
-  const install = installSkillFromClawHub(params);
-  clawHubInstallsInFlight.set(key, install);
-  void install
-    .finally(() => {
-      if (clawHubInstallsInFlight.get(key) === install) {
-        clawHubInstallsInFlight.delete(key);
-      }
-    })
-    .catch(() => undefined);
-  return install;
+  return getOrCreatePromise(clawHubInstallsInFlight, key, () => installSkillFromClawHub(params), {
+    evictOnSettled: true,
+  });
 }
 
 function buildRemoteAwareWorkspaceSkillStatus(resolved: ResolvedSkillsWorkspace) {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -82,6 +82,7 @@ import {
   handleSessionStateSessionReset,
   recordSessionCreated,
 } from "../sessions/session-state-events.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import {
   forgetActiveSessionForShutdown,
   listActiveSessionsForShutdown,
@@ -444,35 +445,32 @@ async function ensureSessionRuntimeCleanup(params: {
     });
   };
   const ensureMcpRetirementWatcher = () => {
-    if (mcpRunEndWatchers.has(sessionId)) {
-      return;
-    }
-    const watcherRef: { current?: Promise<void> } = {};
-    const watcher = (async () => {
-      while (await embeddedAgent.waitForEmbeddedAgentRunEnd(sessionId, null)) {
-        // A replacement can register after the wait promise settles but before
-        // this continuation runs. Keep the required retirement armed for it.
-        if (embeddedAgent.isEmbeddedAgentRunActive(sessionId)) {
-          continue;
+    let watcher!: Promise<void>;
+    watcher = getOrCreatePromise(
+      mcpRunEndWatchers,
+      sessionId,
+      async () => {
+        try {
+          while (await embeddedAgent.waitForEmbeddedAgentRunEnd(sessionId, null)) {
+            // A replacement can register after the wait promise settles but before
+            // this continuation runs. Keep the required retirement armed for it.
+            if (embeddedAgent.isEmbeddedAgentRunActive(sessionId)) {
+              continue;
+            }
+            if (mcpRunEndWatchers.get(sessionId) === watcher) {
+              mcpRunEndWatchers.delete(sessionId);
+            }
+            await retireMcpRuntime(false);
+            return;
+          }
+        } catch (error) {
+          logVerbose(
+            `sessions cleanup: failed to disarm deferred MCP retirement: ${String(error)}`,
+          );
         }
-        if (mcpRunEndWatchers.get(sessionId) === watcherRef.current) {
-          mcpRunEndWatchers.delete(sessionId);
-        }
-        await retireMcpRuntime(false);
-        return;
-      }
-    })();
-    watcherRef.current = watcher;
-    mcpRunEndWatchers.set(sessionId, watcher);
-    void watcher
-      .catch((error: unknown) => {
-        logVerbose(`sessions cleanup: failed to disarm deferred MCP retirement: ${String(error)}`);
-      })
-      .finally(() => {
-        if (mcpRunEndWatchers.get(sessionId) === watcher) {
-          mcpRunEndWatchers.delete(sessionId);
-        }
-      });
+      },
+      { evictOnSettled: true },
+    );
   };
   // Register against the run being stopped before abort or any await allows a
   // later embedded or reply-backed run to replace it in the active registry.

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -445,8 +445,7 @@ async function ensureSessionRuntimeCleanup(params: {
     });
   };
   const ensureMcpRetirementWatcher = () => {
-    let watcher!: Promise<void>;
-    watcher = getOrCreatePromise(
+    const watcher = getOrCreatePromise(
       mcpRunEndWatchers,
       sessionId,
       async () => {

--- a/src/gateway/user-profiles-http.ts
+++ b/src/gateway/user-profiles-http.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { getRuntimeConfig } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import {
   formatUserProfileAvatarEtag,
   getProfileAvatar,
@@ -244,22 +245,18 @@ async function resolveGravatar(
   if (cached) {
     return cached;
   }
-  const inFlight = gravatarRequests.get(hash);
-  if (inFlight) {
-    return await inFlight;
-  }
-  const request = fetchGravatar(hash, options.fetchImpl, options.deadline).then((result) => {
-    if (result.kind !== "error") {
-      cacheGravatar(hash, result, options.nowMs());
-    }
-    return result;
-  });
-  gravatarRequests.set(hash, request);
-  try {
-    return await request;
-  } finally {
-    gravatarRequests.delete(hash);
-  }
+  return await getOrCreatePromise(
+    gravatarRequests,
+    hash,
+    async () => {
+      const result = await fetchGravatar(hash, options.fetchImpl, options.deadline);
+      if (result.kind !== "error") {
+        cacheGravatar(hash, result, options.nowMs());
+      }
+      return result;
+    },
+    { evictOnSettled: true },
+  );
 }
 
 function sendAvatar(

--- a/src/infra/machine-name.ts
+++ b/src/infra/machine-name.ts
@@ -3,8 +3,8 @@ import os from "node:os";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { runExec } from "../process/exec.js";
 
-// Machine display names prefer macOS ComputerName when available and fall back
-// to hostname for deterministic tests and non-macOS hosts.
+// Prefer macOS ComputerName/LocalHostName with hostname fallback; machine
+// identity is process-stable, so retain the first outcome until restart.
 let cachedPromise: Promise<string> | null = null;
 
 async function tryScutil(key: "ComputerName" | "LocalHostName") {

--- a/src/infra/outbound/delivery-queue-migration.ts
+++ b/src/infra/outbound/delivery-queue-migration.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { createRenderedMessageBatchPlan } from "../../channels/message/rendered-batch.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveOutboundMediaMaxBytes } from "../../media/configured-max-bytes.js";
+import { getOrCreatePromise } from "../../shared/lazy-promise.js";
 import {
   movePendingDeliveryQueueEntryNamespace,
   replacePendingDeliveryQueueEntry,
@@ -480,19 +481,12 @@ export async function migrateLegacyPendingOutboundDeliveries(params: {
   stateDir?: string;
 }): Promise<{ moved: number; skipped: number }> {
   const migrationKey = params.stateDir ?? "<default-state>";
-  const active = activeLegacyMigrations.get(migrationKey);
-  if (active) {
-    return await active;
-  }
-  const migration = migrateLegacyPendingOutboundDeliveriesOwned(params);
-  activeLegacyMigrations.set(migrationKey, migration);
-  try {
-    return await migration;
-  } finally {
-    if (activeLegacyMigrations.get(migrationKey) === migration) {
-      activeLegacyMigrations.delete(migrationKey);
-    }
-  }
+  return await getOrCreatePromise(
+    activeLegacyMigrations,
+    migrationKey,
+    () => migrateLegacyPendingOutboundDeliveriesOwned(params),
+    { evictOnSettled: true },
+  );
 }
 
 async function migrateLegacyPendingOutboundDeliveriesOwned(params: {

--- a/src/media-understanding/local-audio.test.ts
+++ b/src/media-understanding/local-audio.test.ts
@@ -77,6 +77,35 @@ describe("local audio selection", () => {
     });
   });
 
+  it("retries binary inspection after a transient failure", async () => {
+    const tempDir = await createTempDir();
+    const modelPath = path.join(tempDir, "whisper.bin");
+    await fs.writeFile(modelPath, "model");
+    const attempts = new Map<string, number>();
+    const checkExecutable = async (filePath: string) => {
+      const attempt = (attempts.get(filePath) ?? 0) + 1;
+      attempts.set(filePath, attempt);
+      if (attempt === 1) {
+        throw new Error("transient filesystem failure");
+      }
+      return path.basename(filePath) === "whisper-cli";
+    };
+    const options = {
+      env: { PATH: tempDir, WHISPER_CPP_MODEL: modelPath },
+      platform: "linux" as const,
+      arch: "x64",
+      checkExecutable,
+      inspectLinkedLibraries: async () => null,
+    };
+
+    await expect(inspectLocalAudioSelection(options)).rejects.toThrow(
+      "transient filesystem failure",
+    );
+    await expect(inspectLocalAudioSelection(options)).resolves.toMatchObject({
+      selected: { id: "whisper-cli", resolvedCommand: path.join(tempDir, "whisper-cli") },
+    });
+  });
+
   it("does not rank Metal-capable whisper ahead of sherpa until a run observes Metal", async () => {
     const tempDir = await createTempDir();
     const modelPath = path.join(tempDir, "whisper.bin");

--- a/src/media-understanding/local-audio.ts
+++ b/src/media-understanding/local-audio.ts
@@ -159,35 +159,40 @@ async function findBinary(
   checkExecutable: (filePath: string, platform: NodeJS.Platform) => Promise<boolean> = isExecutable,
 ): Promise<string | null> {
   const key = `${platform}\0${env.PATH ?? ""}\0${env.PATHEXT ?? ""}\0${name}`;
-  return await getOrCreatePromise(binaryCache, key, async () => {
-    const direct = name.trim();
-    const candidates = binaryNames(direct, platform, env);
-    if (direct.includes("/") || direct.includes("\\")) {
-      for (const candidate of candidates) {
-        const expanded =
-          candidate === "~" || candidate.startsWith("~/") || candidate.startsWith("~\\")
-            ? path.join(env.HOME ?? "~", candidate.slice(candidate === "~" ? 1 : 2))
-            : candidate;
-        if (await checkExecutable(expanded, platform)) {
-          return expanded;
+  return await getOrCreatePromise(
+    binaryCache,
+    key,
+    async () => {
+      const direct = name.trim();
+      const candidates = binaryNames(direct, platform, env);
+      if (direct.includes("/") || direct.includes("\\")) {
+        for (const candidate of candidates) {
+          const expanded =
+            candidate === "~" || candidate.startsWith("~/") || candidate.startsWith("~\\")
+              ? path.join(env.HOME ?? "~", candidate.slice(candidate === "~" ? 1 : 2))
+              : candidate;
+          if (await checkExecutable(expanded, platform)) {
+            return expanded;
+          }
+        }
+        return null;
+      }
+      for (const directory of (env.PATH ?? "").split(path.delimiter)) {
+        const expandedDirectory = expandHomeDir(directory, env);
+        if (!expandedDirectory) {
+          continue;
+        }
+        for (const candidate of candidates) {
+          const fullPath = path.join(expandedDirectory, candidate);
+          if (await checkExecutable(fullPath, platform)) {
+            return fullPath;
+          }
         }
       }
       return null;
-    }
-    for (const directory of (env.PATH ?? "").split(path.delimiter)) {
-      const expandedDirectory = expandHomeDir(directory, env);
-      if (!expandedDirectory) {
-        continue;
-      }
-      for (const candidate of candidates) {
-        const fullPath = path.join(expandedDirectory, candidate);
-        if (await checkExecutable(fullPath, platform)) {
-          return fullPath;
-        }
-      }
-    }
-    return null;
-  });
+    },
+    { cacheRejections: false },
+  );
 }
 
 async function inspectLinkedLibraries(
@@ -195,19 +200,24 @@ async function inspectLinkedLibraries(
   platform: NodeJS.Platform,
 ): Promise<string | null> {
   const key = `${platform}\0${filePath}`;
-  return await getOrCreatePromise(libraryCache, key, async () => {
-    const command = platform === "darwin" ? "otool" : platform === "linux" ? "readelf" : null;
-    if (!command) {
-      return null;
-    }
-    try {
-      const args = platform === "darwin" ? ["-L", filePath] : ["-d", filePath];
-      const result = await runExec(command, args, { timeoutMs: 1500 });
-      return `${result.stdout}\n${result.stderr ?? ""}`;
-    } catch {
-      return null;
-    }
-  });
+  return await getOrCreatePromise(
+    libraryCache,
+    key,
+    async () => {
+      const command = platform === "darwin" ? "otool" : platform === "linux" ? "readelf" : null;
+      if (!command) {
+        return null;
+      }
+      try {
+        const args = platform === "darwin" ? ["-L", filePath] : ["-d", filePath];
+        const result = await runExec(command, args, { timeoutMs: 1500 });
+        return `${result.stdout}\n${result.stderr ?? ""}`;
+      } catch {
+        return null;
+      }
+    },
+    { cacheRejections: false },
+  );
 }
 
 async function inspectWhisperBackend(params: {

--- a/src/media/playback-transcode.ts
+++ b/src/media/playback-transcode.ts
@@ -8,6 +8,7 @@ import { fileStore } from "../infra/file-store.js";
 import { openLocalFileSafely } from "../infra/fs-safe.js";
 import { withTempWorkspace } from "../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { runFfmpeg } from "./ffmpeg-exec.js";
 import { probePlaybackMediaFileDescriptor, type PlaybackMediaProbeResult } from "./media-probe.js";
 import { resolveNativePlaybackCodecCompatibility } from "./playback-codec-policy.js";
@@ -351,13 +352,9 @@ async function inspectPlaybackSource(params: PlaybackSourceParams): Promise<Play
     return { mode: "fallback" };
   }
 
-  const inspectionJob = computeInspection();
-  playbackInspectionJobs.set(cacheKey, inspectionJob);
-  try {
-    return await inspectionJob;
-  } finally {
-    playbackInspectionJobs.delete(cacheKey);
-  }
+  return await getOrCreatePromise(playbackInspectionJobs, cacheKey, computeInspection, {
+    evictOnSettled: true,
+  });
 }
 
 /** Resolves source-aware playback metadata and caches codec classification by file identity. */

--- a/src/node-host/local-id.ts
+++ b/src/node-host/local-id.ts
@@ -1,4 +1,5 @@
 import { resolveStateDir } from "../config/paths.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { loadNodeHostConfig } from "./config.js";
 
 const localNodeIdByStateDir = new Map<string, Promise<string | null>>();
@@ -11,17 +12,10 @@ export async function resolveLocalNodeId(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string | null> {
   const stateDir = resolveStateDir(env);
-  let pending = localNodeIdByStateDir.get(stateDir);
-  if (!pending) {
-    pending = loadNodeHostConfig(env).then((config) => config?.nodeId ?? null);
-    localNodeIdByStateDir.set(stateDir, pending);
-  }
-  try {
-    return await pending;
-  } catch (error) {
-    if (localNodeIdByStateDir.get(stateDir) === pending) {
-      localNodeIdByStateDir.delete(stateDir);
-    }
-    throw error;
-  }
+  return await getOrCreatePromise(
+    localNodeIdByStateDir,
+    stateDir,
+    async () => (await loadNodeHostConfig(env))?.nodeId ?? null,
+    { cacheRejections: false },
+  );
 }

--- a/src/shared/lazy-promise.test.ts
+++ b/src/shared/lazy-promise.test.ts
@@ -26,6 +26,82 @@ describe("getOrCreatePromise", () => {
     );
     expect(create).toHaveBeenCalledTimes(3);
   });
+
+  it("keeps rejected loads cached by default", async () => {
+    const cache = new Map<string, Promise<string>>();
+    const create = vi.fn(async () => {
+      throw new Error("sticky");
+    });
+
+    const first = getOrCreatePromise(cache, "a", create);
+    await expect(first).rejects.toThrow("sticky");
+    expect(getOrCreatePromise(cache, "a", create)).toBe(first);
+    expect(create).toHaveBeenCalledOnce();
+  });
+
+  it("evicts only rejected loads when rejection caching is disabled", async () => {
+    const cache = new Map<string, Promise<string>>();
+    const create = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValue("recovered");
+
+    await expect(
+      getOrCreatePromise(cache, "a", create, { cacheRejections: false }),
+    ).rejects.toThrow("transient");
+    await expect(getOrCreatePromise(cache, "a", create, { cacheRejections: false })).resolves.toBe(
+      "recovered",
+    );
+    await expect(getOrCreatePromise(cache, "a", create, { cacheRejections: false })).resolves.toBe(
+      "recovered",
+    );
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts settled in-flight work without deleting a replacement", async () => {
+    const cache = new Map<string, Promise<string>>();
+    let resolveFirst!: (value: string) => void;
+    const first = getOrCreatePromise(
+      cache,
+      "a",
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFirst = resolve;
+        }),
+      { evictOnSettled: true },
+    );
+    const replacement = Promise.resolve("replacement");
+    cache.set("a", replacement);
+
+    resolveFirst("first");
+    await expect(first).resolves.toBe("first");
+    expect(cache.get("a")).toBe(replacement);
+
+    await expect(
+      getOrCreatePromise(cache, "b", async () => "settled", { evictOnSettled: true }),
+    ).resolves.toBe("settled");
+    expect(cache.has("b")).toBe(false);
+  });
+
+  it("does not let a stale rejection delete a replacement", async () => {
+    const cache = new Map<string, Promise<string>>();
+    let rejectFirst!: (reason: Error) => void;
+    const first = getOrCreatePromise(
+      cache,
+      "a",
+      () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectFirst = reject;
+        }),
+      { cacheRejections: false },
+    );
+    const replacement = Promise.resolve("replacement");
+    cache.set("a", replacement);
+
+    rejectFirst(new Error("stale"));
+    await expect(first).rejects.toThrow("stale");
+    expect(cache.get("a")).toBe(replacement);
+  });
 });
 
 describe("createLazyPromise", () => {

--- a/src/shared/lazy-promise.ts
+++ b/src/shared/lazy-promise.ts
@@ -8,11 +8,19 @@ export type LazyPromiseLoader<T> = {
   clear: () => void;
 };
 
+type KeyedPromiseCacheOptions = {
+  /** Defaults to true; set false to allow retry after a rejected load. */
+  cacheRejections?: boolean;
+  /** Remove the promise after either outcome when the map only tracks in-flight work. */
+  evictOnSettled?: boolean;
+};
+
 /** Returns the cached promise for a key, creating and storing it when absent. */
 export function getOrCreatePromise<K, V>(
   cache: Map<K, Promise<V>>,
   key: K,
   create: () => Promise<V>,
+  options: KeyedPromiseCacheOptions = {},
 ): Promise<V> {
   const cached = cache.get(key);
   if (cached) {
@@ -20,6 +28,16 @@ export function getOrCreatePromise<K, V>(
   }
   const created = create();
   cache.set(key, created);
+  const evict = () => {
+    if (cache.get(key) === created) {
+      cache.delete(key);
+    }
+  };
+  if (options.evictOnSettled === true) {
+    void created.then(evict, evict);
+  } else if (options.cacheRejections === false) {
+    void created.catch(evict);
+  }
   return created;
 }
 

--- a/src/tui/coalesced-refresh.ts
+++ b/src/tui/coalesced-refresh.ts
@@ -1,0 +1,37 @@
+type CoalescedRefreshWork = (requestRerun: () => void) => Promise<boolean | void>;
+
+/** Keeps refresh bursts to one active lookup plus one latest-state rerun. */
+export function createTuiRefreshCoalescer(refresh: CoalescedRefreshWork, afterDrain?: () => void) {
+  let active: Promise<void> | undefined;
+  let rerunRequested = false;
+  const requestRerun = () => {
+    rerunRequested = true;
+  };
+
+  return {
+    isRunning: () => active !== undefined,
+    async run(): Promise<void> {
+      if (active) {
+        requestRerun();
+        return await active;
+      }
+      const current = (async () => {
+        do {
+          rerunRequested = false;
+          if ((await refresh(requestRerun)) === false) {
+            return;
+          }
+        } while (rerunRequested);
+        afterDrain?.();
+      })();
+      active = current;
+      try {
+        await current;
+      } finally {
+        if (active === current) {
+          active = undefined;
+        }
+      }
+    },
+  };
+}

--- a/src/tui/tui-plugin-approvals.ts
+++ b/src/tui/tui-plugin-approvals.ts
@@ -9,6 +9,7 @@ import {
 import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { isApprovalStaleError } from "../infra/approval-errors.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { createTuiRefreshCoalescer } from "./coalesced-refresh.js";
 import { selectListTheme, theme } from "./theme/theme.js";
 import type { TuiApprovalDecision, TuiBackend, TuiPluginApproval } from "./tui-backend.js";
 import { sanitizeRenderableText } from "./tui-formatters.js";
@@ -218,8 +219,7 @@ export function createTuiPluginApprovalController(deps: TuiPluginApprovalControl
   let expiryTimer: ApprovalTimer | null = null;
   let disposed = false;
   let mutationVersion = 0;
-  let refreshAgain = false;
-  let refreshInFlight: Promise<void> | null = null;
+  const refreshRunner = createTuiRefreshCoalescer(async () => await refreshOnce());
   const mutations = new Map<string, ApprovalMutation>();
   const resolvingIds = new Set<string>();
   const dismissedIds = new Set<string>();
@@ -240,7 +240,7 @@ export function createTuiPluginApprovalController(deps: TuiPluginApprovalControl
   };
 
   const recordMutation = (id: string, approval: TuiPluginApproval | null) => {
-    if (!refreshInFlight) {
+    if (!refreshRunner.isRunning()) {
       return;
     }
     mutationVersion += 1;
@@ -435,7 +435,7 @@ export function createTuiPluginApprovalController(deps: TuiPluginApprovalControl
     queue = [...next.values()].toSorted((left, right) => left.createdAtMs - right.createdAtMs);
   };
 
-  const refreshOnce = async () => {
+  async function refreshOnce(): Promise<void> {
     if (disposed || !deps.client.listPluginApprovals) {
       return;
     }
@@ -459,27 +459,13 @@ export function createTuiPluginApprovalController(deps: TuiPluginApprovalControl
     }
     presentNext();
     deps.requestRender();
-  };
+  }
 
   const refreshApprovals = async (): Promise<void> => {
     if (disposed || !deps.client.listPluginApprovals) {
       return;
     }
-    if (refreshInFlight) {
-      refreshAgain = true;
-      return await refreshInFlight;
-    }
-    refreshInFlight = (async () => {
-      do {
-        refreshAgain = false;
-        await refreshOnce();
-      } while (refreshAgain);
-    })();
-    try {
-      await refreshInFlight;
-    } finally {
-      refreshInFlight = null;
-    }
+    await refreshRunner.run();
   };
 
   return {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -9,6 +9,7 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { createTuiRefreshCoalescer } from "./coalesced-refresh.js";
 import type { ChatLog } from "./components/chat-log.js";
 import { refreshTuiAgentList } from "./tui-agent-list-refresh.js";
 import type { TuiAgentsList, TuiBackend, TuiSessionMutationResult } from "./tui-backend.js";
@@ -78,8 +79,6 @@ export function createSessionActions(context: SessionActionContext) {
     clearLocalRunIds,
     rememberSessionKey,
   } = context;
-  let refreshSessionInfoInFlight: Promise<void> | null = null;
-  let refreshSessionInfoQueued = false;
   let historyLoadGeneration = 0;
   let lastSessionDefaults: SessionInfoDefaults | null = null;
 
@@ -343,26 +342,12 @@ export function createSessionActions(context: SessionActionContext) {
     }
   };
 
-  const drainRefreshSessionInfo = async () => {
-    do {
-      // Many TUI paths ask for the same session snapshot at once; keep one in-flight
-      // lookup and at most one follow-up so bursts do not queue stale backend calls.
-      refreshSessionInfoQueued = false;
-      await runRefreshSessionInfo();
-    } while (refreshSessionInfoQueued);
-  };
-
-  const refreshSessionInfo = async () => {
-    if (refreshSessionInfoInFlight) {
-      refreshSessionInfoQueued = true;
-      await refreshSessionInfoInFlight;
-      return;
-    }
-    refreshSessionInfoInFlight = drainRefreshSessionInfo().finally(() => {
-      refreshSessionInfoInFlight = null;
-    });
-    await refreshSessionInfoInFlight;
-  };
+  // Many TUI paths ask for the same session snapshot at once; bursts need only
+  // one active lookup and one follow-up with the latest selection.
+  const refreshSessionInfoRunner = createTuiRefreshCoalescer(async () => {
+    await runRefreshSessionInfo();
+  });
+  const refreshSessionInfo = () => refreshSessionInfoRunner.run();
 
   const applySessionInfoFromPatch = (
     result?: SessionsPatchResult | TuiSessionMutationResult | null,

--- a/src/tui/tui-task-suggestions.ts
+++ b/src/tui/tui-task-suggestions.ts
@@ -9,6 +9,7 @@ import {
 import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import type { TaskSuggestion } from "../../packages/gateway-protocol/src/index.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { createTuiRefreshCoalescer } from "./coalesced-refresh.js";
 import { selectListTheme, theme } from "./theme/theme.js";
 import type { TuiBackend } from "./tui-backend.js";
 import { sanitizeRenderableText } from "./tui-formatters.js";
@@ -203,8 +204,6 @@ export function createTuiTaskSuggestionController(deps: TaskSuggestionController
   let activeActionKey: string | null = null;
   let revision = 0;
   let disposed = false;
-  let refreshInFlight: Promise<void> | null = null;
-  let refreshAgain = false;
 
   const closeActive = () => {
     if (activeOverlay) {
@@ -359,51 +358,45 @@ export function createTuiTaskSuggestionController(deps: TaskSuggestionController
     deps.requestRender();
   };
 
-  const refresh = async (): Promise<void> => {
-    if (disposed || !deps.client.listTaskSuggestions) {
-      return;
-    }
-    if (refreshInFlight) {
-      refreshAgain = true;
-      return await refreshInFlight;
-    }
-    refreshInFlight = (async () => {
-      do {
-        refreshAgain = false;
-        const startRevision = revision;
-        const listed = await deps.client.listTaskSuggestions?.();
-        if (disposed || !listed) {
-          return;
+  const refreshRunner = createTuiRefreshCoalescer(
+    async (requestRerun) => {
+      const startRevision = revision;
+      const listed = await deps.client.listTaskSuggestions?.();
+      if (disposed || !listed) {
+        return false;
+      }
+      // An event raced this snapshot. Retry instead of resurrecting resolved work.
+      if (revision !== startRevision) {
+        requestRerun();
+        return;
+      }
+      suggestions.clear();
+      for (const value of listed) {
+        const suggestion = parseTuiTaskSuggestion(value);
+        if (suggestion) {
+          suggestions.set(suggestion.id, suggestion);
         }
-        // An event raced this snapshot. Retry instead of resurrecting resolved work.
-        if (revision !== startRevision) {
-          refreshAgain = true;
-          continue;
+      }
+      for (const id of hiddenIds) {
+        if (!suggestions.has(id)) {
+          hiddenIds.delete(id);
         }
-        suggestions.clear();
-        for (const value of listed) {
-          const suggestion = parseTuiTaskSuggestion(value);
-          if (suggestion) {
-            suggestions.set(suggestion.id, suggestion);
-          }
-        }
-        for (const id of hiddenIds) {
-          if (!suggestions.has(id)) {
-            hiddenIds.delete(id);
-          }
-        }
-      } while (refreshAgain);
+      }
+    },
+    () => {
       if (activeId && !suggestions.has(activeId)) {
         closeActive();
       }
       presentNext();
       deps.requestRender();
-    })();
-    try {
-      await refreshInFlight;
-    } finally {
-      refreshInFlight = null;
+    },
+  );
+
+  const refresh = async (): Promise<void> => {
+    if (disposed || !deps.client.listTaskSuggestions) {
+      return;
     }
+    await refreshRunner.run();
   };
 
   return {

--- a/src/tui/tui-task-suggestions.ts
+++ b/src/tui/tui-task-suggestions.ts
@@ -368,7 +368,7 @@ export function createTuiTaskSuggestionController(deps: TaskSuggestionController
       // An event raced this snapshot. Retry instead of resurrecting resolved work.
       if (revision !== startRevision) {
         requestRerun();
-        return;
+        return true;
       }
       suggestions.clear();
       for (const value of listed) {

--- a/src/tui/tui-task-suggestions.ts
+++ b/src/tui/tui-task-suggestions.ts
@@ -382,6 +382,7 @@ export function createTuiTaskSuggestionController(deps: TaskSuggestionController
           hiddenIds.delete(id);
         }
       }
+      return true;
     },
     () => {
       if (activeId && !suggestions.has(activeId)) {


### PR DESCRIPTION
## What Problem This Solves

OpenClaw had many keyed single-flight maps that repeated the same create/store/settle/delete lifecycle. The canonical `getOrCreatePromise` helper only supported sticky promises, so callers hand-rolled cleanup and two durable caches retained rejected promises indefinitely.

In particular, one failed CLI channel sender load poisoned both a keyed sender cache and a nested sticky lazy-runtime cache until restart. Local audio inspection likewise retained rejected probe promises until its test-only cache clear.

## Why This Change Was Made

This widens `getOrCreatePromise` with two explicit, identity-safe lifecycle policies while preserving sticky behavior for every existing caller:

- `cacheRejections: false` retains successful values but evicts the exact rejected promise.
- `evictOnSettled: true` models maps that own only in-flight work.

The CLI sender now has one keyed cache instead of two nested sticky caches. Ten clean keyed hand-rolls use the canonical helper, delivery-queue media GC uses the existing single-slot lazy loader, and three TUI refresh loops share one coalesce-plus-rerun owner.

Two surveyed sites were deliberately left alone after direct inspection: iOS approval push pending state is a cleanup projection rather than a single-flight cache, and media cleanup starts synchronously while the lazy loader starts on a microtask. Canonicalizing either would change behavior.

## User Impact

A transient channel sender load failure or rejected local-audio inspection can recover on the next request instead of requiring an OpenClaw restart. Successful cache behavior, cooldowns, LRU limits, status projections, and existing single-flight semantics remain unchanged.

Production code is net 10 lines smaller. Tests add 125 lines of regression and lifecycle coverage.

## Evidence

- `node scripts/run-vitest.mjs src/shared/lazy-promise.test.ts src/cli/deps.test.ts src/media-understanding/local-audio.test.ts`
  - 3 shards passed; 22 tests passed.
- `node scripts/run-vitest.mjs src/gateway/server-methods/skills.clawhub.test.ts src/gateway/node-pairing-ssh-verify.test.ts src/media/playback-transcode.test.ts src/gateway/user-profiles-http.test.ts src/gateway/dashboard-session-title.test.ts src/gateway/mcp-app-reconstruction.test.ts src/infra/outbound/delivery-queue-migration.test.ts src/gateway/control-ui.http.test.ts src/gateway/server.sessions.reset-cleanup.test.ts src/node-host/local-id.test.ts src/gateway/server-maintenance.test.ts`
  - 4 shards passed; 309 tests passed.
- `node scripts/run-vitest.mjs src/tui/tui-plugin-approvals.test.ts src/tui/tui-task-suggestions.test.ts src/tui/tui-session-actions.test.ts`
  - 1 shard passed; 101 tests passed after the final CI type-contract adjustment.
- `node scripts/check-changed.mjs`
  - Correctly delegated the heavy plan, but no remote provider was ready; Blacksmith doctor failed and managed cloud brokers were unavailable. No forbidden local fallback was run.
- Targeted `oxfmt` on all 24 touched files: passed.
- `git diff --check`: passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`: clean before commit and clean again after the CI fix, with no accepted/actionable findings.
