### PR TITLE
fix(minimax): support music cover source audio

### DIFF
--- a/extensions/minimax/music-generation-provider.test.ts
+++ b/extensions/minimax/music-generation-provider.test.ts
@@ -158,6 +158,79 @@ describe("minimax music generation provider", () => {
     expect(result.metadata).not.toHaveProperty("requestedDurationSeconds");
   });
 
+  it("sends cover_feature_id for music-cover models", async () => {
+    mockMusicGenerationResponse({
+      task_id: "task-cover-feature",
+      audio_url: "https://example.com/cover-feature.mp3",
+      base_resp: { status_code: 0 },
+    });
+
+    await buildMinimaxMusicGenerationProvider().generateMusic({
+      provider: "minimax",
+      model: "music-cover",
+      prompt: "cover this song",
+      cfg: {},
+      lyrics: "singing the same song in a new style",
+      coverFeatureId: "feature-123",
+    });
+
+    const body = mockCallArg(postJsonRequestMock).body as Record<string, unknown>;
+    expect(body.model).toBe("music-cover");
+    expect(body.cover_feature_id).toBe("feature-123");
+    expect(body.lyrics).toBe("singing the same song in a new style");
+    expect(body).not.toHaveProperty("audio_url");
+    expect(body).not.toHaveProperty("audio_base64");
+    expect(body).not.toHaveProperty("is_instrumental");
+    expect(body).not.toHaveProperty("lyrics_optimizer");
+  });
+
+  it("serializes buffered cover audio as base64 for music-cover models", async () => {
+    mockMusicGenerationResponse({
+      task_id: "task-cover-audio",
+      audio_url: "https://example.com/cover-audio.mp3",
+      base_resp: { status_code: 0 },
+    });
+
+    const coverAudio = Buffer.from("cover-source-audio");
+    await buildMinimaxMusicGenerationProvider().generateMusic({
+      provider: "minimax",
+      model: "music-cover-free",
+      prompt: "cover this song",
+      cfg: {},
+      inputAudios: [{ buffer: coverAudio, mimeType: "audio/mpeg" }],
+    });
+
+    const body = mockCallArg(postJsonRequestMock).body as Record<string, unknown>;
+    expect(body.model).toBe("music-cover-free");
+    expect(body.audio_base64).toBe(coverAudio.toString("base64"));
+    expect(body).not.toHaveProperty("audio_url");
+    expect(body).not.toHaveProperty("cover_feature_id");
+    expect(body).not.toHaveProperty("is_instrumental");
+    expect(body).not.toHaveProperty("lyrics_optimizer");
+  });
+
+  it("passes source audio URLs through for music-cover models", async () => {
+    mockMusicGenerationResponse({
+      task_id: "task-cover-url",
+      audio_url: "https://example.com/cover-url.mp3",
+      base_resp: { status_code: 0 },
+    });
+
+    await buildMinimaxMusicGenerationProvider().generateMusic({
+      provider: "minimax",
+      model: "music-cover",
+      prompt: "cover this song",
+      cfg: {},
+      inputAudios: [{ url: "https://example.com/source.mp3", mimeType: "audio/mpeg" }],
+    });
+
+    const body = mockCallArg(postJsonRequestMock).body as Record<string, unknown>;
+    expect(body.model).toBe("music-cover");
+    expect(body.audio_url).toBe("https://example.com/source.mp3");
+    expect(body).not.toHaveProperty("audio_base64");
+    expect(body).not.toHaveProperty("cover_feature_id");
+  });
+
   it.each([
     { provider: "minimax", contentType: "application/json", body: '{"error":"denied"}' },
     {

--- a/extensions/minimax/music-generation-provider.ts
+++ b/extensions/minimax/music-generation-provider.ts
@@ -4,6 +4,7 @@ import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import type {
   GeneratedMusicAsset,
   MusicGenerationProvider,
+  MusicGenerationSourceAudio,
 } from "openclaw/plugin-sdk/music-generation";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -264,6 +265,56 @@ function resolveMinimaxMusicModel(model: string | undefined): string {
   return trimmed;
 }
 
+function isMinimaxMusicCoverModel(model: string): boolean {
+  return model === "music-cover" || model === "music-cover-free";
+}
+
+function resolveMinimaxMusicCoverSource(req: {
+  audioUrl?: string;
+  audioBase64?: string;
+  coverFeatureId?: string;
+  inputAudios?: MusicGenerationSourceAudio[];
+}): Record<string, string> | undefined {
+  const coverFeatureId = normalizeOptionalString(req.coverFeatureId);
+  const audioUrl = normalizeOptionalString(req.audioUrl);
+  const audioBase64 = normalizeOptionalString(req.audioBase64);
+  const explicitFields = [coverFeatureId, audioUrl, audioBase64].filter(
+    (value): value is string => Boolean(value),
+  );
+  if (explicitFields.length > 1) {
+    throw new Error(
+      "MiniMax music cover accepts only one of audioUrl, audioBase64, or coverFeatureId.",
+    );
+  }
+  if (coverFeatureId) {
+    return { cover_feature_id: coverFeatureId };
+  }
+  if (audioUrl) {
+    return { audio_url: audioUrl };
+  }
+  if (audioBase64) {
+    return { audio_base64: audioBase64 };
+  }
+  const inputAudios = req.inputAudios ?? [];
+  if (inputAudios.length > 1) {
+    throw new Error("MiniMax music cover accepts at most one reference audio.");
+  }
+  const sourceAudio = inputAudios[0];
+  if (!sourceAudio) {
+    return undefined;
+  }
+  const sourceAudioUrl = normalizeOptionalString(sourceAudio.url);
+  if (sourceAudioUrl) {
+    return { audio_url: sourceAudioUrl };
+  }
+  if (!sourceAudio.buffer || sourceAudio.buffer.byteLength === 0) {
+    throw new Error("MiniMax music cover reference audio is missing data.");
+  }
+  return {
+    audio_base64: Buffer.from(sourceAudio.buffer).toString("base64"),
+  };
+}
+
 function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider {
   return {
     id: providerId,
@@ -334,15 +385,38 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
 
       const model = resolveMinimaxMusicModel(req.model);
       const requestedLyrics = normalizeOptionalString(req.lyrics);
+      const isCoverModel = isMinimaxMusicCoverModel(model);
+      const coverSource = resolveMinimaxMusicCoverSource(req);
+      if (isCoverModel && normalizeOptionalString(req.coverFeatureId) && !requestedLyrics) {
+        throw new Error("MiniMax music cover requires lyrics when using coverFeatureId.");
+      }
+      if (isCoverModel && !coverSource) {
+        throw new Error(
+          "MiniMax music cover requires audioUrl, audioBase64, or coverFeatureId.",
+        );
+      }
+      if (!isCoverModel && coverSource) {
+        throw new Error("MiniMax music cover source audio requires a music-cover model.");
+      }
+      if (isCoverModel && req.instrumental === true) {
+        throw new Error("MiniMax music cover does not support instrumental mode.");
+      }
       const body = {
         model,
         prompt: req.prompt.trim(),
-        ...(req.instrumental === true ? { is_instrumental: true } : {}),
-        ...(requestedLyrics
-          ? { lyrics: requestedLyrics }
-          : req.instrumental === true
-            ? {}
-            : { lyrics_optimizer: true }),
+        ...(isCoverModel
+          ? {
+              ...(requestedLyrics ? { lyrics: requestedLyrics } : {}),
+              ...coverSource,
+            }
+          : {
+              ...(req.instrumental === true ? { is_instrumental: true } : {}),
+              ...(requestedLyrics
+                ? { lyrics: requestedLyrics }
+                : req.instrumental === true
+                  ? {}
+                  : { lyrics_optimizer: true }),
+            }),
         stream: true,
         output_format: "hex",
         audio_setting: {

--- a/extensions/minimax/music-generation-provider.ts
+++ b/extensions/minimax/music-generation-provider.ts
@@ -278,8 +278,8 @@ function resolveMinimaxMusicCoverSource(req: {
   const coverFeatureId = normalizeOptionalString(req.coverFeatureId);
   const audioUrl = normalizeOptionalString(req.audioUrl);
   const audioBase64 = normalizeOptionalString(req.audioBase64);
-  const explicitFields = [coverFeatureId, audioUrl, audioBase64].filter(
-    (value): value is string => Boolean(value),
+  const explicitFields = [coverFeatureId, audioUrl, audioBase64].filter((value): value is string =>
+    Boolean(value),
   );
   if (explicitFields.length > 1) {
     throw new Error(
@@ -391,9 +391,7 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
         throw new Error("MiniMax music cover requires lyrics when using coverFeatureId.");
       }
       if (isCoverModel && !coverSource) {
-        throw new Error(
-          "MiniMax music cover requires audioUrl, audioBase64, or coverFeatureId.",
-        );
+        throw new Error("MiniMax music cover requires audioUrl, audioBase64, or coverFeatureId.");
       }
       if (!isCoverModel && coverSource) {
         throw new Error("MiniMax music cover source audio requires a music-cover model.");

--- a/src/music-generation/normalization.ts
+++ b/src/music-generation/normalization.ts
@@ -9,6 +9,7 @@ import type {
   MusicGenerationNormalization,
   MusicGenerationOutputFormat,
   MusicGenerationProvider,
+  MusicGenerationSourceAudio,
   MusicGenerationSourceImage,
 } from "./types.js";
 
@@ -45,6 +46,10 @@ export function resolveMusicGenerationOverrides(params: {
   durationSeconds?: number;
   format?: MusicGenerationOutputFormat;
   inputImages?: MusicGenerationSourceImage[];
+  audioUrl?: string;
+  audioBase64?: string;
+  coverFeatureId?: string;
+  inputAudios?: MusicGenerationSourceAudio[];
 }): ResolvedMusicGenerationOverrides {
   const { capabilities: caps } = resolveMusicGenerationModeCapabilities({
     provider: params.provider,

--- a/src/music-generation/runtime-types.ts
+++ b/src/music-generation/runtime-types.ts
@@ -7,6 +7,7 @@ import type {
   MusicGenerationIgnoredOverride,
   MusicGenerationNormalization,
   MusicGenerationOutputFormat,
+  MusicGenerationSourceAudio,
   MusicGenerationSourceImage,
 } from "./types.js";
 
@@ -28,6 +29,10 @@ export type GenerateMusicParams = {
   durationSeconds?: number;
   format?: MusicGenerationOutputFormat;
   inputImages?: MusicGenerationSourceImage[];
+  audioUrl?: string;
+  audioBase64?: string;
+  coverFeatureId?: string;
+  inputAudios?: MusicGenerationSourceAudio[];
   autoProviderFallback?: boolean;
   /** Optional per-request provider timeout in milliseconds. */
   timeoutMs?: number;

--- a/src/music-generation/runtime.test.ts
+++ b/src/music-generation/runtime.test.ts
@@ -112,6 +112,45 @@ describe("music-generation runtime", () => {
     ]);
   });
 
+  it("passes cover-source audio through to the selected provider", async () => {
+    let seenRequest: Record<string, unknown> | undefined;
+    providers = [
+      {
+        id: "music-plugin",
+        capabilities: {},
+        async generateMusic(req: Record<string, unknown>) {
+          seenRequest = req;
+          return {
+            tracks: [{ buffer: Buffer.from("mp3-bytes"), mimeType: "audio/mpeg" }],
+            model: "music-cover",
+          };
+        },
+      },
+    ];
+
+    await runGenerateMusic({
+      cfg: {
+        agents: {
+          defaults: {
+            musicGenerationModel: { primary: "music-plugin/music-cover" },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "cover this song",
+      audioUrl: "https://example.com/source.mp3",
+      audioBase64: "c291cmNlLWJ5dGVz",
+      coverFeatureId: "feature-123",
+      inputAudios: [{ buffer: Buffer.from("cover-source"), mimeType: "audio/mpeg" }],
+    });
+
+    expect(seenRequest).toMatchObject({
+      audioUrl: "https://example.com/source.mp3",
+      audioBase64: "c291cmNlLWJ5dGVz",
+      coverFeatureId: "feature-123",
+      inputAudios: [{ mimeType: "audio/mpeg" }],
+    });
+  });
+
   it("uses configured music-generation timeout when call omits timeoutMs", async () => {
     let seenTimeoutMs: number | undefined;
     providers = [

--- a/src/music-generation/runtime.ts
+++ b/src/music-generation/runtime.ts
@@ -100,6 +100,10 @@ export async function generateMusic(
         durationSeconds: params.durationSeconds,
         format: params.format,
         inputImages: params.inputImages,
+        audioUrl: params.audioUrl,
+        audioBase64: params.audioBase64,
+        coverFeatureId: params.coverFeatureId,
+        inputAudios: params.inputAudios,
       });
       const result: MusicGenerationResult = await provider.generateMusic({
         provider: candidate.provider,
@@ -113,6 +117,10 @@ export async function generateMusic(
         durationSeconds: sanitized.durationSeconds,
         format: sanitized.format,
         inputImages: params.inputImages,
+        audioUrl: params.audioUrl,
+        audioBase64: params.audioBase64,
+        coverFeatureId: params.coverFeatureId,
+        inputAudios: params.inputAudios,
         ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       });
       if (!Array.isArray(result.tracks) || result.tracks.length === 0) {

--- a/src/music-generation/types.ts
+++ b/src/music-generation/types.ts
@@ -29,6 +29,15 @@ export type MusicGenerationSourceImage = {
   metadata?: Record<string, unknown>;
 };
 
+/** Optional source audio passed to music-cover models. */
+export type MusicGenerationSourceAudio = {
+  url?: string;
+  buffer?: Buffer;
+  mimeType?: string;
+  fileName?: string;
+  metadata?: Record<string, unknown>;
+};
+
 type MusicGenerationProviderConfiguredContext = {
   cfg?: OpenClawConfig;
   agentDir?: string;
@@ -48,6 +57,10 @@ export type MusicGenerationRequest = {
   durationSeconds?: number;
   format?: MusicGenerationOutputFormat;
   inputImages?: MusicGenerationSourceImage[];
+  audioUrl?: string;
+  audioBase64?: string;
+  coverFeatureId?: string;
+  inputAudios?: MusicGenerationSourceAudio[];
 };
 
 /** Provider result before runtime fallback metadata is attached. */

--- a/src/plugin-sdk/music-generation.ts
+++ b/src/plugin-sdk/music-generation.ts
@@ -9,6 +9,7 @@ export type {
   MusicGenerationProviderCapabilities,
   MusicGenerationRequest,
   MusicGenerationResult,
+  MusicGenerationSourceAudio,
   MusicGenerationSourceImage,
   MusicGenerationOutputFormat,
 } from "../music-generation/types.js";


### PR DESCRIPTION
Reason: MiniMax music-cover requests need to send a cover source audio field so cover generation can run.

Changes:
- Added source-audio fields to the music generation runtime request path.
- Serialized MiniMax music-cover source inputs as audio_url, audio_base64, or cover_feature_id.
- Added provider and runtime tests for cover source passthrough.

Checks:
- node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts extensions/minimax/music-generation-provider.test.ts src/music-generation/runtime.test.ts
- git diff --check
- secret scan

## What Problem This Solves

Music-cover requests previously lost their source audio before the MiniMax provider request was built, so the API could not perform a cover transformation. This change preserves one supported source-audio form through the runtime and serializes it into the provider payload.

## Evidence

- Provider tests cover audio URL, base64 audio, and cover feature ID serialization.
- Runtime tests verify source-audio passthrough to the provider.
- The targeted Vitest command, diff check, and secret scan passed.