### PR TITLE
refactor(plugins): consolidate capability provider test fixtures

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -138,6 +138,80 @@ function expectNoResolvedCapabilityProviders(providers: Array<{ id: string }>) {
   expectResolvedCapabilityProviderIds(providers, []);
 }
 
+type CapabilityFixtureRegistry = ReturnType<typeof createEmptyPluginRegistry>;
+type CapabilityFixtureKey =
+  | "memoryEmbeddingProviders"
+  | "speechProviders"
+  | "realtimeTranscriptionProviders"
+  | "realtimeVoiceProviders"
+  | "mediaUnderstandingProviders"
+  | "imageGenerationProviders"
+  | "videoGenerationProviders"
+  | "musicGenerationProviders";
+
+function addCapabilityProvider(
+  registry: CapabilityFixtureRegistry,
+  key: CapabilityFixtureKey,
+  params: {
+    id: string;
+    pluginId?: string;
+    pluginName?: string;
+    provider?: Record<string, unknown>;
+  },
+) {
+  const pluginId = params.pluginId ?? params.id;
+  (registry[key] as unknown[]).push({
+    pluginId,
+    pluginName: params.pluginName ?? pluginId,
+    source: "test",
+    provider: { id: params.id, ...params.provider },
+  });
+}
+
+function addSpeechProvider(
+  registry: CapabilityFixtureRegistry,
+  id: string,
+  params: {
+    pluginId?: string;
+    pluginName?: string;
+    label?: string;
+    aliases?: string[];
+    provider?: Record<string, unknown>;
+  } = {},
+) {
+  addCapabilityProvider(registry, "speechProviders", {
+    id,
+    pluginId: params.pluginId,
+    pluginName: params.pluginName,
+    provider: {
+      label: params.label ?? params.pluginName ?? id,
+      ...(params.aliases ? { aliases: params.aliases } : {}),
+      isConfigured: () => true,
+      synthesize: async () => ({
+        audioBuffer: Buffer.from("x"),
+        outputFormat: "mp3",
+        voiceCompatible: false,
+        fileExtension: ".mp3",
+      }),
+      ...params.provider,
+    },
+  });
+}
+
+function setCapabilityManifestPlugins(
+  plugins: Array<{
+    id: string;
+    origin?: "bundled" | "global";
+    enabledByDefault?: boolean;
+    contracts: Record<string, string[]>;
+  }>,
+) {
+  mocks.loadPluginManifestRegistry.mockReturnValue({
+    plugins: plugins.map((plugin) => ({ origin: "bundled", ...plugin })) as never,
+    diagnostics: [],
+  });
+}
+
 function expectActiveRegistryLookup(pluginIds: string[]) {
   expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({ onlyPluginIds: pluginIds });
 }
@@ -573,22 +647,7 @@ describe("resolvePluginCapabilityProviders", () => {
 
   it("uses the active registry when capability providers are already loaded", () => {
     const active = createEmptyPluginRegistry();
-    active.speechProviders.push({
-      pluginId: "openai",
-      pluginName: "openai",
-      source: "test",
-      provider: {
-        id: "openai",
-        label: "openai",
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
+    addSpeechProvider(active, "openai");
     mocks.resolveRuntimePluginRegistry.mockReturnValue(active);
 
     const providers = resolvePluginCapabilityProviders({ key: "speechProviders" });
@@ -799,46 +858,13 @@ describe("resolvePluginCapabilityProviders", () => {
 
   it("loads a voiceModel provider that is missing from an active speech registry", () => {
     const active = createEmptyPluginRegistry();
-    active.speechProviders.push({
-      pluginId: "google",
-      pluginName: "Google",
-      source: "test",
-      provider: {
-        id: "google",
-        label: "Google",
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
+    addSpeechProvider(active, "google", { pluginName: "Google", label: "Google" });
     const loaded = createEmptyPluginRegistry();
-    loaded.speechProviders.push({
-      pluginId: "openai",
-      pluginName: "OpenAI",
-      source: "test",
-      provider: {
-        id: "openai",
-        label: "OpenAI",
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      plugins: [
-        { id: "google", origin: "bundled", contracts: { speechProviders: ["google"] } },
-        { id: "openai", origin: "bundled", contracts: { speechProviders: ["openai"] } },
-      ] as never,
-      diagnostics: [],
-    });
+    addSpeechProvider(loaded, "openai", { pluginName: "OpenAI", label: "OpenAI" });
+    setCapabilityManifestPlugins([
+      { id: "google", contracts: { speechProviders: ["google"] } },
+      { id: "openai", contracts: { speechProviders: ["openai"] } },
+    ]);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
       params === undefined ? active : loaded,
     );
@@ -1086,23 +1112,7 @@ describe("resolvePluginCapabilityProviders", () => {
 
   it("keeps active speech providers when cfg requests an active provider alias", () => {
     const active = createEmptyPluginRegistry();
-    active.speechProviders.push({
-      pluginId: "microsoft",
-      pluginName: "microsoft",
-      source: "test",
-      provider: {
-        id: "microsoft",
-        label: "microsoft",
-        aliases: ["edge"],
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
+    addSpeechProvider(active, "microsoft", { aliases: ["edge"] });
     mocks.resolveRuntimePluginRegistry.mockReturnValue(active);
 
     const providers = resolvePluginCapabilityProviders({
@@ -1120,22 +1130,7 @@ describe("resolvePluginCapabilityProviders", () => {
 
   it("keeps active capability providers when cfg has no explicit plugin config", () => {
     const active = createEmptyPluginRegistry();
-    active.speechProviders.push({
-      pluginId: "acme",
-      pluginName: "acme",
-      source: "test",
-      provider: {
-        id: "acme",
-        label: "acme",
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
+    addSpeechProvider(active, "acme");
     mocks.loadPluginManifestRegistry.mockReturnValue({
       plugins: [
         {
@@ -1167,50 +1162,12 @@ describe("resolvePluginCapabilityProviders", () => {
 
   it("merges active and allowlisted bundled capability providers when cfg is passed", () => {
     const active = createEmptyPluginRegistry();
-    active.speechProviders.push({
-      pluginId: "openai",
-      pluginName: "openai",
-      source: "test",
-      provider: {
-        id: "openai",
-        label: "openai",
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
+    addSpeechProvider(active, "openai");
     const loaded = createEmptyPluginRegistry();
-    loaded.speechProviders.push({
-      pluginId: "microsoft",
-      pluginName: "microsoft",
-      source: "test",
-      provider: {
-        id: "microsoft",
-        label: "microsoft",
-        aliases: ["edge"],
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      plugins: [
-        {
-          id: "microsoft",
-          origin: "bundled",
-          contracts: { speechProviders: ["microsoft"] },
-        },
-      ] as never,
-      diagnostics: [],
-    });
+    addSpeechProvider(loaded, "microsoft", { aliases: ["edge"] });
+    setCapabilityManifestPlugins([
+      { id: "microsoft", contracts: { speechProviders: ["microsoft"] } },
+    ]);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
       params === undefined ? active : loaded,
     );
@@ -1230,54 +1187,13 @@ describe("resolvePluginCapabilityProviders", () => {
 
   it("uses bundled capability capture when runtime snapshot is empty for a requested speech provider", () => {
     const active = createEmptyPluginRegistry();
-    active.speechProviders.push({
-      pluginId: "openai",
-      pluginName: "openai",
-      source: "test",
-      provider: {
-        id: "openai",
-        label: "openai",
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
+    addSpeechProvider(active, "openai");
     const captured = createEmptyPluginRegistry();
-    captured.speechProviders.push({
-      pluginId: "google",
-      pluginName: "google",
-      source: "test",
-      provider: {
-        id: "google",
-        label: "google",
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      plugins: [
-        {
-          id: "google",
-          origin: "bundled",
-          contracts: { speechProviders: ["google"] },
-        },
-        {
-          id: "microsoft",
-          origin: "bundled",
-          contracts: { speechProviders: ["microsoft"] },
-        },
-      ] as never,
-      diagnostics: [],
-    });
+    addSpeechProvider(captured, "google");
+    setCapabilityManifestPlugins([
+      { id: "google", contracts: { speechProviders: ["google"] } },
+      { id: "microsoft", contracts: { speechProviders: ["microsoft"] } },
+    ]);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
       params === undefined ? active : createEmptyPluginRegistry(),
     );
@@ -1301,71 +1217,15 @@ describe("resolvePluginCapabilityProviders", () => {
 
   it("uses bundled capability capture when runtime snapshot misses a requested speech provider", () => {
     const active = createEmptyPluginRegistry();
-    active.speechProviders.push({
-      pluginId: "openai",
-      pluginName: "openai",
-      source: "test",
-      provider: {
-        id: "openai",
-        label: "openai",
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
+    addSpeechProvider(active, "openai");
     const loaded = createEmptyPluginRegistry();
-    loaded.speechProviders.push({
-      pluginId: "azure-speech",
-      pluginName: "azure-speech",
-      source: "test",
-      provider: {
-        id: "azure-speech",
-        label: "Azure Speech",
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
+    addSpeechProvider(loaded, "azure-speech", { label: "Azure Speech" });
     const captured = createEmptyPluginRegistry();
-    captured.speechProviders.push({
-      pluginId: "google",
-      pluginName: "google",
-      source: "test",
-      provider: {
-        id: "google",
-        label: "google",
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      plugins: [
-        {
-          id: "azure-speech",
-          origin: "bundled",
-          contracts: { speechProviders: ["azure-speech"] },
-        },
-        {
-          id: "google",
-          origin: "bundled",
-          contracts: { speechProviders: ["google"] },
-        },
-      ] as never,
-      diagnostics: [],
-    });
+    addSpeechProvider(captured, "google");
+    setCapabilityManifestPlugins([
+      { id: "azure-speech", contracts: { speechProviders: ["azure-speech"] } },
+      { id: "google", contracts: { speechProviders: ["google"] } },
+    ]);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
       params === undefined ? active : loaded,
     );
@@ -1500,73 +1360,14 @@ describe("resolvePluginCapabilityProviders", () => {
 
   it("does not merge unrelated bundled capability providers when cfg requests one provider", () => {
     const active = createEmptyPluginRegistry();
-    active.speechProviders.push({
-      pluginId: "openai",
-      pluginName: "openai",
-      source: "test",
-      provider: {
-        id: "openai",
-        label: "openai",
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
+    addSpeechProvider(active, "openai");
     const loaded = createEmptyPluginRegistry();
-    loaded.speechProviders.push(
-      {
-        pluginId: "microsoft",
-        pluginName: "microsoft",
-        source: "test",
-        provider: {
-          id: "microsoft",
-          label: "microsoft",
-          aliases: ["edge"],
-          isConfigured: () => true,
-          synthesize: async () => ({
-            audioBuffer: Buffer.from("x"),
-            outputFormat: "mp3",
-            voiceCompatible: false,
-            fileExtension: ".mp3",
-          }),
-        },
-      } as never,
-      {
-        pluginId: "elevenlabs",
-        pluginName: "elevenlabs",
-        source: "test",
-        provider: {
-          id: "elevenlabs",
-          label: "elevenlabs",
-          isConfigured: () => true,
-          synthesize: async () => ({
-            audioBuffer: Buffer.from("x"),
-            outputFormat: "mp3",
-            voiceCompatible: false,
-            fileExtension: ".mp3",
-          }),
-        },
-      } as never,
-    );
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      plugins: [
-        {
-          id: "microsoft",
-          origin: "bundled",
-          contracts: { speechProviders: ["microsoft"] },
-        },
-        {
-          id: "elevenlabs",
-          origin: "bundled",
-          contracts: { speechProviders: ["elevenlabs"] },
-        },
-      ] as never,
-      diagnostics: [],
-    });
+    addSpeechProvider(loaded, "microsoft", { aliases: ["edge"] });
+    addSpeechProvider(loaded, "elevenlabs");
+    setCapabilityManifestPlugins([
+      { id: "microsoft", contracts: { speechProviders: ["microsoft"] } },
+      { id: "elevenlabs", contracts: { speechProviders: ["elevenlabs"] } },
+    ]);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
       params === undefined ? active : loaded,
     );
@@ -1752,33 +1553,10 @@ describe("resolvePluginCapabilityProviders", () => {
       },
     } as OpenClawConfig;
     const loaded = createEmptyPluginRegistry();
-    loaded.speechProviders.push({
-      pluginId: "microsoft",
-      pluginName: "microsoft",
-      source: "test",
-      provider: {
-        id: "microsoft",
-        label: "microsoft",
-        aliases: ["edge"],
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      plugins: [
-        {
-          id: "microsoft",
-          origin: "bundled",
-          contracts: { speechProviders: ["microsoft"] },
-        },
-      ] as never,
-      diagnostics: [],
-    });
+    addSpeechProvider(loaded, "microsoft", { aliases: ["edge"] });
+    setCapabilityManifestPlugins([
+      { id: "microsoft", contracts: { speechProviders: ["microsoft"] } },
+    ]);
     mocks.withBundledPluginEnablementCompat.mockReturnValue(compatConfig);
     mocks.withBundledPluginVitestCompat.mockReturnValue(compatConfig);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
@@ -1986,38 +1764,11 @@ describe("resolvePluginCapabilityProviders", () => {
       },
     };
     const loaded = createEmptyPluginRegistry();
-    loaded.speechProviders.push({
-      pluginId: "microsoft",
-      pluginName: "microsoft",
-      source: "test",
-      provider: {
-        id: "microsoft",
-        label: "microsoft",
-        aliases: ["edge"],
-        isConfigured: () => true,
-        synthesize: async () => ({
-          audioBuffer: Buffer.from("x"),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        }),
-      },
-    } as never);
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      plugins: [
-        {
-          id: "microsoft",
-          origin: "bundled",
-          contracts: { speechProviders: ["microsoft"] },
-        },
-        {
-          id: "openai",
-          origin: "bundled",
-          contracts: { speechProviders: ["openai"] },
-        },
-      ] as never,
-      diagnostics: [],
-    });
+    addSpeechProvider(loaded, "microsoft", { aliases: ["edge"] });
+    setCapabilityManifestPlugins([
+      { id: "microsoft", contracts: { speechProviders: ["microsoft"] } },
+      { id: "openai", contracts: { speechProviders: ["openai"] } },
+    ]);
     mocks.withBundledPluginEnablementCompat.mockReturnValue(enablementCompat);
     mocks.withBundledPluginVitestCompat.mockReturnValue(enablementCompat);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -48,7 +48,7 @@ let resolveDiscoverableProviderOwnerPluginIds: typeof import("./providers.js").r
 let resolvePluginProviders: typeof import("./providers.runtime.js").resolvePluginProviders;
 let setActivePluginRegistry: SetActivePluginRegistry;
 
-function createManifestProviderPlugin(params: {
+type ManifestProviderPluginFixture = {
   id: string;
   providerIds: string[];
   cliBackends?: string[];
@@ -61,7 +61,9 @@ function createManifestProviderPlugin(params: {
   modelCatalog?: PluginManifestRecord["modelCatalog"];
   providerAuthAliases?: PluginManifestRecord["providerAuthAliases"];
   packageManifest?: OpenClawPackageManifest;
-}): PluginManifestRecord {
+};
+
+function createManifestProviderPlugin(params: ManifestProviderPluginFixture): PluginManifestRecord {
   return {
     id: params.id,
     enabledByDefault: params.enabledByDefault,
@@ -91,8 +93,14 @@ function setManifestPlugins(plugins: PluginManifestRecord[]) {
   });
 }
 
-function setOwningProviderManifestPlugins() {
-  setManifestPlugins([
+function setManifestPlugin(params: ManifestProviderPluginFixture) {
+  const plugin = createManifestProviderPlugin(params);
+  setManifestPlugins([plugin]);
+  return plugin;
+}
+
+function createOwningProviderManifestPlugins() {
+  return [
     createManifestProviderPlugin({
       id: "minimax",
       providerIds: ["minimax", "minimax-portal"],
@@ -112,30 +120,16 @@ function setOwningProviderManifestPlugins() {
         modelPrefixes: ["claude-"],
       },
     }),
-  ]);
+  ];
+}
+
+function setOwningProviderManifestPlugins() {
+  setManifestPlugins(createOwningProviderManifestPlugins());
 }
 
 function setOwningProviderManifestPluginsWithWorkspace() {
   setManifestPlugins([
-    createManifestProviderPlugin({
-      id: "minimax",
-      providerIds: ["minimax", "minimax-portal"],
-    }),
-    createManifestProviderPlugin({
-      id: "openai",
-      providerIds: ["openai", "openai"],
-      modelSupport: {
-        modelPrefixes: ["gpt-", "o1", "o3", "o4"],
-      },
-    }),
-    createManifestProviderPlugin({
-      id: "anthropic",
-      providerIds: ["anthropic"],
-      cliBackends: ["claude-cli"],
-      modelSupport: {
-        modelPrefixes: ["claude-"],
-      },
-    }),
+    ...createOwningProviderManifestPlugins(),
     createManifestProviderPlugin({
       id: "workspace-provider",
       providerIds: ["workspace-provider"],
@@ -545,13 +539,11 @@ describe("resolvePluginProviders", () => {
   });
 
   it("maps setup-only cli backend ids to explicit provider refs via manifests", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "setup-only-backend-owner",
-        providerIds: [],
-        setup: { cliBackends: ["setup-only-cli"] },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "setup-only-backend-owner",
+      providerIds: [],
+      setup: { cliBackends: ["setup-only-cli"] },
+    });
 
     expectOwningPluginIds("setup-only-cli");
     expect(resolveOwningPluginIdsForProviderRef({ provider: "setup-only-cli" })).toEqual([
@@ -598,18 +590,16 @@ describe("resolvePluginProviders", () => {
   });
 
   it("maps manifest model catalog provider aliases to owning plugin ids", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "moonshot",
-        providerIds: ["moonshot"],
-        modelCatalog: {
-          aliases: {
-            moonshotai: { provider: "moonshot" },
-            "moonshot-ai": { provider: "moonshot" },
-          },
+    setManifestPlugin({
+      id: "moonshot",
+      providerIds: ["moonshot"],
+      modelCatalog: {
+        aliases: {
+          moonshotai: { provider: "moonshot" },
+          "moonshot-ai": { provider: "moonshot" },
         },
-      }),
-    ]);
+      },
+    });
 
     expectOwningPluginIds("moonshotai", ["moonshot"]);
     expectOwningPluginIds("moonshot-ai", ["moonshot"]);
@@ -706,15 +696,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("maps manifest provider auth aliases to the target provider owner", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "openai",
-        providerIds: ["openai"],
-        providerAuthAliases: {
-          openai: "openai",
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "openai",
+      providerIds: ["openai"],
+      providerAuthAliases: {
+        openai: "openai",
+      },
+    });
 
     expectOwningPluginIds("openai", ["openai"]);
     expectOwningPluginIds("openai", ["openai"]);
@@ -722,20 +710,16 @@ describe("resolvePluginProviders", () => {
   });
 
   it("reflects provider ownership manifest changes on the next lookup", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "first-owner",
-        providerIds: ["dynamic-provider"],
-      }),
-    ]);
+    setManifestPlugin({
+      id: "first-owner",
+      providerIds: ["dynamic-provider"],
+    });
     expectOwningPluginIds("dynamic-provider", ["first-owner"]);
 
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "second-owner",
-        providerIds: ["dynamic-provider"],
-      }),
-    ]);
+    setManifestPlugin({
+      id: "second-owner",
+      providerIds: ["dynamic-provider"],
+    });
 
     expectOwningPluginIds("dynamic-provider", ["second-owner"]);
   });
@@ -886,16 +870,14 @@ describe("resolvePluginProviders", () => {
   });
 
   it("loads bundled Ollama catalog augment hooks from the manifest runtime flag", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "ollama",
-        providerIds: ["ollama", "ollama-cloud"],
-        enabledByDefault: true,
-        modelCatalog: {
-          runtimeAugment: true,
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "ollama",
+      providerIds: ["ollama", "ollama-cloud"],
+      enabledByDefault: true,
+      modelCatalog: {
+        runtimeAugment: true,
+      },
+    });
 
     expect(
       resolveCatalogHookProviderPluginIds({ config: {}, env: {} as NodeJS.ProcessEnv }),
@@ -1247,13 +1229,11 @@ describe("resolvePluginProviders", () => {
   });
 
   it("activates the owner plugin for custom provider refs that use a native provider api", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "ollama",
-        providerIds: ["ollama"],
-        enabledByDefault: true,
-      }),
-    ]);
+    setManifestPlugin({
+      id: "ollama",
+      providerIds: ["ollama"],
+      enabledByDefault: true,
+    });
 
     resolvePluginProviders({
       config: {
@@ -1284,15 +1264,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("uses activation.onProviders to keep explicit provider owners on the runtime path", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "activation-owned-provider",
-        providerIds: [],
-        activation: {
-          onProviders: ["activation-owned"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "activation-owned-provider",
+      providerIds: [],
+      activation: {
+        onProviders: ["activation-owned"],
+      },
+    });
 
     resolvePluginProviders({
       config: {},
@@ -1313,15 +1291,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("does not activate explicit runtime owners when plugins are globally disabled", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "activation-owned-provider",
-        providerIds: [],
-        activation: {
-          onProviders: ["activation-owned"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "activation-owned-provider",
+      providerIds: [],
+      activation: {
+        onProviders: ["activation-owned"],
+      },
+    });
 
     expect(
       resolveActivatableProviderOwnerPluginIds({
@@ -1336,15 +1312,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("does not activate explicit runtime owners disabled in config", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "activation-owned-provider",
-        providerIds: [],
-        activation: {
-          onProviders: ["activation-owned"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "activation-owned-provider",
+      providerIds: [],
+      activation: {
+        onProviders: ["activation-owned"],
+      },
+    });
 
     expect(
       resolveActivatableProviderOwnerPluginIds({
@@ -1361,15 +1335,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("does not activate explicit runtime owners outside the allowlist", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "activation-owned-provider",
-        providerIds: [],
-        activation: {
-          onProviders: ["activation-owned"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "activation-owned-provider",
+      providerIds: [],
+      activation: {
+        onProviders: ["activation-owned"],
+      },
+    });
 
     expect(
       resolveActivatableProviderOwnerPluginIds({
@@ -1384,15 +1356,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("uses setup.providers to keep explicit provider owners on the setup path", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "setup-owned-provider",
-        providerIds: [],
-        setup: {
-          providers: [{ id: "setup-owned" }],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "setup-owned-provider",
+      providerIds: [],
+      setup: {
+        providers: [{ id: "setup-owned" }],
+      },
+    });
 
     resolvePluginProviders({
       config: {},
@@ -1414,15 +1384,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("does not override global plugin disable during setup owner loading", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "setup-owned-provider",
-        providerIds: [],
-        setup: {
-          providers: [{ id: "setup-owned" }],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "setup-owned-provider",
+      providerIds: [],
+      setup: {
+        providers: [{ id: "setup-owned" }],
+      },
+    });
 
     resolvePluginProviders({
       config: {
@@ -1439,15 +1407,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("does not override explicitly disabled setup owners", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "setup-owned-provider",
-        providerIds: [],
-        setup: {
-          providers: [{ id: "setup-owned" }],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "setup-owned-provider",
+      providerIds: [],
+      setup: {
+        providers: [{ id: "setup-owned" }],
+      },
+    });
 
     resolvePluginProviders({
       config: {
@@ -1466,16 +1432,14 @@ describe("resolvePluginProviders", () => {
   });
 
   it("filters explicit setup owners through the untrusted workspace discovery gate", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "workspace-activation-owner",
-        providerIds: [],
-        origin: "workspace",
-        activation: {
-          onProviders: ["workspace-activation"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "workspace-activation-owner",
+      providerIds: [],
+      origin: "workspace",
+      activation: {
+        onProviders: ["workspace-activation"],
+      },
+    });
 
     const providers = resolvePluginProviders({
       config: {},
@@ -1490,16 +1454,14 @@ describe("resolvePluginProviders", () => {
   });
 
   it("does not auto-activate untrusted workspace runtime owners when requested", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "workspace-activation-owner",
-        providerIds: [],
-        origin: "workspace",
-        activation: {
-          onProviders: ["workspace-activation"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "workspace-activation-owner",
+      providerIds: [],
+      origin: "workspace",
+      activation: {
+        onProviders: ["workspace-activation"],
+      },
+    });
     resolveRuntimePluginRegistryMock.mockReturnValue(createEmptyPluginRegistry());
 
     const providers = resolvePluginProviders({
@@ -1515,16 +1477,14 @@ describe("resolvePluginProviders", () => {
   });
 
   it("does not auto-activate workspace runtime owners by default", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "workspace-activation-owner",
-        providerIds: [],
-        origin: "workspace",
-        activation: {
-          onProviders: ["workspace-activation"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "workspace-activation-owner",
+      providerIds: [],
+      origin: "workspace",
+      activation: {
+        onProviders: ["workspace-activation"],
+      },
+    });
     resolveRuntimePluginRegistryMock.mockReturnValue(createEmptyPluginRegistry());
 
     const providers = resolvePluginProviders({
@@ -1539,15 +1499,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("keeps explicit provider requests scoped when runtime owner activation resolves nothing", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "activation-owned-provider",
-        providerIds: [],
-        activation: {
-          onProviders: ["activation-owned"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "activation-owned-provider",
+      providerIds: [],
+      activation: {
+        onProviders: ["activation-owned"],
+      },
+    });
     resolveRuntimePluginRegistryMock.mockReturnValue(createEmptyPluginRegistry());
 
     const providers = resolvePluginProviders({
@@ -1566,16 +1524,14 @@ describe("resolvePluginProviders", () => {
   });
 
   it("does not keep explicitly trusted disabled workspace setup owners discoverable", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "workspace-activation-owner",
-        providerIds: [],
-        origin: "workspace",
-        activation: {
-          onProviders: ["workspace-activation"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "workspace-activation-owner",
+      providerIds: [],
+      origin: "workspace",
+      activation: {
+        onProviders: ["workspace-activation"],
+      },
+    });
 
     expect(
       resolveDiscoverableProviderOwnerPluginIds({
@@ -1595,16 +1551,14 @@ describe("resolvePluginProviders", () => {
   });
 
   it("does not auto-activate explicitly disabled trusted workspace runtime owners", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "workspace-activation-owner",
-        providerIds: [],
-        origin: "workspace",
-        activation: {
-          onProviders: ["workspace-activation"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "workspace-activation-owner",
+      providerIds: [],
+      origin: "workspace",
+      activation: {
+        onProviders: ["workspace-activation"],
+      },
+    });
 
     expect(
       resolveActivatableProviderOwnerPluginIds({
@@ -1730,15 +1684,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("rejects ReDoS modelPatterns via compileSafeRegex guard", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "malicious",
-        providerIds: ["malicious"],
-        modelSupport: {
-          modelPatterns: ["(a+)+$"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "malicious",
+      providerIds: ["malicious"],
+      modelSupport: {
+        modelPatterns: ["(a+)+$"],
+      },
+    });
 
     // Without the guard, this input causes catastrophic backtracking.
     // With compileSafeRegex, the pattern is rejected and the plugin is not matched.
@@ -1748,15 +1700,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("preserves LM Studio @iq* quant suffixes when resolving model-owned provider plugins", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "lmstudio",
-        providerIds: ["lmstudio"],
-        modelSupport: {
-          modelPatterns: ["^qwen3\\.6-27b@iq3_xxs$"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "lmstudio",
+      providerIds: ["lmstudio"],
+      modelSupport: {
+        modelPatterns: ["^qwen3\\.6-27b@iq3_xxs$"],
+      },
+    });
     const provider: ProviderPlugin = {
       id: "lmstudio",
       label: "LM Studio",
@@ -1789,15 +1739,13 @@ describe("resolvePluginProviders", () => {
   });
 
   it("auto-loads a model-owned provider plugin from shorthand model refs", () => {
-    setManifestPlugins([
-      createManifestProviderPlugin({
-        id: "openai",
-        providerIds: ["openai", "openai"],
-        modelSupport: {
-          modelPrefixes: ["gpt-", "o1", "o3", "o4"],
-        },
-      }),
-    ]);
+    setManifestPlugin({
+      id: "openai",
+      providerIds: ["openai", "openai"],
+      modelSupport: {
+        modelPrefixes: ["gpt-", "o1", "o3", "o4"],
+      },
+    });
     const provider: ProviderPlugin = {
       id: "openai",
       label: "OpenAI",


### PR DESCRIPTION
## What Problem This Solves

The capability-provider and provider-owner test suites repeated large registry, speech-provider, and manifest records across closely related cases. That duplication obscured the behavioral distinctions the suites protect and made future provider contract changes expensive to review consistently.

## Why This Change Was Made

This extracts narrow, file-local fixture helpers while leaving every test title, expanded table case, assertion, ordering constraint, and security-sensitive config explicit. It removes 301 test lines with zero production, config, default, schema, or runtime changes.

Root cause: repeated literal fixture construction in the two owning test modules. The canonical fix is shared registry/manifest construction at that test boundary; obsolete inline copies are removed. Active-versus-scoped lookup semantics, provider ordering and aliases, runtime fallback behavior, global-disable speech compatibility, setup/runtime activation, workspace trust gates, metadata precedence, safe regex handling, and LM Studio suffix matching remain independently asserted.

## User Impact

No user-visible behavior changes. Maintainers get smaller provider-contract suites with less duplicated setup and unchanged regression coverage.

## Evidence

- Diff: 2 test files, +294 / -595, net -301; production delta 0.
- AST parity: capability suite 38 declarations / 50 expanded cases / 52 `expect` sites; provider suite 55 / 61 / 56. Titles, table rows, hook counts, and assertion order are unchanged.
- Local focused proof: 2 files, 111/111 tests passed.
- Blacksmith Testbox focused/owner proof: 6 files, 191/191 tests passed on lease `tbx_01kz267t11zb54b31tk9x4wt5j` ([runner record](https://github.com/openclaw/openclaw/actions/runs/30768092586)); the outer keepalive job is cancelled after external lease shutdown.
- Same-diff `pnpm check:changed`: passed formatting, boundaries, dead-export scans, core-test typecheck, and lint with zero warnings/errors.
- Two independent xhigh reviews: CLEAN; both judged this the best fixture-only fix and personally verified the upstream Codex provider/auth/catalog contracts at sibling Codex SHA `ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff`.
- Final exhaustive open-PR collision census: zero matches on both paths through `2026-08-02T22:14:45.082Z`.
