### PR TITLE
refactor(ui): consolidate icons, formatters, and confirms

### DIFF
--- a/ui/src/components/confirm-dialog.test.ts
+++ b/ui/src/components/confirm-dialog.test.ts
@@ -1,0 +1,81 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRenderedModalDialog, installDialogPolyfill } from "../test-helpers/modal-dialog.ts";
+import { showConfirmDialog } from "./confirm-dialog.ts";
+
+let restoreDialogPolyfill: () => void;
+
+function findButton(label: string): HTMLButtonElement {
+  const button = [...document.body.querySelectorAll("button")].find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Expected ${label} button`);
+  }
+  return button;
+}
+
+describe("showConfirmDialog", () => {
+  beforeEach(() => {
+    restoreDialogPolyfill = installDialogPolyfill();
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    restoreDialogPolyfill();
+  });
+
+  it("renders accessible copy and resolves the selected action", async () => {
+    const result = showConfirmDialog({
+      title: "Delete thread?",
+      message: "This cannot be undone.",
+      details: "thread-1",
+      confirmLabel: "Delete",
+      danger: true,
+    });
+    const { modal, dialog } = await getRenderedModalDialog(document.body);
+
+    expect(dialog.getAttribute("aria-label")).toBe("Delete thread?");
+    expect(dialog.getAttribute("aria-description")).toBe("This cannot be undone.");
+    expect(modal.textContent).toContain("thread-1");
+    expect(findButton("Delete").classList.contains("danger")).toBe(true);
+
+    findButton("Delete").click();
+
+    await expect(result).resolves.toBe(true);
+    expect(document.body.querySelector("openclaw-modal-dialog")).toBeNull();
+  });
+
+  it("treats modal dismissal as cancellation", async () => {
+    const result = showConfirmDialog({ message: "Continue?" });
+    const { modal } = await getRenderedModalDialog(document.body);
+
+    modal.dispatchEvent(new CustomEvent("modal-cancel"));
+
+    await expect(result).resolves.toBe(false);
+  });
+
+  it("removes the dialog and cancels when its owner aborts", async () => {
+    const controller = new AbortController();
+    const result = showConfirmDialog({ message: "Continue?", signal: controller.signal });
+    await getRenderedModalDialog(document.body);
+
+    controller.abort();
+
+    await expect(result).resolves.toBe(false);
+    expect(document.body.querySelector("openclaw-modal-dialog")).toBeNull();
+  });
+
+  it("rejects a reentrant confirmation instead of stacking or replaying it", async () => {
+    const first = showConfirmDialog({ title: "First", message: "First action" });
+    const second = showConfirmDialog({ title: "Second", message: "Second action" });
+    await getRenderedModalDialog(document.body);
+
+    expect(document.body.textContent).toContain("First");
+    expect(document.body.textContent).not.toContain("Second");
+    await expect(second).resolves.toBe(false);
+    findButton("Cancel").click();
+    await expect(first).resolves.toBe(false);
+  });
+});

--- a/ui/src/components/confirm-dialog.ts
+++ b/ui/src/components/confirm-dialog.ts
@@ -1,0 +1,87 @@
+// Control UI helper presents Promise-based confirmation without relying on a native dialog bridge.
+import { html, nothing, render } from "lit";
+import { t } from "../i18n/index.ts";
+import "./modal-dialog.ts";
+
+export type ConfirmDialogOptions = {
+  title?: string;
+  message: string;
+  details?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  danger?: boolean;
+  signal?: AbortSignal;
+};
+
+let confirmationActive = false;
+
+function presentConfirmDialog(options: ConfirmDialogOptions): Promise<boolean> {
+  if (options.signal?.aborted) {
+    return Promise.resolve(false);
+  }
+  const host = document.createElement("div");
+  document.body.append(host);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (confirmed: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      options.signal?.removeEventListener("abort", handleAbort);
+      render(nothing, host);
+      host.remove();
+      resolve(confirmed);
+    };
+    const handleAbort = () => finish(false);
+    options.signal?.addEventListener("abort", handleAbort, { once: true });
+    const title = options.title ?? t("common.confirm");
+    render(
+      html`
+        <openclaw-modal-dialog
+          label=${title}
+          description=${options.message}
+          @modal-cancel=${() => finish(false)}
+        >
+          <div class="exec-approval-card">
+            <div class="exec-approval-header">
+              <div>
+                <div class="exec-approval-title">${title}</div>
+                <div class="exec-approval-sub" style="white-space: pre-line">
+                  ${options.message}
+                </div>
+              </div>
+            </div>
+            ${options.details
+              ? html`<div class="exec-approval-command mono">${options.details}</div>`
+              : nothing}
+            <div class="exec-approval-actions">
+              <button
+                type="button"
+                class="btn ${options.danger ? "danger" : "primary"}"
+                @click=${() => finish(true)}
+              >
+                ${options.confirmLabel ?? t("common.confirm")}
+              </button>
+              <button type="button" class="btn" autofocus @click=${() => finish(false)}>
+                ${options.cancelLabel ?? t("common.cancel")}
+              </button>
+            </div>
+          </div>
+        </openclaw-modal-dialog>
+      `,
+      host,
+    );
+  });
+}
+
+/** Native confirms block reentrancy; reject a second request instead of replaying it later. */
+export function showConfirmDialog(options: ConfirmDialogOptions): Promise<boolean> {
+  if (confirmationActive) {
+    return Promise.resolve(false);
+  }
+  confirmationActive = true;
+  return presentConfirmDialog(options).finally(() => {
+    confirmationActive = false;
+  });
+}

--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -41,6 +41,46 @@ export const icons = {
     <line x1="16" x2="8" y1="13" y2="13" />
     <line x1="16" x2="8" y1="17" y2="17" />
     <line x1="10" x2="8" y1="9" y2="9" />`),
+  file: strokeIcon(svg` <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <polyline points="14 2 14 8 20 8" />`),
+  mail: strokeIcon(svg` <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+    <polyline points="22,6 12,13 2,6" />`),
+  star: strokeIcon(
+    svg`<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />`,
+  ),
+  wandSparkles: strokeIcon(svg` <path d="M15 4V2" />
+    <path d="M15 16v-2" />
+    <path d="M8 9h2" />
+    <path d="M20 9h2" />
+    <path d="M17.8 11.8 19 13" />
+    <path d="M15 9h0" />
+    <path d="M17.8 6.2 19 5" />
+    <path d="m3 21 9-9" />
+    <path d="M12.2 6.2 11 5" />`),
+  chrome: strokeIcon(svg` <circle cx="12" cy="12" r="10" />
+    <circle cx="12" cy="12" r="4" />
+    <line x1="21.17" y1="8" x2="12" y2="8" />
+    <line x1="3.95" y1="6.06" x2="8.54" y2="14" />
+    <line x1="10.88" y1="21.94" x2="15.46" y2="14" />`),
+  panelsTopLeft: strokeIcon(svg` <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+    <line x1="3" y1="9" x2="21" y2="9" />
+    <line x1="9" y1="21" x2="9" y2="9" />`),
+  box: strokeIcon(svg` <path
+      d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"
+    />
+    <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+    <line x1="12" y1="22.08" x2="12" y2="12" />`),
+  music: strokeIcon(svg` <path d="M9 18V5l12-2v13" />
+    <circle cx="6" cy="18" r="3" />
+    <circle cx="18" cy="16" r="3" />`),
+  asterisk: strokeIcon(svg` <path d="M12 2v6" />
+    <path d="m4.93 10.93 4.24 4.24" />
+    <path d="M2 12h6" />
+    <path d="m4.93 13.07 4.24-4.24" />
+    <path d="M12 22v-6" />
+    <path d="m19.07 13.07-4.24-4.24" />
+    <path d="M22 12h-6" />
+    <path d="m19.07 10.93-4.24 4.24" />`),
   zap: strokeIcon(svg`<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />`),
   monitor: strokeIcon(svg` <rect width="20" height="14" x="2" y="3" rx="2" />
     <line x1="8" x2="16" y1="21" y2="21" />

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -15,6 +15,11 @@ import {
 
 const suite = createSessionManagementE2eSuite();
 
+async function confirmDelete(page: import("playwright").Page) {
+  const dialog = page.locator("openclaw-modal-dialog").last();
+  await dialog.getByRole("button", { name: "Delete", exact: true }).click();
+}
+
 suite.define(() => {
   it("deletes every archived thread exactly once when the paged roster reorders", async () => {
     const context = await suite.browser.newContext({
@@ -53,8 +58,9 @@ suite.define(() => {
           sessionsListResponse(archived, { totalCount: 3 }),
         ],
       });
-      page.once("dialog", (dialog) => void dialog.accept());
       await remove.click();
+      await captureUiProof(page, "styled-confirm-delete-archived.png");
+      await confirmDelete(page);
 
       await expect
         .poll(async () =>
@@ -108,11 +114,11 @@ suite.define(() => {
       await expect.poll(() => page.locator(".data-table-bulk-bar").count()).toBe(0);
 
       await rowFor("Bravo").locator('input[type="checkbox"]').check();
-      page.once("dialog", (dialog) => void dialog.accept());
       await page
         .locator(".data-table-bulk-bar")
         .getByRole("button", { name: "Delete", exact: true })
         .click();
+      await confirmDelete(page);
       await gateway.waitForRequest("sessions.delete");
 
       await expect
@@ -522,8 +528,6 @@ suite.define(() => {
       },
       sessionKey: "agent:main:main",
     });
-    page.on("dialog", (dialog) => void dialog.accept());
-
     try {
       await page.goto(`${suite.server.baseUrl}sessions?status=archived`);
       const row = page.locator(".session-data-row").filter({ hasText: "Research notes" });
@@ -533,6 +537,7 @@ suite.define(() => {
       await activateMenuItem(
         page.locator("openclaw-session-menu").getByRole("menuitem", { name: "Delete…" }),
       );
+      await confirmDelete(page);
 
       const request = await gateway.waitForRequest("sessions.delete");
       expect(requireRecord(request.params)).toMatchObject({

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -15,8 +15,15 @@ import {
 
 const suite = createSessionManagementE2eSuite();
 
-async function confirmDelete(page: import("playwright").Page) {
+async function confirmDelete(page: import("playwright").Page, proofName?: string) {
   const dialog = page.locator("openclaw-modal-dialog").last();
+  const nativeDialog = dialog.locator("wa-dialog").locator("dialog");
+  await expect
+    .poll(() => nativeDialog.evaluate((element) => getComputedStyle(element).opacity))
+    .toBe("1");
+  if (proofName) {
+    await captureUiProof(page, proofName);
+  }
   await dialog.getByRole("button", { name: "Delete", exact: true }).click();
 }
 
@@ -59,8 +66,7 @@ suite.define(() => {
         ],
       });
       await remove.click();
-      await captureUiProof(page, "styled-confirm-delete-archived.png");
-      await confirmDelete(page);
+      await confirmDelete(page, "styled-confirm-delete-archived.png");
 
       await expect
         .poll(async () =>

--- a/ui/src/e2e/session-management.operator-scopes.e2e.test.ts
+++ b/ui/src/e2e/session-management.operator-scopes.e2e.test.ts
@@ -14,6 +14,14 @@ const archived = sessionRow(
   { archived: true },
 );
 
+async function confirmDelete(page: import("playwright").Page) {
+  await page
+    .locator("openclaw-modal-dialog")
+    .last()
+    .getByRole("button", { name: "Delete", exact: true })
+    .click();
+}
+
 async function openArchivedPage(operatorScopes: string[]) {
   const context = await suite.browser.newContext({
     locale: "en-US",
@@ -43,9 +51,9 @@ suite.define(() => {
       "operator.write",
     ]);
     try {
-      page.on("dialog", (dialog) => void dialog.accept());
       await expect.poll(() => deleteAll.isEnabled()).toBe(true);
       await deleteAll.click();
+      await confirmDelete(page);
 
       await expect(gateway.waitForRequest("sessions.delete")).resolves.toMatchObject({
         params: {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -840,10 +840,15 @@ export const en: TranslationMap = {
     restoreSession: "Restore thread",
     stopCloudWorker: "Stop cloud worker…",
     stopCloudWorkerConfirm: 'Stop the cloud worker for "{session}"?',
+    stopCloudWorkerConfirmAction: "Stop worker",
     deleteSessionMenu: "Delete…",
     deleteSessionCount: "Delete {count}…",
     deleteSessionConfirm: 'Delete "{session}" and its transcript?',
     deleteSessionsConfirm: "Delete {count} threads and their transcripts?",
+    deleteSelectedConfirmOne:
+      "Delete 1 thread?\n\nThis will delete the thread entry and archive its transcript.",
+    deleteSelectedConfirm:
+      "Delete {count} threads?\n\nThis will delete the thread entries and archive their transcripts.",
     groupBy: "Group by",
     groupByNone: "None",
     groupByCategory: "Custom groups",
@@ -877,7 +882,10 @@ export const en: TranslationMap = {
     noCheckpoints: "No compaction checkpoints recorded for this thread.",
     noSummary: "No summary captured.",
     branchFromCheckpoint: "Branch from checkpoint",
+    branchCheckpointConfirm: "Create a new child thread from this compacted checkpoint?",
     restoreCheckpoint: "Restore checkpoint",
+    restoreCheckpointConfirm:
+      "Restore this thread to the selected compacted checkpoint?\n\nThis replaces the current active transcript for the session key.",
   },
   agents: {
     noAgents: "No agents",
@@ -3105,12 +3113,6 @@ export const en: TranslationMap = {
       workflowHeading: "How the agent will use it",
       applicabilityHeading: "When the agent should use it",
     },
-    relative: {
-      secondsAgo: "{count}s ago",
-      minutesAgo: "{count} minutes ago",
-      hoursAgo: "{count}h ago",
-      daysAgo: "{count}d ago",
-    },
   },
   activity: {
     title: "Activity",
@@ -3762,10 +3764,10 @@ export const en: TranslationMap = {
       resetDiaryComplete: "Removed {count} backfilled dream diary entries.",
       clearReplayedComplete: "Cleared {count} replayed short-term entries.",
       complete: "Dream diary action complete.",
-      confirmRepair:
-        "Repair Dream Cache? This archives derived dream cache files and rebuilds them from clean inputs. Your dream diary stays untouched.",
-      confirmDedupe:
-        "Dedupe Dream Diary? This rewrites DREAMS.md and removes only exact duplicate diary entries.",
+      confirmRepairDescription:
+        "This archives derived dream cache files and rebuilds them from clean inputs. Your dream diary stays untouched.",
+      confirmDedupeDescription:
+        "This rewrites DREAMS.md and removes only exact duplicate diary entries.",
       archivePathCopied: "Archive path copied.",
       archivePathCopyFailed: "Could not copy archive path.",
       updateFailed: "Could not update dreaming settings.",

--- a/ui/src/lib/agents/display.test.ts
+++ b/ui/src/lib/agents/display.test.ts
@@ -163,6 +163,18 @@ describe("formatBytes", () => {
     expect(formatBytes(12 * 1024)).toBe("12 KB");
     expect(formatBytes(2 * 1024 * 1024)).toBe("2.0 MB");
   });
+
+  it("supports caller-owned fallback, unit cap, and precision", () => {
+    const options = {
+      fallback: "0 B",
+      maxUnit: "kilo" as const,
+      fractionDigits: (_value: number, unit: "byte" | "kilo" | "mega" | "giga" | "tera") =>
+        unit === "byte" ? null : 1,
+    };
+    expect(formatBytes(Number.NaN, options)).toBe("0 B");
+    expect(formatBytes(12 * 1024, options)).toBe("12.0 KB");
+    expect(formatBytes(1024 * 1024, options)).toBe("1024.0 KB");
+  });
 });
 
 describe("resolveEffectiveModelFallbacks", () => {

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -352,15 +352,22 @@ export function agentBadgeText(agentId: string, defaultId: string | null) {
   return defaultId && agentId === defaultId ? t("agents.default") : null;
 }
 
-export function formatBytes(bytes?: number) {
+type FormatBytesOptions = {
+  fallback?: string;
+  maxUnit?: "kilo" | "mega" | "giga" | "tera";
+  fractionDigits?: Parameters<typeof formatByteSize>[1]["fractionDigits"];
+};
+
+export function formatBytes(bytes?: number, options: FormatBytesOptions = {}) {
   if (bytes == null || !Number.isFinite(bytes)) {
-    return "-";
+    return options.fallback ?? "-";
   }
   return formatByteSize(bytes, {
     style: "legacy-binary",
-    maxUnit: "tera",
+    maxUnit: options.maxUnit ?? "tera",
     separator: " ",
-    fractionDigits: (value, unit) => (unit === "byte" ? null : value < 10 ? 1 : 0),
+    fractionDigits:
+      options.fractionDigits ?? ((value, unit) => (unit === "byte" ? null : value < 10 ? 1 : 0)),
   });
 }
 

--- a/ui/src/pages/activity/view.ts
+++ b/ui/src/pages/activity/view.ts
@@ -32,7 +32,7 @@ type ActivityProps = {
   onScroll: (event: Event) => void;
 };
 
-function formatTime(value: number): string {
+function formatActivityTime(value: number): string {
   return formatTimeMs(
     value,
     {
@@ -166,7 +166,7 @@ function renderEntry(props: ActivityProps, entry: ActivityEntry) {
           <span class="activity-entry__text">${buildEntrySummary(entry)}</span>
         </span>
         <span class="activity-entry__meta">
-          <span>${formatTime(entry.updatedAt)}</span>
+          <span>${formatActivityTime(entry.updatedAt)}</span>
           <span>${formatDuration(entry.durationMs)}</span>
         </span>
       </summary>

--- a/ui/src/pages/agents/memory/dreaming.test.ts
+++ b/ui/src/pages/agents/memory/dreaming.test.ts
@@ -54,10 +54,10 @@ beforeAll(() => {
         resetDiaryComplete: "Removed {count} backfilled dream diary entries.",
         clearReplayedComplete: "Cleared {count} replayed short-term entries.",
         complete: "Dream diary action complete.",
-        confirmRepair:
-          "Repair Dream Cache? This archives derived dream cache files and rebuilds them from clean inputs. Your dream diary stays untouched.",
-        confirmDedupe:
-          "Dedupe Dream Diary? This rewrites DREAMS.md and removes only exact duplicate diary entries.",
+        confirmRepairDescription:
+          "This archives derived dream cache files and rebuilds them from clean inputs. Your dream diary stays untouched.",
+        confirmDedupeDescription:
+          "This rewrites DREAMS.md and removes only exact duplicate diary entries.",
         archivePathCopied: "Archive path copied.",
         archivePathCopyFailed: "Could not copy archive path.",
         updateFailed: "Could not update dreaming settings.",
@@ -1379,7 +1379,6 @@ describe("dreaming controller", () => {
   it("repairs dreaming artifacts and reloads only dreaming status", async () => {
     const { state, request } = createState();
     state.dreamDiaryContent = "keep existing diary";
-    const confirmSpy = vi.spyOn(globalThis, "confirm").mockReturnValue(true);
     request.mockImplementation(async (method: string) => {
       if (method === "doctor.memory.repairDreamingArtifacts") {
         return {
@@ -1399,9 +1398,6 @@ describe("dreaming controller", () => {
     const ok = await repairDreamingArtifacts(state);
 
     expect(ok).toBe(true);
-    expect(confirmSpy).toHaveBeenCalledWith(
-      "Repair Dream Cache? This archives derived dream cache files and rebuilds them from clean inputs. Your dream diary stays untouched.",
-    );
     expect(request).toHaveBeenCalledWith("doctor.memory.repairDreamingArtifacts", {});
     expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
     expect(request).not.toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
@@ -1418,7 +1414,6 @@ describe("dreaming controller", () => {
 
   it("dedupes dream diary entries and reloads diary plus status", async () => {
     const { state, request } = createState();
-    const confirmSpy = vi.spyOn(globalThis, "confirm").mockReturnValue(true);
     request.mockImplementation(async (method: string) => {
       if (method === "doctor.memory.dedupeDreamDiary") {
         return {
@@ -1439,9 +1434,6 @@ describe("dreaming controller", () => {
     const ok = await dedupeDreamDiary(state);
 
     expect(ok).toBe(true);
-    expect(confirmSpy).toHaveBeenCalledWith(
-      "Dedupe Dream Diary? This rewrites DREAMS.md and removes only exact duplicate diary entries.",
-    );
     expect(request).toHaveBeenCalledWith("doctor.memory.dedupeDreamDiary", {});
     expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
     expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
@@ -1487,17 +1479,6 @@ describe("dreaming controller", () => {
       kind: "error",
       text: "Could not copy archive path.",
     });
-  });
-
-  it("does not run repair when confirmation is cancelled", async () => {
-    const { state, request } = createState();
-    vi.spyOn(globalThis, "confirm").mockReturnValue(false);
-
-    const ok = await repairDreamingArtifacts(state);
-
-    expect(ok).toBe(false);
-    expect(request).not.toHaveBeenCalled();
-    expect(state.dreamDiaryActionMessage).toBeNull();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/agents/memory/dreaming.ts
+++ b/ui/src/pages/agents/memory/dreaming.ts
@@ -175,13 +175,6 @@ type DreamingConfigCapability = Pick<
   "lookupSchemaPath" | "patch" | "state"
 >;
 
-function confirmDreamingAction(message: string): boolean {
-  if (typeof globalThis.confirm !== "function") {
-    return true;
-  }
-  return globalThis.confirm(message);
-}
-
 function isMemoryWikiEnabled(state: DreamingState): boolean {
   return isPluginEnabledInConfigSnapshot(state.configSnapshot, MEMORY_WIKI_PLUGIN_ID, {
     enabledByDefault: false,
@@ -464,18 +457,6 @@ async function runDreamDiaryAction(
   },
 ): Promise<boolean> {
   if (!state.client || !state.connected || state.dreamDiaryActionLoading) {
-    return false;
-  }
-  if (
-    method === "doctor.memory.repairDreamingArtifacts" &&
-    !confirmDreamingAction(t("dreaming.actions.confirmRepair"))
-  ) {
-    return false;
-  }
-  if (
-    method === "doctor.memory.dedupeDreamDiary" &&
-    !confirmDreamingAction(t("dreaming.actions.confirmDedupe"))
-  ) {
     return false;
   }
   state.dreamDiaryActionLoading = true;

--- a/ui/src/pages/agents/memory/memory-panel.test.ts
+++ b/ui/src/pages/agents/memory/memory-panel.test.ts
@@ -4,12 +4,18 @@ import { nothing, render } from "lit";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../../app/context.ts";
+import {
+  showConfirmDialog,
+  type ConfirmDialogOptions,
+} from "../../../components/confirm-dialog.ts";
 import { i18n } from "../../../i18n/index.ts";
 import type { TranslationMap } from "../../../i18n/lib/types.ts";
 import { en } from "../../../i18n/locales/en.ts";
 import type { DreamingState } from "./dreaming.ts";
 import type { DreamingViewState } from "./view.ts";
 import "./memory-panel.ts";
+
+vi.mock("../../../components/confirm-dialog.ts", () => ({ showConfirmDialog: vi.fn() }));
 
 type TestMemoryPanel = HTMLElement & {
   context: ApplicationContext;
@@ -29,6 +35,10 @@ type TestMemoryPanel = HTMLElement & {
     overridden: boolean;
     engineOff: boolean;
   }) => Promise<void>;
+  confirmDreamingTask: (
+    task: (state: DreamingState) => Promise<boolean>,
+    confirmation: ConfirmDialogOptions,
+  ) => Promise<void>;
   render: () => unknown;
   requestUpdate: () => void;
   readonly updateComplete: Promise<boolean>;
@@ -118,10 +128,28 @@ async function replaceContext(page: TestMemoryPanel, context: ApplicationContext
 
 afterEach(() => {
   document.body.replaceChildren();
+  vi.mocked(showConfirmDialog).mockReset();
   vi.restoreAllMocks();
 });
 
 describe("AgentMemoryPanel gateway lifecycle", () => {
+  it("does not run a confirmed dreaming action after the selected agent changes", async () => {
+    const confirmation = deferred<boolean>();
+    vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
+    const page = createPage(contextWithGateway({} as GatewayBrowserClient, true));
+    const task = vi.fn(async () => true);
+    document.body.append(page);
+    await page.updateComplete;
+
+    const pending = page.confirmDreamingTask(task, { message: "Repair?" });
+    page.agentId = "support";
+    await page.updateComplete;
+    confirmation.resolve(true);
+    await pending;
+
+    expect(task).not.toHaveBeenCalled();
+  });
+
   it("loads the selected agent on the first gateway bind", async () => {
     const client = {} as GatewayBrowserClient;
     const context = contextWithGateway(client, true);

--- a/ui/src/pages/agents/memory/memory-panel.ts
+++ b/ui/src/pages/agents/memory/memory-panel.ts
@@ -7,6 +7,10 @@ import {
   type ApplicationGateway,
   type ApplicationGatewaySnapshot,
 } from "../../../app/context.ts";
+import {
+  showConfirmDialog,
+  type ConfirmDialogOptions,
+} from "../../../components/confirm-dialog.ts";
 import { renderSettingsDefaultState } from "../../../components/settings-ui.ts";
 import { t } from "../../../i18n/index.ts";
 import { currentConfigObject } from "../../../lib/config/index.ts";
@@ -270,6 +274,17 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
         this.requestUpdate();
       }
     }
+  }
+
+  private async confirmDreamingTask(
+    task: (state: DreamingState) => Promise<boolean>,
+    confirmation: ConfirmDialogOptions,
+  ) {
+    const scope = this.captureTaskScope();
+    if (!scope || !(await showConfirmDialog(confirmation)) || !this.isTaskScopeCurrent(scope)) {
+      return;
+    }
+    await this.runDreamingTask(task, scope);
   }
 
   private async loadAll(refreshConfig = false) {
@@ -540,10 +555,21 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
         onOpenWikiPage: (lookup) => this.openWikiPage(lookup),
         onBackfillDiary: () => void this.runDreamingTask(backfillDreamDiary),
         onCopyDreamingArchivePath: () => void this.runDreamingTask(copyDreamingArchivePath),
-        onDedupeDreamDiary: () => void this.runDreamingTask(dedupeDreamDiary),
+        onDedupeDreamDiary: () =>
+          void this.confirmDreamingTask(dedupeDreamDiary, {
+            title: t("dreaming.scene.dedupeDiary"),
+            message: t("dreaming.actions.confirmDedupeDescription"),
+            confirmLabel: t("dreaming.scene.dedupeDiary"),
+            danger: true,
+          }),
         onResetDiary: () => void this.runDreamingTask(resetDreamDiary),
         onResetGroundedShortTerm: () => void this.runDreamingTask(resetGroundedShortTerm),
-        onRepairDreamingArtifacts: () => void this.runDreamingTask(repairDreamingArtifacts),
+        onRepairDreamingArtifacts: () =>
+          void this.confirmDreamingTask(repairDreamingArtifacts, {
+            title: t("dreaming.scene.repairCache"),
+            message: t("dreaming.actions.confirmRepairDescription"),
+            confirmLabel: t("dreaming.scene.repairCache"),
+          }),
         onViewStateChange: () => this.requestUpdate(),
       })}
       ${renderDreamingToggleConfirmation({

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -62,7 +62,6 @@ import {
 } from "./steer-lifecycle.ts";
 
 type ChatSendOptions = {
-  confirmReset?: boolean;
   restoreDraft?: boolean;
   skillWorkshopRevision?: ChatQueueSkillWorkshopRevision;
   /** Lets request-scoped UI actions recover from rejected local commands. */
@@ -203,16 +202,6 @@ export async function handleSendChat(
   const skillWorkshopRevision = opts?.skillWorkshopRevision;
 
   if (!message && !hasAttachments) {
-    return;
-  }
-
-  if (
-    messageOverride != null &&
-    opts?.confirmReset &&
-    isChatResetCommand(message) &&
-    (typeof globalThis.confirm !== "function" ||
-      !globalThis.confirm("Start a new thread? This will reset the current chat."))
-  ) {
     return;
   }
 

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -1152,69 +1152,7 @@ describe("handleSendChat", () => {
     vi.unstubAllGlobals();
   });
 
-  it("cancels button-triggered /new resets when confirmation is declined", async () => {
-    const confirm = vi.fn(() => false);
-    vi.stubGlobal("confirm", confirm);
-
-    const host = makeHost({
-      requestHandlers: {},
-      chatMessage: "keep this draft",
-      sessionKey: "agent:main",
-    });
-
-    await handleSendChat(host, "/new", { confirmReset: true, restoreDraft: true });
-
-    expect(confirm).toHaveBeenCalledWith("Start a new thread? This will reset the current chat.");
-    expect(host.request).not.toHaveBeenCalled();
-    expect(host.chatMessage).toBe("keep this draft");
-    expect(host.chatMessages).toStrictEqual([]);
-    expect(host.chatRunId).toBeNull();
-    expect(host.refreshSessionsAfterChat.size).toBe(0);
-  });
-
-  it("cancels button-triggered /new resets when confirmation is unavailable", async () => {
-    vi.stubGlobal("confirm", undefined);
-
-    const host = makeHost({
-      requestHandlers: {},
-      chatMessage: "keep this draft",
-      sessionKey: "agent:main",
-    });
-
-    await handleSendChat(host, "/new", { confirmReset: true, restoreDraft: true });
-
-    expect(host.request).not.toHaveBeenCalled();
-    expect(host.chatMessage).toBe("keep this draft");
-    expect(host.chatMessages).toStrictEqual([]);
-    expect(host.chatRunId).toBeNull();
-    expect(host.refreshSessionsAfterChat.size).toBe(0);
-  });
-
-  it("runs the fresh-session action for confirmed /new overrides", async () => {
-    const confirm = vi.fn(() => true);
-    vi.stubGlobal("confirm", confirm);
-
-    const createChatSession = vi.fn(async () => true);
-    const host = makeHost({
-      requestHandlers: {},
-      chatMessage: "restore me",
-      sessionKey: "agent:main",
-      createChatSession,
-    });
-
-    await handleSendChat(host, "/new", { confirmReset: true, restoreDraft: true });
-
-    expect(confirm).toHaveBeenCalledTimes(1);
-    expect(host.request).not.toHaveBeenCalled();
-    expect(createChatSession).toHaveBeenCalledTimes(1);
-    expect(host.chatMessage).toBe("restore me");
-    expect(host.refreshSessionsAfterChat.size).toBe(0);
-  });
-
   it("routes typed /new through the fresh-session action without confirmation", async () => {
-    const confirm = vi.fn(() => false);
-    vi.stubGlobal("confirm", confirm);
-
     const createChatSession = vi.fn(async () => true);
     const host = makeHost({
       requestHandlers: {},
@@ -1225,7 +1163,6 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    expect(confirm).not.toHaveBeenCalled();
     expect(host.request).not.toHaveBeenCalled();
     expect(createChatSession).toHaveBeenCalledTimes(1);
     expect(host.chatMessage).toBe("");
@@ -1264,9 +1201,6 @@ describe("handleSendChat", () => {
   });
 
   it("preserves typed /reset command dispatch without confirmation", async () => {
-    const confirm = vi.fn(() => false);
-    vi.stubGlobal("confirm", confirm);
-
     const host = makeHost({
       requestHandlers: {
         "chat.send": { status: "started" },
@@ -1277,7 +1211,6 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    expect(confirm).not.toHaveBeenCalled();
     const payload = findRequestPayload(
       host.request as unknown as MockCallSource,
       "chat.send",
@@ -1404,9 +1337,6 @@ describe("handleSendChat", () => {
       expected: "/reset soft please reload system prompt",
     },
   ])("preserves $input args and skips confirmation dialog", async ({ input, expected }) => {
-    const confirm = vi.fn(() => false);
-    vi.stubGlobal("confirm", confirm);
-
     const host = makeHost({
       requestHandlers: {
         "chat.send": { status: "started" },
@@ -1417,7 +1347,6 @@ describe("handleSendChat", () => {
 
     await handleSendChat(host);
 
-    expect(confirm).not.toHaveBeenCalled();
     const payload = findRequestPayload(
       host.request as unknown as MockCallSource,
       "chat.send",
@@ -1426,31 +1355,6 @@ describe("handleSendChat", () => {
     expect(payload.sessionKey).toBe("agent:main");
     expect(payload.message).toBe(expected);
     expect(host.chatMessage).toBe("");
-  });
-
-  it.each([
-    "/reset softish please archive",
-    "/reset\tsoftish please archive",
-    "/reset\nsoftish please archive",
-    "/reset: softish please archive",
-  ])("keeps %s on the hard-reset confirmation path", async (message) => {
-    const confirm = vi.fn(() => false);
-    vi.stubGlobal("confirm", confirm);
-
-    const host = makeHost({
-      requestHandlers: {},
-      chatMessage: "keep this draft",
-      sessionKey: "agent:main",
-    });
-
-    await handleSendChat(host, message, {
-      confirmReset: true,
-      restoreDraft: true,
-    });
-
-    expect(confirm).toHaveBeenCalledTimes(1);
-    expect(host.request).not.toHaveBeenCalled();
-    expect(host.chatMessage).toBe("keep this draft");
   });
 
   it("does not seed refreshSessionsAfterChat for a terminal timeout ack on a refreshing send", async () => {

--- a/ui/src/pages/config/view-navigation.ts
+++ b/ui/src/pages/config/view-navigation.ts
@@ -1,208 +1,40 @@
-import { html } from "lit";
+import type { TemplateResult } from "lit";
+import { icons } from "../../components/icons.ts";
 
-// SVG Icons for sidebar (Lucide-style)
-const sidebarIcons = {
-  all: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <rect x="3" y="3" width="7" height="7"></rect>
-      <rect x="14" y="3" width="7" height="7"></rect>
-      <rect x="14" y="14" width="7" height="7"></rect>
-      <rect x="3" y="14" width="7" height="7"></rect>
-    </svg>
-  `,
-  env: html`
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <circle cx="12" cy="12" r="3"></circle>
-      <path
-        d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"
-      ></path>
-    </svg>
-  `,
-  update: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-    <polyline points="7 10 12 15 17 10"></polyline>
-    <line x1="12" y1="15" x2="12" y2="3"></line>
-  </svg>`,
-  agents: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path
-      d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 0 1 7 7h1a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-1v1a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1H2a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h1a7 7 0 0 1 7-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 0 1 2-2z"
-    ></path>
-    <circle cx="8" cy="14" r="1"></circle>
-    <circle cx="16" cy="14" r="1"></circle>
-  </svg>`,
-  auth: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
-    <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
-  </svg>`,
-  channels: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-  </svg>`,
-  messages: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
-    <polyline points="22,6 12,13 2,6"></polyline>
-  </svg>`,
-  commands: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <polyline points="4 17 10 11 4 5"></polyline>
-    <line x1="12" y1="19" x2="20" y2="19"></line>
-  </svg>`,
-  hooks: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
-    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
-  </svg>`,
-  skills: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <polygon
-      points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
-    ></polygon>
-  </svg>`,
-  tools: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path
-      d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
-    ></path>
-  </svg>`,
-  gateway: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <circle cx="12" cy="12" r="10"></circle>
-    <line x1="2" y1="12" x2="22" y2="12"></line>
-    <path
-      d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
-    ></path>
-  </svg>`,
-  wizard: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M15 4V2"></path>
-    <path d="M15 16v-2"></path>
-    <path d="M8 9h2"></path>
-    <path d="M20 9h2"></path>
-    <path d="M17.8 11.8 19 13"></path>
-    <path d="M15 9h0"></path>
-    <path d="M17.8 6.2 19 5"></path>
-    <path d="m3 21 9-9"></path>
-    <path d="M12.2 6.2 11 5"></path>
-  </svg>`,
-  meta: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M12 20h9"></path>
-    <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"></path>
-  </svg>`,
-  logging: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-    <polyline points="14 2 14 8 20 8"></polyline>
-    <line x1="16" y1="13" x2="8" y2="13"></line>
-    <line x1="16" y1="17" x2="8" y2="17"></line>
-    <polyline points="10 9 9 9 8 9"></polyline>
-  </svg>`,
-  browser: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <circle cx="12" cy="12" r="10"></circle>
-    <circle cx="12" cy="12" r="4"></circle>
-    <line x1="21.17" y1="8" x2="12" y2="8"></line>
-    <line x1="3.95" y1="6.06" x2="8.54" y2="14"></line>
-    <line x1="10.88" y1="21.94" x2="15.46" y2="14"></line>
-  </svg>`,
-  ui: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-    <line x1="3" y1="9" x2="21" y2="9"></line>
-    <line x1="9" y1="21" x2="9" y2="9"></line>
-  </svg>`,
-  models: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path
-      d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"
-    ></path>
-    <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
-    <line x1="12" y1="22.08" x2="12" y2="12"></line>
-  </svg>`,
-  bindings: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect>
-    <rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect>
-    <line x1="6" y1="6" x2="6.01" y2="6"></line>
-    <line x1="6" y1="18" x2="6.01" y2="18"></line>
-  </svg>`,
-  broadcast: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9"></path>
-    <path d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5"></path>
-    <circle cx="12" cy="12" r="2"></circle>
-    <path d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5"></path>
-    <path d="M19.1 4.9C23 8.8 23 15.1 19.1 19"></path>
-  </svg>`,
-  tts: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M9 18V5l12-2v13"></path>
-    <circle cx="6" cy="18" r="3"></circle>
-    <circle cx="18" cy="16" r="3"></circle>
-  </svg>`,
-  session: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
-    <circle cx="9" cy="7" r="4"></circle>
-    <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
-    <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
-  </svg>`,
-  cron: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <circle cx="12" cy="12" r="10"></circle>
-    <polyline points="12 6 12 12 16 14"></polyline>
-  </svg>`,
-  discovery: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <circle cx="11" cy="11" r="8"></circle>
-    <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-  </svg>`,
-  talk: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"></path>
-    <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
-    <line x1="12" y1="19" x2="12" y2="23"></line>
-    <line x1="8" y1="23" x2="16" y2="23"></line>
-  </svg>`,
-  plugins: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M12 2v6"></path>
-    <path d="m4.93 10.93 4.24 4.24"></path>
-    <path d="M2 12h6"></path>
-    <path d="m4.93 13.07 4.24-4.24"></path>
-    <path d="M12 22v-6"></path>
-    <path d="m19.07 13.07-4.24-4.24"></path>
-    <path d="M22 12h-6"></path>
-    <path d="m19.07 10.93-4.24 4.24"></path>
-  </svg>`,
-  diagnostics: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
-  </svg>`,
-  cli: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <polyline points="4 17 10 11 4 5"></polyline>
-    <line x1="12" y1="19" x2="20" y2="19"></line>
-  </svg>`,
-  secrets: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path
-      d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"
-    ></path>
-  </svg>`,
-  acp: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
-    <circle cx="9" cy="7" r="4"></circle>
-    <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
-    <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
-  </svg>`,
-  mcp: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect>
-    <rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect>
-    <line x1="6" y1="6" x2="6.01" y2="6"></line>
-    <line x1="6" y1="18" x2="6.01" y2="18"></line>
-  </svg>`,
-  __appearance__: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <circle cx="12" cy="12" r="5"></circle>
-    <line x1="12" y1="1" x2="12" y2="3"></line>
-    <line x1="12" y1="21" x2="12" y2="23"></line>
-    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-    <line x1="1" y1="12" x2="3" y2="12"></line>
-    <line x1="21" y1="12" x2="23" y2="12"></line>
-    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-  </svg>`,
-  __notifications__: html`<svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-  >
-    <path d="M18 8a6 6 0 0 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9"></path>
-    <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
-  </svg>`,
-  default: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-    <polyline points="14 2 14 8 20 8"></polyline>
-  </svg>`,
+const sidebarIcons: Record<string, TemplateResult> = {
+  all: icons.layoutGrid,
+  env: icons.settings,
+  update: icons.download,
+  agents: icons.bot,
+  auth: icons.lock,
+  channels: icons.messageSquare,
+  messages: icons.mail,
+  commands: icons.terminal,
+  hooks: icons.link,
+  skills: icons.star,
+  tools: icons.wrench,
+  gateway: icons.globe,
+  wizard: icons.wandSparkles,
+  meta: icons.penLine,
+  logging: icons.fileText,
+  browser: icons.chrome,
+  ui: icons.panelsTopLeft,
+  models: icons.box,
+  bindings: icons.server,
+  broadcast: icons.radio,
+  tts: icons.music,
+  session: icons.users,
+  cron: icons.clock,
+  discovery: icons.search,
+  talk: icons.mic,
+  plugins: icons.asterisk,
+  diagnostics: icons.activity,
+  cli: icons.terminal,
+  secrets: icons.key,
+  acp: icons.users,
+  mcp: icons.server,
+  __appearance__: icons.sun,
+  __notifications__: icons.bell,
 };
 
 export type SectionCategory = {
@@ -240,5 +72,5 @@ export const CATEGORISED_KEYS = new Set(
 );
 
 export function getSectionIcon(key: string) {
-  return sidebarIcons[key as keyof typeof sidebarIcons] ?? sidebarIcons.default;
+  return sidebarIcons[key] ?? icons.file;
 }

--- a/ui/src/pages/logs/view.ts
+++ b/ui/src/pages/logs/view.ts
@@ -11,6 +11,7 @@ import {
   renderSettingsToggle,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
+import { formatTimeMs } from "../../lib/format.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 import type { LogEntry, LogLevel } from "./log-lines.ts";
 
@@ -34,7 +35,7 @@ type LogsProps = {
   onScroll: (event: Event) => void;
 };
 
-function formatTime(value?: string | null) {
+function formatLogTime(value?: string | null) {
   if (!value) {
     return "";
   }
@@ -42,7 +43,7 @@ function formatTime(value?: string | null) {
   if (Number.isNaN(date.getTime())) {
     return value;
   }
-  return date.toLocaleTimeString();
+  return formatTimeMs(date.getTime(), undefined, value);
 }
 
 function matchesFilter(entry: LogEntry, needle: string) {
@@ -148,7 +149,7 @@ export function renderLogs(props: LogsProps) {
           : filtered.map(
               (entry) => html`
                 <div class="log-row">
-                  <div class="log-time mono">${formatTime(entry.time)}</div>
+                  <div class="log-time mono">${formatLogTime(entry.time)}</div>
                   <div class="log-level ${entry.level ?? ""}">${entry.level ?? ""}</div>
                   <div class="log-subsystem mono">${entry.subsystem ?? ""}</div>
                   <div class="log-message mono">${entry.message ?? entry.raw}</div>

--- a/ui/src/pages/nodes/nodes-page.test.ts
+++ b/ui/src/pages/nodes/nodes-page.test.ts
@@ -245,7 +245,8 @@ describe("NodesPage gateway lifecycle", () => {
   });
 
   it("cancels a pending removal confirmation when the connection resets", async () => {
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const request = vi.fn();
+    const client = { request } as unknown as GatewayBrowserClient;
     const confirmation = deferred<boolean>();
     vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
     const page = document.createElement("openclaw-nodes-page") as TestNodesPage;
@@ -266,6 +267,6 @@ describe("NodesPage gateway lifecycle", () => {
     await pending;
 
     expect(signal?.aborted).toBe(true);
-    expect(client.request).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/nodes/nodes-page.test.ts
+++ b/ui/src/pages/nodes/nodes-page.test.ts
@@ -4,10 +4,16 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { PresenceEntry } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
-import { createInitialNodesState, loadNodes } from "../../lib/nodes/index.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
+import {
+  createInitialNodesState,
+  loadNodes,
+  type InventoryRemovalRequest,
+} from "../../lib/nodes/index.ts";
 import type { NodesRouteData } from "./nodes-page.ts";
 import "./nodes-page.ts";
-import type { InventoryRemovalPrompt } from "./view.types.ts";
+
+vi.mock("../../components/confirm-dialog.ts", () => ({ showConfirmDialog: vi.fn() }));
 
 type TestNodesPage = HTMLElement & {
   context: ApplicationContext;
@@ -19,7 +25,6 @@ type TestNodesPage = HTMLElement & {
   presence: PresenceEntry[];
   lastError: string | null;
   chatError: string | null;
-  inventoryRemovalPrompt: InventoryRemovalPrompt | null;
   routeData?: NodesRouteData;
   subscriptions: {
     hostConnected: () => void;
@@ -34,6 +39,10 @@ type TestNodesPage = HTMLElement & {
     initialBind?: boolean,
   ) => void;
   ensureInitialData: () => void;
+  confirmInventoryRemoval: (prompt: {
+    kind: "entry";
+    entry: InventoryRemovalRequest;
+  }) => Promise<void>;
 };
 
 function deferred<T>() {
@@ -235,23 +244,28 @@ describe("NodesPage gateway lifecycle", () => {
     page.applyGatewaySnapshot(gatewaySnapshot(client, false), false);
   });
 
-  it("drops a pending removal prompt when the connection resets", () => {
+  it("cancels a pending removal confirmation when the connection resets", async () => {
     const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const confirmation = deferred<boolean>();
+    vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
     const page = document.createElement("openclaw-nodes-page") as TestNodesPage;
     page.client = client;
     page.connected = true;
     page.context = {
       runtimeConfig: { state: { configSnapshot: null, configLoading: false } },
     } as unknown as ApplicationContext;
-    page.inventoryRemovalPrompt = {
+    const pending = page.confirmInventoryRemoval({
       kind: "entry",
       entry: { id: "device-1", name: "Browser", removeNode: false, removeDevice: true },
-    };
+    });
+    await Promise.resolve();
+    const signal = vi.mocked(showConfirmDialog).mock.calls[0]?.[0].signal;
 
-    // Disconnect resets server state; the confirm must not survive onto a
-    // different gateway that reuses the same device ids.
     page.applyGatewaySnapshot(gatewaySnapshot(client, false), false);
+    confirmation.resolve(true);
+    await pending;
 
-    expect(page.inventoryRemovalPrompt).toBeNull();
+    expect(signal?.aborted).toBe(true);
+    expect(client.request).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/nodes/nodes-page.ts
+++ b/ui/src/pages/nodes/nodes-page.ts
@@ -10,6 +10,7 @@ import {
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
@@ -36,13 +37,13 @@ import {
   type ExecApprovalsFile,
   type ExecApprovalsSnapshot,
   type ExecApprovalsTarget,
+  type InventoryRemovalRequest,
   type NodesPageDataState,
 } from "../../lib/nodes/index.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { PollController } from "../../lit/poll-controller.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { renderNodes } from "./view.ts";
-import type { InventoryRemovalPrompt } from "./view.types.ts";
 
 const NODES_DOCS_URL = "https://docs.openclaw.ai/nodes";
 
@@ -54,6 +55,10 @@ export type NodesRouteData = {
 };
 
 const NODES_ACTIVE_POLL_INTERVAL_MS = 30_000;
+
+type InventoryRemovalPrompt =
+  | { kind: "entry"; entry: InventoryRemovalRequest }
+  | { kind: "stale"; entries: InventoryRemovalRequest[] };
 
 function readPresence(value: unknown): PresenceEntry[] | null {
   const presence =
@@ -98,7 +103,7 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
   @state() execApprovalsSelectedAgent: string | null = null;
   @state() private execApprovalsTarget: "gateway" | "node" = "gateway";
   @state() private execApprovalsTargetNodeId: string | null = null;
-  @state() private inventoryRemovalPrompt: InventoryRemovalPrompt | null = null;
+  private inventoryRemovalConfirmation: AbortController | null = null;
 
   private routeDataInitialized = false;
   private hasBoundGateway = false;
@@ -203,6 +208,7 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
   }
 
   override disconnectedCallback() {
+    this.cancelInventoryRemovalConfirmation();
     this.connectionLifecycle.transition({ client: null, phase: "stopped" });
     this.subscriptions.clear();
     void this.presenceTask.run([null, null]);
@@ -210,7 +216,6 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
     this.connected = false;
     this.presence = [];
     this.canPairDevice = false;
-    this.inventoryRemovalPrompt = null;
     super.disconnectedCallback();
   }
 
@@ -294,10 +299,7 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
   }
 
   private resetServerState(snapshot: ApplicationGatewaySnapshot) {
-    // The removal prompt targets entries on the gateway it was opened against.
-    // Drop it on client change/disconnect so a confirm can never fire removal
-    // RPCs at a different gateway that reuses the same device ids.
-    this.inventoryRemovalPrompt = null;
+    this.cancelInventoryRemovalConfirmation();
     const next = createInitialNodesState({
       client: snapshot.client,
       connected: snapshot.phase === "connected",
@@ -355,10 +357,53 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
     return this.presenceTask.run([this.context.gateway, client]);
   }
 
-  private confirmInventoryRemoval() {
-    const prompt = this.inventoryRemovalPrompt;
-    this.inventoryRemovalPrompt = null;
-    if (!prompt) {
+  private cancelInventoryRemovalConfirmation() {
+    this.inventoryRemovalConfirmation?.abort();
+    this.inventoryRemovalConfirmation = null;
+  }
+
+  private async confirmInventoryRemoval(prompt: InventoryRemovalPrompt) {
+    if (this.inventoryRemovalConfirmation) {
+      return;
+    }
+    const controller = new AbortController();
+    this.inventoryRemovalConfirmation = controller;
+    const generation = this.requestGeneration;
+    const client = this.client;
+    const title =
+      prompt.kind === "entry"
+        ? t("nodes.inventory.removePromptTitle", { name: prompt.entry.name })
+        : t(
+            prompt.entries.length === 1
+              ? "nodes.inventory.removeStalePromptTitleOne"
+              : "nodes.inventory.removeStalePromptTitle",
+            { count: String(prompt.entries.length) },
+          );
+    const confirmed = await showConfirmDialog({
+      title,
+      message: t(
+        prompt.kind === "entry"
+          ? "nodes.inventory.removePromptBody"
+          : "nodes.inventory.removeStalePromptBody",
+      ),
+      details:
+        prompt.kind === "entry"
+          ? t("nodes.inventory.deviceId", { id: prompt.entry.id })
+          : undefined,
+      confirmLabel: t("nodes.inventory.remove"),
+      danger: true,
+      signal: controller.signal,
+    });
+    if (this.inventoryRemovalConfirmation === controller) {
+      this.inventoryRemovalConfirmation = null;
+    }
+    if (
+      !confirmed ||
+      controller.signal.aborted ||
+      generation !== this.requestGeneration ||
+      client !== this.client ||
+      !this.connected
+    ) {
       return;
     }
     if (prompt.kind === "entry") {
@@ -419,18 +464,11 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
           onDeviceReject: (requestId) => void rejectDevicePairing(this, requestId),
           onNodeApprove: (requestId) => void approveNodePairingRequest(this, requestId),
           onNodeReject: (requestId) => void rejectNodePairingRequest(this, requestId),
-          inventoryRemovalPrompt: this.inventoryRemovalPrompt,
-          onInventoryRemove: (entry) => {
-            this.inventoryRemovalPrompt = { kind: "entry", entry };
-          },
+          onInventoryRemove: (entry) => void this.confirmInventoryRemoval({ kind: "entry", entry }),
           onInventoryCleanup: (entries) => {
             if (entries.length > 0) {
-              this.inventoryRemovalPrompt = { kind: "stale", entries };
+              void this.confirmInventoryRemoval({ kind: "stale", entries });
             }
-          },
-          onInventoryRemovalConfirm: () => this.confirmInventoryRemoval(),
-          onInventoryRemovalCancel: () => {
-            this.inventoryRemovalPrompt = null;
           },
           onDeviceRotate: (deviceId, role, scopes) =>
             void rotateDeviceToken(this, {

--- a/ui/src/pages/nodes/view-inventory.ts
+++ b/ui/src/pages/nodes/view-inventory.ts
@@ -1,6 +1,5 @@
 // Nodes page renders the unified paired-device / node inventory sections.
 import { html, nothing, type TemplateResult } from "lit";
-import "../../components/modal-dialog.ts";
 import type { PresenceEntry } from "../../api/types.ts";
 import { icons } from "../../components/icons.ts";
 import {
@@ -113,58 +112,6 @@ export function renderNodesInventory(props: NodesProps) {
           unpairedPresence.map((entry) => renderPresenceOnlyEntry(entry)),
         )
       : nothing}
-    ${renderRemovalPrompt(props)}
-  `;
-}
-
-/* In-page confirm instead of window.confirm: hosts without a native dialog
-   bridge silently cancel window.confirm, turning removals into no-ops. */
-function renderRemovalPrompt(props: NodesProps) {
-  const prompt = props.inventoryRemovalPrompt;
-  if (!prompt) {
-    return nothing;
-  }
-  const title =
-    prompt.kind === "entry"
-      ? t("nodes.inventory.removePromptTitle", { name: prompt.entry.name })
-      : t(
-          prompt.entries.length === 1
-            ? "nodes.inventory.removeStalePromptTitleOne"
-            : "nodes.inventory.removeStalePromptTitle",
-          { count: String(prompt.entries.length) },
-        );
-  const body =
-    prompt.kind === "entry"
-      ? t("nodes.inventory.removePromptBody")
-      : t("nodes.inventory.removeStalePromptBody");
-  return html`
-    <openclaw-modal-dialog
-      label=${title}
-      description=${body}
-      @modal-cancel=${props.onInventoryRemovalCancel}
-    >
-      <div class="exec-approval-card">
-        <div class="exec-approval-header">
-          <div>
-            <div class="exec-approval-title">${title}</div>
-            <div class="exec-approval-sub">${body}</div>
-          </div>
-        </div>
-        ${prompt.kind === "entry"
-          ? html`<div class="exec-approval-command mono">
-              ${t("nodes.inventory.deviceId", { id: prompt.entry.id })}
-            </div>`
-          : nothing}
-        <div class="exec-approval-actions">
-          <button class="btn danger" @click=${props.onInventoryRemovalConfirm}>
-            ${t("nodes.inventory.remove")}
-          </button>
-          <button class="btn" autofocus @click=${props.onInventoryRemovalCancel}>
-            ${t("common.cancel")}
-          </button>
-        </div>
-      </div>
-    </openclaw-modal-dialog>
   `;
 }
 

--- a/ui/src/pages/nodes/view.devices.test.ts
+++ b/ui/src/pages/nodes/view.devices.test.ts
@@ -3,7 +3,6 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import type { InventoryRemovalRequest } from "../../lib/nodes/index.ts";
-import { getRenderedModalDialog } from "../../test-helpers/modal-dialog.ts";
 import { renderNodes } from "./view.ts";
 import type { NodesProps } from "./view.types.ts";
 
@@ -41,11 +40,8 @@ function baseProps(overrides: Partial<NodesProps> = {}): NodesProps {
     onDeviceRevoke: () => undefined,
     onNodeApprove: () => undefined,
     onNodeReject: () => undefined,
-    inventoryRemovalPrompt: null,
     onInventoryRemove: () => undefined,
     onInventoryCleanup: () => undefined,
-    onInventoryRemovalConfirm: () => undefined,
-    onInventoryRemovalCancel: () => undefined,
     onLoadConfig: () => undefined,
     onLoadExecApprovals: () => undefined,
     onBindDefault: () => undefined,
@@ -62,8 +58,6 @@ function baseProps(overrides: Partial<NodesProps> = {}): NodesProps {
 
 function renderNodesContainer(overrides: Partial<NodesProps>): HTMLDivElement {
   const container = document.createElement("div");
-  // Attach to the document: the removal-prompt dialog is a custom element and
-  // only upgrades (and renders its shadow DOM) once connected.
   document.body.append(container);
   render(renderNodes(baseProps(overrides)), container);
   return container;
@@ -341,53 +335,6 @@ describe("nodes inventory rendering", () => {
     expect(removed).toEqual([
       { id: "op-only", name: "Browser", removeNode: false, removeDevice: true },
     ]);
-  });
-
-  it("renders the removal prompt and wires confirm and cancel", async () => {
-    let confirmed = 0;
-    let cancelled = 0;
-    const container = renderNodesContainer({
-      inventoryRemovalPrompt: {
-        kind: "stale",
-        entries: [
-          { id: "old-1", name: "Browser", removeNode: false, removeDevice: true },
-          { id: "old-2", name: "Browser", removeNode: false, removeDevice: true },
-        ],
-      },
-      onInventoryRemovalConfirm: () => {
-        confirmed += 1;
-      },
-      onInventoryRemovalCancel: () => {
-        cancelled += 1;
-      },
-    });
-    const { modal } = await getRenderedModalDialog(container);
-    expect(modal.textContent).toContain("Remove 2 stale pairings?");
-    expect(modal.textContent).toContain(
-      "Affected clients re-pair silently on their next connection.",
-    );
-
-    findButton(modal, "Remove").click();
-    expect(confirmed).toBe(1);
-    findButton(modal, "Cancel").click();
-    expect(cancelled).toBe(1);
-  });
-
-  it("shows the device id when confirming a single removal", async () => {
-    const container = renderNodesContainer({
-      inventoryRemovalPrompt: {
-        kind: "entry",
-        entry: {
-          id: "device-ambiguous-id",
-          name: "Browser",
-          removeNode: false,
-          removeDevice: true,
-        },
-      },
-    });
-    const { modal } = await getRenderedModalDialog(container);
-    expect(modal.textContent).toContain("Remove Browser?");
-    expect(modal.textContent).toContain("Device ID: device-ambiguous-id");
   });
 
   it("renders approve and reject actions for pending node approvals", () => {

--- a/ui/src/pages/nodes/view.types.ts
+++ b/ui/src/pages/nodes/view.types.ts
@@ -7,16 +7,6 @@ import type {
   InventoryRemovalRequest,
 } from "../../lib/nodes/index.ts";
 
-/**
- * Pending destructive inventory action awaiting in-page confirmation. Native
- * `window.confirm` silently returns false in webviews without a dialog bridge
- * (macOS app before the confirm-panel fix, Tauri), so the page renders its own
- * confirm dialog instead.
- */
-export type InventoryRemovalPrompt =
-  | { kind: "entry"; entry: InventoryRemovalRequest }
-  | { kind: "stale"; entries: InventoryRemovalRequest[] };
-
 export type NodesProps = {
   loading: boolean;
   nodes: Array<Record<string, unknown>>;
@@ -47,11 +37,8 @@ export type NodesProps = {
   onDeviceRevoke: (deviceId: string, role: string) => void;
   onNodeApprove: (requestId: string) => void;
   onNodeReject: (requestId: string) => void;
-  inventoryRemovalPrompt: InventoryRemovalPrompt | null;
   onInventoryRemove: (entry: InventoryRemovalRequest) => void;
   onInventoryCleanup: (entries: InventoryRemovalRequest[]) => void;
-  onInventoryRemovalConfirm: () => void;
-  onInventoryRemovalCancel: () => void;
   onLoadConfig: () => void;
   onLoadExecApprovals: () => void;
   onBindDefault: (nodeId: string | null) => void;

--- a/ui/src/pages/sessions/sessions-page.archived.test.ts
+++ b/ui/src/pages/sessions/sessions-page.archived.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
   createContext,
@@ -12,8 +13,11 @@ import {
   createSessions,
 } from "./sessions-page.test-support.ts";
 
+vi.mock("../../components/confirm-dialog.ts", () => ({ showConfirmDialog: vi.fn() }));
+
 afterEach(() => {
   document.body.replaceChildren();
+  vi.mocked(showConfirmDialog).mockReset();
   vi.restoreAllMocks();
 });
 
@@ -50,7 +54,7 @@ describe("sessions page archived deletion", () => {
       } as SessionsListResult,
       "archived",
     );
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     page.querySelector<HTMLButtonElement>(".settings-section__actions .danger")?.click();
     await vi.waitFor(() => expect(sessions.deleteMany).toHaveBeenCalledOnce());
@@ -58,7 +62,11 @@ describe("sessions page archived deletion", () => {
     expect(sessions.list).toHaveBeenCalledWith(
       expect.objectContaining({ archivedFilter: "archived", limit: 1000 }),
     );
-    expect(confirm).toHaveBeenCalledWith("Delete 2 archived threads and their transcripts?");
+    expect(showConfirmDialog).toHaveBeenCalledWith({
+      message: "Delete 2 archived threads and their transcripts?",
+      confirmLabel: "Delete",
+      danger: true,
+    });
     expect(sessions.deleteMany).toHaveBeenCalledWith([
       {
         key: archivedKeys[0],
@@ -89,7 +97,7 @@ describe("sessions page archived deletion", () => {
       count: 1,
       sessions: [{ key, archived: false }],
     } as SessionsListResult);
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     await page.deleteSessionFromMenu({ key, archived: false } as SessionsListResult["sessions"][0]);
 
@@ -112,12 +120,12 @@ describe("sessions page archived deletion", () => {
       } as SessionsListResult,
       "archived",
     );
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     page.querySelector<HTMLButtonElement>(".settings-section__actions .danger")?.click();
     await vi.waitFor(() => expect(sessions.list).toHaveBeenCalledOnce());
 
-    expect(confirm).not.toHaveBeenCalled();
+    expect(showConfirmDialog).not.toHaveBeenCalled();
     expect(sessions.deleteMany).not.toHaveBeenCalled();
   });
 
@@ -155,14 +163,18 @@ describe("sessions page archived deletion", () => {
       } as SessionsListResult,
       "archived",
     );
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     page.querySelector<HTMLButtonElement>(".settings-section__actions .danger")?.click();
     await vi.waitFor(() => expect(sessions.deleteMany).toHaveBeenCalledOnce());
 
     expect(list).toHaveBeenCalledTimes(2);
     expect(list).toHaveBeenNthCalledWith(2, expect.objectContaining({ offset: 2 }));
-    expect(confirm).toHaveBeenCalledWith("Delete 3 archived threads and their transcripts?");
+    expect(showConfirmDialog).toHaveBeenCalledWith({
+      message: "Delete 3 archived threads and their transcripts?",
+      confirmLabel: "Delete",
+      danger: true,
+    });
     expect(sessions.deleteMany).toHaveBeenCalledWith(
       [...pageOne, ...pageTwo].map((key) => ({
         key,
@@ -217,13 +229,17 @@ describe("sessions page archived deletion", () => {
       { count: 1, sessions: [archived(keys[0])] } as SessionsListResult,
       "archived",
     );
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     page.querySelector<HTMLButtonElement>(".settings-section__actions .danger")?.click();
     await vi.waitFor(() => expect(sessions.deleteMany).toHaveBeenCalledOnce());
 
     expect(list).toHaveBeenCalledTimes(3);
-    expect(confirm).toHaveBeenCalledWith("Delete 3 archived threads and their transcripts?");
+    expect(showConfirmDialog).toHaveBeenCalledWith({
+      message: "Delete 3 archived threads and their transcripts?",
+      confirmLabel: "Delete",
+      danger: true,
+    });
     expect(sessions.deleteMany).toHaveBeenCalledWith(
       keys.map((key) => ({
         key,
@@ -254,11 +270,11 @@ describe("sessions page archived deletion", () => {
       { count: 1, sessions: [archived] } as SessionsListResult,
       "archived",
     );
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     await page.deleteAllArchived();
 
-    expect(confirm).not.toHaveBeenCalled();
+    expect(showConfirmDialog).not.toHaveBeenCalled();
     expect(sessions.deleteMany).not.toHaveBeenCalled();
     expect(page.error).toContain("archived session enumeration");
   });
@@ -283,11 +299,11 @@ describe("sessions page archived deletion", () => {
       { count: 1, sessions: [archived] } as SessionsListResult,
       "archived",
     );
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     await page.deleteAllArchived();
 
-    expect(confirm).not.toHaveBeenCalled();
+    expect(showConfirmDialog).not.toHaveBeenCalled();
     expect(sessions.deleteMany).not.toHaveBeenCalled();
     expect(page.error).toContain("archived session enumeration was incomplete");
   });
@@ -322,7 +338,7 @@ describe("sessions page archived deletion", () => {
         "archived",
         linked.key,
       );
-      const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+      vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
       await page.deleteAllArchived();
 
@@ -333,7 +349,11 @@ describe("sessions page archived deletion", () => {
       } else {
         expect(options).not.toHaveProperty("agentId");
       }
-      expect(confirm).toHaveBeenCalledWith("Delete 2 archived threads and their transcripts?");
+      expect(showConfirmDialog).toHaveBeenCalledWith({
+        message: "Delete 2 archived threads and their transcripts?",
+        confirmLabel: "Delete",
+        danger: true,
+      });
       expect(sessions.deleteMany).toHaveBeenCalledWith(
         [linked.key, other.key].map((key) => ({
           key,

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -10,6 +10,7 @@ import type {
   SessionsListResult,
 } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { getWorkboardState } from "../../lib/workboard/index.ts";
 import {
@@ -19,6 +20,8 @@ import {
   createSessions,
   type TestSessionsPage,
 } from "./sessions-page.test-support.ts";
+
+vi.mock("../../components/confirm-dialog.ts", () => ({ showConfirmDialog: vi.fn() }));
 
 type TestSessionMenu = HTMLElement & {
   forkDisabled: boolean;
@@ -47,6 +50,7 @@ async function createPage(context: ApplicationContext): Promise<TestSessionsPage
 
 afterEach(() => {
   document.body.replaceChildren();
+  vi.mocked(showConfirmDialog).mockReset();
   vi.restoreAllMocks();
 });
 
@@ -538,7 +542,7 @@ describe("sessions page lifecycle", () => {
     const page = await createPage(createContext(mutableGateway.gateway, sessions));
     page.result = { count: 1, sessions: [{ key }] } as SessionsListResult;
     page.selectedKeys = new Set([key]);
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     await page.deleteSelected();
 
@@ -546,6 +550,27 @@ describe("sessions page lifecycle", () => {
     expect(mutableGateway.setSessionKey).toHaveBeenCalledWith("agent:writer:main");
     expect(page.result?.sessions).toEqual([]);
     expect(page.selectedKeys).toEqual(new Set());
+  });
+
+  it("does not delete a selection after the gateway changes during confirmation", async () => {
+    const confirmation = deferred<boolean>();
+    vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
+    const sessions = createSessions({ deleteMany: vi.fn() });
+    const mutableGateway = createGateway({} as GatewayBrowserClient);
+    const page = await createPage(createContext(mutableGateway.gateway, sessions));
+    page.result = {
+      count: 1,
+      sessions: [{ key: "agent:main:old" }],
+    } as SessionsListResult;
+    page.selectedKeys = new Set(["agent:main:old"]);
+
+    const deleting = page.deleteSelected();
+    await Promise.resolve();
+    mutableGateway.emit({ phase: "reconnecting", client: null });
+    confirmation.resolve(true);
+    await deleting;
+
+    expect(sessions.deleteMany).not.toHaveBeenCalled();
   });
 
   it("archive-gates a confirmed archived row-menu deletion", async () => {
@@ -557,11 +582,11 @@ describe("sessions page lifecycle", () => {
     const page = await createPage(createContext(gateway, sessions));
     const row = { key, label: "Work", archived: true } as GatewaySessionRow;
     page.result = { count: 1, sessions: [row] } as SessionsListResult;
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     await page.deleteSessionFromMenu(row);
 
-    expect(confirm).toHaveBeenCalledOnce();
+    expect(showConfirmDialog).toHaveBeenCalledOnce();
     expect(sessions.deleteMany).toHaveBeenCalledWith([
       { key, agentId: undefined, archivedOnly: true },
     ]);
@@ -584,7 +609,7 @@ describe("sessions page lifecycle", () => {
       ...(archived === undefined ? {} : { archived }),
     } as GatewaySessionRow;
     page.result = { count: 1, sessions: [row] } as SessionsListResult;
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     await page.deleteSessionFromMenu(row);
 
@@ -612,7 +637,7 @@ describe("sessions page lifecycle", () => {
       ],
     } as SessionsListResult;
     page.selectedKeys = new Set([activeKey, archivedKey, unknownKey]);
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     await page.deleteSelected();
 
@@ -651,11 +676,15 @@ describe("sessions page lifecycle", () => {
         remoteWorkspaceDir: "/workspace",
       },
     } as GatewaySessionRow;
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     await page.stopCloudWorker(row);
 
-    expect(confirm).toHaveBeenCalledWith('Stop the cloud worker for "Cloud task"?');
+    expect(showConfirmDialog).toHaveBeenCalledWith({
+      message: 'Stop the cloud worker for "Cloud task"?',
+      confirmLabel: "Stop worker",
+      danger: true,
+    });
     expect(request).toHaveBeenCalledWith(
       "sessions.reclaim",
       { key: "agent:main:cloud", agentId: "main" },
@@ -716,7 +745,7 @@ describe("sessions page lifecycle", () => {
     const page = await createPage(context);
     page.result = { count: 1, sessions: [{ key: "main" }] } as SessionsListResult;
     page.selectedKeys = new Set(["main"]);
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
 
     const requests = [
       page.deleteSelected(),

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -13,6 +13,7 @@ import { selectApplicationSession } from "../../app/agent-selection.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import { fetchSessionMenuWork } from "../../components/session-menu-work.ts";
 import type {
   SessionMenuAction,
@@ -777,10 +778,23 @@ class SessionsPage extends OpenClawLightDomElement {
     if (keys.length === 0 || this.loading || this.sessionMutationPending) {
       return;
     }
+    const scope = this.captureRequestScope();
+    if (!scope) {
+      return;
+    }
+    const message = t(
+      keys.length === 1
+        ? "sessionsView.deleteSelectedConfirmOne"
+        : "sessionsView.deleteSelectedConfirm",
+      { count: String(keys.length) },
+    );
     if (
-      !window.confirm(
-        `Delete ${keys.length} ${keys.length === 1 ? "thread" : "threads"}?\n\nThis will delete the thread entries and archive their transcripts.`,
-      )
+      !(await showConfirmDialog({
+        message,
+        confirmLabel: t("common.delete"),
+        danger: true,
+      })) ||
+      !this.isRequestScopeCurrent(scope)
     ) {
       return;
     }
@@ -924,11 +938,18 @@ class SessionsPage extends OpenClawLightDomElement {
       return;
     }
     const archivedRows = rows.filter((row) => row.archived === true);
+    if (archivedRows.length === 0) {
+      return;
+    }
     if (
-      archivedRows.length === 0 ||
-      !window.confirm(
-        t("sessionsView.deleteAllArchivedConfirm", { count: String(archivedRows.length) }),
-      )
+      !(await showConfirmDialog({
+        message: t("sessionsView.deleteAllArchivedConfirm", {
+          count: String(archivedRows.length),
+        }),
+        confirmLabel: t("common.delete"),
+        danger: true,
+      })) ||
+      !this.isRequestScopeCurrent(scope)
     ) {
       return;
     }
@@ -937,7 +958,16 @@ class SessionsPage extends OpenClawLightDomElement {
 
   private async deleteSessionFromMenu(row: GatewaySessionRow) {
     const label = normalizeOptionalString(row.label) ?? row.key;
-    if (!window.confirm(t("sessionsView.deleteSessionConfirm", { session: label }))) {
+    const scope = this.captureRequestScope();
+    if (
+      !scope ||
+      !(await showConfirmDialog({
+        message: t("sessionsView.deleteSessionConfirm", { session: label }),
+        confirmLabel: t("common.delete"),
+        danger: true,
+      })) ||
+      !this.isRequestScopeCurrent(scope)
+    ) {
       return;
     }
     await this.deleteSessions([row]);
@@ -945,16 +975,18 @@ class SessionsPage extends OpenClawLightDomElement {
 
   private async stopCloudWorker(row: GatewaySessionRow) {
     const label = normalizeOptionalString(row.label) ?? row.key;
-    if (
-      !isStoppableCloudWorkerPlacement(row.placement) ||
-      row.hasActiveRun === true ||
-      !window.confirm(t("sessionsView.stopCloudWorkerConfirm", { session: label }))
-    ) {
+    if (!isStoppableCloudWorkerPlacement(row.placement) || row.hasActiveRun === true) {
       return;
     }
     const scope = this.captureRequestScope();
     if (
       !scope ||
+      !(await showConfirmDialog({
+        message: t("sessionsView.stopCloudWorkerConfirm", { session: label }),
+        confirmLabel: t("sessionsView.stopCloudWorkerConfirmAction"),
+        danger: true,
+      })) ||
+      !this.isRequestScopeCurrent(scope) ||
       !this.requireMutationAccess(scope, {
         method: "sessions.reclaim",
         requiredScope: "operator.admin",
@@ -1213,12 +1245,18 @@ class SessionsPage extends OpenClawLightDomElement {
   }
 
   private async branchCheckpoint(sessionKey: string, checkpointId: string) {
-    if (!window.confirm("Create a new child thread from this compacted checkpoint?")) {
-      return;
-    }
     const scope = this.captureRequestScope();
     if (
       !scope ||
+      !(await showConfirmDialog({
+        message: t("sessionsView.branchCheckpointConfirm"),
+        confirmLabel: t("common.create"),
+      })) ||
+      !this.isRequestScopeCurrent(scope)
+    ) {
+      return;
+    }
+    if (
       !this.requireMutationAccess(scope, {
         method: "sessions.compaction.branch",
         requiredScope: "operator.write",
@@ -1254,16 +1292,19 @@ class SessionsPage extends OpenClawLightDomElement {
   }
 
   private async restoreCheckpoint(sessionKey: string, checkpointId: string) {
-    if (
-      !window.confirm(
-        "Restore this thread to the selected compacted checkpoint?\n\nThis replaces the current active transcript for the session key.",
-      )
-    ) {
-      return;
-    }
     const scope = this.captureRequestScope();
     if (
       !scope ||
+      !(await showConfirmDialog({
+        message: t("sessionsView.restoreCheckpointConfirm"),
+        confirmLabel: t("common.restore"),
+        danger: true,
+      })) ||
+      !this.isRequestScopeCurrent(scope)
+    ) {
+      return;
+    }
+    if (
       !this.requireMutationAccess(scope, {
         method: "sessions.compaction.restore",
         requiredScope: "operator.admin",

--- a/ui/src/pages/skill-workshop/empty-states.ts
+++ b/ui/src/pages/skill-workshop/empty-states.ts
@@ -1,6 +1,7 @@
 // Empty-state renderers for the Workshop board: filtered-queue detail pane
 // and the whole-page no-proposals panel with the self-learning pitch.
-import { html, nothing } from "lit";
+import { html } from "lit";
+import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import type { SkillWorkshopStatusFilter } from "../../lib/skill-workshop/index.ts";
 import { renderSelfLearningPitch, type SkillWorkshopSelfLearning } from "./self-learning.ts";
@@ -83,53 +84,17 @@ function resolveBoardEmptyState(
   };
 }
 
+const emptyStateIcons: Record<SkillWorkshopEmptyIcon, (typeof icons)[keyof typeof icons]> = {
+  search: icons.search,
+  clock: icons.clock,
+  check: icons.check,
+  x: icons.x,
+  shield: icons.shieldCheck,
+  refresh: icons.refresh,
+};
+
 function renderEmptyStateIcon(icon: SkillWorkshopEmptyIcon) {
-  switch (icon) {
-    case "clock":
-      return html`
-        <svg viewBox="0 0 24 24">
-          <circle cx="12" cy="12" r="8"></circle>
-          <path d="M12 7v5l3 2"></path>
-        </svg>
-      `;
-    case "check":
-      return html`
-        <svg viewBox="0 0 24 24">
-          <path d="M5 12.5l4 4L19 7"></path>
-        </svg>
-      `;
-    case "x":
-      return html`
-        <svg viewBox="0 0 24 24">
-          <path d="M7 7l10 10"></path>
-          <path d="M17 7L7 17"></path>
-        </svg>
-      `;
-    case "shield":
-      return html`
-        <svg viewBox="0 0 24 24">
-          <path d="M12 3l7 3v5c0 4.2-2.8 7.8-7 10-4.2-2.2-7-5.8-7-10V6l7-3z"></path>
-          <path d="M9 12l2 2 4-5"></path>
-        </svg>
-      `;
-    case "refresh":
-      return html`
-        <svg viewBox="0 0 24 24">
-          <path d="M17 2v5h-5"></path>
-          <path d="M7 22v-5h5"></path>
-          <path d="M19 10a7 7 0 0 0-12-4l-2 2"></path>
-          <path d="M5 14a7 7 0 0 0 12 4l2-2"></path>
-        </svg>
-      `;
-    case "search":
-      return html`
-        <svg viewBox="0 0 24 24">
-          <circle cx="11" cy="11" r="6"></circle>
-          <path d="M16 16l4 4"></path>
-        </svg>
-      `;
-  }
-  return nothing;
+  return emptyStateIcons[icon];
 }
 
 export function renderWorkshopEmptyState(params: {

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -172,6 +172,32 @@ describe("Skill Workshop proposal RPCs", () => {
     });
   });
 
+  it("preserves capped support-file size formatting through the shared helper", async () => {
+    const { state, context, request } = createFixture();
+    const baseInspect = inspectResult();
+    const inspected = {
+      ...baseInspect,
+      record: {
+        ...baseInspect.record,
+        supportFiles: [{ path: "reference.md", sizeBytes: 1024 * 1024 }],
+      },
+      supportFiles: [{ path: "reference.md", content: "reference" }],
+    };
+    request.mockImplementation(async (method: string) => {
+      if (method === "skills.proposals.list") {
+        return manifest();
+      }
+      if (method === "skills.proposals.inspect") {
+        return inspected;
+      }
+      return {};
+    });
+
+    await loadSkillWorkshopProposals(state, context);
+
+    expect(state.skillWorkshopProposals[0]?.supportFiles[0]?.size).toBe("1024.0 KB");
+  });
+
   it("inspects a selected proposal with the agent from the current session", async () => {
     const { state, context, request } = createFixture(
       { skillWorkshopProposals: [proposal({ body: "" })] },

--- a/ui/src/pages/skill-workshop/proposals.ts
+++ b/ui/src/pages/skill-workshop/proposals.ts
@@ -1,8 +1,9 @@
 // Control UI controller manages skill workshop gateway state.
-import { formatByteSize, formatErrorMessage } from "@openclaw/normalization-core";
+import { formatErrorMessage } from "@openclaw/normalization-core";
 import type { AgentSelectionCapability } from "../../app/agent-selection.ts";
 import type { ApplicationGateway } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
+import { formatBytes } from "../../lib/agents/display.ts";
 import { redactToolDetail } from "../../lib/browser-redact.ts";
 import {
   normalizeAgentId,
@@ -187,18 +188,6 @@ function proposedVersionNumber(value: string | undefined): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
 }
 
-function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) {
-    return "0 B";
-  }
-  return formatByteSize(bytes, {
-    style: "legacy-binary",
-    maxUnit: "kilo",
-    separator: " ",
-    fractionDigits: (_value, unit) => (unit === "byte" ? null : 1),
-  });
-}
-
 function byteLength(value: string): number {
   return new TextEncoder().encode(value).length;
 }
@@ -215,7 +204,11 @@ function supportFilesFromInspect(
   );
   return (result.supportFiles ?? []).map((file) => ({
     path: file.path,
-    size: formatBytes(sizes.get(file.path) ?? byteLength(file.content)),
+    size: formatBytes(Math.max(0, sizes.get(file.path) ?? byteLength(file.content)), {
+      fallback: "0 B",
+      maxUnit: "kilo",
+      fractionDigits: (_value, unit) => (unit === "byte" ? null : 1),
+    }),
     contents: file.content,
   }));
 }

--- a/ui/src/pages/skill-workshop/view.ts
+++ b/ui/src/pages/skill-workshop/view.ts
@@ -7,6 +7,7 @@ import "../../components/file-preview-modal-registration.ts";
 import "../../components/modal-dialog.ts";
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
+import { formatRelativeTimestamp } from "../../lib/format.ts";
 import "../../styles/plugins.css";
 import "../../styles/skill-workshop.css";
 import {
@@ -1110,23 +1111,6 @@ function queueEmptyText(props: SkillWorkshopProps): string {
 }
 
 function formatRelative(ms: number): string {
-  const diff = Math.max(0, Date.now() - ms);
-  const sec = Math.floor(diff / 1000);
-  if (sec < 60) {
-    return t("skillWorkshop.relative.secondsAgo", { count: String(sec) });
-  }
-  const min = Math.floor(sec / 60);
-  if (min < 60) {
-    return t("skillWorkshop.relative.minutesAgo", { count: String(min) });
-  }
-  const hr = Math.floor(min / 60);
-  if (hr < 24) {
-    return t("skillWorkshop.relative.hoursAgo", { count: String(hr) });
-  }
-  const day = Math.floor(hr / 24);
-  if (day < 7) {
-    return t("skillWorkshop.relative.daysAgo", { count: String(day) });
-  }
-  return new Date(ms).toLocaleDateString();
+  return formatRelativeTimestamp(ms, { dateFallback: true });
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/usage/metrics.test.ts
+++ b/ui/src/pages/usage/metrics.test.ts
@@ -3,7 +3,8 @@ import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildPeakErrorHours,
-  formatTokens,
+  formatUsageCost,
+  formatUsageTokens,
   renderUsageMosaic,
   sessionTouchesSelectedHours,
 } from "./metrics.ts";
@@ -520,27 +521,35 @@ describe("usage mosaic token buckets", () => {
   });
 });
 
-describe("formatTokens", () => {
+describe("formatUsageTokens", () => {
   it("formats values below 1,000 verbatim", () => {
-    expect(formatTokens(0)).toBe("0");
-    expect(formatTokens(999)).toBe("999");
+    expect(formatUsageTokens(0)).toBe("0");
+    expect(formatUsageTokens(999)).toBe("999");
   });
 
   it("formats thousands with one decimal and a K suffix", () => {
-    expect(formatTokens(1_000)).toBe("1.0K");
-    expect(formatTokens(12_500)).toBe("12.5K");
-    expect(formatTokens(999_949)).toBe("999.9K");
+    expect(formatUsageTokens(1_000)).toBe("1.0K");
+    expect(formatUsageTokens(12_500)).toBe("12.5K");
+    expect(formatUsageTokens(999_949)).toBe("999.9K");
   });
 
   it("rolls 999,950-999,999 over to the M branch instead of '1000.0K'", () => {
     // These values round up to "1000.0" at one-decimal thousands precision.
     // Without the rollover guard they render the nonsensical "1000.0K".
-    expect(formatTokens(999_950)).toBe("1.0M");
-    expect(formatTokens(999_999)).toBe("1.0M");
+    expect(formatUsageTokens(999_950)).toBe("1.0M");
+    expect(formatUsageTokens(999_999)).toBe("1.0M");
   });
 
   it("formats millions with one decimal and an M suffix", () => {
-    expect(formatTokens(1_000_000)).toBe("1.0M");
-    expect(formatTokens(2_500_000)).toBe("2.5M");
+    expect(formatUsageTokens(1_000_000)).toBe("1.0M");
+    expect(formatUsageTokens(2_500_000)).toBe("2.5M");
+  });
+});
+
+describe("formatUsageCost", () => {
+  it("preserves the caller-selected fixed precision used by chart scales", () => {
+    expect(formatUsageCost(0.5)).toBe("$0.50");
+    expect(formatUsageCost(0.005, 4)).toBe("$0.0050");
+    expect(formatUsageCost(0.000_05, 6)).toBe("$0.000050");
   });
 });

--- a/ui/src/pages/usage/metrics.ts
+++ b/ui/src/pages/usage/metrics.ts
@@ -25,8 +25,14 @@ function charsToTokens(chars: number): number {
   return Math.round(chars / CHARS_PER_TOKEN);
 }
 
-function formatTokens(n: number): string {
+function formatUsageTokens(n: number): string {
   return formatCompactTokenCount(n, { thousandsSuffix: "K", trimTrailingZero: false });
+}
+
+// Usage charts choose fixed precision from the surrounding scale; the shared
+// adaptive cost formatter would change labels as values cross its thresholds.
+function formatUsageCost(n: number, decimals = 2): string {
+  return `$${n.toFixed(decimals)}`;
 }
 
 function formatHourLabel(hour: number): string {
@@ -352,7 +358,7 @@ function renderUsageMosaic(
         description: t("usage.mosaic.subtitleEmpty"),
         actions: html`
           <div class="usage-mosaic-total">
-            ${formatTokens(0)} ${normalizeLowercaseStringOrEmpty(t("usage.metrics.tokens"))}
+            ${formatUsageTokens(0)} ${normalizeLowercaseStringOrEmpty(t("usage.metrics.tokens"))}
           </div>
         `,
       },
@@ -378,7 +384,7 @@ function renderUsageMosaic(
       }),
       actions: html`
         <div class="usage-mosaic-total">
-          ${formatTokens(stats.totalTokens)}
+          ${formatUsageTokens(stats.totalTokens)}
           ${normalizeLowercaseStringOrEmpty(t("usage.metrics.tokens"))}
         </div>
       `,
@@ -398,7 +404,7 @@ function renderUsageMosaic(
                 return html`
                   <div class="usage-daypart-cell" style="background: ${bg};">
                     <div class="usage-daypart-label">${part.label}</div>
-                    <div class="usage-daypart-value">${formatTokens(part.tokens)}</div>
+                    <div class="usage-daypart-value">${formatUsageTokens(part.tokens)}</div>
                   </div>
                 `;
               })}
@@ -416,7 +422,7 @@ function renderUsageMosaic(
                   value > 0
                     ? `color-mix(in srgb, var(--accent) ${(8 + intensity * 70).toFixed(1)}%, transparent)`
                     : "transparent";
-                const title = `${hour}:00 · ${formatTokens(value)} ${normalizeLowercaseStringOrEmpty(
+                const title = `${hour}:00 · ${formatUsageTokens(value)} ${normalizeLowercaseStringOrEmpty(
                   t("usage.metrics.tokens"),
                 )}`;
                 const border =
@@ -454,10 +460,6 @@ function renderUsageMosaic(
       </div>
     `,
   );
-}
-
-function formatCost(n: number, decimals = 2): string {
-  return `$${n.toFixed(decimals)}`;
 }
 
 function formatIsoDate(date: Date): string {
@@ -861,11 +863,11 @@ export {
   buildPeakErrorHours,
   buildUsageInsightStats,
   charsToTokens,
-  formatCost,
+  formatUsageCost,
   formatDayLabel,
   formatFullDate,
   formatIsoDate,
-  formatTokens,
+  formatUsageTokens,
   renderUsageMosaic,
   sessionTouchesSelectedHours,
 };

--- a/ui/src/pages/usage/view-details.ts
+++ b/ui/src/pages/usage/view-details.ts
@@ -12,7 +12,7 @@ import "../../components/tooltip.ts";
 import { formatDateTimeMs, formatMs, formatTimeMs } from "../../lib/format.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 import { parseToolSummary } from "./helpers.ts";
-import { charsToTokens, formatCost, formatTokens } from "./metrics.ts";
+import { charsToTokens, formatUsageCost, formatUsageTokens } from "./metrics.ts";
 import type {
   SessionLogEntry,
   SessionLogRole,
@@ -134,8 +134,8 @@ function renderSessionSummary(
   const modelItems =
     usage.modelUsage?.slice(0, 6).map((entry) => ({
       label: entry.model ?? t("usage.common.unknown"),
-      value: formatCost(entry.totals.totalCost),
-      sub: formatTokens(entry.totals.totalTokens),
+      value: formatUsageCost(entry.totals.totalCost),
+      sub: formatUsageTokens(entry.totals.totalTokens),
     })) ?? [];
   const cards = [
     {
@@ -306,12 +306,15 @@ function renderSessionDetailPanel(
           ${usage
             ? html`
                 <span
-                  ><strong>${formatTokens(headerStats.totalTokens)}</strong>
+                  ><strong>${formatUsageTokens(headerStats.totalTokens)}</strong>
                   ${normalizeLowercaseStringOrEmpty(
                     t("usage.metrics.tokens"),
                   )}${cursorIndicator}</span
                 >
-                <span><strong>${formatCost(headerStats.totalCost)}</strong>${cursorIndicator}</span>
+                <span
+                  ><strong>${formatUsageCost(headerStats.totalCost)}</strong
+                  >${cursorIndicator}</span
+                >
               `
             : nothing}
         </div>
@@ -572,7 +575,7 @@ function renderTimeSeriesCompact(
               svg`<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="var(--border)" />`,
           )}
           ${[
-            { y: padding.top + 5, text: formatTokens(maxValue) },
+            { y: padding.top + 5, text: formatUsageTokens(maxValue) },
             { y: padding.top + chartHeight, text: "0" },
           ].map(
             ({ y, text }) =>
@@ -603,12 +606,12 @@ function renderTimeSeriesCompact(
                 },
                 "",
               ),
-              `${formatTokens(val)} ${normalizeLowercaseStringOrEmpty(t("usage.metrics.tokens"))}`,
+              `${formatUsageTokens(val)} ${normalizeLowercaseStringOrEmpty(t("usage.metrics.tokens"))}`,
             ];
             if (breakdownByType) {
               tooltipLines.push(
                 ...USAGE_TOKEN_CATEGORIES.map(
-                  ({ key, short }) => `${short} ${formatTokens(p[key])}`,
+                  ({ key, short }) => `${short} ${formatUsageTokens(p[key])}`,
                 ),
               );
             }
@@ -750,11 +753,11 @@ function renderTimeSeriesCompact(
                 { hour: "2-digit", minute: "2-digit", ...timeZoneOptions },
                 "",
               )}
-              · ${formatTokens(totalTypeTokens)} ·
-              ${formatCost(filteredPoints.reduce((s, p) => s + (p.cost || 0), 0))}
+              · ${formatUsageTokens(totalTypeTokens)} ·
+              ${formatUsageCost(filteredPoints.reduce((s, p) => s + (p.cost || 0), 0))}
             `
-          : html`${points.length} ${t("usage.overview.messagesAbbrev")} · ${formatTokens(cumTokens)}
-            · ${formatCost(cumCost)}`}
+          : html`${points.length} ${t("usage.overview.messagesAbbrev")} ·
+            ${formatUsageTokens(cumTokens)} · ${formatUsageCost(cumCost)}`}
       </div>
       ${breakdownByType
         ? html`
@@ -775,13 +778,13 @@ function renderTimeSeriesCompact(
                   ({ key, className, labelKey, hintKey }) => html`
                     <div class="legend-item" title=${t(hintKey)}>
                       <span class="legend-dot ${className}"></span>${t(labelKey)}
-                      ${formatTokens(filteredTokens[key])}
+                      ${formatUsageTokens(filteredTokens[key])}
                     </div>
                   `,
                 )}
               </div>
               <div class="cost-breakdown-total">
-                ${t("usage.breakdown.total")}: ${formatTokens(totalTypeTokens)}
+                ${t("usage.breakdown.total")}: ${formatUsageTokens(totalTypeTokens)}
               </div>
             </div>
           `
@@ -875,7 +878,7 @@ function renderContextPanel(
             <div
               class="context-segment ${className}"
               style="width: ${pct(tokens, totalContextTokens).toFixed(1)}%"
-              title="${t(labelKey)}: ~${formatTokens(tokens)}"
+              title="${t(labelKey)}: ~${formatUsageTokens(tokens)}"
             ></div>
           `,
         )}
@@ -887,13 +890,13 @@ function renderContextPanel(
               ><span class="legend-dot ${className}"></span>${t(
                 className === "system" ? "usage.details.systemShort" : labelKey,
               )}
-              ~${formatTokens(tokens)}</span
+              ~${formatUsageTokens(tokens)}</span
             >
           `,
         )}
       </div>
       <div class="context-total">
-        ${t("usage.breakdown.total")}: ~${formatTokens(totalContextTokens)}
+        ${t("usage.breakdown.total")}: ~${formatUsageTokens(totalContextTokens)}
       </div>
       <div class="context-breakdown-grid">
         ${groups
@@ -909,7 +912,7 @@ function renderContextPanel(
                     ({ name, chars }) => html`
                       <div class="context-breakdown-item">
                         <span class="mono" title=${name}>${name}</span>
-                        <span class="muted">~${formatTokens(charsToTokens(chars))}</span>
+                        <span class="muted">~${formatUsageTokens(charsToTokens(chars))}</span>
                       </div>
                     `,
                   )}
@@ -1110,7 +1113,7 @@ function renderSessionLogsCompact(
               <div class="session-log-meta">
                 <span class="session-log-role">${roleLabel}</span>
                 <span>${formatMs(log.timestamp)}</span>
-                ${log.tokens ? html`<span>${formatTokens(log.tokens)}</span>` : nothing}
+                ${log.tokens ? html`<span>${formatUsageTokens(log.tokens)}</span>` : nothing}
               </div>
               <div class="session-log-content">${cleanContent}</div>
               ${toolInfo.tools.length > 0

--- a/ui/src/pages/usage/view-overview.ts
+++ b/ui/src/pages/usage/view-overview.ts
@@ -12,11 +12,11 @@ import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 import {
   buildUsageCostWindows,
   buildUsageCostWindowSummary,
-  formatCost,
+  formatUsageCost,
   formatDayLabel,
   formatFullDate,
   formatIsoDate,
-  formatTokens,
+  formatUsageTokens,
 } from "./metrics.ts";
 import type { UsageInsightStats } from "./metrics.ts";
 import type {
@@ -55,7 +55,7 @@ function pct(part: number, total: number): number {
 function formatAnalysisCost(value: number): string {
   const magnitude = Math.abs(value);
   const decimals = magnitude === 0 || magnitude >= 0.01 ? 2 : magnitude >= 0.0001 ? 4 : 6;
-  return formatCost(value, decimals);
+  return formatUsageCost(value, decimals);
 }
 
 function handleDailyBarKeydown(
@@ -234,7 +234,7 @@ function renderCostWindowComparison(
                 ${formatAnalysisCost(summary.totals.totalCost)}
               </div>
               <div class="cost-window-card__meta">
-                ${formatTokens(summary.totals.totalTokens)} ${t("usage.metrics.tokens")} ·
+                ${formatUsageTokens(summary.totals.totalTokens)} ${t("usage.metrics.tokens")} ·
                 ${formatAnalysisCost(averageDailyCost)} ${t("usage.costWindows.perDay")}
               </div>
             </div>
@@ -323,9 +323,9 @@ function renderDailyChartCompact(
               (value) =>
                 html`<span
                   >${isTokenMode
-                    ? formatTokens(value)
+                    ? formatUsageTokens(value)
                     : value === 0
-                      ? formatCost(0)
+                      ? formatUsageCost(0)
                       : formatAnalysisCost(value)}</span
                 >`,
             )}
@@ -350,15 +350,16 @@ function renderDailyChartCompact(
                   : [];
               const breakdownLines = segments.map(
                 ({ value, labelKey }) =>
-                  `${t(labelKey)} ${isTokenMode ? formatTokens(value) : formatAnalysisCost(value)}`,
+                  `${t(labelKey)} ${isTokenMode ? formatUsageTokens(value) : formatAnalysisCost(value)}`,
               );
               const totalLabel = isTokenMode
-                ? formatTokens(d.totalTokens)
+                ? formatUsageTokens(d.totalTokens)
                 : formatAnalysisCost(d.totalCost);
               const dateLabel = formatFullDate(d.date);
-              const tokensLabel = `${formatTokens(d.totalTokens)} ${normalizeLowercaseStringOrEmpty(
-                t("usage.metrics.tokens"),
-              )}`.trim();
+              const tokensLabel =
+                `${formatUsageTokens(d.totalTokens)} ${normalizeLowercaseStringOrEmpty(
+                  t("usage.metrics.tokens"),
+                )}`.trim();
               const costLabel = formatAnalysisCost(d.totalCost);
               const segmentTotal = segments.reduce((sum, segment) => sum + segment.value, 0) || 1;
               return html`
@@ -420,7 +421,7 @@ function renderCostBreakdownCompact(totals: UsageTotals, mode: "tokens" | "cost"
       className,
       labelKey,
       percentage: pct(value, total),
-      formatted: isTokenMode ? formatTokens(value) : formatAnalysisCost(value),
+      formatted: isTokenMode ? formatUsageTokens(value) : formatAnalysisCost(value),
     };
   });
 
@@ -451,7 +452,9 @@ function renderCostBreakdownCompact(totals: UsageTotals, mode: "tokens" | "cost"
       </div>
       <div class="cost-breakdown-total">
         ${t("usage.breakdown.total")}:
-        ${isTokenMode ? formatTokens(totals.totalTokens) : formatAnalysisCost(totals.totalCost)}
+        ${isTokenMode
+          ? formatUsageTokens(totals.totalTokens)
+          : formatAnalysisCost(totals.totalCost)}
       </div>
     </div>
   `;
@@ -591,7 +594,7 @@ function renderUsageInsights(
   const errorRatePct = stats.errorRate * 100;
   const throughputLabel =
     stats.throughputTokensPerMin !== undefined
-      ? `${formatTokens(Math.round(stats.throughputTokensPerMin))} ${t("usage.overview.tokensPerMinute")}`
+      ? `${formatUsageTokens(Math.round(stats.throughputTokensPerMin))} ${t("usage.overview.tokensPerMinute")}`
       : t("usage.common.emptyValue");
   const throughputCostLabel =
     stats.throughputCostPerMin !== undefined
@@ -609,7 +612,7 @@ function renderUsageInsights(
       return {
         label: formatDayLabel(day.date),
         value: `${(rate * 100).toFixed(2)}%`,
-        sub: `${day.errors} ${normalizeLowercaseStringOrEmpty(t("usage.overview.errors"))} · ${day.messages} ${t("usage.overview.messagesAbbrev")} · ${formatTokens(day.tokens)}`,
+        sub: `${day.errors} ${normalizeLowercaseStringOrEmpty(t("usage.overview.errors"))} · ${day.messages} ${t("usage.overview.messagesAbbrev")} · ${formatUsageTokens(day.tokens)}`,
         rate,
       };
     })
@@ -624,7 +627,7 @@ function renderUsageInsights(
   const costAttributionSub = (cost: number, tokens: number, messageCount?: number) =>
     [
       costShare(cost),
-      formatTokens(tokens),
+      formatUsageTokens(tokens),
       messageCount === undefined ? null : `${messageCount} ${t("usage.overview.messagesAbbrev")}`,
     ]
       .filter((part): part is string => part !== null)
@@ -698,7 +701,7 @@ function renderUsageInsights(
               hintId: "average-tokens",
               title: t("usage.overview.avgTokens"),
               hint: t("usage.overview.avgTokensHint"),
-              value: formatTokens(avgTokens),
+              value: formatUsageTokens(avgTokens),
               sub: t("usage.overview.acrossMessages", {
                 count: String(aggregates.messages.total || 0),
               }),
@@ -709,7 +712,7 @@ function renderUsageInsights(
               title: t("usage.overview.cacheHitRate"),
               hint: t("usage.overview.cacheHint"),
               value: cacheHitLabel,
-              sub: `${formatTokens(totals.cacheRead)} ${t("usage.overview.cached")} · ${formatTokens(cacheBase)} ${t("usage.overview.prompt")}`,
+              sub: `${formatUsageTokens(totals.cacheRead)} ${t("usage.overview.cached")} · ${formatUsageTokens(cacheBase)} ${t("usage.overview.prompt")}`,
               tone: cacheHitRate > 0.6 ? "good" : cacheHitRate > 0.3 ? "warn" : "bad",
               className: "usage-summary-card--medium",
             })}
@@ -926,7 +929,7 @@ function renderSessionsCard(
             ${t("usage.sessions.copy")}
           </button>
           <div class="session-bar-value">
-            ${isTokenMode ? formatTokens(value) : formatAnalysisCost(value)}
+            ${isTokenMode ? formatUsageTokens(value) : formatAnalysisCost(value)}
           </div>
         </div>
       </div>
@@ -956,7 +959,7 @@ function renderSessionsCard(
         <div class="sessions-card-meta">
           <div class="sessions-card-stats">
             <span>
-              ${isTokenMode ? formatTokens(avgValue) : formatAnalysisCost(avgValue)}
+              ${isTokenMode ? formatUsageTokens(avgValue) : formatAnalysisCost(avgValue)}
               ${t("usage.sessions.avg")}
             </span>
             <span

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -13,9 +13,9 @@ import {
   buildAggregatesFromSessions,
   buildPeakErrorHours,
   buildUsageInsightStats,
-  formatCost,
+  formatUsageCost,
   formatIsoDate,
-  formatTokens,
+  formatUsageTokens,
   renderUsageMosaic,
   sessionTouchesSelectedHours,
 } from "./metrics.ts";
@@ -492,11 +492,11 @@ export function renderUsage(props: UsageProps) {
                 ${displayTotals
                   ? html`
                       <span class="usage-metric-badge">
-                        <strong>${formatTokens(displayTotals.totalTokens)}</strong>
+                        <strong>${formatUsageTokens(displayTotals.totalTokens)}</strong>
                         ${t("usage.metrics.tokens")}
                       </span>
                       <span class="usage-metric-badge">
-                        <strong>${formatCost(displayTotals.totalCost)}</strong>
+                        <strong>${formatUsageCost(displayTotals.totalCost)}</strong>
                         ${t("usage.metrics.cost")}
                       </span>
                       <span class="usage-metric-badge">

--- a/ui/src/pages/workboard/view-card.ts
+++ b/ui/src/pages/workboard/view-card.ts
@@ -38,7 +38,7 @@ import {
   formatLifecycle,
   formatPriorityLabel,
   formatStatusLabel,
-  formatTime,
+  formatWorkboardDate,
   formatUpdatedTime,
   taskDetail,
   taskMatchesLifecycle,
@@ -56,7 +56,7 @@ function renderEvents(card: WorkboardCard) {
         (event) => html`
           <li>
             <span>${formatEventLabel(event)}</span>
-            <time>${formatTime(event.at)}</time>
+            <time>${formatWorkboardDate(event.at)}</time>
           </li>
         `,
       )}

--- a/ui/src/pages/workboard/view-helpers.ts
+++ b/ui/src/pages/workboard/view-helpers.ts
@@ -86,7 +86,7 @@ export const formatStatusLabel = (status: WorkboardStatus) => t(`workboard.statu
 export const formatPriorityLabel = (priority: WorkboardPriority) =>
   priority.charAt(0).toUpperCase() + priority.slice(1);
 
-export function formatTime(value: number | undefined): string {
+export function formatWorkboardDate(value: number | undefined): string {
   return value ? formatDateMs(value, { month: "short", day: "numeric" }, "") : "";
 }
 

--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WorktreeRecord } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import { SESSION_FACE_PREFERENCE_PARAM } from "../../lib/sessions/route-navigation.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import "./worktrees-page.ts";
+
+vi.mock("../../components/confirm-dialog.ts", () => ({ showConfirmDialog: vi.fn() }));
 
 type WorktreesPageTestElement = HTMLElement & {
   context: ApplicationContext;
@@ -109,6 +112,7 @@ function contextWithGateway(gateway: ApplicationContext["gateway"]): Application
 
 afterEach(() => {
   document.body.replaceChildren();
+  vi.mocked(showConfirmDialog).mockReset();
   vi.restoreAllMocks();
 });
 
@@ -193,16 +197,16 @@ describe("WorktreesPage lifecycle", () => {
 
     const deleteButton = page.querySelector<HTMLButtonElement>("button.danger");
     expect(deleteButton?.disabled).toBe(true);
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
     await page.removeWorktree(record);
-    expect(confirm).not.toHaveBeenCalled();
+    expect(showConfirmDialog).not.toHaveBeenCalled();
     expect(request).not.toHaveBeenCalledWith("worktrees.remove", { id: record.id });
 
     pendingList.resolve({ worktrees: [record] });
     await refreshing;
 
     await page.removeWorktree(record);
-    expect(confirm).toHaveBeenCalledOnce();
+    expect(showConfirmDialog).toHaveBeenCalledOnce();
     expect(request).toHaveBeenCalledWith("worktrees.remove", { id: record.id });
     expect(listRequests).toBe(3);
     expect(page.records).toEqual([removedRecord]);
@@ -281,7 +285,7 @@ describe("WorktreesPage lifecycle", () => {
     page.context = contextWithGateway(
       gatewayWithClient({ request: firstRequest } as unknown as GatewayBrowserClient),
     );
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
     document.body.append(page);
     await waitForFast(() =>
       expect(firstRequest).toHaveBeenCalledWith(
@@ -304,13 +308,39 @@ describe("WorktreesPage lifecycle", () => {
     pendingRemove.reject(new Error("snapshot failed: stale gateway"));
     await removing;
 
-    expect(confirm).toHaveBeenCalledOnce();
+    expect(showConfirmDialog).toHaveBeenCalledOnce();
     expect(secondRequest).not.toHaveBeenCalledWith("worktrees.remove", {
       id: "worktree-1",
       force: true,
     });
     expect(page.error).toBeNull();
     expect(page.busyId).toBeNull();
+  });
+
+  it("does not remove through a replacement gateway after confirmation", async () => {
+    const confirmation = deferred<boolean>();
+    vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
+    const firstRequest = vi.fn(async () => ({ worktrees: [] }));
+    const secondRequest = vi.fn(async () => ({ worktrees: [] }));
+    const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
+    page.context = contextWithGateway(
+      gatewayWithClient({ request: firstRequest } as unknown as GatewayBrowserClient),
+    );
+    document.body.append(page);
+    await waitForFast(() => expect(firstRequest).toHaveBeenCalledOnce());
+
+    const removing = page.removeWorktree(worktree());
+    await waitForFast(() => expect(showConfirmDialog).toHaveBeenCalledOnce());
+    page.context = contextWithGateway(
+      gatewayWithClient({ request: secondRequest } as unknown as GatewayBrowserClient),
+    );
+    page.requestUpdate();
+    await page.updateComplete;
+    confirmation.resolve(true);
+    await removing;
+
+    expect(firstRequest).not.toHaveBeenCalledWith("worktrees.remove", { id: "worktree-1" });
+    expect(secondRequest).not.toHaveBeenCalledWith("worktrees.remove", { id: "worktree-1" });
   });
 
   it("offers force removal when the gateway reports a snapshot failure", async () => {
@@ -326,7 +356,7 @@ describe("WorktreesPage lifecycle", () => {
     page.context = contextWithGateway(
       gatewayWithClient({ request } as unknown as GatewayBrowserClient),
     );
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(showConfirmDialog).mockResolvedValue(true);
     document.body.append(page);
     await waitForFast(() =>
       expect(request).toHaveBeenCalledWith(
@@ -340,7 +370,7 @@ describe("WorktreesPage lifecycle", () => {
 
     expect(request).toHaveBeenCalledWith("worktrees.remove", { id: "worktree-1" });
     expect(request).toHaveBeenCalledWith("worktrees.remove", { id: "worktree-1", force: true });
-    expect(confirm).toHaveBeenCalledTimes(2);
+    expect(showConfirmDialog).toHaveBeenCalledTimes(2);
     expect(page.error).toBeNull();
   });
 

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -7,6 +7,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { shouldHandleNavigationClick } from "../../components/app-sidebar-nav-menus.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import { renderSessionsHubHeader } from "../../components/sessions-hub-header.ts";
 import {
   renderDocsLink,
@@ -212,10 +213,17 @@ class WorktreesPage extends OpenClawLightDomElement {
 
   private async removeWorktree(record: WorktreeRecord) {
     const scope = this.captureOperationScope();
+    if (!scope || this.operationPending) {
+      return;
+    }
     if (
-      !scope ||
-      this.operationPending ||
-      !window.confirm(t("worktrees.confirmDelete", { name: record.name }))
+      !(await showConfirmDialog({
+        message: t("worktrees.confirmDelete", { name: record.name }),
+        confirmLabel: t("common.delete"),
+        danger: true,
+      })) ||
+      !this.isOperationScopeCurrent(scope) ||
+      this.operationPending
     ) {
       return;
     }
@@ -231,12 +239,16 @@ class WorktreesPage extends OpenClawLightDomElement {
         return;
       }
       const reason = result.snapshotError ?? "";
-      const force = window.confirm(t("worktrees.confirmForceDelete", { error: reason }));
-      if (!force) {
-        this.error = reason || null;
+      const force = await showConfirmDialog({
+        message: t("worktrees.confirmForceDelete", { error: reason }),
+        confirmLabel: t("common.delete"),
+        danger: true,
+      });
+      if (!this.isOperationScopeCurrent(scope)) {
         return;
       }
-      if (!this.isOperationScopeCurrent(scope)) {
+      if (!force) {
+        this.error = reason || null;
         return;
       }
       try {


### PR DESCRIPTION
## What Problem This Solves

The Control UI had three clusters of drift: page-local SVG catalogs duplicated the shared Lucide icon owner, page-local formatters duplicated or obscured shared formatting contracts, and destructive actions used native browser confirms that silently fail in webviews without a dialog bridge. Nodes already carried a one-off styled workaround, so confirmation policy and lifecycle safety were split across pages.

## Why This Change Was Made

This change makes the existing shared owners canonical:

- Config navigation and Skill Workshop empty states now consume the shared icon catalog. Nine genuinely missing glyphs were added once; 39 page-local SVG definitions were removed.
- Workshop relative time, support-file sizes, Activity/Logs/Workboard time labels, and Usage formatter names now route through shared helpers or explicitly retain the Usage-specific fixed-precision contract.
- A small Promise-based confirm helper now renders through the accessible modal primitive, rejects reentrant requests, supports owner cancellation, and centralizes destructive/primary button treatment.
- Sessions, Worktrees, Nodes, and dreaming actions revalidate their captured gateway/task ownership after the asynchronous decision. Nodes also abort the visible modal on connection reset, preserving the original cross-gateway safety invariant.
- The chat send confirm option had no production caller and duplicated Chat's existing styled confirmation path, so that test-only branch was deleted instead of creating a second flow.

The local Workshop relative labels intentionally normalize to the shared localized behavior: for example, sub-minute values become “just now,” buckets round consistently, and the selected Control UI locale owns date/time output.

## User Impact

Destructive confirmations move from browser-native prompts to a consistent in-app modal with localized copy, safe default focus on Cancel, and accessible dialog labels/descriptions. The action semantics are unchanged, while embedded webviews no longer silently cancel these operations.

Icons and compact formatting keep the same page meaning and layout. Usage retains its uppercase K and fixed-decimal chart labels; support-file sizes retain the previous KB cap and precision.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/confirm-dialog.test.ts ui/src/components/modal-dialog.test.ts ui/src/lib/agents/display.test.ts ui/src/pages/usage/metrics.test.ts ui/src/pages/skill-workshop/proposals.test.ts` — 82 passed.
- `node scripts/run-vitest.mjs ui/src/pages/sessions/sessions-page.test.ts ui/src/pages/sessions/sessions-page.archived.test.ts ui/src/pages/worktrees/worktrees-page.test.ts ui/src/pages/nodes/nodes-page.test.ts ui/src/pages/nodes/view.devices.test.ts ui/src/pages/agents/memory/dreaming.test.ts ui/src/pages/agents/memory/memory-panel.test.ts ui/src/pages/chat/chat-send.test.ts` — 381 passed, 1 skipped.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.archive.e2e.test.ts` — 8 passed on isolated rerun. The first combined browser run had two loaded-host `page.goto` timeouts before interaction; the operator-scope file passed and the unchanged archive rerun was green.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.archive.e2e.test.ts -t "deletes every archived thread exactly once"` — 1 passed, 7 skipped; captured the fully settled styled modal. A page-level “before” image is unavailable because the prior native prompt existed outside the document screenshot surface.
- Targeted `oxfmt` over all 38 touched UI files and `git diff --check` passed.
- Structured Codex autoreview passed twice on the full bundle after formatting (`patch is correct`, 0.98 confidence), and the final proof-timing-only review passed at 0.99 confidence.
- `node scripts/check-changed.mjs` classified the heavy UI gate but could not allocate a provider because the local Crabbox client is stale/unready; exact-head hosted CI passed after the scoped lint fix: https://github.com/openclaw/openclaw/actions/runs/30770042060.
- Production LOC: +446 / -506 = -60. Tests: +329 / -228 = +101.

