### PR TITLE
fix(channels): recorded lifecycle facts outrank derived signals at the consumer boundary

### DIFF
--- a/extensions/discord/src/monitor/provider-runtime.ts
+++ b/extensions/discord/src/monitor/provider-runtime.ts
@@ -9,7 +9,7 @@ import {
 import { isVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveDiscordAccount } from "../accounts.js";
 import { Client } from "../internal/discord.js";
-import { fetchDiscordApplicationId } from "../probe.js";
+import { probeDiscordApplicationId } from "../probe.js";
 import { createDiscordNativeCommand } from "./native-command.js";
 import type { GetPluginCommandSpecs } from "./provider.commands.js";
 import { runDiscordGatewayLifecycle } from "./provider.lifecycle.js";
@@ -47,7 +47,7 @@ async function loadDiscordProviderSessionRuntime(): Promise<DiscordProviderSessi
 }
 
 export const discordProviderRuntime = {
-  fetchDiscordApplicationId,
+  probeDiscordApplicationId,
   createDiscordNativeCommand,
   runDiscordGatewayLifecycle,
   loadDiscordVoiceRuntime,

--- a/extensions/discord/src/monitor/provider.test-support.ts
+++ b/extensions/discord/src/monitor/provider.test-support.ts
@@ -6,8 +6,8 @@ export const discordProviderTestSupport = {
   reset(): void {
     Object.assign(discordProviderRuntime, defaultDiscordProviderRuntime);
   },
-  setFetchDiscordApplicationId(mock: typeof discordProviderRuntime.fetchDiscordApplicationId) {
-    discordProviderRuntime.fetchDiscordApplicationId = mock;
+  setProbeDiscordApplicationId(mock: typeof discordProviderRuntime.probeDiscordApplicationId) {
+    discordProviderRuntime.probeDiscordApplicationId = mock;
   },
   setCreateDiscordNativeCommand(mock: typeof discordProviderRuntime.createDiscordNativeCommand) {
     discordProviderRuntime.createDiscordNativeCommand = mock;

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -219,6 +219,7 @@ describe("monitorDiscordProvider", () => {
     }));
     vi.doMock("../probe.js", () => ({
       fetchDiscordApplicationId: async () => "app-1",
+      probeDiscordApplicationId: async () => ({ kind: "resolved", applicationId: "app-1" }),
       parseApplicationIdFromToken: (token: string) => {
         const segment = token.trim().split(".")[0];
         if (!segment) {
@@ -243,7 +244,10 @@ describe("monitorDiscordProvider", () => {
     providerTesting.reset();
     resetDiscordProviderMonitorMocks();
     voiceAutoJoinMock.mockClear();
-    providerTesting.setFetchDiscordApplicationId(async () => "app-1");
+    providerTesting.setProbeDiscordApplicationId(async () => ({
+      kind: "resolved",
+      applicationId: "app-1",
+    }));
     providerTesting.setCreateDiscordNativeCommand(((
       ...args: Parameters<typeof providerTesting.setCreateDiscordNativeCommand>[0] extends
         | ((...inner: infer P) => unknown)
@@ -1113,8 +1117,11 @@ describe("monitorDiscordProvider", () => {
   });
 
   it("derives application id from token before probing Discord over REST", async () => {
-    const fetchApplicationId = vi.fn(async () => "network-app");
-    providerTesting.setFetchDiscordApplicationId(fetchApplicationId);
+    const probeApplicationId = vi.fn(async () => ({
+      kind: "resolved" as const,
+      applicationId: "network-app",
+    }));
+    providerTesting.setProbeDiscordApplicationId(probeApplicationId);
     resolveDiscordAccountMock.mockReturnValue({
       accountId: "default",
       token: "MTIz.abc.def",
@@ -1131,14 +1138,17 @@ describe("monitorDiscordProvider", () => {
       runtime: baseRuntime(),
     });
 
-    expect(fetchApplicationId).not.toHaveBeenCalled();
+    expect(probeApplicationId).not.toHaveBeenCalled();
     expect(clientFetchUserMock).not.toHaveBeenCalled();
     expect(getConstructedClientOptions().clientId).toBe("123");
   });
 
   it("uses configured application id before token parsing or REST lookup", async () => {
-    const fetchApplicationId = vi.fn(async () => "network-app");
-    providerTesting.setFetchDiscordApplicationId(fetchApplicationId);
+    const probeApplicationId = vi.fn(async () => ({
+      kind: "resolved" as const,
+      applicationId: "network-app",
+    }));
+    providerTesting.setProbeDiscordApplicationId(probeApplicationId);
     resolveDiscordAccountMock.mockReturnValue({
       accountId: "default",
       token: "MTIz.abc.def",
@@ -1156,9 +1166,70 @@ describe("monitorDiscordProvider", () => {
       runtime: baseRuntime(),
     });
 
-    expect(fetchApplicationId).not.toHaveBeenCalled();
+    expect(probeApplicationId).not.toHaveBeenCalled();
     expect(getConstructedClientOptions().clientId).toBe("987654321098765432");
   });
+
+  it.each([
+    {
+      name: "401 rejection",
+      result: { kind: "rejected" as const, status: 401 as const, error: new Error("Unauthorized") },
+      lifecycle: "blocked",
+      terminalDisconnect: true,
+    },
+    {
+      name: "403 rejection",
+      result: { kind: "rejected" as const, status: 403 as const, error: new Error("Forbidden") },
+      lifecycle: "blocked",
+      terminalDisconnect: true,
+    },
+    {
+      name: "503 response",
+      result: { kind: "unavailable" as const, status: 503, error: new Error("Unavailable") },
+      lifecycle: "recovering",
+      terminalDisconnect: undefined,
+    },
+    {
+      name: "network failure",
+      result: { kind: "unavailable" as const, status: null, error: new Error("fetch failed") },
+      lifecycle: "recovering",
+      terminalDisconnect: undefined,
+    },
+  ])(
+    "publishes $lifecycle for an application-id $name before gateway startup",
+    async ({ result, lifecycle, terminalDisconnect }) => {
+      const setStatus = vi.fn();
+      providerTesting.setProbeDiscordApplicationId(async () => result);
+      resolveDiscordAccountMock.mockReturnValue({
+        accountId: "default",
+        token: "unparseable.token",
+        config: {
+          commands: { native: true, nativeSkills: false },
+          voice: { enabled: false },
+          agentComponents: { enabled: false },
+          execApprovals: { enabled: false },
+        },
+      });
+
+      await expect(
+        monitorDiscordProvider({ config: baseConfig(), runtime: baseRuntime(), setStatus }),
+      ).rejects.toThrow("Failed to resolve Discord application id");
+
+      expect(setStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connected: false,
+          lifecycle,
+          terminalDisconnect,
+          lastDisconnect:
+            result.status === null
+              ? expect.not.objectContaining({ status: expect.anything() })
+              : expect.objectContaining({ status: result.status }),
+        }),
+      );
+      expect(clientConstructorOptionsMock).not.toHaveBeenCalled();
+      expect(monitorLifecycleMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("reports connected status on startup and shutdown", async () => {
     const setStatus = vi.fn();

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -213,12 +213,29 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       ? discordCfg.applicationId.trim()
       : undefined;
   const parsedApplicationId = configuredApplicationId ?? parseApplicationIdFromToken(token);
-  const applicationId =
-    parsedApplicationId ??
-    (await discordProviderRuntime.fetchDiscordApplicationId(token, 4000, discordRestFetch));
-  if (!applicationId) {
-    throw new Error("Failed to resolve Discord application id");
+  const applicationIdProbe = parsedApplicationId
+    ? ({ kind: "resolved", applicationId: parsedApplicationId } as const)
+    : await discordProviderRuntime.probeDiscordApplicationId(token, 4000, discordRestFetch);
+  if (applicationIdProbe.kind !== "resolved") {
+    const at = Date.now();
+    const terminal = applicationIdProbe.kind === "rejected";
+    const probeError = formatErrorMessage(applicationIdProbe.error);
+    const message = `Failed to resolve Discord application id: ${probeError}`;
+    opts.setStatus?.({
+      connected: false,
+      lifecycle: terminal ? "blocked" : "recovering",
+      terminalDisconnect: terminal ? true : undefined,
+      lastEventAt: at,
+      lastDisconnect: {
+        at,
+        ...(applicationIdProbe.status !== null ? { status: applicationIdProbe.status } : {}),
+        error: probeError,
+      },
+      lastError: message,
+    });
+    throw new Error(message, { cause: applicationIdProbe.error });
   }
+  const applicationId = applicationIdProbe.applicationId;
   logDiscordStartupPhase({
     runtime,
     accountId: account.accountId,

--- a/extensions/discord/src/probe.intents.test.ts
+++ b/extensions/discord/src/probe.intents.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchDiscordApplicationId,
   fetchDiscordApplicationSummary,
+  probeDiscordApplicationId,
   probeDiscord,
   resolveDiscordPrivilegedIntentsFromFlags,
 } from "./probe.js";
@@ -166,6 +167,45 @@ describe("resolveDiscordPrivilegedIntentsFromFlags", () => {
 
     await expect(lookup).resolves.toBe("app-1");
     expect(calls).toBe(2);
+  });
+
+  it.each([
+    { status: 401, kind: "rejected" },
+    { status: 403, kind: "rejected" },
+    { status: 503, kind: "unavailable" },
+  ] as const)("classifies application id HTTP $status as $kind", async ({ status, kind }) => {
+    vi.useFakeTimers();
+    try {
+      const fetcher = withFetchPreconnect(
+        async () =>
+          new Response(JSON.stringify({ message: "probe failed" }), {
+            status,
+            headers: { "content-type": "application/json" },
+          }),
+      );
+      const probe = probeDiscordApplicationId("unparseable.token", 1_000, fetcher);
+      await vi.runAllTimersAsync();
+
+      await expect(probe).resolves.toMatchObject({ kind, status });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves application id network failure as unavailable without an HTTP status", async () => {
+    vi.useFakeTimers();
+    try {
+      const error = new Error("fetch failed");
+      const fetcher = withFetchPreconnect(async () => {
+        throw error;
+      });
+      const probe = probeDiscordApplicationId("unparseable.token", 1_000, fetcher);
+      await vi.runAllTimersAsync();
+
+      await expect(probe).resolves.toEqual({ kind: "unavailable", status: null, error });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not retry Cloudflare HTML rate limits during application summary probes", async () => {

--- a/extensions/discord/src/probe.ts
+++ b/extensions/discord/src/probe.ts
@@ -33,6 +33,11 @@ export type DiscordApplicationSummary = {
   intents?: DiscordPrivilegedIntentsSummary;
 };
 
+export type DiscordApplicationIdProbeResult =
+  | { kind: "resolved"; applicationId: string }
+  | { kind: "rejected"; status: 401 | 403; error: unknown }
+  | { kind: "unavailable"; status: number | null; error: unknown };
+
 const DISCORD_APP_FLAG_GATEWAY_PRESENCE = 1 << 12;
 const DISCORD_APP_FLAG_GATEWAY_PRESENCE_LIMITED = 1 << 13;
 const DISCORD_APP_FLAG_GATEWAY_GUILD_MEMBERS = 1 << 14;
@@ -234,18 +239,18 @@ export function parseApplicationIdFromToken(token: string): string | undefined {
   }
 }
 
-export async function fetchDiscordApplicationId(
+export async function probeDiscordApplicationId(
   token: string,
   timeoutMs: number,
   fetcher: typeof fetch = fetch,
-): Promise<string | undefined> {
+): Promise<DiscordApplicationIdProbeResult> {
   const normalized = normalizeDiscordToken(token, "channels.discord.token");
   if (!normalized) {
-    return undefined;
+    return { kind: "unavailable", status: null, error: new Error("missing token") };
   }
   const parsedApplicationId = parseApplicationIdFromToken(token);
   if (parsedApplicationId) {
-    return parsedApplicationId;
+    return { kind: "resolved", applicationId: parsedApplicationId };
   }
   try {
     const json = await fetchDiscord<{ id?: string }>(
@@ -255,16 +260,36 @@ export async function fetchDiscordApplicationId(
       { timeoutMs },
     );
     if (json?.id) {
-      return json.id;
+      return { kind: "resolved", applicationId: json.id };
     }
-    return undefined;
+    return {
+      kind: "unavailable",
+      status: null,
+      error: new Error("Discord application response did not include an id"),
+    };
   } catch (error) {
-    if (error instanceof DiscordApiError) {
-      if (error.status === 429) {
-        throw error;
-      }
-      return undefined;
+    if (error instanceof DiscordApiError && (error.status === 401 || error.status === 403)) {
+      return { kind: "rejected", status: error.status, error };
     }
-    return undefined;
+    return {
+      kind: "unavailable",
+      status: error instanceof DiscordApiError ? error.status : null,
+      error,
+    };
   }
+}
+
+export async function fetchDiscordApplicationId(
+  token: string,
+  timeoutMs: number,
+  fetcher: typeof fetch = fetch,
+): Promise<string | undefined> {
+  const result = await probeDiscordApplicationId(token, timeoutMs, fetcher);
+  if (result.kind === "resolved") {
+    return result.applicationId;
+  }
+  if (result.kind === "unavailable" && result.status === 429) {
+    throw result.error;
+  }
+  return undefined;
 }

--- a/extensions/discord/src/test-support/provider.test-support.ts
+++ b/extensions/discord/src/test-support/provider.test-support.ts
@@ -451,6 +451,7 @@ vi.mock(buildDiscordSourceModuleId("accounts.js"), () => ({
 
 vi.mock(buildDiscordSourceModuleId("probe.js"), () => ({
   fetchDiscordApplicationId: async () => "app-1",
+  probeDiscordApplicationId: async () => ({ kind: "resolved", applicationId: "app-1" }),
   parseApplicationIdFromToken: (token: string) => {
     const segment = token.trim().split(".")[0];
     if (!segment) {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -2,7 +2,11 @@
  * Channel health policy regression tests.
  */
 import { describe, expect, it } from "vitest";
-import { evaluateChannelHealth, resolveChannelRestartReason } from "./channel-health-policy.js";
+import {
+  evaluateChannelHealth,
+  resolveChannelHealthState,
+  resolveChannelRestartReason,
+} from "./channel-health-policy.js";
 
 function evaluateHealth(
   account: Record<string, unknown>,
@@ -388,6 +392,22 @@ describe("evaluateChannelHealth", () => {
       });
       expect(evaluation).toEqual({ healthy: true, reason: "unmanaged" });
     });
+  });
+});
+
+describe("resolveChannelHealthState", () => {
+  it("preserves authored terminal detail above the shared blocked projection", () => {
+    const snapshot = runningAccount({
+      running: false,
+      connected: false,
+      terminalDisconnect: true,
+      lifecycle: "blocked",
+      healthState: "conflict",
+    });
+    const evaluation = evaluateHealth(snapshot);
+
+    expect(evaluation).toEqual({ healthy: false, reason: "terminal-disconnect" });
+    expect(resolveChannelHealthState(snapshot, evaluation)).toBe("conflict");
   });
 });
 

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -21,6 +21,7 @@ type ChannelHealthSnapshot = {
   mode?: string;
   ingressUnavailable?: true;
   lifecycle?: "starting" | "ready" | "recovering" | "blocked" | "stopped";
+  healthState?: string;
   terminalDisconnect?: boolean;
 };
 
@@ -48,6 +49,16 @@ export type ChannelHealthPolicy = {
   staleEventThresholdMs: number;
   channelConnectGraceMs: number;
 };
+
+/** Keep channel-authored terminal detail above the shared unhealthy projection. */
+export function resolveChannelHealthState(
+  snapshot: ChannelHealthSnapshot,
+  evaluation: ChannelHealthEvaluation,
+): string | undefined {
+  return !evaluation.healthy && !(snapshot.lifecycle === "blocked" && snapshot.healthState)
+    ? evaluation.reason
+    : snapshot.healthState;
+}
 
 type ChannelRestartReason =
   | "gave-up"

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
   evaluateChannelHealth,
+  resolveChannelHealthState,
 } from "../channel-health-policy.js";
 import type { GatewayHotReloadStatus } from "../config-reload-status.types.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
@@ -336,8 +337,9 @@ export async function collectGatewayHealthSnapshot(params: {
         staleEventThresholdMs: DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
         channelConnectGraceMs: DEFAULT_CHANNEL_CONNECT_GRACE_MS,
       });
-      if (!health.healthy) {
-        snapshot.healthState = health.reason;
+      const healthState = resolveChannelHealthState(snapshot, health);
+      if (healthState !== undefined) {
+        snapshot.healthState = healthState;
       }
 
       const summary = plugin.status?.buildChannelSummary

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -881,14 +881,18 @@ describe("server-channels auto restart", () => {
   });
 
   it("does not auto-restart a channel task exit marked as terminal disconnect", async () => {
+    const lifecycleAtHandoff: Array<ChannelAccountSnapshot["lifecycle"]> = [];
     const startAccount = vi.fn(
       async ({
+        getStatus,
         setStatus,
         accountId,
       }: {
+        getStatus: ChannelGatewayContext["getStatus"];
         setStatus: ChannelGatewayContext["setStatus"];
         accountId: string;
       }) => {
+        lifecycleAtHandoff.push(getStatus().lifecycle);
         setStatus({
           accountId,
           terminalDisconnect: true,
@@ -907,10 +911,16 @@ describe("server-channels auto restart", () => {
     const snapshot = manager.getRuntimeSnapshot();
     expect(snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]).toMatchObject({
       terminalDisconnect: true,
-      lifecycle: "stopped",
+      running: false,
+      lifecycle: "blocked",
       lastError: "relink required",
       restartPending: false,
     });
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(lifecycleAtHandoff).toEqual(["starting", "starting"]);
   });
 
   it("consumes rejected stop tasks during manual abort", async () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -387,13 +387,19 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   ): ChannelAccountSnapshot => {
     const store = getStore(channelId);
     const current = getRuntime(channelId, accountId);
+    // Terminal channel diagnosis survives task cleanup and late status patches.
+    // Only the gateway-owned start transition proves a new lifecycle began.
     const lifecycle =
-      patch.lifecycle ??
-      (patch.restartPending === true
-        ? "recovering"
-        : patch.connected === true
-          ? "ready"
-          : undefined);
+      current.lifecycle === "blocked" &&
+      current.terminalDisconnect === true &&
+      patch.lifecycle !== "starting"
+        ? "blocked"
+        : (patch.lifecycle ??
+          (patch.restartPending === true
+            ? "recovering"
+            : patch.connected === true
+              ? "ready"
+              : undefined));
     const next = { ...current, ...patch, ...(lifecycle ? { lifecycle } : {}), accountId };
     store.runtimes.set(accountId, next);
     return next;

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -519,6 +519,30 @@ describe("channelsHandlers channels.status", () => {
     expect(firstChannelAccount(payload, "whatsapp").healthState).toBe("reconnecting");
   });
 
+  it("preserves channel-authored conflict when recorded blocked lifecycle is unhealthy", async () => {
+    mocks.applyPluginAutoEnable.mockReturnValue({ config: { autoEnabled: true }, changes: [] });
+    mocks.buildChannelAccountSnapshot.mockResolvedValue({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      linked: true,
+      running: false,
+      connected: false,
+      terminalDisconnect: true,
+      lifecycle: "blocked",
+      healthState: "conflict",
+      lastError: "status=440",
+    });
+
+    const payload = await runChannelsStatus({ probe: false, timeoutMs: 2000 });
+
+    expect(firstChannelAccount(payload, "whatsapp")).toMatchObject({
+      lifecycle: "blocked",
+      healthState: "conflict",
+      terminalDisconnect: true,
+    });
+  });
+
   it("derives blocked health from recorded lifecycle", async () => {
     mocks.applyPluginAutoEnable.mockReturnValue({ config: { autoEnabled: true }, changes: [] });
     mocks.buildChannelAccountSnapshot.mockResolvedValue({

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
   evaluateChannelHealth,
+  resolveChannelHealthState,
 } from "../channel-health-policy.js";
 import { resolveGatewayPluginConfig } from "../runtime-plugin-config.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
@@ -481,8 +482,9 @@ export const channelsHandlers: GatewayRequestHandlers = {
         staleEventThresholdMs: DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
         channelConnectGraceMs: DEFAULT_CHANNEL_CONNECT_GRACE_MS,
       });
-      if (!health.healthy) {
-        snapshot.healthState = health.reason;
+      const healthState = resolveChannelHealthState(snapshot, health);
+      if (healthState !== undefined) {
+        snapshot.healthState = healthState;
       }
       return { accountId, account, snapshot };
     };


### PR DESCRIPTION
## What Problem This Solves

PR #118110 (channel lifecycle adoption) named three gateway/consumer-boundary limitations where a recorded lifecycle fact loses to a weaker derived signal — the doctrine violation class the lifecycle series exists to remove:

1. A channel publishing durable `blocked` (terminal auth failure) had that fact replaced by gateway-owned `stopped` when its task exited: restart stayed correctly suppressed, but the operator-visible reason degraded from actionable to generic.
2. Discord's pre-gateway REST token probe discarded the HTTP status, so the channel could not distinguish 401 (terminal) from a transient failure, and mapped everything dishonestly.
3. WhatsApp's derived unhealthy projection superseded the channel-authored `conflict` health label in collected status output.

## Why This Change Was Made

Each fix moves precedence to the recorded fact at its owner boundary:

- **Gateway**: terminal `blocked` is now sticky across task finalization; only an explicit channel start clears it. The finalization path no longer rewrites an actionable terminal fact into a generic stopped state.
- **Discord**: the application-ID probe returns a private discriminated result carrying the status class; 401/403 map to `blocked` + terminal disconnect, 5xx/network map to `recovering` — the same structured classification Telegram landed in #118110. The public helper contract is unchanged.
- **WhatsApp**: authored terminal health labels (e.g. `conflict`) outrank derived projections in both status collectors; raw runtime state retains both fields.

## User Impact

Operators keep the actionable diagnosis: a revoked Discord token or a WhatsApp session conflict stays visible as exactly that in `openclaw channels status`, instead of degrading to a generic stopped/unhealthy state after the task exits or the collector runs.

## Evidence

### After-fix real gateway boundary proof

Exact head `1a0828925e88a1e4dedcf717dac0d61be516809c` was built with `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`; `dist/build-info.json` records that full SHA. The proof reused the #117300/#117805/#118110 harness: QA Lab flow scenarios, Crabline local provider APIs, mock OpenAI, and a real dist child gateway. Every run used a QA-owned ephemeral `OPENCLAW_STATE_DIR`, isolated loopback gateway/provider ports, mock-only credentials, and preserved sanitized gateway logs. The operator gateway, state, credentials, and ports were never touched.

Crabline has no Discord provider server and no WhatsApp 440/conflict control. For those two cases, the approved escape hatch used temporary dist-process preloads/producers: Discord injected 401/503 only at the existing Undici runtime seam before the real built Discord status producer; WhatsApp injected the authored `conflict + blocked` tuple before the real dist runtime store, `channels.status`, and health collector. All temporary scenarios, preloads, mock servers, and plugin files were removed after capture; the worktree is clean.

```json
{
  "verdict": "PASS",
  "headSha": "1a0828925e88a1e4dedcf717dac0d61be516809c",
  "harness": "qa-lab dist child gateway + Crabline mock channel API + mock-openai; dist-driven ephemeral escape hatches where Crabline has no fault control",
  "isolation": {
    "stateDir": "ephemeral per run",
    "gatewayPorts": "isolated loopback",
    "providerPorts": "isolated loopback",
    "operatorGatewayTouched": false,
    "credentials": "mock-only"
  },
  "checks": [
    {
      "id": "sticky-blocked-post-exit-explicit-start",
      "channel": "telegram",
      "mockApiAuthStatus": 401,
      "status": "pass",
      "postExit": {
        "lifecycle": "blocked",
        "terminalDisconnect": true,
        "running": false,
        "restartPending": false
      },
      "restartSuppressed": true,
      "explicitStart": {
        "lifecycle": "ready",
        "terminalDisconnect": false,
        "running": true,
        "connected": true,
        "lastStartAtChanged": true
      }
    },
    {
      "id": "discord-application-probe-401",
      "status": "pass",
      "blocked": {
        "lifecycle": "blocked",
        "healthState": "terminal-disconnect",
        "terminalDisconnect": true,
        "running": false,
        "restartPending": false
      },
      "lastStartAtUnchanged": true
    },
    {
      "id": "discord-application-probe-503",
      "status": "pass",
      "recovering": {
        "lifecycle": "recovering",
        "terminalDisconnect": false,
        "running": false,
        "restartPending": true,
        "reconnectAttempts": 2
      },
      "retriedReconnectAttempts": 3,
      "restartContinued": true
    },
    {
      "id": "whatsapp-authored-conflict-precedence",
      "status": "pass",
      "fault": "authored conflict + derived terminal-disconnect",
      "channelsStatus": {
        "lifecycle": "blocked",
        "healthState": "conflict",
        "terminalDisconnect": true,
        "running": false
      },
      "healthCollector": {
        "lifecycle": "blocked",
        "healthState": "conflict",
        "terminalDisconnect": true,
        "running": false
      },
      "authoredConflictWon": true
    }
  ]
}
```

Redacted collected-status excerpts:

```json
{
  "telegramPostExit": {
    "lifecycle": "blocked",
    "healthState": "terminal-disconnect",
    "terminalDisconnect": true,
    "running": false,
    "restartPending": false,
    "lastError": "Unauthorized | Telegram ingress worker exited with code 1"
  },
  "discord401": {
    "lifecycle": "blocked",
    "terminalDisconnect": true,
    "running": false,
    "restartPending": false
  },
  "discord503": {
    "lifecycle": "recovering",
    "terminalDisconnect": false,
    "running": false,
    "restartPending": true,
    "reconnectAttempts": 2
  },
  "whatsappConflict": {
    "channels.status": { "lifecycle": "blocked", "healthState": "conflict" },
    "health": { "lifecycle": "blocked", "healthState": "conflict" }
  }
}
```

Sanitized gateway log excerpts:

```text
[telegram] [default] auto-restart skipped, terminal disconnect
[health-monitor] [telegram:default] health-monitor: skipping restart, terminal-disconnect
[discord] [default] auto-restart skipped, terminal disconnect
[discord] [default] auto-restart attempt 1/10 in 5s
[discord] [default] auto-restart attempt 2/10 in 10s
[discord] [default] auto-restart attempt 3/10 in 22s
[whatsapp-proof] [default] auto-restart skipped, terminal disconnect
```

Run artifacts:

- `.artifacts/qa-e2e/pr118251-lifecycle-boundary-telegram-sticky`
- `.artifacts/qa-e2e/pr118251-discord-probe-401`
- `.artifacts/qa-e2e/pr118251-discord-probe-503`
- `.artifacts/qa-e2e/pr118251-whatsapp-conflict-precedence`

### Source proof

- 295 focused tests across 11 files, including a gateway boundary test proving blocked survives task exit with restart suppressed, and that an explicit start clears it
- Core and extension production/test tsgo lanes; targeted oxlint, formatting, diff checks
- Structured autoreview: clean
- Three surface-scoped commits (gateway, Discord, WhatsApp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
