### PR TITLE
fix: bound pending approvals and preserve delivery order

### DIFF
--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -6,6 +6,7 @@ import { createAbortError } from "../infra/abort-signal.js";
 import { logDebug, logWarn } from "../logger.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
+import { createPendingRequestRegistry } from "../shared/pending-request-registry.js";
 import {
   defaultBundleLspRuntimeDependencies,
   type BundleLspRuntimeDependencies,
@@ -23,7 +24,7 @@ type LspSession = {
   serverName: string;
   process: ChildProcess;
   requestId: number;
-  pendingRequests: Map<number, PendingLspRequest>;
+  pendingRequests: ReturnType<typeof createPendingRequestRegistry<number, unknown, undefined>>;
   buffer: Buffer;
   initialized: boolean;
   capabilities: LspServerCapabilities;
@@ -33,13 +34,6 @@ type LspSession = {
   // Preserve a terminal process/transport failure so later requests reject immediately
   // instead of waiting for the per-request timeout.
   failure?: Error;
-};
-
-type PendingLspRequest = {
-  resolve: (v: unknown) => void;
-  reject: (e: Error) => void;
-  timeout: ReturnType<typeof setTimeout>;
-  dispose: () => void;
 };
 
 type LspServerCapabilities = {
@@ -84,7 +78,7 @@ function createLspSession(
     serverName,
     process: child,
     requestId: 0,
-    pendingRequests: new Map(),
+    pendingRequests: createPendingRequestRegistry<number, unknown, undefined>(),
     buffer: Buffer.alloc(0),
     initialized: false,
     capabilities: {},
@@ -101,22 +95,9 @@ function rememberLspFailure(session: LspSession, error: Error): void {
   session.failure ??= error;
 }
 
-function takePendingLspRequest(session: LspSession, id: number): PendingLspRequest | undefined {
-  const pending = session.pendingRequests.get(id);
-  if (!pending) {
-    return undefined;
-  }
-  session.pendingRequests.delete(id);
-  clearTimeout(pending.timeout);
-  pending.dispose();
-  return pending;
-}
-
 function failLspSession(session: LspSession, error: Error): void {
   rememberLspFailure(session, error);
-  for (const [id] of session.pendingRequests) {
-    takePendingLspRequest(session, id)?.reject(session.failure ?? error);
-  }
+  session.pendingRequests.rejectAll(session.failure ?? error);
 }
 
 function lspProcessExitError(
@@ -279,34 +260,41 @@ function sendRequest(
     return Promise.reject(lspAbortError(signal));
   }
   const id = ++session.requestId;
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      takePendingLspRequest(session, id)?.reject(new Error(`LSP request ${method} timed out`));
-    }, 10_000);
-    timeout.unref?.();
-    const onAbort = () => {
-      const pending = takePendingLspRequest(session, id);
-      if (!pending) {
-        return;
-      }
-      // Bundle tools share the server process, so cancel only this request.
-      try {
-        session.process.stdin?.write(
-          encodeLspMessage({ jsonrpc: "2.0", method: "$/cancelRequest", params: { id } }),
-          "utf-8",
-        );
-      } catch {
-        // Best-effort notification; the local tool promise must still settle.
-      }
-      pending.reject(lspAbortError(signal));
-    };
-    const dispose = () => signal?.removeEventListener("abort", onAbort);
-    session.pendingRequests.set(id, { resolve, reject, timeout, dispose });
-    signal?.addEventListener("abort", onAbort, { once: true });
-    const message = { jsonrpc: "2.0", id, method, params };
+  const onAbort = () => {
+    const aborted = session.pendingRequests.take(id);
+    if (!aborted) {
+      return;
+    }
+    // Bundle tools share the server process, so cancel only this request.
+    try {
+      session.process.stdin?.write(
+        encodeLspMessage({ jsonrpc: "2.0", method: "$/cancelRequest", params: { id } }),
+        "utf-8",
+      );
+    } catch {
+      // Best-effort notification; the local tool promise must still settle.
+    }
+    aborted.reject(lspAbortError(signal));
+  };
+  const pending = session.pendingRequests.add(id, {
+    value: undefined,
+    timeoutMs: 10_000,
+    timeoutError: () => new Error(`LSP request ${method} timed out`),
+    dispose: () => signal?.removeEventListener("abort", onAbort),
+  });
+  if (!pending) {
+    return Promise.reject(new Error(`LSP request id collision: ${id}`));
+  }
+  signal?.addEventListener("abort", onAbort, { once: true });
+  const message = { jsonrpc: "2.0", id, method, params };
+  try {
     const encoded = encodeLspMessage(message);
     session.process.stdin?.write(encoded, "utf-8");
-  });
+  } catch (error) {
+    // Preserve Promise-executor behavior for synchronous stream failures; timeout owns cleanup.
+    pending.reject(error);
+  }
+  return pending.promise;
 }
 
 function handleIncomingData(session: LspSession, chunk: Buffer | string) {
@@ -328,7 +316,7 @@ function handleIncomingData(session: LspSession, chunk: Buffer | string) {
     const record = msg as Record<string, unknown>;
 
     if ("id" in record && typeof record.id === "number") {
-      const pending = takePendingLspRequest(session, record.id);
+      const pending = session.pendingRequests.take(record.id);
       if (pending) {
         if ("error" in record) {
           pending.reject(new Error(JSON.stringify(record.error)));
@@ -406,9 +394,7 @@ async function disposeSession(session: LspSession) {
       // best-effort
     }
   }
-  for (const [id] of session.pendingRequests) {
-    takePendingLspRequest(session, id)?.reject(new Error("LSP session disposed"));
-  }
+  session.pendingRequests.rejectAll(new Error("LSP session disposed"));
   terminateLspProcessTree(session);
 }
 

--- a/src/infra/exec-approval-channel-runtime.ts
+++ b/src/infra/exec-approval-channel-runtime.ts
@@ -7,6 +7,7 @@ import { isApprovalMethod } from "../gateway/method-scopes.js";
 import { createOperatorApprovalsGatewayClient } from "../gateway/operator-approvals-client.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { createDeferred } from "../shared/deferred.js";
+import { createPendingApprovalRegistry } from "../shared/pending-approval-registry.js";
 import { getGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
 import {
   isGatewayNativeApprovalMethod,
@@ -62,16 +63,9 @@ export function isExecApprovalChannelRuntimeTerminalStartError(
   return error instanceof ExecApprovalChannelRuntimeTerminalStartError;
 }
 
-type PendingApprovalEntry<
-  TPending,
-  TRequest extends ApprovalRequestEvent,
-  TResolved extends ApprovalResolvedEvent,
-> = {
+type PendingApprovalValue<TPending, TRequest extends ApprovalRequestEvent> = {
   request: TRequest;
   entries: TPending[];
-  timeoutId: NodeJS.Timeout | null;
-  delivering: boolean;
-  pendingResolution: TResolved | null;
 };
 
 function resolveApprovalReplayMethods(
@@ -106,7 +100,7 @@ export function createExecApprovalChannelRuntime<
   const nowMs = adapter.nowMs ?? Date.now;
   const eventKinds = new Set<ExecApprovalChannelRuntimeEventKind>(adapter.eventKinds ?? ["exec"]);
   const configuredGatewayRuntime = getGatewayNativeApprovalRuntime();
-  const pending = new Map<string, PendingApprovalEntry<TPending, TRequest, TResolved>>();
+  const pending = createPendingApprovalRegistry<PendingApprovalValue<TPending, TRequest>>();
   let gatewayClient: GatewayClient | null = null;
   let gatewayRuntime: typeof configuredGatewayRuntime;
   let unsubscribeGatewayRuntime: (() => void) | null = null;
@@ -133,30 +127,17 @@ export function createExecApprovalChannelRuntime<
     return true;
   };
 
-  const clearPendingEntry = (
-    approvalId: string,
-  ): PendingApprovalEntry<TPending, TRequest, TResolved> | null => {
-    const entry = pending.get(approvalId);
-    if (!entry) {
-      return null;
-    }
-    pending.delete(approvalId);
-    if (entry.timeoutId) {
-      clearTimeout(entry.timeoutId);
-    }
-    return entry;
+  const finalizeExpiredEntry = async (entry: ReturnType<typeof pending.begin>): Promise<void> => {
+    log.debug(`expired ${entry.id}`);
+    await adapter.finalizeExpired?.(entry.value);
   };
 
   const handleExpired = async (approvalId: string): Promise<void> => {
-    const entry = clearPendingEntry(approvalId);
+    const entry = pending.remove(approvalId);
     if (!entry) {
       return;
     }
-    log.debug(`expired ${approvalId}`);
-    await adapter.finalizeExpired?.({
-      request: entry.request,
-      entries: entry.entries,
-    });
+    await finalizeExpiredEntry(entry);
   };
 
   const handleRequested = async (
@@ -175,72 +156,44 @@ export function createExecApprovalChannelRuntime<
     }
 
     log.debug(`received request ${request.id}`);
-    const entry: PendingApprovalEntry<TPending, TRequest, TResolved> = {
-      request,
-      entries: [],
-      timeoutId: null,
-      delivering: true,
-      pendingResolution: null,
-    };
-    pending.set(request.id, entry);
+    const entry = pending.begin(request.id, { request, entries: [] });
     let entries: TPending[];
     try {
       entries = await adapter.deliverRequested(request);
     } catch (err) {
-      if (pending.get(request.id) === entry) {
-        clearPendingEntry(request.id);
-      }
+      pending.remove(request.id, entry);
       throw err;
     }
-    const current = pending.get(request.id);
-    if (current !== entry) {
+    if (!pending.isCurrent(entry)) {
       return;
     }
     if (!entries.length) {
-      pending.delete(request.id);
+      pending.remove(request.id, entry);
       return;
     }
-    entry.entries = entries;
-    entry.delivering = false;
-    if (entry.pendingResolution) {
-      // Resolution can arrive while native delivery is still creating entries; finalize after both.
-      pending.delete(request.id);
-      log.debug(`resolved ${entry.pendingResolution.id} with ${entry.pendingResolution.decision}`);
-      await adapter.finalizeResolved({
-        request: entry.request,
-        resolved: entry.pendingResolution,
-        entries: entry.entries,
-      });
+    await pending.completeDelivery(entry, { request, entries });
+    if (!pending.isCurrent(entry)) {
       return;
     }
 
     const timeoutMs = Math.max(0, request.expiresAtMs - nowMs());
-    const timeoutId = setTimeout(() => {
-      spawn("error handling approval expiration", handleExpired(request.id));
-    }, timeoutMs);
-    timeoutId.unref?.();
-    entry.timeoutId = timeoutId;
+    pending.scheduleExpiry(entry, timeoutMs, (expired) => {
+      spawn("error handling approval expiration", finalizeExpiredEntry(expired));
+    });
   };
 
   const handleResolved = async (resolved: TResolved): Promise<void> => {
-    const entry = pending.get(resolved.id);
-    if (!entry) {
-      return;
-    }
-    if (entry.delivering) {
-      entry.pendingResolution = resolved;
-      return;
-    }
-    const finalizedEntry = clearPendingEntry(resolved.id);
-    if (!finalizedEntry) {
-      return;
-    }
-    log.debug(`resolved ${resolved.id} with ${resolved.decision}`);
-    await adapter.finalizeResolved({
-      request: finalizedEntry.request,
-      resolved,
-      entries: finalizedEntry.entries,
+    const settled = pending.settle(resolved.id, async (entry) => {
+      log.debug(`resolved ${resolved.id} with ${resolved.decision}`);
+      await adapter.finalizeResolved({
+        request: entry.value.request,
+        resolved,
+        entries: entry.value.entries,
+      });
     });
+    if (settled.status === "taken") {
+      await settled.terminal(settled.entry);
+    }
   };
 
   const handleGatewayEvent = (evt: EventFrame): void => {
@@ -450,11 +403,6 @@ export function createExecApprovalChannelRuntime<
       if (!wasActive) {
         await adapter.onStopped?.();
         return;
-      }
-      for (const entry of pending.values()) {
-        if (entry.timeoutId) {
-          clearTimeout(entry.timeoutId);
-        }
       }
       pending.clear();
       await adapter.onStopped?.();

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -409,7 +409,7 @@ describe("exec approval forwarder", () => {
 
   it("keeps pending delivery ahead of a resolution received during route lookup", async () => {
     const target = createDeferred<{ channel: "slack"; to: string }>();
-    const pendingDelivery = createDeferred<void>();
+    const pendingDelivery = createDeferred();
     const deliveryOrder: string[] = [];
     const deliver = vi.fn(async (deliveryParams: { payloads?: Array<{ text?: string }> }) => {
       const text = deliveryParams.payloads?.[0]?.text ?? "";
@@ -449,7 +449,7 @@ describe("exec approval forwarder", () => {
 
   it("keeps pending delivery ahead of expiry", async () => {
     vi.useFakeTimers();
-    const pendingDelivery = createDeferred<void>();
+    const pendingDelivery = createDeferred();
     const deliveryOrder: string[] = [];
     const deliver = vi.fn(async (deliveryParams: { payloads?: Array<{ text?: string }> }) => {
       const text = deliveryParams.payloads?.[0]?.text ?? "";

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -6,6 +6,7 @@ import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import { createExecApprovalForwarder } from "./exec-approval-forwarder.js";
 import type { ExecApprovalRequest } from "./exec-approvals.js";
 
@@ -404,6 +405,71 @@ describe("exec approval forwarder", () => {
 
     await vi.advanceTimersByTimeAsync(baseRequest.expiresAtMs - baseRequest.createdAtMs);
     expect(deliver).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps pending delivery ahead of a resolution received during route lookup", async () => {
+    const target = createDeferred<{ channel: "slack"; to: string }>();
+    const pendingDelivery = createDeferred<void>();
+    const deliveryOrder: string[] = [];
+    const deliver = vi.fn(async (deliveryParams: { payloads?: Array<{ text?: string }> }) => {
+      const text = deliveryParams.payloads?.[0]?.text ?? "";
+      const kind = text.includes("required") ? "pending" : "resolved";
+      deliveryOrder.push(kind);
+      if (kind === "pending") {
+        await pendingDelivery.promise;
+      }
+      return [];
+    });
+    const resolveSessionTarget = vi.fn(() => target.promise);
+    const { forwarder } = createForwarder({
+      cfg: makeSessionCfg(),
+      deliver,
+      resolveSessionTarget,
+    });
+
+    const requested = forwarder.handleRequested(baseRequest);
+    await vi.waitFor(() => expect(resolveSessionTarget).toHaveBeenCalledOnce());
+    await forwarder.handleResolved({
+      id: baseRequest.id,
+      decision: "allow-once",
+      resolvedBy: "slack:U1",
+      ts: 2000,
+    });
+
+    target.resolve({ channel: "slack", to: "U1" });
+    await expect(requested).resolves.toBe(true);
+    await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+    expect(deliveryOrder).toEqual(["pending"]);
+
+    pendingDelivery.resolve();
+    await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(2));
+    expect(deliveryOrder).toEqual(["pending", "resolved"]);
+    expect(resolveSessionTarget).toHaveBeenCalledOnce();
+  });
+
+  it("keeps pending delivery ahead of expiry", async () => {
+    vi.useFakeTimers();
+    const pendingDelivery = createDeferred<void>();
+    const deliveryOrder: string[] = [];
+    const deliver = vi.fn(async (deliveryParams: { payloads?: Array<{ text?: string }> }) => {
+      const text = deliveryParams.payloads?.[0]?.text ?? "";
+      const kind = text.includes("required") ? "pending" : "expired";
+      deliveryOrder.push(kind);
+      if (kind === "pending") {
+        await pendingDelivery.promise;
+      }
+      return [];
+    });
+    const { forwarder } = createForwarder({ cfg: TARGETS_CFG, deliver });
+
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+    expect(deliveryOrder).toEqual(["pending"]);
+    await vi.advanceTimersByTimeAsync(baseRequest.expiresAtMs - 1000);
+    expect(deliveryOrder).toEqual(["pending"]);
+
+    pendingDelivery.resolve();
+    await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(2));
+    expect(deliveryOrder).toEqual(["pending", "expired"]);
   });
 
   it("forwards to explicit targets and expires", async () => {

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -22,6 +22,7 @@ import { channelRouteDedupeKey } from "../plugin-sdk/channel-route.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 // Forwards exec approval requests between runtime sessions and approval handlers.
 import { formatFencedCodeBlock } from "../shared/markdown-code.js";
+import { createPendingApprovalRegistry } from "../shared/pending-approval-registry.js";
 import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { matchesApprovalRequestFilters } from "./approval-request-filters.js";
 import {
@@ -69,7 +70,6 @@ type ApprovalRouteRequest = {
 type PendingApproval<TRouteRequest extends ApprovalRouteRequest> = {
   routeRequest: TRouteRequest;
   targets: ForwardTarget[];
-  timeoutId: NodeJS.Timeout | null;
 };
 
 type ApprovalRenderContext<TRouteRequest extends ApprovalRouteRequest> = {
@@ -558,20 +558,18 @@ function createApprovalHandlers<
   nowMs: () => number;
   resolveSessionTarget: ResolveSessionTargetFn;
 }) {
-  const pending = new Map<string, PendingApproval<TRouteRequest>>();
+  const pending = createPendingApprovalRegistry<PendingApproval<TRouteRequest>>();
 
-  const handleRequested = async (request: TRequest): Promise<boolean> => {
-    const cfg = params.getConfig();
-    const config = params.strategy.config(cfg);
-    const requestId = params.strategy.getRequestId(request);
-    const routeRequest = params.strategy.getRouteRequestFromRequest(request);
-    const filteredTargets = [
-      ...(shouldForwardRoute({ config, routeRequest })
+  const resolveTargets = async (paramsForRoute: {
+    cfg: OpenClawConfig;
+    config?: ExecApprovalForwardingConfig;
+    routeRequest: TRouteRequest;
+  }): Promise<ForwardTarget[]> =>
+    [
+      ...(shouldForwardRoute(paramsForRoute)
         ? await resolveForwardTargets({
-            cfg,
-            config,
+            ...paramsForRoute,
             approvalKind: params.strategy.kind,
-            routeRequest,
             resolveSessionTarget: params.resolveSessionTarget,
           })
         : []),
@@ -580,46 +578,77 @@ function createApprovalHandlers<
         !shouldSkipForwardingFallback({
           approvalKind: params.strategy.kind,
           target,
-          cfg,
-          routeRequest,
+          cfg: paramsForRoute.cfg,
+          routeRequest: paramsForRoute.routeRequest,
         }),
     );
+
+  const deliverResolved = async (
+    resolved: TResolved,
+    entry?: PendingApproval<TRouteRequest>,
+  ): Promise<void> => {
+    const cfg = params.getConfig();
+    const routeRequest =
+      entry?.routeRequest ?? params.strategy.getRouteRequestFromResolved(resolved);
+    const targets =
+      entry?.targets ??
+      (routeRequest
+        ? await resolveTargets({
+            cfg,
+            config: params.strategy.config(cfg),
+            routeRequest,
+          })
+        : []);
+    if (!targets.length) {
+      return;
+    }
+    await deliverToTargets({
+      cfg,
+      targets,
+      buildPayload: (target) =>
+        params.strategy.buildResolvedPayload({
+          cfg,
+          resolved,
+          target,
+          routeRequest: routeRequest ?? ({} as TRouteRequest),
+        }),
+      deliver: params.deliver,
+    });
+  };
+
+  const handleRequested = async (request: TRequest): Promise<boolean> => {
+    const cfg = params.getConfig();
+    const config = params.strategy.config(cfg);
+    const requestId = params.strategy.getRequestId(request);
+    const routeRequest = params.strategy.getRouteRequestFromRequest(request);
+    // Register before route lookup so a fast resolution cannot overtake and resurrect delivery.
+    const pendingEntry = pending.begin(requestId, { routeRequest, targets: [] });
+    let filteredTargets: ForwardTarget[];
+    try {
+      filteredTargets = await resolveTargets({ cfg, config, routeRequest });
+    } catch (error) {
+      pending.remove(requestId, pendingEntry);
+      throw error;
+    }
     if (filteredTargets.length === 0) {
+      pending.remove(requestId, pendingEntry);
       return false;
     }
 
+    pendingEntry.value = { routeRequest, targets: filteredTargets };
     const expiresInMs = Math.max(0, params.strategy.getExpiresAtMs(request) - params.nowMs());
-    const timeoutId = setTimeout(() => {
-      void (async () => {
-        const entry = pending.get(requestId);
-        if (!entry) {
-          return;
-        }
-        pending.delete(requestId);
-        await deliverToTargets({
-          cfg,
-          targets: entry.targets,
-          buildPayload: () => ({ text: params.strategy.buildExpiredText(request) }),
-          deliver: params.deliver,
-        });
-      })().catch((err: unknown) => {
+    pending.scheduleExpiry(pendingEntry, expiresInMs, (expired) => {
+      void deliverToTargets({
+        cfg,
+        targets: expired.value.targets,
+        buildPayload: () => ({ text: params.strategy.buildExpiredText(request) }),
+        deliver: params.deliver,
+      }).catch((err: unknown) => {
         log.error(
           `${params.strategy.kind} approvals: failed to deliver expiry notification for ${requestId}: ${String(err)}`,
         );
       });
-    }, expiresInMs);
-    timeoutId.unref?.();
-
-    const pendingEntry: PendingApproval<TRouteRequest> = {
-      routeRequest,
-      targets: filteredTargets,
-      timeoutId,
-    };
-    pending.set(requestId, pendingEntry);
-
-    if (pending.get(requestId) !== pendingEntry) {
-      return false;
-    }
+    });
 
     void deliverToTargets({
       cfg,
@@ -648,83 +677,32 @@ function createApprovalHandlers<
         });
       },
       deliver: params.deliver,
-      shouldSend: () => pending.get(requestId) === pendingEntry,
-    }).catch((err: unknown) => {
-      log.error(
-        `${params.strategy.kind} approvals: failed to deliver request ${requestId}: ${String(err)}`,
-      );
-    });
+      shouldSend: () => pending.isCurrent(pendingEntry),
+    })
+      .then(() => pending.completeDelivery(pendingEntry, pendingEntry.value))
+      .catch((err: unknown) => {
+        log.error(
+          `${params.strategy.kind} approvals: failed to deliver request ${requestId}: ${String(err)}`,
+        );
+      });
     return true;
   };
 
   const handleResolved = async (resolved: TResolved) => {
-    const resolvedId = params.strategy.getResolvedId(resolved);
-    const entry = pending.get(resolvedId);
-    if (entry?.timeoutId) {
-      clearTimeout(entry.timeoutId);
-    }
-    if (entry) {
-      pending.delete(resolvedId);
-    }
-
-    const cfg = params.getConfig();
-    let targets = entry?.targets;
-    if (!targets) {
-      const routeRequest = params.strategy.getRouteRequestFromResolved(resolved);
-      if (routeRequest) {
-        const config = params.strategy.config(cfg);
-        targets = [
-          ...(shouldForwardRoute({ config, routeRequest })
-            ? await resolveForwardTargets({
-                cfg,
-                config,
-                approvalKind: params.strategy.kind,
-                routeRequest,
-                resolveSessionTarget: params.resolveSessionTarget,
-              })
-            : []),
-        ].filter(
-          (target) =>
-            !shouldSkipForwardingFallback({
-              approvalKind: params.strategy.kind,
-              target,
-              cfg,
-              routeRequest,
-            }),
-        );
-      }
-    }
-    if (!targets?.length) {
+    const settled = pending.settle(params.strategy.getResolvedId(resolved), (entry) =>
+      deliverResolved(resolved, entry.value),
+    );
+    if (settled.status === "queued") {
       return;
     }
-
-    await deliverToTargets({
-      cfg,
-      targets,
-      buildPayload: (target) =>
-        params.strategy.buildResolvedPayload({
-          cfg,
-          resolved,
-          target,
-          routeRequest:
-            entry?.routeRequest ??
-            params.strategy.getRouteRequestFromResolved(resolved) ??
-            ({} as TRouteRequest),
-        }),
-      deliver: params.deliver,
-    });
-  };
-
-  const stop = () => {
-    for (const entry of pending.values()) {
-      if (entry.timeoutId) {
-        clearTimeout(entry.timeoutId);
-      }
+    if (settled.status === "taken") {
+      await settled.terminal(settled.entry);
+      return;
     }
-    pending.clear();
+    await deliverResolved(resolved);
   };
 
-  return { handleRequested, handleResolved, stop };
+  return { handleRequested, handleResolved, stop: () => pending.clear() };
 }
 
 function createApprovalStrategy<

--- a/src/infra/plugin-approval-forwarder.test.ts
+++ b/src/infra/plugin-approval-forwarder.test.ts
@@ -427,6 +427,7 @@ describe("plugin approval forwarding", () => {
       await registerPendingApproval(forwarder, deliver);
 
       await forwarder.handlePluginApprovalResolved!(makePluginResolved());
+      await flushPendingDelivery();
       expect(deliver).toHaveBeenCalled();
       const text = firstDeliveredPayload(deliver)?.text ?? "";
       expect(text).toContain("Plugin approval");

--- a/src/node-host/worker-support.ts
+++ b/src/node-host/worker-support.ts
@@ -1,6 +1,7 @@
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import type { GatewayClientRequestOptions } from "../gateway/client.js";
+import { createPendingRequestRegistry } from "../shared/pending-request-registry.js";
 import type { NodeHostClient } from "./client.js";
 import type { NodeInvokeRequestPayload } from "./invoke.js";
 
@@ -63,15 +64,9 @@ export function parseNodeHostWorkerInput(line: string): NodeHostWorkerInput | nu
   }
 }
 
-type PendingGatewayRequest = {
-  resolve: (value: unknown) => void;
-  reject: (error: Error) => void;
-  timer: NodeJS.Timeout;
-};
-
 export class NodeHostWorkerBridgeClient implements NodeHostClient {
   private nextRequestId = 1;
-  private readonly pending = new Map<string, PendingGatewayRequest>();
+  private readonly pending = createPendingRequestRegistry<string, unknown, undefined>();
 
   constructor(private readonly writeMessage: (message: unknown) => void) {}
 
@@ -91,24 +86,23 @@ export class NodeHostWorkerBridgeClient implements NodeHostClient {
 
     const id = `gateway-${this.nextRequestId++}`;
     const timeoutMs = resolveTimerTimeoutMs(opts?.timeoutMs, 15_000);
-    const response = new Promise<unknown>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`Gateway request timed out: ${method}`));
-      }, timeoutMs);
-      this.pending.set(id, { resolve, reject, timer });
+    const pending = this.pending.add(id, {
+      value: undefined,
+      timeoutMs,
+      timeoutError: () => new Error(`Gateway request timed out: ${method}`),
     });
+    if (!pending) {
+      throw new Error(`Gateway request id collision: ${id}`);
+    }
     this.writeMessage({ type: "gateway-request", id, method, params: params ?? {}, timeoutMs });
-    return (await response) as T;
+    return (await pending.promise) as T;
   }
 
   handleResponse(message: NodeHostWorkerGatewayResponse): boolean {
-    const pending = this.pending.get(message.id);
+    const pending = this.pending.take(message.id);
     if (!pending) {
       return false;
     }
-    this.pending.delete(message.id);
-    clearTimeout(pending.timer);
     if (message.ok) {
       pending.resolve(message.result);
     } else {
@@ -118,11 +112,7 @@ export class NodeHostWorkerBridgeClient implements NodeHostClient {
   }
 
   close(): void {
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer);
-      pending.reject(new Error("node-host worker stopped"));
-    }
-    this.pending.clear();
+    this.pending.rejectAll(new Error("node-host worker stopped"));
   }
 }
 

--- a/src/node-host/worker.test.ts
+++ b/src/node-host/worker.test.ts
@@ -125,6 +125,21 @@ describe("NodeHostWorkerBridgeClient", () => {
     await expect(response).rejects.toThrow("node-host worker stopped");
   });
 
+  it("does not keep the worker alive for a pending gateway timeout", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const client = new NodeHostWorkerBridgeClient(() => {});
+    try {
+      const response = client.request("skills.bins", {}, { timeoutMs: 60_000 });
+      const timer = timeoutSpy.mock.results[0]?.value as NodeJS.Timeout | undefined;
+
+      expect(timer?.hasRef()).toBe(false);
+      client.close();
+      await expect(response).rejects.toThrow("node-host worker stopped");
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
   it.each([
     { requested: Number.MAX_SAFE_INTEGER, expected: MAX_TIMER_TIMEOUT_MS },
     { requested: Number.POSITIVE_INFINITY, expected: 15_000 },

--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -1,5 +1,5 @@
 // Covers plugin conversation binding persistence and lookup behavior.
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import type {
   ConversationRef,
@@ -187,6 +187,11 @@ beforeAll(async () => {
   ({ registerSessionBindingAdapter, unregisterSessionBindingAdapter } =
     await import("../infra/outbound/session-binding-service.js"));
   ({ setActivePluginRegistry } = await import("./runtime.js"));
+});
+
+afterEach(() => {
+  clearPluginBindingPendingRequests();
+  vi.useRealTimers();
 });
 
 function createDiscordCodexBindRequest(
@@ -567,6 +572,50 @@ describe("plugin conversation binding approvals", () => {
     expect(parsePluginBindingApprovalCustomId(allowAlways)).toEqual({
       approvalId: "abcdefghijkl",
       decision: "allow-always",
+    });
+  });
+
+  it("fails closed when a pending bind approval reaches its 30-minute deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const request = await requestPendingBinding(
+      createDiscordCodexBindRequest("channel:ttl", "Bind this conversation to Codex."),
+    );
+
+    // The deadline check is authoritative even when the event loop has not dispatched the timer.
+    vi.setSystemTime(1_000 + 30 * 60_000);
+    await expect(approveBindingRequest(request.approvalId, "allow-once")).resolves.toEqual({
+      status: "expired",
+    });
+    expect(sessionBindingState.bind).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("evicts the oldest pending bind approval after 512 requests", async () => {
+    vi.useFakeTimers();
+    const requests = [];
+    for (let index = 0; index < 513; index += 1) {
+      requests.push(
+        await requestPendingBinding(
+          createDiscordCodexBindRequest(
+            `channel:bounded-${index}`,
+            `Bind this conversation to Codex thread ${index}.`,
+          ),
+        ),
+      );
+    }
+
+    expect(vi.getTimerCount()).toBe(512);
+    const oldest = requests[0];
+    const newest = requests[512];
+    if (!oldest || !newest) {
+      throw new Error("expected bounded pending requests");
+    }
+    await expect(approveBindingRequest(oldest.approvalId, "allow-once")).resolves.toEqual({
+      status: "expired",
+    });
+    await expect(approveBindingRequest(newest.approvalId, "deny")).resolves.toMatchObject({
+      status: "denied",
     });
   });
 

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -77,6 +77,12 @@ type PendingPluginBindingRequest = {
   data?: Record<string, unknown>;
 };
 
+type PendingPluginBindingRequestEntry = {
+  request: PendingPluginBindingRequest;
+  expiresAtMs: number;
+  timeoutId: ReturnType<typeof setTimeout>;
+};
+
 type PluginBindingApprovalAction = {
   approvalId: string;
   decision: PluginBindingApprovalDecision;
@@ -114,10 +120,50 @@ type PluginBindingResolveResult =
       status: "expired";
     };
 
-// Rent: approvals cross request roots through deep SDK paths; unified emission makes this ambient slot safe, and Gateway close bounds its lifetime.
-const pendingRequests = new Map<string, PendingPluginBindingRequest>();
+// Chat approvals get the exec-style 30-minute decision window, with abandoned payloads capped.
+const PENDING_PLUGIN_BINDING_REQUEST_TTL_MS = 30 * 60_000;
+const MAX_PENDING_PLUGIN_BINDING_REQUESTS = 512;
+const pendingRequests = new Map<string, PendingPluginBindingRequestEntry>();
 
-export const clearPluginBindingPendingRequests = () => pendingRequests.clear();
+function takePendingPluginBindingRequest(
+  approvalId: string,
+  expected?: PendingPluginBindingRequestEntry,
+): PendingPluginBindingRequest | undefined {
+  const entry = pendingRequests.get(approvalId);
+  if (!entry || (expected && entry !== expected)) {
+    return undefined;
+  }
+  pendingRequests.delete(approvalId);
+  clearTimeout(entry.timeoutId);
+  return entry.request;
+}
+
+function addPendingPluginBindingRequest(request: PendingPluginBindingRequest): void {
+  const expiresAtMs = Date.now() + PENDING_PLUGIN_BINDING_REQUEST_TTL_MS;
+  let entry: PendingPluginBindingRequestEntry;
+  const timeoutId = setTimeout(() => {
+    takePendingPluginBindingRequest(request.id, entry);
+  }, PENDING_PLUGIN_BINDING_REQUEST_TTL_MS);
+  timeoutId.unref?.();
+  entry = { request, expiresAtMs, timeoutId };
+  pendingRequests.set(request.id, entry);
+
+  // Oldest-first eviction keeps abandoned approval payloads bounded and fail-closed.
+  while (pendingRequests.size > MAX_PENDING_PLUGIN_BINDING_REQUESTS) {
+    const oldestId = pendingRequests.keys().next().value;
+    if (oldestId === undefined) {
+      break;
+    }
+    takePendingPluginBindingRequest(oldestId);
+  }
+}
+
+export function clearPluginBindingPendingRequests(): void {
+  for (const entry of pendingRequests.values()) {
+    clearTimeout(entry.timeoutId);
+  }
+  pendingRequests.clear();
+}
 
 type PluginBindingGlobalState = {
   fallbackNoticeBindingIds: Set<string>;
@@ -834,7 +880,7 @@ export async function requestPluginConversationBinding(params: {
     detachHint: normalizeOptionalString(params.binding?.detachHint),
     data: normalizeBindingData(params.binding?.data),
   };
-  pendingRequests.set(request.id, request);
+  addPendingPluginBindingRequest(request);
   logPluginBindingLifecycleEvent({
     event: "requested",
     pluginId: params.pluginId,
@@ -885,10 +931,14 @@ export async function resolvePluginConversationBindingApproval(params: {
   decision: PluginBindingApprovalDecision;
   senderId?: string;
 }): Promise<PluginBindingResolveResult> {
-  const request = pendingRequests.get(params.approvalId);
-  if (!request) {
+  const entry = pendingRequests.get(params.approvalId);
+  if (!entry || Date.now() >= entry.expiresAtMs) {
+    if (entry) {
+      takePendingPluginBindingRequest(params.approvalId, entry);
+    }
     return { status: "expired" };
   }
+  const request = entry.request;
   if (
     request.requestedBySenderId &&
     params.senderId?.trim() &&
@@ -896,7 +946,7 @@ export async function resolvePluginConversationBindingApproval(params: {
   ) {
     return { status: "expired" };
   }
-  pendingRequests.delete(params.approvalId);
+  takePendingPluginBindingRequest(params.approvalId, entry);
   if (params.decision === "deny") {
     dispatchPluginConversationBindingResolved({
       status: "denied",

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -140,12 +140,14 @@ function takePendingPluginBindingRequest(
 
 function addPendingPluginBindingRequest(request: PendingPluginBindingRequest): void {
   const expiresAtMs = Date.now() + PENDING_PLUGIN_BINDING_REQUEST_TTL_MS;
-  let entry: PendingPluginBindingRequestEntry;
-  const timeoutId = setTimeout(() => {
-    takePendingPluginBindingRequest(request.id, entry);
-  }, PENDING_PLUGIN_BINDING_REQUEST_TTL_MS);
-  timeoutId.unref?.();
-  entry = { request, expiresAtMs, timeoutId };
+  const entry: PendingPluginBindingRequestEntry = {
+    request,
+    expiresAtMs,
+    timeoutId: setTimeout(() => {
+      takePendingPluginBindingRequest(request.id, entry);
+    }, PENDING_PLUGIN_BINDING_REQUEST_TTL_MS),
+  };
+  entry.timeoutId.unref?.();
   pendingRequests.set(request.id, entry);
 
   // Oldest-first eviction keeps abandoned approval payloads bounded and fail-closed.

--- a/src/shared/pending-approval-registry.ts
+++ b/src/shared/pending-approval-registry.ts
@@ -55,7 +55,9 @@ export function createPendingApprovalRegistry<TValue>() {
     timeoutMs: number,
     onExpire: PendingApprovalTerminal<TValue>,
   ) => {
-    if (!isCurrent(entry)) return;
+    if (!isCurrent(entry)) {
+      return;
+    }
     entry.timeoutId = setTimeout(() => {
       const expired = settle(entry.id, onExpire);
       if (expired.status === "taken") {
@@ -65,7 +67,9 @@ export function createPendingApprovalRegistry<TValue>() {
     entry.timeoutId.unref?.();
   };
   const clear = () => {
-    for (const entry of pending.values()) clearTimeout(entry.timeoutId);
+    for (const entry of pending.values()) {
+      clearTimeout(entry.timeoutId);
+    }
     pending.clear();
   };
   const has = (id: string) => pending.has(id);

--- a/src/shared/pending-approval-registry.ts
+++ b/src/shared/pending-approval-registry.ts
@@ -1,0 +1,73 @@
+type PendingApprovalEntry<TValue> = {
+  id: string;
+  value: TValue;
+  delivering: boolean;
+  queued?: (entry: PendingApprovalEntry<TValue>) => void | Promise<void>;
+  timeoutId?: ReturnType<typeof setTimeout>;
+};
+
+type PendingApprovalTerminal<TValue> = NonNullable<PendingApprovalEntry<TValue>["queued"]>;
+
+export function createPendingApprovalRegistry<TValue>() {
+  const pending = new Map<string, PendingApprovalEntry<TValue>>();
+  const remove = (id: string, expected?: PendingApprovalEntry<TValue>) => {
+    const entry = pending.get(id);
+    if (!entry || (expected && entry !== expected)) {
+      return undefined;
+    }
+    pending.delete(id);
+    clearTimeout(entry.timeoutId);
+    return entry;
+  };
+  const isCurrent = (entry: PendingApprovalEntry<TValue>) => pending.get(entry.id) === entry;
+  const begin = (id: string, value: TValue) => {
+    remove(id);
+    const entry: PendingApprovalEntry<TValue> = { id, value, delivering: true };
+    pending.set(id, entry);
+    return entry;
+  };
+  const completeDelivery = async (entry: PendingApprovalEntry<TValue>, value: TValue) => {
+    if (!isCurrent(entry)) {
+      return;
+    }
+    entry.value = value;
+    entry.delivering = false;
+    if (entry.queued) {
+      remove(entry.id, entry);
+      await entry.queued(entry);
+    }
+  };
+  const settle = (id: string, terminal: PendingApprovalTerminal<TValue>) => {
+    const entry = pending.get(id);
+    if (!entry) {
+      return { status: "missing" } as const;
+    }
+    if (entry.delivering) {
+      // First terminal event wins, but its notice waits until pending delivery finishes.
+      entry.queued ??= terminal;
+      return { status: "queued" } as const;
+    }
+    remove(id, entry);
+    return { status: "taken", entry, terminal } as const;
+  };
+  const scheduleExpiry = (
+    entry: PendingApprovalEntry<TValue>,
+    timeoutMs: number,
+    onExpire: PendingApprovalTerminal<TValue>,
+  ) => {
+    if (!isCurrent(entry)) return;
+    entry.timeoutId = setTimeout(() => {
+      const expired = settle(entry.id, onExpire);
+      if (expired.status === "taken") {
+        void expired.terminal(expired.entry);
+      }
+    }, timeoutMs);
+    entry.timeoutId.unref?.();
+  };
+  const clear = () => {
+    for (const entry of pending.values()) clearTimeout(entry.timeoutId);
+    pending.clear();
+  };
+  const has = (id: string) => pending.has(id);
+  return { has, begin, isCurrent, completeDelivery, settle, scheduleExpiry, remove, clear };
+}

--- a/src/shared/pending-request-registry.test.ts
+++ b/src/shared/pending-request-registry.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPendingRequestRegistry } from "./pending-request-registry.js";
+
+describe("createPendingRequestRegistry", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("unrefs each request timeout", () => {
+    const registry = createPendingRequestRegistry<string, void, undefined>();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const entry = registry.add("request", {
+      value: undefined,
+      timeoutMs: 60_000,
+      timeoutError: () => new Error("timed out"),
+    });
+
+    const timer = timeoutSpy.mock.results[0]?.value as NodeJS.Timeout | undefined;
+    expect(entry).toBeDefined();
+    expect(timer?.hasRef()).toBe(false);
+    registry.take("request", entry);
+  });
+
+  it("takes only the expected entry and settles a timeout once", async () => {
+    vi.useFakeTimers();
+    const onTimeout = vi.fn();
+    const registry = createPendingRequestRegistry<string, string, string>();
+    const first = registry.add("first", {
+      value: "first-value",
+      timeoutMs: 10,
+      timeoutError: () => new Error("first timed out"),
+      onTimeout,
+    });
+    const other = registry.add("other", {
+      value: "other-value",
+      timeoutMs: 20,
+      timeoutError: () => new Error("other timed out"),
+    });
+    if (!first || !other) {
+      throw new Error("expected pending requests");
+    }
+
+    expect(registry.take("first", other)).toBeUndefined();
+    const rejected = expect(first.promise).rejects.toThrow("first timed out");
+    await vi.advanceTimersByTimeAsync(10);
+
+    await rejected;
+    expect(onTimeout).toHaveBeenCalledOnce();
+    expect(registry.take("first", first)).toBeUndefined();
+    registry.take("other", other);
+  });
+
+  it("rejects every live entry and runs cleanup once", async () => {
+    vi.useFakeTimers();
+    const dispose = vi.fn();
+    const registry = createPendingRequestRegistry<string, void, undefined>();
+    const first = registry.add("first", {
+      value: undefined,
+      timeoutMs: 100,
+      timeoutError: () => new Error("timed out"),
+      dispose,
+    });
+    const second = registry.add("second", {
+      value: undefined,
+      timeoutMs: 100,
+      timeoutError: () => new Error("timed out"),
+      dispose,
+    });
+    if (!first || !second) {
+      throw new Error("expected pending requests");
+    }
+    const stopped = new Error("stopped");
+    const firstRejected = expect(first.promise).rejects.toBe(stopped);
+    const secondRejected = expect(second.promise).rejects.toBe(stopped);
+
+    registry.rejectAll(stopped);
+
+    await firstRejected;
+    await secondRejected;
+    expect(dispose).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/shared/pending-request-registry.ts
+++ b/src/shared/pending-request-registry.ts
@@ -1,0 +1,61 @@
+import { createDeferred, type Deferred } from "./deferred.js";
+
+export type PendingRequestEntry<TResult, TValue> = Deferred<TResult> & { value: TValue };
+
+type StoredPendingRequest<TResult, TValue> = PendingRequestEntry<TResult, TValue> & {
+  timer?: ReturnType<typeof setTimeout>;
+  dispose?: () => void;
+};
+type AddPendingRequestOptions<TValue> = {
+  value: TValue;
+  timeoutMs: number;
+  timeoutError: () => unknown;
+  onTimeout?: () => void;
+  dispose?: () => void;
+};
+
+export function createPendingRequestRegistry<TKey, TResult, TValue>() {
+  const pending = new Map<TKey, StoredPendingRequest<TResult, TValue>>();
+  const release = (entry: StoredPendingRequest<TResult, TValue>) => {
+    clearTimeout(entry.timer);
+    entry.dispose?.();
+  };
+  const take = (key: TKey, expected?: PendingRequestEntry<TResult, TValue>) => {
+    const entry = pending.get(key);
+    if (!entry || (expected && entry !== expected)) {
+      return undefined;
+    }
+    pending.delete(key);
+    release(entry);
+    return entry;
+  };
+  const add = (key: TKey, options: AddPendingRequestOptions<TValue>) => {
+    if (pending.has(key)) {
+      return undefined;
+    }
+    const entry: StoredPendingRequest<TResult, TValue> = {
+      ...createDeferred<TResult>(),
+      value: options.value,
+      dispose: options.dispose,
+    };
+    pending.set(key, entry);
+    entry.timer = setTimeout(() => {
+      const timedOut = take(key, entry);
+      if (timedOut) {
+        timedOut.reject(options.timeoutError());
+        options.onTimeout?.();
+      }
+    }, options.timeoutMs);
+    entry.timer.unref?.();
+    return entry;
+  };
+  const rejectAll = (reason: unknown) => {
+    const entries = [...pending.values()];
+    pending.clear();
+    for (const entry of entries) {
+      release(entry);
+      entry.reject(reason);
+    }
+  };
+  return { add, get: (key: TKey) => pending.get(key), take, rejectAll };
+}

--- a/src/worker/worker-connection-frames.ts
+++ b/src/worker/worker-connection-frames.ts
@@ -4,27 +4,22 @@ import { WebSocket } from "ws";
 import {
   type WorkerConnectParams,
   type WorkerHeartbeatParams,
-  type WorkerHeartbeatRequestFrame,
   type WorkerHeartbeatResponseFrame,
   WorkerHeartbeatResponseFrameSchema,
   type WorkerLiveEventParams,
-  type WorkerLiveEventRequestFrame,
   type WorkerLiveEventResponseFrame,
   WorkerLiveEventResponseFrameSchema,
   WORKER_PROTOCOL_MAX_PAYLOAD_BYTES,
   type WorkerTranscriptCommitParams,
-  type WorkerTranscriptCommitRequestFrame,
   type WorkerTranscriptCommitResponseFrame,
   WorkerTranscriptCommitResponseFrameSchema,
 } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import {
   type WorkerInferenceCancelParams,
-  type WorkerInferenceCancelRequestFrame,
   type WorkerInferenceCancelResponseFrame,
   WorkerInferenceCancelResponseFrameSchema,
   type WorkerInferenceEventFrame,
   type WorkerInferenceStartParams,
-  type WorkerInferenceStartRequestFrame,
   type WorkerInferenceStartResponseFrame,
   WorkerInferenceStartResponseFrameSchema,
   type WorkerInferenceTerminalFrame,
@@ -32,48 +27,58 @@ import {
   validateWorkerInferenceEventFrame,
   validateWorkerInferenceTerminalFrame,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
+import {
+  createPendingRequestRegistry,
+  type PendingRequestEntry,
+} from "../shared/pending-request-registry.js";
 import { WorkerConnectionInterruptedError, toError } from "./worker-connection-contract.js";
 
-type PendingHeartbeat = {
-  kind: "heartbeat";
-  resolve: (frame: WorkerHeartbeatResponseFrame) => void;
-  reject: (error: Error) => void;
-};
+const WORKER_REQUEST_SPECS = {
+  heartbeat: {
+    method: "worker.heartbeat",
+    responseSchema: WorkerHeartbeatResponseFrameSchema,
+  },
+  transcript: {
+    method: "worker.transcript.commit",
+    responseSchema: WorkerTranscriptCommitResponseFrameSchema,
+  },
+  "live-event": {
+    method: "worker.live-event",
+    responseSchema: WorkerLiveEventResponseFrameSchema,
+  },
+  "inference-start": {
+    method: "worker.inference.start",
+    responseSchema: WorkerInferenceStartResponseFrameSchema,
+  },
+  "inference-cancel": {
+    method: "worker.inference.cancel",
+    responseSchema: WorkerInferenceCancelResponseFrameSchema,
+  },
+} as const;
 
-type PendingTranscript = {
-  kind: "transcript";
-  resolve: (frame: WorkerTranscriptCommitResponseFrame) => void;
-  reject: (error: Error) => void;
+type WorkerRequestKind = keyof typeof WORKER_REQUEST_SPECS;
+type WorkerRequestParams = {
+  heartbeat: WorkerHeartbeatParams;
+  transcript: WorkerTranscriptCommitParams;
+  "live-event": WorkerLiveEventParams;
+  "inference-start": WorkerInferenceStartParams;
+  "inference-cancel": WorkerInferenceCancelParams;
 };
-
-type PendingLiveEvent = {
-  kind: "live-event";
-  resolve: (frame: WorkerLiveEventResponseFrame) => void;
-  reject: (error: Error) => void;
+type WorkerResponseFrames = {
+  heartbeat: WorkerHeartbeatResponseFrame;
+  transcript: WorkerTranscriptCommitResponseFrame;
+  "live-event": WorkerLiveEventResponseFrame;
+  "inference-start": WorkerInferenceStartResponseFrame;
+  "inference-cancel": WorkerInferenceCancelResponseFrame;
 };
-
-type PendingInferenceStart = {
-  kind: "inference-start";
+type WorkerResponseFrame = WorkerResponseFrames[WorkerRequestKind];
+type PendingRequestValue = {
+  kind: WorkerRequestKind;
   // Durable replay can emit its terminal as the next socket frame. Reset the
   // consumer cursor synchronously after validation, before Promise continuation.
-  beforeResolve?: (frame: WorkerInferenceStartResponseFrame) => void;
-  resolve: (frame: WorkerInferenceStartResponseFrame) => void;
-  reject: (error: Error) => void;
+  beforeResolve?: (frame: WorkerResponseFrame) => void;
 };
-
-type PendingInferenceCancel = {
-  kind: "inference-cancel";
-  resolve: (frame: WorkerInferenceCancelResponseFrame) => void;
-  reject: (error: Error) => void;
-};
-
-type PendingRequest = (
-  | PendingHeartbeat
-  | PendingTranscript
-  | PendingLiveEvent
-  | PendingInferenceStart
-  | PendingInferenceCancel
-) & { timeout?: ReturnType<typeof setTimeout> };
+type PendingRequest = PendingRequestEntry<WorkerResponseFrame, PendingRequestValue>;
 
 type WorkerConnectionFrameDispatcherOptions = {
   connectParams: () => WorkerConnectParams;
@@ -100,7 +105,11 @@ export function closeInvalidWorkerFrame(socket: WebSocket): void {
 }
 
 export class WorkerConnectionFrameDispatcher {
-  private readonly pending = new Map<string, PendingRequest>();
+  private readonly pending = createPendingRequestRegistry<
+    string,
+    WorkerResponseFrame,
+    PendingRequestValue
+  >();
   private readonly inferenceEventListeners = new Set<(frame: WorkerInferenceEventFrame) => void>();
   private readonly inferenceTerminalListeners = new Set<
     (frame: WorkerInferenceTerminalFrame) => void
@@ -116,83 +125,6 @@ export class WorkerConnectionFrameDispatcher {
   onInferenceTerminal(listener: (frame: WorkerInferenceTerminalFrame) => void): () => void {
     this.inferenceTerminalListeners.add(listener);
     return () => this.inferenceTerminalListeners.delete(listener);
-  }
-
-  requestHeartbeat(params: WorkerHeartbeatParams): Promise<WorkerHeartbeatResponseFrame> {
-    const id = randomUUID();
-    const frame: WorkerHeartbeatRequestFrame = {
-      type: "req",
-      id,
-      method: "worker.heartbeat",
-      params,
-    };
-    return new Promise((resolve, reject) => {
-      this.sendRequest(id, frame, { kind: "heartbeat", resolve, reject });
-    });
-  }
-
-  requestTranscriptCommit(
-    params: WorkerTranscriptCommitParams,
-  ): Promise<WorkerTranscriptCommitResponseFrame> {
-    const id = randomUUID();
-    const frame: WorkerTranscriptCommitRequestFrame = {
-      type: "req",
-      id,
-      method: "worker.transcript.commit",
-      params,
-    };
-    return new Promise((resolve, reject) => {
-      this.sendRequest(id, frame, { kind: "transcript", resolve, reject });
-    });
-  }
-
-  requestLiveEvent(params: WorkerLiveEventParams): Promise<WorkerLiveEventResponseFrame> {
-    const id = randomUUID();
-    const frame: WorkerLiveEventRequestFrame = {
-      type: "req",
-      id,
-      method: "worker.live-event",
-      params,
-    };
-    return new Promise((resolve, reject) => {
-      this.sendRequest(id, frame, { kind: "live-event", resolve, reject });
-    });
-  }
-
-  requestInferenceStart(
-    params: WorkerInferenceStartParams,
-    beforeResolve?: (frame: WorkerInferenceStartResponseFrame) => void,
-  ): Promise<WorkerInferenceStartResponseFrame> {
-    const id = randomUUID();
-    const frame: WorkerInferenceStartRequestFrame = {
-      type: "req",
-      id,
-      method: "worker.inference.start",
-      params,
-    };
-    return new Promise((resolve, reject) => {
-      this.sendRequest(id, frame, {
-        kind: "inference-start",
-        ...(beforeResolve ? { beforeResolve } : {}),
-        resolve,
-        reject,
-      });
-    });
-  }
-
-  requestInferenceCancel(
-    params: WorkerInferenceCancelParams,
-  ): Promise<WorkerInferenceCancelResponseFrame> {
-    const id = randomUUID();
-    const frame: WorkerInferenceCancelRequestFrame = {
-      type: "req",
-      id,
-      method: "worker.inference.cancel",
-      params,
-    };
-    return new Promise((resolve, reject) => {
-      this.sendRequest(id, frame, { kind: "inference-cancel", resolve, reject });
-    });
   }
 
   dispatchReadyFrame(frame: unknown, socket: WebSocket): void {
@@ -228,15 +160,7 @@ export class WorkerConnectionFrameDispatcher {
   }
 
   rejectPending(error: Error): void {
-    const pending = [...this.pending.values()];
-    this.pending.clear();
-    for (const request of pending) {
-      if (request.timeout) {
-        clearTimeout(request.timeout);
-        request.timeout = undefined;
-      }
-      request.reject(error);
-    }
+    this.pending.rejectAll(error);
   }
 
   private matchesInferenceIdentity(payload: { runEpoch: number; sessionId: string }): boolean {
@@ -244,126 +168,98 @@ export class WorkerConnectionFrameDispatcher {
     return payload.runEpoch === admission.ownerEpoch && payload.sessionId === admission.sessionId;
   }
 
-  private resolvePendingFrame(id: string, pending: PendingRequest, frame: unknown): boolean {
-    switch (pending.kind) {
-      case "heartbeat": {
-        if (!Value.Check(WorkerHeartbeatResponseFrameSchema, frame)) {
-          return false;
-        }
-        this.deletePending(id, pending);
-        pending.resolve(frame as WorkerHeartbeatResponseFrame);
-        return true;
-      }
-      case "transcript": {
-        if (!Value.Check(WorkerTranscriptCommitResponseFrameSchema, frame)) {
-          return false;
-        }
-        this.deletePending(id, pending);
-        pending.resolve(frame as WorkerTranscriptCommitResponseFrame);
-        return true;
-      }
-      case "live-event": {
-        if (!Value.Check(WorkerLiveEventResponseFrameSchema, frame)) {
-          return false;
-        }
-        this.deletePending(id, pending);
-        pending.resolve(frame as WorkerLiveEventResponseFrame);
-        return true;
-      }
-      case "inference-start": {
-        if (!Value.Check(WorkerInferenceStartResponseFrameSchema, frame)) {
-          return false;
-        }
-        const response = frame as WorkerInferenceStartResponseFrame;
-        this.deletePending(id, pending);
-        try {
-          pending.beforeResolve?.(response);
-        } catch (error) {
-          pending.reject(toError(error));
-          return true;
-        }
-        pending.resolve(response);
-        return true;
-      }
-      case "inference-cancel": {
-        if (!Value.Check(WorkerInferenceCancelResponseFrameSchema, frame)) {
-          return false;
-        }
-        this.deletePending(id, pending);
-        pending.resolve(frame as WorkerInferenceCancelResponseFrame);
-        return true;
-      }
-    }
-    return false;
+  request<K extends WorkerRequestKind>(
+    kind: K,
+    params: WorkerRequestParams[K],
+    beforeResolve?: (frame: WorkerResponseFrames[K]) => void,
+  ): Promise<WorkerResponseFrames[K]> {
+    const id = randomUUID();
+    const spec = WORKER_REQUEST_SPECS[kind];
+    const frame = { type: "req", id, method: spec.method, params };
+    const wrappedBeforeResolve = beforeResolve
+      ? (response: WorkerResponseFrame) => beforeResolve(response as WorkerResponseFrames[K])
+      : undefined;
+    return this.sendRequest(id, frame, {
+      kind,
+      ...(wrappedBeforeResolve ? { beforeResolve: wrappedBeforeResolve } : {}),
+    }) as Promise<WorkerResponseFrames[K]>;
   }
 
-  private sendRequest(id: string, frame: object, pending: PendingRequest): void {
+  private resolvePendingFrame(id: string, pending: PendingRequest, frame: unknown): boolean {
+    const spec = WORKER_REQUEST_SPECS[pending.value.kind];
+    if (!Value.Check(spec.responseSchema, frame)) {
+      return false;
+    }
+    const completed = this.pending.take(id, pending);
+    if (!completed) {
+      return false;
+    }
+    const response = frame as WorkerResponseFrame;
+    try {
+      completed.value.beforeResolve?.(response);
+    } catch (error) {
+      completed.reject(toError(error));
+      return true;
+    }
+    completed.resolve(response);
+    return true;
+  }
+
+  private sendRequest(
+    id: string,
+    frame: object,
+    value: PendingRequestValue,
+  ): Promise<WorkerResponseFrame> {
     const ready = this.options.isReady();
     const readySocket = ready ? this.options.socket() : undefined;
     if (!ready || !readySocket || readySocket.readyState !== WebSocket.OPEN) {
-      pending.reject(
+      return Promise.reject(
         this.options.isTerminal()
           ? this.options.terminalError()
           : new WorkerConnectionInterruptedError("worker connection is not ready"),
       );
-      return;
-    }
-    if (this.pending.has(id)) {
-      pending.reject(new Error("worker request id collision"));
-      return;
     }
     let encoded: string;
     try {
       encoded = JSON.stringify(frame);
     } catch (error) {
-      pending.reject(toError(error));
-      return;
+      return Promise.reject(toError(error));
     }
     const payloadLimit =
-      pending.kind === "inference-start"
+      value.kind === "inference-start"
         ? WORKER_PROTOCOL_MAX_INFERENCE_PAYLOAD_BYTES
         : WORKER_PROTOCOL_MAX_PAYLOAD_BYTES;
     if (Buffer.byteLength(encoded, "utf8") > payloadLimit) {
-      pending.reject(new Error("worker request exceeds the protocol payload limit"));
-      return;
+      return Promise.reject(new Error("worker request exceeds the protocol payload limit"));
     }
-    const socket = this.options.socket()!;
-    this.pending.set(id, pending);
-    pending.timeout = setTimeout(() => {
-      if (!this.deletePending(id, pending)) {
-        return;
-      }
-      pending.reject(
-        new WorkerConnectionInterruptedError(`worker ${pending.kind} response timed out`),
-      );
-      this.options.interruptReadySocket(socket);
-    }, this.options.requestTimeoutMs);
-    pending.timeout.unref?.();
+    const pending = this.pending.add(id, {
+      value,
+      timeoutMs: this.options.requestTimeoutMs,
+      timeoutError: () =>
+        new WorkerConnectionInterruptedError(`worker ${value.kind} response timed out`),
+      onTimeout: () => this.options.interruptReadySocket(readySocket),
+    });
+    if (!pending) {
+      return Promise.reject(new Error("worker request id collision"));
+    }
     try {
-      socket.send(encoded, (error) => {
-        if (!error || this.pending.get(id) !== pending) {
+      readySocket.send(encoded, (error) => {
+        if (!error) {
           return;
         }
-        this.deletePending(id, pending);
-        pending.reject(new WorkerConnectionInterruptedError(error.message));
-        this.options.interruptReadySocket(socket);
+        const failed = this.pending.take(id, pending);
+        if (!failed) {
+          return;
+        }
+        failed.reject(new WorkerConnectionInterruptedError(error.message));
+        this.options.interruptReadySocket(readySocket);
       });
     } catch (error) {
-      this.deletePending(id, pending);
-      pending.reject(new WorkerConnectionInterruptedError(toError(error).message));
-      this.options.interruptReadySocket(socket);
+      this.pending
+        .take(id, pending)
+        ?.reject(new WorkerConnectionInterruptedError(toError(error).message));
+      this.options.interruptReadySocket(readySocket);
     }
-  }
-
-  private deletePending(id: string, pending: PendingRequest): boolean {
-    if (this.pending.get(id) !== pending) {
-      return false;
-    }
-    this.pending.delete(id);
-    if (pending.timeout) {
-      clearTimeout(pending.timeout);
-      pending.timeout = undefined;
-    }
-    return true;
+    return pending.promise;
   }
 }

--- a/src/worker/worker-connection.ts
+++ b/src/worker/worker-connection.ts
@@ -182,30 +182,30 @@ export class WorkerConnection {
   }
 
   requestHeartbeat(params: WorkerHeartbeatParams): Promise<WorkerHeartbeatResponseFrame> {
-    return this.frames.requestHeartbeat(params);
+    return this.frames.request("heartbeat", params);
   }
 
   requestTranscriptCommit(
     params: WorkerTranscriptCommitParams,
   ): Promise<WorkerTranscriptCommitResponseFrame> {
-    return this.frames.requestTranscriptCommit(params);
+    return this.frames.request("transcript", params);
   }
 
   requestLiveEvent(params: WorkerLiveEventParams): Promise<WorkerLiveEventResponseFrame> {
-    return this.frames.requestLiveEvent(params);
+    return this.frames.request("live-event", params);
   }
 
   requestInferenceStart(
     params: WorkerInferenceStartParams,
     beforeResolve?: (frame: WorkerInferenceStartResponseFrame) => void,
   ): Promise<WorkerInferenceStartResponseFrame> {
-    return this.frames.requestInferenceStart(params, beforeResolve);
+    return this.frames.request("inference-start", params, beforeResolve);
   }
 
   requestInferenceCancel(
     params: WorkerInferenceCancelParams,
   ): Promise<WorkerInferenceCancelResponseFrame> {
-    return this.frames.requestInferenceCancel(params);
+    return this.frames.request("inference-cancel", params);
   }
 
   private async connectUntilReady(): Promise<WorkerHelloOk> {


### PR DESCRIPTION
## What Problem This Solves

Pending request and approval lifecycles had drifted across several runtimes. A node-host gateway request timer could keep a worker process alive, approval resolution or expiry could overtake a slow pending-message delivery, and plugin conversation-binding approvals could remain actionable and accumulate for the entire Gateway lifetime.

## Why This Change Was Made

This adds one deferred-backed pending-request registry for worker, node-host, and LSP RPCs, and one small delivery-lifecycle registry shared by both approval fanout owners. Transport policy remains local: worker socket interruption, LSP cancellation, channel rendering, and native finalization are unchanged. Worker request definitions are table-driven, and plugin binding approvals now use the previously authored domain policy of a 30-minute deadline with a 512-entry oldest-first cap.

AI-assisted implementation; the complete diff was reviewed with the repository autoreview workflow.

## User Impact

Node-host workers no longer stay alive solely for a pending gateway timeout. Approval prompts are delivered before their resolved or expired notice even when route lookup or channel delivery is slow. Old plugin-binding buttons fail closed with the existing retry guidance, and abandoned binding requests remain memory-bounded. No config, environment, protocol, SDK, or SQLite schema surface changes.

## Evidence

- Exact-head CI is green: https://github.com/openclaw/openclaw/actions/runs/30770745375 at `6680fbc10becf36424a316279e5ac1e6ca5742ad`.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/shared/pending-request-registry.test.ts src/node-host/worker.test.ts src/agents/agent-bundle-lsp-runtime.test.ts src/infra/exec-approval-channel-runtime.test.ts src/infra/exec-approval-forwarder.test.ts src/plugins/conversation-binding.test.ts src/worker/worker.runtime.test.ts` — initial full focused run passed 136/136 tests across five routed shards.
- Exact final non-worker rerun passed 108/108 tests; post-fix approval/conversation coverage passed 74/74, and the exec/plugin forwarder sibling suites passed 41/41.
- Exact final worker rerun passed 26/28; two existing one-second inference-start polling assertions missed under concurrent fleet load. The earlier full run passed all 28 worker tests, and exact-head hosted CI is green.
- `git diff --check` — clean.
- canonical `oxfmt --check`, targeted type-aware `oxlint`, and hosted `check-lint` — clean.
- Codex autoreview (`gpt-5.6-sol`, high) — clean after every fixup; no accepted/actionable findings.
- `node scripts/check-changed.mjs` correctly selected remote workload routing, but local delegation was unavailable because no Crabbox provider was ready. Hosted exact-head CI covered typecheck/lint/guard fanout.
- Production LOC: 483 added / 495 removed = net -12. Tests: 217 added / 1 removed = net +216.
