### PR TITLE
fix(telegram): stop native commands from silently dropping Markdown tables

### DIFF
--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -323,6 +323,25 @@ describe("deliverReplies", () => {
     expect(firstMockCallArg(sendMessage, 1)).toBe("hello");
   });
 
+  it("keeps native-command tables visible in non-rich block-mode replies", async () => {
+    const { runtime, sendMessage, bot } = createSendMessageHarness();
+    const table = "| A | B |\n| --- | --- |\n| 1 | 2 |";
+
+    await deliverWith({
+      replies: [{ text: `Before\n\n${table}\n\nAfter` }],
+      runtime,
+      bot,
+      tableMode: "block",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const sent = firstSendText(sendMessage);
+    expect(sent).toContain("Before");
+    expect(sent).toContain(`<pre><code>${table}\n</code></pre>`);
+    expect(sent).toContain("After");
+    expectRecordFields(firstMockCallArg(sendMessage, 2), { parse_mode: "HTML" });
+  });
+
   it("delivers prepared HTML without reparsing visible syntax as Markdown", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: "123" } });

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -139,12 +139,24 @@ describe("markdownToTelegramHtml", () => {
     );
   });
 
-  it("renders block-mode tables as code in legacy Telegram HTML", () => {
+  it.each([
+    { name: "a table-only reply", before: "", after: "" },
+    { name: "a table between surrounding prose", before: "Before\n\n", after: "\n\nAfter" },
+  ])("keeps $name visible in one-shot and chunked legacy Telegram HTML", ({ before, after }) => {
     const table = "| A | B |\n| --- | --- |\n| 1 | 2 |";
+    const markdown = `${before}${table}${after}`;
+    const html = markdownToTelegramHtml(markdown, { tableMode: "block" });
+    const chunks = markdownToTelegramChunks(markdown, 4096, { tableMode: "block" });
 
-    expect(markdownToTelegramHtml(table, { tableMode: "block" })).toBe(
-      "<pre><code>| A | B |\n| --- | --- |\n| 1 | 2 |\n</code></pre>",
-    );
+    expect(html).toContain(`<pre><code>${table}\n</code></pre>`);
+    expect(chunks.map((chunk) => chunk.html)).toEqual([html]);
+    expect(chunks[0]?.text).toContain("| 1 | 2 |");
+    if (before) {
+      expect(html).toContain("Before");
+    }
+    if (after) {
+      expect(html).toContain("After");
+    }
   });
 
   it("normalizes raw code language HTML without leaking tags", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -147,19 +147,22 @@ function preserveTelegramListBoundarySpacing(markdown: string): string {
   return out.join("\n");
 }
 
-export function markdownToTelegramHtml(
-  markdown: string,
-  options: { tableMode?: MarkdownTableMode; wrapFileRefs?: boolean } = {},
-): string {
-  const tableMode = options.tableMode === "block" ? "code" : options.tableMode;
-  const ir = markdownToIR(preserveTelegramListBoundarySpacing(markdown ?? ""), {
+function parseTelegramLegacyMarkdown(markdown: string, tableMode?: MarkdownTableMode): MarkdownIR {
+  return markdownToIR(preserveTelegramListBoundarySpacing(markdown ?? ""), {
     assistantTranscriptRoleHeaders: true,
     linkify: true,
     enableSpoilers: true,
     headingStyle: "none",
     blockquotePrefix: "",
-    tableMode,
+    tableMode: tableMode === "block" ? "code" : tableMode,
   });
+}
+
+export function markdownToTelegramHtml(
+  markdown: string,
+  options: { tableMode?: MarkdownTableMode; wrapFileRefs?: boolean } = {},
+): string {
+  const ir = parseTelegramLegacyMarkdown(markdown, options.tableMode);
   const html = renderTelegramHtml(ir);
   const telegramHtml = renderSupportedTelegramHtml(html);
   // Apply file reference wrapping if requested (for chunked rendering)
@@ -910,14 +913,7 @@ export function markdownToTelegramChunks(
   limit: number,
   options: { tableMode?: MarkdownTableMode } = {},
 ): TelegramFormattedChunk[] {
-  const ir = markdownToIR(preserveTelegramListBoundarySpacing(markdown ?? ""), {
-    assistantTranscriptRoleHeaders: true,
-    linkify: true,
-    enableSpoilers: true,
-    headingStyle: "none",
-    blockquotePrefix: "",
-    tableMode: options.tableMode,
-  });
+  const ir = parseTelegramLegacyMarkdown(markdown, options.tableMode);
   return renderTelegramChunksWithinHtmlLimit(ir, limit);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram users running native commands would receive replies with entire Markdown tables silently removed when block-table mode was combined with the default non-rich message path. Replies containing only a table could disappear completely; replies containing prose and a table lost the table while otherwise appearing successful.

## Why This Change Was Made

Telegram had two independent legacy Markdown-to-HTML parsing paths. The one-shot path already translated unsupported `block` tables into visible code blocks, but the chunked path passed `block` to the Markdown IR, which extracts tables into blocks that the legacy sender never renders. One private canonical Telegram parser now owns the same table-mode normalization for both paths. This removes four production lines, changes no configuration or public contract, and leaves genuine rich-message delivery untouched.

## User Impact

Telegram native-command responses preserve table-only replies and tables between surrounding prose, render them as supported HTML code blocks, and send complete messages through the existing Bot API transport.

## Evidence

- Frozen candidate: `e3037b99112f448c460a02eb30bfd0b39895af79`; unchanged parent: `8699f10873f04f550084157c9dc1d28e47d0366a`.
- Authentic parent-red proof: replacing only the formatter with the unchanged parent caused **three actual assertion failures**: table-only rendering, mixed prose/table rendering, and the real Telegram `deliverReplies` -> Bot API send boundary.
- Exact-candidate green: `pnpm test extensions/telegram/src/format.test.ts extensions/telegram/src/bot/delivery.test.ts`.
- Full remote changed-file gate: `pnpm check:changed -- extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts extensions/telegram/src/bot/delivery.test.ts` (guards, extension/test typechecks, formatting, lint, boundaries, import cycles).
- Exact production/plugin build: `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`.
- Real isolated product run on Blacksmith Testbox `tbx_01kz27z6e95mr7zfyd5sa9pdw4`: ephemeral Gateway + real Telegram plugin + loopback Crabline Bot API + mock OpenAI provider + native `/new` command against an existing initialized conversation. The actual intercepted `sendMessage` request contained the entire table and surrounding prose with `parse_mode: HTML`; one scenario passed, zero failed/skipped.

```json
{"verdict":"PASS","scenario":"telegram-commands-command","channel":"telegram","driver":"crabline","provider":"mock-openai","gateway":"ephemeral-child","nativeCommand":"new","tableMode":"block","richMessages":false,"providerInvoked":true,"parseMode":"HTML","prosePreserved":true,"tablePreserved":true,"transcript":{"inbound":"/new reply exactly `Before\n\n| A | B |\n| --- | --- |\n| 1 | 2 |\n\nAfter`","outbound":"Before\n\n<pre><code>| A | B |\n| --- | --- |\n| 1 | 2 |\n</code></pre>\nAfter"},"head":"e3037b99112f448c460a02eb30bfd0b39895af79","scenarios":1,"failed":0}
```

- Four independent nonauthor whole-owner/dependency reviews passed with exact-head and clean-tree guards.
- Genuine official `autoreview --mode commit --commit e3037b99112f448c460a02eb30bfd0b39895af79 --engine codex --model gpt-5.6-sol --thinking high --max-priority P3 --no-web-search`: **clean**, with genuine TruffleHog 3.96.0 secret scan.
- Production delta: **−4 lines**; focused regression coverage also checks non-rich Bot API HTML and both legacy formatter entry points.
- Risk: low; private Telegram rendering-owner refactor only. No auth, config, schema, protocol, public SDK, transport, or persistent-state change.

## Maintainer Landing Decision

- Exact-head merge risk resolved: GitHub confirms candidate `e3037b99112f448c460a02eb30bfd0b39895af79` is `MERGEABLE`, all required exact-head hosted checks are complete and green, and current-main review found no drift in the touched Telegram files.
- Protected maintainer next step resolved: authenticated maintainer `@steipete` has repository `admin` permission and explicitly delegated autonomous maintainer landing; no repair job is needed because all four independent reviews, genuine Sol review, real Gateway/Bot API proof, and exact-head CI passed.
