### PR TITLE
refactor: compact trusted channel catalog fixtures

### DIFF
--- a/src/commands/channel-setup/trusted-catalog.test.ts
+++ b/src/commands/channel-setup/trusted-catalog.test.ts
@@ -17,25 +17,118 @@ import {
   listTrustedChannelPluginCatalogEntries,
 } from "./trusted-catalog.js";
 
+type MockCatalogOrigin = "bundled" | "config" | "global" | "workspace";
+
+type CatalogLookupOptions = {
+  extraPaths?: string[];
+  excludePluginRefs?: Array<{ pluginId: string; origin?: string }>;
+};
+
+const RAW_LOAD_PATHS = [" /tmp/load-path-a ", "", "/tmp/load-path-b"];
+const NORMALIZED_LOAD_PATHS = ["/tmp/load-path-a", "/tmp/load-path-b"];
+
+function createCatalogEntry(params: {
+  id: string;
+  pluginId: string;
+  origin: MockCatalogOrigin;
+  label: string;
+  blurb?: string;
+  localPath: string;
+}) {
+  return {
+    id: params.id,
+    pluginId: params.pluginId,
+    origin: params.origin,
+    meta: {
+      id: params.id,
+      label: params.label,
+      selectionLabel: params.label,
+      docsPath: `/channels/${params.id}`,
+      blurb:
+        params.blurb ?? (params.origin === "bundled" ? "bundled entry" : `${params.origin} shadow`),
+    },
+    install: { localPath: params.localPath, defaultChoice: "local" },
+  };
+}
+
+function mockCatalogFallback(params: {
+  rejected: ReturnType<typeof createCatalogEntry>;
+  fallback?: ReturnType<typeof createCatalogEntry>;
+  expectedExtraPaths?: string[];
+}) {
+  getChannelPluginCatalogEntry.mockImplementation(
+    (_channelId: string, options?: CatalogLookupOptions) => {
+      if (params.expectedExtraPaths) {
+        expect(options?.extraPaths).toEqual(params.expectedExtraPaths);
+      }
+      const rejected = options?.excludePluginRefs?.some(
+        (entry) =>
+          entry.pluginId === params.rejected.pluginId && entry.origin === params.rejected.origin,
+      );
+      return rejected ? params.fallback : params.rejected;
+    },
+  );
+}
+
+function mockTelegramShadowFallback(params: {
+  pluginId: string;
+  origin: Exclude<MockCatalogOrigin, "bundled">;
+  localPath: string;
+}) {
+  mockCatalogFallback({
+    rejected: createCatalogEntry({
+      id: "telegram",
+      pluginId: params.pluginId,
+      origin: params.origin,
+      label: "Telegram Shadow",
+      localPath: params.localPath,
+    }),
+    fallback: createCatalogEntry({
+      id: "telegram",
+      pluginId: "@openclaw/telegram",
+      origin: "bundled",
+      label: "Telegram",
+      localPath: "./bundled/telegram",
+    }),
+  });
+}
+
+function mockTeamsConfigFallback() {
+  mockCatalogFallback({
+    rejected: createCatalogEntry({
+      id: "msteams",
+      pluginId: "config-shadow",
+      origin: "config",
+      label: "Shadow Teams",
+      localPath: "./plugins/msteams-shadow",
+    }),
+    fallback: createCatalogEntry({
+      id: "msteams",
+      pluginId: "bundled-msteams",
+      origin: "bundled",
+      label: "Bundled Teams",
+      localPath: "./bundled/msteams",
+    }),
+    expectedExtraPaths: ["/tmp/load-path-a"],
+  });
+}
+
 describe("trusted-catalog load-path discovery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("passes normalized load paths into trusted single-entry resolution", () => {
-    getChannelPluginCatalogEntry.mockReturnValue({
-      id: "e2e-load-paths",
-      pluginId: "e2e-load-paths-shadow",
-      origin: "config",
-      meta: {
+    getChannelPluginCatalogEntry.mockReturnValue(
+      createCatalogEntry({
         id: "e2e-load-paths",
+        pluginId: "e2e-load-paths-shadow",
+        origin: "config",
         label: "E2E Load Paths",
-        selectionLabel: "E2E Load Paths",
-        docsPath: "/channels/e2e-load-paths",
         blurb: "load-paths entry",
-      },
-      install: { localPath: "./plugins/e2e-load-paths", defaultChoice: "local" },
-    });
+        localPath: "./plugins/e2e-load-paths",
+      }),
+    );
 
     expect(
       getTrustedChannelPluginCatalogEntry("e2e-load-paths", {
@@ -43,7 +136,7 @@ describe("trusted-catalog load-path discovery", () => {
           plugins: {
             allow: ["e2e-load-paths-shadow"],
             load: {
-              paths: [" /tmp/load-path-a ", "", "/tmp/load-path-b"],
+              paths: RAW_LOAD_PATHS,
             },
           },
         },
@@ -56,110 +149,43 @@ describe("trusted-catalog load-path discovery", () => {
 
     expect(getChannelPluginCatalogEntry).toHaveBeenCalledWith("e2e-load-paths", {
       env: undefined,
-      extraPaths: ["/tmp/load-path-a", "/tmp/load-path-b"],
+      extraPaths: NORMALIZED_LOAD_PATHS,
       workspaceDir: "/tmp/workspace",
     });
   });
 
-  it("passes normalized load paths into trusted catalog listing and fallback lookup", () => {
+  it.each([
+    [
+      "passes normalized load paths into trusted catalog listing and fallback lookup",
+      listTrustedChannelPluginCatalogEntries,
+    ],
+    [
+      "passes normalized load paths into setup discovery listing",
+      listSetupDiscoveryChannelPluginCatalogEntries,
+    ],
+  ])("%s", (_title, listEntries) => {
     listRawChannelPluginCatalogEntries.mockImplementation(
       (options?: { excludeWorkspace?: boolean; extraPaths?: string[] }) => {
-        expect(options?.extraPaths).toEqual(["/tmp/load-path-a", "/tmp/load-path-b"]);
+        expect(options?.extraPaths).toEqual(NORMALIZED_LOAD_PATHS);
         return [];
       },
     );
 
     expect(
-      listTrustedChannelPluginCatalogEntries({
-        cfg: {
-          plugins: {
-            load: {
-              paths: [" /tmp/load-path-a ", "", "/tmp/load-path-b"],
-            },
-          },
-        },
+      listEntries({
+        cfg: { plugins: { load: { paths: RAW_LOAD_PATHS } } },
         workspaceDir: "/tmp/workspace",
       }),
     ).toStrictEqual([]);
     expect(listRawChannelPluginCatalogEntries).toHaveBeenNthCalledWith(1, {
       env: undefined,
-      extraPaths: ["/tmp/load-path-a", "/tmp/load-path-b"],
-      workspaceDir: "/tmp/workspace",
-    });
-  });
-
-  it("passes normalized load paths into setup discovery listing", () => {
-    listRawChannelPluginCatalogEntries.mockImplementation(
-      (options?: { excludeWorkspace?: boolean; extraPaths?: string[] }) => {
-        expect(options?.extraPaths).toEqual(["/tmp/load-path-a", "/tmp/load-path-b"]);
-        return [];
-      },
-    );
-
-    expect(
-      listSetupDiscoveryChannelPluginCatalogEntries({
-        cfg: {
-          plugins: {
-            load: {
-              paths: [" /tmp/load-path-a ", "", "/tmp/load-path-b"],
-            },
-          },
-        },
-        workspaceDir: "/tmp/workspace",
-      }),
-    ).toStrictEqual([]);
-    expect(listRawChannelPluginCatalogEntries).toHaveBeenNthCalledWith(1, {
-      env: undefined,
-      extraPaths: ["/tmp/load-path-a", "/tmp/load-path-b"],
+      extraPaths: NORMALIZED_LOAD_PATHS,
       workspaceDir: "/tmp/workspace",
     });
   });
 
   it("falls back past an untrusted config-origin shadow to the bundled entry", () => {
-    getChannelPluginCatalogEntry.mockImplementation(
-      (
-        _channelId: string,
-        options?: {
-          extraPaths?: string[];
-          excludePluginRefs?: Array<{ pluginId: string; origin?: string }>;
-          workspaceDir?: string;
-        },
-      ) => {
-        expect(options?.extraPaths).toEqual(["/tmp/load-path-a"]);
-        if (
-          options?.excludePluginRefs?.some(
-            (entry) => entry.pluginId === "config-shadow" && entry.origin === "config",
-          )
-        ) {
-          return {
-            id: "msteams",
-            pluginId: "bundled-msteams",
-            origin: "bundled",
-            meta: {
-              id: "msteams",
-              label: "Bundled Teams",
-              selectionLabel: "Bundled Teams",
-              docsPath: "/channels/msteams",
-              blurb: "bundled entry",
-            },
-            install: { localPath: "./bundled/msteams", defaultChoice: "local" },
-          };
-        }
-        return {
-          id: "msteams",
-          pluginId: "config-shadow",
-          origin: "config",
-          meta: {
-            id: "msteams",
-            label: "Shadow Teams",
-            selectionLabel: "Shadow Teams",
-            docsPath: "/channels/msteams",
-            blurb: "config shadow",
-          },
-          install: { localPath: "./plugins/msteams-shadow", defaultChoice: "local" },
-        };
-      },
-    );
+    mockTeamsConfigFallback();
 
     expect(
       getTrustedChannelPluginCatalogEntry("msteams", {
@@ -191,48 +217,22 @@ describe("trusted-catalog load-path discovery", () => {
   });
 
   it("keeps origin-specific fallback when local and bundled entries share a plugin id", () => {
-    getChannelPluginCatalogEntry.mockImplementation(
-      (
-        _channelId: string,
-        options?: {
-          excludePluginRefs?: Array<{ pluginId: string; origin?: string }>;
-          workspaceDir?: string;
-        },
-      ) => {
-        if (
-          options?.excludePluginRefs?.some(
-            (entry) => entry.pluginId === "telegram" && entry.origin === "config",
-          )
-        ) {
-          return {
-            id: "telegram",
-            pluginId: "telegram",
-            origin: "bundled",
-            meta: {
-              id: "telegram",
-              label: "Telegram",
-              selectionLabel: "Telegram",
-              docsPath: "/channels/telegram",
-              blurb: "bundled entry",
-            },
-            install: { localPath: "./bundled/telegram", defaultChoice: "local" },
-          };
-        }
-        return {
-          id: "telegram",
-          pluginId: "telegram",
-          origin: "config",
-          meta: {
-            id: "telegram",
-            label: "Telegram Shadow",
-            selectionLabel: "Telegram Shadow",
-            docsPath: "/channels/telegram",
-            blurb: "config shadow",
-          },
-          install: { localPath: "./plugins/telegram-shadow", defaultChoice: "local" },
-        };
-      },
-    );
+    mockCatalogFallback({
+      rejected: createCatalogEntry({
+        id: "telegram",
+        pluginId: "telegram",
+        origin: "config",
+        label: "Telegram Shadow",
+        localPath: "./plugins/telegram-shadow",
+      }),
+      fallback: createCatalogEntry({
+        id: "telegram",
+        pluginId: "telegram",
+        origin: "bundled",
+        label: "Telegram",
+        localPath: "./bundled/telegram",
+      }),
+    });
 
     expect(
       getTrustedChannelPluginCatalogEntry("telegram", {
@@ -259,19 +259,15 @@ describe("trusted-catalog load-path discovery", () => {
   });
 
   it("stops when fallback lookup resurfaces the same untrusted local entry", () => {
-    getChannelPluginCatalogEntry.mockReturnValue({
-      id: "msteams",
-      pluginId: "config-shadow",
-      origin: "config",
-      meta: {
+    getChannelPluginCatalogEntry.mockReturnValue(
+      createCatalogEntry({
         id: "msteams",
+        pluginId: "config-shadow",
+        origin: "config",
         label: "Shadow Teams",
-        selectionLabel: "Shadow Teams",
-        docsPath: "/channels/msteams",
-        blurb: "config shadow",
-      },
-      install: { localPath: "./plugins/msteams-shadow", defaultChoice: "local" },
-    });
+        localPath: "./plugins/msteams-shadow",
+      }),
+    );
 
     expect(
       getTrustedChannelPluginCatalogEntry("msteams", {
@@ -295,50 +291,15 @@ describe("trusted-catalog load-path discovery", () => {
   });
 
   it("keeps setup discovery visible when an untrusted config-origin entry has no fallback", () => {
-    listRawChannelPluginCatalogEntries.mockReturnValue([
-      {
-        id: "e2e-load-paths",
-        pluginId: "config-shadow",
-        origin: "config",
-        meta: {
-          id: "e2e-load-paths",
-          label: "E2E Load Paths",
-          selectionLabel: "E2E Load Paths",
-          docsPath: "/channels/e2e-load-paths",
-          blurb: "config shadow",
-        },
-        install: { localPath: "./plugins/e2e-load-paths", defaultChoice: "local" },
-      },
-    ]);
-    getChannelPluginCatalogEntry.mockImplementation(
-      (
-        _channelId: string,
-        options?: {
-          extraPaths?: string[];
-          excludePluginRefs?: Array<{ pluginId: string; origin?: string }>;
-          workspaceDir?: string;
-        },
-      ) => {
-        expect(options?.extraPaths).toEqual(["/tmp/load-path-a"]);
-        return options?.excludePluginRefs?.some(
-          (entry) => entry.pluginId === "config-shadow" && entry.origin === "config",
-        )
-          ? undefined
-          : {
-              id: "e2e-load-paths",
-              pluginId: "config-shadow",
-              origin: "config",
-              meta: {
-                id: "e2e-load-paths",
-                label: "E2E Load Paths",
-                selectionLabel: "E2E Load Paths",
-                docsPath: "/channels/e2e-load-paths",
-                blurb: "config shadow",
-              },
-              install: { localPath: "./plugins/e2e-load-paths", defaultChoice: "local" },
-            };
-      },
-    );
+    const rejected = createCatalogEntry({
+      id: "e2e-load-paths",
+      pluginId: "config-shadow",
+      origin: "config",
+      label: "E2E Load Paths",
+      localPath: "./plugins/e2e-load-paths",
+    });
+    listRawChannelPluginCatalogEntries.mockReturnValue([rejected]);
+    mockCatalogFallback({ rejected, expectedExtraPaths: ["/tmp/load-path-a"] });
 
     expect(
       listSetupDiscoveryChannelPluginCatalogEntries({
@@ -361,50 +322,7 @@ describe("trusted-catalog load-path discovery", () => {
   });
 
   it("falls back past a denylisted config-origin shadow even when it is explicitly allowed", () => {
-    getChannelPluginCatalogEntry.mockImplementation(
-      (
-        _channelId: string,
-        options?: {
-          extraPaths?: string[];
-          excludePluginRefs?: Array<{ pluginId: string; origin?: string }>;
-          workspaceDir?: string;
-        },
-      ) => {
-        expect(options?.extraPaths).toEqual(["/tmp/load-path-a"]);
-        if (
-          options?.excludePluginRefs?.some(
-            (entry) => entry.pluginId === "config-shadow" && entry.origin === "config",
-          )
-        ) {
-          return {
-            id: "msteams",
-            pluginId: "bundled-msteams",
-            origin: "bundled",
-            meta: {
-              id: "msteams",
-              label: "Bundled Teams",
-              selectionLabel: "Bundled Teams",
-              docsPath: "/channels/msteams",
-              blurb: "bundled entry",
-            },
-            install: { localPath: "./bundled/msteams", defaultChoice: "local" },
-          };
-        }
-        return {
-          id: "msteams",
-          pluginId: "config-shadow",
-          origin: "config",
-          meta: {
-            id: "msteams",
-            label: "Shadow Teams",
-            selectionLabel: "Shadow Teams",
-            docsPath: "/channels/msteams",
-            blurb: "config shadow",
-          },
-          install: { localPath: "./plugins/msteams-shadow", defaultChoice: "local" },
-        };
-      },
-    );
+    mockTeamsConfigFallback();
 
     expect(
       getTrustedChannelPluginCatalogEntry("msteams", {
@@ -427,44 +345,11 @@ describe("trusted-catalog load-path discovery", () => {
   });
 
   it("falls back past an auto-enabled config-origin shadow", () => {
-    getChannelPluginCatalogEntry.mockImplementation(
-      (
-        _channelId: string,
-        options?: {
-          excludePluginRefs?: Array<{ pluginId: string; origin?: string }>;
-          workspaceDir?: string;
-        },
-      ) =>
-        options?.excludePluginRefs?.some(
-          (entry) => entry.pluginId === "config-shadow" && entry.origin === "config",
-        )
-          ? {
-              id: "telegram",
-              pluginId: "@openclaw/telegram",
-              origin: "bundled",
-              meta: {
-                id: "telegram",
-                label: "Telegram",
-                selectionLabel: "Telegram",
-                docsPath: "/channels/telegram",
-                blurb: "bundled entry",
-              },
-              install: { localPath: "./bundled/telegram", defaultChoice: "local" },
-            }
-          : {
-              id: "telegram",
-              pluginId: "config-shadow",
-              origin: "config",
-              meta: {
-                id: "telegram",
-                label: "Telegram Shadow",
-                selectionLabel: "Telegram Shadow",
-                docsPath: "/channels/telegram",
-                blurb: "config shadow",
-              },
-              install: { localPath: "./plugins/telegram-shadow", defaultChoice: "local" },
-            },
-    );
+    mockTelegramShadowFallback({
+      pluginId: "config-shadow",
+      origin: "config",
+      localPath: "./plugins/telegram-shadow",
+    });
 
     expect(
       getTrustedChannelPluginCatalogEntry("telegram", {
@@ -490,44 +375,11 @@ describe("trusted-catalog load-path discovery", () => {
   });
 
   it("falls back past an untrusted global shadow to the bundled entry", () => {
-    getChannelPluginCatalogEntry.mockImplementation(
-      (
-        _channelId: string,
-        options?: {
-          excludePluginRefs?: Array<{ pluginId: string; origin?: string }>;
-          workspaceDir?: string;
-        },
-      ) =>
-        options?.excludePluginRefs?.some(
-          (entry) => entry.pluginId === "global-shadow" && entry.origin === "global",
-        )
-          ? {
-              id: "telegram",
-              pluginId: "@openclaw/telegram",
-              origin: "bundled",
-              meta: {
-                id: "telegram",
-                label: "Telegram",
-                selectionLabel: "Telegram",
-                docsPath: "/channels/telegram",
-                blurb: "bundled entry",
-              },
-              install: { localPath: "./bundled/telegram", defaultChoice: "local" },
-            }
-          : {
-              id: "telegram",
-              pluginId: "global-shadow",
-              origin: "global",
-              meta: {
-                id: "telegram",
-                label: "Telegram Shadow",
-                selectionLabel: "Telegram Shadow",
-                docsPath: "/channels/telegram",
-                blurb: "global shadow",
-              },
-              install: { localPath: "./state/extensions/telegram", defaultChoice: "local" },
-            },
-    );
+    mockTelegramShadowFallback({
+      pluginId: "global-shadow",
+      origin: "global",
+      localPath: "./state/extensions/telegram",
+    });
 
     expect(
       getTrustedChannelPluginCatalogEntry("telegram", {
@@ -546,44 +398,11 @@ describe("trusted-catalog load-path discovery", () => {
   });
 
   it("falls back past an explicitly disabled workspace shadow", () => {
-    getChannelPluginCatalogEntry.mockImplementation(
-      (
-        _channelId: string,
-        options?: {
-          excludePluginRefs?: Array<{ pluginId: string; origin?: string }>;
-          workspaceDir?: string;
-        },
-      ) =>
-        options?.excludePluginRefs?.some(
-          (entry) => entry.pluginId === "workspace-shadow" && entry.origin === "workspace",
-        )
-          ? {
-              id: "telegram",
-              pluginId: "@openclaw/telegram",
-              origin: "bundled",
-              meta: {
-                id: "telegram",
-                label: "Telegram",
-                selectionLabel: "Telegram",
-                docsPath: "/channels/telegram",
-                blurb: "bundled entry",
-              },
-              install: { localPath: "./bundled/telegram", defaultChoice: "local" },
-            }
-          : {
-              id: "telegram",
-              pluginId: "workspace-shadow",
-              origin: "workspace",
-              meta: {
-                id: "telegram",
-                label: "Telegram Shadow",
-                selectionLabel: "Telegram Shadow",
-                docsPath: "/channels/telegram",
-                blurb: "workspace shadow",
-              },
-              install: { localPath: "./workspace/telegram", defaultChoice: "local" },
-            },
-    );
+    mockTelegramShadowFallback({
+      pluginId: "workspace-shadow",
+      origin: "workspace",
+      localPath: "./workspace/telegram",
+    });
 
     expect(
       getTrustedChannelPluginCatalogEntry("telegram", {


### PR DESCRIPTION
## What Problem This Solves

The trusted channel catalog security regression suite repeated complete catalog entries and fallback mock logic across each trust-policy case. That made the owner test unnecessarily large and made origin-sensitive fallback coverage harder to audit consistently.

## Why This Change Was Made

This replaces repeated test data with file-local catalog-entry and fallback factories, and parameterizes the two identical normalized-listing cases. The production trust owner and all runtime behavior remain unchanged; the helpers keep origin plus plugin-ID exclusion explicit and preserve the original fixtures, calls, names, and assertion order.

Architectural owner: `src/commands/channel-setup/trusted-catalog.test.ts`. Canonical production owners remain `src/commands/channel-setup/trusted-catalog.ts` and `src/channels/plugins/catalog.ts`.

Removed paths: duplicated config/global/workspace/bundled catalog object construction and repeated fallback mock branches.

## User Impact

No user-visible or production behavior changes. The same security and discovery behavior is covered with 181 fewer test lines, making future trust-policy changes easier to review.

Production LOC delta: **0**. Test/total delta: **+168 / -349, net -181**.

## Evidence

- Exact old/new in-memory trace comparison: **12 test names** and the ordered **28-assertion** trace are identical.
- Local focused proof: `node scripts/run-vitest.mjs src/commands/channel-setup/trusted-catalog.test.ts` — **12/12 passed**.
- Blacksmith Testbox `tbx_01kz26qz4qkng0wfd0jgz3bj3q` (`blue-shrimp-421e`): **134/134** focused and sibling tests passed across trusted catalog, workspace-shadow bypass, resolution, discovery, install, channel list/add, raw catalog, and setup flow. [Actions run](https://github.com/openclaw/openclaw/actions/runs/30768421760)
- Same Testbox: `pnpm check:changed` passed, including formatting, core-test typecheck, lint, boundaries, dependency guards, dead-code scans, and ratchets.
- Hosted exact-head CI: [`openclaw/ci-gate` and all required lanes passed](https://github.com/openclaw/openclaw/actions/runs/30769911282).
- `git diff --check` passed; worktree and remote head match `de23afc246a7a27b97c45166783e4fcf29e7556d`.
- Central overlap audit: exact owner path certified **zero collision** across 179 updated PRs plus tail and race-close checks.
- Independent xhigh fixture-equivalence review: **APPROVE**, no findings; independently confirmed names, assertions, operands, matcher order, calls, fields, coverage sensitivity, and 12/12 focused proof.
- Independent xhigh trust/security review: **APPROVE**, no findings; confirmed origin-aware exclusion, repeated-fallback termination, normalized paths, auto-enable/deny/allow/global/workspace cases, callers, sibling tests, and security history.

### Current-main synthetic merge proof

The reviewed branch was intentionally not rebased so its independently reviewed exact SHA remains immutable. Instead, a conflict-free two-parent synthetic merge was constructed from current `main` `a1c2009b91b9203055ed5888d63f99c207bd3a26` and reviewed head `de23afc246a7a27b97c45166783e4fcf29e7556d`; no target-file drift exists. Synthetic merge `8670d97388dc2521b3077614d6a217d960301ee4` was validated on a fresh Blacksmith Testbox `tbx_01kz29k49kpvqfxja901bvc78d` (`amber-lobster-2dd3`). [Retrievable Actions run](https://github.com/openclaw/openclaw/actions/runs/30770247186)

Redacted after-fix terminal output:

```text
$ pnpm test src/commands/channel-setup/trusted-catalog.test.ts \
  src/commands/channel-setup/workspace-shadow-bypass.test.ts \
  src/commands/channel-setup/channel-plugin-resolution.test.ts \
  src/commands/channel-setup/discovery.test.ts \
  src/channels/plugins/catalog.test.ts
✓ trusted-catalog.test.ts (12 tests)
✓ workspace-shadow-bypass.test.ts (6 tests)
✓ channel-plugin-resolution.test.ts (5 tests)
✓ discovery.test.ts (3 tests)
✓ catalog.test.ts (7 tests)
Test Files  5 passed (5)
Tests       33 passed (33)
[test] passed 2 Vitest shards in 5.57s
blacksmith run summary ... exit=0
```

The change is test-only, so there is no changed user-visible runtime behavior to demonstrate outside the regression contract itself. The current-main proof exercises the unchanged production resolver and catalog owners through the focused/sibling tests.
