### PR TITLE
fix(cron): report a verified agent send instead of "not-requested"

### DIFF
--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -732,17 +732,29 @@ describe("CronService persists delivered status", () => {
     }
   });
 
-  it("persists lastDelivered=true when isolated job reports delivered", async () => {
+  it("persists and emits verified mode-none message-tool delivery", async () => {
+    let finishedEvent: { delivered?: boolean; deliveryStatus?: string } | undefined;
     const updated = await runIsolatedJobAndReadState({
-      job: buildAnnounceIsolatedAgentTurnJob("delivered-true"),
+      job: {
+        ...buildIsolatedAgentTurnJob("mode-none-verified-delivery"),
+        delivery: { mode: "none", channel: "forum", to: "123" },
+      },
       delivered: true,
+      delivery: {
+        delivered: true,
+        resolved: { ok: true, channel: "forum", to: "123" },
+        messageToolSentTo: [{ channel: "forum", to: "123" }],
+      },
+      onFinished: (event) => (finishedEvent = event),
     });
+
     expectSuccessfulCronRun(updated);
-    expect(updated?.state.lastDelivered).toBe(true);
-    expect(updated?.state.lastDeliveryStatus).toBe("delivered");
-    expect(updated?.state.lastDeliveryError).toBeUndefined();
-    expect(updated?.state.lastFailureNotificationDelivered).toBeUndefined();
-    expect(updated?.state.lastFailureNotificationDeliveryStatus).toBe("not-requested");
+    expect(updated?.state).toMatchObject({
+      lastDelivered: true,
+      lastDeliveryStatus: "delivered",
+      lastFailureNotificationDeliveryStatus: "not-requested",
+    });
+    expect(finishedEvent).toMatchObject({ delivered: true, deliveryStatus: "delivered" });
   });
 
   it("persists lastDelivered=false when isolated job explicitly reports not delivered", async () => {
@@ -924,20 +936,6 @@ describe("CronService persists delivered status", () => {
     expect(enqueueSystemEvent).toHaveBeenCalled();
 
     cron.stop();
-  });
-
-  it("emits delivered in the finished event", async () => {
-    let capturedEvent: { jobId: string; delivered?: boolean; deliveryStatus?: string } | undefined;
-    await runIsolatedJobAndReadState({
-      job: buildAnnounceIsolatedAgentTurnJob("event-test"),
-      delivered: true,
-      onFinished: (evt) => {
-        capturedEvent = evt;
-      },
-    });
-
-    expect(capturedEvent?.delivered).toBe(true);
-    expect(capturedEvent?.deliveryStatus).toBe("delivered");
   });
 
   it("surfaces a successful run's delivery error on the finished event", async () => {

--- a/src/cron/service/timer-trigger.ts
+++ b/src/cron/service/timer-trigger.ts
@@ -301,33 +301,31 @@ export function resolveDeliveryState(params: {
   const primaryDeliveryPlan = resolveCronDeliveryPlan(params.job);
   const primaryDeliveryRequested = primaryDeliveryPlan.requested;
   const noFailureNotification = { status: "not-requested" as const };
+  const verifiedDelivery =
+    params.delivered === true &&
+    (params.runStatus !== "error" || params.delivery?.delivered === true);
+  if (verifiedDelivery) {
+    return {
+      delivered: true,
+      status: "delivered",
+      failureNotification: noFailureNotification,
+    };
+  }
   if (!primaryDeliveryRequested) {
-    if (primaryDeliveryPlan.mode === "webhook") {
-      if (params.delivered === true) {
-        return {
-          delivered: true,
-          status: "delivered",
-          failureNotification: noFailureNotification,
-        };
-      }
-      if (params.deliveryAttempted === true) {
-        return {
-          delivered: false,
-          status: "not-delivered",
-          error: params.error,
-          failureNotification: noFailureNotification,
-        };
-      }
+    if (primaryDeliveryPlan.mode === "webhook" && params.deliveryAttempted === true) {
+      return {
+        delivered: false,
+        status: "not-delivered",
+        error: params.error,
+        failureNotification: noFailureNotification,
+      };
     }
     return {
       status: "not-requested",
       failureNotification: noFailureNotification,
     };
   }
-  if (
-    params.runStatus === "error" &&
-    !(params.delivered === true && params.delivery?.delivered === true)
-  ) {
+  if (params.runStatus === "error") {
     if (params.delivered !== undefined) {
       return {
         delivered: false,
@@ -341,13 +339,6 @@ export function resolveDeliveryState(params: {
       status: "unknown",
       error: params.error,
       failureNotification: noFailureNotification,
-    };
-  }
-  if (params.delivered === true) {
-    return {
-      delivered: true,
-      status: "delivered",
-      failureNotification: { status: "not-requested" },
     };
   }
   if (params.delivered === false) {


### PR DESCRIPTION
## What Problem This Solves

A scheduled job with `delivery.mode: "none"` could send a message through the agent's message tool, yet report `lastDeliveryStatus: "not-requested"`.

For this mode, `none` means the cron runner does not perform fallback delivery. It does not mean the agent sent nothing. Operators could not distinguish a verified agent send from a run with no send.

## Why This Change Was Made

The delivery-state projection checked the delivery mode before it checked the verified delivery fact. It handled webhook success in one branch, handled requested delivery success in another branch, and discarded the same verified fact for mode-none jobs.

The projection now has one shared verified-success path. It still reports a mode-none run with no verified send as `not-requested`. Webhook attempted failures keep their separate `not-delivered` result.

This refresh preserves the current delivery trace added after the original PR. That trace is required before an erroring run can keep an earlier successful delivery result.

## User Impact

For `delivery.mode: "none"` jobs, a verified agent message-tool send now persists and emits `delivered`. Runs with no verified send stay `not-requested`. Other delivery modes keep their existing behavior.

## Evidence

### Live Telegram red and green

The same isolated cron action ran against current main and the exact PR merge candidate. A controlled provider invoked the real message tool, and a dedicated Telegram Test Server user observed the result.

| Revision | Telegram result | Provider trace | Persisted run | Finished event | Job state |
| --- | --- | --- | --- | --- | --- |
| Main at red proof `9bd50c803cce88f2ab387ddaf6cc29b4ef004005` | One message received | Two requests: message-tool call, then tool result | `not-requested` | `not-requested` | `not-requested` |
| PR head `a80eae4a14421298f1013b5ae0df86d34690bbb8`, merge candidate `19acdf6174b28e6ca0fa01829c24927ccb27bd50` | The same message received | Two requests: message-tool call, then tool result | `delivered` | `delivered` | `delivered` |

The exact-head build came from the PR's off-host CI artifact. Its merge candidate has the PR head as a parent, and the affected cron and delivery files are identical to the PR head.
Later main commits before the refresh did not change the affected files.

### Anti-cheat control

An otherwise identical mode-none run returned `NO_REPLY` and made no message-tool call. Telegram recorded no message. The persisted run, finished event, and job state all remained `not-requested`.

### Local regression checks

```text
node scripts/run-vitest.mjs src/cron/service.persists-delivered-status.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/service/timer.regression.test.ts
Test Files  3 passed (3)
Tests       147 passed (147)

node scripts/run-oxlint.mjs src/cron/service/timer-trigger.ts src/cron/service.persists-delivered-status.test.ts
exit 0
```

Production code is net 9 lines smaller. Tests are net 2 lines smaller because the regression replaces duplicate announce-state and event coverage.

AI-assisted: prepared with AI assistance and reviewed by the author and maintainer.
