### PR TITLE
refactor(xai): deduplicate search test fixtures

### DIFF
--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -91,22 +91,24 @@ function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
   });
 }
 
+function xaiAnswerResponse(text: string): Response {
+  return jsonResponse({
+    output: [
+      {
+        type: "message",
+        content: [{ type: "output_text", text }],
+      },
+    ],
+  });
+}
+
 function textResponse(body: string, init: ResponseInit = {}): Response {
   return new Response(body, init);
 }
 
 function installXaiWebSearchFetch() {
   const mockFetch = vi.fn((_input?: unknown, _init?: unknown) =>
-    Promise.resolve(
-      jsonResponse({
-        output: [
-          {
-            type: "message",
-            content: [{ type: "output_text", text: "Grounded Grok answer" }],
-          },
-        ],
-      }),
-    ),
+    Promise.resolve(xaiAnswerResponse("Grounded Grok answer")),
   );
   global.fetch = withFetchPreconnect(mockFetch);
   return mockFetch;
@@ -144,6 +146,51 @@ function fetchCallHeader(
     return headers.find(([key]) => key.toLowerCase() === lowerName)?.[1];
   }
   return (headers as Record<string, string | undefined>)[name];
+}
+
+function xaiPluginConfig({
+  enabled,
+  webSearch,
+  xSearch,
+}: {
+  enabled?: boolean;
+  webSearch?: Record<string, unknown>;
+  xSearch?: Record<string, unknown>;
+}) {
+  return {
+    plugins: {
+      entries: {
+        xai: {
+          ...(enabled === undefined ? {} : { enabled }),
+          config: {
+            ...(webSearch ? { webSearch } : {}),
+            ...(xSearch ? { xSearch } : {}),
+          },
+        },
+      },
+    },
+  };
+}
+
+function requireXaiWebSearchTool(
+  ctx: Parameters<ReturnType<typeof createXaiWebSearchProvider>["createTool"]>[0],
+) {
+  const tool = createXaiWebSearchProvider().createTool(ctx);
+  if (!tool) {
+    throw new Error("Expected xAI web search tool");
+  }
+  return tool;
+}
+
+function createAuthSearchTool() {
+  return requireXaiWebSearchTool({
+    config: {
+      agents: {
+        list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
+      },
+      tools: { web: { search: { provider: "grok" } } },
+    },
+  });
 }
 
 function expectCatalogEntry(
@@ -229,22 +276,14 @@ describe("xai web search config resolution", () => {
 
   it("merges canonical plugin config into the tool search config", () => {
     const searchConfig = resolveXaiToolSearchConfig({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              enabled: true,
-              config: {
-                webSearch: {
-                  apiKey: "plugin-key",
-                  inlineCitations: true,
-                  model: "grok-4-fast-reasoning",
-                },
-              },
-            },
-          },
+      config: xaiPluginConfig({
+        enabled: true,
+        webSearch: {
+          apiKey: "plugin-key",
+          inlineCitations: true,
+          model: "grok-4-fast-reasoning",
         },
-      },
+      }),
       searchConfig: { provider: "grok" },
     });
 
@@ -255,30 +294,18 @@ describe("xai web search config resolution", () => {
 
   it("treats unresolved non-env SecretRefs as missing credentials instead of using env fallback", async () => {
     await withEnvAsync({ XAI_API_KEY: "ambient-xai-test-key" }, async () => {
-      const provider = createXaiWebSearchProvider();
-      const maybeTool = provider.createTool({
-        config: {
-          plugins: {
-            entries: {
-              xai: {
-                enabled: true,
-                config: {
-                  webSearch: {
-                    apiKey: {
-                      source: "file",
-                      provider: "vault",
-                      id: "/providers/xai/web-search",
-                    },
-                  },
-                },
-              },
+      const maybeTool = requireXaiWebSearchTool({
+        config: xaiPluginConfig({
+          enabled: true,
+          webSearch: {
+            apiKey: {
+              source: "file",
+              provider: "vault",
+              id: "/providers/xai/web-search",
             },
           },
-        },
+        }),
       });
-      if (!maybeTool) {
-        throw new Error("expected xai web search tool");
-      }
 
       const result = await maybeTool.execute({ query: "OpenClaw" });
       expect(result.error).toBe("missing_xai_api_key");
@@ -294,28 +321,14 @@ describe("xai web search config resolution", () => {
       profileId: "xai:default",
     });
     const mockFetch = installXaiWebSearchFetch();
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
+    const tool = requireXaiWebSearchTool({
       config: {
         agents: {
           list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
         },
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "configured-xai-key",
-                },
-              },
-            },
-          },
-        },
+        ...xaiPluginConfig({ webSearch: { apiKey: "configured-xai-key" } }),
       },
     });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
 
     await tool.execute({ query: "OpenClaw Grok OAuth web search" });
 
@@ -336,8 +349,7 @@ describe("xai web search config resolution", () => {
       profileId: "xai:active",
     });
     const mockFetch = installXaiWebSearchFetch();
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
+    const tool = requireXaiWebSearchTool({
       agentDir: "/tmp/openclaw-xai-active-agent",
       config: {
         agents: {
@@ -348,9 +360,6 @@ describe("xai web search config resolution", () => {
         },
       },
     });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
 
     await tool.execute({ query: "OpenClaw Grok active agent OAuth web search" });
 
@@ -380,35 +389,9 @@ describe("xai web search config resolution", () => {
     const mockFetch = vi
       .fn()
       .mockResolvedValueOnce(textResponse("expired", { status: 401, statusText: "Unauthorized" }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          output: [
-            {
-              type: "message",
-              content: [{ type: "output_text", text: "Fresh OAuth Grok answer" }],
-            },
-          ],
-        }),
-      );
+      .mockResolvedValueOnce(xaiAnswerResponse("Fresh OAuth Grok answer"));
     global.fetch = withFetchPreconnect(mockFetch);
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
-      config: {
-        agents: {
-          list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
-        },
-        tools: {
-          web: {
-            search: {
-              provider: "grok",
-            },
-          },
-        },
-      },
-    });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
+    const tool = createAuthSearchTool();
 
     const result = await tool.execute({ query: "OpenClaw Grok OAuth refresh test" });
 
@@ -449,35 +432,9 @@ describe("xai web search config resolution", () => {
     const mockFetch = vi
       .fn()
       .mockResolvedValueOnce(textResponse("revoked", { status: 401, statusText: "Unauthorized" }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          output: [
-            {
-              type: "message",
-              content: [{ type: "output_text", text: "API key fallback Grok answer" }],
-            },
-          ],
-        }),
-      );
+      .mockResolvedValueOnce(xaiAnswerResponse("API key fallback Grok answer"));
     global.fetch = withFetchPreconnect(mockFetch);
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
-      config: {
-        agents: {
-          list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
-        },
-        tools: {
-          web: {
-            search: {
-              provider: "grok",
-            },
-          },
-        },
-      },
-    });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
+    const tool = createAuthSearchTool();
 
     const result = await tool.execute({ query: "OpenClaw Grok API fallback test" });
 
@@ -544,35 +501,9 @@ describe("xai web search config resolution", () => {
     const mockFetch = vi
       .fn()
       .mockResolvedValueOnce(textResponse("revoked", { status: 401, statusText: "Unauthorized" }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          output: [
-            {
-              type: "message",
-              content: [{ type: "output_text", text: "Profile API key Grok answer" }],
-            },
-          ],
-        }),
-      );
+      .mockResolvedValueOnce(xaiAnswerResponse("Profile API key Grok answer"));
     global.fetch = withFetchPreconnect(mockFetch);
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
-      config: {
-        agents: {
-          list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
-        },
-        tools: {
-          web: {
-            search: {
-              provider: "grok",
-            },
-          },
-        },
-      },
-    });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
+    const tool = createAuthSearchTool();
 
     const result = await tool.execute({ query: "OpenClaw Grok profile fallback test" });
 
@@ -607,35 +538,9 @@ describe("xai web search config resolution", () => {
       .mockResolvedValueOnce(
         textResponse("stale api key", { status: 401, statusText: "Unauthorized" }),
       )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          output: [
-            {
-              type: "message",
-              content: [{ type: "output_text", text: "Env fallback Grok answer" }],
-            },
-          ],
-        }),
-      );
+      .mockResolvedValueOnce(xaiAnswerResponse("Env fallback Grok answer"));
     global.fetch = withFetchPreconnect(mockFetch);
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
-      config: {
-        agents: {
-          list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
-        },
-        tools: {
-          web: {
-            search: {
-              provider: "grok",
-            },
-          },
-        },
-      },
-    });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
+    const tool = createAuthSearchTool();
 
     const result = await tool.execute({ query: "OpenClaw Grok API-key fallback test" });
 
@@ -661,18 +566,10 @@ describe("xai web search config resolution", () => {
 
     const next = await provider.runSetup?.({
       config: {
-        plugins: {
-          entries: {
-            xai: {
-              enabled: true,
-              config: {
-                webSearch: {
-                  apiKey: "xai-test-key",
-                },
-              },
-            },
-          },
-        },
+        ...xaiPluginConfig({
+          enabled: true,
+          webSearch: { apiKey: "xai-test-key" },
+        }),
         tools: {
           web: {
             search: {
@@ -696,17 +593,7 @@ describe("xai web search config resolution", () => {
   it("keeps explicit xSearch disablement untouched during provider-owned setup", async () => {
     const provider = createXaiWebSearchProvider();
     const config = {
-      plugins: {
-        entries: {
-          xai: {
-            config: {
-              xSearch: {
-                enabled: false,
-              },
-            },
-          },
-        },
-      },
+      ...xaiPluginConfig({ xSearch: { enabled: false } }),
       tools: {
         web: {
           search: {
@@ -730,19 +617,9 @@ describe("xai web search config resolution", () => {
 
   it("reuses the plugin web search api key for provider auth fallback", () => {
     expect(
-      resolveFallbackXaiAuth({
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-provider-fallback", // pragma: allowlist secret
-                },
-              },
-            },
-          },
-        },
-      } as never),
+      resolveFallbackXaiAuth(
+        xaiPluginConfig({ webSearch: { apiKey: "xai-provider-fallback" } }) as never,
+      ),
     ).toEqual({
       apiKey: "xai-provider-fallback",
       source: "plugins.entries.xai.config.webSearch.apiKey",
@@ -751,19 +628,13 @@ describe("xai web search config resolution", () => {
 
   it("returns a managed marker for SecretRef-backed plugin auth fallback", () => {
     expect(
-      resolveFallbackXaiAuth({
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: { source: "file", provider: "vault", id: "/xai/api-key" },
-                },
-              },
-            },
+      resolveFallbackXaiAuth(
+        xaiPluginConfig({
+          webSearch: {
+            apiKey: { source: "file", provider: "vault", id: "/xai/api-key" },
           },
-        },
-      } as never),
+        }) as never,
+      ),
     ).toEqual({
       apiKey: NON_ENV_SECRETREF_MARKER,
       source: "plugins.entries.xai.config.webSearch.apiKey",
@@ -789,27 +660,15 @@ describe("xai web search config resolution", () => {
 
   it("routes Grok web search through plugin webSearch.baseUrl", async () => {
     const mockFetch = installXaiWebSearchFetch();
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-config-test",
-                  baseUrl: "https://api.x.ai/proxy/v1/",
-                },
-              },
-            },
-          },
+    const tool = requireXaiWebSearchTool({
+      config: xaiPluginConfig({
+        webSearch: {
+          apiKey: "xai-config-test",
+          baseUrl: "https://api.x.ai/proxy/v1/",
         },
-      },
+      }),
       searchConfig: { provider: "grok" },
     });
-    if (!tool) {
-      throw new Error("Expected xAI web search tool");
-    }
 
     await tool.execute({ query: "OpenClaw Grok proxy test" });
 
@@ -832,25 +691,9 @@ describe("xai web search config resolution", () => {
       ),
     );
     global.fetch = withFetchPreconnect(mockFetch);
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-test-key", // pragma: allowlist secret
-                },
-              },
-            },
-          },
-        },
-      },
+    const tool = requireXaiWebSearchTool({
+      config: xaiPluginConfig({ webSearch: { apiKey: "xai-test-key" } }),
     });
-    if (!tool) {
-      throw new Error("Expected tool definition");
-    }
 
     await expect(tool.execute({ query: "OpenClaw" })).rejects.toThrow(
       "xAI web search failed: malformed JSON response",
@@ -862,25 +705,9 @@ describe("xai web search config resolution", () => {
       Promise.resolve(jsonResponse({ output: [] })),
     );
     global.fetch = withFetchPreconnect(mockFetch);
-    const provider = createXaiWebSearchProvider();
-    const tool = provider.createTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-test-key", // pragma: allowlist secret
-                },
-              },
-            },
-          },
-        },
-      },
+    const tool = requireXaiWebSearchTool({
+      config: xaiPluginConfig({ webSearch: { apiKey: "xai-test-key" } }),
     });
-    if (!tool) {
-      throw new Error("Expected tool definition");
-    }
 
     await expect(tool.execute({ query: "OpenClaw" })).rejects.toThrow(
       "xAI web search failed: malformed JSON response",

--- a/extensions/xai/x-search.test.ts
+++ b/extensions/xai/x-search.test.ts
@@ -76,21 +76,32 @@ function parseFirstRequestBody(mockFetch: ReturnType<typeof installXSearchFetch>
   >;
 }
 
-function createConfiguredXSearchTool() {
-  const tool = createXSearchTool({
-    config: {
-      plugins: {
-        entries: {
-          xai: {
-            config: {
-              webSearch: {
-                apiKey: "xai-config-test", // pragma: allowlist secret
-              },
-            },
+function xaiPluginConfig({
+  apiKey = "xai-config-test",
+  webSearch,
+  xSearch,
+}: {
+  apiKey?: unknown;
+  webSearch?: Record<string, unknown>;
+  xSearch?: Record<string, unknown>;
+} = {}) {
+  return {
+    plugins: {
+      entries: {
+        xai: {
+          config: {
+            webSearch: { apiKey, ...webSearch },
+            ...(xSearch ? { xSearch } : {}),
           },
         },
       },
     },
+  };
+}
+
+function createConfiguredXSearchTool(config?: Parameters<typeof xaiPluginConfig>[0]) {
+  const tool = createXSearchTool({
+    config: xaiPluginConfig(config),
   });
   if (!tool) {
     throw new Error("expected x_search tool to be configured");
@@ -104,21 +115,7 @@ afterEach(() => {
 
 describe("xai x_search tool", () => {
   it("describes query as the required instruction for the Grok X-search agent", () => {
-    const tool = createXSearchTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-plugin-key", // pragma: allowlist secret
-                },
-              },
-            },
-          },
-        },
-      },
-    });
+    const tool = createConfiguredXSearchTool({ apiKey: "xai-plugin-key" });
 
     const parameters = tool?.parameters as
       | { properties?: { query?: { description?: string } } }
@@ -149,19 +146,7 @@ describe("xai x_search tool", () => {
   it("enables x_search when runtime config carries the shared xAI key", () => {
     const tool = createXSearchTool({
       config: {},
-      runtimeConfig: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "x-search-runtime-key", // pragma: allowlist secret
-                },
-              },
-            },
-          },
-        },
-      },
+      runtimeConfig: xaiPluginConfig({ apiKey: "x-search-runtime-key" }),
     });
 
     expect(tool?.name).toBe("x_search");
@@ -187,43 +172,14 @@ describe("xai x_search tool", () => {
   });
 
   it("enables x_search when the xAI plugin web search key is configured", () => {
-    const tool = createXSearchTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-plugin-key", // pragma: allowlist secret
-                },
-              },
-            },
-          },
-        },
-      },
-    });
+    const tool = createConfiguredXSearchTool({ apiKey: "xai-plugin-key" });
 
     expect(tool?.name).toBe("x_search");
   });
 
   it("uses the xAI Responses x_search tool with structured filters", async () => {
     const mockFetch = installXSearchFetch();
-    const tool = createXSearchTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-config-test", // pragma: allowlist secret
-                },
-                xSearch: { maxTurns: 2 },
-              },
-            },
-          },
-        },
-      },
-    });
+    const tool = createConfiguredXSearchTool({ xSearch: { maxTurns: 2 } });
 
     const result = await tool?.execute?.("x-search:1", {
       query: "dinner recipes",
@@ -311,23 +267,10 @@ describe("xai x_search tool", () => {
 
   it("routes x_search through plugin-owned xSearch.baseUrl", async () => {
     const mockFetch = installXSearchFetch();
-    const tool = createXSearchTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-config-test", // pragma: allowlist secret
-                },
-                xSearch: {
-                  enabled: true,
-                  baseUrl: "https://api.x.ai/xai-search/v1/",
-                },
-              },
-            },
-          },
-        },
+    const tool = createConfiguredXSearchTool({
+      xSearch: {
+        enabled: true,
+        baseUrl: "https://api.x.ai/xai-search/v1/",
       },
     });
 
@@ -340,24 +283,10 @@ describe("xai x_search tool", () => {
 
   it("shares plugin webSearch.baseUrl with x_search when xSearch.baseUrl is unset", async () => {
     const mockFetch = installXSearchFetch();
-    const tool = createXSearchTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-plugin-key", // pragma: allowlist secret
-                  baseUrl: "https://api.x.ai/shared/v1/",
-                },
-                xSearch: {
-                  enabled: true,
-                },
-              },
-            },
-          },
-        },
-      },
+    const tool = createConfiguredXSearchTool({
+      apiKey: "xai-plugin-key",
+      webSearch: { baseUrl: "https://api.x.ai/shared/v1/" },
+      xSearch: { enabled: true },
     });
 
     await tool?.execute?.("x-search:web-search-base-url", {
@@ -369,21 +298,7 @@ describe("xai x_search tool", () => {
 
   it("reuses the xAI plugin web search key for x_search requests", async () => {
     const mockFetch = installXSearchFetch();
-    const tool = createXSearchTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-plugin-key", // pragma: allowlist secret
-                },
-              },
-            },
-          },
-        },
-      },
-    });
+    const tool = createConfiguredXSearchTool({ apiKey: "xai-plugin-key" });
 
     await tool?.execute?.("x-search:plugin-key", {
       query: "latest post from huntharo",
@@ -402,23 +317,9 @@ describe("xai x_search tool", () => {
       ),
     );
     global.fetch = withFetchPreconnect(mockFetch);
-    const tool = createXSearchTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-plugin-key", // pragma: allowlist secret
-                },
-                xSearch: {
-                  enabled: true,
-                },
-              },
-            },
-          },
-        },
-      },
+    const tool = createConfiguredXSearchTool({
+      apiKey: "xai-plugin-key",
+      xSearch: { enabled: true },
     });
 
     await expect(
@@ -433,23 +334,9 @@ describe("xai x_search tool", () => {
       Promise.resolve(jsonResponse({ output: [] })),
     );
     global.fetch = withFetchPreconnect(mockFetch);
-    const tool = createXSearchTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-plugin-key", // pragma: allowlist secret
-                },
-                xSearch: {
-                  enabled: true,
-                },
-              },
-            },
-          },
-        },
-      },
+    const tool = createConfiguredXSearchTool({
+      apiKey: "xai-plugin-key",
+      xSearch: { enabled: true },
     });
 
     await expect(
@@ -462,32 +349,10 @@ describe("xai x_search tool", () => {
   it("prefers the active runtime config for shared xAI keys", async () => {
     const mockFetch = installXSearchFetch();
     const tool = createXSearchTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: { source: "env", provider: "default", id: "X_SEARCH_KEY_REF" },
-                },
-              },
-            },
-          },
-        },
-      },
-      runtimeConfig: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "x-search-runtime-key", // pragma: allowlist secret
-                },
-              },
-            },
-          },
-        },
-      },
+      config: xaiPluginConfig({
+        apiKey: { source: "env", provider: "default", id: "X_SEARCH_KEY_REF" },
+      }),
+      runtimeConfig: xaiPluginConfig({ apiKey: "x-search-runtime-key" }),
     });
 
     await tool?.execute?.("x-search:runtime-key", {
@@ -499,21 +364,7 @@ describe("xai x_search tool", () => {
 
   it("rejects invalid date ordering before calling xAI", async () => {
     const mockFetch = installXSearchFetch();
-    const tool = createXSearchTool({
-      config: {
-        plugins: {
-          entries: {
-            xai: {
-              config: {
-                webSearch: {
-                  apiKey: "xai-config-test", // pragma: allowlist secret
-                },
-              },
-            },
-          },
-        },
-      },
-    });
+    const tool = createConfiguredXSearchTool();
 
     await expect(
       tool?.execute?.("x-search:bad-dates", {


### PR DESCRIPTION
## What Problem This Solves

The xAI search tests repeated large plugin-config, configured-tool, and Responses API success fixtures across closely related cases. That obscured the behavioral differences each case was intended to verify and added 322 avoidable lines to the test surface.

## Why This Change Was Made

This consolidates the repeated xAI web-search and X-search setup into small canonical test fixtures while leaving every test title and assertion site intact. The scope is test-only: no production code, runtime behavior, auth precedence, provider contract, or public surface changes.

## User Impact

No user-visible behavior changes. Maintainers get a smaller search-test surface with one canonical representation for xAI plugin config, configured tools, and successful Responses API payloads.

## Evidence

- Production LOC delta: 0; total delta: +154/-476, net -322.
- Baseline and final focused Blacksmith runs: 63/63 tests passed with the same verbose test titles.
- Full xAI plugin suite: 26 files, 397/397 tests passed.
- Final `pnpm check:changed`: format, lint, extension-test typecheck, plugin boundaries, dead-export scans, and ratchets passed.
- `git diff --check`: passed.
- Direct contract preflight covered the current official xAI Web Search, X Search, citations, and tool-usage documentation plus upstream SDK/proto definitions for `web_search`, `x_search`, handle limits, date filters, media toggles, citations, and `max_turns`.
- Central collision sweep: clear for the exact two paths across 244 updated PRs plus race-close.
