### PR TITLE
test(gateway): unsuppress tracer plugin in queued-session rotation e2e

### DIFF
--- a/test/gateway-queued-session-rotation.e2e.test.ts
+++ b/test/gateway-queued-session-rotation.e2e.test.ts
@@ -253,7 +253,10 @@ describe("Gateway queued session rotation", () => {
         name: "queued-session-rotation",
         gatewayToken: "secret-token",
         config,
-        env: { OPENCLAW_SKIP_PROVIDERS: undefined },
+        env: {
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        },
       });
       instances.push(instance);
       await instance.startGateway();


### PR DESCRIPTION
## What Problem This Solves

Two gateway E2Es have been red on main, observed during the lint-cleanup work (#118098) and adjudicated there as not-caused-by-that-branch. This PR resolves their true state:

- `test/gateway-queued-session-rotation.e2e.test.ts` failed deterministically because `OPENCLAW_TEST_MINIMAL_GATEWAY` leaked into its environment and suppressed the tracer plugin the test's assertion depends on — a test-setup bug, not flake.
- `test/huggingface-local-app-openclaw.e2e.test.ts` fails because of a real product regression: the native llama-cpp plugin hijacks an explicitly configured HTTP provider route (MLX passes, llama.cpp returns `LLM request failed`). Filed as #118212 with evidence; no product code is changed blind in this PR.

## Why This Change Was Made

The rotation test now clears `OPENCLAW_TEST_MINIMAL_GATEWAY` for its gateway spawn so the tracer plugin loads. Both tests are ungated hermetic E2Es — neither needs external services, so no environment skip is warranted.

## User Impact

None at runtime (test-only, +4/−1). The rotation E2E is green again; the HF E2E remains red pointing at the real routing regression tracked in #118212.

## Evidence

- Post-fix: queued rotation passed (20.7s); HF MLX case passed, llama.cpp failed exactly as filed in #118212
- `tsgo:test`, changed-file format/oxlint, `git diff --check`: clean; structured autoreview clean
- Full E2E lane on this host is separately unhealthy (multiple unrelated main failures/timeouts before the 300s no-output guard) — targeted runs used for proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)
