### PR TITLE
refactor(msteams): consolidate Graph upload test fixtures

### DIFF
--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -9,6 +9,9 @@ import {
 } from "./request-timeout.js";
 
 const SHAREPOINT_UPLOAD_BASE_TIMEOUT_MS = resolveMSTeamsSharePointUploadTimeoutMs(0);
+const DEFAULT_BUFFER = Buffer.from("world");
+const DEFAULT_UPLOAD_RESULT = { id: "item-1", webUrl: "https://example.com/1", name: "a.txt" };
+const tokenProvider = { getAccessToken: vi.fn(async () => "graph-token") };
 
 type FetchCall = [string, { method?: string; headers?: Record<string, string> } | undefined];
 
@@ -38,6 +41,76 @@ function bodyOnlyErrorResponse(body: string, status = 500): Response {
   } as unknown as Response;
 }
 
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+type GraphRoute = {
+  includes: string;
+  respond: (init?: RequestInit) => Response | Promise<Response>;
+};
+
+function createGraphFetch(...routes: GraphRoute[]): ReturnType<typeof vi.fn> {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const route = routes.find((candidate) => url.includes(candidate.includes));
+    if (!route) {
+      throw new Error(`Unexpected SharePoint request: ${url}`);
+    }
+    return await route.respond(init);
+  });
+}
+
+function fixedGraphRoute(includes: string, value: unknown, status = 200): GraphRoute {
+  return {
+    includes,
+    respond: () =>
+      typeof value === "string" ? new Response(value, { status }) : jsonResponse(value, status),
+  };
+}
+
+function hangingGraphRoute(includes: string): GraphRoute {
+  return {
+    includes,
+    respond: async (init) =>
+      await new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error("Expected fetch AbortSignal"));
+          return;
+        }
+        signal.addEventListener("abort", () => reject(abortReasonError(signal)), { once: true });
+      }),
+  };
+}
+
+function runGraphUpload(
+  fetchFn: ReturnType<typeof vi.fn>,
+  overrides: Partial<Parameters<typeof uploadAndShareSharePoint>[0]> = {},
+): ReturnType<typeof uploadAndShareSharePoint> {
+  return uploadAndShareSharePoint({
+    buffer: DEFAULT_BUFFER,
+    filename: DEFAULT_UPLOAD_RESULT.name,
+    siteId: "site-123",
+    tokenProvider,
+    fetchFn: fetchFn as unknown as typeof fetch,
+    ...overrides,
+  });
+}
+
+function uploadWithPerUserSharing(
+  fetchFn: ReturnType<typeof vi.fn>,
+  accessTokenProvider = tokenProvider,
+) {
+  return runGraphUpload(fetchFn, {
+    chatId: "chat-123",
+    usePerUserSharing: true,
+    tokenProvider: accessTokenProvider,
+  });
+}
+
 async function waitForFetchCall(fetchFn: ReturnType<typeof vi.fn>, index = 0): Promise<void> {
   // Response parsing can span several microtasks before the next Graph request starts.
   for (let i = 0; i < 20 && fetchFn.mock.calls.length <= index; i += 1) {
@@ -60,17 +133,7 @@ function abortReasonError(signal: AbortSignal): Error {
 }
 
 function createHangingFetch(): ReturnType<typeof vi.fn> {
-  return vi.fn(
-    async (_url: string, init?: RequestInit) =>
-      await new Promise<Response>((_resolve, reject) => {
-        const signal = init?.signal;
-        if (!signal) {
-          reject(new Error("Expected fetch AbortSignal"));
-          return;
-        }
-        signal.addEventListener("abort", () => reject(abortReasonError(signal)), { once: true });
-      }),
-  );
+  return createGraphFetch(hangingGraphRoute(""));
 }
 
 function createHangingBodyFetch(): ReturnType<typeof vi.fn> {
@@ -94,6 +157,19 @@ function createHangingBodyFetch(): ReturnType<typeof vi.fn> {
   });
 }
 
+function createDelayedUploadFetch(value: unknown, delayMs: number): ReturnType<typeof vi.fn> {
+  return vi.fn(async (_url: string, init?: RequestInit) => {
+    const signal = init?.signal;
+    if (!signal) {
+      throw new Error("Expected fetch AbortSignal");
+    }
+    return await new Promise<Response>((resolve, reject) => {
+      signal.addEventListener("abort", () => reject(abortReasonError(signal)), { once: true });
+      setTimeout(() => resolve(jsonResponse(value)), delayMs);
+    });
+  });
+}
+
 function expectMSTeamsTimeout(promise: Promise<unknown>, label: string, timeoutMs: number) {
   return expect(promise).rejects.toMatchObject({
     name: "TimeoutError",
@@ -101,32 +177,46 @@ function expectMSTeamsTimeout(promise: Promise<unknown>, label: string, timeoutM
   });
 }
 
-type UploadToSharePointParams = Omit<
-  Parameters<typeof uploadAndShareSharePoint>[0],
-  "chatId" | "usePerUserSharing"
+type UploadToSharePointParams = Partial<
+  Omit<Parameters<typeof uploadAndShareSharePoint>[0], "chatId" | "usePerUserSharing">
 >;
 
-async function uploadToSharePoint(params: UploadToSharePointParams) {
+async function uploadToSharePoint(params: UploadToSharePointParams = {}) {
   const uploadFetch = params.fetchFn ?? fetch;
   const fetchFn: typeof fetch = async (input, init) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
     if (url.endsWith("/createLink")) {
-      return new Response(JSON.stringify({ link: { webUrl: "https://example.com/share" } }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+      return jsonResponse({ link: { webUrl: "https://example.com/share" } });
     }
     return await uploadFetch(input, init);
   };
-  const result = await uploadAndShareSharePoint({ ...params, fetchFn });
+  const result = await uploadAndShareSharePoint({
+    buffer: params.buffer ?? DEFAULT_BUFFER,
+    filename: params.filename ?? DEFAULT_UPLOAD_RESULT.name,
+    siteId: params.siteId ?? "site-123",
+    tokenProvider: params.tokenProvider ?? tokenProvider,
+    contentType: params.contentType,
+    fetchFn,
+  });
   return { id: result.itemId, webUrl: result.webUrl, name: result.name };
 }
 
-describe("graph upload helpers", () => {
-  const tokenProvider = {
-    getAccessToken: vi.fn(async () => "graph-token"),
-  };
+async function startTimedUpload(
+  fetchFn: ReturnType<typeof vi.fn>,
+  filename: string,
+  buffer = DEFAULT_BUFFER,
+) {
+  const timeoutMs = resolveMSTeamsSharePointUploadTimeoutMs(buffer.length);
+  const upload = uploadToSharePoint({
+    buffer,
+    filename,
+    fetchFn: fetchFn as unknown as typeof fetch,
+  });
+  await waitForFetchCall(fetchFn);
+  return { upload, signal: fetchSignal(fetchFn), timeoutMs };
+}
 
+describe("graph upload helpers", () => {
   it("requires a non-empty SharePoint site ID", () => {
     expect(() => requireMSTeamsSharePointSiteId()).toThrow(
       "channels.msteams.sharePointSiteId is required",
@@ -135,22 +225,12 @@ describe("graph upload helpers", () => {
   });
 
   it("uploads to SharePoint with the site drive path", async () => {
-    const fetchFn = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({ id: "item-2", webUrl: "https://example.com/2", name: "b.txt" }),
-          {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          },
-        ),
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({ id: "item-2", webUrl: "https://example.com/2", name: "b.txt" }),
     );
 
     const result = await uploadToSharePoint({
-      buffer: Buffer.from("world"),
       filename: "b.txt",
-      siteId: "site-123",
-      tokenProvider,
       fetchFn: withFetchPreconnect(fetchFn),
     });
 
@@ -169,23 +249,13 @@ describe("graph upload helpers", () => {
     // Regression: openclaw-runtime image assets reuse names (image-1.png). Graph's default
     // replace overwrote the prior file and Teams (caching cards by driveItem URL) showed the
     // stale image; rename mints a distinct item, so callers use the returned name, not the request.
-    const fetchFn = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            id: "item-9",
-            webUrl: "https://example.com/9",
-            name: "image-1 1.png",
-          }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        ),
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({ id: "item-9", webUrl: "https://example.com/9", name: "image-1 1.png" }),
     );
 
     const result = await uploadToSharePoint({
       buffer: Buffer.from("img"),
       filename: "image-1.png",
-      siteId: "site-123",
-      tokenProvider,
       fetchFn: withFetchPreconnect(fetchFn),
     });
 
@@ -197,20 +267,11 @@ describe("graph upload helpers", () => {
   });
 
   it("rejects upload responses missing required fields", async () => {
-    const fetchFn = vi.fn(
-      async () =>
-        new Response(JSON.stringify({ id: "item-3" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-    );
+    const fetchFn = vi.fn(async () => jsonResponse({ id: "item-3" }));
 
     await expect(
       uploadToSharePoint({
-        buffer: Buffer.from("world"),
         filename: "bad.txt",
-        siteId: "site-123",
-        tokenProvider,
         fetchFn: withFetchPreconnect(fetchFn),
       }),
     ).rejects.toThrow("SharePoint upload response missing required fields");
@@ -224,10 +285,7 @@ describe("graph upload helpers", () => {
     let error: unknown;
     try {
       await uploadToSharePoint({
-        buffer: Buffer.from("world"),
         filename: "large.txt",
-        siteId: "site-123",
-        tokenProvider,
         fetchFn: fetchFn as unknown as typeof fetch,
       });
     } catch (caught) {
@@ -243,13 +301,7 @@ describe("graph upload helpers", () => {
 });
 
 describe("graph upload request timeouts", () => {
-  const tokenProvider = {
-    getAccessToken: vi.fn(async () => "graph-token"),
-  };
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+  afterEach(() => vi.useRealTimers());
 
   it("bounds Graph token acquisition before starting an upload", async () => {
     vi.useFakeTimers();
@@ -259,9 +311,7 @@ describe("graph upload request timeouts", () => {
     const fetchFn = vi.fn();
 
     const upload = uploadToSharePoint({
-      buffer: Buffer.from("world"),
       filename: "token-hang.txt",
-      siteId: "site-123",
       tokenProvider: hangingTokenProvider,
       fetchFn: fetchFn as unknown as typeof fetch,
     });
@@ -279,19 +329,7 @@ describe("graph upload request timeouts", () => {
   it("aborts SharePoint uploads that hang before response headers", async () => {
     vi.useFakeTimers();
     const fetchFn = createHangingFetch();
-    const buffer = Buffer.from("world");
-    const timeoutMs = resolveMSTeamsSharePointUploadTimeoutMs(buffer.length);
-
-    const upload = uploadToSharePoint({
-      buffer,
-      filename: "hang.txt",
-      siteId: "site-123",
-      tokenProvider,
-      fetchFn: fetchFn as unknown as typeof fetch,
-    });
-    await waitForFetchCall(fetchFn);
-
-    const signal = fetchSignal(fetchFn);
+    const { upload, signal, timeoutMs } = await startTimedUpload(fetchFn, "hang.txt");
     expect(signal.aborted).toBe(false);
     const assertion = expectMSTeamsTimeout(upload, "MS Teams SharePoint upload", timeoutMs);
 
@@ -304,18 +342,7 @@ describe("graph upload request timeouts", () => {
   it("keeps the SharePoint timeout active while reading the response body", async () => {
     vi.useFakeTimers();
     const fetchFn = createHangingBodyFetch();
-    const buffer = Buffer.from("world");
-    const timeoutMs = resolveMSTeamsSharePointUploadTimeoutMs(buffer.length);
-
-    const upload = uploadToSharePoint({
-      buffer,
-      filename: "body-hang.txt",
-      siteId: "site-123",
-      tokenProvider,
-      fetchFn: fetchFn as unknown as typeof fetch,
-    });
-    await waitForFetchCall(fetchFn);
-    const signal = fetchSignal(fetchFn);
+    const { upload, signal, timeoutMs } = await startTimedUpload(fetchFn, "body-hang.txt");
     const assertion = expectMSTeamsTimeout(upload, "MS Teams SharePoint upload", timeoutMs);
 
     await Promise.all([assertion, vi.advanceTimersByTimeAsync(timeoutMs)]);
@@ -329,35 +356,8 @@ describe("graph upload request timeouts", () => {
       webUrl: "https://example.com/slow",
       name: "slow.txt",
     };
-    const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
-      const signal = init?.signal;
-      if (!signal) {
-        throw new Error("Expected fetch AbortSignal");
-      }
-      return await new Promise<Response>((resolve, reject) => {
-        signal.addEventListener("abort", () => reject(abortReasonError(signal)), { once: true });
-        setTimeout(
-          () =>
-            resolve(
-              new Response(JSON.stringify(uploadResponse), {
-                status: 200,
-                headers: { "content-type": "application/json" },
-              }),
-            ),
-          MSTEAMS_REQUEST_TIMEOUT_MS + 1_000,
-        );
-      });
-    });
-
-    const upload = uploadToSharePoint({
-      buffer: Buffer.from("world"),
-      filename: "slow.txt",
-      siteId: "site-123",
-      tokenProvider,
-      fetchFn: fetchFn as unknown as typeof fetch,
-    });
-    await waitForFetchCall(fetchFn);
-    const signal = fetchSignal(fetchFn);
+    const fetchFn = createDelayedUploadFetch(uploadResponse, MSTEAMS_REQUEST_TIMEOUT_MS + 1_000);
+    const { upload, signal } = await startTimedUpload(fetchFn, "slow.txt");
 
     await vi.advanceTimersByTimeAsync(MSTEAMS_REQUEST_TIMEOUT_MS);
     expect(signal.aborted).toBe(false);
@@ -377,35 +377,11 @@ describe("graph upload request timeouts", () => {
       webUrl: "https://example.com/large",
       name: "large.bin",
     };
-    const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
-      const signal = init?.signal;
-      if (!signal) {
-        throw new Error("Expected fetch AbortSignal");
-      }
-      return await new Promise<Response>((resolve, reject) => {
-        signal.addEventListener("abort", () => reject(abortReasonError(signal)), { once: true });
-        setTimeout(
-          () =>
-            resolve(
-              new Response(JSON.stringify(uploadResponse), {
-                status: 200,
-                headers: { "content-type": "application/json" },
-              }),
-            ),
-          SHAREPOINT_UPLOAD_BASE_TIMEOUT_MS + 1_000,
-        );
-      });
-    });
-
-    const upload = uploadToSharePoint({
-      buffer,
-      filename: "large.bin",
-      siteId: "site-123",
-      tokenProvider,
-      fetchFn: fetchFn as unknown as typeof fetch,
-    });
-    await waitForFetchCall(fetchFn);
-    const signal = fetchSignal(fetchFn);
+    const fetchFn = createDelayedUploadFetch(
+      uploadResponse,
+      SHAREPOINT_UPLOAD_BASE_TIMEOUT_MS + 1_000,
+    );
+    const { upload, signal } = await startTimedUpload(fetchFn, "large.bin", buffer);
 
     await vi.advanceTimersByTimeAsync(SHAREPOINT_UPLOAD_BASE_TIMEOUT_MS);
     expect(signal.aborted).toBe(false);
@@ -419,18 +395,8 @@ describe("graph upload request timeouts", () => {
   it("aborts slow large SharePoint uploads after the size-aware transfer budget", async () => {
     vi.useFakeTimers();
     const buffer = Buffer.alloc(1024 * 1024);
-    const timeoutMs = resolveMSTeamsSharePointUploadTimeoutMs(buffer.length);
     const fetchFn = createHangingFetch();
-
-    const upload = uploadToSharePoint({
-      buffer,
-      filename: "large-hang.bin",
-      siteId: "site-123",
-      tokenProvider,
-      fetchFn: fetchFn as unknown as typeof fetch,
-    });
-    await waitForFetchCall(fetchFn);
-    const signal = fetchSignal(fetchFn);
+    const { upload, signal, timeoutMs } = await startTimedUpload(fetchFn, "large-hang.bin", buffer);
     const assertion = expectMSTeamsTimeout(upload, "MS Teams SharePoint upload", timeoutMs);
 
     await vi.advanceTimersByTimeAsync(timeoutMs);
@@ -441,30 +407,12 @@ describe("graph upload request timeouts", () => {
 
   it("keeps the short timeout for SharePoint control-plane requests", async () => {
     vi.useFakeTimers();
-    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url.includes("/createLink")) {
-        const signal = init?.signal;
-        if (!signal) {
-          throw new Error("Expected fetch AbortSignal");
-        }
-        return await new Promise<Response>((_resolve, reject) => {
-          signal.addEventListener("abort", () => reject(abortReasonError(signal)), { once: true });
-        });
-      }
+    const fetchFn = createGraphFetch(
+      fixedGraphRoute("/content", DEFAULT_UPLOAD_RESULT),
+      hangingGraphRoute("/createLink"),
+    );
 
-      return new Response(
-        JSON.stringify({ id: "item-1", webUrl: "https://example.com/1", name: "a.txt" }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    });
-
-    const upload = uploadAndShareSharePoint({
-      buffer: Buffer.from("world"),
-      filename: "a.txt",
-      siteId: "site-123",
-      tokenProvider,
-      fetchFn: fetchFn as unknown as typeof fetch,
-    });
+    const upload = runGraphUpload(fetchFn);
 
     await vi.advanceTimersByTimeAsync(0);
     await waitForFetchCall(fetchFn);
@@ -485,34 +433,12 @@ describe("graph upload request timeouts", () => {
 
   it("fails closed when per-user member lookup times out", async () => {
     vi.useFakeTimers();
-    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url.includes("/content")) {
-        return new Response(
-          JSON.stringify({ id: "item-1", webUrl: "https://example.com/1", name: "a.txt" }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        );
-      }
-      if (url.includes("/members")) {
-        const signal = init?.signal;
-        if (!signal) {
-          throw new Error("Expected fetch AbortSignal");
-        }
-        return await new Promise<Response>((_resolve, reject) => {
-          signal.addEventListener("abort", () => reject(abortReasonError(signal)), { once: true });
-        });
-      }
-      throw new Error(`Unexpected SharePoint request: ${url}`);
-    });
+    const fetchFn = createGraphFetch(
+      fixedGraphRoute("/content", DEFAULT_UPLOAD_RESULT),
+      hangingGraphRoute("/members"),
+    );
 
-    const upload = uploadAndShareSharePoint({
-      buffer: Buffer.from("world"),
-      filename: "a.txt",
-      siteId: "site-123",
-      chatId: "chat-123",
-      usePerUserSharing: true,
-      tokenProvider,
-      fetchFn: fetchFn as unknown as typeof fetch,
-    });
+    const upload = uploadWithPerUserSharing(fetchFn);
     await vi.advanceTimersByTimeAsync(0);
     await waitForFetchCall(fetchFn, 1);
     const memberSignal = fetchSignal(fetchFn, 1);
@@ -530,70 +456,25 @@ describe("graph upload request timeouts", () => {
   });
 
   it("fails closed when per-user member lookup has a transient Graph error", async () => {
-    const fetchFn = vi.fn(async (url: string) => {
-      if (url.includes("/content")) {
-        return new Response(
-          JSON.stringify({ id: "item-1", webUrl: "https://example.com/1", name: "a.txt" }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        );
-      }
-      if (url.includes("/members")) {
-        return new Response("temporarily unavailable", { status: 503 });
-      }
-      throw new Error(`Unexpected SharePoint request: ${url}`);
-    });
+    const fetchFn = createGraphFetch(
+      fixedGraphRoute("/content", DEFAULT_UPLOAD_RESULT),
+      fixedGraphRoute("/members", "temporarily unavailable", 503),
+    );
 
-    await expect(
-      uploadAndShareSharePoint({
-        buffer: Buffer.from("world"),
-        filename: "a.txt",
-        siteId: "site-123",
-        chatId: "chat-123",
-        usePerUserSharing: true,
-        tokenProvider,
-        fetchFn: fetchFn as unknown as typeof fetch,
-      }),
-    ).rejects.toMatchObject({ statusCode: 503 });
+    await expect(uploadWithPerUserSharing(fetchFn)).rejects.toMatchObject({ statusCode: 503 });
     expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
   it("creates a per-user link when member lookup succeeds", async () => {
-    const fetchFn = vi.fn(async (url: string) => {
-      if (url.includes("/content")) {
-        return new Response(
-          JSON.stringify({ id: "item-1", webUrl: "https://example.com/1", name: "a.txt" }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        );
-      }
-      if (url.includes("/members")) {
-        return new Response(
-          JSON.stringify({ value: [{ userId: "user-1" }, { userId: "user-2" }] }),
-          {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          },
-        );
-      }
-      if (url.endsWith("/createLink")) {
-        return new Response(JSON.stringify({ link: { webUrl: "https://example.com/private" } }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
-      }
-      throw new Error(`Unexpected SharePoint request: ${url}`);
-    });
+    const fetchFn = createGraphFetch(
+      fixedGraphRoute("/content", DEFAULT_UPLOAD_RESULT),
+      fixedGraphRoute("/members", { value: [{ userId: "user-1" }, { userId: "user-2" }] }),
+      fixedGraphRoute("/createLink", { link: { webUrl: "https://example.com/private" } }),
+    );
 
-    await expect(
-      uploadAndShareSharePoint({
-        buffer: Buffer.from("world"),
-        filename: "a.txt",
-        siteId: "site-123",
-        chatId: "chat-123",
-        usePerUserSharing: true,
-        tokenProvider,
-        fetchFn: fetchFn as unknown as typeof fetch,
-      }),
-    ).resolves.toMatchObject({ shareUrl: "https://example.com/private" });
+    await expect(uploadWithPerUserSharing(fetchFn)).resolves.toMatchObject({
+      shareUrl: "https://example.com/private",
+    });
     const [createLinkUrl, createLinkInit] = requireFetchCall(fetchFn, 2);
     expect(createLinkUrl).toContain("/beta/");
     expect((createLinkInit as RequestInit | undefined)?.body).toBe(
@@ -606,30 +487,12 @@ describe("graph upload request timeouts", () => {
   });
 
   it("fails closed when Graph denies member lookup", async () => {
-    const fetchFn = vi.fn(async (url: string) => {
-      if (url.includes("/content")) {
-        return new Response(
-          JSON.stringify({ id: "item-1", webUrl: "https://example.com/1", name: "a.txt" }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        );
-      }
-      if (url.includes("/members")) {
-        return new Response("forbidden", { status: 403 });
-      }
-      throw new Error(`Unexpected SharePoint request: ${url}`);
-    });
+    const fetchFn = createGraphFetch(
+      fixedGraphRoute("/content", DEFAULT_UPLOAD_RESULT),
+      fixedGraphRoute("/members", "forbidden", 403),
+    );
 
-    await expect(
-      uploadAndShareSharePoint({
-        buffer: Buffer.from("world"),
-        filename: "a.txt",
-        siteId: "site-123",
-        chatId: "chat-123",
-        usePerUserSharing: true,
-        tokenProvider,
-        fetchFn: fetchFn as unknown as typeof fetch,
-      }),
-    ).rejects.toMatchObject({
+    await expect(uploadWithPerUserSharing(fetchFn)).rejects.toMatchObject({
       statusCode: 403,
       message: expect.stringContaining("verify Graph chat-member permissions"),
     });
@@ -645,68 +508,27 @@ describe("graph upload request timeouts", () => {
         .mockRejectedValueOnce(tokenError)
         .mockResolvedValueOnce("graph-token"),
     };
-    const fetchFn = vi.fn(async (url: string) => {
-      if (url.includes("/content")) {
-        return new Response(
-          JSON.stringify({ id: "item-1", webUrl: "https://example.com/1", name: "a.txt" }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        );
-      }
-      throw new Error(`Unexpected SharePoint request: ${url}`);
-    });
+    const fetchFn = createGraphFetch(fixedGraphRoute("/content", DEFAULT_UPLOAD_RESULT));
 
-    await expect(
-      uploadAndShareSharePoint({
-        buffer: Buffer.from("world"),
-        filename: "a.txt",
-        siteId: "site-123",
-        chatId: "chat-123",
-        usePerUserSharing: true,
-        tokenProvider: tokenProvider403,
-        fetchFn: fetchFn as unknown as typeof fetch,
-      }),
-    ).rejects.toBe(tokenError);
+    await expect(uploadWithPerUserSharing(fetchFn, tokenProvider403)).rejects.toBe(tokenError);
     expect(tokenProvider403.getAccessToken).toHaveBeenCalledTimes(2);
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
   it("fails closed when member lookup returns no recipients", async () => {
-    const fetchFn = vi.fn(async (url: string) => {
-      if (url.includes("/content")) {
-        return new Response(
-          JSON.stringify({ id: "item-1", webUrl: "https://example.com/1", name: "a.txt" }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        );
-      }
-      if (url.includes("/members")) {
-        return new Response(JSON.stringify({ value: [] }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
-      }
-      throw new Error(`Unexpected SharePoint request: ${url}`);
-    });
+    const fetchFn = createGraphFetch(
+      fixedGraphRoute("/content", DEFAULT_UPLOAD_RESULT),
+      fixedGraphRoute("/members", { value: [] }),
+    );
 
-    await expect(
-      uploadAndShareSharePoint({
-        buffer: Buffer.from("world"),
-        filename: "a.txt",
-        siteId: "site-123",
-        chatId: "chat-123",
-        usePerUserSharing: true,
-        tokenProvider,
-        fetchFn: fetchFn as unknown as typeof fetch,
-      }),
-    ).rejects.toThrow("MS Teams chat member lookup returned no recipients");
+    await expect(uploadWithPerUserSharing(fetchFn)).rejects.toThrow(
+      "MS Teams chat member lookup returned no recipients",
+    );
     expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 });
 
 describe("graph upload response limits", () => {
-  const tokenProvider = {
-    getAccessToken: vi.fn(async () => "graph-token"),
-  };
-
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -750,8 +572,6 @@ describe("graph upload response limits", () => {
           uploadToSharePoint({
             buffer: Buffer.from("x"),
             filename: "big.txt",
-            siteId: "site-123",
-            tokenProvider,
           }),
         ).rejects.toThrow(
           "msteams.graph-upload.uploadSharePointFile: JSON response exceeds 16777216 bytes",


### PR DESCRIPTION
## What Problem This Solves

The Microsoft Teams Graph-upload tests repeated route, authentication, upload, and timeout setup across nearly every case. That repetition obscured the behavior each case protects and made fixture maintenance needlessly error-prone.

This is a maintainer-requested code-cleanup lane toward the repository-wide LOC-reduction goal.

## Why This Change Was Made

The suite now builds its Graph responses, fixed and aborting routes, upload calls, and private-recipient setup through small canonical test helpers. Production code and behavior are unchanged; all 21 test declarations and the full ordered assertion trace remain identical.

## User Impact

No user-visible impact. This test-only refactor removes 180 net lines while retaining coverage for Graph authentication, filename conflict handling, upload limits, response bounds, sharing scopes, and abort deadlines.

## Evidence

- Diff: `+167/-347`, net **-180 test LOC**; production delta **0**.
- Focused Blacksmith Testbox: `extensions/msteams/src/graph-upload.test.ts` — **21/21 passed**.
- Full Microsoft Teams suite: **89 files, 1,371 tests passed**.
- Remote `pnpm check:changed`: **passed**.
- `git diff --check` and `oxfmt --check`: **passed**.
- Static parity trace: 21 titles and 49 ordered matcher chains preserved; SHA-256 `02ea76aff2cb50581392048031d580230355c26ad38e8f0be3c235c9bb30253c` before and after.
- AutoReview on exact head: **clean**, no accepted/actionable findings.
- Final central overlap census: **0 exact open-PR matches** for the changed file.
- Contract verification: Microsoft Graph [upload or replace file contents](https://learn.microsoft.com/en-us/graph/api/driveitem-put-content?view=graph-rest-1.0), [driveItem conflict behavior](https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0), [createLink](https://learn.microsoft.com/en-us/graph/api/driveitem-createlink?view=graph-rest-beta), and [list chat members](https://learn.microsoft.com/en-us/graph/api/chat-list-members?view=graph-rest-1.0).
- AI-assisted implementation and review; no transcript was added because transcript inclusion requires explicit approval.
