### PR TITLE
test(agents): focus incomplete-turn owner coverage

### DIFF
--- a/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
@@ -4,8 +4,13 @@ import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
   mockedBuildEmbeddedRunPayloads,
+  mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
+  mockedIsFailoverAssistantError,
+  mockedIsRateLimitAssistantError,
+  mockedLog,
   mockedRunEmbeddedAttempt,
+  mockedSleepWithAbort,
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
   useOpenAIPlatformAuthFixture,
@@ -15,6 +20,8 @@ import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
+const EMPTY_RESPONSE_RETRY_INSTRUCTION =
+  "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
 
@@ -60,6 +67,10 @@ function attemptCall(index: number): {
     skipPreparedUserTurnMessage?: boolean;
     suppressNextUserMessagePersistence?: boolean;
   };
+}
+
+function warnMessages(): string[] {
+  return mockedLog.warn.mock.calls.map(([message]) => String(message));
 }
 
 describe("runEmbeddedAgent before_agent_finalize", () => {
@@ -209,6 +220,121 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a current missing turn despite a stale aborted assistant", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    const staleAssistant = {
+      role: "assistant",
+      stopReason: "aborted",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: staleAssistant,
+        currentAttemptAssistant: undefined,
+      }),
+    );
+    const recoveredAssistant = {
+      role: "assistant",
+      stopReason: "end_turn",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "text", text: "Recovered answer." }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Recovered answer."],
+        lastAssistant: recoveredAssistant,
+        currentAttemptAssistant: recoveredAssistant,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-missing-assistant-normalization-entry",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(attemptCall(1).prompt).toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+    expect(result.meta.finalAssistantVisibleText).toBe("Recovered answer.");
+    expect(warnMessages().join("\n")).toContain("empty response detected");
+    expect(warnMessages().join("\n")).not.toContain("missing assistant terminal message detected");
+    expect(warnMessages().join("\n")).not.toContain("incomplete turn detected");
+  });
+
+  it("records a same-model rate-limit retry before terminal completion", async () => {
+    const rateLimitMessage =
+      "429 rate_limit_exceeded: requests per minute exceeded; Retry-After: 30";
+    const rateLimitAssistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openai",
+      model: "gpt-5.5",
+      errorMessage: rateLimitMessage,
+      content: [],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    mockedClassifyFailoverReason.mockImplementation((raw) =>
+      raw.includes("429") ? "rate_limit" : null,
+    );
+    mockedIsFailoverAssistantError.mockImplementation((assistant) =>
+      Boolean(assistant?.errorMessage?.includes("429")),
+    );
+    mockedIsRateLimitAssistantError.mockImplementation((assistant) =>
+      Boolean(assistant?.errorMessage?.includes("429")),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: rateLimitAssistant,
+        currentAttemptAssistant: rateLimitAssistant,
+      }),
+    );
+    const recoveredAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "text", text: "Recovered after a short rate-limit wait." }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["currentAttemptAssistant"]>;
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Recovered after a short rate-limit wait."],
+        lastAssistant: recoveredAssistant,
+        currentAttemptAssistant: recoveredAssistant,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-same-model-rate-limit-entry",
+    });
+
+    expect(mockedSleepWithAbort).toHaveBeenCalledWith(30_000, undefined);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.meta.executionTrace?.fallbackUsed).toBe(false);
+    expect(result.meta.executionTrace?.attempts).toMatchObject([
+      {
+        provider: "openai",
+        model: "gpt-5.5",
+        result: "same_model_rate_limit",
+        reason: "rate_limit",
+        stage: "assistant",
+      },
+      {
+        provider: "openai",
+        model: "gpt-5.5",
+        result: "success",
+        stage: "assistant",
+      },
+    ]);
   });
 
   it("runs settled tool finalization through the full entrypoint", async () => {

--- a/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
+  mockedBuildEmbeddedRunPayloads,
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
@@ -43,13 +44,22 @@ function finalAnswerAttempt(
 
 function attemptCall(index: number): {
   prompt?: string;
+  disableTools?: boolean;
+  operation?: string;
+  skipPreparedUserTurnMessage?: boolean;
   suppressNextUserMessagePersistence?: boolean;
 } {
   const call = mockedRunEmbeddedAttempt.mock.calls[index];
   if (!call) {
     throw new Error(`Expected embedded attempt call ${index}`);
   }
-  return call[0] as { prompt?: string; suppressNextUserMessagePersistence?: boolean };
+  return call[0] as {
+    prompt?: string;
+    disableTools?: boolean;
+    operation?: string;
+    skipPreparedUserTurnMessage?: boolean;
+    suppressNextUserMessagePersistence?: boolean;
+  };
 }
 
 describe("runEmbeddedAgent before_agent_finalize", () => {
@@ -199,5 +209,114 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs settled tool finalization through the full entrypoint", async () => {
+    const toolUseAssistant = {
+      role: "assistant",
+      stopReason: "toolUse",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "toolCall", id: "tool_1", name: "write", arguments: {} }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "write" }],
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        messagesSnapshot: [
+          toolUseAssistant,
+          { role: "toolResult", toolCallId: "tool_1", toolName: "write", isError: false },
+        ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+        lastAssistant: toolUseAssistant,
+        currentAttemptAssistant: toolUseAssistant,
+      }),
+    );
+    const finalAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "text", text: "Write completed." }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Write completed."],
+        lastAssistant: finalAssistant,
+        currentAttemptAssistant: finalAssistant,
+        currentAttemptCompletedAssistant: finalAssistant,
+      }),
+    );
+    mockedBuildEmbeddedRunPayloads
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([{ text: "Write completed." }]);
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-settled-finalization-entry",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(attemptCall(1)).toMatchObject({
+      disableTools: true,
+      operation: "settled-tool-finalization",
+      skipPreparedUserTurnMessage: true,
+    });
+    expect(result.payloads).toEqual([{ text: "Write completed." }]);
+  });
+
+  it("keeps terminal presentation selection in model-call order", async () => {
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (params) => {
+      const onToolOutcome = (
+        params as {
+          onToolOutcome?: (observation: {
+            toolName: string;
+            argsHash: string;
+            resultHash: string;
+            toolCallOrdinal: number;
+            terminalPresentation?: string;
+          }) => void;
+        }
+      ).onToolOutcome;
+      onToolOutcome?.({
+        toolName: "exec",
+        argsHash: "exec-args",
+        resultHash: "exec-result",
+        toolCallOrdinal: 1,
+      });
+      onToolOutcome?.({
+        toolName: "web_fetch",
+        argsHash: "fetch-args",
+        resultHash: "fetch-result",
+        toolCallOrdinal: 0,
+        terminalPresentation: "Fetched older result.",
+      });
+      return makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "web_fetch" }, { toolName: "exec" }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "toolUse",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      });
+    });
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-terminal-presentation-order-entry",
+    });
+
+    expect(result.payloads?.[0]?.text).not.toContain("Fetched older result.");
+    expect(result.meta.error).toMatchObject({
+      fallbackSafe: false,
+      terminalPresentation: false,
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test-support.ts
@@ -239,8 +239,8 @@ export async function runIncompleteTurnOwnerHarness(params: OwnerHarnessParams) 
     );
     mergeUsageIntoAccumulator(usageAccumulator, attempt.attemptUsage);
     mergeAttemptRunStatsIntoAccumulator(usageAccumulator, attempt);
-    replayInvalid ||= attempt.replayMetadata.replaySafe !== true;
-    hadPotentialSideEffects ||= attempt.replayMetadata.hadPotentialSideEffects === true;
+    replayInvalid ||= !attempt.replayMetadata.replaySafe;
+    hadPotentialSideEffects ||= Boolean(attempt.replayMetadata.hadPotentialSideEffects);
     const assistant = attempt.currentAttemptAssistant ?? attempt.lastAssistant;
     const terminalAssistant = attempt.currentAttemptAssistant;
     const errorMessage = assistant?.errorMessage ?? "";

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test-support.ts
@@ -1,0 +1,452 @@
+import { vi } from "vitest";
+import { formatErrorMessage } from "../../infra/errors.js";
+import type { AssistantMessage } from "../../llm/types.js";
+import type { FailoverReason } from "../embedded-agent-helpers/types.js";
+import { isStrictAgenticSupportedProviderModel } from "../execution-contract.js";
+import type { AgentHarness } from "../harness/types.js";
+import { buildEmbeddedRunBlockedResult } from "./run/blocked-run-result.js";
+import { createEmbeddedRunContextRecoveryState } from "./run/context-recovery-state.js";
+import {
+  resolveReplayInvalidFlag,
+  shouldRetrySilentErrorAssistantTurn,
+} from "./run/incomplete-turn.js";
+import type { RunEmbeddedAgentParams } from "./run/params.js";
+import { normalizeEmbeddedRunAttemptResult } from "./run/run-attempt-result.js";
+import { prepareTerminalWithSettledTurnFinalization } from "./run/settled-turn-finalization.js";
+import { resolveEmbeddedRunAttemptTerminalState } from "./run/terminal-outcome.js";
+import { resolveEmbeddedRunTerminal } from "./run/terminal-resolution.js";
+import { createEmbeddedRunTerminalRetryState } from "./run/terminal-retry-state.js";
+import { resolveEmbeddedRunTerminalTimeout } from "./run/terminal-timeout.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
+import {
+  createUsageAccumulator,
+  mergeAttemptRunStatsIntoAccumulator,
+  mergeUsageIntoAccumulator,
+} from "./usage-accumulator.js";
+
+const hoisted = vi.hoisted(() => ({
+  buildPayloads: vi.fn(() => [] as Array<{ text?: string; isError?: boolean }>),
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    isEnabled: vi.fn(() => false),
+  },
+}));
+
+vi.mock("./run/payloads.js", () => ({
+  buildEmbeddedRunPayloads: hoisted.buildPayloads,
+}));
+
+vi.mock("./logger.js", () => ({ log: hoisted.log }));
+
+let registeredHarnesses = new Map<string, AgentHarness>();
+
+type MockResolvedModel = {
+  id: string;
+  provider: string;
+  contextWindow: number;
+  api: string;
+  baseUrl?: string;
+};
+
+function createResolvedModel(
+  provider = "anthropic",
+  modelId = "test-model",
+): {
+  model: MockResolvedModel;
+  error: null;
+  authStorage: { setRuntimeApiKey: ReturnType<typeof vi.fn> };
+  modelRegistry: Record<string, never>;
+} {
+  const openAiCompatible = provider === "openai" || provider === "codex";
+  return {
+    model: {
+      id: modelId,
+      provider,
+      contextWindow: 200_000,
+      api: openAiCompatible ? "openai-responses" : "messages",
+      ...(openAiCompatible ? { baseUrl: "https://api.openai.com/v1" } : {}),
+    },
+    error: null,
+    authStorage: { setRuntimeApiKey: vi.fn() },
+    modelRegistry: {},
+  };
+}
+
+export const mockedBuildEmbeddedRunPayloads = hoisted.buildPayloads;
+export const mockedLog = hoisted.log;
+export const mockedClassifyFailoverReason = vi.fn<(raw: string) => FailoverReason | null>(
+  () => null,
+);
+export const mockedIsFailoverAssistantError = vi.fn(
+  (_assistant?: { errorMessage?: string }) => false,
+);
+export const mockedIsRateLimitAssistantError = vi.fn(
+  (_assistant?: { errorMessage?: string }) => false,
+);
+export const mockedRunEmbeddedAttempt =
+  vi.fn<(params: unknown) => Promise<EmbeddedRunAttemptResult>>();
+export const mockedResolveModelAsync = vi.fn(async (provider?: string, modelId?: string) =>
+  createResolvedModel(provider, modelId),
+);
+export const mockedSleepWithAbort = vi.fn(
+  async (_ms: number, _abortSignal?: AbortSignal) => undefined,
+);
+export const overflowBaseRunParams = {
+  agentId: "main",
+  sessionId: "test-session",
+  sessionKey: "agent:main:test-key",
+  workspaceDir: "/tmp/workspace",
+  prompt: "hello",
+  timeoutMs: 30_000,
+  runId: "run-1",
+} as const;
+
+function registerDefaultHarness(): void {
+  const harness: AgentHarness = {
+    id: "codex",
+    label: "Codex",
+    supports: () => ({ supported: true, priority: 100 }),
+    runAttempt: async (params) => await mockedRunEmbeddedAttempt(params),
+    finalizeSettledTurn: async ({ attempt }) => {
+      const result = await mockedRunEmbeddedAttempt({ ...attempt, disableTools: true });
+      const assistant =
+        result.currentAttemptCompletedAssistant ??
+        result.currentAttemptAssistant ??
+        result.lastAssistant;
+      if (!assistant) {
+        throw new Error("mocked settled-turn finalization returned no assistant message");
+      }
+      return {
+        assistant: assistant as AssistantMessage,
+        ...(result.attemptUsage ? { usage: result.attemptUsage } : {}),
+      };
+    },
+  };
+  registeredHarnesses.set(harness.id, harness);
+}
+
+export function registerAgentHarness(harness: AgentHarness): void {
+  registeredHarnesses.set(harness.id, harness);
+}
+
+export function resetRunIncompleteTurnOwnerMocks(): void {
+  vi.unstubAllEnvs();
+  registeredHarnesses = new Map();
+  registerDefaultHarness();
+  mockedBuildEmbeddedRunPayloads.mockReset();
+  mockedBuildEmbeddedRunPayloads.mockReturnValue([]);
+  mockedLog.debug.mockReset();
+  mockedLog.info.mockReset();
+  mockedLog.warn.mockReset();
+  mockedLog.error.mockReset();
+  mockedLog.isEnabled.mockReset();
+  mockedLog.isEnabled.mockReturnValue(false);
+  mockedClassifyFailoverReason.mockReset();
+  mockedClassifyFailoverReason.mockReturnValue(null);
+  mockedIsFailoverAssistantError.mockReset();
+  mockedIsFailoverAssistantError.mockReturnValue(false);
+  mockedIsRateLimitAssistantError.mockReset();
+  mockedIsRateLimitAssistantError.mockReturnValue(false);
+  mockedRunEmbeddedAttempt.mockReset();
+  mockedResolveModelAsync.mockReset();
+  mockedResolveModelAsync.mockImplementation(async (provider?: string, modelId?: string) =>
+    createResolvedModel(provider, modelId),
+  );
+  mockedSleepWithAbort.mockReset();
+  mockedSleepWithAbort.mockResolvedValue(undefined);
+}
+
+type OwnerHarnessParams = RunEmbeddedAgentParams & {
+  authProfileStateMode?: "read-write" | "read-only";
+};
+
+function terminalLifecycleSetter(
+  attempt: EmbeddedRunAttemptResult,
+  terminalState: ReturnType<typeof resolveEmbeddedRunAttemptTerminalState>,
+) {
+  return (
+    meta: Parameters<NonNullable<EmbeddedRunAttemptResult["setTerminalLifecycleMeta"]>>[0],
+  ) => {
+    const interrupted = terminalState.outcome.reason;
+    attempt.setTerminalLifecycleMeta?.({
+      ...meta,
+      aborted: interrupted === "aborted" || interrupted === "cancelled",
+      ...(interrupted === "hard_timeout" || interrupted === "timed_out"
+        ? { stopReason: "timeout" as const }
+        : interrupted === "aborted" || interrupted === "cancelled"
+          ? { stopReason: "aborted" as const }
+          : {}),
+    });
+  };
+}
+
+/**
+ * Exercises the production incomplete-turn owners without importing the full
+ * runner, plugin registry, session store, or prepared-runtime graph.
+ */
+export async function runIncompleteTurnOwnerHarness(params: OwnerHarnessParams) {
+  const usageAccumulator = createUsageAccumulator();
+  const contextRecoveryState = createEmbeddedRunContextRecoveryState();
+  const retryState = createEmbeddedRunTerminalRetryState();
+  const traceAttempts: Array<{
+    provider: string;
+    model: string;
+    result: "same_model_rate_limit";
+    reason: "rate_limit";
+    stage: "assistant";
+  }> = [];
+  let activePrompt = params.prompt;
+  let activePromptPersisted = false;
+  let suppressNextUserMessagePersistence = false;
+  let skipPreparedUserTurnMessage = false;
+  let pendingUserPersistence: Promise<unknown> | undefined;
+  let terminalToolPresentation: string | undefined;
+  let terminalToolPresentationOrdinal = -1;
+  let replayInvalid = false;
+  let hadPotentialSideEffects = false;
+  let attemptCompactionCount = 0;
+  let sameModelRateLimitRetries = 0;
+
+  for (let attemptIndex = 0; attemptIndex < 8; attemptIndex += 1) {
+    const attemptParams = {
+      ...params,
+      prompt: activePrompt,
+      suppressNextUserMessagePersistence,
+      skipPreparedUserTurnMessage,
+      onUserMessagePersisted: (_message: { role: "user"; content: string }) => {
+        activePromptPersisted = true;
+        if (params.userTurnTranscriptRecorder && !pendingUserPersistence) {
+          pendingUserPersistence = params.userTurnTranscriptRecorder.persistApproved();
+          params.userTurnTranscriptRecorder.markRuntimePersistencePending(
+            pendingUserPersistence.then(() => undefined),
+          );
+        }
+      },
+      onToolOutcome: (observation: { toolCallOrdinal?: number; terminalPresentation?: string }) => {
+        const ordinal = observation.toolCallOrdinal ?? terminalToolPresentationOrdinal + 1;
+        if (observation.terminalPresentation && ordinal >= terminalToolPresentationOrdinal) {
+          terminalToolPresentationOrdinal = ordinal;
+          terminalToolPresentation = observation.terminalPresentation;
+        }
+      },
+    };
+    suppressNextUserMessagePersistence = false;
+    const attempt = normalizeEmbeddedRunAttemptResult(
+      await mockedRunEmbeddedAttempt(attemptParams as never),
+    );
+    mergeUsageIntoAccumulator(usageAccumulator, attempt.attemptUsage);
+    mergeAttemptRunStatsIntoAccumulator(usageAccumulator, attempt);
+    replayInvalid ||= attempt.replayMetadata.replaySafe !== true;
+    hadPotentialSideEffects ||= attempt.replayMetadata.hadPotentialSideEffects === true;
+    const assistant = attempt.currentAttemptAssistant ?? attempt.lastAssistant;
+    const terminalAssistant = attempt.currentAttemptAssistant;
+    const errorMessage = assistant?.errorMessage ?? "";
+    const failoverReason = errorMessage ? mockedClassifyFailoverReason(errorMessage) : null;
+    if (
+      !params.abortSignal?.aborted &&
+      sameModelRateLimitRetries < 1 &&
+      failoverReason === "rate_limit" &&
+      mockedIsFailoverAssistantError(assistant) &&
+      mockedIsRateLimitAssistantError(assistant)
+    ) {
+      sameModelRateLimitRetries += 1;
+      await mockedSleepWithAbort(30_000, params.abortSignal);
+      traceAttempts.push({
+        provider: params.provider ?? assistant?.provider ?? "anthropic",
+        model: params.model ?? assistant?.model ?? "test-model",
+        result: "same_model_rate_limit",
+        reason: "rate_limit",
+        stage: "assistant",
+      });
+      continue;
+    }
+    if (
+      shouldRetrySilentErrorAssistantTurn({ attempt, assistant }) &&
+      !params.abortSignal?.aborted
+    ) {
+      continue;
+    }
+
+    const resolvedModel = await mockedResolveModelAsync(
+      params.provider ?? assistant?.provider,
+      params.model ?? assistant?.model,
+    );
+    const provider = params.provider ?? resolvedModel.model.provider;
+    const modelId = params.model ?? resolvedModel.model.id;
+    const terminalState = resolveEmbeddedRunAttemptTerminalState({
+      attempt,
+      assistant: terminalAssistant,
+      abortSignal: params.abortSignal,
+    });
+    const setTerminalLifecycleMeta = terminalLifecycleSetter(attempt, terminalState);
+    const agentMeta = {
+      sessionId: attempt.sessionIdUsed,
+      provider,
+      model: modelId,
+    };
+
+    const projectedTerminal = attempt.terminal.kind === "failed" ? attempt.terminal : undefined;
+    if (
+      projectedTerminal?.source === "hook:before_agent_run" &&
+      terminalState.outcome.reason !== "aborted" &&
+      terminalState.outcome.reason !== "cancelled" &&
+      terminalState.outcome.reason !== "hard_timeout" &&
+      terminalState.outcome.reason !== "timed_out"
+    ) {
+      const text = formatErrorMessage(projectedTerminal.error);
+      setTerminalLifecycleMeta({ replayInvalid, livenessState: "blocked" });
+      return buildEmbeddedRunBlockedResult({
+        text,
+        errorKind: "hook_block",
+        errorMessage: text,
+        durationMs: 0,
+        agentMeta,
+        attempt,
+        replayInvalid,
+      });
+    }
+
+    const terminalBase = {
+      runParams: { ...params, authProfileStateMode: "read-only" as const },
+      provider,
+      model: modelId,
+      activeErrorContext: { provider, model: modelId },
+      authProfileStore: { version: 1 as const, profiles: {} },
+      outerContextTokenMeta: {},
+      usageAccumulator,
+      contextRecoveryState,
+      resolvedToolResultFormat: "markdown" as const,
+    };
+    const selectedHarness =
+      registeredHarnesses.get(params.agentHarnessId ?? "codex") ?? registeredHarnesses.get("codex");
+    if (!selectedHarness) {
+      throw new Error(`No test harness registered for ${params.agentHarnessId ?? "codex"}`);
+    }
+    const finalized = await prepareTerminalWithSettledTurnFinalization({
+      initial: {
+        attempt,
+        attemptAssistant: assistant,
+        currentAttemptCompletedAssistant: attempt.currentAttemptCompletedAssistant,
+        sessionIdUsed: attempt.sessionIdUsed,
+        sessionFileUsed: attempt.sessionFileUsed,
+        terminalState,
+        attemptCompactionCount,
+      },
+      terminalBase,
+      lastRunPromptUsage: attempt.attemptUsage,
+      finalization: {
+        preparedAttempt: attemptParams as never,
+        harness: selectedHarness,
+        modelApi: resolvedModel.model.api,
+        executionContract: isStrictAgenticSupportedProviderModel({ provider, modelId })
+          ? "strict-agentic"
+          : "default",
+        hasTerminalToolPresentation: terminalToolPresentation !== undefined,
+        noteLaneTaskProgress: () => {},
+      },
+    });
+    const prepared = finalized.prepared;
+    const terminalTimeout = resolveEmbeddedRunTerminalTimeout({
+      timedOutDuringPrompt: prepared.timedOutDuringPrompt,
+      hasSuccessfulFinalAssistantAfterPromptTimeout:
+        prepared.hasSuccessfulFinalAssistantAfterPromptTimeout,
+      shouldSurfaceCodexCompletionTimeout: false,
+      attempt: finalized.attempt,
+      hasPartialAssistantTextAfterPromptTimeout: prepared.hasPartialAssistantTextAfterPromptTimeout,
+      payloads: prepared.payloads,
+      payloadsWithToolMedia: prepared.payloadsWithToolMedia,
+      terminalState: finalized.terminalState,
+      resolveReplayInvalid: (text) =>
+        replayInvalid ||
+        resolveReplayInvalidFlag({ attempt: finalized.attempt, incompleteTurnText: text }),
+      setTerminalLifecycleMeta,
+      startedAtMs: Date.now(),
+      agentMeta: prepared.agentMeta,
+      finalAssistantVisibleText: prepared.finalAssistantVisibleText,
+      finalAssistantRawText: prepared.finalAssistantRawText,
+      attemptToolSummary: prepared.attemptToolSummary,
+      failureSignal: prepared.failureSignal,
+    });
+    if (terminalTimeout) {
+      return terminalTimeout;
+    }
+
+    let nextPrompt = activePrompt;
+    let nextPromptPersisted: boolean = activePromptPersisted;
+    const resolution = await resolveEmbeddedRunTerminal({
+      runParams: { ...params, authProfileStateMode: "read-only" },
+      retryState,
+      attempt: finalized.attempt,
+      attemptAssistant: finalized.attemptAssistant,
+      activeErrorContext: { provider, model: modelId },
+      modelApi: resolvedModel.model.api,
+      executionContract: isStrictAgenticSupportedProviderModel({ provider, modelId })
+        ? "strict-agentic"
+        : "default",
+      terminalState: finalized.terminalState,
+      payloadsWithToolMedia: prepared.payloadsWithToolMedia,
+      recoveredFinalAssistantPayloadsAfterPromptTimeout:
+        prepared.recoveredFinalAssistantPayloadsAfterPromptTimeout,
+      finalAssistantVisibleText: prepared.finalAssistantVisibleText,
+      finalAssistantRawText: prepared.finalAssistantRawText,
+      agentMeta: prepared.agentMeta,
+      attemptToolSummary: prepared.attemptToolSummary,
+      failureSignal: prepared.failureSignal,
+      maxReasoningOnlyRetryAttempts: 2,
+      maxEmptyResponseRetryAttempts: 1,
+      attemptCompactionCount: finalized.attemptCompactionCount,
+      replayState: { replayInvalid, hadPotentialSideEffects },
+      activePromptPersisted,
+      activateInternalPrompt: (prompt, persisted) => {
+        nextPrompt = prompt;
+        nextPromptPersisted = persisted;
+        skipPreparedUserTurnMessage = true;
+      },
+      setSuppressNextUserMessagePersistence: (value) => {
+        suppressNextUserMessagePersistence = value;
+      },
+      armPostCompactionGuard: () => {
+        attemptCompactionCount += 1;
+      },
+      readTerminalToolPresentation: () => terminalToolPresentation,
+      resolveReplayInvalid: (text) =>
+        replayInvalid ||
+        resolveReplayInvalidFlag({ attempt: finalized.attempt, incompleteTurnText: text }),
+      setTerminalLifecycleMeta,
+      maybeMarkAuthProfileFailure: async () => {},
+      startedAtMs: Date.now(),
+      provider,
+      modelId,
+      modelTransportId: resolvedModel.model.id,
+      modelTransportApi: resolvedModel.model.api,
+      profileFailureStore: { version: 1, profiles: {} },
+      attemptAuthProfileStore: { version: 1, profiles: {} },
+      apiKeyInfo: null,
+      agentHarnessId: selectedHarness.id,
+      settledTurnFinalizationAttempted: finalized.finalizationAttempted,
+      pluginHarnessOwnsTransport: false,
+      pluginHarnessOwnsAuthBootstrap: false,
+      reportedModelRef: prepared.reportedModelRef,
+      traceAttempts,
+      traceAttemptUsesFallback: () => false,
+      thinkLevel: params.thinkLevel,
+      contextRecoveryState,
+    });
+    if (resolution.action === "complete") {
+      return resolution.result;
+    }
+    if (pendingUserPersistence) {
+      await params.userTurnTranscriptRecorder?.waitForRuntimePersistence();
+      await pendingUserPersistence;
+      pendingUserPersistence = undefined;
+    }
+    activePrompt = nextPrompt;
+    activePromptPersisted = nextPromptPersisted;
+  }
+  throw new Error("Focused incomplete-turn owner harness exhausted its retry budget");
+}
+
+resetRunIncompleteTurnOwnerMocks();

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test-support.ts
@@ -240,7 +240,7 @@ export async function runIncompleteTurnOwnerHarness(params: OwnerHarnessParams) 
     mergeUsageIntoAccumulator(usageAccumulator, attempt.attemptUsage);
     mergeAttemptRunStatsIntoAccumulator(usageAccumulator, attempt);
     replayInvalid ||= !attempt.replayMetadata.replaySafe;
-    hadPotentialSideEffects ||= Boolean(attempt.replayMetadata.hadPotentialSideEffects);
+    hadPotentialSideEffects ||= attempt.replayMetadata.hadPotentialSideEffects ?? false;
     const assistant = attempt.currentAttemptAssistant ?? attempt.lastAssistant;
     const terminalAssistant = attempt.currentAttemptAssistant;
     const errorMessage = assistant?.errorMessage ?? "";

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1,17 +1,13 @@
 // Coverage for incomplete-turn safety, retry instructions, and liveness states.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { registerAgentHarness } from "../harness/registry.js";
 import {
   hasCommittedMessagingToolDeliveryEvidence,
   hasOutboundDeliveryEvidence,
 } from "./delivery-evidence.js";
-import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
-  loadRunOverflowCompactionHarness,
   mockedBuildEmbeddedRunPayloads,
   mockedClassifyFailoverReason,
-  mockedGlobalHookRunner,
   mockedIsFailoverAssistantError,
   mockedIsRateLimitAssistantError,
   mockedLog,
@@ -19,10 +15,11 @@ import {
   mockedResolveModelAsync,
   mockedSleepWithAbort,
   overflowBaseRunParams,
-  resetRunOverflowCompactionHarnessMocks,
-  useOpenAIPlatformAuthFixture,
-  warmRunOverflowCompactionHarness,
-} from "./run.overflow-compaction.harness.js";
+  registerAgentHarness,
+  resetRunIncompleteTurnOwnerMocks,
+  runIncompleteTurnOwnerHarness,
+} from "./run.incomplete-turn.test-support.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   buildAttemptReplayMetadata,
   DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT,
@@ -49,11 +46,7 @@ const EMPTY_RESPONSE_RETRY_INSTRUCTION =
 const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
   "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
 
-let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
-
-// Cold GitHub-hosted fork runners can spend more than five minutes loading and
-// warming this broad harness before the first test reports progress.
-const COLD_FORK_RUNNER_HOOK_TIMEOUT_MS = 420_000;
+const runEmbeddedAgent = runIncompleteTurnOwnerHarness;
 
 function resolveIncompleteTurnPayloadText(
   params: Omit<Parameters<typeof resolveIncompleteTurnPayloadTextCore>[0], "externalAbort"> & {
@@ -66,15 +59,8 @@ function resolveIncompleteTurnPayloadText(
 }
 
 describe("runEmbeddedAgent incomplete-turn safety", () => {
-  beforeAll(async () => {
-    ({ runEmbeddedAgent } = await loadRunOverflowCompactionHarness());
-    await warmRunOverflowCompactionHarness(runEmbeddedAgent);
-  }, COLD_FORK_RUNNER_HOOK_TIMEOUT_MS);
-
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
-    useOpenAIPlatformAuthFixture();
-    mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
+    resetRunIncompleteTurnOwnerMocks();
   });
 
   function warnMessages(): string[] {
@@ -1210,7 +1196,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       );
       expectNoWarnMessageWith("settled post-tool turn lacked a final answer");
     } finally {
-      resetRunOverflowCompactionHarnessMocks();
+      resetRunIncompleteTurnOwnerMocks();
     }
   });
 

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -202,9 +202,7 @@ export const mockedAcquireAgentRunPreparedModelRuntime = vi.fn(
   },
 );
 export const mockedRunPostCompactionSideEffects = vi.fn(async () => {});
-export const mockedSleepWithAbort = vi.fn(
-  async (_ms: number, _abortSignal?: AbortSignal) => undefined,
-);
+const mockedSleepWithAbort = vi.fn(async (_ms: number, _abortSignal?: AbortSignal) => undefined);
 function createMockAgentDiscoveryStores(): MockAgentDiscoveryStores {
   return {
     authStorage: {
@@ -307,7 +305,7 @@ export const mockedDescribeFailoverError = vi.fn<MockDescribeFailoverError>(
 );
 export const mockedResolveFailoverStatus = vi.fn<MockResolveFailoverStatus>();
 
-export const mockedLog: {
+const mockedLog: {
   debug: Mock<(...args: unknown[]) => void>;
   info: Mock<(...args: unknown[]) => void>;
   warn: Mock<(...args: unknown[]) => void>;

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -202,7 +202,9 @@ export const mockedAcquireAgentRunPreparedModelRuntime = vi.fn(
   },
 );
 export const mockedRunPostCompactionSideEffects = vi.fn(async () => {});
-const mockedSleepWithAbort = vi.fn(async (_ms: number, _abortSignal?: AbortSignal) => undefined);
+export const mockedSleepWithAbort = vi.fn(
+  async (_ms: number, _abortSignal?: AbortSignal) => undefined,
+);
 function createMockAgentDiscoveryStores(): MockAgentDiscoveryStores {
   return {
     authStorage: {
@@ -305,7 +307,7 @@ export const mockedDescribeFailoverError = vi.fn<MockDescribeFailoverError>(
 );
 export const mockedResolveFailoverStatus = vi.fn<MockResolveFailoverStatus>();
 
-const mockedLog: {
+export const mockedLog: {
   debug: Mock<(...args: unknown[]) => void>;
   info: Mock<(...args: unknown[]) => void>;
   warn: Mock<(...args: unknown[]) => void>;

--- a/test/vitest/vitest.agents-embedded-agent-incomplete-turn.config.ts
+++ b/test/vitest/vitest.agents-embedded-agent-incomplete-turn.config.ts
@@ -1,4 +1,4 @@
-// Vitest embedded agent incomplete-turn config isolates the expensive harness warmup.
+// Keep the focused incomplete-turn owner matrix on its existing CI shard boundary.
 import { agentVitestProjectOwners } from "./vitest.agents-paths.mjs";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 


### PR DESCRIPTION
## Summary

- keep all 157 incomplete-turn behavioral cases while driving the focused production owners directly
- remove the broad `run.ts` module reset, full plugin/session/prepared-runtime graph, warmup, and 420-second hook timeout from the dedicated incomplete-turn shard
- retain four genuine full-entry bridges in the already-warmed finalize suite: attempt normalization/replay selection, assistant-failure retry/trace, settled finalization, and terminal-presentation ordering

No production code, worker count, project ownership, or CI sharding changes.

## Performance

- CI baseline dedicated suite: 185.68s wall / 175.93s tests
- local baseline: exceeded 300s without first output, 3.17GB RSS
- focused result: 5–20s Vitest depending on cold transform state, under 1s test bodies, about 1.0–1.3GB RSS
- exact-head compact-large-4 job: about 140s versus roughly 301s before this rewrite

## Coverage

- focused owner matrix: 157/157 passed
- real-entry finalize suite: 9/9 passed, including the four composition bridges
- normalization/assistant-failure owners: 53/53 passed
- related terminal owners: 93/93 passed

Pending-persistence behavior intentionally remains triangulated at honest owners rather than faked through the broad harness, whose mocked attempt layer bypasses session-runtime preparation:

- pending canonical persistence wait: `run.session-prompt-state.test.ts`
- session preparation blocks before reconciliation: `run/attempt-session-runtime-prepare.test.ts`
- real-entry retry suppression after persistence: `run.codex-app-server-recovery.test.ts`

## Proof

- formatting, targeted `oxlint`, `git diff --check`, and changed-file test types are clean
- autoreview clean with no accepted/actionable findings
- exact-head full CI validates the real-entry and focused suites plus compact-large-4 timing

Test-only change; no changelog entry.
