### PR TITLE
test(feishu): consolidate monitor lifecycle fixtures

### DIFF
--- a/extensions/feishu/src/monitor.cleanup.test.ts
+++ b/extensions/feishu/src/monitor.cleanup.test.ts
@@ -27,6 +27,8 @@ type MockWsClient = {
   close: ReturnType<typeof vi.fn>;
 };
 
+type MockRuntime = ReturnType<typeof createRuntime>;
+
 function createAccount(accountId: string): ResolvedFeishuAccount {
   return {
     accountId,
@@ -47,6 +49,34 @@ function createWsClient(): MockWsClient {
     start: vi.fn(),
     close: vi.fn(),
   };
+}
+
+function createRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+function startWebSocketMonitor(accountId: string, runtime: MockRuntime = createRuntime()) {
+  const abortController = new AbortController();
+  return {
+    abortController,
+    runtime,
+    monitorPromise: monitorWebSocket({
+      account: createAccount(accountId),
+      accountId,
+      runtime,
+      abortSignal: abortController.signal,
+      eventDispatcher: {} as never,
+    }),
+  };
+}
+
+function seedBotIdentity(accountId: string, botOpenId: string, botName: string): void {
+  botOpenIds.set(accountId, botOpenId);
+  botNames.set(accountId, botName);
 }
 
 function createHttpServerMock(): {
@@ -105,23 +135,9 @@ describe("feishu websocket cleanup", () => {
     const wsClient = createWsClient();
     createFeishuWSClientMock.mockReturnValue(wsClient);
 
-    const abortController = new AbortController();
     const accountId = "alpha";
-
-    botOpenIds.set(accountId, "ou_alpha");
-    botNames.set(accountId, "Alpha");
-
-    const monitorPromise = monitorWebSocket({
-      account: createAccount(accountId),
-      accountId,
-      runtime: {
-        log: vi.fn(),
-        error: vi.fn(),
-        exit: vi.fn(),
-      },
-      abortSignal: abortController.signal,
-      eventDispatcher: {} as never,
-    });
+    seedBotIdentity(accountId, "ou_alpha", "Alpha");
+    const { abortController, monitorPromise } = startWebSocketMonitor(accountId);
 
     await vi.waitFor(() => {
       expect(wsClient.start).toHaveBeenCalledTimes(1);
@@ -148,21 +164,8 @@ describe("feishu websocket cleanup", () => {
       .mockResolvedValueOnce(failedClient)
       .mockResolvedValueOnce(recoveredClient);
 
-    const abortController = new AbortController();
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
     const accountId = "retry";
-
-    const monitorPromise = monitorWebSocket({
-      account: createAccount(accountId),
-      accountId,
-      runtime,
-      abortSignal: abortController.signal,
-      eventDispatcher: {} as never,
-    });
+    const { abortController, runtime, monitorPromise } = startWebSocketMonitor(accountId);
 
     await vi.waitFor(() => {
       expect(failedClient.start).toHaveBeenCalledTimes(1);
@@ -200,23 +203,9 @@ describe("feishu websocket cleanup", () => {
       .mockResolvedValueOnce(exhaustedClient)
       .mockResolvedValueOnce(recoveredClient);
 
-    const abortController = new AbortController();
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
     const accountId = "exhausted";
-    botOpenIds.set(accountId, "ou_exhausted");
-    botNames.set(accountId, "Exhausted");
-
-    const monitorPromise = monitorWebSocket({
-      account: createAccount(accountId),
-      accountId,
-      runtime,
-      abortSignal: abortController.signal,
-      eventDispatcher: {} as never,
-    });
+    seedBotIdentity(accountId, "ou_exhausted", "Exhausted");
+    const { abortController, runtime, monitorPromise } = startWebSocketMonitor(accountId);
 
     await vi.waitFor(() => {
       expect(exhaustedClient.start).toHaveBeenCalledTimes(1);
@@ -260,21 +249,8 @@ describe("feishu websocket cleanup", () => {
     const wsClient = createWsClient();
     createFeishuWSClientMock.mockResolvedValueOnce(wsClient);
 
-    const abortController = new AbortController();
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
     const accountId = "recoverable-callback";
-
-    const monitorPromise = monitorWebSocket({
-      account: createAccount(accountId),
-      accountId,
-      runtime,
-      abortSignal: abortController.signal,
-      eventDispatcher: {} as never,
-    });
+    const { abortController, runtime, monitorPromise } = startWebSocketMonitor(accountId);
 
     await vi.waitFor(() => {
       expect(wsClient.start).toHaveBeenCalledTimes(1);
@@ -306,22 +282,9 @@ describe("feishu websocket cleanup", () => {
     const exhaustedClient = createWsClient();
     createFeishuWSClientMock.mockResolvedValueOnce(exhaustedClient);
 
-    const abortController = new AbortController();
     const accountId = "abort-backoff";
-    botOpenIds.set(accountId, "ou_abort");
-    botNames.set(accountId, "Abort");
-
-    const monitorPromise = monitorWebSocket({
-      account: createAccount(accountId),
-      accountId,
-      runtime: {
-        log: vi.fn(),
-        error: vi.fn(),
-        exit: vi.fn(),
-      },
-      abortSignal: abortController.signal,
-      eventDispatcher: {} as never,
-    });
+    seedBotIdentity(accountId, "ou_abort", "Abort");
+    const { abortController, monitorPromise } = startWebSocketMonitor(accountId);
 
     await vi.waitFor(() => {
       expect(exhaustedClient.start).toHaveBeenCalledTimes(1);
@@ -349,20 +312,7 @@ describe("feishu websocket cleanup", () => {
     });
     createFeishuWSClientMock.mockReturnValue(wsClient);
 
-    const abortController = new AbortController();
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
-
-    const monitorPromise = monitorWebSocket({
-      account: createAccount("close-error"),
-      accountId: "close-error",
-      runtime,
-      abortSignal: abortController.signal,
-      eventDispatcher: {} as never,
-    });
+    const { abortController, runtime, monitorPromise } = startWebSocketMonitor("close-error");
 
     await vi.waitFor(() => {
       expect(wsClient.start).toHaveBeenCalledTimes(1);
@@ -385,19 +335,7 @@ describe("feishu websocket cleanup", () => {
     });
     createFeishuWSClientMock.mockReturnValue(wsClient);
 
-    const abortController = new AbortController();
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
-    const monitorPromise = monitorWebSocket({
-      account: createAccount("close-error-utf16"),
-      accountId: "close-error-utf16",
-      runtime,
-      abortSignal: abortController.signal,
-      eventDispatcher: {} as never,
-    });
+    const { abortController, runtime, monitorPromise } = startWebSocketMonitor("close-error-utf16");
 
     await vi.waitFor(() => {
       expect(wsClient.start).toHaveBeenCalledTimes(1);

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -47,7 +47,7 @@ function buildMonitorConfig(): ClawdbotConfig {
 function makeDriveCommentEvent(
   overrides: Partial<FeishuDriveCommentNoticeEvent> = {},
 ): FeishuDriveCommentNoticeEvent {
-  return {
+  const event: FeishuDriveCommentNoticeEvent = {
     comment_id: "7623358762119646411",
     event_id: "10d9d60b990db39f96a4c2fd357fb877",
     is_mentioned: true,
@@ -65,7 +65,52 @@ function makeDriveCommentEvent(
     reply_id: "7623358762136374451",
     timestamp: "1774951528000",
     type: "drive.notice.comment_add_v1",
+  };
+  return {
+    ...event,
     ...overrides,
+    notice_meta: {
+      ...event.notice_meta,
+      ...overrides.notice_meta,
+    },
+  };
+}
+
+type ReplyFixture = {
+  id: string;
+  text: string;
+  userId?: string;
+  createTime?: number;
+  encoding?: "content" | "text";
+};
+
+type CommentFixture = {
+  id: string;
+  userId?: string;
+  createTime?: number;
+  isWhole?: boolean;
+  replies: ReplyFixture[];
+};
+
+function makeReplyPayload(reply: ReplyFixture) {
+  const textRun = reply.encoding === "content" ? { content: reply.text } : { text: reply.text };
+  return {
+    reply_id: reply.id,
+    ...(reply.userId ? { user_id: reply.userId } : {}),
+    ...(reply.createTime == null ? {} : { create_time: reply.createTime }),
+    content: {
+      elements: [{ type: "text_run", text_run: textRun }],
+    },
+  };
+}
+
+function makeCommentPayload(comment: CommentFixture) {
+  return {
+    comment_id: comment.id,
+    ...(comment.userId ? { user_id: comment.userId } : {}),
+    ...(comment.createTime == null ? {} : { create_time: comment.createTime }),
+    is_whole: comment.isWhole,
+    reply_list: { replies: comment.replies.map(makeReplyPayload) },
   };
 }
 
@@ -79,8 +124,27 @@ function makeOpenApiClient(params: {
   targetReplyText?: string;
   includeTargetReplyInBatch?: boolean;
   repliesSequence?: Array<Array<{ reply_id: string; text: string }>>;
+  batchReplies?: ReplyFixture[];
+  wholeComments?: CommentFixture[];
 }) {
   const remainingReplyBatches = [...(params.repliesSequence ?? [])];
+  const rootReply: ReplyFixture = {
+    id: "7623358762136374451",
+    text: params.rootReplyText ?? "Also send it to the agent after receiving the comment event",
+    encoding: "content",
+  };
+  const batchReplies = params.batchReplies ?? [
+    rootReply,
+    ...(params.includeTargetReplyInBatch
+      ? [
+          {
+            id: "7623359125036043462",
+            text: params.targetReplyText ?? "Please follow up on this comment",
+            encoding: "content" as const,
+          },
+        ]
+      : []),
+  ];
   return {
     request: vi.fn(async (request: { method: "GET" | "POST"; url: string; data: unknown }) => {
       if (request.url === "/open-apis/drive/v1/metas/batch_query") {
@@ -107,91 +171,34 @@ function makeOpenApiClient(params: {
                 is_whole: params.isWholeComment,
                 quote: params.quoteText ?? "im.message.receive_v1 message trigger implementation",
                 reply_list: {
-                  replies: [
-                    {
-                      reply_id: "7623358762136374451",
-                      content: {
-                        elements: [
-                          {
-                            type: "text_run",
-                            text_run: {
-                              content:
-                                params.rootReplyText ??
-                                "Also send it to the agent after receiving the comment event",
-                            },
-                          },
-                        ],
-                      },
-                    },
-                    ...(params.includeTargetReplyInBatch
-                      ? [
-                          {
-                            reply_id: "7623359125036043462",
-                            content: {
-                              elements: [
-                                {
-                                  type: "text_run",
-                                  text_run: {
-                                    content:
-                                      params.targetReplyText ?? "Please follow up on this comment",
-                                  },
-                                },
-                              ],
-                            },
-                          },
-                        ]
-                      : []),
-                  ],
+                  replies: batchReplies.map(makeReplyPayload),
                 },
               },
             ],
           },
         };
       }
+      if (request.url.includes("/comments?file_type=docx&is_whole=true")) {
+        return {
+          code: 0,
+          data: {
+            has_more: false,
+            items: (params.wholeComments ?? []).map(makeCommentPayload),
+          },
+        };
+      }
       if (request.url.includes("/replies")) {
         const replyBatch = remainingReplyBatches.shift();
-        const items = replyBatch?.map((reply) => ({
-          reply_id: reply.reply_id,
-          content: {
-            elements: [
-              {
-                type: "text_run",
-                text_run: {
-                  content: reply.text,
-                },
-              },
-            ],
-          },
-        })) ?? [
-          {
-            reply_id: "7623358762136374451",
-            content: {
-              elements: [
-                {
-                  type: "text_run",
-                  text_run: {
-                    content:
-                      params.rootReplyText ??
-                      "Also send it to the agent after receiving the comment event",
-                  },
-                },
-              ],
+        const items = (
+          replyBatch?.map((reply) => ({ id: reply.reply_id, text: reply.text })) ?? [
+            rootReply,
+            {
+              id: "7623359125036043462",
+              text: params.targetReplyText ?? "Please follow up on this comment",
+              encoding: "content" as const,
             },
-          },
-          {
-            reply_id: "7623359125036043462",
-            content: {
-              elements: [
-                {
-                  type: "text_run",
-                  text_run: {
-                    content: params.targetReplyText ?? "Please follow up on this comment",
-                  },
-                },
-              ],
-            },
-          },
-        ];
+          ]
+        ).map((reply) => makeReplyPayload({ ...reply, encoding: "content" }));
         return {
           code: 0,
           data: {
@@ -202,7 +209,28 @@ function makeOpenApiClient(params: {
       }
       throw new Error(`unexpected request: ${request.method} ${request.url}`);
     }),
+    wiki: {
+      space: {
+        getNode: vi.fn(async () => ({ code: 0, data: { node: {} } })),
+      },
+    },
   };
+}
+
+function resolveCommentTurn(params: {
+  client?: unknown;
+  event?: FeishuDriveCommentNoticeEvent;
+  botOpenId?: string | null;
+  abortSignal?: AbortSignal;
+}) {
+  return resolveDriveCommentEventTurn({
+    cfg: buildMonitorConfig(),
+    accountId: "default",
+    event: params.event ?? makeDriveCommentEvent(),
+    botOpenId: params.botOpenId === null ? undefined : (params.botOpenId ?? "ou_bot"),
+    createClient: () => (params.client ?? makeOpenApiClient({})) as never,
+    abortSignal: params.abortSignal,
+  });
 }
 
 async function setupCommentMonitorHandler(
@@ -236,13 +264,7 @@ describe("resolveDriveCommentEventTurn", () => {
   it("builds a real comment-turn prompt for add_comment notices", async () => {
     const client = makeOpenApiClient({ includeTargetReplyInBatch: true });
 
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
-      event: makeDriveCommentEvent(),
-      botOpenId: "ou_bot",
-      createClient: () => client as never,
-    });
+    const turn = await resolveCommentTurn({ client });
 
     expect(turn?.senderId).toBe("ou_509d4d7ace4a9addec2312676ffcba9b");
     expect(turn?.messageId).toBe("drive-comment:10d9d60b990db39f96a4c2fd357fb877");
@@ -342,13 +364,7 @@ describe("resolveDriveCommentEventTurn", () => {
       },
     };
 
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
-      event: makeDriveCommentEvent(),
-      botOpenId: "ou_bot",
-      createClient: () => client as never,
-    });
+    const turn = await resolveCommentTurn({ client });
 
     expect(turn?.targetReplyText).toBe(
       `请 总结下 https://www.larksuite.com/docx/${TEST_DOC_TOKEN} 和 https://www.larksuite.com/wiki/${TEST_WIKI_TOKEN}`,
@@ -377,13 +393,7 @@ describe("resolveDriveCommentEventTurn", () => {
       isWholeComment: true,
     });
 
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
-      event: makeDriveCommentEvent(),
-      botOpenId: "ou_bot",
-      createClient: () => client as never,
-    });
+    const turn = await resolveCommentTurn({ client });
 
     expect(turn?.isWholeComment).toBe(true);
     expect(turn?.prompt).toContain("This is a whole-document comment.");
@@ -391,155 +401,47 @@ describe("resolveDriveCommentEventTurn", () => {
   });
 
   it("builds a whole-comment timeline and highlights the nearest bot-authored follow-up", async () => {
-    const client = {
-      request: vi.fn(async (request: { method: "GET" | "POST"; url: string; data: unknown }) => {
-        if (request.url === "/open-apis/drive/v1/metas/batch_query") {
-          return {
-            code: 0,
-            data: {
-              metas: [
-                {
-                  doc_token: TEST_DOC_TOKEN,
-                  title: "Comment event handling request",
-                  url: `https://www.larksuite.com/docx/${TEST_DOC_TOKEN}`,
-                },
-              ],
-            },
-          };
-        }
-        if (request.url.includes("/comments/batch_query")) {
-          return {
-            code: 0,
-            data: {
-              items: [
-                {
-                  comment_id: "7623358762119646411",
-                  is_whole: true,
-                  reply_list: {
-                    replies: [
-                      {
-                        reply_id: "7623358762136374451",
-                        user_id: "ou_509d4d7ace4a9addec2312676ffcba9b",
-                        create_time: 1775531531,
-                        content: {
-                          elements: [
-                            {
-                              type: "text_run",
-                              text_run: {
-                                text: "请帮我总结这个文档",
-                              },
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          };
-        }
-        if (request.url.includes("/comments?file_type=docx&is_whole=true")) {
-          return {
-            code: 0,
-            data: {
-              has_more: false,
-              items: [
-                {
-                  comment_id: "7623358762119646411",
-                  create_time: 1775531531,
-                  user_id: "ou_509d4d7ace4a9addec2312676ffcba9b",
-                  is_whole: true,
-                  reply_list: {
-                    replies: [
-                      {
-                        reply_id: "reply_a",
-                        user_id: "ou_509d4d7ace4a9addec2312676ffcba9b",
-                        create_time: 1775531531,
-                        content: {
-                          elements: [
-                            {
-                              type: "text_run",
-                              text_run: {
-                                text: "请帮我总结这个文档",
-                              },
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                },
-                {
-                  comment_id: "comment_bot_followup",
-                  create_time: 1775531540,
-                  user_id: "ou_bot",
-                  is_whole: true,
-                  reply_list: {
-                    replies: [
-                      {
-                        reply_id: "reply_b",
-                        user_id: "ou_bot",
-                        create_time: 1775531540,
-                        content: {
-                          elements: [
-                            {
-                              type: "text_run",
-                              text_run: {
-                                text: "这是刚才的总结结果",
-                              },
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                },
-                {
-                  comment_id: "comment_other_user",
-                  create_time: 1775531550,
-                  user_id: "ou_other",
-                  is_whole: true,
-                  reply_list: {
-                    replies: [
-                      {
-                        reply_id: "reply_c",
-                        user_id: "ou_other",
-                        create_time: 1775531550,
-                        content: {
-                          elements: [
-                            {
-                              type: "text_run",
-                              text_run: {
-                                text: "另一个 whole comment",
-                              },
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          };
-        }
-        throw new Error(`unexpected request: ${request.method} ${request.url}`);
-      }),
-      wiki: {
-        space: {
-          getNode: vi.fn(async () => ({ code: 0, data: { node: {} } })),
+    const userId = "ou_509d4d7ace4a9addec2312676ffcba9b";
+    const client = makeOpenApiClient({
+      isWholeComment: true,
+      batchReplies: [
+        { id: "7623358762136374451", text: "请帮我总结这个文档", userId, createTime: 1775531531 },
+      ],
+      wholeComments: [
+        {
+          id: "7623358762119646411",
+          userId,
+          createTime: 1775531531,
+          isWhole: true,
+          replies: [{ id: "reply_a", text: "请帮我总结这个文档", userId, createTime: 1775531531 }],
         },
-      },
-    };
-
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
-      event: makeDriveCommentEvent(),
-      botOpenId: "ou_bot",
-      createClient: () => client as never,
+        {
+          id: "comment_bot_followup",
+          userId: "ou_bot",
+          createTime: 1775531540,
+          isWhole: true,
+          replies: [
+            { id: "reply_b", text: "这是刚才的总结结果", userId: "ou_bot", createTime: 1775531540 },
+          ],
+        },
+        {
+          id: "comment_other_user",
+          userId: "ou_other",
+          createTime: 1775531550,
+          isWhole: true,
+          replies: [
+            {
+              id: "reply_c",
+              text: "另一个 whole comment",
+              userId: "ou_other",
+              createTime: 1775531550,
+            },
+          ],
+        },
+      ],
     });
+
+    const turn = await resolveCommentTurn({ client });
 
     expect(turn?.isWholeComment).toBe(true);
     expect(turn?.prompt).toContain(
@@ -554,103 +456,27 @@ describe("resolveDriveCommentEventTurn", () => {
   });
 
   it("treats replies with missing user_id as user-authored even when bot id hints are missing", async () => {
-    const client = {
-      request: vi.fn(async (request: { method: "GET" | "POST"; url: string; data: unknown }) => {
-        if (request.url === "/open-apis/drive/v1/metas/batch_query") {
-          return {
-            code: 0,
-            data: {
-              metas: [
-                {
-                  doc_token: TEST_DOC_TOKEN,
-                  title: "Comment event handling request",
-                  url: `https://www.larksuite.com/docx/${TEST_DOC_TOKEN}`,
-                },
-              ],
-            },
-          };
-        }
-        if (request.url.includes("/comments/batch_query")) {
-          return {
-            code: 0,
-            data: {
-              items: [
-                {
-                  comment_id: "7623358762119646411",
-                  is_whole: true,
-                  reply_list: {
-                    replies: [
-                      {
-                        reply_id: "reply_missing_user",
-                        create_time: 1775531531,
-                        content: {
-                          elements: [
-                            {
-                              type: "text_run",
-                              text_run: {
-                                text: "reply without user id",
-                              },
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          };
-        }
-        if (request.url.includes("/comments?file_type=docx&is_whole=true")) {
-          return {
-            code: 0,
-            data: {
-              has_more: false,
-              items: [
-                {
-                  comment_id: "7623358762119646411",
-                  create_time: 1775531531,
-                  is_whole: true,
-                  reply_list: {
-                    replies: [
-                      {
-                        reply_id: "reply_missing_user",
-                        create_time: 1775531531,
-                        content: {
-                          elements: [
-                            {
-                              type: "text_run",
-                              text_run: {
-                                text: "reply without user id",
-                              },
-                            },
-                          ],
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          };
-        }
-        throw new Error(`unexpected request: ${request.method} ${request.url}`);
-      }),
-      wiki: {
-        space: {
-          getNode: vi.fn(async () => ({ code: 0, data: { node: {} } })),
-        },
-      },
+    const missingUserReply = {
+      id: "reply_missing_user",
+      text: "reply without user id",
+      createTime: 1775531531,
     };
+    const client = makeOpenApiClient({
+      isWholeComment: true,
+      batchReplies: [missingUserReply],
+      wholeComments: [
+        {
+          id: "7623358762119646411",
+          createTime: 1775531531,
+          isWhole: true,
+          replies: [missingUserReply],
+        },
+      ],
+    });
 
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
-      event: makeDriveCommentEvent({
-        reply_id: "reply_missing_user",
-      }),
-      botOpenId: "ou_bot",
-      createClient: () => client as never,
+    const turn = await resolveCommentTurn({
+      client,
+      event: makeDriveCommentEvent({ reply_id: "reply_missing_user" }),
     });
 
     expect(turn?.prompt).toContain(
@@ -668,13 +494,7 @@ describe("resolveDriveCommentEventTurn", () => {
       batchCommentId: "different_comment_id",
     });
 
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
-      event: makeDriveCommentEvent(),
-      botOpenId: "ou_bot",
-      createClient: () => client as never,
-    });
+    const turn = await resolveCommentTurn({ client });
 
     expect(turn?.isWholeComment).toBeUndefined();
     expect(turn?.prompt).not.toContain("This is a whole-document comment.");
@@ -683,20 +503,16 @@ describe("resolveDriveCommentEventTurn", () => {
   it("preserves sender user_id for downstream allowlist checks", async () => {
     const client = makeOpenApiClient({ includeTargetReplyInBatch: true });
 
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
+    const turn = await resolveCommentTurn({
+      client,
       event: makeDriveCommentEvent({
         notice_meta: {
-          ...makeDriveCommentEvent().notice_meta,
           from_user_id: {
             open_id: "ou_509d4d7ace4a9addec2312676ffcba9b",
             user_id: "on_comment_user_1",
           },
         },
       }),
-      botOpenId: "ou_bot",
-      createClient: () => client as never,
     });
 
     expect(turn?.senderId).toBe("ou_509d4d7ace4a9addec2312676ffcba9b");
@@ -709,18 +525,12 @@ describe("resolveDriveCommentEventTurn", () => {
       targetReplyText: "Please follow up on this comment",
     });
 
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
+    const turn = await resolveCommentTurn({
+      client,
       event: makeDriveCommentEvent({
-        notice_meta: {
-          ...makeDriveCommentEvent().notice_meta,
-          notice_type: "add_reply",
-        },
+        notice_meta: { notice_type: "add_reply" },
         reply_id: "7623359125036043462",
       }),
-      botOpenId: "ou_bot",
-      createClient: () => client as never,
     });
 
     expect(turn?.prompt).toContain('The user added a reply in "Comment event handling request".');
@@ -770,18 +580,12 @@ describe("resolveDriveCommentEventTurn", () => {
       ],
     });
 
-    const turnPromise = resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
+    const turnPromise = resolveCommentTurn({
+      client,
       event: makeDriveCommentEvent({
-        notice_meta: {
-          ...makeDriveCommentEvent().notice_meta,
-          notice_type: "add_reply",
-        },
+        notice_meta: { notice_type: "add_reply" },
         reply_id: "7623359125999999999",
       }),
-      botOpenId: "ou_bot",
-      createClient: () => client as never,
     });
 
     await vi.waitFor(() => {
@@ -815,12 +619,9 @@ describe("resolveDriveCommentEventTurn", () => {
         ],
       ],
     });
-    const turnPromise = resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
+    const turnPromise = resolveCommentTurn({
+      client,
       event: makeDriveCommentEvent({ reply_id: "7623358762999999999" }),
-      botOpenId: "ou_bot",
-      createClient: () => client as never,
       abortSignal: abortController.signal,
     });
 
@@ -842,64 +643,41 @@ describe("resolveDriveCommentEventTurn", () => {
   });
 
   it("ignores self-authored comment notices", async () => {
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
+    const turn = await resolveCommentTurn({
       event: makeDriveCommentEvent({
-        notice_meta: {
-          ...makeDriveCommentEvent().notice_meta,
-          from_user_id: { open_id: "ou_bot" },
-        },
+        notice_meta: { from_user_id: { open_id: "ou_bot" } },
       }),
-      botOpenId: "ou_bot",
-      createClient: () => makeOpenApiClient({}) as never,
     });
 
     expect(turn).toBeNull();
   });
 
   it("uses a mentioned event recipient when startup bot identity is unavailable", async () => {
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
-      event: makeDriveCommentEvent(),
-      botOpenId: undefined,
-      createClient: () => makeOpenApiClient({}) as never,
-    });
+    const turn = await resolveCommentTurn({ botOpenId: null });
 
     expect(turn?.senderId).toBe("ou_509d4d7ace4a9addec2312676ffcba9b");
   });
 
   it("uses the event recipient to reject self-authored cold-start notices", async () => {
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
+    const turn = await resolveCommentTurn({
       event: makeDriveCommentEvent({
-        notice_meta: {
-          ...makeDriveCommentEvent().notice_meta,
-          from_user_id: { open_id: "ou_bot" },
-        },
+        notice_meta: { from_user_id: { open_id: "ou_bot" } },
       }),
-      botOpenId: undefined,
-      createClient: () => makeOpenApiClient({}) as never,
+      botOpenId: null,
     });
 
     expect(turn).toBeNull();
   });
 
   it("prefers startup bot identity over a mismatched event recipient", async () => {
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
+    const turn = await resolveCommentTurn({
       event: makeDriveCommentEvent({
         notice_meta: {
-          ...makeDriveCommentEvent().notice_meta,
           from_user_id: { open_id: "ou_configured_bot" },
           to_user_id: { open_id: "ou_other_bot" },
         },
       }),
       botOpenId: "ou_configured_bot",
-      createClient: () => makeOpenApiClient({}) as never,
     });
 
     expect(turn).toBeNull();
@@ -913,20 +691,11 @@ describe("resolveDriveCommentEventTurn", () => {
     {
       name: "missing recipient identity",
       event: makeDriveCommentEvent({
-        notice_meta: {
-          ...makeDriveCommentEvent().notice_meta,
-          to_user_id: undefined,
-        },
+        notice_meta: { to_user_id: undefined },
       }),
     },
   ])("skips a cold-start comment notice when $name", async ({ event }) => {
-    const turn = await resolveDriveCommentEventTurn({
-      cfg: buildMonitorConfig(),
-      accountId: "default",
-      event,
-      botOpenId: undefined,
-      createClient: () => makeOpenApiClient({}) as never,
-    });
+    const turn = await resolveCommentTurn({ event, botOpenId: null });
 
     expect(turn).toBeNull();
   });

--- a/extensions/feishu/src/subagent-hooks.test.ts
+++ b/extensions/feishu/src/subagent-hooks.test.ts
@@ -33,29 +33,72 @@ async function expectHookError(value: unknown, expectedErrorFragment: string): P
   expect(result.error).toContain(expectedErrorFragment);
 }
 
+function dmOrigin(sender = "ou_sender_1") {
+  return {
+    channel: "feishu" as const,
+    accountId: "work",
+    to: `user:${sender}`,
+  };
+}
+
+type FeishuOrigin = ReturnType<typeof dmOrigin> & { threadId?: string };
+
+function topicOrigin() {
+  return {
+    channel: "feishu" as const,
+    accountId: "work",
+    to: "chat:oc_group_chat",
+    threadId: "om_topic_root",
+  };
+}
+
+function spawnEvent(params: { childSessionKey: string; requester?: FeishuOrigin; label?: string }) {
+  return {
+    childSessionKey: params.childSessionKey,
+    agentId: "codex",
+    label: params.label,
+    mode: "session" as const,
+    requester: params.requester ?? dmOrigin(),
+    threadRequested: true,
+  };
+}
+
+function deliveryEvent(params: {
+  childSessionKey: string;
+  requesterOrigin?: FeishuOrigin;
+  requesterSessionKey?: string;
+}) {
+  return {
+    childSessionKey: params.childSessionKey,
+    requesterSessionKey: params.requesterSessionKey ?? "agent:main:main",
+    requesterOrigin: params.requesterOrigin ?? dmOrigin(),
+    expectsCompletionMessage: true,
+  };
+}
+
+function managedHookFixture() {
+  const handlers = registerHandlersForTest();
+  return {
+    spawnHandler: getRequiredHookHandler(handlers, "subagent_spawning"),
+    deliveryHandler: getRequiredHookHandler(handlers, "subagent_delivery_target"),
+    endedHandler: getRequiredHookHandler(handlers, "subagent_ended"),
+    manager: createFeishuThreadBindingManager({ cfg: baseConfig, accountId: "work" }),
+  };
+}
+
 describe("feishu subagent hook handlers", () => {
   beforeEach(() => {
     threadBindingTesting.resetFeishuThreadBindingsForTests();
   });
 
   it("binds a Feishu DM conversation on subagent_spawning", async () => {
-    const handlers = registerHandlersForTest();
-    const handler = getRequiredHookHandler(handlers, "subagent_spawning");
-    createFeishuThreadBindingManager({ cfg: baseConfig, accountId: "work" });
+    const { spawnHandler, deliveryHandler } = managedHookFixture();
 
-    const result = await handler(
-      {
+    const result = await spawnHandler(
+      spawnEvent({
         childSessionKey: "agent:main:subagent:child",
-        agentId: "codex",
         label: "banana",
-        mode: "session",
-        requester: {
-          channel: "feishu",
-          accountId: "work",
-          to: "user:ou_sender_1",
-        },
-        threadRequested: true,
-      },
+      }),
       {},
     );
 
@@ -69,21 +112,8 @@ describe("feishu subagent hook handlers", () => {
       },
     });
 
-    const deliveryTargetHandler = getRequiredHookHandler(handlers, "subagent_delivery_target");
     await expect(
-      deliveryTargetHandler(
-        {
-          childSessionKey: "agent:main:subagent:child",
-          requesterSessionKey: "agent:main:main",
-          requesterOrigin: {
-            channel: "feishu",
-            accountId: "work",
-            to: "user:ou_sender_1",
-          },
-          expectsCompletionMessage: true,
-        },
-        {},
-      ),
+      deliveryHandler(deliveryEvent({ childSessionKey: "agent:main:subagent:child" }), {}),
     ).resolves.toEqual({
       origin: {
         channel: "feishu",
@@ -94,9 +124,7 @@ describe("feishu subagent hook handlers", () => {
   });
 
   it("preserves the original Feishu DM delivery target", async () => {
-    const handlers = registerHandlersForTest();
-    const deliveryHandler = getRequiredHookHandler(handlers, "subagent_delivery_target");
-    const manager = createFeishuThreadBindingManager({ cfg: baseConfig, accountId: "work" });
+    const { deliveryHandler, manager } = managedHookFixture();
 
     manager.bindConversation({
       conversationId: "ou_sender_1",
@@ -110,16 +138,14 @@ describe("feishu subagent hook handlers", () => {
 
     await expect(
       deliveryHandler(
-        {
+        deliveryEvent({
           childSessionKey: "agent:main:subagent:chat-dm-child",
-          requesterSessionKey: "agent:main:main",
           requesterOrigin: {
             channel: "feishu",
             accountId: "work",
             to: "chat:oc_dm_chat_1",
           },
-          expectsCompletionMessage: true,
-        },
+        }),
         {},
       ),
     ).resolves.toEqual({
@@ -132,25 +158,14 @@ describe("feishu subagent hook handlers", () => {
   });
 
   it("binds a Feishu topic conversation and preserves parent context", async () => {
-    const handlers = registerHandlersForTest();
-    const spawnHandler = getRequiredHookHandler(handlers, "subagent_spawning");
-    const deliveryHandler = getRequiredHookHandler(handlers, "subagent_delivery_target");
-    createFeishuThreadBindingManager({ cfg: baseConfig, accountId: "work" });
+    const { spawnHandler, deliveryHandler } = managedHookFixture();
 
     const result = await spawnHandler(
-      {
+      spawnEvent({
         childSessionKey: "agent:main:subagent:topic-child",
-        agentId: "codex",
         label: "topic-child",
-        mode: "session",
-        requester: {
-          channel: "feishu",
-          accountId: "work",
-          to: "chat:oc_group_chat",
-          threadId: "om_topic_root",
-        },
-        threadRequested: true,
-      },
+        requester: topicOrigin(),
+      }),
       {},
     );
 
@@ -166,17 +181,10 @@ describe("feishu subagent hook handlers", () => {
     });
     await expect(
       deliveryHandler(
-        {
+        deliveryEvent({
           childSessionKey: "agent:main:subagent:topic-child",
-          requesterSessionKey: "agent:main:main",
-          requesterOrigin: {
-            channel: "feishu",
-            accountId: "work",
-            to: "chat:oc_group_chat",
-            threadId: "om_topic_root",
-          },
-          expectsCompletionMessage: true,
-        },
+          requesterOrigin: topicOrigin(),
+        }),
         {},
       ),
     ).resolves.toEqual({
@@ -190,10 +198,7 @@ describe("feishu subagent hook handlers", () => {
   });
 
   it("uses the requester session binding to preserve sender-scoped topic conversations", async () => {
-    const handlers = registerHandlersForTest();
-    const spawnHandler = getRequiredHookHandler(handlers, "subagent_spawning");
-    const deliveryHandler = getRequiredHookHandler(handlers, "subagent_delivery_target");
-    const manager = createFeishuThreadBindingManager({ cfg: baseConfig, accountId: "work" });
+    const { spawnHandler, deliveryHandler, manager } = managedHookFixture();
 
     manager.bindConversation({
       conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_sender_1",
@@ -208,19 +213,11 @@ describe("feishu subagent hook handlers", () => {
     });
 
     const reboundResult = await spawnHandler(
-      {
+      spawnEvent({
         childSessionKey: "agent:main:subagent:sender-child",
-        agentId: "codex",
         label: "sender-child",
-        mode: "session",
-        requester: {
-          channel: "feishu",
-          accountId: "work",
-          to: "chat:oc_group_chat",
-          threadId: "om_topic_root",
-        },
-        threadRequested: true,
-      },
+        requester: topicOrigin(),
+      }),
       {
         requesterSessionKey: "agent:main:parent",
       },
@@ -244,17 +241,11 @@ describe("feishu subagent hook handlers", () => {
     expect(childBindings[0]?.parentConversationId).toBe("oc_group_chat");
     await expect(
       deliveryHandler(
-        {
+        deliveryEvent({
           childSessionKey: "agent:main:subagent:sender-child",
           requesterSessionKey: "agent:main:parent",
-          requesterOrigin: {
-            channel: "feishu",
-            accountId: "work",
-            to: "chat:oc_group_chat",
-            threadId: "om_topic_root",
-          },
-          expectsCompletionMessage: true,
-        },
+          requesterOrigin: topicOrigin(),
+        }),
         {},
       ),
     ).resolves.toEqual({
@@ -268,54 +259,30 @@ describe("feishu subagent hook handlers", () => {
   });
 
   it("prefers requester-matching bindings when multiple child bindings exist", async () => {
-    const handlers = registerHandlersForTest();
-    const spawnHandler = getRequiredHookHandler(handlers, "subagent_spawning");
-    const deliveryHandler = getRequiredHookHandler(handlers, "subagent_delivery_target");
-    createFeishuThreadBindingManager({ cfg: baseConfig, accountId: "work" });
+    const { spawnHandler, deliveryHandler } = managedHookFixture();
 
     await spawnHandler(
-      {
+      spawnEvent({
         childSessionKey: "agent:main:subagent:shared",
-        agentId: "codex",
         label: "shared",
-        mode: "session",
-        requester: {
-          channel: "feishu",
-          accountId: "work",
-          to: "user:ou_sender_1",
-        },
-        threadRequested: true,
-      },
+      }),
       {},
     );
     await spawnHandler(
-      {
+      spawnEvent({
         childSessionKey: "agent:main:subagent:shared",
-        agentId: "codex",
         label: "shared",
-        mode: "session",
-        requester: {
-          channel: "feishu",
-          accountId: "work",
-          to: "user:ou_sender_2",
-        },
-        threadRequested: true,
-      },
+        requester: dmOrigin("ou_sender_2"),
+      }),
       {},
     );
 
     await expect(
       deliveryHandler(
-        {
+        deliveryEvent({
           childSessionKey: "agent:main:subagent:shared",
-          requesterSessionKey: "agent:main:main",
-          requesterOrigin: {
-            channel: "feishu",
-            accountId: "work",
-            to: "user:ou_sender_2",
-          },
-          expectsCompletionMessage: true,
-        },
+          requesterOrigin: dmOrigin("ou_sender_2"),
+        }),
         {},
       ),
     ).resolves.toEqual({
@@ -328,10 +295,7 @@ describe("feishu subagent hook handlers", () => {
   });
 
   it("fails closed when requester-session bindings remain ambiguous for the same topic", async () => {
-    const handlers = registerHandlersForTest();
-    const spawnHandler = getRequiredHookHandler(handlers, "subagent_spawning");
-    const deliveryHandler = getRequiredHookHandler(handlers, "subagent_delivery_target");
-    const manager = createFeishuThreadBindingManager({ cfg: baseConfig, accountId: "work" });
+    const { spawnHandler, deliveryHandler, manager } = managedHookFixture();
 
     manager.bindConversation({
       conversationId: "oc_group_chat:topic:om_topic_root:sender:ou_sender_1",
@@ -350,19 +314,11 @@ describe("feishu subagent hook handlers", () => {
 
     await expectHookError(
       spawnHandler(
-        {
+        spawnEvent({
           childSessionKey: "agent:main:subagent:ambiguous-child",
-          agentId: "codex",
           label: "ambiguous-child",
-          mode: "session",
-          requester: {
-            channel: "feishu",
-            accountId: "work",
-            to: "chat:oc_group_chat",
-            threadId: "om_topic_root",
-          },
-          threadRequested: true,
-        },
+          requester: topicOrigin(),
+        }),
         {
           requesterSessionKey: "agent:main:parent",
         },
@@ -372,27 +328,18 @@ describe("feishu subagent hook handlers", () => {
 
     await expect(
       deliveryHandler(
-        {
+        deliveryEvent({
           childSessionKey: "agent:main:subagent:ambiguous-child",
           requesterSessionKey: "agent:main:parent",
-          requesterOrigin: {
-            channel: "feishu",
-            accountId: "work",
-            to: "chat:oc_group_chat",
-            threadId: "om_topic_root",
-          },
-          expectsCompletionMessage: true,
-        },
+          requesterOrigin: topicOrigin(),
+        }),
         {},
       ),
     ).resolves.toBeUndefined();
   });
 
   it("fails closed when both topic-level and sender-scoped requester bindings exist", async () => {
-    const handlers = registerHandlersForTest();
-    const spawnHandler = getRequiredHookHandler(handlers, "subagent_spawning");
-    const deliveryHandler = getRequiredHookHandler(handlers, "subagent_delivery_target");
-    const manager = createFeishuThreadBindingManager({ cfg: baseConfig, accountId: "work" });
+    const { spawnHandler, deliveryHandler, manager } = managedHookFixture();
 
     manager.bindConversation({
       conversationId: "oc_group_chat:topic:om_topic_root",
@@ -411,19 +358,11 @@ describe("feishu subagent hook handlers", () => {
 
     await expectHookError(
       spawnHandler(
-        {
+        spawnEvent({
           childSessionKey: "agent:main:subagent:mixed-topic-child",
-          agentId: "codex",
           label: "mixed-topic-child",
-          mode: "session",
-          requester: {
-            channel: "feishu",
-            accountId: "work",
-            to: "chat:oc_group_chat",
-            threadId: "om_topic_root",
-          },
-          threadRequested: true,
-        },
+          requester: topicOrigin(),
+        }),
         {
           requesterSessionKey: "agent:main:parent",
         },
@@ -433,17 +372,11 @@ describe("feishu subagent hook handlers", () => {
 
     await expect(
       deliveryHandler(
-        {
+        deliveryEvent({
           childSessionKey: "agent:main:subagent:mixed-topic-child",
           requesterSessionKey: "agent:main:parent",
-          requesterOrigin: {
-            channel: "feishu",
-            accountId: "work",
-            to: "chat:oc_group_chat",
-            threadId: "om_topic_root",
-          },
-          expectsCompletionMessage: true,
-        },
+          requesterOrigin: topicOrigin(),
+        }),
         {},
       ),
     ).resolves.toBeUndefined();
@@ -519,11 +452,10 @@ describe("feishu subagent hook handlers", () => {
   });
 
   it("returns an error for unsupported non-topic Feishu group conversations", async () => {
-    const handler = getRequiredHookHandler(registerHandlersForTest(), "subagent_spawning");
-    createFeishuThreadBindingManager({ cfg: baseConfig, accountId: "work" });
+    const { spawnHandler } = managedHookFixture();
 
     await expectHookError(
-      handler(
+      spawnHandler(
         {
           childSessionKey: "agent:main:subagent:child",
           agentId: "codex",
@@ -542,26 +474,9 @@ describe("feishu subagent hook handlers", () => {
   });
 
   it("unbinds Feishu bindings on subagent_ended", async () => {
-    const handlers = registerHandlersForTest();
-    const spawnHandler = getRequiredHookHandler(handlers, "subagent_spawning");
-    const deliveryHandler = getRequiredHookHandler(handlers, "subagent_delivery_target");
-    const endedHandler = getRequiredHookHandler(handlers, "subagent_ended");
-    createFeishuThreadBindingManager({ cfg: baseConfig, accountId: "work" });
+    const { spawnHandler, deliveryHandler, endedHandler } = managedHookFixture();
 
-    await spawnHandler(
-      {
-        childSessionKey: "agent:main:subagent:child",
-        agentId: "codex",
-        mode: "session",
-        requester: {
-          channel: "feishu",
-          accountId: "work",
-          to: "user:ou_sender_1",
-        },
-        threadRequested: true,
-      },
-      {},
-    );
+    await spawnHandler(spawnEvent({ childSessionKey: "agent:main:subagent:child" }), {});
 
     await endedHandler(
       {
@@ -574,19 +489,7 @@ describe("feishu subagent hook handlers", () => {
     );
 
     await expect(
-      deliveryHandler(
-        {
-          childSessionKey: "agent:main:subagent:child",
-          requesterSessionKey: "agent:main:main",
-          requesterOrigin: {
-            channel: "feishu",
-            accountId: "work",
-            to: "user:ou_sender_1",
-          },
-          expectsCompletionMessage: true,
-        },
-        {},
-      ),
+      deliveryHandler(deliveryEvent({ childSessionKey: "agent:main:subagent:child" }), {}),
     ).resolves.toBeUndefined();
   });
 
@@ -597,36 +500,16 @@ describe("feishu subagent hook handlers", () => {
 
     await expectHookError(
       spawnHandler(
-        {
+        spawnEvent({
           childSessionKey: "agent:main:subagent:no-manager",
-          agentId: "codex",
-          mode: "session",
-          requester: {
-            channel: "feishu",
-            accountId: "work",
-            to: "user:ou_sender_1",
-          },
-          threadRequested: true,
-        },
+        }),
         {},
       ),
       "monitor is not active",
     );
 
     await expect(
-      deliveryHandler(
-        {
-          childSessionKey: "agent:main:subagent:no-manager",
-          requesterSessionKey: "agent:main:main",
-          requesterOrigin: {
-            channel: "feishu",
-            accountId: "work",
-            to: "user:ou_sender_1",
-          },
-          expectsCompletionMessage: true,
-        },
-        {},
-      ),
+      deliveryHandler(deliveryEvent({ childSessionKey: "agent:main:subagent:no-manager" }), {}),
     ).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The Feishu monitor lifecycle suites repeated the same Lark comment response envelopes, WebSocket runtime setup, and subagent hook events throughout three large test files. The duplicated scaffolding obscured the actual comment, retry, abort, transport cleanup, identity, and fail-closed binding scenarios and added 410 avoidable lines.

## Root Cause and Architectural Owner

These values are suite-local test fixtures, but each scenario hand-built the full transport or hook object instead of expressing only its behavioral delta. The owning production flows remain `monitor.comment`, `monitor.transport`, monitor state, subagent hooks, and thread bindings; this change keeps all fixture consolidation inside their existing test files.

## Canonical Fix

- Add small typed builders for comment replies, whole-comment timelines, and comment turns while preserving both SDK text-run encodings.
- Reuse one fresh WebSocket monitor/runtime fixture and one explicit bot-identity seeder.
- Reuse typed Feishu DM/topic origins, spawn/delivery events, and the monitor-owned binding-manager fixture.

## Removed Paths

- Repeated Drive metadata, batch-comment, whole-comment, and reply response plumbing.
- Repeated AbortController, runtime mock, account, and monitor startup objects.
- Repeated subagent requester origins, delivery targets, handler lookup, and binding-manager setup.

Production behavior and files are untouched.

## Validation Evidence

- Exact head: `9e5502cdc6abdf781971c283b658e34d27a39de5`
- Test LOC: `+331 / -741`, net `-410`; production LOC delta: `0`
- TypeScript-AST baseline parity: 40 declarations, 41 expanded cases, and all 176 ordered matcher assertions are identical
- Focused Blacksmith proof: 3 files, 41/41 tests ([run](https://github.com/openclaw/openclaw/actions/runs/30768096019))
- Full Feishu suite: 94 files, 1,467/1,467 tests
- Remote changed gate: formatting, ratchets, extension-test typecheck, and lint passed
- Direct `@larksuiteoapi/node-sdk` 1.71.1 source/types inspection confirmed ready/error/reconnect/exhaustion/close contracts
- Two independent xhigh reviews returned CLEAN on the frozen full-index binary diff
- Current-main owner-path check and synthetic merge are clean; the central inventory has no competing reservation or cached open-PR match for the three paths

## Sibling Coverage and Observed Behavior

The full plugin suite covers the adjacent webhook security, monitor lifecycle, identity recovery, ingress, comment serialization, and thread-binding paths. Focused execution preserves comment prompt timelines, self/cold-start identity handling, retry and abort ordering, WS terminal versus recoverable behavior, HTTP/WS cleanup, error redaction, sender-scoped topic selection, ambiguity failure, and ended-session unbinding.

## User Impact

No runtime or user-visible behavior changes. No changelog entry is required for this test-only cleanup.