### PR TITLE
fix(mcp): accept projected names in tool filters

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -445,7 +445,7 @@ Notes:
 - `add` accepts stdio flags such as `--command`, `--arg`, `--env`, and `--cwd`, or HTTP flags such as `--url`, `--transport`, `--header`, `--auth oauth`, TLS, timeout, and tool-selection flags. Use `--approval auto|prompt|approve` to set the Codex tool approval mode.
 - `set` expects one JSON object value on the command line.
 - `configure` updates enablement, tool filters, timeouts, OAuth, TLS, Codex approval mode, and parallel-tool-call hints without replacing the whole server definition. Add `--probe` to verify the updated server before saving.
-- `tools` updates per-server tool filters. Include/exclude entries are MCP tool names and simple `*` globs.
+- `tools` updates per-server tool filters. Include/exclude entries accept raw MCP tool names and exact names printed by `mcp probe`; simple `*` globs match raw MCP tool names only.
 - `login` runs the OAuth flow for HTTP servers configured with `auth: "oauth"`. For a loopback redirect, OpenClaw listens for the browser callback and completes login automatically. The printed `--code` command remains the fallback for remote, headless, or unreachable callbacks.
 - `logout` clears stored OAuth credentials for the named server without removing the saved server definition.
 - `reload` disposes cached in-process MCP runtimes for the current CLI process only. Gateway or agent processes in another process still need their own reload or restart path.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -166,10 +166,11 @@ target server during config edits.
   for private endpoints and mutual TLS.
 - `mcp.servers.<name>.toolFilter`: optional per-server tool selection. `include`
   limits the discovered MCP tools to matching names; `exclude` hides matching
-  names. Entries are exact MCP tool names or simple `*` globs. Servers with
+  names. Entries accept exact raw MCP tool names and exact names printed by
+  `mcp probe`; simple `*` globs match raw MCP tool names only. Servers with
   resources or prompts also generate utility tool names (`resources_list`,
   `resources_read`, `prompts_list`, `prompts_get`), and those names use the
-  same filter.
+  same raw-name filter.
 - `mcp.servers.<name>.codex`: optional Codex app-server projection controls.
   This block is OpenClaw metadata for Codex app-server threads only; it does not
   affect ACP sessions, generic Codex harness config, or other runtime adapters.

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -18,6 +18,7 @@ import type {
   BundleMcpToolRuntime,
   McpCatalogTool,
   McpToolCatalog,
+  McpUtilityToolOperation,
   SessionMcpRuntime,
 } from "./agent-bundle-mcp-types.js";
 import { projectMcpCallToolResultContent } from "./mcp-content.js";
@@ -185,6 +186,10 @@ function serverAllowsUtilityTool(
   server: McpToolCatalog["servers"][string],
   operation: string,
   sessionDeniedOnly: boolean,
+  options: {
+    projectedToolName: string;
+    modelVisibleRawToolNames: ReadonlySet<string>;
+  },
 ): boolean {
   // Two disjoint passes share this gate: the executable pass (sessionDeniedOnly=false)
   // admits only non-denied utilities; the denied-inventory pass admits only denied ones.
@@ -192,28 +197,35 @@ function serverAllowsUtilityTool(
   if ((server.deniedToolNames?.includes(operation) === true) !== sessionDeniedOnly) {
     return false;
   }
-  return isMcpToolAllowed(server.toolFilter, operation);
+  return isMcpToolAllowed(server.toolFilter, operation, options);
 }
 
 function addMcpUtilityTool(params: {
   tools: AnyAgentTool[];
   reservedNames: Set<string>;
+  externalReservedNames: ReadonlySet<string>;
+  claimedNames: Set<string>;
   serverName: string;
   safeServerName: string;
   executionMode: AnyAgentTool["executionMode"];
   operation: Exclude<PluginToolMcpMeta["operation"], "tool">;
+  projectedToolName?: string;
   label: string;
   description: string;
   parameters: Record<string, unknown>;
   deniedBySession?: true;
   execute?: AnyAgentTool["execute"];
 }) {
-  const name = buildSafeToolName({
+  const name = resolveProjectedMcpToolName({
     serverName: params.safeServerName,
     toolName: params.operation,
+    projectedToolName: params.projectedToolName,
     reservedNames: params.reservedNames,
+    externalReservedNames: params.externalReservedNames,
+    claimedNames: params.claimedNames,
   });
   params.reservedNames.add(normalizeLowercaseStringOrEmpty(name));
+  params.claimedNames.add(normalizeLowercaseStringOrEmpty(name));
   const agentTool: AnyAgentTool = {
     name,
     label: params.label,
@@ -240,6 +252,30 @@ function addMcpUtilityTool(params: {
   params.tools.push(agentTool);
 }
 
+function resolveProjectedMcpToolName(params: {
+  serverName: string;
+  toolName: string;
+  projectedToolName?: string;
+  reservedNames: Set<string>;
+  externalReservedNames: ReadonlySet<string>;
+  claimedNames: ReadonlySet<string>;
+}): string {
+  const projectedToolName = params.projectedToolName?.trim();
+  const normalizedProjectedToolName = normalizeLowercaseStringOrEmpty(projectedToolName);
+  if (
+    projectedToolName &&
+    !params.externalReservedNames.has(normalizedProjectedToolName) &&
+    !params.claimedNames.has(normalizedProjectedToolName)
+  ) {
+    return projectedToolName;
+  }
+  return buildSafeToolName({
+    serverName: params.serverName,
+    toolName: params.toolName,
+    reservedNames: params.reservedNames,
+  });
+}
+
 /**
  * Projects an already-listed MCP catalog into agent tools. Without `createExecute`,
  * the projected tools are inventory-only and throw if execution is attempted.
@@ -264,9 +300,20 @@ export function buildBundleMcpToolsFromCatalog(params: {
         includeSessionDenied: false,
       })
     : [];
+  const externalReservedNames = initialReservedNames;
+  const claimedNames = normalizeReservedToolNames(tools.map((tool) => tool.name));
+  const plannedProjectedNames = [
+    ...Object.values(params.catalog.servers).flatMap(
+      (server) =>
+        server.reservedProjectedToolNames ?? Object.values(server.projectedUtilityToolNames ?? {}),
+    ),
+    ...params.catalog.tools.flatMap((tool) => tool.projectedToolName ?? []),
+    ...(params.catalog.sessionDeniedTools ?? []).flatMap((tool) => tool.projectedToolName ?? []),
+  ];
   const reservedNames = normalizeReservedToolNames([
-    ...initialReservedNames,
-    ...tools.map((tool) => tool.name),
+    ...externalReservedNames,
+    ...claimedNames,
+    ...plannedProjectedNames,
   ]);
   const catalogTools = sessionDeniedOnly
     ? (params.catalog.sessionDeniedTools ?? [])
@@ -294,10 +341,13 @@ export function buildBundleMcpToolsFromCatalog(params: {
     const server = params.catalog.servers[tool.serverName];
     const executionMode: AnyAgentTool["executionMode"] =
       server?.supportsParallelToolCalls === true ? "parallel" : "sequential";
-    const safeToolName = buildSafeToolName({
+    const safeToolName = resolveProjectedMcpToolName({
       serverName: tool.safeServerName,
       toolName: originalName,
+      projectedToolName: tool.projectedToolName,
       reservedNames,
+      externalReservedNames,
+      claimedNames,
     });
     if (safeToolName !== `${tool.safeServerName}${TOOL_NAME_SEPARATOR}${originalName}`) {
       logWarn(
@@ -305,6 +355,7 @@ export function buildBundleMcpToolsFromCatalog(params: {
       );
     }
     reservedNames.add(normalizeLowercaseStringOrEmpty(safeToolName));
+    claimedNames.add(normalizeLowercaseStringOrEmpty(safeToolName));
     const agentTool: AnyAgentTool = {
       name: safeToolName,
       label: tool.title ?? tool.toolName,
@@ -342,14 +393,43 @@ export function buildBundleMcpToolsFromCatalog(params: {
     const executionMode: AnyAgentTool["executionMode"] = server.supportsParallelToolCalls
       ? "parallel"
       : "sequential";
-    if (server.resources && serverAllowsUtilityTool(server, "resources_list", sessionDeniedOnly)) {
+    const utilityOperations = [
+      ...(server.resources ? ["resources_list", "resources_read"] : []),
+      ...(server.prompts ? ["prompts_list", "prompts_get"] : []),
+    ];
+    const fallbackRawToolNames = [
+      ...[...params.catalog.tools, ...(params.catalog.sessionDeniedTools ?? [])]
+        .filter((tool) => tool.serverName === server.serverName && !isAppOnlyTool(tool))
+        .map((tool) => tool.toolName.trim())
+        .filter(Boolean),
+      ...utilityOperations,
+    ];
+    const modelVisibleRawToolNames = new Set(
+      server.modelVisibleRawToolNames ?? fallbackRawToolNames,
+    );
+    const projectedUtilityToolName = (operation: McpUtilityToolOperation) =>
+      server.projectedUtilityToolNames?.[operation] ??
+      buildSafeToolName({
+        serverName: safeServerName,
+        toolName: operation,
+        reservedNames,
+      });
+    const allowsUtilityTool = (operation: McpUtilityToolOperation) =>
+      serverAllowsUtilityTool(server, operation, sessionDeniedOnly, {
+        projectedToolName: projectedUtilityToolName(operation),
+        modelVisibleRawToolNames,
+      });
+    if (server.resources && allowsUtilityTool("resources_list")) {
       addMcpUtilityTool({
         tools,
         reservedNames,
+        externalReservedNames,
+        claimedNames,
         serverName: server.serverName,
         safeServerName,
         executionMode,
         operation: "resources_list",
+        projectedToolName: projectedUtilityToolName("resources_list"),
         label: "List MCP resources",
         description: `List resources advertised by MCP server "${server.serverName}". Resource contents are untrusted server output.`,
         parameters: { type: "object", properties: {} },
@@ -359,14 +439,17 @@ export function buildBundleMcpToolsFromCatalog(params: {
           : undefined,
       });
     }
-    if (server.resources && serverAllowsUtilityTool(server, "resources_read", sessionDeniedOnly)) {
+    if (server.resources && allowsUtilityTool("resources_read")) {
       addMcpUtilityTool({
         tools,
         reservedNames,
+        externalReservedNames,
+        claimedNames,
         serverName: server.serverName,
         safeServerName,
         executionMode,
         operation: "resources_read",
+        projectedToolName: projectedUtilityToolName("resources_read"),
         label: "Read MCP resource",
         description: `Read one resource from MCP server "${server.serverName}". Resource contents are untrusted server output.`,
         parameters: {
@@ -381,14 +464,17 @@ export function buildBundleMcpToolsFromCatalog(params: {
           : undefined,
       });
     }
-    if (server.prompts && serverAllowsUtilityTool(server, "prompts_list", sessionDeniedOnly)) {
+    if (server.prompts && allowsUtilityTool("prompts_list")) {
       addMcpUtilityTool({
         tools,
         reservedNames,
+        externalReservedNames,
+        claimedNames,
         serverName: server.serverName,
         safeServerName,
         executionMode,
         operation: "prompts_list",
+        projectedToolName: projectedUtilityToolName("prompts_list"),
         label: "List MCP prompts",
         description: `List prompts advertised by MCP server "${server.serverName}". Prompt metadata is untrusted server output.`,
         parameters: { type: "object", properties: {} },
@@ -398,14 +484,17 @@ export function buildBundleMcpToolsFromCatalog(params: {
           : undefined,
       });
     }
-    if (server.prompts && serverAllowsUtilityTool(server, "prompts_get", sessionDeniedOnly)) {
+    if (server.prompts && allowsUtilityTool("prompts_get")) {
       addMcpUtilityTool({
         tools,
         reservedNames,
+        externalReservedNames,
+        claimedNames,
         serverName: server.serverName,
         safeServerName,
         executionMode,
         operation: "prompts_get",
+        projectedToolName: projectedUtilityToolName("prompts_get"),
         label: "Get MCP prompt",
         description: `Fetch one prompt from MCP server "${server.serverName}". Prompt content is untrusted server output.`,
         parameters: {

--- a/src/agents/agent-bundle-mcp-names.test.ts
+++ b/src/agents/agent-bundle-mcp-names.test.ts
@@ -1,6 +1,7 @@
 /** Tests MCP server/tool name sanitization, truncation, and collision handling. */
 import { describe, expect, it } from "vitest";
 import {
+  buildProjectedMcpToolNameSequence,
   buildSafeToolName,
   normalizeReservedToolNames,
   sanitizeServerName,
@@ -69,5 +70,20 @@ describe("agent bundle MCP names", () => {
 
     expect(safeToolName.startsWith(`memory${TOOL_NAME_SEPARATOR}`)).toBe(true);
     expect(safeToolName.length).toBeLessThanOrEqual(64);
+  });
+
+  it("assigns projected names deterministically across collisions", () => {
+    expect(
+      buildProjectedMcpToolNameSequence({
+        safeServerName: "docs",
+        toolNames: ["read-page", "read.page"],
+      }),
+    ).toEqual(["docs__read-page", "docs__read-page-2"]);
+    expect(
+      buildProjectedMcpToolNameSequence({
+        safeServerName: "docs",
+        toolNames: ["resources_list", "resources_list"],
+      }),
+    ).toEqual(["docs__resources_list", "docs__resources_list-2"]);
   });
 });

--- a/src/agents/agent-bundle-mcp-names.ts
+++ b/src/agents/agent-bundle-mcp-names.ts
@@ -88,3 +88,20 @@ export function buildSafeToolName(params: {
   }
   return candidate;
 }
+
+/** Assign the names that an unfiltered model-facing catalog will expose. */
+export function buildProjectedMcpToolNameSequence(params: {
+  safeServerName: string;
+  toolNames: Iterable<string>;
+}): string[] {
+  const reservedNames = new Set<string>();
+  return Array.from(params.toolNames, (toolName) => {
+    const projectedName = buildSafeToolName({
+      serverName: params.safeServerName,
+      toolName,
+      reservedNames,
+    });
+    reservedNames.add(normalizeLowercaseStringOrEmpty(projectedName));
+    return projectedName;
+  });
+}

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -547,6 +547,96 @@ afterEach(async () => {
 });
 
 describe("session MCP runtime", () => {
+  it("lets a probe-projected model tool outrank an app-only raw-name collision", async () => {
+    const tempDir = tempDirTracker.make("bundle-mcp-projected-app-collision-");
+    const serverPath = path.join(tempDir, "projected-app-collision.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      tools: [
+        {
+          name: "docs__read",
+          inputSchema: { type: "object", properties: {} },
+          _meta: { ui: { visibility: ["app"] } },
+        },
+        { name: "read", inputSchema: { type: "object", properties: {} } },
+      ],
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-projected-app-collision",
+      sessionKey: "agent:test:session-projected-app-collision",
+      workspaceDir: tempDir,
+      cfg: {
+        mcp: {
+          servers: {
+            docs: {
+              command: process.execPath,
+              args: [serverPath],
+              toolFilter: { include: ["docs__read"] },
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+      expect(catalog.tools.map((tool) => tool.toolName).toSorted()).toEqual(["docs__read", "read"]);
+      const materialized = await materializeBundleMcpToolsForRun({ runtime });
+      expect(materialized.tools.map((tool) => tool.name)).toEqual(["docs__read"]);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("retains a projected utility suffix after filtering its listed collision", async () => {
+    const tempDir = tempDirTracker.make("bundle-mcp-projected-utility-collision-");
+    const serverPath = path.join(tempDir, "projected-utility-collision.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      capabilities: { tools: {}, resources: {} },
+      tools: [
+        {
+          name: "resources_list",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-projected-utility-collision",
+      sessionKey: "agent:test:session-projected-utility-collision",
+      workspaceDir: tempDir,
+      cfg: {
+        mcp: {
+          servers: {
+            docs: {
+              command: process.execPath,
+              args: [serverPath],
+              toolFilter: { include: ["docs__resources_list-2"] },
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+      expect(catalog.tools).toEqual([]);
+      expect(catalog.servers.docs?.projectedUtilityToolNames?.resources_list).toBe(
+        "docs__resources_list-2",
+      );
+      const materialized = await materializeBundleMcpToolsForRun({ runtime });
+      expect(materialized.tools.map((tool) => tool.name)).toEqual(["docs__resources_list-2"]);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
   it("advertises the stable MCP Apps client extension only when enabled", () => {
     expect(testing.buildMcpClientCapabilities(false)).toEqual({});
     expect(testing.buildMcpClientCapabilities(true)).toEqual({

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -34,7 +34,11 @@ import {
   createSessionMcpRuntimeManager,
   setDefaultCreateSessionMcpRuntime,
 } from "./agent-bundle-mcp-manager.js";
-import { assignSafeServerNames, sanitizeServerName } from "./agent-bundle-mcp-names.js";
+import {
+  assignSafeServerNames,
+  buildProjectedMcpToolNameSequence,
+  sanitizeServerName,
+} from "./agent-bundle-mcp-names.js";
 import { getSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
 import {
   loadSessionMcpConfig,
@@ -47,6 +51,7 @@ import type {
   McpServerCatalog,
   McpToolCatalog,
   McpToolCatalogDiagnostic,
+  McpUtilityToolOperation,
   RequesterMcpConnect,
   SessionMcpRequesterScope,
   SessionMcpRuntime,
@@ -249,6 +254,17 @@ function normalizeToolUiVisibility(value: unknown): Array<"app" | "model"> | und
     (entry): entry is "app" | "model" => entry === "app" || entry === "model",
   );
   return [...new Set(normalized)].toSorted();
+}
+
+function getListedToolUiVisibility(tool: ListedTool): Array<"app" | "model"> | undefined {
+  const { _meta: metadata } = tool;
+  const uiMeta = isRecord(metadata?.ui) ? metadata.ui : undefined;
+  return normalizeToolUiVisibility(uiMeta?.visibility);
+}
+
+function isModelVisibleListedTool(tool: ListedTool): boolean {
+  const visibility = getListedToolUiVisibility(tool);
+  return visibility === undefined || visibility.includes("model");
 }
 
 function summarizeServerCapabilities(capabilities: ServerCapabilities | undefined) {
@@ -780,8 +796,53 @@ export function createSessionMcpRuntime(params: {
                 const deniedToolNames = new Set(
                   denialMap && Object.hasOwn(denialMap, serverName) ? denialMap[serverName] : [],
                 );
+                const listedModelRawToolNames = [
+                  ...new Set(
+                    listedTools
+                      .filter(isModelVisibleListedTool)
+                      .map((tool) => tool.name.trim())
+                      .filter(Boolean),
+                  ),
+                ].toSorted((left, right) => left.localeCompare(right));
+                const resourceOperations: McpUtilityToolOperation[] = capabilities.resources
+                  ? ["resources_list", "resources_read"]
+                  : [];
+                const promptOperations: McpUtilityToolOperation[] = capabilities.prompts
+                  ? ["prompts_list", "prompts_get"]
+                  : [];
+                const utilityOperations: McpUtilityToolOperation[] = [
+                  ...resourceOperations,
+                  ...promptOperations,
+                ];
+                const projectedNameSequence = buildProjectedMcpToolNameSequence({
+                  safeServerName,
+                  toolNames: [...listedModelRawToolNames, ...utilityOperations],
+                });
+                const projectedToolNames = new Map<string, string>();
+                for (const [index, toolName] of listedModelRawToolNames.entries()) {
+                  const projectedName = projectedNameSequence[index];
+                  if (projectedName) {
+                    projectedToolNames.set(toolName, projectedName);
+                  }
+                }
+                const projectedUtilityToolNames: Partial<Record<McpUtilityToolOperation, string>> =
+                  {};
+                for (const [index, operation] of utilityOperations.entries()) {
+                  const projectedName =
+                    projectedNameSequence[listedModelRawToolNames.length + index];
+                  if (projectedName) {
+                    projectedUtilityToolNames[operation] = projectedName;
+                  }
+                }
+                const modelVisibleRawToolNames = new Set([
+                  ...listedModelRawToolNames,
+                  ...utilityOperations,
+                ]);
                 const policyEligibleTools = listedTools.filter((tool) =>
-                  isMcpToolAllowed(toolFilter, tool.name.trim()),
+                  isMcpToolAllowed(toolFilter, tool.name.trim(), {
+                    projectedToolName: projectedToolNames.get(tool.name.trim()),
+                    modelVisibleRawToolNames,
+                  }),
                 );
                 const exposedTools = policyEligibleTools.filter((tool) => {
                   const toolName = tool.name.trim();
@@ -807,6 +868,9 @@ export function createSessionMcpRuntime(params: {
                       }
                     : {}),
                   ...(toolFilter ? { toolFilter } : {}),
+                  projectedUtilityToolNames,
+                  modelVisibleRawToolNames: [...modelVisibleRawToolNames],
+                  reservedProjectedToolNames: projectedNameSequence,
                   ...(deniedToolNames.size > 0
                     ? { deniedToolNames: [...deniedToolNames].toSorted() }
                     : {}),
@@ -828,11 +892,12 @@ export function createSessionMcpRuntime(params: {
                     typeof rawResourceUri === "string" && rawResourceUri.startsWith("ui://")
                       ? rawResourceUri
                       : undefined;
-                  const uiVisibility = normalizeToolUiVisibility(uiMeta?.visibility);
+                  const uiVisibility = getListedToolUiVisibility(tool);
                   toolEntries.push({
                     serverName,
                     safeServerName,
                     toolName,
+                    projectedToolName: projectedToolNames.get(toolName),
                     title: tool.title,
                     description: sanitizeMcpMetadataText(tool.description),
                     inputSchema: tool.inputSchema,

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -570,6 +570,115 @@ describe("createBundleMcpToolRuntime", () => {
     expect(runtime.tools.map((tool) => tool.name)).toEqual(["knowledge__resources_list"]);
   });
 
+  it("accepts an exact probe-projected utility name", () => {
+    const tools = buildBundleMcpToolsFromCatalog({
+      catalog: {
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          knowledge: {
+            serverName: "knowledge",
+            safeServerName: "knowledge",
+            launchSummary: "knowledge",
+            toolCount: 0,
+            resources: { listChanged: false },
+            toolFilter: { include: ["knowledge__resources_list"] },
+          },
+        },
+        tools: [],
+      },
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["knowledge__resources_list"]);
+  });
+
+  it("keeps a listed raw tool ahead of the same projected utility name", () => {
+    const tools = buildBundleMcpToolsFromCatalog({
+      catalog: {
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          knowledge: {
+            serverName: "knowledge",
+            safeServerName: "knowledge",
+            launchSummary: "knowledge",
+            toolCount: 1,
+            resources: { listChanged: false },
+            toolFilter: { include: ["knowledge__resources_list"] },
+          },
+        },
+        tools: [
+          {
+            serverName: "knowledge",
+            safeServerName: "knowledge",
+            toolName: "knowledge__resources_list",
+            inputSchema: { type: "object" },
+            fallbackDescription: "raw tool",
+          },
+        ],
+      },
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["knowledge__knowledge__resources_list"]);
+  });
+
+  it("keeps a pre-filter projected utility suffix after its listed collision is removed", () => {
+    const tools = buildBundleMcpToolsFromCatalog({
+      catalog: {
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          knowledge: {
+            serverName: "knowledge",
+            safeServerName: "knowledge",
+            launchSummary: "knowledge",
+            toolCount: 0,
+            resources: { listChanged: false },
+            toolFilter: { include: ["knowledge__resources_list-2"] },
+            projectedUtilityToolNames: {
+              resources_list: "knowledge__resources_list-2",
+            },
+            modelVisibleRawToolNames: ["resources_list"],
+          },
+        },
+        tools: [],
+      },
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["knowledge__resources_list-2"]);
+  });
+
+  it("does not reuse a filtered projected alias during external-name reallocation", () => {
+    const tools = buildBundleMcpToolsFromCatalog({
+      reservedToolNames: ["docs__read-page"],
+      catalog: {
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          docs: {
+            serverName: "docs",
+            safeServerName: "docs",
+            launchSummary: "docs",
+            toolCount: 1,
+            reservedProjectedToolNames: ["docs__read-page", "docs__read-page-2"],
+          },
+        },
+        tools: [
+          {
+            serverName: "docs",
+            safeServerName: "docs",
+            toolName: "read-page",
+            projectedToolName: "docs__read-page",
+            inputSchema: { type: "object" },
+            fallbackDescription: "surviving tool",
+          },
+        ],
+      },
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["docs__read-page-3"]);
+  });
+
   it("projects resource and prompt utility tools for inventory-only catalogs", async () => {
     const tools = buildBundleMcpToolsFromCatalog({
       catalog: {

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -23,6 +23,12 @@ export type BundleMcpToolRuntime = {
 };
 
 /** Catalog metadata for one configured MCP server. */
+export type McpUtilityToolOperation =
+  | "resources_list"
+  | "resources_read"
+  | "prompts_list"
+  | "prompts_get";
+
 export type McpServerCatalog = {
   serverName: string;
   safeServerName?: string;
@@ -41,6 +47,12 @@ export type McpServerCatalog = {
   requestTimeoutMs?: number;
   supportsParallelToolCalls?: boolean;
   toolFilter?: McpServerToolFilterConfig;
+  /** Filter aliases computed before listed tools are removed from the catalog. */
+  projectedUtilityToolNames?: Partial<Record<McpUtilityToolOperation, string>>;
+  /** Full pre-filter raw-name precedence set used by exact projected aliases. */
+  modelVisibleRawToolNames?: string[];
+  /** Complete pre-filter projected namespace, including filtered-out tools. */
+  reservedProjectedToolNames?: string[];
   deniedToolNames?: string[];
   codexApprovalMode?: McpCodexToolApprovalMode;
 };
@@ -50,6 +62,8 @@ export type McpCatalogTool = {
   serverName: string;
   safeServerName: string;
   toolName: string;
+  /** Stable pre-filter model-facing name printed by `mcp probe`. */
+  projectedToolName?: string;
   title?: string;
   description?: string;
   inputSchema: TSchema;

--- a/src/agents/mcp-tool-filter.test.ts
+++ b/src/agents/mcp-tool-filter.test.ts
@@ -42,4 +42,44 @@ describe("isMcpToolAllowed", () => {
     expect(isMcpToolAllowed(filter, "search_docs")).toBe(false);
     expect(isMcpToolAllowed(filter, "read_file")).toBe(false);
   });
+
+  it("accepts exact projected names without broadening wildcard matching", () => {
+    const modelVisibleRawToolNames = new Set(["read_page", "docs__raw"]);
+
+    expect(
+      isMcpToolAllowed({ include: ["docs__read_page"] }, "read_page", {
+        projectedToolName: "docs__read_page",
+        modelVisibleRawToolNames,
+      }),
+    ).toBe(true);
+    expect(
+      isMcpToolAllowed({ include: ["docs__*"] }, "read_page", {
+        projectedToolName: "docs__read_page",
+        modelVisibleRawToolNames,
+      }),
+    ).toBe(false);
+    expect(
+      isMcpToolAllowed({ exclude: ["docs__read_page"] }, "read_page", {
+        projectedToolName: "docs__read_page",
+        modelVisibleRawToolNames,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps model-visible raw names ahead of projected aliases", () => {
+    const modelVisibleRawToolNames = new Set(["read", "docs__read"]);
+
+    expect(
+      isMcpToolAllowed({ include: ["docs__read"] }, "read", {
+        projectedToolName: "docs__read",
+        modelVisibleRawToolNames,
+      }),
+    ).toBe(false);
+    expect(
+      isMcpToolAllowed({ include: ["docs__read"] }, "docs__read", {
+        projectedToolName: "docs__docs__read",
+        modelVisibleRawToolNames,
+      }),
+    ).toBe(true);
+  });
 });

--- a/src/agents/mcp-tool-filter.ts
+++ b/src/agents/mcp-tool-filter.ts
@@ -57,8 +57,24 @@ export function normalizeMcpToolFilter(raw: unknown): McpServerToolFilterConfig 
 export function isMcpToolAllowed(
   toolFilter: McpServerToolFilterConfig | undefined,
   toolName: string,
+  options?: {
+    projectedToolName?: string;
+    modelVisibleRawToolNames?: ReadonlySet<string>;
+  },
 ): boolean {
-  const matches = (pattern: string) => matchesMcpToolFilterPattern(pattern, toolName);
+  const matches = (pattern: string) => {
+    const trimmed = pattern.trim();
+    if (matchesMcpToolFilterPattern(trimmed, toolName)) {
+      return true;
+    }
+    // Probe output is an exact copy/paste contract. Wildcards remain scoped to
+    // raw MCP names, and a model-visible raw name wins over the same alias.
+    return (
+      !trimmed.includes("*") &&
+      trimmed === options?.projectedToolName &&
+      !options?.modelVisibleRawToolNames?.has(trimmed)
+    );
+  };
   return (
     (!toolFilter?.include?.length || toolFilter.include.some(matches)) &&
     !toolFilter?.exclude?.some(matches)

--- a/src/config/schema.help.agents.ts
+++ b/src/config/schema.help.agents.ts
@@ -216,11 +216,11 @@ export const AGENT_FIELD_HELP: Record<string, string> = {
   "mcp.servers.*.codex":
     "OpenClaw projection metadata for Codex app-server threads only. It does not affect ACP sessions or generic Codex harness config. Omit this block to keep the server available to every Codex app-server agent with Codex's default MCP approval behavior.",
   "mcp.servers.*.toolFilter":
-    "Per-server MCP tool selection. Use include to expose only selected MCP tool names, or exclude to hide selected MCP tool names. Entries accept exact names and simple '*' globs.",
+    "Per-server MCP tool selection. Use include to expose only selected MCP tool names, or exclude to hide selected MCP tool names. Entries accept exact raw names and exact names printed by mcp probe; simple '*' globs match raw names only.",
   "mcp.servers.*.toolFilter.include":
-    "Exact MCP tool names or simple '*' globs to expose from this server. When omitted, all server tools remain eligible unless excluded.",
+    "Exact raw MCP tool names, exact names printed by mcp probe, or simple raw-name '*' globs to expose from this server. When omitted, all server tools remain eligible unless excluded.",
   "mcp.servers.*.toolFilter.exclude":
-    "Exact MCP tool names or simple '*' globs to hide from this server.",
+    "Exact raw MCP tool names, exact names printed by mcp probe, or simple raw-name '*' globs to hide from this server.",
   "mcp.servers.*.oauth.identity":
     'OAuth credential ownership for this server. Omit this field or use "shared" for operator-managed credentials; use "per-requester" to let each authenticated sender connect their own account.',
   "mcp.servers.*.oauth.authProfileId":


### PR DESCRIPTION
## What Problem This Solves

`openclaw mcp probe` prints provider-safe tool names such as `docs__read-page`, but per-server `toolFilter` rules previously matched only raw MCP names. Copying an exact name from probe could therefore hide the intended tool, especially when sanitization, App-only tools, utility tools, or reserved names introduced collision suffixes.

## Summary

- accept exact model-facing names printed by `openclaw mcp probe` in per-server include and exclude filters
- keep simple `*` globs scoped to raw MCP names
- keep model-visible raw exact names ahead of projected aliases; App-only raw names do not shadow model-visible aliases
- allocate the complete projected namespace before filtering, including resource and prompt utility tools
- preserve the planned model-facing IDs after filtered or session-denied tools disappear
- keep external/native reserved names safe without reusing a filtered tool's planned alias
- implement matching in the canonical `mcp-tool-filter.ts` owner and name allocation in `agent-bundle-mcp-names.ts`
- document the raw/projected matching contract

Fixes #98193.

## Evidence

The regressions cover:

- exact projected include and exclude matching
- raw-only wildcard behavior
- listed-tool sanitization collisions
- hidden App-only raw-name collisions
- resource/prompt utility aliases
- listed/utility duplicate raw names
- collision suffixes retained after filtering
- session-denied inventory
- external reserved names skipping every pre-filter planned alias
- a real stdio MCP runtime catalog and materialization path

## Validation

- `node scripts/run-vitest.mjs src/agents/mcp-tool-filter.test.ts src/agents/agent-bundle-mcp-names.test.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts` (48 passed)
- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts` (94 passed)
- `pnpm tsgo:core`
- `node scripts/run-oxlint.mjs` on all changed TypeScript files (0 warnings, 0 errors)
- `oxfmt --check` on all changed files
- `pnpm docs:check-config-examples`
- `node scripts/check-changed.mjs -- <changed files>`; all completed gates passed through core typecheck, and its final core-test lane was rerun separately after the combined 600-second orchestration window ended
- `pnpm tsgo:test:src` (PASS)
- independent fail-closed review of projected-name, utility, session-denied, and external-reserved collision matrices

## Duplicate Check

Checked current `origin/main`, issue #98193, this PR, and open PR search for MCP probe/projected-name filter fixes. Current main centralizes raw matching in `mcp-tool-filter.ts` but does not implement the projected-name contract added here.

## Browser / Playwright

Not applicable. This changes MCP runtime filtering, materialization, CLI/config documentation, and TypeScript tests; it does not change browser or Control UI behavior.
