### PR TITLE
refactor: consolidate audit migration test fixtures

### DIFF
--- a/src/infra/state-migrations.audit-logs.test.ts
+++ b/src/infra/state-migrations.audit-logs.test.ts
@@ -2,118 +2,56 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { CONFIG_AUDIT_MAX_ENTRIES, CONFIG_AUDIT_SCOPE } from "../config/io.audit.js";
-import { listConfigAuditRecordsForTests } from "../config/io.audit.test-support.js";
 import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
 import { SYSTEM_AGENT_AUDIT_SCOPE } from "../system-agent/audit.js";
-import { listSystemAgentAuditEntriesForTests } from "../system-agent/audit.test-support.js";
-import { withTempDir } from "../test-helpers/temp-dir.js";
 import { acquireGatewayLock } from "./gateway-lock.js";
 import { createSqliteAuditRecordStore } from "./sqlite-audit-record-store.js";
 import { openLegacyAuditRawCheckpointStore } from "./state-migrations.audit-checkpoints.js";
-import { detectLegacyAuditLogs, migrateLegacyAuditLogs } from "./state-migrations.audit-logs.js";
-
-const TEST_AUDIT_SCRUB_PATTERN = Buffer.from(
-  Array.from({ length: 32 }, (_, index) => (index % 2 === 0 ? 0x20 : 0x09)),
-);
-
-function buildTestAuditScrubbedContent(length: number): Buffer {
-  const content = Buffer.allocUnsafe(length);
-  for (let offset = 0; offset < length; offset += TEST_AUDIT_SCRUB_PATTERN.length) {
-    TEST_AUDIT_SCRUB_PATTERN.copy(
-      content,
-      offset,
-      0,
-      Math.min(TEST_AUDIT_SCRUB_PATTERN.length, length - offset),
-    );
-  }
-  return content;
-}
-
-async function buildTestAuditRestoreJournal(
-  rawPath: string,
-  sourceRaw: Buffer,
-  progress: { restoredBytes: number; scrubbedBytes: number } = {
-    restoredBytes: 0,
-    scrubbedBytes: 0,
-  },
-): Promise<string> {
-  const stat = await fs.stat(rawPath);
-  const journal = `${JSON.stringify({
-    schemaVersion: 6,
-    rawBase64: sourceRaw.toString("base64"),
-    scrubPatternBase64: TEST_AUDIT_SCRUB_PATTERN.toString("base64"),
-    target: { dev: stat.dev, ino: stat.ino, size: sourceRaw.length },
-  })}\n`;
-  await fs.writeFile(
-    `${rawPath}.doctor-scrub-progress`,
-    `${JSON.stringify({
-      schemaVersion: 1,
-      journalHash: createHash("sha256").update(journal).digest("hex"),
-      direction: progress.restoredBytes > 0 ? "restoring" : "scrubbing",
-      committedBytes: progress.restoredBytes > 0 ? progress.restoredBytes : progress.scrubbedBytes,
-      pendingEnd: progress.restoredBytes > 0 ? progress.restoredBytes : progress.scrubbedBytes,
-      extentBytes: progress.restoredBytes > 0 ? progress.scrubbedBytes : sourceRaw.length,
-    })}\n`,
-  );
-  return journal;
-}
+import {
+  AuditMigrationFixture,
+  buildAuditScrubbedContent,
+  configAuditRecord,
+  failChmodCall,
+  failSecondScrubWrite,
+  systemAuditEvent,
+  withAuditMigrationFixture,
+  writeAuditRestoreJournal,
+} from "./state-migrations.audit.test-support.js";
 
 describe("legacy core audit log migration", () => {
-  afterEach(() => {
-    resetPluginStateStoreForTests();
-  });
+  afterEach(resetPluginStateStoreForTests);
 
   it("imports config and system audit JSONL only through explicit doctor repair", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-" }, async (stateDir) => {
-      const configPath = path.join(stateDir, "logs", "config-audit.jsonl");
-      const systemPath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const crestodianPath = path.join(stateDir, "audit", "crestodian.jsonl");
-      await fs.mkdir(path.dirname(configPath), { recursive: true });
-      await fs.mkdir(path.dirname(systemPath), { recursive: true });
-      const unredactedConfigRecord = {
-        ts: "2026-07-01T00:00:00.000Z",
-        source: "config-io",
-        event: "config.write",
-        argv: ["openclaw", "config", "set", "token", "must-redact"],
-        execArgv: [],
-      };
+    await withAuditMigrationFixture(async (audit) => {
+      const { source: configPath } = audit.config;
+      const { source: systemPath } = audit.system;
+      const crestodianPath = path.join(audit.stateDir, "audit", "crestodian.jsonl");
+      const unredactedConfigRecord = configAuditRecord("must-redact");
       const unredactedDigest = createHash("sha256")
         .update(JSON.stringify(unredactedConfigRecord))
         .digest("hex")
         .slice(0, 16);
-      await fs.writeFile(configPath, `${JSON.stringify(unredactedConfigRecord)}\n`);
-      await fs.writeFile(
-        systemPath,
-        `${JSON.stringify({
+      await audit.writeJsonLines(configPath, [unredactedConfigRecord]);
+      await audit.writeJsonLines(systemPath, [
+        systemAuditEvent("Set config", {
           timestamp: "2026-07-02T00:00:00.000Z",
           operation: "config.set",
-          summary: "Set config",
-        })}\n`,
-      );
-      await fs.writeFile(
-        crestodianPath,
-        `${JSON.stringify({
-          timestamp: "2026-07-03T00:00:00.000Z",
-          operation: "gateway.restart",
-          summary: "Restarted gateway",
-        })}\n`,
-      );
+        }),
+      ]);
+      await audit.writeJsonLines(crestodianPath, [systemAuditEvent("Restarted gateway")]);
 
-      expect(detectLegacyAuditLogs({ stateDir }).hasLegacy).toBe(false);
-      const detected = detectLegacyAuditLogs({
-        stateDir,
-        doctorOnlyStateMigrations: true,
-      });
+      expect(audit.detect(false).hasLegacy).toBe(false);
+      const detected = audit.detect();
       expect(detected.sources).toHaveLength(3);
 
-      const result = await migrateLegacyAuditLogs({ detected, stateDir });
+      const result = await audit.migrate(detected);
       expect(result.warnings).toEqual([]);
       expect(result.changes).toHaveLength(6);
 
-      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
-      const configRecords = listConfigAuditRecordsForTests({ env, homedir: () => stateDir });
+      const { env } = audit;
+      const configRecords = audit.configRecords();
       expect(configRecords).toHaveLength(1);
       expect(JSON.stringify(configRecords)).not.toContain("must-redact");
       const configEntries = createSqliteAuditRecordStore({
@@ -134,78 +72,57 @@ describe("legacy core audit log migration", () => {
       expect(JSON.parse(archivedConfig.trim())).toMatchObject({
         argv: ["openclaw", "config", "set", "token", "***"],
       });
-      expect(
-        listSystemAgentAuditEntriesForTests({ env })
-          .map((entry) => entry.value.operation)
-          .toSorted(),
-      ).toEqual(["config.set", "gateway.restart"]);
+      expect(audit.systemOperations()).toEqual(["config.set", "gateway.restart"]);
       await expect(fs.access(configPath)).rejects.toThrow();
       await expect(fs.access(systemPath)).rejects.toThrow();
       await expect(fs.access(crestodianPath)).rejects.toThrow();
 
-      expect(detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }).hasLegacy).toBe(
-        false,
-      );
+      expect(audit.detect().hasLegacy).toBe(false);
       const laterConfigRecord = {
         ...unredactedConfigRecord,
         ts: "2026-07-04T00:00:00.000Z",
         argv: ["openclaw", "config", "set", "token", "later-redaction-marker"],
       };
       await fs.appendFile(`${configPath}.migrated.raw`, `${JSON.stringify(laterConfigRecord)}\n`);
-      const rawRecovery = detectLegacyAuditLogs({
-        stateDir,
-        doctorOnlyStateMigrations: true,
-      });
+      const rawRecovery = audit.detect();
       expect(rawRecovery.sources).toMatchObject([{ storage: "raw-archive" }]);
-      const recovered = await migrateLegacyAuditLogs({ detected: rawRecovery, stateDir });
+      const recovered = await audit.migrate(rawRecovery);
       expect(recovered.warnings).toEqual([]);
       expect(recovered.changes.join("\n")).toContain("Recovered 1 later config audit log row");
-      expect(listConfigAuditRecordsForTests({ env, homedir: () => stateDir })).toHaveLength(2);
+      expect(audit.configRecords()).toHaveLength(2);
       await expect(fs.readFile(`${configPath}.migrated`, "utf8")).resolves.not.toContain(
         "later-redaction-marker",
       );
       await expect(fs.readFile(`${configPath}.migrated.raw`, "utf8")).resolves.not.toContain(
         "later-redaction-marker",
       );
-      const recoveredArchiveRows = (await fs.readFile(`${configPath}.migrated`, "utf8"))
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line) as { ts: string });
+      const recoveredArchiveRows = await audit.readJsonLines<{ ts: string }>(
+        audit.config.sanitized,
+      );
       expect(recoveredArchiveRows.map((row) => row.ts)).toEqual([
         "2026-07-01T00:00:00.000Z",
         "2026-07-04T00:00:00.000Z",
       ]);
-      expect(detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }).hasLegacy).toBe(
-        false,
-      );
+      expect(audit.detect().hasLegacy).toBe(false);
     });
   });
 
   it("rehashes a checkpointed raw archive before treating it as clean", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-rehash-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const rawPath = `${sourcePath}.migrated.raw`;
-      const original = {
-        timestamp: "2026-07-03T00:00:00.000Z",
-        operation: "gateway.restart",
-        summary: "original",
-      };
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw: rawPath, source: sourcePath } = audit.system;
+      const original = systemAuditEvent("original");
       const modified = { ...original, summary: "modified" };
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(sourcePath, `${JSON.stringify(original)}\n`);
+      await audit.writeJsonLines(sourcePath, [original]);
       const stableMtime = new Date("2026-07-03T01:00:00.000Z");
       await fs.utimes(sourcePath, stableMtime, stableMtime);
-      await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      await audit.migrate();
       const checkpointedStat = await fs.stat(rawPath);
       const modifiedRaw = `${JSON.stringify(modified)}\n`;
       expect(Buffer.byteLength(modifiedRaw)).toBe(checkpointedStat.size);
       await fs.writeFile(rawPath, modifiedRaw);
       const rewrittenStat = await fs.stat(rawPath);
       expect(rewrittenStat.size).toBe(checkpointedStat.size);
-      const checkpointStore = openLegacyAuditRawCheckpointStore(stateDir);
+      const checkpointStore = openLegacyAuditRawCheckpointStore(audit.stateDir);
       const checkpoint = checkpointStore.entries()[0];
       if (!checkpoint) {
         throw new Error("expected a raw archive checkpoint");
@@ -224,334 +141,174 @@ describe("legacy core audit log migration", () => {
         checkpoint.createdAt,
       );
 
-      const detected = detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true });
+      const detected = audit.detect();
       expect(detected.sources).toMatchObject([{ sourcePath: rawPath, storage: "raw-archive" }]);
-      const result = await migrateLegacyAuditLogs({ detected, stateDir });
+      const result = await audit.migrate(detected);
 
       expect(result.warnings.join("\n")).toContain("changed other than by append");
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }).map((entry) => entry.value.summary),
-      ).toEqual(["original"]);
+      expect(audit.systemSummaries()).toEqual(["original"]);
     });
   });
 
   it("restores the captured archive prefix when an in-place scrub write fails", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-scrub-write-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "logs", "config-audit.jsonl");
-      const rawPath = `${sourcePath}.migrated.raw`;
-      const originalRecord = {
-        ts: "2026-07-01T00:00:00.000Z",
-        source: "config-io",
-        event: "config.write",
-        argv: ["openclaw", "config", "set", "token", "scrub-write-marker"],
-        execArgv: [],
-      };
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw: rawPath, source: sourcePath } = audit.config;
+      const originalRecord = configAuditRecord("scrub-write-marker");
       const originalContent = `${JSON.stringify(originalRecord)}\n`;
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(sourcePath, originalContent);
+      await audit.write(sourcePath, originalContent);
+      const writeSpy = await failSecondScrubWrite(audit);
 
-      const probe = await fs.open(path.join(stateDir, "write-probe"), "w+");
-      const fileHandlePrototype = Object.getPrototypeOf(probe) as {
-        write(
-          buffer: Uint8Array,
-          offset: number,
-          length: number,
-          position: number | null,
-        ): Promise<{ bytesWritten: number; buffer: Uint8Array }>;
-      };
-      await probe.close();
-      const originalWrite = Reflect.get(
-        fileHandlePrototype,
-        "write",
-      ) as typeof fileHandlePrototype.write;
-      let scrubWriteCalls = 0;
-      const writeSpy = vi.spyOn(fileHandlePrototype, "write").mockImplementation(async function (
-        this: typeof fileHandlePrototype,
-        buffer: Uint8Array,
-        offset: number,
-        length: number,
-        position: number | null,
-      ) {
-        scrubWriteCalls += 1;
-        if (scrubWriteCalls === 1) {
-          return await originalWrite.call(
-            this,
-            buffer,
-            offset,
-            Math.max(1, Math.floor(length / 2)),
-            position,
-          );
-        }
-        if (scrubWriteCalls === 2) {
-          throw new Error("simulated scrub write failure");
-        }
-        return await originalWrite.call(this, buffer, offset, length, position);
-      });
-
-      let failed: Awaited<ReturnType<typeof migrateLegacyAuditLogs>>;
+      let failed: Awaited<ReturnType<typeof audit.migrate>>;
       try {
-        failed = await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
+        failed = await audit.migrate();
       } finally {
         writeSpy.mockRestore();
       }
 
       expect(failed.warnings.join("\n")).toContain("restored it for Doctor retry");
       await expect(fs.readFile(rawPath, "utf8")).resolves.toBe(originalContent);
-      expect(detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }).hasLegacy).toBe(
-        true,
-      );
+      expect(audit.detect().hasLegacy).toBe(true);
 
-      const recovered = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      const recovered = await audit.migrate();
       expect(recovered.warnings).toEqual([]);
       await expect(fs.readFile(rawPath, "utf8")).resolves.not.toContain("scrub-write-marker");
-      expect(detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }).hasLegacy).toBe(
-        false,
-      );
+      expect(audit.detect().hasLegacy).toBe(false);
     });
   });
 
   it("restores a moved scrub journal before parsing an interrupted archive", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-scrub-restart-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "logs", "config-audit.jsonl");
-      const sanitizedPath = `${sourcePath}.migrated`;
-      const rawPath = `${sanitizedPath}.raw`;
-      const restorePath = `${rawPath}.doctor-scrub-restore`;
-      const originalRecord = {
-        ts: "2026-07-01T00:00:00.000Z",
-        source: "config-io",
-        event: "config.write",
-        argv: ["openclaw", "config", "set", "token", "restart-redaction-marker"],
-        execArgv: [],
-      };
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, restore } = audit.config;
+      const originalRecord = configAuditRecord("restart-redaction-marker");
       const originalContent = `${JSON.stringify(originalRecord)}\n`;
       const damagedContent = Buffer.from(originalContent, "utf8");
-      buildTestAuditScrubbedContent(damagedContent.length)
+      buildAuditScrubbedContent(damagedContent.length)
         .subarray(0, Math.floor(damagedContent.length / 2))
         .copy(damagedContent);
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(sanitizedPath, "{}\n");
-      await fs.writeFile(rawPath, damagedContent);
-      await fs.writeFile(
-        restorePath,
-        await buildTestAuditRestoreJournal(rawPath, Buffer.from(originalContent, "utf8"), {
-          restoredBytes: 0,
-          scrubbedBytes: Math.floor(damagedContent.length / 2),
-        }),
-      );
-
-      const result = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
+      await audit.seedRawArchive(audit.config, damagedContent);
+      await writeAuditRestoreJournal(raw, Buffer.from(originalContent, "utf8"), {
+        restoredBytes: 0,
+        scrubbedBytes: Math.floor(damagedContent.length / 2),
       });
 
+      const result = await audit.migrate();
+
       expect(result.warnings).toEqual([]);
-      await expect(fs.access(restorePath)).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fs.readFile(rawPath, "utf8")).resolves.not.toContain("restart-redaction-marker");
-      expect(
-        listConfigAuditRecordsForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-          homedir: () => stateDir,
-        }),
-      ).toHaveLength(1);
-      expect(detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }).hasLegacy).toBe(
-        false,
-      );
+      await expect(fs.access(restore)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readFile(raw, "utf8")).resolves.not.toContain("restart-redaction-marker");
+      expect(audit.configRecords()).toHaveLength(1);
+      expect(audit.detect().hasLegacy).toBe(false);
     });
   });
 
   it("discards a stale restore journal while recovering a post-checkpoint append", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-stale-journal-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const rawPath = `${sourcePath}.migrated.raw`;
-      const restorePath = `${rawPath}.doctor-scrub-restore`;
-      const originalContent = `${JSON.stringify({
-        timestamp: "2026-07-03T00:00:00.000Z",
-        operation: "config.set",
-        summary: ["token", "redaction-marker"].join("="),
-      })}\n`;
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(sourcePath, originalContent);
-      await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
-      await fs.writeFile(
-        restorePath,
-        await buildTestAuditRestoreJournal(rawPath, Buffer.from(originalContent, "utf8")),
-      );
-      await fs.appendFile(
-        rawPath,
-        `${JSON.stringify({
-          timestamp: "2026-07-04T00:00:00.000Z",
-          operation: "gateway.restart",
-          summary: "later",
-        })}\n`,
-      );
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, restore, source } = audit.system;
+      const originalContent = `${JSON.stringify(
+        systemAuditEvent(["token", "redaction-marker"].join("="), { operation: "config.set" }),
+      )}\n`;
+      await audit.write(source, originalContent);
+      await audit.migrate();
+      await writeAuditRestoreJournal(raw, Buffer.from(originalContent, "utf8"));
+      await audit.appendJsonLines(raw, [
+        systemAuditEvent("later", { timestamp: "2026-07-04T00:00:00.000Z" }),
+      ]);
 
-      const detected = detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true });
+      const detected = audit.detect();
       expect(detected.hasLegacy).toBe(true);
-      const result = await migrateLegacyAuditLogs({ detected, stateDir });
+      const result = await audit.migrate(detected);
 
       expect(result.warnings).toEqual([]);
       expect(result.changes.join("\n")).toContain("Recovered 1 later");
-      await expect(fs.readFile(rawPath, "utf8")).resolves.not.toContain(
+      await expect(fs.readFile(raw, "utf8")).resolves.not.toContain(
         ["token", "redaction-marker"].join("="),
       );
-      await expect(fs.access(restorePath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(restore)).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 
   it("does not replay a scrub journal over a same-inode replacement archive", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-scrub-replaced-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const sanitizedPath = `${sourcePath}.migrated`;
-      const rawPath = `${sanitizedPath}.raw`;
-      const restorePath = `${rawPath}.doctor-scrub-restore`;
-      const originalContent = `${JSON.stringify({
-        timestamp: "2026-07-03T00:00:00.000Z",
-        operation: "gateway.restart",
-        summary: "original archive",
-      })}\n`;
-      const replacementContent = `${JSON.stringify({
-        timestamp: "2026-07-04T00:00:00.000Z",
-        operation: "gateway.restart",
-        summary: "replacement archive",
-      })}\n`;
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(sanitizedPath, "{}\n");
-      await fs.writeFile(rawPath, originalContent);
-      await fs.writeFile(
-        restorePath,
-        await buildTestAuditRestoreJournal(rawPath, Buffer.from(originalContent, "utf8")),
-      );
-      await fs.writeFile(rawPath, replacementContent);
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, restore } = audit.system;
+      const originalContent = `${JSON.stringify(systemAuditEvent("original archive"))}\n`;
+      const replacementContent = `${JSON.stringify(
+        systemAuditEvent("replacement archive", { timestamp: "2026-07-04T00:00:00.000Z" }),
+      )}\n`;
+      await audit.seedRawArchive(audit.system, originalContent);
+      await writeAuditRestoreJournal(raw, Buffer.from(originalContent, "utf8"));
+      await fs.writeFile(raw, replacementContent);
 
-      const result = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      const result = await audit.migrate();
 
       expect(result.warnings.join("\n")).toContain("no longer matches its restore journal target");
-      await expect(fs.readFile(rawPath, "utf8")).resolves.toBe(replacementContent);
-      await expect(fs.access(restorePath)).resolves.toBeUndefined();
+      await expect(fs.readFile(raw, "utf8")).resolves.toBe(replacementContent);
+      await expect(fs.access(restore)).resolves.toBeUndefined();
     });
   });
 
   it("resumes a deterministic audit claim left by an interrupted Doctor", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-resume-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const claimPath = path.join(
-        path.dirname(sourcePath),
-        `.${path.basename(sourcePath)}.doctor-importing`,
-      );
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(
-        sourcePath,
-        `${JSON.stringify({
-          timestamp: "2026-07-03T00:00:00.000Z",
-          operation: "gateway.restart",
-          summary: "Restarted gateway",
-        })}\n`,
-      );
-      await fs.rename(sourcePath, claimPath);
+    await withAuditMigrationFixture(async (audit) => {
+      const { claim, raw, source } = audit.system;
+      await audit.writeJsonLines(source, [systemAuditEvent("Restarted gateway")]);
+      await fs.rename(source, claim);
 
-      const detected = detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true });
-      expect(detected.sources).toMatchObject([{ sourcePath: claimPath, storage: "claim" }]);
-      const result = await migrateLegacyAuditLogs({ detected, stateDir });
+      const detected = audit.detect();
+      expect(detected.sources).toMatchObject([{ sourcePath: claim, storage: "claim" }]);
+      const result = await audit.migrate(detected);
 
       expect(result.warnings).toEqual([]);
-      await expect(fs.access(claimPath)).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fs.access(`${sourcePath}.migrated.raw`)).resolves.toBeUndefined();
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }),
-      ).toHaveLength(1);
+      await expect(fs.access(claim)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(raw)).resolves.toBeUndefined();
+      expect(audit.systemEntries()).toHaveLength(1);
 
-      const tenthRawArchive = `${sourcePath}.migrated.10.raw`;
-      await fs.writeFile(
-        tenthRawArchive,
-        `${JSON.stringify({
+      const tenthRawArchive = `${source}.migrated.10.raw`;
+      await audit.writeJsonLines(tenthRawArchive, [
+        systemAuditEvent("Reloaded gateway", {
           timestamp: "2026-07-04T00:00:00.000Z",
           operation: "gateway.reload",
-          summary: "Reloaded gateway",
-        })}\n`,
-      );
-      const numberedRaw = detectLegacyAuditLogs({
-        stateDir,
-        doctorOnlyStateMigrations: true,
-      });
+        }),
+      ]);
+      const numberedRaw = audit.detect();
       expect(numberedRaw.sources).toMatchObject([
         { sourcePath: tenthRawArchive, storage: "raw-archive" },
       ]);
-      await migrateLegacyAuditLogs({ detected: numberedRaw, stateDir });
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }),
-      ).toHaveLength(2);
+      await audit.migrate(numberedRaw);
+      expect(audit.systemEntries()).toHaveLength(2);
     });
   });
 
   it("does not resurrect a pruned raw-archive head when later rows are appended", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-late-tail-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const records = ["first", "second", "third"].map((summary, index) => ({
-        timestamp: `2026-07-03T00:00:0${index}.000Z`,
-        operation: "gateway.restart",
-        summary,
-      }));
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(
-        sourcePath,
-        `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, source } = audit.system;
+      const records = ["first", "second", "third"].map((summary, index) =>
+        systemAuditEvent(summary, { timestamp: `2026-07-03T00:00:0${index}.000Z` }),
       );
-      await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      await audit.writeJsonLines(source, records);
+      await audit.migrate();
       createSqliteAuditRecordStore({
         scope: SYSTEM_AGENT_AUDIT_SCOPE,
         maxEntries: 3,
-        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-      }).register("runtime", {
-        timestamp: "2026-07-04T00:00:00.000Z",
-        operation: "gateway.reload",
-        summary: "runtime",
-      });
-      await fs.appendFile(
-        `${sourcePath}.migrated.raw`,
-        `${JSON.stringify({
-          timestamp: "2026-07-05T00:00:00.000Z",
-          operation: "gateway.restart",
-          summary: "appended",
-        })}\n`,
+        env: audit.env,
+      }).register(
+        "runtime",
+        systemAuditEvent("runtime", {
+          timestamp: "2026-07-04T00:00:00.000Z",
+          operation: "gateway.reload",
+        }),
       );
+      await audit.appendJsonLines(raw, [
+        systemAuditEvent("appended", { timestamp: "2026-07-05T00:00:00.000Z" }),
+      ]);
 
-      const recovered = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      const recovered = await audit.migrate();
 
       expect(recovered.warnings).toEqual([]);
       expect(recovered.changes.join("\n")).toContain("Recovered 1 later");
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }).map((entry) => entry.value.summary),
-      ).toEqual(["second", "third", "appended", "runtime"]);
+      expect(audit.systemSummaries()).toEqual(["second", "third", "appended", "runtime"]);
       const rawCheckpoints = createSqliteAuditRecordStore<{ recordCount: number }>({
         scope: "migration.legacy-audit-raw",
         maxEntries: 10_000,
-        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+        env: audit.env,
       }).entries();
       expect(rawCheckpoints).toHaveLength(1);
       expect(rawCheckpoints[0]?.value.recordCount).toBe(0);
@@ -559,370 +316,204 @@ describe("legacy core audit log migration", () => {
   });
 
   it("keeps identical rows from separate raw archive generations", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-generations-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const record = {
-        timestamp: "2026-07-03T00:00:00.000Z",
-        operation: "gateway.restart",
-        summary: "Repeated operation",
-      };
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(`${sourcePath}.migrated.raw`, `${JSON.stringify(record)}\n`);
-      await fs.writeFile(`${sourcePath}.migrated.2.raw`, `${JSON.stringify(record)}\n`);
-      await fs.writeFile(`${sourcePath}.migrated.10.raw`, `${JSON.stringify(record)}\n`);
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, source } = audit.system;
+      const record = systemAuditEvent("Repeated operation");
+      await audit.writeJsonLines(raw, [record]);
+      await audit.writeJsonLines(`${source}.migrated.2.raw`, [record]);
+      await audit.writeJsonLines(`${source}.migrated.10.raw`, [record]);
       const claimPath = path.join(
-        path.dirname(sourcePath),
-        `.${path.basename(sourcePath)}.doctor-importing.11`,
+        path.dirname(source),
+        `.${path.basename(source)}.doctor-importing.11`,
       );
-      await fs.writeFile(claimPath, `${JSON.stringify(record)}\n`);
-      await fs.writeFile(sourcePath, `${JSON.stringify(record)}\n`);
+      await audit.writeJsonLines(claimPath, [record]);
+      await audit.writeJsonLines(source, [record]);
 
-      const detected = detectLegacyAuditLogs({
-        stateDir,
-        doctorOnlyStateMigrations: true,
-      });
-      expect(detected.sources.map((source) => path.basename(source.sourcePath))).toEqual([
+      const detected = audit.detect();
+      expect(detected.sources.map((entry) => path.basename(entry.sourcePath))).toEqual([
         "system-agent.jsonl.migrated.raw",
         "system-agent.jsonl.migrated.2.raw",
         "system-agent.jsonl.migrated.10.raw",
         ".system-agent.jsonl.doctor-importing.11",
         "system-agent.jsonl",
       ]);
-      const result = await migrateLegacyAuditLogs({ detected, stateDir });
+      const result = await audit.migrate(detected);
 
       expect(result.warnings).toEqual([]);
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }),
-      ).toHaveLength(5);
-      expect(detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }).hasLegacy).toBe(
-        false,
-      );
+      expect(audit.systemEntries()).toHaveLength(5);
+      expect(audit.detect().hasLegacy).toBe(false);
     });
   });
 
   it("keeps restored raw archives idempotent after device and inode changes", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-restored-" }, async (rootDir) => {
-      const stateDir = path.join(rootDir, "source-state");
-      const restoredStateDir = path.join(rootDir, "restored-state");
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(
-        sourcePath,
-        `${JSON.stringify({
-          timestamp: "2026-07-03T00:00:00.000Z",
-          operation: "gateway.restart",
-          summary: "Restored operation",
-        })}\n`,
-      );
-      await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+    await withAuditMigrationFixture(async (root) => {
+      const sourceAudit = new AuditMigrationFixture(path.join(root.stateDir, "source-state"));
+      const restoredAudit = new AuditMigrationFixture(path.join(root.stateDir, "restored-state"));
+      await sourceAudit.writeJsonLines(sourceAudit.system.source, [
+        systemAuditEvent("Restored operation"),
+      ]);
+      await sourceAudit.migrate();
       resetPluginStateStoreForTests();
-      await fs.cp(stateDir, restoredStateDir, { recursive: true });
+      await fs.cp(sourceAudit.stateDir, restoredAudit.stateDir, { recursive: true });
       createSqliteAuditRecordStore({
         scope: SYSTEM_AGENT_AUDIT_SCOPE,
         maxEntries: 1,
-        env: { ...process.env, OPENCLAW_STATE_DIR: restoredStateDir },
-      }).register("runtime-after-restore", {
-        timestamp: "2026-07-04T00:00:00.000Z",
-        operation: "gateway.reload",
-        summary: "Runtime after restore",
-      });
+        env: restoredAudit.env,
+      }).register(
+        "runtime-after-restore",
+        systemAuditEvent("Runtime after restore", {
+          timestamp: "2026-07-04T00:00:00.000Z",
+          operation: "gateway.reload",
+        }),
+      );
 
-      const restored = detectLegacyAuditLogs({
-        stateDir: restoredStateDir,
-        doctorOnlyStateMigrations: true,
-      });
+      const restored = restoredAudit.detect();
       expect(restored.sources).toMatchObject([{ storage: "raw-archive" }]);
-      const result = await migrateLegacyAuditLogs({
-        detected: restored,
-        stateDir: restoredStateDir,
-      });
+      const result = await restoredAudit.migrate(restored);
 
       expect(result.warnings).toEqual([]);
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: restoredStateDir },
-        }).map((entry) => entry.value.summary),
-      ).toEqual(["Runtime after restore"]);
-      expect(
-        detectLegacyAuditLogs({
-          stateDir: restoredStateDir,
-          doctorOnlyStateMigrations: true,
-        }).hasLegacy,
-      ).toBe(false);
+      expect(restoredAudit.systemSummaries()).toEqual(["Runtime after restore"]);
+      expect(restoredAudit.detect().hasLegacy).toBe(false);
     });
   });
 
   it("resumes the stable generation of an interrupted sanitized archive", async () => {
-    await withTempDir(
-      { prefix: "openclaw-audit-migration-sanitized-resume-" },
-      async (stateDir) => {
-        const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-        const claimPath = path.join(
-          path.dirname(sourcePath),
-          `.${path.basename(sourcePath)}.doctor-importing`,
-        );
-        const record = {
-          timestamp: "2026-07-03T00:00:00.000Z",
-          operation: "gateway.restart",
-          summary: "Interrupted operation",
-        };
-        await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-        await fs.writeFile(claimPath, `${JSON.stringify(record)}\n`);
-        await fs.writeFile(`${sourcePath}.migrated`, `${JSON.stringify(record)}\n`);
+    await withAuditMigrationFixture(async (audit) => {
+      const { claim, raw, sanitized, source } = audit.system;
+      const record = systemAuditEvent("Interrupted operation");
+      await audit.writeJsonLines(claim, [record]);
+      await audit.writeJsonLines(sanitized, [record]);
 
-        const result = await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
+      const result = await audit.migrate();
 
-        expect(result.warnings).toEqual([]);
-        await expect(fs.access(`${sourcePath}.migrated.raw`)).resolves.toBeUndefined();
-        await expect(fs.access(`${sourcePath}.migrated.2.raw`)).rejects.toMatchObject({
-          code: "ENOENT",
-        });
-        expect(
-          listSystemAgentAuditEntriesForTests({
-            env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-          }),
-        ).toHaveLength(1);
-      },
-    );
+      expect(result.warnings).toEqual([]);
+      await expect(fs.access(raw)).resolves.toBeUndefined();
+      await expect(fs.access(`${source}.migrated.2.raw`)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      expect(audit.systemEntries()).toHaveLength(1);
+    });
   });
 
   it("allocates a new generation when an active source follows a sanitized-only archive", async () => {
-    await withTempDir(
-      { prefix: "openclaw-audit-migration-sanitized-recreated-" },
-      async (stateDir) => {
-        const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-        const record = {
-          timestamp: "2026-07-03T00:00:00.000Z",
-          operation: "gateway.restart",
-          summary: "Repeated after downgrade",
-        };
-        await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-        await fs.writeFile(sourcePath, `${JSON.stringify(record)}\n`);
-        await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
-        await fs.rm(`${sourcePath}.migrated.raw`);
-        const firstSanitized = await fs.readFile(`${sourcePath}.migrated`, "utf8");
-        await fs.writeFile(sourcePath, `${JSON.stringify(record)}\n`);
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, sanitized, source } = audit.system;
+      const record = systemAuditEvent("Repeated after downgrade");
+      await audit.writeJsonLines(source, [record]);
+      await audit.migrate();
+      await fs.rm(raw);
+      const firstSanitized = await fs.readFile(sanitized, "utf8");
+      await audit.writeJsonLines(source, [record]);
 
-        const repeated = await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
+      const repeated = await audit.migrate();
 
-        expect(repeated.warnings).toEqual([]);
-        expect(repeated.changes.join("\n")).toContain("1 new row");
-        await expect(fs.readFile(`${sourcePath}.migrated`, "utf8")).resolves.toBe(firstSanitized);
-        await expect(fs.access(`${sourcePath}.migrated.2.raw`)).resolves.toBeUndefined();
-        expect(
-          listSystemAgentAuditEntriesForTests({
-            env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-          }),
-        ).toHaveLength(2);
-      },
-    );
+      expect(repeated.warnings).toEqual([]);
+      expect(repeated.changes.join("\n")).toContain("1 new row");
+      await expect(fs.readFile(sanitized, "utf8")).resolves.toBe(firstSanitized);
+      await expect(fs.access(`${source}.migrated.2.raw`)).resolves.toBeUndefined();
+      expect(audit.systemEntries()).toHaveLength(2);
+    });
   });
 
   it("resumes a claim at its reserved generation instead of an older sanitized-only slot", async () => {
-    await withTempDir(
-      { prefix: "openclaw-audit-migration-claimed-generation-" },
-      async (stateDir) => {
-        const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-        const secondClaimPath = path.join(
-          path.dirname(sourcePath),
-          `.${path.basename(sourcePath)}.doctor-importing.2`,
-        );
-        const record = {
-          timestamp: "2026-07-03T00:00:00.000Z",
-          operation: "gateway.restart",
-          summary: "Repeated after interrupted downgrade",
-        };
-        await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-        await fs.writeFile(sourcePath, `${JSON.stringify(record)}\n`);
-        await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
-        await fs.rm(`${sourcePath}.migrated.raw`);
-        await fs.writeFile(sourcePath, `${JSON.stringify(record)}\n`);
-        await fs.rename(sourcePath, secondClaimPath);
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, source } = audit.system;
+      const secondClaimPath = path.join(
+        path.dirname(source),
+        `.${path.basename(source)}.doctor-importing.2`,
+      );
+      const record = systemAuditEvent("Repeated after interrupted downgrade");
+      await audit.writeJsonLines(source, [record]);
+      await audit.migrate();
+      await fs.rm(raw);
+      await audit.writeJsonLines(source, [record]);
+      await fs.rename(source, secondClaimPath);
 
-        const detected = detectLegacyAuditLogs({
-          stateDir,
-          doctorOnlyStateMigrations: true,
-        });
-        expect(detected.sources).toMatchObject([
-          {
-            sourcePath: secondClaimPath,
-            storage: "claim",
-            sanitizedArchivePath: `${sourcePath}.migrated.2`,
-            rawArchivePath: `${sourcePath}.migrated.2.raw`,
-          },
-        ]);
-        const resumed = await migrateLegacyAuditLogs({ detected, stateDir });
+      const detected = audit.detect();
+      expect(detected.sources).toMatchObject([
+        {
+          sourcePath: secondClaimPath,
+          storage: "claim",
+          sanitizedArchivePath: `${source}.migrated.2`,
+          rawArchivePath: `${source}.migrated.2.raw`,
+        },
+      ]);
+      const resumed = await audit.migrate(detected);
 
-        expect(resumed.warnings).toEqual([]);
-        await expect(fs.access(`${sourcePath}.migrated.2.raw`)).resolves.toBeUndefined();
-        expect(
-          listSystemAgentAuditEntriesForTests({
-            env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-          }),
-        ).toHaveLength(2);
-      },
-    );
+      expect(resumed.warnings).toEqual([]);
+      await expect(fs.access(`${source}.migrated.2.raw`)).resolves.toBeUndefined();
+      expect(audit.systemEntries()).toHaveLength(2);
+    });
   });
 
   it("leaves malformed audit sources in place without partial imports", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-invalid-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(sourcePath, "{bad json\n");
-      const detected = detectLegacyAuditLogs({
-        stateDir,
-        doctorOnlyStateMigrations: true,
-      });
+    await withAuditMigrationFixture(async (audit) => {
+      const { source } = audit.system;
+      await audit.write(source, "{bad json\n");
+      const detected = audit.detect();
 
-      const result = await migrateLegacyAuditLogs({ detected, stateDir });
+      const result = await audit.migrate(detected);
       expect(result.warnings.join("\n")).toContain("Failed reading system-agent audit log");
-      await expect(fs.access(sourcePath)).resolves.toBeUndefined();
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }),
-      ).toEqual([]);
+      await expect(fs.access(source)).resolves.toBeUndefined();
+      expect(audit.systemEntries()).toEqual([]);
     });
   });
 
   it("does not migrate newer audit generations before an older source is repaired", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-order-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const rawPath = `${sourcePath}.migrated.raw`;
-      const event = (summary: string) => ({
-        timestamp: "2026-07-03T00:00:00.000Z",
-        operation: "gateway.restart",
-        summary,
-      });
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(rawPath, "{bad json\n");
-      await fs.writeFile(sourcePath, `${JSON.stringify(event("newer generation"))}\n`);
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, source } = audit.system;
+      await audit.write(raw, "{bad json\n");
+      await audit.writeJsonLines(source, [systemAuditEvent("newer generation")]);
 
-      const blocked = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      const blocked = await audit.migrate();
 
       expect(blocked.changes).toEqual([]);
       expect(blocked.warnings.join("\n")).toContain("Failed reading system-agent audit log");
-      await expect(fs.access(sourcePath)).resolves.toBeUndefined();
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }),
-      ).toEqual([]);
+      await expect(fs.access(source)).resolves.toBeUndefined();
+      expect(audit.systemEntries()).toEqual([]);
 
-      await fs.writeFile(rawPath, `${JSON.stringify(event("repaired older generation"))}\n`);
-      const repaired = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      await audit.writeJsonLines(raw, [systemAuditEvent("repaired older generation")]);
+      const repaired = await audit.migrate();
 
       expect(repaired.warnings).toEqual([]);
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }).map((entry) => entry.value.summary),
-      ).toEqual(["repaired older generation", "newer generation"]);
+      expect(audit.systemSummaries()).toEqual(["repaired older generation", "newer generation"]);
     });
   });
 
   it("restores the active source when raw archive hardening fails", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-permissions-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "logs", "config-audit.jsonl");
-      const record = {
-        ts: "2026-07-01T00:00:00.000Z",
-        source: "config-io",
-        event: "config.write",
-        argv: ["openclaw", "config", "set", "token", "must-redact"],
-        execArgv: [],
-      };
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(sourcePath, `${JSON.stringify(record)}\n`);
-      const probe = await fs.open(path.join(stateDir, "chmod-probe"), "w");
-      const fileHandlePrototype = Object.getPrototypeOf(probe) as {
-        chmod(mode: number): Promise<void>;
-      };
-      await probe.close();
-      const originalChmod = Reflect.get(fileHandlePrototype, "chmod") as (
-        this: typeof fileHandlePrototype,
-        mode: number,
-      ) => Promise<void>;
-      let chmodCalls = 0;
-      const chmodSpy = vi.spyOn(fileHandlePrototype, "chmod").mockImplementation(function (
-        this: typeof fileHandlePrototype,
-        mode: number,
-      ) {
-        chmodCalls += 1;
-        // fs-safe 0.5 applies the requested mode while creating the sanitized file before the
-        // migration's explicit hardening checks. Fail the later raw-archive hardening call.
-        if (chmodCalls === 4) {
-          return Promise.reject(new Error("simulated chmod failure"));
-        }
-        return originalChmod.call(this, mode);
-      });
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, sanitized, source } = audit.config;
+      await audit.writeJsonLines(source, [configAuditRecord("must-redact")]);
+      // fs-safe applies the write mode before the migration's explicit hardening checks.
+      const chmodSpy = await failChmodCall(audit, "chmod-probe", 4, "simulated chmod failure");
 
-      let failed: Awaited<ReturnType<typeof migrateLegacyAuditLogs>>;
+      let failed: Awaited<ReturnType<typeof audit.migrate>>;
       try {
-        failed = await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
+        failed = await audit.migrate();
       } finally {
         chmodSpy.mockRestore();
       }
 
       expect(failed.changes).toEqual([]);
       expect(failed.warnings.join("\n")).toContain("Failed securing raw archived config audit log");
-      await expect(fs.readFile(sourcePath, "utf8")).resolves.toContain("must-redact");
-      await expect(fs.access(`${sourcePath}.migrated`)).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fs.access(`${sourcePath}.migrated.raw`)).rejects.toMatchObject({
-        code: "ENOENT",
-      });
+      await expect(fs.readFile(source, "utf8")).resolves.toContain("must-redact");
+      await expect(fs.access(sanitized)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(raw)).rejects.toMatchObject({ code: "ENOENT" });
 
-      const recovered = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      const recovered = await audit.migrate();
       expect(recovered.warnings).toEqual([]);
-      await expect(fs.access(sourcePath)).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fs.access(`${sourcePath}.migrated.raw`)).resolves.toBeUndefined();
+      await expect(fs.access(source)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(raw)).resolves.toBeUndefined();
     });
   });
 
   it("requires exclusive state ownership before claiming legacy audit files", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-lock-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(
-        sourcePath,
-        `${JSON.stringify({
-          timestamp: "2026-07-03T00:00:00.000Z",
-          operation: "gateway.restart",
-          summary: "Restarted gateway",
-        })}\n`,
-      );
-      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    await withAuditMigrationFixture(async (audit) => {
+      const { source } = audit.system;
+      await audit.writeJsonLines(source, [systemAuditEvent("Restarted gateway")]);
       const gatewayLock = await acquireGatewayLock({
         allowInTests: true,
-        env,
+        env: audit.env,
         pollIntervalMs: 10,
         port: 18_791,
         timeoutMs: 100,
@@ -931,26 +522,22 @@ describe("legacy core audit log migration", () => {
         throw new Error("expected test Gateway lock");
       }
 
-      let result: Awaited<ReturnType<typeof migrateLegacyAuditLogs>>;
+      let result: Awaited<ReturnType<typeof audit.migrate>>;
       try {
-        result = await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
+        result = await audit.migrate();
       } finally {
         await gatewayLock.release();
       }
 
       expect(result.warnings.join("\n")).toContain("exclusive state ownership is unavailable");
-      await expect(fs.access(sourcePath)).resolves.toBeUndefined();
-      expect(listSystemAgentAuditEntriesForTests({ env })).toEqual([]);
+      await expect(fs.access(source)).resolves.toBeUndefined();
+      expect(audit.systemEntries()).toEqual([]);
     });
   });
 
   it("leaves rows from an old config writer at the recreated source path", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-concurrent-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "logs", "config-audit.jsonl");
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await withAuditMigrationFixture(async (audit) => {
+      const { source } = audit.config;
       const records = Array.from({ length: 10_000 }, (_, index) =>
         JSON.stringify({
           ts: new Date(Date.UTC(2026, 6, 1, 0, 0, index)).toISOString(),
@@ -960,25 +547,19 @@ describe("legacy core audit log migration", () => {
           execArgv: [],
         }),
       );
-      await fs.writeFile(sourcePath, `${records.join("\n")}\n`);
-      const retainedRecord = {
+      await audit.write(source, `${records.join("\n")}\n`);
+      const retainedRecord = configAuditRecord("value", {
         ts: "2026-07-02T00:00:00.000Z",
-        source: "config-io",
-        event: "config.write",
         argv: ["openclaw", "config", "set", "later", "value"],
-        execArgv: [],
-      };
+      });
 
       let settled = false;
-      const migration = migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      }).finally(() => {
+      const migration = audit.migrate().finally(() => {
         settled = true;
       });
       for (let attempt = 0; attempt < 500; attempt += 1) {
         try {
-          await fs.access(sourcePath);
+          await fs.access(source);
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code === "ENOENT") {
             break;
@@ -990,25 +571,22 @@ describe("legacy core audit log migration", () => {
         });
       }
       expect(settled).toBe(false);
-      await fs.appendFile(sourcePath, `${JSON.stringify(retainedRecord)}\n`);
+      await audit.appendJsonLines(source, [retainedRecord]);
 
       const first = await migration;
       expect(first.warnings.join("\n")).toContain("An old writer recreated config audit log");
-      await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe(
+      await expect(fs.readFile(source, "utf8")).resolves.toBe(
         `${JSON.stringify(retainedRecord)}\n`,
       );
 
-      const second = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      const second = await audit.migrate();
       expect(second.warnings).toEqual([]);
-      await expect(fs.access(sourcePath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(source)).rejects.toMatchObject({ code: "ENOENT" });
       expect(
         createSqliteAuditRecordStore({
           scope: CONFIG_AUDIT_SCOPE,
           maxEntries: CONFIG_AUDIT_MAX_ENTRIES,
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+          env: audit.env,
         }).entries(),
       ).toHaveLength(10_001);
     });
@@ -1021,23 +599,13 @@ describe("legacy core audit log migration", () => {
         path.join(os.tmpdir(), "openclaw-audit-migration-external-"),
       );
       try {
-        await withTempDir({ prefix: "openclaw-audit-migration-symlink-" }, async (stateDir) => {
+        await withAuditMigrationFixture(async (audit) => {
           const externalSource = path.join(externalAuditDir, "system-agent.jsonl");
-          await fs.writeFile(
-            externalSource,
-            `${JSON.stringify({
-              timestamp: "2026-07-03T00:00:00.000Z",
-              operation: "gateway.restart",
-              summary: "Outside state root",
-            })}\n`,
-          );
-          await fs.symlink(externalAuditDir, path.join(stateDir, "audit"));
-          const detected = detectLegacyAuditLogs({
-            stateDir,
-            doctorOnlyStateMigrations: true,
-          });
+          await audit.writeJsonLines(externalSource, [systemAuditEvent("Outside state root")]);
+          await fs.symlink(externalAuditDir, path.join(audit.stateDir, "audit"));
+          const detected = audit.detect();
 
-          const result = await migrateLegacyAuditLogs({ detected, stateDir });
+          const result = await audit.migrate(detected);
 
           expect(result.changes).toEqual([]);
           expect(result.warnings.join("\n")).toMatch(/alias|symlink|outside workspace/u);
@@ -1047,11 +615,7 @@ describe("legacy core audit log migration", () => {
           await expect(fs.access(`${externalSource}.migrated`)).rejects.toMatchObject({
             code: "ENOENT",
           });
-          expect(
-            listSystemAgentAuditEntriesForTests({
-              env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-            }),
-          ).toEqual([]);
+          expect(audit.systemEntries()).toEqual([]);
         });
       } finally {
         await fs.rm(externalAuditDir, { recursive: true, force: true });

--- a/src/infra/state-migrations.audit-recovery.test.ts
+++ b/src/infra/state-migrations.audit-recovery.test.ts
@@ -1,102 +1,46 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
-import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
-import { listSystemAgentAuditEntriesForTests } from "../system-agent/audit.test-support.js";
-import { withTempDir } from "../test-helpers/temp-dir.js";
 import { openLegacyAuditRawCheckpointStore } from "./state-migrations.audit-checkpoints.js";
-import { detectLegacyAuditLogs, migrateLegacyAuditLogs } from "./state-migrations.audit-logs.js";
-
-const TEST_AUDIT_SCRUB_PATTERN = Buffer.from(
-  Array.from({ length: 32 }, (_, index) => (index % 2 === 0 ? 0x20 : 0x09)),
-);
-
-function buildTestAuditScrubbedContent(length: number): Buffer {
-  const content = Buffer.allocUnsafe(length);
-  for (let offset = 0; offset < length; offset += TEST_AUDIT_SCRUB_PATTERN.length) {
-    TEST_AUDIT_SCRUB_PATTERN.copy(
-      content,
-      offset,
-      0,
-      Math.min(TEST_AUDIT_SCRUB_PATTERN.length, length - offset),
-    );
-  }
-  return content;
-}
-
-async function buildTestAuditRestoreJournal(
-  rawPath: string,
-  sourceRaw: Buffer,
-  progress: { restoredBytes: number; scrubbedBytes: number } = {
-    restoredBytes: 0,
-    scrubbedBytes: 0,
-  },
-): Promise<string> {
-  const stat = await fs.stat(rawPath);
-  const journal = `${JSON.stringify({
-    schemaVersion: 6,
-    rawBase64: sourceRaw.toString("base64"),
-    scrubPatternBase64: TEST_AUDIT_SCRUB_PATTERN.toString("base64"),
-    target: { dev: stat.dev, ino: stat.ino, size: sourceRaw.length },
-  })}\n`;
-  await fs.writeFile(
-    `${rawPath}.doctor-scrub-progress`,
-    `${JSON.stringify({
-      schemaVersion: 1,
-      journalHash: createHash("sha256").update(journal).digest("hex"),
-      direction: progress.restoredBytes > 0 ? "restoring" : "scrubbing",
-      committedBytes: progress.restoredBytes > 0 ? progress.restoredBytes : progress.scrubbedBytes,
-      pendingEnd: progress.restoredBytes > 0 ? progress.restoredBytes : progress.scrubbedBytes,
-      extentBytes: progress.restoredBytes > 0 ? progress.scrubbedBytes : sourceRaw.length,
-    })}\n`,
-  );
-  return journal;
-}
+import {
+  buildAuditScrubbedContent,
+  configAuditRecord,
+  failChmodCall,
+  FIRST_AUDIT_SCRUB_BYTE,
+  systemAuditEvent,
+  withAuditMigrationFixture,
+  writeAuditRestoreJournal,
+} from "./state-migrations.audit.test-support.js";
 
 describe("legacy audit recovery byte handling", () => {
-  afterEach(() => {
-    resetPluginStateStoreForTests();
-  });
+  afterEach(resetPluginStateStoreForTests);
 
   it("blanks a zero-slack source within the fixed-size recovery inode", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-short-secret-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "logs", "config-audit.jsonl");
-      const record = {
-        ts: "2026-07-01T00:00:00.000Z",
-        source: "config-io",
-        event: "config.write",
-        argv: ["openclaw", "config", "set", "token", "x"],
-        execArgv: [],
-      };
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, restore, sanitized, source } = audit.config;
+      const record = configAuditRecord("x");
       const original = `${JSON.stringify(record)}\n`;
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(sourcePath, original);
+      await audit.write(source, original);
 
-      const result = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      const result = await audit.migrate();
 
       expect(result.warnings).toEqual([]);
-      const sanitized = await fs.readFile(`${sourcePath}.migrated`, "utf8");
-      const recovery = await fs.readFile(`${sourcePath}.migrated.raw`, "utf8");
+      const sanitizedContent = await fs.readFile(sanitized, "utf8");
+      const recovery = await fs.readFile(raw, "utf8");
       expect(Buffer.byteLength(recovery)).toBe(Buffer.byteLength(original));
-      expect(JSON.parse(sanitized.trim())).toMatchObject({
+      expect(JSON.parse(sanitizedContent.trim())).toMatchObject({
         argv: ["openclaw", "config", "set", "token", "***"],
       });
       expect(recovery.trim()).toBe("");
-      await expect(
-        fs.access(`${sourcePath}.migrated.raw.doctor-scrub-restore`),
-      ).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(restore)).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 
   it("uses original byte offsets when decoded audit text contains replacement characters", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-invalid-utf8-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const rawPath = `${sourcePath}.migrated.raw`;
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw: rawPath, source: sourcePath } = audit.system;
       const original = Buffer.concat([
         Buffer.from(
           '{"timestamp":"2026-07-03T00:00:00.000Z","operation":"gateway.restart","summary":"',
@@ -104,168 +48,94 @@ describe("legacy audit recovery byte handling", () => {
         Buffer.from([0x80]),
         Buffer.from('"}'),
       ]);
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(sourcePath, original);
+      await audit.write(sourcePath, original);
 
-      const migrated = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      const migrated = await audit.migrate();
 
       expect(migrated.warnings).toEqual([]);
       const blanked = await fs.readFile(rawPath);
       expect(blanked).toHaveLength(original.length);
       expect(blanked.every((byte) => byte === 0x20 || byte === 0x09)).toBe(true);
 
-      await fs.appendFile(
-        rawPath,
-        `${JSON.stringify({
-          timestamp: "2026-07-04T00:00:00.000Z",
-          operation: "gateway.restart",
-          summary: "later",
-        })}\n`,
-      );
-      const recovered = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      await audit.appendJsonLines(rawPath, [
+        systemAuditEvent("later", { timestamp: "2026-07-04T00:00:00.000Z" }),
+      ]);
+      const recovered = await audit.migrate();
 
       expect(recovered.warnings).toEqual([]);
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }).map((entry) => entry.value.summary),
-      ).toEqual(["�", "later"]);
+      expect(audit.systemSummaries()).toEqual(["�", "later"]);
     });
   });
 
   it("upgrades a legacy nonzero raw checkpoint to the blank append pad", async () => {
-    await withTempDir(
-      { prefix: "openclaw-audit-migration-checkpoint-upgrade-" },
-      async (stateDir) => {
-        const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-        await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-        await fs.writeFile(
-          sourcePath,
-          `${JSON.stringify({
-            timestamp: "2026-07-03T00:00:00.000Z",
-            operation: "gateway.restart",
-            summary: "original",
-          })}\n`,
-        );
-        await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
-        const rawPath = `${sourcePath}.migrated.raw`;
-        const legacyRaw = Buffer.concat([
-          Buffer.from(
-            '{"timestamp":"2026-07-03T00:00:00.000Z","operation":"gateway.restart","summary":"',
-          ),
-          Buffer.from([0x80]),
-          Buffer.from('"}\n'),
-        ]);
-        await fs.writeFile(rawPath, legacyRaw);
-        const legacyStat = await fs.stat(rawPath);
-        const checkpointStore = openLegacyAuditRawCheckpointStore(stateDir);
-        const checkpoint = checkpointStore.entries()[0]!;
-        checkpointStore.upsert(checkpoint.key, {
-          ...checkpoint.value,
-          dev: legacyStat.dev,
-          ino: legacyStat.ino,
-          mtimeMs: legacyStat.mtimeMs,
-          size: legacyStat.size,
-          contentHash: createHash("sha256").update(legacyRaw.toString("utf8")).digest("hex"),
-          recordCount: 1,
-        });
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw: rawPath, source: sourcePath } = audit.system;
+      await audit.writeJsonLines(sourcePath, [systemAuditEvent("original")]);
+      await audit.migrate();
+      const legacyRaw = Buffer.concat([
+        Buffer.from(
+          '{"timestamp":"2026-07-03T00:00:00.000Z","operation":"gateway.restart","summary":"',
+        ),
+        Buffer.from([0x80]),
+        Buffer.from('"}\n'),
+      ]);
+      await fs.writeFile(rawPath, legacyRaw);
+      const legacyStat = await fs.stat(rawPath);
+      const checkpointStore = openLegacyAuditRawCheckpointStore(audit.stateDir);
+      const checkpoint = checkpointStore.entries()[0]!;
+      checkpointStore.upsert(checkpoint.key, {
+        ...checkpoint.value,
+        dev: legacyStat.dev,
+        ino: legacyStat.ino,
+        mtimeMs: legacyStat.mtimeMs,
+        size: legacyStat.size,
+        contentHash: createHash("sha256").update(legacyRaw.toString("utf8")).digest("hex"),
+        recordCount: 1,
+      });
 
-        const detected = detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true });
-        expect(detected.hasLegacy).toBe(true);
-        const result = await migrateLegacyAuditLogs({ detected, stateDir });
+      const detected = audit.detect();
+      expect(detected.hasLegacy).toBe(true);
+      const result = await audit.migrate(detected);
 
-        expect(result.warnings).toEqual([]);
-        expect(openLegacyAuditRawCheckpointStore(stateDir).entries()[0]?.value.recordCount).toBe(0);
-      },
-    );
+      expect(result.warnings).toEqual([]);
+      expect(
+        openLegacyAuditRawCheckpointStore(audit.stateDir).entries()[0]?.value.recordCount,
+      ).toBe(0);
+    });
   });
 
   it("does not confuse an older prefix checkpoint with a later scrub generation", async () => {
-    await withTempDir(
-      { prefix: "openclaw-audit-migration-scrub-generation-" },
-      async (stateDir) => {
-        const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-        const rawPath = `${sourcePath}.migrated.raw`;
-        const restorePath = `${rawPath}.doctor-scrub-restore`;
-        await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-        await fs.writeFile(
-          sourcePath,
-          `${JSON.stringify({
-            timestamp: "2026-07-03T00:00:00.000Z",
-            operation: "gateway.restart",
-            summary: "original",
-          })}\n`,
-        );
-        await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
-        await fs.appendFile(
-          rawPath,
-          `${JSON.stringify({
-            timestamp: "2026-07-04T00:00:00.000Z",
-            operation: "gateway.restart",
-            summary: "later",
-          })}\n`,
-        );
-        const interruptedRaw = await fs.readFile(rawPath);
-        await fs.writeFile(
-          restorePath,
-          await buildTestAuditRestoreJournal(rawPath, interruptedRaw, {
-            restoredBytes: 0,
-            scrubbedBytes: interruptedRaw.length,
-          }),
-        );
-        await fs.writeFile(rawPath, buildTestAuditScrubbedContent(interruptedRaw.length));
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw: rawPath, restore: restorePath, source: sourcePath } = audit.system;
+      await audit.writeJsonLines(sourcePath, [systemAuditEvent("original")]);
+      await audit.migrate();
+      await audit.appendJsonLines(rawPath, [
+        systemAuditEvent("later", { timestamp: "2026-07-04T00:00:00.000Z" }),
+      ]);
+      const interruptedRaw = await fs.readFile(rawPath);
+      await writeAuditRestoreJournal(rawPath, interruptedRaw, {
+        restoredBytes: 0,
+        scrubbedBytes: interruptedRaw.length,
+      });
+      await fs.writeFile(rawPath, buildAuditScrubbedContent(interruptedRaw.length));
 
-        const result = await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
+      const result = await audit.migrate();
 
-        expect(result.warnings).toEqual([]);
-        expect(
-          listSystemAgentAuditEntriesForTests({
-            env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-          }).map((entry) => entry.value.summary),
-        ).toEqual(["original", "later"]);
-        await expect(fs.access(restorePath)).rejects.toMatchObject({ code: "ENOENT" });
-      },
-    );
+      expect(result.warnings).toEqual([]);
+      expect(audit.systemSummaries()).toEqual(["original", "later"]);
+      await expect(fs.access(restorePath)).rejects.toMatchObject({ code: "ENOENT" });
+    });
   });
 
   it("does not replay a scrub journal over an equal-width space redaction", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-scrub-redacted-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const rawPath = `${sourcePath}.migrated.raw`;
-      const restorePath = `${rawPath}.doctor-scrub-restore`;
-      const originalContent = `${JSON.stringify({
-        timestamp: "2026-07-03T00:00:00.000Z",
-        operation: "gateway.restart",
-        summary: "secret archive value",
-      })}\n`;
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw: rawPath, restore: restorePath } = audit.system;
+      const originalContent = `${JSON.stringify(systemAuditEvent("secret archive value"))}\n`;
       const replacementContent = originalContent.replace("secret archive value", " ".repeat(20));
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(`${sourcePath}.migrated`, "{}\n");
-      await fs.writeFile(rawPath, replacementContent);
-      await fs.writeFile(
-        restorePath,
-        await buildTestAuditRestoreJournal(rawPath, Buffer.from(originalContent, "utf8")),
-      );
+      await audit.seedRawArchive(audit.system, replacementContent);
+      await writeAuditRestoreJournal(rawPath, Buffer.from(originalContent, "utf8"));
 
-      const result = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      const result = await audit.migrate();
 
       expect(result.warnings.join("\n")).toContain("no longer matches its restore journal target");
       await expect(fs.readFile(rawPath, "utf8")).resolves.toBe(replacementContent);
@@ -274,32 +144,18 @@ describe("legacy audit recovery byte handling", () => {
   });
 
   it("resumes a one-byte scrub interruption using exact journal progress", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-scrub-one-byte-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const rawPath = `${sourcePath}.migrated.raw`;
-      const restorePath = `${rawPath}.doctor-scrub-restore`;
-      const originalContent = `${JSON.stringify({
-        timestamp: "2026-07-03T00:00:00.000Z",
-        operation: "gateway.restart",
-        summary: "original archive",
-      })}\n`;
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw: rawPath, restore: restorePath } = audit.system;
+      const originalContent = `${JSON.stringify(systemAuditEvent("original archive"))}\n`;
       const replacementBytes = Buffer.from(originalContent);
-      replacementBytes[0] = TEST_AUDIT_SCRUB_PATTERN[0]!;
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(`${sourcePath}.migrated`, "{}\n");
-      await fs.writeFile(rawPath, replacementBytes);
-      await fs.writeFile(
-        restorePath,
-        await buildTestAuditRestoreJournal(rawPath, Buffer.from(originalContent), {
-          restoredBytes: 0,
-          scrubbedBytes: 1,
-        }),
-      );
-
-      const result = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
+      replacementBytes[0] = FIRST_AUDIT_SCRUB_BYTE;
+      await audit.seedRawArchive(audit.system, replacementBytes);
+      await writeAuditRestoreJournal(rawPath, Buffer.from(originalContent), {
+        restoredBytes: 0,
+        scrubbedBytes: 1,
       });
+
+      const result = await audit.migrate();
 
       expect(result.warnings).toEqual([]);
       expect((await fs.readFile(rawPath, "utf8")).trim()).toBe("");
@@ -308,209 +164,110 @@ describe("legacy audit recovery byte handling", () => {
   });
 
   it("resumes restoration after an interrupted rollback write", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-restore-restart-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const rawPath = `${sourcePath}.migrated.raw`;
-      const restorePath = `${rawPath}.doctor-scrub-restore`;
-      const originalContent = `${JSON.stringify({
-        timestamp: "2026-07-03T00:00:00.000Z",
-        operation: "gateway.restart",
-        summary: "restore after restart",
-      })}\n`;
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw: rawPath, restore: restorePath } = audit.system;
+      const originalContent = `${JSON.stringify(systemAuditEvent("restore after restart"))}\n`;
       const originalBytes = Buffer.from(originalContent, "utf8");
-      const interruptedRestore = buildTestAuditScrubbedContent(originalBytes.length);
+      const interruptedRestore = buildAuditScrubbedContent(originalBytes.length);
       originalBytes.subarray(0, Math.floor(originalBytes.length / 2)).copy(interruptedRestore);
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(`${sourcePath}.migrated`, "{}\n");
-      await fs.writeFile(rawPath, interruptedRestore);
-      await fs.writeFile(
-        restorePath,
-        await buildTestAuditRestoreJournal(rawPath, originalBytes, {
-          restoredBytes: Math.floor(originalBytes.length / 2),
-          scrubbedBytes: originalBytes.length,
-        }),
-      );
-
-      const result = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
+      await audit.seedRawArchive(audit.system, interruptedRestore);
+      await writeAuditRestoreJournal(rawPath, originalBytes, {
+        restoredBytes: Math.floor(originalBytes.length / 2),
+        scrubbedBytes: originalBytes.length,
       });
 
+      const result = await audit.migrate();
+
       expect(result.warnings).toEqual([]);
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }).map((entry) => entry.value.summary),
-      ).toEqual(["restore after restart"]);
+      expect(audit.systemSummaries()).toEqual(["restore after restart"]);
       await expect(fs.access(restorePath)).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 
   it("retries raw archive recovery when sanitized archive hardening fails", async () => {
-    await withTempDir(
-      { prefix: "openclaw-audit-migration-recovery-permissions-" },
-      async (stateDir) => {
-        const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-        const event = (summary: string) => ({
-          timestamp: "2026-07-03T00:00:00.000Z",
-          operation: "gateway.restart",
-          summary,
-        });
-        await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-        await fs.writeFile(sourcePath, `${JSON.stringify(event("before archive"))}\n`);
-        await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
-        await fs.appendFile(
-          `${sourcePath}.migrated.raw`,
-          `${JSON.stringify(event("later row"))}\n`,
-        );
-        const probe = await fs.open(path.join(stateDir, "recovery-chmod-probe"), "w");
-        const fileHandlePrototype = Object.getPrototypeOf(probe) as {
-          chmod(mode: number): Promise<void>;
-        };
-        await probe.close();
-        const originalChmod = Reflect.get(fileHandlePrototype, "chmod") as (
-          this: typeof fileHandlePrototype,
-          mode: number,
-        ) => Promise<void>;
-        let chmodCalls = 0;
-        const chmodSpy = vi.spyOn(fileHandlePrototype, "chmod").mockImplementation(function (
-          this: typeof fileHandlePrototype,
-          mode: number,
-        ) {
-          chmodCalls += 1;
-          // fs-safe 0.5 applies the write mode before the migration's explicit hardening check.
-          if (chmodCalls === 3) {
-            return Promise.reject(new Error("simulated recovery chmod failure"));
-          }
-          return originalChmod.call(this, mode);
-        });
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, sanitized, source } = audit.system;
+      await audit.writeJsonLines(source, [systemAuditEvent("before archive")]);
+      await audit.migrate();
+      await audit.appendJsonLines(raw, [systemAuditEvent("later row")]);
+      // fs-safe applies the write mode before the migration's explicit hardening check.
+      const chmodSpy = await failChmodCall(
+        audit,
+        "recovery-chmod-probe",
+        3,
+        "simulated recovery chmod failure",
+      );
 
-        let failed: Awaited<ReturnType<typeof migrateLegacyAuditLogs>>;
-        try {
-          failed = await migrateLegacyAuditLogs({
-            detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-            stateDir,
-          });
-        } finally {
-          chmodSpy.mockRestore();
-        }
+      let failed: Awaited<ReturnType<typeof audit.migrate>>;
+      try {
+        failed = await audit.migrate();
+      } finally {
+        chmodSpy.mockRestore();
+      }
 
-        expect(failed.changes).toEqual([]);
-        expect(failed.warnings.join("\n")).toContain(
-          "Failed securing sanitized system-agent audit log",
-        );
-        expect(
-          detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }).sources,
-        ).toMatchObject([{ storage: "raw-archive" }]);
+      expect(failed.changes).toEqual([]);
+      expect(failed.warnings.join("\n")).toContain(
+        "Failed securing sanitized system-agent audit log",
+      );
+      expect(audit.detect().sources).toMatchObject([{ storage: "raw-archive" }]);
 
-        const recovered = await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
-        expect(recovered.warnings).toEqual([]);
-        expect(
-          listSystemAgentAuditEntriesForTests({
-            env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-          }).map((entry) => entry.value.summary),
-        ).toEqual(["before archive", "later row"]);
-        const sanitizedRows = (await fs.readFile(`${sourcePath}.migrated`, "utf8"))
-          .trim()
-          .split("\n")
-          .map((line) => JSON.parse(line) as { summary: string });
-        expect(sanitizedRows.map((row) => row.summary)).toEqual(["before archive", "later row"]);
-        expect(
-          detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }).sources,
-        ).toEqual([]);
-      },
-    );
+      const recovered = await audit.migrate();
+      expect(recovered.warnings).toEqual([]);
+      expect(audit.systemSummaries()).toEqual(["before archive", "later row"]);
+      const sanitizedRows = await audit.readJsonLines<{ summary: string }>(sanitized);
+      expect(sanitizedRows.map((row) => row.summary)).toEqual(["before archive", "later row"]);
+      expect(audit.detect().sources).toEqual([]);
+    });
   });
 
   it("completes a verified partial sanitized tail after an interrupted write", async () => {
-    await withTempDir(
-      { prefix: "openclaw-audit-migration-partial-sanitized-tail-" },
-      async (stateDir) => {
-        const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-        const sanitizedPath = `${sourcePath}.migrated`;
-        const rawPath = `${sanitizedPath}.raw`;
-        const event = (day: string, summary: string) => ({
-          timestamp: `2026-07-${day}T00:00:00.000Z`,
-          operation: "gateway.restart",
-          summary,
-        });
-        await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-        await fs.writeFile(sourcePath, `${JSON.stringify(event("01", "before archive"))}\n`);
-        await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
-        const firstLater = event("02", "first later row");
-        const secondLater = event("03", "second later row");
-        await fs.appendFile(
-          rawPath,
-          `${JSON.stringify(firstLater)}\n${JSON.stringify(secondLater)}\n`,
-        );
-        // Simulate a stopped sanitized write: the durable checkpoint prefix plus
-        // one complete candidate row is a byte-for-byte prefix of the desired file.
-        await fs.appendFile(sanitizedPath, `${JSON.stringify(firstLater)}\n`);
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, sanitized, source } = audit.system;
+      const event = (day: string, summary: string) =>
+        systemAuditEvent(summary, { timestamp: `2026-07-${day}T00:00:00.000Z` });
+      await audit.writeJsonLines(source, [event("01", "before archive")]);
+      await audit.migrate();
+      const firstLater = event("02", "first later row");
+      const secondLater = event("03", "second later row");
+      await audit.appendJsonLines(raw, [firstLater, secondLater]);
+      // Simulate a stopped sanitized write: the durable checkpoint prefix plus
+      // one complete candidate row is a byte-for-byte prefix of the desired file.
+      await audit.appendJsonLines(sanitized, [firstLater]);
 
-        const recovered = await migrateLegacyAuditLogs({
-          detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-          stateDir,
-        });
+      const recovered = await audit.migrate();
 
-        expect(recovered.warnings).toEqual([]);
-        expect(
-          listSystemAgentAuditEntriesForTests({
-            env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-          }).map((entry) => entry.value.summary),
-        ).toEqual(["before archive", "first later row", "second later row"]);
-        const sanitizedRows = (await fs.readFile(sanitizedPath, "utf8"))
-          .trim()
-          .split("\n")
-          .map((line) => JSON.parse(line) as { summary: string });
-        expect(sanitizedRows.map((row) => row.summary)).toEqual([
-          "before archive",
-          "first later row",
-          "second later row",
-        ]);
-      },
-    );
+      expect(recovered.warnings).toEqual([]);
+      expect(audit.systemSummaries()).toEqual([
+        "before archive",
+        "first later row",
+        "second later row",
+      ]);
+      const sanitizedRows = await audit.readJsonLines<{ summary: string }>(sanitized);
+      expect(sanitizedRows.map((row) => row.summary)).toEqual([
+        "before archive",
+        "first later row",
+        "second later row",
+      ]);
+    });
   });
 
   it("preserves identical appends and blocks checkpointless whitespace ambiguity", async () => {
-    await withTempDir({ prefix: "openclaw-audit-migration-duplicate-tail-" }, async (stateDir) => {
-      const sourcePath = path.join(stateDir, "audit", "system-agent.jsonl");
-      const rawPath = `${sourcePath}.migrated.raw`;
-      const event = {
-        timestamp: "2026-07-03T00:00:00.000Z",
-        operation: "gateway.restart",
-        summary: "Repeated operation",
-      };
-      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
-      await fs.writeFile(sourcePath, `${JSON.stringify(event)}\n\n${JSON.stringify(event)}\n`);
-      await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
-      await fs.appendFile(rawPath, `${JSON.stringify(event)}\n`);
+    await withAuditMigrationFixture(async (audit) => {
+      const { raw, sanitized, source } = audit.system;
+      const event = systemAuditEvent("Repeated operation");
+      await audit.write(source, `${JSON.stringify(event)}\n\n${JSON.stringify(event)}\n`);
+      await audit.migrate();
+      await audit.appendJsonLines(raw, [event]);
 
-      const recovered = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      const recovered = await audit.migrate();
 
       expect(recovered.warnings).toEqual([]);
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }).map((entry) => entry.value.summary),
-      ).toEqual(["Repeated operation", "Repeated operation", "Repeated operation"]);
-      const sanitizedRows = (await fs.readFile(`${sourcePath}.migrated`, "utf8"))
-        .trim()
-        .split("\n");
+      expect(audit.systemSummaries()).toEqual([
+        "Repeated operation",
+        "Repeated operation",
+        "Repeated operation",
+      ]);
+      const sanitizedRows = (await fs.readFile(sanitized, "utf8")).trim().split("\n");
       expect(sanitizedRows).toHaveLength(3);
 
       runOpenClawStateWriteTransaction(
@@ -519,25 +276,16 @@ describe("legacy audit recovery byte handling", () => {
             .prepare("DELETE FROM diagnostic_events WHERE scope = ?")
             .run("migration.legacy-audit-raw");
         },
-        { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } },
+        { env: audit.env },
       );
-      await fs.appendFile(rawPath, `${JSON.stringify(event)}\n`);
-      const ambiguous = await migrateLegacyAuditLogs({
-        detected: detectLegacyAuditLogs({ stateDir, doctorOnlyStateMigrations: true }),
-        stateDir,
-      });
+      await audit.appendJsonLines(raw, [event]);
+      const ambiguous = await audit.migrate();
       expect(ambiguous.changes).toEqual([]);
       expect(ambiguous.warnings).toEqual([
         expect.stringContaining("checkpointless raw archive begins with ambiguous whitespace"),
       ]);
-      expect(
-        listSystemAgentAuditEntriesForTests({
-          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        }),
-      ).toHaveLength(3);
-      expect((await fs.readFile(`${sourcePath}.migrated`, "utf8")).trim().split("\n")).toHaveLength(
-        3,
-      );
+      expect(audit.systemEntries()).toHaveLength(3);
+      expect((await fs.readFile(sanitized, "utf8")).trim().split("\n")).toHaveLength(3);
     });
   });
 });

--- a/src/infra/state-migrations.audit.test-support.ts
+++ b/src/infra/state-migrations.audit.test-support.ts
@@ -1,0 +1,230 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { vi } from "vitest";
+import { listConfigAuditRecordsForTests } from "../config/io.audit.test-support.js";
+import { listSystemAgentAuditEntriesForTests } from "../system-agent/audit.test-support.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import { detectLegacyAuditLogs, migrateLegacyAuditLogs } from "./state-migrations.audit-logs.js";
+
+const AUDIT_SCRUB_PATTERN = Buffer.from(" \t".repeat(16));
+
+type SystemAuditEvent = {
+  timestamp: string;
+  operation: string;
+  summary: string;
+};
+
+type ConfigAuditRecord = {
+  ts: string;
+  source: string;
+  event: string;
+  argv: string[];
+  execArgv: string[];
+};
+
+function auditPaths(stateDir: string, relativePath: string) {
+  const source = path.join(stateDir, relativePath);
+  const raw = `${source}.migrated.raw`;
+  return {
+    source,
+    sanitized: `${source}.migrated`,
+    raw,
+    restore: `${raw}.doctor-scrub-restore`,
+    claim: path.join(path.dirname(source), `.${path.basename(source)}.doctor-importing`),
+  };
+}
+
+export function systemAuditEvent(
+  summary: string,
+  overrides: Partial<SystemAuditEvent> = {},
+): SystemAuditEvent {
+  return {
+    timestamp: "2026-07-03T00:00:00.000Z",
+    operation: "gateway.restart",
+    summary,
+    ...overrides,
+  };
+}
+
+export function configAuditRecord(
+  marker: string,
+  overrides: Partial<ConfigAuditRecord> = {},
+): ConfigAuditRecord {
+  return {
+    ts: "2026-07-01T00:00:00.000Z",
+    source: "config-io",
+    event: "config.write",
+    argv: ["openclaw", "config", "set", "token", marker],
+    execArgv: [],
+    ...overrides,
+  };
+}
+
+export class AuditMigrationFixture {
+  readonly env: NodeJS.ProcessEnv;
+  readonly config;
+  readonly system;
+
+  constructor(readonly stateDir: string) {
+    this.env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    this.config = auditPaths(stateDir, path.join("logs", "config-audit.jsonl"));
+    this.system = auditPaths(stateDir, path.join("audit", "system-agent.jsonl"));
+  }
+
+  detect(doctorOnlyStateMigrations = true) {
+    return detectLegacyAuditLogs({
+      stateDir: this.stateDir,
+      doctorOnlyStateMigrations,
+    });
+  }
+
+  migrate(detected = this.detect()) {
+    return migrateLegacyAuditLogs({ detected, stateDir: this.stateDir });
+  }
+
+  async write(target: string, content: string | Uint8Array): Promise<void> {
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, content);
+  }
+
+  writeJsonLines(target: string, records: unknown[]): Promise<void> {
+    return this.write(target, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+  }
+
+  appendJsonLines(target: string, records: unknown[]): Promise<void> {
+    return fs.appendFile(target, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+  }
+
+  async readJsonLines<T>(target: string): Promise<T[]> {
+    return (await fs.readFile(target, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as T);
+  }
+
+  async seedRawArchive(paths: { raw: string; sanitized: string }, raw: string | Uint8Array) {
+    await this.write(paths.sanitized, "{}\n");
+    await this.write(paths.raw, raw);
+  }
+
+  systemEntries = () => listSystemAgentAuditEntriesForTests({ env: this.env });
+  configRecords = () =>
+    listConfigAuditRecordsForTests({ env: this.env, homedir: () => this.stateDir });
+  systemSummaries = () => this.systemEntries().map((entry) => entry.value.summary);
+  systemOperations = () =>
+    this.systemEntries()
+      .map((entry) => entry.value.operation)
+      .toSorted();
+}
+
+export const withAuditMigrationFixture = (
+  run: (fixture: AuditMigrationFixture) => Promise<void>,
+): Promise<void> =>
+  withTempDir({ prefix: "openclaw-audit-migration-" }, (stateDir) =>
+    run(new AuditMigrationFixture(stateDir)),
+  );
+
+export function buildAuditScrubbedContent(length: number): Buffer {
+  return Buffer.from(" \t".repeat(Math.ceil(length / 2))).subarray(0, length);
+}
+
+export const FIRST_AUDIT_SCRUB_BYTE = AUDIT_SCRUB_PATTERN[0]!;
+
+export async function writeAuditRestoreJournal(
+  rawPath: string,
+  sourceRaw: Buffer,
+  progress: { restoredBytes: number; scrubbedBytes: number } = {
+    restoredBytes: 0,
+    scrubbedBytes: 0,
+  },
+): Promise<void> {
+  const stat = await fs.stat(rawPath);
+  const journal = `${JSON.stringify({
+    schemaVersion: 6,
+    rawBase64: sourceRaw.toString("base64"),
+    scrubPatternBase64: AUDIT_SCRUB_PATTERN.toString("base64"),
+    target: { dev: stat.dev, ino: stat.ino, size: sourceRaw.length },
+  })}\n`;
+  await fs.writeFile(
+    `${rawPath}.doctor-scrub-progress`,
+    `${JSON.stringify({
+      schemaVersion: 1,
+      journalHash: createHash("sha256").update(journal).digest("hex"),
+      direction: progress.restoredBytes > 0 ? "restoring" : "scrubbing",
+      committedBytes: progress.restoredBytes || progress.scrubbedBytes,
+      pendingEnd: progress.restoredBytes || progress.scrubbedBytes,
+      extentBytes: progress.restoredBytes > 0 ? progress.scrubbedBytes : sourceRaw.length,
+    })}\n`,
+  );
+  await fs.writeFile(`${rawPath}.doctor-scrub-restore`, journal);
+}
+
+async function fileHandlePrototype<T>(
+  fixture: AuditMigrationFixture,
+  probeName: string,
+): Promise<T> {
+  const probe = await fs.open(path.join(fixture.stateDir, probeName), "w+");
+  const prototype = Object.getPrototypeOf(probe) as T;
+  await probe.close();
+  return prototype;
+}
+
+export async function failChmodCall(
+  fixture: AuditMigrationFixture,
+  probeName: string,
+  callNumber: number,
+  message: string,
+) {
+  const prototype = await fileHandlePrototype<{ chmod(mode: number): Promise<void> }>(
+    fixture,
+    probeName,
+  );
+  const original = Reflect.get(prototype, "chmod") as typeof prototype.chmod;
+  let calls = 0;
+  return vi.spyOn(prototype, "chmod").mockImplementation(function (
+    this: typeof prototype,
+    mode: number,
+  ) {
+    calls += 1;
+    if (calls === callNumber) {
+      return Promise.reject(new Error(message));
+    }
+    return original.call(this, mode);
+  });
+}
+
+export async function failSecondScrubWrite(fixture: AuditMigrationFixture) {
+  const prototype = await fileHandlePrototype<{
+    write(
+      buffer: Uint8Array,
+      offset: number,
+      length: number,
+      position: number | null,
+    ): Promise<{ bytesWritten: number; buffer: Uint8Array }>;
+  }>(fixture, "write-probe");
+  const original = Reflect.get(prototype, "write") as typeof prototype.write;
+  let calls = 0;
+  return vi.spyOn(prototype, "write").mockImplementation(async function (
+    this: typeof prototype,
+    buffer: Uint8Array,
+    offset: number,
+    length: number,
+    position: number | null,
+  ) {
+    calls += 1;
+    if (calls === 1) {
+      return await original.call(
+        this,
+        buffer,
+        offset,
+        Math.max(1, Math.floor(length / 2)),
+        position,
+      );
+    }
+    if (calls === 2) {
+      throw new Error("simulated scrub write failure");
+    }
+    return await original.call(this, buffer, offset, length, position);
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

The audit-log import and crash-recovery suites repeated their temporary state layout, audit event construction, journal bytes, migration invocation, and file-handle fault injection across 1,604 lines. That duplication made the same migration lifecycle harder to review and update consistently.

## Why This Change Was Made

This introduces one test-only fixture owned by the legacy audit migration lifecycle and rewrites the two existing suites around it. Distinct checkpoint, generation, downgrade, restore, durability, lock, symlink, and old-writer scenarios remain explicit in their test bodies.

- Architectural owner: legacy audit import/recovery test lifecycle under `src/infra/`
- Canonical fix: one test-only path/event/journal/fault-injection fixture
- Removed paths: duplicated setup and recovery-journal builders in both suites
- Production LOC delta: 0
- SQLite schema/version delta: 0
- Test delta: +703/-1161, net -458 LOC
- Behavior inventory: exact 29/29 test titles/order and 156/156 assertion sites preserved

## User Impact

No user-visible or production behavior change. Maintainers get a smaller, more coherent audit migration regression surface.

## Evidence

- Local focused Vitest before final lint-only rename: 29/29 tests passed.
- Exact-head Blacksmith Testbox `tbx_01kz29pbcd3ej9g5y73tm2wm8j`: `pnpm check:changed` passed, including formatting, ratchets, dead-export scan, core-test typecheck, and lint.
- Same exact-head Testbox run: 122/122 focused and sibling tests passed across audit logs, audit recovery, audit backup, SQLite audit record store, and the state migration orchestrator.
- AST parity against the parent commit: audit logs 19 titles + 114 assertions; audit recovery 10 titles + 42 assertions; exact order and counts unchanged.
- `git diff --check`: passed.
- Exhaustive central collision audit: zero open exact-path overlaps across all three touched paths through 2026-08-02T22:00:54Z.
