### PR TITLE
fix(telegram): preserve pre-tool text during CLI tool calls

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -336,10 +336,17 @@ export function createTelegramReplyDelivery(params: {
         !params.draft.isAnswerToolProgressOnly() &&
         !ownedByQueuedRotation &&
         segment.update.text.trimEnd() === params.draft.answerLane.lastPartialText.trimEnd();
+      const isDurableProgressCommentary =
+        params.streamMode === "progress" &&
+        info.kind === "block" &&
+        effectivePayload.isCommentary === true;
+      // CLI finals exclude separately classified commentary. Send that block outside
+      // the disposable progress stream or its collapse summary erases the text.
       const suppressProgressAnswerBlock =
         params.streamMode === "progress" &&
         info.kind === "block" &&
         segment.lane === "answer" &&
+        !isDurableProgressCommentary &&
         !reply.hasMedia &&
         !hasExecApprovalPayload(effectivePayload) &&
         telegramButtons === undefined;
@@ -381,6 +388,7 @@ export function createTelegramReplyDelivery(params: {
               payload: lanePayload,
               infoKind: info.kind,
               buttons: telegramButtons,
+              allowStream: !isDurableProgressCommentary,
             });
       if (
         segment.lane === "answer" &&

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -241,6 +241,7 @@ export async function runTelegramDispatchTurn(params: {
                 ? params.progress.commentaryProgressEnabled
                 : undefined,
             progressPreambleEnabled: params.progress.progressPreambleEnabled,
+            commentaryPayloadsEnabled: params.progress.progressPreambleEnabled,
             reasoningPayloadsEnabled: params.draft.durableReasoningPayloadsEnabled,
             onToolStart: params.progress.handleToolStart,
             onItemEvent: params.progress.handleItemEvent,

--- a/extensions/telegram/src/bot-message-dispatch.progress-summary.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-summary.test.ts
@@ -314,6 +314,36 @@ describeTelegramDispatch("dispatchTelegramMessage progress-summary", () => {
     );
   });
 
+  it("keeps Claude CLI pre-tool commentary after the progress window collapses", async () => {
+    const markers = "Test markers: caribou-lampion-473, fromage-quantique, satellite-en-tricot";
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        expect(replyOptions?.commentaryPayloadsEnabled).toBe(true);
+        await replyOptions?.onItemEvent?.({
+          kind: "preamble",
+          itemId: "commentary-1",
+          progressText: markers,
+          suppressDurableProgress: true,
+        });
+        await replyOptions?.onBlockReplyQueued?.({ text: markers, isCommentary: true });
+        await dispatcherOptions.deliver({ text: markers, isCommentary: true }, { kind: "block" });
+        await replyOptions?.onToolStart?.({ name: "Bash", phase: "start" });
+        await dispatcherOptions.deliver({ text: "TEST DONE" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
+    expect(allDeliveredReplyTexts()).toEqual([markers, "TEST DONE"]);
+  });
+
   it("never streams an interim answer block into the progress window (Discord parity)", async () => {
     // Progress mode: the window is a pure activity log. An intermediate assistant
     // answer block (info.kind === "block", before the final) must NOT render into


### PR DESCRIPTION
Related: #106760

## What Problem This Solves

Fixes an issue where Telegram users lost Claude CLI text written before a tool call when progress streaming collapsed its activity window. Only the post-tool closer remained visible.

## Why This Change Was Made

Telegram now opts into the shared durable CLI commentary lane. Completed commentary blocks bypass the disposable progress stream, while ordinary interim answer blocks and the stationary progress window keep their existing behavior.

Root cause: Telegram enabled CLI preamble classification without enabling its paired durable commentary delivery. The classified pre-tool text therefore lived only in the cosmetic progress message, which the end-of-turn activity summary intentionally replaces.

## User Impact

Explanations written before Claude CLI tool calls remain visible in Telegram after the turn completes. Tool progress still collapses to the normal summary.

## Evidence

Real-user Telegram E2E against `461e61aacd4`, Claude CLI backend, DM:

- Sent an authorized marker fixture: `caribou-lampion-473`, `fromage-quantique`, `satellite-en-tricot` → Bash → `TEST DONE`.
- Before: marker message was edited into `🛠️ 1 tool call · ⏱️ 8s`; all markers disappeared.
- After: all three markers remain in durable message 278; progress message 279 collapses to `🛠️ 1 tool call · ⏱️ 7s`; `TEST DONE` remains in message 280. No marker edit or deletion.
- Recorded totals: 3 messages, 1 progress edit, 0 deletions.

Focused proof:

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.progress-summary.test.ts` — 18 passed
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts` — 3 passed
- `pnpm tsgo:extensions` — passed
- `pnpm tsgo:extensions:test` — passed
- targeted Oxlint and `git diff --check` — passed

Review passes:

- Distill: unified the durable-progress-commentary decision; no parallel policy paths.
- Greybeard: no performance findings; constant-time lane decision, no new hot-loop allocation or lookup.
- Autoreview: TruffleHog preflight passed, but the helper could not launch because the host has no `codex` executable. Manual source review found no blocking issue.

The normal changed-gate router was also unavailable because the installed Crabbox binary failed its own `--version/--help` sanity check; targeted local checks above were used as the trusted-source fallback.
