### PR TITLE
refactor(plugins): consolidate npm install E2E fixtures

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -863,7 +863,6 @@ src/plugins/discovery.ts
 src/plugins/hook-types.ts
 src/plugins/hooks.ts
 src/plugins/install-security-scan.runtime.ts
-src/plugins/install.npm-spec.e2e.test.ts
 src/plugins/install.npm-spec.test.ts
 src/plugins/install.test.ts
 src/plugins/installed-plugin-index.test.ts

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -24,6 +24,25 @@ type PackedVersion = {
   version: string;
 };
 
+type PackPluginParams = {
+  dependencies?: Record<string, string>;
+  indexJs?: string;
+  openclaw?: Record<string, unknown>;
+  optionalDependencies?: Record<string, string>;
+  packageName: string;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  pluginId?: string;
+  rootDir: string;
+  version?: string;
+};
+
+type RegistryPackage = {
+  latest: string;
+  packageName: string;
+  versions: PackedVersion[];
+};
+
 const tempDirs: string[] = [];
 const servers: http.Server[] = [];
 const envKeys = ["NPM_CONFIG_REGISTRY", "npm_config_registry"] as const;
@@ -51,6 +70,19 @@ async function makeTempDir(label: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), `openclaw-${label}-`));
   tempDirs.push(dir);
   return dir;
+}
+
+async function makeInstallFixture(label: string) {
+  const rootDir = await makeTempDir(label);
+  return { rootDir, npmRoot: path.join(rootDir, "managed-npm") };
+}
+
+function uniquePackageName(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  return JSON.parse(await fs.readFile(filePath, "utf8")) as T;
 }
 
 function configWithInstalledPackageTreeBlockPolicy(): OpenClawConfig {
@@ -93,19 +125,9 @@ function pluginNpmProjectRoot(npmRoot: string, packageName: string): string {
   return resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
 }
 
-async function packPlugin(params: {
-  dependencies?: Record<string, string>;
-  packageName: string;
-  optionalDependencies?: Record<string, string>;
-  openclaw?: Record<string, unknown>;
-  peerDependencies?: Record<string, string>;
-  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
-  pluginId: string;
-  version: string;
-  rootDir: string;
-  indexJs?: string;
-}): Promise<PackedVersion> {
-  const packageDir = path.join(params.rootDir, `package-${params.packageName}-${params.version}`);
+async function packPlugin(params: PackPluginParams): Promise<PackedVersion> {
+  const version = params.version ?? "1.0.0";
+  const packageDir = path.join(params.rootDir, `package-${params.packageName}-${version}`);
   const peerDependenciesMeta = params.peerDependencies
     ? (params.peerDependenciesMeta ??
       Object.fromEntries(
@@ -118,7 +140,7 @@ async function packPlugin(params: {
     `${JSON.stringify(
       {
         name: params.packageName,
-        version: params.version,
+        version,
         type: "module",
         openclaw: params.openclaw ?? { extensions: ["./dist/index.js"] },
         ...(params.dependencies ? { dependencies: params.dependencies } : {}),
@@ -141,8 +163,8 @@ async function packPlugin(params: {
     path.join(packageDir, "openclaw.plugin.json"),
     `${JSON.stringify(
       {
-        id: params.pluginId,
-        name: params.pluginId,
+        id: params.pluginId ?? params.packageName,
+        name: params.pluginId ?? params.packageName,
         configSchema: { type: "object" },
       },
       null,
@@ -177,17 +199,22 @@ async function packPlugin(params: {
     ...(peerDependenciesMeta ? { peerDependenciesMeta } : {}),
     shasum: crypto.createHash("sha1").update(archive).digest("hex"),
     tarballName,
-    version: params.version,
+    version,
   };
 }
 
-async function startStaticRegistry(
-  packages: Array<{
-    latest: string;
-    packageName: string;
-    versions: PackedVersion[];
-  }>,
-): Promise<string> {
+async function registryPackage(
+  params: PackPluginParams & { latest?: string },
+): Promise<RegistryPackage> {
+  const version = params.version ?? "1.0.0";
+  return {
+    packageName: params.packageName,
+    latest: params.latest ?? version,
+    versions: [await packPlugin({ ...params, version })],
+  };
+}
+
+async function startStaticRegistry(packages: RegistryPackage[]): Promise<string> {
   const packageEntries = packages.map((pkg) => ({
     ...pkg,
     encodedPackageName: encodeURIComponent(pkg.packageName).replace("%40", "@"),
@@ -262,6 +289,57 @@ async function startStaticRegistry(
   });
   servers.push(server);
   return `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+}
+
+async function useStaticRegistry(packages: RegistryPackage[]): Promise<string> {
+  const registry = await startStaticRegistry(packages);
+  useRegistry(registry);
+  return registry;
+}
+
+function useRegistry(registry: string): void {
+  process.env.NPM_CONFIG_REGISTRY = registry;
+  process.env.npm_config_registry = registry;
+}
+
+async function installNpmPlugin(params: {
+  config?: OpenClawConfig;
+  npmRoot: string;
+  spec: string;
+}) {
+  return await installPluginFromNpmSpec({
+    ...(params.config ? { config: params.config } : {}),
+    spec: params.spec,
+    npmDir: params.npmRoot,
+    logger: { info: () => {}, warn: () => {} },
+    timeoutMs: 120_000,
+  });
+}
+
+async function installProjectDependencies(
+  projectRoot: string,
+  dependencies: Record<string, string>,
+): Promise<void> {
+  await fs.mkdir(projectRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(projectRoot, "package.json"),
+    `${JSON.stringify({ private: true, dependencies }, null, 2)}\n`,
+    "utf8",
+  );
+  await execFileAsync(
+    "npm",
+    [
+      "install",
+      "--omit=dev",
+      "--omit=peer",
+      "--legacy-peer-deps",
+      "--loglevel=error",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+    ],
+    { cwd: projectRoot },
+  );
 }
 
 async function startMutableRegistry(params: {
@@ -347,9 +425,8 @@ async function startMutableRegistry(params: {
 
 describe("installPluginFromNpmSpec e2e", () => {
   it("installs the newest compatible stable package when npm latest requires a newer plugin API", async () => {
-    const rootDir = await makeTempDir("npm-plugin-compatible-version-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const packageName = `compatible-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-compatible-version-e2e");
+    const packageName = uniquePackageName("compatible-plugin");
     const compatibleOpenClaw = {
       extensions: ["./dist/index.js"],
       install: { minHostVersion: ">=2026.4.25" },
@@ -363,22 +440,18 @@ describe("installPluginFromNpmSpec e2e", () => {
     const versions = [
       await packPlugin({
         packageName,
-        pluginId: packageName,
         version: "2026.5.26",
         rootDir,
         openclaw: compatibleOpenClaw,
       }),
       await packPlugin({
         packageName,
-        pluginId: packageName,
         version: "2026.5.27",
         rootDir,
         openclaw: incompatibleOpenClaw,
       }),
     ];
-    const registry = await startStaticRegistry([{ packageName, latest: "2026.5.27", versions }]);
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
+    await useStaticRegistry([{ packageName, latest: "2026.5.27", versions }]);
     const previousHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
     process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = "2026.5.10-beta.1";
     const warnings: string[] = [];
@@ -398,12 +471,9 @@ describe("installPluginFromNpmSpec e2e", () => {
       expect(result.npmResolution?.resolvedSpec).toBe(`${packageName}@2026.5.26`);
       expect(warnings.join("\n")).toContain(`using newest compatible ${packageName}@2026.5.26`);
       const projectRoot = pluginNpmProjectRoot(npmRoot, packageName);
-      const installedPackageJson = JSON.parse(
-        await fs.readFile(
-          path.join(projectRoot, "node_modules", packageName, "package.json"),
-          "utf8",
-        ),
-      ) as { version?: string };
+      const installedPackageJson = await readJson<{ version?: string }>(
+        path.join(projectRoot, "node_modules", packageName, "package.json"),
+      );
       expect(installedPackageJson.version).toBe("2026.5.26");
     } finally {
       if (previousHostVersion === undefined) {
@@ -415,33 +485,22 @@ describe("installPluginFromNpmSpec e2e", () => {
   });
 
   it("scrubs root openclaw materialized by required npm peers", async () => {
-    const rootDir = await makeTempDir("npm-plugin-required-peer-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const packageName = `required-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const versions = [
-      await packPlugin({
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-required-peer-e2e");
+    const packageName = uniquePackageName("required-peer-plugin");
+    const registry = await useStaticRegistry([
+      await registryPackage({
         packageName,
         peerDependencies: { openclaw: ">=2026.0.0" },
         peerDependenciesMeta: {},
-        pluginId: packageName,
-        version: "1.0.0",
         rootDir,
       }),
-    ];
-    const openClawVersions = [
-      await packPlugin({
+      await registryPackage({
         packageName: "openclaw",
         pluginId: "registry-openclaw-copy",
         version: "2026.0.0",
         rootDir,
       }),
-    ];
-    const registry = await startStaticRegistry([
-      { packageName, latest: "1.0.0", versions },
-      { packageName: "openclaw", latest: "2026.0.0", versions: openClawVersions },
     ]);
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
 
     const rawNpmRoot = path.join(rootDir, "raw-managed-npm");
     await fs.mkdir(rawNpmRoot, { recursive: true });
@@ -467,33 +526,27 @@ describe("installPluginFromNpmSpec e2e", () => {
         timeout: 120_000,
       },
     );
-    const rawLock = JSON.parse(
-      await fs.readFile(path.join(rawNpmRoot, "package-lock.json"), "utf8"),
-    ) as {
+    const rawLock = await readJson<{
       packages?: Record<string, unknown>;
-    };
+    }>(path.join(rawNpmRoot, "package-lock.json"));
     const rawOpenClawLockEntry = rawLock.packages?.["node_modules/openclaw"] as
       | { peer?: unknown; version?: unknown }
       | undefined;
     expect(rawOpenClawLockEntry?.peer).toBe(true);
     expect(rawOpenClawLockEntry?.version).toBe("2026.0.0");
 
-    const result = await installPluginFromNpmSpec({
+    const result = await installNpmPlugin({
       spec: `${packageName}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
     if (!result.ok) {
       throw new Error(result.error);
     }
 
     const projectRoot = pluginNpmProjectRoot(npmRoot, packageName);
-    const lock = JSON.parse(
-      await fs.readFile(path.join(projectRoot, "package-lock.json"), "utf8"),
-    ) as {
+    const lock = await readJson<{
       packages?: Record<string, unknown>;
-    };
+    }>(path.join(projectRoot, "package-lock.json"));
     expect(lock.packages?.["node_modules/openclaw"]).toBeUndefined();
     await expect(
       fs.lstat(path.join(projectRoot, "node_modules", "openclaw")),
@@ -506,59 +559,24 @@ describe("installPluginFromNpmSpec e2e", () => {
   });
 
   it("keeps third-party peer dependencies in the owning npm project across later installs", async () => {
-    const rootDir = await makeTempDir("npm-plugin-third-party-peer-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const pluginWithRuntimePeer = `runtime-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const laterPlugin = `later-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const runtimePeer = `runtime-peer-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const registry = await startStaticRegistry([
-      {
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-third-party-peer-e2e");
+    const pluginWithRuntimePeer = uniquePackageName("runtime-peer-plugin");
+    const laterPlugin = uniquePackageName("later-plugin");
+    const runtimePeer = uniquePackageName("runtime-peer");
+    await useStaticRegistry([
+      await registryPackage({
         packageName: pluginWithRuntimePeer,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: pluginWithRuntimePeer,
-            peerDependencies: { [runtimePeer]: "^1.0.0" },
-            peerDependenciesMeta: {},
-            pluginId: pluginWithRuntimePeer,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
-        packageName: laterPlugin,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: laterPlugin,
-            pluginId: laterPlugin,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
-        packageName: runtimePeer,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: runtimePeer,
-            pluginId: runtimePeer,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
+        peerDependencies: { [runtimePeer]: "^1.0.0" },
+        peerDependenciesMeta: {},
+        rootDir,
+      }),
+      await registryPackage({ packageName: laterPlugin, rootDir }),
+      await registryPackage({ packageName: runtimePeer, rootDir }),
     ]);
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
 
-    const first = await installPluginFromNpmSpec({
+    const first = await installNpmPlugin({
       spec: `${pluginWithRuntimePeer}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
     if (!first.ok) {
       throw new Error(first.error);
@@ -568,11 +586,9 @@ describe("installPluginFromNpmSpec e2e", () => {
       fs.lstat(path.join(firstProjectRoot, "node_modules", runtimePeer, "package.json")),
     ).resolves.toBeTruthy();
 
-    const second = await installPluginFromNpmSpec({
+    const second = await installNpmPlugin({
       spec: `${laterPlugin}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
     if (!second.ok) {
       throw new Error(second.error);
@@ -584,60 +600,28 @@ describe("installPluginFromNpmSpec e2e", () => {
   });
 
   it("plans peers from installed optional dependencies", async () => {
-    const rootDir = await makeTempDir("npm-plugin-optional-peer-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const pluginWithOptionalDependency = `optional-owner-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const optionalDependency = `optional-dep-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const runtimePeer = `optional-peer-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const registry = await startStaticRegistry([
-      {
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-optional-peer-e2e");
+    const pluginWithOptionalDependency = uniquePackageName("optional-owner-plugin");
+    const optionalDependency = uniquePackageName("optional-dep");
+    const runtimePeer = uniquePackageName("optional-peer");
+    await useStaticRegistry([
+      await registryPackage({
         packageName: pluginWithOptionalDependency,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: pluginWithOptionalDependency,
-            optionalDependencies: { [optionalDependency]: "1.0.0" },
-            pluginId: pluginWithOptionalDependency,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
+        optionalDependencies: { [optionalDependency]: "1.0.0" },
+        rootDir,
+      }),
+      await registryPackage({
         packageName: optionalDependency,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: optionalDependency,
-            peerDependencies: { [runtimePeer]: "^1.0.0" },
-            peerDependenciesMeta: {},
-            pluginId: optionalDependency,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
-        packageName: runtimePeer,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: runtimePeer,
-            pluginId: runtimePeer,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
+        peerDependencies: { [runtimePeer]: "^1.0.0" },
+        peerDependenciesMeta: {},
+        rootDir,
+      }),
+      await registryPackage({ packageName: runtimePeer, rootDir }),
     ]);
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
 
-    const result = await installPluginFromNpmSpec({
+    const result = await installNpmPlugin({
       spec: `${pluginWithOptionalDependency}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
     if (!result.ok) {
       throw new Error(result.error);
@@ -650,102 +634,38 @@ describe("installPluginFromNpmSpec e2e", () => {
     await expect(
       fs.lstat(path.join(projectRoot, "node_modules", runtimePeer, "package.json")),
     ).resolves.toBeTruthy();
-    const rootManifest = JSON.parse(
-      await fs.readFile(path.join(projectRoot, "package.json"), "utf8"),
-    ) as {
+    const rootManifest = await readJson<{
       dependencies?: Record<string, string>;
       openclaw?: { managedPeerDependencies?: string[] };
-    };
+    }>(path.join(projectRoot, "package.json"));
     expect(["1.0.0", "^1.0.0"]).toContain(rootManifest.dependencies?.[runtimePeer]);
     expect(rootManifest.openclaw?.managedPeerDependencies ?? []).toContain(runtimePeer);
   });
 
   it("leaves legacy flat-root peer dependencies alone during isolated later installs", async () => {
-    const rootDir = await makeTempDir("npm-plugin-repaired-peer-scan-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const pluginWithRuntimePeer = `existing-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const laterPlugin = `later-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const runtimePeer = `runtime-peer-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const registry = await startStaticRegistry([
-      {
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-repaired-peer-scan-e2e");
+    const pluginWithRuntimePeer = uniquePackageName("existing-peer-plugin");
+    const laterPlugin = uniquePackageName("later-plugin");
+    const runtimePeer = uniquePackageName("runtime-peer");
+    await useStaticRegistry([
+      await registryPackage({
         packageName: pluginWithRuntimePeer,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: pluginWithRuntimePeer,
-            peerDependencies: { [runtimePeer]: "^1.0.0" },
-            peerDependenciesMeta: {},
-            pluginId: pluginWithRuntimePeer,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
-        packageName: laterPlugin,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: laterPlugin,
-            pluginId: laterPlugin,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
-        packageName: runtimePeer,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            indexJs: "eval('1');\n",
-            packageName: runtimePeer,
-            pluginId: runtimePeer,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
+        peerDependencies: { [runtimePeer]: "^1.0.0" },
+        peerDependenciesMeta: {},
+        rootDir,
+      }),
+      await registryPackage({ packageName: laterPlugin, rootDir }),
+      await registryPackage({ indexJs: "eval('1');\n", packageName: runtimePeer, rootDir }),
     ]);
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
 
-    await fs.mkdir(npmRoot, { recursive: true });
-    await fs.writeFile(
-      path.join(npmRoot, "package.json"),
-      `${JSON.stringify(
-        {
-          private: true,
-          dependencies: { [pluginWithRuntimePeer]: "1.0.0" },
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-    await execFileAsync(
-      "npm",
-      [
-        "install",
-        "--omit=dev",
-        "--omit=peer",
-        "--legacy-peer-deps",
-        "--loglevel=error",
-        "--ignore-scripts",
-        "--no-audit",
-        "--no-fund",
-      ],
-      { cwd: npmRoot },
-    );
+    await installProjectDependencies(npmRoot, { [pluginWithRuntimePeer]: "1.0.0" });
     await expect(
       fs.lstat(path.join(npmRoot, "node_modules", runtimePeer, "package.json")),
     ).rejects.toHaveProperty("code", "ENOENT");
 
-    const later = await installPluginFromNpmSpec({
+    const later = await installNpmPlugin({
       spec: `${laterPlugin}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
     if (!later.ok) {
       throw new Error(later.error);
@@ -758,87 +678,32 @@ describe("installPluginFromNpmSpec e2e", () => {
     await expect(
       fs.lstat(path.join(npmRoot, "node_modules", runtimePeer, "package.json")),
     ).rejects.toHaveProperty("code", "ENOENT");
-    const rootManifest = JSON.parse(
-      await fs.readFile(path.join(npmRoot, "package.json"), "utf8"),
-    ) as {
+    const rootManifest = await readJson<{
       dependencies?: Record<string, string>;
       openclaw?: { managedPeerDependencies?: string[] };
-    };
+    }>(path.join(npmRoot, "package.json"));
     expect(rootManifest.dependencies?.[laterPlugin]).toBeUndefined();
     expect(rootManifest.dependencies?.[runtimePeer]).toBeUndefined();
     expect(rootManifest.openclaw?.managedPeerDependencies ?? []).not.toContain(runtimePeer);
   });
 
   it("ignores legacy flat-root package cycles during isolated installs", async () => {
-    const rootDir = await makeTempDir("npm-plugin-peer-cycle-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const existingPlugin = `existing-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const laterPlugin = `later-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const registry = await startStaticRegistry([
-      {
-        packageName: existingPlugin,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: existingPlugin,
-            pluginId: existingPlugin,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
-        packageName: laterPlugin,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: laterPlugin,
-            pluginId: laterPlugin,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-peer-cycle-e2e");
+    const existingPlugin = uniquePackageName("existing-plugin");
+    const laterPlugin = uniquePackageName("later-plugin");
+    await useStaticRegistry([
+      await registryPackage({ packageName: existingPlugin, rootDir }),
+      await registryPackage({ packageName: laterPlugin, rootDir }),
     ]);
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
 
-    await fs.mkdir(npmRoot, { recursive: true });
-    await fs.writeFile(
-      path.join(npmRoot, "package.json"),
-      `${JSON.stringify(
-        {
-          private: true,
-          dependencies: { [existingPlugin]: "1.0.0" },
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-    await execFileAsync(
-      "npm",
-      [
-        "install",
-        "--omit=dev",
-        "--omit=peer",
-        "--legacy-peer-deps",
-        "--loglevel=error",
-        "--ignore-scripts",
-        "--no-audit",
-        "--no-fund",
-      ],
-      { cwd: npmRoot },
-    );
+    await installProjectDependencies(npmRoot, { [existingPlugin]: "1.0.0" });
     const existingPluginDir = path.join(npmRoot, "node_modules", existingPlugin);
     await fs.mkdir(path.join(existingPluginDir, "node_modules"), { recursive: true });
     await fs.symlink(existingPluginDir, path.join(existingPluginDir, "node_modules", "self"));
 
-    const later = await installPluginFromNpmSpec({
+    const later = await installNpmPlugin({
       spec: `${laterPlugin}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
 
     expect(later.ok).toBe(true);
@@ -855,48 +720,24 @@ describe("installPluginFromNpmSpec e2e", () => {
   });
 
   it("rolls back managed peer dependencies added before a failed installed package policy scan", async () => {
-    const rootDir = await makeTempDir("npm-plugin-peer-rollback-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const blockedPlugin = `blocked-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const runtimePeer = `runtime-peer-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const registry = await startStaticRegistry([
-      {
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-peer-rollback-e2e");
+    const blockedPlugin = uniquePackageName("blocked-plugin");
+    const runtimePeer = uniquePackageName("runtime-peer");
+    await useStaticRegistry([
+      await registryPackage({
+        indexJs: "eval('1');\n",
         packageName: blockedPlugin,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            indexJs: "eval('1');\n",
-            packageName: blockedPlugin,
-            peerDependencies: { [runtimePeer]: "^1.0.0" },
-            peerDependenciesMeta: {},
-            pluginId: blockedPlugin,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
-        packageName: runtimePeer,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: runtimePeer,
-            pluginId: runtimePeer,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
+        peerDependencies: { [runtimePeer]: "^1.0.0" },
+        peerDependenciesMeta: {},
+        rootDir,
+      }),
+      await registryPackage({ packageName: runtimePeer, rootDir }),
     ]);
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
 
-    const result = await installPluginFromNpmSpec({
+    const result = await installNpmPlugin({
       config: configWithInstalledPackageTreeBlockPolicy(),
       spec: `${blockedPlugin}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
 
     expect(result.ok).toBe(false);
@@ -906,12 +747,10 @@ describe("installPluginFromNpmSpec e2e", () => {
     }
     const projectRoot = pluginNpmProjectRoot(npmRoot, blockedPlugin);
     try {
-      const rootManifest = JSON.parse(
-        await fs.readFile(path.join(projectRoot, "package.json"), "utf8"),
-      ) as {
+      const rootManifest = await readJson<{
         dependencies?: Record<string, string>;
         openclaw?: { managedPeerDependencies?: string[] };
-      };
+      }>(path.join(projectRoot, "package.json"));
       expect(rootManifest.dependencies?.[blockedPlugin]).toBeUndefined();
       expect(rootManifest.dependencies?.[runtimePeer]).toBeUndefined();
       expect(rootManifest.openclaw?.managedPeerDependencies ?? []).not.toContain(runtimePeer);
@@ -927,44 +766,29 @@ describe("installPluginFromNpmSpec e2e", () => {
   });
 
   it("falls back to the legacy npm peer mode inside the plugin project when npm cannot plan third-party peers", async () => {
-    const rootDir = await makeTempDir("npm-plugin-peer-plan-fallback-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const blockedPlugin = `missing-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const missingPeer = `missing-peer-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const registry = await startStaticRegistry([
-      {
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-peer-plan-fallback-e2e");
+    const blockedPlugin = uniquePackageName("missing-peer-plugin");
+    const missingPeer = uniquePackageName("missing-peer");
+    await useStaticRegistry([
+      await registryPackage({
         packageName: blockedPlugin,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: blockedPlugin,
-            peerDependencies: { [missingPeer]: "^1.0.0" },
-            peerDependenciesMeta: {},
-            pluginId: blockedPlugin,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
+        peerDependencies: { [missingPeer]: "^1.0.0" },
+        peerDependenciesMeta: {},
+        rootDir,
+      }),
     ]);
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
 
-    const result = await installPluginFromNpmSpec({
+    const result = await installNpmPlugin({
       spec: `${blockedPlugin}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
 
     expect(result.ok).toBe(true);
     const projectRoot = pluginNpmProjectRoot(npmRoot, blockedPlugin);
-    const rootManifest = JSON.parse(
-      await fs.readFile(path.join(projectRoot, "package.json"), "utf8"),
-    ) as {
+    const rootManifest = await readJson<{
       dependencies?: Record<string, string>;
       openclaw?: { managedPeerDependencies?: string[] };
-    };
+    }>(path.join(projectRoot, "package.json"));
     expect(rootManifest.dependencies?.[blockedPlugin]).toBe("1.0.0");
     expect(rootManifest.dependencies?.[missingPeer]).toBeUndefined();
     expect(rootManifest.openclaw?.managedPeerDependencies ?? []).not.toContain(missingPeer);
@@ -974,93 +798,34 @@ describe("installPluginFromNpmSpec e2e", () => {
   });
 
   it("does not take ownership of an existing root dependency observed as a peer", async () => {
-    const rootDir = await makeTempDir("npm-plugin-peer-existing-root-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const existingRootDependency = `existing-root-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const blockedPlugin = `blocked-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const runtimePeer = `runtime-peer-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const registry = await startStaticRegistry([
-      {
-        packageName: existingRootDependency,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: existingRootDependency,
-            pluginId: existingRootDependency,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-peer-existing-root-e2e");
+    const existingRootDependency = uniquePackageName("existing-root");
+    const blockedPlugin = uniquePackageName("blocked-plugin");
+    const runtimePeer = uniquePackageName("runtime-peer");
+    await useStaticRegistry([
+      await registryPackage({ packageName: existingRootDependency, rootDir }),
+      await registryPackage({
+        indexJs: "eval('1');\n",
         packageName: blockedPlugin,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            indexJs: "eval('1');\n",
-            packageName: blockedPlugin,
-            peerDependencies: {
-              [existingRootDependency]: "^1.0.0",
-              [runtimePeer]: "^1.0.0",
-            },
-            peerDependenciesMeta: {},
-            pluginId: blockedPlugin,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
-        packageName: runtimePeer,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: runtimePeer,
-            pluginId: runtimePeer,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
+        peerDependencies: {
+          [existingRootDependency]: "^1.0.0",
+          [runtimePeer]: "^1.0.0",
+        },
+        peerDependenciesMeta: {},
+        rootDir,
+      }),
+      await registryPackage({ packageName: runtimePeer, rootDir }),
     ]);
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
 
     const blockedProjectRoot = pluginNpmProjectRoot(npmRoot, blockedPlugin);
-    await fs.mkdir(blockedProjectRoot, { recursive: true });
-    await fs.writeFile(
-      path.join(blockedProjectRoot, "package.json"),
-      `${JSON.stringify(
-        {
-          private: true,
-          dependencies: { [existingRootDependency]: "1.0.0" },
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-    await execFileAsync(
-      "npm",
-      [
-        "install",
-        "--omit=dev",
-        "--omit=peer",
-        "--legacy-peer-deps",
-        "--loglevel=error",
-        "--ignore-scripts",
-        "--no-audit",
-        "--no-fund",
-      ],
-      { cwd: blockedProjectRoot },
-    );
+    await installProjectDependencies(blockedProjectRoot, {
+      [existingRootDependency]: "1.0.0",
+    });
 
-    const result = await installPluginFromNpmSpec({
+    const result = await installNpmPlugin({
       config: configWithInstalledPackageTreeBlockPolicy(),
       spec: `${blockedPlugin}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
 
     expect(result.ok).toBe(false);
@@ -1068,12 +833,10 @@ describe("installPluginFromNpmSpec e2e", () => {
       expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
       expect(result.error).toContain("blocked by install policy: blocked installed package tree");
     }
-    const rootManifest = JSON.parse(
-      await fs.readFile(path.join(blockedProjectRoot, "package.json"), "utf8"),
-    ) as {
+    const rootManifest = await readJson<{
       dependencies?: Record<string, string>;
       openclaw?: { managedPeerDependencies?: string[] };
-    };
+    }>(path.join(blockedProjectRoot, "package.json"));
     expect(rootManifest.dependencies?.[existingRootDependency]).toBe("1.0.0");
     expect(rootManifest.dependencies?.[blockedPlugin]).toBeUndefined();
     expect(rootManifest.dependencies?.[runtimePeer]).toBeUndefined();
@@ -1095,70 +858,41 @@ describe("installPluginFromNpmSpec e2e", () => {
   });
 
   it("scrubs host peers inside each isolated npm project", async () => {
-    const rootDir = await makeTempDir("npm-plugin-sibling-peer-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const codexName = `codex-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const opikName = `opik-peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const registry = await startStaticRegistry([
-      {
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-sibling-peer-e2e");
+    const codexName = uniquePackageName("codex-peer-plugin");
+    const opikName = uniquePackageName("opik-peer-plugin");
+    await useStaticRegistry([
+      await registryPackage({
         packageName: codexName,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: codexName,
-            peerDependencies: { openclaw: ">=2026.5.5-beta.2" },
-            peerDependenciesMeta: { openclaw: { optional: true } },
-            pluginId: codexName,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
+        peerDependencies: { openclaw: ">=2026.5.5-beta.2" },
+        peerDependenciesMeta: { openclaw: { optional: true } },
+        rootDir,
+      }),
+      await registryPackage({
         packageName: opikName,
-        latest: "1.0.0",
-        versions: [
-          await packPlugin({
-            packageName: opikName,
-            peerDependencies: { openclaw: ">=2026.3.2" },
-            peerDependenciesMeta: {},
-            pluginId: opikName,
-            version: "1.0.0",
-            rootDir,
-          }),
-        ],
-      },
-      {
+        peerDependencies: { openclaw: ">=2026.3.2" },
+        peerDependenciesMeta: {},
+        rootDir,
+      }),
+      await registryPackage({
         packageName: "openclaw",
-        latest: "2026.5.4",
-        versions: [
-          await packPlugin({
-            packageName: "openclaw",
-            pluginId: "registry-openclaw-copy",
-            version: "2026.5.4",
-            rootDir,
-          }),
-        ],
-      },
+        pluginId: "registry-openclaw-copy",
+        version: "2026.5.4",
+        rootDir,
+      }),
     ]);
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
 
-    const first = await installPluginFromNpmSpec({
+    const first = await installNpmPlugin({
       spec: `${codexName}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
     if (!first.ok) {
       throw new Error(first.error);
     }
 
-    const second = await installPluginFromNpmSpec({
+    const second = await installNpmPlugin({
       spec: `${opikName}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
     if (!second.ok) {
       throw new Error(second.error);
@@ -1167,11 +901,9 @@ describe("installPluginFromNpmSpec e2e", () => {
     const codexProjectRoot = pluginNpmProjectRoot(npmRoot, codexName);
     const opikProjectRoot = pluginNpmProjectRoot(npmRoot, opikName);
     for (const projectRoot of [codexProjectRoot, opikProjectRoot]) {
-      const lock = JSON.parse(
-        await fs.readFile(path.join(projectRoot, "package-lock.json"), "utf8"),
-      ) as {
+      const lock = await readJson<{
         packages?: Record<string, unknown>;
-      };
+      }>(path.join(projectRoot, "package-lock.json"));
       expect(lock.packages?.["node_modules/openclaw"]).toBeUndefined();
       await expect(
         fs.lstat(path.join(projectRoot, "node_modules", "openclaw")),
@@ -1190,39 +922,21 @@ describe("installPluginFromNpmSpec e2e", () => {
   });
 
   it("keeps an earlier isolated openclaw peer link after later plugin installs", async () => {
-    const rootDir = await makeTempDir("npm-plugin-peer-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const peerPackageName = `peer-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const laterPackageName = `later-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const peerVersions = [
-      await packPlugin({
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-peer-e2e");
+    const peerPackageName = uniquePackageName("peer-plugin");
+    const laterPackageName = uniquePackageName("later-plugin");
+    await useStaticRegistry([
+      await registryPackage({
         packageName: peerPackageName,
         peerDependencies: { openclaw: ">=2026.0.0" },
-        pluginId: peerPackageName,
-        version: "1.0.0",
         rootDir,
       }),
-    ];
-    const laterVersions = [
-      await packPlugin({
-        packageName: laterPackageName,
-        pluginId: laterPackageName,
-        version: "1.0.0",
-        rootDir,
-      }),
-    ];
-    const registry = await startStaticRegistry([
-      { packageName: peerPackageName, latest: "1.0.0", versions: peerVersions },
-      { packageName: laterPackageName, latest: "1.0.0", versions: laterVersions },
+      await registryPackage({ packageName: laterPackageName, rootDir }),
     ]);
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
 
-    const first = await installPluginFromNpmSpec({
+    const first = await installNpmPlugin({
       spec: `${peerPackageName}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
     if (!first.ok) {
       throw new Error(first.error);
@@ -1230,11 +944,9 @@ describe("installPluginFromNpmSpec e2e", () => {
     const peerLink = path.join(first.targetDir, "node_modules", "openclaw");
     await expect(fs.lstat(peerLink).then((stat) => stat.isSymbolicLink())).resolves.toBe(true);
 
-    const second = await installPluginFromNpmSpec({
+    const second = await installNpmPlugin({
       spec: `${laterPackageName}@1.0.0`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
     if (!second.ok) {
       throw new Error(second.error);
@@ -1242,28 +954,22 @@ describe("installPluginFromNpmSpec e2e", () => {
 
     await expect(fs.lstat(peerLink).then((stat) => stat.isSymbolicLink())).resolves.toBe(true);
     const peerProjectRoot = pluginNpmProjectRoot(npmRoot, peerPackageName);
-    const manifest = JSON.parse(
-      await fs.readFile(path.join(peerProjectRoot, "package.json"), "utf8"),
-    ) as {
+    const manifest = await readJson<{
       dependencies?: Record<string, string>;
-    };
+    }>(path.join(peerProjectRoot, "package.json"));
     expect(manifest.dependencies?.openclaw).toBeUndefined();
-    const lock = JSON.parse(
-      await fs.readFile(path.join(peerProjectRoot, "package-lock.json"), "utf8"),
-    ) as {
+    const lock = await readJson<{
       packages?: Record<string, unknown>;
-    };
+    }>(path.join(peerProjectRoot, "package-lock.json"));
     expect(lock.packages?.["node_modules/openclaw"]).toBeUndefined();
   });
 
   it("pins a mutable npm tag to the version resolved before install", async () => {
-    const rootDir = await makeTempDir("npm-plugin-e2e");
-    const npmRoot = path.join(rootDir, "managed-npm");
-    const packageName = `mutable-plugin-${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-    const pluginId = packageName;
+    const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-e2e");
+    const packageName = uniquePackageName("mutable-plugin");
     const versions = [
-      await packPlugin({ packageName, pluginId, version: "1.0.0", rootDir }),
-      await packPlugin({ packageName, pluginId, version: "2.0.0", rootDir }),
+      await packPlugin({ packageName, version: "1.0.0", rootDir }),
+      await packPlugin({ packageName, version: "2.0.0", rootDir }),
     ];
     const registry = await startMutableRegistry({
       packageName,
@@ -1271,14 +977,11 @@ describe("installPluginFromNpmSpec e2e", () => {
       laterLatest: "2.0.0",
       versions,
     });
-    process.env.NPM_CONFIG_REGISTRY = registry;
-    process.env.npm_config_registry = registry;
+    useRegistry(registry);
 
-    const result = await installPluginFromNpmSpec({
+    const result = await installNpmPlugin({
       spec: `${packageName}@latest`,
-      npmDir: npmRoot,
-      logger: { info: () => {}, warn: () => {} },
-      timeoutMs: 120_000,
+      npmRoot,
     });
 
     if (!result.ok) {
@@ -1288,26 +991,21 @@ describe("installPluginFromNpmSpec e2e", () => {
     expect(result.npmResolution?.version).toBe("1.0.0");
 
     const projectRoot = pluginNpmProjectRoot(npmRoot, packageName);
-    const manifest = JSON.parse(
-      await fs.readFile(path.join(projectRoot, "package.json"), "utf8"),
-    ) as {
+    const manifest = await readJson<{
       dependencies?: Record<string, string>;
-    };
+    }>(path.join(projectRoot, "package.json"));
     expect(manifest.dependencies?.[packageName]).toBe("1.0.0");
 
-    const installedManifest = JSON.parse(
-      await fs.readFile(path.join(result.targetDir, "package.json"), "utf8"),
-    ) as { version?: string };
+    const installedManifest = await readJson<{ version?: string }>(
+      path.join(result.targetDir, "package.json"),
+    );
     expect(installedManifest.version).toBe("1.0.0");
 
-    const lock = JSON.parse(
-      await fs.readFile(path.join(projectRoot, "package-lock.json"), "utf8"),
-    ) as {
+    const lock = await readJson<{
       packages?: Record<string, { integrity?: string; version?: string }>;
-    };
+    }>(path.join(projectRoot, "package-lock.json"));
     const installedLockEntry = lock.packages?.[`node_modules/${packageName}`];
     expect(installedLockEntry?.integrity).toBe(versions[0]?.integrity);
     expect(installedLockEntry?.version).toBe("1.0.0");
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The real npm installer E2E repeated package packing, registry wiring, installer invocation, and project dependency setup across 12 scenarios. That duplication grew the fixture to 1,313 lines, obscured the security- and ownership-sensitive differences between scenarios, and kept an obsolete max-lines exception alive.

## Why This Change Was Made

This AI-assisted change consolidates only repeated test scaffolding into file-local helpers while leaving the dependency-sensitive raw peer install, compatibility warning path, mutable registry behavior, rollback, and security assertions explicit. It also removes the target's now-stale max-lines baseline entry.

## User Impact

There is no production or user-visible behavior change. Maintainers get the same real npm coverage in a 1,011-line fixture with less repeated setup and clearer exceptional paths.

## Evidence

- Production delta: 0. Total diff: `+284/-587` (net `-303`); test fixture alone is net `-302`.
- Exact static parity against `main`: all 12 ordered test titles and all 63 ordered assertion expressions are unchanged.
- Scenario accounting is unchanged: 28 package packs, 12 registry starts, 15 installer calls, and 4 real npm installs.
- Exact-final focused E2E: 12/12 passed on Blacksmith Testbox [`tbx_01kz2b04c4c6m6epd3n9d0n539`](https://github.com/openclaw/openclaw/actions/runs/30771140650).
- Installer sibling suites passed for npm-spec unit behavior, managed npm root, security-scan runtime, install paths, and peer links on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30768921657).
- Exact-final `check:changed` passed, including max-lines ratchet, formatting, typecheck, dead-code scan, boundaries, and all lint shards, on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30769443530).
- Two independent exact-head reviews returned CLEAN after direct owner, history, and npm 11.17 contract inspection.
- A local Node 26/Homebrew run rejects two policy-command cases because `/opt/homebrew/Cellar` permissions fail the install-policy hardening. The identical 10/12 result and error reproduce on untouched `main`; the exact-final Testbox run passes all 12.
- Collision audit: the target test file has no open overlap. The shared max-lines baseline has known open touches, but all remove different non-neighboring entries; this one-line ratchet deletion is mechanically disjoint.
