### PR TITLE
fix(llama-cpp): stop hijacking explicitly configured HTTP provider routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **llama.cpp custom HTTP routing:** keep explicitly configured OpenAI-compatible HTTP endpoints on their authored transport even when the provider id is `llama-cpp`, reserving native in-process inference for `local://llama-cpp`. Fixes #118212.
 - **Control UI operator session permissions:** honor Gateway-advertised operator scopes for new-thread creation, thread management, checkpoints, and sharing controls while preserving read-only navigation and legacy Gateway compatibility. Fixes #117786. Thanks @shakkernerd.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **llama.cpp custom HTTP routing:** keep explicitly configured OpenAI-compatible HTTP endpoints on their authored transport even when the provider id is `llama-cpp`, reserving native in-process inference for `local://llama-cpp`. Fixes #118212.
 - **Control UI operator session permissions:** honor Gateway-advertised operator scopes for new-thread creation, thread management, checkpoints, and sharing controls while preserving read-only navigation and legacy Gateway compatibility. Fixes #117786. Thanks @shakkernerd.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.
 - **Control UI command recovery:** keep delayed detached and immediate command failures scoped to their submitting session, preserving failed drafts and attachments for that pane without overwriting the active session. Fixes #116846. Thanks @shakkernerd.

--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -14,6 +14,7 @@ import {
   getRegisteredEmbeddingProvider,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const memoryHostEmbeddingMocks = vi.hoisted(() => ({
@@ -26,6 +27,7 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
 }));
 
 import llamaCppPlugin from "./index.js";
+import { LLAMA_CPP_LOCAL_BASE_URL } from "./src/defaults.js";
 import { llamaCppEmbeddingProviderAdapter } from "./src/embedding-provider.js";
 
 const DEFAULT_LLAMA_CPP_EMBEDDING_MODEL =
@@ -40,6 +42,22 @@ let previousPluginRegistry: ReturnType<typeof getActivePluginRegistry>;
 beforeEach(() => {
   previousPluginRegistry = getActivePluginRegistry();
 });
+
+function registerLlamaCppTextProvider(): ProviderPlugin {
+  const providers: ProviderPlugin[] = [];
+  llamaCppPlugin.register(
+    createTestPluginApi({
+      id: "llama-cpp",
+      name: "llama.cpp Provider",
+      source: "test",
+      config: {},
+      pluginConfig: {},
+      runtime: {} as never,
+      registerProvider: (provider) => providers.push(provider),
+    }),
+  );
+  return expectDefined(providers[0], "llama.cpp text provider");
+}
 
 async function createLlamaCppMemoryEmbeddingProvider(options: MemoryCreateTestOptions) {
   const { fallback: _fallback, outputDimensionality, ...adapterOptions } = options;
@@ -58,21 +76,7 @@ afterEach(() => {
 
 describe("llama.cpp provider plugin", () => {
   it("registers the local text-inference provider", () => {
-    const registerProvider = vi.fn();
-
-    llamaCppPlugin.register(
-      createTestPluginApi({
-        id: "llama-cpp",
-        name: "llama.cpp Provider",
-        source: "test",
-        config: {},
-        pluginConfig: {},
-        runtime: {} as never,
-        registerProvider,
-      }),
-    );
-
-    expect(registerProvider).toHaveBeenCalledWith(
+    expect(registerLlamaCppTextProvider()).toEqual(
       expect.objectContaining({
         id: "llama-cpp",
         label: "llama.cpp",
@@ -82,6 +86,35 @@ describe("llama.cpp provider plugin", () => {
         auth: [expect.objectContaining({ id: "local" })],
       }),
     );
+  });
+
+  it("keeps explicit HTTP routes on the configured transport", () => {
+    const provider = registerLlamaCppTextProvider();
+    const createStream = (baseUrl: string) =>
+      provider.createStreamFn?.({
+        config: {
+          models: {
+            providers: {
+              "llama-cpp": {
+                api: "openai-completions",
+                baseUrl,
+                models: [],
+              },
+            },
+          },
+        },
+        model: {
+          api: "openai-completions",
+          baseUrl,
+          id: "local-model",
+          provider: "llama-cpp",
+        },
+        modelId: "local-model",
+        provider: "llama-cpp",
+      } as never);
+
+    expect(createStream("http://127.0.0.1:8080/v1")).toBeUndefined();
+    expect(createStream(LLAMA_CPP_LOCAL_BASE_URL)).toBeTypeOf("function");
   });
 
   it("registers the local embedding provider through the generic SDK contract", () => {

--- a/extensions/llama-cpp/index.ts
+++ b/extensions/llama-cpp/index.ts
@@ -3,6 +3,7 @@ import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider
 import {
   LLAMA_CPP_PROVIDER_ID,
   LLAMA_CPP_PROVIDER_LABEL,
+  LLAMA_CPP_LOCAL_BASE_URL,
   buildLlamaCppProviderConfig,
   resolveLlamaCppSyntheticApiKey,
 } from "./src/defaults.js";
@@ -45,10 +46,15 @@ export default definePluginEntry({
         order: "late",
         run: async () => ({ provider: buildLlamaCppProviderConfig() }),
       },
-      createStreamFn: ({ config, provider }) =>
-        createLlamaCppStreamFn({
+      createStreamFn: ({ config, model, provider }) => {
+        // Explicit HTTP routes sharing this provider id stay on the configured transport.
+        if (model.baseUrl !== LLAMA_CPP_LOCAL_BASE_URL) {
+          return undefined;
+        }
+        return createLlamaCppStreamFn({
           providerConfig: config?.models?.providers?.[provider],
-        }),
+        });
+      },
       resolveSyntheticAuth: () => ({
         apiKey: resolveLlamaCppSyntheticApiKey(),
         source: "local llama.cpp runtime",

--- a/extensions/llama-cpp/src/defaults.ts
+++ b/extensions/llama-cpp/src/defaults.ts
@@ -8,7 +8,7 @@ import type {
 export const LLAMA_CPP_PROVIDER_ID = "llama-cpp";
 export const LLAMA_CPP_PROVIDER_LABEL = "llama.cpp";
 const LLAMA_CPP_LOCAL_AUTH_MARKER = "llama-cpp-local";
-const LLAMA_CPP_LOCAL_BASE_URL = "local://llama-cpp";
+export const LLAMA_CPP_LOCAL_BASE_URL = "local://llama-cpp";
 
 export function resolveLlamaCppSyntheticApiKey(): string {
   return LLAMA_CPP_LOCAL_AUTH_MARKER;


### PR DESCRIPTION
## What Problem This Solves

Fixes #118212: the native llama-cpp plugin hijacked explicitly configured HTTP provider routes. An operator pointing a model at a Hugging Face local-app HTTP endpoint got `LLM request failed` because the plugin's stream factory intercepted the route instead of letting the configured HTTP transport serve it. Discovered when the `huggingface-local-app-openclaw` E2E was adjudicated red on main (MLX passed, llama.cpp failed).

## Why This Change Was Made

Provenance: commit `658b601ee584` (PR #109444) introduced an unconditional llama.cpp `createStreamFn`, which preempted the generic HTTP fallback for any route the plugin could claim. Nothing in the commit, PR, or docs indicates that precedence was intentional — explicit configuration losing to plugin-native discovery inverts the repo's routing contract.

The fix scopes the plugin to its canonical route: `extensions/llama-cpp` claims `local://llama-cpp` only, and returns `undefined` for explicit HTTP routes so the existing configured transport handles them. No shim, no shared-resolver change; +10/−4 production lines.

## User Impact

Explicitly configured HTTP endpoints (Hugging Face local apps, self-hosted llama.cpp servers addressed by URL) work again regardless of the native plugin being installed. The native `local://llama-cpp` path is unchanged.

## Evidence

- HF local-app E2E: 2/2 green (GGUF llama.cpp and MLX) — previously red on main for the llama.cpp case
- llama.cpp suite 56/56; provider-routing suite 65/65; 123 focused tests total
- Exact-source build; `tsgo` + `tsgo:test`; format/oxlint/diff checks; structured autoreview clean

Fixes #118212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
