### PR TITLE
fix: setup ignores configured custom Control UI assets

### DIFF
--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -575,6 +575,21 @@ describe("runConfigureWizard", () => {
     );
   });
 
+  it("prepares the configured Control UI root instead of default assets", async () => {
+    setupBaseWizardState({
+      gateway: {
+        mode: "local",
+        controlUi: { root: "/srv/openclaw-control-ui" },
+      },
+    });
+
+    await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
+
+    expect(mocks.ensureControlUiAssetsBuilt).toHaveBeenCalledWith(expect.anything(), {
+      rootOverride: "/srv/openclaw-control-ui",
+    });
+  });
+
   it("shows static Windows Firewall guidance for LAN Gateway links without inspection", async () => {
     setupBaseWizardState({
       gateway: {

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -814,7 +814,9 @@ export async function runConfigureWizard(
       return;
     }
 
-    const controlUiAssets = await ensureControlUiAssetsBuilt(runtime);
+    const controlUiAssets = await ensureControlUiAssetsBuilt(runtime, {
+      rootOverride: nextConfig.gateway?.controlUi?.root,
+    });
     if (!controlUiAssets.ok && controlUiAssets.message) {
       runtime.error(controlUiAssets.message);
     }

--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -252,6 +252,38 @@ describe("runGuidedOnboarding", () => {
     expect(prompter.outro).toHaveBeenCalledWith("Your browser is ready — I'll be in Settings.");
   });
 
+  it("uses a configured Control UI root without preparing default assets", async () => {
+    const config = {
+      gateway: { controlUi: { root: "/srv/openclaw-control-ui" } },
+    } satisfies OpenClawConfig;
+    readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      path: "/tmp/openclaw.json",
+      issues: [],
+      config,
+    });
+    const prompter = createWizardPrompter();
+    const probeBrowserHandoffGateway = vi.fn(async () => ({ ok: true }));
+    const runBrowserHandoff = vi.fn(async () => ({ handedOff: true as const }));
+    const deps = setupDeps({
+      prompter,
+      probeBrowserHandoffGateway,
+      runBrowserHandoff,
+    });
+    const runtime = makeRuntime();
+
+    await runGuidedOnboarding({ acceptRisk: true, workspace: "/tmp/work" }, runtime, deps);
+
+    expect(deps.ensureControlUiAssetsBuilt).toHaveBeenCalledWith(runtime, {
+      onBuildStart: expect.any(Function),
+      rootOverride: "/srv/openclaw-control-ui",
+    });
+    expect(probeBrowserHandoffGateway).toHaveBeenCalledWith({ config });
+    expect(runBrowserHandoff).toHaveBeenCalledWith({ config, prompter });
+    expect(deps.launchHatchTui).not.toHaveBeenCalled();
+  });
+
   it("falls through to the terminal hatch when browser handoff does not connect", async () => {
     const prompter = createWizardPrompter();
     const runBrowserHandoff = vi.fn(async () => ({

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -442,6 +442,7 @@ async function runGuidedOnboardingFlow(
       onBuildStart: () => {
         controlUiProgress = prompter.progress(t("wizard.guided.controlUiPreparing"));
       },
+      rootOverride: persistedConfig.gateway?.controlUi?.root,
     }).finally(() => controlUiProgress?.stop());
     controlUiAssetsReady = assets.ok;
     if (!assets.ok && assets.message) {

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -158,6 +158,29 @@ describe("control UI assets helpers (fs-mocked)", () => {
     }
   });
 
+  it("accepts a configured Control UI root without preparing default assets", async () => {
+    const uiDir = abs("fixtures/custom-control-ui");
+    setDir(uiDir);
+    setFile(path.join(uiDir, "index.html"), "<html></html>\n");
+
+    await expect(ensureControlUiAssetsBuilt(undefined, { rootOverride: uiDir })).resolves.toEqual({
+      ok: true,
+      built: false,
+    });
+    expect(state.runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid configured Control UI root without building default assets", async () => {
+    const uiDir = abs("fixtures/missing-custom-control-ui");
+
+    await expect(ensureControlUiAssetsBuilt(undefined, { rootOverride: uiDir })).resolves.toEqual({
+      ok: false,
+      built: false,
+      message: `Control UI assets not found at ${uiDir}. Build the custom UI there or update \`gateway.controlUi.root\`.`,
+    });
+    expect(state.runCommandWithTimeout).not.toHaveBeenCalled();
+  });
+
   it("resolves control-ui root from override file or directory", () => {
     const root = abs("fixtures/override");
     const uiDir = path.join(root, "dist", "control-ui");

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -289,8 +289,23 @@ function summarizeCommandOutput(text: string): string | undefined {
 
 export async function ensureControlUiAssetsBuilt(
   runtime: RuntimeEnv = defaultRuntime,
-  opts?: { timeoutMs?: number; onBuildStart?: () => void },
+  opts?: { timeoutMs?: number; onBuildStart?: () => void; rootOverride?: string },
 ): Promise<EnsureControlUiAssetsResult> {
+  const rootOverride = opts?.rootOverride?.trim();
+  if (rootOverride) {
+    // Gateway overrides are authoritative. Never hide an invalid custom root
+    // by building or serving the unrelated package-default assets.
+    const resolvedRoot = resolveControlUiRootOverrideSync(rootOverride);
+    if (resolvedRoot) {
+      return { ok: true, built: false };
+    }
+    return {
+      ok: false,
+      built: false,
+      message: `Control UI assets not found at ${path.resolve(rootOverride)}. Build the custom UI there or update \`gateway.controlUi.root\`.`,
+    };
+  }
+
   const health = await resolveControlUiDistIndexHealth({ argv1: process.argv[1] });
   const indexFromDist = health.indexPath;
   if (health.exists) {

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -33,6 +33,7 @@ const resolveLocalControlUiProbeLinks = vi.hoisted(() =>
     wsUrl: "ws://127.0.0.1:18789",
   })),
 );
+const ensureControlUiAssetsBuilt = vi.hoisted(() => vi.fn(async () => ({ ok: true })));
 const setupWizardShellCompletion = vi.hoisted(() => vi.fn(async () => {}));
 const healthCommand = vi.hoisted(() => vi.fn(async () => {}));
 const resolveDefaultModelAuthStatus = vi.hoisted(() =>
@@ -215,7 +216,7 @@ vi.mock("../daemon/systemd.js", () => ({
 }));
 
 vi.mock("../infra/control-ui-assets.js", () => ({
-  ensureControlUiAssetsBuilt: vi.fn(async () => ({ ok: true })),
+  ensureControlUiAssetsBuilt,
 }));
 
 vi.mock("../infra/container-environment.js", () => ({
@@ -496,6 +497,20 @@ describe("finalizeSetupWizard", () => {
     resolveDefaultModelCatalogFacts.mockReturnValue({ found: true });
     loadModelCatalog.mockReset();
     loadModelCatalog.mockResolvedValue([]);
+    ensureControlUiAssetsBuilt.mockClear();
+  });
+
+  it("prepares the configured Control UI root instead of default assets", async () => {
+    const prompter = createLaterPrompter();
+    const nextConfig = {
+      gateway: { controlUi: { root: "/srv/openclaw-control-ui" } },
+    } satisfies OpenClawConfig;
+
+    await finalizeSetupWizard(createModelAuthFinalizeArgs({ prompter, nextConfig }));
+
+    expect(ensureControlUiAssetsBuilt).toHaveBeenCalledWith(expect.anything(), {
+      rootOverride: "/srv/openclaw-control-ui",
+    });
   });
 
   it("resolves gateway password SecretRef for probe but omits auth from TUI hatch", async () => {

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -503,7 +503,11 @@ export async function finalizeSetupWizard(
     const controlUiEnabled =
       nextConfig.gateway?.controlUi?.enabled ?? baseConfig.gateway?.controlUi?.enabled ?? true;
     if (!opts.skipUi && controlUiEnabled) {
-      const controlUiAssets = await ensureControlUiAssetsBuilt(runtime);
+      const controlUiRoot =
+        nextConfig.gateway?.controlUi?.root ?? baseConfig.gateway?.controlUi?.root;
+      const controlUiAssets = await ensureControlUiAssetsBuilt(runtime, {
+        rootOverride: controlUiRoot,
+      });
       if (!controlUiAssets.ok && controlUiAssets.message) {
         runtime.error(controlUiAssets.message);
       }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running onboarding or gateway configuration with a custom Control UI root would have setup prepare unrelated default assets and could report a false build failure instead of using the configured UI.

## Why This Change Was Made

Control UI asset preparation now treats `gateway.controlUi.root` as authoritative: it validates the configured UI and never falls back to building package-default assets. Guided onboarding, the configuration wizard, and setup finalization all pass the effective configured root through the same canonical check.

## User Impact

Operators can complete setup with an existing custom Control UI without triggering an unnecessary default UI build. Invalid custom roots now produce an actionable error that points to the configured path and setting.

## Evidence

- `node scripts/run-vitest.mjs src/commands/configure.wizard.test.ts src/commands/onboard-guided.test.ts src/infra/control-ui-assets.test.ts src/wizard/setup.finalize.test.ts` — 4 files, 89 tests passed.
- `git diff --check upstream/main...HEAD` — passed.
- Fresh autoreview reported no accepted or actionable findings.
- Proof images will be added before marking this PR ready for review.
