### PR TITLE
refactor(agents): compact OpenAI transport test fixtures

### DIFF
--- a/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
+++ b/src/agents/openai-transport-stream.reasoning-and-cache.test.ts
@@ -10,6 +10,42 @@ import {
   expectRecordFields,
 } from "./openai-transport-stream.test-harness.js";
 
+function emptyContext() {
+  return { systemPrompt: "system", messages: [], tools: [] } as never;
+}
+
+function lookupWeatherContext(
+  parameters: Record<string, unknown> = { type: "object", properties: {} },
+) {
+  return {
+    systemPrompt: "system",
+    messages: [],
+    tools: [
+      {
+        name: "lookup_weather",
+        description: "Get forecast",
+        parameters,
+      },
+    ],
+  } as never;
+}
+
+function promptCacheModel() {
+  return {
+    id: "custom-model",
+    name: "Custom Model",
+    api: "openai-completions",
+    provider: "custom-cpa",
+    baseUrl: "https://proxy.example.com/v1",
+    compat: { supportsPromptCacheKey: true },
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 32768,
+    maxTokens: 8192,
+  } as unknown as Model<"openai-completions">;
+}
+
 describe("openai transport stream", () => {
   it("omits responses strict tool shaping for proxy-like OpenAI routes", () => {
     const params = buildOpenAIResponsesParams(
@@ -18,17 +54,7 @@ describe("openai transport stream", () => {
         name: "Custom Model",
         baseUrl: "https://proxy.example.com/v1",
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [
-          {
-            name: "lookup_weather",
-            description: "Get forecast",
-            parameters: { type: "object", properties: {} },
-          },
-        ],
-      } as never,
+      lookupWeatherContext(),
       undefined,
     ) as { tools?: Array<{ strict?: boolean }> };
 
@@ -94,17 +120,7 @@ describe("openai transport stream", () => {
         name: "Custom Model",
         baseUrl: "https://proxy.example.com/v1",
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [
-          {
-            name: "lookup_weather",
-            description: "Get forecast",
-            parameters: {},
-          },
-        ],
-      } as never,
+      lookupWeatherContext({}),
       undefined,
     ) as { tools?: Array<{ strict?: boolean; parameters?: Record<string, unknown> }> };
 
@@ -152,11 +168,7 @@ describe("openai transport stream", () => {
         id: "gpt-5.4",
         name: "GPT-5.4",
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       { sessionId: "session-123" } as never,
       {
         openclaw_session_id: "session-123",
@@ -181,11 +193,7 @@ describe("openai transport stream", () => {
         name: "Custom Model",
         baseUrl: "https://proxy.example.com/v1",
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       { sessionId: "session-123" } as never,
       undefined,
     ) as { metadata?: Record<string, string> };
@@ -199,11 +207,7 @@ describe("openai transport stream", () => {
         id: "gpt-5.4",
         name: "GPT-5.4",
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       {
         serviceTier: "priority",
       },
@@ -214,11 +218,7 @@ describe("openai transport stream", () => {
         name: "Custom Model",
         baseUrl: "https://proxy.example.com/v1",
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       {
         serviceTier: "priority",
       },
@@ -243,11 +243,7 @@ describe("openai transport stream", () => {
         contextWindow: 200000,
         maxTokens: 8192,
       } as never,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     ) as { store?: unknown };
 
@@ -262,11 +258,7 @@ describe("openai transport stream", () => {
         provider: "xai",
         baseUrl: "https://api.x.ai/v1",
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     ) as { input?: Array<{ role?: string }> };
 
@@ -287,11 +279,7 @@ describe("openai transport stream", () => {
         contextWindow: 200000,
         maxTokens: 8192,
       } as unknown as Model<"openai-completions">,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     ) as { messages?: Array<{ role?: string }> };
 
@@ -322,11 +310,7 @@ describe("openai transport stream", () => {
         id: "gpt-5.4",
         name: "GPT-5.4",
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       {
         reasoning: "medium",
       } as never,
@@ -341,11 +325,7 @@ describe("openai transport stream", () => {
         id: "gpt-5.4",
         name: "GPT-5.4",
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       {
         reasoning: "minimal",
       } as never,
@@ -360,11 +340,7 @@ describe("openai transport stream", () => {
         id: "gpt-5.4",
         name: "GPT-5.4",
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     ) as { reasoning_effort?: unknown };
 
@@ -509,11 +485,7 @@ describe("openai transport stream", () => {
         contextWindow: 1000000,
         maxTokens: 128000,
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       {
         reasoning: "medium",
       } as never,
@@ -531,11 +503,7 @@ describe("openai transport stream", () => {
         contextWindow: 400000,
         maxTokens: 128000,
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       {
         reasoning: "medium",
       } as never,
@@ -637,11 +605,7 @@ describe("openai transport stream", () => {
           thinkingFormat: "qwen-chat-template",
         },
       } as unknown as Model<"openai-completions">,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       {
         reasoning: "off",
       } as never,
@@ -712,11 +676,7 @@ describe("openai transport stream", () => {
           supportedReasoningEfforts: ["low", "medium", "high"],
         },
       } as unknown as Model<"openai-completions">,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       {
         reasoning: "off",
       } as never,
@@ -734,11 +694,7 @@ describe("openai transport stream", () => {
         baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
         compat: { supportsUsageInStreaming: true },
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     ) as {
       messages?: Array<{ role?: string }>;
@@ -758,11 +714,7 @@ describe("openai transport stream", () => {
         baseUrl: "https://coding.dashscope.aliyuncs.com/v1",
         compat: { supportsUsageInStreaming: true },
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     ) as {
       stream_options?: { include_usage?: boolean };
@@ -786,11 +738,7 @@ describe("openai transport stream", () => {
         contextWindow: 32768,
         maxTokens: 8192,
       } as unknown as Model<"openai-completions">,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     ) as {
       stream_options?: { include_usage?: boolean };
@@ -848,27 +796,10 @@ describe("openai transport stream", () => {
   });
 
   it("forwards prompt_cache_key for opted-in OpenAI-compatible completions providers", () => {
-    const params = buildOpenAICompletionsParams(
-      {
-        id: "custom-model",
-        name: "Custom Model",
-        api: "openai-completions",
-        provider: "custom-cpa",
-        baseUrl: "https://proxy.example.com/v1",
-        compat: { supportsPromptCacheKey: true },
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 32768,
-        maxTokens: 8192,
-      } as unknown as Model<"openai-completions">,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
-      { sessionId: "session-123", promptCacheKey: "cron-cache-key" },
-    ) as { prompt_cache_key?: string };
+    const params = buildOpenAICompletionsParams(promptCacheModel(), emptyContext(), {
+      sessionId: "session-123",
+      promptCacheKey: "cron-cache-key",
+    }) as { prompt_cache_key?: string };
 
     expect(params.prompt_cache_key).toBe("cron-cache-key");
   });
@@ -905,24 +836,8 @@ describe("openai transport stream", () => {
   });
 
   it("emits prompt_cache_retention=24h for completions when cacheRetention is long", () => {
-    const model = {
-      id: "custom-model",
-      name: "Custom Model",
-      api: "openai-completions",
-      provider: "custom-cpa",
-      baseUrl: "https://proxy.example.com/v1",
-      compat: { supportsPromptCacheKey: true },
-      reasoning: false,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 32768,
-      maxTokens: 8192,
-    } as unknown as Model<"openai-completions">;
-    const context = {
-      systemPrompt: "system",
-      messages: [],
-      tools: [],
-    } as never;
+    const model = promptCacheModel();
+    const context = emptyContext();
 
     const longRetention = buildOpenAICompletionsParams(model, context, {
       sessionId: "session-123",
@@ -934,24 +849,8 @@ describe("openai transport stream", () => {
   });
 
   it("omits prompt_cache_retention for completions when cacheRetention is short or unset", () => {
-    const model = {
-      id: "custom-model",
-      name: "Custom Model",
-      api: "openai-completions",
-      provider: "custom-cpa",
-      baseUrl: "https://proxy.example.com/v1",
-      compat: { supportsPromptCacheKey: true },
-      reasoning: false,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 32768,
-      maxTokens: 8192,
-    } as unknown as Model<"openai-completions">;
-    const context = {
-      systemPrompt: "system",
-      messages: [],
-      tools: [],
-    } as never;
+    const model = promptCacheModel();
+    const context = emptyContext();
 
     const shortRetention = buildOpenAICompletionsParams(model, context, {
       sessionId: "session-123",
@@ -1001,19 +900,7 @@ describe("openai transport stream", () => {
   });
 
   it("sorts Chat Completions tools by function name for stable prompt-cache payloads", () => {
-    const model = {
-      id: "custom-model",
-      name: "Custom Model",
-      api: "openai-completions",
-      provider: "custom-cpa",
-      baseUrl: "https://proxy.example.com/v1",
-      compat: { supportsPromptCacheKey: true },
-      reasoning: false,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 32768,
-      maxTokens: 8192,
-    } as unknown as Model<"openai-completions">;
+    const model = promptCacheModel();
     const zetaTool = {
       name: "zeta",
       description: "Z",
@@ -1056,17 +943,7 @@ describe("openai transport stream", () => {
         provider: "custom-cpa",
         baseUrl: "https://proxy.example.com/v1",
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [
-          {
-            name: "lookup_weather",
-            description: "Get forecast",
-            parameters: { type: "object", properties: {} },
-          },
-        ],
-      } as never,
+      lookupWeatherContext(),
       {
         reasoningEffort: "high",
       } as never,

--- a/src/agents/openai-transport-stream.usage-and-calls.test.ts
+++ b/src/agents/openai-transport-stream.usage-and-calls.test.ts
@@ -12,6 +12,122 @@ import {
 } from "./openai-transport-stream.test-harness.js";
 import { testing } from "./openai-transport-stream.test-support.js";
 
+function emptyContext(systemPrompt: string | undefined = "system") {
+  return { systemPrompt, messages: [], tools: [] } as never;
+}
+
+function weatherToolContext(systemPrompt = "system") {
+  return {
+    systemPrompt,
+    messages: [],
+    tools: [
+      {
+        name: "get_weather",
+        description: "Get weather information",
+        parameters: { type: "object", properties: {} },
+      },
+    ],
+  } as never;
+}
+
+function toolHistoryContext(systemPrompt = "You are a helpful assistant") {
+  return {
+    systemPrompt,
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_abc",
+            name: "get_weather",
+            arguments: "{}",
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: "sunny" }],
+        toolCallId: "call_abc",
+      },
+    ],
+  } as never;
+}
+
+function toolChoiceModel(native: boolean) {
+  return makeCompletionsModel(
+    native
+      ? {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          reasoning: false,
+          contextWindow: 4096,
+          maxTokens: 2048,
+        }
+      : {
+          id: "test-model",
+          name: "Test Model",
+          provider: "vllm",
+          baseUrl: "http://localhost:8000/v1",
+          reasoning: false,
+          contextWindow: 4096,
+          maxTokens: 2048,
+        },
+  );
+}
+
+function geminiToolReplayContext(
+  model: Model<"openai-completions">,
+  options: {
+    sourceApi?: string;
+    thoughtSignature?: string;
+    arguments?: unknown;
+    includeUserAndResult?: boolean;
+  } = {},
+) {
+  const assistant = {
+    role: "assistant",
+    api: options.sourceApi ?? model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "toolUse",
+    timestamp: 1,
+    content: [
+      {
+        type: "toolCall",
+        id: "call_abc",
+        name: "echo_value",
+        arguments: options.arguments ?? {},
+        ...(options.thoughtSignature ? { thoughtSignature: options.thoughtSignature } : {}),
+      },
+    ],
+  };
+  return {
+    messages: options.includeUserAndResult
+      ? [
+          { role: "user", content: "echo" },
+          assistant,
+          {
+            role: "toolResult",
+            toolCallId: "call_abc",
+            toolName: "echo_value",
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+          },
+        ]
+      : [assistant],
+    tools: [],
+  } as never;
+}
+
 describe("openai transport stream", () => {
   it("uses model params max_completion_tokens for OpenAI completions before model maxTokens", () => {
     const params = buildOpenAICompletionsParams(
@@ -30,11 +146,7 @@ describe("openai transport stream", () => {
           max_completion_tokens: 64_000,
         },
       } as never,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     );
 
@@ -59,11 +171,7 @@ describe("openai transport stream", () => {
           max_completion_tokens: 64_000,
         },
       } as never,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       { maxTokens: 16_000 } as never,
     );
 
@@ -80,11 +188,7 @@ describe("openai transport stream", () => {
         baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1",
         maxTokens: 32_000,
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       { maxTokens: 200_000 } as never,
     );
 
@@ -109,11 +213,7 @@ describe("openai transport stream", () => {
           max_completion_tokens: 64_000,
         },
       } as never,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       { maxTokens: 0 } as never,
     );
 
@@ -134,11 +234,7 @@ describe("openai transport stream", () => {
         contextWindow: 200000,
         maxTokens: 65_536,
       } as never,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     );
 
@@ -162,11 +258,7 @@ describe("openai transport stream", () => {
         contextWindow: 262_144,
         maxTokens: 262_144,
       }),
-      {
-        systemPrompt,
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(systemPrompt),
       undefined,
     );
 
@@ -284,11 +376,7 @@ describe("openai transport stream", () => {
         contextTokens: 4_096,
         maxTokens: 200_000,
       } as unknown as Model<"openai-completions">,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     );
 
@@ -308,11 +396,7 @@ describe("openai transport stream", () => {
         contextWindow: 131_072,
         maxTokens: 200_000,
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     );
 
@@ -333,11 +417,7 @@ describe("openai transport stream", () => {
         reasoning: false,
         contextWindow: 131_072,
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     );
 
@@ -353,11 +433,7 @@ describe("openai transport stream", () => {
         contextWindow: 100_000,
         maxTokens: 200_000,
       }),
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       undefined,
     );
 
@@ -661,28 +737,8 @@ describe("openai transport stream", () => {
       contextWindow: 1_000_000,
     });
 
-    function makeAssistantOutput(model: Model<"openai-completions">) {
-      return {
-        role: "assistant" as const,
-        content: [] as Array<Record<string, unknown>>,
-        api: model.api,
-        provider: model.provider,
-        model: model.id,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
-        stopReason: "stop",
-        timestamp: Date.now(),
-      };
-    }
-
     it("captures thought_signature from streamed Google tool_calls", async () => {
-      const output = makeAssistantOutput(geminiModel);
+      const output = createAssistantOutput(geminiModel);
       const chunks = [
         makeCompletionsChunk({
           tool_calls: [
@@ -724,44 +780,11 @@ describe("openai transport stream", () => {
     it("re-emits captured thought_signature for same Google route tool-call replay", () => {
       const params = buildOpenAICompletionsParams(
         geminiModel,
-        {
-          messages: [
-            { role: "user", content: "echo" },
-            {
-              role: "assistant",
-              api: geminiModel.api,
-              provider: geminiModel.provider,
-              model: geminiModel.id,
-              usage: {
-                input: 0,
-                output: 0,
-                cacheRead: 0,
-                cacheWrite: 0,
-                totalTokens: 0,
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-              },
-              stopReason: "toolUse",
-              timestamp: 1,
-              content: [
-                {
-                  type: "toolCall",
-                  id: "call_abc",
-                  name: "echo_value",
-                  arguments: { value: "repro" },
-                  thoughtSignature: "SIG-OPAQUE-ABC==",
-                },
-              ],
-            },
-            {
-              role: "toolResult",
-              toolCallId: "call_abc",
-              toolName: "echo_value",
-              content: [{ type: "text", text: "ok" }],
-              isError: false,
-            },
-          ],
-          tools: [],
-        } as never,
+        geminiToolReplayContext(geminiModel, {
+          thoughtSignature: "SIG-OPAQUE-ABC==",
+          arguments: { value: "repro" },
+          includeUserAndResult: true,
+        }),
         undefined,
       ) as { messages: Array<Record<string, unknown>> };
 
@@ -776,36 +799,11 @@ describe("openai transport stream", () => {
     it("uses the Gemini skip-validator signature across a different API surface", () => {
       const params = buildOpenAICompletionsParams(
         geminiModel,
-        {
-          messages: [
-            {
-              role: "assistant",
-              api: "google-generative-ai",
-              provider: geminiModel.provider,
-              model: geminiModel.id,
-              usage: {
-                input: 0,
-                output: 0,
-                cacheRead: 0,
-                cacheWrite: 0,
-                totalTokens: 0,
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-              },
-              stopReason: "toolUse",
-              timestamp: 1,
-              content: [
-                {
-                  type: "toolCall",
-                  id: "call_abc",
-                  name: "echo_value",
-                  arguments: { value: "repro" },
-                  thoughtSignature: "SIG-OPAQUE-ABC==",
-                },
-              ],
-            },
-          ],
-          tools: [],
-        } as never,
+        geminiToolReplayContext(geminiModel, {
+          sourceApi: "google-generative-ai",
+          thoughtSignature: "SIG-OPAQUE-ABC==",
+          arguments: { value: "repro" },
+        }),
         undefined,
       ) as { messages: Array<Record<string, unknown>> };
 
@@ -820,28 +818,7 @@ describe("openai transport stream", () => {
     it("uses the Gemini skip-validator signature when no thought_signature was captured", () => {
       const params = buildOpenAICompletionsParams(
         geminiModel,
-        {
-          messages: [
-            {
-              role: "assistant",
-              api: geminiModel.api,
-              provider: geminiModel.provider,
-              model: geminiModel.id,
-              usage: {
-                input: 0,
-                output: 0,
-                cacheRead: 0,
-                cacheWrite: 0,
-                totalTokens: 0,
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-              },
-              stopReason: "toolUse",
-              timestamp: 1,
-              content: [{ type: "toolCall", id: "call_abc", name: "echo_value", arguments: {} }],
-            },
-          ],
-          tools: [],
-        } as never,
+        geminiToolReplayContext(geminiModel),
         undefined,
       ) as { messages: Array<Record<string, unknown>> };
 
@@ -859,37 +836,11 @@ describe("openai transport stream", () => {
       // The guard should fall back to the sentinel instead of dropping the field.
       const params = buildOpenAICompletionsParams(
         geminiModel,
-        {
-          messages: [
-            {
-              role: "assistant",
-              api: geminiModel.api,
-              provider: geminiModel.provider,
-              model: geminiModel.id,
-              usage: {
-                input: 0,
-                output: 0,
-                cacheRead: 0,
-                cacheWrite: 0,
-                totalTokens: 0,
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-              },
-              stopReason: "toolUse",
-              timestamp: 1,
-              content: [
-                {
-                  type: "toolCall",
-                  id: "call_abc",
-                  name: "echo_value",
-                  arguments: { value: "repro" },
-                  thoughtSignature:
-                    "CmcBjz1rX55U6JcpC2oZVTk40Kx6nVK8LKzbl61rOFztcvSdL7pdIvBEDyJLRqWrPVpdD+rj3GsJ3f9PG6b2Ry2UnK38+dInfGIlJbXHt++EC",
-                },
-              ],
-            },
-          ],
-          tools: [],
-        } as never,
+        geminiToolReplayContext(geminiModel, {
+          arguments: { value: "repro" },
+          thoughtSignature:
+            "CmcBjz1rX55U6JcpC2oZVTk40Kx6nVK8LKzbl61rOFztcvSdL7pdIvBEDyJLRqWrPVpdD+rj3GsJ3f9PG6b2Ry2UnK38+dInfGIlJbXHt++EC",
+        }),
         undefined,
       ) as { messages: Array<Record<string, unknown>> };
 
@@ -912,37 +863,11 @@ describe("openai transport stream", () => {
       };
       const params = buildOpenAICompletionsParams(
         nonGemini3Model,
-        {
-          messages: [
-            {
-              role: "assistant",
-              api: nonGemini3Model.api,
-              provider: nonGemini3Model.provider,
-              model: nonGemini3Model.id,
-              usage: {
-                input: 0,
-                output: 0,
-                cacheRead: 0,
-                cacheWrite: 0,
-                totalTokens: 0,
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-              },
-              stopReason: "toolUse",
-              timestamp: 1,
-              content: [
-                {
-                  type: "toolCall",
-                  id: "call_abc",
-                  name: "echo_value",
-                  arguments: { value: "repro" },
-                  thoughtSignature:
-                    "CmcBjz1rX55U6JcpC2oZVTk40Kx6nVK8LKzbl61rOFztcvSdL7pdIvBEDyJLRqWrPVpdD+rj3GsJ3f9PG6b2Ry2UnK38+dInfGIlJbXHt++EC",
-                },
-              ],
-            },
-          ],
-          tools: [],
-        } as never,
+        geminiToolReplayContext(nonGemini3Model, {
+          arguments: { value: "repro" },
+          thoughtSignature:
+            "CmcBjz1rX55U6JcpC2oZVTk40Kx6nVK8LKzbl61rOFztcvSdL7pdIvBEDyJLRqWrPVpdD+rj3GsJ3f9PG6b2Ry2UnK38+dInfGIlJbXHt++EC",
+        }),
         undefined,
       ) as { messages: Array<Record<string, unknown>> };
 
@@ -960,36 +885,11 @@ describe("openai transport stream", () => {
       };
       const params = buildOpenAICompletionsParams(
         nonGemini3Model,
-        {
-          messages: [
-            {
-              role: "assistant",
-              api: "google-generative-ai",
-              provider: nonGemini3Model.provider,
-              model: nonGemini3Model.id,
-              usage: {
-                input: 0,
-                output: 0,
-                cacheRead: 0,
-                cacheWrite: 0,
-                totalTokens: 0,
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-              },
-              stopReason: "toolUse",
-              timestamp: 1,
-              content: [
-                {
-                  type: "toolCall",
-                  id: "call_abc",
-                  name: "echo_value",
-                  arguments: { value: "repro" },
-                  thoughtSignature: "SIG-OPAQUE-ABC==",
-                },
-              ],
-            },
-          ],
-          tools: [],
-        } as never,
+        geminiToolReplayContext(nonGemini3Model, {
+          sourceApi: "google-generative-ai",
+          thoughtSignature: "SIG-OPAQUE-ABC==",
+          arguments: { value: "repro" },
+        }),
         undefined,
       ) as { messages: Array<Record<string, unknown>> };
 
@@ -1009,28 +909,7 @@ describe("openai transport stream", () => {
         const latestModel = { ...geminiModel, id: modelId, name: modelName };
         const params = buildOpenAICompletionsParams(
           latestModel,
-          {
-            messages: [
-              {
-                role: "assistant",
-                api: latestModel.api,
-                provider: latestModel.provider,
-                model: latestModel.id,
-                usage: {
-                  input: 0,
-                  output: 0,
-                  cacheRead: 0,
-                  cacheWrite: 0,
-                  totalTokens: 0,
-                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-                },
-                stopReason: "toolUse",
-                timestamp: 1,
-                content: [{ type: "toolCall", id: "call_abc", name: "echo_value", arguments: {} }],
-              },
-            ],
-            tools: [],
-          } as never,
+          geminiToolReplayContext(latestModel),
           undefined,
         ) as { messages: Array<Record<string, unknown>> };
 
@@ -1057,11 +936,7 @@ describe("openai transport stream", () => {
         contextWindow: 200000,
         maxTokens: 8192,
       } as never,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       {
         maxTokens: 2048,
         reasoningEffort: "high",
@@ -1088,11 +963,7 @@ describe("openai transport stream", () => {
         contextWindow: 200000,
         maxTokens: 8192,
       } as never,
-      {
-        systemPrompt: "system",
-        messages: [],
-        tools: [],
-      } as never,
+      emptyContext(),
       {
         maxTokens: 2048,
         reasoningEffort: "high",
@@ -1155,26 +1026,8 @@ describe("openai transport stream", () => {
 
   it("defaults tool_choice to auto for proxy-like openai-completions endpoints", () => {
     const params = buildOpenAICompletionsParams(
-      makeCompletionsModel({
-        id: "test-model",
-        name: "Test Model",
-        provider: "vllm",
-        baseUrl: "http://localhost:8000/v1",
-        reasoning: false,
-        contextWindow: 4096,
-        maxTokens: 2048,
-      }),
-      {
-        systemPrompt: "You are a helpful assistant",
-        messages: [],
-        tools: [
-          {
-            name: "get_weather",
-            description: "Get weather information",
-            parameters: { type: "object", properties: {} },
-          },
-        ],
-      } as never,
+      toolChoiceModel(false),
+      weatherToolContext("You are a helpful assistant"),
       undefined,
     );
 
@@ -1184,24 +1037,8 @@ describe("openai transport stream", () => {
 
   it("does not send tool_choice by default for native openai-completions endpoints", () => {
     const params = buildOpenAICompletionsParams(
-      makeCompletionsModel({
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        reasoning: false,
-        contextWindow: 4096,
-        maxTokens: 2048,
-      }),
-      {
-        systemPrompt: "You are a helpful assistant",
-        messages: [],
-        tools: [
-          {
-            name: "get_weather",
-            description: "Get weather information",
-            parameters: { type: "object", properties: {} },
-          },
-        ],
-      } as never,
+      toolChoiceModel(true),
+      weatherToolContext("You are a helpful assistant"),
       undefined,
     );
 
@@ -1211,26 +1048,8 @@ describe("openai transport stream", () => {
 
   it("sends tool_choice when explicitly configured", () => {
     const params = buildOpenAICompletionsParams(
-      makeCompletionsModel({
-        id: "test-model",
-        name: "Test Model",
-        provider: "vllm",
-        baseUrl: "http://localhost:8000/v1",
-        reasoning: false,
-        contextWindow: 4096,
-        maxTokens: 2048,
-      }),
-      {
-        systemPrompt: "You are a helpful assistant",
-        messages: [],
-        tools: [
-          {
-            name: "get_weather",
-            description: "Get weather information",
-            parameters: { type: "object", properties: {} },
-          },
-        ],
-      } as never,
+      toolChoiceModel(false),
+      weatherToolContext("You are a helpful assistant"),
       {
         toolChoice: "required",
       },
@@ -1242,20 +1061,8 @@ describe("openai transport stream", () => {
 
   it("omits empty tools and tool_choice for proxy-like openai-completions endpoints when context.tools is []", () => {
     const params = buildOpenAICompletionsParams(
-      makeCompletionsModel({
-        id: "test-model",
-        name: "Test Model",
-        provider: "vllm",
-        baseUrl: "http://localhost:8000/v1",
-        reasoning: false,
-        contextWindow: 4096,
-        maxTokens: 2048,
-      }),
-      {
-        systemPrompt: "You are a helpful assistant",
-        messages: [],
-        tools: [],
-      } as never,
+      toolChoiceModel(false),
+      emptyContext("You are a helpful assistant"),
       undefined,
     );
 
@@ -1265,36 +1072,8 @@ describe("openai transport stream", () => {
 
   it("omits tools for proxy-like openai-completions endpoints when only prior tool history is present", () => {
     const params = buildOpenAICompletionsParams(
-      makeCompletionsModel({
-        id: "test-model",
-        name: "Test Model",
-        provider: "vllm",
-        baseUrl: "http://localhost:8000/v1",
-        reasoning: false,
-        contextWindow: 4096,
-        maxTokens: 2048,
-      }),
-      {
-        systemPrompt: "You are a helpful assistant",
-        messages: [
-          {
-            role: "assistant",
-            content: [
-              {
-                type: "toolCall",
-                id: "call_abc",
-                name: "get_weather",
-                arguments: "{}",
-              },
-            ],
-          },
-          {
-            role: "toolResult",
-            content: [{ type: "text", text: "sunny" }],
-            toolCallId: "call_abc",
-          },
-        ],
-      } as never,
+      toolChoiceModel(false),
+      toolHistoryContext(),
       undefined,
     );
 
@@ -1304,18 +1083,8 @@ describe("openai transport stream", () => {
 
   it("preserves empty tools array for native openai-completions endpoints (existing behavior)", () => {
     const params = buildOpenAICompletionsParams(
-      makeCompletionsModel({
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        reasoning: false,
-        contextWindow: 4096,
-        maxTokens: 2048,
-      }),
-      {
-        systemPrompt: "You are a helpful assistant",
-        messages: [],
-        tools: [],
-      } as never,
+      toolChoiceModel(true),
+      emptyContext("You are a helpful assistant"),
       undefined,
     );
 
@@ -1325,34 +1094,8 @@ describe("openai transport stream", () => {
 
   it("preserves tools: [] fallback for native openai-completions endpoints when only prior tool history is present (existing behavior)", () => {
     const params = buildOpenAICompletionsParams(
-      makeCompletionsModel({
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        reasoning: false,
-        contextWindow: 4096,
-        maxTokens: 2048,
-      }),
-      {
-        systemPrompt: "You are a helpful assistant",
-        messages: [
-          {
-            role: "assistant",
-            content: [
-              {
-                type: "toolCall",
-                id: "call_abc",
-                name: "get_weather",
-                arguments: "{}",
-              },
-            ],
-          },
-          {
-            role: "toolResult",
-            content: [{ type: "text", text: "sunny" }],
-            toolCallId: "call_abc",
-          },
-        ],
-      } as never,
+      toolChoiceModel(true),
+      toolHistoryContext(),
       undefined,
     );
 


### PR DESCRIPTION
## What Problem This Solves

OpenAI transport tests repeated large request-context, model, tool-history, and Gemini replay fixtures across many scenarios. That duplication made the suite harder to audit and increased the chance that equivalent cases would drift apart.

## Why This Change Was Made

This AI-assisted cleanup moves only byte-equivalent repeated test setup into local fixture helpers. It preserves every test title, expanded case count, ordered assertion, provider route, streaming usage/reasoning/cache scenario, tool payload, and error expectation. Production code, config, protocol, and runtime behavior are unchanged.

Direct contract checks covered the pinned OpenAI SDK 6.49.0 streaming/request types and sibling Codex request/event mappings, including `../codex/codex-rs/core/src/client.rs`, `../codex/codex-rs/codex-api/src/common.rs`, `../codex/codex-rs/codex-api/src/sse/responses.rs`, `../codex/codex-rs/protocol/src/models.rs`, and `../codex/codex-rs/model-provider-info/src/lib.rs`.

## User Impact

No user-visible behavior changes. The OpenAI transport regression suite is 380 lines smaller and has clearer canonical setup for usage, reasoning/cache, tool-choice, and Gemini replay cases.

## Evidence

- Diff: 235 insertions, 615 deletions; net -380 test LOC; production delta 0.
- Source parity: usage/calls 42/42 declarations and 70/70 assertion calls; reasoning/cache 40/40 declarations and 76/76 assertion calls. No `it` or `expect` line changed.
- AutoReview: clean, correctness 0.99, no actionable findings.
- Blacksmith Testbox `tbx_01kz279ewvynf2w3qgpjqcc4z8`: focused 2 files, 90/90 tests passed.
- Same Testbox run: all 10 OpenAI transport-stream sibling files, 369/369 tests passed.
- Same Testbox run: full `check:changed` passed, including formatting, dependency/boundary/dead-export guards, core-test typecheck, and lint.
- GitHub Actions evidence: https://github.com/openclaw/openclaw/actions/runs/30768766249
- Central overlap audit: both exact paths clear; no active or ready reservation conflict for head `cbbe223ccfad106bea34906cfcd023aa76cf89f3`.
