### PR TITLE
fix(agents): prevent internal subagent completion events from leaking into chats

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -235,6 +235,10 @@ export const QA_WHATSAPP_REPLY_TO_BOT_TRIGGER_MARKER_RE =
 export const QA_WHATSAPP_BATCHED_FINAL_MARKER_RE = /\bWHATSAPP_QA_BATCHED_FINAL_([A-Z0-9]+)\b/u;
 export const QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE = /subagent direct fallback qa check/i;
 export const QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE = /subagent direct fallback worker/i;
+export const QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE =
+  /subagent terminal reply qa check:\s*(visible|silent|empty|restart|fallback)/i;
+export const QA_SUBAGENT_TERMINAL_MATRIX_WORKER_RE =
+  /subagent terminal reply qa worker:\s*(visible|silent|empty|restart|fallback)/i;
 
 export function buildStrandedFinalRecoveryText(): string {
   return [
@@ -259,6 +263,14 @@ export function isStrandedFinalRetryFailureRequest(allInputText: string): boolea
   );
 }
 export const QA_SUBAGENT_DIRECT_FALLBACK_MARKER = "QA-SUBAGENT-DIRECT-FALLBACK-OK";
+export const QA_SUBAGENT_TERMINAL_MARKERS = {
+  visible: "QA-SUBAGENT-TERMINAL-VISIBLE-OK",
+  empty: "QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED",
+  restart: "QA-SUBAGENT-TERMINAL-RESTART-OK",
+  fallback: "QA-SUBAGENT-TERMINAL-FALLBACK-OK",
+} as const;
+export const QA_SUBAGENT_TERMINAL_METADATA_SENTINEL = "QA-SUBAGENT-TERMINAL-INTERNAL-MUST-NOT-LEAK";
+export const QA_SUBAGENT_TERMINAL_WORKER_DELAY_MS = 5_000;
 export const QA_NATIVE_STOP_DELAY_PROMPT_RE =
   /subagent recovery worker native command target proof\.\s*wait until stopped\./i;
 export const QA_NATIVE_STOP_DELAY_MS = 180_000;

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -2842,6 +2842,32 @@ describe("qa mock openai server", () => {
     },
   );
 
+  it.each(["visible", "silent", "fallback", "restart"])(
+    "uses explicit silence for the %s completion-agent direct fallback",
+    async (terminalCase) => {
+      const server = await startMockServer();
+      const payload = await expectNonStreamingResponsesJson(server, {
+        tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
+        input: [
+          makeUserInput(`Subagent terminal reply QA check: ${terminalCase}.`),
+          makeUserInput(
+            TEST_RUNTIME_CONTEXT_CARRIER.replace(
+              "runtime metadata",
+              [
+                "[Internal task completion event]",
+                `Task: qa-terminal-${terminalCase}`,
+                `Result: QA-SUBAGENT-TERMINAL-${terminalCase.toUpperCase()}-OK`,
+              ].join("\n"),
+            ),
+          ),
+        ],
+      });
+
+      expect(outputItems(payload).some((item) => item.type === "function_call")).toBe(false);
+      expect(outputText(payload)).toBe("NO_REPLY");
+    },
+  );
+
   it("uses the latest terminal-reply case in a shared parent transcript", async () => {
     const server = await startMockServer();
     const payload = await expectNonStreamingResponsesJson(server, {
@@ -2860,6 +2886,32 @@ describe("qa mock openai server", () => {
     expect(debugRequest.plannedToolName).toBe("sessions_spawn");
     expect(requireRecord(debugRequest.plannedToolArgs, "latest terminal case args").label).toBe(
       "qa-terminal-silent",
+    );
+  });
+
+  it("ignores a stale terminal-reply case in a later internal runtime carrier", async () => {
+    const server = await startMockServer();
+    const payload = await expectNonStreamingResponsesJson(server, {
+      tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
+      input: [
+        makeUserInput("Subagent terminal reply QA check: fallback."),
+        makeUserInput(
+          TEST_RUNTIME_CONTEXT_CARRIER.replace(
+            "runtime metadata",
+            "Subagent terminal reply QA check: silent.",
+          ),
+        ),
+      ],
+    });
+
+    expect(outputItems(payload).some((item) => item.type === "function_call")).toBe(true);
+    const debugRequest = requireRecord(
+      await (await fetch(`${server.baseUrl}/debug/last-request`)).json(),
+      "current terminal case debug request",
+    );
+    expect(debugRequest.plannedToolName).toBe("sessions_spawn");
+    expect(requireRecord(debugRequest.plannedToolArgs, "current terminal case args").label).toBe(
+      "qa-terminal-fallback",
     );
   });
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -2659,6 +2659,210 @@ describe("qa mock openai server", () => {
     expect(outputText(payload)).toBe("QA-SUBAGENT-DIRECT-FALLBACK-OK");
   });
 
+  it.each([
+    ["visible", "QA-SUBAGENT-TERMINAL-VISIBLE-OK"],
+    ["silent", "NO_REPLY"],
+    [
+      "empty",
+      [
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+        "QA-SUBAGENT-TERMINAL-INTERNAL-MUST-NOT-LEAK",
+        "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      ].join("\n"),
+    ],
+    [
+      "fallback",
+      [
+        "QA-SUBAGENT-TERMINAL-FALLBACK-OK",
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+        "QA-SUBAGENT-TERMINAL-INTERNAL-MUST-NOT-LEAK",
+        "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      ].join("\n"),
+    ],
+  ])("returns the terminal-reply matrix worker result for %s", async (terminalCase, expected) => {
+    const server = await startMockServer();
+    const payload = await expectNonStreamingResponsesJson(server, {
+      input: [makeUserInput(`Subagent terminal reply QA worker: ${terminalCase}.`)],
+    });
+
+    expect(outputText(payload)).toBe(expected);
+  });
+
+  it("keeps the empty terminal worker empty across retry prompts", async () => {
+    const server = await startMockServer();
+    const payload = await expectNonStreamingResponsesJson(server, {
+      input: [
+        makeUserInput("Subagent terminal reply QA worker: empty."),
+        makeUserInput("Continue after the previous empty response."),
+      ],
+    });
+
+    expect(outputText(payload)).toContain("QA-SUBAGENT-TERMINAL-INTERNAL-MUST-NOT-LEAK");
+    expect(outputText(payload)).not.toContain("Protocol note:");
+  });
+
+  it("makes the empty terminal worker terminal after one side effect", async () => {
+    const server = await startMockServer();
+    await expectNonStreamingResponsesJson(server, {
+      tools: [{ type: "function", name: "write" }],
+      input: [makeUserInput("Subagent terminal reply QA worker: empty.")],
+    });
+    const writeRequest = requireRecord(
+      await (await fetch(`${server.baseUrl}/debug/last-request`)).json(),
+      "empty terminal write request",
+    );
+    expect(writeRequest.plannedToolName).toBe("write");
+    expect(requireRecord(writeRequest.plannedToolArgs, "empty terminal write args")).toMatchObject({
+      path: "qa-terminal-empty-side-effect.txt",
+    });
+
+    const payload = await expectNonStreamingResponsesJson(server, {
+      tools: [{ type: "function", name: "write" }],
+      input: [
+        makeUserInput("Subagent terminal reply QA worker: empty."),
+        makeToolOutputWithCallId(String(writeRequest.plannedToolCallId), "Wrote 40 bytes"),
+      ],
+    });
+    expect(outputText(payload)).toContain("QA-SUBAGENT-TERMINAL-INTERNAL-MUST-NOT-LEAK");
+  });
+
+  it("represents an empty terminal reply intentionally in the resumed parent turn", async () => {
+    const server = await startMockServer();
+    const payload = await expectNonStreamingResponsesJson(server, {
+      input: [
+        makeUserInput("Subagent terminal reply QA check: empty."),
+        makeUserInput(
+          [
+            "[Internal task completion event]",
+            "Task: qa-terminal-empty",
+            "Result: (no output)",
+          ].join("\n"),
+        ),
+      ],
+    });
+
+    expect(outputText(payload)).toBe("QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED");
+  });
+
+  it.each([
+    {
+      name: "OpenAI private-source guidance",
+      instructions:
+        "Current source visible reply MUST use `message(action=send)`; final text is private.",
+      final: undefined,
+    },
+    {
+      name: "Codex private-source guidance",
+      instructions:
+        "Visible source replies are not automatically delivered for this run. Use `message(action=send)` for user-visible source-channel output. When the message is the completed reply to the current source conversation, set `final=true`.",
+      final: true,
+    },
+  ])("delivers an empty terminal representation with $name", async ({ instructions, final }) => {
+    const server = await startMockServer();
+    const completionInput = [
+      makeUserInput("Subagent terminal reply QA check: empty."),
+      {
+        type: "function_call",
+        call_id: "call_empty_historical_write",
+        name: "write",
+        arguments: '{"path":"qa-terminal-empty-side-effect.txt"}',
+      },
+      makeToolOutputWithCallId("call_empty_historical_write", "Wrote 40 bytes"),
+      makeUserInput(
+        TEST_RUNTIME_CONTEXT_CARRIER.replace(
+          "runtime metadata",
+          "[Internal task completion event]\nTask: qa-terminal-empty\nResult: (no output)",
+        ),
+      ),
+    ];
+    const delivery = await expectNonStreamingResponsesJson(server, {
+      tools: [MESSAGE_TOOL],
+      instructions,
+      input: completionInput,
+    });
+    const messageCall = outputToolCall(delivery, "message");
+    expect(outputToolArgsFromItem(messageCall)).toEqual({
+      action: "send",
+      message: "QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED",
+      ...(final ? { final } : {}),
+    });
+
+    const settled = await expectNonStreamingResponsesJson(server, {
+      tools: [MESSAGE_TOOL],
+      instructions,
+      input: [
+        ...completionInput,
+        messageCall,
+        makeToolOutputWithCallId(
+          outputToolCallId(messageCall, "call_mock_message_empty_terminal"),
+          '{"ok":true,"messageId":"qa-empty-terminal"}',
+        ),
+      ],
+    });
+    expect(outputItems(settled).some((item) => item.type === "function_call")).toBe(false);
+    expect(outputText(settled)).toBe("");
+  });
+
+  it("classifies a completion event before the child task text it quotes", async () => {
+    const server = await startMockServer();
+    const payload = await expectNonStreamingResponsesJson(server, {
+      input: [
+        makeUserInput("Subagent terminal reply QA check: empty."),
+        makeUserInput(
+          [
+            "[Internal task completion event]",
+            "Task: Subagent terminal reply QA worker: empty.",
+            "Result: (no output)",
+          ].join("\n"),
+        ),
+      ],
+    });
+
+    expect(outputText(payload)).toBe("QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED");
+  });
+
+  it.each(["visible", "silent", "fallback", "restart", "empty"])(
+    "ends the %s parent turn before direct terminal delivery",
+    async (terminalCase) => {
+      const server = await startMockServer();
+      const prompt = `Subagent terminal reply QA check: ${terminalCase}.`;
+      const payload = await expectNonStreamingResponsesJson(server, {
+        tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
+        input: [
+          makeUserInput(prompt),
+          makeToolOutputWithCallId(
+            "call_mock_sessions_spawn_1",
+            JSON.stringify({ status: "accepted", runId: `run-${terminalCase}` }),
+          ),
+        ],
+      });
+
+      expect(outputItems(payload).some((item) => item.type === "function_call")).toBe(false);
+      expect(outputText(payload)).toBe("NO_REPLY");
+    },
+  );
+
+  it("uses the latest terminal-reply case in a shared parent transcript", async () => {
+    const server = await startMockServer();
+    const payload = await expectNonStreamingResponsesJson(server, {
+      tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
+      input: [
+        makeUserInput("Subagent terminal reply QA check: visible."),
+        makeUserInput("Subagent terminal reply QA check: silent."),
+      ],
+    });
+
+    expect(outputItems(payload).some((item) => item.type === "function_call")).toBe(true);
+    const debugRequest = requireRecord(
+      await (await fetch(`${server.baseUrl}/debug/last-request`)).json(),
+      "latest terminal case debug request",
+    );
+    expect(debugRequest.plannedToolName).toBe("sessions_spawn");
+    expect(requireRecord(debugRequest.plannedToolArgs, "latest terminal case args").label).toBe(
+      "qa-terminal-silent",
+    );
+  });
+
   it("does not treat prompt or instruction mentions as callable subagent tools", async () => {
     const server = await startMockServer();
     const payload = await expectNonStreamingResponsesJson(server, {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -56,10 +56,15 @@ import {
   QA_WHATSAPP_AGENT_MESSAGE_ACTION_UPLOAD_PROMPT_RE,
   QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE,
   QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE,
+  QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE,
+  QA_SUBAGENT_TERMINAL_MATRIX_WORKER_RE,
   buildStrandedFinalRecoveryText,
   buildStrandedFinalRetryFailureText,
   isStrandedFinalRetryFailureRequest,
   QA_SUBAGENT_DIRECT_FALLBACK_MARKER,
+  QA_SUBAGENT_TERMINAL_MARKERS,
+  QA_SUBAGENT_TERMINAL_METADATA_SENTINEL,
+  QA_SUBAGENT_TERMINAL_WORKER_DELAY_MS,
   QA_NATIVE_STOP_DELAY_PROMPT_RE,
   QA_NATIVE_STOP_DELAY_MS,
   QA_IMAGE_GENERATION_PROMPT_RE,
@@ -482,6 +487,14 @@ async function buildResponsesPayload(
     codeModeControlJson?.status === "completed" && Object.hasOwn(codeModeControlJson, "value")
       ? stringifyScenarioToolOutput(codeModeControlJson.value)
       : rawToolOutput;
+  const completedToolCall = findToolCallByCallId(input, extractToolOutputCallId(input));
+  const completedToolName = (() => {
+    if (completedToolCall?.name !== "exec") {
+      return completedToolCall?.name;
+    }
+    const code = parseToolCallArguments(completedToolCall)?.code;
+    return typeof code === "string" ? decodeCodeModeTarget(code)?.name : undefined;
+  })();
   const buildToolCallEventsWithArgs = (name: string, args: Record<string, unknown>) =>
     buildScenarioToolCallEvents(toolDeclarationBody, name, args);
   const allInputText = extractAllRequestTexts(input, body);
@@ -720,6 +733,101 @@ async function buildResponsesPayload(
   }
   if (QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE.test(prompt)) {
     return buildAssistantEvents(QA_SUBAGENT_DIRECT_FALLBACK_MARKER);
+  }
+  const terminalCompletionCase = Array.from(
+    allInputText.matchAll(
+      new RegExp(
+        QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE.source,
+        `${QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE.flags.replaceAll("g", "")}g`,
+      ),
+    ),
+  )
+    .at(-1)?.[1]
+    ?.toLowerCase();
+  if (terminalCompletionCase && /Internal task completion event/i.test(allInputText)) {
+    if (terminalCompletionCase === "empty") {
+      if (completedToolName === "message") {
+        return buildAssistantEvents("");
+      }
+      if (hasToolDefinition(toolDeclarationBody, "message") || hasCallableCodeMode) {
+        const deliveryInstructions = extractAllRequestTexts(
+          input.filter((item) => item.role === "system" || item.role === "developer"),
+          body,
+        );
+        const requiresFinal =
+          /visible source replies are not automatically delivered for this run\.[\s\S]*set `?final=true`?/i.test(
+            deliveryInstructions,
+          );
+        return buildToolCallEventsWithArgs("message", {
+          action: "send",
+          message: QA_SUBAGENT_TERMINAL_MARKERS.empty,
+          ...(requiresFinal ? { final: true } : {}),
+        });
+      }
+      return buildAssistantEvents(QA_SUBAGENT_TERMINAL_MARKERS.empty);
+    }
+    // The direct delivery fallback owns visible, silent, restart, and sanitized
+    // fallback results when the resumed requester turn has no visible answer.
+    return buildAssistantEvents("");
+  }
+  const terminalWorkerCase = Array.from(
+    allInputText.matchAll(
+      new RegExp(
+        QA_SUBAGENT_TERMINAL_MATRIX_WORKER_RE.source,
+        `${QA_SUBAGENT_TERMINAL_MATRIX_WORKER_RE.flags.replaceAll("g", "")}g`,
+      ),
+    ),
+  )
+    .at(-1)?.[1]
+    ?.toLowerCase();
+  if (terminalWorkerCase) {
+    await sleep(QA_SUBAGENT_TERMINAL_WORKER_DELAY_MS);
+  }
+  if (terminalWorkerCase === "silent") {
+    return buildAssistantEvents("NO_REPLY");
+  }
+  if (terminalWorkerCase === "empty") {
+    if (!hasCompletedToolOutput && hasDeclaredTool(body, "write")) {
+      return buildToolCallEventsWithArgs("write", {
+        path: "qa-terminal-empty-side-effect.txt",
+        content: "empty terminal QA side effect completed\n",
+      });
+    }
+    return buildAssistantEvents(
+      [
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+        QA_SUBAGENT_TERMINAL_METADATA_SENTINEL,
+        "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      ].join("\n"),
+    );
+  }
+  if (terminalWorkerCase === "fallback") {
+    return buildAssistantEvents(
+      [
+        QA_SUBAGENT_TERMINAL_MARKERS.fallback,
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+        QA_SUBAGENT_TERMINAL_METADATA_SENTINEL,
+        "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      ].join("\n"),
+    );
+  }
+  if (terminalWorkerCase === "visible" || terminalWorkerCase === "restart") {
+    return buildAssistantEvents(QA_SUBAGENT_TERMINAL_MARKERS[terminalWorkerCase]);
+  }
+  if (terminalCompletionCase) {
+    if (!hasCompletedToolOutput && canCallSessionsSpawn) {
+      return buildToolCallEventsWithArgs("sessions_spawn", {
+        task: `Subagent terminal reply QA worker: ${terminalCompletionCase}.`,
+        label: `qa-terminal-${terminalCompletionCase}`,
+        thread: false,
+        mode: "run",
+      });
+    }
+    if (hasCompletedToolOutput) {
+      // End the requester turn before the delayed worker settles. The terminal
+      // result must therefore use the runtime's direct channel fallback.
+      return buildAssistantEvents("NO_REPLY");
+    }
   }
   // Protected completion context is excluded from the current user prompt;
   // ignoring it replays the historical kickoff and recursively spawns workers.

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -734,15 +734,11 @@ async function buildResponsesPayload(
   if (QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE.test(prompt)) {
     return buildAssistantEvents(QA_SUBAGENT_DIRECT_FALLBACK_MARKER);
   }
-  const terminalCompletionCase = Array.from(
-    allInputText.matchAll(
-      new RegExp(
-        QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE.source,
-        `${QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE.flags.replaceAll("g", "")}g`,
-      ),
-    ),
+  const terminalCompletionCase = extractLastMatchingUserTurn(
+    input,
+    QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE,
   )
-    .at(-1)?.[1]
+    ?.text.match(QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE)?.[1]
     ?.toLowerCase();
   if (terminalCompletionCase && /Internal task completion event/i.test(allInputText)) {
     if (terminalCompletionCase === "empty") {
@@ -767,8 +763,9 @@ async function buildResponsesPayload(
       return buildAssistantEvents(QA_SUBAGENT_TERMINAL_MARKERS.empty);
     }
     // The direct delivery fallback owns visible, silent, restart, and sanitized
-    // fallback results when the resumed requester turn has no visible answer.
-    return buildAssistantEvents("");
+    // fallback results. Use explicit silence so generic empty-response recovery
+    // cannot replay the historical spawn before that fallback runs.
+    return buildAssistantEvents("NO_REPLY");
   }
   const terminalWorkerCase = Array.from(
     allInputText.matchAll(

--- a/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
+++ b/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
@@ -1,4 +1,4 @@
-title: Subagent completion direct fallback
+title: Subagent completion terminal-reply delivery
 
 scenario:
   id: subagent-completion-direct-fallback
@@ -9,33 +9,53 @@ scenario:
     secondary:
       - agent-runtime.subagent-turns-subagents
       - channels.qa-channel-final-reply
-  objective: Verify a yielded parent still receives a successful subagent result through direct fallback delivery when the dormant announce turn produces no visible reply.
+  objective: Prove visible, silent, empty, restart-recovered, and sanitized direct-fallback subagent completion behavior through real QA channel ingress.
+  gatewayConfigPatch:
+    tools:
+      alsoAllow:
+        - message
+    agents:
+      entries:
+        qa:
+          tools:
+            alsoAllow:
+              - message
   successCriteria:
-    - Parent launches a native subagent.
-    - Parent yields instead of waiting in-turn.
-    - Subagent completion result is delivered to the original QA DM without a thread id.
-    - Durable task delivery is marked delivered, not failed.
+    - Visible completion output reaches the originating QA DM exactly once.
+    - Exact NO_REPLY completion output produces no channel delivery.
+    - Genuinely empty completion output is represented intentionally once.
+    - Gateway restart does not replay prior terminal payloads, represents the interrupted handoff explicitly, and a post-restart completion is delivered exactly once.
+    - Direct fallback strips protected internal metadata before one channel delivery.
   docsRefs:
     - docs/tools/subagents.md
     - docs/help/testing.md
     - docs/channels/qa-channel.md
   codeRefs:
+    - src/agents/agent-run-terminal-reply.ts
     - src/agents/subagent-announce-delivery.ts
     - src/agents/subagent-registry-lifecycle.ts
-    - src/agents/tools/sessions-yield-tool.ts
     - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
     retryCount: 0
-    summary: Reproduce yielded-parent subagent completion delivery and require frozen-result fallback to the QA DM.
+    summary: Exercise terminal-reply dispositions through mock provider, ephemeral Gateway, SQLite task state, and qa-channel capture.
     config:
-      prompt: "Subagent direct fallback QA check: spawn one native subagent worker. The worker must finish with exactly QA-SUBAGENT-DIRECT-FALLBACK-OK. After spawning it, call sessions_yield and wait for the completion event. Do not use ACP."
-      expectedMarker: QA-SUBAGENT-DIRECT-FALLBACK-OK
-      expectedLabel: qa-direct-fallback-worker
+      cases:
+        - name: visible
+          marker: QA-SUBAGENT-TERMINAL-VISIBLE-OK
+          expectedSendCount: 1
+        - name: silent
+          marker: NO_REPLY
+          expectedSendCount: 0
+        - name: fallback
+          marker: QA-SUBAGENT-TERMINAL-FALLBACK-OK
+          expectedSendCount: 1
+      restartMarker: QA-SUBAGENT-TERMINAL-RESTART-OK
+      metadataSentinel: QA-SUBAGENT-TERMINAL-INTERNAL-MUST-NOT-LEAK
 
 flow:
   steps:
-    - name: yielded parent receives child completion through direct fallback
+    - name: proves terminal-reply channel behavior including restart recovery
       actions:
         - call: waitForGatewayHealthy
           args:
@@ -45,77 +65,223 @@ flow:
           args:
             - ref: env
             - 120000
-        - call: reset
-        - set: sessionKey
+        - set: verdicts
           value:
-            expr: "`agent:qa:subagent-direct-fallback:${randomUUID().slice(0, 8)}`"
-        - try:
+            expr: "[]"
+        - forEach:
+            items:
+              expr: config.cases
+            item: terminalCase
             actions:
-              - call: runAgentPrompt
+              - set: startIndex
+                value:
+                  expr: state.getSnapshot().messages.length
+              - set: requestCursor
+                value:
+                  expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
+              - set: conversationId
+                value:
+                  expr: "`terminal-${terminalCase.name}-${randomUUID().slice(0, 8)}`"
+              - sendInbound:
+                  accountId: default
+                  conversation:
+                    id:
+                      ref: conversationId
+                    kind: direct
+                  senderId:
+                    ref: conversationId
+                  senderName: QA Terminal Reply Operator
+                  text:
+                    expr: "`Subagent terminal reply QA check: ${terminalCase.name}. Spawn one native worker, then finish the parent turn without waiting. Do not use ACP.`"
+              - call: sleep
                 args:
-                  - ref: env
-                  - sessionKey:
-                      ref: sessionKey
-                    message:
-                      expr: config.prompt
-                    timeoutMs:
-                      expr: liveTurnTimeoutMs(env, 90000)
+                  - 20000
               - call: waitForCondition
-                saveAs: outbound
                 args:
                   - lambda:
-                      expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && String(message.text ?? '').trim() === config.expectedMarker).at(-1)"
-                  - expr: liveTurnTimeoutMs(env, 180000)
-                  - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
-              - assert:
-                  expr: "String(outbound.text ?? '').trim() === config.expectedMarker"
-                  message:
-                    expr: "`fallback completion marker missing from outbound QA DM: ${recentOutboundSummary(state)}`"
-            catchAs: fallbackError
-            catch:
-              - set: fallbackOutboundPreviews
+                      expr: "terminalCase.expectedSendCount === 0 || state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === conversationId && String(candidate.text ?? '').trim() === terminalCase.marker).length >= terminalCase.expectedSendCount"
+                  - 60000
+                  - 250
+              - set: caseOutbound
                 value:
-                  expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(-8).map((message) => ({ conversationId: message.conversation.id, text: String(message.text ?? '').trim().slice(0, 280), exactMarker: String(message.text ?? '').trim() === config.expectedMarker }))"
-              - set: fallbackDebugRequests
+                  expr: "state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === conversationId)"
+              - set: matchingOutbound
                 value:
-                  expr: "env.mock ? await (async () => { const cursor = Number((await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor ?? 0); return [...(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${Math.max(0, cursor - 20)}`))].map((request) => ({ plannedToolName: request.plannedToolName ?? null, plannedToolArgs: request.plannedToolArgs ?? null, prompt: String(request.prompt ?? '').slice(0, 280), allInputText: String(request.allInputText ?? '').slice(0, 280), toolOutput: request.toolOutput ? String(request.toolOutput).slice(0, 280) : null })); })() : []"
-              - set: fallbackTasks
+                  expr: "caseOutbound.filter((candidate) => String(candidate.text ?? '').trim() === terminalCase.marker)"
+              - set: caseRequests
                 value:
-                  expr: "(await runQaCli(env, ['tasks', 'list', '--json', '--runtime', 'subagent'], { timeoutMs: liveTurnTimeoutMs(env, 60000), json: true }).catch((error) => ({ error: String(error?.message ?? error) })))"
-              - throw:
-                  expr: "`subagent fallback exact marker missing: ${fallbackError?.message ?? fallbackError}; outbound=${recentOutboundSummary(state, 8)} outboundPreviews=${JSON.stringify(fallbackOutboundPreviews)} tasks=${JSON.stringify(fallbackTasks)} requests=${JSON.stringify(fallbackDebugRequests)}`"
-        - if:
-            expr: "Boolean(env.mock)"
-            then:
-              - set: fallbackDebugRequests
+                  expr: "env.mock ? await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursor}`) : []"
+              - assert:
+                  expr: "matchingOutbound.length === terminalCase.expectedSendCount"
+                  message:
+                    expr: "`terminal ${terminalCase.name}: expected ${terminalCase.expectedSendCount} outbound, got ${matchingOutbound.length}; messages=${JSON.stringify(state.getSnapshot().messages.slice(-10))} requests=${JSON.stringify(caseRequests)} logs=${JSON.stringify((env.gateway.logs?.().split('\\n') ?? []).filter((line) => /qa-channel|subagent|announce|completion|requester/i.test(line)).slice(-30))}`"
+              - assert:
+                  expr: "caseOutbound.every((candidate) => !String(candidate.text ?? '').includes(config.metadataSentinel) && !String(candidate.text ?? '').includes('BEGIN_OPENCLAW_INTERNAL_CONTEXT'))"
+                  message:
+                    expr: "`terminal ${terminalCase.name}: protected internal metadata leaked; outbound=${recentOutboundSummary(state)}`"
+              - assert:
+                  expr: "caseOutbound.every((candidate) => String(candidate.text ?? '').trim() !== 'NO_REPLY')"
+                  message:
+                    expr: "`terminal ${terminalCase.name}: exact silence token leaked to the channel; outbound=${recentOutboundSummary(state)}`"
+              - assert:
+                  expr: "caseOutbound.every((candidate) => !String(candidate.text ?? '').includes(`Agent couldn't generate a response`))"
+                  message:
+                    expr: "`terminal ${terminalCase.name}: unexpected failure diagnostic; outbound=${recentOutboundSummary(state)}`"
+              - assert:
+                  expr: "caseOutbound.every((candidate) => !String(candidate.text ?? '').includes(`Yield:`))"
+                  message:
+                    expr: "`terminal ${terminalCase.name}: yield raced child completion; outbound=${recentOutboundSummary(state)}`"
+              - assert:
+                  expr: "caseRequests.some((request) => request.plannedToolName === 'sessions_spawn' && request.plannedToolArgs?.label === `qa-terminal-${terminalCase.name}`)"
+                  message:
+                    expr: "`terminal ${terminalCase.name}: sessions_spawn not observed; requests=${JSON.stringify(caseRequests)}`"
+              - assert:
+                  expr: "!caseRequests.some((request) => request.plannedToolName === 'sessions_yield')"
+                  message:
+                    expr: "`terminal ${terminalCase.name}: parent did not end before direct fallback; requests=${JSON.stringify(caseRequests)}`"
+              - set: appendVerdict
                 value:
-                  expr: "await (async () => { const cursor = Number((await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor ?? 0); return [...(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${Math.max(0, cursor - 20)}`))]; })()"
-              - assert:
-                  expr: "fallbackDebugRequests.some((request) => !request.toolOutput && /subagent direct fallback qa check/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_spawn' && request.plannedToolArgs?.label === config.expectedLabel)"
-                  message:
-                    expr: "`expected sessions_spawn for yielded fallback scenario, saw ${JSON.stringify(fallbackDebugRequests.map((request) => ({ plannedToolName: request.plannedToolName ?? null, plannedToolArgs: request.plannedToolArgs ?? null })))}`"
-              - assert:
-                  expr: "fallbackDebugRequests.some((request) => /subagent direct fallback qa check/i.test(String(request.allInputText ?? '')) && request.plannedToolName === 'sessions_yield')"
-                  message:
-                    expr: "`expected sessions_yield for yielded fallback scenario, saw ${JSON.stringify(fallbackDebugRequests.map((request) => request.plannedToolName ?? null))}`"
-              - try:
-                  actions:
-                    - call: waitForCondition
-                      saveAs: deliveredTask
-                      args:
-                        - lambda:
-                            expr: "(async () => { const payload = await runQaCli(env, ['tasks', 'list', '--json', '--runtime', 'subagent'], { timeoutMs: liveTurnTimeoutMs(env, 60000), json: true }); return (payload.tasks ?? []).find((task) => task.label === config.expectedLabel && task.ownerKey === sessionKey && task.deliveryStatus === 'delivered' && task.status === 'succeeded') ?? null; })()"
-                        - expr: liveTurnTimeoutMs(env, 60000)
-                        - 250
-                  catchAs: fallbackDeliveryError
-                  catch:
-                    - set: observedFallbackTasks
-                      value:
-                        expr: "await runQaCli(env, ['tasks', 'list', '--json', '--runtime', 'subagent'], { timeoutMs: liveTurnTimeoutMs(env, 60000), json: true }).catch((error) => ({ tasks: [], error: String(error?.message ?? error) }))"
-                    - throw:
-                        expr: "`subagent fallback delivery state missing for ${sessionKey}: ${fallbackDeliveryError?.message ?? fallbackDeliveryError}; tasks=${JSON.stringify((observedFallbackTasks.tasks ?? []).filter((task) => task.label === config.expectedLabel).map((task) => ({ runId: task.runId ?? null, status: task.status, deliveryStatus: task.deliveryStatus, ownerKey: task.ownerKey, error: task.error ?? null })))}${observedFallbackTasks.error ? `; taskQueryError=${observedFallbackTasks.error}` : ''}`"
-              - assert:
-                  expr: "deliveredTask.deliveryStatus === 'delivered'"
-                  message:
-                    expr: "`expected delivered task status for ${config.expectedLabel}, got ${JSON.stringify(deliveredTask)}`"
-      detailsExpr: "outbound.text"
+                  expr: "verdicts.push({ case: terminalCase.name, conversationId, inputDisposition: terminalCase.name, representation: terminalCase.name === 'silent' ? 'no terminal channel payload' : 'exact terminal text', restart: false, fallback: terminalCase.name === 'fallback', expectedTerminalSendCount: terminalCase.expectedSendCount, actualTerminalSendCount: matchingOutbound.length, capturedTerminalPayloads: matchingOutbound.map((message) => String(message.text ?? '')), auxiliaryChannelEvents: caseOutbound.filter((message) => !matchingOutbound.includes(message)).map((message) => String(message.text ?? '')), silenceTokenLeaked: caseOutbound.some((message) => String(message.text ?? '').trim() === 'NO_REPLY'), internalMetadataLeak: caseOutbound.some((message) => String(message.text ?? '').includes(config.metadataSentinel)), pass: true })"
+        # The direct platform send commits before transcript mirroring and
+        # requester cleanup. Restart only after those post-send owners settle.
+        - call: sleep
+          args:
+            - 15000
+        - set: preRestartOutbound
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && verdicts.some((verdict) => verdict.conversationId === message.conversation.id)).map((message) => ({ id: message.id, conversationId: message.conversation.id, text: String(message.text ?? '') }))"
+        - set: restartPatch
+          value:
+            expr: "({ gateway: { controlUi: { allowedOrigins: [`http://127.0.0.1:${64000 + Math.floor(Math.random() * 999)}`] } } })"
+        - call: restartGatewayWithConfigPatch
+          args:
+            - env:
+                ref: env
+              patch:
+                ref: restartPatch
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 180000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 180000
+        - call: sleep
+          args:
+            - 3000
+        - set: postRestartOutbound
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && verdicts.some((verdict) => verdict.conversationId === message.conversation.id)).map((message) => ({ id: message.id, conversationId: message.conversation.id, text: String(message.text ?? '') }))"
+        - set: postRestartTerminalPayloads
+          value:
+            expr: "postRestartOutbound.filter((message) => verdicts.some((verdict) => verdict.capturedTerminalPayloads.includes(message.text)))"
+        - set: restartInterruptionPayloads
+          value:
+            expr: "postRestartOutbound.filter((message) => !preRestartOutbound.some((before) => before.id === message.id))"
+        - assert:
+            expr: "JSON.stringify(postRestartTerminalPayloads) === JSON.stringify(preRestartOutbound)"
+            message:
+              expr: "`Gateway restart replayed or lost a prior terminal payload: before=${JSON.stringify(preRestartOutbound)} after=${JSON.stringify(postRestartTerminalPayloads)}`"
+        - assert:
+            expr: "restartInterruptionPayloads.length === 1 && restartInterruptionPayloads.every((message) => message.text.includes('interrupted by a gateway restart'))"
+            message:
+              expr: "`Gateway restart did not represent the interrupted completion handoff exactly once: ${JSON.stringify(restartInterruptionPayloads)}`"
+        - set: restartStartIndex
+          value:
+            expr: state.getSnapshot().messages.length
+        - set: restartConversationId
+          value:
+            expr: "`terminal-restart-${randomUUID().slice(0, 8)}`"
+        - sendInbound:
+            accountId: default
+            conversation:
+              id:
+                ref: restartConversationId
+              kind: direct
+            senderId:
+              ref: restartConversationId
+            senderName: QA Restart Operator
+            text: "Subagent terminal reply QA check: restart. Spawn one native worker, then finish the parent turn without waiting. Do not use ACP."
+        - call: sleep
+          args:
+            - 20000
+        - call: waitForCondition
+          args:
+            - lambda:
+                expr: "state.getSnapshot().messages.slice(restartStartIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === restartConversationId && String(candidate.text ?? '').trim() === config.restartMarker).length >= 1"
+            - 60000
+            - 250
+        - set: restartMatches
+          value:
+            expr: "state.getSnapshot().messages.slice(restartStartIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === restartConversationId && String(candidate.text ?? '').trim() === config.restartMarker)"
+        - assert:
+            expr: "restartMatches.length === 1"
+            message:
+              expr: "`restart completion expected exactly one outbound, got ${restartMatches.length}; outbound=${recentOutboundSummary(state)}`"
+        - assert:
+            expr: "state.getSnapshot().messages.slice(restartStartIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === restartConversationId).every((candidate) => !String(candidate.text ?? '').includes(`Agent couldn't generate a response`))"
+            message:
+              expr: "`restart completion produced a failure diagnostic: outbound=${recentOutboundSummary(state)}`"
+        - set: appendRestartVerdict
+          value:
+            expr: "verdicts.push({ case: 'restart', conversationId: restartConversationId, inputDisposition: 'visible', restart: true, fallback: true, preRestartTerminalMessageCount: preRestartOutbound.length, postRestartTerminalPayloadCount: postRestartTerminalPayloads.length, priorTerminalPayloadReplayCount: postRestartTerminalPayloads.length - preRestartOutbound.length, interruptedHandoffRepresentationCount: restartInterruptionPayloads.length, interruptedHandoffPayloads: restartInterruptionPayloads.map((message) => message.text), expectedTerminalSendCount: 1, actualTerminalSendCount: restartMatches.length, capturedTerminalPayloads: restartMatches.map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
+        - set: emptyStartIndex
+          value:
+            expr: state.getSnapshot().messages.length
+        - set: emptyRequestCursor
+          value:
+            expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
+        - set: emptyConversationId
+          value:
+            expr: "`terminal-empty-${randomUUID().slice(0, 8)}`"
+        - sendInbound:
+            accountId: default
+            conversation:
+              id:
+                ref: emptyConversationId
+              kind: direct
+            senderId:
+              ref: emptyConversationId
+            senderName: QA Empty Reply Operator
+            text: "Subagent terminal reply QA check: empty. Spawn one native worker, then finish the parent turn without waiting. Do not use ACP."
+        # Empty output after one side effect is terminal and must surface one
+        # explicit representation without leaking the protected raw result.
+        - call: sleep
+          args:
+            - 45000
+        - call: waitForCondition
+          args:
+            - lambda:
+                expr: "state.getSnapshot().messages.slice(emptyStartIndex).some((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === emptyConversationId)"
+            - 60000
+            - 250
+        - set: emptyOutbound
+          value:
+            expr: "state.getSnapshot().messages.slice(emptyStartIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === emptyConversationId)"
+        - set: emptyRepresentation
+          value:
+            expr: "emptyOutbound.filter((candidate) => String(candidate.text ?? '').trim() === `QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED`)"
+        - set: emptyRequests
+          value:
+            expr: "env.mock ? await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${emptyRequestCursor}`) : []"
+        - assert:
+            expr: "emptyRepresentation.length === 1"
+            message:
+              expr: "`empty completion expected one intentional visible representation, got ${emptyRepresentation.length}; outbound=${recentOutboundSummary(state)} requests=${JSON.stringify(emptyRequests)} logs=${JSON.stringify((env.gateway.logs?.().split('\\n') ?? []).filter((line) => /empty response|incomplete turn|qa-terminal-empty|subagent|announce|completion/i.test(line)).slice(-50))}`"
+        - assert:
+            expr: "emptyOutbound.every((candidate) => String(candidate.text ?? '').trim() !== 'NO_REPLY' && !String(candidate.text ?? '').includes(config.metadataSentinel) && !String(candidate.text ?? '').includes('BEGIN_OPENCLAW_INTERNAL_CONTEXT'))"
+            message:
+              expr: "`empty completion leaked silence or internal metadata; outbound=${recentOutboundSummary(state)}`"
+        - assert:
+            expr: "emptyRequests.some((request) => request.plannedToolName === 'sessions_spawn' && request.plannedToolArgs?.label === 'qa-terminal-empty') && emptyRequests.some((request) => request.plannedToolName === 'write' && request.plannedToolArgs?.path === 'qa-terminal-empty-side-effect.txt') && emptyRequests.some((request) => request.plannedToolName === 'message' && request.plannedToolArgs?.action === 'send' && request.plannedToolArgs?.message === 'QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED') && !emptyRequests.some((request) => request.plannedToolName === 'sessions_yield')"
+            message:
+              expr: "`empty completion did not exercise native spawn/direct-fallback: ${JSON.stringify(emptyRequests)}`"
+        - set: appendEmptyVerdict
+          value:
+            expr: "verdicts.push({ case: 'empty', conversationId: emptyConversationId, inputDisposition: 'empty-after-side-effect', representation: 'visible ambiguity warning for producer-empty result', restart: false, fallback: false, expectedTerminalSendCount: 1, actualTerminalSendCount: emptyRepresentation.length, capturedTerminalPayloads: emptyRepresentation.map((message) => String(message.text ?? '')), auxiliaryChannelEvents: emptyOutbound.filter((message) => !emptyRepresentation.includes(message)).map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
+        - assert:
+            expr: "verdicts.length === 5 && verdicts.every((verdict) => verdict.pass === true)"
+            message:
+              expr: "`terminal reply verdict matrix incomplete: ${JSON.stringify(verdicts)}`"
+      detailsExpr: "JSON.stringify({ harness: 'qa-channel + qa-lab bus + ephemeral Gateway child + mock-openai', verdicts }, null, 2)"

--- a/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
+++ b/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
@@ -150,6 +150,9 @@ flow:
         - set: preRestartOutbound
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && verdicts.some((verdict) => verdict.conversationId === message.conversation.id)).map((message) => ({ id: message.id, conversationId: message.conversation.id, text: String(message.text ?? '') }))"
+        - set: preRestartTerminalPayloads
+          value:
+            expr: "preRestartOutbound.filter((message) => verdicts.some((verdict) => verdict.capturedTerminalPayloads.includes(message.text)))"
         - set: restartPatch
           value:
             expr: "({ gateway: { controlUi: { allowedOrigins: [`http://127.0.0.1:${64000 + Math.floor(Math.random() * 999)}`] } } })"
@@ -180,9 +183,9 @@ flow:
           value:
             expr: "postRestartOutbound.filter((message) => !preRestartOutbound.some((before) => before.id === message.id))"
         - assert:
-            expr: "JSON.stringify(postRestartTerminalPayloads) === JSON.stringify(preRestartOutbound)"
+            expr: "JSON.stringify(postRestartTerminalPayloads) === JSON.stringify(preRestartTerminalPayloads)"
             message:
-              expr: "`Gateway restart replayed or lost a prior terminal payload: before=${JSON.stringify(preRestartOutbound)} after=${JSON.stringify(postRestartTerminalPayloads)}`"
+              expr: "`Gateway restart replayed or lost a prior terminal payload: before=${JSON.stringify(preRestartTerminalPayloads)} after=${JSON.stringify(postRestartTerminalPayloads)}`"
         - assert:
             expr: "restartInterruptionPayloads.length === 1 && restartInterruptionPayloads.every((message) => message.text.includes('interrupted by a gateway restart'))"
             message:
@@ -225,7 +228,7 @@ flow:
               expr: "`restart completion produced a failure diagnostic: outbound=${recentOutboundSummary(state)}`"
         - set: appendRestartVerdict
           value:
-            expr: "verdicts.push({ case: 'restart', conversationId: restartConversationId, inputDisposition: 'visible', restart: true, fallback: true, preRestartTerminalMessageCount: preRestartOutbound.length, postRestartTerminalPayloadCount: postRestartTerminalPayloads.length, priorTerminalPayloadReplayCount: postRestartTerminalPayloads.length - preRestartOutbound.length, interruptedHandoffRepresentationCount: restartInterruptionPayloads.length, interruptedHandoffPayloads: restartInterruptionPayloads.map((message) => message.text), expectedTerminalSendCount: 1, actualTerminalSendCount: restartMatches.length, capturedTerminalPayloads: restartMatches.map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
+            expr: "verdicts.push({ case: 'restart', conversationId: restartConversationId, inputDisposition: 'visible', restart: true, fallback: true, preRestartTerminalMessageCount: preRestartTerminalPayloads.length, postRestartTerminalPayloadCount: postRestartTerminalPayloads.length, priorTerminalPayloadReplayCount: postRestartTerminalPayloads.length - preRestartTerminalPayloads.length, interruptedHandoffRepresentationCount: restartInterruptionPayloads.length, interruptedHandoffPayloads: restartInterruptionPayloads.map((message) => message.text), expectedTerminalSendCount: 1, actualTerminalSendCount: restartMatches.length, capturedTerminalPayloads: restartMatches.map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
         - set: emptyStartIndex
           value:
             expr: state.getSnapshot().messages.length

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -7,6 +7,9 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { AcpInitializeSessionInput } from "../acp/control-plane/manager.types.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { CallGatewayOptions } from "../gateway/call.js";
+import { setGatewayDedupeEntry, waitForAgentJob } from "../gateway/server-methods/agent-job.js";
+import type { DedupeEntry } from "../gateway/server-shared.js";
 import {
   testing as sessionBindingServiceTesting,
   registerSessionBindingAdapter,
@@ -16,7 +19,18 @@ import {
 } from "../infra/outbound/session-binding-service.js";
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
 import { reserveChildAdmissionSlot } from "./child-admission.js";
+import type { AgentRunTerminalReplySnapshot } from "./agent-run-terminal-reply.js";
+import { createAcpVisibleTextAccumulator } from "./command/attempt-execution.helpers.js";
+import {
+  buildAcpResult,
+  createAcpToolLifecycleTracker,
+  emitAcpLifecycleEnd,
+} from "./command/attempt-execution.js";
 import { resolveThinkingDefault } from "./model-selection.js";
+import { SUBAGENT_ENDED_REASON_COMPLETE } from "./subagent-lifecycle-events.js";
+import { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
+import type { RegisterSubagentRunParams } from "./subagent-registry-run-manager.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 type SessionBindingAdapterCapabilities = NonNullable<SessionBindingAdapter["capabilities"]>;
 
@@ -200,7 +214,10 @@ vi.mock("../config/sessions/paths.js", () => ({
   resolveStorePath: hoisted.resolveStorePathMock,
 }));
 
-vi.mock("../config/sessions/session-accessor.js", () => hoisted.createSessionAccessorMock());
+vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/sessions/session-accessor.js")>()),
+  ...hoisted.createSessionAccessorMock(),
+}));
 
 vi.mock("../config/sessions.js", () => ({
   loadSessionStore: hoisted.loadSessionStoreMock,
@@ -227,14 +244,16 @@ vi.mock("./acp-spawn-parent-stream.js", () => ({
   startAcpSpawnParentStreamRelay: hoisted.startAcpSpawnParentStreamRelayMock,
 }));
 
-vi.mock("./subagent-registry.js", () => ({
+vi.mock("./subagent-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./subagent-registry.js")>()),
   countActiveRunsForSession: hoisted.countActiveRunsForSessionMock,
   getSubagentRunByChildSessionKey: hoisted.getSubagentRunByChildSessionKeyMock,
   // ACP registration deliberately moved behind the shared spawn pipeline.
   registerSubagentRun: hoisted.registerSubagentRunMock,
 }));
 
-vi.mock("../tasks/runtime-internal.js", () => ({
+vi.mock("../tasks/runtime-internal.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../tasks/runtime-internal.js")>()),
   listTasksForOwnerKey: hoisted.listTasksForOwnerKeyMock,
 }));
 
@@ -403,6 +422,54 @@ function expectAcceptedSpawn(result: SpawnResult): Extract<SpawnResult, { status
     throw new Error("Expected ACP spawn to be accepted");
   }
   return result;
+}
+
+async function waitForAgentReplySnapshot(runId: string) {
+  const result = await waitForAgentJob({ runId, timeoutMs: 0 });
+  expect(result).toEqual(expect.objectContaining({ status: "ok" }));
+  return result as { terminalReply?: AgentRunTerminalReplySnapshot };
+}
+
+function createRegisteredRunEntry(registration: RegisterSubagentRunParams): SubagentRunRecord {
+  return {
+    ...registration,
+    createdAt: 100,
+    execution: { status: "running", startedAt: 100 },
+  };
+}
+
+function createBoundaryLifecycleController(params: {
+  entry: SubagentRunRecord;
+  captureSubagentCompletionReply: ReturnType<typeof vi.fn>;
+  runSubagentAnnounceFlow: ReturnType<typeof vi.fn>;
+}) {
+  return createSubagentRegistryLifecycleController({
+    runs: new Map([[params.entry.runId, params.entry]]),
+    resumedRuns: new Set(),
+    subagentAnnounceTimeoutMs: 1_000,
+    getRuntimeConfig: () => ({}),
+    persist: vi.fn(),
+    persistOrThrow: vi.fn(),
+    clearPendingLifecycleError: vi.fn(),
+    countPendingDescendantRuns: () => 0,
+    suppressAnnounceForSteerRestart: () => false,
+    resolveSubagentTask: () => ({ lookup: "unavailable" }),
+    shouldEmitEndedHookForRun: () => false,
+    emitSubagentEndedHookForRun: vi.fn(async () => {}),
+    emitSubagentProgressEndedForRun: vi.fn(async () => {}),
+    notifyContextEngineSubagentEnded: vi.fn(async () => {}),
+    retireSupersededRun: vi.fn(async () => {}),
+    resumeSubagentRun: vi.fn(),
+    callGateway: async <T = Record<string, unknown>>(_opts: CallGatewayOptions): Promise<T> =>
+      ({}) as T,
+    captureSubagentCompletionReply: params.captureSubagentCompletionReply,
+    runSubagentAnnounceFlow: params.runSubagentAnnounceFlow,
+    maybeWakeRequesterAfterAllChildrenSettled: vi.fn(async (wakeParams) => {
+      wakeParams.completeBatch([wakeParams.settledEntry.runId]);
+      return false;
+    }),
+    warn: vi.fn(),
+  });
 }
 
 function expectRecordFields(
@@ -2871,6 +2938,118 @@ describe("spawnAcpDirect", () => {
     expect(firstHandle.notifyStarted).not.toHaveBeenCalled();
     expect(secondHandle.notifyStarted).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    {
+      name: "visible",
+      chunks: ["v".repeat(5_000)],
+      expected: { disposition: "visible", text: `${"v".repeat(4_095)}…` } as const,
+      resultText: `${"v".repeat(4_095)}…`,
+    },
+    {
+      name: "silent",
+      chunks: ["NO_REPLY"],
+      expected: { disposition: "silent" } as const,
+      resultText: "NO_REPLY",
+    },
+    {
+      name: "empty",
+      chunks: [] as string[],
+      expected: { disposition: "empty" } as const,
+      resultText: null,
+    },
+  ])(
+    "carries bounded $name ACP output from spawn pipeline through wait and registry",
+    async ({ name, chunks, expected, resultText }) => {
+      for (const order of ["lifecycle-first", "dedupe-first"] as const) {
+        const runId = `run-acp-boundary-${name}-${order}`;
+        hoisted.callGatewayMock.mockImplementation(async (argsUnknown: unknown) => {
+          const args = argsUnknown as { method?: string };
+          if (args.method === "agent") {
+            return { runId };
+          }
+          if (args.method === "sessions.patch" || args.method === "sessions.delete") {
+            return { ok: true };
+          }
+          return {};
+        });
+
+        const spawned = expectAcceptedSpawn(
+          await spawnAcpDirect(createSpawnRequest(), createRequesterContext()),
+        );
+        expect(spawned).toMatchObject({ runId, mode: "run" });
+        const registration = latestMockCall(
+          hoisted.registerSubagentRunMock,
+          "subagent registration",
+        )[0] as RegisterSubagentRunParams;
+        expect(registration).toMatchObject({ runId, spawnMode: "run" });
+
+        const accumulator = createAcpVisibleTextAccumulator();
+        for (const chunk of chunks) {
+          accumulator.consume(chunk);
+        }
+        const terminalReply = accumulator.finalizeReplySnapshot();
+        expect(terminalReply).toEqual(expected);
+        const result = buildAcpResult({
+          payloadText: accumulator.finalize(),
+          terminalReply,
+          startedAt: 100,
+          resultStatus: "completed",
+        });
+        const dedupe = new Map<string, DedupeEntry>();
+        const observeLifecycle = () =>
+          emitAcpLifecycleEnd({
+            runId,
+            toolTracker: createAcpToolLifecycleTracker(),
+            resultStatus: "completed",
+            terminalReply,
+          });
+        const observeDedupe = () =>
+          setGatewayDedupeEntry({
+            dedupe,
+            key: `agent:${runId}`,
+            entry: {
+              ts: 200,
+              ok: true,
+              payload: { runId, status: "ok", startedAt: 100, endedAt: 200, result },
+            },
+          });
+        for (const observe of order === "lifecycle-first"
+          ? [observeLifecycle, observeDedupe]
+          : [observeDedupe, observeLifecycle]) {
+          observe();
+        }
+
+        const waited = await waitForAgentReplySnapshot(runId);
+        expect(waited.terminalReply).toEqual(expected);
+        const entry = createRegisteredRunEntry(registration);
+        const captureSubagentCompletionReply = vi.fn(async () => undefined);
+        const runSubagentAnnounceFlow = vi.fn(async () => true);
+        await createBoundaryLifecycleController({
+          entry,
+          captureSubagentCompletionReply,
+          runSubagentAnnounceFlow,
+        }).completeSubagentRun({
+          runId,
+          endedAt: 200,
+          outcome: { status: "ok" },
+          reason: SUBAGENT_ENDED_REASON_COMPLETE,
+          triggerCleanup: true,
+          terminalReply: waited.terminalReply,
+        });
+
+        expect(captureSubagentCompletionReply).not.toHaveBeenCalled();
+        expect(entry.completion).toMatchObject({
+          terminalReply: expected,
+          resultText,
+        });
+        expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+        expect(runSubagentAnnounceFlow).toHaveBeenCalledWith(
+          expect.objectContaining({ terminalReply: expected }),
+        );
+      }
+    },
+  );
 
   it("implicitly streams mode=run ACP spawns for subagent requester sessions", async () => {
     replaceSpawnConfig({

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -2958,6 +2958,12 @@ describe("spawnAcpDirect", () => {
       resultText: "NO_REPLY",
     },
     {
+      name: "punctuation-wrapped-silent",
+      chunks: ["NO_REPLY:"],
+      expected: { disposition: "silent" } as const,
+      resultText: "NO_REPLY",
+    },
+    {
       name: "empty",
       chunks: [] as string[],
       expected: { disposition: "empty" } as const,

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -18,8 +18,8 @@ import {
   type SessionBindingRecord,
 } from "../infra/outbound/session-binding-service.js";
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
-import { reserveChildAdmissionSlot } from "./child-admission.js";
 import type { AgentRunTerminalReplySnapshot } from "./agent-run-terminal-reply.js";
+import { reserveChildAdmissionSlot } from "./child-admission.js";
 import { createAcpVisibleTextAccumulator } from "./command/attempt-execution.helpers.js";
 import {
   buildAcpResult,

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -224,6 +224,8 @@ vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => ({
 
 vi.mock("../config/sessions.js", () => ({
   loadSessionStore: hoisted.loadSessionStoreMock,
+  resolveAgentIdFromSessionKey: (sessionKey: string) =>
+    sessionKey.match(/^agent:([^:]+)/)?.[1] ?? "main",
   resolveStorePath: hoisted.resolveStorePathMock,
 }));
 

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -33,6 +33,9 @@ import type { RegisterSubagentRunParams } from "./subagent-registry-run-manager.
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 type SessionBindingAdapterCapabilities = NonNullable<SessionBindingAdapter["capabilities"]>;
+type BoundaryLifecycleControllerParams = Parameters<
+  typeof createSubagentRegistryLifecycleController
+>[0];
 
 function createDefaultSpawnConfig(): OpenClawConfig {
   return {
@@ -440,8 +443,8 @@ function createRegisteredRunEntry(registration: RegisterSubagentRunParams): Suba
 
 function createBoundaryLifecycleController(params: {
   entry: SubagentRunRecord;
-  captureSubagentCompletionReply: ReturnType<typeof vi.fn>;
-  runSubagentAnnounceFlow: ReturnType<typeof vi.fn>;
+  captureSubagentCompletionReply: BoundaryLifecycleControllerParams["captureSubagentCompletionReply"];
+  runSubagentAnnounceFlow: BoundaryLifecycleControllerParams["runSubagentAnnounceFlow"];
 }) {
   return createSubagentRegistryLifecycleController({
     runs: new Map([[params.entry.runId, params.entry]]),

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -899,6 +899,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         },
         finalizeRaw: () => text,
         finalize: () => text,
+        finalizeReplySnapshot: () => ({ disposition: "visible" as const, text }),
       };
     });
     state.buildAcpResultMock.mockImplementation((params: { payloadText?: string }) => ({

--- a/src/agents/agent-run-terminal-reply.ts
+++ b/src/agents/agent-run-terminal-reply.ts
@@ -1,6 +1,6 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { stripInternalMetadataForDisplay } from "../auto-reply/reply/display-text-sanitize.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 
 const AGENT_RUN_TERMINAL_REPLY_MAX_CHARS = 4_096;
 
@@ -8,10 +8,6 @@ export type AgentRunTerminalReplySnapshot =
   | { disposition: "visible"; text: string }
   | { disposition: "silent" }
   | { disposition: "empty" };
-
-function isExactSilentReply(text: string | undefined): boolean {
-  return text?.trim().toUpperCase() === SILENT_REPLY_TOKEN;
-}
 
 /** Sanitizes and caps producer-owned text before it enters lifecycle or durable state. */
 export function sanitizeAgentRunTerminalReplyText(text: string): string {
@@ -28,7 +24,10 @@ export function buildAgentRunTerminalReplySnapshot(params: {
   rawText?: string;
   terminalReplyKind?: "silent-empty";
 }): AgentRunTerminalReplySnapshot {
-  if (params.terminalReplyKind === "silent-empty" || isExactSilentReply(params.rawText)) {
+  if (
+    params.terminalReplyKind === "silent-empty" ||
+    isSilentReplyText(params.rawText, SILENT_REPLY_TOKEN)
+  ) {
     return { disposition: "silent" };
   }
   const text = sanitizeAgentRunTerminalReplyText(params.visibleText ?? "");

--- a/src/agents/agent-run-terminal-reply.ts
+++ b/src/agents/agent-run-terminal-reply.ts
@@ -2,7 +2,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { stripInternalMetadataForDisplay } from "../auto-reply/reply/display-text-sanitize.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 
-export const AGENT_RUN_TERMINAL_REPLY_MAX_CHARS = 4_096;
+const AGENT_RUN_TERMINAL_REPLY_MAX_CHARS = 4_096;
 
 export type AgentRunTerminalReplySnapshot =
   | { disposition: "visible"; text: string }

--- a/src/agents/agent-run-terminal-reply.ts
+++ b/src/agents/agent-run-terminal-reply.ts
@@ -1,0 +1,75 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { stripInternalMetadataForDisplay } from "../auto-reply/reply/display-text-sanitize.js";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+
+export const AGENT_RUN_TERMINAL_REPLY_MAX_CHARS = 4_096;
+
+export type AgentRunTerminalReplySnapshot =
+  | { disposition: "visible"; text: string }
+  | { disposition: "silent" }
+  | { disposition: "empty" };
+
+function isExactSilentReply(text: string | undefined): boolean {
+  return text?.trim().toUpperCase() === SILENT_REPLY_TOKEN;
+}
+
+/** Sanitizes and caps producer-owned text before it enters lifecycle or durable state. */
+export function sanitizeAgentRunTerminalReplyText(text: string): string {
+  const sanitized = stripInternalMetadataForDisplay(text).trim();
+  if (sanitized.length <= AGENT_RUN_TERMINAL_REPLY_MAX_CHARS) {
+    return sanitized;
+  }
+  return `${truncateUtf16Safe(sanitized, AGENT_RUN_TERMINAL_REPLY_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+/** Builds the authoritative terminal reply fact while raw assistant text is still available. */
+export function buildAgentRunTerminalReplySnapshot(params: {
+  visibleText?: string;
+  rawText?: string;
+  terminalReplyKind?: "silent-empty";
+}): AgentRunTerminalReplySnapshot {
+  if (params.terminalReplyKind === "silent-empty" || isExactSilentReply(params.rawText)) {
+    return { disposition: "silent" };
+  }
+  const text = sanitizeAgentRunTerminalReplyText(params.visibleText ?? "");
+  return text ? { disposition: "visible", text } : { disposition: "empty" };
+}
+
+/** Normalizes lifecycle/RPC evidence without allowing raw or unbounded text through. */
+export function normalizeAgentRunTerminalReplySnapshot(
+  value: unknown,
+): AgentRunTerminalReplySnapshot | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const disposition = (value as { disposition?: unknown }).disposition;
+  if (disposition === "silent" || disposition === "empty") {
+    return { disposition };
+  }
+  if (disposition !== "visible") {
+    return undefined;
+  }
+  const rawText = (value as { text?: unknown }).text;
+  if (typeof rawText !== "string") {
+    return undefined;
+  }
+  const text = sanitizeAgentRunTerminalReplyText(rawText);
+  return text ? { disposition: "visible", text } : { disposition: "empty" };
+}
+
+/** Reply evidence merges independently from sticky timeout/cancellation precedence. */
+export function mergeAgentRunTerminalReplySnapshot(
+  existing: AgentRunTerminalReplySnapshot | undefined,
+  incoming: AgentRunTerminalReplySnapshot | undefined,
+): AgentRunTerminalReplySnapshot | undefined {
+  if (!incoming) {
+    return existing;
+  }
+  if (!existing || existing.disposition === "empty") {
+    return incoming;
+  }
+  if (incoming.disposition === "empty") {
+    return existing;
+  }
+  return incoming;
+}

--- a/src/agents/command/acp-execution.ts
+++ b/src/agents/command/acp-execution.ts
@@ -175,6 +175,7 @@ export async function runAcpAgentCommand(params: {
 
   const finalTextRaw = visibleTextAccumulator.finalizeRaw();
   const finalText = visibleTextAccumulator.finalize();
+  const terminalReply = visibleTextAccumulator.finalizeReplySnapshot();
   let sessionEntry = params.sessionEntry;
   try {
     const { resolveAcpSessionCwd } = await loadAcpSessionIdentifiersRuntime();
@@ -247,11 +248,13 @@ export async function runAcpAgentCommand(params: {
     abortSignal: params.opts.abortSignal,
     stopReason,
     resultStatus,
+    terminalReply,
   });
 
   const result = applyAgentRunAbortMetadata(
     attemptExecutionRuntime.buildAcpResult({
       payloadText: finalText,
+      terminalReply,
       startedAt,
       stopReason,
       resultStatus,

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -23,7 +23,7 @@ import {
   readClaudeCliFallbackSeed,
 } from "../../gateway/cli-session-history.js";
 import {
-  sanitizeAgentRunTerminalReplyText,
+  buildAgentRunTerminalReplySnapshot,
   type AgentRunTerminalReplySnapshot,
 } from "../agent-run-terminal-reply.js";
 import { cliBackendLog } from "../cli-runner/log.js";
@@ -500,7 +500,7 @@ export function createAcpVisibleTextAccumulator() {
         const leadCandidate = resolveNextCandidate(pendingSilentPrefix, chunk);
         const trimmedLeadCandidate = leadCandidate.trim();
         if (
-          trimmedLeadCandidate.toUpperCase() === SILENT_REPLY_TOKEN ||
+          isSilentReplyText(trimmedLeadCandidate, SILENT_REPLY_TOKEN) ||
           isSilentReplyPrefixText(trimmedLeadCandidate, SILENT_REPLY_TOKEN)
         ) {
           pendingSilentPrefix = leadCandidate;
@@ -543,15 +543,10 @@ export function createAcpVisibleTextAccumulator() {
       return visibleText;
     },
     finalizeReplySnapshot(): AgentRunTerminalReplySnapshot {
-      const text = sanitizeAgentRunTerminalReplyText(visibleText);
-      if (text) {
-        return { disposition: "visible", text };
-      }
-      // ACP owns this distinction only until finalization; preserve it before
-      // the buffered exact control token is otherwise indistinguishable from no output.
-      return pendingSilentPrefix.trim().toUpperCase() === SILENT_REPLY_TOKEN
-        ? { disposition: "silent" }
-        : { disposition: "empty" };
+      return buildAgentRunTerminalReplySnapshot({
+        visibleText,
+        rawText: pendingSilentPrefix,
+      });
     },
   };
 }

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -22,6 +22,10 @@ import {
   type ClaudeCliFallbackSeed,
   readClaudeCliFallbackSeed,
 } from "../../gateway/cli-session-history.js";
+import {
+  sanitizeAgentRunTerminalReplyText,
+  type AgentRunTerminalReplySnapshot,
+} from "../agent-run-terminal-reply.js";
 import { cliBackendLog } from "../cli-runner/log.js";
 import { resolveClaudeCliProjectDirForWorkspace } from "./claude-cli-project-dir.js";
 
@@ -496,7 +500,7 @@ export function createAcpVisibleTextAccumulator() {
         const leadCandidate = resolveNextCandidate(pendingSilentPrefix, chunk);
         const trimmedLeadCandidate = leadCandidate.trim();
         if (
-          isSilentReplyText(trimmedLeadCandidate, SILENT_REPLY_TOKEN) ||
+          trimmedLeadCandidate.toUpperCase() === SILENT_REPLY_TOKEN ||
           isSilentReplyPrefixText(trimmedLeadCandidate, SILENT_REPLY_TOKEN)
         ) {
           pendingSilentPrefix = leadCandidate;
@@ -537,6 +541,17 @@ export function createAcpVisibleTextAccumulator() {
     },
     finalizeRaw(): string {
       return visibleText;
+    },
+    finalizeReplySnapshot(): AgentRunTerminalReplySnapshot {
+      const text = sanitizeAgentRunTerminalReplyText(visibleText);
+      if (text) {
+        return { disposition: "visible", text };
+      }
+      // ACP owns this distinction only until finalization; preserve it before
+      // the buffered exact control token is otherwise indistinguishable from no output.
+      return pendingSilentPrefix.trim().toUpperCase() === SILENT_REPLY_TOKEN
+        ? { disposition: "silent" }
+        : { disposition: "empty" };
     },
   };
 }

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -1164,6 +1164,10 @@ describe("createAcpVisibleTextAccumulator", () => {
     });
 
     expect(acc.finalize()).toBe("NO_REPLY: explanation");
+    expect(acc.finalizeReplySnapshot()).toEqual({
+      disposition: "visible",
+      text: "NO_REPLY: explanation",
+    });
   });
 
   it("buffers chunked NO_REPLY prefixes before emitting visible text", () => {
@@ -1189,9 +1193,19 @@ describe("createAcpVisibleTextAccumulator", () => {
     { name: "clean empty output", chunks: [], expected: { disposition: "empty" } },
     { name: "partial control prefix", chunks: ["NO_RE"], expected: { disposition: "empty" } },
     {
-      name: "punctuation-attached control text",
+      name: "punctuation-wrapped silence",
       chunks: ["NO_REPLY:"],
-      expected: { disposition: "visible", text: "NO_REPLY:" },
+      expected: { disposition: "silent" },
+    },
+    {
+      name: "ellipsis-wrapped silence",
+      chunks: ["NO_REPLY..."],
+      expected: { disposition: "silent" },
+    },
+    {
+      name: "chunked punctuation-wrapped silence",
+      chunks: ["NO_REPLY", ":"],
+      expected: { disposition: "silent" },
     },
     {
       name: "glued visible continuation",

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -1178,5 +1178,32 @@ describe("createAcpVisibleTextAccumulator", () => {
       delta: "Actual answer",
     });
   });
+
+  it.each([
+    {
+      name: "visible output",
+      chunks: ["Final answer"],
+      expected: { disposition: "visible", text: "Final answer" },
+    },
+    { name: "exact silence", chunks: ["NO_REPLY"], expected: { disposition: "silent" } },
+    { name: "clean empty output", chunks: [], expected: { disposition: "empty" } },
+    { name: "partial control prefix", chunks: ["NO_RE"], expected: { disposition: "empty" } },
+    {
+      name: "punctuation-attached control text",
+      chunks: ["NO_REPLY:"],
+      expected: { disposition: "visible", text: "NO_REPLY:" },
+    },
+    {
+      name: "glued visible continuation",
+      chunks: ["NO_REPLYVisible continuation"],
+      expected: { disposition: "visible", text: "Visible continuation" },
+    },
+  ])("classifies $name at ACP finalization", ({ chunks, expected }) => {
+    const acc = createAcpVisibleTextAccumulator();
+    for (const chunk of chunks) {
+      acc.consume(chunk);
+    }
+    expect(acc.finalizeReplySnapshot()).toEqual(expected);
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -50,6 +50,7 @@ import {
 } from "../../tasks/task-status-access.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveMessageChannel } from "../../utils/message-channel.js";
+import type { AgentRunTerminalReplySnapshot } from "../agent-run-terminal-reply.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
 import { ensureAuthProfileStore } from "../auth-profiles/store.js";
 import {
@@ -1246,6 +1247,7 @@ export function runAgentAttempt(params: {
 
 export function buildAcpResult(params: {
   payloadText: string;
+  terminalReply?: AgentRunTerminalReplySnapshot;
   startedAt: number;
   stopReason?: string;
   resultStatus?: Extract<AcpRuntimeEvent, { type: "done" }>["status"];
@@ -1263,6 +1265,7 @@ export function buildAcpResult(params: {
       durationMs: Date.now() - params.startedAt,
       aborted: abortFields.aborted ?? resultCancelled,
       stopReason: abortFields.stopReason ?? (resultCancelled ? "stop" : params.stopReason),
+      ...(params.terminalReply ? { terminalReply: params.terminalReply } : {}),
     },
   };
 }
@@ -1625,6 +1628,7 @@ export function emitAcpLifecycleEnd(params: {
   abortSignal?: AbortSignal;
   stopReason?: string;
   resultStatus?: Extract<AcpRuntimeEvent, { type: "done" }>["status"];
+  terminalReply?: AgentRunTerminalReplySnapshot;
   auditOnly?: boolean;
 }) {
   finalizeAcpToolsForRun(
@@ -1648,6 +1652,7 @@ export function emitAcpLifecycleEnd(params: {
       phase: "end",
       endedAt: Date.now(),
       ...resolveAcpLifecycleEndFields(params.abortSignal, params.stopReason, params.resultStatus),
+      ...(params.terminalReply ? { terminalReply: params.terminalReply } : {}),
     },
   });
 }

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -78,7 +78,7 @@ export function createAgentCommandLifecycle(params: {
     error?: string,
     fallbackExhausted?: boolean,
   ) => {
-    const { aborted, yielded, replayInvalid } = terminal.metadata;
+    const { aborted, yielded, replayInvalid, terminalReply } = terminal.metadata;
     const { stopReason, livenessState, timeoutPhase, providerStarted } = terminal.outcome;
     emitAgentEvent({
       runId: params.runId,
@@ -97,6 +97,7 @@ export function createAgentCommandLifecycle(params: {
         ...(providerStarted !== undefined ? { providerStarted } : {}),
         ...(error ? { error: formatErrorMessage(error) } : {}),
         ...(fallbackExhausted ? { fallbackExhaustedFailure: true } : {}),
+        ...(terminalReply ? { terminalReply } : {}),
         ...resolveAgentRunAbortLifecycleFields(params.abortSignal),
       },
     });

--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -376,4 +376,48 @@ describe("runEmbeddedAgentEntry", () => {
     expect(result.outcome).toBe("exhausted");
     expect(result.result.payloads).toEqual([]);
   });
+
+  it.each([
+    {
+      name: "embedded visible reply",
+      meta: { finalAssistantVisibleText: "visible", finalAssistantRawText: "visible" },
+      expected: { disposition: "visible", text: "visible" },
+    },
+    {
+      name: "CLI exact silence",
+      meta: { finalAssistantVisibleText: "NO_REPLY", finalAssistantRawText: "NO_REPLY" },
+      expected: { disposition: "silent" },
+    },
+    {
+      name: "clean empty reply",
+      meta: {},
+      expected: { disposition: "empty" },
+    },
+  ])("records the producer-owned terminal snapshot for $name", async ({ name, meta, expected }) => {
+    state.runWithModelFallback.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      outcome: "completed" as const,
+      result: await params.run(params.provider, params.model),
+      provider: params.provider,
+      model: params.model,
+      attempts: [],
+    }));
+    const { runEmbeddedAgentEntry } = await import("./run-entry.js");
+    const result = await runEmbeddedAgentEntry({
+      selection: { cfg: {}, provider: "provider", model: "model" },
+      identity: { runId: `terminal-${name}`, agentId: "main", sessionId: "session-1" },
+      harness: {
+        workspaceDir: "/tmp/workspace",
+        preparation: { kind: "direct" },
+        resolveRuntimeOverride: () => undefined,
+      },
+      behavior: { kind: "command-rpc", hasCommittedSideEffect: () => false },
+      sessionOverride: { kind: "preserve" },
+      runCandidate: async (provider, model) => ({
+        ...makeResult({ provider, model }),
+        meta: { ...makeResult({ provider, model }).meta, ...meta },
+      }),
+    });
+
+    expect(result.terminal.metadata.terminalReply).toEqual(expected);
+  });
 });

--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -389,6 +389,11 @@ describe("runEmbeddedAgentEntry", () => {
       expected: { disposition: "silent" },
     },
     {
+      name: "CLI punctuation-wrapped silence",
+      meta: { finalAssistantVisibleText: "NO_REPLY...", finalAssistantRawText: "NO_REPLY..." },
+      expected: { disposition: "silent" },
+    },
+    {
       name: "clean empty reply",
       meta: {},
       expected: { disposition: "empty" },

--- a/src/agents/embedded-agent-runner/run-entry.ts
+++ b/src/agents/embedded-agent-runner/run-entry.ts
@@ -1,6 +1,10 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { requireActivePluginRegistry } from "../../plugins/runtime.js";
 import { buildAgentRunTerminalOutcome } from "../agent-run-terminal-outcome.js";
+import {
+  buildAgentRunTerminalReplySnapshot,
+  normalizeAgentRunTerminalReplySnapshot,
+} from "../agent-run-terminal-reply.js";
 import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
 import type { ModelFallbackResultClassification } from "../model-fallback-attempt.js";
 import type { ModelFallbackStepFields } from "../model-fallback-observation.js";
@@ -155,6 +159,13 @@ function buildTerminal(params: {
     providerStarted: meta.providerStarted,
   });
   const metadata: Record<string, unknown> = {};
+  metadata.terminalReply =
+    normalizeAgentRunTerminalReplySnapshot(meta.terminalReply) ??
+    buildAgentRunTerminalReplySnapshot({
+      visibleText: meta.finalAssistantVisibleText,
+      rawText: meta.finalAssistantRawText,
+      terminalReplyKind: meta.terminalReplyKind,
+    });
   if (params.behavior.kind === "channel-delivery" || params.behavior.kind === "followup-delivery") {
     for (const key of [
       "stopReason",

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../config/sessions/types.js";
 import type { DiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import type { AcceptedSessionSpawn } from "../accepted-session-spawn.js";
+import type { AgentRunTerminalReplySnapshot } from "../agent-run-terminal-reply.js";
 import type {
   MessagingToolSend,
   MessagingToolSourceReplyPayload,
@@ -192,6 +193,7 @@ export type EmbeddedAgentRunMeta = {
   providerStarted?: boolean;
   agentHarnessResultClassification?: "empty" | "reasoning-only" | "planning-only";
   terminalReplyKind?: "silent-empty";
+  terminalReply?: AgentRunTerminalReplySnapshot;
   yielded?: boolean;
   error?: {
     kind:

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -324,6 +324,18 @@ describe("waitForAgentRun", () => {
     });
   });
 
+  it("carries a bounded terminal reply snapshot from agent.wait", async () => {
+    callGatewayMock.mockResolvedValue({
+      status: "ok",
+      terminalReply: { disposition: "visible", text: "final reply" },
+    });
+
+    await expect(waitForAgentRun({ runId: "run-reply", timeoutMs: 500 })).resolves.toEqual({
+      status: "ok",
+      terminalReply: { disposition: "visible", text: "final reply" },
+    });
+  });
+
   it("normalizes wait timeouts before sending agent.wait", async () => {
     callGatewayMock.mockResolvedValue({ status: "ok" });
 

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -26,6 +26,10 @@ import {
   type AgentRunTerminalOutcome,
 } from "./agent-run-terminal-outcome.js";
 import {
+  normalizeAgentRunTerminalReplySnapshot,
+  type AgentRunTerminalReplySnapshot,
+} from "./agent-run-terminal-reply.js";
+import {
   normalizeAgentRunTimeoutPhase,
   normalizeProviderStarted,
   type AgentRunTimeoutPhase,
@@ -66,6 +70,7 @@ export type AgentWaitResult = {
   pendingError?: boolean;
   timeoutPhase?: AgentRunTimeoutPhase;
   providerStarted?: boolean;
+  terminalReply?: AgentRunTerminalReplySnapshot;
 };
 
 /** Summary returned after waiting for a dynamic set of pending runs to drain. */
@@ -86,6 +91,7 @@ type RawAgentWaitResponse = {
   pendingError?: unknown;
   timeoutPhase?: unknown;
   providerStarted?: unknown;
+  terminalReply?: unknown;
 };
 
 function normalizeAgentWaitResult(
@@ -106,6 +112,7 @@ function normalizeAgentWaitResult(
     pendingError: wait?.pendingError === true ? true : undefined,
     timeoutPhase: normalizeAgentRunTimeoutPhase(wait?.timeoutPhase),
     providerStarted: normalizeProviderStarted(wait?.providerStarted),
+    terminalReply: normalizeAgentRunTerminalReplySnapshot(wait?.terminalReply),
   };
 }
 

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -16,6 +16,10 @@ import type {
 } from "./embedded-agent-runner/runs.js";
 import type { AgentInternalEvent } from "./internal-events.js";
 import {
+  INTERNAL_RUNTIME_CONTEXT_BEGIN,
+  INTERNAL_RUNTIME_CONTEXT_END,
+} from "./internal-runtime-context.js";
+import {
   callGateway as runtimeCallGateway,
   dispatchGatewayMethodInProcess as runtimeDispatchGatewayMethodInProcess,
   sendMessage as runtimeSendMessage,
@@ -1210,6 +1214,36 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         sourceReplyDeliveryMode: "message_tool_only",
       });
     }
+  });
+
+  it("sanitizes and bounds text before direct completion fallback delivery", async () => {
+    const callGateway = createPayloadGatewayMock();
+    const sendMessage = createSendMessageMock();
+    const leaked = [
+      "Visible completion",
+      INTERNAL_RUNTIME_CONTEXT_BEGIN,
+      "sourceTool: subagent_announce\nsourceId: video_generate:private",
+      INTERNAL_RUNTIME_CONTEXT_END,
+      "x".repeat(8_000),
+    ].join("\n");
+
+    await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        result: leaked,
+      }),
+    });
+
+    const content = mockCallArg(sendMessage, 0, 0).content;
+    if (typeof content !== "string") {
+      throw new Error("expected direct completion text");
+    }
+    expect(content).toContain("Visible completion");
+    expect(content).not.toContain("subagent_announce");
+    expect(content).not.toContain("video_generate");
+    expect(content.length).toBeLessThanOrEqual(4_096);
   });
 
   it("reports direct completion delivery before post-send transcript mirroring settles", async () => {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -7,6 +7,7 @@ import { clampTimerTimeoutMs } from "@openclaw/normalization-core/number-coercio
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeUniqueTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { completionRequiresMessageToolDelivery } from "../auto-reply/reply/completion-delivery-policy.js";
+import { sanitizePendingFinalDeliveryText } from "../auto-reply/reply/pending-final-delivery.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isFastTestRuntimeEnv } from "../infra/env.js";
 import { isOutboundDeliveryError } from "../infra/outbound/deliver-types.js";
@@ -31,6 +32,7 @@ import {
   isGatewayMessageChannel,
   normalizeMessageChannel,
 } from "../utils/message-channel.js";
+import { sanitizeAgentRunTerminalReplyText } from "./agent-run-terminal-reply.js";
 import { resolveDefaultAgentId } from "./agent-scope-config.js";
 import {
   getAgentCommandDeliveryFailure,
@@ -687,7 +689,10 @@ function resolveTextCompletionDirectFallback(events: readonly AgentInternalEvent
     if (event.status !== "ok") {
       continue;
     }
-    const result = typeof event.result === "string" ? event.result.trim() : "";
+    const result =
+      typeof event.result === "string"
+        ? sanitizeAgentRunTerminalReplyText(sanitizePendingFinalDeliveryText(event.result))
+        : "";
     if (result && result !== "(no output)") {
       return result;
     }

--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -158,15 +158,13 @@ describe("readSubagentOutput", () => {
   });
 
   it.each(["toolUse", "functionCall", "function_call"])(
-    "reports visible tool activity for provider-specific %s transcript blocks",
+    "does not synthesize output from provider-specific %s transcript blocks",
     async (type) => {
       installOutputDeps({
         messages: [{ role: "assistant", content: [{ type, name: "read" }] }],
       });
 
-      await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBe(
-        "1 tool call(s) made without visible output.",
-      );
+      await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
     },
   );
 
@@ -265,7 +263,7 @@ describe("readSubagentOutput", () => {
     await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
   });
 
-  it("reports only tool calls belonging to the latest user turn", async () => {
+  it("does not synthesize output from tool calls in the latest user turn", async () => {
     installOutputDeps({
       messages: [
         {
@@ -280,9 +278,7 @@ describe("readSubagentOutput", () => {
       ],
     });
 
-    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBe(
-      "1 tool call(s) made without visible output.",
-    );
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
   });
 
   it("does not fall back to tool output when the last assistant turn is empty", async () => {

--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -168,6 +168,42 @@ describe("readSubagentOutput", () => {
     },
   );
 
+  it.each(["toolUse", "functionCall", "function_call"])(
+    "summarizes provider-specific %s transcript blocks after a timeout",
+    async (type) => {
+      installOutputDeps({
+        messages: [{ role: "assistant", content: [{ type, name: "read" }] }],
+      });
+
+      await expect(
+        readSubagentOutput("agent:main:subagent:child", { status: "timeout" }),
+      ).resolves.toBe("1 tool call(s) made without visible output.");
+    },
+  );
+
+  it.each(["toolCalls", "tool_calls"])("summarizes top-level %s after a timeout", async (field) => {
+    installOutputDeps({
+      messages: [{ role: "assistant", [field]: [{ name: "read" }, { name: "exec" }] }],
+    });
+
+    await expect(
+      readSubagentOutput("agent:main:subagent:child", { status: "timeout" }),
+    ).resolves.toBe("2 tool call(s) made without visible output.");
+  });
+
+  it("keeps an intentional silent reply ahead of timeout tool progress", async () => {
+    installOutputDeps({
+      messages: [
+        { role: "assistant", content: [{ type: "toolCall", name: "read" }] },
+        { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+      ],
+    });
+
+    await expect(
+      readSubagentOutput("agent:main:subagent:child", { status: "timeout" }),
+    ).resolves.toBe("NO_REPLY");
+  });
+
   it("returns final assistant output that arrives after a sessions_yield wait turn", async () => {
     installOutputDeps({
       messages: [
@@ -279,6 +315,29 @@ describe("readSubagentOutput", () => {
     });
 
     await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
+  });
+
+  it("resets timeout tool progress at the latest user turn", async () => {
+    installOutputDeps({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "old-read", name: "read", arguments: {} },
+            { type: "toolCall", id: "old-exec", name: "exec", arguments: {} },
+          ],
+        },
+        { role: "user", content: [{ type: "text", text: "Start the next task." }] },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "current-call", name: "write", arguments: {} }],
+        },
+      ],
+    });
+
+    await expect(
+      readSubagentOutput("agent:main:subagent:child", { status: "timeout" }),
+    ).resolves.toBe("1 tool call(s) made without visible output.");
   });
 
   it("does not fall back to tool output when the last assistant turn is empty", async () => {

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -33,14 +33,6 @@ const MAX_CHILD_COMPLETION_RESULT_CHARS = 512;
 const MAX_CHILD_COMPLETION_FIELD_CHARS = 256;
 const MAX_CHILD_COMPLETION_FINDINGS_CHARS = 4_096;
 const CHILD_RESULT_TRUNCATION_NOTICE = "\n[child result truncated]";
-const ASSISTANT_TOOL_CALL_BLOCK_TYPES = new Set([
-  "toolCall",
-  "tool_use",
-  "toolUse",
-  "functionCall",
-  "function_call",
-]);
-
 type SubagentAnnounceOutputDeps = {
   callGateway: typeof callGateway;
   getRuntimeConfig: typeof getRuntimeConfig;
@@ -68,7 +60,6 @@ function isFastTestMode() {
 type SubagentOutputSnapshot = {
   latestAssistantText?: string;
   latestSilentText?: string;
-  latestToolCallCount?: number;
   waitingForContinuation?: boolean;
 };
 
@@ -130,25 +121,6 @@ function extractSubagentAssistantText(message: unknown): string {
   return extractAssistantText(message) ?? "";
 }
 
-function countAssistantToolCalls(message: unknown): number {
-  if (!message || typeof message !== "object") {
-    return 0;
-  }
-  const content = (message as { content?: unknown }).content;
-  const contentToolCalls = Array.isArray(content)
-    ? content.filter(
-        (block) =>
-          block &&
-          typeof block === "object" &&
-          ASSISTANT_TOOL_CALL_BLOCK_TYPES.has((block as { type?: string }).type ?? ""),
-      ).length
-    : 0;
-  const toolCalls =
-    (message as { toolCalls?: unknown; tool_calls?: unknown }).toolCalls ??
-    (message as { tool_calls?: unknown }).tool_calls;
-  return contentToolCalls + (Array.isArray(toolCalls) ? toolCalls.length : 0);
-}
-
 function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutputSnapshot {
   const snapshot: SubagentOutputSnapshot = {};
   let previousAssistantCalledYield = false;
@@ -169,7 +141,6 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
       // when the current run fails or completes without visible output.
       snapshot.latestAssistantText = undefined;
       snapshot.latestSilentText = undefined;
-      snapshot.latestToolCallCount = undefined;
       snapshot.waitingForContinuation = false;
       previousAssistantCalledYield = false;
       continue;
@@ -184,8 +155,6 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
       }
       const text = extractSubagentAssistantText(message).trim();
       if (!text) {
-        snapshot.latestToolCallCount =
-          (snapshot.latestToolCallCount ?? 0) + countAssistantToolCalls(message);
         snapshot.waitingForContinuation = false;
         previousAssistantCalledYield = false;
         continue;
@@ -224,9 +193,6 @@ function selectSubagentOutputText(snapshot: SubagentOutputSnapshot): string | un
   }
   if (snapshot.latestAssistantText) {
     return snapshot.latestAssistantText;
-  }
-  if (snapshot.latestToolCallCount && snapshot.latestToolCallCount > 0) {
-    return `${snapshot.latestToolCallCount} tool call(s) made without visible output.`;
   }
   return undefined;
 }

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -33,6 +33,13 @@ const MAX_CHILD_COMPLETION_RESULT_CHARS = 512;
 const MAX_CHILD_COMPLETION_FIELD_CHARS = 256;
 const MAX_CHILD_COMPLETION_FINDINGS_CHARS = 4_096;
 const CHILD_RESULT_TRUNCATION_NOTICE = "\n[child result truncated]";
+const ASSISTANT_TOOL_CALL_BLOCK_TYPES = new Set([
+  "toolCall",
+  "tool_use",
+  "toolUse",
+  "functionCall",
+  "function_call",
+]);
 type SubagentAnnounceOutputDeps = {
   callGateway: typeof callGateway;
   getRuntimeConfig: typeof getRuntimeConfig;
@@ -60,6 +67,7 @@ function isFastTestMode() {
 type SubagentOutputSnapshot = {
   latestAssistantText?: string;
   latestSilentText?: string;
+  latestToolCallCount?: number;
   waitingForContinuation?: boolean;
 };
 
@@ -121,6 +129,25 @@ function extractSubagentAssistantText(message: unknown): string {
   return extractAssistantText(message) ?? "";
 }
 
+function countAssistantToolCalls(message: unknown): number {
+  if (!message || typeof message !== "object") {
+    return 0;
+  }
+  const content = (message as { content?: unknown }).content;
+  const contentToolCalls = Array.isArray(content)
+    ? content.filter(
+        (block) =>
+          block &&
+          typeof block === "object" &&
+          ASSISTANT_TOOL_CALL_BLOCK_TYPES.has((block as { type?: string }).type ?? ""),
+      ).length
+    : 0;
+  const toolCalls =
+    (message as { toolCalls?: unknown; tool_calls?: unknown }).toolCalls ??
+    (message as { tool_calls?: unknown }).tool_calls;
+  return contentToolCalls + (Array.isArray(toolCalls) ? toolCalls.length : 0);
+}
+
 function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutputSnapshot {
   const snapshot: SubagentOutputSnapshot = {};
   let previousAssistantCalledYield = false;
@@ -141,6 +168,7 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
       // when the current run fails or completes without visible output.
       snapshot.latestAssistantText = undefined;
       snapshot.latestSilentText = undefined;
+      snapshot.latestToolCallCount = undefined;
       snapshot.waitingForContinuation = false;
       previousAssistantCalledYield = false;
       continue;
@@ -155,6 +183,8 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
       }
       const text = extractSubagentAssistantText(message).trim();
       if (!text) {
+        snapshot.latestToolCallCount =
+          (snapshot.latestToolCallCount ?? 0) + countAssistantToolCalls(message);
         snapshot.waitingForContinuation = false;
         previousAssistantCalledYield = false;
         continue;
@@ -184,7 +214,10 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
   return snapshot;
 }
 
-function selectSubagentOutputText(snapshot: SubagentOutputSnapshot): string | undefined {
+function selectSubagentOutputText(
+  snapshot: SubagentOutputSnapshot,
+  outcome?: SubagentRunOutcome,
+): string | undefined {
   if (snapshot.waitingForContinuation) {
     return undefined;
   }
@@ -194,12 +227,21 @@ function selectSubagentOutputText(snapshot: SubagentOutputSnapshot): string | un
   if (snapshot.latestAssistantText) {
     return snapshot.latestAssistantText;
   }
+  // Tool activity is partial-progress evidence only for a timed-out run. It is
+  // not authoritative completion output when producer terminal facts are absent.
+  if (
+    outcome?.status === "timeout" &&
+    snapshot.latestToolCallCount &&
+    snapshot.latestToolCallCount > 0
+  ) {
+    return `${snapshot.latestToolCallCount} tool call(s) made without visible output.`;
+  }
   return undefined;
 }
 
 export async function readSubagentOutput(
   sessionKey: string,
-  _outcome?: SubagentRunOutcome,
+  outcome?: SubagentRunOutcome,
   options?: { sessionTarget?: SessionTranscriptRuntimeTarget },
 ): Promise<string | undefined> {
   let messages: unknown[] | undefined;
@@ -223,7 +265,7 @@ export async function readSubagentOutput(
       : undefined;
   const sourceMessages = messages ?? (Array.isArray(history?.messages) ? history.messages : []);
   const snapshot = summarizeSubagentOutputHistory(sourceMessages);
-  const selected = selectSubagentOutputText(snapshot);
+  const selected = selectSubagentOutputText(snapshot, outcome);
   if (selected?.trim()) {
     return selected;
   }
@@ -242,6 +284,20 @@ export async function readLatestSubagentOutputWithRetry(params: {
     retryIntervalMs: isFastTestMode() ? FAST_TEST_RETRY_INTERVAL_MS : 100,
     readSubagentOutput,
   });
+}
+
+export async function readSubagentTimeoutProgress(
+  sessionKey: string,
+  maxWaitMs: number,
+  outcome: SubagentRunOutcome,
+): Promise<string | undefined> {
+  const initial = await readSubagentOutput(sessionKey, outcome);
+  const progress = initial?.trim()
+    ? initial
+    : await readLatestSubagentOutputWithRetry({ sessionKey, maxWaitMs, outcome });
+  return progress && !isAnnounceSkip(progress) && !isSilentReplyText(progress, SILENT_REPLY_TOKEN)
+    ? progress
+    : undefined;
 }
 
 export async function waitForSubagentRunOutcome(

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -914,23 +914,48 @@ describe("subagent announce formatting", () => {
     expect(agentSpy).not.toHaveBeenCalled();
   });
 
-  it("records producer-owned empty output without consulting transcript fallback", async () => {
-    const didAnnounce = await runSubagentAnnounceFlow({
-      childSessionKey: "agent:main:subagent:test",
-      childRunId: "run-direct-completion-empty",
-      requesterSessionKey: "agent:main:main",
-      requesterDisplayKey: "main",
-      requesterOrigin: { channel: "slack", to: "channel:C123", accountId: "acct-1" },
-      ...defaultOutcomeAnnounce,
-      expectsCompletionMessage: true,
-      terminalReply: { disposition: "empty" },
-    });
+  it.each([
+    {
+      name: "visible",
+      terminalReply: { disposition: "visible", text: "restored visible reply" } as const,
+      expectedAgentCalls: 1,
+      expectedMessage: "restored visible reply",
+    },
+    {
+      name: "silent",
+      terminalReply: { disposition: "silent" } as const,
+      expectedAgentCalls: 0,
+      expectedMessage: undefined,
+    },
+    {
+      name: "empty",
+      terminalReply: { disposition: "empty" } as const,
+      expectedAgentCalls: 1,
+      expectedMessage: "(no output)",
+    },
+  ])(
+    "replays restored durable $name output without transcript inference",
+    async ({ name, terminalReply, expectedAgentCalls, expectedMessage }) => {
+      const didAnnounce = await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:test",
+        childRunId: `run-restored-completion-${name}`,
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        requesterOrigin: { channel: "slack", to: "channel:C123", accountId: "acct-1" },
+        ...defaultOutcomeAnnounce,
+        expectsCompletionMessage: true,
+        terminalReply,
+      });
 
-    expect(didAnnounce).toBe(true);
-    expect(chatHistoryMock).not.toHaveBeenCalled();
-    expect(readLatestAssistantReplyMock).not.toHaveBeenCalled();
-    expect(getAgentCall()?.params?.message).toContain("(no output)");
-  });
+      expect(didAnnounce).toBe(true);
+      expect(chatHistoryMock).not.toHaveBeenCalled();
+      expect(readLatestAssistantReplyMock).not.toHaveBeenCalled();
+      expect(agentSpy).toHaveBeenCalledTimes(expectedAgentCalls);
+      if (expectedMessage) {
+        expect(getAgentCall()?.params?.message).toContain(expectedMessage);
+      }
+    },
+  );
 
   it("uses fallback reply when wake continuation returns NO_REPLY", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -914,6 +914,24 @@ describe("subagent announce formatting", () => {
     expect(agentSpy).not.toHaveBeenCalled();
   });
 
+  it("records producer-owned empty output without consulting transcript fallback", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-completion-empty",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "slack", to: "channel:C123", accountId: "acct-1" },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      terminalReply: { disposition: "empty" },
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(chatHistoryMock).not.toHaveBeenCalled();
+    expect(readLatestAssistantReplyMock).not.toHaveBeenCalled();
+    expect(getAgentCall()?.params?.message).toContain("(no output)");
+  });
+
   it("uses fallback reply when wake continuation returns NO_REPLY", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:test",

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -469,6 +469,80 @@ describe("subagent announce timeout config", () => {
     expect(internalEvents[0]?.result).not.toContain("data");
   });
 
+  it("uses timeout progress without replacing an authoritative empty terminal fact", async () => {
+    chatHistoryMessages = [
+      { role: "user", content: "do a complex task" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
+      },
+      { role: "toolResult", toolCallId: "call-1", content: "private tool output" },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-empty-terminal-progress", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+      terminalReply: { disposition: "empty" },
+    });
+
+    const directAgentCall = findFinalDirectAgentCall();
+    const internalEvents =
+      (directAgentCall?.params?.internalEvents as Array<{ result?: string }>) ?? [];
+    expect(internalEvents[0]?.result).toBe("1 tool call(s) made without visible output.");
+    expect(internalEvents[0]?.result).not.toContain("private tool output");
+  });
+
+  it("keeps authoritative visible timeout output without transcript inference", async () => {
+    chatHistoryMessages = [
+      { role: "assistant", content: [{ type: "text", text: "stale transcript output" }] },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-visible-terminal", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+      terminalReply: { disposition: "visible", text: "authoritative progress" },
+    });
+
+    const directAgentCall = findFinalDirectAgentCall();
+    const internalEvents =
+      (directAgentCall?.params?.internalEvents as Array<{ result?: string }>) ?? [];
+    expect(internalEvents[0]?.result).toBe("authoritative progress");
+    expect(gatewayCalls.some((call) => call.method === "chat.history")).toBe(false);
+  });
+
+  it("keeps authoritative silence on timeout without transcript inference", async () => {
+    chatHistoryMessages = [
+      { role: "assistant", content: [{ type: "text", text: "stale transcript output" }] },
+    ];
+
+    await runAnnounceFlowForTest("run-timeout-silent-terminal", {
+      outcome: { status: "timeout" },
+      roundOneReply: undefined,
+      terminalReply: { disposition: "silent" },
+    });
+
+    expect(findFinalDirectAgentCall()).toBeUndefined();
+    expect(gatewayCalls.some((call) => call.method === "chat.history")).toBe(false);
+  });
+
+  it("keeps authoritative empty success intentional without transcript inference", async () => {
+    chatHistoryMessages = [
+      { role: "assistant", content: [{ type: "text", text: "stale transcript output" }] },
+    ];
+
+    await runAnnounceFlowForTest("run-ok-empty-terminal", {
+      outcome: { status: "ok" },
+      roundOneReply: undefined,
+      terminalReply: { disposition: "empty" },
+    });
+
+    const directAgentCall = findFinalDirectAgentCall();
+    const internalEvents =
+      (directAgentCall?.params?.internalEvents as Array<{ result?: string }>) ?? [];
+    expect(internalEvents[0]?.result).toBe("(no output)");
+    expect(gatewayCalls.some((call) => call.method === "chat.history")).toBe(false);
+  });
+
   it("keeps delete-mode timeout retryable while the embedded child request is still active", async () => {
     sessionStore["agent:main:subagent:worker"] = {
       sessionId: "child-session",

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -22,6 +22,7 @@ import { isCronSessionKey } from "../sessions/session-key-utils.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
+import type { AgentRunTerminalReplySnapshot } from "./agent-run-terminal-reply.js";
 import {
   buildAnnounceIdFromChildRun,
   buildAnnounceIdempotencyKey,
@@ -286,6 +287,7 @@ export async function runSubagentAnnounceFlow(params: {
   timeoutMs: number;
   cleanup: "delete" | "keep";
   roundOneReply?: string;
+  terminalReply?: AgentRunTerminalReplySnapshot;
   /**
    * Fallback text preserved from the pre-wake run when a wake continuation
    * completes with NO_REPLY despite an earlier final summary already existing.
@@ -337,7 +339,12 @@ export async function runSubagentAnnounceFlow(params: {
         ? childSessionEntry.lifecycleRevision.trim()
         : undefined;
     const settleTimeoutMs = Math.min(Math.max(params.timeoutMs, 1), 120_000);
-    let reply = params.roundOneReply;
+    let reply =
+      params.terminalReply?.disposition === "visible"
+        ? params.terminalReply.text
+        : params.terminalReply?.disposition === "silent"
+          ? SILENT_REPLY_TOKEN
+          : params.roundOneReply;
     let outcome: SubagentRunOutcome | undefined = params.outcome;
     if (childSessionId && isEmbeddedAgentRunActive(childSessionId)) {
       const settled = await waitForEmbeddedAgentRunEnd(childSessionId, settleTimeoutMs);
@@ -369,7 +376,7 @@ export async function runSubagentAnnounceFlow(params: {
     const failedTerminalOutcome = outcome.status === "error";
     const allowFailedOutputCapture =
       !failedTerminalOutcome || (!params.roundOneReply && !params.fallbackReply);
-    if (failedTerminalOutcome) {
+    if (failedTerminalOutcome && !params.terminalReply) {
       reply = undefined;
     }
     let requesterDepth = getSubagentDepthFromSessionStore(targetRequesterSessionKey);
@@ -457,55 +464,70 @@ export async function runSubagentAnnounceFlow(params: {
     }
 
     if (!childCompletionFindings) {
-      const fallbackReply = failedTerminalOutcome
-        ? undefined
-        : normalizeOptionalString(params.fallbackReply);
-      const fallbackIsSilent =
-        Boolean(fallbackReply) &&
-        (isAnnounceSkip(fallbackReply) || isSilentReplyText(fallbackReply, SILENT_REPLY_TOKEN));
-
-      if (childSessionEffectsAllowed() && !reply && allowFailedOutputCapture) {
-        reply = await readSubagentOutput(params.childSessionKey, outcome);
+      if (params.terminalReply?.disposition === "silent") {
+        return true;
       }
+      if (!params.terminalReply) {
+        const fallbackReply = failedTerminalOutcome
+          ? undefined
+          : normalizeOptionalString(params.fallbackReply);
+        const fallbackIsSilent =
+          Boolean(fallbackReply) &&
+          (isAnnounceSkip(fallbackReply) || isSilentReplyText(fallbackReply, SILENT_REPLY_TOKEN));
 
-      if (childSessionEffectsAllowed() && !reply?.trim() && allowFailedOutputCapture) {
-        reply = await readLatestSubagentOutputWithRetry({
-          sessionKey: params.childSessionKey,
-          maxWaitMs: params.timeoutMs,
-          outcome,
-        });
-      }
-
-      if (!reply?.trim() && fallbackReply && !fallbackIsSilent) {
-        reply = fallbackReply;
-      }
-
-      // A worker can finish just after the first wait request timed out.
-      // If we already have real completion content, do one cached recheck so
-      // the final completion event prefers the authoritative terminal state.
-      // This is best-effort; if the recheck fails, keep the known timeout
-      // outcome instead of dropping the announcement entirely.
-      if (outcome?.status === "timeout" && reply?.trim() && params.waitForCompletion !== false) {
-        try {
-          const rechecked = await waitForSubagentRunOutcome(params.childRunId, 0);
-          const applied = applySubagentWaitOutcome({
-            wait: rechecked,
-            outcome,
-            startedAt: params.startedAt,
-            endedAt: params.endedAt,
-          });
-          outcome = applied.outcome;
-          params.startedAt = applied.startedAt;
-          params.endedAt = applied.endedAt;
-        } catch {
-          // Best-effort recheck; keep the existing timeout outcome on failure.
+        if (childSessionEffectsAllowed() && !reply && allowFailedOutputCapture) {
+          reply = await readSubagentOutput(params.childSessionKey, outcome);
         }
-      }
 
-      if (isAnnounceSkip(reply) || isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
-        if (fallbackReply && !fallbackIsSilent) {
-          const cleaned = stripAndClassifyReply(fallbackReply);
-          if (cleaned === null) {
+        if (childSessionEffectsAllowed() && !reply?.trim() && allowFailedOutputCapture) {
+          reply = await readLatestSubagentOutputWithRetry({
+            sessionKey: params.childSessionKey,
+            maxWaitMs: params.timeoutMs,
+            outcome,
+          });
+        }
+
+        if (!reply?.trim() && fallbackReply && !fallbackIsSilent) {
+          reply = fallbackReply;
+        }
+
+        // A worker can finish just after the first wait request timed out.
+        // If we already have real completion content, do one cached recheck so
+        // the final completion event prefers the authoritative terminal state.
+        // This is best-effort; if the recheck fails, keep the known timeout
+        // outcome instead of dropping the announcement entirely.
+        if (outcome?.status === "timeout" && reply?.trim() && params.waitForCompletion !== false) {
+          try {
+            const rechecked = await waitForSubagentRunOutcome(params.childRunId, 0);
+            const applied = applySubagentWaitOutcome({
+              wait: rechecked,
+              outcome,
+              startedAt: params.startedAt,
+              endedAt: params.endedAt,
+            });
+            outcome = applied.outcome;
+            params.startedAt = applied.startedAt;
+            params.endedAt = applied.endedAt;
+          } catch {
+            // Best-effort recheck; keep the existing timeout outcome on failure.
+          }
+        }
+
+        if (isAnnounceSkip(reply) || isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
+          if (fallbackReply && !fallbackIsSilent) {
+            const cleaned = stripAndClassifyReply(fallbackReply);
+            if (cleaned === null) {
+              if (isAnnounceSkip(reply) && isCronSessionKey(targetRequesterSessionKey)) {
+                logWarn(
+                  `cron job completion for session=${targetRequesterSessionKey} ` +
+                    `run=${params.childRunId} suppressed by ANNOUNCE_SKIP; ` +
+                    `the agent replied with the skip sentinel instead of delivering a result`,
+                );
+              }
+              return true;
+            }
+            reply = cleaned;
+          } else {
             if (isAnnounceSkip(reply) && isCronSessionKey(targetRequesterSessionKey)) {
               logWarn(
                 `cron job completion for session=${targetRequesterSessionKey} ` +
@@ -515,31 +537,21 @@ export async function runSubagentAnnounceFlow(params: {
             }
             return true;
           }
-          reply = cleaned;
-        } else {
-          if (isAnnounceSkip(reply) && isCronSessionKey(targetRequesterSessionKey)) {
-            logWarn(
-              `cron job completion for session=${targetRequesterSessionKey} ` +
-                `run=${params.childRunId} suppressed by ANNOUNCE_SKIP; ` +
-                `the agent replied with the skip sentinel instead of delivering a result`,
-            );
-          }
-          return true;
-        }
-      } else if (reply) {
-        const cleaned = stripAndClassifyReply(reply);
-        if (cleaned === null) {
-          if (fallbackReply && !fallbackIsSilent) {
-            const cleanedFallback = stripAndClassifyReply(fallbackReply);
-            if (cleanedFallback === null) {
+        } else if (reply) {
+          const cleaned = stripAndClassifyReply(reply);
+          if (cleaned === null) {
+            if (fallbackReply && !fallbackIsSilent) {
+              const cleanedFallback = stripAndClassifyReply(fallbackReply);
+              if (cleanedFallback === null) {
+                return true;
+              }
+              reply = cleanedFallback;
+            } else {
               return true;
             }
-            reply = cleanedFallback;
           } else {
-            return true;
+            reply = cleaned;
           }
-        } else {
-          reply = cleaned;
         }
       }
     }

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -48,6 +48,7 @@ import {
   filterCurrentDirectChildCompletionRows,
   readLatestSubagentOutputWithRetry,
   readSubagentOutput,
+  readSubagentTimeoutProgress,
   type SubagentRunOutcome,
   waitForSubagentRunOutcome,
 } from "./subagent-announce-output.js";
@@ -466,6 +467,18 @@ export async function runSubagentAnnounceFlow(params: {
     if (!childCompletionFindings) {
       if (params.terminalReply?.disposition === "silent") {
         return true;
+      }
+      if (params.terminalReply?.disposition === "empty" && outcome.status === "timeout") {
+        const timeoutProgress = await readSubagentTimeoutProgress(
+          params.childSessionKey,
+          params.timeoutMs,
+          outcome,
+        );
+        // Empty remains the authoritative terminal fact. Transcript text is a
+        // timeout-only progress hint and must never reclassify silence as output.
+        if (timeoutProgress) {
+          reply = stripAndClassifyReply(timeoutProgress) ?? undefined;
+        }
       }
       if (!params.terminalReply) {
         const fallbackReply = failedTerminalOutcome

--- a/src/agents/subagent-delivery-state.ts
+++ b/src/agents/subagent-delivery-state.ts
@@ -1,3 +1,4 @@
+import { normalizeAgentRunTerminalReplySnapshot } from "./agent-run-terminal-reply.js";
 import type {
   SubagentCompletionDeliveryState,
   SubagentCompletionState,
@@ -32,6 +33,11 @@ export function normalizeSubagentRunState(entry: SubagentRunRecord): SubagentRun
     entry.pauseReason !== "sessions_yield"
       ? "interrupted-recovery"
       : undefined;
+  if (entry.completion) {
+    entry.completion.terminalReply = normalizeAgentRunTerminalReplySnapshot(
+      entry.completion.terminalReply,
+    );
+  }
   const killReconciliation = entry.killReconciliation;
   if (
     !killReconciliation ||

--- a/src/agents/subagent-registry-lifecycle-cleanup.ts
+++ b/src/agents/subagent-registry-lifecycle-cleanup.ts
@@ -552,6 +552,7 @@ export function createSubagentRegistryLifecycleCleanup(
       timeoutMs: params.subagentAnnounceTimeoutMs,
       cleanup: suppressSessionEffects ? "keep" : cleanup,
       roundOneReply: pendingPayload.frozenResultText ?? undefined,
+      terminalReply: pendingPayload.terminalReply,
       fallbackReply: pendingPayload.fallbackFrozenResultText ?? undefined,
       waitForCompletion: false,
       startedAt: pendingPayload.startedAt,

--- a/src/agents/subagent-registry-lifecycle-completion.ts
+++ b/src/agents/subagent-registry-lifecycle-completion.ts
@@ -1,5 +1,5 @@
-import { isAgentEventLifecycleGenerationCurrent } from "../infra/agent-events.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { isAgentEventLifecycleGenerationCurrent } from "../infra/agent-events.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { recordSubagentTerminalState } from "../sessions/session-state-events.js";
 import type { DetachedTaskFindResult } from "../tasks/detached-task-runtime-contract.js";

--- a/src/agents/subagent-registry-lifecycle-completion.ts
+++ b/src/agents/subagent-registry-lifecycle-completion.ts
@@ -1,8 +1,10 @@
 import { isAgentEventLifecycleGenerationCurrent } from "../infra/agent-events.js";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { recordSubagentTerminalState } from "../sessions/session-state-events.js";
 import type { DetachedTaskFindResult } from "../tasks/detached-task-runtime-contract.js";
 import { isProvisionalSubagentKillTask } from "../tasks/task-cancellation-state.js";
+import { mergeAgentRunTerminalReplySnapshot } from "./agent-run-terminal-reply.js";
 import { type SubagentRunOutcome, withSubagentOutcomeTiming } from "./subagent-announce-output.js";
 import { clearDeliveryState, ensureCompletionState } from "./subagent-delivery-state.js";
 import {
@@ -412,6 +414,28 @@ export function createSubagentRegistryLifecycleCompletion(
         ) {
           completion.resultText = completeParams.completionSnapshot.resultText;
           completion.capturedAt = completeParams.completionSnapshot.capturedAt;
+          mutated = true;
+        }
+      }
+
+      if (completeParams.terminalReply) {
+        const completion = ensureCompletionState(entry);
+        const terminalReply = mergeAgentRunTerminalReplySnapshot(
+          completion.terminalReply,
+          completeParams.terminalReply,
+        );
+        if (
+          terminalReply &&
+          JSON.stringify(terminalReply) !== JSON.stringify(completion.terminalReply)
+        ) {
+          completion.terminalReply = terminalReply;
+          completion.resultText =
+            terminalReply.disposition === "visible"
+              ? terminalReply.text
+              : terminalReply.disposition === "silent"
+                ? SILENT_REPLY_TOKEN
+                : null;
+          completion.capturedAt = endedAt;
           mutated = true;
         }
       }

--- a/src/agents/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagent-registry-lifecycle-delivery.ts
@@ -444,6 +444,7 @@ export function createSubagentRegistryLifecycleDelivery(
         entry.delivery?.payload?.fallbackFrozenResultText ?? entry.completion?.fallbackResultText,
       wakeOnDescendantSettle:
         entry.delivery?.payload?.wakeOnDescendantSettle ?? entry.wakeOnDescendantSettle,
+      terminalReply: entry.delivery?.payload?.terminalReply ?? entry.completion?.terminalReply,
     };
   };
 
@@ -476,6 +477,7 @@ export function createSubagentRegistryLifecycleDelivery(
       outcome: entry.execution.outcome,
       frozenResultText: entry.completion?.resultText,
       fallbackFrozenResultText: entry.completion?.fallbackResultText,
+      terminalReply: entry.completion?.terminalReply,
     };
     return true;
   };

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -417,6 +417,64 @@ describe("subagent registry lifecycle hardening", () => {
     });
   });
 
+  it.each([
+    {
+      terminalReply: { disposition: "visible", text: "authoritative final" } as const,
+      resultText: "authoritative final",
+    },
+    {
+      terminalReply: { disposition: "silent" } as const,
+      resultText: "NO_REPLY",
+    },
+    {
+      terminalReply: { disposition: "empty" } as const,
+      resultText: null,
+    },
+  ])(
+    "persists $terminalReply.disposition producer evidence without transcript inference",
+    async ({ terminalReply, resultText }) => {
+      const entry = createRunEntry({ expectsCompletionMessage: true });
+      const captureSubagentCompletionReply = vi.fn(async () => "stale transcript reply");
+      const runSubagentAnnounceFlow = vi.fn(async () => true);
+      const controller = createLifecycleController({
+        entry,
+        captureSubagentCompletionReply,
+        runSubagentAnnounceFlow,
+      });
+
+      await completeRun(controller, entry, {
+        triggerCleanup: true,
+        terminalReply,
+      });
+
+      expect(captureSubagentCompletionReply).not.toHaveBeenCalled();
+      expect(entry.completion).toMatchObject({ terminalReply, resultText });
+      expect(runSubagentAnnounceFlow).toHaveBeenCalledWith(
+        expect.objectContaining({ terminalReply }),
+      );
+    },
+  );
+
+  it("merges late visible reply evidence into an already-terminal completion", async () => {
+    const entry = createRunEntry({ expectsCompletionMessage: true });
+    const captureSubagentCompletionReply = vi.fn(async () => "legacy fallback");
+    const controller = createLifecycleController({ entry, captureSubagentCompletionReply });
+
+    await completeRun(controller, entry, {
+      terminalReply: { disposition: "empty" },
+    });
+    await completeRun(controller, entry, {
+      endedAt: 4_001,
+      terminalReply: { disposition: "visible", text: "late authoritative reply" },
+    });
+
+    expect(entry.completion).toMatchObject({
+      resultText: "late authoritative reply",
+      terminalReply: { disposition: "visible", text: "late authoritative reply" },
+    });
+    expect(captureSubagentCompletionReply).not.toHaveBeenCalled();
+  });
+
   it("runs detached cleanup outside a disposed requester transcript owner", async () => {
     const sessionKey = "agent:main:disposed-cleanup-owner";
     const entry = createRunEntry({

--- a/src/agents/subagent-registry-listener.ts
+++ b/src/agents/subagent-registry-listener.ts
@@ -6,6 +6,7 @@ import {
   isAbandonedLivenessState,
   isBlockedLivenessState,
 } from "../shared/agent-liveness.js";
+import { normalizeAgentRunTerminalReplySnapshot } from "./agent-run-terminal-reply.js";
 import { isAbortedAgentStopReason } from "./run-termination.js";
 import {
   SUBAGENT_ENDED_REASON_COMPLETE,
@@ -86,6 +87,7 @@ export function createSubagentRegistryListener(config: {
           typeof evt.data?.livenessState === "string" ? evt.data.livenessState : undefined;
         const stopReason =
           typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
+        const terminalReply = normalizeAgentRunTerminalReplySnapshot(evt.data?.terminalReply);
         // sessions_yield ends the turn by aborting the run signal, so a yielded
         // terminal can also look aborted. An explicit yield is authoritative — pause,
         // don't kill — else the tracking task settles `cancelled` with a false notice (#92448).
@@ -119,6 +121,7 @@ export function createSubagentRegistryListener(config: {
               accountId: entry.requesterOrigin?.accountId,
               triggerCleanup: true,
               startedAt,
+              terminalReply,
             },
             "lifecycle-killed-event",
           );
@@ -129,6 +132,7 @@ export function createSubagentRegistryListener(config: {
             runId: evt.runId,
             endedAt,
             startedAt,
+            terminalReply,
             error,
           });
           return;
@@ -151,6 +155,7 @@ export function createSubagentRegistryListener(config: {
             accountId: entry.requesterOrigin?.accountId,
             triggerCleanup: true,
             startedAt,
+            terminalReply,
           };
           await completeSubagentRunWithRecovery(
             blockedParams,
@@ -163,6 +168,7 @@ export function createSubagentRegistryListener(config: {
             runId: evt.runId,
             endedAt,
             startedAt,
+            terminalReply,
           });
           return;
         }
@@ -176,6 +182,7 @@ export function createSubagentRegistryListener(config: {
           accountId: entry.requesterOrigin?.accountId,
           triggerCleanup: true,
           startedAt,
+          terminalReply,
         };
         await completeSubagentRunWithRecovery(completionParams, "lifecycle-ok-event");
       })().catch((err: unknown) => {

--- a/src/agents/subagent-registry-pending-lifecycle.ts
+++ b/src/agents/subagent-registry-pending-lifecycle.ts
@@ -15,6 +15,7 @@ type PendingLifecycleTerminal = {
   endedAt: number;
   startedAt?: number;
   error?: string;
+  terminalReply?: SubagentCompletionRequest["terminalReply"];
 };
 
 export function createPendingLifecycleScheduler(params: {
@@ -39,7 +40,13 @@ export function createPendingLifecycleScheduler(params: {
 
   function schedule(
     kind: PendingLifecycleKind,
-    scheduleParams: { runId: string; endedAt: number; startedAt?: number; error?: string },
+    scheduleParams: {
+      runId: string;
+      endedAt: number;
+      startedAt?: number;
+      error?: string;
+      terminalReply?: SubagentCompletionRequest["terminalReply"];
+    },
   ) {
     clearKind(scheduleParams.runId);
     const timer = setTimeout(() => {
@@ -71,6 +78,7 @@ export function createPendingLifecycleScheduler(params: {
           accountId: entry.requesterOrigin?.accountId,
           triggerCleanup: true,
           startedAt: pending.startedAt,
+          terminalReply: pending.terminalReply,
         },
         `lifecycle-${kind}-grace`,
       );

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -422,6 +422,7 @@ export function createSubagentRunManager(params: {
           sendFarewell: true,
           accountId: entry.requesterOrigin?.accountId,
           triggerCleanup: true,
+          terminalReply: wait.terminalReply,
         };
         if (typeof endedAt === "number") {
           timeoutCompletion.endedAt = endedAt;

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -40,7 +40,6 @@ import {
   SUBAGENT_ENDED_REASON_COMPLETE,
   SUBAGENT_ENDED_REASON_ERROR,
   SUBAGENT_ENDED_REASON_KILLED,
-  type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
 import { shouldSuppressSubagentRecoverySessionEffects } from "./subagent-recovery-state.js";
 import {
@@ -53,6 +52,7 @@ import {
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
 import type {
+  SubagentCompletionRequest,
   SubagentProgressOrigin,
   SubagentRestartRecoveryReceipt,
   SubagentRunRecord,
@@ -212,6 +212,7 @@ export function markSubagentRunPausedAfterYield(params: {
   if (completion.resultText !== undefined) {
     completion.resultText = undefined;
     completion.capturedAt = undefined;
+    completion.terminalReply = undefined;
     mutated = true;
   }
   return mutated;
@@ -294,16 +295,7 @@ export function createSubagentRunManager(params: {
     preserveTranscript?: boolean;
     provisionalKill?: boolean;
   }): void;
-  completeSubagentRun(args: {
-    runId: string;
-    endedAt?: number;
-    outcome: SubagentRunOutcome;
-    reason: SubagentLifecycleEndedReason;
-    sendFarewell?: boolean;
-    accountId?: string;
-    triggerCleanup: boolean;
-    startedAt?: number;
-  }): Promise<void>;
+  completeSubagentRun(args: SubagentCompletionRequest): Promise<void>;
   resolveSubagentTask(entry: SubagentRunRecord): DetachedTaskFindResult;
 }) {
   const findRunByIdentity = (runId: string): SubagentRunRecord | undefined =>
@@ -543,6 +535,7 @@ export function createSubagentRunManager(params: {
         accountId: entry.requesterOrigin?.accountId,
         triggerCleanup: true,
         startedAt: observedStartedAt,
+        terminalReply: wait.terminalReply,
       };
       await params.completeSubagentRun(completionForRetry);
     } catch (error) {

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -42,6 +42,7 @@ function createRun(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecor
       required: true,
       resultText: "done",
       capturedAt: 260,
+      terminalReply: { disposition: "visible", text: "done" },
     },
     delivery: {
       status: "pending",

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -139,6 +139,68 @@ describe("subagent registry sqlite store", () => {
     });
   });
 
+  it.each([
+    {
+      name: "visible",
+      terminalReply: { disposition: "visible", text: "restart-visible" } as const,
+      resultText: "restart-visible",
+    },
+    {
+      name: "silent",
+      terminalReply: { disposition: "silent" } as const,
+      resultText: "NO_REPLY",
+    },
+    {
+      name: "empty",
+      terminalReply: { disposition: "empty" } as const,
+      resultText: null,
+    },
+  ])(
+    "restores $name terminal reply in completion and pending delivery after restart",
+    async ({ name, terminalReply, resultText }) => {
+      await withTempStateEnv(async () => {
+        const runId = `run-restart-${name}`;
+        const run = createRun({
+          runId,
+          childSessionKey: `agent:main:subagent:${name}`,
+          completion: {
+            required: true,
+            resultText,
+            capturedAt: 260,
+            terminalReply,
+          },
+          delivery: {
+            status: "pending",
+            createdAt: 270,
+            attemptCount: 0,
+            payload: {
+              requesterSessionKey: "agent:main:main",
+              requesterDisplayKey: "main",
+              childSessionKey: `agent:main:subagent:${name}`,
+              childRunId: runId,
+              task: "check terminal reply restart",
+              startedAt: 110,
+              endedAt: 250,
+              outcome: { status: "ok" },
+              expectsCompletionMessage: true,
+              terminalReply,
+            },
+          },
+        });
+
+        saveSubagentRegistryToSqlite(new Map([[runId, run]]));
+        closeOpenClawStateDatabaseForTest();
+
+        const restored = loadSubagentRegistryFromSqlite().get(runId);
+        expect(restored?.completion).toMatchObject({ terminalReply, resultText });
+        expect(restored?.delivery).toMatchObject({
+          status: "pending",
+          payload: { terminalReply },
+        });
+      });
+    },
+  );
+
   it("uses save calls as whole-registry snapshots", async () => {
     await withTempStateEnv(async () => {
       const first = createRun({ runId: "run-one", childSessionKey: "agent:main:subagent:one" });

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -3469,6 +3469,37 @@ describe("subagent registry seam flow", () => {
     expect(run?.execution.outcome?.status).toBe(expectedOutcome.status);
   });
 
+  it("carries producer reply evidence through a provider hard-timeout wait", async () => {
+    mockGatewayMethods(mocks.callGateway, {
+      "agent.wait": {
+        status: "error",
+        startedAt: 100,
+        endedAt: 250,
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: "model timed out",
+        terminalReply: { disposition: "empty" },
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-hard-timeout-terminal-reply",
+      task: "provider timeout reply evidence",
+      expectsCompletionMessage: true,
+    });
+
+    await waitForFast(() => expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1));
+    expect(getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "timeout announce")).toMatchObject({
+      childRunId: "run-hard-timeout-terminal-reply",
+      outcome: { status: "timeout" },
+      terminalReply: { disposition: "empty" },
+    });
+    expect(findRequesterRun("run-hard-timeout-terminal-reply")?.completion).toMatchObject({
+      terminalReply: { disposition: "empty" },
+      resultText: null,
+    });
+  });
+
   it("publishes aborted agent.wait snapshots only after killed reconciliation", async () => {
     mockGatewayMethods(mocks.callGateway, {
       "agent.wait": {

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -1,6 +1,7 @@
 import type { SubagentEndReason } from "../context-engine/types.js";
 /** Persisted execution, completion, delivery, and attachment state for child runs. */
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import type { AgentRunTerminalReplySnapshot } from "./agent-run-terminal-reply.js";
 import type { AgentRunSessionTarget } from "./run-session-target.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import type { SubagentLaunchAuthorization } from "./subagent-launch-authorization.js";
@@ -21,6 +22,7 @@ export type SubagentCompletionRequest = {
   suppressSessionEffects?: boolean;
   recoverInterrupted?: true;
   completionSnapshot?: { resultText: string | null; capturedAt: number };
+  terminalReply?: AgentRunTerminalReplySnapshot;
 };
 
 export type ContextEngineSubagentEndedParams = {
@@ -55,6 +57,7 @@ export type PendingFinalDeliveryPayload = {
   frozenResultText?: string | null;
   fallbackFrozenResultText?: string | null;
   wakeOnDescendantSettle?: boolean;
+  terminalReply?: AgentRunTerminalReplySnapshot;
 };
 
 export type SubagentRestartRecoveryReceipt = {
@@ -89,6 +92,7 @@ export type SubagentCompletionState = {
   capturedAt?: number;
   fallbackResultText?: string | null;
   fallbackCapturedAt?: number;
+  terminalReply?: AgentRunTerminalReplySnapshot;
 };
 
 export type SwarmCollectorStatus = "done" | "failed" | "killed" | "timeout";

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -72,9 +72,11 @@ vi.mock("../agents/command/delivery.runtime.js", () => ({
 vi.mock("../agents/command/attempt-execution.runtime.js", () => {
   const createAcpVisibleTextAccumulator = () => {
     let text = "";
+    let silent = false;
     return {
       consume(chunk: string) {
         if (!chunk || chunk === "NO_REPLY") {
+          silent ||= chunk === "NO_REPLY";
           return null;
         }
         text += chunk;
@@ -82,6 +84,12 @@ vi.mock("../agents/command/attempt-execution.runtime.js", () => {
       },
       finalize: () => text.trim(),
       finalizeRaw: () => text,
+      finalizeReplySnapshot: () =>
+        text
+          ? { disposition: "visible" as const, text }
+          : silent
+            ? { disposition: "silent" as const }
+            : { disposition: "empty" as const },
     };
   };
 

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -10,6 +10,11 @@ import {
   mergeAgentRunTerminalOutcome,
   type AgentRunTerminalOutcome,
 } from "../../agents/agent-run-terminal-outcome.js";
+import {
+  mergeAgentRunTerminalReplySnapshot,
+  normalizeAgentRunTerminalReplySnapshot,
+  type AgentRunTerminalReplySnapshot,
+} from "../../agents/agent-run-terminal-reply.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
 import { isNonTerminalAgentRunStatus } from "../../shared/agent-run-status.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
@@ -30,6 +35,7 @@ type AgentJobTerminalSnapshot = {
   pendingError?: boolean;
   timeoutPhase?: AgentRunTerminalOutcome["timeoutPhase"];
   providerStarted?: boolean;
+  terminalReply?: AgentRunTerminalReplySnapshot;
 };
 
 type AgentJobSource = "agent" | "chat" | "lifecycle";
@@ -155,10 +161,23 @@ function mergeSnapshot(
   existing: AgentRunSnapshot | undefined,
   incoming: AgentRunSnapshot,
 ): AgentRunSnapshot {
-  if (!existing || !shouldPreserveTerminalSnapshot(existing, incoming)) {
+  if (!existing) {
     return incoming;
   }
-  return { ...existing, cachedAt: incoming.cachedAt };
+  const terminalReply = mergeAgentRunTerminalReplySnapshot(
+    existing.terminalReply,
+    incoming.terminalReply,
+  );
+  const canonical = shouldPreserveTerminalSnapshot(existing, incoming) ? existing : incoming;
+  // Terminal status precedence and producer reply evidence are independent;
+  // a late sticky timeout must not erase the final reply (or vice versa).
+  return {
+    ...canonical,
+    ...(terminalReply ? { terminalReply } : {}),
+    cachedAt: incoming.cachedAt,
+    recordedAt: incoming.recordedAt,
+    version: incoming.version,
+  };
 }
 
 function notifyAgentRunWaiters(runId: string) {
@@ -280,6 +299,7 @@ function createSnapshotFromLifecycleEvent(params: {
   // Modern explicit stop reasons keep the canonical cancellation projection.
   const legacyBareAbort =
     terminalOutcome.reason === "aborted" && data?.stopReason == null && data?.status == null;
+  const terminalReply = normalizeAgentRunTerminalReplySnapshot(data?.terminalReply);
   return {
     runId,
     source: "lifecycle",
@@ -295,6 +315,7 @@ function createSnapshotFromLifecycleEvent(params: {
     ...(terminalOutcome.providerStarted !== undefined
       ? { providerStarted: terminalOutcome.providerStarted }
       : {}),
+    ...(terminalReply ? { terminalReply } : {}),
     version: nextAgentRunVersion(),
   };
 }
@@ -356,6 +377,7 @@ function parseDedupeObservation(entry: DedupeEntry): DedupeObservation {
         timeoutPhase?: unknown;
         providerStarted?: unknown;
         result?: unknown;
+        terminalReply?: unknown;
       }
     | undefined;
   const status = typeof payload?.status === "string" ? payload.status : undefined;
@@ -374,6 +396,9 @@ function parseDedupeObservation(entry: DedupeEntry): DedupeObservation {
   }
 
   const resultMeta = asOptionalRecord(asOptionalRecord(payload?.result)?.meta);
+  const terminalReply = normalizeAgentRunTerminalReplySnapshot(
+    payload?.terminalReply ?? resultMeta?.terminalReply,
+  );
   const startedAt = asFiniteNumber(payload?.startedAt);
   const endedAt = asFiniteNumber(payload?.endedAt) ?? entry.ts;
   const stopReason = asString(payload?.stopReason) ?? asString(resultMeta?.stopReason);
@@ -407,6 +432,7 @@ function parseDedupeObservation(entry: DedupeEntry): DedupeObservation {
       ...(terminalOutcome.providerStarted !== undefined
         ? { providerStarted: terminalOutcome.providerStarted }
         : {}),
+      ...(terminalReply ? { terminalReply } : {}),
     },
   };
 }
@@ -534,6 +560,7 @@ function publicSnapshot(snapshot: AgentRunObservation): AgentJobTerminalSnapshot
     pendingError: snapshot.pendingError,
     timeoutPhase: snapshot.timeoutPhase,
     providerStarted: snapshot.providerStarted,
+    terminalReply: snapshot.terminalReply,
   };
 }
 

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent } from "../../infra/agent-events.js";
 import type { DedupeEntry } from "../server-shared.js";
 import { setGatewayDedupeEntry } from "./agent-job.js";
 import { agentHandlers } from "./agent.js";
@@ -141,4 +142,61 @@ describe("agent.wait gateway dedupe observations", () => {
       );
     }
   });
+
+  it.each(["lifecycle-first", "dedupe-first"] as const)(
+    "keeps reply evidence when sticky status arrives $0",
+    async (order) => {
+      const runId = `run-reply-merge-${order}`;
+      const dedupe = new Map<string, DedupeEntry>();
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 100 },
+      });
+      const lifecycleEnd = () =>
+        emitAgentEvent({
+          runId,
+          stream: "lifecycle",
+          data: {
+            phase: "end",
+            startedAt: 100,
+            endedAt: 300,
+            terminalReply: { disposition: "visible", text: "canonical reply" },
+          },
+        });
+      const dedupeTimeout = () =>
+        setGatewayDedupeEntry({
+          dedupe,
+          key: `agent:${runId}`,
+          entry: {
+            ts: 200,
+            ok: false,
+            payload: {
+              runId,
+              status: "timeout",
+              startedAt: 100,
+              endedAt: 200,
+              timeoutPhase: "provider",
+            },
+          },
+        });
+
+      for (const observe of order === "lifecycle-first"
+        ? [lifecycleEnd, dedupeTimeout]
+        : [dedupeTimeout, lifecycleEnd]) {
+        observe();
+      }
+
+      const waiter = waitThroughGateway({ runId, timeoutMs: 0 });
+      await waiter.promise;
+      expect(waiter.respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          runId,
+          status: "timeout",
+          terminalReply: { disposition: "visible", text: "canonical reply" },
+        }),
+      );
+    },
+  );
 });

--- a/src/gateway/server-methods/agent-wait.ts
+++ b/src/gateway/server-methods/agent-wait.ts
@@ -47,5 +47,6 @@ export const agentWaitHandler: GatewayRequestHandlers["agent.wait"] = async ({
     pendingError: snapshot.pendingError,
     timeoutPhase: snapshot.timeoutPhase,
     providerStarted: snapshot.providerStarted,
+    terminalReply: snapshot.terminalReply,
   });
 };


### PR DESCRIPTION
Closes #110378

## What Problem This Solves

Registered subagents lost the producer's final reply classification at the lifecycle boundary. Exact intentional silence, genuinely empty output, and visible output could collapse into the same downstream state, causing transcript inference or fabricated tool-count summaries. The exceptional direct-delivery fallback could also send captured child text without the completion path's sanitization and size bound.

## Why This Change Was Made

Record one producer-owned terminal reply snapshot with visible, silent, or empty disposition while the authoritative raw result is still available. Carry that bounded sanitized fact through lifecycle events, agent waiting, durable registry state, restart, and announcement. Keep reply evidence independent of sticky timeout and cancellation precedence, use transcript capture only for legacy missing evidence, suppress only explicit silence, remove synthetic tool-count output, and sanitize the exceptional direct fallback before transport.

The architectural owner is the terminal-reply producer/lifecycle boundary, not the downstream channel. The canonical flow is now producer snapshot -> lifecycle event -> `agent.wait`/durable registry -> announcement. The old synthetic tool-count projection and connected transcript-only inference are removed.

## User Impact

Tool-using subagents now deliver their real final text instead of an invented tool summary. Token-only intentional silence, including punctuation-wrapped forms, remains silent across embedded, CLI, and ACP execution, while genuinely empty completion remains a recorded no-output outcome rather than being mistaken for silence. Durable completion behaves consistently after restart, and direct fallback delivery no longer exposes protected internal metadata or unbounded text.

## Real Behavior Proof

Exact pushed head: `f3d98a88dbafa5695ea301498f498d67cbd15e01`.

[Exact-head CI run 30789927663](https://github.com/openclaw/openclaw/actions/runs/30789927663) ran `subagent-completion-direct-fallback` at that commit through the QA Lab bus, mock OpenAI HTTP provider, ephemeral Gateway child, SQLite-backed task lifecycle, and the real Telegram channel plugin via Crabline. The retained artifact `qa-smoke-profile-profile-2-of-4-30789927663-1` contains `primary/qa-suite-report.md`, `primary/qa-suite-summary.json`, `primary/qa-evidence.json`, and redacted Telegram provider JSONL; the scenario status is `pass`.

Directly inspectable verdict from the run artifact:

```json
{
  "harness": "qa-channel + qa-lab bus + ephemeral Gateway child + mock-openai",
  "visible": { "expected": 1, "actual": 1, "payload": "QA-SUBAGENT-TERMINAL-VISIBLE-OK" },
  "silent": { "expected": 0, "actual": 0, "silenceTokenLeaked": false },
  "fallback": { "expected": 1, "actual": 1, "payload": "QA-SUBAGENT-TERMINAL-FALLBACK-OK", "internalMetadataLeak": false },
  "restart": { "priorTerminalPayloadReplayCount": 0, "interruptedHandoffRepresentationCount": 1, "freshExpected": 1, "freshActual": 1, "payload": "QA-SUBAGENT-TERMINAL-RESTART-OK" },
  "empty": { "inputDisposition": "empty-after-side-effect", "representation": "visible ambiguity warning for producer-empty result", "expected": 1, "actual": 1, "payload": "QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED" }
}
```

The scenario also asserts that every captured channel payload excludes `NO_REPLY`, the protected metadata sentinel, and `BEGIN_OPENCLAW_INTERNAL_CONTEXT`. Empty completion uses the actual `message(action=send)` tool once; a bare private assistant marker does not satisfy the assertion.

## Dependency and Current-Main Contract Proof

- Direct Codex source inspection at sibling commit [`5b402270f926`](https://github.com/openai/codex/commit/5b402270f926cd1f9288c24cddd27410400cabe6): [`turn.rs:1738-1769`](https://github.com/openai/codex/blob/5b402270f926cd1f9288c24cddd27410400cabe6/codex-rs/core/src/session/turn.rs#L1738-L1769), [`event_mapping.rs:362-370`](https://github.com/openai/codex/blob/5b402270f926cd1f9288c24cddd27410400cabe6/codex-rs/app-server-protocol/src/protocol/event_mapping.rs#L362-L370), [`thread_state.rs:154-167`](https://github.com/openai/codex/blob/5b402270f926cd1f9288c24cddd27410400cabe6/codex-rs/app-server/src/thread_state.rs#L154-L167), and [`bespoke_event_handling.rs:1258-1283`](https://github.com/openai/codex/blob/5b402270f926cd1f9288c24cddd27410400cabe6/codex-rs/app-server/src/bespoke_event_handling.rs#L1258-L1283) / [`1447-1474`](https://github.com/openai/codex/blob/5b402270f926cd1f9288c24cddd27410400cabe6/codex-rs/app-server/src/bespoke_event_handling.rs#L1447-L1474) confirms completion is a terminal event/state transition and does not itself guarantee non-empty assistant output.
- Pinned `@zed-industries/codex-acp` 1.1.7 and `acpx` 0.13.0 source/types were inspected directly. Both derive visible output from agent-message content; a successful terminal turn may therefore contain zero visible text. The tri-state snapshot preserves that dependency contract instead of inventing output downstream.
- The branch was rebased onto `f5facf8cbfe`. Exact-head CI passed against the resulting PR merge tree with no failures, and GitHub reports the branch mergeable after the rebase.

## Verification

- [Exact-head CI run 30789927663](https://github.com/openclaw/openclaw/actions/runs/30789927663): aggregate passed with no failures, including lint/format/type checks, build artifacts, all compact Node shards, and QA smoke profile 2.
- Exact-head QA artifact `qa-smoke-profile-profile-2-of-4-30789927663-1`: visible 1/1, silent 0/0, fallback 1/1, restart replay 0 with one interruption representation and fresh delivery 1/1, empty representation 1/1; no silence-token or internal-metadata leak.
- Post-rebase lifecycle/announcement matrix: 426 focused tests passed; the timeout-output refactor added 64/64 passing focused tests; the ACP rebase integration file passed 74/74.
- QA provider and scenario-catalog matrix: 232/232 and 47/47 tests passed.
- Punctuation regression proof: `NO_REPLY:`, `NO_REPLY...`, and chunked `NO_REPLY` + `:` classify as silent; `NO_REPLY: explanation` remains visible. The accumulator, embedded producer, and ACP spawn-to-registry suites passed 152/152 focused tests.
- Structured autoreview passed with no actionable findings; focused oxlint and `git diff --check` passed.
- No configuration, environment variable, protocol-version, or SQLite schema-version change is introduced.

## Scope and LOC

Production: `+331/-86` (net `+245`). Tests and private QA: `+1316/-82` (net `+1234`). The positive production delta establishes the producer-owned terminal-reply contract across embedded/ACP execution, lifecycle, Gateway wait, durable registry, timeout progress, and announcement; connected synthetic output and obsolete inference paths are removed. Sibling embedded, CLI, ACP, active-wait, dormant-direct-delivery, restart, and sanitized-fallback paths are covered.