### PR TITLE
feat(channels): lifecycle wave 2 — fifteen more channels publish recorded lifecycle

### DIFF
--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -178,6 +178,30 @@ describe("ClickClack gateway", () => {
     await run;
   });
 
+  it("publishes ready only after the realtime socket opens", async () => {
+    const socket = new FakeSocket();
+    mocks.client.websocket.mockReturnValue(socket);
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await waitForGatewayState(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+    expect(ctx.setStatus).not.toHaveBeenCalledWith(expect.objectContaining({ lifecycle: "ready" }));
+
+    socket.emit("open");
+    expect(ctx.setStatus).toHaveBeenCalledWith({
+      accountId: "default",
+      connected: true,
+      lifecycle: "ready",
+      lastConnectedAt: expect.any(Number),
+      lastError: null,
+      terminalDisconnect: undefined,
+    });
+
+    abort.abort();
+    await run;
+  });
+
   it.each([
     { label: "unset", commandMenu: undefined },
     { label: "enabled", commandMenu: true },
@@ -254,6 +278,7 @@ describe("ClickClack gateway", () => {
     expect(ctx.setStatus).toHaveBeenCalledWith({
       accountId: "default",
       running: true,
+      lifecycle: "starting",
       configured: true,
       enabled: true,
       baseUrl: "https://clickclack.example",
@@ -603,6 +628,12 @@ describe("ClickClack gateway", () => {
     expect(ctx.log?.warn).toHaveBeenCalledWith(
       "[default] ClickClack websocket error; reconnecting: gateway dropped",
     );
+    expect(ctx.setStatus).toHaveBeenCalledWith({
+      accountId: "default",
+      connected: false,
+      lifecycle: "recovering",
+      lastError: "gateway dropped",
+    });
     abort.abort();
     await run;
   });
@@ -623,6 +654,11 @@ describe("ClickClack gateway", () => {
       firstSocket.emit("close");
       await vi.advanceTimersByTimeAsync(0);
       expect(vi.getTimerCount()).toBe(1);
+      expect(ctx.setStatus).toHaveBeenCalledWith({
+        accountId: "default",
+        connected: false,
+        lifecycle: "recovering",
+      });
 
       abort.abort();
       await run;
@@ -632,6 +668,8 @@ describe("ClickClack gateway", () => {
       expect(ctx.setStatus).toHaveBeenLastCalledWith({
         accountId: "default",
         running: false,
+        connected: false,
+        lifecycle: "stopped",
       });
     } finally {
       vi.useRealTimers();
@@ -667,6 +705,7 @@ describe("ClickClack gateway", () => {
     expect(ctx.setStatus).toHaveBeenCalledWith({
       accountId: "default",
       running: true,
+      lifecycle: "starting",
       configured: true,
       enabled: true,
       baseUrl: "https://clickclack.example",
@@ -674,6 +713,8 @@ describe("ClickClack gateway", () => {
     expect(ctx.setStatus).toHaveBeenLastCalledWith({
       accountId: "default",
       running: false,
+      connected: false,
+      lifecycle: "stopped",
     });
   });
 

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -204,6 +204,7 @@ export async function startClickClackGatewayAccount(
   ctx.setStatus({
     accountId: account.accountId,
     running: true,
+    lifecycle: "starting",
     configured: true,
     enabled: account.enabled,
     baseUrl: account.baseUrl,
@@ -287,6 +288,16 @@ export async function startClickClackGatewayAccount(
         };
         ctx.abortSignal.addEventListener("abort", abort, { once: true });
         removeAbortListener = () => ctx.abortSignal.removeEventListener("abort", abort);
+        socket.on("open", () => {
+          ctx.setStatus({
+            accountId: account.accountId,
+            connected: true,
+            lifecycle: "ready",
+            lastConnectedAt: Date.now(),
+            lastError: null,
+            terminalDisconnect: undefined,
+          });
+        });
         socket.on("message", (data) => {
           if (closing || settled) {
             return;
@@ -308,6 +319,13 @@ export async function startClickClackGatewayAccount(
         });
         socket.on("close", () => {
           closing = true;
+          if (!ctx.abortSignal.aborted) {
+            ctx.setStatus({
+              accountId: account.accountId,
+              connected: false,
+              lifecycle: "recovering",
+            });
+          }
           finishAfterQueuedMessages();
         });
         socket.on("error", (error) => {
@@ -323,6 +341,12 @@ export async function startClickClackGatewayAccount(
               error instanceof Error ? error.message : String(error)
             }`,
           );
+          ctx.setStatus({
+            accountId: account.accountId,
+            connected: false,
+            lifecycle: "recovering",
+            lastError: error instanceof Error ? error.message : String(error),
+          });
           closing = true;
           socket.close();
         });
@@ -340,6 +364,11 @@ export async function startClickClackGatewayAccount(
       }
     }
   } finally {
-    ctx.setStatus({ accountId: account.accountId, running: false });
+    ctx.setStatus({
+      accountId: account.accountId,
+      running: false,
+      connected: false,
+      lifecycle: "stopped",
+    });
   }
 }

--- a/extensions/feishu/src/monitor.transport-status.test-support.ts
+++ b/extensions/feishu/src/monitor.transport-status.test-support.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type StatusPatch = {
   connected?: boolean;
+  lifecycle?: "ready" | "recovering" | "blocked";
+  terminalDisconnect?: boolean;
   lastConnectedAt?: number | null;
   lastEventAt?: number | null;
   lastTransportActivityAt?: number | null;
@@ -96,6 +98,8 @@ describe("monitorWebSocket status publishing", () => {
     callbacks?.onReady?.();
     const first = recorder.calls[0];
     expect(first?.connected).toBe(true);
+    expect(first?.lifecycle).toBe("ready");
+    expect(first?.terminalDisconnect).toBeUndefined();
     expect(first?.lastConnectedAt).toBe(nowValue);
     expect(first?.lastEventAt).toBe(nowValue);
     expect(first?.lastTransportActivityAt).toBeUndefined();
@@ -105,6 +109,7 @@ describe("monitorWebSocket status publishing", () => {
     callbacks?.onReconnected?.();
     const second = recorder.calls[1];
     expect(second?.connected).toBe(true);
+    expect(second?.lifecycle).toBe("ready");
     expect(second?.lastConnectedAt).toBe(nowValue);
     expect(second?.lastEventAt).toBe(nowValue);
     expect(second?.lastTransportActivityAt).toBeUndefined();
@@ -114,6 +119,7 @@ describe("monitorWebSocket status publishing", () => {
     callbacks?.onReconnecting?.();
     const third = recorder.calls[2];
     expect(third?.connected).toBe(false);
+    expect(third?.lifecycle).toBe("recovering");
     expect(third?.lastEventAt).toBe(nowValue);
     expect(third?.lastTransportActivityAt).toBeUndefined();
 
@@ -155,8 +161,51 @@ describe("monitorWebSocket status publishing", () => {
 
     const disconnected = recorder.calls.find((c) => c.connected === false);
     expect(disconnected).toBeDefined();
+    expect(disconnected?.lifecycle).toBe("recovering");
     expect(disconnected?.lastEventAt).toBe(nowValue);
     expect(disconnected?.lastTransportActivityAt).toBeUndefined();
+  });
+
+  it("publishes blocked for the SDK terminal WebSocket error", async () => {
+    const recorder = createRecordingSink();
+    const { monitorWebSocket } = await loadTransportModule();
+    const abortController = new AbortController();
+    let onError: ((error: Error) => void) | undefined;
+    const wsClientModule = await import("./client.js");
+    vi.spyOn(wsClientModule, "createFeishuWSClient").mockImplementation(
+      async (_account, callbacks) => {
+        onError = callbacks?.onError;
+        return { start: vi.fn(async () => undefined), close: vi.fn() } as never;
+      },
+    );
+
+    const monitor = monitorWebSocket({
+      account: {
+        accountId: "acct-terminal",
+        appId: "app",
+        appSecret: "secret",
+        domain: "https://open.feishu.cn",
+        config: { connectionMode: "websocket" as const },
+      } as never,
+      accountId: "acct-terminal",
+      abortSignal: abortController.signal,
+      eventDispatcher: { register: () => undefined } as never,
+      statusSink: recorder.sink,
+    });
+
+    await vi.waitFor(() => expect(onError).toBeTypeOf("function"));
+    onError?.(new Error("WebSocket reconnect exhausted after 3 attempts"));
+    await vi.waitFor(() =>
+      expect(recorder.calls).toContainEqual(
+        expect.objectContaining({
+          connected: false,
+          lifecycle: "blocked",
+          terminalDisconnect: true,
+        }),
+      ),
+    );
+    abortController.abort();
+    await monitor;
   });
 });
 
@@ -211,6 +260,7 @@ describe("monitorWebhook status publishing", () => {
 
     const connected = recorder.calls.find((c) => c.connected === true);
     expect(connected).toBeDefined();
+    expect(connected?.lifecycle).toBe("ready");
     expect(connected?.lastConnectedAt).toBe(nowValue);
     expect(connected?.lastEventAt).toBe(nowValue);
     expect(connected?.lastTransportActivityAt).toBeUndefined();

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -255,6 +255,8 @@ export async function monitorWebSocket({
         const connectedAt = Date.now();
         statusSink?.({
           connected: true,
+          lifecycle: "ready",
+          terminalDisconnect: undefined,
           lastConnectedAt: connectedAt,
           lastEventAt: connectedAt,
           lastError: null,
@@ -264,6 +266,7 @@ export async function monitorWebSocket({
         const reconnectingAt = Date.now();
         statusSink?.({
           connected: false,
+          lifecycle: "recovering",
           lastEventAt: reconnectingAt,
         });
       };
@@ -302,7 +305,10 @@ export async function monitorWebSocket({
       const disconnectedAt = Date.now();
       statusSink?.({
         connected: false,
+        lifecycle: "blocked",
+        terminalDisconnect: true,
         lastEventAt: disconnectedAt,
+        lastError: formatFeishuWsErrorForLog(cycleEnd),
       });
 
       attempt += 1;
@@ -323,9 +329,15 @@ export async function monitorWebSocket({
 
       // WS start failed (e.g. handshake / auth) — publish disconnected.
       const failedAt = Date.now();
+      // The SDK classifier is the only terminal contract here. App-secret/auth refinement is
+      // deferred until Feishu exposes a structured authentication failure at this boundary.
+      const terminal = err instanceof Error && isFeishuWsTerminalError(err);
       statusSink?.({
         connected: false,
+        lifecycle: terminal ? "blocked" : "recovering",
+        ...(terminal ? { terminalDisconnect: true } : {}),
         lastEventAt: failedAt,
+        lastError: formatFeishuWsErrorForLog(err),
       });
 
       attempt += 1;
@@ -515,6 +527,8 @@ export async function monitorWebhook({
       const webhookConnectedAt = Date.now();
       statusSink?.({
         connected: true,
+        lifecycle: "ready",
+        terminalDisconnect: undefined,
         lastConnectedAt: webhookConnectedAt,
         lastEventAt: webhookConnectedAt,
         lastError: null,
@@ -523,6 +537,11 @@ export async function monitorWebhook({
 
     server.on("error", (err) => {
       error(`feishu[${accountId}]: Webhook server error: ${err}`);
+      statusSink?.({
+        connected: false,
+        lifecycle: "recovering",
+        lastError: formatFeishuWsErrorForLog(err),
+      });
       abortSignal?.removeEventListener("abort", handleAbort);
       reject(err);
     });

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -29,6 +29,8 @@ type MonitorFeishuOpts = {
  */
 export type FeishuStatusSink = (patch: {
   connected?: boolean;
+  lifecycle?: "ready" | "recovering" | "blocked";
+  terminalDisconnect?: boolean;
   lastConnectedAt?: number | null;
   lastEventAt?: number | null;
   lastTransportActivityAt?: number | null;

--- a/extensions/googlechat/src/gateway.ts
+++ b/extensions/googlechat/src/gateway.ts
@@ -51,7 +51,7 @@ export async function startGoogleChatGatewayAccount(ctx: {
     running: true,
     lastStartAt: Date.now(),
     ...(webhookPath
-      ? { webhookPath }
+      ? { webhookPath, lifecycle: "starting" as const }
       : {
           webhookPath: undefined,
           lifecycle: "blocked" as const,

--- a/extensions/googlechat/src/monitor-types.ts
+++ b/extensions/googlechat/src/monitor-types.ts
@@ -1,3 +1,4 @@
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 // Googlechat plugin module implements monitor types behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
@@ -10,6 +11,8 @@ export type GoogleChatRuntimeEnv = {
   error?: (message: string) => void;
 };
 
+export type GoogleChatStatusSink = (patch: Partial<ChannelAccountSnapshot>) => void;
+
 export type GoogleChatMonitorOptions = {
   account: ResolvedGoogleChatAccount;
   config: OpenClawConfig;
@@ -17,7 +20,7 @@ export type GoogleChatMonitorOptions = {
   abortSignal: AbortSignal;
   webhookPath?: string;
   webhookUrl?: string;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: GoogleChatStatusSink;
 };
 
 export type GoogleChatCoreRuntime = ReturnType<typeof getGoogleChatRuntime>;
@@ -30,7 +33,7 @@ export type WebhookTarget = {
   path: string;
   audienceType?: GoogleChatAudienceType;
   audience?: string;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: GoogleChatStatusSink;
   mediaMaxMb: number;
   ingress: Pick<GoogleChatIngressMonitor, "receive">;
 };

--- a/extensions/googlechat/src/monitor.lifecycle.test.ts
+++ b/extensions/googlechat/src/monitor.lifecycle.test.ts
@@ -1,0 +1,58 @@
+// Google Chat tests cover monitor lifecycle status publication.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ingressStart: vi.fn(),
+  ingressStop: vi.fn(async () => undefined),
+  registerTarget: vi.fn(() => vi.fn()),
+  setProcessor: vi.fn(),
+}));
+
+vi.mock("./monitor-ingress.js", () => ({
+  createGoogleChatIngressMonitor: () => ({
+    receive: vi.fn(),
+    start: mocks.ingressStart,
+    stop: mocks.ingressStop,
+  }),
+}));
+
+vi.mock("./monitor-routing.js", () => ({
+  registerGoogleChatWebhookTarget: mocks.registerTarget,
+  setGoogleChatWebhookEventProcessor: mocks.setProcessor,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getGoogleChatRuntime: () => ({}),
+}));
+
+import { startGoogleChatMonitor } from "./monitor.js";
+
+describe("Google Chat monitor lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.registerTarget.mockReturnValue(vi.fn());
+  });
+
+  it("publishes ready after the webhook target is registered", async () => {
+    const statusSink = vi.fn();
+
+    const stop = await startGoogleChatMonitor({
+      account: { accountId: "default", enabled: true, credentialSource: "config", config: {} },
+      config: {},
+      runtime: {},
+      abortSignal: new AbortController().signal,
+      webhookPath: "/googlechat",
+      statusSink,
+    } as never);
+
+    expect(mocks.registerTarget).toHaveBeenCalledOnce();
+    expect(statusSink).toHaveBeenCalledWith({
+      connected: true,
+      lifecycle: "ready",
+      lastConnectedAt: expect.any(Number),
+      lastError: null,
+      terminalDisconnect: undefined,
+    });
+    await stop();
+  });
+});

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -33,6 +33,7 @@ import type {
   GoogleChatCoreRuntime,
   GoogleChatMonitorOptions,
   GoogleChatRuntimeEnv,
+  GoogleChatStatusSink,
   WebhookTarget,
 } from "./monitor-types.js";
 import { warnAppPrincipalMisconfiguration } from "./monitor-webhook.js";
@@ -186,7 +187,7 @@ async function processMessageWithPipeline(params: {
   config: OpenClawConfig;
   runtime: GoogleChatRuntimeEnv;
   core: GoogleChatCoreRuntime;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: GoogleChatStatusSink;
   mediaMaxMb: number;
   turnAdoptionLifecycle?: GoogleChatIngressLifecycle;
 }): Promise<void> {
@@ -528,6 +529,13 @@ async function monitorGoogleChatProvider(
   let unregisterTarget: (() => void) | undefined;
   try {
     unregisterTarget = registerGoogleChatWebhookTarget(target);
+    options.statusSink?.({
+      connected: true,
+      lifecycle: "ready",
+      lastConnectedAt: Date.now(),
+      lastError: null,
+      terminalDisconnect: undefined,
+    });
   } catch (error) {
     await ingress.stop();
     throw error;

--- a/extensions/googlechat/src/setup.test.ts
+++ b/extensions/googlechat/src/setup.test.ts
@@ -379,7 +379,11 @@ describe("googlechat setup", () => {
       task,
     });
 
-    expectLifecyclePatch(patches, { running: true, webhookPath: "/googlechat" });
+    expectLifecyclePatch(patches, {
+      running: true,
+      webhookPath: "/googlechat",
+      lifecycle: "starting",
+    });
     expect(patches.some((patch) => patch.lifecycle === "blocked")).toBe(false);
   });
 

--- a/extensions/imessage/src/channel.runtime.test.ts
+++ b/extensions/imessage/src/channel.runtime.test.ts
@@ -52,7 +52,7 @@ describe("startIMessageGatewayAccount duplicate-source handling", () => {
         },
       },
     } as never;
-    const { ctx, abort, logEvents } = makeCtx({ cfg, accountId: "default" });
+    const { ctx, abort, logEvents, statusEvents } = makeCtx({ cfg, accountId: "default" });
 
     const settled = vi.fn();
     const task = startIMessageGatewayAccount(ctx).then(settled);
@@ -63,6 +63,8 @@ describe("startIMessageGatewayAccount duplicate-source handling", () => {
     expect(settled).not.toHaveBeenCalled();
     expect(logEvents.some((e) => e.line.includes("skipping watcher"))).toBe(true);
     expect(logEvents.some((e) => e.line.includes('using account "swang430-gmail-com"'))).toBe(true);
+    expect(statusEvents).not.toEqual([]);
+    expect(statusEvents.every((event) => !(event as Record<string, unknown>).lifecycle)).toBe(true);
 
     abort();
     await task;
@@ -83,10 +85,16 @@ describe("startIMessageGatewayAccount duplicate-source handling", () => {
         },
       },
     } as never;
-    const { ctx } = makeCtx({ cfg, accountId: "swang430-gmail-com" });
+    const { ctx, statusEvents } = makeCtx({ cfg, accountId: "swang430-gmail-com" });
 
     await startIMessageGatewayAccount(ctx);
     expect(monitorMock).toHaveBeenCalledTimes(1);
+    expect(statusEvents).toContainEqual(
+      expect.objectContaining({ lifecycle: "starting", accountId: "swang430-gmail-com" }),
+    );
+    expect(monitorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ statusSink: expect.any(Function) }),
+    );
   });
 
   it("starts monitorIMessageProvider when an account has no duplicate sibling", async () => {

--- a/extensions/imessage/src/channel.runtime.ts
+++ b/extensions/imessage/src/channel.runtime.ts
@@ -1,5 +1,8 @@
 // Imessage plugin module implements channel behavior.
-import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  createAccountStatusSink,
+  resolveOutboundSendDep,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { resolveIMessageDuplicateSourceOwner, type ResolvedIMessageAccount } from "./accounts.js";
 import { PAIRING_APPROVED_MESSAGE, resolveChannelMediaMaxBytes } from "./channel-api.js";
 import type { ChannelPlugin } from "./channel-api.js";
@@ -95,7 +98,8 @@ export async function startIMessageGatewayAccount(
     // openclaw/openclaw#65141: this account shares a local Messages source with
     // an already-owning account, so spawning a second `imsg rpc` would deliver
     // every inbound twice. Keep the account enabled for outbound sends, status,
-    // and capability surfaces; just park the watcher slot until shutdown.
+    // and capability surfaces; just park the watcher slot until shutdown. Lifecycle stays silent:
+    // ready would lie about admission and stopped would invite restart; parked semantics are deferred.
     ctx.log?.info?.(
       `[${account.accountId}] skipping watcher: duplicate iMessage source; using account "${ownerAccountId}"`,
     );
@@ -107,6 +111,11 @@ export async function startIMessageGatewayAccount(
     });
     return;
   }
+  const statusSink = createAccountStatusSink({
+    accountId: account.accountId,
+    setStatus: ctx.setStatus,
+  });
+  statusSink({ lifecycle: "starting" });
   ctx.log?.info?.(
     `[${account.accountId}] starting provider (${cliPath}${dbPath ? ` db=${dbPath}` : ""})`,
   );
@@ -116,6 +125,7 @@ export async function startIMessageGatewayAccount(
     runtime: ctx.runtime,
     abortSignal: ctx.abortSignal,
     channelRuntime: ctx.channelRuntime,
+    statusSink,
   });
 }
 

--- a/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
+++ b/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
@@ -86,6 +86,7 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
 
   it("retries a transient watch.subscribe startup timeout without tearing down the monitor", async () => {
     const runtime = createRuntime();
+    const statusSink = vi.fn();
     const firstClient = createRpcClient({
       request: async () => {
         throw new Error("imsg rpc timeout (watch.subscribe)");
@@ -100,6 +101,7 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
     const monitorPromise = monitorIMessageProvider({
       config: { channels: { imessage: {} } } as never,
       runtime: runtime as never,
+      statusSink,
     });
 
     await vi.advanceTimersByTimeAsync(1_000);
@@ -109,6 +111,18 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
     expect(firstClient.stop).toHaveBeenCalledTimes(1);
     expect(secondClient.waitForClose).toHaveBeenCalledTimes(1);
     expect(secondClient.stop).toHaveBeenCalledTimes(1);
+    expect(statusSink).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ lifecycle: "recovering", connected: false }),
+    );
+    expect(statusSink).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        lifecycle: "ready",
+        connected: true,
+        terminalDisconnect: undefined,
+      }),
+    );
     expect(secondClient.request).toHaveBeenCalledWith(
       "watch.subscribe",
       { attachments: false, include_reactions: true },
@@ -134,6 +148,7 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
 
   it("still fails after bounded startup retries are exhausted", async () => {
     const runtime = createRuntime();
+    const statusSink = vi.fn();
     createIMessageRpcClientMock.mockImplementation(async () =>
       createRpcClient({
         request: async () => {
@@ -145,6 +160,7 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
     const monitorErrorPromise = monitorIMessageProvider({
       config: { channels: { imessage: {} } } as never,
       runtime: runtime as never,
+      statusSink,
     }).catch((error: unknown) => error);
 
     await vi.advanceTimersByTimeAsync(2_000);
@@ -161,6 +177,34 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
     expect(failureLog).toContain("account=default");
     expect(failureLog).toContain("timeoutMs=10000");
     expect(failureLog).toContain("Error: imsg rpc timeout (watch.subscribe)");
+    expect(statusSink).toHaveBeenLastCalledWith(
+      expect.objectContaining({ lifecycle: "recovering", terminalDisconnect: undefined }),
+    );
+    expect(statusSink).not.toHaveBeenCalledWith(expect.objectContaining({ lifecycle: "blocked" }));
+  });
+
+  it("publishes blocked for a non-retriable watch.subscribe failure", async () => {
+    const statusSink = vi.fn();
+    createIMessageRpcClientMock.mockResolvedValueOnce(
+      createRpcClient({
+        request: async () => {
+          throw new Error("permission denied");
+        },
+      }),
+    );
+
+    await expect(
+      monitorIMessageProvider({
+        config: { channels: { imessage: {} } } as never,
+        runtime: createRuntime() as never,
+        statusSink,
+      }),
+    ).rejects.toThrow("permission denied");
+
+    expect(createIMessageRpcClientMock).toHaveBeenCalledOnce();
+    expect(statusSink).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycle: "blocked", terminalDisconnect: true }),
+    );
   });
 
   it("logs one redacted diagnostic for repeated from-me drops", async () => {

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1552,6 +1552,13 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         { timeoutMs: probeTimeoutMs },
       );
       attemptSubscriptionId = result?.subscription ?? null;
+      opts.statusSink?.({
+        connected: true,
+        lifecycle: "ready",
+        lastConnectedAt: Date.now(),
+        lastError: null,
+        terminalDisconnect: undefined,
+      });
       client = attemptClient;
       detachAbortHandler = attemptDetachAbortHandler;
       keepAttemptClient = true;
@@ -1560,9 +1567,15 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       if (abort?.aborted) {
         return;
       }
-      const shouldRetry =
-        attempt < WATCH_SUBSCRIBE_MAX_ATTEMPTS && isRetriableWatchSubscribeStartupError(err);
+      const retriable = isRetriableWatchSubscribeStartupError(err);
+      const shouldRetry = attempt < WATCH_SUBSCRIBE_MAX_ATTEMPTS && retriable;
       if (!shouldRetry) {
+        opts.statusSink?.({
+          connected: false,
+          lifecycle: retriable ? "recovering" : "blocked",
+          terminalDisconnect: retriable ? undefined : true,
+          lastError: String(err),
+        });
         runtime.error?.(
           danger(
             `imessage: monitor failed: ${describeIMessageWatchSubscribeStartupFailure({
@@ -1581,6 +1594,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         );
         throw err;
       }
+      opts.statusSink?.({
+        connected: false,
+        lifecycle: "recovering",
+        lastError: String(err),
+      });
       runtime.log?.(
         warn(
           describeIMessageWatchSubscribeStartupFailure({

--- a/extensions/imessage/src/monitor/types.ts
+++ b/extensions/imessage/src/monitor/types.ts
@@ -1,5 +1,8 @@
 // Imessage type declarations define plugin contracts.
-import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
+import type {
+  ChannelAccountSnapshot,
+  ChannelRuntimeSurface,
+} from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 
@@ -84,4 +87,5 @@ export type MonitorIMessageOpts = {
    * runtime). Threaded through from the gateway via ChannelGatewayAccountContext.
    */
   channelRuntime?: ChannelRuntimeSurface;
+  statusSink?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
 };

--- a/extensions/line/src/channel.status.test.ts
+++ b/extensions/line/src/channel.status.test.ts
@@ -12,6 +12,27 @@ function collectIssues(accounts: ChannelAccountSnapshot[]) {
 }
 
 describe("linePlugin status.collectStatusIssues", () => {
+  it("projects lifecycle from the runtime status record", async () => {
+    const snapshot = await lineStatusAdapter.buildAccountSnapshot?.({
+      cfg: {},
+      account: {
+        accountId: "default",
+        name: "LINE",
+        enabled: true,
+        configured: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        signingSecretSource: "config",
+        tokenStatus: "available",
+        signingSecretStatus: "available",
+        config: {},
+      } as never,
+      runtime: { accountId: "default", lifecycle: "recovering", connected: false },
+    });
+    expect(snapshot).toMatchObject({ lifecycle: "recovering", connected: false });
+  });
+
   it("does not warn when a sanitized snapshot is configured", () => {
     expect(
       collectIssues([

--- a/extensions/line/src/gateway.ts
+++ b/extensions/line/src/gateway.ts
@@ -1,4 +1,5 @@
 // Line plugin module implements gateway behavior.
+import { createAccountStatusSink } from "openclaw/plugin-sdk/channel-outbound";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveLineAccount } from "./accounts.js";
 import {
@@ -17,6 +18,10 @@ const loadLineMonitorRuntime = createLazyRuntimeModule(() => import("./monitor.r
 export const lineGatewayAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>["gateway"]> = {
   startAccount: async (ctx) => {
     const account = ctx.account;
+    const statusSink = createAccountStatusSink({
+      accountId: account.accountId,
+      setStatus: ctx.setStatus,
+    });
     const token = account.channelAccessToken.trim();
     const secret = account.channelSecret.trim();
     if (!token) {
@@ -29,6 +34,7 @@ export const lineGatewayAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>[
         `LINE webhook mode requires a non-empty channel secret for account "${account.accountId}".`,
       );
     }
+    statusSink({ lifecycle: "starting" });
 
     let lineBotLabel = "";
     try {
@@ -57,6 +63,7 @@ export const lineGatewayAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>[
       runtime: ctx.runtime,
       abortSignal: ctx.abortSignal,
       webhookPath: account.config.webhookPath,
+      statusSink,
     });
   },
   logoutAccount: async ({ accountId, cfg }) => {

--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -169,7 +169,7 @@ describe("monitorLineProvider lifecycle", () => {
     createLineBotMock.mockImplementation(() => ({
       account: { accountId: "default" },
       handleWebhook: vi.fn<LineHandleWebhook>(),
-      stop: vi.fn(),
+      stop: vi.fn(async () => undefined),
     }));
     // Clear call history only; the implementation was wired to the actual
     // helper once in the module mock factory.
@@ -221,6 +221,7 @@ describe("monitorLineProvider lifecycle", () => {
 
   it("waits for abort before resolving", async () => {
     const abort = new AbortController();
+    const statusSink = vi.fn();
     let resolved = false;
 
     const task = monitorLineProvider({
@@ -229,6 +230,7 @@ describe("monitorLineProvider lifecycle", () => {
       config: {} as OpenClawConfig,
       runtime: {} as RuntimeEnv,
       abortSignal: abort.signal,
+      statusSink,
     }).then((monitor) => {
       resolved = true;
       return monitor;
@@ -236,11 +238,17 @@ describe("monitorLineProvider lifecycle", () => {
 
     expect(registerWebhookTargetWithPluginRouteMock).toHaveBeenCalledTimes(1);
     expect(requireWebhookRegistration().route.auth).toBe("plugin");
+    expect(statusSink).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycle: "ready", connected: true }),
+    );
     expect(resolved).toBe(false);
 
     abort.abort();
     await task;
     expect(unregisterHttpMock).toHaveBeenCalledTimes(1);
+    expect(statusSink).toHaveBeenLastCalledWith(
+      expect.objectContaining({ lifecycle: "stopped", running: false }),
+    );
   });
 
   it("registers an account target without replacing existing route ownership", async () => {

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -1,5 +1,6 @@
 // Line plugin module implements monitor behavior.
 import type { webhook } from "@line/bot-sdk";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import { hasFinalInboundReplyDispatch } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -53,6 +54,7 @@ interface MonitorLineProviderOptions {
   abortSignal?: AbortSignal;
   webhookUrl?: string;
   webhookPath?: string;
+  statusSink?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
 }
 
 interface LineProviderMonitor {
@@ -120,6 +122,7 @@ export async function monitorLineProvider(
     runtime,
     abortSignal,
     webhookPath,
+    statusSink,
   } = opts;
   const resolvedAccountId = accountId ?? resolveDefaultLineAccountId(config);
   const token = channelAccessToken.trim();
@@ -409,6 +412,13 @@ export async function monitorLineProvider(
   });
 
   logVerbose(`line: registered webhook handler at ${normalizedPath}`);
+  statusSink?.({
+    connected: true,
+    lifecycle: "ready",
+    lastConnectedAt: Date.now(),
+    lastError: null,
+    terminalDisconnect: undefined,
+  });
 
   let stopped = false;
   let stopPromise: Promise<void> | undefined;
@@ -422,7 +432,9 @@ export async function monitorLineProvider(
     stopped = true;
     logVerbose(`line: stopping provider for account ${resolvedAccountId}`);
     unregisterHttp();
-    stopPromise = bot.stop();
+    stopPromise = bot.stop().finally(() => {
+      statusSink?.({ running: false, connected: false, lifecycle: "stopped" });
+    });
     return stopPromise;
   };
   const stopOnAbort = () => void stopHandler();

--- a/extensions/line/src/setup-surface.test.ts
+++ b/extensions/line/src/setup-surface.test.ts
@@ -350,13 +350,16 @@ function createAccount(params: { token: string; secret: string }): ResolvedLineA
 
 function startLineAccount(params: { account: ResolvedLineAccount; abortSignal?: AbortSignal }) {
   const { runtime, monitorLineProvider } = createRuntime();
+  const statusEvents: unknown[] = [];
   setLineRuntime(runtime);
   return {
     monitorLineProvider,
+    statusEvents,
     task: lineGatewayAdapter.startAccount!(
       createStartAccountContext({
         account: params.account,
         abortSignal: params.abortSignal,
+        statusPatchSink: (patch) => statusEvents.push(patch),
       }),
     ),
   };
@@ -387,7 +390,7 @@ describe("linePlugin gateway.startAccount", () => {
 
   it("starts provider when token and secret are present", async () => {
     const abort = new AbortController();
-    const { monitorLineProvider, task } = startLineAccount({
+    const { monitorLineProvider, statusEvents, task } = startLineAccount({
       account: createAccount({ token: "token", secret: "secret" }),
       abortSignal: abort.signal,
     });
@@ -401,6 +404,10 @@ describe("linePlugin gateway.startAccount", () => {
     expect(startupParams?.channelAccessToken).toBe("token");
     expect(startupParams?.channelSecret).toBe("secret");
     expect(startupParams?.accountId).toBe("default");
+    expect(statusEvents).toContainEqual(
+      expect.objectContaining({ accountId: "default", lifecycle: "starting" }),
+    );
+    expect(startupParams).toEqual(expect.objectContaining({ statusSink: expect.any(Function) }));
 
     abort.abort();
     await task;

--- a/extensions/matrix/src/matrix/monitor/status.ts
+++ b/extensions/matrix/src/matrix/monitor/status.ts
@@ -5,6 +5,7 @@ import {
   createConnectedChannelStatusPatch,
   createTransportActivityStatusPatch,
 } from "openclaw/plugin-sdk/gateway-runtime";
+import { isMatrixAccessTokenInvalidatedError } from "../sdk/client-support.js";
 import {
   isMatrixDisconnectedSyncState,
   isMatrixReadySyncState,
@@ -47,6 +48,7 @@ export function createMatrixMonitorStatusController(params: {
     lastDisconnect: null,
     lastError: null,
     healthState: "starting",
+    lifecycle: "starting",
   };
 
   const emit = () => {
@@ -68,6 +70,8 @@ export function createMatrixMonitorStatusController(params: {
     status.lastError = null;
     status.lastDisconnect = null;
     status.healthState = "healthy";
+    status.lifecycle = "ready";
+    status.terminalDisconnect = undefined;
     emit();
   };
 
@@ -86,6 +90,9 @@ export function createMatrixMonitorStatusController(params: {
     };
     status.lastError = error;
     status.healthState = paramsLocal.state.toLowerCase();
+    const tokenInvalidated = isMatrixAccessTokenInvalidatedError(paramsLocal.error);
+    status.lifecycle = tokenInvalidated ? "blocked" : "recovering";
+    status.terminalDisconnect = tokenInvalidated || undefined;
     emit();
   };
 
@@ -116,8 +123,9 @@ export function createMatrixMonitorStatusController(params: {
     markStopped(at = Date.now()) {
       status.connected = false;
       status.lastEventAt = at;
-      if (status.healthState !== "error") {
+      if (status.lifecycle !== "blocked" && status.healthState !== "error") {
         status.healthState = "stopped";
+        status.lifecycle = "stopped";
       }
       emit();
     },

--- a/extensions/matrix/src/matrix/monitor/status.ts
+++ b/extensions/matrix/src/matrix/monitor/status.ts
@@ -81,6 +81,15 @@ export function createMatrixMonitorStatusController(params: {
     error?: unknown;
   }) => {
     const at = paramsLocal.at ?? Date.now();
+    const tokenInvalidated = isMatrixAccessTokenInvalidatedError(paramsLocal.error);
+    if (status.lifecycle === "blocked" && status.terminalDisconnect === true && !tokenInvalidated) {
+      // The invalidated-token diagnosis is authoritative until a ready sync proves recovery.
+      // Late startup timeouts must not re-enable supervisor restarts or hide the auth failure.
+      status.connected = false;
+      status.lastEventAt = at;
+      emit();
+      return;
+    }
     const error = formatSyncError(paramsLocal.error);
     status.connected = false;
     status.lastEventAt = at;
@@ -90,7 +99,6 @@ export function createMatrixMonitorStatusController(params: {
     };
     status.lastError = error;
     status.healthState = paramsLocal.state.toLowerCase();
-    const tokenInvalidated = isMatrixAccessTokenInvalidatedError(paramsLocal.error);
     status.lifecycle = tokenInvalidated ? "blocked" : "recovering";
     status.terminalDisconnect = tokenInvalidated || undefined;
     emit();

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
@@ -60,6 +60,38 @@ function expectLastStatusFields(
 }
 
 describe("createMatrixMonitorSyncLifecycle", () => {
+  it("publishes blocked for an invalidated token and preserves it through cleanup", () => {
+    const { setStatus, statusController } = createSyncLifecycleHarness();
+    const tokenError = Object.assign(new Error("Unknown token"), {
+      statusCode: 401,
+      data: { errcode: "M_UNKNOWN_TOKEN" },
+    });
+
+    statusController.noteSyncState("RECONNECTING", tokenError);
+    expectLastStatusFields(setStatus, {
+      lifecycle: "blocked",
+      terminalDisconnect: true,
+    });
+
+    statusController.markStopped();
+    expectLastStatusFields(setStatus, {
+      lifecycle: "blocked",
+      terminalDisconnect: true,
+    });
+
+    statusController.noteSyncState("SYNCING", undefined);
+    expectLastStatusFields(setStatus, {
+      lifecycle: "ready",
+      terminalDisconnect: undefined,
+    });
+  });
+
+  it("publishes recovering for transient disconnects", () => {
+    const { setStatus, statusController } = createSyncLifecycleHarness();
+    statusController.noteSyncState("RECONNECTING", new Error("network reset"));
+    expectLastStatusFields(setStatus, { lifecycle: "recovering" });
+  });
+
   it("rejects the channel wait on unexpected sync errors", async () => {
     const { client, lifecycle, setStatus } = createSyncLifecycleHarness();
 

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
@@ -73,6 +73,13 @@ describe("createMatrixMonitorSyncLifecycle", () => {
       terminalDisconnect: true,
     });
 
+    statusController.noteUnexpectedError(new Error("startup readiness timed out"));
+    expectLastStatusFields(setStatus, {
+      lifecycle: "blocked",
+      terminalDisconnect: true,
+      lastError: "Unknown token",
+    });
+
     statusController.markStopped();
     expectLastStatusFields(setStatus, {
       lifecycle: "blocked",

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1615,6 +1615,22 @@ describe("MatrixClient event bridge", () => {
     await expect(client.start()).resolves.toBeUndefined();
   });
 
+  it("rejects structured invalid-token ERROR during startup without waiting for timeout", async () => {
+    const invalidToken = Object.assign(new Error("Invalid access token"), {
+      statusCode: 401,
+      data: { errcode: "M_UNKNOWN_TOKEN" },
+    });
+    matrixJsClient.startClient = vi.fn(async () => {
+      queueMicrotask(() => {
+        matrixJsClient.emit("sync", "ERROR", null, { error: invalidToken });
+      });
+    });
+
+    const client = new MatrixClient("https://matrix.example.org", "invalid-token");
+
+    await expect(client.start()).rejects.toBe(invalidToken);
+  });
+
   it("aborts startup when the readiness wait is canceled", async () => {
     matrixJsClient.startClient = vi.fn(async () => {});
 

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -611,8 +611,9 @@ export class MatrixClient extends MatrixClientVerification {
       emitter: this.emitter,
       emitMembershipForRoom: (room) => this.emitMembershipForRoom(room),
       getSelfUserId: () => this.client.getUserId() ?? this.selfUserId ?? "",
-      setCurrentSyncState: (state) => {
+      setCurrentSyncState: (state, error) => {
         this.currentSyncState = state;
+        this.currentSyncError = error;
       },
     });
   }

--- a/extensions/matrix/src/matrix/sdk/client-base.ts
+++ b/extensions/matrix/src/matrix/sdk/client-base.ts
@@ -22,6 +22,7 @@ import {
 import {
   MATRIX_AUTOMATIC_REPAIR_BOOTSTRAP_OPTIONS,
   MATRIX_INITIAL_CRYPTO_BOOTSTRAP_OPTIONS,
+  isMatrixAccessTokenInvalidatedError,
   resolveMatrixLocalTimeoutMs,
   type MatrixOwnDeviceInfo,
   type MatrixOwnDeviceVerificationStatus,
@@ -136,6 +137,7 @@ export abstract class MatrixClientBase {
   protected stopPersistPromise: Promise<void> | null = null;
   protected verificationSummaryListenerBound = false;
   protected currentSyncState: MatrixSyncState | null = null;
+  protected currentSyncError: unknown = undefined;
   protected readonly transactionScopeHomeserver: string;
   protected readonly transactionScopeAccessTokenHash: string;
   protected transactionScopeDeviceId: string | null;
@@ -381,6 +383,11 @@ export abstract class MatrixClientBase {
     if (isMatrixReadySyncState(this.currentSyncState)) {
       return;
     }
+    if (isMatrixAccessTokenInvalidatedError(this.currentSyncError)) {
+      throw this.currentSyncError instanceof Error
+        ? this.currentSyncError
+        : new Error("Matrix access token invalidated", { cause: this.currentSyncError });
+    }
     if (isMatrixTerminalSyncState(this.currentSyncState)) {
       throw new Error(`Matrix sync entered ${this.currentSyncState} during startup`);
     }
@@ -421,6 +428,12 @@ export abstract class MatrixClientBase {
       const onSyncState = (state: MatrixSyncState, _prevState: string | null, error?: unknown) => {
         if (isMatrixReadySyncState(state)) {
           settleResolve();
+          return;
+        }
+        if (isMatrixAccessTokenInvalidatedError(error)) {
+          settleReject(
+            error instanceof Error ? error : new Error("Matrix access token invalidated"),
+          );
           return;
         }
         if (isMatrixTerminalSyncState(state)) {
@@ -527,6 +540,7 @@ export abstract class MatrixClientBase {
       this.idbPersistTimer = null;
     }
     this.currentSyncState = null;
+    this.currentSyncError = undefined;
     this.client.stopClient();
     this.started = false;
   }

--- a/extensions/matrix/src/matrix/sdk/client-event-bridge.ts
+++ b/extensions/matrix/src/matrix/sdk/client-event-bridge.ts
@@ -16,7 +16,7 @@ export function registerMatrixClientBridge(params: {
   emitter: EventEmitter;
   emitMembershipForRoom: (room: Room) => void;
   getSelfUserId: () => string;
-  setCurrentSyncState: (state: MatrixSyncState) => void;
+  setCurrentSyncState: (state: MatrixSyncState, error?: unknown) => void;
 }): void {
   params.client.on(ClientEvent.Event, (event: MatrixEvent) => {
     const roomId = event.getRoomId();
@@ -57,11 +57,11 @@ export function registerMatrixClientBridge(params: {
   params.client.on(
     ClientEvent.Sync,
     (state: MatrixSyncState, prevState: string | null, data?: unknown) => {
-      params.setCurrentSyncState(state);
       const error =
         data && typeof data === "object" && "error" in data
           ? (data as { error?: unknown }).error
           : undefined;
+      params.setCurrentSyncState(state, error);
       params.emitter.emit("sync.state", state, prevState, error);
     },
   );

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -224,7 +224,40 @@ describe("mattermost websocket monitor", () => {
       seq: 1,
     });
     expect(countMatching(patches, (patch) => patch.connected === true)).toBe(1);
-    expect(countMatching(patches, (patch) => patch.connected === false)).toBe(2);
+    expect(countMatching(patches, (patch) => patch.connected === false)).toBe(3);
+    expect(patches).toContainEqual(expect.objectContaining({ lifecycle: "starting" }));
+    expect(patches).toContainEqual(expect.objectContaining({ lifecycle: "recovering" }));
+  });
+
+  it("publishes ready only after the authentication challenge is acknowledged", async () => {
+    const socket = new FakeWebSocket();
+    const patches: Array<Record<string, unknown>> = [];
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "token",
+      runtime: testRuntime(),
+      nextSeq: () => 7,
+      onPosted: async () => {},
+      statusSink: (patch) => patches.push(patch as Record<string, unknown>),
+      webSocketFactory: () => socket,
+    });
+    const connected = connectOnce();
+
+    socket.emitOpen();
+    expect(patches).toContainEqual({ connected: true, lifecycle: "starting" });
+    expect(patches).not.toContainEqual(expect.objectContaining({ lifecycle: "ready" }));
+
+    socket.emitMessage(Buffer.from(JSON.stringify({ status: "OK", seq_reply: 7 })));
+    expect(patches).toContainEqual({
+      connected: true,
+      lifecycle: "ready",
+      lastConnectedAt: expect.any(Number),
+      lastError: null,
+      terminalDisconnect: undefined,
+    });
+
+    socket.emitClose(1000);
+    await connected;
   });
 
   it("accepts large valid post envelopes and rejects oversized websocket payloads", async () => {

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -14,6 +14,8 @@ import type { ChannelAccountSnapshot, RuntimeEnv } from "./runtime-api.js";
 
 export type MattermostEventPayload = {
   event?: string;
+  status?: string;
+  seq_reply?: number;
   data?: {
     post?: unknown;
     reaction?: string | Record<string, unknown>;
@@ -56,6 +58,8 @@ const MATTERMOST_WEBSOCKET_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
 const MATTERMOST_WEBSOCKET_HANDSHAKE_TIMEOUT_MS = 30_000;
 const MattermostEventPayloadSchema = z.object({
   event: z.string().optional(),
+  status: z.string().optional(),
+  seq_reply: z.number().optional(),
   data: z
     .object({
       // Durable ingress validates the post only after claiming the raw envelope.
@@ -158,6 +162,7 @@ export function createMattermostConnectOnce(
         let protocolPingTimer: ReturnType<typeof setTimeout> | undefined;
         let protocolPongTimer: ReturnType<typeof setTimeout> | undefined;
         let initialUpdateAt: number | undefined;
+        let authenticationSeq: number | undefined;
 
         const clearTimers = () => {
           if (healthCheckTimer !== undefined) {
@@ -292,11 +297,11 @@ export function createMattermostConnectOnce(
           });
           opts.statusSink?.({
             connected: true,
-            lastConnectedAt: Date.now(),
-            lastError: null,
+            lifecycle: "starting",
           });
+          authenticationSeq = opts.nextSeq();
           const authPayload = JSON.stringify({
-            seq: opts.nextSeq(),
+            seq: authenticationSeq,
             action: "authentication_challenge",
             data: { token: opts.botToken },
           });
@@ -344,6 +349,17 @@ export function createMattermostConnectOnce(
             return;
           }
 
+          if (payload.status === "OK" && payload.seq_reply === authenticationSeq) {
+            opts.statusSink?.({
+              connected: true,
+              lifecycle: "ready",
+              lastConnectedAt: Date.now(),
+              lastError: null,
+              terminalDisconnect: undefined,
+            });
+            return;
+          }
+
           if (payload.event === "reaction_added" || payload.event === "reaction_removed") {
             if (!opts.onReaction) {
               return;
@@ -387,6 +403,7 @@ export function createMattermostConnectOnce(
           const message = reasonToString(reason);
           opts.statusSink?.({
             connected: false,
+            lifecycle: "recovering",
             lastDisconnect: {
               at: Date.now(),
               status: code,
@@ -411,6 +428,8 @@ export function createMattermostConnectOnce(
           });
           opts.runtime.error?.(`mattermost websocket error: ${String(err)}`);
           opts.statusSink?.({
+            connected: false,
+            lifecycle: "recovering",
             lastError: String(err),
           });
           try {

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -568,6 +568,29 @@ describe("mattermost inbound user posts", () => {
     });
   });
 
+  it("publishes recovering while API authentication retries, including 401", async () => {
+    const abortController = new AbortController();
+    const statusSink = vi.fn();
+    mockState.fetchMattermostMe.mockRejectedValue(new Error("HTTP 401 Unauthorized"));
+
+    const monitor = monitorMattermostProvider({
+      config: testConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      statusSink,
+    });
+
+    await vi.waitFor(() => {
+      expect(statusSink).toHaveBeenCalledWith({
+        connected: false,
+        lifecycle: "recovering",
+        lastError: "Error: HTTP 401 Unauthorized",
+      });
+    });
+    abortController.abort();
+    await monitor;
+  });
+
   it("does not enqueue regular user posts as system events", async () => {
     const socket = new FakeWebSocket();
     const abortController = new AbortController();

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -16,21 +16,6 @@ import {
   shouldUpdateMattermostDraftToolProgress,
 } from "./monitor-context.js";
 import { buildMattermostInboundMediaPayload } from "./monitor-resources.js";
-import { publishMattermostRecoveringStatus } from "./monitor.js";
-
-describe("Mattermost lifecycle status", () => {
-  it("keeps API and websocket retry failures recovering, including 401", () => {
-    const statusSink = vi.fn();
-
-    publishMattermostRecoveringStatus(statusSink, new Error("HTTP 401 Unauthorized"));
-
-    expect(statusSink).toHaveBeenCalledWith({
-      connected: false,
-      lifecycle: "recovering",
-      lastError: "Error: HTTP 401 Unauthorized",
-    });
-  });
-});
 
 function resolveMattermostEffectiveReplyToId(params: {
   kind: "direct" | "group" | "channel";

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,5 +1,5 @@
 // Mattermost tests cover monitor plugin behavior.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {
@@ -16,6 +16,21 @@ import {
   shouldUpdateMattermostDraftToolProgress,
 } from "./monitor-context.js";
 import { buildMattermostInboundMediaPayload } from "./monitor-resources.js";
+import { publishMattermostRecoveringStatus } from "./monitor.js";
+
+describe("Mattermost lifecycle status", () => {
+  it("keeps API and websocket retry failures recovering, including 401", () => {
+    const statusSink = vi.fn();
+
+    publishMattermostRecoveringStatus(statusSink, new Error("HTTP 401 Unauthorized"));
+
+    expect(statusSink).toHaveBeenCalledWith({
+      connected: false,
+      lifecycle: "recovering",
+      lastError: "Error: HTTP 401 Unauthorized",
+    });
+  });
+});
 
 function resolveMattermostEffectiveReplyToId(params: {
   kind: "direct" | "group" | "channel";

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,5 +1,5 @@
 // Mattermost tests cover monitor plugin behavior.
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -60,6 +60,17 @@ type MonitorMattermostOpts = {
   webSocketFactory?: MattermostWebSocketFactory;
 };
 
+export function publishMattermostRecoveringStatus(
+  statusSink: MonitorMattermostOpts["statusSink"],
+  error: unknown,
+): void {
+  statusSink?.({
+    lastError: String(error),
+    connected: false,
+    lifecycle: "recovering",
+  });
+}
+
 export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}): Promise<void> {
   const core = getMattermostRuntime();
   const runtime =
@@ -112,7 +123,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       shouldReconnect: ({ outcome }) => outcome === "rejected",
       onError: (err) => {
         runtime.error?.(`mattermost: API auth failed: ${String(err)}`);
-        opts.statusSink?.({ lastError: String(err), connected: false });
+        publishMattermostRecoveringStatus(opts.statusSink, err);
       },
       onReconnect: (delayMs) => {
         runtime.log?.(`mattermost: API not accessible, retrying in ${Math.round(delayMs / 1000)}s`);
@@ -348,7 +359,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       jitterRatio: 0.2,
       onError: (err) => {
         runtime.error?.(`mattermost connection failed: ${String(err)}`);
-        opts.statusSink?.({ lastError: String(err), connected: false });
+        publishMattermostRecoveringStatus(opts.statusSink, err);
       },
       onReconnect: (delayMs) => {
         runtime.log?.(`mattermost reconnecting in ${Math.round(delayMs / 1000)}s`);

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -60,7 +60,7 @@ type MonitorMattermostOpts = {
   webSocketFactory?: MattermostWebSocketFactory;
 };
 
-export function publishMattermostRecoveringStatus(
+function publishMattermostRecoveringStatus(
   statusSink: MonitorMattermostOpts["statusSink"],
   error: unknown,
 ): void {

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -6,6 +6,7 @@ import type {
 } from "openclaw/plugin-sdk/channel-contract";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import {
+  createAccountStatusSink,
   createChannelMessageAdapterFromOutbound,
   createRuntimeOutboundDelegates,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -1263,12 +1264,17 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
         startAccount: async (ctx) => {
           const { monitorMSTeamsProvider } = await import("./index.js");
           const port = ctx.cfg.channels?.msteams?.webhook?.port ?? 3978;
-          ctx.setStatus({ accountId: ctx.accountId, port });
+          const statusSink = createAccountStatusSink({
+            accountId: ctx.accountId,
+            setStatus: ctx.setStatus,
+          });
+          statusSink({ port });
           ctx.log?.info(`starting provider (port ${port})`);
           return monitorMSTeamsProvider({
             cfg: ctx.cfg,
             runtime: ctx.runtime,
             abortSignal: ctx.abortSignal,
+            statusSink,
           });
         },
       },

--- a/extensions/msteams/src/monitor-status.test.ts
+++ b/extensions/msteams/src/monitor-status.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  publishMSTeamsBlocked,
+  publishMSTeamsReady,
+  publishMSTeamsRecovering,
+  publishMSTeamsStopped,
+} from "./monitor-status.js";
+
+describe("Microsoft Teams monitor status", () => {
+  it("publishes blocked, ready, recovering, and stopped lifecycle patches", () => {
+    const statusSink = vi.fn();
+    publishMSTeamsBlocked(statusSink, "credentials missing");
+    publishMSTeamsReady(statusSink, 42);
+    publishMSTeamsRecovering(statusSink, "server failed");
+    publishMSTeamsStopped(statusSink);
+
+    expect(statusSink.mock.calls.map(([patch]) => patch)).toEqual([
+      expect.objectContaining({ lifecycle: "blocked", terminalDisconnect: true }),
+      expect.objectContaining({
+        lifecycle: "ready",
+        connected: true,
+        lastConnectedAt: 42,
+        terminalDisconnect: undefined,
+      }),
+      expect.objectContaining({ lifecycle: "recovering", lastError: "server failed" }),
+      expect.objectContaining({ lifecycle: "stopped", running: false }),
+    ]);
+  });
+});

--- a/extensions/msteams/src/monitor-status.ts
+++ b/extensions/msteams/src/monitor-status.ts
@@ -1,0 +1,37 @@
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
+
+export type MSTeamsStatusSink = (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
+
+export function publishMSTeamsBlocked(
+  statusSink: MSTeamsStatusSink | undefined,
+  lastError: string,
+) {
+  statusSink?.({
+    running: true,
+    lifecycle: "blocked",
+    terminalDisconnect: true,
+    lastError,
+  });
+}
+
+export function publishMSTeamsReady(statusSink: MSTeamsStatusSink | undefined, now = Date.now()) {
+  statusSink?.({
+    running: true,
+    connected: true,
+    lifecycle: "ready",
+    lastConnectedAt: now,
+    lastError: null,
+    terminalDisconnect: undefined,
+  });
+}
+
+export function publishMSTeamsRecovering(
+  statusSink: MSTeamsStatusSink | undefined,
+  lastError: string,
+) {
+  statusSink?.({ connected: false, lifecycle: "recovering", lastError });
+}
+
+export function publishMSTeamsStopped(statusSink: MSTeamsStatusSink | undefined) {
+  statusSink?.({ running: false, connected: false, lifecycle: "stopped" });
+}

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -24,6 +24,13 @@ import {
   type MSTeamsActivityHandler,
 } from "./monitor-handler.js";
 import type { MSTeamsMessageHandlerDeps } from "./monitor-handler.types.js";
+import {
+  publishMSTeamsBlocked,
+  publishMSTeamsReady,
+  publishMSTeamsRecovering,
+  publishMSTeamsStopped,
+  type MSTeamsStatusSink,
+} from "./monitor-status.js";
 import { createMSTeamsIngress } from "./msteams-ingress.js";
 import {
   createMSTeamsPollStoreState,
@@ -63,6 +70,7 @@ type MonitorMSTeamsOpts = {
   abortSignal?: AbortSignal;
   conversationStore?: MSTeamsConversationStore;
   pollStore?: MSTeamsPollStore;
+  statusSink?: MSTeamsStatusSink;
 };
 
 type MonitorMSTeamsResult = {
@@ -79,12 +87,14 @@ export async function monitorMSTeamsProvider(
   let msteamsCfg = cfg.channels?.msteams;
   if (!msteamsCfg?.enabled) {
     log.debug?.("msteams provider disabled");
+    publishMSTeamsBlocked(opts.statusSink, "Microsoft Teams provider is disabled");
     return { app: null, shutdown: async () => {} };
   }
 
   const creds = resolveMSTeamsCredentials(msteamsCfg);
   if (!creds) {
     log.error("msteams credentials not configured");
+    publishMSTeamsBlocked(opts.statusSink, "Microsoft Teams credentials are not configured");
     return { app: null, shutdown: async () => {} };
   }
   const appId = creds.appId; // Extract for use in closures
@@ -591,10 +601,12 @@ export async function monitorMSTeamsProvider(
     throw err;
   });
   log.info(`msteams provider started on port ${port}`);
+  publishMSTeamsReady(opts.statusSink);
   applyMSTeamsWebhookTimeouts(httpServer);
 
   httpServer.on("error", (err) => {
     log.error("msteams server error", { error: formatUnknownError(err) });
+    publishMSTeamsRecovering(opts.statusSink, formatUnknownError(err));
   });
 
   const shutdown = async () => {
@@ -608,6 +620,7 @@ export async function monitorMSTeamsProvider(
       });
     });
     await ingress.stop();
+    publishMSTeamsStopped(opts.statusSink);
   };
 
   // Keep this task alive until close so gateway runtime does not treat startup as exit.

--- a/extensions/nostr/src/channel.lifecycle.test.ts
+++ b/extensions/nostr/src/channel.lifecycle.test.ts
@@ -112,4 +112,40 @@ describe("nostr gateway lifecycle", () => {
     abort.abort();
     await task;
   });
+
+  it("publishes ready with one relay and recovering only after the last relay disconnects", async () => {
+    const bus = createMockBus();
+    mocks.startNostrBus.mockResolvedValueOnce(bus as never);
+    const abort = new AbortController();
+    const statusEvents: Array<Record<string, unknown>> = [];
+    const context = createStartAccountContext({
+      account: buildResolvedNostrAccount(),
+      abortSignal: abort.signal,
+      statusPatchSink: (patch) => statusEvents.push(patch as Record<string, unknown>),
+    });
+
+    const task = startNostrGatewayAccount(context);
+    await vi.waitFor(() => expect(mocks.startNostrBus).toHaveBeenCalledOnce());
+    const options = mocks.startNostrBus.mock.calls[0]?.[0] as
+      | { onConnect?: (relay: string) => void; onDisconnect?: (relay: string) => void }
+      | undefined;
+    expect(statusEvents[0]).toMatchObject({ lifecycle: "starting" });
+
+    options?.onConnect?.("wss://relay-one.example/");
+    expect(statusEvents.at(-1)).toMatchObject({
+      lifecycle: "ready",
+      connected: true,
+      terminalDisconnect: undefined,
+    });
+    options?.onConnect?.("wss://relay-two.example/");
+    const afterTwoConnected = statusEvents.length;
+    options?.onDisconnect?.("wss://relay-one.example");
+    expect(statusEvents).toHaveLength(afterTwoConnected);
+
+    options?.onDisconnect?.("wss://relay-two.example");
+    expect(statusEvents.at(-1)).toMatchObject({ lifecycle: "recovering", connected: false });
+
+    abort.abort();
+    await task;
+  });
 });

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -37,6 +37,10 @@ const activeBuses = new Map<string, NostrBusHandle>();
 const metricsSnapshots = new Map<string, MetricsSnapshot>();
 const ACCESS_GROUP_PREFIX = "accessGroup:";
 
+function normalizeRelayLifecycleKey(relay: string): string {
+  return new URL(relay).toString();
+}
+
 function parseNostrAccessGroupAllowFromEntry(entry: string): string | null {
   const trimmed = entry.trim();
   if (!trimmed.startsWith(ACCESS_GROUP_PREFIX)) {
@@ -86,6 +90,7 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
   ctx.setStatus({
     accountId: account.accountId,
     publicKey: account.publicKey,
+    lifecycle: "starting",
   });
   ctx.log?.info?.(`[${account.accountId}] starting Nostr provider (pubkey: ${account.publicKey})`);
 
@@ -121,6 +126,7 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
     });
 
   let busHandle: NostrBusHandle | null = null;
+  const connectedRelays = new Set<string>();
 
   const authorizeSender = async (input: {
     senderId: string;
@@ -233,9 +239,28 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
           ctx.log?.error?.(`[${account.accountId}] Nostr error (${context}): ${error.message}`);
         },
         onConnect: (relay) => {
+          connectedRelays.add(normalizeRelayLifecycleKey(relay));
+          // Treat >=1 connected relay as ready. This favors partial availability over quorum
+          // fidelity; circuit-breaker health stays private to nostr-bus, so ready is not all-relays.
+          ctx.setStatus({
+            accountId: account.accountId,
+            connected: true,
+            lifecycle: "ready",
+            lastConnectedAt: Date.now(),
+            lastError: null,
+            terminalDisconnect: undefined,
+          });
           ctx.log?.debug?.(`[${account.accountId}] Connected to relay: ${relay}`);
         },
         onDisconnect: (relay) => {
+          connectedRelays.delete(normalizeRelayLifecycleKey(relay));
+          if (connectedRelays.size === 0) {
+            ctx.setStatus({
+              accountId: account.accountId,
+              connected: false,
+              lifecycle: "recovering",
+            });
+          }
           ctx.log?.debug?.(`[${account.accountId}] Disconnected from relay: ${relay}`);
         },
         onEose: (relays) => {

--- a/extensions/qa-channel/src/gateway.test.ts
+++ b/extensions/qa-channel/src/gateway.test.ts
@@ -165,12 +165,59 @@ describe("qa-channel gateway", () => {
         configured: true,
         enabled: true,
         running: true,
+        lifecycle: "starting",
+      },
+      {
+        accountId: "default",
+        connected: false,
+        lifecycle: "recovering",
+        lastError: "qa bus unavailable",
       },
       {
         accountId: "default",
         running: false,
+        connected: false,
+        lifecycle: "stopped",
       },
     ]);
+  });
+
+  it("publishes ready after the first successful poll", async () => {
+    const controller = new AbortController();
+    const server = await startJsonServer(() => ({
+      body: JSON.stringify({ cursor: 0, events: [] }),
+    }));
+    stops.push(() => server.stop());
+    const setStatus = vi.fn();
+
+    const run = startQaGatewayAccount("qa-channel", "QA Channel", {
+      abortSignal: controller.signal,
+      account: {
+        accountId: "default",
+        baseUrl: server.baseUrl,
+        botDisplayName: "QA Bot",
+        botUserId: "qa-bot",
+        config: {},
+        configured: true,
+        enabled: true,
+        pollTimeoutMs: 1,
+      },
+      cfg: {},
+      setStatus,
+    } as unknown as ChannelGatewayContext<ResolvedQaChannelAccount>);
+
+    await vi.waitFor(() =>
+      expect(setStatus).toHaveBeenCalledWith({
+        accountId: "default",
+        connected: true,
+        lifecycle: "ready",
+        lastConnectedAt: expect.any(Number),
+        lastError: null,
+        terminalDisconnect: undefined,
+      }),
+    );
+    controller.abort();
+    await run;
   });
 
   it("stops the ordered inbound queue after the first dispatch failure", async () => {

--- a/extensions/qa-channel/src/gateway.ts
+++ b/extensions/qa-channel/src/gateway.ts
@@ -16,11 +16,13 @@ export async function startQaGatewayAccount(
   ctx.setStatus({
     accountId: account.accountId,
     running: true,
+    lifecycle: "starting",
     configured: true,
     enabled: account.enabled,
     baseUrl: account.baseUrl,
   });
   let cursor = 0;
+  let ready = false;
   let inboundError: Error | undefined;
   let queuedInbound = Promise.resolve();
   const controlTasks = new Set<Promise<void>>();
@@ -58,6 +60,17 @@ export async function startQaGatewayAccount(
         timeoutMs: account.pollTimeoutMs,
         signal: ctx.abortSignal,
       });
+      if (!ready) {
+        ready = true;
+        ctx.setStatus({
+          accountId: account.accountId,
+          connected: true,
+          lifecycle: "ready",
+          lastConnectedAt: Date.now(),
+          lastError: null,
+          terminalDisconnect: undefined,
+        });
+      }
       cursor = result.cursor;
       for (const event of result.events) {
         if (event.kind !== "inbound-message") {
@@ -75,6 +88,12 @@ export async function startQaGatewayAccount(
     }
   } catch (error) {
     if (!(error instanceof Error) || error.name !== "AbortError") {
+      ctx.setStatus({
+        accountId: account.accountId,
+        connected: false,
+        lifecycle: "recovering",
+        lastError: error instanceof Error ? error.message : String(error),
+      });
       throw error;
     }
   } finally {
@@ -82,6 +101,8 @@ export async function startQaGatewayAccount(
     ctx.setStatus({
       accountId: account.accountId,
       running: false,
+      connected: false,
+      lifecycle: "stopped",
     });
   }
   if (inboundError) {

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -4,6 +4,7 @@ import { buildDmGroupAccountAllowlistAdapter } from "openclaw/plugin-sdk/allowli
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import {
+  createAccountStatusSink,
   createReplyToFanout,
   defineChannelMessageAdapter,
   resolveOutboundSendDep,
@@ -607,8 +608,11 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount, SignalProbe> =
       gateway: {
         startAccount: async (ctx) => {
           const account = ctx.account;
-          ctx.setStatus({
+          const statusSink = createAccountStatusSink({
             accountId: account.accountId,
+            setStatus: ctx.setStatus,
+          });
+          statusSink({
             baseUrl: account.baseUrl,
           });
           ctx.log?.info(`[${account.accountId}] starting provider (${account.baseUrl})`);
@@ -620,6 +624,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount, SignalProbe> =
             channelRuntime: ctx.channelRuntime,
             abortSignal: ctx.abortSignal,
             mediaMaxMb: account.config.mediaMaxMb,
+            statusSink,
           });
         },
       },

--- a/extensions/signal/src/client-adapter.test.ts
+++ b/extensions/signal/src/client-adapter.test.ts
@@ -115,6 +115,7 @@ describe("streamSignalEvents", () => {
       params.onEvent({ event: "receive", data: "native" });
     });
     const onEvent = vi.fn();
+    const onStreamOpen = vi.fn();
 
     await streamSignalEvents({
       baseUrl: "http://native:8080",
@@ -122,6 +123,7 @@ describe("streamSignalEvents", () => {
       transportKind: "managed-native",
       timeoutMs: 0,
       onEvent,
+      onStreamOpen,
     });
 
     expect(nativeStream).toHaveBeenCalledWith(
@@ -129,6 +131,7 @@ describe("streamSignalEvents", () => {
         baseUrl: "http://native:8080",
         account: "+15555550123",
         timeoutMs: 0,
+        onStreamOpen,
       }),
     );
     expect(onEvent).toHaveBeenCalledWith({ event: "receive", data: "native" });
@@ -140,18 +143,21 @@ describe("streamSignalEvents", () => {
       params.onEvent({ envelope: { sourceNumber: "+15555550124" } });
     });
     const onEvent = vi.fn();
+    const onStreamOpen = vi.fn();
 
     await streamSignalEvents({
       baseUrl: "http://container:8080",
       account: "+15555550123",
       transportKind: "container",
       onEvent,
+      onStreamOpen,
     });
 
     expect(containerStream).toHaveBeenCalledWith(
       expect.objectContaining({
         baseUrl: "http://container:8080",
         account: "+15555550123",
+        onStreamOpen,
       }),
     );
     expect(onEvent).toHaveBeenCalledWith({

--- a/extensions/signal/src/client-adapter.ts
+++ b/extensions/signal/src/client-adapter.ts
@@ -75,6 +75,7 @@ export async function streamSignalEvents(params: {
   abortSignal?: AbortSignal;
   timeoutMs?: number;
   onEvent: (event: SignalSseEvent) => unknown;
+  onStreamOpen?: () => void;
   logger?: { log?: (msg: string) => void; error?: (msg: string) => void };
   transportKind?: SignalTransportKind;
 }): Promise<void> {
@@ -85,6 +86,7 @@ export async function streamSignalEvents(params: {
       abortSignal: params.abortSignal,
       timeoutMs: params.timeoutMs,
       onEvent: (event) => params.onEvent({ event: "receive", data: JSON.stringify(event) }),
+      onStreamOpen: params.onStreamOpen,
       logger: params.logger,
     });
   }
@@ -95,5 +97,6 @@ export async function streamSignalEvents(params: {
     abortSignal: params.abortSignal,
     timeoutMs: params.timeoutMs,
     onEvent: (event) => params.onEvent(event),
+    onStreamOpen: params.onStreamOpen,
   });
 }

--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -273,6 +273,7 @@ vi.mock("ws", () => ({
       setTimeout(() => {
         if (wsMockState.behavior === "open") {
           this.emit("open");
+          this.emit("close", 1000, Buffer.from("done"));
         } else if (wsMockState.behavior === "error") {
           this.emit("error", new Error("WebSocket failed"));
         } else if (wsMockState.behavior === "unexpected-response") {
@@ -1587,14 +1588,18 @@ describe("streamContainerEvents", () => {
 
   it("redacts the account and bounds the opening handshake wait", async () => {
     const log = vi.fn();
+    const onStreamOpen = vi.fn();
+    wsMockState.behavior = "open";
 
     await streamContainerEvents({
       baseUrl: "http://localhost:8080",
       account: "+14259798283",
       onEvent: vi.fn(),
+      onStreamOpen,
       logger: { log },
     });
 
+    expect(onStreamOpen).toHaveBeenCalledOnce();
     expect(log).toHaveBeenCalledWith(
       "[signal-ws] connecting to ws://localhost:8080/v1/receive/<redacted>",
     );

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -429,6 +429,7 @@ export async function streamContainerEvents(params: {
   abortSignal?: AbortSignal;
   timeoutMs?: number;
   onEvent: (event: ContainerWebSocketMessage) => unknown;
+  onStreamOpen?: () => void;
   logger?: { log?: (msg: string) => void; error?: (msg: string) => void };
 }): Promise<void> {
   const normalized = normalizeBaseUrl(params.baseUrl);
@@ -480,6 +481,7 @@ export async function streamContainerEvents(params: {
 
     ws.on("open", () => {
       log("[signal-ws] connected");
+      params.onStreamOpen?.();
     });
 
     ws.on("message", (data: Buffer) => {

--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -307,6 +307,7 @@ describe("streamSignalEvents", () => {
   it("streams events through node http instead of fetch", async () => {
     type StreamEvent = Parameters<Parameters<typeof streamSignalEvents>[0]["onEvent"]>[0];
     const events: StreamEvent[] = [];
+    const onStreamOpen = vi.fn();
     const baseUrl = await withSignalServer((req, res) => {
       expect(req.url).toBe("/api/v1/events?account=%2B15555550123");
       expect(req.headers.accept).toBe("text/event-stream");
@@ -317,9 +318,11 @@ describe("streamSignalEvents", () => {
     await streamSignalEvents({
       baseUrl,
       account: "+15555550123",
+      onStreamOpen,
       onEvent: (event) => events.push(event),
     });
 
+    expect(onStreamOpen).toHaveBeenCalledOnce();
     expect(events).toEqual([{ id: "42", event: "message", data: '{"group":true}' }]);
   });
 

--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -343,6 +343,7 @@ export async function streamSignalEvents(params: {
   abortSignal?: AbortSignal;
   timeoutMs?: number;
   onEvent: (event: SignalSseEvent) => unknown;
+  onStreamOpen?: () => void;
 }): Promise<void> {
   const url = resolveSignalEndpointUrl(params.baseUrl, "/api/v1/events");
   if (params.account) {
@@ -354,6 +355,7 @@ export async function streamSignalEvents(params: {
     params.abortSignal,
     params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
   );
+  params.onStreamOpen?.();
   const decoder = new TextDecoder();
   let buffer = "";
   let bufferedBytes = 0;

--- a/extensions/signal/src/daemon-lifecycle.ts
+++ b/extensions/signal/src/daemon-lifecycle.ts
@@ -1,0 +1,38 @@
+import { formatSignalDaemonExit, type SignalDaemonHandle } from "./daemon.js";
+
+export function createSignalDaemonLifecycle(params: { abortSignal?: AbortSignal }) {
+  let daemonHandle: SignalDaemonHandle | null = null;
+  let daemonStopRequested = false;
+  let daemonStopPromise: Promise<void> | undefined;
+  let daemonExitError: Error | undefined;
+  const daemonAbortController = new AbortController();
+  const abortSignal = params.abortSignal
+    ? AbortSignal.any([params.abortSignal, daemonAbortController.signal])
+    : daemonAbortController.signal;
+  const stop = (): Promise<void> => {
+    if (daemonStopPromise) {
+      return daemonStopPromise;
+    }
+    daemonStopRequested = true;
+    if (!daemonAbortController.signal.aborted) {
+      daemonAbortController.abort(
+        params.abortSignal?.reason ?? new Error("Signal monitor stopped"),
+      );
+    }
+    daemonStopPromise = daemonHandle?.stop() ?? Promise.resolve();
+    return daemonStopPromise;
+  };
+  const attach = (handle: SignalDaemonHandle) => {
+    daemonHandle = handle;
+    void handle.exited.then((exit) => {
+      if (daemonStopRequested || params.abortSignal?.aborted) {
+        return;
+      }
+      daemonExitError = new Error(formatSignalDaemonExit(exit));
+      if (!daemonAbortController.signal.aborted) {
+        daemonAbortController.abort(daemonExitError);
+      }
+    });
+  };
+  return { attach, stop, getExitError: () => daemonExitError, abortSignal };
+}

--- a/extensions/signal/src/monitor.tool-result.autostart.test.ts
+++ b/extensions/signal/src/monitor.tool-result.autostart.test.ts
@@ -198,6 +198,7 @@ describe("monitorSignalProvider autostart", () => {
 
   it("fails fast when auto-started signal daemon exits during startup", async () => {
     const runtime = createMonitorRuntime();
+    const statusSink = vi.fn();
     setSignalAutoStartConfig();
     spawnSignalDaemonMock.mockReturnValueOnce(
       createMockSignalDaemonHandle({
@@ -232,8 +233,12 @@ describe("monitorSignalProvider autostart", () => {
         autoStart: true,
         baseUrl: SIGNAL_BASE_URL,
         runtime,
+        statusSink,
       }),
     ).rejects.toThrow(/signal daemon exited/i);
+    expect(statusSink).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycle: "recovering", connected: false }),
+    );
   });
 
   it("treats daemon exit after user abort as clean shutdown", async () => {

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -48,7 +48,8 @@ import { isSignalNativeApprovalHandlerConfigured } from "./approval-native.js";
 import { addSignalApprovalReactionHintToStructuredPayload } from "./approval-reactions.js";
 import { signalRpcRequest, signalCheck } from "./client-adapter.js";
 import type { SignalTransportKind } from "./client-adapter.js";
-import { formatSignalDaemonExit, spawnSignalDaemon, type SignalDaemonHandle } from "./daemon.js";
+import { createSignalDaemonLifecycle } from "./daemon-lifecycle.js";
+import { spawnSignalDaemon, type SignalDaemonHandle } from "./daemon.js";
 import { isSignalSenderAllowed, type resolveSignalSender } from "./identity.js";
 import { createSignalEventHandler } from "./monitor/event-handler.js";
 import type {
@@ -61,7 +62,11 @@ import { materializeSignalPresentationFallback } from "./presentation-fallback.j
 import { registerSignalReactionTargetsForDeliveredPayload } from "./reaction-targets.js";
 import { sendMessageSignal } from "./send.js";
 import { startSignalIngressMonitor, type SignalIngressMonitor } from "./signal-ingress.js";
-import { runSignalSseLoop } from "./sse-reconnect.js";
+import {
+  publishSignalRecovering,
+  runSignalSseLoop,
+  type SignalStatusSink,
+} from "./sse-reconnect.js";
 
 export type MonitorSignalOpts = {
   runtime?: RuntimeEnv;
@@ -86,6 +91,7 @@ export type MonitorSignalOpts = {
   mediaMaxMb?: number;
   reconnectPolicy?: Partial<BackoffPolicy>;
   waitForTransportReady?: typeof waitForTransportReady;
+  statusSink?: SignalStatusSink;
 };
 
 function createSignalMonitorTaskRunner(runtime: RuntimeEnv) {
@@ -105,49 +111,6 @@ function createSignalMonitorTaskRunner(runtime: RuntimeEnv) {
         await Promise.allSettled(inFlight);
       }
     },
-  };
-}
-
-function createSignalDaemonLifecycle(params: { abortSignal?: AbortSignal }) {
-  let daemonHandle: SignalDaemonHandle | null = null;
-  let daemonStopRequested = false;
-  let daemonStopPromise: Promise<void> | undefined;
-  let daemonExitError: Error | undefined;
-  const daemonAbortController = new AbortController();
-  const abortSignal = params.abortSignal
-    ? AbortSignal.any([params.abortSignal, daemonAbortController.signal])
-    : daemonAbortController.signal;
-  const stop = (): Promise<void> => {
-    if (daemonStopPromise) {
-      return daemonStopPromise;
-    }
-    daemonStopRequested = true;
-    if (!daemonAbortController.signal.aborted) {
-      daemonAbortController.abort(
-        params.abortSignal?.reason ?? new Error("Signal monitor stopped"),
-      );
-    }
-    daemonStopPromise = daemonHandle?.stop() ?? Promise.resolve();
-    return daemonStopPromise;
-  };
-  const attach = (handle: SignalDaemonHandle) => {
-    daemonHandle = handle;
-    void handle.exited.then((exit) => {
-      if (daemonStopRequested || params.abortSignal?.aborted) {
-        return;
-      }
-      daemonExitError = new Error(formatSignalDaemonExit(exit));
-      if (!daemonAbortController.signal.aborted) {
-        daemonAbortController.abort(daemonExitError);
-      }
-    });
-  };
-  const getExitError = () => daemonExitError;
-  return {
-    attach,
-    stop,
-    getExitError,
-    abortSignal,
   };
 }
 
@@ -707,6 +670,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       timeoutMs: 0,
       transportKind,
       policy: opts.reconnectPolicy,
+      statusSink: opts.statusSink,
       onEvent: (event) =>
         monitorTaskRunner.runTask(async () => await ingressMonitor?.receive(event)),
     });
@@ -718,6 +682,9 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     const daemonExitError = daemonLifecycle.getExitError();
     if (opts.abortSignal?.aborted && !daemonExitError) {
       return;
+    }
+    if (daemonExitError) {
+      publishSignalRecovering(opts.statusSink, daemonExitError.message);
     }
     throw err;
   } finally {

--- a/extensions/signal/src/sse-reconnect.test.ts
+++ b/extensions/signal/src/sse-reconnect.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const streamSignalEvents = vi.hoisted(() => vi.fn());
+
+vi.mock("./client-adapter.js", () => ({ streamSignalEvents }));
+
+import { runSignalSseLoop } from "./sse-reconnect.js";
+
+function createRuntime() {
+  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+}
+
+describe("runSignalSseLoop lifecycle", () => {
+  beforeEach(() => {
+    streamSignalEvents.mockReset();
+  });
+
+  it("publishes ready on stream open and recovering when the stream ends", async () => {
+    const abort = new AbortController();
+    const statusSink = vi.fn((patch: { lifecycle?: string }) => {
+      if (patch.lifecycle === "recovering") {
+        abort.abort();
+      }
+    });
+    streamSignalEvents.mockImplementationOnce(async (params) => {
+      params.onStreamOpen?.();
+    });
+
+    await runSignalSseLoop({
+      baseUrl: "http://signal.test",
+      abortSignal: abort.signal,
+      runtime: createRuntime(),
+      onEvent: vi.fn(),
+      statusSink,
+    });
+
+    expect(statusSink).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ lifecycle: "ready", connected: true }),
+    );
+    expect(statusSink).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ lifecycle: "recovering", connected: false }),
+    );
+  });
+
+  it("publishes recovering for stream errors", async () => {
+    const abort = new AbortController();
+    const statusSink = vi.fn((patch: { lifecycle?: string }) => {
+      if (patch.lifecycle === "recovering") {
+        abort.abort();
+      }
+    });
+    streamSignalEvents.mockRejectedValueOnce(new Error("stream failed"));
+
+    await runSignalSseLoop({
+      baseUrl: "http://signal.test",
+      abortSignal: abort.signal,
+      runtime: createRuntime(),
+      onEvent: vi.fn(),
+      statusSink,
+    });
+
+    expect(statusSink).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycle: "recovering", lastError: "Error: stream failed" }),
+    );
+  });
+});

--- a/extensions/signal/src/sse-reconnect.ts
+++ b/extensions/signal/src/sse-reconnect.ts
@@ -1,4 +1,5 @@
 // Signal plugin module implements sse reconnect behavior.
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import {
   computeBackoff,
   logVerbose,
@@ -20,6 +21,19 @@ const DEFAULT_RECONNECT_POLICY: BackoffPolicy = {
   jitter: 0.2,
 };
 
+export type SignalStatusSink = (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
+
+export function publishSignalRecovering(
+  statusSink: SignalStatusSink | undefined,
+  lastError?: string,
+) {
+  statusSink?.({
+    connected: false,
+    lifecycle: "recovering",
+    ...(lastError ? { lastError } : {}),
+  });
+}
+
 type RunSignalSseLoopParams = {
   baseUrl: string;
   account?: string;
@@ -29,6 +43,7 @@ type RunSignalSseLoopParams = {
   timeoutMs?: number;
   transportKind?: SignalTransportKind;
   policy?: Partial<BackoffPolicy>;
+  statusSink?: SignalStatusSink;
 };
 
 export async function runSignalSseLoop({
@@ -40,6 +55,7 @@ export async function runSignalSseLoop({
   timeoutMs,
   transportKind,
   policy,
+  statusSink,
 }: RunSignalSseLoopParams) {
   const reconnectPolicy = {
     ...DEFAULT_RECONNECT_POLICY,
@@ -65,6 +81,15 @@ export async function runSignalSseLoop({
         abortSignal,
         timeoutMs,
         transportKind,
+        onStreamOpen: () => {
+          statusSink?.({
+            connected: true,
+            lifecycle: "ready",
+            lastConnectedAt: Date.now(),
+            lastError: null,
+            terminalDisconnect: undefined,
+          });
+        },
         onEvent: async (event: SignalSseEvent) => {
           reconnectAttempts = 0;
           await onEvent(event);
@@ -77,6 +102,7 @@ export async function runSignalSseLoop({
       if (abortSignal?.aborted) {
         return;
       }
+      publishSignalRecovering(statusSink);
       reconnectAttempts += 1;
       const delayMs = computeBackoff(reconnectPolicy, reconnectAttempts);
       logReconnectVerbose(`Signal stream ended, reconnecting in ${delayMs / 1000}s...`);
@@ -86,6 +112,7 @@ export async function runSignalSseLoop({
         return;
       }
       runtime.error?.(`Signal stream error: ${String(err)}`);
+      publishSignalRecovering(statusSink, String(err));
       reconnectAttempts += 1;
       const delayMs = computeBackoff(reconnectPolicy, reconnectAttempts);
       runtime.log?.(`Signal connection lost, reconnecting in ${delayMs / 1000}s...`);

--- a/extensions/slack/src/monitor/provider-support.ts
+++ b/extensions/slack/src/monitor/provider-support.ts
@@ -196,7 +196,23 @@ export function publishSlackConnectedStatus(
   setStatus({
     connected: true,
     lastConnectedAt: Date.now(),
+    terminalDisconnect: undefined,
     ...identityHealth,
+  });
+}
+
+export function publishSlackBlockedStatus(
+  setStatus: ((next: Record<string, unknown>) => void) | undefined,
+  error: unknown,
+) {
+  if (!setStatus) {
+    return;
+  }
+  setStatus({
+    connected: false,
+    lifecycle: "blocked",
+    terminalDisconnect: true,
+    lastError: formatUnknownError(error),
   });
 }
 

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -618,6 +618,7 @@ describe("connected identity health", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: expect.any(Number),
+      terminalDisconnect: undefined,
       ...expected,
     });
   });
@@ -632,6 +633,7 @@ describe("connected identity health", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: expect.any(Number),
+      terminalDisconnect: undefined,
       lifecycle: "ready",
       lastError: null,
     });
@@ -663,6 +665,7 @@ describe("connected identity health", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: expect.any(Number),
+      terminalDisconnect: undefined,
       lifecycle: "blocked",
       lastError: "request_timeout",
     });
@@ -688,6 +691,7 @@ describe("connected identity health", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: expect.any(Number),
+      terminalDisconnect: undefined,
       lifecycle: "ready",
       lastError: null,
     });

--- a/extensions/slack/src/monitor/provider.reconnect-loop.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect-loop.test.ts
@@ -42,6 +42,7 @@ describe("slack socket reconnect loop", () => {
     async (_label, createError) => {
       const controller = new AbortController();
       const runtimeError = vi.fn();
+      const setStatus = vi.fn();
       let attempts = 0;
       slackTestState.appStartMock.mockImplementation(async () => {
         attempts += 1;
@@ -61,6 +62,7 @@ describe("slack socket reconnect loop", () => {
           error: runtimeError,
           exit: vi.fn(),
         },
+        setStatus,
       });
 
       await vi.runAllTimersAsync();
@@ -68,6 +70,9 @@ describe("slack socket reconnect loop", () => {
 
       expect(slackTestState.appStartMock).toHaveBeenCalledTimes(14);
       expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("retry 13/∞"));
+      expect(setStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ connected: false, lifecycle: "recovering" }),
+      );
     },
   );
 
@@ -107,6 +112,30 @@ describe("slack socket reconnect loop", () => {
         "last SDK log: socket-mode:socket-mode failed to retrieve WSS URL slack error: missing_scope; needed: connections:write",
       ),
     );
+  });
+
+  it("publishes blocked before rejecting a non-recoverable socket start failure", async () => {
+    const controller = new AbortController();
+    const setStatus = vi.fn();
+    slackTestState.appStartMock.mockRejectedValue(new Error("invalid_auth"));
+
+    await expect(
+      monitorSlackProvider({
+        botToken: "bot-token",
+        appToken: "app-token",
+        abortSignal: controller.signal,
+        config: slackTestState.config,
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        setStatus,
+      }),
+    ).rejects.toThrow("invalid_auth");
+
+    expect(setStatus).toHaveBeenCalledWith({
+      connected: false,
+      lifecycle: "blocked",
+      terminalDisconnect: true,
+      lastError: "invalid_auth",
+    });
   });
 
   it("re-resolves degraded identity after a recoverable reconnect", async () => {
@@ -152,6 +181,7 @@ describe("slack socket reconnect loop", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: expect.any(Number),
+      terminalDisconnect: undefined,
       lifecycle: "ready",
       lastError: null,
     });

--- a/extensions/slack/src/monitor/provider.reconnect.test.ts
+++ b/extensions/slack/src/monitor/provider.reconnect.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   gracefulStopSlackApp,
+  publishSlackBlockedStatus,
   publishSlackConnectedStatus,
   publishSlackDisconnectedStatus,
   startSlackSocketAndWaitForDisconnect,
@@ -82,8 +83,22 @@ describe("slack socket reconnect helpers", () => {
     expect(setStatus).toHaveBeenCalledWith({
       connected: true,
       lastConnectedAt: 1_711_406_400_500,
+      terminalDisconnect: undefined,
       lifecycle: "blocked",
       lastError: "auth.test returned no user_id",
+    });
+  });
+
+  it("marks non-recoverable socket authentication failures blocked", () => {
+    const setStatus = vi.fn();
+
+    publishSlackBlockedStatus(setStatus, new Error("invalid_auth"));
+
+    expect(setStatus).toHaveBeenCalledWith({
+      connected: false,
+      lifecycle: "blocked",
+      terminalDisconnect: true,
+      lastError: "invalid_auth",
     });
   });
 

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -73,6 +73,7 @@ import {
   formatSlackUserResolved,
   gracefulStopSlackApp,
   publishSlackConnectedStatus,
+  publishSlackBlockedStatus,
   publishSlackDisconnectedStatus,
   resolveSlackBoltInterop,
   startSlackSocketAndWaitForDisconnect,
@@ -852,6 +853,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
 
           // Permanent account and credential failures need operator action.
           if (disconnect.error && isNonRecoverableSlackAuthError(disconnect.error)) {
+            publishSlackBlockedStatus(opts.setStatus, disconnect.error);
             runtime.error?.(
               `slack socket mode disconnected due to non-recoverable auth error — skipping channel (${formatUnknownError(disconnect.error)})`,
             );
@@ -880,11 +882,13 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           }
         } catch (err) {
           if (isNonRecoverableSlackAuthError(err)) {
+            publishSlackBlockedStatus(opts.setStatus, err);
             runtime.error?.(
               `slack socket mode failed to start due to non-recoverable auth error — skipping channel (${formatUnknownError(err)})`,
             );
             throw err;
           }
+          publishSlackDisconnectedStatus(opts.setStatus, err);
           reconnectAttempts += 1;
           const delayMs = computeBackoff(SLACK_SOCKET_RECONNECT_POLICY, reconnectAttempts);
           runtime.error?.(

--- a/extensions/sms/src/channel.test.ts
+++ b/extensions/sms/src/channel.test.ts
@@ -48,13 +48,37 @@ describe("smsPlugin status", () => {
       },
     });
 
-    expect(snapshot).toEqual({
+    expect(snapshot).toMatchObject({
       accountId: "support",
       name: "+15557654321",
       enabled: true,
       configured: true,
       statusState: "configured",
     });
+  });
+
+  it("projects lifecycle from the runtime status record", async () => {
+    const snapshot = await smsPlugin.status?.buildAccountSnapshot?.({
+      cfg: {},
+      account: {
+        accountId: "support",
+        enabled: true,
+        accountSid: "AC123",
+        authToken: "secret",
+        fromNumber: "+15557654321",
+        messagingServiceSid: "",
+        defaultTo: "",
+        webhookPath: "/webhooks/sms",
+        publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
+        dangerouslyDisableSignatureValidation: false,
+        dmPolicy: "pairing",
+        allowFrom: [],
+        textChunkLimit: 1500,
+      },
+      runtime: { accountId: "support", lifecycle: "blocked", terminalDisconnect: true },
+    });
+
+    expect(snapshot).toMatchObject({ lifecycle: "blocked", terminalDisconnect: true });
   });
 });
 

--- a/extensions/sms/src/channel.ts
+++ b/extensions/sms/src/channel.ts
@@ -12,6 +12,7 @@ import {
   type ChannelPlugin,
 } from "openclaw/plugin-sdk/channel-core";
 import {
+  createAccountStatusSink,
   createMessageReceiptFromOutboundResults,
   defineChannelMessageAdapter,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -21,6 +22,10 @@ import {
   type ChannelSetupInput,
 } from "openclaw/plugin-sdk/channel-setup";
 import { createEmptyChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
+import {
+  createComputedAccountStatusAdapter,
+  createDefaultChannelRuntimeState,
+} from "openclaw/plugin-sdk/status-helpers";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 import {
@@ -328,24 +333,32 @@ export const smsPlugin: ChannelPlugin<ResolvedSmsAccount, SmsProbe> = createChat
           ctx.log?.warn?.("SMS channel runtime is not available; webhook route not started");
           return;
         }
+        const statusSink = createAccountStatusSink({
+          accountId: ctx.account.accountId,
+          setStatus: ctx.setStatus,
+        });
         return await startSmsGatewayAccount({
           cfg: ctx.cfg,
           account: ctx.account,
           channelRuntime: ctx.channelRuntime as unknown as SmsChannelRuntime,
           abortSignal: ctx.abortSignal,
           log: ctx.log,
+          statusSink,
         });
       },
     },
-    status: {
-      buildAccountSnapshot: ({ account }) => {
+    status: createComputedAccountStatusAdapter<ResolvedSmsAccount, SmsProbe>({
+      defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID),
+      resolveAccountSnapshot: ({ account }) => {
         const configured = isSmsAccountConfigured(account);
         return {
           accountId: account.accountId,
           name: account.fromNumber || account.messagingServiceSid || "SMS",
           enabled: account.enabled,
           configured,
-          statusState: !account.enabled ? "disabled" : configured ? "configured" : "unconfigured",
+          extra: {
+            statusState: !account.enabled ? "disabled" : configured ? "configured" : "unconfigured",
+          },
         };
       },
       probeAccount: async ({ account, timeoutMs }) => await probeSmsAccount({ account, timeoutMs }),
@@ -353,7 +366,7 @@ export const smsPlugin: ChannelPlugin<ResolvedSmsAccount, SmsProbe> = createChat
       buildCapabilitiesDiagnostics: async ({ account }) => ({
         lines: collectSmsStartupWarnings(account).map((text) => ({ text, tone: "warn" })),
       }),
-    },
+    }),
     secrets: {
       secretTargetRegistryEntries,
       collectRuntimeConfigAssignments,

--- a/extensions/sms/src/gateway.test.ts
+++ b/extensions/sms/src/gateway.test.ts
@@ -96,6 +96,49 @@ describe("startSmsGatewayAccount", () => {
     });
   }
 
+  it("publishes ready and stopped around an active webhook route", async () => {
+    const statusSink = vi.fn();
+    await startRoute({
+      cfg: {},
+      account: createAccount("default"),
+      channelRuntime: {} as SmsChannelRuntime,
+      statusSink,
+    });
+
+    expect(statusSink).toHaveBeenNthCalledWith(1, { lifecycle: "starting" });
+    expect(statusSink).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycle: "ready", connected: true }),
+    );
+    expect(statusSink).toHaveBeenLastCalledWith(
+      expect.objectContaining({ lifecycle: "stopped", running: false }),
+    );
+  });
+
+  it("publishes stopped for disabled accounts and blocked for missing required config", async () => {
+    const disabledSink = vi.fn();
+    await startRoute({
+      cfg: {},
+      account: { ...createAccount("disabled"), enabled: false },
+      channelRuntime: {} as SmsChannelRuntime,
+      statusSink: disabledSink,
+    });
+    expect(disabledSink).toHaveBeenLastCalledWith(
+      expect.objectContaining({ lifecycle: "stopped", running: false }),
+    );
+
+    const blockedSink = vi.fn();
+    await startRoute({
+      cfg: {},
+      account: { ...createAccount("missing"), authToken: "" },
+      channelRuntime: {} as SmsChannelRuntime,
+      statusSink: blockedSink,
+    });
+    expect(blockedSink).toHaveBeenLastCalledWith(
+      expect.objectContaining({ lifecycle: "blocked", terminalDisconnect: true }),
+    );
+    expect(registerPluginHttpRoute).not.toHaveBeenCalled();
+  });
+
   it("rejects duplicate webhook paths across SMS accounts", async () => {
     const channelRuntime = {} as SmsChannelRuntime;
     await startRoute({

--- a/extensions/sms/src/gateway.ts
+++ b/extensions/sms/src/gateway.ts
@@ -1,4 +1,5 @@
 // Sms plugin module implements gateway behavior.
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import { waitUntilAbort } from "openclaw/plugin-sdk/channel-outbound";
 import { registerPluginHttpRoute } from "openclaw/plugin-sdk/webhook-ingress";
 import { createSmsIngressSpool, type SmsIngressLog } from "./ingress-spool.js";
@@ -153,9 +154,12 @@ export async function startSmsGatewayAccount(params: {
   channelRuntime: Parameters<typeof createSmsIngressSpool>[0]["channelRuntime"];
   abortSignal: AbortSignal;
   log?: SmsIngressLog;
+  statusSink?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
 }) {
+  params.statusSink?.({ lifecycle: "starting" });
   if (!params.account.enabled) {
     params.log?.info?.(`SMS account ${params.account.accountId} is disabled`);
+    params.statusSink?.({ running: false, connected: false, lifecycle: "stopped" });
     return waitUntilAbort(params.abortSignal);
   }
   const warnings = collectSmsStartupWarnings(params.account);
@@ -163,6 +167,13 @@ export async function startSmsGatewayAccount(params: {
     for (const warning of warnings) {
       params.log?.warn?.(warning);
     }
+    params.statusSink?.({
+      running: true,
+      connected: false,
+      lifecycle: "blocked",
+      terminalDisconnect: true,
+      lastError: warnings.join("; "),
+    });
     return waitUntilAbort(params.abortSignal);
   }
   for (const warning of warnings) {
@@ -173,6 +184,16 @@ export async function startSmsGatewayAccount(params: {
     params.log?.info?.(
       `Registered SMS webhook route ${params.account.webhookPath} for account ${params.account.accountId}`,
     );
+    params.statusSink?.({
+      running: true,
+      connected: true,
+      lifecycle: "ready",
+      lastConnectedAt: Date.now(),
+      lastError: null,
+      terminalDisconnect: undefined,
+    });
   }
-  return registration.lifecycle;
+  return registration.lifecycle.finally(() => {
+    params.statusSink?.({ running: false, connected: false, lifecycle: "stopped" });
+  });
 }

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -146,6 +146,30 @@ describe("createSynologyChatPlugin", () => {
     });
   });
 
+  it("projects lifecycle through the computed status adapter", async () => {
+    const cfg = {
+      channels: {
+        "synology-chat": {
+          token: "test-token",
+          incomingUrl: "https://nas/incoming",
+        },
+      },
+    };
+    const account = synologyChatPlugin.config.resolveAccount(cfg, "default");
+
+    const snapshot = await synologyChatPlugin.status?.buildAccountSnapshot?.({
+      account,
+      cfg,
+      runtime: { accountId: "default", lifecycle: "ready" },
+    });
+
+    expect(snapshot).toMatchObject({
+      accountId: "default",
+      configured: true,
+      lifecycle: "ready",
+    });
+  });
+
   describe("config", () => {
     it("listAccountIds includes default and named accounts when configured", () => {
       const plugin = synologyChatPlugin;
@@ -639,6 +663,7 @@ describe("createSynologyChatPlugin", () => {
           accountId: "default",
           log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
           abortSignal: abortController.signal,
+          setStatus: vi.fn(),
         },
       };
     }
@@ -673,6 +698,7 @@ describe("createSynologyChatPlugin", () => {
           accountId: "alerts",
           log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
           abortSignal: abortController.signal,
+          setStatus: vi.fn(),
         },
       };
     }
@@ -705,7 +731,51 @@ describe("createSynologyChatPlugin", () => {
     }
 
     it("startAccount returns pending promise for disabled account", async () => {
-      await expectPendingStartAccount({ enabled: false });
+      const { ctx, abortController } = makeStartAccountCtx({ enabled: false });
+      const result = synologyChatPlugin.gateway.startAccount(ctx);
+      await Promise.resolve();
+      expect(ctx.setStatus).toHaveBeenCalledWith({
+        accountId: "default",
+        running: true,
+        lifecycle: "blocked",
+        terminalDisconnect: true,
+        lastError: "Synology Chat account failed startup validation",
+      });
+      await expectPendingStartAccountPromise(result, abortController);
+    });
+
+    it("publishes ready after route registration and stopped after abort cleanup", async () => {
+      const cleanup = vi.fn(async () => undefined);
+      registerSynologyWebhookRouteMock.mockResolvedValueOnce(cleanup);
+      const { ctx, abortController } = makeStartAccountCtx({
+        enabled: true,
+        token: "t",
+        incomingUrl: "https://nas/incoming",
+        dmPolicy: "allowlist",
+        allowedUserIds: ["123"],
+      });
+
+      const result = synologyChatPlugin.gateway.startAccount(ctx);
+      await vi.waitFor(() => expect(registerSynologyWebhookRouteMock).toHaveBeenCalledOnce());
+      expect(ctx.setStatus).toHaveBeenCalledWith({
+        accountId: "default",
+        running: true,
+        connected: true,
+        lifecycle: "ready",
+        lastConnectedAt: expect.any(Number),
+        lastError: null,
+        terminalDisconnect: undefined,
+      });
+
+      abortController.abort();
+      await result;
+      expect(cleanup).toHaveBeenCalledOnce();
+      expect(ctx.setStatus).toHaveBeenLastCalledWith({
+        accountId: "default",
+        running: false,
+        connected: false,
+        lifecycle: "stopped",
+      });
     });
 
     it("startAccount returns pending promise for account without token", async () => {

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -10,7 +10,10 @@ import {
   createHybridChannelConfigAdapter,
   createScopedDmSecurityResolver,
 } from "openclaw/plugin-sdk/channel-config-helpers";
-import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-contract";
+import type {
+  ChannelAccountSnapshot,
+  ChannelOutboundAdapter,
+} from "openclaw/plugin-sdk/channel-contract";
 import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { waitUntilAbort } from "openclaw/plugin-sdk/channel-outbound";
 import {
@@ -27,6 +30,10 @@ import {
 } from "openclaw/plugin-sdk/channel-policy";
 import { createEmptyChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
+import {
+  createComputedAccountStatusAdapter,
+  createDefaultChannelRuntimeState,
+} from "openclaw/plugin-sdk/status-helpers";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeStringEntriesLower,
@@ -69,6 +76,7 @@ type SynologyChannelGatewayContext = {
   cfg: OpenClawConfig;
   accountId: string;
   abortSignal: AbortSignal;
+  setStatus?: (patch: ChannelAccountSnapshot) => void;
   log?: {
     info: (message: string) => void;
     warn: (message: string) => void;
@@ -371,11 +379,30 @@ function createSynologyChatPlugin(): SynologyChatPlugin {
         },
       },
       directory: createEmptyChannelDirectoryAdapter(),
+      status: createComputedAccountStatusAdapter<ResolvedSynologyChatAccount>({
+        defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID),
+        buildChannelSummary: ({ snapshot }) => ({
+          webhookPath: snapshot.webhookPath ?? null,
+        }),
+        resolveAccountSnapshot: ({ account }) => ({
+          accountId: account.accountId,
+          enabled: account.enabled,
+          configured: Boolean(account.token && account.incomingUrl),
+          extra: { webhookPath: account.webhookPath },
+        }),
+      }),
       gateway: {
         startAccount: async (ctx: SynologyChannelGatewayContext) => {
           const { cfg, accountId, log, abortSignal } = ctx;
           const account = resolveAccount(cfg, accountId);
           if (!validateSynologyGatewayAccountStartup({ cfg, account, accountId, log }).ok) {
+            ctx.setStatus?.({
+              accountId,
+              running: true,
+              lifecycle: "blocked",
+              terminalDisconnect: true,
+              lastError: "Synology Chat account failed startup validation",
+            });
             return waitUntilAbort(abortSignal);
           }
 
@@ -391,6 +418,15 @@ function createSynologyChatPlugin(): SynologyChatPlugin {
           });
 
           log?.info?.(`Registered HTTP route: ${account.webhookPath} for Synology Chat`);
+          ctx.setStatus?.({
+            accountId,
+            running: true,
+            connected: true,
+            lifecycle: "ready",
+            lastConnectedAt: Date.now(),
+            lastError: null,
+            terminalDisconnect: undefined,
+          });
 
           // Keep alive until abort signal fires.
           // The gateway expects a Promise that stays pending while the channel is running.
@@ -398,6 +434,12 @@ function createSynologyChatPlugin(): SynologyChatPlugin {
           return waitUntilAbort(abortSignal, async () => {
             log?.info?.(`Stopping Synology Chat channel (account: ${accountId})`);
             await cleanup();
+            ctx.setStatus?.({
+              accountId,
+              running: false,
+              connected: false,
+              lifecycle: "stopped",
+            });
           });
         },
 

--- a/extensions/twitch/src/client-manager-registry.ts
+++ b/extensions/twitch/src/client-manager-registry.ts
@@ -6,7 +6,7 @@
  */
 
 import { TwitchClientManager } from "./twitch-client.js";
-import type { ChannelLogSink } from "./types.js";
+import type { ChannelAccountSnapshot, ChannelLogSink } from "./types.js";
 
 /**
  * Registry entry tracking a client manager and its associated account.
@@ -38,13 +38,15 @@ const registry = new Map<string, RegistryEntry>();
 export function getOrCreateClientManager(
   accountId: string,
   logger: ChannelLogSink,
+  statusSink?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void,
 ): TwitchClientManager {
   const existing = registry.get(accountId);
   if (existing) {
+    existing.manager.setStatusSink(statusSink);
     return existing.manager;
   }
 
-  const manager = new TwitchClientManager(logger);
+  const manager = new TwitchClientManager(logger, statusSink);
   registry.set(accountId, {
     manager,
     accountId,

--- a/extensions/twitch/src/monitor.ts
+++ b/extensions/twitch/src/monitor.ts
@@ -5,6 +5,7 @@
  * resolves agent routes, and handles replies.
  */
 
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import { createChannelInboundEnvelopeBuilder } from "openclaw/plugin-sdk/channel-inbound";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -28,7 +29,7 @@ type TwitchMonitorOptions = {
   config: unknown; // OpenClawConfig
   runtime: TwitchRuntimeEnv;
   abortSignal: AbortSignal;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
 };
 
 type TwitchMonitorResult = {
@@ -49,7 +50,7 @@ async function processTwitchMessage(params: {
   runtime: TwitchRuntimeEnv;
   core: TwitchCoreRuntime;
   turnAdoptionLifecycle: TwitchIngressLifecycle;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
 }): Promise<void> {
   const { message, account, accountId, config, runtime, core, turnAdoptionLifecycle, statusSink } =
     params;
@@ -241,7 +242,7 @@ export async function monitorTwitchProvider(
     debug: logVerboseMessage,
   };
 
-  const clientManager = getOrCreateClientManager(accountId, logger);
+  const clientManager = getOrCreateClientManager(accountId, logger, statusSink);
 
   try {
     await clientManager.getClient(

--- a/extensions/twitch/src/plugin.lifecycle.test.ts
+++ b/extensions/twitch/src/plugin.lifecycle.test.ts
@@ -76,6 +76,29 @@ describe("twitch startAccount lifecycle", () => {
     });
   });
 
+  it("publishes starting and forwards a bound status sink to the monitor", async () => {
+    const stop = mockStartedMonitor();
+    const patches: ChannelAccountSnapshot[] = [];
+    const abort = new AbortController();
+    const task = requireStartAccount()(
+      createStartAccountContext({
+        account: buildAccount(),
+        abortSignal: abort.signal,
+        statusPatchSink: (next) => patches.push({ ...next }),
+      }),
+    );
+
+    await vi.waitFor(() => expect(hoisted.monitorTwitchProvider).toHaveBeenCalledOnce());
+    expectLifecyclePatch(patches, { lifecycle: "starting", running: true });
+    expect(hoisted.monitorTwitchProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ statusSink: expect.any(Function) }),
+    );
+
+    abort.abort();
+    await task;
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
   it("stops immediately when startAccount receives an already-aborted signal", async () => {
     const stop = mockStartedMonitor();
     const abort = new AbortController();

--- a/extensions/twitch/src/plugin.ts
+++ b/extensions/twitch/src/plugin.ts
@@ -12,7 +12,10 @@ import {
   createChatChannelPlugin,
   stripChannelTargetPrefix,
 } from "openclaw/plugin-sdk/channel-core";
-import { runPassiveAccountLifecycle } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  createAccountStatusSink,
+  runPassiveAccountLifecycle,
+} from "openclaw/plugin-sdk/channel-outbound";
 import {
   createLoggedPairingApprovalNotifier,
   createPairingPrefixStripper,
@@ -181,12 +184,16 @@ export const twitchPlugin: ChannelPlugin<ResolvedTwitchAccount> =
         startAccount: async (ctx): Promise<void> => {
           const account = ctx.account;
           const accountId = ctx.accountId;
-
-          ctx.setStatus?.({
+          const statusSink = createAccountStatusSink({
             accountId,
+            setStatus: ctx.setStatus,
+          });
+
+          statusSink({
             running: true,
             lastStartAt: Date.now(),
             lastError: null,
+            lifecycle: "starting",
           });
 
           ctx.log?.info(`Starting Twitch connection for ${account.username}`);
@@ -206,6 +213,7 @@ export const twitchPlugin: ChannelPlugin<ResolvedTwitchAccount> =
                   config: ctx.cfg,
                   runtime: ctx.runtime,
                   abortSignal: ctx.abortSignal,
+                  statusSink,
                 });
               },
               stop: async (monitor) => {

--- a/extensions/twitch/src/twitch-client.test.ts
+++ b/extensions/twitch/src/twitch-client.test.ts
@@ -13,7 +13,12 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveTwitchToken } from "./token.js";
 import { TwitchClientManager } from "./twitch-client.js";
-import type { ChannelLogSink, TwitchAccountConfig, TwitchChatMessage } from "./types.js";
+import type {
+  ChannelAccountSnapshot,
+  ChannelLogSink,
+  TwitchAccountConfig,
+  TwitchChatMessage,
+} from "./types.js";
 
 // Mock @twurple dependencies
 const mockConnect = vi.fn(() => {
@@ -112,6 +117,9 @@ vi.mock("./token.js", () => ({
 describe("TwitchClientManager", () => {
   let manager: TwitchClientManager;
   let mockLogger: ChannelLogSink;
+  let statusSink: ReturnType<
+    typeof vi.fn<(patch: Omit<ChannelAccountSnapshot, "accountId">) => void>
+  >;
   let resolveTwitchTokenMock: ReturnType<typeof vi.mocked<typeof resolveTwitchToken>>;
 
   const testAccount: TwitchAccountConfig = {
@@ -159,7 +167,8 @@ describe("TwitchClientManager", () => {
     };
 
     // Create manager instance
-    manager = new TwitchClientManager(mockLogger);
+    statusSink = vi.fn<(patch: Omit<ChannelAccountSnapshot, "accountId">) => void>();
+    manager = new TwitchClientManager(mockLogger, statusSink);
   });
 
   afterEach(() => {
@@ -168,6 +177,28 @@ describe("TwitchClientManager", () => {
   });
 
   describe("getClient", () => {
+    it("publishes ready and recovering from authentication and disconnect events", async () => {
+      await manager.getClient(testAccount);
+      expect(statusSink).toHaveBeenCalledWith(
+        expect.objectContaining({ lifecycle: "ready", connected: true }),
+      );
+
+      authFailureHandlers.at(-1)?.("retrying auth", 1);
+      expect(statusSink).toHaveBeenLastCalledWith(
+        expect.objectContaining({ lifecycle: "recovering", lastError: "retrying auth" }),
+      );
+
+      disconnectHandlers.at(-1)?.(false, new Error("connection lost"));
+      expect(statusSink).toHaveBeenLastCalledWith(
+        expect.objectContaining({ lifecycle: "recovering", lastError: "connection lost" }),
+      );
+
+      authSuccessHandlers.at(-1)?.();
+      expect(statusSink).toHaveBeenLastCalledWith(
+        expect.objectContaining({ lifecycle: "ready", terminalDisconnect: undefined }),
+      );
+    });
+
     it("should create a new client connection", async () => {
       const ignoredClientForTest = await manager.getClient(testAccount);
       void ignoredClientForTest;

--- a/extensions/twitch/src/twitch-client.ts
+++ b/extensions/twitch/src/twitch-client.ts
@@ -7,7 +7,12 @@ import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { TWITCH_CHAT_MESSAGE_LIMIT } from "./constants.js";
 import { resolveTwitchToken } from "./token.js";
-import type { ChannelLogSink, TwitchAccountConfig, TwitchChatMessage } from "./types.js";
+import type {
+  ChannelAccountSnapshot,
+  ChannelLogSink,
+  TwitchAccountConfig,
+  TwitchChatMessage,
+} from "./types.js";
 import { normalizeToken } from "./utils/twitch.js";
 
 const TWITCH_CHAT_AUTH_INTENTS = ["chat"];
@@ -22,7 +27,30 @@ export class TwitchClientManager {
   private messageHandlers = new Map<string, (message: TwitchChatMessage) => void>();
   private messageHandlerTokens = new Map<string, symbol>();
 
-  constructor(private logger: ChannelLogSink) {}
+  constructor(
+    private logger: ChannelLogSink,
+    private statusSink?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void,
+  ) {}
+
+  setStatusSink(statusSink?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void): void {
+    if (statusSink) {
+      this.statusSink = statusSink;
+    }
+  }
+
+  private publishReady(): void {
+    this.statusSink?.({
+      connected: true,
+      lifecycle: "ready",
+      lastConnectedAt: Date.now(),
+      lastError: null,
+      terminalDisconnect: undefined,
+    });
+  }
+
+  private publishRecovering(lastError: string): void {
+    this.statusSink?.({ connected: false, lifecycle: "recovering", lastError });
+  }
 
   /**
    * Create an auth provider for the account.
@@ -175,8 +203,6 @@ export class TwitchClientManager {
       },
     });
 
-    this.setupClientHandlers(client, account);
-
     this.pendingClients.set(key, client);
     try {
       await this.connectClient(client, account);
@@ -192,6 +218,7 @@ export class TwitchClientManager {
       throw error;
     }
 
+    this.setupClientHandlers(client, account);
     this.clients.set(key, client);
     this.logger.info(`Connected to Twitch as ${account.username}`);
 
@@ -227,14 +254,21 @@ export class TwitchClientManager {
         resolve();
       };
       listeners.push(
-        client.onAuthenticationSuccess(() => finish()),
+        client.onAuthenticationSuccess(() => {
+          this.publishReady();
+          finish();
+        }),
         client.onAuthenticationFailure((text) => {
           authRetryPending = true;
+          this.publishRecovering(text);
           this.logger.warn(
             `Twitch authentication failed for ${account.username}; waiting for retry, disconnect, or timeout: ${text}`,
           );
         }),
         client.onDisconnect((manual, reason) => {
+          if (!manual) {
+            this.publishRecovering(reason ? formatErrorMessage(reason) : "Twitch connection lost");
+          }
           if (authRetryPending && !manual) {
             this.logger.debug?.(
               `Twitch disconnected during auth retry for ${account.username}: ${formatErrorMessage(reason)}`,
@@ -295,6 +329,15 @@ export class TwitchClientManager {
           isSub: msg.userInfo.isSubscriber,
           chatType: "group",
         });
+      }
+    });
+    client.onAuthenticationSuccess(() => this.publishReady());
+    client.onAuthenticationFailure((text) => {
+      this.publishRecovering(text);
+    });
+    client.onDisconnect((manual, reason) => {
+      if (!manual) {
+        this.publishRecovering(reason ? formatErrorMessage(reason) : "Twitch connection lost");
       }
     });
 

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -57,6 +57,7 @@ async function settleLifecycleWork(): Promise<void> {
 
 async function startLifecycleMonitor(
   options: {
+    statusSink?: (patch: Record<string, unknown>) => void;
     useWebhook?: boolean;
     webhookSecret?: string;
     webhookUrl?: string;
@@ -132,6 +133,26 @@ describe("monitorZaloProvider lifecycle", () => {
     expect(runtime.log).toHaveBeenCalledWith("[default] Zalo provider stopped mode=polling");
   });
 
+  it("publishes ready after the first successful polling response", async () => {
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: undefined })
+      .mockImplementation(() => new Promise(() => {}));
+    const statusSink = vi.fn();
+    const { abort, run } = await startLifecycleMonitor({ statusSink });
+
+    await vi.waitFor(() =>
+      expect(statusSink).toHaveBeenCalledWith({
+        connected: true,
+        lifecycle: "ready",
+        terminalDisconnect: undefined,
+        lastConnectedAt: expect.any(Number),
+        lastError: null,
+      }),
+    );
+    abort.abort();
+    await run;
+  });
+
   it("clears poll error backoff on abort without retrying", async () => {
     vi.useFakeTimers();
     let abort: AbortController | undefined;
@@ -139,8 +160,9 @@ describe("monitorZaloProvider lifecycle", () => {
     try {
       getUpdatesMock.mockReset();
       getUpdatesMock.mockRejectedValue(new Error("zalo poll transport failed"));
+      const statusSink = vi.fn();
 
-      const started = await startLifecycleMonitor();
+      const started = await startLifecycleMonitor({ statusSink });
       abort = started.abort;
       run = started.run;
 
@@ -148,6 +170,11 @@ describe("monitorZaloProvider lifecycle", () => {
       expect(started.runtime.error).toHaveBeenCalledWith(
         expect.stringContaining("zalo poll transport failed"),
       );
+      expect(statusSink).toHaveBeenCalledWith({
+        connected: false,
+        lifecycle: "recovering",
+        lastError: expect.stringContaining("zalo poll transport failed"),
+      });
       expect(getUpdatesMock).toHaveBeenCalledTimes(1);
       expect(vi.getTimerCount()).toBe(1);
 
@@ -236,7 +263,9 @@ describe("monitorZaloProvider lifecycle", () => {
     );
 
     let settled = false;
+    const statusSink = vi.fn();
     const { abort, runtime, run } = await startLifecycleMonitor({
+      statusSink,
       useWebhook: true,
       webhookUrl: "https://example.com/hooks/zalo",
       webhookSecret: "supersecret", // pragma: allowlist secret
@@ -246,6 +275,14 @@ describe("monitorZaloProvider lifecycle", () => {
     });
 
     await setWebhookCalled;
+    await settleLifecycleWork();
+    expect(statusSink).toHaveBeenCalledWith({
+      connected: true,
+      lifecycle: "ready",
+      terminalDisconnect: undefined,
+      lastConnectedAt: expect.any(Number),
+      lastError: null,
+    });
     await settleLifecycleWork();
     expect(setWebhookMock).toHaveBeenCalledTimes(1);
     expect(registry.httpRoutes).toHaveLength(2);

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -72,7 +72,7 @@ type ZaloMonitorOptions = {
   webhookSecret?: string;
   webhookPath?: string;
   fetcher?: ZaloFetch;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: ZaloStatusSink;
 };
 
 const ZALO_TEXT_LIMIT = 2000;
@@ -82,7 +82,15 @@ const ZALO_TYPING_TIMEOUT_MS = 5_000;
 const UNIX_MILLISECONDS_THRESHOLD = 1_000_000_000_000;
 
 type ZaloCoreRuntime = ReturnType<typeof getZaloRuntime>;
-type ZaloStatusSink = (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+type ZaloStatusSink = (patch: {
+  connected?: boolean;
+  lifecycle?: "ready" | "recovering";
+  terminalDisconnect?: boolean;
+  lastConnectedAt?: number;
+  lastError?: string | null;
+  lastInboundAt?: number;
+  lastOutboundAt?: number;
+}) => void;
 type ZaloProcessingContext = {
   token: string;
   account: ResolvedZaloAccount;
@@ -276,6 +284,15 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
       if (isStopped() || abortSignal.aborted) {
         return undefined;
       }
+      if (response.ok) {
+        statusSink?.({
+          connected: true,
+          lifecycle: "ready",
+          terminalDisconnect: undefined,
+          lastConnectedAt: Date.now(),
+          lastError: null,
+        });
+      }
       if (response.ok && response.result) {
         statusSink?.({ lastInboundAt: Date.now() });
         await processUpdate({
@@ -287,7 +304,9 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
       if (err instanceof ZaloApiError && err.isPollingTimeout) {
         // no updates
       } else if (!isStopped() && !abortSignal.aborted) {
-        runtime.error?.(`[${account.accountId}] Zalo polling error: ${formatZaloError(err)}`);
+        const error = formatZaloError(err);
+        runtime.error?.(`[${account.accountId}] Zalo polling error: ${error}`);
+        statusSink?.({ connected: false, lifecycle: "recovering", lastError: error });
         // Abort-aware backoff; bottom poll reschedule already checks stopped/aborted.
         await sleepWithAbort(5000, abortSignal).catch(() => undefined);
       }
@@ -988,6 +1007,13 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
         { url: effectiveWebhookUrl, secret_token: webhookSecret }, // pragma: allowlist secret
         fetcher,
       );
+      statusSink?.({
+        connected: true,
+        lifecycle: "ready",
+        terminalDisconnect: undefined,
+        lastConnectedAt: Date.now(),
+        lastError: null,
+      });
       let webhookCleanupPromise: Promise<void> | undefined;
       cleanupWebhook = async () => {
         if (!webhookCleanupPromise) {
@@ -1061,9 +1087,11 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
 
     await waitForAbortSignal(abortSignal);
   } catch (err) {
-    runtime.error?.(
-      `[${account.accountId}] Zalo provider startup failed mode=${mode}: ${formatZaloError(err)}`,
-    );
+    const error = formatZaloError(err);
+    runtime.error?.(`[${account.accountId}] Zalo provider startup failed mode=${mode}: ${error}`);
+    // Zalo does not expose a stable structured auth-terminal contract at this boundary yet;
+    // keep startup failures recovering until that owner-specific classifier exists.
+    statusSink?.({ connected: false, lifecycle: "recovering", lastError: error });
     throw err;
   } finally {
     abortSignal.removeEventListener("abort", stopOnAbort);


### PR DESCRIPTION
## What Problem This Solves

Wave 1 (#118110) brought ten bundled channels onto the recorded lifecycle fact and classified the rest with named gaps. A scoping pass against current main found the remaining gaps tractable without new sink infrastructure. This PR closes them: fifteen more channels now publish `lifecycle` at their true transition sites, ending multi-signal health inference for effectively the whole bundled fleet.

## Why This Change Was Made

Two batches, one commit each:

**Batch A — sink already in scope, publish additions:** ClickClack (was publishing `running` before the socket existed; now starting → ready on socket open → recovering on close/error → stopped), Mattermost (ready moves to auth acknowledgement instead of pre-auth socket open; 401 stays recovering per its deliberate retry contract), QA Channel (ready after first successful poll), Feishu (ready/recovering on both WS and webhook transports; blocked via its existing terminal-error classifier), Zalo (ready after webhook registration / first poll success), Slack residuals (blocked + terminal before the non-recoverable auth throws; recovering during socket-start retry, which previously published nothing while backing off), Google Chat residuals (ready on successful webhook registration — the blocked branch already existed), Synology Chat (previously silent `waitUntilAbort` on validation failure now publishes blocked; ready after route registration).

**Batch B — one optional setStatus/onReady opt threaded (the QQBot precedent):** MS Teams (listener readiness instead of port metadata), Matrix (its existing `isMatrixAccessTokenInvalidatedError` classifier now distinguishes blocked from recovering in the sync controller), Signal (both SSE and WS transports report the same stream-open readiness point), Twitch (Twurple auth success/failure/disconnect events reach a widened per-account sink), LINE and SMS (first runtime status publishers; previously invisible parked states now publish), Nostr (connected-relay aggregate with the ≥1-relay readiness rule, tradeoff documented in-code), iMessage (watcher-path only; the duplicate-source parked branch intentionally stays silent — parked semantics are a deferred product decision, noted in-code).

**Skipped under escape hatch:** Tlon — its auth helper collapses transient 5xx and terminal auth failures into one error type and reconnect lacks a post-open readiness callback; safe adoption needs wider seams than local sink widening.

LINE/SMS/Synology status adapters also forward lifecycle so the status surface shows what health consumes. Wave-1 rules preserved throughout: blocked only for structured terminal failures, ready only at true readiness, READY clears retained terminal-auth state.

## User Impact

Operators of fifteen more channels get truthful `blocked` vs `recovering` vs `ready` in status and health, including channels that previously parked silently on misconfiguration (SMS, Synology) — the worst class of silent non-outcome.

## Evidence

- 11,867 tests passed across 764 files, including 423 gateway health/status/readiness boundary tests; every new publish site has a transition-seam test
- Both extension tsgo lanes; SDK surface check; changed-file lint/format; madge; QA-inclusive build; structured autoreview clean
- Numstat: production +563/−89, tests +809/−12
- Conflict-free rebase onto current main

### Real gateway boundary proof

Reused the lifecycle-series harness from #118110: QA Lab’s dist child gateway, Crabline’s local Mattermost/Matrix provider servers, the mock OpenAI provider, and a small local WebSocket relay for the optional Nostr aggregate. Head `6704c690cc8e8bb258142f1e0f6d088dd45e19a8` was built first with `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`; `dist/build-info.json` matched that SHA. Every gateway used a harness-owned ephemeral `OPENCLAW_STATE_DIR` and isolated loopback port. No operator gateway, state, credentials, or fixed gateway port was used.

```json
{
  "verdict": "PASS",
  "headSha": "6704c690cc8e8bb258142f1e0f6d088dd45e19a8",
  "harness": "QA Lab dist child gateway + Crabline/local mock channel APIs + mock-openai",
  "isolation": {
    "stateDir": "ephemeral-per-gateway",
    "gatewayPorts": "isolated-loopback",
    "operatorGatewayTouched": false,
    "credentials": "mock-only",
    "distBuilt": true
  },
  "checks": [
    {
      "id": "mattermost-auth-readiness",
      "channel": "mattermost",
      "status": "pass",
      "transition": ["starting", "ready"],
      "trueReadiness": "Crabline WebSocket authentication acknowledgement"
    },
    {
      "id": "sms-missing-required-config",
      "channel": "sms",
      "status": "pass",
      "lifecycle": "blocked",
      "terminalDisconnect": true,
      "silentParkingEliminated": true
    },
    {
      "id": "matrix-transient-recovery",
      "channel": "matrix",
      "status": "pass",
      "transition": ["ready", "recovering"],
      "terminalDisconnect": false
    },
    {
      "id": "matrix-invalid-token-no-restart",
      "channel": "matrix",
      "status": "pass",
      "lifecycle": "blocked",
      "healthState": "error",
      "terminalDisconnect": true,
      "restartPending": false,
      "lastStartAtUnchanged": true
    },
    {
      "id": "nostr-first-relay-ready",
      "channel": "nostr",
      "status": "pass",
      "connectedRelaysRequired": 1,
      "lifecycle": "ready"
    }
  ]
}
```

Redacted `channels.status` excerpts:

```json
{
  "mattermost": {
    "beforeAuthAck": {
      "lifecycle": "starting",
      "running": true,
      "connected": true,
      "restartPending": false
    },
    "afterAuthAck": {
      "lifecycle": "ready",
      "running": true,
      "connected": true,
      "restartPending": false,
      "lastError": null,
      "lastStartAtUnchanged": true
    }
  },
  "smsMissingPublicWebhookUrl": {
    "lifecycle": "blocked",
    "terminalDisconnect": true,
    "running": false,
    "restartPending": false,
    "lastError": "publicWebhookUrl is required for Twilio signature validation"
  },
  "matrixTransient": {
    "beforeOutage": {
      "lifecycle": "ready",
      "healthState": "healthy",
      "running": true,
      "connected": true,
      "restartPending": false
    },
    "duringOutage": {
      "lifecycle": "recovering",
      "healthState": "reconnecting",
      "running": true,
      "connected": false,
      "restartPending": false,
      "lastStartAtUnchanged": true
    }
  },
  "matrixStructured401": {
    "initial": {
      "lifecycle": "blocked",
      "healthState": "error",
      "terminalDisconnect": true,
      "running": true,
      "connected": false,
      "restartPending": false,
      "lastError": "MatrixError: [401] Invalid access token (<isolated-loopback>)"
    },
    "after65Seconds": {
      "lifecycle": "blocked",
      "healthState": "error",
      "terminalDisconnect": true,
      "running": false,
      "connected": false,
      "restartPending": false,
      "lastStartAtUnchanged": true
    }
  },
  "nostrFirstRelay": {
    "lifecycle": "ready",
    "running": true,
    "connected": true,
    "restartPending": false,
    "lastError": null
  }
}
```

Sanitized gateway log excerpts:

```text
[matrix] [default] auto-restart skipped, terminal disconnect
[health-monitor] [matrix:default] health-monitor: skipping restart, terminal-disconnect
```

The harness found and repaired a real Matrix startup race. The SDK could emit structured `M_UNKNOWN_TOKEN` before its readiness waiter attached, losing the error and falling through to a generic 30-second timeout/restart. Commit `6704c690cc8` records that sync error at the event bridge and rejects invalid-token startup immediately; transient `ERROR` states remain recoverable. Post-fix proof: full Matrix suite 1,835/1,835, Mattermost suite 744/744, both extension tsgo lanes, changed-file lint, exact-head QA build, and delta autoreview clean.

One diagnostic nuance is recorded rather than hidden: Matrix’s legacy SDK-owned `healthState` remains `error` for `M_UNKNOWN_TOKEN`, while authoritative `lifecycle=blocked` and `terminalDisconnect=true` drive restart policy. The stable `lastStartAt`, supervisor log, and health-monitor log prove both restart paths were suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
