### PR TITLE
docs(memory): explain overlapping hook and transcript recall

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -245,6 +245,18 @@ openclaw hooks enable <hook-name>
 
 On `/new`, `/reset`, daily reset, or idle expiry, extracts the last user/assistant messages (default 15, configurable with `hooks.internal.entries.session-memory.messages`) and saves them to `<workspace>/memory/YYYY-MM-DD-HHMM.md` using `agents.defaults.userTimezone`. When no user timezone is configured, it falls back to the host timezone. Memory capture runs in the background so reset handling and replacement sessions are not delayed by transcript reads or optional slug generation. Set `hooks.internal.entries.session-memory.llmSlug: true` to generate descriptive filename slugs, and optionally set `hooks.internal.entries.session-memory.model` to a configured alias such as `sonnet`, a bare model ID on the agent's default provider, or a `provider/model` ref. Slug generation uses the agent's default model when `model` is omitted and falls back to timestamp slugs when unavailable. Requires `workspace.dir` to be configured.
 
+<Note>
+The `memory` source already indexes this hook's saved conversation excerpts. If
+[session transcript indexing](/reference/memory-config#session-memory-search)
+is also enabled, the same conversation can appear from both `memory` and
+`sessions`, producing overlapping search results and additional embedding work.
+For hook-only recall, set `memory.search.sources: ["memory"]` and
+`memory.search.rememberAcrossConversations: false`; `sources` alone does not
+prevent cross-conversation recall from adding `sessions`. For full-transcript
+recall instead, run `openclaw hooks disable session-memory`. Enable both only
+when you intentionally want both representations.
+</Note>
+
 <a id="bootstrap-extra-files"></a>
 
 ### bootstrap-extra-files config

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -465,6 +465,18 @@ Index session transcripts and surface them via `memory_search`:
 Session indexing is opt-in and runs asynchronously. Results can be slightly stale. Session logs live on disk, so treat filesystem access as the trust boundary.
 </Warning>
 
+<Note>
+The [session-memory hook](/automation/hooks#session-memory) saves conversation
+excerpts to `<workspace>/memory/`, which the `memory` source already indexes.
+If transcript indexing is also enabled, the same conversation can appear from
+both `memory` and `sessions`, resulting in overlapping search results and
+additional embedding work. For hook-only recall, set `sources: ["memory"]` and
+`rememberAcrossConversations: false`; `sources` alone is insufficient because
+cross-conversation recall automatically adds `sessions`. For full-transcript
+recall instead, run `openclaw hooks disable session-memory`. Enable both only
+when you intentionally want both representations.
+</Note>
+
 Ordinary model-invoked session transcript search obeys
 [`tools.sessions.visibility`](/gateway/config-tools#toolssessions). The default
 `tree` visibility exposes the current session, sessions it spawned, and


### PR DESCRIPTION
Closes #54524

## What Problem This Solves

Users who enable both the session-memory hook and session transcript indexing can see the same conversation twice in memory search results and pay for additional embedding work, with no documentation explaining why or how to choose one representation.

## Why This Change Was Made

Document the existing intentional distinction between hook-created workspace memory and full session-transcript indexing at both configuration entry points. Explain that disabling transcript recall requires both `sources: ["memory"]` and `rememberAcrossConversations: false`, while transcript-only users can disable the session-memory hook.

## User Impact

Operators can understand overlapping recall, avoid duplicate search results and unnecessary embedding work, or deliberately retain both representations without changing any runtime defaults.

## Evidence

- Verified the hook writes conversation excerpts into the indexed workspace memory directory and `rememberAcrossConversations` independently adds the sessions source.
- `git diff --check` passed.
- Existing repository formatter checked both changed Markdown files.
- `node scripts/docs-list.js` passed.
- `node scripts/check-changed.mjs --dry-run -- docs/reference/memory-config.md docs/automation/hooks.md` classified the change as docs-only.
- Both documentation pages were independently checked for matching opt-outs and valid existing cross-page anchors.
