### PR TITLE
fix(telegram): recover directed turns after empty model replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -285,6 +285,8 @@ export async function runTelegramDispatchTurn(params: {
       return false;
     }
     params.state.queuedFinal = turnResult.dispatchResult.queuedFinal;
+    params.state.noVisibleReplyFallbackEligible =
+      turnResult.dispatchResult.noVisibleReplyFallbackEligible === true;
     if ((turnResult.dispatchResult.counts?.final ?? 0) > 0) {
       params.progress.markSawFinal();
     }

--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -226,6 +226,42 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("recovers a directed turn when shared dispatch marks the empty fallback eligible", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+      noVisibleReplyFallbackEligible: true,
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        chatId: -1001234,
+        isGroup: true,
+        ctxPayload: {
+          SessionKey: "agent:test:telegram:group:-1001234",
+          ChatType: "group",
+        } as TelegramMessageContext["ctxPayload"],
+        primaryCtx: {
+          message: { chat: { id: -1001234, type: "supergroup" } },
+        } as TelegramMessageContext["primaryCtx"],
+        msg: {
+          chat: { id: -1001234, type: "supergroup" },
+          message_id: 456,
+        } as TelegramMessageContext["msg"],
+        threadSpec: { id: undefined, scope: "none" },
+        replyThreadId: undefined,
+      }),
+      streamMode: "off",
+    });
+
+    expect(deliverReplies).toHaveBeenCalledOnce();
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [{ text: "No response generated. Please try again." }],
+      }),
+    );
+  });
+
   describe("non-streaming media dedup", () => {
     const finalDeliveryPayload = () => {
       for (const [params] of deliverInboundReplyWithMessageSendContext.mock.calls) {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1,8 +1,4 @@
 // Telegram plugin module coordinates one inbound message dispatch lifecycle.
-import {
-  createOutboundPayloadPlan,
-  projectOutboundPayloadPlanForDelivery,
-} from "openclaw/plugin-sdk/channel-outbound";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { createSubsystemLogger, danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -384,6 +380,7 @@ export const dispatchTelegramMessage = async ({
   });
   const state: TelegramDispatchTurnState = {
     queuedFinal: false,
+    noVisibleReplyFallbackEligible: false,
     suppressSilentReplyFallback: false,
     hadErrorReplyFailureOrSkip: false,
   };
@@ -509,25 +506,12 @@ export const dispatchTelegramMessage = async ({
     !deliverySummary.delivered &&
     !state.suppressSilentReplyFallback &&
     !state.queuedFinal &&
-    dispatchContext.isGroup
+    state.noVisibleReplyFallbackEligible
   ) {
-    const policySessionKey =
-      dispatchContext.ctxPayload.CommandSource === "native"
-        ? (dispatchContext.ctxPayload.CommandTargetSessionKey ??
-          dispatchContext.ctxPayload.SessionKey)
-        : dispatchContext.ctxPayload.SessionKey;
-    const silentReplyFallback = projectOutboundPayloadPlanForDelivery(
-      createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
-        cfg,
-        sessionKey: policySessionKey,
-        surface: "telegram",
-      }),
-    );
-    if (silentReplyFallback.length > 0) {
-      sentFallback = (await delivery.deliverFallback(silentReplyFallback, false)).delivered;
-    }
-    silentReplyDispatchLogger.debug("telegram turn ended without visible final response", {
-      hasSessionKey: Boolean(policySessionKey),
+    sentFallback = (await delivery.deliverFallback([{ text: EMPTY_RESPONSE_FALLBACK }], false))
+      .delivered;
+    silentReplyDispatchLogger.debug("telegram recovered eligible turn without visible response", {
+      hasSessionKey: Boolean(dispatchContext.ctxPayload.SessionKey),
       hasChatId: dispatchContext.chatId != null,
       queuedFinal: state.queuedFinal,
       sentFallback,

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -66,6 +66,7 @@ export type TelegramAnswerBlockDelivery = {
 
 export type TelegramDispatchTurnState = {
   queuedFinal: boolean;
+  noVisibleReplyFallbackEligible: boolean;
   suppressSilentReplyFallback: boolean;
   hadErrorReplyFailureOrSkip: boolean;
   dispatchError?: unknown;

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1687,7 +1687,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
+    const result = await runEmbeddedAgent({
       ...overflowBaseRunParams,
       provider: "openai",
       model: "gpt-5.4",
@@ -4507,7 +4507,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
+    await runEmbeddedAgent({
       ...overflowBaseRunParams,
       allowEmptyAssistantReplyAsSilent: true,
       provider: "openai",
@@ -4542,7 +4542,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
+    await runEmbeddedAgent({
       ...overflowBaseRunParams,
       allowEmptyAssistantReplyAsSilent: true,
       provider: "openai",

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -117,7 +117,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
+    await runEmbeddedAgent({
       ...overflowBaseRunParams,
       runId: "run-tool-summary-failure-count",
     });
@@ -1566,7 +1566,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectNoWarnMessageWith("settled post-tool turn lacked a final answer");
   });
 
-  it("returns NO_REPLY without retrying reasoning-only assistant turns when silence is allowed", async () => {
+  it("retries reasoning-only assistant turns even when deliberate silence is allowed", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
@@ -1586,6 +1586,18 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
       }),
     );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Visible answer."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: "Visible answer." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
 
     const result = await runEmbeddedAgent({
       ...overflowBaseRunParams,
@@ -1595,14 +1607,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       runId: "run-reasoning-only-silent",
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    const onlyCall = runAttemptCall(0);
-    expect(onlyCall.prompt).not.toContain(REASONING_ONLY_RETRY_INSTRUCTION);
-    expect(onlyCall.prompt).not.toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
-    expectNoWarnMessageWith("reasoning-only assistant turn detected");
-    expect(result.payloads).toEqual([{ text: "NO_REPLY" }]);
-    expect(result.meta.terminalReplyKind).toBe("silent-empty");
-    expect(result.meta.livenessState).toBe("working");
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(runAttemptCall(1).prompt).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
+    expectWarnMessageWith("reasoning-only assistant turn detected");
   });
 
   it("replays an unpersisted reasoning continuation across a missing-assistant retry", async () => {
@@ -1680,7 +1687,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
+    await runEmbeddedAgent({
       ...overflowBaseRunParams,
       provider: "openai",
       model: "gpt-5.4",
@@ -4243,7 +4250,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
-  it("treats clean empty assistant turns as silent only when the caller allows it", () => {
+  it("treats clean empty assistant turns as silent only for reply-optional runs", () => {
     const attempt = makeAttemptResult({
       assistantTexts: [],
       lastAssistant: {
@@ -4263,6 +4270,16 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         timedOut: false,
         attempt,
       }),
+    ).toBe(false);
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        terminalReplyExpectation: "optional",
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
     ).toBe(true);
     expect(
       shouldTreatEmptyAssistantReplyAsSilent({
@@ -4275,7 +4292,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
-  it("treats reasoning-only assistant turns as silent only when the caller allows it", () => {
+  it("treats reasoning-only assistant turns as silent only for reply-optional runs", () => {
     const attempt = makeAttemptResult({
       assistantTexts: [],
       lastAssistant: {
@@ -4296,6 +4313,16 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(
       shouldTreatEmptyAssistantReplyAsSilent({
         allowEmptyAssistantReplyAsSilent: true,
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        terminalReplyExpectation: "optional",
         payloadCount: 0,
         aborted: false,
         timedOut: false,
@@ -4453,9 +4480,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
-  it("returns NO_REPLY without retrying clean empty assistant turns when silence is allowed", async () => {
+  it("retries clean empty assistant turns even when deliberate silence is allowed", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
-    mockedRunEmbeddedAttempt.mockResolvedValue(
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
         lastAssistant: {
@@ -4464,6 +4491,18 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           provider: "openai",
           model: "gpt-5.5",
           content: [{ type: "text", text: "" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Visible answer."],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: "Visible answer." }],
         } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
       }),
     );
@@ -4476,13 +4515,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       runId: "run-empty-assistant-silent",
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    const onlyCall = runAttemptCall(0);
-    expect(onlyCall.prompt).not.toContain(REASONING_ONLY_RETRY_INSTRUCTION);
-    expect(onlyCall.prompt).not.toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
-    expect(result.payloads).toEqual([{ text: "NO_REPLY" }]);
-    expect(result.meta.terminalReplyKind).toBe("silent-empty");
-    expect(result.meta.livenessState).toBe("working");
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(runAttemptCall(1).prompt).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+    expectWarnMessageWith("empty response detected");
   });
 
   it("returns NO_REPLY without retrying exact silent assistant replies when silence is allowed", async () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -117,7 +117,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
+    const result = await runEmbeddedAgent({
       ...overflowBaseRunParams,
       runId: "run-tool-summary-failure-count",
     });
@@ -1599,7 +1599,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    const result = await runEmbeddedAgent({
+    await runEmbeddedAgent({
       ...overflowBaseRunParams,
       allowEmptyAssistantReplyAsSilent: true,
       provider: "openai",
@@ -4542,7 +4542,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     );
 
-    await runEmbeddedAgent({
+    const result = await runEmbeddedAgent({
       ...overflowBaseRunParams,
       allowEmptyAssistantReplyAsSilent: true,
       provider: "openai",

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -700,19 +700,10 @@ export function shouldTreatEmptyAssistantReplyAsSilent(params: {
   ) {
     return true;
   }
-  if (params.onlyExplicitSilentReply) {
-    return false;
-  }
-  // Post-tool empty stops are ambiguous provider failures when a reply is still
-  // expected; reply-optional runs settle their work in the tools themselves.
-  if (
-    !terminalReplyOptional &&
-    params.attempt.toolMetas.length > 0 &&
-    isEmptyResponseAssistantTurn({
-      payloadCount: params.payloadCount,
-      attempt: params.attempt,
-    })
-  ) {
+  // A visible turn owes a reply unless the model explicitly chose NO_REPLY.
+  // Bare empty and reasoning-only stops are provider failures, even when the
+  // conversation policy permits deliberate silence.
+  if (params.onlyExplicitSilentReply || !terminalReplyOptional) {
     return false;
   }
   return isNonVisibleAssistantTurnEligibleForSilentReply({


### PR DESCRIPTION
Closes #116277

## What Problem This Solves

Fixes an issue where users sending directed Telegram group messages could receive no response when a model completed with no visible content, while the Telegram last-mile recovery also discarded its own fallback as intentional silence.

## Why This Change Was Made

Visible turns now treat bare empty and reasoning-only model completions as incomplete and use the existing bounded continuation path; only explicit `NO_REPLY` or genuinely reply-optional jobs remain silent. Telegram also consumes the shared settled `noVisibleReplyFallbackEligible` fact instead of re-inferring failure from zero payloads, preserving ambient group silence, room events, send-policy denial, message-tool delivery, and observed delivery.

The issue's original DeepSeek attribution was retracted by the reporter after the affected interactive session was identified as Kimi. No provider-specific workaround is included.

## User Impact

Directed Telegram group turns recover with a real answer when a bounded retry succeeds, or send one generic recovery message when the shared terminal classifier proves the turn is eligible. Explicit silence remains silent.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts -- -t "retries .* even when deliberate silence is allowed"` — 2 passed, 155 skipped.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts` — 12 passed.
- Full embedded incomplete-turn file before the assertion-only test correction — 155 unchanged tests passed; the two new behavior cases were corrected and rerun above.
- Direct live `deepseek-v4-flash` streaming probe, 3/3 HTTP 200 completions with visible content, `finishReason=stop`, and `[DONE]`; first visible content in 625–950 ms.
- Autoreview: clean, no accepted/actionable findings.
- [CI run 30773802153](https://github.com/openclaw/openclaw/actions/runs/30773802153) — green on exact head `b04e3f33ecdf`.

Real Telegram proof remains blocked by the proof infrastructure before any scenario assertion:

- [Desktop proof run 30774069639](https://github.com/openclaw/openclaw/actions/runs/30774069639) and bounded fresh-run retry [30775459608](https://github.com/openclaw/openclaw/actions/runs/30775459608) both authenticated the burner account, then skipped baseline and candidate because the isolated candidate SUT exited before a proof message; both runs released their Telegram and Crabbox leases.
- [Telegram live QA run 30776603434](https://github.com/openclaw/openclaw/actions/runs/30776603434) failed while preparing the candidate worktree, before `telegram-empty-response-after-write-recovery` ran or produced an evidence manifest.

No proof run observed a product failure; none reached the Telegram assertion. The PR remains open because ClawSweeper requires real after-fix Telegram evidence before merge.
