### PR TITLE
fix(scripts): report failing gateway concurrency probes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1836,7 +1836,7 @@
     "test:force": "node --import tsx scripts/test-force.ts",
     "test:gateway": "node scripts/run-with-env.mjs OPENCLAW_GATEWAY_PROJECT_SHARDS=1 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts",
     "test:gateway:cpu-scenarios": "node scripts/check-gateway-cpu-scenarios.mjs",
-    "test:gateway:concurrency": "node --import tsx scripts/bench-gateway-concurrency.ts",
+    "test:gateway:concurrency": "node scripts/bench-gateway-concurrency.ts",
     "test:gateway:memory-fd-repro": "node scripts/check-memory-fd-repro.mjs",
     "test:gateway:watch-regression": "node scripts/check-gateway-watch-regression.mjs",
     "test:install:e2e": "bash scripts/test-install-sh-e2e-docker.sh",

--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
-import { PROTOCOL_VERSION } from "../packages/gateway-protocol/src/index.js";
+import { PROTOCOL_VERSION } from "../packages/gateway-protocol/src/version.ts";
 import { applyMockOpenAiModelConfig } from "./e2e/lib/fixtures/mock-openai-config.mjs";
 import { delay, stopChild } from "./lib/gateway-bench-child.ts";
 import { getFreePort } from "./lib/gateway-bench-probes.ts";
@@ -39,6 +39,7 @@ type MetricSummary = {
 
 type TimedProbe = {
   atMs: number;
+  error: string | null;
   latencyMs: number;
   ok: boolean;
 };
@@ -52,10 +53,20 @@ type ReadyProbe = TimedProbe & {
   utilization: number | null;
 };
 
+type ControlUiProbe = TimedProbe & {
+  status: number;
+};
+
+type GatewaySample = {
+  controlUi: ControlUiProbe;
+  readyz: ReadyProbe;
+  sessionsList: TimedProbe;
+};
+
 type GatewayRpc = <T>(method: string, params: unknown, timeoutMs?: number) => Promise<T>;
 
 type BenchmarkRun = {
-  controlUi: TimedProbe[];
+  controlUi: ControlUiProbe[];
   durationMs: number;
   readyz: ReadyProbe[];
   sessionsList: TimedProbe[];
@@ -164,7 +175,7 @@ function printUsage(): void {
 
 Usage:
   pnpm test:gateway:concurrency -- [options]
-  node --import tsx scripts/bench-gateway-concurrency.ts [options]
+  node scripts/bench-gateway-concurrency.ts [options]
 
 Options:
   --concurrency <n>  Concurrent synthetic streaming turns (default: ${DEFAULT_CONCURRENCY})
@@ -262,6 +273,29 @@ async function requestHttp(params: {
 
 function numberOrNull(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function describeProbeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.slice(0, 500);
+}
+
+function formatProbeResult(name: string, probe: TimedProbe & { status?: number }): string {
+  const status = probe.status === undefined ? (probe.ok ? "ok" : "failed") : probe.status;
+  return `${name}(ok=${probe.ok} status=${status} error=${probe.error ? JSON.stringify(probe.error) : "none"} latencyMs=${probe.latencyMs.toFixed(1)})`;
+}
+
+function assertBaselineProbes(baseline: GatewaySample): void {
+  if (baseline.readyz.ok && baseline.sessionsList.ok && baseline.controlUi.ok) {
+    return;
+  }
+  throw new Error(
+    `gateway probes did not pass before concurrent load: ${[
+      formatProbeResult("readyz", baseline.readyz),
+      formatProbeResult("sessionsList", baseline.sessionsList),
+      formatProbeResult("controlUi", baseline.controlUi),
+    ].join("; ")}`,
+  );
 }
 
 function captureChildOutput(child: ChildProcessWithoutNullStreams): () => string {
@@ -425,7 +459,8 @@ async function sampleGateway(params: {
   port: number;
   rpc: GatewayRpc;
   runStartedAt: number;
-}): Promise<{ controlUi: TimedProbe; readyz: ReadyProbe; sessionsList: TimedProbe }> {
+  serial?: boolean;
+}): Promise<GatewaySample> {
   const atMs = performance.now() - params.runStartedAt;
   const safeHttpProbe = async (pathValue: string, accept: string) => {
     const startedAt = performance.now();
@@ -437,30 +472,38 @@ async function sampleGateway(params: {
           path: pathValue,
           port: params.port,
         })),
+        error: null,
         ok: true,
       };
-    } catch {
+    } catch (error) {
       return {
         body: "",
+        error: describeProbeError(error),
         latencyMs: performance.now() - startedAt,
         ok: false,
         status: 0,
       };
     }
   };
-  const [readyz, controlUi, sessions] = await Promise.all([
-    safeHttpProbe("/readyz", "application/json"),
-    safeHttpProbe("/", "text/html"),
-    (async () => {
-      const startedAt = performance.now();
-      try {
-        const payload = await params.rpc("sessions.list", {}, HTTP_TIMEOUT_MS);
-        return { latencyMs: performance.now() - startedAt, ok: true, payload };
-      } catch {
-        return { latencyMs: performance.now() - startedAt, ok: false, payload: null };
-      }
-    })(),
-  ]);
+  const probeReadyz = () => safeHttpProbe("/readyz", "application/json");
+  const probeControlUi = () => safeHttpProbe("/", "text/html");
+  const probeSessions = async () => {
+    const startedAt = performance.now();
+    try {
+      const payload = await params.rpc("sessions.list", {}, HTTP_TIMEOUT_MS);
+      return { error: null, latencyMs: performance.now() - startedAt, ok: true, payload };
+    } catch (error) {
+      return {
+        error: describeProbeError(error),
+        latencyMs: performance.now() - startedAt,
+        ok: false,
+        payload: null,
+      };
+    }
+  };
+  const [readyz, controlUi, sessions] = params.serial
+    ? [await probeReadyz(), await probeControlUi(), await probeSessions()]
+    : await Promise.all([probeReadyz(), probeControlUi(), probeSessions()]);
   const readyBody = (() => {
     if (readyz.status !== 200) {
       return {};
@@ -475,11 +518,18 @@ async function sampleGateway(params: {
   return {
     controlUi: {
       atMs,
+      error:
+        controlUi.error ??
+        (controlUi.status === 200 && !controlUi.body.includes("<html")
+          ? "response body did not contain <html"
+          : null),
       latencyMs: controlUi.latencyMs,
       ok: controlUi.ok && controlUi.status === 200 && controlUi.body.includes("<html"),
+      status: controlUi.status,
     },
     readyz: {
       atMs,
+      error: readyz.error,
       latencyMs: readyz.latencyMs,
       ok: readyz.ok && readyz.status === 200,
       status: readyz.status,
@@ -489,7 +539,12 @@ async function sampleGateway(params: {
       utilization: numberOrNull(eventLoop?.utilization),
       cpuCoreRatio: numberOrNull(eventLoop?.cpuCoreRatio),
     },
-    sessionsList: { atMs, latencyMs: sessions.latencyMs, ok: sessions.ok },
+    sessionsList: {
+      atMs,
+      error: sessions.error,
+      latencyMs: sessions.latencyMs,
+      ok: sessions.ok,
+    },
   };
 }
 
@@ -553,12 +608,11 @@ async function runGatewaySample(options: {
       port,
       rpc,
       runStartedAt,
+      serial: true,
     });
-    if (!baseline.readyz.ok || !baseline.sessionsList.ok || !baseline.controlUi.ok) {
-      throw new Error("gateway probes did not pass before concurrent load");
-    }
+    assertBaselineProbes(baseline);
 
-    const controlUi: TimedProbe[] = [];
+    const controlUi: ControlUiProbe[] = [];
     const readyz: ReadyProbe[] = [];
     const sessionsList: TimedProbe[] = [];
     let turnsDone = false;
@@ -700,7 +754,9 @@ async function main(): Promise<void> {
 
 export const testing = {
   parseOptions,
+  assertBaselineProbes,
   runTurn,
+  sampleGateway,
   summarizeNumbers,
   summarizeRuns,
 };

--- a/scripts/check-gateway-cpu-scenarios.mjs
+++ b/scripts/check-gateway-cpu-scenarios.mjs
@@ -411,8 +411,6 @@ async function runGatewayCpuScenarios(options, params = {}) {
             "concurrency bench",
             process.execPath,
             [
-              "--import",
-              "tsx",
               "scripts/bench-gateway-concurrency.ts",
               "--concurrency",
               String(DEFAULT_GATEWAY_CONCURRENCY),

--- a/scripts/lib/dev-tooling-safety.ts
+++ b/scripts/lib/dev-tooling-safety.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { redactSensitiveText } from "../../src/logging/redact.js";
 
+export { parseStrictIntegerOption } from "./strict-integer-option.ts";
+
 const REDACT_OPTIONS = { mode: "tools" } as const;
 
 export function redactForDevToolLog(value: string): string {
@@ -39,30 +41,6 @@ export function redactHomePath(value: string, home = process.env.HOME ?? ""): st
   }
   if (resolved.startsWith(`${normalizedHome}${path.sep}`)) {
     return `~${resolved.slice(normalizedHome.length)}`;
-  }
-  return value;
-}
-
-export function parseStrictIntegerOption(params: {
-  fallback: number;
-  label: string;
-  min: number;
-  raw: string | undefined;
-}): number {
-  const raw = params.raw?.trim();
-  if (!raw) {
-    return params.fallback;
-  }
-  if (!/^\d+$/u.test(raw)) {
-    throw new Error(
-      `${params.label} must be an integer >= ${params.min}; got ${JSON.stringify(raw)}`,
-    );
-  }
-  const value = Number(raw);
-  if (!Number.isSafeInteger(value) || value < params.min) {
-    throw new Error(
-      `${params.label} must be an integer >= ${params.min}; got ${JSON.stringify(raw)}`,
-    );
   }
   return value;
 }

--- a/scripts/lib/gateway-bench-probes.ts
+++ b/scripts/lib/gateway-bench-probes.ts
@@ -2,7 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { request } from "node:http";
 import { createServer } from "node:net";
-import { expectDefined } from "../../packages/normalization-core/src/expect.js";
+import { expectDefined } from "../../packages/normalization-core/src/expect.ts";
 
 export async function getFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {

--- a/scripts/lib/gateway-bench-runtime.ts
+++ b/scripts/lib/gateway-bench-runtime.ts
@@ -1,10 +1,10 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
-import { expectDefined } from "../../packages/normalization-core/src/expect.js";
-import { parseStrictIntegerOption } from "./dev-tooling-safety.ts";
+import { expectDefined } from "../../packages/normalization-core/src/expect.ts";
 import { delay } from "./gateway-bench-child.ts";
 import { requestProbeStatus } from "./gateway-bench-probes.ts";
+import { parseStrictIntegerOption } from "./strict-integer-option.ts";
 
 type GatewayBenchCase = {
   config: Record<string, unknown>;

--- a/scripts/lib/strict-integer-option.ts
+++ b/scripts/lib/strict-integer-option.ts
@@ -1,0 +1,24 @@
+// Strict integer parsing is dependency-free so native Node TypeScript scripts can reuse it.
+export function parseStrictIntegerOption(params: {
+  fallback: number;
+  label: string;
+  min: number;
+  raw: string | undefined;
+}): number {
+  const raw = params.raw?.trim();
+  if (!raw) {
+    return params.fallback;
+  }
+  if (!/^\d+$/u.test(raw)) {
+    throw new Error(
+      `${params.label} must be an integer >= ${params.min}; got ${JSON.stringify(raw)}`,
+    );
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < params.min) {
+    throw new Error(
+      `${params.label} must be an integer >= ${params.min}; got ${JSON.stringify(raw)}`,
+    );
+  }
+  return value;
+}

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -1,5 +1,6 @@
 // Gateway concurrency benchmark tests cover CLI parsing and bounded percentile summaries.
 import { spawnSync } from "node:child_process";
+import { createServer } from "node:http";
 import { performance } from "node:perf_hooks";
 import { describe, expect, it } from "vitest";
 import { testing } from "../../scripts/bench-gateway-concurrency.ts";
@@ -74,12 +75,65 @@ describe("gateway concurrency benchmark script", () => {
     expect(wait?.timeoutMs).toBeLessThanOrEqual(2_000);
   });
 
+  it("preserves HTTP and RPC failures in baseline probe diagnostics", async () => {
+    const probeOrder: string[] = [];
+    const server = createServer((req, res) => {
+      probeOrder.push(req.url ?? "missing-url");
+      res.statusCode = req.url === "/readyz" ? 503 : 200;
+      res.end(req.url === "/readyz" ? '{"status":"starting"}' : "not html");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected HTTP test server address");
+    }
+    try {
+      const sample = await testing.sampleGateway({
+        deadlineAt: performance.now() + 5_000,
+        port: address.port,
+        rpc: async () => {
+          probeOrder.push("sessions.list");
+          throw new Error("sessions.list failed: unauthorized");
+        },
+        runStartedAt: performance.now(),
+        serial: true,
+      });
+
+      expect(probeOrder).toEqual(["/readyz", "/", "sessions.list"]);
+      expect(sample.readyz).toMatchObject({ error: null, ok: false, status: 503 });
+      expect(sample.controlUi).toMatchObject({
+        error: "response body did not contain <html",
+        ok: false,
+        status: 200,
+      });
+      expect(sample.sessionsList).toMatchObject({
+        error: "sessions.list failed: unauthorized",
+        ok: false,
+      });
+      expect(() => testing.assertBaselineProbes(sample)).toThrow(
+        /readyz\(ok=false status=503 error=none .*sessionsList\(ok=false status=failed error="sessions\.list failed: unauthorized" .*controlUi\(ok=false status=200 error="response body did not contain <html"/u,
+      );
+    } finally {
+      server.close();
+    }
+  });
+
+  it("loads through native Node TypeScript stripping", () => {
+    const result = spawnSync(process.execPath, ["scripts/bench-gateway-concurrency.ts", "--help"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OpenClaw Gateway concurrency benchmark");
+  });
+
   it("ends CLI failures with the required wrapper marker", () => {
-    const result = spawnSync(
-      process.execPath,
-      ["--import", "tsx", "scripts/bench-gateway-concurrency.ts", "--wat"],
-      { cwd: process.cwd(), encoding: "utf8" },
-    );
+    const result = spawnSync(process.execPath, ["scripts/bench-gateway-concurrency.ts", "--wat"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
 
     expect(result.status).toBe(1);
     expect(result.stderr.trim().split("\n").at(-1)).toBe(

--- a/test/scripts/check-gateway-cpu-scenarios.test.ts
+++ b/test/scripts/check-gateway-cpu-scenarios.test.ts
@@ -186,7 +186,7 @@ describe("gateway CPU scenario guard", () => {
     expect(calls.map((call) => call.args[0])).toEqual([
       "scripts/ensure-cli-startup-build.mjs",
       "--import",
-      "--import",
+      "scripts/bench-gateway-concurrency.ts",
     ]);
     expect(calls[1]?.args).toContain("scripts/bench-gateway-startup.ts");
     expect(calls[2]?.args).toContain("scripts/bench-gateway-concurrency.ts");


### PR DESCRIPTION
Related: #118193

## What Problem This Solves

Fixes an issue where operators running the gateway concurrency benchmark on Linux received only `gateway probes did not pass before concurrent load`, with no indication whether readiness, session listing, or the Control UI failed. The benchmark also failed before startup under native Node with `ERR_MODULE_NOT_FOUND`, despite Node's built-in TypeScript support.

## Why This Change Was Made

The pre-load probes now run serially for attribution, retain bounded status/error details, and report every probe in the failure. Load-time sampling remains parallel. The benchmark's small source import graph now uses native-Node-compatible TypeScript specifiers and a dependency-free integer parser, so the canonical command no longer needs tsx.

## User Impact

Operators can run the benchmark directly on supported Node versions and immediately see which baseline probe failed. The Hetzner reproduction now shows that readiness and Control UI pass while `sessions.list` times out, ruling out both the production UI asset and authentication theories without masking the underlying latency with a larger timeout.

## Evidence

- Before: [Hetzner Node 26.5 reproduction](https://crabbox.openclaw.ai/portal/runs/run_8ed1536b0765) reached a clean gateway startup but emitted only the generic probe failure.
- After: [Hetzner Node 26.5 diagnostic run](https://crabbox.openclaw.ai/portal/runs/run_da705e1bdf69) reported `readyz` 200 in 18.5 ms, Control UI 200 in 392 ms, and only `sessionsList` failing with `timeout waiting for sessions.list` after 20 seconds.
- Native Node: [Hetzner Node 22.22.3 and 26.5.0 proof](https://crabbox.openclaw.ai/portal/runs/run_5c8666320b48), including 85 focused tests.
- Changed gate: [Hetzner Node 26.5.0](https://crabbox.openclaw.ai/portal/runs/run_1a909851e141), all selected formatting, package, boundary, declaration, typecheck, and lint lanes passed.
- Autoreview: Codex `gpt-5.6-sol` high reasoning, clean with 0.98 confidence. Source-blind behavior validation passed all native execution, invalid-input, and attributable-diagnostic clauses.
