### PR TITLE
fix(memory): honor keyed agents in standalone operations

### DIFF
--- a/extensions/memory-core/cli-metadata.test.ts
+++ b/extensions/memory-core/cli-metadata.test.ts
@@ -2,11 +2,7 @@
 import { Command } from "commander";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  configureMemoryCoreDreamingState,
-  openMemoryCoreStateStore,
-} from "./src/dreaming-state.js";
+import { describe, expect, it, vi } from "vitest";
 
 const registerMemoryCliMock = vi.hoisted(() => vi.fn());
 
@@ -17,15 +13,7 @@ vi.mock("./src/cli.js", () => ({
 import plugin from "./cli-metadata.js";
 
 describe("memory-core CLI metadata", () => {
-  const resetDreamingState = () =>
-    configureMemoryCoreDreamingState(() => {
-      throw new Error("memory-core dreaming SQLite state store is not configured");
-    });
-
-  beforeEach(resetDreamingState);
-  afterEach(resetDreamingState);
-
-  it("binds SQLite state and lease hosts to the standalone CLI", async () => {
+  it("passes SQLite state and lease hosts to the standalone CLI", async () => {
     let registrar: Parameters<OpenClawPluginApi["registerCli"]>[0] | undefined;
     const hostWithLease = vi.fn();
     const keyedStore = {};
@@ -45,19 +33,24 @@ describe("memory-core CLI metadata", () => {
     if (!registrar) {
       throw new Error("CLI registrar missing");
     }
-    const storeOptions = { namespace: "cli-status-regression", maxEntries: 1 };
-
-    expect(openMemoryCoreStateStore(storeOptions)).toBe(keyedStore);
-    expect(openKeyedStore).toHaveBeenCalledWith(storeOptions);
-
     const program = new Command();
 
     await registrar({ program } as never);
 
     expect(registerMemoryCliMock).toHaveBeenCalledWith(program, {
       acquireLocalService,
+      openKeyedStore: expect.any(Function),
       withLease: expect.any(Function),
     });
+    const boundOpenKeyedStore = registerMemoryCliMock.mock.calls[0]?.[1]?.openKeyedStore as
+      | ((options: unknown) => unknown)
+      | undefined;
+    if (!boundOpenKeyedStore) {
+      throw new Error("bound SQLite state hook missing");
+    }
+    const storeOptions = { namespace: "cli-status-regression", maxEntries: 1 };
+    expect(boundOpenKeyedStore(storeOptions)).toBe(keyedStore);
+    expect(openKeyedStore).toHaveBeenCalledWith(storeOptions);
     const withLease = registerMemoryCliMock.mock.calls[0]?.[1]?.withLease as
       | ((...args: unknown[]) => unknown)
       | undefined;

--- a/extensions/memory-core/cli-metadata.test.ts
+++ b/extensions/memory-core/cli-metadata.test.ts
@@ -2,7 +2,11 @@
 import { Command } from "commander";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  configureMemoryCoreDreamingState,
+  openMemoryCoreStateStore,
+} from "./src/dreaming-state.js";
 
 const registerMemoryCliMock = vi.hoisted(() => vi.fn());
 
@@ -13,15 +17,25 @@ vi.mock("./src/cli.js", () => ({
 import plugin from "./cli-metadata.js";
 
 describe("memory-core CLI metadata", () => {
-  it("passes the bound SQLite lease host to the lazy CLI registrar", async () => {
+  const resetDreamingState = () =>
+    configureMemoryCoreDreamingState(() => {
+      throw new Error("memory-core dreaming SQLite state store is not configured");
+    });
+
+  beforeEach(resetDreamingState);
+  afterEach(resetDreamingState);
+
+  it("binds SQLite state and lease hosts to the standalone CLI", async () => {
     let registrar: Parameters<OpenClawPluginApi["registerCli"]>[0] | undefined;
     const hostWithLease = vi.fn();
+    const keyedStore = {};
+    const openKeyedStore = vi.fn(() => keyedStore);
     const acquireLocalService = vi.fn(async () => undefined);
     plugin.register(
       createTestPluginApi({
         runtime: {
           llm: { acquireLocalService },
-          state: { withLease: hostWithLease },
+          state: { openKeyedStore, withLease: hostWithLease },
         } as unknown as OpenClawPluginApi["runtime"],
         registerCli(nextRegistrar) {
           registrar = nextRegistrar;
@@ -31,6 +45,11 @@ describe("memory-core CLI metadata", () => {
     if (!registrar) {
       throw new Error("CLI registrar missing");
     }
+    const storeOptions = { namespace: "cli-status-regression", maxEntries: 1 };
+
+    expect(openMemoryCoreStateStore(storeOptions)).toBe(keyedStore);
+    expect(openKeyedStore).toHaveBeenCalledWith(storeOptions);
+
     const program = new Command();
 
     await registrar({ program } as never);

--- a/extensions/memory-core/cli-metadata.ts
+++ b/extensions/memory-core/cli-metadata.ts
@@ -1,21 +1,19 @@
 // Memory Core plugin module implements cli metadata behavior.
 import { definePluginEntry } from "openclaw/plugin-sdk/core";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
-import { configureMemoryCoreDreamingState } from "./src/dreaming-state.js";
 
 export default definePluginEntry({
   id: "memory-core",
   name: "OpenClaw Memory",
   description: "File-backed memory search tools and CLI",
   register(api) {
-    configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
-      api.runtime.state.openKeyedStore<T>(options),
-    );
     api.registerCli(
       async ({ program }) => {
         const { registerMemoryCli } = await import("./cli.js");
         registerMemoryCli(program, {
           acquireLocalService: api.runtime.llm?.acquireLocalService,
+          openKeyedStore: <T>(options: OpenKeyedStoreOptions) =>
+            api.runtime.state.openKeyedStore<T>(options),
           withLease: api.runtime.state.withLease.bind(api.runtime.state),
         });
       },

--- a/extensions/memory-core/cli-metadata.ts
+++ b/extensions/memory-core/cli-metadata.ts
@@ -1,11 +1,16 @@
 // Memory Core plugin module implements cli metadata behavior.
 import { definePluginEntry } from "openclaw/plugin-sdk/core";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { configureMemoryCoreDreamingState } from "./src/dreaming-state.js";
 
 export default definePluginEntry({
   id: "memory-core",
   name: "OpenClaw Memory",
   description: "File-backed memory search tools and CLI",
   register(api) {
+    configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
+      api.runtime.state.openKeyedStore<T>(options),
+    );
     api.registerCli(
       async ({ program }) => {
         const { registerMemoryCli } = await import("./cli.js");

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -207,7 +207,7 @@ describe("memory-core plugin runtime registration", () => {
       .mockResolvedValueOnce({ manager: { sync: syncMain } } as never)
       .mockResolvedValueOnce({ manager: { sync: syncWork } } as never);
     const config = {
-      agents: { list: [{ id: "main" }, { id: "work" }] },
+      agents: { entries: { main: { default: true }, work: {} } },
     } as OpenClawConfig;
     const testApi = createTestPluginApi({
       config,

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -317,6 +317,7 @@ describe("memory-core plugin runtime registration", () => {
 
     expect(createMemoryRuntimeMock).toHaveBeenCalledWith({
       acquireLocalService: hostRuntime.llm.acquireLocalService,
+      openKeyedStore: expect.any(Function),
       withLease: expect.any(Function),
     });
   });
@@ -353,17 +354,21 @@ describe("memory-core plugin runtime registration", () => {
     });
     expect(createMemoryRuntimeMock).toHaveBeenCalledWith({
       acquireLocalService: hostRuntime.llm.acquireLocalService,
+      openKeyedStore: expect.any(Function),
       withLease: expect.any(Function),
     });
   });
 
-  it("binds the host SQLite lease hook to tools and CLI runtime", async () => {
+  it("binds the host SQLite state hooks to tools and CLI runtime", async () => {
     const runtime = registerMemoryCoreRuntime();
     const cfg = {} as OpenClawConfig;
 
     await runtime.getMemorySearchManager({ cfg, agentId: "main" });
 
     const host = createMemoryRuntimeMock.mock.calls.at(-1)?.[0];
+    const storeOptions = { namespace: "cli-status-regression", maxEntries: 1 };
+    host?.openKeyedStore?.(storeOptions);
+    expect(hostRuntime.state.openKeyedStore).toHaveBeenCalledWith(storeOptions);
     expect(host?.withLease).toEqual(expect.any(Function));
   });
 });

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -317,11 +317,11 @@ export default definePluginEntry({
   kind: "memory",
   register(api) {
     const acquireLocalService = api.runtime.llm?.acquireLocalService;
+    const openKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
+      api.runtime.state.openKeyedStore<T>(options);
     const withLease = api.runtime.state.withLease.bind(api.runtime.state);
-    const host = { acquireLocalService, withLease } satisfies MemoryCoreRuntimeHost;
-    configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
-      api.runtime.state.openKeyedStore<T>(options),
-    );
+    const host = { acquireLocalService, openKeyedStore, withLease } satisfies MemoryCoreRuntimeHost;
+    configureMemoryCoreDreamingState(openKeyedStore);
     const memoryRuntime = createLazyMemoryRuntime(host);
     registerShortTermPromotionDreaming(api);
     registerSessionBackfillGatewayMethods(api);

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,3 +1,4 @@
+import { listAgentIds } from "openclaw/plugin-sdk/agent-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Memory Core plugin entrypoint registers its OpenClaw integration.
 import {
@@ -274,14 +275,6 @@ function createLazyMemoryRuntime(host: MemoryCoreRuntimeHost): MemoryPluginRunti
   };
 }
 
-function configuredMemoryAgentIds(config: OpenClawConfig): string[] {
-  const configured = (config.agents?.list ?? []).map((entry) => entry.id).filter(Boolean);
-  if (configured.length > 0) {
-    return [...new Set(configured)];
-  }
-  return [resolveSessionAgentIds({ config }).sessionAgentId];
-}
-
 function registerMemoryManagerWarmup(
   api: OpenClawPluginApi,
   memoryRuntime: MemoryPluginRuntime,
@@ -291,7 +284,7 @@ function registerMemoryManagerWarmup(
     if (normalizePluginsConfig(config.plugins).slots.memory !== "memory-core") {
       return;
     }
-    for (const agentId of configuredMemoryAgentIds(config)) {
+    for (const agentId of listAgentIds(config)) {
       const backend = memoryRuntime.resolveMemoryBackendConfig({ cfg: config, agentId });
       void memoryRuntime
         .getMemorySearchManager({ cfg: config, agentId })

--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -1,6 +1,7 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { listAgentIds } from "openclaw/plugin-sdk/agent-runtime";
 import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import type { PluginStateLeaseRunner } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
@@ -148,11 +149,7 @@ function resolveAgentIds(cfg: OpenClawConfig, agent?: string): string[] {
   if (trimmed) {
     return [trimmed];
   }
-  const list = cfg.agents?.list ?? [];
-  if (list.length > 0) {
-    return list.map((entry) => entry.id).filter(Boolean);
-  }
-  return [resolveDefaultAgentId(cfg)];
+  return listAgentIds(cfg);
 }
 export function formatExtraPaths(workspaceDir: string, extraPaths: string[]): string[] {
   return normalizeExtraMemoryPaths(workspaceDir, extraPaths).map((entry) => shortenHomePath(entry));

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -611,6 +611,29 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it("fans status out to every keyed agent entry", async () => {
+    const agentIds = ["main", ...Array.from({ length: 21 }, (_, index) => `agent-${index + 1}`)];
+    getRuntimeConfig.mockReturnValue({
+      agents: {
+        entries: Object.fromEntries(
+          agentIds.map((agentId, index) => [agentId, { default: index === 0 }]),
+        ),
+      },
+    });
+    getMemorySearchManager.mockImplementation(async () => ({
+      manager: {
+        status: () => makeMemoryStatus({ workspaceDir: undefined }),
+        close: vi.fn(async () => {}),
+      },
+    }));
+
+    await runMemoryCli(["status"]);
+
+    expect(
+      getMemorySearchManager.mock.calls.map(([params]) => (params as { agentId: string }).agentId),
+    ).toEqual(agentIds);
+  });
+
   it("resolves configured memory SecretRefs through gateway snapshot", async () => {
     const config = {
       memory: {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -13,6 +13,7 @@ import {
   spyRuntimeLogs,
 } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { openMemoryCoreStateStore } from "./dreaming-state.js";
 import { readShortTermRecallEntries, recordShortTermRecalls } from "./short-term-promotion.js";
 import {
   configureMemoryCoreDreamingStateForTests,
@@ -631,18 +632,30 @@ describe("memory cli", () => {
       },
     }));
     const json = spyRuntimeJson(defaultRuntime);
+    const keyedStore = {};
+    const openKeyedStore = vi.fn(() => keyedStore);
+    resetMemoryCoreDreamingStateForTests();
 
-    await runMemoryCli(["status", "--json"]);
+    try {
+      await runMemoryCli(["status", "--json"], { openKeyedStore: openKeyedStore as never });
 
-    expect(
-      getMemorySearchManager.mock.calls.map(([params]) => (params as { agentId: string }).agentId),
-    ).toEqual(agentIds);
-    const payload =
-      firstWrittenJsonArg<Array<{ agentId: string; status: { dbPath: string } }>>(json);
-    expect(payload?.map(({ agentId }) => agentId)).toEqual(agentIds);
-    expect(payload?.map(({ status }) => status.dbPath)).toEqual(
-      agentIds.map((agentId) => `/state/agents/${agentId}/agent/openclaw-agent.sqlite`),
-    );
+      expect(
+        getMemorySearchManager.mock.calls.map(
+          ([params]) => (params as { agentId: string }).agentId,
+        ),
+      ).toEqual(agentIds);
+      const payload =
+        firstWrittenJsonArg<Array<{ agentId: string; status: { dbPath: string } }>>(json);
+      expect(payload?.map(({ agentId }) => agentId)).toEqual(agentIds);
+      expect(payload?.map(({ status }) => status.dbPath)).toEqual(
+        agentIds.map((agentId) => `/state/agents/${agentId}/agent/openclaw-agent.sqlite`),
+      );
+      const storeOptions = { namespace: "cli-status-regression", maxEntries: 1 };
+      expect(openMemoryCoreStateStore(storeOptions)).toBe(keyedStore);
+      expect(openKeyedStore).toHaveBeenCalledWith(storeOptions);
+    } finally {
+      await configureMemoryCoreDreamingStateForTests();
+    }
   });
 
   it("resolves configured memory SecretRefs through gateway snapshot", async () => {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -611,7 +611,7 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
   });
 
-  it("fans status out to every keyed agent entry", async () => {
+  it("fans JSON status out to every keyed agent entry", async () => {
     const agentIds = ["main", ...Array.from({ length: 21 }, (_, index) => `agent-${index + 1}`)];
     getRuntimeConfig.mockReturnValue({
       agents: {
@@ -620,18 +620,29 @@ describe("memory cli", () => {
         ),
       },
     });
-    getMemorySearchManager.mockImplementation(async () => ({
+    getMemorySearchManager.mockImplementation(async ({ agentId }: { agentId: string }) => ({
       manager: {
-        status: () => makeMemoryStatus({ workspaceDir: undefined }),
+        status: () =>
+          makeMemoryStatus({
+            workspaceDir: undefined,
+            dbPath: `/state/agents/${agentId}/agent/openclaw-agent.sqlite`,
+          }),
         close: vi.fn(async () => {}),
       },
     }));
+    const json = spyRuntimeJson(defaultRuntime);
 
-    await runMemoryCli(["status"]);
+    await runMemoryCli(["status", "--json"]);
 
     expect(
       getMemorySearchManager.mock.calls.map(([params]) => (params as { agentId: string }).agentId),
     ).toEqual(agentIds);
+    const payload =
+      firstWrittenJsonArg<Array<{ agentId: string; status: { dbPath: string } }>>(json);
+    expect(payload?.map(({ agentId }) => agentId)).toEqual(agentIds);
+    expect(payload?.map(({ status }) => status.dbPath)).toEqual(
+      agentIds.map((agentId) => `/state/agents/${agentId}/agent/openclaw-agent.sqlite`),
+    );
   });
 
   it("resolves configured memory SecretRefs through gateway snapshot", async () => {

--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -18,6 +18,7 @@ import type {
   MemoryRemHarnessOptions,
   MemorySearchCommandOptions,
 } from "./cli.types.js";
+import { configureMemoryCoreDreamingState } from "./dreaming-state.js";
 import type { MemoryCoreRuntimeHost } from "./memory/runtime-host.js";
 import type { MemorySessionBackfillOptions } from "./session-backfill.js";
 import {
@@ -126,6 +127,9 @@ function parseMemoryCliNonNegativeIntegerOption(value: string, flag: string): nu
 }
 
 export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreRuntimeHost) {
+  if (hostOptions?.openKeyedStore) {
+    configureMemoryCoreDreamingState(hostOptions.openKeyedStore);
+  }
   const memory = program
     .command("memory")
     .description("Search, inspect, and reindex memory files")

--- a/extensions/memory-core/src/dreaming-state.ts
+++ b/extensions/memory-core/src/dreaming-state.ts
@@ -22,7 +22,9 @@ const DREAMING_WORKSPACE_STATE_MAX_ENTRIES = 50_000;
 export const SHORT_TERM_LOCK_MAX_ENTRIES = 4_096;
 export const SESSION_SEEN_HASHES_PER_CHUNK = 512;
 
-type MemoryCoreOpenKeyedStore = <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>;
+export type MemoryCoreOpenKeyedStore = <T>(
+  options: OpenKeyedStoreOptions,
+) => PluginStateKeyedStore<T>;
 
 type WorkspaceValue<T> = {
   version: 1;

--- a/extensions/memory-core/src/memory/runtime-host.ts
+++ b/extensions/memory-core/src/memory/runtime-host.ts
@@ -1,9 +1,11 @@
 import { resolveGlobalSingleton } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import type { PluginStateLeaseRunner } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type { MemoryCoreOpenKeyedStore } from "../dreaming-state.js";
 import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
 
 export type MemoryCoreRuntimeHost = {
   acquireLocalService?: MemoryCoreAcquireLocalService;
+  openKeyedStore?: MemoryCoreOpenKeyedStore;
   withLease?: PluginStateLeaseRunner;
 };
 

--- a/extensions/memory-core/src/runtime-provider.test.ts
+++ b/extensions/memory-core/src/runtime-provider.test.ts
@@ -19,6 +19,7 @@ const getMemorySearchManagerMock = vi.hoisted(() =>
   })),
 );
 const filterMemorySearchHitsBySessionVisibilityMock = vi.hoisted(() => vi.fn());
+const configureMemoryCoreDreamingStateMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./memory/index.js", () => ({
   closeAllMemorySearchManagers: vi.fn(async () => {}),
@@ -28,6 +29,10 @@ vi.mock("./memory/index.js", () => ({
 
 vi.mock("./session-search-visibility.js", () => ({
   filterMemorySearchHitsBySessionVisibility: filterMemorySearchHitsBySessionVisibilityMock,
+}));
+
+vi.mock("./dreaming-state.js", () => ({
+  configureMemoryCoreDreamingState: configureMemoryCoreDreamingStateMock,
 }));
 
 import { createMemoryRuntime, memoryRuntime } from "./runtime-provider.js";
@@ -102,6 +107,19 @@ describe("memoryRuntime", () => {
       agentId: "second",
       withLease: secondLease,
     });
+  });
+
+  it("binds the scoped state opener inside each lazy runtime instance", async () => {
+    const cfg = {} as OpenClawConfig;
+    const openKeyedStore = vi.fn();
+    configureMemoryCoreDreamingStateMock.mockClear();
+
+    await createMemoryRuntime({ openKeyedStore }).getMemorySearchManager({
+      cfg,
+      agentId: "main",
+    });
+
+    expect(configureMemoryCoreDreamingStateMock).toHaveBeenCalledWith(openKeyedStore);
   });
 
   it("delegates raw-hit authorization to the canonical session visibility filter", async () => {

--- a/extensions/memory-core/src/runtime-provider.ts
+++ b/extensions/memory-core/src/runtime-provider.ts
@@ -1,12 +1,12 @@
 // Memory Core provider module implements model/runtime integration.
 import type { MemoryPluginRuntime } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { resolveMemoryBackendConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+import { configureMemoryCoreDreamingState } from "./dreaming-state.js";
 import {
   closeAllMemorySearchManagers,
   closeMemorySearchManager,
   getMemorySearchManager,
 } from "./memory/index.js";
-import { configureMemoryCoreDreamingState } from "./dreaming-state.js";
 import type { MemoryCoreRuntimeHost } from "./memory/runtime-host.js";
 
 export function createMemoryRuntime(host: MemoryCoreRuntimeHost = {}): MemoryPluginRuntime {

--- a/extensions/memory-core/src/runtime-provider.ts
+++ b/extensions/memory-core/src/runtime-provider.ts
@@ -6,9 +6,14 @@ import {
   closeMemorySearchManager,
   getMemorySearchManager,
 } from "./memory/index.js";
+import { configureMemoryCoreDreamingState } from "./dreaming-state.js";
 import type { MemoryCoreRuntimeHost } from "./memory/runtime-host.js";
 
 export function createMemoryRuntime(host: MemoryCoreRuntimeHost = {}): MemoryPluginRuntime {
+  if (host.openKeyedStore) {
+    configureMemoryCoreDreamingState(host.openKeyedStore);
+  }
+
   return {
     async getMemorySearchManager(params) {
       const { manager, debug, error } = await getMemorySearchManager({

--- a/extensions/memory-core/src/session-backfill-gateway.test.ts
+++ b/extensions/memory-core/src/session-backfill-gateway.test.ts
@@ -30,14 +30,16 @@ function createHarness(config?: Record<string, unknown>) {
       ? config
       : {
           agents: {
-            list: [{ id: "main", default: true, workspace: "/tmp/main-workspace" }],
+            entries: { main: { default: true, workspace: "/tmp/main-workspace" } },
           },
         };
   const api = {
     runtime: {
       config: { current: () => runtimeConfig },
       agent: {
-        resolveAgentWorkspaceDir: vi.fn(() => "/tmp/main-workspace"),
+        resolveAgentWorkspaceDir: vi.fn(
+          (_config: unknown, agentId: string) => `/tmp/${agentId}-workspace`,
+        ),
       },
     },
     registerGatewayMethod(
@@ -150,6 +152,42 @@ describe("session backfill gateway methods", () => {
       code: "INVALID_REQUEST",
       message: 'Unknown agent id "missing".',
     });
+  });
+
+  it("accepts a keyed non-default agent", async () => {
+    const { methods } = createHarness({
+      agents: {
+        entries: {
+          main: { default: true },
+          tester: {},
+        },
+      },
+    });
+    executeBatchMock.mockResolvedValueOnce({
+      result: {
+        agentId: "tester",
+        workspaceDir: "/tmp/tester-workspace",
+        applied: false,
+        rem: false,
+        days: [],
+        candidateCount: 0,
+        stagedEntries: 0,
+        writtenDiaryEntries: 0,
+        replacedDiaryEntries: 0,
+      },
+      continuation: { advanced: false, hasMore: false },
+    });
+
+    const respond = await invoke(methods.get(SESSION_BACKFILL_GATEWAY_METHODS.preview)!, {
+      agentId: "tester",
+    });
+
+    expect(executeBatchMock).toHaveBeenCalledWith({
+      agentId: "tester",
+      limitDays: 92,
+      workspaceDir: "/tmp/tester-workspace",
+    });
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
   });
 
   it("allows only the implicit default agent when no roster is configured", async () => {

--- a/extensions/memory-core/src/session-backfill-gateway.ts
+++ b/extensions/memory-core/src/session-backfill-gateway.ts
@@ -1,3 +1,4 @@
+import { listAgentIds } from "openclaw/plugin-sdk/agent-runtime";
 import { readPositiveIntegerParam, readStringParam } from "openclaw/plugin-sdk/channel-actions";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -5,7 +6,6 @@ import {
   errorShape,
   type GatewayRequestHandlerOptions,
 } from "openclaw/plugin-sdk/gateway-runtime";
-import { resolveSessionAgentIds } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { resolveMemoryRemDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
 import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
@@ -91,10 +91,7 @@ function readRollbackParams(value: unknown): { agentId: string } {
 
 function resolveExecutionContext(api: OpenClawPluginApi, agentId: string) {
   const config = api.runtime.config.current() as OpenClawConfig;
-  const configuredAgentIds = (config.agents?.list ?? []).map((entry) => normalizeAgentId(entry.id));
-  if (configuredAgentIds.length === 0) {
-    configuredAgentIds.push(resolveSessionAgentIds({ config }).sessionAgentId);
-  }
+  const configuredAgentIds = listAgentIds(config);
   if (!configuredAgentIds.includes(agentId)) {
     throw new InvalidSessionBackfillRequestError(`Unknown agent id "${agentId}".`);
   }


### PR DESCRIPTION
## What Problem This Solves

Canonical keyed `agents.entries` rosters were not consistently honored by all-agent memory operations. After the roster fanout was fixed, the real standalone `memory status --json` path still failed because its lazy built CLI runtime could not see the memory-core plugin's scoped SQLite state opener:

```text
memory-core dreaming SQLite state store is not configured
```

Indexing and explicit-agent search already resolved the correct per-agent topology, so status was the remaining native-memory gap.

## Root Fix

- Uses the existing `listAgentIds` contract for unscoped CLI fanout, startup warmup, and session-backfill validation.
- Threads the plugin-scoped `openKeyedStore` capability through `MemoryCoreRuntimeHost`.
- Binds that capability at `registerMemoryCli`, inside the same built module graph used by the lazy status runtime.
- Binds the same opener when `createMemoryRuntime` constructs the lazy gateway runtime.
- Preserves explicit-agent selection and implicit-main behavior.
- Adds no fallback store, process-global project lookup, config shape, schema, or live-profile change.

## Evidence

A planted regression resets the memory-core state binding before a keyed 22-agent JSON status run. Before the registration fix it fails at `openMemoryCoreStateStore` with the exact error above. With the fix, it returns all 22 agents in roster order with distinct agent-scoped database paths.

The credential-free acceptance harness from WGM draft PR #2554 ran against the earlier implementation head:

- `native.unscoped_status_fanout`: PASS, 22/22 agents.
- `memory status --json`: exit 0, empty stderr, all keyed agents returned.
- `native.sqlite_topology`: PASS.
- `native.cross_project_isolation_all_agents`: PASS.
- Explicit-agent positive/negative search commands: PASS across the keyed roster.

## Verification

- Planted 22-agent status regression: passed after the old-code failure.
- Standalone CLI metadata host test: passed.
- Existing fanout/startup/backfill suite: passed.
- Lazy runtime state-opener binding regression: passed.
- Hosted changed-node memory-core test shards: passed on the current code head.
- Hosted gateway-watch regression: passed on the current formatted head; the gateway reached `ready`, remained healthy through the watch window, and shut down cleanly without a state-store configuration error. Redacted artifacts: [gateway-watch-regression](https://github.com/openclaw/openclaw/actions/runs/30828448805/artifacts/8862200709).
- Hosted `Real behavior proof` check: passed for the current formatted head.

Current PR head: `edc6a906457544d7dac5f1721afed3fa3582f741`.

AI-assisted contribution. No secrets, live profile/store access, or local contributor-code execution was used for this review/landing workflow.
