### PR TITLE
fix(agents): prevent embedded E2E registry crashes

### DIFF
--- a/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
+++ b/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
@@ -4,8 +4,14 @@
  * Installs targeted Vitest module mocks for tests that do not need live plugin/runtime boot.
  */
 import { vi } from "vitest";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
+import type {
+  PreparedModelRuntimeInput,
+  PreparedModelRuntimeSnapshot,
+} from "../prepared-model-runtime.types.js";
 
 type EmbeddedRunnerFastRunMockOptions = {
   runEmbeddedAttempt: (params: unknown) => unknown;
@@ -22,6 +28,71 @@ type EmbeddedRunnerBackoffMockOptions = {
   ) => number;
   sleepWithAbort: (ms: number, abortSignal?: AbortSignal) => unknown;
 };
+
+function createEmptyPluginMetadataSnapshot(workspaceDir?: string): PluginMetadataSnapshot {
+  return {
+    policyHash: "",
+    ...(workspaceDir !== undefined ? { workspaceDir } : {}),
+    index: {
+      version: 1,
+      hostContractVersion: "test",
+      compatRegistryVersion: "test",
+      migrationVersion: 1,
+      policyHash: "",
+      generatedAtMs: 1,
+      installRecords: {},
+      plugins: [],
+      diagnostics: [],
+    },
+    registryDiagnostics: [],
+    manifestRegistry: { plugins: [], diagnostics: [] },
+    plugins: [],
+    diagnostics: [],
+    byPluginId: new Map(),
+    normalizePluginId: (pluginId) => pluginId,
+    owners: {
+      channels: new Map(),
+      channelConfigs: new Map(),
+      providers: new Map(),
+      modelCatalogProviders: new Map(),
+      cliBackends: new Map(),
+      setupProviders: new Map(),
+      commandAliases: new Map(),
+      contracts: new Map(),
+    },
+    metrics: {
+      registrySnapshotMs: 0,
+      manifestRegistryMs: 0,
+      ownerMapsMs: 0,
+      totalMs: 0,
+      indexPluginCount: 0,
+      manifestPluginCount: 0,
+    },
+  };
+}
+
+function createEmptyPreparedModelRuntimeSnapshot(
+  input: PreparedModelRuntimeInput,
+): PreparedModelRuntimeSnapshot {
+  return {
+    ...(input.agentId !== undefined ? { agentId: input.agentId } : {}),
+    agentDir: input.agentDir,
+    ...(input.inheritedAuthDir !== undefined ? { inheritedAuthDir: input.inheritedAuthDir } : {}),
+    ...(input.workspaceDir !== undefined ? { workspaceDir: input.workspaceDir } : {}),
+    activeProjectKeys: [],
+    config: input.config,
+    metadataSnapshot: createEmptyPluginMetadataSnapshot(input.workspaceDir),
+    pluginRegistry: createEmptyPluginRegistry(),
+    allowGatewaySubagentBinding: input.allowGatewaySubagentBinding === true,
+    modelCatalog: { entries: [], routeVariants: [] },
+    configuredRuntimeModels: [],
+    inlineProviderModels: [],
+    createStores: () => ({
+      authStorage: { setRuntimeApiKey: vi.fn() } as never,
+      modelRegistry: {} as never,
+    }),
+  };
+}
 
 /** Installs baseline mocks for hook runner, context engine, and runtime plugin loading. */
 export function installEmbeddedRunnerBaseE2eMocks(options?: {
@@ -51,7 +122,37 @@ export function installEmbeddedRunnerBaseE2eMocks(options?: {
     resolveContextEngineOwnerPluginId: vi.fn(() => undefined),
   }));
   vi.doMock("../runtime-plugins.js", () => ({
-    loadAgentRuntimePluginRegistryHandle: vi.fn(() => ({ agentHarnesses: [] })),
+    loadAgentRuntimePluginRegistryHandle: vi.fn(() => createEmptyPluginRegistry()),
+  }));
+  vi.doMock("../prepared-model-runtime.js", () => {
+    const acquire = async (input: PreparedModelRuntimeInput) => {
+      if (!input.readOnly) {
+        const { ensureOpenClawModelsJson } = await import("../models-config.js");
+        await ensureOpenClawModelsJson(
+          input.config,
+          input.agentDir,
+          input.workspaceDir !== undefined ? { workspaceDir: input.workspaceDir } : {},
+        );
+      }
+      return {
+        snapshot: createEmptyPreparedModelRuntimeSnapshot(input),
+        release: vi.fn(),
+      };
+    };
+    return {
+      acquireAgentRunPreparedModelRuntime: vi.fn(acquire),
+      acquireReadOnlyPreparedModelRuntime: vi.fn(acquire),
+      prepareModelRuntimeSnapshot: vi.fn(async (input: PreparedModelRuntimeInput) =>
+        createEmptyPreparedModelRuntimeSnapshot(input),
+      ),
+    };
+  });
+  vi.doMock("../../plugins/provider-hook-runtime.js", () => ({
+    prepareProviderExtraParams: vi.fn(() => undefined),
+    resolveProviderExtraParamsForTransport: vi.fn(() => undefined),
+    resolveProviderRuntimePlugin: vi.fn(() => undefined),
+    resolveProviderRuntimePluginHandle: vi.fn((params: object) => params),
+    wrapProviderStreamFn: vi.fn(() => undefined),
   }));
   vi.doMock("../harness/runtime-plugin.js", () => ({
     ensureSelectedAgentHarnessPlugin: vi.fn(async () => {}),


### PR DESCRIPTION
Closes #118312

## What Problem This Solves

Fixes an issue where embedded-runner E2E suites crashed or exceeded their 120-second timeout when the shared fast fixture was asked to represent current plugin and prepared-runtime lifecycle state.

The regression was introduced when #117587 changed the runtime registry ownership boundary but left this test helper returning only `{ agentHarnesses: [] }`. Provider hooks now correctly assume a complete `PluginRegistry`; replacing only that partial object exposed two more real runtime fallthroughs in the supposedly fast harness.

## Why This Change Was Made

The shared E2E helper now owns one coherent, lifecycle-shaped empty runtime fixture:

- the canonical complete empty plugin registry;
- empty plugin metadata and provider-hook results;
- an empty prepared-model runtime lease that preserves writable `models.json` publication ordering;
- no real plugin or prepared-runtime discovery.

This repairs the producer fixture instead of weakening production registry assumptions, adding consumer guards, or raising test timeouts. The earlier one-line registry insight from Vincent Koc is preserved through commit co-authorship.

## User Impact

There is no production runtime behavior change. Maintainers regain reliable embedded-runner, model-fallback, and auth-profile regression coverage, and broad Gateway QA no longer accumulates cascading failures from this malformed fixture.

## Evidence

Exact reviewed head: `ee902385219501bf2fcec88716b944a39d409c75`

Before on current main:

- `model-fallback.run-embedded.e2e.test.ts`: 18/18 failed at `registry.providers`.
- Completing only the registry caused `does not persist auth profile bookkeeping for read-only probes` to time out at 120 seconds.
- Trace evidence showed a 105735.6ms real OpenAI plugin load and a 56865ms real prepared-runtime stage.

After on a fresh Blacksmith Testbox:

- `CI=1 pnpm test src/agents/model-fallback.run-embedded.e2e.test.ts src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts src/agents/embedded-agent-runner.e2e.test.ts`
  - 66/66 passed.
  - The formerly timing-out read-only case completed in 1450ms.
- `CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed`
  - Passed formatting, production/test typechecks, lint, dead-code, boundary, schema, import-cycle, and architecture guards.
- Testbox: `tbx_01kz2e9hr88dfed73yq8gwh2kk`
- Run: https://github.com/openclaw/openclaw/actions/runs/30773169676
- Fresh Codex autoreview on the rebased head: clean, no accepted/actionable findings, 0.98 confidence.

Production LOC delta: 0. Test-helper delta: +102/-1. No config, protocol, persistence, dependency, or public API surface changes.

AI-assisted: yes. The final implementation and proof were reviewed directly in this maintainer task.
