### PR TITLE
refactor(telegram): deduplicate reasoning room-event fixtures

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.reasoning-room-events.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.reasoning-room-events.test.ts
@@ -15,15 +15,111 @@ import {
   sendMessageTelegram,
   setupDraftStreams,
 } from "./bot-message-dispatch.test-harness.js";
-import type { TelegramMessageContext } from "./bot-message-dispatch.test-harness.js";
+import type {
+  DispatchReplyWithBufferedBlockDispatcherArgs,
+  TelegramMessageContext,
+} from "./bot-message-dispatch.test-harness.js";
 import { telegramInboundEventDelivery } from "./inbound-event-delivery.js";
+
+const GROUP_CHAT_ID = -100123;
+const GROUP_SESSION_KEY = "agent:main:telegram:group:-100123";
+
+const emptyDispatchResult = {
+  queuedFinal: false,
+  counts: { block: 0, final: 0, tool: 0 },
+};
+
+const messageToolOnlyDispatchResult = {
+  ...emptyDispatchResult,
+  sourceReplyDeliveryMode: "message_tool_only" as const,
+};
+
+function mockTurn(
+  run: (params: DispatchReplyWithBufferedBlockDispatcherArgs) => Promise<void>,
+  result: unknown = { queuedFinal: true },
+) {
+  dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async (params) => {
+    await run(params);
+    return result;
+  });
+}
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function createGroupFixture(
+  params: {
+    commandAuthorized?: boolean;
+    entries?: Array<{ sender: string; body: string; timestamp: number }>;
+    topicId?: number;
+  } = {},
+) {
+  const { commandAuthorized, topicId } = params;
+  const entries = params.entries ?? [{ sender: "Alice", body: "lunch at two", timestamp: 1 }];
+  const historyKey = `telegram:group:${GROUP_CHAT_ID}${topicId ? `:topic:${topicId}` : ""}`;
+  const groupHistories = new Map([[historyKey, entries]]);
+  const context = (
+    messageId: number,
+    body: string,
+    kind: "user_request" | "room_event" = "room_event",
+    overrides: Partial<TelegramMessageContext> = {},
+  ) =>
+    createContext({
+      ...overrides,
+      ctxPayload: {
+        InboundEventKind: kind,
+        SessionKey: GROUP_SESSION_KEY,
+        ChatType: "group",
+        MessageSid: String(messageId),
+        RawBody: body,
+        BodyForAgent: body,
+        CommandBody: body,
+        ...(commandAuthorized ? { CommandAuthorized: true } : {}),
+      } as unknown as TelegramMessageContext["ctxPayload"],
+      msg: {
+        chat: { id: GROUP_CHAT_ID, type: "supergroup", ...(topicId ? { is_forum: true } : {}) },
+        message_id: messageId,
+        ...(topicId ? { message_thread_id: topicId } : {}),
+      } as unknown as TelegramMessageContext["msg"],
+      chatId: GROUP_CHAT_ID,
+      isGroup: true,
+      historyKey,
+      historyLimit: 10,
+      groupHistories,
+      threadSpec: topicId ? { id: topicId, scope: "forum" } : { id: undefined, scope: "none" },
+    });
+  return { context, groupHistories, historyKey };
+}
+
+function mockSupersedingRoomEvents() {
+  const firstStarted = createDeferred();
+  const firstRelease = createDeferred();
+  const secondStarted = createDeferred();
+  dispatchReplyWithBufferedBlockDispatcher
+    .mockImplementationOnce(async () => {
+      firstStarted.resolve();
+      await firstRelease.promise;
+      return messageToolOnlyDispatchResult;
+    })
+    .mockImplementationOnce(async () => {
+      secondStarted.resolve();
+      return messageToolOnlyDispatchResult;
+    });
+  return {
+    firstStarted: firstStarted.promise,
+    releaseFirst: firstRelease.resolve,
+    secondStarted: secondStarted.promise,
+  };
+}
 
 describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => {
   it("keeps shared durable reasoning payloads disabled when reasoning is off", async () => {
-    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
-      queuedFinal: false,
-      counts: { block: 0, final: 0, tool: 0 },
-    });
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(emptyDispatchResult);
 
     await dispatchWithContext({ context: createContext() });
 
@@ -38,10 +134,7 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
       answerMessageId: 2001,
       reasoningMessageId: 3001,
     });
-    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
-      queuedFinal: false,
-      counts: { block: 0, final: 0, tool: 0 },
-    });
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(emptyDispatchResult);
 
     await dispatchWithContext({ context: createReasoningStreamContext() });
 
@@ -53,10 +146,7 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
 
   it("keeps shared durable reasoning payloads disabled in progress stream mode", async () => {
     setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
-      queuedFinal: false,
-      counts: { block: 0, final: 0, tool: 0 },
-    });
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(emptyDispatchResult);
 
     await dispatchWithContext({
       context: createReasoningStreamContext(),
@@ -71,12 +161,11 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
 
   it("suppresses typed reasoning-only finals without raw text fallback", async () => {
     setupDraftStreams({ answerMessageId: 2001, reasoningMessageId: 3001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+    mockTurn(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver(
         { text: "<think>hidden</think>", isReasoning: true },
         { kind: "final" },
       );
-      return { queuedFinal: true };
     });
 
     await dispatchWithContext({ context: createContext() });
@@ -90,12 +179,11 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
       answerMessageId: 2001,
       reasoningMessageId: 3001,
     });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+    mockTurn(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver(
         { text: "<think>hidden</think>", isReasoning: true },
         { kind: "final" },
       );
-      return { queuedFinal: true };
     });
 
     await dispatchWithContext({ context: createReasoningStreamContext() });
@@ -108,12 +196,11 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
     loadSessionStore.mockReturnValue({
       s1: { reasoningLevel: "on" },
     });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+    mockTurn(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver(
         { text: "<think>hidden</think>", isReasoning: true },
         { kind: "final" },
       );
-      return { queuedFinal: true };
     });
 
     await dispatchWithContext({
@@ -128,12 +215,11 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
 
   it("does not persist typed reasoning-only finals in progress stream mode", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+    mockTurn(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver(
         { text: "<think>hidden</think>", isReasoning: true },
         { kind: "final" },
       );
-      return { queuedFinal: true };
     });
 
     await dispatchWithContext({
@@ -150,12 +236,11 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
       answerMessageId: 2001,
       reasoningMessageId: 3001,
     });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+    mockTurn(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver(
         { text: "Before <think>literal tag text after" },
         { kind: "final" },
       );
-      return { queuedFinal: true };
     });
 
     await dispatchWithContext({ context: createContext() });
@@ -166,11 +251,7 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
 
   it("does not add silent fallback when source delivery is message-tool-only", async () => {
     setupDraftStreams({ answerMessageId: 2001, reasoningMessageId: 3001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
-      queuedFinal: false,
-      counts: { block: 0, final: 0, tool: 0 },
-      sourceReplyDeliveryMode: "message_tool_only",
-    });
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue(messageToolOnlyDispatchResult);
 
     await dispatchWithContext({
       context: createContext({
@@ -196,48 +277,23 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
   });
 
   it("runs ambient room events as tool-only invisible turns", async () => {
-    const historyKey = "telegram:group:-100123";
-    const groupHistories = new Map([
-      [historyKey, [{ sender: "Alice", body: "side chatter", timestamp: 1 }]],
-    ]);
+    const { context, groupHistories, historyKey } = createGroupFixture({
+      entries: [{ sender: "Alice", body: "side chatter", timestamp: 1 }],
+    });
     const statusReactionController = createStatusReactionController();
     loadSessionStore.mockReturnValue({
-      "agent:main:telegram:group:-100123": { reasoningLevel: "stream" },
+      [GROUP_SESSION_KEY]: { reasoningLevel: "stream" },
     });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+    mockTurn(async ({ replyOptions }) => {
       await replyOptions?.onReasoningStream?.({ text: "<think>ambient reasoning</think>" });
       await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
       await replyOptions?.onCompactionStart?.();
       await replyOptions?.onCompactionEnd?.();
-      return {
-        queuedFinal: false,
-        counts: { block: 0, final: 0, tool: 0 },
-        sourceReplyDeliveryMode: "message_tool_only",
-      };
-    });
+    }, messageToolOnlyDispatchResult);
 
     await dispatchWithContext({
-      context: createContext({
+      context: context(99, "ambient", "room_event", {
         statusReactionController: statusReactionController as never,
-        ctxPayload: {
-          InboundEventKind: "room_event",
-          SessionKey: "agent:main:telegram:group:-100123",
-          ChatType: "group",
-          MessageSid: "99",
-          RawBody: "ambient",
-          BodyForAgent: "ambient",
-          CommandBody: "ambient",
-        } as unknown as TelegramMessageContext["ctxPayload"],
-        msg: {
-          chat: { id: -100123, type: "supergroup" },
-          message_id: 99,
-        } as unknown as TelegramMessageContext["msg"],
-        chatId: -100123,
-        isGroup: true,
-        historyKey,
-        historyLimit: 10,
-        groupHistories,
-        threadSpec: { id: undefined, scope: "none" },
       }),
       streamMode: "partial",
     });
@@ -269,257 +325,89 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
   });
 
   it("keeps room-event history when a newer turn supersedes dispatch", async () => {
-    const historyKey = "telegram:group:-100123";
-    const groupHistories = new Map([
-      [historyKey, [{ sender: "Alice", body: "lunch at two", timestamp: 1 }]],
-    ]);
-    let releaseFirst: (() => void) | undefined;
-    const firstGate = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-    let secondStarted: (() => void) | undefined;
-    const secondStartGate = new Promise<void>((resolve) => {
-      secondStarted = resolve;
-    });
-    dispatchReplyWithBufferedBlockDispatcher
-      .mockImplementationOnce(async () => {
-        await firstGate;
-        return {
-          queuedFinal: false,
-          counts: { block: 0, final: 0, tool: 0 },
-          sourceReplyDeliveryMode: "message_tool_only",
-        };
-      })
-      .mockImplementationOnce(async () => {
-        secondStarted?.();
-        return {
-          queuedFinal: false,
-          counts: { block: 0, final: 0, tool: 0 },
-          sourceReplyDeliveryMode: "message_tool_only",
-        };
-      });
-
-    const createRoomContext = (messageId: number, body: string) =>
-      createContext({
-        ctxPayload: {
-          InboundEventKind: "room_event",
-          SessionKey: "agent:main:telegram:group:-100123",
-          ChatType: "group",
-          MessageSid: String(messageId),
-          RawBody: body,
-          BodyForAgent: body,
-          CommandBody: body,
-        } as unknown as TelegramMessageContext["ctxPayload"],
-        msg: {
-          chat: { id: -100123, type: "supergroup" },
-          message_id: messageId,
-        } as unknown as TelegramMessageContext["msg"],
-        chatId: -100123,
-        isGroup: true,
-        historyKey,
-        historyLimit: 10,
-        groupHistories,
-        threadSpec: { id: undefined, scope: "none" },
-      });
+    const { context, groupHistories, historyKey } = createGroupFixture();
+    const { releaseFirst, secondStarted } = mockSupersedingRoomEvents();
 
     const firstPromise = dispatchWithContext({
-      context: createRoomContext(99, "ambient one"),
+      context: context(99, "ambient one"),
       streamMode: "partial",
     });
     const secondPromise = dispatchWithContext({
-      context: createRoomContext(100, "ambient two"),
+      context: context(100, "ambient two"),
       streamMode: "partial",
     });
 
-    await secondStartGate;
-    releaseFirst?.();
+    await secondStarted;
+    releaseFirst();
     await Promise.all([firstPromise, secondPromise]);
 
     expect(groupHistories.get(historyKey)).toHaveLength(1);
   });
 
   it("keeps delivered room-event history when a newer turn supersedes dispatch", async () => {
-    const historyKey = "telegram:group:-100123";
-    const groupHistories = new Map([
-      [historyKey, [{ sender: "Alice", body: "lunch at two", timestamp: 1 }]],
-    ]);
-    let firstStarted: (() => void) | undefined;
-    const firstStartGate = new Promise<void>((resolve) => {
-      firstStarted = resolve;
-    });
-    let releaseFirst: (() => void) | undefined;
-    const firstGate = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-    let secondStarted: (() => void) | undefined;
-    const secondStartGate = new Promise<void>((resolve) => {
-      secondStarted = resolve;
-    });
-    dispatchReplyWithBufferedBlockDispatcher
-      .mockImplementationOnce(async () => {
-        firstStarted?.();
-        await firstGate;
-        return {
-          queuedFinal: false,
-          counts: { block: 0, final: 0, tool: 0 },
-          sourceReplyDeliveryMode: "message_tool_only",
-        };
-      })
-      .mockImplementationOnce(async () => {
-        secondStarted?.();
-        return {
-          queuedFinal: false,
-          counts: { block: 0, final: 0, tool: 0 },
-          sourceReplyDeliveryMode: "message_tool_only",
-        };
-      });
-
-    const createRoomContext = (messageId: number, body: string) =>
-      createContext({
-        ctxPayload: {
-          InboundEventKind: "room_event",
-          SessionKey: "agent:main:telegram:group:-100123",
-          ChatType: "group",
-          MessageSid: String(messageId),
-          RawBody: body,
-          BodyForAgent: body,
-          CommandBody: body,
-        } as unknown as TelegramMessageContext["ctxPayload"],
-        msg: {
-          chat: { id: -100123, type: "supergroup" },
-          message_id: messageId,
-        } as unknown as TelegramMessageContext["msg"],
-        chatId: -100123,
-        isGroup: true,
-        historyKey,
-        historyLimit: 10,
-        groupHistories,
-        threadSpec: { id: undefined, scope: "none" },
-      });
+    const { context, groupHistories, historyKey } = createGroupFixture();
+    const { firstStarted, releaseFirst, secondStarted } = mockSupersedingRoomEvents();
 
     const firstPromise = dispatchWithContext({
-      context: createRoomContext(99, "ambient one"),
+      context: context(99, "ambient one"),
       streamMode: "partial",
     });
-    await firstStartGate;
+    await firstStarted;
     telegramInboundEventDelivery.notify({
-      sessionKey: "agent:main:telegram:group:-100123",
+      sessionKey: GROUP_SESSION_KEY,
       to: "telegram:-100123",
       inboundEventKind: "room_event",
     });
     const secondPromise = dispatchWithContext({
-      context: createRoomContext(100, "ambient two"),
+      context: context(100, "ambient two"),
       streamMode: "partial",
     });
 
-    await secondStartGate;
-    releaseFirst?.();
+    await secondStarted;
+    releaseFirst();
     await Promise.all([firstPromise, secondPromise]);
 
     expect(groupHistories.get(historyKey)).toHaveLength(1);
   });
 
   it("keeps topic room-event history for a send to another topic", async () => {
-    const historyKey = "telegram:group:-100123:topic:77";
-    const groupHistories = new Map([
-      [historyKey, [{ sender: "Alice", body: "topic 77 context", timestamp: 1 }]],
-    ]);
-    let firstStarted: (() => void) | undefined;
-    const firstStartGate = new Promise<void>((resolve) => {
-      firstStarted = resolve;
+    const { context, groupHistories, historyKey } = createGroupFixture({
+      entries: [{ sender: "Alice", body: "topic 77 context", timestamp: 1 }],
+      topicId: 77,
     });
-    let releaseFirst: (() => void) | undefined;
-    const firstGate = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-    let secondStarted: (() => void) | undefined;
-    const secondStartGate = new Promise<void>((resolve) => {
-      secondStarted = resolve;
-    });
-    dispatchReplyWithBufferedBlockDispatcher
-      .mockImplementationOnce(async () => {
-        firstStarted?.();
-        await firstGate;
-        return {
-          queuedFinal: false,
-          counts: { block: 0, final: 0, tool: 0 },
-          sourceReplyDeliveryMode: "message_tool_only",
-        };
-      })
-      .mockImplementationOnce(async () => {
-        secondStarted?.();
-        return {
-          queuedFinal: false,
-          counts: { block: 0, final: 0, tool: 0 },
-          sourceReplyDeliveryMode: "message_tool_only",
-        };
-      });
-
-    const createRoomContext = (messageId: number, body: string) =>
-      createContext({
-        ctxPayload: {
-          InboundEventKind: "room_event",
-          SessionKey: "agent:main:telegram:group:-100123",
-          ChatType: "group",
-          MessageSid: String(messageId),
-          RawBody: body,
-          BodyForAgent: body,
-          CommandBody: body,
-        } as unknown as TelegramMessageContext["ctxPayload"],
-        msg: {
-          chat: { id: -100123, type: "supergroup", is_forum: true },
-          message_id: messageId,
-          message_thread_id: 77,
-        } as unknown as TelegramMessageContext["msg"],
-        chatId: -100123,
-        isGroup: true,
-        historyKey,
-        historyLimit: 10,
-        groupHistories,
-        threadSpec: { id: 77, scope: "forum" },
-      });
+    const { firstStarted, releaseFirst, secondStarted } = mockSupersedingRoomEvents();
 
     const firstPromise = dispatchWithContext({
-      context: createRoomContext(99, "ambient one"),
+      context: context(99, "ambient one"),
       streamMode: "partial",
     });
-    await firstStartGate;
+    await firstStarted;
     telegramInboundEventDelivery.notify({
-      sessionKey: "agent:main:telegram:group:-100123",
+      sessionKey: GROUP_SESSION_KEY,
       to: "telegram:group:-100123:topic:88",
       inboundEventKind: "room_event",
     });
     const secondPromise = dispatchWithContext({
-      context: createRoomContext(100, "ambient two"),
+      context: context(100, "ambient two"),
       streamMode: "partial",
     });
 
-    await secondStartGate;
-    releaseFirst?.();
+    await secondStarted;
+    releaseFirst();
     await Promise.all([firstPromise, secondPromise]);
 
     expect(groupHistories.get(historyKey)).toHaveLength(1);
   });
 
   it("does not let room events supersede active user-request dispatch", async () => {
-    const historyKey = "telegram:group:-100123";
-    const groupHistories = new Map([[historyKey, []]]);
-    let firstStarted: (() => void) | undefined;
-    const firstStartGate = new Promise<void>((resolve) => {
-      firstStarted = resolve;
-    });
-    let releaseFirst: (() => void) | undefined;
-    const firstGate = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-    let roomEventStarted: (() => void) | undefined;
-    const roomEventStartGate = new Promise<void>((resolve) => {
-      roomEventStarted = resolve;
-    });
+    const { context } = createGroupFixture({ commandAuthorized: true, entries: [] });
+    const firstStarted = createDeferred();
+    const firstRelease = createDeferred();
+    const roomEventStarted = createDeferred();
     dispatchReplyWithBufferedBlockDispatcher
       .mockImplementationOnce(async ({ dispatcherOptions }) => {
-        firstStarted?.();
-        await firstGate;
+        firstStarted.resolve();
+        await firstRelease.promise;
         await dispatcherOptions.deliver({ text: "visible request answer" }, { kind: "final" });
         return {
           queuedFinal: true,
@@ -527,53 +415,21 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
         };
       })
       .mockImplementationOnce(async () => {
-        roomEventStarted?.();
-        return {
-          queuedFinal: false,
-          counts: { block: 0, final: 0, tool: 0 },
-          sourceReplyDeliveryMode: "message_tool_only",
-        };
-      });
-
-    const createGroupContext = (
-      kind: "user_request" | "room_event",
-      messageId: number,
-      body: string,
-    ) =>
-      createContext({
-        ctxPayload: {
-          InboundEventKind: kind,
-          SessionKey: "agent:main:telegram:group:-100123",
-          ChatType: "group",
-          MessageSid: String(messageId),
-          RawBody: body,
-          BodyForAgent: body,
-          CommandBody: body,
-          CommandAuthorized: true,
-        } as unknown as TelegramMessageContext["ctxPayload"],
-        msg: {
-          chat: { id: -100123, type: "supergroup" },
-          message_id: messageId,
-        } as unknown as TelegramMessageContext["msg"],
-        chatId: -100123,
-        isGroup: true,
-        historyKey,
-        historyLimit: 10,
-        groupHistories,
-        threadSpec: { id: undefined, scope: "none" },
+        roomEventStarted.resolve();
+        return messageToolOnlyDispatchResult;
       });
 
     const userRequestPromise = dispatchWithContext({
-      context: createGroupContext("user_request", 99, "@bot answer this"),
+      context: context(99, "@bot answer this", "user_request"),
       streamMode: "off",
     });
-    await firstStartGate;
+    await firstStarted.promise;
     const roomEventPromise = dispatchWithContext({
-      context: createGroupContext("room_event", 100, "ambient chatter"),
+      context: context(100, "ambient chatter"),
       streamMode: "off",
     });
-    await roomEventStartGate;
-    releaseFirst?.();
+    await roomEventStarted.promise;
+    firstRelease.resolve();
     await Promise.all([userRequestPromise, roomEventPromise]);
 
     const deliveredTexts = deliverReplies.mock.calls.flatMap((call) =>


### PR DESCRIPTION
## What Problem This Solves

The Telegram dispatch reasoning/room-event suite repeated large inline dispatch-result, deferred-gate, and group/topic-context fixtures. That repetition made its ordering invariants harder to audit and made future test maintenance unnecessarily expensive.

## Why This Change Was Made

This refactors only the owning test suite around small suite-local fixtures. It keeps one canonical setup for empty and message-tool-only dispatch results, deferred gates, and Telegram group/topic context while leaving every production path and public contract untouched.

Root cause: the suites grew scenario-by-scenario without consolidating stable setup. The test suites own the repair; no shared harness or production abstraction is warranted. The canonical fix removes the duplicate setup while preserving the distinct scenario bodies and assertions.

## User Impact

No user-visible behavior changes. The test coverage is equivalent and easier to review and extend.

- Production LOC delta: **0**
- Test LOC delta: **+153 / -297, net -144**
- Removed paths: duplicated inline dispatch-result, gate, and group/topic fixtures
- Unchanged surfaces: production code, shared test harnesses, docs, config, schemas, baselines, package/API surfaces

## Evidence

- Exact frozen head: `c5323409e6798bdfb96d158b8b3af0807e141f0f`
- Full-index diff SHA-256: `333e92b83acce07f52c30704dba4311b313a66670f809f40d00a3e59f8266036`
- Local focused proof: 1 file, 14/14 tests; targeted oxlint and `git diff --check` passed
- Exact-tree Testbox wrapper proof: [run 30772815627](https://github.com/openclaw/openclaw/actions/runs/30772815627), lease `tbx_01kz2dpsm1z9kzf3s14yj37vfs`
  - before testing, the remote emitted target blob SHA-256 `079ffbff6774d429d70d00151da10555744c725764fb99c70f6ebbe581496f1d`, sole-file `153 / 297` numstat, and full-index diff SHA-256 `333e92b83acce07f52c30704dba4311b313a66670f809f40d00a3e59f8266036`
  - dispatch sibling cluster: 17 files, 227/227 tests passed
  - `pnpm check:changed`: passed, including ratchets, format, dependency/policy guards, plugin boundaries, dead-code scans, extension-test typecheck, and lint; wrapper timing JSON reported `exitCode: 0`, `runStatus: succeeded`

Structural parity against current main:

- reasoning/room events: 14/14 test names, 31/31 ordered assertions, and per-test ordered callback events exactly equal
- hashes: names `9407f6b3923012b10cd43f28363bd23d24d705fe08bcee9476f6629506b32071`; assertions `aea556c5f88af7125370ee49f08f670b95aeb04f9ba3a7605a41c9e8c68bcf60`; events `c1f7f5a1d7cb50805362ac30ffdf8ed71021a962c2e2ba4723fb11f838e79952`

The ordered event comparison covers reasoning, tool, item, delivery, and correlation callbacks. The final user-request/room-event scenarios continue to pass `commandAuthorized: true` in both contexts.

An initially planned cleanup of the progress-summary suite was dropped completely when external PR #118287 added a production regression fix and a test in that file. This PR has zero path overlap with #118287.

The earlier broad `pnpm test extensions/telegram` probe was stopped by the repository watchdog after a long silent aggregate phase; the large `bot`, `send`, and bot-construction suites had passed before the stall, and no target failure occurred. This PR therefore claims the focused and complete dispatch-cluster proof above, not a green full-plugin aggregate.

No live-channel or mock-gateway run is needed for this test-only fixture extraction: production code is unchanged, exact names/assertions/event order are structurally equal, and the full dispatch sibling cluster passed on the exact head.

Dependency and sibling-contract audit covered Grammy 1.45.1, `@grammyjs/types` 4.0.0, Telegram dispatch owners/callers/callees, Discord delivery/progress siblings, and the OpenAI Codex message-phase/reasoning runtime and OpenClaw Codex bridge. Two independent xhigh reviewers also re-derived the result from the frozen head before readying.
