### PR TITLE
improve(tests): reuse system agent gateway fixtures

### DIFF
--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -3,7 +3,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSafeGatewayRestartPreflight } from "../../infra/restart-coordinator.js";
@@ -18,7 +18,9 @@ import { SystemAgentChatEngine } from "../../system-agent/chat-engine.js";
 import { SystemAgentInferenceUnavailableError } from "../../system-agent/inference-error.js";
 import {
   createSystemAgentVerifiedInferenceTestFixture,
+  installSystemAgentPluginMetadataTestSnapshot,
   readLastSystemAgentAuditEntry,
+  type SystemAgentPluginMetadataTestSnapshot,
 } from "../../system-agent/system-agent.test-helpers.js";
 import type {
   SystemAgentVerifiedInferenceBinding,
@@ -155,6 +157,7 @@ const verifiedConfig: OpenClawConfig = {
 };
 let verifiedInference: SystemAgentVerifiedInferenceBinding | undefined;
 let verifiedInferenceDeps: SystemAgentVerifiedInferenceDeps | undefined;
+let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 const systemAgentTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function requireVerifiedInferenceFixture(): SystemAgentVerifiedInferenceBinding {
@@ -215,10 +218,20 @@ function seededSession(overrides?: Partial<SystemAgentChatSession>): SystemAgent
   };
 }
 
-beforeEach(async () => {
+beforeAll(async () => {
+  pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(verifiedConfig);
   const fixture = await createSystemAgentVerifiedInferenceTestFixture(verifiedConfig);
   verifiedInference = fixture.binding;
   verifiedInferenceDeps = fixture.deps;
+});
+
+afterAll(() => {
+  pluginMetadataSnapshot?.restore();
+  verifiedInference = undefined;
+  verifiedInferenceDeps = undefined;
+});
+
+beforeEach(() => {
   setupInferenceMocks.verifySetupInference.mockResolvedValue({
     ok: true,
     modelRef: "openai/gpt-5.5",
@@ -260,11 +273,10 @@ beforeEach(async () => {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetAllMocks();
-  verifiedInference = undefined;
-  verifiedInferenceDeps = undefined;
   resetPluginStateStoreForTests();
   resetCommandQueueStateForTest();
   vi.unstubAllEnvs();
+  pluginMetadataSnapshot?.rebindForCurrentEnv();
 });
 
 async function callChat(


### PR DESCRIPTION
## What Problem This Solves

The Gateway system-agent suite recreated process-stable plugin metadata discovery and the same immutable verified-inference proof for all 28 cases. That repeated setup dominated this compact test shard even though each case only needed a fresh engine, handler mocks, queues, and temporary state.

## Why This Change Was Made

Install the canonical plugin metadata snapshot and verified-inference fixture once at suite ownership, while retaining per-test engines, mocks, command queues, plugin state, and temporary directories. The environment-changing restart case explicitly rebinds the snapshot after environment cleanup so no state leaks between tests.

## User Impact

No runtime or user-visible behavior changes. The same Gateway assertions complete substantially faster and use less memory.

## Evidence

- Three-sample median wall time: 54.60s -> 13.20s (75.8% faster).
- Median Vitest duration: 48.74s -> 10.32s; median test bodies: 40.12s -> 6.66s (83.4% faster).
- Median max RSS: about 1.182GB -> 1.022GB (13.5% lower).
- Test count unchanged: 28/28 passed in every benchmark; final current-main proof passed in 10.27s Vitest.
- Formatting, targeted lint, `git diff --check`, and autoreview are clean.
- Test-only diff: +16/-4; production LOC delta: 0.
