### PR TITLE
fix(ui): center settings help glyph, shrink thinking mascot, add user avatar error fallback

### DIFF
--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -86,6 +86,22 @@ describe("renderChatAvatar", () => {
     expect(textAvatar?.tagName).toBe("DIV");
     expect(textAvatar?.textContent?.trim()).toBe("AB");
   });
+
+  it("swaps a failing local user image to initials instead of a broken image", () => {
+    const container = document.createElement("div");
+    render(
+      renderChatAvatar("user", undefined, { name: "Buns", avatar: "/avatar/user" }),
+      container,
+    );
+    const slot = container.querySelector<HTMLElement>(".chat-avatar-slot");
+    const image = slot?.querySelector("img");
+    expect(image?.getAttribute("src")).toBe("/avatar/user");
+    expect(slot?.classList.contains("is-fallback")).toBe(false);
+
+    image?.dispatchEvent(new Event("error"));
+    expect(slot?.classList.contains("is-fallback")).toBe(true);
+    expect(slot?.querySelector(".chat-avatar--sender-initials")?.textContent?.trim()).toBe("B");
+  });
 });
 
 describe("refreshChatAvatar", () => {

--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -12,6 +12,7 @@ import {
   identityAvatarClass,
   renderIdentityAvatarImage,
   resolveIdentityAvatarView,
+  type IdentityAvatarView,
 } from "../../components/identity-avatar-view.ts";
 import type { AssistantIdentity } from "../../lib/assistant-identity.ts";
 import {
@@ -22,6 +23,7 @@ import {
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import type { SenderIdentity } from "../../lib/chat/sender-label.ts";
 import { formatSenderLabel } from "../../lib/chat/sender-label.ts";
+import { resolveAvatarInitials } from "../../lib/identity-avatar.ts";
 import {
   DEFAULT_AGENT_ID,
   isUiGlobalSessionKey,
@@ -41,29 +43,7 @@ export function renderChatAvatar(
   // Attributed multi-user messages show the author's own avatar (profile
   // upload → gateway Gravatar proxy → initials), not the local viewer's.
   if (normalized === "user" && sender) {
-    const label = formatSenderLabel(sender) ?? "";
-    const view = resolveIdentityAvatarView(sender);
-    const initialsAvatar = html`<div
-      class="chat-avatar user chat-avatar--sender-initials"
-      style=${`background: hsl(${view.fallback.colorSeed % 360} 48% 42%)`}
-      aria-label="${label}"
-    >
-      ${view.fallback.initials}
-    </div>`;
-    if (!view.imageUrl) {
-      return initialsAvatar;
-    }
-    // The derived route may 404 (no upload, no Gravatar); swap to initials
-    // instead of a broken image. Lit reuses DOM parts, so a load must clear a
-    // prior sender's error state.
-    return html`<span class=${identityAvatarClass("chat-avatar-slot", view)}>
-      ${renderIdentityAvatarImage({
-        view,
-        fallbackSelector: ".chat-avatar-slot",
-        className: "chat-avatar user",
-        alt: label,
-      })}${initialsAvatar}
-    </span>`;
+    return renderUserAvatarSlot(resolveIdentityAvatarView(sender), formatSenderLabel(sender) ?? "");
   }
   const assistantName = assistant?.name?.trim() || "Assistant";
   const assistantAvatar = assistant?.avatar?.trim() || "";
@@ -119,7 +99,14 @@ export function renderChatAvatar(
           : "other";
 
   if (normalized === "user" && userAvatarUrl) {
-    return html`<img class="chat-avatar ${className}" src="${userAvatarUrl}" alt="${userName}" />`;
+    return renderUserAvatarSlot(
+      {
+        fallback: resolveAvatarInitials({ name: userName }),
+        imageUrl: userAvatarUrl,
+        pending: false,
+      },
+      userName,
+    );
   }
 
   if (normalized === "user" && userAvatarText) {
@@ -164,6 +151,32 @@ export function renderChatAvatar(
   }
 
   return html`<div class="chat-avatar ${className}">${initial}</div>`;
+}
+
+/**
+ * The avatar URL may 404 or be unreachable (missing upload, dead Gravatar,
+ * stale configured URL); swap to initials instead of a broken image. Lit
+ * reuses DOM parts, so a load must clear a prior identity's error state.
+ */
+function renderUserAvatarSlot(view: IdentityAvatarView, label: string) {
+  const initialsAvatar = html`<div
+    class="chat-avatar user chat-avatar--sender-initials"
+    style=${`background: hsl(${view.fallback.colorSeed % 360} 48% 42%)`}
+    aria-label="${label}"
+  >
+    ${view.fallback.initials}
+  </div>`;
+  if (!view.imageUrl) {
+    return initialsAvatar;
+  }
+  return html`<span class=${identityAvatarClass("chat-avatar-slot", view)}>
+    ${renderIdentityAvatarImage({
+      view,
+      fallbackSelector: ".chat-avatar-slot",
+      className: "chat-avatar user",
+      alt: label,
+    })}${initialsAvatar}
+  </span>`;
 }
 
 function isAvatarUrl(value: string): boolean {

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -177,7 +177,7 @@ class CustodianSurface extends OpenClawLightDomElement {
           ${store.sending
             ? html`<div class="chat-group assistant custodian__thinking-row" role="status">
                 <div class="chat-avatar assistant custodian__mascot-avatar" aria-hidden="true">
-                  <openclaw-mascot mood="thinking" .size=${32}></openclaw-mascot>
+                  <openclaw-mascot mood="thinking" .size=${26}></openclaw-mascot>
                 </div>
                 <div class="chat-group-messages custodian__thinking">
                   <span></span><span></span><span></span>

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -160,6 +160,13 @@
   cursor: pointer;
 }
 
+.settings-section__help-button > span {
+  /* SF's ascent+descent exceed 1em, so a centered line box parks the glyph
+     below the circle's midline; trim to cap bounds for true centering. */
+  display: block;
+  text-box: trim-both cap alphabetic;
+}
+
 .settings-section__help-button:hover,
 .settings-section__help-button:focus-visible {
   border-color: color-mix(in srgb, var(--accent) 55%, var(--border));


### PR DESCRIPTION
## What Problem This Solves

Three Control UI polish/robustness issues reported from a live gateway:

1. The settings-section "?" help button glyph sits visibly below the circle's midline (e.g. `/settings/appearance`).
2. In the settings "Ask OpenClaw" panel, the thinking-row mascot avatar (32px) presses against the 36px avatar box border with ~1px of breathing room.
3. In chat (`/chat/main`), a local user avatar whose configured URL fails to load renders as a browser broken-image icon with alt text instead of a graceful placeholder.

## Why This Change Was Made

- The help glyph offset is a font-metrics issue: SF's ascent+descent exceed 1em, so a centered line box parks the glyph below the visual midline. `text-box: trim-both cap alphabetic` on the glyph span trims to cap bounds so grid centering is exact (progressive enhancement; unsupported browsers keep current behavior).
- The thinking-row mascot is reduced to 26px, giving it 4px of padding inside the 34px inner box instead of 1px.
- The attributed-sender avatar path directly above already solves the broken-image problem with a `.chat-avatar-slot` that swaps to identity initials on image error. The local-user image path was the one `<img>` without that protection. The slot render is now a shared `renderUserAvatarSlot` helper used by both paths, so the sender branch and the local-user branch cannot drift.

## User Impact

- Settings help buttons look properly centered.
- The Ask OpenClaw thinking indicator avatar no longer crowds its border.
- A failing user avatar URL degrades to colored initials (same treatment attributed senders already get) instead of a broken-image glyph.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-avatar.test.ts ui/src/pages/custodian/custodian-page.test.ts ui/src/e2e/chat-attributed-identity.e2e.test.ts` — all green, including a new regression test that dispatches an `error` event on the local user avatar image and asserts the initials fallback appears.
- `pnpm tsgo:ui`, `pnpm tsgo:test:ui`, `pnpm lint:ui:styles` — clean (run locally; Crabbox/Testbox remote routing was unavailable — no ready provider — so changed-gate proof fell back to local per repo policy).
- Autoreview (Codex, gpt-5.6-sol, high): clean, no accepted findings.
- "?" centering verified visually with an isolated HTML repro of the exact button CSS at 3x scale with a midline overlay: before, the glyph center sits clearly below the midline; with `text-box: trim-both cap alphabetic` it is dead-center. Screenshot upload is blocked (Crabbox artifact publishing unavailable this session); the repro is three lines of CSS and trivially reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
