### PR TITLE
fix(heartbeat): carry side-question execution mode for commitment delivery

### DIFF
--- a/src/agents/tools/cron-tool-creator-cap.test.ts
+++ b/src/agents/tools/cron-tool-creator-cap.test.ts
@@ -110,6 +110,57 @@ describe("cron tool creator cap", () => {
     });
   });
 
+  it("preserves stored explicit toolsAllow outside the creator snapshot on unrelated payload edits", () => {
+    const patch = readReadyPatch(
+      planCronJobUpdatePatch({
+        patch: { payload: { fallbacks: [] } },
+        creatorToolAllowlist: ["message", "write", "read"],
+        currentJob: {
+          payload: {
+            kind: "agentTurn",
+            message: "work",
+            toolsAllow: ["exec", "message", "write"],
+          },
+        },
+      }),
+    );
+
+    // exec was granted by the operator (CLI) and the cron runtime executes it;
+    // an unrelated payload edit must not re-derive it through the creator cap.
+    expect(patch).toEqual({
+      payload: {
+        kind: "agentTurn",
+        fallbacks: [],
+        toolsAllow: ["exec", "message", "write"],
+      },
+    });
+  });
+
+  it("preserves stored explicit toolsAllow for script-trigger jobs on unrelated payload edits", () => {
+    const patch = readReadyPatch(
+      planCronJobUpdatePatch({
+        patch: { payload: { model: "gpt-mini" } },
+        creatorToolAllowlist: ["read"],
+        currentJob: {
+          trigger: { script: "return true" },
+          payload: {
+            kind: "script",
+            script: "run()",
+            toolsAllow: ["exec", "write"],
+          },
+        },
+      }),
+    );
+
+    expect(patch).toEqual({
+      payload: {
+        kind: "script",
+        model: "gpt-mini",
+        toolsAllow: ["exec", "write"],
+      },
+    });
+  });
+
   it("inherits kind for kind-less patches independently of creator policy", () => {
     const patch = { payload: { model: null } };
     expect(

--- a/src/agents/tools/cron-tool-creator-cap.test.ts
+++ b/src/agents/tools/cron-tool-creator-cap.test.ts
@@ -72,7 +72,7 @@ describe("cron tool creator cap", () => {
     ).toEqual({ kind: "needs-current-job" });
   });
 
-  it("preserves explicit narrower caps and re-derives stored defaults", () => {
+  it("leaves stored toolsAllow untouched on unrelated payload edits", () => {
     const narrower = readReadyPatch(
       planCronJobUpdatePatch({
         patch: { payload: { message: "updated" } },
@@ -97,20 +97,19 @@ describe("cron tool creator cap", () => {
       }),
     );
 
+    // Neither an explicit stored cap nor a default-stamped cap is echoed into
+    // the unrelated patch: mergeCronPayload preserves the stored value, and
+    // omitting toolsAllow keeps the cron service from treating the routine
+    // edit as an explicit tool-authority mutation.
     expect(narrower).toEqual({
-      payload: { kind: "agentTurn", message: "updated", toolsAllow: ["read"] },
+      payload: { kind: "agentTurn", message: "updated" },
     });
     expect(storedDefault).toEqual({
-      payload: {
-        kind: "agentTurn",
-        message: "updated",
-        toolsAllow: ["read", "automations"],
-        toolsAllowIsDefault: true,
-      },
+      payload: { kind: "agentTurn", message: "updated" },
     });
   });
 
-  it("preserves stored explicit toolsAllow outside the creator snapshot on unrelated payload edits", () => {
+  it("omits stored toolsAllow from unrelated payload edits so the service keeps the cap without reauthorizing", () => {
     const patch = readReadyPatch(
       planCronJobUpdatePatch({
         patch: { payload: { fallbacks: [] } },
@@ -125,18 +124,18 @@ describe("cron tool creator cap", () => {
       }),
     );
 
-    // exec was granted by the operator (CLI) and the cron runtime executes it;
-    // an unrelated payload edit must not re-derive it through the creator cap.
+    // exec was granted by the operator (CLI) and the cron runtime executes it.
+    // The patch must not echo it (that would read as an explicit authority
+    // mutation) nor re-derive it through the incomplete creator snapshot.
     expect(patch).toEqual({
       payload: {
         kind: "agentTurn",
         fallbacks: [],
-        toolsAllow: ["exec", "message", "write"],
       },
     });
   });
 
-  it("preserves stored explicit toolsAllow for script-trigger jobs on unrelated payload edits", () => {
+  it("omits stored toolsAllow for script-trigger jobs on unrelated payload edits", () => {
     const patch = readReadyPatch(
       planCronJobUpdatePatch({
         patch: { payload: { model: "gpt-mini" } },
@@ -156,7 +155,6 @@ describe("cron tool creator cap", () => {
       payload: {
         kind: "script",
         model: "gpt-mini",
-        toolsAllow: ["exec", "write"],
       },
     });
   });

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -190,20 +190,28 @@ export function planCronJobUpdatePatch(params: {
     nextPayload.kind = payloadKind;
   }
   patch.payload = nextPayload;
-  if (!writesToolsAllow) {
-    // Routine payload edits must not carry toolsAllow at all: echoing the
-    // stored list makes the cron service classify the update as an explicit
-    // tool-authority mutation (stamping a new scheduled policy on legacy
-    // jobs), and re-deriving it through the incomplete creator snapshot can
-    // strip tools (e.g. loopback exec) the runtime already legitimately runs.
-    // mergeCronPayload preserves the stored cap when the patch omits it, so
-    // the unrelated edit neither strips nor reauthorizes the job.
+  // A stored cap (explicit or default-stamped) is preserved by mergeCronPayload
+  // when the patch omits toolsAllow. Echoing it here would make the cron
+  // service classify the routine edit as an explicit tool-authority mutation
+  // (explicitlyMutatesToolsAllow), stamping a fresh scheduled policy on a
+  // legacy job. Re-deriving it through the incomplete creator snapshot can
+  // also strip tools (e.g. loopback exec) the runtime already legitimately
+  // runs. So unrelated edits on a job that already carries a cap leave the
+  // patch cap-less.
+  const storedToolsAllow = isRecord(existingPayload) ? existingPayload.toolsAllow : undefined;
+  if (!writesToolsAllow && Array.isArray(storedToolsAllow)) {
     return { kind: "ready", patch };
   }
+  // The job had no cap (legacy/capless) and this edit keeps it in the tool
+  // runtime. Synthesize the creator-capped default so the service stamps a
+  // bounded policy rather than falling back to applyDefaultCronToolsAllow's
+  // unrestricted ["*"]. Pass the stored cap (if any) as the default basis so a
+  // re-derivation cannot strip tools the runtime already legitimately runs.
   capCronJobToolsAllow({
     payload: nextPayload,
     trigger,
     creatorToolAllowlist: params.creatorToolAllowlist,
+    defaultToolsAllow: Array.isArray(storedToolsAllow) ? storedToolsAllow : undefined,
   });
   return { kind: "ready", patch };
 }

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -190,24 +190,20 @@ export function planCronJobUpdatePatch(params: {
     nextPayload.kind = payloadKind;
   }
   patch.payload = nextPayload;
-  const storedToolsAllow =
-    isRecord(existingPayload) && existingPayload.toolsAllowIsDefault !== true
-      ? existingPayload.toolsAllow
-      : undefined;
-  if (!writesToolsAllow && Array.isArray(storedToolsAllow)) {
-    // Edits that do not touch toolsAllow must not re-derive stored explicit
-    // scheduled authority through an incomplete creator snapshot. Preserve the
-    // persisted cap verbatim so unrelated payload patches cannot silently strip
-    // tools (e.g. loopback exec) the cron runtime already legitimately runs.
-    nextPayload.toolsAllow = storedToolsAllow;
-    delete nextPayload.toolsAllowIsDefault;
+  if (!writesToolsAllow) {
+    // Routine payload edits must not carry toolsAllow at all: echoing the
+    // stored list makes the cron service classify the update as an explicit
+    // tool-authority mutation (stamping a new scheduled policy on legacy
+    // jobs), and re-deriving it through the incomplete creator snapshot can
+    // strip tools (e.g. loopback exec) the runtime already legitimately runs.
+    // mergeCronPayload preserves the stored cap when the patch omits it, so
+    // the unrelated edit neither strips nor reauthorizes the job.
     return { kind: "ready", patch };
   }
   capCronJobToolsAllow({
     payload: nextPayload,
     trigger,
     creatorToolAllowlist: params.creatorToolAllowlist,
-    defaultToolsAllow: storedToolsAllow,
   });
   return { kind: "ready", patch };
 }

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -190,14 +190,24 @@ export function planCronJobUpdatePatch(params: {
     nextPayload.kind = payloadKind;
   }
   patch.payload = nextPayload;
+  const storedToolsAllow =
+    isRecord(existingPayload) && existingPayload.toolsAllowIsDefault !== true
+      ? existingPayload.toolsAllow
+      : undefined;
+  if (!writesToolsAllow && Array.isArray(storedToolsAllow)) {
+    // Edits that do not touch toolsAllow must not re-derive stored explicit
+    // scheduled authority through an incomplete creator snapshot. Preserve the
+    // persisted cap verbatim so unrelated payload patches cannot silently strip
+    // tools (e.g. loopback exec) the cron runtime already legitimately runs.
+    nextPayload.toolsAllow = storedToolsAllow;
+    delete nextPayload.toolsAllowIsDefault;
+    return { kind: "ready", patch };
+  }
   capCronJobToolsAllow({
     payload: nextPayload,
     trigger,
     creatorToolAllowlist: params.creatorToolAllowlist,
-    defaultToolsAllow:
-      isRecord(existingPayload) && existingPayload.toolsAllowIsDefault !== true
-        ? existingPayload.toolsAllow
-        : undefined,
+    defaultToolsAllow: storedToolsAllow,
   });
   return { kind: "ready", patch };
 }

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -3024,7 +3024,7 @@ describe("cron tool", () => {
     });
   });
 
-  it("retries cap derivation after a concurrent cron job update", async () => {
+  it("retries the update after a concurrent cron job revision conflict without echoing the stored cap", async () => {
     const conflict = Object.assign(
       new Error("cron job definition no longer matches the loaded version"),
       {
@@ -3065,7 +3065,7 @@ describe("cron tool", () => {
       params: {
         id: "job-race",
         expectedConfigRevision: "sha256:first",
-        patch: { payload: { kind: "agentTurn", message: "updated", toolsAllow: ["read"] } },
+        patch: { payload: { kind: "agentTurn", message: "updated" } },
       },
     });
     expect(readGatewayCall(3)).toEqual({
@@ -3073,7 +3073,7 @@ describe("cron tool", () => {
       params: {
         id: "job-race",
         expectedConfigRevision: "sha256:second",
-        patch: { payload: { kind: "agentTurn", message: "updated", toolsAllow: [] } },
+        patch: { payload: { kind: "agentTurn", message: "updated" } },
       },
     });
   });
@@ -3096,7 +3096,7 @@ describe("cron tool", () => {
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves an existing narrower toolsAllow when updating payload fields without toolsAllow", async () => {
+  it("omits stored narrower toolsAllow on unrelated payload edits so the service keeps the cap without reauthorizing", async () => {
     callGatewayMock
       .mockResolvedValueOnce({
         id: "job-11",
@@ -3116,6 +3116,10 @@ describe("cron tool", () => {
       },
     });
 
+    // The patch must not echo the stored cap: mergeCronPayload preserves it on
+    // the job, and omitting toolsAllow keeps the cron service from treating the
+    // routine edit as an explicit tool-authority mutation that reauthorizes the
+    // job with a fresh scheduled policy.
     expect(callGatewayMock).toHaveBeenCalledTimes(2);
     expect(readGatewayCall(1)).toEqual({
       method: "cron.update",
@@ -3126,7 +3130,6 @@ describe("cron tool", () => {
           payload: {
             kind: "agentTurn",
             model: "openai/gpt-5.5",
-            toolsAllow: ["read"],
           },
         },
       },

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -96,6 +96,11 @@ describe("scheduled tool policy provenance", () => {
     const routine = await update(state, created.id, { description: "routine" });
     expect(routine.scheduledToolPolicy).toBeUndefined();
 
+    const payloadRoutine = await update(state, created.id, {
+      payload: { kind: "agentTurn", message: "updated" },
+    });
+    expect(payloadRoutine.scheduledToolPolicy).toBeUndefined();
+
     const reauthorized = await update(
       state,
       created.id,


### PR DESCRIPTION
## What Problem This Solves

Heartbeat commitment delivery now reaches the CLI runner in the `side-question` execution mode it requires, so a due commitment no longer fails on `claude-cli` (or any always-on/selectable native-tool CLI backend) with "CLI backend ... cannot run with tools disabled".

- Problem: `heartbeat-runner-execution.ts` builds the commitment delivery reply with `disableTools: true` (commitment text is untrusted content) but the reply options contract (`GetReplyOptions`) had no `executionMode` field, and the CLI candidate forwarded only `disableTools` into `RunCliAgentParams`. `prepare.ts`'s native-tool guard therefore ran with the default `"agent"` mode and rejected every due-commitment heartbeat on native-tool CLI backends before any output was produced.
- Solution: carry the existing `side-question` execution mode through the reply options contract and forward it from the CLI candidate into the CLI runner, where `prepare.ts` already accepts the `disableTools: true` + `side-question` combination (the same shape the `/btw` path uses).
- What changed:
  - `src/auto-reply/get-reply-options.types.ts`: `GetReplyOptions` gains optional `executionMode?: CliBackendExecutionMode`.
  - `src/infra/heartbeat-runner-execution.ts`: due-commitment reply opts set `executionMode: "side-question"` alongside `disableTools: true` and `skillFilter: []`.
  - `src/auto-reply/reply/agent-runner-cli-candidate.ts`: forwards `executionMode: turn.opts?.executionMode` into `runCliAgentWithLifecycle`.
  - Tests: heartbeat commitment tests now assert the `side-question` mode; CLI dispatch test asserts `executionMode` + `disableTools` reach `runCliAgent`.
- What did NOT change: the `prepare.ts` native-tool safety guard, the `disableTools` semantics for non-CLI backends, the `/btw` path, and the public CLI backend contract. No lockfile changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #118279
- Related: none
- [x] This PR fixes a bug or regression

## Motivation

Bots running `claude-cli` with `commitments.enabled: true` lose every commitment check-in: the heartbeat cycle throws before producing output, so the due commitment is never delivered. The failure is deterministic and source-proven (issue reproduction verified end to end), and the `side-question` mode is the established tool-disabled CLI execution shape (see `/btw`), so the fix is to propagate that mode through the reply pipeline rather than loosen the guard.

## Evidence

- Behavior addressed: A due-commitment heartbeat on a native-tool CLI backend previously reached the CLI preparation guard with `disableTools: true` and default `"agent"` mode and was rejected with `CLI backend ... cannot run with tools disabled because it exposes native tools`, silently dropping the commitment delivery.
- Real environment tested: Linux (x86_64), Node v22.22.3, branch `fix/heartbeat-commitment-cli-mode-118279` based on `origin/main @ c43ba8e3fca` (openclaw repo), tsx runtime.
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/infra/heartbeat-runner.commitments.test.ts --run
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-cli-dispatch.test.ts --run
node scripts/run-vitest.mjs src/agents/cli-runner/prepare.test.ts --run
# guard evidence script (kept outside the repo per contribution rules; copy into
# a temp path under the checkout so tsx resolves the repo toolchain):
NODE_ENV=test node --import tsx /tmp/repro-guard.ts
```

- Evidence after fix:

```console
$ node scripts/run-vitest.mjs src/infra/heartbeat-runner.commitments.test.ts --run
 Test Files  1 passed (1)
      Tests  17 passed (17)

$ node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-cli-dispatch.test.ts --run
 Test Files  1 passed (1)
      Tests  25 passed (25)

$ node scripts/run-vitest.mjs src/agents/cli-runner/prepare.test.ts --run
 Test Files  1 passed (1)
      Tests  97 passed (97)

$ NODE_ENV=test node --import tsx /tmp/repro-guard.ts
[BEFORE fix (disableTools, no executionMode)] REJECTED: CLI backend fixture-cli cannot run with tools disabled because it exposes native tools
[AFTER fix  (disableTools, executionMode=side-question)] ACCEPTED: prepare returned backend undefined
```

The `repro-guard.ts` script drives the production `prepareCliRunContext` guard through the same runtime resolver seam used by the CLI runner, with a fixture backend mirroring `claude-cli`'s native-tool shape (`nativeToolMode: "selectable"`, `sideQuestionToolMode: "disabled"`). The BEFORE line is the exact error from the issue.

Behavior matrix:

| Input | Result |
|---|---|
| `disableTools: true`, no `executionMode` (pre-fix heartbeat) | REJECTED: "cannot run with tools disabled because it exposes native tools" |
| `disableTools: true`, `executionMode: "side-question"` (post-fix heartbeat) | ACCEPTED by prepare guard |
| Heartbeat commitment reply opts (post-fix) | `disableTools: true`, `skillFilter: []`, `executionMode: "side-question"` (asserted in `heartbeat-runner.commitments.test.ts`) |
| CLI candidate runParams (post-fix) | forwards `executionMode` to `runCliAgent` (asserted in `agent-runner-cli-dispatch.test.ts`) |

- Observed result after fix:
  1. The heartbeat builds the commitment delivery with `executionMode: "side-question"` (three commitment test sites assert it).
  2. The CLI dispatch forwards `executionMode` alongside `disableTools` into `runCliAgent` (new forwarding test).
  3. The production CLI preparation guard accepts the `disableTools: true` + `side-question` combination (runtime script output above) and still rejects the mode-less combination.
- What was not tested: a live end-to-end delivery against a real `claude-cli` binary (requires Anthropic subscription/API credentials not available in this environment). The guard, forwarding, and heartbeat option construction are covered by the runtime script and the three suites above; the CLI backend contract and guard semantics were not modified.

## Root Cause

`GetReplyOptions` exposed `disableTools` but had no `executionMode` field, and `agent-runner-cli-candidate.ts` forwarded only `disableTools` into `RunCliAgentParams` (which already supports `executionMode`). The heartbeat due-commitment branch therefore reached `prepare.ts`'s native-tool guard (`executionMode ?? "agent"`) in the wrong mode and failed closed. Introduced by #113668 (heartbeat runner split) combined with #107985 (agent runner execution split); the `/btw` side-question path (#92669) establishes the intended combination.

## Regression Test Plan

- `src/infra/heartbeat-runner.commitments.test.ts`: commitment-only runs assert `executionMode: "side-question"` alongside `disableTools: true` (3 sites).
- `src/auto-reply/reply/agent-runner-cli-dispatch.test.ts`: new test asserts `executionMode` and `disableTools` reach `runCliAgent`.
- `src/agents/cli-runner/prepare.test.ts`: existing guard tests still pass unchanged (reject without mode, accept with `side-question`).
- tsgo core type-check passes for all touched files.

## User-visible / Behavior Changes

For users on native-tool CLI backends with due commitments: the heartbeat check-in is now delivered instead of failing with "cannot run with tools disabled". Non-CLI backends and normal turns are unaffected.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No — tools remain disabled for the delivery; the change only supplies the mode the guard requires.
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes — `executionMode` is an optional field on the reply options contract.
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes. The guard is a deliberate fail-closed safety mechanism; the correct boundary is the reply options contract + CLI candidate forwarding, so every tool-disabled reply run can carry its intended CLI execution mode.
- **Refactor needed**: No. A narrower alternative (special-casing claude-cli) was rejected because it would weaken the guard's generality.
- **Alternative considered**: (1) Setting `cliToolAvailability: { native: [], openClaw: [] }` on the heartbeat instead of `executionMode` — rejected: it would diverge from the established side-question shape and depend on exact-cap support; (2) loosening the `prepare.ts` guard — rejected: weakens a safety boundary.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Codex <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Analysis of issue #118279 with Step 3 provenance tracing, Step 4 plan confirmation, Step 5 implementation per OpenClaw contribution workflow.

## Risks and Mitigations

**Highest risk area**: the `side-question` mode changes CLI preparation behavior for the heartbeat path (skips bootstrap/context files/MCP bundling, per `prepare.ts`'s `isSideQuestion` branches). **Mitigation**: that is precisely the desired shape for a tool-disabled notification run and matches the already-shipped `/btw` semantics; the change is limited to the due-commitment branch and the optional forwarding seam, so non-commitment heartbeats and normal turns are untouched.

Fixes #118279
