### PR TITLE
fix(agents): restore channel and cron replies after a failed final tool

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -6777,6 +6777,79 @@ describe("qa mock openai server", () => {
     });
     expect(outputText(laterHeartbeatPayload)).toBe("HEARTBEAT_OK");
   });
+
+  it("scripts one failure-honest Code Mode terminal-tool continuation (#118274)", async () => {
+    const server = await startMockServer();
+    const prompt =
+      "Failed tool terminal recovery QA check: read the missing file, then respond with exact marker: `QA-FAILED-TOOL-FINALIZED-OK`.";
+    const codeModeTools = [
+      {
+        type: "function",
+        name: "exec",
+        parameters: {
+          type: "object",
+          properties: { code: { type: "string" } },
+          required: ["code"],
+        },
+      },
+      {
+        type: "function",
+        name: "wait",
+        parameters: {
+          type: "object",
+          properties: { runId: { type: "string" } },
+          required: ["runId"],
+        },
+      },
+    ];
+
+    const toolPlan = await postStreamingResponses(server, {
+      model: "gpt-5.6-luna",
+      tools: codeModeTools,
+      input: [makeUserInput(prompt)],
+    });
+    const plannedResponse = await toolPlan.text();
+    expect(plannedResponse).toContain('"name":"exec"');
+    expect(plannedResponse).toContain("qa-failed-terminal-missing-file.txt");
+    const plannedRequest = requireRecord(
+      await (await fetch(`${server.baseUrl}/debug/last-request`)).json(),
+      "failed terminal tool plan",
+    );
+    expect(plannedRequest.plannedToolName).toBe("read");
+    expect(plannedRequest.plannedWireToolName).toBe("exec");
+
+    const failedToolOutput = makeToolOutputWithCallId(
+      String(plannedRequest.plannedToolCallId),
+      JSON.stringify({ status: "failed", error: "ENOENT: qa-failed-terminal-missing-file.txt" }),
+    );
+    const dishonestFinalization = await expectNonStreamingResponsesJson<{
+      output?: Array<{ content?: Array<{ text?: string }> }>;
+    }>(server, {
+      model: "gpt-5.6-luna",
+      input: [
+        makeUserInput(prompt),
+        makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION),
+        failedToolOutput,
+      ],
+    });
+    expect(outputText(dishonestFinalization)).toBe("FAILED-TOOL-HONESTY-INSTRUCTION-MISSING");
+
+    const recovered = await expectNonStreamingResponsesJson<{
+      output?: Array<{ content?: Array<{ text?: string }> }>;
+    }>(server, {
+      model: "gpt-5.6-luna",
+      input: [
+        makeUserInput(prompt),
+        makeUserInput(
+          `${QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} If any tool failed, state that failure plainly and do not claim it succeeded.`,
+        ),
+        failedToolOutput,
+      ],
+    });
+    expect(outputText(recovered)).toBe(
+      "The requested file could not be read: ENOENT. QA-FAILED-TOOL-FINALIZED-OK",
+    );
+  });
 });
 
 describe("qa mock openai server provider variant tagging", () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -173,6 +173,7 @@ const QA_STREAMING_TOOL_PROGRESS_FAMILY_PROMPT_RE =
 const QA_STREAMING_TOOL_PROGRESS_CONTINUATION_RE =
   /^Continue with (?:the current Matrix QA scenario|the QA scenario plan and report worked, failed, and blocked items)\.$/i;
 const QA_CODE_MODE_TARGET_MARKER = "qa-code-mode-target:";
+const QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE = /failed tool terminal recovery qa check/i;
 
 function isStreamingToolProgressContinuationText(text: string) {
   const trimmed = text.trim();
@@ -542,6 +543,10 @@ async function buildResponsesPayload(
     QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE.test(prompt) ||
     (prompt.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) &&
       QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE.test(allInputText));
+  const isActiveFailedToolTerminalRecovery =
+    QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE.test(prompt) ||
+    (prompt.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) &&
+      QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE.test(allInputText));
   const hasCallableCodeMode = hasCodeModeExecSurface(toolDeclarationBody);
   const canCallSessionsSpawn =
     hasToolDefinition(toolDeclarationBody, "sessions_spawn") || hasCallableCodeMode;
@@ -755,6 +760,19 @@ async function buildResponsesPayload(
       });
     }
     return buildAssistantEvents("");
+  }
+  if (isActiveFailedToolTerminalRecovery) {
+    if (allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE)) {
+      if (!allInputText.includes("state that failure plainly and do not claim it succeeded")) {
+        return buildAssistantEvents("FAILED-TOOL-HONESTY-INSTRUCTION-MISSING");
+      }
+      const marker = exactMarkerDirective ?? exactReplyDirective ?? "QA-FAILED-TOOL-FINALIZED-OK";
+      return buildAssistantEvents(`The requested file could not be read: ENOENT. ${marker}`);
+    }
+    if (!hasCompletedToolOutput) {
+      return buildToolCallEventsWithArgs("read", { path: "qa-failed-terminal-missing-file.txt" });
+    }
+    return buildAssistantEvents("FAILED-TOOL-TERMINAL-WAS-REPLAYED");
   }
   if (isHeartbeatPrompt(prompt)) {
     return buildAssistantEvents("HEARTBEAT_OK");

--- a/qa/scenarios/channels/qa-channel-failed-tool-terminal-finalization.yaml
+++ b/qa/scenarios/channels/qa-channel-failed-tool-terminal-finalization.yaml
@@ -1,0 +1,130 @@
+title: QA channel final reply after a failed terminal tool
+
+scenario:
+  id: qa-channel-failed-tool-terminal-finalization
+  surface: channel
+  coverage:
+    primary: [agent-runtime.failure-recovery-empty-response-recovery]
+    secondary: [channels.qa-channel-final-reply, agent-runtime.failure-recovery-retry-policy]
+  regressionRefs:
+    - openclaw/openclaw#118274
+  gatewayConfigPatch:
+    tools:
+      codeMode:
+        enabled: true
+  objective: Verify a settled failed terminal tool receives one failure-honest, tool-free finalization and one channel reply.
+  successCriteria:
+    - Code Mode dispatches exactly one missing-file read and records one failed exec result.
+    - The failed tool call is never replayed or described as successful.
+    - The model receives one tools-disabled finalization and qa-channel delivers exactly one visible reply.
+  codeRefs:
+    - src/agents/embedded-agent-runner/run/incomplete-turn.ts
+    - src/agents/embedded-agent-runner/run/code-mode-repair.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
+  execution:
+    kind: flow
+    suiteIsolation: isolated
+    isolationReason: Enables Code Mode and verifies one exact tool call and isolated qa-channel delivery.
+    channel: qa-channel
+    retryCount: 0
+    summary: Prove a real failed terminal Code Mode tool still produces one failure-honest qa-channel reply.
+    config:
+      requiredProviderMode: mock-openai
+      channelId: qa-failed-terminal
+      promptSnippet: Failed tool terminal recovery QA check
+      retryNeedle: The previous assistant turn completed its tool calls but did not produce a user-visible answer.
+      failureHonestyNeedle: state that failure plainly and do not claim it succeeded
+      expectedMarker: QA-FAILED-TOOL-FINALIZED-OK
+      expectedReply: "The requested file could not be read: ENOENT. QA-FAILED-TOOL-FINALIZED-OK"
+
+flow:
+  steps:
+    - name: finalizes one failed Code Mode tool without replaying it
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: failed-terminal qa-channel proof requires mock-openai
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - call: reset
+        - set: requestCursorBefore
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - set: sessionKey
+          value:
+            expr: "`agent:qa:qa-channel:group:group:${config.channelId}`"
+        - sendInbound:
+            conversation:
+              id:
+                ref: config.channelId
+              kind: group
+            senderId: qa-driver
+            senderName: QA Driver
+            text: "@openclaw Failed tool terminal recovery QA check: read the missing workspace file, then respond with exact marker: `QA-FAILED-TOOL-FINALIZED-OK`."
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: config.channelId
+              kind: group
+            sinceIndex:
+              ref: outboundStartIndex
+            textIncludes:
+              ref: config.expectedMarker
+            timeoutMs: 60000
+          saveAs: reply
+        - set: scenarioRequests
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
+        - set: readPlans
+          value:
+            expr: "scenarioRequests.filter((request) => request.plannedToolName === 'read')"
+        - set: finalizations
+          value:
+            expr: "scenarioRequests.filter((request) => String(request.allInputText ?? '').includes(config.retryNeedle))"
+        - assert:
+            expr: "readPlans.length === 1 && readPlans[0].plannedWireToolName === 'exec'"
+            message:
+              expr: "`expected one Code Mode read plan, got ${JSON.stringify(readPlans)}`"
+        - assert:
+            expr: "finalizations.length === 1 && String(finalizations[0].allInputText ?? '').includes(config.failureHonestyNeedle)"
+            message:
+              expr: "`expected one failure-honest finalization, got ${JSON.stringify(finalizations)}`"
+        - set: replayedExecCalls
+          value:
+            expr: "(Array.isArray(finalizations[0].body?.input) ? finalizations[0].body.input : []).filter((item) => item?.type === 'function_call' && item.name === 'exec' && String(item.arguments ?? '').includes('qa-failed-terminal-missing-file.txt'))"
+        - set: failedExecOutputs
+          value:
+            expr: "(Array.isArray(finalizations[0].body?.input) ? finalizations[0].body.input : []).filter((item) => item?.type === 'function_call_output' && item.call_id === replayedExecCalls[0]?.call_id && /ENOENT|no such file/i.test(typeof item.output === 'string' ? item.output : JSON.stringify(item.output ?? '')))"
+        - assert:
+            expr: "replayedExecCalls.length === 1 && failedExecOutputs.length === 1 && finalizations[0].toolOutputCallId === replayedExecCalls[0].call_id"
+            message:
+              expr: "`finalization did not preserve the normalized parent exec/result pairing: calls=${JSON.stringify(replayedExecCalls.map((item) => item.call_id))} outputs=${JSON.stringify(failedExecOutputs.map((item) => item.call_id))}`"
+        - assert:
+            expr: "!Array.isArray(finalizations[0].body?.tools) || finalizations[0].body.tools.length === 0"
+            message: failed-tool finalization exposed a replayable model tool surface
+        - call: readSessionTranscriptSummary
+          saveAs: transcript
+          args:
+            - ref: env
+            - ref: sessionKey
+        - assert:
+            expr: "transcript.assistantToolCallCounts.exec === 1 && transcript.completedToolCallCounts.exec === 1 && !transcript.successfulToolCallCounts.exec"
+            message:
+              expr: "`expected exactly one settled failed exec result, got ${JSON.stringify(transcript)}`"
+        - set: deliveries
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.channelId)"
+        - assert:
+            expr: "deliveries.length === 1 && reply.text.trim() === config.expectedReply"
+            message:
+              expr: "`expected exactly one failure-honest reply, got ${JSON.stringify(deliveries)}`"
+      detailsExpr: "`${reply.text}; calls=${String(transcript.assistantToolCallCounts.exec)} failed=${String(transcript.completedToolCallCounts.exec)} finalizations=${String(finalizations.length)}`"

--- a/qa/scenarios/scheduling/cron-failed-tool-terminal-finalization.yaml
+++ b/qa/scenarios/scheduling/cron-failed-tool-terminal-finalization.yaml
@@ -1,0 +1,175 @@
+title: Cron final reply after a failed terminal tool
+
+scenario:
+  id: cron-failed-tool-terminal-finalization
+  surface: cron
+  coverage:
+    primary: [agent-runtime.failure-recovery-empty-response-recovery]
+    secondary: [automation.isolated-cron-execution, channels.qa-channel-final-reply]
+  regressionRefs:
+    - openclaw/openclaw#118274
+  gatewayConfigPatch:
+    tools:
+      codeMode:
+        enabled: true
+  objective: Verify an isolated announce cron finalizes one failed terminal tool honestly and delivers one visible reply.
+  successCriteria:
+    - The isolated cron run completes successfully after one failed Code Mode exec.
+    - One failure-honest finalization observes the exact failed call and exposes no tools.
+    - The failed tool never replays and qa-channel receives exactly one final reply.
+  codeRefs:
+    - src/cron/isolated-agent/run-executor.ts
+    - src/agents/embedded-agent-runner/run/incomplete-turn.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
+  execution:
+    kind: flow
+    suiteIsolation: isolated
+    isolationReason: Enables Code Mode and forces an isolated cron with exact delivery assertions.
+    channel: qa-channel
+    retryCount: 0
+    summary: Prove a real failed terminal Code Mode tool still produces one visible cron announcement.
+    config:
+      requiredProviderMode: mock-openai
+      channelId: qa-failed-cron
+      promptSnippet: Failed tool terminal recovery QA check
+      retryNeedle: The previous assistant turn completed its tool calls but did not produce a user-visible answer.
+      failureHonestyNeedle: state that failure plainly and do not claim it succeeded
+      expectedMarker: CRON-FAILED-TOOL-FINALIZED-OK
+      expectedReply: "The requested file could not be read: ENOENT. CRON-FAILED-TOOL-FINALIZED-OK"
+
+flow:
+  steps:
+    - name: forces an isolated cron containing one terminal tool failure
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: failed-terminal cron proof requires mock-openai
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - call: reset
+        - set: requestCursorBefore
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+        - set: scheduledFor
+          value:
+            expr: "new Date(Date.now() + 10 * 60 * 1000).toISOString()"
+        - call: env.gateway.call
+          saveAs: added
+          args:
+            - cron.add
+            - agentId: qa
+              name:
+                expr: "`qa-failed-terminal-${randomUUID()}`"
+              enabled: true
+              deleteAfterRun: false
+              schedule:
+                kind: at
+                at:
+                  ref: scheduledFor
+              sessionTarget: isolated
+              wakeMode: now
+              payload:
+                kind: agentTurn
+                message: "Failed tool terminal recovery QA check: read the missing workspace file, then respond with exact marker: `CRON-FAILED-TOOL-FINALIZED-OK`."
+              delivery:
+                mode: announce
+                channel: qa-channel
+                to:
+                  expr: "`channel:${config.channelId}`"
+        - set: jobId
+          value:
+            expr: added.id
+        - set: runStartedAt
+          value:
+            expr: "Date.now()"
+        - call: env.gateway.call
+          saveAs: runResponse
+          args:
+            - cron.run
+            - id:
+                ref: jobId
+              mode: force
+            - timeoutMs: 30000
+        - assert:
+            expr: "runResponse?.ok === true && runResponse?.ran !== false"
+            message:
+              expr: "`expected one forced cron run, got ${JSON.stringify(runResponse)}`"
+
+    - name: proves one failed call, one honest finalization, and one delivery
+      actions:
+        - call: waitForCronRunCompletion
+          saveAs: completedRun
+          args:
+            - callGateway:
+                expr: "env.gateway.call.bind(env.gateway)"
+              jobId:
+                ref: jobId
+              afterTs:
+                ref: runStartedAt
+              timeoutMs:
+                expr: "liveTurnTimeoutMs(env, 60000)"
+        - set: scenarioRequests
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
+        - assert:
+            expr: "typeof completedRun?.sessionKey === 'string' && completedRun.sessionKey.startsWith(`agent:qa:cron:${jobId}:run:`)"
+            message:
+              expr: "`expected an isolated cron run session, got ${JSON.stringify(completedRun)}`"
+        - assert:
+            expr: "completedRun.status === 'ok'"
+            message:
+              expr: "`expected a successful cron run, got ${JSON.stringify({ run: completedRun, requests: scenarioRequests.map((request) => ({ tool: request.plannedToolName, wireTool: request.plannedWireToolName, callId: request.plannedToolCallId, outputCallId: request.toolOutputCallId, finalization: String(request.allInputText ?? '').includes(config.retryNeedle) })) })}`"
+        - set: readPlans
+          value:
+            expr: "scenarioRequests.filter((request) => request.plannedToolName === 'read')"
+        - set: finalizations
+          value:
+            expr: "scenarioRequests.filter((request) => String(request.allInputText ?? '').includes(config.retryNeedle))"
+        - assert:
+            expr: "readPlans.length === 1 && readPlans[0].plannedWireToolName === 'exec'"
+            message:
+              expr: "`expected one Code Mode read plan, got ${JSON.stringify(readPlans)}`"
+        - assert:
+            expr: "finalizations.length === 1 && String(finalizations[0].allInputText ?? '').includes(config.failureHonestyNeedle)"
+            message:
+              expr: "`expected one failure-honest cron finalization, got ${JSON.stringify(finalizations)}`"
+        - set: replayedExecCalls
+          value:
+            expr: "(Array.isArray(finalizations[0].body?.input) ? finalizations[0].body.input : []).filter((item) => item?.type === 'function_call' && item.name === 'exec' && String(item.arguments ?? '').includes('qa-failed-terminal-missing-file.txt'))"
+        - set: failedExecOutputs
+          value:
+            expr: "(Array.isArray(finalizations[0].body?.input) ? finalizations[0].body.input : []).filter((item) => item?.type === 'function_call_output' && item.call_id === replayedExecCalls[0]?.call_id && /ENOENT|no such file/i.test(typeof item.output === 'string' ? item.output : JSON.stringify(item.output ?? '')))"
+        - assert:
+            expr: "replayedExecCalls.length === 1 && failedExecOutputs.length === 1 && finalizations[0].toolOutputCallId === replayedExecCalls[0].call_id"
+            message:
+              expr: "`cron finalization did not preserve the normalized parent exec/result pairing: calls=${JSON.stringify(replayedExecCalls.map((item) => item.call_id))} outputs=${JSON.stringify(failedExecOutputs.map((item) => item.call_id))}`"
+        - assert:
+            expr: "!Array.isArray(finalizations[0].body?.tools) || finalizations[0].body.tools.length === 0"
+            message: cron finalization exposed a replayable model tool surface
+        - call: readSessionTranscriptSummary
+          saveAs: transcript
+          args:
+            - ref: env
+            - expr: "`agent:qa:cron:${jobId}`"
+        - assert:
+            expr: "transcript.assistantToolCallCounts.exec === 1 && transcript.completedToolCallCounts.exec === 1 && !transcript.successfulToolCallCounts.exec"
+            message:
+              expr: "`expected exactly one failed cron exec result, got ${JSON.stringify(transcript)}`"
+        - call: waitForCondition
+          saveAs: deliveries
+          args:
+            - lambda:
+                expr: "(() => { const matches = state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.channelId); return matches.length > 0 ? matches : undefined; })()"
+            - 10000
+            - 100
+        - assert:
+            expr: "deliveries.length === 1 && deliveries[0].text.trim() === config.expectedReply"
+            message:
+              expr: "`expected exactly one failure-honest cron announcement, got ${JSON.stringify(deliveries)}`"
+      detailsExpr: "`${deliveries[0].text}; calls=${String(transcript.assistantToolCallCounts.exec)} failed=${String(transcript.completedToolCallCounts.exec)} finalizations=${String(finalizations.length)}`"

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1148,6 +1148,192 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectWarnMessageWith("settled post-tool turn lacked a final answer");
   });
 
+  it.each([
+    { label: "interactive user", trigger: "user" as const },
+    {
+      label: "required isolated cron",
+      trigger: "cron" as const,
+      terminalReplyExpectation: "required" as const,
+    },
+  ])("finalizes a settled failed tool once for a $label turn (#118274)", async (runPolicy) => {
+    const toolUseAssistant = {
+      role: "assistant",
+      stopReason: "toolUse",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    const failureText = "The exec tool failed: post-processing error.";
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
+      markUserMessagePersisted(attemptParams);
+      return makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [
+          { toolName: "read", isError: true, replaySafe: true },
+          { toolName: "exec", isError: true, replaySafe: false },
+        ],
+        itemLifecycle: { startedCount: 3, completedCount: 3, activeCount: 0 },
+        messagesSnapshot: [
+          toolUseAssistant,
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            toolName: "exec",
+            isError: true,
+            content: [{ type: "text", text: "post-processing error" }],
+          },
+          {
+            role: "assistant",
+            stopReason: "toolUse",
+            content: [
+              {
+                type: "toolCall",
+                id: "tool_search_code:tool_1:read:1",
+                name: "read",
+                arguments: {},
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_search_code:tool_1:read:1",
+            toolName: "read",
+            isError: true,
+            content: [{ type: "text", text: "post-processing error" }],
+          },
+        ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+        lastAssistant: toolUseAssistant,
+        currentAttemptAssistant: toolUseAssistant,
+        lastToolError: { toolName: "exec", error: "post-processing error" },
+      });
+    });
+    const finalAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "text", text: failureText }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [failureText],
+        lastAssistant: finalAssistant,
+        currentAttemptAssistant: finalAssistant,
+        currentAttemptCompletedAssistant: finalAssistant,
+      }),
+    );
+    mockedBuildEmbeddedRunPayloads
+      .mockReturnValueOnce([{ text: "⚠️ 🛠️ Exec failed", isError: true }])
+      .mockReturnValueOnce([{ text: failureText }]);
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      ...runPolicy,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: `run-settled-failed-tool-${runPolicy.trigger}`,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]?.text).toBe(failureText);
+    const finalizationCall = runAttemptCall(1);
+    expect(finalizationCall.operation).toBe("settled-tool-finalization");
+    expect(finalizationCall.disableTools).toBe(true);
+    expect(finalizationCall.prompt).toContain(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
+    expect(finalizationCall.prompt).toContain(
+      "If any tool failed, state that failure plainly and do not claim it succeeded.",
+    );
+  });
+
+  it("preserves a structured visible failed-tool payload without finalizing (#118274)", async () => {
+    const toolUseAssistant = {
+      role: "assistant",
+      stopReason: "toolUse",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    const visibleError = {
+      text: "Review the failed operation.",
+      isError: true,
+      channelData: { structuredError: true },
+    };
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "exec", isError: true }],
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        messagesSnapshot: [
+          toolUseAssistant,
+          { role: "toolResult", toolCallId: "tool_1", toolName: "exec", isError: true },
+        ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+        lastAssistant: toolUseAssistant,
+        currentAttemptAssistant: toolUseAssistant,
+        lastToolError: { toolName: "exec", error: "post-processing error" },
+      }),
+    );
+    mockedBuildEmbeddedRunPayloads.mockReturnValueOnce([visibleError]);
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-structured-failed-tool-payload",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
+    expect(result.payloads?.[0]).toMatchObject(visibleError);
+    expectNoWarnMessageWith("settled post-tool turn lacked a final answer");
+  });
+
+  it("keeps the original failed-tool warning if finalization fails (#118274)", async () => {
+    const toolUseAssistant = {
+      role: "assistant",
+      stopReason: "toolUse",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    const warning = { text: "⚠️ 🛠️ Exec failed", isError: true };
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          assistantTexts: [],
+          toolMetas: [{ toolName: "exec", isError: true }],
+          itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+          messagesSnapshot: [
+            toolUseAssistant,
+            { role: "toolResult", toolCallId: "tool_1", toolName: "exec", isError: true },
+          ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+          lastAssistant: toolUseAssistant,
+          currentAttemptAssistant: toolUseAssistant,
+          lastToolError: { toolName: "exec", error: "post-processing error" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          assistantTexts: [],
+          promptError: new Error("finalizer provider failure"),
+          promptErrorSource: "prompt",
+        }),
+      );
+    mockedBuildEmbeddedRunPayloads.mockReturnValue([warning]);
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-failed-tool-finalization-fallback",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]).toEqual(warning);
+    expectWarnMessageWith("settled-turn finalization failed closed");
+  });
+
   it("preserves the incomplete-turn failure when the selected harness cannot finalize safely", async () => {
     registerAgentHarness({
       id: "legacy",
@@ -2488,6 +2674,195 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
         lastAssistant: toolUseAssistant,
         currentAttemptAssistant: toolUseAssistant,
+      }),
+    });
+
+    expect(instruction).toBeNull();
+  });
+
+  it.each([
+    {
+      label: "a matching failure summary",
+      lastToolError: { toolName: "exec", error: "post-processing error" },
+    },
+    { label: "no remaining failure summary", lastToolError: undefined },
+  ])(
+    "recognizes successful and failed current-batch tools with $label (#118274)",
+    ({ lastToolError }) => {
+      const toolUseAssistant = {
+        role: "assistant",
+        stopReason: "toolUse",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [
+          { type: "toolCall", id: "tool_ok", name: "read", arguments: {} },
+          { type: "toolCall", id: "tool_failed", name: "exec", arguments: {} },
+        ],
+      } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+      const instruction = resolveSettledToolTerminalContinuationInstruction({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        modelApi: "openai-chatgpt-responses",
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          toolMetas: [{ toolName: "read" }, { toolName: "exec", isError: true }],
+          itemLifecycle: { startedCount: 2, completedCount: 2, activeCount: 0 },
+          messagesSnapshot: [
+            toolUseAssistant,
+            { role: "toolResult", toolCallId: "tool_ok", toolName: "read", isError: false },
+            { role: "toolResult", toolCallId: "tool_failed", toolName: "exec", isError: true },
+          ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+          lastAssistant: toolUseAssistant,
+          currentAttemptAssistant: toolUseAssistant,
+          lastToolError,
+        }),
+      });
+
+      expect(instruction).toContain(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
+      expect(instruction).toContain(
+        "If any tool failed, state that failure plainly and do not claim it succeeded.",
+      );
+    },
+  );
+
+  it.each([
+    {
+      label: "an unrelated current-batch failure summary",
+      resultToolName: "exec",
+      lastErrorToolName: "read",
+    },
+    {
+      label: "a failed result with the wrong tool identity",
+      resultToolName: "read",
+      lastErrorToolName: "exec",
+    },
+  ])("does not finalize $label (#118274)", ({ resultToolName, lastErrorToolName }) => {
+    const toolUseAssistant = {
+      role: "assistant",
+      stopReason: "toolUse",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    const instruction = resolveSettledToolTerminalContinuationInstruction({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      modelApi: "openai-chatgpt-responses",
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: resultToolName, isError: true }],
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        messagesSnapshot: [
+          toolUseAssistant,
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            toolName: resultToolName,
+            isError: true,
+          },
+        ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+        lastAssistant: toolUseAssistant,
+        currentAttemptAssistant: toolUseAssistant,
+        lastToolError: { toolName: lastErrorToolName, error: "post-processing error" },
+      }),
+    });
+
+    expect(instruction).toBeNull();
+  });
+
+  it("does not settle same-name terminal calls from one failed result (#118274)", () => {
+    const toolUseAssistant = {
+      role: "assistant",
+      stopReason: "toolUse",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [
+        { type: "toolCall", id: "tool_1", name: "exec", arguments: {} },
+        { type: "toolCall", id: "tool_2", name: "exec", arguments: {} },
+      ],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    const instruction = resolveSettledToolTerminalContinuationInstruction({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      modelApi: "openai-chatgpt-responses",
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "exec", isError: true }],
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        messagesSnapshot: [
+          toolUseAssistant,
+          { role: "toolResult", toolCallId: "tool_1", toolName: "exec", isError: true },
+        ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+        lastAssistant: toolUseAssistant,
+        currentAttemptAssistant: toolUseAssistant,
+        lastToolError: { toolName: "exec", error: "post-processing error" },
+      }),
+    });
+
+    expect(instruction).toBeNull();
+  });
+
+  it.each([
+    {
+      label: "an async tool is still running",
+      attemptOverrides: { toolMetas: [{ toolName: "exec", isError: true, asyncStarted: true }] },
+    },
+    {
+      label: "an accepted child session owns the response",
+      attemptOverrides: {
+        acceptedSessionSpawns: [
+          { runId: "run-child", childSessionKey: "agent:main:subagent:child" },
+        ],
+      },
+    },
+    {
+      label: "a client tool remains pending",
+      attemptOverrides: { clientToolCalls: [{ name: "pending", params: {} }] },
+    },
+    {
+      label: "the turn yielded",
+      attemptOverrides: { yieldDetected: true },
+    },
+    {
+      label: "an approval prompt was already delivered",
+      attemptOverrides: { didSendDeterministicApprovalPrompt: true },
+    },
+  ])("does not finalize a failed terminal tool when $label (#118274)", ({ attemptOverrides }) => {
+    const toolUseAssistant = {
+      role: "assistant",
+      stopReason: "toolUse",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "toolCall", id: "tool_1", name: "exec", arguments: {} }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    const instruction = resolveSettledToolTerminalContinuationInstruction({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      modelApi: "openai-chatgpt-responses",
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "exec", isError: true }],
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        messagesSnapshot: [
+          toolUseAssistant,
+          { role: "toolResult", toolCallId: "tool_1", toolName: "exec", isError: true },
+        ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+        lastAssistant: toolUseAssistant,
+        currentAttemptAssistant: toolUseAssistant,
+        lastToolError: { toolName: "exec", error: "post-processing error" },
+        ...attemptOverrides,
       }),
     });
 

--- a/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
@@ -181,6 +181,114 @@ describe("embedded attempt phase lifecycle state", () => {
     expect(hoisted.waitForCompletionRequiredAsyncTasks).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps projected nested tool evidence from owning the model terminal (#118274)", async () => {
+    const modelAssistant = {
+      role: "assistant",
+      stopReason: "toolUse",
+      content: [{ type: "toolCall", id: "outer-exec", name: "exec", arguments: {} }],
+    };
+    const messages = [
+      { role: "user", content: "Read a missing file." },
+      modelAssistant,
+      {
+        role: "toolResult",
+        toolCallId: "outer-exec",
+        toolName: "exec",
+        isError: true,
+        content: [{ type: "text", text: "ENOENT" }],
+      },
+    ];
+    const activeSession = {
+      agent: { state: { messages } },
+      isCompacting: false,
+      isStreaming: false,
+      messages,
+      sessionId: "session-1",
+    };
+    const sessionManager = {
+      appendCustomEntry: vi.fn(),
+      buildSessionContext: () => ({ messages }),
+      getEntries: () => [],
+      removeTrailingEntries: vi.fn(() => 0),
+    };
+
+    const result = await settleEmbeddedAttemptStream({
+      attempt: {
+        runId: "run-1",
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        sessionFile: "/tmp/session.jsonl",
+        provider: "mock-openai",
+        modelId: "gpt-5.6-luna",
+        model: { api: "openai-responses" },
+      } as never,
+      activeSession: activeSession as never,
+      sessionManager: sessionManager as never,
+      sessionLockController: {} as never,
+      withOwnedSessionWriteLock: async (operation) => await operation(),
+      subscription: {
+        toolMetas: [
+          { toolName: "read", isError: true },
+          { toolName: "exec", isError: true },
+        ],
+        waitForCompactionRetry: async () => {},
+        isCompactionInFlight: () => false,
+        getCompactionCount: () => 0,
+        getCurrentAttemptAssistant: () => structuredClone(modelAssistant),
+        getUsageTotals: () => undefined,
+        getLastAssistantUsage: () => undefined,
+      } as never,
+      state: {
+        promptError: null,
+        promptErrorSource: null,
+        yieldAborted: false,
+        sessionIdUsed: "session-1",
+      },
+      readLifecycleState: () => ({
+        aborted: false,
+        timedOut: false,
+        timedOutDuringCompaction: false,
+      }),
+      markTimedOutDuringCompaction: () => {},
+      runAbortDeadlineAtMs: Date.now() + 60_000,
+      runAbortSignal: new AbortController().signal,
+      isProbeSession: true,
+      abortable: async (promise) => await promise,
+      prePromptMessageCount: 1,
+      toolSearchTargetTranscriptProjections: [
+        {
+          parentToolCallId: "outer-exec",
+          toolCallId: "tool_search_code:outer-exec:read:1",
+          toolName: "read",
+          input: { path: "missing.txt" },
+          result: { content: [{ type: "text", text: "ENOENT" }] },
+          isError: true,
+        },
+      ],
+      cache: {
+        observabilityEnabled: false,
+        changesForTurn: null,
+        retention: undefined,
+      },
+      shouldFlushForContextEngine: false,
+    });
+
+    expect(result.lastAssistant).toBe(modelAssistant);
+    expect(result.currentAttemptAssistant).toBe(modelAssistant);
+    expect(result.currentAttemptCompletedAssistant).toEqual(modelAssistant);
+    expect(result.messagesSnapshot).toHaveLength(5);
+    expect(result.messagesSnapshot.at(-2)).toMatchObject({
+      role: "assistant",
+      stopReason: "toolUse",
+      content: [{ name: "read" }],
+    });
+    expect(result.messagesSnapshot.at(-1)).toMatchObject({
+      role: "toolResult",
+      toolName: "read",
+      isError: true,
+    });
+  });
+
   it("emits an abort-classified agent_end event when a teardown error races the abort", async () => {
     const abortError = Object.assign(new Error("This operation was aborted"), {
       name: "AbortError",

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -280,17 +280,20 @@ export async function settleEmbeddedAttemptStream(input: {
           `runId=${attempt.runId} sessionId=${attempt.sessionId}`,
       );
     }
+    const modelMessagesSnapshot = snapshotSelection.messagesSnapshot;
     messagesSnapshot = projectToolSearchTargetTranscriptMessages(
-      snapshotSelection.messagesSnapshot,
+      modelMessagesSnapshot,
       input.toolSearchTargetTranscriptProjections,
     );
     sessionIdUsed = snapshotSelection.sessionIdUsed;
-    lastAssistant = messagesSnapshot
+    // Projected target-tool assistants are transcript evidence, not model
+    // turns. Letting one own terminal state hides its parent tool's outcome.
+    lastAssistant = modelMessagesSnapshot
       .slice()
       .toReversed()
       .find((message): message is AssistantMessage => message.role === "assistant");
     currentAttemptAssistant = findCurrentAttemptAssistantMessage({
-      messagesSnapshot,
+      messagesSnapshot: modelMessagesSnapshot,
       prePromptMessageCount: input.prePromptMessageCount,
     });
     currentAttemptCompletedAssistant = subscription.getCurrentAttemptAssistant();

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -793,15 +793,20 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
       attempt: params.attempt,
     }),
   );
-  // Idle is not proof of completion: a toolUse terminal whose requested tools never
-  // (or only partially) dispatched must keep the incomplete-turn error, or the model
-  // could claim skipped side effects succeeded. Lifecycle counts are attempt-cumulative
-  // and alias across batches, so completion is proven per tool-call id: every toolCall
-  // in the terminal assistant needs a non-error toolResult in the message snapshot.
-  const requestedToolCallIds = Array.isArray(assistant?.content)
+  // Idle is not proof of settlement: skipped or partially dispatched tools must
+  // never be described as completed. Match each terminal call's id and owner to
+  // its own current-batch result; a reported failure is settled, not successful.
+  const requestedToolCalls = Array.isArray(assistant?.content)
     ? assistant.content.flatMap((item) => {
-        const block = item as { type?: unknown; id?: unknown } | null;
-        return block?.type === "toolCall" ? [typeof block.id === "string" ? block.id : null] : [];
+        const block = item as { type?: unknown; id?: unknown; name?: unknown } | null;
+        return block?.type === "toolCall"
+          ? [
+              {
+                id: typeof block.id === "string" ? block.id : null,
+                name: typeof block.name === "string" ? block.name : null,
+              },
+            ]
+          : [];
       })
     : [];
   // Scan only results AFTER the terminal assistant: the snapshot spans the whole
@@ -810,28 +815,58 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
   // the snapshot fails closed to the existing incomplete-turn error.
   const snapshot = params.attempt.messagesSnapshot ?? [];
   const assistantIndex = assistant ? snapshot.indexOf(assistant) : -1;
-  const completedToolCallIds = new Set(
+  const settledToolResults = new Map(
     (assistantIndex >= 0 ? snapshot.slice(assistantIndex + 1) : []).flatMap((message) => {
-      const result = message as { role?: unknown; toolCallId?: unknown; isError?: unknown };
+      const result = message as {
+        role?: unknown;
+        toolCallId?: unknown;
+        toolName?: unknown;
+        isError?: unknown;
+      };
       return result.role === "toolResult" &&
-        result.isError !== true &&
-        typeof result.toolCallId === "string"
-        ? [result.toolCallId]
+        typeof result.toolCallId === "string" &&
+        typeof result.toolName === "string"
+        ? [
+            [
+              result.toolCallId,
+              { toolName: result.toolName, isError: result.isError === true },
+            ] as const,
+          ]
         : [];
     }),
   );
-  const allToolsProvenComplete =
+  const allToolsProvenSettled =
     params.attempt.itemLifecycle?.activeCount === 0 &&
-    requestedToolCallIds.length > 0 &&
-    requestedToolCallIds.every((id) => id !== null && completedToolCallIds.has(id));
+    requestedToolCalls.length > 0 &&
+    requestedToolCalls.every(
+      ({ id, name }) =>
+        id !== null && name !== null && settledToolResults.get(id)?.toolName === name,
+    );
+  const failedTerminalToolNames = new Set(
+    requestedToolCalls.flatMap(({ id, name }) =>
+      id !== null && name !== null && settledToolResults.get(id)?.isError === true ? [name] : [],
+    ),
+  );
+  const hasSettledTerminalToolFailure = allToolsProvenSettled && failedTerminalToolNames.size > 0;
+  // ToolErrorSummary has no call id: its owner must match a failed result in the
+  // proven terminal batch, or a stale/unrelated error could authorize finalization.
+  const hasUnsettledToolError = Boolean(
+    params.attempt.lastToolError &&
+    (assistant?.stopReason !== "toolUse" ||
+      !hasSettledTerminalToolFailure ||
+      !failedTerminalToolNames.has(params.attempt.lastToolError.toolName)),
+  );
   if (
     params.payloadCount !== 0 ||
     params.hasTerminalToolPresentation ||
     params.aborted ||
     params.promptError != null ||
     params.timedOut ||
-    (assistant?.stopReason === "toolUse" ? !allToolsProvenComplete : !emptyStopAfterSettledTools) ||
-    params.attempt.lastToolError ||
+    (assistant?.stopReason === "toolUse" ? !allToolsProvenSettled : !emptyStopAfterSettledTools) ||
+    hasUnsettledToolError ||
+    (hasSettledTerminalToolFailure &&
+      (hasAsyncStartedToolActivity(params.attempt.toolMetas) ||
+        hasAcceptedSessionSpawn(params.attempt.acceptedSessionSpawns))) ||
     params.attempt.clientToolCalls ||
     params.attempt.yieldDetected ||
     params.attempt.didSendDeterministicApprovalPrompt
@@ -851,7 +886,9 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
   ) {
     return null;
   }
-  return SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION;
+  return hasSettledTerminalToolFailure
+    ? `${SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} If any tool failed, state that failure plainly and do not claim it succeeded.`
+    : SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION;
 }
 
 /**

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -87,13 +87,30 @@ export function resolveSettledTurnFinalizationRequest(input: {
     timedOut: terminalTimedOut,
     attempt: input.attempt,
   });
+  const terminalAssistant = input.attempt.currentAttemptAssistant ?? input.attempt.lastAssistant;
+  // Payload preparation renders an undelivered tool-error fallback before the
+  // model gets its final answer. It must not masquerade as an assistant reply;
+  // exact failed-call settlement is independently proven by the finalizer owner.
+  const hasOnlySyntheticToolErrorPayload = Boolean(
+    terminalAssistant?.stopReason === "toolUse" &&
+    input.attempt.lastToolError &&
+    input.attempt.assistantTexts.every((text) => text.trim().length === 0) &&
+    (input.payloadsWithToolMedia?.length ?? 0) > 0 &&
+    input.payloadsWithToolMedia?.every(
+      (payload) =>
+        payload.isError === true &&
+        Object.keys(payload).every((key) => key === "text" || key === "isError"),
+    ),
+  );
   const payloadCount = input.recoveredFinalAssistantPayloadsAfterPromptTimeout
     ? input.recoveredFinalAssistantPayloadsAfterPromptTimeout.length
-    : input.payloadsWithToolMedia?.length
-      ? input.payloadsWithToolMedia.length
-      : silentToolResultReplyPayload
-        ? 1
-        : 0;
+    : hasOnlySyntheticToolErrorPayload
+      ? 0
+      : input.payloadsWithToolMedia?.length
+        ? input.payloadsWithToolMedia.length
+        : silentToolResultReplyPayload
+          ? 1
+          : 0;
   const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
     allowEmptyAssistantReplyAsSilent: input.runParams.allowEmptyAssistantReplyAsSilent,
     terminalReplyExpectation: input.runParams.terminalReplyExpectation,


### PR DESCRIPTION
Closes #118274
Related: #118315

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users whose final tool call fails would receive no final assistant reply in channel conversations, including Telegram, or isolated cron announcements even though every requested tool had fully settled. The failed operation became a generic missing-reply warning instead of an honest, user-visible explanation.

Reported with a detailed source reproduction by @Cuttingwater in #118274; the Telegram failure mode was independently confirmed by @wzg0911.

## Why This Change Was Made

Finish settled failed-tool turns at the existing shared agent-runner owner boundary, with exactly one tools-disabled finalization only after every current-batch tool-call ID and tool owner matches its settled result. Preserve the real model assistant as the terminal owner when Code Mode projects nested tool evidence, recognize the internal synthetic error fallback without dropping genuine visible payloads, and explicitly require the model to report failures honestly.

Existing fail-closed protections remain in place for missing or partial results, wrong tool owners, stale errors, active/background work, child sessions, approvals, yielded turns, and finalization failures. The existing warning remains the fallback if finalization cannot complete.

## User Impact

Channel users and scheduled-job operators receive one accurate final reply explaining a completed tool failure instead of a silent turn, generic missing-response warning, or failed cron announcement. Failed tools are never replayed, duplicate side effects are not introduced, and successful tool-turn behavior is unchanged.

## Evidence

- Real gateway + `qa-channel` + isolated cron end-to-end proof, using the deterministic mock OpenAI provider:

  ```bash
  FS_SAFE_NATIVE_MODE=off pnpm openclaw qa suite \
    --provider-mode mock-openai \
    --scenario qa-channel-failed-tool-terminal-finalization \
    --scenario cron-failed-tool-terminal-finalization \
    --concurrency 1 --fast \
    --output-dir .artifacts/qa-e2e/failed-terminal-118274-stable-owner
  ```

  Both scenarios passed. Each executes exactly one real failing Code Mode `exec`, proves the persisted transcript contains one failed result and zero successful results, verifies the exact normalized parent `function_call` / `function_call_output` ID and `ENOENT` payload, observes exactly one failure-honest tools-disabled finalization, and receives exactly one visible `qa-channel` reply without replay.

- Complete owner, projection-sibling, and mock-provider regression suites: **473 tests passed across four complete Vitest shards**:

  ```bash
  OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=420000 \
  OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=15000 \
  FS_SAFE_NATIVE_MODE=off pnpm test \
    src/agents/embedded-agent-runner/run.incomplete-turn.test.ts \
    src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts \
    extensions/qa-lab/src/providers/mock-openai/server.test.ts \
    src/agents/tool-search.test.ts \
    --maxWorkers=1 --reporter=dot
  ```

- Full nine-path `pnpm check:changed` completed successfully on Blacksmith Testbox, including all-project TypeScript, all core/plugin/script lint lanes, formatting, SDK contract and plugin-boundary guards, dead-export and storage guards, and **zero runtime import cycles**.
- Fresh independent **xhigh** autoreview completed with zero accepted findings. One suggestion to read the ephemeral isolated-cron run session was rejected using direct source and the live scenario: `src/cron/isolated-agent/run.ts` removes that transient session, while `src/cron/isolated-agent/run-session-state.test.ts` proves the stable cron job session owns the persisted transcript.
- Upstream Codex protocol/runtime contract inspected directly at `openai/codex@07490c75234ed3c63291a8eb7629f04f647038fa`:
  - [Function-call output identity and success metadata](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/protocol/src/models.rs#L676-L699)
  - [Function-call output payload contract](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/protocol/src/models.rs#L1918-L1985)
  - [Tool response preserves the exact call ID](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/core/src/tools/context.rs#L470-L498)
  - [Tool calls require a follow-up model turn](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/core/src/stream_events_utils.rs#L294-L328)
  - [Turn loop honors the follow-up requirement](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/core/src/session/turn.rs#L363-L387)

AI-assisted; independently reviewed and validated end to end.


## Canonical Maintainer Decision and Rank-Up Moves

- Select this maintainer-authored PR as canonical over bot PR #118315. Its three-file patch does not correct the synthetic tool-error payload count or projected target-tool assistant ownership; both independently block the actual channel/cron user path. This PR repairs all three shared-owner causes and proves both real end-to-end delivery paths.
- Direct Codex upstream inspection was completed personally at `openai/codex@07490c75234ed3c63291a8eb7629f04f647038fa`: `codex-rs/protocol/src/models.rs:676`, `codex-rs/core/src/tools/context.rs:470`, `codex-rs/core/src/stream_events_utils.rs:294`, and `codex-rs/core/src/session/turn.rs:363`.
- Current `main` was refreshed and all nine changed paths were independently checked: no upstream commit has touched any of them since the reviewed branch base. Following the repository policy not to rebase solely because unrelated `main` commits advanced, the proven exact head is retained; its required `openclaw/ci-gate` is `SUCCESS`.
- Net production growth is +75 lines, justified by exact failed-call/owner correlation, synthetic-payload ownership, and projected-assistant terminal ownership. Tests and the two executable QA scenarios account for the remaining growth.
