### PR TITLE
fix(doctor): restore E2E runtime fixture contracts

### DIFF
--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -384,6 +384,7 @@ vi.mock("../skills/discovery/status.js", () => ({
 }));
 
 vi.mock("../plugins/loader.js", () => ({
+  getRuntimePluginRegistryForLoadOptions: () => null,
   isPluginRegistryLoadInFlight: () => false,
   loadOpenClawPlugins: () => createEmptyPluginRegistry(),
   loadPluginRegistryHandle: () => createEmptyPluginRegistry(),
@@ -495,6 +496,24 @@ vi.mock("../infra/update-runner.js", () => ({
 
 vi.mock("../flows/doctor-health-contributions.js", () => ({
   runDoctorHealthContributions,
+}));
+
+vi.mock("../flows/doctor-core-checks.runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../flows/doctor-core-checks.runtime.js")>()),
+  collectRuntimeToolSchemaFindings: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("./doctor/shared/active-tool-schema-warnings.js", () => ({
+  collectActiveToolSchemaProjectionWarnings: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("./doctor-browser.js", () => ({
+  detectLegacyClawdBrowserProfileResidue: vi.fn().mockResolvedValue(null),
+  maybeArchiveLegacyClawdBrowserProfileResidue: vi.fn().mockResolvedValue({
+    changes: [],
+    warnings: [],
+  }),
+  noteChromeMcpBrowserReadiness: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("./doctor-memory-search.js", () => ({


### PR DESCRIPTION
Closes #118346

## What Problem This Solves

Fixes an issue where Doctor E2E suites failed after a plugin-loader ownership refactor and could exceed their existing 30-second timeout while testing unrelated migrations.

Current `main` has two deterministic symptoms in the same shared harness: Vitest rejects the incomplete whole-module loader mock, and yes-mode migration coverage cold-loads active-tool schemas, the browser doctor plugin, and structured runtime-tool schemas owned by dedicated suites.

## Why This Change Was Made

The shared Doctor E2E harness now restores the current loader export contract and explicitly isolates the three unrelated cold runtime surfaces:

- `getRuntimePluginRegistryForLoadOptions` matches the existing null runtime-registry fixture;
- active-tool projection warnings return an empty fast result;
- the browser doctor facade returns empty readiness/residue results;
- only the structured runtime-tool-schema collector is overridden, while the other core health collectors remain real.

This repairs the harness boundary rather than weakening production loader assumptions, changing Doctor behavior, increasing timeouts, or skipping the migration/repair assertions. Vincent Koc's original loader-mock repair is preserved through commit co-authorship.

## User Impact

There is no production runtime behavior change. Maintainers regain deterministic Doctor migration, repair, browser-degradation, and routing regression coverage without unrelated plugin/tool startup dominating the tests.

## Evidence

Exact reviewed head: `53d4cce835eef86279176474e9ced83a54600cb2`

Before on current main:

- `doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts`: 3 failed, 3 passed.
- Two failures reported the missing `getRuntimePluginRegistryForLoadOptions` mock export.
- The yes-mode migration exceeded its 30-second timeout; cold traces measured 57-133 seconds in unrelated runtime contributors.

After on a fresh Blacksmith Testbox:

- `CI=1 pnpm test src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.e2e.test.ts src/commands/doctor.warns-per-agent-sandbox-docker-browser-prune.e2e.test.ts src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts`
  - 38/38 passed.
  - The formerly timing-out yes-mode migration completed in 3019ms.
- `CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed`
  - Passed formatting, production/test typechecks, lint, dead-code, boundary, schema, import-cycle, and architecture guards.
- Testbox: `tbx_01kz2hx70vz7vvbb3zrp4z4k0s`
- Run: https://github.com/openclaw/openclaw/actions/runs/30775622970
- Fresh Codex autoreview on the rebased branch: clean, no accepted/actionable findings, 0.98 confidence.

Production LOC delta: 0. Test-helper delta: +19/-0. No config, protocol, persistence, dependency, public API, docs, or changelog surface changes.

AI-assisted: yes. The final implementation and proof were reviewed directly in this maintainer task.
