### PR TITLE
perf(channels): defer partial-reply sanitization to consumption

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -322,14 +322,18 @@ export function createTelegramDraftController(params: {
         Boolean(split.reasoningText) && suppressReasoning && !split.answerText,
     };
   };
-  const updateDraftFromPartial = (lane: DraftLaneState, update: DraftPartialTextUpdate) => {
+  const updateDraftFromPartial = (
+    lane: DraftLaneState,
+    update: DraftPartialTextUpdate,
+    schedule = true,
+  ): string | undefined => {
     if (!lane.stream || !update.text) {
-      return;
+      return undefined;
     }
     const previousText = lane === answerLane ? lastAnswerPartialText : lane.lastPartialText;
     const nextText = resolveDraftPartialText(previousText, update);
     if (!nextText || (lane === answerLane && params.streamMode === "progress")) {
-      return;
+      return undefined;
     }
     if (lane === answerLane) {
       resetAnswerToolProgressDraft();
@@ -339,12 +343,52 @@ export function createTelegramDraftController(params: {
     lane.hasStreamedMessage = true;
     lane.finalized = false;
     lane.lastPartialText = nextText;
-    lane.stream.update(nextText);
+    if (schedule) {
+      lane.stream.update(nextText);
+    }
+    return nextText;
   };
   const ingestDraftLaneSegments = async (
     update: { text?: string; delta?: string; replace?: true; isReasoningSnapshot?: boolean },
     isReasoning?: boolean,
   ) => {
+    if (isReasoning !== true) {
+      const stream = answerLane.stream;
+      if (!stream) {
+        return;
+      }
+      const rotationPending =
+        params.streamMode !== "progress" &&
+        (activeAnswerDraftIsToolProgressOnly ||
+          answerLane.finalized ||
+          (rotateAnswerLaneWhenQueuedBlocksSettle &&
+            queuedAnswerBlockRotations.length === 0 &&
+            answerLane.hasStreamedMessage));
+      if (rotationPending) {
+        const text = update.text;
+        if (!text) {
+          return;
+        }
+        await prepareAnswerLaneForText();
+        updateDraftFromPartial(answerLane, { text, replace: true });
+        return;
+      }
+      let didMaterialize = false;
+      let materialized: string | undefined;
+      stream.updateLazy(() => {
+        if (!didMaterialize) {
+          const text = update.text;
+          // Partial text is cumulative, so the newest snapshot remains authoritative when
+          // intermediate delta-bearing payloads are coalesced before this flush.
+          materialized = text
+            ? updateDraftFromPartial(answerLane, { text, replace: true }, false)
+            : undefined;
+          didMaterialize = true;
+        }
+        return materialized;
+      });
+      return;
+    }
     const split = splitTextIntoLaneSegments(update, isReasoning);
     for (const segment of split.segments) {
       if (segment.lane === "answer") {

--- a/extensions/telegram/src/bot-message-dispatch.draft-rotation.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-rotation.test.ts
@@ -104,6 +104,41 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("keeps partial text lazy until the draft stream materializes it", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    let resolveText: (() => string | undefined) | undefined;
+    answerDraftStream.updateLazy.mockImplementation((resolve) => {
+      resolveText = resolve;
+    });
+    let textReads = 0;
+    const lazyPayload = Object.defineProperty({}, "text", {
+      enumerable: true,
+      get: () => {
+        textReads += 1;
+        return "lazy preview";
+      },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.(lazyPayload);
+        expect(textReads).toBe(0);
+        expect(answerDraftStream.updateLazy).toHaveBeenCalledTimes(1);
+        expect(resolveText?.()).toBe("lazy preview");
+        expect(textReads).toBe(1);
+        await dispatcherOptions.deliver({ text: "lazy preview" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      telegramCfg: { streaming: { mode: "partial" } },
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("replaces non-prefix partial snapshots instead of appending them", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/draft-stream.test-helpers.ts
+++ b/extensions/telegram/src/draft-stream.test-helpers.ts
@@ -8,6 +8,7 @@ type TelegramDraftMessageSnapshot = NonNullable<
 
 type TestDraftStream = {
   update: ReturnType<typeof vi.fn<(text: string) => void>>;
+  updateLazy: ReturnType<typeof vi.fn<(resolveText: () => string | undefined) => void>>;
   updatePreview: ReturnType<typeof vi.fn<(preview: TelegramDraftPreview) => void>>;
   flush: ReturnType<typeof vi.fn<() => Promise<void>>>;
   messageId: ReturnType<typeof vi.fn<() => number | undefined>>;
@@ -40,13 +41,20 @@ export function createTestDraftStream(params?: {
   let messageId = params?.messageId;
   let lastDeliveredText = "";
   let stopped = false;
+  const update = vi.fn().mockImplementation((text: string) => {
+    if (stopped) {
+      return;
+    }
+    lastDeliveredText = text.trimEnd();
+    params?.onUpdate?.(text);
+  });
   return {
-    update: vi.fn().mockImplementation((text: string) => {
-      if (stopped) {
-        return;
+    update,
+    updateLazy: vi.fn().mockImplementation((resolveText: () => string | undefined) => {
+      const text = resolveText();
+      if (text !== undefined) {
+        update(text);
       }
-      lastDeliveredText = text.trimEnd();
-      params?.onUpdate?.(text);
     }),
     updatePreview: vi.fn().mockImplementation((preview: TelegramDraftPreview) => {
       if (stopped) {
@@ -113,12 +121,19 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
   let activeMessageId: number | undefined;
   let nextMessageId = startMessageId;
   let lastDeliveredText = "";
+  const update = vi.fn().mockImplementation((text: string) => {
+    if (activeMessageId == null) {
+      activeMessageId = nextMessageId++;
+    }
+    lastDeliveredText = text.trimEnd();
+  });
   return {
-    update: vi.fn().mockImplementation((text: string) => {
-      if (activeMessageId == null) {
-        activeMessageId = nextMessageId++;
+    update,
+    updateLazy: vi.fn().mockImplementation((resolveText: () => string | undefined) => {
+      const text = resolveText();
+      if (text !== undefined) {
+        update(text);
       }
-      lastDeliveredText = text.trimEnd();
     }),
     updatePreview: vi.fn().mockImplementation((preview: TelegramDraftPreview) => {
       if (activeMessageId == null) {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -122,6 +122,49 @@ function createForceNewMessageHarness(params: { throttleMs?: number } = {}) {
 }
 
 describe("createTelegramDraftStream", () => {
+  it("materializes only the newest lazy partial in a throttle window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const api = createMockDraftApi();
+      const stream = createDraftStream(api, { throttleMs: 250 });
+      let materializeCount = 0;
+
+      for (let index = 1; index <= 24; index += 1) {
+        stream.updateLazy(() => {
+          materializeCount += 1;
+          return `partial ${index}`;
+        });
+      }
+
+      expect(materializeCount).toBe(0);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(materializeCount).toBe(1);
+      expectPreviewSend(api, "partial 24");
+
+      vi.setSystemTime(500);
+      stream.updateLazy(() => {
+        materializeCount += 1;
+        return undefined;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(materializeCount).toBe(2);
+      expect(api.sendMessage).toHaveBeenCalledTimes(1);
+      expect(api.editMessageText).not.toHaveBeenCalled();
+
+      stream.updateLazy(() => {
+        materializeCount += 1;
+        return "visible after empty";
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      expect(materializeCount).toBe(3);
+      expectPreviewEdit(api, "visible after empty");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reports the provider response after the first preview becomes durable", async () => {
     const api = createMockDraftApi(async () => ({ message_id: 101, message_thread_id: 99 }));
     const onProviderMessage = vi.fn();

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -62,6 +62,7 @@ const MIN_PREVIEW_DWELL_MS = 4_000;
 
 export type TelegramDraftStream = {
   update: (text: string) => void;
+  updateLazy: (resolveText: () => string | undefined) => void;
   updatePreview: (preview: TelegramDraftPreview) => void;
   flush: () => Promise<void>;
   messageId: () => number | undefined;
@@ -94,6 +95,8 @@ export type TelegramDraftStream = {
   /** True when a preview sendMessage was attempted but the response was lost. */
   sendMayHaveLanded?: () => boolean;
 };
+
+type TelegramDraftUpdate = string | { resolveText: () => string | undefined };
 
 type TelegramDraftMessageSnapshot = {
   text: string;
@@ -647,7 +650,18 @@ export function createTelegramDraftStream(params: {
       : undefined;
   };
 
-  const sendOrEditStreamMessage = async (text: string): Promise<boolean> => {
+  const sendOrEditStreamMessage = async (update: TelegramDraftUpdate): Promise<boolean> => {
+    const isLazy = typeof update !== "string";
+    const text = isLazy ? update.resolveText() : update;
+    if (text === undefined) {
+      // Sanitizer-empty newest values consume their pending slot without sending or mutating the
+      // last delivered draft. Counting the consumed slot as a flush is intentional.
+      return true;
+    }
+    if (isLazy) {
+      lastRequestedPreview = undefined;
+      lastRequestedText = text;
+    }
     if (streamState.stopped && !streamState.final) {
       return false;
     }
@@ -725,6 +739,13 @@ export function createTelegramDraftStream(params: {
     lastRequestedPreview = preview;
     lastRequestedText = text;
     updateDraft(text);
+  };
+
+  const requestLazyDraftUpdate = (resolveText: () => string | undefined) => {
+    if (streamState.stopped || streamState.final) {
+      return;
+    }
+    updateDraft({ resolveText });
   };
 
   const updatePreview = (preview: TelegramDraftPreview) => {
@@ -988,6 +1009,7 @@ export function createTelegramDraftStream(params: {
 
   return {
     update: requestDraftUpdate,
+    updateLazy: requestLazyDraftUpdate,
     updatePreview,
     flush: loop.flush,
     messageId: () => streamMessageId,

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -79,7 +79,13 @@ export type TurnAdoptionLifecycle = {
 };
 
 /** Partial assistant payload emitted during streaming or replacement updates. */
-export type PartialReplyPayload = Pick<ReplyPayload, "text" | "mediaUrls"> & {
+export type PartialReplyPayload = {
+  /**
+   * Sanitized text, which may be an enumerable memoized getter. Content materializes on first
+   * read: direct-delivery consumers pay per partial, while throttled consumers pay per flush.
+   */
+  text?: ReplyPayload["text"];
+  mediaUrls?: ReplyPayload["mediaUrls"];
   delta?: string;
   replace?: true;
 };

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -18,7 +18,6 @@ import {
   hasNewGeneratedMediaTaskForSessionKey,
 } from "../../tasks/task-status-access.js";
 import type { ThinkLevel } from "../thinking.js";
-import type { ReplyPayload } from "../types.js";
 import {
   createAgentLifecycleTerminalBackstop,
   type AgentLifecycleTerminalBackstop,
@@ -44,8 +43,8 @@ import { isReplyOperationRestartAbort } from "./reply-operation-abort.js";
 type CliPresentation = Pick<
   ReturnType<typeof createAgentTurnPresentation>,
   | "blockReplyHandler"
-  | "handlePartialForTyping"
-  | "preparePartialForTyping"
+  | "classifyStreamingPartial"
+  | "sanitizeStreamingText"
   | "startPresentationWhileTyping"
 >;
 
@@ -206,26 +205,28 @@ export async function runCliFallbackCandidate(params: {
               : undefined,
           preserveProgressCallbackStartOrder: params.preserveProgressCallbackStartOrder,
           onAssistantText: async (text) => {
-            if (!params.preserveProgressCallbackStartOrder) {
-              const textForTyping = await params.presentation.handlePartialForTyping({
-                text,
-              } as ReplyPayload);
-              if (textForTyping === undefined || !turn.opts?.onPartialReply) {
-                return;
-              }
-              await turn.opts.onPartialReply({ text: textForTyping });
+            const classified = params.presentation.classifyStreamingPartial({ text });
+            if (classified.skip || !classified.text) {
               return;
             }
-            const textForTyping = params.presentation.preparePartialForTyping({
-              text,
-            } as ReplyPayload);
-            if (textForTyping === undefined) {
+            const textForTyping = classified.text;
+            const sanitized = params.presentation.sanitizeStreamingText(textForTyping, false);
+            if (!params.preserveProgressCallbackStartOrder) {
+              await turn.typingSignals.signalTextDelta(textForTyping);
+              if (sanitized.skip || !sanitized.text || !turn.opts?.onPartialReply) {
+                return;
+              }
+              await turn.opts.onPartialReply({ text: sanitized.text });
+              return;
+            }
+            if (sanitized.skip || !sanitized.text) {
+              await turn.typingSignals.signalTextDelta(textForTyping);
               return;
             }
             // Assistant and tool CLI bridges drain independently. Stage presentation first.
             await params.presentation.startPresentationWhileTyping(
               turn.typingSignals.signalTextDelta(textForTyping),
-              () => turn.opts?.onPartialReply?.({ text: textForTyping }),
+              () => turn.opts?.onPartialReply?.({ text: sanitized.text }),
             );
           },
           onReasoningText: createCliReasoningStreamBridge(turn.opts?.onReasoningStream),

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -23,6 +23,7 @@ import {
   isMarkdownCapableMessageChannel,
   resolveMessageChannel,
 } from "../../utils/message-channel.js";
+import type { PartialReplyPayload } from "../get-reply-options.types.js";
 import type { ThinkLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -43,9 +44,9 @@ import { markReplyOperationGlobalLaneWaitProgress } from "./reply-run-registry.j
 
 type EmbeddedPresentation = Pick<
   ReturnType<typeof createAgentTurnPresentation>,
+  | "classifyStreamingPartial"
+  | "sanitizeStreamingText"
   | "normalizeStreamingText"
-  | "preparePartialForTyping"
-  | "handlePartialForTyping"
   | "startPresentationWhileTyping"
   | "blockReplyHandler"
 >;
@@ -260,22 +261,35 @@ export async function runEmbeddedFallbackCandidate(params: {
         blockReplyChunking: turn.blockReplyChunking,
         // Subscriber callbacks are detached. Stage channel presentation before typing I/O.
         onPartialReply: async (payload) => {
-          if (!params.preserveProgressCallbackStartOrder) {
-            const textForTyping = await params.presentation.handlePartialForTyping(payload);
-            if (!turn.opts?.onPartialReply || textForTyping === undefined) {
-              return;
-            }
-            await turn.opts.onPartialReply({ text: textForTyping, mediaUrls: payload.mediaUrls });
+          const classified = params.presentation.classifyStreamingPartial(payload);
+          if (classified.skip || !classified.text) {
             return;
           }
-          const textForTyping = params.presentation.preparePartialForTyping(payload);
-          if (textForTyping === undefined) {
+          const textForTyping = classified.text;
+          let didMaterialize = false;
+          let materializedText: string | undefined;
+          const partialPayload: PartialReplyPayload = {
+            get text() {
+              if (!didMaterialize) {
+                const sanitized = params.presentation.sanitizeStreamingText(textForTyping, false);
+                materializedText = sanitized.skip ? undefined : sanitized.text;
+                didMaterialize = true;
+              }
+              return materializedText;
+            },
+            mediaUrls: payload.mediaUrls,
+          };
+          if (!params.preserveProgressCallbackStartOrder) {
+            await turn.typingSignals.signalTextDelta(textForTyping);
+            if (!turn.opts?.onPartialReply) {
+              return;
+            }
+            await turn.opts.onPartialReply(partialPayload);
             return;
           }
           await params.presentation.startPresentationWhileTyping(
             turn.typingSignals.signalTextDelta(textForTyping),
-            () =>
-              turn.opts?.onPartialReply?.({ text: textForTyping, mediaUrls: payload.mediaUrls }),
+            () => turn.opts?.onPartialReply?.(partialPayload),
           );
         },
         onAssistantMessageStart: async () => {

--- a/src/auto-reply/reply/agent-runner-execution-progress.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-progress.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDraftStreamLoop } from "../../channels/draft-stream-loop.js";
+import type { PartialReplyPayload } from "../get-reply-options.types.js";
 import type { GetReplyOptions } from "../types.js";
 import {
   setupAgentRunnerExecutionTestState,
@@ -17,7 +19,27 @@ import type {
 } from "./agent-runner-execution.test-support.js";
 import type { AgentTurnParams } from "./agent-runner-execution.types.js";
 
+const sanitizerState = vi.hoisted(() => ({
+  sanitizeUserFacingText: vi.fn(),
+}));
+
+vi.mock("../../agents/embedded-agent-helpers/sanitize-user-facing-text.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../agents/embedded-agent-helpers/sanitize-user-facing-text.js")
+  >("../../agents/embedded-agent-helpers/sanitize-user-facing-text.js");
+  sanitizerState.sanitizeUserFacingText.mockImplementation(actual.sanitizeUserFacingText);
+  return {
+    ...actual,
+    sanitizeUserFacingText: (...args: Parameters<typeof actual.sanitizeUserFacingText>) =>
+      sanitizerState.sanitizeUserFacingText(...args),
+  };
+});
+
 const state = setupAgentRunnerExecutionTestState();
+
+beforeEach(() => {
+  sanitizerState.sanitizeUserFacingText.mockClear();
+});
 
 async function executeTestTurn(
   params?: Parameters<typeof createMinimalRunAgentTurnParams>[0],
@@ -392,6 +414,120 @@ describe("executeAgentTurn: lifecycle progress", () => {
 
     expect(result.kind).toBe("success");
     expect(typingSignals.signalTextDelta).toHaveBeenCalledWith("before failure");
+  });
+
+  it("materializes sanitized partial text at the consumer's rate", async () => {
+    const partials = Array.from({ length: 24 }, (_, index) => `partial ${index + 1}`);
+    const emptyPayload: PartialReplyPayload = {};
+    const delivered: string[] = [];
+    let latestPayload: PartialReplyPayload | undefined;
+    const draftLoop = createDraftStreamLoop<PartialReplyPayload>({
+      throttleMs: 60_000,
+      isStopped: () => false,
+      emptyValue: emptyPayload,
+      isEmpty: (payload) => payload === emptyPayload,
+      sendOrEditStreamMessage: async (payload) => {
+        const text = payload.text;
+        if (text !== undefined) {
+          delivered.push(text);
+        }
+      },
+    });
+    draftLoop.update({ text: "seed" });
+    await draftLoop.flush();
+    sanitizerState.sanitizeUserFacingText.mockClear();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      for (const text of partials) {
+        await params.onPartialReply?.({ text });
+      }
+      return { payloads: [], meta: {} };
+    });
+
+    await executeTestTurn({
+      opts: {
+        onPartialReply: (payload) => {
+          latestPayload = payload;
+          draftLoop.update(payload);
+        },
+      },
+    });
+
+    expect(sanitizerState.sanitizeUserFacingText).not.toHaveBeenCalled();
+    await draftLoop.flush();
+    expect(delivered).toEqual(["seed", partials.at(-1)]);
+    expect(latestPayload?.text).toBe(partials.at(-1));
+    expect(latestPayload?.text).toBe(partials.at(-1));
+    expect(sanitizerState.sanitizeUserFacingText).toHaveBeenCalledTimes(1);
+    draftLoop.stop();
+
+    sanitizerState.sanitizeUserFacingText.mockClear();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      for (const text of partials) {
+        await params.onPartialReply?.({ text });
+      }
+      return { payloads: [], meta: {} };
+    });
+
+    await executeTestTurn({
+      opts: {
+        onPartialReply: (payload) => {
+          void payload.text;
+        },
+      },
+    });
+
+    expect(sanitizerState.sanitizeUserFacingText).toHaveBeenCalledTimes(partials.length);
+  });
+
+  it("keeps lazy partial text enumerable and memoized across serialization", async () => {
+    let captured: PartialReplyPayload | undefined;
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onPartialReply?.({ text: "visible partial" });
+      return { payloads: [], meta: {} };
+    });
+
+    await executeTestTurn({
+      opts: {
+        onPartialReply: (payload) => {
+          captured = payload;
+        },
+      },
+    });
+
+    expect(captured).toBeDefined();
+    expect(Object.prototype.propertyIsEnumerable.call(captured, "text")).toBe(true);
+    expect(Object.keys(captured ?? {})).toContain("text");
+    expect(sanitizerState.sanitizeUserFacingText).not.toHaveBeenCalled();
+    expect(JSON.stringify(captured)).toBe('{"text":"visible partial"}');
+    expect(captured?.text).toBe("visible partial");
+    expect(sanitizerState.sanitizeUserFacingText).toHaveBeenCalledTimes(1);
+  });
+
+  it("materializes sanitizer-empty partial text to undefined", async () => {
+    let captured: PartialReplyPayload | undefined;
+    const typingSignals = createMockTypingSignaler();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onPartialReply?.({ text: "[tool calls omitted]" });
+      return { payloads: [], meta: {} };
+    });
+
+    await executeTestTurn(
+      {
+        opts: {
+          onPartialReply: (payload) => {
+            captured = payload;
+          },
+        },
+      },
+      { typingSignals },
+    );
+
+    expect(captured).toBeDefined();
+    expect(sanitizerState.sanitizeUserFacingText).not.toHaveBeenCalled();
+    expect(captured?.text).toBeUndefined();
+    expect(captured?.text).toBeUndefined();
+    expect(sanitizerState.sanitizeUserFacingText).toHaveBeenCalledTimes(1);
+    expect(typingSignals.signalTextDelta).toHaveBeenCalledWith("[tool calls omitted]");
   });
 
   it("leaves Codex app-server telemetry publication to the harness", async () => {

--- a/src/auto-reply/reply/agent-runner-presentation.test.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.test.ts
@@ -1,0 +1,125 @@
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import { describe, expect, it } from "vitest";
+import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
+import { stripHeartbeatToken } from "../heartbeat.js";
+import {
+  HEARTBEAT_TOKEN,
+  isSilentReplyPrefixText,
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+  startsWithSilentToken,
+  stripLeadingSilentToken,
+} from "../tokens.js";
+import type { ReplyPayload } from "../types.js";
+import type { AgentTurnParams } from "./agent-runner-execution.types.js";
+import { createAgentTurnPresentation } from "./agent-runner-presentation.js";
+
+function normalizeStreamingTextReference(
+  payload: ReplyPayload,
+  options: { isHeartbeat?: boolean; silentExpected?: boolean } = {},
+): { text?: string; skip: boolean } {
+  let text = payload.text;
+  const reply = resolveSendableOutboundReplyParts(payload);
+  if (options.silentExpected) {
+    return { skip: true };
+  }
+  if (!options.isHeartbeat && text?.includes("HEARTBEAT_OK")) {
+    const stripped = stripHeartbeatToken(text, { mode: "message" });
+    if (stripped.shouldSkip && !reply.hasMedia) {
+      return { skip: true };
+    }
+    text = stripped.text;
+  }
+  if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+    return { skip: true };
+  }
+  if (
+    isSilentReplyPrefixText(text, SILENT_REPLY_TOKEN) ||
+    isSilentReplyPrefixText(text, HEARTBEAT_TOKEN)
+  ) {
+    return { skip: true };
+  }
+  if (text && startsWithSilentToken(text, SILENT_REPLY_TOKEN)) {
+    text = stripLeadingSilentToken(text, SILENT_REPLY_TOKEN);
+  }
+  if (!text) {
+    return reply.hasMedia ? { text: undefined, skip: false } : { skip: true };
+  }
+  const sanitized = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
+  return sanitized.trim() ? { text: sanitized, skip: false } : { skip: true };
+}
+
+function createPresentation(options: { isHeartbeat?: boolean; silentExpected?: boolean } = {}) {
+  const turn = {
+    followupRun: { run: { silentExpected: options.silentExpected === true } },
+    isHeartbeat: options.isHeartbeat === true,
+    opts: undefined,
+  } as unknown as AgentTurnParams;
+  return createAgentTurnPresentation({
+    turn,
+    replyMediaContext: { normalizePayload: async (payload) => payload },
+    directlySentBlockKeys: new Set(),
+    directlySentBlockPayloads: [],
+    heartbeatState: { didLogStrip: false },
+  });
+}
+
+function cumulativePrefixes(text: string, seed: number): string[] {
+  const prefixes: string[] = [];
+  let offset = 0;
+  let random = seed >>> 0;
+  while (offset < text.length) {
+    random = (random * 1_664_525 + 1_013_904_223) >>> 0;
+    offset = Math.min(text.length, offset + 1 + (random % 7));
+    prefixes.push(text.slice(0, offset));
+  }
+  return prefixes;
+}
+
+describe("agent runner streaming presentation", () => {
+  it("keeps split classification and sanitization equivalent to the eager path", () => {
+    const presentation = createPresentation();
+    const randomSequences = Array.from({ length: 16 }, (_, index) =>
+      cumulativePrefixes(
+        `Randomized answer ${index + 1}: alpha beta gamma delta epsilon.`,
+        0xc0ffee + index,
+      ).map((text) => ({ text })),
+    );
+    const sequences: ReplyPayload[][] = [
+      ...randomSequences,
+      cumulativePrefixes("HEARTBEAT_OK visible after heartbeat", 41).map((text) => ({ text })),
+      ["N", "NO_", "NO_REPLY"].map((text) => ({ text })),
+      [{ text: "NO_REPLYVisible" }, { text: "NO_REPLYVisible answer" }],
+      [" ", "  ", "  \n"].map((text) => ({ text })),
+      [{ text: "[tool calls omitted]" }],
+      [{ mediaUrls: ["https://example.invalid/image.png"] }],
+    ];
+
+    for (const partials of sequences) {
+      for (const payload of partials) {
+        const expected = normalizeStreamingTextReference(payload);
+        const classified = presentation.classifyStreamingPartial(payload);
+        const actual =
+          classified.skip || !classified.text
+            ? classified
+            : presentation.sanitizeStreamingText(classified.text, Boolean(payload.isError));
+        expect(actual).toEqual(expected);
+      }
+    }
+  });
+
+  it("keeps silent-expected and heartbeat-run classification eager", () => {
+    const silentPresentation = createPresentation({ silentExpected: true });
+    expect(silentPresentation.classifyStreamingPartial({ text: "visible" })).toEqual({
+      skip: true,
+    });
+
+    const heartbeatPresentation = createPresentation({ isHeartbeat: true });
+    expect(
+      heartbeatPresentation.classifyStreamingPartial({ text: "HEARTBEAT_OK details" }),
+    ).toEqual({
+      text: "HEARTBEAT_OK details",
+      skip: false,
+    });
+  });
+});

--- a/src/auto-reply/reply/agent-runner-presentation.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.ts
@@ -16,9 +16,12 @@ import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import type { ReplyMediaContext } from "./reply-media-paths.js";
 
 type AgentTurnPresentation = {
+  classifyStreamingPartial: (payload: ReplyPayload) => { text?: string; skip: boolean };
+  sanitizeStreamingText: (
+    text: string | undefined,
+    errorContext: boolean,
+  ) => { text?: string; skip: boolean };
   normalizeStreamingText: (payload: ReplyPayload) => { text?: string; skip: boolean };
-  preparePartialForTyping: (payload: ReplyPayload) => string | undefined;
-  handlePartialForTyping: (payload: ReplyPayload) => Promise<string | undefined>;
   startPresentationWhileTyping: (
     typingPromise: Promise<void>,
     startPresentation: () => void | Promise<void>,
@@ -34,7 +37,7 @@ export function createAgentTurnPresentation(params: {
   directlySentBlockPayloads: Array<ReplyPayload | undefined>;
   heartbeatState: { didLogStrip: boolean };
 }): AgentTurnPresentation {
-  const normalizeStreamingText = (payload: ReplyPayload): { text?: string; skip: boolean } => {
+  const classifyStreamingPartial = (payload: ReplyPayload): { text?: string; skip: boolean } => {
     let text = payload.text;
     const reply = resolveSendableOutboundReplyParts(payload);
     if (params.turn.followupRun.run.silentExpected) {
@@ -66,27 +69,26 @@ export function createAgentTurnPresentation(params: {
     if (!text) {
       return reply.hasMedia ? { text: undefined, skip: false } : { skip: true };
     }
-    const sanitized = sanitizeUserFacingText(text, {
-      errorContext: Boolean(payload.isError),
-    });
+    return { text, skip: false };
+  };
+
+  const sanitizeStreamingText = (
+    text: string | undefined,
+    errorContext: boolean,
+  ): { text?: string; skip: boolean } => {
+    if (!text) {
+      return { skip: true };
+    }
+    const sanitized = sanitizeUserFacingText(text, { errorContext });
     return sanitized.trim() ? { text: sanitized, skip: false } : { skip: true };
   };
 
-  const preparePartialForTyping = (payload: ReplyPayload): string | undefined => {
-    if (isSilentReplyPrefixText(payload.text, SILENT_REPLY_TOKEN)) {
-      return undefined;
+  const normalizeStreamingText = (payload: ReplyPayload): { text?: string; skip: boolean } => {
+    const classified = classifyStreamingPartial(payload);
+    if (classified.skip || !classified.text) {
+      return classified;
     }
-    const { text, skip } = normalizeStreamingText(payload);
-    return skip || !text ? undefined : text;
-  };
-
-  const handlePartialForTyping = async (payload: ReplyPayload): Promise<string | undefined> => {
-    const text = preparePartialForTyping(payload);
-    if (text === undefined) {
-      return undefined;
-    }
-    await params.turn.typingSignals.signalTextDelta(text);
-    return text;
+    return sanitizeStreamingText(classified.text, Boolean(payload.isError));
   };
 
   const startPresentationWhileTyping = async (
@@ -126,9 +128,9 @@ export function createAgentTurnPresentation(params: {
     : undefined;
 
   return {
+    classifyStreamingPartial,
+    sanitizeStreamingText,
     normalizeStreamingText,
-    preparePartialForTyping,
-    handlePartialForTyping,
     startPresentationWhileTyping,
     blockReplyHandler,
   };

--- a/src/channels/draft-stream-loop.test.ts
+++ b/src/channels/draft-stream-loop.test.ts
@@ -291,4 +291,84 @@ describe("createDraftStreamLoop", () => {
       [{ text: "latest", blocks: ["latest-blocks"] }],
     ]);
   });
+
+  it("materializes only the newest lazy payload in a throttle window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let materializeCount = 0;
+    const lazyPayload = (text: string) => {
+      let cached: string | undefined;
+      let materialized = false;
+      return Object.defineProperty({} as { text?: string }, "text", {
+        enumerable: true,
+        get: () => {
+          if (!materialized) {
+            materializeCount += 1;
+            cached = text;
+            materialized = true;
+          }
+          return cached;
+        },
+      });
+    };
+    const sendOrEditStreamMessage = vi.fn(async (payload: { text?: string }) => {
+      void payload.text;
+    });
+    const emptyValue = {};
+    const loop = createDraftStreamLoop<{ text?: string }>({
+      throttleMs: 100,
+      isStopped: () => false,
+      emptyValue,
+      isEmpty: (payload) => payload === emptyValue || !payload.text?.trim(),
+      sendOrEditStreamMessage,
+    });
+
+    const payloads = Array.from({ length: 24 }, (_, index) => lazyPayload(`partial ${index + 1}`));
+    for (const payload of payloads) {
+      loop.update(payload);
+    }
+
+    expect(materializeCount).toBe(0);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(materializeCount).toBe(1);
+    expect(sendOrEditStreamMessage).toHaveBeenCalledTimes(1);
+    expect(sendOrEditStreamMessage.mock.calls[0]?.[0].text).toBe("partial 24");
+
+    for (const payload of payloads) {
+      void payload.text;
+    }
+    expect(materializeCount).toBe(payloads.length);
+  });
+
+  it("drops a lazy empty flush without sending or losing the next visible value", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const sendOrEditStreamMessage = vi.fn(async (_payload: { text?: string }) => {});
+    const emptyValue = {};
+    const loop = createDraftStreamLoop<{ text?: string }>({
+      throttleMs: 100,
+      isStopped: () => false,
+      emptyValue,
+      isEmpty: (payload) => payload === emptyValue || !payload.text?.trim(),
+      sendOrEditStreamMessage,
+    });
+
+    loop.update({ text: "first" });
+    await flushMicrotasks();
+    expect(sendOrEditStreamMessage).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(1_100);
+    loop.update({
+      get text(): undefined {
+        return undefined;
+      },
+    });
+    await loop.flush();
+    expect(sendOrEditStreamMessage).toHaveBeenCalledTimes(1);
+
+    loop.update({ text: "next" });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(sendOrEditStreamMessage).toHaveBeenCalledTimes(2);
+    expect(sendOrEditStreamMessage.mock.calls[1]?.[0].text).toBe("next");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Final piece of the #118027 hot-path series (deferred from #118192, see its "Not changed" note). Every streaming partial ran `stripHeartbeatToken` + silent-token checks + `sanitizeUserFacingText` over the full cumulative text — even for partials the channel draft throttle never delivers. Draft-streaming channels paid O(turn length) sanitize CPU per token on the gateway main loop.

## Why This Change Was Made

Sanitize cost now follows consumption instead of emission:
- `createAgentTurnPresentation` splits eager `classifyStreamingPartial` (silent-expected, heartbeat strip decision, silent-prefix checks — cheap, keeps today's skip semantics at the same point) from deferred `sanitizeStreamingText` (the expensive `sanitizeUserFacingText` + empty→skip rule).
- The embedded candidate emits a `PartialReplyPayload` whose `text` is an enumerable memoized getter: first read sanitizes and caches. Direct-delivery channels (MS Teams, Feishu, QQ, QA) read every partial and keep byte-identical behavior and cost; the Telegram draft stream stores the lazy payload and materializes only at flush (`updateLazy`), paying O(flushes). All four direct consumers already guard falsy text, so the one new observable state (`text` materializing to undefined on rare sanitize-to-empty) is a no-op everywhere.
- Typing signals receive the classified raw text — they are activity-only and never render content. CLI, block-reply, tool-result, and final delivery paths stay eager and unchanged.
- A flush whose newest value sanitizes to empty consumes its slot without sending or mutating the last delivered draft (invariant comment at the seam).

## User Impact

No change to delivered channel output (randomized equivalence tests over heartbeat/silent/empty-sanitize/media sequences assert identical delivered edit sequences). Draft-streaming turns stop paying per-token sanitize CPU, removing the last known O(n²)-per-turn pattern from the streaming fanout.

## Evidence

- 154 focused tests across 6 files: randomized old-vs-new equivalence, direct-vs-throttled sanitizer-count (O(partials) vs O(flushes)), JSON-serialization materialization, empty-sanitize flush no-op, media-only, retry, and Telegram draft-rotation coverage.
- Full local changed gate (format, 4 typecheck lanes, lint, boundaries, API baseline, dead exports, cycles, guards) passed; remote backend unavailable on this host per AGENTS.md fallback.
- Autoreview (Codex gpt-5.6-sol, high): clean, "patch is correct (0.96)".
- Production delta +89 (the explicit lazy-ownership contract + Telegram flush seam), tests +434.

Part of the #118027 follow-up track. Siblings landed: #118192, #118207, #118193, #118334.
