### PR TITLE
fix(auto-reply): preserve pendingFinalDelivery on retryable no-send delivery failure (#117441)

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -697,6 +697,13 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     ["aggregate partial envelope", new AggregateError([createPartialDelivery()]), false],
     ["observer-attached delivery evidence", createNoSendFailure(), false],
     ["ambiguous transport failure", new Error("transport failed"), false],
+    [
+      "outbound delivery with no send (listener not ready)",
+      new OutboundDeliveryError("No active WhatsApp Web listener", {
+        cause: new Error("no listener"),
+      }),
+      true,
+    ],
   ] as const)("reconciles pending final delivery after %s", async (name, error, preserve) => {
     hookMocks.runner.hasHooks.mockReturnValue(false);
     const pending = pendingFinalDelivery("recoverable final reply");

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -8,6 +8,7 @@ import {
   isProvenDeliveryNotSentError,
 } from "../../infra/delivery-recovery.shared.js";
 import { collectErrorGraphCandidates } from "../../infra/errors.js";
+import { isOutboundDeliveryError } from "../../infra/outbound/deliver-types.js";
 import { generateSecureInt } from "../../infra/secure-random.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
@@ -50,6 +51,13 @@ export type ReplyDispatchDeliveryOutcome =
   | "failed-deliver";
 
 function isRetryableNoSendFailure(error: unknown): boolean {
+  // An OutboundDeliveryError with sentBeforeError === false proves no
+  // recipient-visible send occurred (e.g. channel listener not ready,
+  // reachout timelock active). Such failures are retryable and must not
+  // clear the pendingFinalDelivery marker (#117441).
+  if (isOutboundDeliveryError(error) && !error.sentBeforeError) {
+    return !findPlatformMessageRejectedError(error);
+  }
   return (
     isProvenDeliveryNotSentError(error) &&
     !findPlatformMessageRejectedError(error) &&


### PR DESCRIPTION
## What Problem This Solves

When a final reply's delivery fails with a retryable `OutboundDeliveryError` where no recipient-visible send occurred (`sentBeforeError: false` — e.g. WhatsApp listener not ready, reachout timelock active), the gateway classified it as `failed-deliver` and `reconcilePendingFinalDeliveryAfterSettlement` cleared the `pendingFinalDelivery` marker. This caused **permanent message loss**: the reply text was persisted in the transcript but never delivered, and not even a gateway restart could recover it.

Fixes #117441

## Why This Change Was Made

`isRetryableNoSendFailure` only recognized `isProvenDeliveryNotSentError` (which requires `PlatformMessageNotDispatchedError` or pre-connect proof). A plain `OutboundDeliveryError` with `sentBeforeError === false` — proving no send reached the recipient — was not recognized as retryable, so it fell through to `failed-deliver` and the marker was cleared.

The fix extends `isRetryableNoSendFailure` to recognize `OutboundDeliveryError` with `sentBeforeError === false` as a retryable no-send failure (unless it carries a permanent `PlatformMessageRejectedError`). This classifies it as `failed-before-deliver`, so the `pendingFinalDelivery` marker is preserved and the restart recovery path can replay the final reply.

This is the single-point fix: the outcome classification at `reply-dispatcher.ts:515` already uses `isRetryableNoSendFailure` to decide `failed-before-deliver` vs `failed-deliver`, and `reconcilePendingFinalDeliveryAfterSettlement` already preserves the marker for `failed-before-deliver`. No changes to the reconcile logic or `SettledFinalDelivery` type are needed.

## User Impact

- **Before:** a retryable transport failure on a final reply (channel not ready, timelock) permanently lost the message — no retry, no recovery, no signal beyond a generic WARN.
- **After:** the `pendingFinalDelivery` marker is preserved, so a gateway restart (or steady-state recovery) replays the final reply to the channel.

## Evidence

**Behavior addressed:** `OutboundDeliveryError` with `sentBeforeError: false` is now classified as `failed-before-deliver` (marker preserved) instead of `failed-deliver` (marker cleared).

**Validation (trusted source, local checkout on Node 24.18.0):**

```
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
# Test Files 1 passed (1) | Tests 30 passed (30)
```

New test case in the existing `it.each` parameterized "reconciles pending final delivery after %s" suite:
- `"outbound delivery with no send (listener not ready)"` — `new OutboundDeliveryError("No active WhatsApp Web listener", { cause: ... })` (sentBeforeError defaults to false) → asserts `pendingFinalDelivery` is **preserved** (not cleared).

All 9 existing cases in the same suite still pass, including:
- `"partial outbound delivery"` (sentBeforeError: true) → marker cleared (no regression — partial sends still clear to avoid duplicate delivery on replay).
- `"permanent provider rejection"` → marker cleared (permanent failures still clear).
- `"ambiguous transport failure"` → marker cleared (unrecognized errors still clear).

**Boundary:** change is 2 files, +15 lines: `src/auto-reply/reply/reply-dispatcher.ts` (add `OutboundDeliveryError` import + early-return in `isRetryableNoSendFailure`) and the test. No changes to `reconcilePendingFinalDeliveryAfterSettlement`, `SettledFinalDelivery` type, or the delivery outcome enum.
