### PR TITLE
perf(system-agent): reuse setup metadata per activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **System-agent setup performance:** prepare compatible plugin metadata once per verified inference activation so staged route checks and persistence retries avoid repeated manifest discovery while still refreshing after plugin installs.
 - **Browser extension relay CDP compat:** answer `Target.getBrowserContexts` so Puppeteer-based clients (chrome-devtools-mcp) can drive the paired Chrome without the remote-debugging permission prompt, serve DevTools-style `/json/list` target descriptors, and add `openclaw browser extension cdp` to print the relay endpoint plus auth header for external CDP clients.
 - **Local model setup:** advertise provider-owned Ollama, llama.cpp, and LM Studio setup choices to Control UI and macOS, retry unavailable LM Studio services in place, and verify the exact prepared model before showing success.
 - **Control UI first-run setup:** continue verified model setup into Custodian, explain that the web app is ready without a channel, and offer an optional dismissible path to Channels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **System-agent setup performance:** prepare compatible plugin metadata once per verified inference activation so staged route checks and persistence retries avoid repeated manifest discovery while still refreshing after plugin installs.
 - **Browser extension relay CDP compat:** answer `Target.getBrowserContexts` so Puppeteer-based clients (chrome-devtools-mcp) can drive the paired Chrome without the remote-debugging permission prompt, serve DevTools-style `/json/list` target descriptors, and add `openclaw browser extension cdp` to print the relay endpoint plus auth header for external CDP clients.
 - **Local model setup:** advertise provider-owned Ollama, llama.cpp, and LM Studio setup choices to Control UI and macOS, retry unavailable LM Studio services in place, and verify the exact prepared model before showing success.
 - **Control UI first-run setup:** continue verified model setup into Custodian, explain that the web app is ready without a channel, and offer an optional dismissible path to Channels.

--- a/src/agents/model-runtime-aliases.test.ts
+++ b/src/agents/model-runtime-aliases.test.ts
@@ -103,6 +103,26 @@ describe("resolveCliRuntimeExecutionProvider", () => {
     ).toBe("claude-cli");
   });
 
+  it("uses caller-provided plugin auth aliases without metadata discovery", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        authProfileId: "anthropic:claude-cli",
+        cfg: createAnthropicAuthConfig({ order: ["anthropic:api"] }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+        metadataSnapshot: {
+          plugins: [
+            {
+              id: "anthropic",
+              origin: "bundled",
+              providerAuthAliases: { "claude-cli": "anthropic" },
+            },
+          ],
+        } as never,
+      }),
+    ).toBe("claude-cli");
+  });
+
   it("does not override an explicit OpenClaw model-runtime policy with CLI auth", () => {
     // Runtime policy is more explicit than profile order, so CLI auth cannot
     // force a model onto the CLI harness when config says OpenClaw.

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -13,7 +13,10 @@ import {
   resolveCliRuntimeModelBackendBinding,
 } from "./cli-backends.js";
 import { resolveModelRuntimePolicy } from "./model-runtime-policy.js";
-import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
+import {
+  resolveProviderIdForAuth,
+  type ProviderAuthAliasLookupParams,
+} from "./provider-auth-aliases.js";
 
 const RETIRED_MODEL_PICKER_PROVIDERS = new Set(["codex", "codex-cli"]);
 
@@ -169,11 +172,24 @@ function resolveConfiguredRuntime(params: {
   };
 }
 
-function resolveProfileRuntimeAlias(params: {
+type RuntimeAuthAliasParams = {
   cfg?: OpenClawConfig;
-  provider: string;
-  profileId: string;
-}): string | undefined {
+  metadataSnapshot?: ProviderAuthAliasLookupParams["metadataSnapshot"];
+};
+
+function resolveRuntimeAuthProvider(provider: string, params: RuntimeAuthAliasParams): string {
+  return resolveProviderIdForAuth(provider, {
+    config: params.cfg,
+    ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
+  });
+}
+
+function resolveProfileRuntimeAlias(
+  params: RuntimeAuthAliasParams & {
+    provider: string;
+    profileId: string;
+  },
+): string | undefined {
   const profile = params.cfg?.auth?.profiles?.[params.profileId];
   if (!profile?.provider) {
     return undefined;
@@ -183,8 +199,8 @@ function resolveProfileRuntimeAlias(params: {
   if (!provider || !profileProvider) {
     return undefined;
   }
-  const providerAuthKey = resolveProviderIdForAuth(provider, { config: params.cfg });
-  const profileAuthKey = resolveProviderIdForAuth(profileProvider, { config: params.cfg });
+  const providerAuthKey = resolveRuntimeAuthProvider(provider, params);
+  const profileAuthKey = resolveRuntimeAuthProvider(profileProvider, params);
   if (providerAuthKey !== profileAuthKey) {
     return undefined;
   }
@@ -198,24 +214,25 @@ function resolveProfileRuntimeAlias(params: {
   })?.runtime;
 }
 
-function resolveCliRuntimeFromAuthProfile(params: {
-  cfg?: OpenClawConfig;
-  provider: string;
-  authProfileId?: string;
-}): string | undefined {
+function resolveCliRuntimeFromAuthProfile(
+  params: RuntimeAuthAliasParams & {
+    provider: string;
+    authProfileId?: string;
+  },
+): string | undefined {
   if (!params.cfg?.auth?.profiles) {
     return undefined;
   }
   if (params.authProfileId?.trim()) {
     return resolveProfileRuntimeAlias({
-      cfg: params.cfg,
+      ...params,
       provider: params.provider,
       profileId: params.authProfileId.trim(),
     });
   }
 
   const provider = normalizeProviderId(params.provider);
-  const providerAuthKey = resolveProviderIdForAuth(provider, { config: params.cfg });
+  const providerAuthKey = resolveRuntimeAuthProvider(provider, params);
   const orderedProfileIds = [
     ...(params.cfg.auth.order?.[providerAuthKey] ?? []),
     ...(providerAuthKey === provider ? [] : (params.cfg.auth.order?.[provider] ?? [])),
@@ -225,11 +242,15 @@ function resolveCliRuntimeFromAuthProfile(params: {
     if (!profile?.provider) {
       continue;
     }
-    const profileAuthKey = resolveProviderIdForAuth(profile.provider, { config: params.cfg });
+    const profileAuthKey = resolveRuntimeAuthProvider(profile.provider, params);
     if (profileAuthKey !== providerAuthKey) {
       continue;
     }
-    return resolveProfileRuntimeAlias({ cfg: params.cfg, provider, profileId });
+    return resolveProfileRuntimeAlias({
+      ...params,
+      provider,
+      profileId,
+    });
   }
 
   const compatibleProfileIds = Object.entries(params.cfg.auth.profiles)
@@ -237,7 +258,7 @@ function resolveCliRuntimeFromAuthProfile(params: {
       if (!profile?.provider) {
         return false;
       }
-      return resolveProviderIdForAuth(profile.provider, { config: params.cfg }) === providerAuthKey;
+      return resolveRuntimeAuthProvider(profile.provider, params) === providerAuthKey;
     })
     .map(([profileId]) => profileId);
   if (compatibleProfileIds.length !== 1) {
@@ -245,17 +266,22 @@ function resolveCliRuntimeFromAuthProfile(params: {
   }
   const [profileId] = compatibleProfileIds;
   return profileId
-    ? resolveProfileRuntimeAlias({ cfg: params.cfg, provider, profileId })
+    ? resolveProfileRuntimeAlias({
+        ...params,
+        provider,
+        profileId,
+      })
     : undefined;
 }
 
-export function resolveCliRuntimeExecutionProvider(params: {
-  provider: string;
-  cfg?: OpenClawConfig;
-  agentId?: string;
-  modelId?: string;
-  authProfileId?: string;
-}): string | undefined {
+export function resolveCliRuntimeExecutionProvider(
+  params: RuntimeAuthAliasParams & {
+    provider: string;
+    agentId?: string;
+    modelId?: string;
+    authProfileId?: string;
+  },
+): string | undefined {
   const provider = normalizeProviderId(params.provider);
   const { runtime, matchedProvider } = resolveConfiguredRuntime({ ...params, provider });
   if (runtime === "openclaw") {

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -44,6 +44,7 @@ import {
   buildModelAliasIndex,
   resolveDefaultModelForAgent,
   resolveModelRefFromString,
+  type ModelManifestNormalizationContext,
 } from "./model-selection.js";
 import { resolveOpenAIModelRoutes, selectOpenAIModelRouteAuth } from "./openai-model-routes.js";
 import { OPENAI_PROVIDER_ID, isOpenAIProvider } from "./openai-routing.js";
@@ -117,10 +118,12 @@ export function resolveSimpleCompletionSelectionForAgent(params: {
   agentDir?: string;
   modelRef?: string;
   useUtilityModel?: boolean;
+  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
 }): AgentSimpleCompletionSelection | null {
   const fallbackRef = resolveDefaultModelForAgent({
     cfg: params.cfg,
     agentId: params.agentId,
+    manifestPlugins: params.manifestPlugins,
   });
   // Utility routing derives a provider-declared small model when unset and
   // treats an explicit empty utilityModel as "use the primary" (disabled).
@@ -138,12 +141,14 @@ export function resolveSimpleCompletionSelectionForAgent(params: {
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg,
     defaultProvider: fallbackRef.provider || DEFAULT_PROVIDER,
+    manifestPlugins: params.manifestPlugins,
   });
   const resolved = split
     ? resolveModelRefFromString({
         raw: split.model,
         defaultProvider: fallbackRef.provider || DEFAULT_PROVIDER,
         aliasIndex,
+        manifestPlugins: params.manifestPlugins,
       })
     : null;
   const provider = resolved?.ref.provider ?? fallbackRef.provider;

--- a/src/system-agent/inference-route.ts
+++ b/src/system-agent/inference-route.ts
@@ -12,6 +12,7 @@ import {
   resolveCliExecutionAuthProfileId,
 } from "../agents/cli-execution-auth.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 
 export type SystemAgentConfiguredRoute = {
@@ -46,7 +47,12 @@ export function resolveSystemAgentTargetAgentId(
 export type SystemAgentConfiguredRouteDeps = {
   readConfigFileSnapshot?: typeof import("../config/config.js").readConfigFileSnapshot;
   loadAuthProfileStoreForRuntime?: typeof import("../agents/auth-profiles/store.js").loadAuthProfileStoreForRuntime;
+  pluginMetadataPlugins?: PluginMetadataSnapshot["plugins"];
 };
+type SystemAgentRouteProjectionDeps = Pick<
+  SystemAgentConfiguredRouteDeps,
+  "loadAuthProfileStoreForRuntime" | "pluginMetadataPlugins"
+>;
 
 type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
 
@@ -114,7 +120,7 @@ function projectSystemAgentExecutionConfig(
 export async function resolveSystemAgentConfiguredRouteFromConfig(
   runConfig: OpenClawConfig,
   requestedAgentId?: string,
-  deps: Pick<SystemAgentConfiguredRouteDeps, "loadAuthProfileStoreForRuntime"> = {},
+  deps: SystemAgentRouteProjectionDeps = {},
 ): Promise<SystemAgentConfiguredRoute | null> {
   const [agentScope, modelSelection, modelRuntimeAliases, simpleCompletion, harnessPolicy] =
     await Promise.all([
@@ -131,16 +137,21 @@ export async function resolveSystemAgentConfiguredRouteFromConfig(
   const selection = simpleCompletion.resolveSimpleCompletionSelectionForAgent({
     cfg: runConfig,
     agentId: modelOwnerAgentId,
+    manifestPlugins: deps.pluginMetadataPlugins,
   });
   if (!selection) {
     return null;
   }
+  const metadataSnapshot = deps.pluginMetadataPlugins
+    ? { plugins: deps.pluginMetadataPlugins }
+    : undefined;
   const cliExecutionProvider = modelRuntimeAliases.resolveCliRuntimeExecutionProvider({
     provider: selection.provider,
     cfg: runConfig,
     agentId: modelOwnerAgentId,
     modelId: selection.modelId,
     ...(selection.profileId ? { authProfileId: selection.profileId } : {}),
+    ...(metadataSnapshot ? { metadataSnapshot } : {}),
   });
   const executionProvider = cliExecutionProvider ?? selection.runtimeProvider ?? selection.provider;
   const isCliRoute = modelSelection.isCliProvider(executionProvider, runConfig);
@@ -220,15 +231,16 @@ function projectRelevantModelMap(params: {
 /** Project every config input that can change the configured default-agent route. */
 export async function projectDefaultInferenceRoute(
   config: OpenClawConfig,
+  deps: SystemAgentRouteProjectionDeps = {},
 ): Promise<DefaultInferenceRouteProjection> {
-  return await projectInferenceRoute(config);
+  return await projectInferenceRoute(config, undefined, deps);
 }
 
 /** Project every config input that can change one configured agent route. */
 export async function projectInferenceRoute(
   config: OpenClawConfig,
   requestedAgentId?: string,
-  deps: Pick<SystemAgentConfiguredRouteDeps, "loadAuthProfileStoreForRuntime"> = {},
+  deps: SystemAgentRouteProjectionDeps = {},
 ): Promise<DefaultInferenceRouteProjection> {
   const { resolveProviderIdForAuth } = await import("../agents/provider-auth-aliases.js");
   const routeAgentId = resolveSystemAgentTargetAgentId(config, requestedAgentId);
@@ -243,17 +255,24 @@ export async function projectInferenceRoute(
   const providerIds = new Set(
     [logicalProvider, normalizeProviderId(route?.provider ?? "")].filter(Boolean),
   );
+  const metadataSnapshot = deps.pluginMetadataPlugins
+    ? { plugins: deps.pluginMetadataPlugins }
+    : undefined;
+  const authAliasParams = {
+    config,
+    ...(metadataSnapshot ? { metadataSnapshot } : {}),
+  };
   const authProviderIds = new Set(
-    [...providerIds].map((provider) => resolveProviderIdForAuth(provider, { config })),
+    [...providerIds].map((provider) => resolveProviderIdForAuth(provider, authAliasParams)),
   );
   const authProfiles = Object.fromEntries(
     Object.entries(config.auth?.profiles ?? {}).filter(([, profile]) =>
-      authProviderIds.has(resolveProviderIdForAuth(profile.provider, { config })),
+      authProviderIds.has(resolveProviderIdForAuth(profile.provider, authAliasParams)),
     ),
   );
   const authOrder = Object.fromEntries(
     Object.entries(config.auth?.order ?? {}).filter(([provider]) =>
-      authProviderIds.has(resolveProviderIdForAuth(provider, { config })),
+      authProviderIds.has(resolveProviderIdForAuth(provider, authAliasParams)),
     ),
   );
   const modelProviders = Object.fromEntries(

--- a/src/system-agent/setup-inference-activate-persist.ts
+++ b/src/system-agent/setup-inference-activate-persist.ts
@@ -11,7 +11,10 @@ import {
   resolveSystemAgentConfiguredRouteFromConfig,
   sameDefaultInferenceRoute,
 } from "./inference-route.js";
-import type { SystemAgentConfiguredRoute } from "./inference-route.js";
+import type {
+  SystemAgentConfiguredRoute,
+  SystemAgentConfiguredRouteDeps,
+} from "./inference-route.js";
 import { createSystemAgentModelSelectionUpdater } from "./setup-apply.js";
 import {
   SetupInferenceActivationIndeterminateError,
@@ -63,6 +66,7 @@ export async function persistActivatedSetupInference(input: {
   stagedOwnerPluginArtifacts: SystemAgentOwnerPluginArtifactSnapshot;
   baselineTargetModelMetadata: unknown;
   sourceTargetModelMetadata: unknown;
+  routeDeps: Pick<SystemAgentConfiguredRouteDeps, "pluginMetadataPlugins">;
   readSnapshot: NonNullable<ActivateSetupInferenceDeps["readConfigFileSnapshot"]>;
   hasPreparedAuthProfiles: boolean;
   state: SetupInferenceActivationPersistenceState;
@@ -89,6 +93,7 @@ export async function persistActivatedSetupInference(input: {
     stagedOwnerPluginArtifacts,
     baselineTargetModelMetadata,
     sourceTargetModelMetadata,
+    routeDeps,
     readSnapshot,
     hasPreparedAuthProfiles,
     state,
@@ -96,6 +101,9 @@ export async function persistActivatedSetupInference(input: {
   } = input;
   let committedConfig: OpenClawConfig | undefined;
   let { codexInstallOwnership } = state;
+  const projectRoute = (config: OpenClawConfig) => projectDefaultInferenceRoute(config, routeDeps);
+  const resolveRoute = (config: OpenClawConfig) =>
+    resolveSystemAgentConfiguredRouteFromConfig(config, undefined, routeDeps);
 
   const { stripPendingPluginInstallRecords } = await import("../plugins/install-record-commit.js");
   const agentRuntimeId = resolveSetupAgentRuntimeId(params.kind);
@@ -154,16 +162,12 @@ export async function persistActivatedSetupInference(input: {
   // so post-write reconciliation must compare against the stripped route
   // and verify the exact index record separately below.
   const persistedRoute = pendingCodexInstall
-    ? await projectDefaultInferenceRoute(
-        stripPendingPluginInstallRecords(stageCandidate(cfg, "runtime")),
-      )
+    ? await projectRoute(stripPendingPluginInstallRecords(stageCandidate(cfg, "runtime")))
     : verifiedRoute;
   // Runtime config may materialize provider defaults that are intentionally
   // absent from authored config. Compare source writes against the candidate
   // produced from the original source shape, without ignoring concurrent rows.
-  const expectedSourceCandidateRoute = await projectDefaultInferenceRoute(
-    stageCandidate(sourceCfg, "source"),
-  );
+  const expectedSourceCandidateRoute = await projectRoute(stageCandidate(sourceCfg, "source"));
   // Resolve every fallible config-commit dependency before writing a
   // credential into the real agent store. From this point onward, any
   // failure is inside the rollback boundary below.
@@ -174,8 +178,8 @@ export async function persistActivatedSetupInference(input: {
   if (hasPreparedAuthProfiles && plan.manualAuth) {
     throwIfSetupInferenceCancelled(params);
     const initialCandidate = stageCandidate(cfg, "runtime");
-    const initialRoute = await projectDefaultInferenceRoute(initialCandidate);
-    const resolvedRoute = await resolveSystemAgentConfiguredRouteFromConfig(initialCandidate);
+    const initialRoute = await projectRoute(initialCandidate);
+    const resolvedRoute = await resolveRoute(initialCandidate);
     if (
       !sameDefaultInferenceRoute(initialRoute, verifiedRoute) ||
       !resolvedRoute ||
@@ -229,7 +233,7 @@ export async function persistActivatedSetupInference(input: {
         // Validate that the candidate is still admissible before reporting
         // broader route drift, so policy revocations retain their actionable error.
         const stagedRuntime = stageCandidate(latestRuntime, "runtime");
-        const latestBaseline = await projectDefaultInferenceRoute(latestRuntime);
+        const latestBaseline = await projectRoute(latestRuntime);
         if (!sameDefaultInferenceRoute(latestBaseline, baselineRoute)) {
           throw new Error(
             "The default-agent inference route changed during its live test, so the verified candidate was not saved. Review the current model/auth/runtime settings and retry.",
@@ -245,13 +249,13 @@ export async function persistActivatedSetupInference(input: {
             "The target model metadata changed during its live inference test, so the verified candidate was not saved. Review the current model settings and retry.",
           );
         }
-        const currentRoute = await projectDefaultInferenceRoute(stagedRuntime);
+        const currentRoute = await projectRoute(stagedRuntime);
         if (!sameDefaultInferenceRoute(currentRoute, verifiedRoute)) {
           throw new Error(
             "The default-agent inference route changed during its live test, so the verified candidate was not saved. Review the current model/auth/runtime settings and retry.",
           );
         }
-        const resolvedRoute = await resolveSystemAgentConfiguredRouteFromConfig(stagedRuntime);
+        const resolvedRoute = await resolveRoute(stagedRuntime);
         if (
           !resolvedRoute ||
           resolvedRoute.modelLabel !== plan.modelRef ||
@@ -277,8 +281,8 @@ export async function persistActivatedSetupInference(input: {
           modelRef: plan.modelRef,
         });
         const nextConfig = stageCandidate(current, "source");
-        const nextRouteProjection = await projectDefaultInferenceRoute(nextConfig);
-        const nextResolvedRoute = await resolveSystemAgentConfiguredRouteFromConfig(nextConfig);
+        const nextRouteProjection = await projectRoute(nextConfig);
+        const nextResolvedRoute = await resolveRoute(nextConfig);
         if (
           !sameDefaultInferenceRoute(nextRouteProjection, expectedSourceCandidateRoute) ||
           !nextResolvedRoute ||
@@ -325,9 +329,7 @@ export async function persistActivatedSetupInference(input: {
       reconciledSnapshot?.exists && reconciledSnapshot.valid
         ? (reconciledSnapshot.runtimeConfig ?? reconciledSnapshot.config)
         : undefined;
-    const reconciledRoute = reconciledRuntime
-      ? await projectDefaultInferenceRoute(reconciledRuntime)
-      : undefined;
+    const reconciledRoute = reconciledRuntime ? await projectRoute(reconciledRuntime) : undefined;
     const codexInstallPersisted = pendingCodexInstall
       ? await isCodexInstallRecordPersisted(pendingCodexInstall, deps)
       : true;

--- a/src/system-agent/setup-inference-activate.ts
+++ b/src/system-agent/setup-inference-activate.ts
@@ -14,6 +14,8 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { normalizePluginTargetConfig } from "../plugins/config-state.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { getActivePluginRegistryWorkspaceDirFromState } from "../plugins/runtime-state.js";
 import { resolveUserPath } from "../utils.js";
 import { appendSystemAgentAuditEntry } from "./audit.js";
 import {
@@ -307,10 +309,26 @@ async function activateSetupInferenceUnredacted(
         };
       }
     }
-    const baselineRoute = await projectDefaultInferenceRoute(cfg);
-    const verifiedRoute = await projectDefaultInferenceRoute(testPlan.config);
+    const metadataWorkspaceDir = getActivePluginRegistryWorkspaceDirFromState();
+    // Manifest inventory is process-stable for one activation attempt. A plugin
+    // install is the lifecycle boundary: bypass the old process snapshot after refresh.
+    const resolveRouteMetadata =
+      deps.resolvePluginMetadataSnapshot ?? resolvePluginMetadataSnapshot;
+    const routeMetadataSnapshot = resolveRouteMetadata({
+      config: testPlan.config,
+      env: process.env,
+      ...(metadataWorkspaceDir ? { workspaceDir: metadataWorkspaceDir } : {}),
+      ...(codexRegistryNeedsReload ? { allowCurrent: false } : {}),
+    });
+    const routeDeps = { pluginMetadataPlugins: routeMetadataSnapshot.plugins };
+    const baselineRoute = await projectDefaultInferenceRoute(cfg, routeDeps);
+    const verifiedRoute = await projectDefaultInferenceRoute(testPlan.config, routeDeps);
     const stagedRoute = verifiedRoute.route;
-    const stagedExecutionRoute = await resolveSystemAgentConfiguredRouteFromConfig(testPlan.config);
+    const stagedExecutionRoute = await resolveSystemAgentConfiguredRouteFromConfig(
+      testPlan.config,
+      undefined,
+      routeDeps,
+    );
     if (
       !stagedRoute ||
       !stagedExecutionRoute ||
@@ -492,7 +510,7 @@ async function activateSetupInferenceUnredacted(
           ? (latestSnapshot.runtimeConfig ?? latestSnapshot.config)
           : undefined;
       const latestRoute = latestRuntime
-        ? await projectDefaultInferenceRoute(latestRuntime)
+        ? await projectDefaultInferenceRoute(latestRuntime, routeDeps)
         : undefined;
       if (!latestRoute || !sameDefaultInferenceRoute(latestRoute, verifiedRoute)) {
         return {
@@ -503,7 +521,7 @@ async function activateSetupInferenceUnredacted(
         };
       }
       const latestResolvedRoute = latestRuntime
-        ? await resolveSystemAgentConfiguredRouteFromConfig(latestRuntime)
+        ? await resolveSystemAgentConfiguredRouteFromConfig(latestRuntime, undefined, routeDeps)
         : null;
       if (!latestResolvedRoute) {
         return {
@@ -542,6 +560,7 @@ async function activateSetupInferenceUnredacted(
         stagedOwnerPluginArtifacts,
         baselineTargetModelMetadata,
         sourceTargetModelMetadata,
+        routeDeps,
         readSnapshot,
         hasPreparedAuthProfiles,
         state: persistenceState,

--- a/src/system-agent/setup-inference-core.ts
+++ b/src/system-agent/setup-inference-core.ts
@@ -260,6 +260,7 @@ export type ActivateSetupInferenceDeps = {
   resolveCliRuntimeArtifactFingerprint?: typeof import("../agents/cli-auth-epoch.js").resolveCliRuntimeArtifactFingerprint;
   resolveCliRuntimeOwnerFingerprint?: typeof import("../agents/cli-auth-epoch.js").resolveCliRuntimeOwnerFingerprint;
   resolveApiKeyForProvider?: typeof import("../agents/model-auth.js").resolveApiKeyForProvider;
+  resolvePluginMetadataSnapshot?: typeof import("../plugins/plugin-metadata-snapshot.js").resolvePluginMetadataSnapshot;
   readCodexCliActiveApiKey?: typeof readCodexCliActiveApiKey;
   loadPluginRegistrySnapshot?: SystemAgentVerifiedInferenceDeps["loadPluginRegistrySnapshot"];
   fingerprintPluginRuntimeArtifact?: SystemAgentVerifiedInferenceDeps["fingerprintPluginRuntimeArtifact"];

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -21,6 +21,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { withoutPluginInstallRecords } from "../plugins/installed-plugin-index-records.js";
 import { hasRetainedManagedNpmInstallMarker } from "../plugins/managed-npm-retention.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderAuthChoiceMetadata } from "../plugins/provider-auth-choices.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
@@ -1390,10 +1391,12 @@ describe("activateSetupInference", () => {
     } satisfies OpenClawConfig;
     const configHarness = createConfigTransformHarness(initialConfig);
     const runCliAgent = vi.fn(successfulRunner("claude-cli", "claude-opus-5"));
+    const resolveRouteMetadata = vi.fn(resolvePluginMetadataSnapshot);
     const result = await activateSetupInference({
       kind: "claude-cli",
       deps: {
         readConfigFileSnapshot: mockConfigSnapshot(initialConfig),
+        resolvePluginMetadataSnapshot: resolveRouteMetadata,
         runCliAgent: runCliAgent as never,
         transformConfigWithPendingPluginInstalls: configHarness.transform as never,
       },
@@ -1424,6 +1427,7 @@ describe("activateSetupInference", () => {
       tools: { allow: ["exec"] },
     });
     expect(configHarness.transform).toHaveBeenCalledOnce();
+    expect(resolveRouteMetadata).toHaveBeenCalledOnce();
   });
 
   it("rejects an unattested successful candidate before persisting its model", async () => {
@@ -3863,6 +3867,12 @@ describe("activateSetupInference", () => {
     const ensureRegistryLoaded = vi.fn(() => {
       events.push("reload-active-registry");
     });
+    const resolveRouteMetadata = vi.fn(
+      (...args: Parameters<typeof resolvePluginMetadataSnapshot>) => {
+        events.push("resolve-route-metadata");
+        return resolvePluginMetadataSnapshot(...args);
+      },
+    );
     const result = await activateCodexSetup({
       workspace: "/tmp/openclaw-workspace",
       runtime: { log: runtimeLog, error: () => {}, exit: () => {} } as never,
@@ -3879,6 +3889,7 @@ describe("activateSetupInference", () => {
             runtimeConfig: config,
           };
         }) as never,
+        resolvePluginMetadataSnapshot: resolveRouteMetadata,
         runEmbeddedAgent: runEmbeddedAgent as never,
         ensureCodexRuntimePlugin: ensureCodex as never,
         markRetainedManagedNpmInstall: markRetainedInstall,
@@ -3938,10 +3949,15 @@ describe("activateSetupInference", () => {
       }),
     );
     expect(refreshPluginRegistry).toHaveBeenCalledTimes(2);
+    expect(resolveRouteMetadata).toHaveBeenCalledOnce();
+    expect(resolveRouteMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({ allowCurrent: false }),
+    );
     expect(events).toEqual([
       "install-plugin",
       "retain-plugin-install",
       "refresh-plugin-registry",
+      "resolve-route-metadata",
       "live-test",
       "persist-plugin-config",
       "refresh-plugin-registry",


### PR DESCRIPTION
## What Problem This Solves

Verified inference setup repeatedly rediscovered process-stable plugin metadata while projecting the baseline, staged, persisted, retried, and reconciled routes for one activation. The 122-case setup suite exposed the same cost operators pay during real model setup.

## Why This Change Was Made

Prepare one compatibility-checked plugin manifest list after the setup plan and any Codex install/registry refresh, then carry only that immutable list through route selection and persistence retries. Config and workspace trust are still recalculated for every live config, and a plugin refresh explicitly bypasses the prior generation. No broad cache, sharding, config, dependency, or storage surface is added.

## User Impact

Verified model setup and recovery checks complete faster, especially for staged provider/plugin configurations, while preserving route-drift, auth-alias, workspace, and post-install safety checks.

## Evidence

- Same-SHA alternating benchmark, 122/122 before and after:
  - wall: 75.67s -> 47.40s (37.4% faster)
  - Vitest: 70.27s -> 42.13s (40.0% faster)
  - max RSS: 1.45GB -> 1.07GB (26.3% lower)
- Sibling matrix: 270/270 across setup, apply, verified inference, simple completion, runtime/auth aliases, and plugin metadata snapshots.
- New regressions prove one metadata preparation per activation and a fresh `allowCurrent: false` generation after Codex registry refresh.
- Direct Codex contract check at `openai/codex` `origin/main` `bb5054fe47ab`: the app server requires an initialized client to consume `turn/*` notifications, every started turn ends with a matching `turn/completed`, and transport closure remains terminal. Checked `codex-rs/app-server/README.md:1444,1495`, `app-server/src/bespoke_event_handling.rs:1271`, `app-server/tests/common/test_app_server.rs:1005`, `app-server/src/lib.rs:1003`, and `app-server-client/src/remote.rs:414`. The "Codex registry refresh" in this PR is OpenClaw's plugin-manifest lifecycle; the upstream app-server probe and its protocol are unchanged.
- Post-rebase proof on the current-main base reran the full 270-test sibling matrix successfully, followed by a clean branch autoreview.
- Formatting, targeted lint, `git diff --check`, focused type diagnostics, independent owner-boundary review, and final autoreview are clean.
- Production delta: +125/-53 (net +72), establishing one operation-scoped prepared-fact boundary that replaces repeated discovery across all setup route projections.
