### PR TITLE
fix: Control UI avatars load with Tailscale identity auth

### DIFF
--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -114,7 +114,7 @@ This tokenless flow assumes the gateway host is trusted. If untrusted local code
 
 Scope of the bypass:
 
-- Applies only to the Control UI WebSocket auth surface. HTTP API endpoints (`/v1/*`, `/tools/invoke`, `/api/channels/*`, etc.) never use Tailscale identity-header auth; they always follow the gateway's normal HTTP auth mode.
+- Applies to the Control UI WebSocket auth surface and read-only `GET`/`HEAD` requests for Control UI profile avatars. Other HTTP API endpoints (`/v1/*`, `/tools/invoke`, `/api/channels/*`, etc.) never use Tailscale identity-header auth; they always follow the gateway's normal HTTP auth mode.
 - For Control UI operator sessions that already carry browser device identity, a verified Tailscale identity skips the bootstrap-token/QR pairing round trip.
 - It does not bypass device identity itself: device-less clients are still rejected, and node-role connections still go through normal pairing and auth checks.
 

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -57,12 +57,25 @@ function createTailscaleForwardedReq(): TailscaleForwardedRequest {
       "x-forwarded-host": "ai-hub.bone-egret.ts.net",
       "tailscale-user-login": "peter",
       "tailscale-user-name": "Peter",
+      "sec-fetch-site": "same-origin",
     },
   } as unknown as TailscaleForwardedRequest;
 }
 
 function createTailscaleWhois() {
   return async () => ({ login: "peter", name: "Peter" });
+}
+
+function createAvatarBrowserOriginPolicy(
+  req: TailscaleForwardedRequest,
+  allowedOrigins: string[] = [],
+) {
+  return {
+    requestHost: req.headers.host,
+    origin: req.headers.origin,
+    fetchSite: req.headers["sec-fetch-site"],
+    allowedOrigins,
+  };
 }
 
 describe("gateway auth", () => {
@@ -94,11 +107,13 @@ describe("gateway auth", () => {
       | typeof authorizeWsControlUiGatewayConnect;
     expected: { ok: false; reason: string } | { ok: true; method: string; user: string };
   }) {
+    const req = createTailscaleForwardedReq();
     const res = await params.authorize({
       auth: { mode: "token", token: "secret", allowTailscale: true },
       connectAuth: null,
       tailscaleWhois: createTailscaleWhois(),
-      req: createTailscaleForwardedReq(),
+      req,
+      browserOriginPolicy: createAvatarBrowserOriginPolicy(req),
     });
     expect(res.ok).toBe(params.expected.ok);
     if (!params.expected.ok) {
@@ -487,20 +502,82 @@ describe("gateway auth", () => {
     expect(res.user).toBe("peter");
   });
 
-  it("allows verified tailscale identity on the profile avatar HTTP surface", async () => {
+  it("allows an origin-less same-origin image through the profile avatar surface", async () => {
     const limiter = createLimiterSpy();
+    const req = createTailscaleForwardedReq();
     const res = await authorizeUserProfileAvatarHttpGatewayConnect({
       auth: { mode: "token", token: "secret", allowTailscale: true },
       connectAuth: null,
       tailscaleWhois: createTailscaleWhois(),
-      req: createTailscaleForwardedReq(),
+      req,
       rateLimiter: limiter,
+      browserOriginPolicy: createAvatarBrowserOriginPolicy(req),
     });
 
     expect(res).toMatchObject({ ok: true, method: "tailscale", user: "peter" });
     expect(limiter.check).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
     expect(limiter.reset).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
   });
+
+  it("rejects a cross-origin page before verifying Tailscale avatar identity", async () => {
+    const req = createTailscaleForwardedReq();
+    req.headers.origin = "https://evil.example";
+    req.headers["sec-fetch-site"] = "cross-site";
+    const tailscaleWhois = vi.fn(createTailscaleWhois());
+
+    const res = await authorizeUserProfileAvatarHttpGatewayConnect({
+      auth: { mode: "token", token: "secret", allowTailscale: true },
+      connectAuth: null,
+      tailscaleWhois,
+      req,
+      browserOriginPolicy: createAvatarBrowserOriginPolicy(req, ["https://control.example.com"]),
+    });
+
+    expect(res).toMatchObject({ ok: false, reason: "origin_not_allowed" });
+    expect(tailscaleWhois).not.toHaveBeenCalled();
+  });
+
+  it("allows an approved Control UI origin before verifying Tailscale avatar identity", async () => {
+    const req = createTailscaleForwardedReq();
+    req.headers.origin = "https://control.example.com";
+    req.headers["sec-fetch-site"] = "cross-site";
+    const tailscaleWhois = vi.fn(createTailscaleWhois());
+
+    const res = await authorizeUserProfileAvatarHttpGatewayConnect({
+      auth: { mode: "token", token: "secret", allowTailscale: true },
+      connectAuth: null,
+      tailscaleWhois,
+      req,
+      browserOriginPolicy: createAvatarBrowserOriginPolicy(req, ["https://control.example.com"]),
+    });
+
+    expect(res).toMatchObject({ ok: true, method: "tailscale", user: "peter" });
+    expect(tailscaleWhois).toHaveBeenCalledOnce();
+  });
+
+  it.each(["cross-site", "same-site", "none", undefined])(
+    "rejects an origin-less avatar request with fetch-site %s",
+    async (fetchSite) => {
+      const req = createTailscaleForwardedReq();
+      if (fetchSite === undefined) {
+        delete req.headers["sec-fetch-site"];
+      } else {
+        req.headers["sec-fetch-site"] = fetchSite;
+      }
+      const tailscaleWhois = vi.fn(createTailscaleWhois());
+
+      const res = await authorizeUserProfileAvatarHttpGatewayConnect({
+        auth: { mode: "token", token: "secret", allowTailscale: true },
+        connectAuth: null,
+        tailscaleWhois,
+        req,
+        browserOriginPolicy: createAvatarBrowserOriginPolicy(req),
+      });
+
+      expect(res).toMatchObject({ ok: false, reason: "origin_not_allowed" });
+      expect(tailscaleWhois).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     {
@@ -538,6 +615,7 @@ describe("gateway auth", () => {
       connectAuth: null,
       tailscaleWhois: whois,
       req,
+      browserOriginPolicy: createAvatarBrowserOriginPolicy(req),
     });
 
     expect(res).toMatchObject({ ok: false, reason: "token_missing" });
@@ -555,7 +633,14 @@ describe("gateway auth", () => {
       method: "password",
     },
   ])("keeps $method auth on the profile avatar HTTP surface", async (testCase) => {
-    const res = await authorizeUserProfileAvatarHttpGatewayConnect(testCase);
+    const req = createTailscaleForwardedReq();
+    req.headers.origin = "https://evil.example";
+    req.headers["sec-fetch-site"] = "cross-site";
+    const res = await authorizeUserProfileAvatarHttpGatewayConnect({
+      ...testCase,
+      req,
+      browserOriginPolicy: createAvatarBrowserOriginPolicy(req),
+    });
 
     expect(res).toMatchObject({ ok: true, method: testCase.method });
   });

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from "node:http";
 // Gateway auth tests cover shared-secret, Tailscale, loopback, forwarded-header,
 // control-UI, and HTTP/WebSocket authorization decisions.
 import os from "node:os";
@@ -7,6 +8,7 @@ import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.j
 import {
   assertGatewayAuthConfigured,
   authorizeHttpGatewayConnect,
+  authorizeUserProfileAvatarHttpGatewayConnect,
   hasForwardedRequestHeaders,
   isLocalDirectRequest,
   resolveEffectiveSharedGatewayAuth,
@@ -40,7 +42,12 @@ function createLimiterSpy(): AuthRateLimiter & {
   };
 }
 
-function createTailscaleForwardedReq(): never {
+type TailscaleForwardedRequest = IncomingMessage & {
+  socket: IncomingMessage["socket"] & { remoteAddress?: string };
+  headers: IncomingMessage["headers"] & Record<string, string | undefined>;
+};
+
+function createTailscaleForwardedReq(): TailscaleForwardedRequest {
   return {
     socket: { remoteAddress: "127.0.0.1" },
     headers: {
@@ -51,7 +58,7 @@ function createTailscaleForwardedReq(): never {
       "tailscale-user-login": "peter",
       "tailscale-user-name": "Peter",
     },
-  } as never;
+  } as unknown as TailscaleForwardedRequest;
 }
 
 function createTailscaleWhois() {
@@ -81,7 +88,10 @@ describe("gateway auth", () => {
   }
 
   async function expectTailscaleHeaderAuthResult(params: {
-    authorize: typeof authorizeHttpGatewayConnect | typeof authorizeWsControlUiGatewayConnect;
+    authorize:
+      | typeof authorizeHttpGatewayConnect
+      | typeof authorizeUserProfileAvatarHttpGatewayConnect
+      | typeof authorizeWsControlUiGatewayConnect;
     expected: { ok: false; reason: string } | { ok: true; method: string; user: string };
   }) {
     const res = await params.authorize({
@@ -477,6 +487,79 @@ describe("gateway auth", () => {
     expect(res.user).toBe("peter");
   });
 
+  it("allows verified tailscale identity on the profile avatar HTTP surface", async () => {
+    const limiter = createLimiterSpy();
+    const res = await authorizeUserProfileAvatarHttpGatewayConnect({
+      auth: { mode: "token", token: "secret", allowTailscale: true },
+      connectAuth: null,
+      tailscaleWhois: createTailscaleWhois(),
+      req: createTailscaleForwardedReq(),
+      rateLimiter: limiter,
+    });
+
+    expect(res).toMatchObject({ ok: true, method: "tailscale", user: "peter" });
+    expect(limiter.check).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
+    expect(limiter.reset).toHaveBeenCalledWith("127.0.0.1", "shared-secret");
+  });
+
+  it.each([
+    {
+      name: "missing identity",
+      mutate: (req: ReturnType<typeof createTailscaleForwardedReq>) => {
+        delete req.headers["tailscale-user-login"];
+      },
+      whois: createTailscaleWhois(),
+    },
+    {
+      name: "mismatched identity",
+      mutate: () => {},
+      whois: async () => ({ login: "mallory", name: "Mallory" }),
+    },
+    {
+      name: "non-loopback source",
+      mutate: (req: ReturnType<typeof createTailscaleForwardedReq>) => {
+        req.socket.remoteAddress = "192.0.2.10";
+      },
+      whois: createTailscaleWhois(),
+    },
+    {
+      name: "incomplete forwarded headers",
+      mutate: (req: ReturnType<typeof createTailscaleForwardedReq>) => {
+        delete req.headers["x-forwarded-host"];
+      },
+      whois: createTailscaleWhois(),
+    },
+  ])("rejects $name on the profile avatar HTTP surface", async ({ mutate, whois }) => {
+    const req = createTailscaleForwardedReq();
+    mutate(req);
+
+    const res = await authorizeUserProfileAvatarHttpGatewayConnect({
+      auth: { mode: "token", token: "secret", allowTailscale: true },
+      connectAuth: null,
+      tailscaleWhois: whois,
+      req,
+    });
+
+    expect(res).toMatchObject({ ok: false, reason: "token_missing" });
+  });
+
+  it.each([
+    {
+      auth: { mode: "token" as const, token: "secret", allowTailscale: true },
+      connectAuth: { token: "secret" },
+      method: "token",
+    },
+    {
+      auth: { mode: "password" as const, password: "secret", allowTailscale: true },
+      connectAuth: { password: "secret" },
+      method: "password",
+    },
+  ])("keeps $method auth on the profile avatar HTTP surface", async (testCase) => {
+    const res = await authorizeUserProfileAvatarHttpGatewayConnect(testCase);
+
+    expect(res).toMatchObject({ ok: true, method: testCase.method });
+  });
+
   it("serializes async auth attempts per rate-limit key", async () => {
     const limiter = createAuthRateLimiter({
       maxAttempts: 1,
@@ -524,6 +607,13 @@ describe("gateway auth", () => {
     await expectTailscaleHeaderAuthResult({
       authorize: authorizeHttpGatewayConnect,
       expected: { ok: false, reason: "token_missing" },
+    });
+  });
+
+  it("enables tailscale header auth on the profile avatar HTTP wrapper", async () => {
+    await expectTailscaleHeaderAuthResult({
+      authorize: authorizeUserProfileAvatarHttpGatewayConnect,
+      expected: { ok: true, method: "tailscale", user: "peter" },
     });
   });
 

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -537,6 +537,24 @@ describe("gateway auth", () => {
     expect(tailscaleWhois).not.toHaveBeenCalled();
   });
 
+  it("rejects wildcard origin grants for ambient Tailscale avatar identity", async () => {
+    const req = createTailscaleForwardedReq();
+    req.headers.origin = "https://evil.example";
+    req.headers["sec-fetch-site"] = "cross-site";
+    const tailscaleWhois = vi.fn(createTailscaleWhois());
+
+    const res = await authorizeUserProfileAvatarHttpGatewayConnect({
+      auth: { mode: "token", token: "secret", allowTailscale: true },
+      connectAuth: null,
+      tailscaleWhois,
+      req,
+      browserOriginPolicy: createAvatarBrowserOriginPolicy(req, ["*"]),
+    });
+
+    expect(res).toMatchObject({ ok: false, reason: "origin_not_allowed" });
+    expect(tailscaleWhois).not.toHaveBeenCalled();
+  });
+
   it("allows an approved Control UI origin before verifying Tailscale avatar identity", async () => {
     const req = createTailscaleForwardedReq();
     req.headers.origin = "https://control.example.com";
@@ -639,7 +657,7 @@ describe("gateway auth", () => {
     const res = await authorizeUserProfileAvatarHttpGatewayConnect({
       ...testCase,
       req,
-      browserOriginPolicy: createAvatarBrowserOriginPolicy(req),
+      browserOriginPolicy: createAvatarBrowserOriginPolicy(req, ["*"]),
     });
 
     expect(res).toMatchObject({ ok: true, method: testCase.method });

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -58,7 +58,7 @@ type ConnectAuth = {
   password?: string;
 };
 
-type GatewayAuthSurface = "http" | "ws-control-ui";
+type GatewayAuthSurface = "http" | "http-user-profile-avatar" | "ws-control-ui";
 
 /** Inputs needed to authorize one HTTP or websocket gateway connection. */
 type AuthorizeGatewayConnectParams = {
@@ -324,7 +324,7 @@ function authorizeTrustedProxy(params: {
 }
 
 function shouldAllowTailscaleHeaderAuth(authSurface: GatewayAuthSurface): boolean {
-  return authSurface === "ws-control-ui";
+  return authSurface === "ws-control-ui" || authSurface === "http-user-profile-avatar";
 }
 
 function authorizeHttpBrowserOrigin(params: {
@@ -333,7 +333,7 @@ function authorizeHttpBrowserOrigin(params: {
   isLocalClient: boolean;
   reason: string;
 }): { ok: false; reason: string } | null {
-  if (params.authSurface !== "http") {
+  if (params.authSurface === "ws-control-ui") {
     return null;
   }
 
@@ -579,6 +579,16 @@ export async function authorizeHttpGatewayConnect(
   return authorizeGatewayConnect({
     ...params,
     authSurface: "http",
+  });
+}
+
+/** Authorize the read-only profile avatar route, including verified Tailscale identity. */
+export async function authorizeUserProfileAvatarHttpGatewayConnect(
+  params: Omit<AuthorizeGatewayConnectParams, "authSurface">,
+): Promise<GatewayAuthResult> {
+  return authorizeGatewayConnect({
+    ...params,
+    authSurface: "http-user-profile-avatar",
   });
 }
 

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -334,6 +334,7 @@ function authorizeHttpBrowserOrigin(params: {
   isLocalClient: boolean;
   reason: string;
   requireSameOriginFetchWithoutOrigin?: boolean;
+  allowWildcardOrigin?: boolean;
 }): { ok: false; reason: string } | null {
   if (params.authSurface === "ws-control-ui") {
     return null;
@@ -350,7 +351,12 @@ function authorizeHttpBrowserOrigin(params: {
   const originCheck = checkBrowserOrigin({
     requestHost: params.browserOriginPolicy?.requestHost,
     origin,
-    allowedOrigins: params.browserOriginPolicy?.allowedOrigins,
+    allowedOrigins:
+      params.allowWildcardOrigin === false
+        ? params.browserOriginPolicy?.allowedOrigins?.filter(
+            (candidate) => normalizeLowercaseStringOrEmpty(candidate) !== "*",
+          )
+        : params.browserOriginPolicy?.allowedOrigins,
     allowHostHeaderOriginFallback: params.browserOriginPolicy?.allowHostHeaderOriginFallback,
     isLocalClient: params.isLocalClient,
   });
@@ -541,13 +547,15 @@ async function authorizeGatewayConnectCore(
   ) {
     if (authSurface === "http-user-profile-avatar") {
       // Same-origin <img> loads may omit Origin, but Fetch Metadata still identifies
-      // their source. Ambient identity accepts that omission only for same-origin loads.
+      // their source. Ambient identity accepts that omission only for same-origin loads,
+      // and wildcard CORS never grants ambient identity.
       const originResult = authorizeHttpBrowserOrigin({
         authSurface,
         browserOriginPolicy: params.browserOriginPolicy,
         isLocalClient: localDirect,
         reason: "origin_not_allowed",
         requireSameOriginFetchWithoutOrigin: true,
+        allowWildcardOrigin: false,
       });
       if (originResult) {
         return originResult;

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -84,6 +84,7 @@ type AuthorizeGatewayConnectParams = {
   browserOriginPolicy?: {
     requestHost?: string;
     origin?: string;
+    fetchSite?: string;
     allowedOrigins?: string[];
     allowHostHeaderOriginFallback?: boolean;
   };
@@ -332,6 +333,7 @@ function authorizeHttpBrowserOrigin(params: {
   browserOriginPolicy?: AuthorizeGatewayConnectParams["browserOriginPolicy"];
   isLocalClient: boolean;
   reason: string;
+  requireSameOriginFetchWithoutOrigin?: boolean;
 }): { ok: false; reason: string } | null {
   if (params.authSurface === "ws-control-ui") {
     return null;
@@ -339,7 +341,10 @@ function authorizeHttpBrowserOrigin(params: {
 
   const origin = params.browserOriginPolicy?.origin?.trim();
   if (!origin) {
-    return null;
+    return params.requireSameOriginFetchWithoutOrigin &&
+      normalizeLowercaseStringOrEmpty(params.browserOriginPolicy?.fetchSite) !== "same-origin"
+      ? { ok: false, reason: params.reason }
+      : null;
   }
 
   const originCheck = checkBrowserOrigin({
@@ -534,6 +539,20 @@ async function authorizeGatewayConnectCore(
     !localDirect &&
     !hasExplicitSharedSecretAuth(connectAuth)
   ) {
+    if (authSurface === "http-user-profile-avatar") {
+      // Same-origin <img> loads may omit Origin, but Fetch Metadata still identifies
+      // their source. Ambient identity accepts that omission only for same-origin loads.
+      const originResult = authorizeHttpBrowserOrigin({
+        authSurface,
+        browserOriginPolicy: params.browserOriginPolicy,
+        isLocalClient: localDirect,
+        reason: "origin_not_allowed",
+        requireSameOriginFetchWithoutOrigin: true,
+      });
+      if (originResult) {
+        return originResult;
+      }
+    }
     const tailscaleCheck = await resolveVerifiedTailscaleUser({
       req,
       tailscaleWhois,

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import {
   authorizeHttpGatewayConnect,
+  authorizeUserProfileAvatarHttpGatewayConnect,
   type GatewayAuthResult,
   type ResolvedGatewayAuth,
 } from "./auth.js";
@@ -66,6 +67,23 @@ export type GatewayHttpRequestAuthCheckResult =
       authResult: GatewayAuthResult;
     };
 
+type GatewayHttpRequestAuthParams = {
+  req: IncomingMessage;
+  res: ServerResponse;
+  auth: ResolvedGatewayAuth;
+  trustedProxies?: string[];
+  allowRealIpFallback?: boolean;
+  rateLimiter?: AuthRateLimiter;
+};
+
+type GatewayHttpRequestAuthCheckParams = Omit<GatewayHttpRequestAuthParams, "res"> & {
+  cfg?: OpenClawConfig;
+};
+
+type GatewayHttpConnectAuthorizer = (
+  params: Parameters<typeof authorizeHttpGatewayConnect>[0],
+) => Promise<GatewayAuthResult>;
+
 export function resolveHttpBrowserOriginPolicy(
   req: IncomingMessage,
   cfg = getRuntimeConfig(),
@@ -102,7 +120,14 @@ export async function authorizeGatewayHttpRequestOrReply(params: {
   allowRealIpFallback?: boolean;
   rateLimiter?: AuthRateLimiter;
 }): Promise<AuthorizedGatewayHttpRequest | null> {
-  const result = await checkGatewayHttpRequestAuth(params);
+  return await authorizeGatewayHttpRequestWithOrReply(params, authorizeHttpGatewayConnect);
+}
+
+async function authorizeGatewayHttpRequestWithOrReply(
+  params: GatewayHttpRequestAuthParams,
+  authorizeConnect: GatewayHttpConnectAuthorizer,
+): Promise<AuthorizedGatewayHttpRequest | null> {
+  const result = await checkGatewayHttpRequestAuthWith(params, authorizeConnect);
   if (!result.ok) {
     sendGatewayAuthFailure(params.res, result.authResult);
     return null;
@@ -205,9 +230,16 @@ export async function checkGatewayHttpRequestAuth(params: {
   rateLimiter?: AuthRateLimiter;
   cfg?: OpenClawConfig;
 }): Promise<GatewayHttpRequestAuthCheckResult> {
+  return await checkGatewayHttpRequestAuthWith(params, authorizeHttpGatewayConnect);
+}
+
+async function checkGatewayHttpRequestAuthWith(
+  params: GatewayHttpRequestAuthCheckParams,
+  authorizeConnect: GatewayHttpConnectAuthorizer,
+): Promise<GatewayHttpRequestAuthCheckResult> {
   const token = getBearerToken(params.req);
   const browserOriginPolicy = resolveHttpBrowserOriginPolicy(params.req, params.cfg);
-  const authResult = await authorizeHttpGatewayConnect({
+  const authResult = await authorizeConnect({
     auth: params.auth,
     connectAuth: token ? { token, password: token } : null,
     req: params.req,
@@ -252,15 +284,35 @@ export async function authorizeScopedGatewayHttpRequestOrReply(params: {
   requestAuth: AuthorizedGatewayHttpRequest;
   operatorScopes: string[];
 } | null> {
+  return await authorizeScopedGatewayHttpRequestWithOrReply(params, authorizeHttpGatewayConnect);
+}
+
+/** Authorize the read-only avatar route without broadening ordinary HTTP auth. */
+export async function authorizeScopedUserProfileAvatarHttpRequestOrReply(
+  params: Parameters<typeof authorizeScopedGatewayHttpRequestOrReply>[0],
+): ReturnType<typeof authorizeScopedGatewayHttpRequestOrReply> {
+  return await authorizeScopedGatewayHttpRequestWithOrReply(
+    params,
+    authorizeUserProfileAvatarHttpGatewayConnect,
+  );
+}
+
+async function authorizeScopedGatewayHttpRequestWithOrReply(
+  params: Parameters<typeof authorizeScopedGatewayHttpRequestOrReply>[0],
+  authorizeConnect: GatewayHttpConnectAuthorizer,
+): ReturnType<typeof authorizeScopedGatewayHttpRequestOrReply> {
   const cfg = getRuntimeConfig();
-  const requestAuth = await authorizeGatewayHttpRequestOrReply({
-    req: params.req,
-    res: params.res,
-    auth: params.auth,
-    trustedProxies: params.trustedProxies ?? cfg.gateway?.trustedProxies,
-    allowRealIpFallback: params.allowRealIpFallback ?? cfg.gateway?.allowRealIpFallback,
-    rateLimiter: params.rateLimiter,
-  });
+  const requestAuth = await authorizeGatewayHttpRequestWithOrReply(
+    {
+      req: params.req,
+      res: params.res,
+      auth: params.auth,
+      trustedProxies: params.trustedProxies ?? cfg.gateway?.trustedProxies,
+      allowRealIpFallback: params.allowRealIpFallback ?? cfg.gateway?.allowRealIpFallback,
+      rateLimiter: params.rateLimiter,
+    },
+    authorizeConnect,
+  );
   if (!requestAuth) {
     return null;
   }

--- a/src/gateway/http-utils.authorize-request.test.ts
+++ b/src/gateway/http-utils.authorize-request.test.ts
@@ -103,6 +103,7 @@ describe("authorizeGatewayHttpRequestOrReply", () => {
       req: createReq({
         host: "gateway.example.com",
         origin: "https://evil.example",
+        "sec-fetch-site": "cross-site",
       }),
       res: {} as ServerResponse,
       auth: {
@@ -120,6 +121,7 @@ describe("authorizeGatewayHttpRequestOrReply", () => {
     expect(authParams.browserOriginPolicy).toEqual({
       requestHost: "gateway.example.com",
       origin: "https://evil.example",
+      fetchSite: "cross-site",
       allowedOrigins: ["https://control.example.com"],
       allowHostHeaderOriginFallback: false,
     });

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -34,6 +34,7 @@ export {
   authorizeOpenAiCompatibleHttpModelOverride,
   authorizeGatewayHttpRequestOrReply,
   authorizeScopedGatewayHttpRequestOrReply,
+  authorizeScopedUserProfileAvatarHttpRequestOrReply,
   checkGatewayHttpRequestAuth,
   getBearerToken,
   getHeader,

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -24,6 +24,7 @@ type OriginCheckResult =
 type BrowserOriginPolicy = {
   requestHost?: string;
   origin?: string;
+  fetchSite?: string;
   allowedOrigins?: string[];
   allowHostHeaderOriginFallback?: boolean;
 };
@@ -40,6 +41,7 @@ export function resolveBrowserOriginPolicy(params: {
   return {
     requestHost: headerValue(params.req.headers.host),
     origin: headerValue(params.req.headers.origin),
+    fetchSite: headerValue(params.req.headers["sec-fetch-site"]),
     allowedOrigins: params.cfg?.gateway?.controlUi?.allowedOrigins,
     allowHostHeaderOriginFallback:
       params.cfg?.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true,

--- a/src/gateway/user-profiles-http.test.ts
+++ b/src/gateway/user-profiles-http.test.ts
@@ -3,14 +3,14 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleUserProfileAvatarHttpRequest } from "./user-profiles-http.js";
 
-const authorizeScopedGatewayHttpRequestOrReply = vi.hoisted(() => vi.fn());
+const authorizeScopedUserProfileAvatarHttpRequestOrReply = vi.hoisted(() => vi.fn());
 const getRuntimeConfig = vi.hoisted(() => vi.fn());
 const getProfileAvatar = vi.hoisted(() => vi.fn());
 const getUserProfileListItem = vi.hoisted(() => vi.fn());
 
 vi.mock("./http-utils.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./http-utils.js")>()),
-  authorizeScopedGatewayHttpRequestOrReply,
+  authorizeScopedUserProfileAvatarHttpRequestOrReply,
 }));
 vi.mock("../config/io.js", () => ({ getRuntimeConfig }));
 vi.mock("../state/user-profiles.js", () => ({
@@ -47,11 +47,11 @@ function request(path: string, headers: Record<string, string> = {}) {
 
 describe("profile avatar HTTP endpoint", () => {
   beforeEach(() => {
-    authorizeScopedGatewayHttpRequestOrReply.mockReset();
+    authorizeScopedUserProfileAvatarHttpRequestOrReply.mockReset();
     getProfileAvatar.mockReset();
     getUserProfileListItem.mockReset();
     getRuntimeConfig.mockReset();
-    authorizeScopedGatewayHttpRequestOrReply.mockResolvedValue({});
+    authorizeScopedUserProfileAvatarHttpRequestOrReply.mockResolvedValue({});
     getRuntimeConfig.mockReturnValue({
       gateway: { controlUi: { allowedOrigins: ["https://control.example"] } },
     });
@@ -69,7 +69,7 @@ describe("profile avatar HTTP endpoint", () => {
       auth: {} as never,
     });
 
-    expect(authorizeScopedGatewayHttpRequestOrReply).not.toHaveBeenCalled();
+    expect(authorizeScopedUserProfileAvatarHttpRequestOrReply).not.toHaveBeenCalled();
     expect(res.setHeader).toHaveBeenCalledWith(
       "Access-Control-Allow-Origin",
       "https://control.example",
@@ -95,7 +95,7 @@ describe("profile avatar HTTP endpoint", () => {
       { auth: {} as never },
     );
 
-    expect(authorizeScopedGatewayHttpRequestOrReply).toHaveBeenCalledWith(
+    expect(authorizeScopedUserProfileAvatarHttpRequestOrReply).toHaveBeenCalledWith(
       expect.objectContaining({ operatorMethod: "users.list" }),
     );
     expect(res.writeHead).toHaveBeenCalledWith(
@@ -103,6 +103,20 @@ describe("profile avatar HTTP endpoint", () => {
       expect.objectContaining({ "Content-Type": "image/webp", ETag: '"first-hash-webp"' }),
     );
     expect(res.end).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+  });
+
+  it("rejects mutating methods before avatar authentication", async () => {
+    const res = response();
+    const req = { method: "POST", headers: {} } as unknown as IncomingMessage;
+
+    await handleUserProfileAvatarHttpRequest(req, res.response, "/api/users/profile-1/avatar", {
+      auth: {} as never,
+    });
+
+    expect(res.response.statusCode).toBe(405);
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", "GET, HEAD");
+    expect(authorizeScopedUserProfileAvatarHttpRequestOrReply).not.toHaveBeenCalled();
+    expect(getProfileAvatar).not.toHaveBeenCalled();
   });
 
   it("answers a matching ETag without a body", async () => {

--- a/src/gateway/user-profiles-http.ts
+++ b/src/gateway/user-profiles-http.ts
@@ -15,7 +15,7 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, sendMethodNotAllowed } from "./http-common.js";
 import { matchesHttpIfNoneMatch } from "./http-conditional.js";
 import {
-  authorizeScopedGatewayHttpRequestOrReply,
+  authorizeScopedUserProfileAvatarHttpRequestOrReply,
   resolveSharedSecretHttpOperatorScopes,
 } from "./http-utils.js";
 import { matchUserProfileAvatarPath } from "./user-profiles-http-path.js";
@@ -281,7 +281,7 @@ function sendAvatar(
   res.end(req.method === "HEAD" ? undefined : avatar.bytes);
 }
 
-/** Serves a profile avatar with the same HTTP operator auth as sibling gateway endpoints. */
+/** Serves a profile avatar to authenticated HTTP or verified Tailscale UI sessions. */
 export async function handleUserProfileAvatarHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -318,7 +318,7 @@ export async function handleUserProfileAvatarHttpRequest(
     sendMethodNotAllowed(res, "GET, HEAD");
     return true;
   }
-  const authResult = await authorizeScopedGatewayHttpRequestOrReply({
+  const authResult = await authorizeScopedUserProfileAvatarHttpRequestOrReply({
     req,
     res,
     auth: opts.auth,


### PR DESCRIPTION
Related: #118341

## What Problem This Solves

Fixes an issue where operators using Tailscale Serve identity-header authentication could load the Control UI but its profile avatar request returned 401. The UI renders the avatar as a same-origin image, which cannot attach the Gateway bearer credential required by the ordinary HTTP auth path.

## Why This Change Was Made

This adds an explicit `http-user-profile-avatar` auth surface used only after the avatar handler has limited the request to `GET` or `HEAD`. It reuses the existing Tailscale verification chain unchanged: the request must arrive from loopback with the required `x-forwarded-for`, `x-forwarded-proto`, and `x-forwarded-host` headers; the forwarded client is resolved with local `tailscale whois`; and the verified login must match the identity header. The same rate limiter and browser-origin policy remain in force.

Existing token/password HTTP authentication remains the fallback for this route. The ordinary HTTP auth wrapper is unchanged, and no mutating or unrelated endpoint accepts Tailscale identity headers.

After security review, the ambient Tailscale success path now applies the canonical browser-origin policy before identity verification can succeed. Requests with an `Origin` must pass the existing Host/allowlist rules, and wildcard allowed-origins never grant ambient identity. Same-origin image requests may omit `Origin`, so that narrow case requires browser-controlled `Sec-Fetch-Site: same-origin`; cross-site, same-site, navigation, and missing Fetch Metadata cannot authorize ambient identity. Explicit token/password behavior, including wildcard CORS configuration, is unchanged.

This PR fixes only the avatar 401 half of #118341. Adopting Tailscale display names and profile pictures into durable profiles remains open. The current persistence model has only `user_profile_emails` in `src/state/user-profiles-schema.ts`, and `ensureProfileForEmail` stores any authenticated login, including `<user>@<provider>`, as an email alias. Upstream Tailscale defines `LoginName` as an email address or an “email-ish” value such as `alice@github`, so preserving shipped profile IDs and user-set values while separating provider identity needs an explicit schema/migration design.

The branch is rebased onto the canonical composer max-lines repair now on `main` (`d93d07ac02a`); this PR no longer carries a separate UI refactor.

## User Impact

Operators authenticated only through verified Tailscale Serve identity can now see profile avatars already configured in Settings. Token/password users see no behavior change.

## Evidence

### Live behavior verification (maintainer hardware, exact head 8d1a1e7f5f4)

With the branch build running on the gateway host and the browser authenticated only by verified Tailscale identity, with no token configured, the Control UI avatar loaded successfully from the tailnet dashboard origin. The rendered bitmap was 400×400, and a direct fetch of the avatar URL returned HTTP 200 with `Content-Type: image/png`. Before this change, the same request returned HTTP 401 JSON and the UI displayed a placeholder.

From an unrelated public origin in the same browser, while the identity-bearing proxy still supplied the same verified Tailscale session, a credentialed CORS fetch of the avatar URL failed and a plain `<img>` load of the same URL did not load, including with the wildcard-origin hardening in place. This confirms that the Origin and `Sec-Fetch-Site` enforcement added for ClawSweeper’s P1 blocks cross-origin authenticated reads.

A request to the avatar URL that did not arrive through the identity-bearing proxy path returned HTTP 401, confirming that the existing token/password contract remains unchanged.

The repository owner, acting as the gateway security owner, accepts the scoped Tailscale HTTP identity exception for this read-only avatar route.

- `node scripts/run-vitest.mjs src/gateway/auth.test.ts src/gateway/user-profiles-http.test.ts`
  - 2 test files passed
  - 106 tests passed
- `node scripts/check-changed.mjs -- <touched files>`
  - Blacksmith/Testbox routing was unavailable, so trusted-source policy fell back to the local gate
  - core production and test typechecks, formatting, lint/guards, dead-export scan, schema guard, and import-cycle check passed
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
  - clean; no accepted/actionable findings
- `node scripts/run-vitest.mjs src/gateway/auth.test.ts src/gateway/origin-check.test.ts src/gateway/user-profiles-http.test.ts src/gateway/http-utils.authorize-request.test.ts`
  - 4 test files passed
  - 148 tests passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P1 --stream-engine-output`
  - clean; no P0/P1 findings
