### PR TITLE
fix(discord): preserve accepted partial reply receipts

### DIFF
--- a/extensions/discord/src/durable-delivery.test.ts
+++ b/extensions/discord/src/durable-delivery.test.ts
@@ -1,4 +1,5 @@
 // Discord tests cover durable delivery plugin behavior.
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { sendDurableMessageBatch } from "openclaw/plugin-sdk/channel-outbound";
 import {
   createEmptyPluginRegistry,
@@ -6,6 +7,7 @@ import {
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   createDiscordOutboundHoisted,
@@ -17,12 +19,16 @@ const hoisted = createDiscordOutboundHoisted();
 await installDiscordOutboundModuleSpies(hoisted);
 
 let discordPlugin: typeof import("./channel.js").discordPlugin;
+let deliverDiscordReply: typeof import("./monitor/reply-delivery.js").deliverDiscordReply;
 
 beforeAll(async () => {
   ({ discordPlugin } = await import("./channel.js"));
+  ({ deliverDiscordReply } = await import("./monitor/reply-delivery.js"));
 });
 
 describe("durable Discord delivery", () => {
+  const cfg = { channels: { discord: { token: "test-token" } } };
+
   beforeEach(() => {
     resetDiscordOutboundMocks(hoisted);
     setActivePluginRegistry(
@@ -50,13 +56,7 @@ describe("durable Discord delivery", () => {
       .mockRejectedValueOnce(Object.assign(new Error("discord 500"), { status: 500 }));
 
     const result = await sendDurableMessageBatch({
-      cfg: {
-        channels: {
-          discord: {
-            token: "test-token",
-          },
-        },
-      },
+      cfg,
       channel: "discord",
       to: "channel:123456",
       payloads: [{ text: "first chunk\nsecond chunk" }],
@@ -81,6 +81,44 @@ describe("durable Discord delivery", () => {
     expect(result.receipt.platformMessageIds).toEqual(["msg-chunk-1"]);
     expect(result.sentBeforeError).toBe(true);
     expect(hoisted.sendMessageDiscordMock).toHaveBeenCalledTimes(2);
+    expect(hoisted.sendMessageDiscordMock.mock.calls.map((call) => call[1])).toEqual([
+      "first chunk",
+      "second chunk",
+    ]);
+  });
+
+  it("keeps accepted Discord chunks visible when monitored reply delivery fails", async () => {
+    hoisted.sendMessageDiscordMock
+      .mockResolvedValueOnce({ messageId: "msg-chunk-1", channelId: "ch-1" })
+      .mockRejectedValueOnce(Object.assign(new Error("discord 500"), { status: 500 }));
+
+    let error: unknown;
+    try {
+      await deliverDiscordReply({
+        cfg,
+        replies: [{ text: "first chunk\nsecond chunk" }],
+        target: "channel:123456",
+        token: "test-token",
+        runtime: {} as RuntimeEnv,
+        textLimit: 2000,
+        maxLinesPerMessage: 1,
+        chunkMode: "newline",
+        kind: "final",
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(isChannelPartialDeliveryError(error)).toBe(true);
+    expect(error).toMatchObject({
+      sentBeforeError: true,
+      visibleReplySent: true,
+      deliveryResult: {
+        messageIds: ["msg-chunk-1"],
+        receipt: { platformMessageIds: ["msg-chunk-1"] },
+        visibleReplySent: true,
+      },
+    });
     expect(hoisted.sendMessageDiscordMock.mock.calls.map((call) => call[1])).toEqual([
       "first chunk",
       "second chunk",

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -1,5 +1,7 @@
 // Discord tests cover reply delivery plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,6 +12,9 @@ const sendDurableMessageBatchMock = vi.hoisted(() =>
     async (): Promise<unknown> => ({
       status: "sent" as const,
       results: [{ messageId: "msg-1", channelId: "channel-1" }],
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ messageId: "msg-1", channelId: "channel-1" }],
+      }),
     }),
   ),
 );
@@ -97,6 +102,9 @@ describe("deliverDiscordReply", () => {
     sendDurableMessageBatchMock.mockResolvedValue({
       status: "sent",
       results: [{ messageId: "msg-1", channelId: "channel-1" }],
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ messageId: "msg-1", channelId: "channel-1" }],
+      }),
     });
     sendMessageDiscordMock.mockReset().mockResolvedValue({
       messageId: "msg-1",
@@ -161,6 +169,94 @@ describe("deliverDiscordReply", () => {
     });
 
     expect(firstDeliverParams().payloads).toEqual([{ text: "Thinking\n\n_Because it helps_" }]);
+  });
+
+  it("preserves the accepted receipt when a later Discord delivery fails", async () => {
+    const cause = new Error("second Discord chunk failed");
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "discord", messageId: "accepted-1" }],
+    });
+    sendDurableMessageBatchMock.mockResolvedValueOnce({
+      status: "partial_failed",
+      results: [{ channel: "discord", messageId: "accepted-1" }],
+      receipt,
+      error: cause,
+      sentBeforeError: true,
+    });
+
+    let error: unknown;
+    try {
+      await deliverDiscordReply({
+        replies: [{ text: "first chunk\nsecond chunk" }],
+        target: "channel:101",
+        token: "token",
+        runtime,
+        cfg,
+        textLimit: 2000,
+        kind: "final",
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(isChannelPartialDeliveryError(error)).toBe(true);
+    expect(error).toMatchObject({
+      cause,
+      sentBeforeError: true,
+      visibleReplySent: true,
+      deliveryResult: {
+        messageIds: ["accepted-1"],
+        receipt,
+        visibleReplySent: true,
+      },
+    });
+  });
+
+  it("preserves the original failure when Discord accepted no message", async () => {
+    const cause = new Error("Discord send failed before acceptance");
+    sendDurableMessageBatchMock.mockResolvedValueOnce({ status: "failed", error: cause });
+
+    await expect(
+      deliverDiscordReply({
+        replies: [{ text: "not delivered" }],
+        target: "channel:101",
+        token: "token",
+        runtime,
+        cfg,
+        textLimit: 2000,
+        kind: "final",
+      }),
+    ).rejects.toBe(cause);
+  });
+
+  it("preserves every accepted Discord message from a nested delivery receipt", async () => {
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [
+        { channel: "discord", messageId: "accepted-1" },
+        { channel: "discord", messageId: "accepted-2" },
+      ],
+    });
+    sendDurableMessageBatchMock.mockResolvedValueOnce({
+      status: "sent",
+      results: [{ channel: "discord", messageId: "accepted-2", receipt }],
+      receipt,
+    });
+
+    await expect(
+      deliverDiscordReply({
+        replies: [{ text: "first chunk\nsecond chunk" }],
+        target: "channel:101",
+        token: "token",
+        runtime,
+        cfg,
+        textLimit: 2000,
+        kind: "final",
+      }),
+    ).resolves.toEqual({
+      messageIds: ["accepted-1", "accepted-2"],
+      receipt,
+      visibleReplySent: true,
+    });
   });
 
   it("fails when shared outbound accepts a final reply but delivers no Discord message", async () => {

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -1,7 +1,9 @@
 // Discord plugin module implements reply delivery behavior.
 import { formatReasoningMessage, resolveAgentAvatar } from "openclaw/plugin-sdk/agent-runtime";
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import {
   buildOutboundSessionContext,
+  listMessageReceiptPlatformIds,
   sendDurableMessageBatch,
   type OutboundDeliveryFormattingOptions,
   type OutboundIdentity,
@@ -266,7 +268,7 @@ export async function deliverDiscordReply(params: {
       requesterAccountId: params.accountId,
     }),
   });
-  if (send.status === "failed" || send.status === "partial_failed") {
+  if (send.status === "failed") {
     throw send.error;
   }
   if (send.status === "suppressed") {
@@ -282,12 +284,17 @@ export async function deliverDiscordReply(params: {
       },
     };
   }
-  const results = send.results;
-  if (results.length === 0) {
+  if (send.results.length === 0) {
     throw new Error(`discord final reply produced no delivered message for ${delivery.to}`);
   }
-  return {
-    messageIds: results.flatMap((result) => (result.messageId ? [result.messageId] : [])),
-    visibleReplySent: true,
+  const deliveryResult = {
+    messageIds: listMessageReceiptPlatformIds(send.receipt),
+    receipt: send.receipt,
+    visibleReplySent: true as const,
   };
+  if (send.status === "partial_failed") {
+    // Accepted receipts must survive failure so dispatch never replays visible chunks.
+    throw createChannelPartialDeliveryError(send.error, deliveryResult);
+  }
+  return deliveryResult;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord could resend already-visible reply chunks or lose their message IDs when one chunk succeeded and a later chunk failed.

## Why This Change Was Made

Discord's durable transport already records the accepted receipt and partial-failure visibility, but the private reply owner threw away those authoritative facts and flattened only top-level message IDs. The owner now uses the existing canonical partial-delivery envelope and receipt ID accessor for both successful and partially successful sends. Complete failures, suppressed replies, and existing transport behavior remain unchanged.

## User Impact

Already-delivered Discord reply chunks stay visible without being replayed or replaced by duplicate fallback text. Accepted Discord message IDs and original delivery receipts remain available across nested receipts and partial errors.

## Evidence

- Frozen full branch: `cedf1a4e19b2b4f323caec16e8d71b9eb80f1369`; base: `c6ef95604e55d7684077cc5db35375f4da08ebe2`.
- Authentic unchanged-parent owner regressions reproduce lost accepted partial-delivery metadata and nested receipt message IDs.
- Exact candidate passes focused private Discord reply-owner, actual durable-transport-to-monitor, native command, and canonical turn lifecycle suites.
- Real loopback Discord REST requests exercise an accepted first message followed by a failing second request through the actual production sender, durable transport, monitor owner, and canonical partial-delivery error; success and zero-acceptance failure controls preserve their existing contracts.
- Complete exact-head changed-code/typecheck/lint gate and full production build run on a trusted isolated Blacksmith Testbox.
- Exact-head hosted CI resolution: all required checks, including `check-lint`, `build-artifacts`, and `openclaw/ci-gate`, passed in [CI run 30779083528](https://github.com/openclaw/openclaw/actions/runs/30779083528) against the repaired current-main merge ref. Earlier failed checks on the same immutable head predated the upstream composer-lint repair and are superseded by this complete green run.
- Four independent nonauthor whole-branch hostile reviews pass exact SHA and clean start/end guards. Genuine official whole-branch `gpt-5.6-sol` high/P3 review passes with confidence **0.93**; genuine checksum-verified TruffleHog 3.96.0 secret scan is clean.
- Risk: low. Three private Discord production/test files; production delta **+7 lines**; existing public SDK helpers are consumed without modifying their contracts. No authentication, configuration, protocol, persistent state, or dependencies change.

```json
{"status":"PASS","head":"cedf1a4e19b2b4f323caec16e8d71b9eb80f1369","distinctRootCauses":1,"transport":"real-loopback-discord-rest","acceptedFirstChunk":true,"laterChunkFails":true,"receiptPreserved":true,"acceptedMessageIdsPreserved":true,"productionLocDelta":7,"changedGate":"PASS","productionBuild":"PASS"}
```

## Maintainer Landing Decision

- Protected maintainer next step resolved: authenticated repository administrator `@steipete` explicitly delegated autonomous maintainer review and landing of individually verified low-risk QA refactors; this private canonical-owner change has four independent exact-head approvals, a clean genuine whole-branch Sol review, authentic unchanged-parent failures, and actual Discord REST/durable/monitor proof. Final repository-native landing remains gated on all required exact-head hosted checks and the latest ClawSweeper review.
- ClawSweeper merge-risk resolution: its sole remaining unchecked item required completed exact-head hosted validation; the complete current-head CI run above is now green, including lint, build artifacts, and the final required gate, and GitHub reports the unchanged reviewed head cleanly mergeable.
