### PR TITLE
improve(tests): batch Gateway chat history fixtures

### DIFF
--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -17,6 +17,7 @@ import {
   loadExactSessionEntry,
   loadTranscriptEventsSync,
   patchSessionEntry,
+  replaceTranscriptEvents,
   replaceSessionEntry,
   withTranscriptWriteLock,
 } from "../config/sessions/session-accessor.js";
@@ -25,6 +26,12 @@ import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { onDiagnosticEvent, type DiagnosticPayloadLargeEvent } from "../infra/diagnostic-events.js";
+import {
+  captureCurrentPluginMetadataSnapshotState,
+  restoreCurrentPluginMetadataSnapshotState,
+  setCurrentPluginMetadataSnapshot,
+} from "../plugins/current-plugin-metadata-snapshot.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { runExclusiveSessionLifecycleMutation } from "../sessions/session-lifecycle-admission.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import { createDeferred } from "../test-utils/deferred.js";
@@ -201,20 +208,22 @@ async function writeMainSessionTranscript(
   if (!storePath) {
     throw new Error("session store path was not initialized");
   }
-  for (const event of events) {
-    if (typeof event === "string" && !event.trim()) {
-      continue;
-    }
-    await appendTranscriptEvent(
-      {
-        agentId: opts?.agentId ?? "main",
-        sessionId,
-        sessionKey: opts?.sessionKey ?? "agent:main:main",
-        storePath,
-      },
-      typeof event === "string" ? (JSON.parse(event) as unknown) : event,
-    );
-  }
+  // These fixtures always seed a complete fresh transcript. Replace it in one
+  // transaction so large history cases do not pay one SQLite commit per event.
+  const transcriptEvents = events
+    .filter((event) => typeof event !== "string" || event.trim())
+    .map((event) => (typeof event === "string" ? JSON.parse(event) : event)) as Parameters<
+    typeof replaceTranscriptEvents
+  >[1];
+  await replaceTranscriptEvents(
+    {
+      agentId: opts?.agentId ?? "main",
+      sessionId,
+      sessionKey: opts?.sessionKey ?? "agent:main:main",
+      storePath,
+    },
+    transcriptEvents,
+  );
 }
 
 async function withDirectChatSession(
@@ -1229,6 +1238,7 @@ describe("gateway server chat", () => {
         },
       },
       async (state) => {
+        const previousPluginMetadata = captureCurrentPluginMetadataSnapshotState();
         openDirectChatSession();
         try {
           const config = {
@@ -1358,6 +1368,14 @@ describe("gateway server chat", () => {
           const { createGatewayAgentModelCatalogProjector } =
             await import("./server-methods/models-list-result.js");
           const persistedConfig = getRuntimeConfig();
+          // Direct handlers bypass Gateway startup, so publish its process-lifecycle handoff once.
+          // Otherwise every route projector rediscovers the full plugin metadata graph.
+          const pluginMetadata = resolvePluginMetadataSnapshot({ config, env: process.env });
+          setCurrentPluginMetadataSnapshot(pluginMetadata, {
+            config,
+            compatibleConfigs: [persistedConfig],
+            env: process.env,
+          });
           expect(persistedConfig.auth?.order?.openai).toEqual([
             "openai:api",
             "openai:chatgpt",
@@ -1384,7 +1402,9 @@ describe("gateway server chat", () => {
           });
 
           expect(context.loadGatewayModelCatalogSnapshot).toHaveBeenCalledTimes(1);
-          expect(context.loadGatewayModelCatalogSnapshot).toHaveBeenCalledWith({ agentId: "work" });
+          expect(context.loadGatewayModelCatalogSnapshot).toHaveBeenCalledWith({
+            agentId: "work",
+          });
           expect(responses).toHaveLength(1);
           expect(responses[0]?.ok).toBe(true);
           const payload = responses[0]?.payload as
@@ -1460,6 +1480,7 @@ describe("gateway server chat", () => {
           }
         } finally {
           testState.sessionStorePath = undefined;
+          restoreCurrentPluginMetadataSnapshotState(previousPluginMetadata);
         }
       },
     );


### PR DESCRIPTION
## What Problem This Solves

The Gateway chat-b suite seeded every transcript event with a separate SQLite writer and transaction, including hundreds of events in the history-budget cases. One direct-handler test also rediscovered the full process-stable plugin metadata graph because it bypassed Gateway startup's normal handoff.

## Why This Change Was Made

Seed each complete fresh transcript through the public `replaceTranscriptEvents` API in one transaction, and install/restore the production-style metadata snapshot around the direct-handler case. All Gateway RPC, route, auth, redaction, thinking-level, and transcript assertions remain real. Sharding, concurrency, and production behavior are unchanged.

## User Impact

No runtime or user-visible behavior changes. The same Gateway coverage completes faster with less redundant database and plugin-discovery setup.

## Evidence

- Warm paired benchmark: 50.07s -> 33.86s (32.4% faster); refreshed run 34.24s.
- Test bodies: 48.20s -> 32.14s; max RSS: 2.13GB -> 2.01GB.
- Test count unchanged: 93/93.
- Gateway sibling: 51/51; plugin metadata snapshot owner: 23/23.
- Formatting, typed targeted lint, `git diff --check`, and autoreview are clean.
- Test-only diff: +36/-15; production LOC delta: 0.
