### PR TITLE
fix(scripts): make the gateway concurrency bench diagnosable and Node-native

### DIFF
--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -68,6 +68,10 @@ type GatewayRpc = <T>(method: string, params: unknown, timeoutMs?: number) => Pr
 type BenchmarkRun = {
   controlUi: ControlUiProbe[];
   durationMs: number;
+  probeWarmup: {
+    durationMs: number;
+    samples: GatewaySample[];
+  };
   readyz: ReadyProbe[];
   sessionsList: TimedProbe[];
   turnCount: number;
@@ -98,6 +102,10 @@ const MAX_WARMUP = 10;
 const MAX_SAMPLES_PER_RUN = 2_048;
 const MAX_HTTP_BODY_BYTES = 1_048_576;
 const HTTP_TIMEOUT_MS = 20_000;
+const PROBE_WARMUP_TIMEOUT_MS = 60_000;
+const PROBE_WARMUP_TARGET_MS = 1_000;
+const PROBE_WARMUP_RETRY_DELAY_MS = 100;
+const GATEWAY_STDERR_TAIL_LINES = 20;
 const AGENT_WAIT_RPC_GRACE_MS = 5_000;
 const BOOLEAN_FLAGS = new Set(["--help", "-h", "--json"]);
 const VALUE_FLAGS = new Set([
@@ -182,7 +190,7 @@ Options:
   --runs <n>         Measured gateway runs (default: ${DEFAULT_RUNS})
   --warmup <n>       Warmup gateway runs (default: ${DEFAULT_WARMUP})
   --cadence-ms <ms>  Probe cadence (default: ${DEFAULT_CADENCE_MS})
-  --timeout-ms <ms>  Whole benchmark wall-clock cap (default: ${DEFAULT_TIMEOUT_MS})
+  --timeout-ms <ms>  Whole benchmark cap, excluding probe warmup (default: ${DEFAULT_TIMEOUT_MS})
   --entry <path>     Gateway CLI entry file (default: ${DEFAULT_ENTRY})
   --output <path>    Write machine-readable JSON to a file
   --json             Emit machine-readable JSON
@@ -281,31 +289,58 @@ function describeProbeError(error: unknown): string {
 }
 
 function formatProbeResult(name: string, probe: TimedProbe & { status?: number }): string {
-  const status = probe.status === undefined ? (probe.ok ? "ok" : "failed") : probe.status;
-  return `${name}(ok=${probe.ok} status=${status} error=${probe.error ? JSON.stringify(probe.error) : "none"} latencyMs=${probe.latencyMs.toFixed(1)})`;
+  const status = probe.status === undefined ? "n/a" : probe.status;
+  return `${name}: ok=${probe.ok} status=${status} latencyMs=${probe.latencyMs.toFixed(1)} error=${probe.error ? JSON.stringify(probe.error) : "none"}`;
 }
 
-function assertBaselineProbes(baseline: GatewaySample): void {
-  if (baseline.readyz.ok && baseline.sessionsList.ok && baseline.controlUi.ok) {
-    return;
-  }
-  throw new Error(
-    `gateway probes did not pass before concurrent load: ${[
-      formatProbeResult("readyz", baseline.readyz),
-      formatProbeResult("sessionsList", baseline.sessionsList),
-      formatProbeResult("controlUi", baseline.controlUi),
-    ].join("; ")}`,
-  );
+function formatProbeFailure(sample: GatewaySample): string {
+  return [
+    "gateway probes did not become fast and healthy before concurrent load",
+    formatProbeResult("readyz", sample.readyz),
+    formatProbeResult("sessionsList", sample.sessionsList),
+    formatProbeResult("controlUi", sample.controlUi),
+  ].join("\n  ");
 }
 
-function captureChildOutput(child: ChildProcessWithoutNullStreams): () => string {
+function tailLines(output: string, lineCount: number): string {
+  return output.trimEnd().split(/\r?\n/u).slice(-lineCount).join("\n");
+}
+
+function captureChildOutput(child: ChildProcessWithoutNullStreams): {
+  readOutput: () => string;
+  readStderrTail: () => string;
+} {
   let output = "";
-  const append = (chunk: Buffer) => {
+  let stderr = "";
+  const appendOutput = (chunk: Buffer) => {
     output = `${output}${chunk.toString("utf8")}`.slice(-64 * 1_024);
   };
-  child.stdout.on("data", append);
-  child.stderr.on("data", append);
-  return () => output;
+  child.stdout.on("data", appendOutput);
+  child.stderr.on("data", (chunk: Buffer) => {
+    appendOutput(chunk);
+    stderr = `${stderr}${chunk.toString("utf8")}`.slice(-64 * 1_024);
+  });
+  return {
+    readOutput: () => output,
+    readStderrTail: () => tailLines(stderr, GATEWAY_STDERR_TAIL_LINES),
+  };
+}
+
+function formatRunFailure(
+  error: unknown,
+  gatewayOutput: { readOutput: () => string; readStderrTail: () => string },
+  mockOutput: { readOutput: () => string },
+): string {
+  return [
+    error instanceof Error ? error.message : String(error),
+    gatewayOutput.readStderrTail()
+      ? `gateway stderr tail:\n${gatewayOutput.readStderrTail()}`
+      : "gateway stderr tail: (empty)",
+    gatewayOutput.readOutput() ? `gateway output tail:\n${gatewayOutput.readOutput()}` : "",
+    mockOutput.readOutput() ? `mock provider output tail:\n${mockOutput.readOutput()}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 async function waitForMockServer(port: number, deadlineAt: number): Promise<void> {
@@ -371,6 +406,7 @@ function buildConfig(root: string, mockPort: number, concurrency: number): strin
 }
 
 async function connectGateway(port: number, deadlineAt: number) {
+  let requestDeadlineAt = deadlineAt;
   const client = createGatewayWsClient({
     handshakeTimeoutMs: Math.min(8_000, requireRemainingMs(deadlineAt, "connecting WebSocket")),
     openTimeoutMs: Math.min(8_000, requireRemainingMs(deadlineAt, "opening WebSocket")),
@@ -390,7 +426,7 @@ async function connectGateway(port: number, deadlineAt: number) {
         1,
         Math.min(
           requestedTimeoutMs ?? 65_000,
-          requireRemainingMs(deadlineAt, `waiting for ${method}`),
+          requireRemainingMs(requestDeadlineAt, `waiting for ${method}`),
         ),
       ),
     );
@@ -418,7 +454,13 @@ async function connectGateway(port: number, deadlineAt: number) {
     scopes: ["operator.read", "operator.write", "operator.admin"],
     caps: [],
   });
-  return { close: client.close, request: requestRpc };
+  return {
+    close: client.close,
+    request: requestRpc,
+    setDeadlineAt: (value: number) => {
+      requestDeadlineAt = value;
+    },
+  };
 }
 
 async function runTurn(rpc: GatewayRpc, index: number, deadlineAt: number): Promise<void> {
@@ -490,7 +532,11 @@ async function sampleGateway(params: {
   const probeSessions = async () => {
     const startedAt = performance.now();
     try {
-      const payload = await params.rpc("sessions.list", {}, HTTP_TIMEOUT_MS);
+      const payload = await params.rpc(
+        "sessions.list",
+        {},
+        Math.min(HTTP_TIMEOUT_MS, requireRemainingMs(params.deadlineAt, "probing sessions.list")),
+      );
       return { error: null, latencyMs: performance.now() - startedAt, ok: true, payload };
     } catch (error) {
       return {
@@ -548,6 +594,40 @@ async function sampleGateway(params: {
   };
 }
 
+async function warmGatewayProbes(params: {
+  deadlineAt: number;
+  sample: (deadlineAt: number) => Promise<GatewaySample>;
+  retryDelayMs?: number;
+  targetMs?: number;
+}): Promise<{ durationMs: number; samples: GatewaySample[] }> {
+  const startedAt = performance.now();
+  const samples: GatewaySample[] = [];
+  const targetMs = params.targetMs ?? PROBE_WARMUP_TARGET_MS;
+  while (remainingMs(params.deadlineAt) > 0) {
+    const sample = await params.sample(params.deadlineAt);
+    samples.push(sample);
+    const healthy = sample.readyz.ok && sample.sessionsList.ok && sample.controlUi.ok;
+    const fast =
+      Math.max(
+        sample.readyz.latencyMs,
+        sample.sessionsList.latencyMs,
+        sample.controlUi.latencyMs,
+      ) <= targetMs;
+    if (healthy && fast) {
+      return { durationMs: performance.now() - startedAt, samples };
+    }
+    await delay(
+      Math.min(params.retryDelayMs ?? PROBE_WARMUP_RETRY_DELAY_MS, remainingMs(params.deadlineAt)),
+    );
+  }
+  const lastSample = samples.at(-1);
+  throw new Error(
+    lastSample
+      ? formatProbeFailure(lastSample)
+      : "gateway probes did not run before the warmup deadline",
+  );
+}
+
 async function runGatewaySample(options: {
   cadenceMs: number;
   concurrency: number;
@@ -560,8 +640,8 @@ async function runGatewaySample(options: {
   let gateway: ChildProcessWithoutNullStreams | undefined;
   let mockProvider: ChildProcessWithoutNullStreams | undefined;
   let client: Awaited<ReturnType<typeof connectGateway>> | undefined;
-  let gatewayOutput = () => "";
-  let mockOutput = () => "";
+  let gatewayOutput = { readOutput: () => "", readStderrTail: () => "" };
+  let mockOutput = { readOutput: () => "", readStderrTail: () => "" };
 
   try {
     const configPath = buildConfig(root, mockPort, options.concurrency);
@@ -598,19 +678,28 @@ async function runGatewaySample(options: {
       startAt: runStartedAt,
     });
     if (ready.status !== 200) {
-      throw new Error(`gateway did not become ready\n${gatewayOutput()}`);
+      throw new Error(`gateway did not become ready\n${gatewayOutput.readOutput()}`);
     }
-    await waitForGatewayDispatchReady(gatewayOutput, options.deadlineAt);
+    await waitForGatewayDispatchReady(gatewayOutput.readOutput, options.deadlineAt);
     client = await connectGateway(port, options.deadlineAt);
     const rpc = client.request;
-    const baseline = await sampleGateway({
-      deadlineAt: options.deadlineAt,
-      port,
-      rpc,
-      runStartedAt,
-      serial: true,
+    // The first authenticated RPC lazily imports the server-method graph. It measured 6.9s
+    // on an idle M4 Pro (previously 18.4s) and crossed 20s on Linux; hot probes took 15-40ms.
+    // Keep that cold work out of the load-phase deadline and latency distributions.
+    const probeWarmupDeadlineAt = performance.now() + PROBE_WARMUP_TIMEOUT_MS;
+    client.setDeadlineAt(probeWarmupDeadlineAt);
+    const probeWarmup = await warmGatewayProbes({
+      deadlineAt: probeWarmupDeadlineAt,
+      sample: (deadlineAt) =>
+        sampleGateway({
+          deadlineAt,
+          port,
+          rpc,
+          runStartedAt,
+        }),
     });
-    assertBaselineProbes(baseline);
+    const loadDeadlineAt = options.deadlineAt + probeWarmup.durationMs;
+    client.setDeadlineAt(loadDeadlineAt);
 
     const controlUi: ControlUiProbe[] = [];
     const readyz: ReadyProbe[] = [];
@@ -619,7 +708,7 @@ async function runGatewaySample(options: {
     const turnsStartedAt = performance.now();
     const turns = Promise.all(
       Array.from({ length: options.concurrency }, (_, index) =>
-        runTurn(rpc, index, options.deadlineAt),
+        runTurn(rpc, index, loadDeadlineAt),
       ),
     ).finally(() => {
       turnsDone = true;
@@ -628,7 +717,7 @@ async function runGatewaySample(options: {
       for (;;) {
         const sampleStartedAt = performance.now();
         const sample = await sampleGateway({
-          deadlineAt: options.deadlineAt,
+          deadlineAt: loadDeadlineAt,
           port,
           rpc,
           runStartedAt,
@@ -642,7 +731,7 @@ async function runGatewaySample(options: {
         await delay(
           Math.min(
             Math.max(0, options.cadenceMs - (performance.now() - sampleStartedAt)),
-            requireRemainingMs(options.deadlineAt, "sampling gateway load"),
+            requireRemainingMs(loadDeadlineAt, "sampling gateway load"),
           ),
         );
       }
@@ -653,19 +742,14 @@ async function runGatewaySample(options: {
     return {
       controlUi,
       durationMs: performance.now() - runStartedAt,
+      probeWarmup,
       readyz,
       sessionsList,
       turnCount: options.concurrency,
       turnsDurationMs,
     };
   } catch (error) {
-    const detail = [
-      error instanceof Error ? error.message : String(error),
-      gatewayOutput() ? `gateway output:\n${gatewayOutput()}` : "",
-      mockOutput() ? `mock provider output:\n${mockOutput()}` : "",
-    ]
-      .filter(Boolean)
-      .join("\n");
+    const detail = formatRunFailure(error, gatewayOutput, mockOutput);
     throw new Error(detail, { cause: error });
   } finally {
     client?.close();
@@ -717,12 +801,13 @@ async function main(): Promise<void> {
     return;
   }
   const options = parseOptions(argv);
-  const deadlineAt = performance.now() + options.timeoutMs;
+  let deadlineAt = performance.now() + options.timeoutMs;
   const runs: BenchmarkRun[] = [];
   const total = options.runs + options.warmup;
   for (let index = 0; index < total; index += 1) {
     requireRemainingMs(deadlineAt, "starting gateway run");
     const run = await runGatewaySample({ ...options, deadlineAt });
+    deadlineAt += run.probeWarmup.durationMs;
     if (index >= options.warmup) {
       runs.push(run);
       console.error(
@@ -754,11 +839,14 @@ async function main(): Promise<void> {
 
 export const testing = {
   parseOptions,
-  assertBaselineProbes,
+  formatProbeFailure,
+  formatRunFailure,
   runTurn,
   sampleGateway,
   summarizeNumbers,
   summarizeRuns,
+  tailLines,
+  warmGatewayProbes,
 };
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -111,9 +111,38 @@ describe("gateway concurrency benchmark script", () => {
         error: "sessions.list failed: unauthorized",
         ok: false,
       });
-      expect(() => testing.assertBaselineProbes(sample)).toThrow(
-        /readyz\(ok=false status=503 error=none .*sessionsList\(ok=false status=failed error="sessions\.list failed: unauthorized" .*controlUi\(ok=false status=200 error="response body did not contain <html"/u,
+      const failure = testing.formatRunFailure(
+        new Error(testing.formatProbeFailure(sample)),
+        {
+          readOutput: () => "gateway output",
+          readStderrTail: () => testing.tailLines("old\nfirst retained\nlast retained\n", 2),
+        },
+        { readOutput: () => "mock output" },
       );
+      expect(failure).toMatch(
+        /readyz: ok=false status=503 latencyMs=\d+\.\d error=none\n  sessionsList: ok=false status=n\/a latencyMs=\d+\.\d error="sessions\.list failed: unauthorized"\n  controlUi: ok=false status=200 latencyMs=\d+\.\d error="response body did not contain <html"/u,
+      );
+      expect(failure).toContain("gateway stderr tail:\nfirst retained\nlast retained");
+      expect(failure).not.toContain("old");
+
+      const healthySlow = {
+        controlUi: { ...sample.controlUi, error: null, latencyMs: 200, ok: true },
+        readyz: { ...sample.readyz, latencyMs: 200, ok: true, status: 200 },
+        sessionsList: { ...sample.sessionsList, error: null, latencyMs: 200, ok: true },
+      };
+      const healthyFast = {
+        controlUi: { ...healthySlow.controlUi, latencyMs: 10 },
+        readyz: { ...healthySlow.readyz, latencyMs: 10 },
+        sessionsList: { ...healthySlow.sessionsList, latencyMs: 10 },
+      };
+      const samples = [sample, healthySlow, healthyFast];
+      const warmed = await testing.warmGatewayProbes({
+        deadlineAt: performance.now() + 5_000,
+        retryDelayMs: 0,
+        sample: async () => samples.shift() ?? healthyFast,
+        targetMs: 100,
+      });
+      expect(warmed.samples).toHaveLength(3);
     } finally {
       server.close();
     }


### PR DESCRIPTION
## What Problem This Solves

scripts/bench-gateway-concurrency.ts (from #118193) failed opaquely on the team Hetzner host ("gateway probes did not pass before concurrent load" — no probe detail), needed `--import tsx` on Node 26.5 (ERR_MODULE_NOT_FOUND on a relative `.js`→`.ts` import), and its 20 s probe budget silently absorbed a ~7 s cold-path cost that tipped over on slower hosts.

## Why This Change Was Made

- Root cause of the slow baseline probes: the first authenticated RPC lazily imports the server-method graph (src/gateway/server/ws-connection/authenticated-request-dispatch.ts), measured 6.9 s cold on an M4 Pro (first probe round readyz 6802 ms / sessions.list 6708 ms / UI 6862 ms; second round 15-40 ms). The bench now runs an explicit warm-until-fast phase (60 s own deadline, all probes < 1 s target) whose time and samples are excluded from load-phase deadlines and percentiles, and recorded separately in the JSON. The cold-first-RPC latency itself is a named gateway follow-up, deliberately not changed here (no production files touched).
- Pre-load failures now report each probe's name, status/error, and latency plus the gateway child's last 20 stderr lines.
- The protocol import uses an explicit `.ts` specifier (`../packages/gateway-protocol/src/version.ts`) so plain `node scripts/bench-gateway-concurrency.ts` runs on supported Node (verified 24.18.1 and 26.x) while staying tsx-compatible. CPU-scenario wiring already used plain node.
- The `[bench-gateway-concurrency] FAILED (exit N)` wrapper contract is preserved.

## User Impact

Tooling only. The concurrency benchmark from #118027 now runs on the production-class Linux hosts it was built to measure, and failures say which probe failed and why.

## Evidence

- Plain Node 26 run: duration 47.1 s, warmup 7.0 s/2 attempts, turns 7.9 s, 22 samples, 0 probe failures. Node 24.18.1 loads bench + CPU-scenario wrapper directly.
- Simulated failure shows all three probe records, stderr tail, and the FAILED marker.
- 21 tests across 2 files; local changed gate (typechecks, lint, format, 249 script-declaration contracts) passed; autoreview (Codex gpt-5.6-sol, high) clean.

Follow-up to #118193 / #118027. Bench-only: +164/−47 across script + tests.
