### PR TITLE
fix: keep queued follow-up regression bounded

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -169,6 +169,14 @@ vi.mock("../../agents/model-fallback-attempt.js", () => ({
     Array.isArray((err as { attempts?: unknown[] }).attempts),
 }));
 
+vi.mock("../../agents/runtime-plan/build.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/runtime-plan/build.js")>()),
+  buildAgentRuntimeDeliveryPlan: () => ({
+    isSilentPayload: () => false,
+    resolveFollowupRoute: () => undefined,
+  }),
+}));
+
 vi.mock("../../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: () => ({
     hasHooks: state.beforeAgentReplyHasHooksMock,
@@ -714,8 +722,9 @@ describe("runReplyAgent active steering", () => {
       gatewayHealth: "live",
     });
     const onAdopted = vi.fn();
+    const onBlockReply = vi.fn();
     const { run } = createMinimalRun({
-      opts: { turnAdoptionLifecycle: { onAdopted } },
+      opts: { onBlockReply, turnAdoptionLifecycle: { onAdopted } },
       isActive: true,
       isStreaming: true,
       shouldSteer: true,
@@ -735,6 +744,7 @@ describe("runReplyAgent active steering", () => {
 
     expect(state.beforeAgentReplyRunMock).toHaveBeenCalledOnce();
     expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
+    expect(onBlockReply).toHaveBeenCalledWith(expect.objectContaining({ text: "model reply" }));
     expect(onAdopted).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Closes #118367

## What Problem This Solves

Fixes an issue where maintainers running the auto-reply E2E shard from a cold worker would hit the 120-second Vitest timeout while proving the transcript-rejected steering fallback. The timeout made the intended queued follow-up regression unreliable as merge and release evidence.

## Why This Change Was Made

The test mocks embedded-agent execution but, after queued follow-up execution was consolidated, still crossed the real provider delivery-plan boundary. A cold run spent about 126.7 seconds discovering provider/plugin runtime metadata that real execution would already have prepared. The test now mirrors the existing `followup-delivery` unit-test boundary by mocking only delivery-plan construction, and it supplies and verifies the visible dispatcher required by the manually invoked queued runner.

The queued admission, hook, execution, accounting, lifecycle, typing, and delivery composition remain real in this E2E test. Increasing the timeout or changing production runtime behavior would hide the stale fixture instead of repairing its ownership boundary.

## User Impact

There is no product-runtime behavior change. Maintainers get deterministic coverage for transcript-rejected steering follow-ups, and the complete 123-test file returns in about 40 seconds instead of failing after roughly two and a half minutes.

Production LOC delta: 0. Test delta: +11/-1 in one file. No paths or compatibility behavior were removed.

Provenance: the queued-runner test originated in https://github.com/openclaw/openclaw/pull/108353; the later canonical queued follow-up convergence in https://github.com/openclaw/openclaw/pull/114599 made the stale runtime-plan mock boundary observable. Both were merged by @steipete.

## Evidence

Source: trusted maintainer branch based on `cbd4b8dec83949d9307f440caaeb01bd8d0ebee6`.

Blacksmith Testbox: `tbx_01kz2kmaaea4avvx5pj64m5s2y` (`blacksmith-testbox`), https://github.com/openclaw/openclaw/actions/runs/30776850794

Before:

```text
pnpm test src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
1 failed, 122 passed; failing test timed out in 120000ms

pnpm test src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts \
  -t 'queues a follow-up when transcript-backed steering is unsupported'
1 failed, 122 skipped; failing test timed out in 120000ms
```

After:

```text
pnpm test src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts \
  -t 'queues a follow-up when transcript-backed steering is unsupported'
1 passed, 122 skipped; 23.88s

pnpm test src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
123 passed; 39.60s

pnpm check:changed
passed: formatting, guards, core-test typecheck, lint, dependency pins,
plugin boundaries, and dead-export scans
```

Fresh autoreview:

```text
.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output
gpt-5.6-sol, xhigh: no findings; patch is correct; confidence 0.99
```

No external live boundary applies because the change is test-only. The exact mocked queued-reply behavior and its full sibling file are the relevant observable proof.

Public model identifier audit: PASS. The candidate diff and proof contain no undisclosed or questionable model identifiers.
