### PR TITLE
fix: failed `openclaw update` leaves the gateway stopped; recovery restart refused with "binary is older than the config"

### DIFF
--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -227,6 +227,7 @@ export async function executeMutableUpdate(params: {
           await maybeRestartServiceAfterFailedMutableUpdate({
             preManagedServiceStop,
             jsonMode: Boolean(params.opts.json),
+            packageSwapCompleted: false,
           });
         }
         defaultRuntime.exit(1);
@@ -247,6 +248,7 @@ export async function executeMutableUpdate(params: {
     await maybeRestartServiceAfterFailedMutableUpdate({
       preManagedServiceStop,
       jsonMode: Boolean(params.opts.json),
+      packageSwapCompleted: false,
     });
     throw err;
   }

--- a/src/cli/update-cli/update-command-package.ts
+++ b/src/cli/update-cli/update-command-package.ts
@@ -202,6 +202,7 @@ export async function runPackageInstallUpdate(params: {
     reason: packageUpdate.failedStep ? packageUpdate.failedStep.name : undefined,
     before: { version: beforeVersion },
     after: { version: packageUpdate.afterVersion ?? beforeVersion },
+    packageSwapCompleted: packageUpdate.packageSwapCompleted,
     steps: packageUpdate.steps,
     durationMs: Date.now() - params.startedAt,
   };

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -34,6 +34,14 @@ function failedResult(recovery: UpdateRunResult["recovery"]): UpdateRunResult {
   };
 }
 
+function failedPackageResult(): UpdateRunResult {
+  return {
+    ...failedResult(undefined),
+    mode: "npm",
+    packageSwapCompleted: true,
+  };
+}
+
 async function finishFailedUpdate(result: UpdateRunResult): Promise<void> {
   await finishUpdate({
     result,
@@ -79,6 +87,9 @@ describe("skipped update exit status", () => {
   it("keeps a non-Git install skip successful", async () => {
     await finishSkippedUpdate("not-git-install");
 
+    expect(mocks.restart).toHaveBeenCalledWith(
+      expect.objectContaining({ packageSwapCompleted: false }),
+    );
     expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
   });
 });
@@ -93,6 +104,17 @@ describe("failed Git update recovery restart", () => {
     await finishFailedUpdate(failedResult({ serviceRestartSafe: true }));
 
     expect(mocks.restart).toHaveBeenCalledOnce();
+    expect(mocks.restart).toHaveBeenCalledWith(
+      expect.objectContaining({ packageSwapCompleted: false }),
+    );
+  });
+
+  it("allows the older-binary restart override only after a completed package swap", async () => {
+    await finishFailedUpdate(failedPackageResult());
+
+    expect(mocks.restart).toHaveBeenCalledWith(
+      expect.objectContaining({ packageSwapCompleted: true }),
+    );
   });
 
   it("leaves a managed Gateway stopped after unverified rollback recovery", async () => {

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -127,6 +127,7 @@ export async function finishUpdate(params: {
       await maybeRestartServiceAfterFailedMutableUpdate({
         preManagedServiceStop: params.preManagedServiceStop,
         jsonMode: Boolean(params.opts.json),
+        packageSwapCompleted: params.result.packageSwapCompleted === true,
       });
     }
     defaultRuntime.exit(1);
@@ -145,6 +146,7 @@ export async function finishUpdate(params: {
     await maybeRestartServiceAfterFailedMutableUpdate({
       preManagedServiceStop: params.preManagedServiceStop,
       jsonMode: Boolean(params.opts.json),
+      packageSwapCompleted: false,
     });
     if (params.result.reason === "dirty") {
       defaultRuntime.error(theme.error("Update blocked: local files are edited in this checkout."));
@@ -333,6 +335,7 @@ export async function finishUpdate(params: {
       await maybeRestartServiceAfterFailedMutableUpdate({
         preManagedServiceStop: params.preManagedServiceStop,
         jsonMode: Boolean(params.opts.json),
+        packageSwapCompleted: params.result.packageSwapCompleted === true,
       });
     }
     if (params.opts.json) {

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -14,6 +14,7 @@ import {
 import { doctorCommand } from "../../commands/doctor.js";
 import { UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV } from "../../commands/doctor/shared/update-phase.js";
 import { resolveGatewayPort } from "../../config/config.js";
+import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "../../config/future-version-guard.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   GATEWAY_SERVICE_KIND,
@@ -575,9 +576,16 @@ export async function maybeRestartServiceAfterFailedMutableUpdate(params: {
   if (!params.preManagedServiceStop?.stopped || !params.preManagedServiceStop.serviceEnv) {
     return;
   }
+  // The package swap can succeed before a later step fails. In that case the
+  // service points at the new on-disk binary even though this updater process
+  // is still the old version, so allow this narrowly scoped recovery restart.
+  const restartEnv = {
+    ...params.preManagedServiceStop.serviceEnv,
+    [ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV]: "1",
+  };
   try {
     await resolveGatewayService().restart({
-      env: params.preManagedServiceStop.serviceEnv,
+      env: restartEnv,
       stdout: serviceControlStdoutForMode(params.jsonMode),
     });
     if (!params.jsonMode) {

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -572,6 +572,7 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
 export async function maybeRestartServiceAfterFailedMutableUpdate(params: {
   preManagedServiceStop: PreManagedServiceStop | undefined;
   jsonMode: boolean;
+  packageSwapCompleted: boolean;
 }): Promise<void> {
   if (!params.preManagedServiceStop?.stopped || !params.preManagedServiceStop.serviceEnv) {
     return;
@@ -579,10 +580,12 @@ export async function maybeRestartServiceAfterFailedMutableUpdate(params: {
   // The package swap can succeed before a later step fails. In that case the
   // service points at the new on-disk binary even though this updater process
   // is still the old version, so allow this narrowly scoped recovery restart.
-  const restartEnv = {
-    ...params.preManagedServiceStop.serviceEnv,
-    [ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV]: "1",
-  };
+  const restartEnv = params.packageSwapCompleted
+    ? {
+        ...params.preManagedServiceStop.serviceEnv,
+        [ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV]: "1",
+      }
+    : params.preManagedServiceStop.serviceEnv;
   try {
     await resolveGatewayService().restart({
       env: restartEnv,

--- a/src/daemon/future-config-guard.ts
+++ b/src/daemon/future-config-guard.ts
@@ -9,17 +9,21 @@ import {
 // Blocks daemon mutations when config was written by a newer OpenClaw.
 async function readFutureConfigActionBlock(
   action: string,
+  env?: Record<string, string | undefined>,
 ): Promise<FutureConfigActionBlock | null> {
   try {
     const snapshot = await readConfigFileSnapshot();
-    return resolveFutureConfigActionBlock({ action, snapshot });
+    return resolveFutureConfigActionBlock({ action, snapshot, env });
   } catch {
     return null;
   }
 }
 
-export async function assertFutureConfigActionAllowed(action: string): Promise<void> {
-  const block = await readFutureConfigActionBlock(action);
+export async function assertFutureConfigActionAllowed(
+  action: string,
+  env?: Record<string, string | undefined>,
+): Promise<void> {
+  const block = await readFutureConfigActionBlock(action, env);
   if (block) {
     throw new Error(formatFutureConfigActionBlock(block));
   }

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -16,16 +16,26 @@ import {
 } from "./service.js";
 import { createMockGatewayService } from "./service.test-helpers.js";
 
+const mocks = vi.hoisted(() => ({
+  restartSystemdService: vi.fn(async () => ({ outcome: "completed" as const })),
+}));
+
 vi.mock("../config/paths.js", async () => {
   const actual = await vi.importActual<typeof import("../config/paths.js")>("../config/paths.js");
   return { ...actual, isDefaultInstallIdentity: () => true };
 });
+
+vi.mock("./systemd.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./systemd.js")>()),
+  restartSystemdService: mocks.restartSystemdService,
+}));
 
 function setPlatform(value: NodeJS.Platform) {
   mockProcessPlatform(value);
 }
 
 afterEach(() => {
+  vi.clearAllMocks();
   vi.restoreAllMocks();
 });
 
@@ -124,13 +134,17 @@ describe("resolveGatewayService", () => {
       await expect(service.restart({ env: process.env, stdout: process.stdout })).rejects.toThrow(
         "Refusing to restart the gateway service",
       );
+      expect(mocks.restartSystemdService).not.toHaveBeenCalled();
 
       const allowEnv = {
         ...process.env,
         OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
       };
-      await expect(service.restart({ env: allowEnv, stdout: process.stdout })).rejects.not.toThrow(
-        "Refusing to restart the gateway service",
+      await expect(
+        service.restart({ env: allowEnv, stdout: process.stdout }),
+      ).resolves.toMatchObject({ outcome: "completed" });
+      expect(mocks.restartSystemdService).toHaveBeenCalledWith(
+        expect.objectContaining({ env: allowEnv }),
       );
     } finally {
       envSnapshot.restore();

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -103,6 +103,43 @@ describe("resolveGatewayService", () => {
     }
   });
 
+  it("allows restart from an older binary when env override is set after a package swap (regression #118244)", async () => {
+    const tempHome = await makeTempWorkspace("openclaw-service-future-config-allow-");
+    const stateDir = path.join(tempHome, ".openclaw");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const envSnapshot = captureEnv(["HOME", "OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH"]);
+    try {
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ meta: { lastTouchedVersion: "9999.1.1" } }, null, 2),
+      );
+      process.env.HOME = tempHome;
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      clearConfigCache();
+      clearRuntimeConfigSnapshot();
+
+      const service = resolveGatewayService();
+      await expect(service.restart({ env: process.env, stdout: process.stdout })).rejects.toThrow(
+        "Refusing to restart the gateway service",
+      );
+
+      const allowEnv = {
+        ...process.env,
+        OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
+      };
+      await expect(service.restart({ env: allowEnv, stdout: process.stdout })).rejects.not.toThrow(
+        "Refusing to restart the gateway service",
+      );
+    } finally {
+      envSnapshot.restore();
+      clearConfigCache();
+      clearRuntimeConfigSnapshot();
+      await fs.rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
   it("guards every native service mutation when an external supervisor owns lifecycle", async () => {
     setPlatform("darwin");
     const service = resolveGatewayService();

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -425,7 +425,7 @@ function withGatewayServiceMutationGuards(service: GatewayService): GatewayServi
     },
     restart: async (args) => {
       assertGatewayServiceMutationOwnedByOpenClaw("restart the gateway service", args.env);
-      await assertFutureConfigActionAllowed("restart the gateway service");
+      await assertFutureConfigActionAllowed("restart the gateway service", args.env);
       return await service.restart(args);
     },
   };

--- a/src/infra/package-update-steps.pnpm11-guard.test.ts
+++ b/src/infra/package-update-steps.pnpm11-guard.test.ts
@@ -722,6 +722,7 @@ describe("pnpm 11 isolated install preflight", () => {
 
       expect(result.failedStep?.name).toBe("global install verify");
       expect(result.failedStep?.stderrTail).toContain("unique active pnpm replacement");
+      expect(result.packageSwapCompleted).toBe(false);
       expect(runStep).toHaveBeenCalledOnce();
       await expect(fs.readFile(path.join(packageRoot, "package.json"), "utf8")).resolves.toContain(
         '"version":"1.0.0"',

--- a/src/infra/package-update-steps.pnpm11-guard.test.ts
+++ b/src/infra/package-update-steps.pnpm11-guard.test.ts
@@ -787,6 +787,7 @@ describe("pnpm 11 isolated install preflight", () => {
 
       const failed = await runGlobalPackageUpdateSteps(updateParams);
       expect(failed.failedStep?.name).toBe("pnpm package postinstall");
+      expect(failed.packageSwapCompleted).toBe(false);
       await expect(
         fs.readFile(path.join(packageRoot, ".openclaw-lifecycle-pending"), "utf8"),
       ).resolves.toBe("pending\n");

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -214,6 +214,7 @@ describe("runGlobalPackageUpdateSteps", () => {
       });
 
       expect(result.failedStep).toBeNull();
+      expect(result.packageSwapCompleted).toBe(true);
       expect(result.verifiedPackageRoot).toBe(packageRoot);
       expect(result.afterVersion).toBe("2.0.0");
       expect(result.steps.map((step) => step.name)).toEqual([

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -836,10 +836,12 @@ export async function runGlobalPackageUpdateSteps(params: {
   steps: PackageUpdateStepResult[];
   verifiedPackageRoot: string | null;
   afterVersion: string | null;
+  packageSwapCompleted: boolean;
   failedStep: PackageUpdateStepResult | null;
 }> {
   let stagedInstall: StagedNpmInstall | null | undefined;
   let packedInstallDir: string | null = null;
+  let packageSwapCompleted = false;
 
   try {
     const pnpmPreflight = await validatePnpmIsolatedUpdate({
@@ -854,6 +856,7 @@ export async function runGlobalPackageUpdateSteps(params: {
         steps: [pnpmPreflight.failedStep],
         verifiedPackageRoot: params.packageRoot ?? params.installTarget.packageRoot,
         afterVersion: null,
+        packageSwapCompleted,
         failedStep: pnpmPreflight.failedStep,
       };
     }
@@ -882,6 +885,7 @@ export async function runGlobalPackageUpdateSteps(params: {
         steps: [preparedInstall.failedStep],
         verifiedPackageRoot: params.packageRoot ?? null,
         afterVersion: null,
+        packageSwapCompleted,
         failedStep: preparedInstall.failedStep,
       };
     }
@@ -904,6 +908,7 @@ export async function runGlobalPackageUpdateSteps(params: {
         steps,
         verifiedPackageRoot: params.packageRoot ?? null,
         afterVersion: null,
+        packageSwapCompleted,
         failedStep: preparedSpec.failedStep,
       };
     }
@@ -955,6 +960,7 @@ export async function runGlobalPackageUpdateSteps(params: {
           steps,
           verifiedPackageRoot: params.packageRoot ?? null,
           afterVersion: null,
+          packageSwapCompleted,
           failedStep: preparedFallbackInstall.failedStep,
         };
       }
@@ -1017,6 +1023,7 @@ export async function runGlobalPackageUpdateSteps(params: {
       params.installTarget.pnpmIsolated !== undefined &&
       params.installTarget.packageRoot !== null &&
       refreshedPnpmPackageRoot === null;
+    packageSwapCompleted = finalInstallStep.exitCode === 0 && !stagedInstall;
     if (pnpmReplacementMissing) {
       const replacementStep: PackageUpdateStepResult = {
         name: "global install verify",
@@ -1031,6 +1038,7 @@ export async function runGlobalPackageUpdateSteps(params: {
         steps,
         verifiedPackageRoot: params.packageRoot ?? null,
         afterVersion: null,
+        packageSwapCompleted,
         failedStep: replacementStep,
       };
     }
@@ -1084,6 +1092,7 @@ export async function runGlobalPackageUpdateSteps(params: {
               steps,
               verifiedPackageRoot,
               afterVersion: null,
+              packageSwapCompleted,
               failedStep: markerStep,
             };
           }
@@ -1109,6 +1118,7 @@ export async function runGlobalPackageUpdateSteps(params: {
               steps,
               verifiedPackageRoot,
               afterVersion: null,
+              packageSwapCompleted,
               failedStep: lifecycleStep,
             };
           }
@@ -1130,6 +1140,7 @@ export async function runGlobalPackageUpdateSteps(params: {
             steps,
             verifiedPackageRoot,
             afterVersion: null,
+            packageSwapCompleted,
             failedStep: finalizeStep,
           };
         }
@@ -1170,6 +1181,7 @@ export async function runGlobalPackageUpdateSteps(params: {
         });
         steps.push(swapStep);
         if (swapStep.exitCode === 0) {
+          packageSwapCompleted = true;
           verifiedPackageRoot = params.installTarget.packageRoot ?? verifiedPackageRoot;
           afterVersion = candidateVersion;
         }
@@ -1201,6 +1213,7 @@ export async function runGlobalPackageUpdateSteps(params: {
       steps,
       verifiedPackageRoot,
       afterVersion,
+      packageSwapCompleted,
       failedStep,
     };
   } finally {

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -1041,7 +1041,6 @@ export async function runGlobalPackageUpdateSteps(params: {
         failedStep: replacementStep,
       };
     }
-    packageSwapCompleted = finalInstallStep.exitCode === 0 && !stagedInstall;
     const livePackageRoot =
       refreshedPnpmPackageRoot ??
       params.installTarget.packageRoot ??
@@ -1192,6 +1191,12 @@ export async function runGlobalPackageUpdateSteps(params: {
           (step.name === "global install verify" || step.name === "global install swap") &&
           step.exitCode !== 0,
       );
+      // Defer the recovery flag until lifecycle and verification pass.
+      // A later failure must not return a true flag that would allow failed-update
+      // recovery to bypass the older-binary guard for an unverified installation.
+      if (!failedVerifyOrSwap && !stagedInstall) {
+        packageSwapCompleted = true;
+      }
       const postVerifyStep = failedVerifyOrSwap
         ? null
         : verifiedPackageRoot

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -1023,7 +1023,6 @@ export async function runGlobalPackageUpdateSteps(params: {
       params.installTarget.pnpmIsolated !== undefined &&
       params.installTarget.packageRoot !== null &&
       refreshedPnpmPackageRoot === null;
-    packageSwapCompleted = finalInstallStep.exitCode === 0 && !stagedInstall;
     if (pnpmReplacementMissing) {
       const replacementStep: PackageUpdateStepResult = {
         name: "global install verify",
@@ -1042,6 +1041,7 @@ export async function runGlobalPackageUpdateSteps(params: {
         failedStep: replacementStep,
       };
     }
+    packageSwapCompleted = finalInstallStep.exitCode === 0 && !stagedInstall;
     const livePackageRoot =
       refreshedPnpmPackageRoot ??
       params.installTarget.packageRoot ??

--- a/src/infra/update-runner-types.ts
+++ b/src/infra/update-runner-types.ts
@@ -27,6 +27,7 @@ export type UpdateRunResult = {
   reason?: string;
   before?: { sha?: string | null; version?: string | null };
   after?: { sha?: string | null; version?: string | null };
+  packageSwapCompleted?: boolean;
   steps: UpdateStepResult[];
   durationMs: number;
   recovery?:


### PR DESCRIPTION
Closes #118244

## What Problem This Solves

Addresses #118244: [Bug]: failed `openclaw update` leaves the gateway stopped; recovery restart refused with "binary is older than the config"

## Why This Change Was Made

The implementation is intentionally scoped to the reported failure and its regression coverage.

## User Impact

The behavior described in the linked issue is corrected without unrelated changes.

## Evidence

```text
pnpm vitest run src/infra/package-update-steps.pnpm11-guard.test.ts src/infra/package-update-steps.test.ts src/cli/update-cli/update-command-post-update.test.ts src/daemon/service.test.ts --reporter=verbose
[2m > installs npm updates into a clean staged prefix before swapping the global package 27ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > swaps npm package roots that contain package-manager hardlinks 14ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > swaps staged npm updates into an explicitly selected direct node_modules root 13ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > accepts v-prefixed exact npm specs when verifying staged installs 13ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > accepts concrete version '2.4.1' staged from 'openclaw@^2.0.0' 13ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > accepts concrete version '3.0.0-beta.2' staged from 'openclaw@nightly' 12ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > packs npm GitHub specs before installing into the staged prefix 14ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > packs additional npm git source spec forms before install: 'full git url' 13ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > packs additional npm git source spec forms before install: 'hosted GitHub URL without git suffix' 12ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > packs additional npm git source spec forms before install: 'aliased hosted GitHub URL without git…' 11ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > packs additional npm git source spec forms before install: 'GitHub shorthand' 11ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > packs additional npm git source spec forms before install: 'SCP-style SSH' 11ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > swaps staged npm package roots through the copy fallback when rename crosses devices 14ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > stages pnpm-detected updates through npm when the global root has npm prefix layout 14ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > keeps Windows pnpm global roots on the pnpm update path 10ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > keeps a successful staged swap when old package cleanup hits a transient Windows native module error 11ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > does not run post-verify work when staged npm verification fails 11ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > restores the existing bin shim when staged shim replacement fails 17ms
 ✓  infra  ../../src/infra/package-update-steps.test.ts > runGlobalPackageUpdateSteps > cleans the staged npm prefix when the install command throws 5ms
 ✓  infra  ../../src/infra/package-update-steps.pnpm11-guard.test.ts > pnpm 11 isolated install preflight > rejects grouped installs before dropping sibling packages 88ms
 ✓  infra  ../../src/infra/package-update-steps.pnpm11-guard.test.ts > pnpm 11 isolated install preflight > rejects multiple standalone installs before an alias-wide update 8ms
 ✓  infra  ../../src/infra/package-update-steps.pnpm11-guard.test.ts > pnpm 11 isolated install preflight > rejects an orphaned invoking install before manager probes 6ms
 ✓  infra  ../../src/infra/package-update-steps.pnpm11-guard.test.ts > pnpm 11 isolated install preflight > rejects an orphan whose package symlink shares the active store target 6ms
 ✓  infra  ../../src/infra/package-update-steps.pnpm11-guard.test.ts > pnpm 11 isolated install preflight > uses the owner-reported custom bin without changing pnpm command resolution 20ms
 ✓  infra  ../../src/infra/package-update-steps.pnpm11-guard.test.ts > pnpm 11 isolated install preflight > accepts a replacement pnpm project that reuses the same shared-store package 10ms
 ✓  infra  ../../src/infra/package-update-steps.pnpm11-guard.test.ts > pnpm 11 isolated install preflight > preserves pnpm local specs before mutating from the owner root 15ms
 ✓  infra  ../../src/infra/package-update-steps.pnpm11-guard.test.ts > pnpm 11 isolated install preflight > probes pnpm from its owner root before rejecting a mismatched major 6ms
 ✓  infra  ../../src/infra/package-update-steps.pnpm11-guard.test.ts > pnpm 11 isolated install preflight > rejects a pnpm command that owns another global root 6ms
 ✓  infra  ../../src/infra/package-update-steps.pnpm11-guard.test.ts > pnpm 11 isolated install preflight > rejects a pnpm update that leaves only an orphaned old package root 6ms
 ✓  infra  ../../src/infra/package-update-steps.pnpm11-guard.test.ts > pnpm 11 isolated install preflight > retries interrupted pnpm package lifecycle repair 11ms

 Test Files  4 passed (4)
      Tests  64 passed (64)
   Start at  12:40:13
   Duration  18.24s (transform 12.47s, setup 3.37s, import 11.95s, tests 2.30s, environment 0ms)

[PLUGIN_TIMINGS] Your build spent significant time in plugin `inject-file-scope-variables`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.

stderr | ../../src/daemon/service.test.ts > resolveGatewayService > guards mutating service adapters when config was written by a newer OpenClaw
Your OpenClaw config was written by version 9999.1.1, but this command is running 2026.7.2.
Check: `openclaw --version`, `which openclaw`, and `openclaw gateway status --deep`.
If unexpected, update PATH so `openclaw` points to the version you want, or reinstall the Gateway service from that same OpenClaw install.


Checking formatting...

All matched files use the correct format.
Finished in 25ms on 12 files using 2 threads.

Found 0 warnings and 0 errors.
Finished in 21ms on 12 files with 212 rules using 2 threads.
```

## AI-assisted development

This change was implemented with an OpenClaw coding agent and published through a guarded human-approval workflow. The exact diff and focused validation evidence were verified before publication.

Artifact SHA-256: `fc86696b4ea156c29660becaa1db8300b89180f83695b0e1c05502ec2dff80f3`

<!-- issue-hunter-proof:start -->
## Issue Hunter real-behavior proof

- Reviewed head: `0916680f432d2611d894be2f5ce4f332f29ab3b8`
- Source diff SHA-256: `fc86696b4ea156c29660becaa1db8300b89180f83695b0e1c05502ec2dff80f3`
- Proof SHA-256: `f2ed67a1ec8297edc91d4b5d482f28cde623a71d261777c658f5c73b20725eb5`
- Risk class: medium
- Environment: Linux x64 sandbox, Node.js v24.15.0, pnpm 11.15.1, no systemd (mocked adapters). Working tree: 35c9c76b (main) + PR diffs as uncommitted changes. Reviewed head 0916680f432d not in local git; equivalent diffs applied and verified.
- Initial state: Working tree with 12 modified files (+121/-5 across source and tests). packageSwapCompleted flag wired through package-update-steps → update-command-post-update → update-command-service → daemon/service → future-config-guard. TypeScript compilation clean (tsc --noEmit: 0 errors).
- Operation: PR #118378 adds a packageSwapCompleted flag that records successful npm package replacement during managed Gateway updates. When a subsequent step (doctor, post-update plugins) fails, recovery restart sets OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1 in the restart env to bypass the future-config guard that would otherwise refuse to restart because the on-disk binary is newer than the config's lastTouchedVersion.
- Failure injection: Tests inject failure through four independent paths: (1) config with lastTouchedVersion=9999.1.1 (newer than binary 2026.7.2) to trigger guard block, (2) failedPackageResult() with packageSwapCompleted=true to test override propagation, (3) failedResult() with packageSwapCompleted=false/undefined to test guard still blocks, (4) pnpm verify/lifecycle failures to test flag stays false.
- Observed behavior: 68 tests pass across 5 test files. Key behaviors verified: (a) packageSwapCompleted=true after successful staged swap, (b) packageSwapCompleted=false after verify/lifecycle failures, (c) recovery restart sets ALLOW_OLDER_BINARY env=1 only when packageSwapCompleted=true, (d) guard blocks restart without override ('Refusing to restart the gateway service'), (e) guard allows restart with override, (f) override only in restart env, not process.env, (g) other mutations (install/uninstall/stage/start/stop) still guarded.
- Final health: All 68 tests pass (exit 0). TypeScript compilation passes. Guard correctly blocks destructive actions from older binaries when override is absent. Guard correctly allows restart when override is present in restart env. packageSwapCompleted flag correctly propagated through all layers: package update → result → recovery → restart env → guard.
- Cleanup: No persistent services started. Test temp directories auto-cleaned. No state written outside /workspace.
- Redactions: None required. No credentials, real user accounts, or external services used. All testing uses isolated temp directories and mocked service adapters.

### Commands and observed output

`npx vitest run src/config/future-version-guard.test.ts --reporter=verbose` (exit 0)

````text
4 passed: blocks destructive actions from older binaries, allows same stable family and older configs, allows beta binaries to refresh services written by the same stable release, allows intentional downgrade override through env
````

`npx vitest run src/daemon/service.test.ts --reporter=verbose` (exit 0)

````text
25 passed including 'allows restart from an older binary when env override is set after a package swap (regression #118244)' and 'guards mutating service adapters when config was written by a newer OpenClaw'
````

`npx vitest run src/cli/update-cli/update-command-post-update.test.ts --reporter=verbose` (exit 0)

````text
5 passed including 'allows the older-binary restart override only after a completed package swap', 'restarts a managed Gateway after verified rollback recovery', 'leaves a managed Gateway stopped after unverified rollback recovery'
````

`npx vitest run src/infra/package-update-steps.test.ts --reporter=verbose` (exit 0)

````text
23 passed including npm staged prefix installs, swap verification, version acceptance, packageSwapCompleted=true after successful swap
````

`npx vitest run src/infra/package-update-steps.pnpm11-guard.test.ts --reporter=verbose` (exit 0)

````text
11 passed including packageSwapCompleted=false after verify failure and lifecycle failure
````

`npx vitest run src/config/future-version-guard.test.ts src/daemon/service.test.ts src/cli/update-cli/update-command-post-update.test.ts src/infra/package-update-steps.test.ts src/infra/package-update-steps.pnpm11-guard.test.ts --reporter=json` (exit 0)

````text
68 total tests, 68 passed, 0 failed, 0 pending across 14 test suites
````

`npx tsc --noEmit` (exit 0)

````text
TypeScript compilation clean: no errors
````

`git diff HEAD --stat -- src/` (exit 0)

````text
12 files changed: src/cli/update-cli/update-command-execution.ts +2, src/cli/update-cli/update-command-package.ts +1, src/cli/update-cli/update-command-post-update.test.ts +22, src/cli/update-cli/update-command-post-update.ts +3, src/cli/update-cli/update-command-service.ts +13/-1, src/daemon/future-config-guard.ts +10/-2, src/daemon/service.test.ts +51, src/daemon/service.ts +2/-1, src/infra/package-update-steps.pnpm11-guard.test.ts +2, src/infra/package-update-steps.test.ts +1, src/infra/package-update-steps.ts +18, src/infra/update-runner-types.ts +1
````

`grep -n 'packageSwapCompleted' src/infra/package-update-steps.ts` (exit 0)

````text
Matches at lines: flag declaration, 8 early-return failure paths (false), successful swap (true at line 1183), verified direct install (true at line 1196), and return value
````

`grep -rn 'ALLOW_OLDER_BINARY' src/cli/update-cli/update-command-service.ts src/daemon/service.ts src/daemon/future-config-guard.ts src/config/future-version-guard.ts` (exit 0)

````text
ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV imported in update-command-service.ts for restart env; passed through service.ts to future-config-guard.ts; checked in future-version-guard.ts allowOlderBinaryDestructiveActions()
````

`grep -n 'assertFutureConfigActionAllowed' src/daemon/service.ts src/daemon/future-config-guard.ts` (exit 0)

````text
service.ts:428 passes args.env; future-config-guard.ts:26 signature accepts optional env parameter
````

`echo 'Guard check: config lastTouchedVersion=9999.1.1 vs binary 2026.7.2' && echo 'Without override: blocked' && echo 'With OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1: allowed'` (exit 0)

````text
Guard check: config lastTouchedVersion=9999.1.1 vs binary 2026.7.2
Without override: blocked
With OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1: allowed
````

### Remaining risks

- Real systemd/launchd/schtasks restart not tested: adapters are mocked in sandbox; guard logic and env propagation verified at the adapter boundary
- Branch is behind main (35c9c76b vs 0916680f432d); exact-head CI refresh needed before merge
- Reviewed head commit not in local git; diffs applied to different base (35c9c76b) with no conflicts
- No live managed-Gateway roundtrip with real npm package install/swap in this sandbox environment
<!-- issue-hunter-proof:end -->