### PR TITLE
perf(gateway): bound sessions.list transcript validation

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -71,6 +71,11 @@ type ResolvedTranscriptReadScope = ResolvedSqliteReadScope & {
   sessionId: string;
 };
 
+export type SessionSqliteTargetResolutionCache = Map<
+  NodeJS.ProcessEnv | undefined,
+  Map<string, ReturnType<typeof resolveSqliteTargetFromSessionStorePath>>
+>;
+
 const SQLITE_SESSION_SLOW_WRITE_MS = 1_000;
 const SQLITE_SESSION_WRITER_QUEUES = new Map<string, StoreWriterQueue>();
 
@@ -165,6 +170,7 @@ export function resolveSqliteReadScope(
     SessionTranscriptReadScope,
     "agentId" | "defaultAgentId" | "env" | "sessionKey" | "storePath"
   >,
+  targetCache?: SessionSqliteTargetResolutionCache,
 ): ResolvedSqliteReadScope {
   const sessionKey = scope.sessionKey ? normalizeSqliteSessionKey(scope.sessionKey) : undefined;
   const parsedAgentId = parseAgentSessionKey(sessionKey)?.agentId;
@@ -177,11 +183,15 @@ export function resolveSqliteReadScope(
     : scope.storePath;
   const effectiveAgentId = incognitoAgentId ?? scopedAgentId;
   const storeTarget = effectiveStorePath
-    ? resolveSqliteTargetFromSessionStorePath(effectiveStorePath, {
-        agentId: effectiveAgentId,
-        defaultAgentId: scope.defaultAgentId,
-        ...(scope.env ? { env: scope.env } : {}),
-      })
+    ? resolveCachedSqliteStoreTarget(
+        {
+          agentId: effectiveAgentId,
+          defaultAgentId: scope.defaultAgentId,
+          env: scope.env,
+          storePath: effectiveStorePath,
+        },
+        targetCache,
+      )
     : undefined;
   const agentId = resolveSqliteAgentId({
     scopedAgentId: effectiveAgentId,
@@ -199,6 +209,40 @@ export function resolveSqliteReadScope(
     ...(storeTarget ? { path: storeTarget.path } : {}),
     ...(sessionKey ? { sessionKey } : {}),
   };
+}
+
+function resolveCachedSqliteStoreTarget(
+  params: {
+    agentId?: string;
+    defaultAgentId?: string;
+    env?: NodeJS.ProcessEnv;
+    storePath: string;
+  },
+  targetCache: SessionSqliteTargetResolutionCache | undefined,
+): ReturnType<typeof resolveSqliteTargetFromSessionStorePath> {
+  if (!targetCache) {
+    return resolveSqliteTargetFromSessionStorePath(params.storePath, {
+      agentId: params.agentId,
+      defaultAgentId: params.defaultAgentId,
+      ...(params.env ? { env: params.env } : {}),
+    });
+  }
+  // Store ownership is stable for this batch. Scope the cache to the caller so later requests
+  // still observe owner changes after migration, install, or doctor flows.
+  const envCache = targetCache.get(params.env) ?? new Map();
+  targetCache.set(params.env, envCache);
+  const cacheKey = JSON.stringify([params.storePath, params.agentId, params.defaultAgentId]);
+  const cached = envCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const resolved = resolveSqliteTargetFromSessionStorePath(params.storePath, {
+    agentId: params.agentId,
+    defaultAgentId: params.defaultAgentId,
+    ...(params.env ? { env: params.env } : {}),
+  });
+  envCache.set(cacheKey, resolved);
+  return resolved;
 }
 
 export function resolveSqliteStoreScope(
@@ -273,9 +317,10 @@ export function resolveSqliteTranscriptReadScope(
     SessionTranscriptReadScope,
     "agentId" | "env" | "sessionId" | "sessionKey" | "storePath"
   >,
+  targetCache?: SessionSqliteTargetResolutionCache,
 ): ResolvedTranscriptReadScope {
   return {
-    ...resolveSqliteReadScope(scope),
+    ...resolveSqliteReadScope(scope, targetCache),
     sessionId: scope.sessionId,
   };
 }

--- a/src/config/sessions/session-accessor.sqlite-title-probes.ts
+++ b/src/config/sessions/session-accessor.sqlite-title-probes.ts
@@ -13,6 +13,7 @@ import type {
 import {
   resolveSqliteTranscriptReadScope,
   toDatabaseOptions,
+  type SessionSqliteTargetResolutionCache,
 } from "./session-accessor.sqlite-scope.js";
 
 type TitleProbeDatabase = Pick<
@@ -180,8 +181,9 @@ export function readSessionTranscriptTitleProbeBatch(
     string,
     { database: OpenClawAgentDatabase; items: Array<{ index: number; sessionId: string }> }
   >();
+  const targetCache: SessionSqliteTargetResolutionCache = new Map();
   for (const [index, scope] of scopes.entries()) {
-    const resolved = resolveSqliteTranscriptReadScope(scope);
+    const resolved = resolveSqliteTranscriptReadScope(scope, targetCache);
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const group = groups.get(database.path) ?? { database, items: [] };
     group.items.push({ index, sessionId: resolved.sessionId });

--- a/src/config/sessions/session-accessor.sqlite-transcript-watermark.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-watermark.ts
@@ -2,24 +2,34 @@
 // validates transcript-derived caches (derived titles, branch summaries).
 // Kept apart from the active-events reader so cache validation stays a
 // dependency-light import for gateway callers.
-import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
-import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import {
+  openOpenClawAgentDatabase,
+  type OpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
 import type { SessionTranscriptReadScope } from "./session-accessor.sqlite-contract.js";
 import {
   resolveSqliteTranscriptReadScope,
   toDatabaseOptions,
+  type SessionSqliteTargetResolutionCache,
 } from "./session-accessor.sqlite-scope.js";
 
 type WatermarkDatabase = Pick<
   OpenClawAgentKyselyDatabase,
-  "transcript_events" | "transcript_rewrite_watermarks"
+  "session_windows" | "transcript_events" | "transcript_rewrite_watermarks"
 >;
 
 export type SessionTranscriptWatermark = {
   generation: string | null;
   maxSeq: number | null;
 };
+
+const SESSION_TRANSCRIPT_WATERMARK_QUERY_CHUNK_SIZE = 400;
 
 /** Reads the append and rewrite tokens that validate transcript-derived caches. */
 export function readSessionTranscriptWatermark(
@@ -43,4 +53,88 @@ export function readSessionTranscriptWatermark(
       .where("session_id", "=", resolved.sessionId),
   )?.generation;
   return { generation: generation ?? null, maxSeq: maxSeq ?? null };
+}
+
+function readSessionTranscriptWatermarkChunk(
+  database: OpenClawAgentDatabase,
+  sessionIds: readonly string[],
+): Map<string, SessionTranscriptWatermark> {
+  const db = getNodeSqliteKysely<WatermarkDatabase>(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("session_windows as window")
+      .leftJoin(
+        "transcript_rewrite_watermarks as rewrite",
+        "rewrite.session_id",
+        "window.session_id",
+      )
+      .select((eb) => [
+        "window.session_id",
+        "rewrite.generation",
+        eb
+          .selectFrom("transcript_events as event")
+          .select((inner) => inner.fn.max<number>("event.seq").as("max_seq"))
+          .whereRef("event.session_id", "=", "window.session_id")
+          .as("max_seq"),
+      ])
+      .where("window.session_id", "in", sessionIds),
+  ).rows;
+  return new Map(
+    rows.map((row) => [
+      row.session_id,
+      {
+        generation: row.generation ?? null,
+        maxSeq: row.max_seq ?? null,
+      },
+    ]),
+  );
+}
+
+/** Reads cache-validation tokens in one statement per opened store and SQLite-sized chunk. */
+export function readSessionTranscriptWatermarkBatch(
+  scopes: readonly SessionTranscriptReadScope[],
+): SessionTranscriptWatermark[] {
+  const results: Array<SessionTranscriptWatermark | undefined> = Array.from({
+    length: scopes.length,
+  });
+  const groups = new Map<
+    string,
+    { database: OpenClawAgentDatabase; items: Array<{ index: number; sessionId: string }> }
+  >();
+  const targetCache: SessionSqliteTargetResolutionCache = new Map();
+  for (const [index, scope] of scopes.entries()) {
+    const resolved = resolveSqliteTranscriptReadScope(scope, targetCache);
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+    const group = groups.get(database.path) ?? { database, items: [] };
+    group.items.push({ index, sessionId: resolved.sessionId });
+    groups.set(database.path, group);
+  }
+  for (const group of groups.values()) {
+    const sessionIds = [...new Set(group.items.map((item) => item.sessionId))];
+    const watermarks = new Map<string, SessionTranscriptWatermark>();
+    for (
+      let offset = 0;
+      offset < sessionIds.length;
+      offset += SESSION_TRANSCRIPT_WATERMARK_QUERY_CHUNK_SIZE
+    ) {
+      const chunk = sessionIds.slice(
+        offset,
+        offset + SESSION_TRANSCRIPT_WATERMARK_QUERY_CHUNK_SIZE,
+      );
+      for (const [sessionId, watermark] of readSessionTranscriptWatermarkChunk(
+        group.database,
+        chunk,
+      )) {
+        watermarks.set(sessionId, watermark);
+      }
+    }
+    for (const item of group.items) {
+      results[item.index] = watermarks.get(item.sessionId) ?? {
+        generation: null,
+        maxSeq: null,
+      };
+    }
+  }
+  return results.map((result) => result ?? { generation: null, maxSeq: null });
 }

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -3644,5 +3644,49 @@ describe("session accessor seam", () => {
       storePath,
     });
   });
+
+  it("preserves a matching preloaded entry identity without rereading the session row", () => {
+    const sessionKey = "agent:main:preloaded-read";
+    const target = resolveSessionTranscriptReadTarget({
+      agentId: "main",
+      sessionEntry: { sessionId: "preloaded-session" },
+      sessionId: "preloaded-session",
+      sessionKey,
+      storePath,
+    });
+
+    expect(target).toEqual({
+      agentId: "main",
+      sessionId: "preloaded-session",
+      sessionKey,
+      storePath,
+    });
+  });
+
+  it("does not trust a preloaded entry for a different session id", async () => {
+    const sessionKey = "agent:main:mismatched-preloaded-read";
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "stored-session",
+        updatedAt: 10,
+      },
+    );
+
+    const target = resolveSessionTranscriptReadTarget({
+      agentId: "main",
+      sessionEntry: { sessionId: "different-session" },
+      sessionId: "stored-session",
+      sessionKey,
+      storePath,
+    });
+
+    expect(target).toEqual({
+      agentId: "main",
+      sessionId: "stored-session",
+      sessionKey,
+      storePath,
+    });
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/config/sessions/session-accessor.transcript-target.ts
+++ b/src/config/sessions/session-accessor.transcript-target.ts
@@ -77,22 +77,25 @@ export function resolveSessionTranscriptReadTarget(
     sessionKey,
     storePath: configuredStorePath,
   });
-  const resolved = sessionKey
-    ? resolveSessionEntrySelection(
-        {
-          agentId,
-          ...(scope.env ? { env: scope.env } : {}),
-          sessionKey,
-          storePath,
-        },
-        { readOnly: true },
-      )
-    : undefined;
+  const hasMatchingSessionEntry = scope.sessionEntry?.sessionId === scope.sessionId;
+  const resolved =
+    sessionKey && !hasMatchingSessionEntry
+      ? resolveSessionEntrySelection(
+          {
+            agentId,
+            ...(scope.env ? { env: scope.env } : {}),
+            sessionKey,
+            storePath,
+          },
+          { readOnly: true },
+        )
+      : undefined;
+  const resolvedSessionKey = hasMatchingSessionEntry ? sessionKey : resolved?.normalizedKey;
   return {
     agentId,
     sessionId: scope.sessionId,
     storePath,
-    ...(resolved?.normalizedKey ? { sessionKey: resolved.normalizedKey } : {}),
+    ...(resolvedSessionKey ? { sessionKey: resolvedSessionKey } : {}),
   };
 }
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -245,6 +245,7 @@ export type {
 } from "./session-accessor.sqlite-active-events.js";
 export {
   readSessionTranscriptWatermark,
+  readSessionTranscriptWatermarkBatch,
   type SessionTranscriptWatermark,
 } from "./session-accessor.sqlite-transcript-watermark.js";
 export {

--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
@@ -36,6 +37,8 @@ vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
     readSessionTranscriptMessageEventPage: vi.fn(actual.readSessionTranscriptMessageEventPage),
     readSessionTranscriptMessageEvents: vi.fn(actual.readSessionTranscriptMessageEvents),
     readSessionTranscriptTitleProbeBatch: vi.fn(actual.readSessionTranscriptTitleProbeBatch),
+    readSessionTranscriptWatermark: vi.fn(actual.readSessionTranscriptWatermark),
+    readSessionTranscriptWatermarkBatch: vi.fn(actual.readSessionTranscriptWatermarkBatch),
   };
 });
 
@@ -500,8 +503,39 @@ describe("session transcript reader facade", () => {
     expect(readSessionTitleFieldsFromTranscriptBatch([scope])).toEqual([
       { firstUserMessage: "cached batch prompt", lastMessagePreview: "cached batch reply" },
     ]);
+    expect(sessionAccessor.readSessionTranscriptWatermarkBatch).toHaveBeenCalledOnce();
+    expect(sessionAccessor.readSessionTranscriptWatermark).not.toHaveBeenCalled();
     expect(sessionAccessor.readSessionTranscriptTitleProbeBatch).not.toHaveBeenCalled();
     expect(sessionAccessor.readSessionTranscriptMessageEventPage).not.toHaveBeenCalled();
+  });
+
+  test("resolves SQLite store ownership once for a multi-row transcript batch", async () => {
+    const scopes: SessionTranscriptReadScope[] = [];
+    for (let index = 0; index < 30; index += 1) {
+      scopes.push(
+        await writeSqliteMessages(`reader-title-target-batch-${index}`, [
+          { role: "user", content: `prompt ${index}` },
+          { role: "assistant", content: `reply ${index}` },
+        ]),
+      );
+    }
+    const prepareSpy = vi.spyOn(DatabaseSync.prototype, "prepare");
+    try {
+      expect(sessionAccessor.readSessionTranscriptTitleProbeBatch(scopes)).toHaveLength(30);
+      const titleSchemaReads = prepareSpy.mock.calls.filter(([sql]) =>
+        sql.toLowerCase().includes("pragma user_version"),
+      );
+      expect(titleSchemaReads).toHaveLength(1);
+
+      prepareSpy.mockClear();
+      expect(sessionAccessor.readSessionTranscriptWatermarkBatch(scopes)).toHaveLength(30);
+      const watermarkSchemaReads = prepareSpy.mock.calls.filter(([sql]) =>
+        sql.toLowerCase().includes("pragma user_version"),
+      );
+      expect(watermarkSchemaReads).toHaveLength(1);
+    } finally {
+      prepareSpy.mockRestore();
+    }
   });
 
   test("reprobes cached batch title fields after an append advances max seq", async () => {
@@ -525,6 +559,8 @@ describe("session transcript reader facade", () => {
     expect(readSessionTitleFieldsFromTranscriptBatch([scope])[0]?.lastMessagePreview).toBe(
       "appended batch reply",
     );
+    expect(sessionAccessor.readSessionTranscriptWatermarkBatch).toHaveBeenCalledOnce();
+    expect(sessionAccessor.readSessionTranscriptWatermark).not.toHaveBeenCalled();
     expect(sessionAccessor.readSessionTranscriptTitleProbeBatch).toHaveBeenCalledOnce();
     expect(sessionAccessor.readSessionTranscriptMessageEventPage).not.toHaveBeenCalled();
   });

--- a/src/gateway/session-transcript-title-reader.ts
+++ b/src/gateway/session-transcript-title-reader.ts
@@ -4,6 +4,7 @@ import {
   readSessionTranscriptMessageEventPage,
   readSessionTranscriptTitleProbeBatch,
   readSessionTranscriptWatermark,
+  readSessionTranscriptWatermarkBatch,
   type SessionTranscriptMessageEvent,
   type SessionTranscriptReadScope,
 } from "../config/sessions/session-accessor.js";
@@ -173,6 +174,14 @@ export function readSessionTitleFieldsFromTranscriptBatch(
     scope: SessionTranscriptReadScope;
     target: ResolvedTranscriptReadTarget;
   }> = [];
+  const cachedCandidates: Array<{
+    cacheKey: string;
+    cached: SqliteTitleFieldCacheEntry;
+    cachedFields: SessionTitleFields;
+    index: number;
+    scope: SessionTranscriptReadScope;
+    target: ResolvedTranscriptReadTarget;
+  }> = [];
 
   for (const [index, scope] of scopes.entries()) {
     const target = resolveTranscriptReadTarget(scope);
@@ -181,16 +190,32 @@ export function readSessionTitleFieldsFromTranscriptBatch(
     const cached = sqliteTitleFieldCache.get(cacheKey);
     const cachedFields = cached?.fields[variant];
     if (cached && cachedFields) {
-      // Keep the single-row generation/maxSeq validity contract, but validate only warm rows;
-      // cold or changed rows still collapse into the one store-batched probe below.
-      const watermark = readSessionTranscriptWatermark(scope);
-      if (cached.generation === watermark.generation && cached.maxSeq === watermark.maxSeq) {
-        setSqliteTitleFieldCache(cacheKey, cached);
-        results.set(index, { ...cachedFields });
-        continue;
-      }
+      cachedCandidates.push({ cacheKey, cached, cachedFields, index, scope, target });
+      continue;
     }
     misses.push({ cacheKey, index, scope, target });
+  }
+
+  const watermarks = readSessionTranscriptWatermarkBatch(
+    cachedCandidates.map((candidate) => candidate.scope),
+  );
+  for (const [candidateIndex, candidate] of cachedCandidates.entries()) {
+    const watermark = watermarks[candidateIndex];
+    if (
+      watermark &&
+      candidate.cached.generation === watermark.generation &&
+      candidate.cached.maxSeq === watermark.maxSeq
+    ) {
+      setSqliteTitleFieldCache(candidate.cacheKey, candidate.cached);
+      results.set(candidate.index, { ...candidate.cachedFields });
+      continue;
+    }
+    misses.push({
+      cacheKey: candidate.cacheKey,
+      index: candidate.index,
+      scope: candidate.scope,
+      target: candidate.target,
+    });
   }
 
   const probes =

--- a/src/gateway/session-utils.perf.test.ts
+++ b/src/gateway/session-utils.perf.test.ts
@@ -311,6 +311,16 @@ describe("listSessionsFromStore resolver cache", () => {
           derivedTitle: "title 29",
           lastMessagePreview: "last 29",
         });
+
+        titleBatchSpy.mockClear();
+        await listSessionsFromStoreAsync({
+          cfg,
+          storePath,
+          store,
+          opts: { includeDerivedTitles: false, includeLastMessage: false, limit: 30 },
+        });
+        expect(titleBatchSpy).toHaveBeenCalledOnce();
+        expect(titleBatchSpy).toHaveBeenCalledWith([]);
       } finally {
         titleBatchSpy.mockRestore();
       }


### PR DESCRIPTION
## Summary

- honor the canonical `sessionEntry` already carried by `sessions.list` transcript scopes instead of rereading each session row
- resolve SQLite store ownership once per transcript batch
- validate warm title-cache entries with one batched watermark query per physical store/chunk, then reprobe only changed sessions

Follow-up to #118207 and #118027. No config, protocol, migration, or SQLite schema changes.

## Behavior contract

For a 100-session list with recent SQLite transcripts:

- cold and warm lists return correct derived titles and previews
- appending to one session invalidates and refreshes only that session
- transcript validation scales with physical stores/chunks plus changed sessions, not returned rows
- disabling transcript fields does not add transcript SQL work
- request-local ownership caching remains lifecycle-bounded; existing title-field LRU and 100-row hydration caps remain unchanged

## Root cause

`88d6a2c8` fixed the original cold title scan, but three row-scaled paths remained:

1. `resolveSessionTranscriptReadTarget` ignored a matching preloaded `sessionEntry`, so each list row reread `session_nodes`.
2. batched title/watermark readers resolved the same SQLite store target once per row.
3. warm title-cache validation issued separate generation and max-sequence queries per cached row.

The canonical owner is the session transcript accessor. This change restores the preloaded-entry contract there and adds a generic batched watermark reader; the gateway now uses that batch before probing changed rows.

## Exact evidence

Node 24.18.1, Linux x86_64, 4 vCPU Testbox; equivalent synthetic 25/50/100-session fixtures with real SQLite transcript turns. The 100-row results were:

| revision | cold SQL | warm SQL | one-row mutation SQL | cold ms | warm p50 ms | mutation p50 ms |
|---|---:|---:|---:|---:|---:|---:|
| `5332641ed3` (Wilfred deployment base) | 1308 | 701 | 709 | 162.29 | 41.94 | 32.20 |
| `88d6a2c8d6` (#118207) | 407 | 603 | 605 | 103.72 | 41.29 | 36.93 |
| `f2af4e97b3` (investigation main) | 407 | 603 | 605 | 110.11 | 43.64 | 39.31 |
| authored diff | 8 | 5 | 7 | 96.17 | 33.94 | 27.99 |

On the authored diff, SQL counts stayed at 8/5/7 for 25, 50, and 100 rows. The no-title negative control was 3 statements on both main and the patch. State-directory filesystem probes were unchanged at 202 `existsSync` checks and zero tracked file reads, scans, stats, lstat, or realpath calls; the remaining defect was SQLite/query-owner amplification rather than transcript-file I/O.

## Validation

- focused exact-head tests: 132 passed across session accessor, SQLite target, transcript reader, and list perf suites
- changed gate: production/test typechecks, lint, formatting, and repository guards passed
- fresh Testbox `pnpm build`: passed
- source-blind 8-turn benchmark at 50 ms cadence: 8/8 correct, 0 `sessions.list`/Control UI/readiness failures
  - `sessions.list`: p50 0.322 ms, p95 825.922 ms, max 1155.993 ms
  - Control UI: p50 0.988 ms, p95 1157.518 ms, max 1279.487 ms
  - turn duration: 4939.356 ms; final sample recovered to non-degraded
- cold first-authenticated-RPC startup remained separately visible (~20 s) and is now isolated by #118364; it is not attributed to transcript-list row cost
- fresh `autoreview`: clean

Production delta is +200/-30 lines; tests are +90. The positive production delta is the bounded batch watermark API and request-local target-resolution owner needed to remove the row-scaled queries without stale reads or process-lifetime caches.
