### PR TITLE
improve(tests): reuse PowerShell completion process

### DIFF
--- a/src/cli/completion-cli.aliases.test.ts
+++ b/src/cli/completion-cli.aliases.test.ts
@@ -1,13 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { getCompletionScript } from "./completion-cli.js";
 import {
   createAliasedCompletionProgram,
   itWithFish,
   itWithPowerShell,
+  PowerShellCompletionRunner,
   runGeneratedBashCompletion,
   runGeneratedFishCompletion,
-  runGeneratedPowerShellCompletion,
 } from "./completion-cli.test-support.js";
+
+const powerShellCompletion = new PowerShellCompletionRunner();
+
+afterAll(async () => {
+  await powerShellCompletion.close();
+});
 
 // Aliases are typeable commands, so every shell must preserve their nested command paths.
 describe("completion-cli command aliases", () => {
@@ -136,9 +142,9 @@ describe("completion-cli command aliases", () => {
     ["repeated global options", "openclaw --profile first --profile second cron create --a"],
     ["an inherited option after the parent", "openclaw cron --profile work create --a"],
     ["the canonical nested command", "openclaw --profile work cron add --a"],
-  ])("completes real PowerShell nested aliases after %s", (_name, commandLine) => {
-    expect(runGeneratedPowerShellCompletion(createAliasedCompletionProgram(), commandLine)).toEqual(
-      ["--at"],
-    );
+  ])("completes real PowerShell nested aliases after %s", async (_name, commandLine) => {
+    expect(
+      await powerShellCompletion.complete(createAliasedCompletionProgram(), commandLine),
+    ).toEqual(["--at"]);
   });
 });

--- a/src/cli/completion-cli.test-support.ts
+++ b/src/cli/completion-cli.test-support.ts
@@ -1,6 +1,8 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import path from "node:path";
+import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import { Command } from "commander";
 import { expect, it } from "vitest";
 import { getCompletionScript } from "./completion-cli.js";
@@ -102,32 +104,291 @@ function findPowerShell(): string | null {
 const powerShellPath = findPowerShell();
 export const itWithPowerShell = powerShellPath ? it : it.skip;
 
-export function runGeneratedPowerShellCompletion(program: Command, commandLine: string): string[] {
-  if (!powerShellPath) {
-    throw new Error("PowerShell is unavailable");
+type PowerShellCompletionResponse =
+  | { version: 1; id: string; ok: true; completions: string[] }
+  | { version: 1; id: string; ok: false; error: string };
+
+type PendingPowerShellCompletion = {
+  reject: (error: Error) => void;
+  resolve: (completions: string[]) => void;
+  timeout: ReturnType<typeof setTimeout>;
+};
+
+const POWERSHELL_CASE_TIMEOUT_MS = 15_000;
+const POWERSHELL_CLOSE_TIMEOUT_MS = 5_000;
+
+function encodePowerShellHostScript(framePrefix: string): string {
+  const script = String.raw`
+$ErrorActionPreference = 'Stop'
+[Console]::Out.WriteLine('${framePrefix}READY')
+[Console]::Out.Flush()
+while (($encodedRequest = [Console]::In.ReadLine()) -ne $null) {
+  $request = $null
+  try {
+    $requestJson = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($encodedRequest))
+    $request = $requestJson | ConvertFrom-Json
+    $completionScript = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String([string]$request.script))
+    $commandLine = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String([string]$request.commandLine))
+    Register-ArgumentCompleter -Native -CommandName openclaw -ScriptBlock $null
+    Invoke-Expression $completionScript | Out-Null
+    $completions = @(
+      [System.Management.Automation.CommandCompletion]::CompleteInput(
+        $commandLine,
+        $commandLine.Length,
+        $null
+      ).CompletionMatches | ForEach-Object { [string]$_.CompletionText }
+    )
+    $response = @{ version = 1; id = [string]$request.id; ok = $true; completions = $completions }
+  } catch {
+    $responseId = if ($null -ne $request -and $null -ne $request.id) {
+      [string]$request.id
+    } else {
+      'unknown'
+    }
+    $response = @{ version = 1; id = $responseId; ok = $false; error = ($_ | Out-String).Trim() }
+  } finally {
+    Register-ArgumentCompleter -Native -CommandName openclaw -ScriptBlock $null
+  }
+  $responseJson = $response | ConvertTo-Json -Compress -Depth 5
+  $encodedResponse = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($responseJson))
+  [Console]::Out.WriteLine('${framePrefix}' + $encodedResponse)
+  [Console]::Out.Flush()
+}
+`;
+  return Buffer.from(script, "utf16le").toString("base64");
+}
+
+function decodePowerShellCompletionResponse(encoded: string): PowerShellCompletionResponse {
+  const value = JSON.parse(Buffer.from(encoded, "base64").toString("utf8")) as unknown;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("PowerShell completion response was not an object");
+  }
+  const response = value as Record<string, unknown>;
+  if (
+    response.version !== 1 ||
+    typeof response.id !== "string" ||
+    typeof response.ok !== "boolean"
+  ) {
+    throw new Error("PowerShell completion response had an invalid envelope");
+  }
+  if (response.ok) {
+    if (
+      !Array.isArray(response.completions) ||
+      !response.completions.every((completion) => typeof completion === "string")
+    ) {
+      throw new Error("PowerShell completion response had invalid completions");
+    }
+    return {
+      version: 1,
+      id: response.id,
+      ok: true,
+      completions: response.completions,
+    };
+  }
+  if (typeof response.error !== "string") {
+    throw new Error("PowerShell completion response had no error text");
+  }
+  return { version: 1, id: response.id, ok: false, error: response.error };
+}
+
+/** One live PowerShell process per test file; cases remain sequential and state-isolated. */
+export class PowerShellCompletionRunner {
+  private child: ChildProcessWithoutNullStreams | undefined;
+  private closing = false;
+  private exitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }> | undefined;
+  private failure: Error | undefined;
+  private readonly framePrefix = `OPENCLAW_PWSH_V1:${randomBytes(8).toString("hex")}:`;
+  private pending = new Map<string, PendingPowerShellCompletion>();
+  private queue: Promise<void> = Promise.resolve();
+  private readyPromise: Promise<void> | undefined;
+  private stdoutLines: ReadlineInterface | undefined;
+
+  complete(program: Command, commandLine: string): Promise<string[]> {
+    const script = getCompletionScript("powershell", program);
+    const caseId = createHash("sha256")
+      .update(script)
+      .update("\0")
+      .update(commandLine)
+      .digest("hex")
+      .slice(0, 20);
+    const result = this.queue.then(() => this.completeCase(caseId, script, commandLine));
+    this.queue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 
-  const script = getCompletionScript("powershell", program);
-  const quotedCommandLine = commandLine.replaceAll("'", "''");
-  const result = spawnSync(
-    powerShellPath,
-    [
-      "-NoLogo",
-      "-NoProfile",
-      "-NonInteractive",
-      "-Command",
-      `${script}
-$line = '${quotedCommandLine}'
-[System.Management.Automation.CommandCompletion]::CompleteInput($line, $line.Length, $null).CompletionMatches | ForEach-Object { $_.CompletionText }
-`,
-    ],
-    { encoding: "utf8" },
-  );
-
-  if (result.error) {
-    throw result.error;
+  async close(): Promise<void> {
+    await this.queue;
+    if (!this.child || !this.exitPromise) {
+      return;
+    }
+    this.closing = true;
+    this.child.stdin.end();
+    let closeTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const outcome = await Promise.race([
+        this.exitPromise,
+        new Promise<never>((_resolve, reject) => {
+          closeTimer = setTimeout(
+            () => reject(new Error("PowerShell completion runner did not exit after stdin closed")),
+            POWERSHELL_CLOSE_TIMEOUT_MS,
+          );
+        }),
+      ]);
+      if (outcome.code !== 0 || outcome.signal !== null) {
+        throw new Error(
+          `PowerShell completion runner exited with code ${String(outcome.code)} signal ${String(outcome.signal)}`,
+        );
+      }
+      if (this.failure) {
+        throw this.failure;
+      }
+    } catch (error) {
+      this.child.kill("SIGTERM");
+      setTimeout(() => this.child?.kill("SIGKILL"), 1_000).unref();
+      throw error;
+    } finally {
+      if (closeTimer) {
+        clearTimeout(closeTimer);
+      }
+      this.stdoutLines?.close();
+    }
   }
-  expect(result.stderr).toBe("");
-  expect(result.status).toBe(0);
-  return result.stdout.split(/\r?\n/).filter(Boolean);
+
+  private async completeCase(
+    caseId: string,
+    script: string,
+    commandLine: string,
+  ): Promise<string[]> {
+    await this.start();
+    if (this.failure) {
+      throw this.failure;
+    }
+    const child = this.child;
+    if (!child) {
+      throw new Error("PowerShell completion runner did not start");
+    }
+    const request = Buffer.from(
+      JSON.stringify({
+        version: 1,
+        id: caseId,
+        script: Buffer.from(script, "utf8").toString("base64"),
+        commandLine: Buffer.from(commandLine, "utf8").toString("base64"),
+      }),
+      "utf8",
+    ).toString("base64");
+    return await new Promise<string[]>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.poison(new Error(`PowerShell completion case ${caseId} timed out`));
+      }, POWERSHELL_CASE_TIMEOUT_MS);
+      this.pending.set(caseId, { reject, resolve, timeout });
+      child.stdin.write(`${request}\n`, (error) => {
+        if (error) {
+          this.poison(new Error(`PowerShell completion write failed: ${error.message}`));
+        }
+      });
+    });
+  }
+
+  private start(): Promise<void> {
+    if (this.readyPromise) {
+      return this.readyPromise;
+    }
+    if (!powerShellPath) {
+      return Promise.reject(new Error("PowerShell is unavailable"));
+    }
+    const child = spawn(
+      powerShellPath,
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-EncodedCommand",
+        encodePowerShellHostScript(this.framePrefix),
+      ],
+      { stdio: "pipe" },
+    );
+    this.child = child;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    this.stdoutLines = createInterface({ input: child.stdout });
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      const readyTimeout = setTimeout(() => {
+        const error = new Error("PowerShell completion runner did not become ready");
+        reject(error);
+        this.poison(error);
+      }, POWERSHELL_CASE_TIMEOUT_MS);
+      this.stdoutLines?.on("line", (line) => {
+        if (line === `${this.framePrefix}READY`) {
+          clearTimeout(readyTimeout);
+          resolve();
+          return;
+        }
+        if (!line.startsWith(this.framePrefix)) {
+          this.poison(new Error(`Unexpected PowerShell completion stdout: ${line}`));
+          return;
+        }
+        try {
+          const response = decodePowerShellCompletionResponse(line.slice(this.framePrefix.length));
+          const pending = this.pending.get(response.id);
+          if (!pending) {
+            this.poison(new Error(`Unexpected PowerShell completion response id: ${response.id}`));
+            return;
+          }
+          clearTimeout(pending.timeout);
+          this.pending.delete(response.id);
+          if (response.ok) {
+            pending.resolve(response.completions);
+          } else {
+            pending.reject(
+              new Error(`PowerShell completion case ${response.id} failed: ${response.error}`),
+            );
+          }
+        } catch (error) {
+          this.poison(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
+      child.once("error", (error) => {
+        reject(error);
+        this.poison(error);
+      });
+      child.stderr.on("data", (chunk: string) => {
+        const stderr = chunk.trim();
+        if (stderr) {
+          this.poison(new Error(`Unexpected PowerShell completion stderr: ${stderr}`));
+        }
+      });
+      this.exitPromise = new Promise((exitResolve) => {
+        child.once("exit", (code, signal) => {
+          clearTimeout(readyTimeout);
+          exitResolve({ code, signal });
+          if (!this.closing || code !== 0 || signal !== null) {
+            this.poison(
+              new Error(
+                `PowerShell completion runner exited unexpectedly with code ${String(code)} signal ${String(signal)}`,
+              ),
+            );
+          }
+        });
+      });
+    });
+    return this.readyPromise;
+  }
+
+  private poison(error: Error): void {
+    if (this.failure) {
+      return;
+    }
+    this.failure = error;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.pending.clear();
+    if (!this.closing) {
+      this.child?.kill("SIGTERM");
+    }
+  }
 }

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -4,16 +4,22 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Command, Option } from "commander";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { getCompletionScript, registerCompletionCli } from "./completion-cli.js";
 import {
   createAliasedCompletionProgram,
   itWithFish,
   itWithPowerShell,
+  PowerShellCompletionRunner,
   runGeneratedBashCompletion,
   runGeneratedFishCompletion,
-  runGeneratedPowerShellCompletion,
 } from "./completion-cli.test-support.js";
+
+const powerShellCompletion = new PowerShellCompletionRunner();
+
+afterAll(async () => {
+  await powerShellCompletion.close();
+});
 
 function createCompletionProgram(): Command {
   const program = new Command();
@@ -238,9 +244,9 @@ _openclaw_root_completion
   itWithPowerShell.each([
     ["a long shell flag", "openclaw completion --shell f"],
     ["a short shell flag", "openclaw completion -s f"],
-  ])("completes validated values in real PowerShell after %s", (_name, commandLine) => {
+  ])("completes validated values in real PowerShell after %s", async (_name, commandLine) => {
     expect(
-      runGeneratedPowerShellCompletion(createDocumentedCompletionProgram(), commandLine),
+      await powerShellCompletion.complete(createDocumentedCompletionProgram(), commandLine),
     ).toEqual(["fish"]);
   });
 
@@ -260,9 +266,9 @@ _openclaw_root_completion
       commandLine: "openclaw --mode -l",
       expected: ["-legacy"],
     },
-  ])("preserves real PowerShell completion after $name", ({ commandLine, expected }) => {
+  ])("preserves real PowerShell completion after $name", async ({ commandLine, expected }) => {
     expect(
-      runGeneratedPowerShellCompletion(createOptionalChoiceCompletionProgram(), commandLine),
+      await powerShellCompletion.complete(createOptionalChoiceCompletionProgram(), commandLine),
     ).toEqual(expected);
   });
 
@@ -292,13 +298,13 @@ _openclaw_root_completion
       commandLine: "openclaw --value=a*",
       expected: ["--value='a*literal'"],
     },
-  ])("matches real PowerShell choices with $name", ({ commandLine, expected }) => {
+  ])("matches real PowerShell choices with $name", async ({ commandLine, expected }) => {
     const program = new Command().name("openclaw");
     program.addOption(
       new Option("--value <value>", "Value").choices(["alpha", "a*literal", "a[bracket]"]),
     );
 
-    expect(runGeneratedPowerShellCompletion(program, commandLine)).toEqual(expected);
+    expect(await powerShellCompletion.complete(program, commandLine)).toEqual(expected);
   });
 
   itWithPowerShell.each([
@@ -320,23 +326,23 @@ _openclaw_root_completion
       value: "literal; Write-Error OPENCLAW_COMPLETION_VALUE_EXECUTED",
       prefix: "literal",
     },
-  ])("inserts PowerShell $name as one safe argument", ({ value, prefix }) => {
+  ])("inserts PowerShell $name as one safe argument", async ({ value, prefix }) => {
     const program = new Command().name("openclaw");
     program.addOption(new Option("--value <value>", "Value").choices([value]));
     const safeValue = /^[A-Za-z0-9_./:+-]+$/.test(value)
       ? value
       : `'${value.replaceAll("'", "''")}'`;
 
-    expect(runGeneratedPowerShellCompletion(program, `openclaw --value ${prefix}`)).toEqual([
+    expect(await powerShellCompletion.complete(program, `openclaw --value ${prefix}`)).toEqual([
       safeValue,
     ]);
-    expect(runGeneratedPowerShellCompletion(program, `openclaw --value=${prefix}`)).toEqual([
+    expect(await powerShellCompletion.complete(program, `openclaw --value=${prefix}`)).toEqual([
       `--value=${safeValue}`,
     ]);
   });
 
-  itWithPowerShell("completes root short and long flags in real PowerShell", () => {
-    const completions = runGeneratedPowerShellCompletion(
+  itWithPowerShell("completes root short and long flags in real PowerShell", async () => {
+    const completions = await powerShellCompletion.complete(
       createDocumentedCompletionProgram(),
       "openclaw -",
     );
@@ -344,16 +350,27 @@ _openclaw_root_completion
     expect(completions).toEqual(expect.arrayContaining(["-v", "--verbose", "--status-json"]));
   });
 
-  itWithPowerShell("completes documented nested short and long flags in real PowerShell", () => {
-    const completions = runGeneratedPowerShellCompletion(
-      createDocumentedCompletionProgram(),
-      "openclaw completion -",
-    );
+  itWithPowerShell(
+    "completes documented nested short and long flags in real PowerShell",
+    async () => {
+      const completions = await powerShellCompletion.complete(
+        createDocumentedCompletionProgram(),
+        "openclaw completion -",
+      );
 
-    expect(completions).toEqual(
-      expect.arrayContaining(["-s", "--shell", "-i", "--install", "-y", "--yes", "--write-state"]),
-    );
-  });
+      expect(completions).toEqual(
+        expect.arrayContaining([
+          "-s",
+          "--shell",
+          "-i",
+          "--install",
+          "-y",
+          "--yes",
+          "--write-state",
+        ]),
+      );
+    },
+  );
 
   itWithPowerShell.each([
     ["a long flag", "openclaw gateway --token secret st"],
@@ -361,8 +378,8 @@ _openclaw_root_completion
     ["an inline long value", "openclaw gateway --token=secret st"],
     ["an inline short value", "openclaw gateway -t=secret st"],
     ["a preceding boolean flag", "openclaw gateway --force --token secret st"],
-  ])("keeps real PowerShell nested completions after %s", (_name, commandLine) => {
-    expect(runGeneratedPowerShellCompletion(createCompletionProgram(), commandLine)).toEqual([
+  ])("keeps real PowerShell nested completions after %s", async (_name, commandLine) => {
+    expect(await powerShellCompletion.complete(createCompletionProgram(), commandLine)).toEqual([
       "status",
     ]);
   });
@@ -370,9 +387,12 @@ _openclaw_root_completion
   itWithPowerShell.each([
     ["-v", ["-v"]],
     ["--v", ["--verbose"]],
-  ])("filters real PowerShell root flag aliases for %s", (prefix, expected) => {
+  ])("filters real PowerShell root flag aliases for %s", async (prefix, expected) => {
     expect(
-      runGeneratedPowerShellCompletion(createDocumentedCompletionProgram(), `openclaw ${prefix}`),
+      await powerShellCompletion.complete(
+        createDocumentedCompletionProgram(),
+        `openclaw ${prefix}`,
+      ),
     ).toEqual(expected);
   });
 
@@ -880,15 +900,15 @@ _openclaw_root_completion
     ["an attached short option value", "openclaw completion -sf", "-sfish"],
     ["a short-option cluster value", "openclaw completion -ysf", "-ysfish"],
     ["a separated short-option cluster value", "openclaw completion -ys f", "fish"],
-  ])("completes PowerShell Commander choices after %s", (_name, commandLine, expected) => {
+  ])("completes PowerShell Commander choices after %s", async (_name, commandLine, expected) => {
     expect(
-      runGeneratedPowerShellCompletion(createDocumentedCompletionProgram(), commandLine),
+      await powerShellCompletion.complete(createDocumentedCompletionProgram(), commandLine),
     ).toEqual([expected]);
   });
 
-  itWithPowerShell("completes an empty attached short-option cluster value", () => {
+  itWithPowerShell("completes an empty attached short-option cluster value", async () => {
     expect(
-      runGeneratedPowerShellCompletion(
+      await powerShellCompletion.complete(
         createDocumentedCompletionProgram(),
         "openclaw completion -ys",
       ),
@@ -900,24 +920,26 @@ _openclaw_root_completion
     ["an attached spaced choice", "openclaw --theme=l", "--theme='light blue'"],
     ["an apostrophe", "openclaw --theme Bob", "'Bob''s green'"],
     ["a backtick", "openclaw --theme p", "'path`name'"],
-  ])("quotes %s in real PowerShell completion text", (_name, commandLine, expected) => {
+  ])("quotes %s in real PowerShell completion text", async (_name, commandLine, expected) => {
     const program = new Command()
       .name("openclaw")
       .addOption(new Option("--theme <theme>").choices(["light blue", "Bob's green", "path`name"]));
 
-    expect(runGeneratedPowerShellCompletion(program, commandLine)).toEqual([expected]);
+    expect(await powerShellCompletion.complete(program, commandLine)).toEqual([expected]);
   });
 
   itWithPowerShell(
     "keeps optional choice values from consuming the following PowerShell option",
-    () => {
+    async () => {
       const program = new Command()
         .name("openclaw")
         .addOption(new Option("-c, --color [when]").choices(["always", "never"]))
         .option("-v, --verbose", "Verbose output");
 
-      expect(runGeneratedPowerShellCompletion(program, "openclaw --color a")).toEqual(["always"]);
-      expect(runGeneratedPowerShellCompletion(program, "openclaw --color --v")).toEqual([
+      expect(await powerShellCompletion.complete(program, "openclaw --color a")).toEqual([
+        "always",
+      ]);
+      expect(await powerShellCompletion.complete(program, "openclaw --color --v")).toEqual([
         "--verbose",
       ]);
     },


### PR DESCRIPTION
## What Problem This Solves

The completion CLI tests launched a fresh PowerShell process for every live completion assertion. The two owner files made 48 real `pwsh` startups even though each case only needed a clean native completer inside the same shell runtime.

## Why This Change Was Made

Use one explicit PowerShell runner per test file, serialize versioned base64-framed requests, and remove/re-register the `openclaw` completer before and after every case. Every generated script still comes from the production completion owner and every assertion still executes real PowerShell `CommandCompletion`. The two files remain in their existing isolated lanes; sharding and concurrency are unchanged.

## User Impact

No runtime or user-visible behavior changes. Real-shell completion coverage finishes much faster with deterministic per-case diagnostics and strict timeout/exit handling.

## Evidence

- Real PowerShell startups: 48 -> 2.
- Combined wrapper: 34.72s -> 10.74s (69.1% faster); real wall: 34.88s -> 10.91s.
- Primary CLI file: 24.69s -> 3.72s; alias file: 3.67s -> 1.36s.
- Max RSS: 439.8MB -> 337.6MB.
- All 108 completion siblings pass; every live shell assertion is retained.
- Formatting, typed targeted lint, `git diff --check`, and autoreview are clean.
- Test-only diff: +355/-66; production LOC delta: 0.

### Exact rebased real-shell proof

Exact head `337628b20827a4d83097a31ea0f4ef511b94511f`:

- `src/cli/completion-cli.aliases.test.ts`: 11 passed, including five real PowerShell alias requests; the persistent runner exited cleanly in `afterAll`.
- `src/cli/completion-cli.test.ts`: 84 passed, including every real PowerShell value, quoting, injection-safety, nested-path, and option-form assertion; the persistent runner exited cleanly in `afterAll`.
- Combined wrapper: 10.47s.
- Final branch autoreview: clean.
- Installed `pwsh` probe: `Register-ArgumentCompleter -Native -CommandName openclaw -ScriptBlock $null` printed `OK` and exited 0.
- Upstream contract: PowerShell marks `ScriptBlock` `[AllowNull]` and removes the completer key when the value is null in [`ExtensibleCompletion.cs`](https://github.com/PowerShell/PowerShell/blob/f9543fa3ff30f21a3cf86eefc1973c69ecbf272b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs#L199-L201) and its [`SetKeyValue`](https://github.com/PowerShell/PowerShell/blob/f9543fa3ff30f21a3cf86eefc1973c69ecbf272b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs#L269-L278) helper.
