### PR TITLE
improve(tests): isolate session diff baseline coverage

### DIFF
--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -5,7 +5,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterEach, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { findGitCheckoutRoot } from "../agents/worktrees/git.js";
 import {
@@ -57,10 +57,34 @@ import {
   seedSessionTranscript,
 } from "./test/server-sessions.test-helpers.js";
 
+type EnsureSessionDiffBaseline =
+  (typeof import("../sessions/session-diff-baseline.js"))["ensureSessionDiffBaseline"];
+
+const sessionDiffBaselineMocks = vi.hoisted(() => ({
+  ensure: vi.fn<EnsureSessionDiffBaseline>(),
+  useReal: false,
+}));
+
+vi.mock("../sessions/session-diff-baseline.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../sessions/session-diff-baseline.js")>();
+  sessionDiffBaselineMocks.ensure.mockImplementation(async (params) =>
+    sessionDiffBaselineMocks.useReal
+      ? await actual.ensureSessionDiffBaseline(params)
+      : params.entry,
+  );
+  return { ...actual, ensureSessionDiffBaseline: sessionDiffBaselineMocks.ensure };
+});
+
 const { createSessionStoreDir, createSelectedGlobalSessionStore, openClient } =
   setupGatewaySessionsTestHarness();
 const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+beforeEach(() => {
+  sessionDiffBaselineMocks.ensure.mockClear();
+  // Baseline capture has dedicated owner coverage and one authenticated integration below.
+  sessionDiffBaselineMocks.useReal = false;
+});
 
 async function makeNonGitTempDir(prefix: string): Promise<string> {
   let root = await fs.realpath(os.tmpdir());
@@ -694,6 +718,51 @@ async function initializeGitWorkspace(root: string): Promise<string> {
   ]);
   return await fs.realpath(workspace);
 }
+
+test("sessions.create captures and persists the initial workspace diff baseline", async () => {
+  const root = tempDirs.make("openclaw-session-diff-baseline-");
+  const workspace = await initializeGitWorkspace(root);
+  await fs.appendFile(path.join(workspace, "README.md"), "dirty at session start\n");
+  const { storePath } = await createSessionStoreDir();
+  sessionDiffBaselineMocks.useReal = true;
+  const { ws } = await openClient({
+    browserOrigin: "http://127.0.0.1",
+    client: {
+      id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+      version: "dev",
+      platform: "web",
+      mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+    },
+  });
+  try {
+    const created = await rpcReq<{ key?: string; sessionId?: string }>(ws, "sessions.create", {
+      agentId: "main",
+      cwd: workspace,
+    });
+    expect(created.ok, JSON.stringify(created.error)).toBe(true);
+    expect(sessionDiffBaselineMocks.ensure).toHaveBeenCalledTimes(1);
+    const sessionKey = requireNonEmptyString(created.payload?.key, "baseline session key");
+    const sessionId = requireNonEmptyString(created.payload?.sessionId, "baseline session id");
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      sessionId,
+      spawnedCwd: workspace,
+      sessionDiffBaseline: {
+        version: 1,
+        sessionId,
+        root: workspace,
+        files: [
+          {
+            path: "README.md",
+            fingerprint: expect.any(String),
+          },
+        ],
+      },
+    });
+  } finally {
+    sessionDiffBaselineMocks.useReal = false;
+    ws.close();
+  }
+});
 
 function requireNonEmptyString(value: string | undefined, label: string): string {
   if (!value) {


### PR DESCRIPTION
## What Problem This Solves

The sessions.create stress suite ran real Git-based session-diff baseline capture after every successful create, adopt, and fork—even when the case owned lifecycle, authorization, or persistence behavior rather than diff capture. The concurrency cases alone triggered more than one hundred successful creates and hundreds of irrelevant Git subprocesses.

## Why This Change Was Made

Default this test file's diff-baseline dependency to a pass-through fixture, while adding one authenticated Control UI `sessions.create` integration case that uses the real owner against a dirty Git workspace and verifies the baseline persisted in SQLite. Every existing create/delete/fork stress count and assertion remains unchanged.

## User Impact

No runtime or user-visible behavior changes. Gateway session lifecycle coverage completes faster while the real create-to-diff-to-SQLite boundary is now asserted explicitly.

## Evidence

- Warm file runtime: 68.91s -> 49.14s (28.7% faster).
- Test bodies: 63.54s -> 46.50s.
- Coverage increases from 83 to 84 tests.
- Target: 84/84; sessions-diff owner sibling: 17/17.
- Formatting, typed targeted lint, `git diff --check`, and autoreview are clean.
- Test-only diff: +70/-1; production LOC delta: 0.
