### PR TITLE
chore(android): compact onboarding gateway test fixtures

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -100,120 +100,78 @@ class GatewayConfigResolverTest {
 
   @Test
   fun parseGatewayEndpointUsesDefaultTlsPortForBareWssUrls() {
-    val parsed = parseGatewayEndpoint("wss://gateway.example")
-
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "gateway.example",
-        port = 443,
-        tls = true,
-        displayUrl = "https://gateway.example",
-      ),
-      parsed,
+    assertParsedEndpoint(
+      input = "wss://gateway.example",
+      host = "gateway.example",
+      port = 443,
+      tls = true,
+      displayUrl = "https://gateway.example",
     )
   }
 
   @Test
   fun parseGatewayEndpointRejectsNonLoopbackCleartextWsUrls() {
-    val parsed = parseGatewayEndpoint("ws://gateway.example")
-
-    assertNull(parsed)
+    assertEndpointRejected("ws://gateway.example")
   }
 
   @Test
   fun parseGatewayEndpointRejectsTailnetCleartextWsUrls() {
-    val parsed = parseGatewayEndpoint("ws://100.64.0.9:18789")
-
-    assertNull(parsed)
+    assertEndpointRejected("ws://100.64.0.9:18789")
   }
 
   @Test
   fun parseGatewayEndpointOmitsExplicitDefaultTlsPortFromDisplayUrl() {
-    val parsed = parseGatewayEndpoint("https://gateway.example:443")
-
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "gateway.example",
-        port = 443,
-        tls = true,
-        displayUrl = "https://gateway.example",
-      ),
-      parsed,
+    assertParsedEndpoint(
+      input = "https://gateway.example:443",
+      host = "gateway.example",
+      port = 443,
+      tls = true,
+      displayUrl = "https://gateway.example",
     )
   }
 
   @Test
   fun parseGatewayEndpointAllowsLoopbackCleartextWsUrls() {
-    val parsed = parseGatewayEndpoint("ws://127.0.0.1")
-
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "127.0.0.1",
-        port = 18789,
-        tls = false,
-        displayUrl = "http://127.0.0.1:18789",
-      ),
-      parsed,
+    assertParsedEndpoint(
+      input = "ws://127.0.0.1",
+      host = "127.0.0.1",
+      displayUrl = "http://127.0.0.1:18789",
     )
   }
 
   @Test
   fun parseGatewayEndpointAllowsLocalhostCleartextWsUrls() {
-    val parsed = parseGatewayEndpoint("ws://localhost:18789")
-
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "localhost",
-        port = 18789,
-        tls = false,
-        displayUrl = "http://localhost:18789",
-      ),
-      parsed,
+    assertParsedEndpoint(
+      input = "ws://localhost:18789",
+      host = "localhost",
+      displayUrl = "http://localhost:18789",
     )
   }
 
   @Test
   fun parseGatewayEndpointAllowsAndroidEmulatorCleartextWsUrls() {
-    val parsed = parseGatewayEndpoint("ws://10.0.2.2:18789")
-
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "10.0.2.2",
-        port = 18789,
-        tls = false,
-        displayUrl = "http://10.0.2.2:18789",
-      ),
-      parsed,
+    assertParsedEndpoint(
+      input = "ws://10.0.2.2:18789",
+      host = "10.0.2.2",
+      displayUrl = "http://10.0.2.2:18789",
     )
   }
 
   @Test
   fun parseGatewayEndpointAllowsPrivateLanCleartextWsUrls() {
-    val parsed = parseGatewayEndpoint("ws://192.168.1.20:18789")
-
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "192.168.1.20",
-        port = 18789,
-        tls = false,
-        displayUrl = "http://192.168.1.20:18789",
-      ),
-      parsed,
+    assertParsedEndpoint(
+      input = "ws://192.168.1.20:18789",
+      host = "192.168.1.20",
+      displayUrl = "http://192.168.1.20:18789",
     )
   }
 
   @Test
   fun parseGatewayEndpointAllowsMdnsCleartextWsUrls() {
-    val parsed = parseGatewayEndpoint("ws://gateway.local:18789")
-
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "gateway.local",
-        port = 18789,
-        tls = false,
-        displayUrl = "http://gateway.local:18789",
-      ),
-      parsed,
+    assertParsedEndpoint(
+      input = "ws://gateway.local:18789",
+      host = "gateway.local",
+      displayUrl = "http://gateway.local:18789",
     )
   }
 
@@ -265,16 +223,12 @@ class GatewayConfigResolverTest {
 
   @Test
   fun parseGatewayEndpointRejectsCleartextLoopbackPrefixBypassHost() {
-    val parsed = parseGatewayEndpoint("http://127.attacker.example:80")
-
-    assertNull(parsed)
+    assertEndpointRejected("http://127.attacker.example:80")
   }
 
   @Test
   fun parseGatewayEndpointRejectsNonLoopbackIpv6CleartextWsUrls() {
-    val parsed = parseGatewayEndpoint("ws://[2001:db8::1]")
-
-    assertNull(parsed)
+    assertEndpointRejected("ws://[2001:db8::1]")
   }
 
   @Test
@@ -291,59 +245,37 @@ class GatewayConfigResolverTest {
 
   @Test
   fun parseGatewayEndpointRejectsUnspecifiedIpv4CleartextHttpUrls() {
-    val parsed = parseGatewayEndpoint("http://0.0.0.0:80")
-
-    assertNull(parsed)
+    assertEndpointRejected("http://0.0.0.0:80")
   }
 
   @Test
   fun parseGatewayEndpointRejectsUnspecifiedIpv6CleartextWsUrls() {
-    val parsed = parseGatewayEndpoint("ws://[::]")
-
-    assertNull(parsed)
+    assertEndpointRejected("ws://[::]")
   }
 
   @Test
   fun parseGatewayEndpointAllowsLoopbackCleartextHttpUrls() {
-    val parsed = parseGatewayEndpoint("http://localhost:80")
-
-    assertEquals(
-      GatewayEndpointConfig(
-        host = "localhost",
-        port = 80,
-        tls = false,
-        displayUrl = "http://localhost:80",
-      ),
-      parsed,
+    assertParsedEndpoint(
+      input = "http://localhost:80",
+      host = "localhost",
+      port = 80,
+      displayUrl = "http://localhost:80",
     )
   }
 
   @Test
   fun resolveScannedSetupCodeResultAcceptsRawSetupCode() {
-    val setupCode =
-      encodeSetupCode("""{"url":"wss://gateway.example:18789","bootstrapToken":"bootstrap-1"}""")
-
-    val resolved = resolveScannedSetupCodeResult(setupCode)
-
-    assertEquals(setupCode, resolved.setupCode)
-    assertNull(resolved.error)
+    assertScannedSetupCodeAccepted(setupCode("wss://gateway.example:18789"))
   }
 
   @Test
   fun resolveScannedSetupCodeResultAcceptsEmulatorSetupCode() {
-    val setupCode =
-      encodeSetupCode("""{"url":"ws://10.0.2.2:18789","bootstrapToken":"bootstrap-1"}""")
-
-    val resolved = resolveScannedSetupCodeResult(setupCode)
-
-    assertEquals(setupCode, resolved.setupCode)
-    assertNull(resolved.error)
+    assertScannedSetupCodeAccepted(setupCode("ws://10.0.2.2:18789"))
   }
 
   @Test
   fun resolveScannedSetupCodeResultAcceptsQrJsonPayload() {
-    val setupCode =
-      encodeSetupCode("""{"url":"wss://gateway.example:18789","bootstrapToken":"bootstrap-1"}""")
+    val setupCode = setupCode("wss://gateway.example:18789")
     val qrJson =
       """
       {
@@ -362,69 +294,43 @@ class GatewayConfigResolverTest {
 
   @Test
   fun resolveScannedSetupCodeResultRejectsInvalidInput() {
-    val resolved = resolveScannedSetupCodeResult("not-a-valid-setup-code")
-    assertNull(resolved.setupCode)
-    assertEquals(GatewayEndpointValidationError.INVALID_URL, resolved.error)
+    assertScannedSetupCodeRejected("not-a-valid-setup-code", GatewayEndpointValidationError.INVALID_URL)
   }
 
   @Test
   fun resolveScannedSetupCodeResultRejectsJsonWithInvalidSetupCode() {
-    val qrJson = """{"setupCode":"invalid"}"""
-    val resolved = resolveScannedSetupCodeResult(qrJson)
-    assertNull(resolved.setupCode)
-    assertEquals(GatewayEndpointValidationError.INVALID_URL, resolved.error)
+    assertScannedSetupCodeRejected("""{"setupCode":"invalid"}""", GatewayEndpointValidationError.INVALID_URL)
   }
 
   @Test
   fun resolveScannedSetupCodeResultRejectsJsonWithNonStringSetupCode() {
-    val qrJson = """{"setupCode":{"nested":"value"}}"""
-    val resolved = resolveScannedSetupCodeResult(qrJson)
-    assertNull(resolved.setupCode)
-    assertEquals(GatewayEndpointValidationError.INVALID_URL, resolved.error)
+    assertScannedSetupCodeRejected("""{"setupCode":{"nested":"value"}}""", GatewayEndpointValidationError.INVALID_URL)
   }
 
   @Test
   fun resolveScannedSetupCodeResultRejectsNonLoopbackCleartextGateway() {
-    val setupCode =
-      encodeSetupCode("""{"url":"ws://attacker.example:18789","bootstrapToken":"bootstrap-1"}""")
-
-    val resolved = resolveScannedSetupCodeResult(setupCode)
-
-    assertNull(resolved.setupCode)
-    assertEquals(GatewayEndpointValidationError.INSECURE_REMOTE_URL, resolved.error)
+    assertScannedSetupCodeRejected(
+      setupCode("ws://attacker.example:18789"),
+      GatewayEndpointValidationError.INSECURE_REMOTE_URL,
+    )
   }
 
   @Test
   fun resolveScannedSetupCodeResultAcceptsPrivateLanCleartextGateway() {
-    val setupCode =
-      encodeSetupCode("""{"url":"ws://192.168.31.100:18789","bootstrapToken":"bootstrap-1"}""")
-
-    val resolved = resolveScannedSetupCodeResult(setupCode)
-
-    assertEquals(setupCode, resolved.setupCode)
-    assertNull(resolved.error)
+    assertScannedSetupCodeAccepted(setupCode("ws://192.168.31.100:18789"))
   }
 
   @Test
   fun resolveScannedSetupCodeResultAcceptsMdnsCleartextGateway() {
-    val setupCode =
-      encodeSetupCode("""{"url":"ws://gateway.local:18789","bootstrapToken":"bootstrap-1"}""")
-
-    val resolved = resolveScannedSetupCodeResult(setupCode)
-
-    assertEquals(setupCode, resolved.setupCode)
-    assertNull(resolved.error)
+    assertScannedSetupCodeAccepted(setupCode("ws://gateway.local:18789"))
   }
 
   @Test
   fun resolveScannedSetupCodeResultPreservesIpv6ZoneError() {
-    val setupCode =
-      encodeSetupCode("""{"url":"wss://[fe80::1%25wlan0]:443","bootstrapToken":"bootstrap-1"}""")
-
-    val resolved = resolveScannedSetupCodeResult(setupCode)
-
-    assertNull(resolved.setupCode)
-    assertEquals(GatewayEndpointValidationError.IPV6_ZONE_ID_UNSUPPORTED, resolved.error)
+    assertScannedSetupCodeRejected(
+      setupCode("wss://[fe80::1%25wlan0]:443"),
+      GatewayEndpointValidationError.IPV6_ZONE_ID_UNSUPPORTED,
+    )
   }
 
   @Test
@@ -528,19 +434,10 @@ class GatewayConfigResolverTest {
 
   @Test
   fun resolveGatewayConnectConfigPrefersBootstrapTokenFromSetupCode() {
-    val setupCode =
-      encodeSetupCode(
-        """{"url":"wss://gateway.example:18789","bootstrapToken":"bootstrap-1"}""",
-      )
-
     val resolved =
-      resolveGatewayConnectConfig(
+      resolveConnectConfigFixture(
         useSetupCode = true,
-        setupCode = setupCode,
-        manualHostInput = "",
-        manualPortInput = "",
-        manualTlsInput = false,
-        bootstrapTokenInput = "",
+        setupCode = setupCode("wss://gateway.example:18789"),
         tokenInput = "shared-token",
         passwordInput = "shared-password",
       )
@@ -555,18 +452,13 @@ class GatewayConfigResolverTest {
 
   @Test
   fun resolveGatewayConnectConfigAcceptsQrJsonSetupCodePayload() {
-    val setupCode =
-      encodeSetupCode("""{"url":"wss://gateway.example:18789","bootstrapToken":"bootstrap-1"}""")
+    val setupCode = setupCode("wss://gateway.example:18789")
     val qrPayload = """{"setupCode":"$setupCode"}"""
 
     val resolved =
-      resolveGatewayConnectConfig(
+      resolveConnectConfigFixture(
         useSetupCode = true,
         setupCode = qrPayload,
-        manualHostInput = "",
-        manualPortInput = "",
-        manualTlsInput = false,
-        bootstrapTokenInput = "",
         tokenInput = "shared-token",
         passwordInput = "shared-password",
       )
@@ -581,21 +473,10 @@ class GatewayConfigResolverTest {
 
   @Test
   fun resolveGatewayConnectConfigDefaultsPortlessWssSetupCodeTo443() {
-    val setupCode =
-      encodeSetupCode(
-        """{"url":"wss://gateway.example","bootstrapToken":"bootstrap-1"}""",
-      )
-
     val resolved =
-      resolveGatewayConnectConfig(
+      resolveConnectConfigFixture(
         useSetupCode = true,
-        setupCode = setupCode,
-        manualHostInput = "",
-        manualPortInput = "",
-        manualTlsInput = false,
-        bootstrapTokenInput = "",
-        tokenInput = "",
-        passwordInput = "",
+        setupCode = setupCode("wss://gateway.example"),
       )
 
     assertEquals("gateway.example", resolved?.host)
@@ -605,21 +486,10 @@ class GatewayConfigResolverTest {
 
   @Test
   fun resolveGatewayConnectConfigAllowsMdnsCleartextSetupCode() {
-    val setupCode =
-      encodeSetupCode(
-        """{"url":"ws://gateway.local:18789","bootstrapToken":"bootstrap-1"}""",
-      )
-
     val resolved =
-      resolveGatewayConnectConfig(
+      resolveConnectConfigFixture(
         useSetupCode = true,
-        setupCode = setupCode,
-        manualHostInput = "",
-        manualPortInput = "",
-        manualTlsInput = false,
-        bootstrapTokenInput = "",
-        tokenInput = "",
-        passwordInput = "",
+        setupCode = setupCode("ws://gateway.local:18789"),
       )
 
     assertEquals("gateway.local", resolved?.host)
@@ -629,20 +499,7 @@ class GatewayConfigResolverTest {
 
   @Test
   fun resolveGatewayConnectPlanPreservesRuntimeOwnedAuthForUnchangedEndpoint() {
-    val plan =
-      resolveGatewayConnectPlan(
-        useSetupCode = false,
-        setupCode = "",
-        savedManualHost = "127.0.0.1",
-        savedManualPort = "18789",
-        savedManualTls = false,
-        manualHostInput = "127.0.0.1",
-        manualPortInput = "18789",
-        manualTlsInput = false,
-        bootstrapTokenInput = "",
-        tokenInput = "",
-        passwordInput = "",
-      )
+    val plan = resolveConnectPlanFixture()
 
     assertEquals(GatewaySavedAuthAction.PRESERVE, plan?.savedAuthAction)
     assertEquals("", plan?.config?.bootstrapToken)
@@ -653,18 +510,8 @@ class GatewayConfigResolverTest {
   @Test
   fun resolveGatewayConnectPlanReplacesAuthWhenEndpointChanges() {
     val plan =
-      resolveGatewayConnectPlan(
-        useSetupCode = false,
-        setupCode = "",
-        savedManualHost = "127.0.0.1",
-        savedManualPort = "18789",
-        savedManualTls = false,
+      resolveConnectPlanFixture(
         manualHostInput = "127.0.0.2",
-        manualPortInput = "18789",
-        manualTlsInput = false,
-        bootstrapTokenInput = "",
-        tokenInput = "",
-        passwordInput = "",
       )
 
     assertEquals(GatewaySavedAuthAction.REPLACE_ENDPOINT, plan?.savedAuthAction)
@@ -674,18 +521,9 @@ class GatewayConfigResolverTest {
   @Test
   fun resolveGatewayConnectPlanTreatsMissingSavedEndpointAsReplacement() {
     val plan =
-      resolveGatewayConnectPlan(
-        useSetupCode = false,
-        setupCode = "",
+      resolveConnectPlanFixture(
         savedManualHost = "",
         savedManualPort = "",
-        savedManualTls = false,
-        manualHostInput = "127.0.0.1",
-        manualPortInput = "18789",
-        manualTlsInput = false,
-        bootstrapTokenInput = "",
-        tokenInput = "",
-        passwordInput = "",
       )
 
     assertEquals(GatewaySavedAuthAction.REPLACE_ENDPOINT, plan?.savedAuthAction)
@@ -693,24 +531,10 @@ class GatewayConfigResolverTest {
 
   @Test
   fun resolveGatewayConnectPlanMarksSetupCodeAsExplicitReplacement() {
-    val setupCode =
-      encodeSetupCode(
-        """{"url":"wss://gateway.example:18789","bootstrapToken":"bootstrap-1"}""",
-      )
-
     val plan =
-      resolveGatewayConnectPlan(
+      resolveConnectPlanFixture(
         useSetupCode = true,
-        setupCode = setupCode,
-        savedManualHost = "127.0.0.1",
-        savedManualPort = "18789",
-        savedManualTls = false,
-        manualHostInput = "127.0.0.1",
-        manualPortInput = "18789",
-        manualTlsInput = false,
-        bootstrapTokenInput = "",
-        tokenInput = "",
-        passwordInput = "",
+        setupCode = setupCode("wss://gateway.example:18789"),
       )
 
     assertEquals(GatewaySavedAuthAction.REPLACE_SETUP, plan?.savedAuthAction)
@@ -721,15 +545,7 @@ class GatewayConfigResolverTest {
   @Test
   fun resolveGatewayConnectPlanUsesOneExplicitCredentialFamily() {
     val plan =
-      resolveGatewayConnectPlan(
-        useSetupCode = false,
-        setupCode = "",
-        savedManualHost = "127.0.0.1",
-        savedManualPort = "18789",
-        savedManualTls = false,
-        manualHostInput = "127.0.0.1",
-        manualPortInput = "18789",
-        manualTlsInput = false,
+      resolveConnectPlanFixture(
         bootstrapTokenInput = "bootstrap",
         tokenInput = "token",
         passwordInput = "password",
@@ -744,18 +560,10 @@ class GatewayConfigResolverTest {
   @Test
   fun resolveGatewayConnectPlanReplacesStalePairingForExplicitBootstrapAuth() {
     val plan =
-      resolveGatewayConnectPlan(
-        useSetupCode = false,
-        setupCode = "",
+      resolveConnectPlanFixture(
         savedManualHost = "gateway.local",
-        savedManualPort = "18789",
-        savedManualTls = false,
         manualHostInput = "gateway.local",
-        manualPortInput = "18789",
-        manualTlsInput = false,
         bootstrapTokenInput = "replacement-bootstrap",
-        tokenInput = "",
-        passwordInput = "",
       )
 
     assertEquals(GatewaySavedAuthAction.REPLACE_SETUP, plan?.savedAuthAction)
@@ -765,18 +573,9 @@ class GatewayConfigResolverTest {
   @Test
   fun resolveGatewayConnectPlanPreservesAuthForHostnameCaseOnlyEdit() {
     val plan =
-      resolveGatewayConnectPlan(
-        useSetupCode = false,
-        setupCode = "",
+      resolveConnectPlanFixture(
         savedManualHost = "Gateway.Local",
-        savedManualPort = "18789",
-        savedManualTls = false,
         manualHostInput = "gateway.local",
-        manualPortInput = "18789",
-        manualTlsInput = false,
-        bootstrapTokenInput = "",
-        tokenInput = "",
-        passwordInput = "",
       )
 
     assertEquals(GatewaySavedAuthAction.PRESERVE, plan?.savedAuthAction)
@@ -785,15 +584,10 @@ class GatewayConfigResolverTest {
   @Test
   fun resolveGatewayConnectConfigAllowsPrivateLanManualCleartextEndpoint() {
     val resolved =
-      resolveGatewayConnectConfig(
-        useSetupCode = false,
-        setupCode = "",
+      resolveConnectConfigFixture(
         manualHostInput = "192.168.31.100",
         manualPortInput = "18789",
-        manualTlsInput = false,
         bootstrapTokenInput = "bootstrap-1",
-        tokenInput = "",
-        passwordInput = "",
       )
 
     assertEquals("192.168.31.100", resolved?.host)
@@ -804,15 +598,10 @@ class GatewayConfigResolverTest {
   @Test
   fun resolveGatewayConnectConfigAllowsMdnsManualCleartextEndpoint() {
     val resolved =
-      resolveGatewayConnectConfig(
-        useSetupCode = false,
-        setupCode = "",
+      resolveConnectConfigFixture(
         manualHostInput = "gateway.local",
         manualPortInput = "18789",
-        manualTlsInput = false,
         bootstrapTokenInput = "bootstrap-1",
-        tokenInput = "",
-        passwordInput = "",
       )
 
     assertEquals("gateway.local", resolved?.host)
@@ -869,15 +658,10 @@ class GatewayConfigResolverTest {
   @Test
   fun resolveGatewayConnectConfigManualAcceptsCompleteLanEndpoint() {
     val resolved =
-      resolveGatewayConnectConfig(
-        useSetupCode = false,
-        setupCode = "",
+      resolveConnectConfigFixture(
         manualHostInput = "ws://192.168.178.57:18790",
         manualPortInput = "18789",
         manualTlsInput = true,
-        bootstrapTokenInput = "",
-        tokenInput = "",
-        passwordInput = "",
       )
 
     assertEquals("192.168.178.57", resolved?.host)
@@ -899,15 +683,10 @@ class GatewayConfigResolverTest {
   fun resolveGatewayConnectConfigPreservesPastedManualAuthorities() {
     for (case in pastedManualAuthorityCases) {
       val resolved =
-        resolveGatewayConnectConfig(
-          useSetupCode = false,
-          setupCode = "",
+        resolveConnectConfigFixture(
           manualHostInput = case.hostInput,
           manualPortInput = case.portInput,
           manualTlsInput = case.tls,
-          bootstrapTokenInput = "",
-          tokenInput = "",
-          passwordInput = "",
         )
 
       assertEquals(
@@ -929,18 +708,13 @@ class GatewayConfigResolverTest {
   fun resolveGatewayConnectPlanPreservesSavedAuthForPastedManualAuthorities() {
     for (case in pastedManualAuthorityCases) {
       val plan =
-        resolveGatewayConnectPlan(
-          useSetupCode = false,
-          setupCode = "",
+        resolveConnectPlanFixture(
           savedManualHost = case.expectedHost,
           savedManualPort = case.expectedPort.toString(),
           savedManualTls = case.tls,
           manualHostInput = case.hostInput,
           manualPortInput = case.portInput,
           manualTlsInput = case.tls,
-          bootstrapTokenInput = "",
-          tokenInput = "",
-          passwordInput = "",
         )
 
       assertEquals(case.hostInput, GatewaySavedAuthAction.PRESERVE, plan?.savedAuthAction)
@@ -970,15 +744,9 @@ class GatewayConfigResolverTest {
       assertNull(hostInput, composeGatewayManualUrl(hostInput, "18789", tls = false))
       assertNull(
         hostInput,
-        resolveGatewayConnectConfig(
-          useSetupCode = false,
-          setupCode = "",
+        resolveConnectConfigFixture(
           manualHostInput = hostInput,
           manualPortInput = "18789",
-          manualTlsInput = false,
-          bootstrapTokenInput = "",
-          tokenInput = "",
-          passwordInput = "",
         ),
       )
     }
@@ -1001,15 +769,10 @@ class GatewayConfigResolverTest {
       assertNull(hostInput, composeGatewayManualUrl(hostInput, "18789", tls = true))
       assertNull(
         hostInput,
-        resolveGatewayConnectConfig(
-          useSetupCode = false,
-          setupCode = "",
+        resolveConnectConfigFixture(
           manualHostInput = hostInput,
           manualPortInput = "18789",
           manualTlsInput = true,
-          bootstrapTokenInput = "",
-          tokenInput = "",
-          passwordInput = "",
         ),
       )
     }
@@ -1147,21 +910,103 @@ class GatewayConfigResolverTest {
   @Test
   fun resolveGatewayConnectConfigManualAcceptsTailscaleHostWithoutPort() {
     val resolved =
-      resolveGatewayConnectConfig(
-        useSetupCode = false,
-        setupCode = "",
+      resolveConnectConfigFixture(
         manualHostInput = "mydevice.tail1234.ts.net",
         manualPortInput = "",
         manualTlsInput = true,
-        bootstrapTokenInput = "",
-        tokenInput = "",
-        passwordInput = "",
       )
 
     assertEquals("mydevice.tail1234.ts.net", resolved?.host)
     assertEquals(443, resolved?.port)
     assertEquals(true, resolved?.tls)
   }
+
+  private fun assertParsedEndpoint(
+    input: String,
+    host: String,
+    port: Int = 18789,
+    tls: Boolean = false,
+    displayUrl: String,
+  ) {
+    assertEquals(
+      GatewayEndpointConfig(
+        host = host,
+        port = port,
+        tls = tls,
+        displayUrl = displayUrl,
+      ),
+      parseGatewayEndpoint(input),
+    )
+  }
+
+  private fun assertEndpointRejected(input: String) {
+    assertNull(parseGatewayEndpoint(input))
+  }
+
+  private fun setupCode(url: String): String = encodeSetupCode("""{"url":"$url","bootstrapToken":"bootstrap-1"}""")
+
+  private fun assertScannedSetupCodeAccepted(setupCode: String) {
+    val resolved = resolveScannedSetupCodeResult(setupCode)
+    assertEquals(setupCode, resolved.setupCode)
+    assertNull(resolved.error)
+  }
+
+  private fun assertScannedSetupCodeRejected(
+    setupCode: String,
+    expectedError: GatewayEndpointValidationError,
+  ) {
+    val resolved = resolveScannedSetupCodeResult(setupCode)
+    assertNull(resolved.setupCode)
+    assertEquals(expectedError, resolved.error)
+  }
+
+  private fun resolveConnectConfigFixture(
+    useSetupCode: Boolean = false,
+    setupCode: String = "",
+    manualHostInput: String = "",
+    manualPortInput: String = "",
+    manualTlsInput: Boolean = false,
+    bootstrapTokenInput: String = "",
+    tokenInput: String = "",
+    passwordInput: String = "",
+  ): GatewayConnectConfig? =
+    resolveGatewayConnectConfig(
+      useSetupCode = useSetupCode,
+      setupCode = setupCode,
+      manualHostInput = manualHostInput,
+      manualPortInput = manualPortInput,
+      manualTlsInput = manualTlsInput,
+      bootstrapTokenInput = bootstrapTokenInput,
+      tokenInput = tokenInput,
+      passwordInput = passwordInput,
+    )
+
+  private fun resolveConnectPlanFixture(
+    useSetupCode: Boolean = false,
+    setupCode: String = "",
+    savedManualHost: String = "127.0.0.1",
+    savedManualPort: String = "18789",
+    savedManualTls: Boolean = false,
+    manualHostInput: String = "127.0.0.1",
+    manualPortInput: String = "18789",
+    manualTlsInput: Boolean = false,
+    bootstrapTokenInput: String = "",
+    tokenInput: String = "",
+    passwordInput: String = "",
+  ): GatewayConnectPlan? =
+    resolveGatewayConnectPlan(
+      useSetupCode = useSetupCode,
+      setupCode = setupCode,
+      savedManualHost = savedManualHost,
+      savedManualPort = savedManualPort,
+      savedManualTls = savedManualTls,
+      manualHostInput = manualHostInput,
+      manualPortInput = manualPortInput,
+      manualTlsInput = manualTlsInput,
+      bootstrapTokenInput = bootstrapTokenInput,
+      tokenInput = tokenInput,
+      passwordInput = passwordInput,
+    )
 
   private val pastedManualAuthorityCases =
     listOf(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -22,53 +22,38 @@ import java.util.Base64
 class OnboardingFlowLogicTest {
   @Test
   fun mascotMoodTracksVisibleOnboardingState() {
-    assertEquals(MascotMood.Idle, onboardingMascotMood(OnboardingStep.Welcome))
-    assertEquals(MascotMood.Curious, onboardingMascotMood(OnboardingStep.Permissions))
-    assertEquals(MascotMood.Thinking, onboardingMascotMood(OnboardingStep.NodeApproval))
-    assertEquals(
-      MascotMood.Working,
-      onboardingMascotMood(OnboardingStep.Recovery, GatewayRecoveryUiState.Finishing),
-    )
-    assertEquals(
-      MascotMood.Working,
-      onboardingMascotMood(OnboardingStep.Recovery, GatewayRecoveryUiState.TakingLonger),
-    )
-    assertEquals(
-      MascotMood.Celebrating,
-      onboardingMascotMood(OnboardingStep.Recovery, GatewayRecoveryUiState.Connected),
-    )
-    assertEquals(
-      MascotMood.Sad,
-      onboardingMascotMood(OnboardingStep.Recovery, GatewayRecoveryUiState.Failed),
-    )
-    assertEquals(
-      MascotMood.Sad,
-      onboardingMascotMood(
-        step = OnboardingStep.EnterSetupCode,
-        setupErrorCode = OnboardingErrorCode.SetupCodeRejected,
-      ),
-    )
-    assertEquals(
-      MascotMood.Sad,
-      onboardingMascotMood(
-        step = OnboardingStep.SetupCode,
-        setupScanErrorCode = OnboardingErrorCode.InvalidSetupQr,
-      ),
+    assertEqualsCases(
+      MascotMood.Idle to onboardingMascotMood(OnboardingStep.Welcome),
+      MascotMood.Curious to onboardingMascotMood(OnboardingStep.Permissions),
+      MascotMood.Thinking to onboardingMascotMood(OnboardingStep.NodeApproval),
+      MascotMood.Working to onboardingMascotMood(OnboardingStep.Recovery, GatewayRecoveryUiState.Finishing),
+      MascotMood.Working to onboardingMascotMood(OnboardingStep.Recovery, GatewayRecoveryUiState.TakingLonger),
+      MascotMood.Celebrating to onboardingMascotMood(OnboardingStep.Recovery, GatewayRecoveryUiState.Connected),
+      MascotMood.Sad to onboardingMascotMood(OnboardingStep.Recovery, GatewayRecoveryUiState.Failed),
+      MascotMood.Sad to
+        onboardingMascotMood(
+          step = OnboardingStep.EnterSetupCode,
+          setupErrorCode = OnboardingErrorCode.SetupCodeRejected,
+        ),
+      MascotMood.Sad to
+        onboardingMascotMood(
+          step = OnboardingStep.SetupCode,
+          setupScanErrorCode = OnboardingErrorCode.InvalidSetupQr,
+        ),
     )
   }
 
   @Test
   fun onboardingBackDestinationsMatchTheVisibleFlow() {
-    assertEquals(null, onboardingBackDestination(OnboardingStep.Welcome))
-    assertEquals(OnboardingBackDestination(OnboardingStep.Welcome), onboardingBackDestination(OnboardingStep.Gateway))
-    assertEquals(OnboardingBackDestination(OnboardingStep.Gateway), onboardingBackDestination(OnboardingStep.SetupCode))
-    assertEquals(
-      OnboardingBackDestination(OnboardingStep.SetupCode),
-      onboardingBackDestination(OnboardingStep.EnterSetupCode),
+    assertEqualsCases(
+      null to onboardingBackDestination(OnboardingStep.Welcome),
+      OnboardingBackDestination(OnboardingStep.Welcome) to onboardingBackDestination(OnboardingStep.Gateway),
+      OnboardingBackDestination(OnboardingStep.Gateway) to onboardingBackDestination(OnboardingStep.SetupCode),
+      OnboardingBackDestination(OnboardingStep.SetupCode) to onboardingBackDestination(OnboardingStep.EnterSetupCode),
+      OnboardingBackDestination(OnboardingStep.Gateway) to onboardingBackDestination(OnboardingStep.Manual),
+      OnboardingBackDestination(OnboardingStep.Recovery) to onboardingBackDestination(OnboardingStep.NodeApproval),
+      OnboardingBackDestination(OnboardingStep.NodeApproval) to onboardingBackDestination(OnboardingStep.Permissions),
     )
-    assertEquals(OnboardingBackDestination(OnboardingStep.Gateway), onboardingBackDestination(OnboardingStep.Manual))
-    assertEquals(OnboardingBackDestination(OnboardingStep.Recovery), onboardingBackDestination(OnboardingStep.NodeApproval))
-    assertEquals(OnboardingBackDestination(OnboardingStep.NodeApproval), onboardingBackDestination(OnboardingStep.Permissions))
   }
 
   @Test
@@ -196,17 +181,21 @@ class OnboardingFlowLogicTest {
 
   @Test
   fun cameraCapabilityStartsOffEvenWhenScannerPermissionWasGranted() {
-    assertFalse(initialCameraCapabilityEnabled(savedCapabilityEnabled = false, androidCameraPermissionGranted = false))
-    assertFalse(initialCameraCapabilityEnabled(savedCapabilityEnabled = false, androidCameraPermissionGranted = true))
-    assertFalse(initialCameraCapabilityEnabled(savedCapabilityEnabled = true, androidCameraPermissionGranted = false))
-    assertTrue(initialCameraCapabilityEnabled(savedCapabilityEnabled = true, androidCameraPermissionGranted = true))
+    assertBooleanCases(
+      false to initialCameraCapabilityEnabled(savedCapabilityEnabled = false, androidCameraPermissionGranted = false),
+      false to initialCameraCapabilityEnabled(savedCapabilityEnabled = false, androidCameraPermissionGranted = true),
+      false to initialCameraCapabilityEnabled(savedCapabilityEnabled = true, androidCameraPermissionGranted = false),
+      true to initialCameraCapabilityEnabled(savedCapabilityEnabled = true, androidCameraPermissionGranted = true),
+    )
   }
 
   @Test
   fun cameraPermissionRowDistinguishesAndroidPermissionFromCapabilityOptIn() {
-    assertEquals("Not allowed", cameraPermissionRowStatusText(capabilityEnabled = false, androidCameraPermissionGranted = false).resolveNativeText())
-    assertEquals("Off", cameraPermissionRowStatusText(capabilityEnabled = false, androidCameraPermissionGranted = true).resolveNativeText())
-    assertEquals("Enabled", cameraPermissionRowStatusText(capabilityEnabled = true, androidCameraPermissionGranted = true).resolveNativeText())
+    assertEqualsCases(
+      "Not allowed" to cameraPermissionRowStatusText(capabilityEnabled = false, androidCameraPermissionGranted = false).resolveNativeText(),
+      "Off" to cameraPermissionRowStatusText(capabilityEnabled = false, androidCameraPermissionGranted = true).resolveNativeText(),
+      "Enabled" to cameraPermissionRowStatusText(capabilityEnabled = true, androidCameraPermissionGranted = true).resolveNativeText(),
+    )
   }
 
   @Test
@@ -226,46 +215,30 @@ class OnboardingFlowLogicTest {
 
   @Test
   fun permissionChangesRequireNodeApprovalWhenAdvertisedSurfaceChanges() {
-    assertTrue(
-      permissionChangesRequireNodeApproval(
-        currentCameraEnabled = false,
-        requestedCameraEnabled = true,
-        currentLocationMode = LocationMode.Off,
-        requestedLocationMode = LocationMode.Off,
-        currentSmsGranted = true,
-        requestedSmsGranted = true,
-      ),
-    )
-    assertTrue(
-      permissionChangesRequireNodeApproval(
-        currentCameraEnabled = false,
-        requestedCameraEnabled = false,
-        currentLocationMode = LocationMode.Off,
-        requestedLocationMode = LocationMode.WhileUsing,
-        currentSmsGranted = true,
-        requestedSmsGranted = true,
-      ),
-    )
-    assertTrue(
-      permissionChangesRequireNodeApproval(
-        currentCameraEnabled = false,
-        requestedCameraEnabled = false,
-        currentLocationMode = LocationMode.Off,
-        requestedLocationMode = LocationMode.Off,
-        currentSmsGranted = false,
-        requestedSmsGranted = true,
-      ),
-    )
-    assertFalse(
-      permissionChangesRequireNodeApproval(
+    listOf(
+      PermissionApprovalCase(expected = true, requestedCameraEnabled = true),
+      PermissionApprovalCase(expected = true, requestedLocationMode = LocationMode.WhileUsing),
+      PermissionApprovalCase(expected = true, currentSmsGranted = false),
+      PermissionApprovalCase(
+        expected = false,
         currentCameraEnabled = true,
         requestedCameraEnabled = true,
         currentLocationMode = LocationMode.WhileUsing,
         requestedLocationMode = LocationMode.WhileUsing,
-        currentSmsGranted = true,
-        requestedSmsGranted = true,
       ),
-    )
+    ).forEach { case ->
+      assertBoolean(
+        case.expected,
+        permissionChangesRequireNodeApproval(
+          currentCameraEnabled = case.currentCameraEnabled,
+          requestedCameraEnabled = case.requestedCameraEnabled,
+          currentLocationMode = case.currentLocationMode,
+          requestedLocationMode = case.requestedLocationMode,
+          currentSmsGranted = case.currentSmsGranted,
+          requestedSmsGranted = true,
+        ),
+      )
+    }
   }
 
   @Test
@@ -284,57 +257,12 @@ class OnboardingFlowLogicTest {
 
   @Test
   fun nearbyGatewayManualTlsPreservesDiscoverySecurityPolicy() {
-    assertFalse(
-      nearbyGatewayManualTls(
-        GatewayEndpoint(
-          stableId = "_openclaw-gw._tcp.|local.|Lan",
-          name = "Lan",
-          host = "192.168.1.12",
-          port = 18789,
-        ),
-      ),
-    )
-    assertTrue(
-      nearbyGatewayManualTls(
-        GatewayEndpoint(
-          stableId = "_openclaw-gw._tcp.|local.|Tls",
-          name = "Tls",
-          host = "192.168.1.12",
-          port = 18789,
-          tlsEnabled = true,
-        ),
-      ),
-    )
-    assertTrue(
-      nearbyGatewayManualTls(
-        GatewayEndpoint(
-          stableId = "_openclaw-gw._tcp.|local.|Pinned",
-          name = "Pinned",
-          host = "127.0.0.1",
-          port = 18789,
-          tlsFingerprintSha256 = "abc123",
-        ),
-      ),
-    )
-    assertTrue(
-      nearbyGatewayManualTls(
-        GatewayEndpoint(
-          stableId = "_openclaw-gw._tcp.|local.|Remote",
-          name = "Remote",
-          host = "gateway.example.com",
-          port = 443,
-        ),
-      ),
-    )
-    assertFalse(
-      nearbyGatewayManualTls(
-        GatewayEndpoint(
-          stableId = "_openclaw-gw._tcp.|local.|Loopback",
-          name = "Loopback",
-          host = "127.0.0.1",
-          port = 18789,
-        ),
-      ),
+    assertBooleanCases(
+      false to nearbyGatewayManualTls(gatewayEndpoint(name = "Lan", host = "192.168.1.12")),
+      true to nearbyGatewayManualTls(gatewayEndpoint(name = "Tls", host = "192.168.1.12", tlsEnabled = true)),
+      true to nearbyGatewayManualTls(gatewayEndpoint(name = "Pinned", host = "127.0.0.1", tlsFingerprintSha256 = "abc123")),
+      true to nearbyGatewayManualTls(gatewayEndpoint(name = "Remote", host = "gateway.example.com", port = 443)),
+      false to nearbyGatewayManualTls(gatewayEndpoint(name = "Loopback", host = "127.0.0.1")),
     )
   }
 
@@ -355,9 +283,13 @@ class OnboardingFlowLogicTest {
 
   @Test
   fun blocksFinishWhenNodeCapabilityApprovalIsPending() {
-    assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApproval = GatewayNodeCapabilityApproval.PendingApproval(null)))
-    assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApproval = GatewayNodeCapabilityApproval.PendingReapproval(null)))
-    assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApproval = GatewayNodeCapabilityApproval.Unapproved))
+    listOf(
+      GatewayNodeCapabilityApproval.PendingApproval(null),
+      GatewayNodeCapabilityApproval.PendingReapproval(null),
+      GatewayNodeCapabilityApproval.Unapproved,
+    ).forEach { approval ->
+      assertFalse(canFinishOnboarding(isConnected = true, isNodeConnected = true, nodeCapabilityApproval = approval))
+    }
   }
 
   @Test
@@ -447,263 +379,164 @@ class OnboardingFlowLogicTest {
 
   @Test
   fun recoveryGatewayNamePrefersServerThenAttemptedGateway() {
-    assertEquals("Server Gateway", recoveryGatewayName(serverName = "Server Gateway", attemptedGatewayName = "Discovered Gateway"))
-    assertEquals("Discovered Gateway", recoveryGatewayName(serverName = null, attemptedGatewayName = "Discovered Gateway"))
-    assertEquals("Home Gateway", recoveryGatewayName(serverName = " ", attemptedGatewayName = " "))
+    assertEqualsCases(
+      "Server Gateway" to recoveryGatewayName(serverName = "Server Gateway", attemptedGatewayName = "Discovered Gateway"),
+      "Discovered Gateway" to recoveryGatewayName(serverName = null, attemptedGatewayName = "Discovered Gateway"),
+      "Home Gateway" to recoveryGatewayName(serverName = " ", attemptedGatewayName = " "),
+    )
   }
 
   @Test
   fun recoveryNodeApprovalCommandUsesRequestIdWhenAvailable() {
-    assertEquals("openclaw nodes approve request-1", recoveryNodeApprovalCommand(" request-1 "))
-    assertEquals("openclaw nodes approve REQUEST_ID", recoveryNodeApprovalCommand(null))
-    assertEquals("openclaw nodes approve REQUEST_ID", recoveryNodeApprovalCommand(" "))
+    assertEqualsCases(
+      "openclaw nodes approve request-1" to recoveryNodeApprovalCommand(" request-1 "),
+      "openclaw nodes approve REQUEST_ID" to recoveryNodeApprovalCommand(null),
+      "openclaw nodes approve REQUEST_ID" to recoveryNodeApprovalCommand(" "),
+    )
   }
 
   @Test
   fun nodeCapabilityApprovalNeedsUserActionOnlyForPendingStates() {
-    assertTrue(nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.PendingApproval(null)))
-    assertTrue(nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.PendingReapproval(null)))
-    assertTrue(nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.Unapproved))
-    assertFalse(nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.Approved))
-    assertFalse(nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.Loading))
-    assertFalse(nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.Unsupported))
+    assertBooleanCases(
+      true to nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.PendingApproval(null)),
+      true to nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.PendingReapproval(null)),
+      true to nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.Unapproved),
+      false to nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.Approved),
+      false to nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.Loading),
+      false to nodeCapabilityApprovalNeedsUserAction(GatewayNodeCapabilityApproval.Unsupported),
+    )
   }
 
   @Test
   fun gatewayPairingContinueOnlyRoutesToNodeApprovalWhenApprovalNeedsUserAction() {
-    assertEquals(
-      OnboardingStep.Permissions,
-      gatewayPairingContinueDestination(
-        ready = true,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.PendingApproval(null),
-      ),
-    )
-    assertEquals(
-      OnboardingStep.NodeApproval,
-      gatewayPairingContinueDestination(
-        ready = false,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.PendingApproval(null),
-      ),
-    )
-    assertEquals(
-      OnboardingStep.NodeApproval,
-      gatewayPairingContinueDestination(
-        ready = false,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.PendingReapproval(null),
-      ),
-    )
-    assertEquals(
-      OnboardingStep.NodeApproval,
-      gatewayPairingContinueDestination(
-        ready = false,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Unapproved,
-      ),
-    )
-    assertNull(
-      gatewayPairingContinueDestination(
-        ready = false,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Loading,
-      ),
-    )
-    assertNull(
-      gatewayPairingContinueDestination(
-        ready = false,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-      ),
-    )
-    assertNull(
-      gatewayPairingContinueDestination(
-        ready = false,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Unsupported,
-      ),
-    )
+    listOf(
+      GatewayContinueCase(OnboardingStep.Permissions, ready = true, approval = GatewayNodeCapabilityApproval.PendingApproval(null)),
+      GatewayContinueCase(OnboardingStep.NodeApproval, ready = false, approval = GatewayNodeCapabilityApproval.PendingApproval(null)),
+      GatewayContinueCase(OnboardingStep.NodeApproval, ready = false, approval = GatewayNodeCapabilityApproval.PendingReapproval(null)),
+      GatewayContinueCase(OnboardingStep.NodeApproval, ready = false, approval = GatewayNodeCapabilityApproval.Unapproved),
+      GatewayContinueCase(null, ready = false, approval = GatewayNodeCapabilityApproval.Loading),
+      GatewayContinueCase(null, ready = false, approval = GatewayNodeCapabilityApproval.Approved),
+      GatewayContinueCase(null, ready = false, approval = GatewayNodeCapabilityApproval.Unsupported),
+    ).forEach { case ->
+      assertEquals(
+        case.expected,
+        gatewayPairingContinueDestination(
+          ready = case.ready,
+          nodeCapabilityApproval = case.approval,
+        ),
+      )
+    }
   }
 
   @Test
   fun permissionContinueReturnsToNodeApprovalWhenApprovalIsStillPending() {
-    assertTrue(
-      permissionContinueNeedsNodeApproval(
+    listOf(
+      PermissionContinueCase(
+        expected = true,
         ready = false,
-        requiresNodeApprovalAfterApply = false,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.PendingReapproval(null),
+        requiresApproval = false,
+        approval = GatewayNodeCapabilityApproval.PendingReapproval(null),
       ),
-    )
-    assertTrue(
-      permissionContinueNeedsNodeApproval(
-        ready = false,
-        requiresNodeApprovalAfterApply = true,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-      ),
-    )
-    assertTrue(
-      permissionContinueNeedsNodeApproval(
-        ready = true,
-        requiresNodeApprovalAfterApply = true,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-      ),
-    )
-    assertFalse(
-      permissionContinueNeedsNodeApproval(
-        ready = true,
-        requiresNodeApprovalAfterApply = true,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Unsupported,
-      ),
-    )
-    assertFalse(
-      permissionContinueNeedsNodeApproval(
-        ready = true,
-        requiresNodeApprovalAfterApply = false,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-      ),
-    )
+      PermissionContinueCase(expected = true, ready = false, requiresApproval = true, approval = GatewayNodeCapabilityApproval.Approved),
+      PermissionContinueCase(expected = true, ready = true, requiresApproval = true, approval = GatewayNodeCapabilityApproval.Approved),
+      PermissionContinueCase(expected = false, ready = true, requiresApproval = true, approval = GatewayNodeCapabilityApproval.Unsupported),
+      PermissionContinueCase(expected = false, ready = true, requiresApproval = false, approval = GatewayNodeCapabilityApproval.Approved),
+    ).forEach { case ->
+      assertBoolean(
+        case.expected,
+        permissionContinueNeedsNodeApproval(
+          ready = case.ready,
+          requiresNodeApprovalAfterApply = case.requiresApproval,
+          nodeCapabilityApproval = case.approval,
+        ),
+      )
+    }
   }
 
   @Test
   fun nodeApprovalCheckingOnlyTracksActiveRefresh() {
-    assertTrue(
-      nodeApprovalCheckingInProgress(
-        checkRequested = true,
-        refreshStarted = false,
-        nodesDevicesRefreshing = false,
-      ),
-    )
-    assertTrue(
-      nodeApprovalCheckingInProgress(
-        checkRequested = true,
-        refreshStarted = true,
-        nodesDevicesRefreshing = true,
-      ),
-    )
-    assertFalse(
-      nodeApprovalCheckingInProgress(
-        checkRequested = true,
-        refreshStarted = true,
-        nodesDevicesRefreshing = false,
-      ),
-    )
-    assertFalse(
-      nodeApprovalCheckingInProgress(
-        checkRequested = false,
-        refreshStarted = true,
-        nodesDevicesRefreshing = true,
-      ),
-    )
+    listOf(
+      ApprovalRefreshCase(expected = true, checkRequested = true, refreshStarted = false, refreshing = false),
+      ApprovalRefreshCase(expected = true, checkRequested = true, refreshStarted = true, refreshing = true),
+      ApprovalRefreshCase(expected = false, checkRequested = true, refreshStarted = true, refreshing = false),
+      ApprovalRefreshCase(expected = false, checkRequested = false, refreshStarted = true, refreshing = true),
+    ).forEach { case ->
+      assertBoolean(
+        case.expected,
+        nodeApprovalCheckingInProgress(
+          checkRequested = case.checkRequested,
+          refreshStarted = case.refreshStarted,
+          nodesDevicesRefreshing = case.refreshing,
+        ),
+      )
+    }
   }
 
   @Test
   fun nodeApprovalCheckClearsUnobservedRefreshOnlyOnApprovalScreen() {
-    assertTrue(
-      nodeApprovalCheckShouldClearUnobservedRefresh(
-        step = OnboardingStep.NodeApproval,
+    listOf(
+      ApprovalRefreshCase(expected = true, checkRequested = true, refreshStarted = false, refreshing = false),
+      ApprovalRefreshCase(expected = false, checkRequested = true, refreshStarted = true, refreshing = false),
+      ApprovalRefreshCase(expected = false, checkRequested = true, refreshStarted = false, refreshing = true),
+      ApprovalRefreshCase(
+        expected = false,
         checkRequested = true,
         refreshStarted = false,
-        nodesDevicesRefreshing = false,
-      ),
-    )
-    assertFalse(
-      nodeApprovalCheckShouldClearUnobservedRefresh(
-        step = OnboardingStep.NodeApproval,
-        checkRequested = true,
-        refreshStarted = true,
-        nodesDevicesRefreshing = false,
-      ),
-    )
-    assertFalse(
-      nodeApprovalCheckShouldClearUnobservedRefresh(
-        step = OnboardingStep.NodeApproval,
-        checkRequested = true,
-        refreshStarted = false,
-        nodesDevicesRefreshing = true,
-      ),
-    )
-    assertFalse(
-      nodeApprovalCheckShouldClearUnobservedRefresh(
+        refreshing = false,
         step = OnboardingStep.Permissions,
-        checkRequested = true,
-        refreshStarted = false,
-        nodesDevicesRefreshing = false,
       ),
-    )
+    ).forEach { case ->
+      assertBoolean(
+        case.expected,
+        nodeApprovalCheckShouldClearUnobservedRefresh(
+          step = case.step,
+          checkRequested = case.checkRequested,
+          refreshStarted = case.refreshStarted,
+          nodesDevicesRefreshing = case.refreshing,
+        ),
+      )
+    }
   }
 
   @Test
   fun nodeApprovalCheckContinuesWhenRequestedCheckFindsGatewayReady() {
-    assertFalse(
-      nodeApprovalCheckCanContinue(
-        checkRequested = true,
-        refreshStarted = false,
-        nodesDevicesRefreshing = false,
-        ready = true,
-      ),
-    )
-    assertFalse(
-      nodeApprovalCheckCanContinue(
-        checkRequested = true,
-        refreshStarted = false,
-        nodesDevicesRefreshing = true,
-        ready = true,
-      ),
-    )
-    assertFalse(
-      nodeApprovalCheckCanContinue(
-        checkRequested = true,
-        refreshStarted = true,
-        nodesDevicesRefreshing = true,
-        ready = true,
-      ),
-    )
-    assertFalse(
-      nodeApprovalCheckCanContinue(
-        checkRequested = true,
-        refreshStarted = true,
-        nodesDevicesRefreshing = false,
-        ready = false,
-      ),
-    )
-    assertTrue(
-      nodeApprovalCheckCanContinue(
-        checkRequested = true,
-        refreshStarted = true,
-        nodesDevicesRefreshing = false,
-        ready = true,
-      ),
-    )
+    listOf(
+      ApprovalContinueCase(expected = false, refreshStarted = false, refreshing = false, ready = true),
+      ApprovalContinueCase(expected = false, refreshStarted = false, refreshing = true, ready = true),
+      ApprovalContinueCase(expected = false, refreshStarted = true, refreshing = true, ready = true),
+      ApprovalContinueCase(expected = false, refreshStarted = true, refreshing = false, ready = false),
+      ApprovalContinueCase(expected = true, refreshStarted = true, refreshing = false, ready = true),
+    ).forEach { case ->
+      assertBoolean(
+        case.expected,
+        nodeApprovalCheckCanContinue(
+          checkRequested = true,
+          refreshStarted = case.refreshStarted,
+          nodesDevicesRefreshing = case.refreshing,
+          ready = case.ready,
+        ),
+      )
+    }
   }
 
   @Test
   fun nodeApprovalAutoContinuesWhenGatewayReportsReady() {
-    assertTrue(
-      nodeApprovalShouldAutoContinue(
-        step = OnboardingStep.NodeApproval,
-        ready = true,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-        autoContinueEnabled = true,
-      ),
-    )
-    assertFalse(
-      nodeApprovalShouldAutoContinue(
-        step = OnboardingStep.NodeApproval,
-        ready = true,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.PendingApproval(null),
-        autoContinueEnabled = true,
-      ),
-    )
-    assertFalse(
-      nodeApprovalShouldAutoContinue(
-        step = OnboardingStep.Permissions,
-        ready = true,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-        autoContinueEnabled = true,
-      ),
-    )
-    assertFalse(
-      nodeApprovalShouldAutoContinue(
-        step = OnboardingStep.NodeApproval,
-        ready = true,
-        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-        autoContinueEnabled = false,
-      ),
-    )
+    listOf(
+      ApprovalAutoContinueCase(expected = true),
+      ApprovalAutoContinueCase(expected = false, approval = GatewayNodeCapabilityApproval.PendingApproval(null)),
+      ApprovalAutoContinueCase(expected = false, step = OnboardingStep.Permissions),
+      ApprovalAutoContinueCase(expected = false, autoContinueEnabled = false),
+    ).forEach { case ->
+      assertBoolean(
+        case.expected,
+        nodeApprovalShouldAutoContinue(
+          step = case.step,
+          ready = true,
+          nodeCapabilityApproval = case.approval,
+          autoContinueEnabled = case.autoContinueEnabled,
+        ),
+      )
+    }
   }
 
   @Test
@@ -729,16 +562,7 @@ class OnboardingFlowLogicTest {
         gatewayPairingCanContinue = true,
         statusText = "Connected (node offline)",
         connectSettling = false,
-        gatewayConnectionProblem =
-          GatewayConnectionProblem(
-            code = "PAIRING_REQUIRED",
-            message = "pairing required: device approval is required",
-            reason = "not-paired",
-            requestId = "request-1",
-            recommendedNextStep = null,
-            pauseReconnect = true,
-            retryable = false,
-          ),
+        gatewayConnectionProblem = pairingRequiredProblem(),
       ),
     )
   }
@@ -752,16 +576,7 @@ class OnboardingFlowLogicTest {
         gatewayPairingCanContinue = false,
         statusText = "Connected (node offline)",
         connectSettling = false,
-        gatewayConnectionProblem =
-          GatewayConnectionProblem(
-            code = "PAIRING_REQUIRED",
-            message = "pairing required: device approval is required",
-            reason = "not-paired",
-            requestId = "request-1",
-            recommendedNextStep = null,
-            pauseReconnect = true,
-            retryable = false,
-          ),
+        gatewayConnectionProblem = pairingRequiredProblem(),
       ),
     )
   }
@@ -775,99 +590,39 @@ class OnboardingFlowLogicTest {
         gatewayPairingCanContinue = false,
         statusText = "Connected (node offline)",
         connectSettling = false,
-        gatewayConnectionProblem =
-          GatewayConnectionProblem(
-            code = "PAIRING_REQUIRED",
-            message = "pairing required: device approval is required",
-            reason = "not-paired",
-            requestId = "request-1",
-            recommendedNextStep = "wait_then_retry",
-            pauseReconnect = false,
-            retryable = true,
-          ),
+        gatewayConnectionProblem = pairingRequiredProblem(retryable = true),
       ),
     )
   }
 
   @Test
   fun gatewayPairingWaitsWhenOperatorConnectedButNoContinueDestinationExists() {
-    assertEquals(
-      GatewayRecoveryUiState.Finishing,
-      gatewayPairingUiState(
-        gatewayPaired = true,
-        gatewayPairingCanContinue = false,
-        statusText = "Connected (node offline)",
-        connectSettling = false,
-        connectTimedOut = false,
-      ),
-    )
-    assertEquals(
-      GatewayRecoveryUiState.TakingLonger,
-      gatewayPairingUiState(
-        gatewayPaired = true,
-        gatewayPairingCanContinue = false,
-        statusText = "Connected (node offline)",
-        connectSettling = false,
-        connectTimedOut = true,
-      ),
+    assertEqualsCases(
+      GatewayRecoveryUiState.Finishing to gatewayPairingState(gatewayPaired = true, connectTimedOut = false),
+      GatewayRecoveryUiState.TakingLonger to gatewayPairingState(gatewayPaired = true, connectTimedOut = true),
     )
   }
 
   @Test
   fun gatewayPairingShowsSlowConnectionWhenGatewayNeverPairs() {
-    assertEquals(
-      GatewayRecoveryUiState.Finishing,
-      gatewayPairingUiState(
-        gatewayPaired = false,
-        gatewayPairingCanContinue = false,
-        statusText = "Connecting…",
-        connectSettling = false,
-        connectTimedOut = false,
-      ),
-    )
-    assertEquals(
-      GatewayRecoveryUiState.TakingLonger,
-      gatewayPairingUiState(
-        gatewayPaired = false,
-        gatewayPairingCanContinue = false,
-        statusText = "Connecting…",
-        connectSettling = false,
-        connectTimedOut = true,
-      ),
+    assertEqualsCases(
+      GatewayRecoveryUiState.Finishing to gatewayPairingState(gatewayPaired = false, connectTimedOut = false),
+      GatewayRecoveryUiState.TakingLonger to gatewayPairingState(gatewayPaired = false, connectTimedOut = true),
     )
   }
 
   @Test
   fun gatewayPairingPreservesExplicitFailureStatusText() {
-    assertEquals(
-      GatewayRecoveryUiState.Failed,
-      gatewayPairingUiState(
-        gatewayPaired = false,
-        gatewayPairingCanContinue = false,
-        statusText = "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
-        connectSettling = false,
-        connectTimedOut = false,
-      ),
-    )
-    assertEquals(
-      GatewayRecoveryUiState.Failed,
-      gatewayPairingUiState(
-        gatewayPaired = false,
-        gatewayPairingCanContinue = false,
-        statusText = "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
-        connectSettling = false,
-        connectTimedOut = true,
-      ),
-    )
-    assertEquals(
-      GatewayRecoveryUiState.Failed,
-      gatewayPairingUiState(
-        gatewayPaired = false,
-        gatewayPairingCanContinue = false,
-        statusText = "Gateway error: unauthorized: gateway token missing",
-        connectSettling = false,
-        connectTimedOut = false,
-      ),
+    val tlsError = "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected."
+    assertEqualsCases(
+      GatewayRecoveryUiState.Failed to gatewayPairingState(gatewayPaired = false, connectTimedOut = false, statusText = tlsError),
+      GatewayRecoveryUiState.Failed to gatewayPairingState(gatewayPaired = false, connectTimedOut = true, statusText = tlsError),
+      GatewayRecoveryUiState.Failed to
+        gatewayPairingState(
+          gatewayPaired = false,
+          connectTimedOut = false,
+          statusText = "Gateway error: unauthorized: gateway token missing",
+        ),
     )
   }
 
@@ -880,16 +635,7 @@ class OnboardingFlowLogicTest {
         remoteAddress = null,
         statusText = "Connected (node offline)",
         nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-        gatewayConnectionProblem =
-          GatewayConnectionProblem(
-            code = "PAIRING_REQUIRED",
-            message = "pairing required: device approval is required",
-            reason = "not-paired",
-            requestId = "request-1",
-            recommendedNextStep = "wait_then_retry",
-            pauseReconnect = false,
-            retryable = true,
-          ),
+        gatewayConnectionProblem = pairingRequiredProblem(retryable = true),
       ),
     )
   }
@@ -903,16 +649,7 @@ class OnboardingFlowLogicTest {
         remoteAddress = "wss://gateway.example.test",
         statusText = "Connected (node offline)",
         nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-        gatewayConnectionProblem =
-          GatewayConnectionProblem(
-            code = "AUTH_DEVICE_TOKEN_MISMATCH",
-            message = "authentication needed",
-            reason = null,
-            requestId = null,
-            recommendedNextStep = "update_auth_credentials",
-            pauseReconnect = true,
-            retryable = false,
-          ),
+        gatewayConnectionProblem = authProblem(),
       ),
     )
   }
@@ -926,16 +663,7 @@ class OnboardingFlowLogicTest {
         remoteAddress = "wss://gateway.example.test",
         statusText = "Connected (node offline)",
         nodeCapabilityApproval = GatewayNodeCapabilityApproval.Loading,
-        gatewayConnectionProblem =
-          GatewayConnectionProblem(
-            code = "AUTH_DEVICE_TOKEN_MISMATCH",
-            message = "authentication needed",
-            reason = null,
-            requestId = null,
-            recommendedNextStep = "update_auth_credentials",
-            pauseReconnect = true,
-            retryable = false,
-          ),
+        gatewayConnectionProblem = authProblem(),
       ),
     )
   }
@@ -954,17 +682,7 @@ class OnboardingFlowLogicTest {
     cases.forEach { (code, expected) ->
       assertEquals(
         expected,
-        recoveryGatewayAuthDetail(
-          GatewayConnectionProblem(
-            code = code,
-            message = "authentication needed",
-            reason = null,
-            requestId = null,
-            recommendedNextStep = null,
-            pauseReconnect = true,
-            retryable = false,
-          ),
-        ),
+        recoveryGatewayAuthDetail(authProblem(code = code, recommendedNextStep = null)),
       )
     }
   }
@@ -973,20 +691,7 @@ class OnboardingFlowLogicTest {
   fun recoveryGatewayAuthDetailPreservesProtocolMismatchGuidance() {
     assertEquals(
       "This app is older than the Gateway. Update OpenClaw on this device, then retry. (app protocol v4, gateway protocol v5).",
-      recoveryGatewayAuthDetail(
-        GatewayConnectionProblem(
-          code = "PROTOCOL_MISMATCH",
-          message = "protocol mismatch",
-          reason = null,
-          requestId = null,
-          recommendedNextStep = null,
-          pauseReconnect = true,
-          retryable = false,
-          clientMinProtocol = 4,
-          clientMaxProtocol = 4,
-          expectedProtocol = 5,
-        ),
-      ),
+      recoveryGatewayAuthDetail(protocolMismatchProblem(clientMin = 4, clientMax = 4, expected = 5)),
     )
   }
 
@@ -994,37 +699,11 @@ class OnboardingFlowLogicTest {
   fun recoveryGatewayAuthDetailExplainsOlderGatewayProtocolMismatch() {
     assertEquals(
       "The Gateway is older than this app. Update OpenClaw on the Gateway host, then retry. (app protocol v6, gateway protocol v5).",
-      recoveryGatewayAuthDetail(
-        GatewayConnectionProblem(
-          code = "PROTOCOL_MISMATCH",
-          message = "protocol mismatch",
-          reason = null,
-          requestId = null,
-          recommendedNextStep = null,
-          pauseReconnect = true,
-          retryable = false,
-          clientMinProtocol = 6,
-          clientMaxProtocol = 6,
-          expectedProtocol = 5,
-        ),
-      ),
+      recoveryGatewayAuthDetail(protocolMismatchProblem(clientMin = 6, clientMax = 6, expected = 5)),
     )
     assertEquals(
       "openclaw update",
-      recoveryGatewayProtocolMismatchCommand(
-        GatewayConnectionProblem(
-          code = "PROTOCOL_MISMATCH",
-          message = "protocol mismatch",
-          reason = null,
-          requestId = null,
-          recommendedNextStep = null,
-          pauseReconnect = true,
-          retryable = false,
-          clientMinProtocol = 6,
-          clientMaxProtocol = 6,
-          expectedProtocol = 5,
-        ),
-      ),
+      recoveryGatewayProtocolMismatchCommand(protocolMismatchProblem(clientMin = 6, clientMax = 6, expected = 5)),
     )
   }
 
@@ -1032,20 +711,7 @@ class OnboardingFlowLogicTest {
   fun recoveryGatewayAuthDetailExplainsIncompatibleProtocolMismatch() {
     assertEquals(
       "The app and Gateway use incompatible protocol versions. Update OpenClaw on both, then retry. (app protocols v4-v6).",
-      recoveryGatewayAuthDetail(
-        GatewayConnectionProblem(
-          code = "PROTOCOL_MISMATCH",
-          message = "protocol mismatch",
-          reason = null,
-          requestId = null,
-          recommendedNextStep = null,
-          pauseReconnect = true,
-          retryable = false,
-          clientMinProtocol = 4,
-          clientMaxProtocol = 6,
-          expectedProtocol = null,
-        ),
-      ),
+      recoveryGatewayAuthDetail(protocolMismatchProblem(clientMin = 4, clientMax = 6, expected = null)),
     )
   }
 
@@ -1053,48 +719,25 @@ class OnboardingFlowLogicTest {
   fun recoveryGatewayAuthDetailUsesRecommendedNextStepFallbacks() {
     assertEquals(
       "Gateway authentication is not configured. Edit this connection and try again.",
-      recoveryGatewayAuthDetail(
-        GatewayConnectionProblem(
-          code = "UNKNOWN",
-          message = "authentication needed",
-          reason = null,
-          requestId = null,
-          recommendedNextStep = "update_auth_configuration",
-          pauseReconnect = true,
-          retryable = false,
-        ),
-      ),
+      recoveryGatewayAuthDetail(authProblem(code = "UNKNOWN", recommendedNextStep = "update_auth_configuration")),
     )
     assertEquals(
       "gateway says no",
-      recoveryGatewayAuthDetail(
-        GatewayConnectionProblem(
-          code = "UNKNOWN",
-          message = "gateway says no",
-          reason = null,
-          requestId = null,
-          recommendedNextStep = null,
-          pauseReconnect = true,
-          retryable = false,
-        ),
-      ),
+      recoveryGatewayAuthDetail(authProblem(code = "UNKNOWN", message = "gateway says no", recommendedNextStep = null)),
     )
   }
 
   @Test
   fun recoveryPrimaryActionOnlyAppearsForCompleteFailureOrSlowConnectionStates() {
-    assertEquals(GatewayRecoveryPrimaryAction.Finish, gatewayRecoveryPrimaryAction(GatewayRecoveryUiState.Connected))
-    assertEquals(GatewayRecoveryPrimaryAction.Back, gatewayRecoveryPrimaryAction(GatewayRecoveryUiState.Failed))
-    assertEquals(GatewayRecoveryPrimaryAction.Retry, gatewayRecoveryPrimaryAction(GatewayRecoveryUiState.TakingLonger))
-    assertEquals(GatewayRecoveryPrimaryAction.Retry, gatewayRecoveryPrimaryAction(GatewayRecoveryUiState.ApprovalRequired))
-
-    listOf(
-      GatewayRecoveryUiState.NodeCapabilityApprovalPending,
-      GatewayRecoveryUiState.Pairing,
-      GatewayRecoveryUiState.Finishing,
-    ).forEach { state ->
-      assertEquals(null, gatewayRecoveryPrimaryAction(state))
-    }
+    assertEqualsCases(
+      GatewayRecoveryPrimaryAction.Finish to gatewayRecoveryPrimaryAction(GatewayRecoveryUiState.Connected),
+      GatewayRecoveryPrimaryAction.Back to gatewayRecoveryPrimaryAction(GatewayRecoveryUiState.Failed),
+      GatewayRecoveryPrimaryAction.Retry to gatewayRecoveryPrimaryAction(GatewayRecoveryUiState.TakingLonger),
+      GatewayRecoveryPrimaryAction.Retry to gatewayRecoveryPrimaryAction(GatewayRecoveryUiState.ApprovalRequired),
+      null to gatewayRecoveryPrimaryAction(GatewayRecoveryUiState.NodeCapabilityApprovalPending),
+      null to gatewayRecoveryPrimaryAction(GatewayRecoveryUiState.Pairing),
+      null to gatewayRecoveryPrimaryAction(GatewayRecoveryUiState.Finishing),
+    )
   }
 
   @Test
@@ -1104,16 +747,7 @@ class OnboardingFlowLogicTest {
     assertTrue(
       gatewayRecoveryShowsDiagnosticAction(
         GatewayRecoveryUiState.Pairing,
-        gatewayConnectionProblem =
-          GatewayConnectionProblem(
-            code = "PAIRING_REQUIRED",
-            message = "pairing required",
-            reason = "not-paired",
-            requestId = "request-1",
-            recommendedNextStep = "wait_then_retry",
-            pauseReconnect = false,
-            retryable = true,
-          ),
+        gatewayConnectionProblem = pairingRequiredProblem(retryable = true, message = "pairing required"),
       ),
     )
     assertFalse(gatewayRecoveryShowsDiagnosticAction(GatewayRecoveryUiState.Finishing, gatewayConnectionProblem = null))
@@ -1224,14 +858,8 @@ class OnboardingFlowLogicTest {
     val scanned = resolveScannedSetupCodeResult(setupCode)
 
     val plan =
-      resolveOnboardingGatewayConnectPlan(
+      resolveOnboardingPlanFixture(
         setupCode = requireNotNull(scanned.setupCode),
-        savedManualHost = "127.0.0.1",
-        savedManualPort = "18789",
-        savedManualTls = false,
-        manualHost = "127.0.0.1",
-        manualPort = "18789",
-        manualTls = false,
         token = "stale-shared-token",
         password = "stale-shared-password",
       )
@@ -1249,14 +877,7 @@ class OnboardingFlowLogicTest {
   @Test
   fun resolvesOnboardingManualConnectConfigWhenSetupCodeIsBlank() {
     val plan =
-      resolveOnboardingGatewayConnectPlan(
-        setupCode = "",
-        savedManualHost = "127.0.0.1",
-        savedManualPort = "18789",
-        savedManualTls = false,
-        manualHost = "127.0.0.1",
-        manualPort = "18789",
-        manualTls = false,
+      resolveOnboardingPlanFixture(
         token = "shared-token",
         password = "shared-password",
       )
@@ -1273,22 +894,174 @@ class OnboardingFlowLogicTest {
   @Test
   fun onboardingManualEndpointChangeReplacesSavedGatewayAuth() {
     val plan =
-      resolveOnboardingGatewayConnectPlan(
-        setupCode = "",
-        savedManualHost = "127.0.0.1",
-        savedManualPort = "18789",
-        savedManualTls = false,
+      resolveOnboardingPlanFixture(
         manualHost = "10.0.2.2",
         manualPort = "18790",
-        manualTls = false,
         token = "replacement-token",
-        password = "",
       )
 
     assertEquals(GatewaySavedAuthAction.REPLACE_ENDPOINT, plan?.savedAuthAction)
     assertEquals("10.0.2.2", plan?.config?.host)
     assertEquals("replacement-token", plan?.config?.token)
   }
+
+  private data class PermissionApprovalCase(
+    val expected: Boolean,
+    val currentCameraEnabled: Boolean = false,
+    val requestedCameraEnabled: Boolean = false,
+    val currentLocationMode: LocationMode = LocationMode.Off,
+    val requestedLocationMode: LocationMode = LocationMode.Off,
+    val currentSmsGranted: Boolean = true,
+  )
+
+  private data class GatewayContinueCase(
+    val expected: OnboardingStep?,
+    val ready: Boolean,
+    val approval: GatewayNodeCapabilityApproval,
+  )
+
+  private data class PermissionContinueCase(
+    val expected: Boolean,
+    val ready: Boolean,
+    val requiresApproval: Boolean,
+    val approval: GatewayNodeCapabilityApproval,
+  )
+
+  private data class ApprovalRefreshCase(
+    val expected: Boolean,
+    val checkRequested: Boolean,
+    val refreshStarted: Boolean,
+    val refreshing: Boolean,
+    val step: OnboardingStep = OnboardingStep.NodeApproval,
+  )
+
+  private data class ApprovalContinueCase(
+    val expected: Boolean,
+    val refreshStarted: Boolean,
+    val refreshing: Boolean,
+    val ready: Boolean,
+  )
+
+  private data class ApprovalAutoContinueCase(
+    val expected: Boolean,
+    val step: OnboardingStep = OnboardingStep.NodeApproval,
+    val approval: GatewayNodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
+    val autoContinueEnabled: Boolean = true,
+  )
+
+  private fun assertBoolean(
+    expected: Boolean,
+    actual: Boolean,
+  ) {
+    if (expected) assertTrue(actual) else assertFalse(actual)
+  }
+
+  private fun assertBooleanCases(vararg cases: Pair<Boolean, Boolean>) {
+    cases.forEach { (expected, actual) -> assertBoolean(expected, actual) }
+  }
+
+  private fun <T> assertEqualsCases(vararg cases: Pair<T, T>) {
+    cases.forEach { (expected, actual) -> assertEquals(expected, actual) }
+  }
+
+  private fun gatewayEndpoint(
+    name: String,
+    host: String,
+    port: Int = 18789,
+    tlsEnabled: Boolean = false,
+    tlsFingerprintSha256: String? = null,
+  ): GatewayEndpoint =
+    GatewayEndpoint(
+      stableId = "_openclaw-gw._tcp.|local.|$name",
+      name = name,
+      host = host,
+      port = port,
+      tlsEnabled = tlsEnabled,
+      tlsFingerprintSha256 = tlsFingerprintSha256,
+    )
+
+  private fun gatewayPairingState(
+    gatewayPaired: Boolean,
+    connectTimedOut: Boolean,
+    statusText: String = if (gatewayPaired) "Connected (node offline)" else "Connecting…",
+  ): GatewayRecoveryUiState =
+    gatewayPairingUiState(
+      gatewayPaired = gatewayPaired,
+      gatewayPairingCanContinue = false,
+      statusText = statusText,
+      connectSettling = false,
+      connectTimedOut = connectTimedOut,
+    )
+
+  private fun pairingRequiredProblem(
+    retryable: Boolean = false,
+    message: String = "pairing required: device approval is required",
+  ): GatewayConnectionProblem =
+    GatewayConnectionProblem(
+      code = "PAIRING_REQUIRED",
+      message = message,
+      reason = "not-paired",
+      requestId = "request-1",
+      recommendedNextStep = "wait_then_retry".takeIf { retryable },
+      pauseReconnect = !retryable,
+      retryable = retryable,
+    )
+
+  private fun authProblem(
+    code: String = "AUTH_DEVICE_TOKEN_MISMATCH",
+    message: String = "authentication needed",
+    recommendedNextStep: String? = "update_auth_credentials",
+  ): GatewayConnectionProblem =
+    GatewayConnectionProblem(
+      code = code,
+      message = message,
+      reason = null,
+      requestId = null,
+      recommendedNextStep = recommendedNextStep,
+      pauseReconnect = true,
+      retryable = false,
+    )
+
+  private fun protocolMismatchProblem(
+    clientMin: Int,
+    clientMax: Int,
+    expected: Int?,
+  ): GatewayConnectionProblem =
+    GatewayConnectionProblem(
+      code = "PROTOCOL_MISMATCH",
+      message = "protocol mismatch",
+      reason = null,
+      requestId = null,
+      recommendedNextStep = null,
+      pauseReconnect = true,
+      retryable = false,
+      clientMinProtocol = clientMin,
+      clientMaxProtocol = clientMax,
+      expectedProtocol = expected,
+    )
+
+  private fun resolveOnboardingPlanFixture(
+    setupCode: String = "",
+    savedManualHost: String = "127.0.0.1",
+    savedManualPort: String = "18789",
+    savedManualTls: Boolean = false,
+    manualHost: String = "127.0.0.1",
+    manualPort: String = "18789",
+    manualTls: Boolean = false,
+    token: String = "",
+    password: String = "",
+  ): GatewayConnectPlan? =
+    resolveOnboardingGatewayConnectPlan(
+      setupCode = setupCode,
+      savedManualHost = savedManualHost,
+      savedManualPort = savedManualPort,
+      savedManualTls = savedManualTls,
+      manualHost = manualHost,
+      manualPort = manualPort,
+      manualTls = manualTls,
+      token = token,
+      password = password,
+    )
 
   private fun encodeSetupCode(payloadJson: String): String = Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray(Charsets.UTF_8))
 }


### PR DESCRIPTION
## What Problem This Solves

Android onboarding and gateway resolver unit tests repeat large endpoint, connection-problem, and decision-state fixtures. The duplication makes the behavior matrix harder to audit and maintain, and adds 382 avoidable test lines.

## Why This Change Was Made

This AI-assisted cleanup consolidates repeated setup and assertion patterns into local typed cases and fixture helpers while preserving every existing test method, input variant, assertion outcome, and production boundary. It changes no Android runtime behavior, generated surface, dependency, or public API.

## User Impact

No user-visible behavior changes. Android contributors get a smaller, more explicit onboarding/gateway test suite that is easier to extend without duplicating fixture policy.

## Evidence

- Exact `@Test` name/order comparison is unchanged; all 63 onboarding test methods remain present.
- `git diff --check`
- Blacksmith Testbox `tbx_01kz2ntka3vvg4cthm07273fkh` (`crimson-crab-5ba7`): `cd apps/android && ./gradlew :app:ktlintCheck`
- Same Testbox: `./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest --tests ai.openclaw.app.ui.GatewayConfigResolverTest`
- Same Testbox: `./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest --tests ai.openclaw.app.ui.GatewayConfigResolverTest`
- Testbox hydration run: https://github.com/openclaw/openclaw/actions/runs/30778376281
- Fresh autoreview: `gpt-5.6-sol`, `xhigh`, TruffleHog clean, no accepted/actionable findings, overall correctness 0.99.
- Diff: +560/−942 test LOC (net −382); production LOC +0/−0.

AI-assisted: yes. I reviewed the complete diff and the exercised production contracts.