### PR TITLE
refactor(ios): remove redundant node test seams

### DIFF
--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -7708,7 +7708,7 @@ extension NodeAppModel {
     }
 
     @discardableResult
-    func handleExecApprovalResolvedForCurrentGateway(
+    private func handleExecApprovalResolvedForCurrentGateway(
         approvalId: String,
         approvalKind: ApprovalKind = .exec,
         recoveryPushGatewayDeviceID: String? = nil,
@@ -10542,6 +10542,15 @@ extension NodeAppModel {
         self.watchExecApprovalPromptsByID.keys
             .map(\.rawValue)
             .sorted(by: Self.approvalIDSortsBefore)
+    }
+
+    func _test_handleExecApprovalResolvedForCurrentGateway(
+        approvalId: String,
+        recoveryPushGatewayDeviceID: String?) async
+    {
+        await self.handleExecApprovalResolvedForCurrentGateway(
+            approvalId: approvalId,
+            recoveryPushGatewayDeviceID: recoveryPushGatewayDeviceID)
     }
 
     func _test_refreshWatchExecApprovalSnapshotOnDemand(

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -5191,7 +5191,7 @@ extension NodeAppModel {
         return storedOperatorScopes.contains("operator.admin")
     }
 
-    func makeOperatorConnectOptions(
+    private func makeOperatorConnectOptions(
         clientId: String,
         displayName: String?,
         deviceAuthGatewayID: String? = nil,
@@ -10454,6 +10454,21 @@ extension NodeAppModel {
                 enqueuedAtMs: nil)
         }
         await self.applyPendingForegroundNodeActions(mapped, trigger: "test")
+    }
+
+    func _test_makeOperatorConnectOptions(
+        clientId: String,
+        displayName: String?,
+        includeAdminScope: Bool = false,
+        includeApprovalScope: Bool,
+        forceExplicitScopes: Bool = false) -> GatewayConnectOptions
+    {
+        self.makeOperatorConnectOptions(
+            clientId: clientId,
+            displayName: displayName,
+            includeAdminScope: includeAdminScope,
+            includeApprovalScope: includeApprovalScope,
+            forceExplicitScopes: forceExplicitScopes)
     }
 
     func _test_presentExecApprovalPrompt(_ prompt: ExecApprovalPrompt) {

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -509,10 +509,10 @@ final class NodeAppModel {
     private let healthSummaryService: any HealthSummaryServicing
     private let watchMessagingService: any WatchMessagingServicing
     #if DEBUG
-    @ObservationIgnored private var testAgentRequestHandler: ((AgentDeepLink) async throws -> Void)?
-    @ObservationIgnored private var testTalkCapturePreparationHandler: (() async -> Void)?
-    @ObservationIgnored private var testTalkCaptureStartedHandler: (() async -> Void)?
-    @ObservationIgnored private var testChatSessionRoutingRestoreHandler: (() async -> Void)?
+    @ObservationIgnored var testAgentRequestHandler: ((AgentDeepLink) async throws -> Void)?
+    @ObservationIgnored var testTalkCapturePreparationHandler: (() async -> Void)?
+    @ObservationIgnored var testTalkCaptureStartedHandler: (() async -> Void)?
+    @ObservationIgnored var testChatSessionRoutingRestoreHandler: (() async -> Void)?
     @ObservationIgnored private var testExecApprovalPromptFetchHandler:
         ((String, String) async -> ExecApprovalPromptFetchOutcome)?
     @ObservationIgnored private var testExecApprovalResolutionHandler:
@@ -521,31 +521,31 @@ final class NodeAppModel {
     #endif
     private var pttVoiceWakeLeaseCaptureId: String?
     private var chatDictationCaptureId: String?
-    private var talkPttCommandEpoch: UInt64 = 0
+    var talkPttCommandEpoch: UInt64 = 0
     private var chatDictationCommandEpoch: UInt64 = 0
     private(set) var isChatDictationPending = false
     private var talkPreparationInFlight = false
     private var auxiliaryAudioCapture: AuxiliaryAudioCapture?
     private var foregroundCaptureCancellations: [UUID: @MainActor () -> Void] = [:]
-    private var talkPreparationWaiters: [(id: UUID, continuation: CheckedContinuation<Bool, Never>)] = []
+    var talkPreparationWaiters: [(id: UUID, continuation: CheckedContinuation<Bool, Never>)] = []
     private var backgroundTalkKeptActive = false
     private var backgroundedAt: Date?
     private var reconnectAfterBackgroundArmed = false
     private var backgroundGraceTaskID: UIBackgroundTaskIdentifier = .invalid
     @ObservationIgnored private var backgroundGraceTaskTimer: Task<Void, Never>?
-    private var backgroundReconnectSuppressed = false
+    var backgroundReconnectSuppressed = false
     private var backgroundReconnectLeaseUntil: Date?
     @ObservationIgnored private var foregroundGatewayResumeCheckInFlight = false
     private var lastSignificantLocationWakeAt: Date?
-    @ObservationIgnored private let watchMessageOutbox = WatchMessageOutbox()
+    @ObservationIgnored let watchMessageOutbox = WatchMessageOutbox()
     @ObservationIgnored private var watchMessageFlushInFlight = false
-    @ObservationIgnored private var watchMessageRetryAttempts: [String: Int] = [:]
+    @ObservationIgnored var watchMessageRetryAttempts: [String: Int] = [:]
     @ObservationIgnored private var watchMessageRetryTask: Task<Void, Never>?
     @ObservationIgnored private let appleReviewDemoChatTransport = AppleReviewDemoChatTransport()
     @ObservationIgnored private var clientDatabases: OpenClawClientDatabases?
     @ObservationIgnored private var chatTranscriptCachesByGatewayID:
         [GatewayStableIdentifier.Key: OpenClawChatSQLiteTranscriptCache] = [:]
-    @ObservationIgnored private var chatSessionRoutingRestoreTask: Task<Void, Never>?
+    @ObservationIgnored var chatSessionRoutingRestoreTask: Task<Void, Never>?
     private var watchExecApprovalPromptsByID: [ExecApprovalIdentifier.Key: ExecApprovalPrompt] = [:]
     private var execApprovalInboxPromptsByKey: [ExecApprovalInboxKey: ExecApprovalPrompt] = [:]
     private var dismissedExecApprovalPresentationKeys: Set<ExecApprovalInboxKey> = []
@@ -559,14 +559,14 @@ final class NodeAppModel {
     @ObservationIgnored private var execApprovalUncertainties:
         [ExecApprovalResolutionKey: ExecApprovalUncertaintyState] = [:]
     @ObservationIgnored private var pendingWatchExecApprovalResolutionFlushInFlight = false
-    private var pendingWatchExecApprovalRecoveryPushes: [ExecApprovalNotificationPrompt] = []
-    private var pendingExecApprovalResolvedPushes: [ExecApprovalNotificationPrompt] = []
+    var pendingWatchExecApprovalRecoveryPushes: [ExecApprovalNotificationPrompt] = []
+    var pendingExecApprovalResolvedPushes: [ExecApprovalNotificationPrompt] = []
     private var pendingWatchExecApprovalResolutions: [WatchExecApprovalResolveEvent] = []
     private var pendingForegroundActionDrainInFlight = false
     private var pendingForegroundActionDrainRequested = false
     private var completedPendingForegroundActionIDsByGateway: [String: Set<String>] = [:]
 
-    private var gatewayConnected = false
+    var gatewayConnected = false
     private var operatorConnected = false
     private var shareDeliveryChannel: String?
     private var shareDeliveryTo: String?
@@ -673,7 +673,7 @@ final class NodeAppModel {
     private var chatTranscriptCacheGeneration = 0
     private var quarantinedChatOfflineGatewayIDs: Set<GatewayStableIdentifier.Key> = []
     #if DEBUG
-    @ObservationIgnored private var testRemoveAllChatDatabaseFilesHandler: (() throws -> Void)?
+    @ObservationIgnored var testRemoveAllChatDatabaseFilesHandler: (() throws -> Void)?
     #endif
 
     /// Gateway-scoped facade over the installation-wide cache and client-state
@@ -905,7 +905,7 @@ final class NodeAppModel {
         }
     }
 
-    private(set) var activeGatewayConnectConfig: GatewayConnectConfig?
+    var activeGatewayConnectConfig: GatewayConnectConfig?
 
     private static let watchExecApprovalBridgeStateKey = "watch.execApproval.bridge.state.v1"
     private static let backgroundAliveLastSuccessAtMsKey = "gateway.backgroundAlive.lastSuccessAtMs"
@@ -1075,7 +1075,7 @@ final class NodeAppModel {
         }
     }
 
-    private func handleCanvasA2UIAction(body: [String: Any]) async {
+    func handleCanvasA2UIAction(body: [String: Any]) async {
         let userActionAny = body["userAction"] ?? body
         let userAction: [String: Any] = {
             if let dict = userActionAny as? [String: Any] { return dict }
@@ -1815,7 +1815,7 @@ final class NodeAppModel {
         }
     }
 
-    private func handleOperatorGatewayServerEvent(
+    func handleOperatorGatewayServerEvent(
         _ evt: EventFrame,
         expectedOperatorRoute: GatewayNodeSessionRoute? = nil,
         shouldContinue: @MainActor @Sendable () -> Bool = { true }) async
@@ -1875,7 +1875,7 @@ final class NodeAppModel {
         }
     }
 
-    private nonisolated static func execApprovalEventID(from payload: AnyCodable) -> String? {
+    nonisolated static func execApprovalEventID(from payload: AnyCodable) -> String? {
         guard let decoded = try? GatewayPayloadDecoding.decode(
             payload,
             as: ExecApprovalGatewayEventPayload.self)
@@ -2250,7 +2250,7 @@ final class NodeAppModel {
         self.gatewayHealthMonitor.stop()
     }
 
-    private func handleInvoke(
+    func handleInvoke(
         _ req: BridgeInvokeRequest,
         gatewayStableID: String? = nil) async -> BridgeInvokeResponse
     {
@@ -3150,7 +3150,7 @@ final class NodeAppModel {
         }
     }
 
-    private func acquirePttVoiceWakeLease(for captureId: String) {
+    func acquirePttVoiceWakeLease(for captureId: String) {
         guard self.pttVoiceWakeLeaseCaptureId != captureId else { return }
         self.pttVoiceWakeLeaseCaptureId = captureId
         // The suppression reason outlives Voice Wake enable/disable toggles,
@@ -3158,7 +3158,7 @@ final class NodeAppModel {
         self.voiceWake.setSuppressedByPushToTalk(true)
     }
 
-    private func releasePttVoiceWakeLease(for captureId: String) {
+    func releasePttVoiceWakeLease(for captureId: String) {
         guard self.pttVoiceWakeLeaseCaptureId == captureId else { return }
         self.pttVoiceWakeLeaseCaptureId = nil
         // Capture identity makes stale stop/cancel cleanup harmless. Resume Voice
@@ -3464,7 +3464,7 @@ extension NodeAppModel {
         true
     }
 
-    fileprivate static func decodeParams<T: Decodable>(_ type: T.Type, from json: String?) throws -> T {
+    static func decodeParams<T: Decodable>(_ type: T.Type, from json: String?) throws -> T {
         guard let json, let data = json.data(using: .utf8) else {
             throw NSError(domain: "Gateway", code: 20, userInfo: [
                 NSLocalizedDescriptionKey: "INVALID_REQUEST: paramsJSON required",
@@ -3473,7 +3473,7 @@ extension NodeAppModel {
         return try JSONDecoder().decode(type, from: data)
     }
 
-    fileprivate static func encodePayload(_ obj: some Encodable) throws -> String {
+    static func encodePayload(_ obj: some Encodable) throws -> String {
         let data = try JSONEncoder().encode(obj)
         guard let json = String(bytes: data, encoding: .utf8) else {
             throw NSError(domain: "NodeAppModel", code: 21, userInfo: [
@@ -3942,7 +3942,7 @@ extension NodeAppModel {
         self.talkMode.updateGatewayConnected(false)
     }
 
-    private func restartGatewaySessionsAfterForegroundStaleConnection() async {
+    func restartGatewaySessionsAfterForegroundStaleConnection() async {
         guard self.gatewayAutoReconnectEnabled, let cfg = activeGatewayConnectConfig else { return }
         let generation = self.gatewayConnectGeneration
         await self.resetGatewaySessionsForForcedReconnect()
@@ -4045,7 +4045,7 @@ extension NodeAppModel {
         }
     }
 
-    private func prepareForGatewayConnect(
+    func prepareForGatewayConnect(
         stableID: String,
         preservingGatewayProblem: Bool = false,
         preservingFocusedChatSession: Bool = false)
@@ -4103,7 +4103,7 @@ extension NodeAppModel {
         }
     }
 
-    private func clearGatewayConnectionProblem() {
+    func clearGatewayConnectionProblem() {
         self.nodeGatewayProblem = nil
         if let operatorGatewayProblem {
             self.lastGatewayProblem = operatorGatewayProblem
@@ -4160,7 +4160,7 @@ extension NodeAppModel {
         }
     }
 
-    private func applyOperatorGatewayConnectionProblem(_ problem: GatewayConnectionProblem) {
+    func applyOperatorGatewayConnectionProblem(_ problem: GatewayConnectionProblem) {
         guard !self.isLocalGatewayFixtureEnabled else { return }
         self.operatorGatewayProblem = problem
         self.lastGatewayProblem = problem
@@ -4179,7 +4179,7 @@ extension NodeAppModel {
         }
     }
 
-    private func clearOperatorGatewayConnectionProblemIfCurrent() {
+    func clearOperatorGatewayConnectionProblemIfCurrent() {
         guard let operatorGatewayProblem else { return }
         self.operatorGatewayProblem = nil
         guard self.lastGatewayProblem == operatorGatewayProblem else { return }
@@ -4236,7 +4236,7 @@ extension NodeAppModel {
             gatewayID: gatewayID) != nil
     }
 
-    fileprivate nonisolated static func shouldStartOperatorGatewayLoop(
+    nonisolated static func shouldStartOperatorGatewayLoop(
         token: String?,
         bootstrapToken: String?,
         password: String?,
@@ -4268,7 +4268,7 @@ extension NodeAppModel {
         return (fallbackToken, fallbackBootstrapToken, fallbackPassword)
     }
 
-    private func currentGatewayReconnectOptions(
+    func currentGatewayReconnectOptions(
         stableID: String,
         fallback: GatewayConnectOptions) -> GatewayConnectOptions
     {
@@ -4278,7 +4278,7 @@ extension NodeAppModel {
         return config.nodeOptions
     }
 
-    private nonisolated static func usesBootstrapCredential(
+    nonisolated static func usesBootstrapCredential(
         token: String?,
         bootstrapToken: String?,
         password: String?) -> Bool
@@ -4787,7 +4787,7 @@ extension NodeAppModel {
         self.invalidateOperatorTalkRoute()
     }
 
-    private func invalidateOperatorTalkRoute() {
+    func invalidateOperatorTalkRoute() {
         self.operatorTalkConnectionGeneration &+= 1
         self.operatorTalkHydrationGeneration = nil
         // A socket replacement invalidates Talk, not gateway identity hydration. The
@@ -4802,7 +4802,7 @@ extension NodeAppModel {
         self.invalidateNodePushToTalkRoute()
     }
 
-    private func invalidateNodePushToTalkRoute() {
+    func invalidateNodePushToTalkRoute() {
         self.talkPttCommandEpoch &+= 1
         self.voiceWake.invalidatePendingCommand()
         _ = self.talkMode.cancelPushToTalk(expectedTranscriptionOnly: false)
@@ -5080,7 +5080,7 @@ extension NodeAppModel {
         }
     }
 
-    private func mapNodeGatewayConnectionError(_ error: Error) -> GatewayConnectionProblem? {
+    func mapNodeGatewayConnectionError(_ error: Error) -> GatewayConnectionProblem? {
         GatewayConnectionProblemMapper.map(
             error: error,
             preserving: self.operatorGatewayProblem ?? self.nodeGatewayProblem)
@@ -5130,7 +5130,7 @@ extension NodeAppModel {
             forceTalkPermissionUpgradeRequest: forceTalkPermissionUpgradeRequest)
     }
 
-    fileprivate nonisolated static func shouldRequestOperatorApprovalScope(
+    nonisolated static func shouldRequestOperatorApprovalScope(
         token: String?,
         password: String?,
         storedOperatorScopes: [String],
@@ -5171,7 +5171,7 @@ extension NodeAppModel {
             forceTalkPermissionUpgradeRequest: forceTalkPermissionUpgradeRequest)
     }
 
-    fileprivate nonisolated static func shouldRequestOperatorAdminScope(
+    nonisolated static func shouldRequestOperatorAdminScope(
         token: String?,
         password: String?,
         storedOperatorScopes: [String],
@@ -5191,7 +5191,7 @@ extension NodeAppModel {
         return storedOperatorScopes.contains("operator.admin")
     }
 
-    private func makeOperatorConnectOptions(
+    func makeOperatorConnectOptions(
         clientId: String,
         displayName: String?,
         deviceAuthGatewayID: String? = nil,
@@ -5241,7 +5241,7 @@ extension NodeAppModel {
         self.operatorConnected
     }
 
-    private func setOperatorConnected(_ connected: Bool) {
+    func setOperatorConnected(_ connected: Bool) {
         let changed = self.operatorConnected != connected
         self.operatorConnected = connected
         self.operatorStatusText = connected ? "Connected" : "Offline"
@@ -5275,7 +5275,7 @@ extension NodeAppModel {
         }
     }
 
-    private func refreshOperatorAdminScopeFromStore() {
+    func refreshOperatorAdminScopeFromStore() {
         guard let config = activeGatewayConnectConfig else {
             self.hasOperatorAdminScope = false
             return
@@ -6025,7 +6025,7 @@ extension NodeAppModel {
         self.persistWatchExecApprovalBridgeState()
     }
 
-    private func removePendingWatchExecApprovalRecoveryPush(_ push: ExecApprovalNotificationPrompt) {
+    func removePendingWatchExecApprovalRecoveryPush(_ push: ExecApprovalNotificationPrompt) {
         guard Self.removePendingApproval(
             push,
             from: &self.pendingWatchExecApprovalRecoveryPushes,
@@ -6050,7 +6050,7 @@ extension NodeAppModel {
         self.persistWatchExecApprovalBridgeState()
     }
 
-    private func removePendingExecApprovalResolvedPush(_ push: ExecApprovalNotificationPrompt) {
+    func removePendingExecApprovalResolvedPush(_ push: ExecApprovalNotificationPrompt) {
         guard Self.removePendingApproval(
             push,
             from: &self.pendingExecApprovalResolvedPushes,
@@ -7005,7 +7005,7 @@ extension NodeAppModel {
     }
 
     @discardableResult
-    private func reconcileWatchExecApprovalCache(
+    func reconcileWatchExecApprovalCache(
         reason: String,
         heldApprovals: [WatchExecApprovalSnapshotRequestItem] = [],
         syncSnapshots: Bool = true) async -> Bool
@@ -7211,7 +7211,7 @@ extension NodeAppModel {
         return (loadedPrompts, isAuthoritative)
     }
 
-    private nonisolated static func watchExecApprovalIDsNeedingFetch(
+    nonisolated static func watchExecApprovalIDsNeedingFetch(
         candidateIDs: [String],
         cachedApprovalIDs: [String]) -> [String]
     {
@@ -7349,7 +7349,7 @@ extension NodeAppModel {
     }
 
     @discardableResult
-    private func handleWatchExecApprovalResolve(_ event: WatchExecApprovalResolveEvent) async -> Bool {
+    func handleWatchExecApprovalResolve(_ event: WatchExecApprovalResolveEvent) async -> Bool {
         guard let approvalID = Self.validatedApprovalID(event.approvalId) else { return true }
         guard let routedEvent = ownerScopedWatchExecApprovalEvent(
             event,
@@ -7708,7 +7708,7 @@ extension NodeAppModel {
     }
 
     @discardableResult
-    private func handleExecApprovalResolvedForCurrentGateway(
+    func handleExecApprovalResolvedForCurrentGateway(
         approvalId: String,
         approvalKind: ApprovalKind = .exec,
         recoveryPushGatewayDeviceID: String? = nil,
@@ -8178,7 +8178,7 @@ extension NodeAppModel {
             topic: topic)
     }
 
-    private func canPublishAPNsRegistration(usesRelayTransport: Bool) async -> Bool {
+    func canPublishAPNsRegistration(usesRelayTransport: Bool = true) async -> Bool {
         if usesRelayTransport, !PushEnrollmentConsent.disclosureAccepted {
             GatewayDiagnostics.pushRelay.skipped("enrollment_disclosure_not_accepted")
             return false
@@ -8310,7 +8310,7 @@ extension NodeAppModel {
             shouldContinue: shouldContinue)
     }
 
-    private func presentExecApprovalGatewayEventPrompt(
+    func presentExecApprovalGatewayEventPrompt(
         approvalId: String,
         expectedOperatorRoute: GatewayNodeSessionRoute? = nil,
         shouldContinue: @MainActor @Sendable () -> Bool = { true }) async
@@ -8854,7 +8854,7 @@ extension NodeAppModel {
         }
     }
 
-    private nonisolated static func shouldUseBackgroundAwareExecApprovalReconnect(
+    nonisolated static func shouldUseBackgroundAwareExecApprovalReconnect(
         sourceReason: String,
         isBackgrounded: Bool) -> Bool
     {
@@ -9752,7 +9752,7 @@ extension NodeAppModel {
         self.pendingNotificationPermissionGuidancePrompt = nil
     }
 
-    private nonisolated static func isApprovalNotificationStaleError(_ error: Error) -> Bool {
+    nonisolated static func isApprovalNotificationStaleError(_ error: Error) -> Bool {
         guard let gatewayError = error as? GatewayResponseError else { return false }
         if gatewayError.code != "INVALID_REQUEST" {
             return false
@@ -10281,7 +10281,7 @@ extension NodeAppModel {
         self.gatewayConnected
     }
 
-    private func applyMainSessionKey(_ key: String?) {
+    func applyMainSessionKey(_ key: String?) {
         let trimmed = (key ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         let current = self.mainSessionBaseKey.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -10397,7 +10397,7 @@ extension NodeAppModel {
         return normalizedKey == Self.canvasUnattendedDeepLinkKey || normalizedKey == Self.expectedDeepLinkKey()
     }
 
-    private static func expectedDeepLinkKey() -> String {
+    static func expectedDeepLinkKey() -> String {
         let defaults = UserDefaults.standard
         if let key = defaults.string(forKey: deepLinkKeyUserDefaultsKey), !key.isEmpty {
             return key
@@ -10427,84 +10427,8 @@ extension NodeAppModel {
 
 #if DEBUG
 extension NodeAppModel {
-    func _test_backgroundReconnectIsSuppressed() -> Bool {
-        self.backgroundReconnectSuppressed
-    }
-
-    func _test_setActiveGatewayConnectConfig(_ config: GatewayConnectConfig?) {
-        self.activeGatewayConnectConfig = config
-    }
-
-    func _test_forceTalkPermissionUpgradeRequest() -> Bool {
-        self.forceOperatorTalkPermissionUpgradeRequest
-    }
-
-    func _test_handleInvoke(
-        _ req: BridgeInvokeRequest,
-        gatewayStableID: String? = nil) async -> BridgeInvokeResponse
-    {
-        await self.handleInvoke(req, gatewayStableID: gatewayStableID)
-    }
-
-    func _test_acquirePttVoiceWakeLease(captureId: String) {
-        self.acquirePttVoiceWakeLease(for: captureId)
-    }
-
-    func _test_releasePttVoiceWakeLease(captureId: String) {
-        self.releasePttVoiceWakeLease(for: captureId)
-    }
-
-    func _test_setTalkCapturePreparationHandler(_ handler: (() async -> Void)?) {
-        self.testTalkCapturePreparationHandler = handler
-    }
-
-    func _test_setTalkCaptureStartedHandler(_ handler: (() async -> Void)?) {
-        self.testTalkCaptureStartedHandler = handler
-    }
-
-    func _test_setChatSessionRoutingRestoreHandler(_ handler: (() async -> Void)?) {
-        self.testChatSessionRoutingRestoreHandler = handler
-    }
-
-    func _test_setRemoveAllChatDatabaseFilesHandler(_ handler: (() throws -> Void)?) {
-        self.testRemoveAllChatDatabaseFilesHandler = handler
-    }
-
-    func _test_hasChatSessionRoutingRestoreTask() -> Bool {
-        self.chatSessionRoutingRestoreTask != nil
-    }
-
-    func _test_talkPreparationWaiterCount() -> Int {
-        self.talkPreparationWaiters.count
-    }
-
-    func _test_talkPttCommandEpoch() -> UInt64 {
-        self.talkPttCommandEpoch
-    }
-
     func _test_pttVoiceWakeLeaseCaptureIds() -> Set<String> {
         self.pttVoiceWakeLeaseCaptureId.map { [$0] } ?? []
-    }
-
-    func _test_invalidateNodePushToTalkRoute() {
-        self.invalidateNodePushToTalkRoute()
-    }
-
-    func _test_invalidateOperatorTalkRoute() {
-        self.invalidateOperatorTalkRoute()
-    }
-
-    func _test_applyMainSessionKey(_ key: String?) {
-        self.applyMainSessionKey(key)
-    }
-
-    func _test_prepareForGatewayConnect(
-        stableID: String,
-        preservingGatewayProblem: Bool = false)
-    {
-        self.prepareForGatewayConnect(
-            stableID: stableID,
-            preservingGatewayProblem: preservingGatewayProblem)
     }
 
     func _test_admitTalkAfterSessionHydration() async {
@@ -10513,97 +10437,6 @@ extension NodeAppModel {
         }
         self.chatSessionRoutingRestoreTask = nil
         self.admitTalkAfterSessionHydration()
-    }
-
-    static func _test_decodeParams<T: Decodable>(_ type: T.Type, from json: String?) throws -> T {
-        try self.decodeParams(type, from: json)
-    }
-
-    static func _test_encodePayload(_ obj: some Encodable) throws -> String {
-        try self.encodePayload(obj)
-    }
-
-    func _test_handleCanvasA2UIAction(body: [String: Any]) async {
-        await self.handleCanvasA2UIAction(body: body)
-    }
-
-    func _test_queuedWatchReplyCount() -> Int {
-        self.watchMessageOutbox.queuedCount(kind: .quickReply)
-    }
-
-    func _test_setWatchMessageRetryAttempts(_ attempts: Int, messageID: String) {
-        self.watchMessageRetryAttempts[messageID] = attempts
-    }
-
-    func _test_watchMessageRetryAttempts(messageID: String) -> Int? {
-        self.watchMessageRetryAttempts[messageID]
-    }
-
-    func _test_queuedWatchChatCommandCount() -> Int {
-        self.watchMessageOutbox.queuedCount(kind: .chat)
-    }
-
-    func _test_queuedWatchChatCommandIds() -> [String] {
-        self.watchMessageOutbox.queuedMessageIDs(kind: .chat)
-    }
-
-    func _test_recordWatchPromptRoute(promptID: String, gatewayStableID: String) {
-        self.watchMessageOutbox.recordPromptRoute(
-            promptID: promptID,
-            gatewayStableID: gatewayStableID)
-    }
-
-    func _test_setConnectedGatewayID(_ gatewayID: String?) {
-        self.connectedGatewayID = gatewayID
-    }
-
-    func _test_setAgentRequestHandler(_ handler: @escaping (AgentDeepLink) async throws -> Void) {
-        self.testAgentRequestHandler = handler
-    }
-
-    static func _test_resetPersistedWatchChatQueueState() {
-        WatchMessageOutbox.resetPersistedQueue()
-    }
-
-    static func _test_resetPersistedWatchReplyQueueState() {
-        WatchMessageOutbox.resetPersistedQueue()
-    }
-
-    func _test_setGatewayConnected(_ connected: Bool) {
-        self.gatewayConnected = connected
-    }
-
-    func _test_setOperatorConnected(_ connected: Bool) {
-        self.setOperatorConnected(connected)
-    }
-
-    func _test_canPublishAPNsRegistration(usesRelayTransport: Bool = true) async -> Bool {
-        await self.canPublishAPNsRegistration(usesRelayTransport: usesRelayTransport)
-    }
-
-    nonisolated static func _test_makeWatchChatItems(from raw: [OpenClawKit.AnyCodable]) -> [OpenClawWatchChatItem] {
-        WatchChatPresentation.makeItems(from: raw)
-    }
-
-    nonisolated static func _test_watchChatReplyText(
-        from raw: [OpenClawKit.AnyCodable],
-        runId: String,
-        submittedText: String,
-        submittedAtMs: Int64) -> String?
-    {
-        WatchChatPresentation.replyText(
-            from: raw,
-            runID: runId,
-            submittedText: submittedText,
-            submittedAtMs: submittedAtMs)
-    }
-
-    func _test_isGatewayConnected() -> Bool {
-        self.gatewayConnected
-    }
-
-    func _test_refreshOperatorAdminScopeFromStore() {
-        self.refreshOperatorAdminScopeFromStore()
     }
 
     func _test_applyPendingForegroundNodeActions(
@@ -10619,21 +10452,6 @@ extension NodeAppModel {
         await self.applyPendingForegroundNodeActions(mapped, trigger: "test")
     }
 
-    func _test_makeOperatorConnectOptions(
-        clientId: String,
-        displayName: String?,
-        includeAdminScope: Bool = false,
-        includeApprovalScope: Bool,
-        forceExplicitScopes: Bool = false) -> GatewayConnectOptions
-    {
-        self.makeOperatorConnectOptions(
-            clientId: clientId,
-            displayName: displayName,
-            includeAdminScope: includeAdminScope,
-            includeApprovalScope: includeApprovalScope,
-            forceExplicitScopes: forceExplicitScopes)
-    }
-
     func _test_presentExecApprovalPrompt(_ prompt: ExecApprovalPrompt) {
         if self.currentExecApprovalGatewayStableID() == nil {
             self.connectedGatewayID = prompt.gatewayStableID
@@ -10641,34 +10459,10 @@ extension NodeAppModel {
         self.presentFetchedExecApprovalPrompt(prompt)
     }
 
-    func _test_dismissPendingExecApprovalPrompt() {
-        self.dismissPendingExecApprovalPrompt()
-    }
-
-    func _test_applyOperatorGatewayConnectionProblem(_ problem: GatewayConnectionProblem) {
-        self.applyOperatorGatewayConnectionProblem(problem)
-    }
-
-    func _test_clearOperatorGatewayConnectionProblemIfCurrent() {
-        self.clearOperatorGatewayConnectionProblemIfCurrent()
-    }
-
-    func _test_clearGatewayConnectionProblem() {
-        self.clearGatewayConnectionProblem()
-    }
-
-    func _test_mapNodeGatewayConnectionError(_ error: Error) -> GatewayConnectionProblem? {
-        self.mapNodeGatewayConnectionError(error)
-    }
-
     func _test_applyNodeGatewayConnectionError(_ error: Error) -> GatewayConnectionProblem? {
         let nextProblem = self.mapNodeGatewayConnectionError(error)
         self.recordNodeGatewayConnectionError(nextProblem, error: error)
         return nextProblem
-    }
-
-    func _test_pendingExecApprovalPrompt() -> ExecApprovalPrompt? {
-        self.pendingExecApprovalPrompt
     }
 
     func _test_pendingExecApprovalInboxItems() -> [(id: String, gatewayStableID: String)] {
@@ -10717,18 +10511,10 @@ extension NodeAppModel {
             message: message)
     }
 
-    func _test_pendingNotificationPermissionGuidancePrompt() -> NotificationPermissionGuidancePrompt? {
-        self.pendingNotificationPermissionGuidancePrompt
-    }
-
     func _debug_presentNotificationPermissionGuidancePromptForScreenshot() {
         self.resetExecApprovalNotificationGuidanceSuppression()
         self.pendingNotificationPermissionGuidancePrompt =
             NotificationPermissionGuidancePrompt(approvalId: "screenshot-exec-approval")
-    }
-
-    func _test_resetExecApprovalNotificationGuidanceSuppression() {
-        self.resetExecApprovalNotificationGuidanceSuppression()
     }
 
     func _test_recordPendingWatchExecApprovalRecoveryID(
@@ -10740,20 +10526,8 @@ extension NodeAppModel {
             gatewayDeviceId: gatewayDeviceId))
     }
 
-    func _test_removePendingWatchExecApprovalRecoveryPush(_ push: ExecApprovalNotificationPrompt) {
-        self.removePendingWatchExecApprovalRecoveryPush(push)
-    }
-
-    func _test_removePendingExecApprovalResolvedPush(_ push: ExecApprovalNotificationPrompt) {
-        self.removePendingExecApprovalResolvedPush(push)
-    }
-
     func _test_pendingWatchExecApprovalRecoveryIDs() -> [String] {
         self.pendingWatchExecApprovalRecoveryPushes.map(\.approvalId)
-    }
-
-    func _test_pendingWatchExecApprovalRecoveryPushes() -> [ExecApprovalNotificationPrompt] {
-        self.pendingWatchExecApprovalRecoveryPushes
     }
 
     func _test_pendingPersistedExecApprovalReadbacks()
@@ -10770,19 +10544,6 @@ extension NodeAppModel {
             .sorted(by: Self.approvalIDSortsBefore)
     }
 
-    func _test_handleExecApprovalResolvedForCurrentGateway(
-        approvalId: String,
-        recoveryPushGatewayDeviceID: String?) async
-    {
-        await self.handleExecApprovalResolvedForCurrentGateway(
-            approvalId: approvalId,
-            recoveryPushGatewayDeviceID: recoveryPushGatewayDeviceID)
-    }
-
-    func _test_handleWatchExecApprovalResolve(_ event: WatchExecApprovalResolveEvent) async -> Bool {
-        await self.handleWatchExecApprovalResolve(event)
-    }
-
     func _test_refreshWatchExecApprovalSnapshotOnDemand(
         _ event: WatchExecApprovalSnapshotRequestEvent) async
     {
@@ -10791,11 +10552,6 @@ extension NodeAppModel {
             requestId: event.requestId,
             requestGatewayStableID: event.gatewayStableID,
             heldApprovals: event.heldApprovals)
-    }
-
-    @discardableResult
-    func _test_reconcileWatchExecApprovalCache(reason: String) async -> Bool {
-        await self.reconcileWatchExecApprovalCache(reason: reason)
     }
 
     func _test_setUnifiedExecApprovalGetResponse(
@@ -10894,10 +10650,6 @@ extension NodeAppModel {
         }
     }
 
-    func _test_presentExecApprovalGatewayEventPrompt(_ approvalID: String) async {
-        await self.presentExecApprovalGatewayEventPrompt(approvalId: approvalID)
-    }
-
     func _test_presentExecApprovalNotificationPrompt(_ push: ExecApprovalNotificationPrompt) async {
         await self.presentExecApprovalPrompt(
             approvalId: push.approvalId,
@@ -10929,49 +10681,8 @@ extension NodeAppModel {
         return false
     }
 
-    func _test_pendingExecApprovalResolvedPushes() -> [ExecApprovalNotificationPrompt] {
-        self.pendingExecApprovalResolvedPushes
-    }
-
     func _test_pendingExecApprovalIDsForWatchRecovery() async -> [String] {
         await self.pendingExecApprovalPushesForWatchRecovery().map(\.approvalId)
-    }
-
-    nonisolated static func _test_isApprovalNotificationStaleError(_ error: Error) -> Bool {
-        self.isApprovalNotificationStaleError(error)
-    }
-
-    nonisolated static func _test_shouldUseBackgroundAwareExecApprovalReconnect(
-        sourceReason: String,
-        isBackgrounded: Bool) -> Bool
-    {
-        self.shouldUseBackgroundAwareExecApprovalReconnect(
-            sourceReason: sourceReason,
-            isBackgrounded: isBackgrounded)
-    }
-
-    nonisolated static func _test_execApprovalEventID(from payload: AnyCodable) -> String? {
-        self.execApprovalEventID(from: payload)
-    }
-
-    func _test_handleOperatorGatewayServerEvent(_ event: EventFrame) async {
-        await self.handleOperatorGatewayServerEvent(event)
-    }
-
-    func _test_handleOperatorGatewayServerEvent(
-        _ event: EventFrame,
-        shouldContinue: @escaping @MainActor @Sendable () -> Bool) async
-    {
-        await self.handleOperatorGatewayServerEvent(event, shouldContinue: shouldContinue)
-    }
-
-    nonisolated static func _test_watchExecApprovalIDsNeedingFetch(
-        candidateIDs: [String],
-        cachedApprovalIDs: [String]) -> [String]
-    {
-        self.watchExecApprovalIDsNeedingFetch(
-            candidateIDs: candidateIDs,
-            cachedApprovalIDs: cachedApprovalIDs)
     }
 
     static func _test_makeExecApprovalPrompt(
@@ -11100,10 +10811,6 @@ extension NodeAppModel {
         }
     }
 
-    static func _test_currentDeepLinkKey() -> String {
-        self.expectedDeepLinkKey()
-    }
-
     nonisolated static func _test_shouldDiscardFailedWatchMessage(
         code: String,
         message: String = "test") -> Bool
@@ -11122,43 +10829,6 @@ extension NodeAppModel {
             forKey: self.watchExecApprovalBridgeStateKey)
     }
 
-    nonisolated static func _test_shouldStartOperatorGatewayLoop(
-        token: String?,
-        bootstrapToken: String?,
-        password: String?,
-        hasStoredOperatorToken: Bool) -> Bool
-    {
-        self.shouldStartOperatorGatewayLoop(
-            token: token,
-            bootstrapToken: bootstrapToken,
-            password: password,
-            hasStoredOperatorToken: hasStoredOperatorToken)
-    }
-
-    nonisolated static func _test_usesBootstrapCredential(
-        token: String?,
-        bootstrapToken: String?,
-        password: String?) -> Bool
-    {
-        self.usesBootstrapCredential(
-            token: token,
-            bootstrapToken: bootstrapToken,
-            password: password)
-    }
-
-    nonisolated static func _test_shouldRequestOperatorApprovalScope(
-        token: String?,
-        password: String?,
-        storedOperatorScopes: [String],
-        forceTalkPermissionUpgradeRequest: Bool = false) -> Bool
-    {
-        self.shouldRequestOperatorApprovalScope(
-            token: token,
-            password: password,
-            storedOperatorScopes: storedOperatorScopes,
-            forceTalkPermissionUpgradeRequest: forceTalkPermissionUpgradeRequest)
-    }
-
     func _test_shouldRequestStoredOperatorApprovalScope(
         gatewayID: String,
         forceTalkPermissionUpgradeRequest: Bool = false) -> Bool
@@ -11167,19 +10837,6 @@ extension NodeAppModel {
             gatewayID: gatewayID,
             token: nil,
             password: nil,
-            forceTalkPermissionUpgradeRequest: forceTalkPermissionUpgradeRequest)
-    }
-
-    nonisolated static func _test_shouldRequestOperatorAdminScope(
-        token: String?,
-        password: String?,
-        storedOperatorScopes: [String],
-        forceTalkPermissionUpgradeRequest: Bool = false) -> Bool
-    {
-        self.shouldRequestOperatorAdminScope(
-            token: token,
-            password: password,
-            storedOperatorScopes: storedOperatorScopes,
             forceTalkPermissionUpgradeRequest: forceTalkPermissionUpgradeRequest)
     }
 
@@ -11197,13 +10854,6 @@ extension NodeAppModel {
             routeGeneration: self.gatewayRouteGeneration,
             issuedRoles: issuedRoles,
             nodeOptions: nodeOptions)
-    }
-
-    func _test_currentGatewayReconnectOptions(
-        stableID: String,
-        fallback: GatewayConnectOptions) -> GatewayConnectOptions
-    {
-        self.currentGatewayReconnectOptions(stableID: stableID, fallback: fallback)
     }
 
     func _test_hasGatewayLoopTasks() -> (node: Bool, operator: Bool) {
@@ -11231,10 +10881,6 @@ extension NodeAppModel {
                 self.gatewaySessionResetTask = nil
             }
         }
-    }
-
-    func _test_restartGatewaySessionsAfterForegroundStaleConnection() async {
-        await self.restartGatewaySessionsAfterForegroundStaleConnection()
     }
 }
 #endif

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -10431,6 +10431,10 @@ extension NodeAppModel {
         self.pttVoiceWakeLeaseCaptureId.map { [$0] } ?? []
     }
 
+    func _test_forceTalkPermissionUpgradeRequest() -> Bool {
+        self.forceOperatorTalkPermissionUpgradeRequest
+    }
+
     func _test_admitTalkAfterSessionHydration() async {
         if let chatSessionRoutingRestoreTask {
             await chatSessionRoutingRestoreTask.value

--- a/apps/ios/Tests/AppCoverageTests.swift
+++ b/apps/ios/Tests/AppCoverageTests.swift
@@ -26,7 +26,7 @@ struct AppCoverageTests {
 
         #expect(appModel.isBackgrounded)
         #expect(appModel.voiceWake._test_isSuppressedForBackground())
-        let blocked = await appModel._test_handleInvoke(BridgeInvokeRequest(
+        let blocked = await appModel.handleInvoke(BridgeInvokeRequest(
             id: "initial-scene-blocked",
             command: OpenClawTalkCommand.pttStart.rawValue))
         #expect(!blocked.ok)
@@ -35,11 +35,11 @@ struct AppCoverageTests {
 
         #expect(!appModel.isBackgrounded)
         #expect(!appModel.voiceWake._test_isSuppressedForBackground())
-        let admitted = await appModel._test_handleInvoke(BridgeInvokeRequest(
+        let admitted = await appModel.handleInvoke(BridgeInvokeRequest(
             id: "initial-scene-active",
             command: OpenClawTalkCommand.pttStart.rawValue))
         #expect(admitted.ok)
-        _ = await appModel._test_handleInvoke(BridgeInvokeRequest(
+        _ = await appModel.handleInvoke(BridgeInvokeRequest(
             id: "initial-scene-cleanup",
             command: OpenClawTalkCommand.pttCancel.rawValue))
     }

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -174,9 +174,9 @@ private func waitUntil(
         let appModel = NodeAppModel()
         defer { appModel.disconnectGateway() }
         let problem = pairingScopeUpgradeProblem
-        appModel._test_applyOperatorGatewayConnectionProblem(problem)
+        appModel.applyOperatorGatewayConnectionProblem(problem)
 
-        appModel._test_prepareForGatewayConnect(
+        appModel.prepareForGatewayConnect(
             stableID: "manual|gateway.example.com|443",
             preservingGatewayProblem: true)
 
@@ -189,7 +189,7 @@ private func waitUntil(
             domain: URLError.errorDomain,
             code: URLError.cancelled.rawValue,
             userInfo: [NSLocalizedDescriptionKey: "gateway receive: cancelled"])
-        let mapped = appModel._test_mapNodeGatewayConnectionError(cancelled)
+        let mapped = appModel.mapNodeGatewayConnectionError(cancelled)
         #expect(mapped?.kind == .websocketCancelled)
         #expect(mapped?.requestId == nil)
         #expect(mapped?.pauseReconnect == false)
@@ -199,7 +199,7 @@ private func waitUntil(
         let appModel = NodeAppModel()
         defer { appModel.disconnectGateway() }
         let problem = pairingScopeUpgradeProblem
-        appModel._test_applyOperatorGatewayConnectionProblem(problem)
+        appModel.applyOperatorGatewayConnectionProblem(problem)
 
         let cancelled = NSError(
             domain: URLError.errorDomain,
@@ -212,7 +212,7 @@ private func waitUntil(
         #expect(appModel.gatewayPairingPaused)
         #expect(appModel.gatewayPairingRequestId == "req-admin")
 
-        appModel._test_clearOperatorGatewayConnectionProblemIfCurrent()
+        appModel.clearOperatorGatewayConnectionProblemIfCurrent()
         #expect(appModel.lastGatewayProblem == nil)
         #expect(!appModel.gatewayPairingPaused)
         #expect(appModel.gatewayPairingRequestId == nil)
@@ -238,11 +238,11 @@ private func waitUntil(
         let disconnectedOwner = appModel.chatViewModelOwnerID
         let disconnectedRefreshIdentity = appModel.chatViewModelIdentityID
 
-        appModel._test_setOperatorConnected(true)
+        appModel.setOperatorConnected(true)
         #expect(appModel.chatViewModelOwnerID == disconnectedOwner)
         #expect(appModel.chatViewModelIdentityID != disconnectedRefreshIdentity)
 
-        appModel._test_setOperatorConnected(false)
+        appModel.setOperatorConnected(false)
         #expect(appModel.chatViewModelOwnerID == disconnectedOwner)
         #expect(appModel.chatViewModelIdentityID == disconnectedRefreshIdentity)
     }
@@ -373,15 +373,15 @@ private func waitUntil(
 
     @Test @MainActor func `operator connect options only request approval scope when enabled`() {
         let appModel = NodeAppModel()
-        let withoutApprovalScope = appModel._test_makeOperatorConnectOptions(
+        let withoutApprovalScope = appModel.makeOperatorConnectOptions(
             clientId: "openclaw-ios",
             displayName: "OpenClaw iOS",
             includeApprovalScope: false)
-        let withApprovalScope = appModel._test_makeOperatorConnectOptions(
+        let withApprovalScope = appModel.makeOperatorConnectOptions(
             clientId: "openclaw-ios",
             displayName: "OpenClaw iOS",
             includeApprovalScope: true)
-        let withAdminScope = appModel._test_makeOperatorConnectOptions(
+        let withAdminScope = appModel.makeOperatorConnectOptions(
             clientId: "openclaw-ios",
             displayName: "OpenClaw iOS",
             includeAdminScope: true,
@@ -407,7 +407,7 @@ private func waitUntil(
 
     @Test @MainActor func `operator talk permission upgrade uses explicit least privilege scopes`() {
         let appModel = NodeAppModel()
-        let options = appModel._test_makeOperatorConnectOptions(
+        let options = appModel.makeOperatorConnectOptions(
             clientId: "openclaw-ios",
             displayName: "OpenClaw iOS",
             includeApprovalScope: false,
@@ -450,27 +450,27 @@ private func waitUntil(
 
     @Test func `operator admin scope requests only when shared auth or already granted`() {
         #expect(
-            !NodeAppModel._test_shouldRequestOperatorAdminScope(
+            !NodeAppModel.shouldRequestOperatorAdminScope(
                 token: nil,
                 password: nil,
                 storedOperatorScopes: ["operator.read", "operator.write", "operator.talk.secrets"]))
         #expect(
-            NodeAppModel._test_shouldRequestOperatorAdminScope(
+            NodeAppModel.shouldRequestOperatorAdminScope(
                 token: nil,
                 password: nil,
                 storedOperatorScopes: ["operator.admin"]))
         #expect(
-            NodeAppModel._test_shouldRequestOperatorAdminScope(
+            NodeAppModel.shouldRequestOperatorAdminScope(
                 token: "shared-token",
                 password: nil,
                 storedOperatorScopes: []))
         #expect(
-            NodeAppModel._test_shouldRequestOperatorAdminScope(
+            NodeAppModel.shouldRequestOperatorAdminScope(
                 token: nil,
                 password: "shared-password",
                 storedOperatorScopes: []))
         #expect(
-            !NodeAppModel._test_shouldRequestOperatorAdminScope(
+            !NodeAppModel.shouldRequestOperatorAdminScope(
                 token: "shared-token",
                 password: nil,
                 storedOperatorScopes: [],
@@ -497,12 +497,12 @@ private func waitUntil(
 
     @Test func `operator approval scope requests stay backward compatible`() {
         #expect(
-            !NodeAppModel._test_shouldRequestOperatorApprovalScope(
+            !NodeAppModel.shouldRequestOperatorApprovalScope(
                 token: nil,
                 password: nil,
                 storedOperatorScopes: ["operator.read", "operator.write", "operator.talk.secrets"]))
         #expect(
-            NodeAppModel._test_shouldRequestOperatorApprovalScope(
+            NodeAppModel.shouldRequestOperatorApprovalScope(
                 token: nil,
                 password: nil,
                 storedOperatorScopes: [
@@ -512,18 +512,18 @@ private func waitUntil(
                     "operator.talk.secrets",
                 ]))
         #expect(
-            NodeAppModel._test_shouldRequestOperatorApprovalScope(
+            NodeAppModel.shouldRequestOperatorApprovalScope(
                 token: "shared-token",
                 password: nil,
                 storedOperatorScopes: []))
         #expect(
-            !NodeAppModel._test_shouldRequestOperatorApprovalScope(
+            !NodeAppModel.shouldRequestOperatorApprovalScope(
                 token: "shared-token",
                 password: nil,
                 storedOperatorScopes: [],
                 forceTalkPermissionUpgradeRequest: true))
         #expect(
-            NodeAppModel._test_shouldRequestOperatorApprovalScope(
+            NodeAppModel.shouldRequestOperatorApprovalScope(
                 token: nil,
                 password: nil,
                 storedOperatorScopes: ["operator.approvals"],
@@ -532,29 +532,29 @@ private func waitUntil(
 
     @Test @MainActor func `operator pairing problem preserves primary gateway connection state`() {
         let appModel = NodeAppModel()
-        appModel._test_setGatewayConnected(true)
+        appModel.gatewayConnected = true
         appModel.gatewayServerName = "gateway.example.com"
         appModel.gatewayRemoteAddress = "127.0.0.1:53380"
         let problem = pairingScopeUpgradeProblem
 
-        appModel._test_applyOperatorGatewayConnectionProblem(problem)
+        appModel.applyOperatorGatewayConnectionProblem(problem)
 
-        #expect(appModel._test_isGatewayConnected())
+        #expect(appModel.gatewayConnected)
         #expect(appModel.gatewayServerName == "gateway.example.com")
         #expect(appModel.gatewayRemoteAddress == "127.0.0.1:53380")
         #expect(appModel.lastGatewayProblem == problem)
         #expect(appModel.gatewayPairingPaused)
         #expect(appModel.gatewayPairingRequestId == "req-admin")
 
-        appModel._test_clearGatewayConnectionProblem()
+        appModel.clearGatewayConnectionProblem()
 
         #expect(appModel.lastGatewayProblem == problem)
         #expect(appModel.gatewayPairingPaused)
         #expect(appModel.gatewayPairingRequestId == "req-admin")
 
-        appModel._test_clearOperatorGatewayConnectionProblemIfCurrent()
+        appModel.clearOperatorGatewayConnectionProblemIfCurrent()
 
-        #expect(appModel._test_isGatewayConnected())
+        #expect(appModel.gatewayConnected)
         #expect(appModel.gatewayServerName == "gateway.example.com")
         #expect(appModel.lastGatewayProblem == nil)
         #expect(!appModel.gatewayPairingPaused)
@@ -574,7 +574,7 @@ private func waitUntil(
             message: "The gateway refused the connection.",
             retryable: true,
             pauseReconnect: false)
-        appModel._test_applyOperatorGatewayConnectionProblem(problem)
+        appModel.applyOperatorGatewayConnectionProblem(problem)
 
         #expect(appModel.lastGatewayProblem == problem)
 
@@ -684,7 +684,7 @@ private func waitUntil(
         let config = Self.makeGatewayConnectConfig()
         appModel.applyGatewayConnectConfig(config)
         let problem = pairingScopeUpgradeProblem
-        appModel._test_applyOperatorGatewayConnectionProblem(problem)
+        appModel.applyOperatorGatewayConnectionProblem(problem)
         #expect(appModel.gatewayPairingPaused)
 
         appModel.applyGatewayConnectConfig(config, forceReconnect: true)
@@ -694,7 +694,7 @@ private func waitUntil(
         #expect(!appModel.gatewayPairingPaused)
         #expect(appModel.gatewayPairingRequestId == nil)
 
-        appModel._test_clearGatewayConnectionProblem()
+        appModel.clearGatewayConnectionProblem()
 
         #expect(appModel.lastGatewayProblem == nil)
         #expect(!appModel.gatewayPairingPaused)
@@ -707,7 +707,7 @@ private func waitUntil(
         let config = Self.makeGatewayConnectConfig()
         appModel.applyGatewayConnectConfig(config)
         let problem = pairingScopeUpgradeProblem
-        appModel._test_applyOperatorGatewayConnectionProblem(problem)
+        appModel.applyOperatorGatewayConnectionProblem(problem)
 
         appModel.beginGatewayPreconnectVerification(statusText: "Verifying gateway TLS fingerprint…")
 
@@ -717,7 +717,7 @@ private func waitUntil(
         #expect(!appModel.gatewayPairingPaused)
         #expect(appModel.gatewayPairingRequestId == nil)
 
-        appModel._test_clearGatewayConnectionProblem()
+        appModel.clearGatewayConnectionProblem()
         #expect(appModel.lastGatewayProblem == nil)
     }
 
@@ -767,7 +767,7 @@ private func waitUntil(
         var fallback = config.nodeOptions
         fallback.clientId = "fallback-client"
 
-        let selected = appModel._test_currentGatewayReconnectOptions(
+        let selected = appModel.currentGatewayReconnectOptions(
             stableID: decomposedID,
             fallback: fallback)
 
@@ -1135,7 +1135,7 @@ private func waitUntil(
             role: "node",
             gatewayID: previousStableID)?.token == "previous-node-token")
         #expect(appModel._test_hasGatewayLoopTasks().operator)
-        #expect(appModel._test_currentGatewayReconnectOptions(
+        #expect(appModel.currentGatewayReconnectOptions(
             stableID: stableID,
             fallback: bootstrapOptions).allowStoredDeviceAuth)
     }
@@ -1352,7 +1352,7 @@ private func waitUntil(
             #expect(appModel.gatewayServerName == nil)
             #expect(!appModel._test_hasGatewayLoopTasks().node)
             #expect(!appModel._test_hasGatewayLoopTasks().operator)
-            #expect(!appModel._test_hasChatSessionRoutingRestoreTask())
+            #expect(!appModel.chatSessionRoutingRestoreTask != nil)
             #expect(ShareGatewayRelaySettings.loadConfig() == nil)
 
             let relaunchedModel = NodeAppModel()
@@ -1662,7 +1662,7 @@ private func waitUntil(
             message: "Upgrade the gateway before reconnecting.",
             retryable: false,
             pauseReconnect: true)
-        appModel._test_applyOperatorGatewayConnectionProblem(problem)
+        appModel.applyOperatorGatewayConnectionProblem(problem)
         let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
 
         controller.cancelPendingConnectionAttempts()
@@ -2351,7 +2351,7 @@ private func waitUntil(
         let focusedSessionKey = "agent:main:ios-foreground-focused"
         appModel.applyGatewayConnectConfig(config)
         appModel.focusChatSession(focusedSessionKey)
-        await appModel._test_restartGatewaySessionsAfterForegroundStaleConnection()
+        await appModel.restartGatewaySessionsAfterForegroundStaleConnection()
 
         #expect(appModel.gatewayStatusText == "Reconnecting…")
         #expect(appModel.activeGatewayConnectConfig?.hasSameConnectionInputs(as: config) == true)

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -373,15 +373,15 @@ private func waitUntil(
 
     @Test @MainActor func `operator connect options only request approval scope when enabled`() {
         let appModel = NodeAppModel()
-        let withoutApprovalScope = appModel.makeOperatorConnectOptions(
+        let withoutApprovalScope = appModel._test_makeOperatorConnectOptions(
             clientId: "openclaw-ios",
             displayName: "OpenClaw iOS",
             includeApprovalScope: false)
-        let withApprovalScope = appModel.makeOperatorConnectOptions(
+        let withApprovalScope = appModel._test_makeOperatorConnectOptions(
             clientId: "openclaw-ios",
             displayName: "OpenClaw iOS",
             includeApprovalScope: true)
-        let withAdminScope = appModel.makeOperatorConnectOptions(
+        let withAdminScope = appModel._test_makeOperatorConnectOptions(
             clientId: "openclaw-ios",
             displayName: "OpenClaw iOS",
             includeAdminScope: true,
@@ -407,7 +407,7 @@ private func waitUntil(
 
     @Test @MainActor func `operator talk permission upgrade uses explicit least privilege scopes`() {
         let appModel = NodeAppModel()
-        let options = appModel.makeOperatorConnectOptions(
+        let options = appModel._test_makeOperatorConnectOptions(
             clientId: "openclaw-ios",
             displayName: "OpenClaw iOS",
             includeApprovalScope: false,

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -1352,7 +1352,7 @@ private func waitUntil(
             #expect(appModel.gatewayServerName == nil)
             #expect(!appModel._test_hasGatewayLoopTasks().node)
             #expect(!appModel._test_hasGatewayLoopTasks().operator)
-            #expect(!appModel.chatSessionRoutingRestoreTask != nil)
+            #expect(!(appModel.chatSessionRoutingRestoreTask != nil))
             #expect(ShareGatewayRelaySettings.loadConfig() == nil)
 
             let relaunchedModel = NodeAppModel()

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -435,7 +435,7 @@ import Testing
             requestId: "stale-request",
             retryable: true,
             pauseReconnect: true)
-        appModel._test_applyOperatorGatewayConnectionProblem(staleProblem)
+        appModel.applyOperatorGatewayConnectionProblem(staleProblem)
         let controller = GatewayConnectionController(
             appModel: appModel,
             startDiscovery: false,

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -2999,11 +2999,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         appModel.setTalkEnabled(true)
         await waitForTalkCondition { talkMode.gatewayTalkPermissionState == .requestingUpgrade }
 
-        #expect(appModel.forceOperatorTalkPermissionUpgradeRequest)
+        #expect(appModel._test_forceTalkPermissionUpgradeRequest())
         appModel.gatewayAutoReconnectEnabled = false
         appModel.gatewayPairingPaused = true
         appModel.setTalkEnabled(false)
-        #expect(!appModel.forceOperatorTalkPermissionUpgradeRequest)
+        #expect(!appModel._test_forceTalkPermissionUpgradeRequest())
         #expect(appModel.gatewayAutoReconnectEnabled)
         #expect(!appModel.gatewayPairingPaused)
 

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -985,7 +985,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 @Suite(.serialized) struct NodeAppModelInvokeTests {
     @Test @MainActor func `decode params fails without JSON`() {
         #expect(throws: Error.self) {
-            _ = try NodeAppModel._test_decodeParams(OpenClawCanvasNavigateParams.self, from: nil)
+            _ = try NodeAppModel.decodeParams(OpenClawCanvasNavigateParams.self, from: nil)
         }
     }
 
@@ -993,7 +993,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         struct Payload: Codable, Equatable {
             var value: String
         }
-        let json = try NodeAppModel._test_encodePayload(Payload(value: "ok"))
+        let json = try NodeAppModel.encodePayload(Payload(value: "ok"))
         #expect(json.contains("\"value\""))
     }
 
@@ -1005,7 +1005,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawHealthCommand.summary.rawValue,
             paramsJSON: #"{"period":"today"}"#)
 
-        let response = await appModel._test_handleInvoke(request)
+        let response = await appModel.handleInvoke(request)
         let payload = try decodeTalkPayload(OpenClawHealthSummaryPayload.self, from: response)
 
         #expect(response.ok)
@@ -1022,7 +1022,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawHealthCommand.summary.rawValue,
             paramsJSON: #"{"period":"90d"}"#)
 
-        let response = await appModel._test_handleInvoke(request)
+        let response = await appModel.handleInvoke(request)
 
         #expect(response.ok == false)
         #expect(response.error?.code == .invalidRequest)
@@ -1190,7 +1190,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                     commandText: "echo first",
                     expiresAtMs: 1)))
 
-        let firstPrompt = try #require(appModel._test_pendingExecApprovalPrompt())
+        let firstPrompt = try #require(appModel.pendingExecApprovalPrompt)
         #expect(firstPrompt.id == "approval-1")
         #expect(firstPrompt.commandText == "echo first")
         #expect(firstPrompt.allowsAllowAlways == false)
@@ -1205,19 +1205,19 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                     agentId: nil,
                     expiresAtMs: 2)))
 
-        let secondPrompt = try #require(appModel._test_pendingExecApprovalPrompt())
+        let secondPrompt = try #require(appModel.pendingExecApprovalPrompt)
         #expect(secondPrompt.id == "approval-2")
         #expect(secondPrompt.commandText == "echo second")
         #expect(secondPrompt.allowsAllowAlways)
 
-        appModel._test_dismissPendingExecApprovalPrompt()
-        #expect(appModel._test_pendingExecApprovalPrompt() == nil)
+        appModel.dismissPendingExecApprovalPrompt()
+        #expect(appModel.pendingExecApprovalPrompt == nil)
     }
 
     @Test @MainActor func `explicit notification tap replaces visible approval after canonical fetch`() async throws {
         let fetchGate = WatchSnapshotSendGate()
         let appModel = makeNodeModelWithMockServices()
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-visible-a",
@@ -1237,11 +1237,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             await Task.yield()
         }
 
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-visible-a")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-visible-a")
         await fetchGate.resume()
         await fetching.value
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-tapped-b")
-        #expect(appModel._test_pendingExecApprovalPrompt()?.commandText == "echo tapped-b")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-tapped-b")
+        #expect(appModel.pendingExecApprovalPrompt?.commandText == "echo tapped-b")
     }
 
     @Test @MainActor func `unified approval get accepts matching exec and plugin presentations`() throws {
@@ -1347,7 +1347,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let capture = ApprovalResolutionCapture()
         let (watchService, appModel) = makeWatchModel(
             notificationCenter: MockBootstrapNotificationCenter())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         appModel._test_setUnifiedExecApprovalGetResponse(pluginJSON)
         appModel._test_setExecApprovalResolutionSuccessHandler { _, kind, _, _ in
             await capture.record(kind: kind)
@@ -1358,7 +1358,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             gatewayDeviceId: nil,
             kind: .plugin))
 
-        let prompt = try #require(appModel._test_pendingExecApprovalPrompt())
+        let prompt = try #require(appModel.pendingExecApprovalPrompt)
         #expect(prompt.kind == "plugin")
         #expect(prompt.commandText == "Allow guarded plugin tool?")
         #expect(prompt.descriptionText == "The plugin wants to perform a guarded action.")
@@ -1380,7 +1380,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         let firstWatchService = MockWatchMessagingService()
         let firstModel = NodeAppModel(watchMessagingService: firstWatchService)
-        firstModel._test_setConnectedGatewayID("test-gateway")
+        firstModel.connectedGatewayID = "test-gateway"
         try firstModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-plugin-restored",
@@ -1396,7 +1396,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         let restoredWatchService = MockWatchMessagingService()
         let restoredModel = NodeAppModel(watchMessagingService: restoredWatchService)
-        restoredModel._test_setConnectedGatewayID("test-gateway")
+        restoredModel.connectedGatewayID = "test-gateway"
 
         #expect(restoredModel._test_pendingExecApprovalInboxItems().map(\.id) == [
             "approval-plugin-restored",
@@ -1404,7 +1404,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         restoredModel._test_presentPendingExecApprovalFromInbox(
             approvalID: "approval-plugin-restored",
             gatewayStableID: "test-gateway")
-        #expect(restoredModel._test_pendingExecApprovalPrompt()?.kind == "plugin")
+        #expect(restoredModel.pendingExecApprovalPrompt?.kind == "plugin")
         #expect(restoredWatchService.lastSentExecApprovalPrompt == nil)
     }
 
@@ -1517,7 +1517,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             responseJSON,
             approvalID: "approval-race",
             attemptedDecision: .deny))
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-race")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-race")
         #expect(appModel._test_pendingExecApprovalState().resolved ==
             "This approval was already set to Always Allow.")
         #expect(appModel._test_pendingExecApprovalState().tone == .success)
@@ -1546,7 +1546,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             ownWinnerResponse,
             approvalID: "approval-race",
             attemptedDecision: .allowAlways))
-        #expect(ownWinnerModel._test_pendingExecApprovalPrompt()?.id == "approval-race")
+        #expect(ownWinnerModel.pendingExecApprovalPrompt?.id == "approval-race")
         #expect(ownWinnerModel._test_pendingExecApprovalState().resolved ==
             "Approval set to Always Allow.")
         #expect(ownWinnerModel._test_pendingExecApprovalInboxItems().isEmpty)
@@ -1576,7 +1576,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             approvalID: "approval-legacy-ack",
             decision: .deny)
 
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-legacy-ack")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-legacy-ack")
         #expect(appModel._test_pendingExecApprovalState().resolved == "Approval denied.")
         #expect(watchService.lastSentExecApprovalResolved?.source == "gateway")
         #expect(watchService.lastSentExecApprovalResolved?.outcome == .denied)
@@ -1660,7 +1660,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             await Task.yield()
         }
 
-        #expect(appModel._test_pendingExecApprovalPrompt() == nil)
+        #expect(appModel.pendingExecApprovalPrompt == nil)
         #expect(appModel._test_pendingWatchExecApprovalRecoveryIDs().isEmpty)
         #expect(watchService.lastSentExecApprovalSnapshot?.approvals.isEmpty == true)
         #expect(notificationCenter.pendingRemovedIdentifiers.contains([
@@ -1714,8 +1714,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         #expect(appModel._test_pendingExecApprovalState().resolving)
         #expect(appModel._test_pendingExecApprovalState().canDismiss)
-        appModel._test_dismissPendingExecApprovalPrompt()
-        #expect(appModel._test_pendingExecApprovalPrompt() == nil)
+        appModel.dismissPendingExecApprovalPrompt()
+        #expect(appModel.pendingExecApprovalPrompt == nil)
 
         appModel._test_presentPendingExecApprovalFromInbox(
             approvalID: approvalID,
@@ -1729,7 +1729,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(restoredModel._test_pendingExecApprovalState().error == uncertainMessage)
 
         restoredModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(approvalID))
-        await restoredModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
+        await restoredModel.reconcileWatchExecApprovalCache(reason: "operator_reconnected")
         #expect(!restoredModel._test_pendingExecApprovalState().resolving)
         #expect(restoredModel._test_pendingExecApprovalState().error ==
             "The previous decision was not recorded. Review and try again.")
@@ -1751,7 +1751,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             beforeResponse: { await fetchGate.wait() })
 
         let reconciliation = Task { @MainActor in
-            await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
+            await appModel.reconcileWatchExecApprovalCache(reason: "operator_reconnected")
         }
         let deadline = ContinuousClock().now.advanced(by: .seconds(2))
         while await !fetchGate.hasStarted(), ContinuousClock().now < deadline {
@@ -1782,15 +1782,15 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(firstModel._test_pendingPersistedExecApprovalReadbacks().map(\.approvalId) == [approvalID])
 
         let restoredModel = NodeAppModel(watchMessagingService: MockWatchMessagingService())
-        restoredModel._test_setConnectedGatewayID(prompt.gatewayStableID)
+        restoredModel.connectedGatewayID = prompt.gatewayStableID
         #expect(restoredModel._test_watchExecApprovalCacheIDs().isEmpty)
         #expect(restoredModel._test_pendingPersistedExecApprovalReadbacks().map(\.approvalId) == [approvalID])
         restoredModel._test_setUnifiedExecApprovalGetResponse(makeExpiredExecApprovalJSON(approvalID))
-        await restoredModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
+        await restoredModel.reconcileWatchExecApprovalCache(reason: "operator_reconnected")
 
         #expect(restoredModel._test_pendingPersistedExecApprovalReadbacks().isEmpty)
         restoredModel._test_presentExecApprovalPrompt(prompt)
-        #expect(restoredModel._test_pendingExecApprovalPrompt() == nil)
+        #expect(restoredModel.pendingExecApprovalPrompt == nil)
     }
 
     @Test @MainActor func `canonical pending readback resumes queued watch decision`() async throws {
@@ -1811,7 +1811,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             decision: .deny,
             sentAtMs: 123,
             transport: "test")
-        let resolvedImmediately = await appModel._test_handleWatchExecApprovalResolve(watchEvent)
+        let resolvedImmediately = await appModel.handleWatchExecApprovalResolve(watchEvent)
         #expect(!resolvedImmediately)
 
         let writeGate = ExecApprovalResolutionGate()
@@ -1819,7 +1819,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             await writeGate.waitForFirstCall()
         }
         appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(approvalID))
-        await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
+        await appModel.reconcileWatchExecApprovalCache(reason: "operator_reconnected")
         let deadline = ContinuousClock().now.advanced(by: .seconds(10))
         while await !writeGate.hasStarted(), ContinuousClock().now < deadline {
             try await Task.sleep(for: .milliseconds(10))
@@ -1860,8 +1860,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         await writeGate.resume()
         await firstWrite.value
 
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == secondPrompt.id)
-        appModel._test_dismissPendingExecApprovalPrompt()
+        #expect(appModel.pendingExecApprovalPrompt?.id == secondPrompt.id)
+        appModel.dismissPendingExecApprovalPrompt()
         appModel._test_presentPendingExecApprovalFromInbox(
             approvalID: firstPrompt.id,
             gatewayStableID: firstPrompt.gatewayStableID)
@@ -1941,7 +1941,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         // The invalidated attempt must not surface UI on the newly selected gateway,
         // but the lost outcome must survive as an owner-scoped readback candidate.
-        #expect(appModel._test_pendingExecApprovalPrompt() == nil)
+        #expect(appModel.pendingExecApprovalPrompt == nil)
         #expect(appModel._test_pendingPersistedExecApprovalReadbacks().contains { readback in
             readback.approvalId == approvalID && readback.gatewayStableID == gatewayA.effectiveStableID
         })
@@ -2081,7 +2081,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             beforeResponse: { _ = await fetchGate.waitForFirstCall() })
 
         let watchResolve = Task { @MainActor in
-            await appModel._test_handleWatchExecApprovalResolve(WatchExecApprovalResolveEvent(
+            await appModel.handleWatchExecApprovalResolve(WatchExecApprovalResolveEvent(
                 replyId: "watch-unknown-ack-retry",
                 approvalId: approvalID,
                 gatewayStableID: prompt.gatewayStableID,
@@ -2138,7 +2138,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         }
 
         let watchResolve = Task { @MainActor in
-            await appModel._test_handleWatchExecApprovalResolve(WatchExecApprovalResolveEvent(
+            await appModel.handleWatchExecApprovalResolve(WatchExecApprovalResolveEvent(
                 replyId: "watch-switch-mid-uncertain",
                 approvalId: approvalID,
                 gatewayStableID: gatewayA.effectiveStableID,
@@ -2192,14 +2192,14 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 commandText: "echo composed",
                 expiresAtMs: 4_000_000_000_000)))
         switchModel.applyGatewayConnectConfig(decomposedGateway)
-        #expect(switchModel._test_pendingExecApprovalPrompt() == nil)
+        #expect(switchModel.pendingExecApprovalPrompt == nil)
         #expect(switchModel._test_watchExecApprovalCacheIDs().isEmpty)
 
         let watchService = MockWatchMessagingService()
         let resolveModel = NodeAppModel(
             notificationCenter: MockBootstrapNotificationCenter(),
             watchMessagingService: watchService)
-        resolveModel._test_setConnectedGatewayID(composedGatewayID)
+        resolveModel.connectedGatewayID = composedGatewayID
         try resolveModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-exact-gateway-resolve",
@@ -2207,14 +2207,14 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 commandText: "echo resolve",
                 allowedDecisions: ["deny"],
                 expiresAtMs: 4_000_000_000_000)))
-        resolveModel._test_setConnectedGatewayID(decomposedGatewayID)
+        resolveModel.connectedGatewayID = decomposedGatewayID
 
         let applied = await resolveModel._test_applyLegacyExecApprovalTerminal(
             approvalID: "approval-exact-gateway-resolve",
             decision: .deny,
             expectedGatewayStableID: composedGatewayID)
         #expect(!applied)
-        #expect(resolveModel._test_pendingExecApprovalPrompt()?.id == "approval-exact-gateway-resolve")
+        #expect(resolveModel.pendingExecApprovalPrompt?.id == "approval-exact-gateway-resolve")
         #expect(watchService.lastSentExecApprovalResolved == nil)
     }
 
@@ -2237,7 +2237,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let firstModel = NodeAppModel(notificationCenter: notificationCenter)
 
         #expect(await firstModel.handleExecApprovalResolvedRemotePush(push))
-        #expect(firstModel._test_pendingExecApprovalResolvedPushes() == [push])
+        #expect(firstModel.pendingExecApprovalResolvedPushes == [push])
         #expect(notificationCenter.pendingRemovedIdentifiers == [[
             "exec.approval-v2.16:gateway-device-a.approval-resolved-offline",
             "exec.approval.gateway-device-a.approval-resolved-offline",
@@ -2245,7 +2245,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(notificationCenter.deliveredRemovedIdentifiers == [["offline-request-alert"]])
 
         let restoredModel = NodeAppModel(notificationCenter: MockBootstrapNotificationCenter())
-        #expect(restoredModel._test_pendingExecApprovalResolvedPushes() == [push])
+        #expect(restoredModel.pendingExecApprovalResolvedPushes == [push])
     }
 
     @Test @MainActor func `offline approval request remains durable until its gateway reconnects`() async {
@@ -2285,7 +2285,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let request = BridgeInvokeRequest(
             id: "ptt-start",
             command: OpenClawTalkCommand.pttStart.rawValue)
-        let response = await appModel._test_handleInvoke(request)
+        let response = await appModel.handleInvoke(request)
 
         #expect(response.ok == false)
         #expect(response.error?.message.contains("Gateway not connected") == true)
@@ -2304,7 +2304,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let request = BridgeInvokeRequest(
             id: "ptt-start-with-voice-note",
             command: OpenClawTalkCommand.pttStart.rawValue)
-        let response = await appModel._test_handleInvoke(request)
+        let response = await appModel.handleInvoke(request)
 
         #expect(response.ok == false)
         #expect(response.error?.message.contains("active voice note") == true)
@@ -2317,23 +2317,23 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
-        appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
+        appModel.testTalkCapturePreparationHandler = { await barrier.suspendFirstPreparation() }
         defer {
-            appModel._test_setTalkCapturePreparationHandler(nil)
+            appModel.testTalkCapturePreparationHandler = nil
             appModel.voiceWake.stop()
         }
 
         let active = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "ptt-active", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "ptt-active", command: .pttStart))
         }
         await barrier.waitUntilEntered()
         let queued = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "ptt-queued", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "ptt-queued", command: .pttStart))
         }
-        await waitForTalkCondition { appModel._test_talkPreparationWaiterCount() == 1 }
+        await waitForTalkCondition { appModel.talkPreparationWaiters.count == 1 }
 
         queued.cancel()
-        await waitForTalkCondition { appModel._test_talkPreparationWaiterCount() == 0 }
+        await waitForTalkCondition { appModel.talkPreparationWaiters.count == 0 }
         barrier.release()
 
         let activeResponse = await active.value
@@ -2343,28 +2343,28 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(!queuedResponse.ok)
         #expect(talkMode._test_activePushToTalkCaptureId() == activePayload.captureId)
 
-        #expect(await appModel._test_handleInvoke(talkRequest(id: "cleanup", command: .pttCancel)).ok)
+        #expect(await appModel.handleInvoke(talkRequest(id: "cleanup", command: .pttCancel)).ok)
     }
 
     @Test @MainActor func `PTT cancel invalidates suspended preparation without waiting`() async {
         let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
-        appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
+        appModel.testTalkCapturePreparationHandler = { await barrier.suspendFirstPreparation() }
         defer {
-            appModel._test_setTalkCapturePreparationHandler(nil)
+            appModel.testTalkCapturePreparationHandler = nil
             appModel.voiceWake.stop()
         }
 
         let start = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "stale-start", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "stale-start", command: .pttStart))
         }
         await barrier.waitUntilEntered()
-        let epoch = appModel._test_talkPttCommandEpoch()
+        let epoch = appModel.talkPttCommandEpoch
 
-        let cancel = await appModel._test_handleInvoke(talkRequest(id: "cancel", command: .pttCancel))
+        let cancel = await appModel.handleInvoke(talkRequest(id: "cancel", command: .pttCancel))
         #expect(cancel.ok)
-        #expect(appModel._test_talkPttCommandEpoch() == epoch + 1)
+        #expect(appModel.talkPttCommandEpoch == epoch + 1)
         barrier.release()
 
         #expect(await start.value.ok == false)
@@ -2376,21 +2376,21 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
-        appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
+        appModel.testTalkCapturePreparationHandler = { await barrier.suspendFirstPreparation() }
         defer {
-            appModel._test_setTalkCapturePreparationHandler(nil)
+            appModel.testTalkCapturePreparationHandler = nil
             appModel.voiceWake.stop()
         }
 
         let stale = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "old-epoch", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "old-epoch", command: .pttStart))
         }
         await barrier.waitUntilEntered()
-        #expect(await appModel._test_handleInvoke(talkRequest(id: "cancel", command: .pttCancel)).ok)
+        #expect(await appModel.handleInvoke(talkRequest(id: "cancel", command: .pttCancel)).ok)
         let fresh = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "new-epoch", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "new-epoch", command: .pttStart))
         }
-        await waitForTalkCondition { appModel._test_talkPreparationWaiterCount() == 1 }
+        await waitForTalkCondition { appModel.talkPreparationWaiters.count == 1 }
         barrier.release()
 
         #expect(await stale.value.ok == false)
@@ -2399,7 +2399,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(freshResponse.ok)
         #expect(talkMode._test_activePushToTalkCaptureId() == freshPayload.captureId)
 
-        #expect(await appModel._test_handleInvoke(talkRequest(id: "cleanup", command: .pttCancel)).ok)
+        #expect(await appModel.handleInvoke(talkRequest(id: "cleanup", command: .pttCancel)).ok)
     }
 
     @Test @MainActor func `chat focus switch invalidates reserved and queued PTT starts`() async {
@@ -2414,18 +2414,18 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         }
 
         let reserved = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "focus-reserved", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "focus-reserved", command: .pttStart))
         }
         await barrier.waitUntilEntered()
         let queued = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "focus-queued", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "focus-queued", command: .pttStart))
         }
-        await waitForTalkCondition { appModel._test_talkPreparationWaiterCount() == 1 }
-        let epoch = appModel._test_talkPttCommandEpoch()
+        await waitForTalkCondition { appModel.talkPreparationWaiters.count == 1 }
+        let epoch = appModel.talkPttCommandEpoch
 
         appModel.focusChatSession("agent:main:focused-replacement")
 
-        #expect(appModel._test_talkPttCommandEpoch() == epoch + 1)
+        #expect(appModel.talkPttCommandEpoch == epoch + 1)
         #expect(talkMode.isUsingMainSessionKey("agent:main:focused-replacement"))
         barrier.release()
         #expect(await reserved.value.ok == false)
@@ -2446,23 +2446,23 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         }
 
         let reserved = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "route-reserved", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "route-reserved", command: .pttStart))
         }
         await barrier.waitUntilEntered()
         let queued = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "route-queued", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "route-queued", command: .pttStart))
         }
-        await waitForTalkCondition { appModel._test_talkPreparationWaiterCount() == 1 }
-        let epoch = appModel._test_talkPttCommandEpoch()
+        await waitForTalkCondition { appModel.talkPreparationWaiters.count == 1 }
+        let epoch = appModel.talkPttCommandEpoch
 
-        appModel._test_invalidateOperatorTalkRoute()
+        appModel.invalidateOperatorTalkRoute()
         talkMode.updateGatewayConnected(true)
 
-        #expect(appModel._test_talkPttCommandEpoch() == epoch + 1)
+        #expect(appModel.talkPttCommandEpoch == epoch + 1)
         barrier.release()
         #expect(await reserved.value.ok == false)
         #expect(await queued.value.ok == false)
-        #expect(appModel._test_talkPreparationWaiterCount() == 0)
+        #expect(appModel.talkPreparationWaiters.count == 0)
         #expect(appModel._test_pttVoiceWakeLeaseCaptureIds().isEmpty)
     }
 
@@ -2479,21 +2479,21 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let store = databases.store(gatewayID: stableID)
         await store.storeSessionRoutingIdentity(identity)
         await store.retire()
-        appModel._test_setChatSessionRoutingRestoreHandler {
+        appModel.testChatSessionRoutingRestoreHandler = {
             await barrier.suspendFirstPreparation()
         }
         defer {
             barrier.release()
-            appModel._test_setChatSessionRoutingRestoreHandler(nil)
+            appModel.testChatSessionRoutingRestoreHandler = nil
             try? databases.removeGatewayData(gatewayID: stableID)
             appModel.voiceWake.stop()
         }
 
-        appModel._test_prepareForGatewayConnect(stableID: stableID)
+        appModel.prepareForGatewayConnect(stableID: stableID)
         await barrier.waitUntilEntered()
-        appModel._test_invalidateOperatorTalkRoute()
+        appModel.invalidateOperatorTalkRoute()
 
-        #expect(appModel._test_hasChatSessionRoutingRestoreTask())
+        #expect(appModel.chatSessionRoutingRestoreTask != nil)
         #expect(!talkMode.isGatewayConnected)
         #expect(appModel.chatSessionRoutingContract == nil)
 
@@ -2518,13 +2518,13 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let store = databases.store(gatewayID: stableID)
         await store.storeSessionRoutingIdentity(identity)
         await store.retire()
-        appModel._test_setConnectedGatewayID(stableID)
-        appModel._test_setChatSessionRoutingRestoreHandler {
+        appModel.connectedGatewayID = stableID
+        appModel.testChatSessionRoutingRestoreHandler = {
             await barrier.suspendFirstPreparation()
         }
         defer {
             barrier.release()
-            appModel._test_setChatSessionRoutingRestoreHandler(nil)
+            appModel.testChatSessionRoutingRestoreHandler = nil
             try? databases.removeGatewayData(gatewayID: stableID)
             appModel.voiceWake.stop()
         }
@@ -2554,12 +2554,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             appModel.cancelChatOfflineDataRemoval(gatewayID: composedGatewayID)
         }
 
-        appModel._test_setConnectedGatewayID(composedGatewayID)
+        appModel.connectedGatewayID = composedGatewayID
         let composedStore = try #require(appModel.makeChatOfflineStore())
         let composedOwnerID = appModel.chatViewModelOwnerID
         #expect(await appModel.stageChatOfflineDataRemoval(gatewayID: composedGatewayID))
 
-        appModel._test_setConnectedGatewayID(decomposedGatewayID)
+        appModel.connectedGatewayID = decomposedGatewayID
         let decomposedStore = try #require(appModel.makeChatOfflineStore())
 
         #expect(ObjectIdentifier(composedStore) != ObjectIdentifier(decomposedStore))
@@ -2575,13 +2575,13 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `failed full offline reset never reuses retired facade`() async throws {
         let appModel = NodeAppModel()
         let gatewayID = "offline-reset-failure-\(UUID().uuidString)"
-        appModel._test_setConnectedGatewayID(gatewayID)
+        appModel.connectedGatewayID = gatewayID
         let originalStore = try #require(appModel.makeChatOfflineStore())
-        appModel._test_setRemoveAllChatDatabaseFilesHandler {
+        appModel.testRemoveAllChatDatabaseFilesHandler = {
             throw CocoaError(.fileWriteUnknown)
         }
         defer {
-            appModel._test_setRemoveAllChatDatabaseFilesHandler(nil)
+            appModel.testRemoveAllChatDatabaseFilesHandler = nil
         }
 
         let didPurge = await appModel.purgeChatTranscriptCache()
@@ -2589,40 +2589,40 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let replacementStore = try #require(appModel.makeChatOfflineStore())
 
         #expect(ObjectIdentifier(originalStore) != ObjectIdentifier(replacementStore))
-        appModel._test_setRemoveAllChatDatabaseFilesHandler(nil)
+        appModel.testRemoveAllChatDatabaseFilesHandler = nil
         _ = await appModel.purgeChatTranscriptCache(gatewayID: gatewayID)
     }
 
     @Test @MainActor func `gateway main key refresh preserves focused Talk session`() {
         let (talkMode, appModel) = makeTalkModel()
         appModel.focusChatSession("agent:focused:thread")
-        let epoch = appModel._test_talkPttCommandEpoch()
+        let epoch = appModel.talkPttCommandEpoch
 
-        appModel._test_applyMainSessionKey("gateway-main")
+        appModel.applyMainSessionKey("gateway-main")
 
         #expect(appModel.chatSessionKey == "agent:focused:thread")
         #expect(talkMode.isUsingMainSessionKey("agent:focused:thread"))
-        #expect(appModel._test_talkPttCommandEpoch() == epoch)
+        #expect(appModel.talkPttCommandEpoch == epoch)
     }
 
     @Test @MainActor func `gateway replacement waits for final Talk session before admission`() async {
         let (talkMode, appModel) = makeTalkModel()
         appModel.focusChatSession("agent:old:thread")
-        let epoch = appModel._test_talkPttCommandEpoch()
+        let epoch = appModel.talkPttCommandEpoch
         let stableID = "talk-session-replacement-\(UUID().uuidString)"
         defer { GatewaySettingsStore.saveGatewaySelectedAgentId(stableID: stableID, agentId: nil) }
 
-        appModel._test_prepareForGatewayConnect(stableID: stableID)
+        appModel.prepareForGatewayConnect(stableID: stableID)
 
         #expect(appModel.chatSessionKey != "agent:old:thread")
         #expect(talkMode.isUsingMainSessionKey(appModel.chatSessionKey))
-        #expect(appModel._test_talkPttCommandEpoch() > epoch)
+        #expect(appModel.talkPttCommandEpoch > epoch)
         #expect(!talkMode.isGatewayConnected)
-        let blocked = await appModel._test_handleInvoke(
+        let blocked = await appModel.handleInvoke(
             talkRequest(id: "pre-hydration", command: .pttStart))
         #expect(!blocked.ok)
 
-        appModel._test_applyMainSessionKey("custom-main")
+        appModel.applyMainSessionKey("custom-main")
         appModel.gatewayDefaultAgentId = "main"
         appModel.setSelectedAgentId("worker")
         await appModel._test_admitTalkAfterSessionHydration()
@@ -2630,10 +2630,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(talkMode.isGatewayConnected)
         #expect(appModel.chatSessionKey == "agent:worker:custom-main")
         #expect(talkMode.isUsingMainSessionKey(appModel.chatSessionKey))
-        let admitted = await appModel._test_handleInvoke(
+        let admitted = await appModel.handleInvoke(
             talkRequest(id: "post-hydration", command: .pttStart))
         #expect(admitted.ok)
-        _ = await appModel._test_handleInvoke(
+        _ = await appModel.handleInvoke(
             talkRequest(id: "post-hydration-cleanup", command: .pttCancel))
     }
 
@@ -2641,14 +2641,14 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
-        appModel._test_setTalkCaptureStartedHandler { await barrier.suspendFirstPreparation() }
+        appModel.testTalkCaptureStartedHandler = { await barrier.suspendFirstPreparation() }
         defer {
-            appModel._test_setTalkCaptureStartedHandler(nil)
+            appModel.testTalkCaptureStartedHandler = nil
             appModel.voiceWake.stop()
         }
 
         let start = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "cancel-after-start", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "cancel-after-start", command: .pttStart))
         }
         await barrier.waitUntilEntered()
         #expect(talkMode._test_activePushToTalkCaptureId() != nil)
@@ -2665,15 +2665,15 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
-        appModel._test_setTalkCaptureStartedHandler { await barrier.suspendFirstPreparation() }
+        appModel.testTalkCaptureStartedHandler = { await barrier.suspendFirstPreparation() }
         defer {
             barrier.release()
-            appModel._test_setTalkCaptureStartedHandler(nil)
+            appModel.testTalkCaptureStartedHandler = nil
             appModel.voiceWake.stop()
         }
 
         let start = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "session-switch-after-start", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "session-switch-after-start", command: .pttStart))
         }
         await barrier.waitUntilEntered()
         #expect(talkMode._test_activePushToTalkCaptureId() != nil)
@@ -2698,7 +2698,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         }
 
         let once = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "session-switch-once", command: .pttOnce))
+            await appModel.handleInvoke(talkRequest(id: "session-switch-once", command: .pttOnce))
         }
         await barrier.waitUntilEntered()
         #expect(talkMode._test_activePushToTalkCaptureId() != nil)
@@ -2717,27 +2717,27 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         talkMode.updateGatewayConnected(true)
         defer {
             barrier.release()
-            appModel._test_setTalkCapturePreparationHandler(nil)
+            appModel.testTalkCapturePreparationHandler = nil
             appModel.voiceWake.stop()
         }
 
-        let activeResponse = await appModel._test_handleInvoke(
+        let activeResponse = await appModel.handleInvoke(
             talkRequest(id: "node-route-active", command: .pttStart))
         let active = try decodeTalkPayload(OpenClawTalkPTTStartPayload.self, from: activeResponse)
         #expect(talkMode._test_activePushToTalkCaptureId() == active.captureId)
 
-        appModel._test_invalidateNodePushToTalkRoute()
+        appModel.invalidateNodePushToTalkRoute()
 
         #expect(talkMode._test_activePushToTalkCaptureId() == nil)
         #expect(appModel._test_pttVoiceWakeLeaseCaptureIds().isEmpty)
 
-        appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
+        appModel.testTalkCapturePreparationHandler = { await barrier.suspendFirstPreparation() }
         let preparing = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "node-route-preparing", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "node-route-preparing", command: .pttStart))
         }
         await barrier.waitUntilEntered()
 
-        appModel._test_invalidateNodePushToTalkRoute()
+        appModel.invalidateNodePushToTalkRoute()
         barrier.release()
 
         #expect(await preparing.value.ok == false)
@@ -2753,12 +2753,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             barrier.release()
             _ = talkMode.cancelPushToTalk()
         }
-        let startResponse = await appModel._test_handleInvoke(
+        let startResponse = await appModel.handleInvoke(
             talkRequest(id: "fresh-before-stale-cancel", command: .pttStart))
         let active = try decodeTalkPayload(OpenClawTalkPTTStartPayload.self, from: startResponse)
         let staleCancel = Task { @MainActor in
             await barrier.suspendFirstPreparation()
-            return await appModel._test_handleInvoke(
+            return await appModel.handleInvoke(
                 talkRequest(id: "stale-route-cancel", command: .pttCancel))
         }
         await barrier.waitUntilEntered()
@@ -2836,11 +2836,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { appModel.voiceWake.stop() }
 
         let cancelledOnce = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "once-cancel", command: .pttOnce))
+            await appModel.handleInvoke(talkRequest(id: "once-cancel", command: .pttOnce))
         }
         await waitForTalkCondition { talkMode._test_activePushToTalkCaptureId() != nil }
         let cancelledCaptureId = try #require(talkMode._test_activePushToTalkCaptureId())
-        let cancelResponse = await appModel._test_handleInvoke(talkRequest(id: "cancel", command: .pttCancel))
+        let cancelResponse = await appModel.handleInvoke(talkRequest(id: "cancel", command: .pttCancel))
         let cancelPayload = try decodeTalkPayload(OpenClawTalkPTTStopPayload.self, from: cancelResponse)
         let cancelledOncePayload = try await decodeTalkPayload(
             OpenClawTalkPTTStopPayload.self,
@@ -2850,11 +2850,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(cancelledOncePayload == cancelPayload)
 
         let stoppedOnce = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "once-stop", command: .pttOnce))
+            await appModel.handleInvoke(talkRequest(id: "once-stop", command: .pttOnce))
         }
         await waitForTalkCondition { talkMode._test_activePushToTalkCaptureId() != nil }
         let stoppedCaptureId = try #require(talkMode._test_activePushToTalkCaptureId())
-        let stopResponse = await appModel._test_handleInvoke(talkRequest(id: "stop", command: .pttStop))
+        let stopResponse = await appModel.handleInvoke(talkRequest(id: "stop", command: .pttStop))
         let stopPayload = try decodeTalkPayload(OpenClawTalkPTTStopPayload.self, from: stopResponse)
         let stoppedOncePayload = try await decodeTalkPayload(OpenClawTalkPTTStopPayload.self, from: stoppedOnce.value)
         #expect(stopPayload.captureId == stoppedCaptureId)
@@ -2989,7 +2989,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 clientId: "openclaw-ios",
                 clientMode: "node",
                 clientDisplayName: nil))
-        appModel._test_setActiveGatewayConnectConfig(config)
+        appModel.activeGatewayConnectConfig = config
         talkMode.gatewayTalkPermissionState = .missingScope("operator.talk.secrets")
         defer {
             appModel.setTalkEnabled(false)
@@ -2999,11 +2999,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         appModel.setTalkEnabled(true)
         await waitForTalkCondition { talkMode.gatewayTalkPermissionState == .requestingUpgrade }
 
-        #expect(appModel._test_forceTalkPermissionUpgradeRequest())
+        #expect(appModel.forceOperatorTalkPermissionUpgradeRequest)
         appModel.gatewayAutoReconnectEnabled = false
         appModel.gatewayPairingPaused = true
         appModel.setTalkEnabled(false)
-        #expect(!appModel._test_forceTalkPermissionUpgradeRequest())
+        #expect(!appModel.forceOperatorTalkPermissionUpgradeRequest)
         #expect(appModel.gatewayAutoReconnectEnabled)
         #expect(!appModel.gatewayPairingPaused)
 
@@ -3087,13 +3087,13 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         await waitForTalkCondition { appModel.isChatDictationActive }
         let captureId = try #require(talkMode._test_activePushToTalkCaptureId())
 
-        let remoteStart = await appModel._test_handleInvoke(
+        let remoteStart = await appModel.handleInvoke(
             talkRequest(id: "remote-start-during-dictation", command: .pttStart))
         #expect(!remoteStart.ok)
         #expect(remoteStart.error?.message.contains("PTT_BUSY") == true)
 
         for command in [OpenClawTalkCommand.pttStop, .pttCancel] {
-            let response = await appModel._test_handleInvoke(
+            let response = await appModel.handleInvoke(
                 talkRequest(id: "remote-\(command.rawValue)-during-dictation", command: command))
             let payload = try decodeTalkPayload(OpenClawTalkPTTStopPayload.self, from: response)
             #expect(payload.status == "idle")
@@ -3179,10 +3179,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `route and remote PTT invalidation preserve dictation preparation`() async throws {
         let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
-        appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
+        appModel.testTalkCapturePreparationHandler = { await barrier.suspendFirstPreparation() }
         defer {
             barrier.release()
-            appModel._test_setTalkCapturePreparationHandler(nil)
+            appModel.testTalkCapturePreparationHandler = nil
             appModel.voiceWake.stop()
         }
 
@@ -3191,8 +3191,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         }
         await barrier.waitUntilEntered()
 
-        #expect(await appModel._test_handleInvoke(talkRequest(id: "remote-cancel", command: .pttCancel)).ok)
-        appModel._test_invalidateOperatorTalkRoute()
+        #expect(await appModel.handleInvoke(talkRequest(id: "remote-cancel", command: .pttCancel)).ok)
+        appModel.invalidateOperatorTalkRoute()
         barrier.release()
 
         await waitForTalkCondition { appModel.isChatDictationActive }
@@ -3211,10 +3211,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `backgrounding invalidates dictation preparation`() async {
         let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
-        appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
+        appModel.testTalkCapturePreparationHandler = { await barrier.suspendFirstPreparation() }
         defer {
             barrier.release()
-            appModel._test_setTalkCapturePreparationHandler(nil)
+            appModel.testTalkCapturePreparationHandler = nil
             appModel.setScenePhase(.active)
             appModel.voiceWake.stop()
         }
@@ -3238,10 +3238,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `cancelling invalidates dictation preparation before capture reservation`() async {
         let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
-        appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
+        appModel.testTalkCapturePreparationHandler = { await barrier.suspendFirstPreparation() }
         defer {
             barrier.release()
-            appModel._test_setTalkCapturePreparationHandler(nil)
+            appModel.testTalkCapturePreparationHandler = nil
             appModel.voiceWake.stop()
         }
 
@@ -3543,7 +3543,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { appModel.voiceWake.stop() }
 
         let once = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "once-background", command: .pttOnce))
+            await appModel.handleInvoke(talkRequest(id: "once-background", command: .pttOnce))
         }
         await waitForTalkCondition { talkMode._test_activePushToTalkCaptureId() != nil }
         let captureId = try #require(talkMode._test_activePushToTalkCaptureId())
@@ -3566,7 +3566,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         appModel.voiceWake.statusText = "Listening"
         defer { appModel.voiceWake.stop() }
 
-        let startResponse = await appModel._test_handleInvoke(talkRequest(id: "background-start", command: .pttStart))
+        let startResponse = await appModel.handleInvoke(talkRequest(id: "background-start", command: .pttStart))
         let start = try decodeTalkPayload(OpenClawTalkPTTStartPayload.self, from: startResponse)
         #expect(appModel._test_pttVoiceWakeLeaseCaptureIds() == [start.captureId])
 
@@ -3601,7 +3601,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             talkMode.stop()
         }
 
-        let response = await appModel._test_handleInvoke(talkRequest(id: "background-pref-start", command: .pttStart))
+        let response = await appModel.handleInvoke(talkRequest(id: "background-pref-start", command: .pttStart))
         let start = try decodeTalkPayload(OpenClawTalkPTTStartPayload.self, from: response)
         #expect(talkMode._test_activePushToTalkCaptureId() == start.captureId)
 
@@ -3677,14 +3677,14 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             appModel.voiceWake.stop()
         }
 
-        let startResponse = await appModel._test_handleInvoke(
+        let startResponse = await appModel.handleInvoke(
             talkRequest(id: "background-finalizer-start", command: .pttStart))
         let start = try decodeTalkPayload(OpenClawTalkPTTStartPayload.self, from: startResponse)
         await talkMode._test_handlePushToTalkTranscript(
             "finish in background",
             isFinal: false,
             captureId: start.captureId)
-        let stopResponse = await appModel._test_handleInvoke(
+        let stopResponse = await appModel.handleInvoke(
             talkRequest(id: "background-finalizer-stop", command: .pttStop))
         #expect(try decodeTalkPayload(OpenClawTalkPTTStopPayload.self, from: stopResponse).status == "queued")
         await barrier.waitUntilEntered()
@@ -3732,7 +3732,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         appModel.setScenePhase(.background)
         appModel.setScenePhase(.inactive)
-        let response = await appModel._test_handleInvoke(
+        let response = await appModel.handleInvoke(
             talkRequest(id: "inactive-ptt-start", command: .pttStart))
 
         #expect(!response.ok)
@@ -3753,7 +3753,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         }
 
         #expect(appModel.isBackgrounded)
-        #expect(!appModel._test_backgroundReconnectIsSuppressed())
+        #expect(!appModel.backgroundReconnectSuppressed)
         #expect(appModel.gatewayStatusText != "Background idle")
     }
 
@@ -3814,7 +3814,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let (talkMode, appModel) = makeTalkModel()
         talkMode.updateGatewayConnected(true)
 
-        let response = await appModel._test_handleInvoke(
+        let response = await appModel.handleInvoke(
             talkRequest(id: "disconnect-ptt-start", command: .pttStart))
         let start = try decodeTalkPayload(OpenClawTalkPTTStartPayload.self, from: response)
         #expect(appModel._test_pttVoiceWakeLeaseCaptureIds() == [start.captureId])
@@ -3830,28 +3830,28 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let (talkMode, appModel) = makeTalkModel()
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
-        appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
+        appModel.testTalkCapturePreparationHandler = { await barrier.suspendFirstPreparation() }
         defer {
-            appModel._test_setTalkCapturePreparationHandler(nil)
+            appModel.testTalkCapturePreparationHandler = nil
             appModel.setScenePhase(.active)
             appModel.voiceWake.stop()
         }
 
         let active = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "background-active", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "background-active", command: .pttStart))
         }
         await barrier.waitUntilEntered()
         let queued = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "background-queued", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "background-queued", command: .pttStart))
         }
-        await waitForTalkCondition { appModel._test_talkPreparationWaiterCount() == 1 }
+        await waitForTalkCondition { appModel.talkPreparationWaiters.count == 1 }
 
         appModel.setScenePhase(.background)
         barrier.release()
 
         #expect(await active.value.ok == false)
         #expect(await queued.value.ok == false)
-        #expect(appModel._test_talkPreparationWaiterCount() == 0)
+        #expect(appModel.talkPreparationWaiters.count == 0)
         #expect(talkMode._test_activePushToTalkCaptureId() == nil)
         #expect(appModel._test_pttVoiceWakeLeaseCaptureIds().isEmpty)
     }
@@ -3862,16 +3862,16 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         appModel.voiceWake.isListening = true
         appModel.voiceWake.statusText = "Listening"
 
-        appModel._test_acquirePttVoiceWakeLease(captureId: "capture-a")
+        appModel.acquirePttVoiceWakeLease(for: "capture-a")
         #expect(appModel.isTalkCaptureActive == true)
-        appModel._test_acquirePttVoiceWakeLease(captureId: "capture-a")
+        appModel.acquirePttVoiceWakeLease(for: "capture-a")
         #expect(appModel.voiceWake._test_isSuppressedByPushToTalk())
         #expect(appModel._test_pttVoiceWakeLeaseCaptureIds() == ["capture-a"])
 
-        appModel._test_releasePttVoiceWakeLease(captureId: "stale-capture")
+        appModel.releasePttVoiceWakeLease(for: "stale-capture")
         #expect(appModel.voiceWake._test_isSuppressedByPushToTalk())
 
-        appModel._test_releasePttVoiceWakeLease(captureId: "capture-a")
+        appModel.releasePttVoiceWakeLease(for: "capture-a")
         #expect(!appModel.voiceWake._test_isSuppressedByPushToTalk())
         #expect(appModel.isTalkCaptureActive == false)
         appModel.voiceWake.stop()
@@ -3879,7 +3879,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `enabling Voice Wake during standalone PTT remains suppressed`() async {
         let appModel = NodeAppModel(talkMode: TalkModeManager(allowSimulatorCapture: true))
-        appModel._test_acquirePttVoiceWakeLease(captureId: "standalone-ptt")
+        appModel.acquirePttVoiceWakeLease(for: "standalone-ptt")
 
         appModel.setVoiceWakeEnabled(true)
         await appModel.voiceWake._test_waitForScheduledStart()
@@ -3887,7 +3887,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(appModel.voiceWake.statusText == "Paused")
         #expect(!appModel.voiceWake.isListening)
 
-        appModel._test_releasePttVoiceWakeLease(captureId: "standalone-ptt")
+        appModel.releasePttVoiceWakeLease(for: "standalone-ptt")
         await appModel.voiceWake._test_waitForScheduledStart()
         #expect(appModel.voiceWake.statusText == "Voice Wake isn’t supported on Simulator")
         appModel.voiceWake.stop()
@@ -3899,13 +3899,13 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let appModel = NodeAppModel(
             talkMode: TalkModeManager(allowSimulatorCapture: true),
             voiceNoteRecorder: recorder)
-        appModel._test_acquirePttVoiceWakeLease(captureId: "voice-note-race")
+        appModel.acquirePttVoiceWakeLease(for: "voice-note-race")
 
         #expect(await recorder.start() == false)
         #expect(recorder.isRecording == false)
         #expect(capture.permissionRequestCount == 0)
 
-        appModel._test_releasePttVoiceWakeLease(captureId: "voice-note-race")
+        appModel.releasePttVoiceWakeLease(for: "voice-note-race")
     }
 
     @Test @MainActor func `voice note cannot start after the app backgrounds`() async {
@@ -3929,15 +3929,15 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let appModel = NodeAppModel(talkMode: talkMode, voiceNoteRecorder: recorder)
         let barrier = TalkPreparationBarrier()
         talkMode.updateGatewayConnected(true)
-        appModel._test_setTalkCapturePreparationHandler { await barrier.suspendFirstPreparation() }
+        appModel.testTalkCapturePreparationHandler = { await barrier.suspendFirstPreparation() }
         defer {
             barrier.release()
-            appModel._test_setTalkCapturePreparationHandler(nil)
+            appModel.testTalkCapturePreparationHandler = nil
             _ = talkMode.cancelPushToTalk()
         }
 
         let start = Task { @MainActor in
-            await appModel._test_handleInvoke(talkRequest(id: "voice-note-preparation", command: .pttStart))
+            await appModel.handleInvoke(talkRequest(id: "voice-note-preparation", command: .pttStart))
         }
         await barrier.waitUntilEntered()
 
@@ -3954,15 +3954,15 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let appModel = NodeAppModel(
             camera: camera,
             talkMode: TalkModeManager(allowSimulatorCapture: true))
-        appModel._test_acquirePttVoiceWakeLease(captureId: "camera-audio-ptt")
-        defer { appModel._test_releasePttVoiceWakeLease(captureId: "camera-audio-ptt") }
+        appModel.acquirePttVoiceWakeLease(for: "camera-audio-ptt")
+        defer { appModel.releasePttVoiceWakeLease(for: "camera-audio-ptt") }
         let params = try JSONEncoder().encode(OpenClawCameraClipParams(includeAudio: true))
         let request = try BridgeInvokeRequest(
             id: "camera-audio-during-ptt",
             command: OpenClawCameraCommand.clip.rawValue,
             paramsJSON: #require(String(data: params, encoding: .utf8)))
 
-        let response = await appModel._test_handleInvoke(request)
+        let response = await appModel.handleInvoke(request)
 
         #expect(!response.ok)
         #expect(response.error?.message.contains("Finish the active audio capture") == true)
@@ -3988,10 +3988,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             id: "blocking-camera-audio",
             command: OpenClawCameraCommand.clip.rawValue,
             paramsJSON: #require(String(data: params, encoding: .utf8)))
-        let clip = Task { @MainActor in await appModel._test_handleInvoke(clipRequest) }
+        let clip = Task { @MainActor in await appModel.handleInvoke(clipRequest) }
         await barrier.waitUntilEntered()
 
-        let ptt = await appModel._test_handleInvoke(
+        let ptt = await appModel.handleInvoke(
             talkRequest(id: "ptt-during-camera-audio", command: .pttStart))
         appModel.setTalkEnabled(true)
         let voiceNoteStarted = await voiceNoteRecorder.start()
@@ -4024,10 +4024,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             id: "blocking-screen-audio",
             command: OpenClawScreenCommand.record.rawValue,
             paramsJSON: #require(String(data: params, encoding: .utf8)))
-        let recording = Task { @MainActor in await appModel._test_handleInvoke(recordRequest) }
+        let recording = Task { @MainActor in await appModel.handleInvoke(recordRequest) }
         await barrier.waitUntilEntered()
 
-        let ptt = await appModel._test_handleInvoke(
+        let ptt = await appModel.handleInvoke(
             talkRequest(id: "ptt-during-screen-audio", command: .pttStart))
 
         #expect(!ptt.ok)
@@ -4055,11 +4055,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 command: OpenClawScreenCommand.record.rawValue,
                 paramsJSON: #require(String(data: secondParams, encoding: .utf8)))
 
-            let first = Task { @MainActor in await appModel._test_handleInvoke(firstRequest) }
+            let first = Task { @MainActor in await appModel.handleInvoke(firstRequest) }
             await barrier.waitUntilEntered()
             #expect(appModel.screenRecordActive)
 
-            let second = await appModel._test_handleInvoke(secondRequest)
+            let second = await appModel.handleInvoke(secondRequest)
 
             #expect(!second.ok)
             #expect(second.error?.message.contains("screen recording already active") == true)
@@ -4086,7 +4086,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             id: "background-camera-audio",
             command: OpenClawCameraCommand.clip.rawValue,
             paramsJSON: #require(String(data: params, encoding: .utf8)))
-        let capture = Task { @MainActor in await appModel._test_handleInvoke(request) }
+        let capture = Task { @MainActor in await appModel.handleInvoke(request) }
         await barrier.waitUntilEntered()
 
         appModel.setScenePhase(.background)
@@ -4110,7 +4110,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             id: "background-screen-no-audio",
             command: OpenClawScreenCommand.record.rawValue,
             paramsJSON: #require(String(data: params, encoding: .utf8)))
-        let capture = Task { @MainActor in await appModel._test_handleInvoke(request) }
+        let capture = Task { @MainActor in await appModel.handleInvoke(request) }
         await barrier.waitUntilEntered()
 
         appModel.setScenePhase(.background)
@@ -4138,7 +4138,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             id: "late-cancelled-screen",
             command: OpenClawScreenCommand.record.rawValue,
             paramsJSON: #require(String(data: params, encoding: .utf8)))
-        let capture = Task { @MainActor in await appModel._test_handleInvoke(request) }
+        let capture = Task { @MainActor in await appModel.handleInvoke(request) }
         await barrier.waitUntilEntered()
 
         appModel.setScenePhase(.background)
@@ -4221,7 +4221,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         appModel.dismissPendingExecApprovalPrompt(approvalId: "approval-stale")
 
-        let prompt = try #require(appModel._test_pendingExecApprovalPrompt())
+        let prompt = try #require(appModel.pendingExecApprovalPrompt)
         #expect(prompt.id == "approval-active")
     }
 
@@ -4371,7 +4371,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let (watchService, appModel) = makeWatchModel(
             notificationCenter: MockBootstrapNotificationCenter())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         let approvalID = "approval-held-pending"
         let resolutionAttemptID = "attempt-e\u{0301}-\u{0085}"
         appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(approvalID))
@@ -4397,7 +4397,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let (watchService, appModel) = makeWatchModel(
             notificationCenter: MockBootstrapNotificationCenter())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         appModel._test_setUnifiedExecApprovalGetResponse(#"{"invalid":true}"#)
         let snapshotCount = watchService.sentExecApprovalSnapshots.count
 
@@ -4417,7 +4417,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let (watchService, appModel) = makeWatchModel(
             notificationCenter: MockBootstrapNotificationCenter())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         let approvalIDs = ["approval-held-b", "approval-held-a"]
         appModel._test_setUnifiedExecApprovalGetResponses(approvalIDs.map {
             (approvalID: $0, json: makePendingExecApprovalJSON($0))
@@ -4454,7 +4454,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         """#)
         let (watchService, appModel) = makeWatchModel(
             notificationCenter: MockBootstrapNotificationCenter())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-cached-owner",
@@ -4502,7 +4502,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(GatewayStableIdentifier.key(composedGatewayID) !=
             GatewayStableIdentifier.key(decomposedGatewayID))
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_setConnectedGatewayID(composedGatewayID)
+        appModel.connectedGatewayID = composedGatewayID
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-watch-exact-owner",
@@ -4536,7 +4536,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let (watchService, appModel) = makeWatchModel(
             notificationCenter: MockBootstrapNotificationCenter())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-watch-not-found",
@@ -4561,7 +4561,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let (watchService, appModel) = makeWatchModel(
             notificationCenter: MockBootstrapNotificationCenter())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-watch-stale-cache",
@@ -4589,12 +4589,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let (watchService, appModel) = makeWatchModel(
             notificationCenter: MockBootstrapNotificationCenter())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         appModel._test_setUnifiedExecApprovalGetResponse(makeDeniedExecApprovalJSON(
             "approval-watch-terminal-readback",
             commandText: "echo guarded"))
 
-        let handled = await appModel._test_handleWatchExecApprovalResolve(
+        let handled = await appModel.handleWatchExecApprovalResolve(
             WatchExecApprovalResolveEvent(
                 replyId: "watch-terminal-readback",
                 approvalId: "approval-watch-terminal-readback",
@@ -4616,14 +4616,14 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let (watchService, appModel) = makeWatchModel(
             notificationCenter: MockBootstrapNotificationCenter())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(
             "approval-watch-pending-readback",
             commandText: "echo guarded",
             warningText: "Review this command",
             allowedDecisions: [.deny]))
 
-        let handled = await appModel._test_handleWatchExecApprovalResolve(
+        let handled = await appModel.handleWatchExecApprovalResolve(
             WatchExecApprovalResolveEvent(
                 replyId: "watch-pending-readback",
                 approvalId: "approval-watch-pending-readback",
@@ -4645,7 +4645,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let fetchGate = WatchSnapshotSendGate()
         let appModel = makeNodeModelWithMockServices()
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
                 id: "approval-visible-b",
@@ -4656,18 +4656,18 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             beforeResponse: { await fetchGate.wait() })
 
         let fetching = Task { @MainActor in
-            await appModel._test_presentExecApprovalGatewayEventPrompt("approval-terminal-a")
+            await appModel.presentExecApprovalGatewayEventPrompt(approvalId: "approval-terminal-a")
         }
         let deadline = ContinuousClock().now.advanced(by: .seconds(2))
         while await !(fetchGate.hasStarted()), ContinuousClock().now < deadline {
             await Task.yield()
         }
 
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-visible-b")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-visible-b")
         #expect(appModel._test_pendingExecApprovalState().resolving == false)
         await fetchGate.resume()
         await fetching.value
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-visible-b")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-visible-b")
         #expect(appModel._test_pendingExecApprovalState().resolving == false)
         #expect(appModel._test_pendingExecApprovalState().resolved == nil)
     }
@@ -4677,12 +4677,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let fetchGate = WatchSnapshotSendGate()
         let appModel = NodeAppModel(watchMessagingService: MockWatchMessagingService())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         appModel._test_setUnifiedExecApprovalGetResponse(
             makePendingExecApprovalJSON("approval-delayed-a", commandText: "echo delayed-a"),
             beforeResponse: { await fetchGate.wait() })
         let fetching = Task { @MainActor in
-            await appModel._test_presentExecApprovalGatewayEventPrompt("approval-delayed-a")
+            await appModel.presentExecApprovalGatewayEventPrompt(approvalId: "approval-delayed-a")
         }
         let deadline = ContinuousClock().now.advanced(by: .seconds(2))
         while await !(fetchGate.hasStarted()), ContinuousClock().now < deadline {
@@ -4696,7 +4696,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
         await fetchGate.resume()
         await fetching.value
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-newer-b")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-newer-b")
         #expect(appModel._test_pendingExecApprovalState().resolving == false)
     }
 
@@ -4705,7 +4705,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let fetchGate = WatchSnapshotSendGate()
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         let approvalID = "approval-terminal-interleave"
         try appModel._test_presentExecApprovalPrompt(#require(
             NodeAppModel._test_makeExecApprovalPrompt(
@@ -4720,7 +4720,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         })
 
         let reconciling = Task { @MainActor in
-            await appModel._test_reconcileWatchExecApprovalCache(reason: "watch_request")
+            await appModel.reconcileWatchExecApprovalCache(reason: "watch_request")
         }
         let deadline = ContinuousClock().now.advanced(by: .seconds(2))
         while await !fetchGate.hasStarted(), ContinuousClock().now < deadline {
@@ -4740,7 +4740,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         _ = await reconciling.value
 
         #expect(appModel._test_pendingExecApprovalInboxItems().isEmpty)
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == approvalID)
+        #expect(appModel.pendingExecApprovalPrompt?.id == approvalID)
         #expect(appModel._test_pendingExecApprovalState().resolved == "Approval allowed once.")
         #expect(watchService.sentExecApprovalPrompts.isEmpty)
         #expect(watchService.lastSentExecApprovalResolved?.approvalId == approvalID)
@@ -4750,7 +4750,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         let prompt = try #require(NodeAppModel._test_makeExecApprovalPrompt(
             id: "approval-reconnect-restore",
             commandText: "echo restore",
@@ -4758,15 +4758,15 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             expiresAtMs: 4_000_000_000_000))
         appModel._test_presentExecApprovalPrompt(prompt)
         appModel.dismissPendingExecApprovalPrompt()
-        #expect(appModel._test_pendingExecApprovalPrompt() == nil)
+        #expect(appModel.pendingExecApprovalPrompt == nil)
         appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(
             "approval-reconnect-restore",
             commandText: "echo restore",
             warningText: "Review after reconnect"))
 
-        await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
+        await appModel.reconcileWatchExecApprovalCache(reason: "operator_reconnected")
 
-        #expect(appModel._test_pendingExecApprovalPrompt() == nil)
+        #expect(appModel.pendingExecApprovalPrompt == nil)
         #expect(appModel._test_pendingExecApprovalInboxItems().map(\.id) == ["approval-reconnect-restore"])
         await waitForMainActorWork { watchService.lastSentExecApprovalPrompt != nil }
         #expect(watchService.lastSentExecApprovalPrompt?.approval.id == "approval-reconnect-restore")
@@ -4774,7 +4774,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         appModel._test_presentPendingExecApprovalFromInbox(
             approvalID: "approval-reconnect-restore",
             gatewayStableID: "test-gateway")
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-reconnect-restore")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-reconnect-restore")
     }
 
     @Test @MainActor func `watch reconciliation does not reopen dismissed phone presentation`() async throws {
@@ -4788,18 +4788,18 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 commandText: "echo reconcile",
                 expiresAtMs: 4_000_000_000_000)))
         await waitForMainActorWork { watchService.lastSentExecApprovalPrompt != nil }
-        appModel._test_dismissPendingExecApprovalPrompt()
+        appModel.dismissPendingExecApprovalPrompt()
         watchService.lastSentExecApprovalPrompt = nil
         appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(
             "approval-watch-reconcile",
             commandText: "echo reconcile"))
 
-        await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
+        await appModel.reconcileWatchExecApprovalCache(reason: "operator_reconnected")
 
         await waitForMainActorWork { watchService.lastSentExecApprovalPrompt != nil }
         #expect(watchService.lastSentExecApprovalPrompt?.approval.id == "approval-watch-reconcile")
         #expect(watchService.lastSentExecApprovalPrompt?.resetResolutionAttemptId == nil)
-        #expect(appModel._test_pendingExecApprovalPrompt() == nil)
+        #expect(appModel.pendingExecApprovalPrompt == nil)
         #expect(appModel._test_pendingExecApprovalInboxItems().map(\.id) == ["approval-watch-reconcile"])
     }
 
@@ -4832,7 +4832,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(initialWriteCount == 1)
         #expect(appModel._test_pendingExecApprovalState().resolving)
 
-        await appModel._test_reconcileWatchExecApprovalCache(reason: "watch_request")
+        await appModel.reconcileWatchExecApprovalCache(reason: "watch_request")
         #expect(appModel._test_pendingExecApprovalState().resolving)
         #expect(appModel._test_pendingExecApprovalState().error == nil)
 
@@ -4871,7 +4871,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         while await probe.snapshot().calls.count < 1, ContinuousClock().now < deadline {
             await Task.yield()
         }
-        let queuedWatchDecision = await appModel._test_handleWatchExecApprovalResolve(
+        let queuedWatchDecision = await appModel.handleWatchExecApprovalResolve(
             WatchExecApprovalResolveEvent(
                 replyId: "watch-lease-attempt",
                 approvalId: approvalID,
@@ -4902,7 +4902,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let appModel = NodeAppModel(watchMessagingService: MockWatchMessagingService())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         for approvalID in ["approval-b", "approval-a"] {
             try appModel._test_presentExecApprovalPrompt(#require(
                 NodeAppModel._test_makeExecApprovalPrompt(
@@ -4920,10 +4920,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         ]
         appModel._test_setUnifiedExecApprovalGetResponses(responses)
 
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-a")
-        await appModel._test_reconcileWatchExecApprovalCache(reason: "watch_request")
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-a")
-        #expect(appModel._test_pendingExecApprovalPrompt()?.commandText == "canonical approval-a")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-a")
+        await appModel.reconcileWatchExecApprovalCache(reason: "watch_request")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-a")
+        #expect(appModel.pendingExecApprovalPrompt?.commandText == "canonical approval-a")
 
         let fetchGate = WatchSnapshotSendGate()
         appModel._test_setUnifiedExecApprovalGetResponses(responses, beforeResponse: { approvalID in
@@ -4932,7 +4932,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             }
         })
         let reconciling = Task { @MainActor in
-            await appModel._test_reconcileWatchExecApprovalCache(reason: "watch_request")
+            await appModel.reconcileWatchExecApprovalCache(reason: "watch_request")
         }
         let deadline = ContinuousClock().now.advanced(by: .seconds(2))
         while await !(fetchGate.hasStarted()), ContinuousClock().now < deadline {
@@ -4945,13 +4945,13 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 expiresAtMs: 4_000_000_000_000)))
         await fetchGate.resume()
         _ = await reconciling.value
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-b")
-        #expect(appModel._test_pendingExecApprovalPrompt()?.commandText == "newer visible b")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-b")
+        #expect(appModel.pendingExecApprovalPrompt?.commandText == "newer visible b")
 
-        appModel._test_dismissPendingExecApprovalPrompt()
+        appModel.dismissPendingExecApprovalPrompt()
         appModel._test_setUnifiedExecApprovalGetResponses(responses)
-        await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-a")
+        await appModel.reconcileWatchExecApprovalCache(reason: "operator_reconnected")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-a")
     }
 
     @Test @MainActor func `watch app snapshot request publishes current dashboard state`() async throws {
@@ -4959,9 +4959,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let (watchService, appModel) = makeWatchModel()
         let gatewayStableID = " gateway-watch-snapshot "
-        appModel._test_setGatewayConnected(true)
-        appModel._test_setOperatorConnected(true)
-        appModel._test_setConnectedGatewayID(gatewayStableID)
+        appModel.gatewayConnected = true
+        appModel.setOperatorConnected(true)
+        appModel.connectedGatewayID = gatewayStableID
         appModel.gatewayStatusText = "Connected"
         appModel.talkMode.setEnabled(true)
         appModel.talkMode.statusText = "Listening"
@@ -4993,7 +4993,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `watch gateway problem keeps localization semantics`() async throws {
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_applyOperatorGatewayConnectionProblem(GatewayConnectionProblem(
+        appModel.applyOperatorGatewayConnectionProblem(GatewayConnectionProblem(
             kind: .pairingRequired,
             owner: .gateway,
             title: "Pairing approval required",
@@ -5024,8 +5024,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `watch app snapshot publishes offline when operator disconnects`() async {
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_setGatewayConnected(true)
-        appModel._test_setOperatorConnected(true)
+        appModel.gatewayConnected = true
+        appModel.setOperatorConnected(true)
         appModel.gatewayStatusText = "Connected"
 
         watchService.emitAppSnapshotRequest(
@@ -5142,7 +5142,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `watch app snapshot publishes online when operator reconnects`() async {
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_setGatewayConnected(true)
+        appModel.gatewayConnected = true
         appModel.gatewayStatusText = "Connected"
 
         watchService.emitAppSnapshotRequest(
@@ -5158,7 +5158,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         }
         #expect(watchService.lastSentAppSnapshot?.gatewayConnected == false)
 
-        appModel._test_setOperatorConnected(true)
+        appModel.setOperatorConnected(true)
         for _ in 0..<20 {
             if watchService.lastSentAppSnapshot?.gatewayConnected == true {
                 break
@@ -5258,7 +5258,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let watchService = MockWatchMessagingService()
         let talkMode = TalkModeManager(allowSimulatorCapture: true)
         let appModel = NodeAppModel(watchMessagingService: watchService, talkMode: talkMode)
-        appModel._test_setConnectedGatewayID("gateway-current")
+        appModel.connectedGatewayID = "gateway-current"
         appModel.setTalkEnabled(false)
 
         for command in [OpenClawWatchAppCommand.openChat, .startTalk] {
@@ -5335,7 +5335,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                     timestamp: 2000 + Double(index)))
         }
 
-        let items = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
+        let items = WatchChatPresentation.makeItems(from: rawMessages)
 
         #expect(items.map(\.text) == ["Still worth reading"])
     }
@@ -5386,7 +5386,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 timestamp: 1000),
         ]
 
-        let items = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
+        let items = WatchChatPresentation.makeItems(from: rawMessages)
 
         #expect(items.map(\.text) == ["Responses reply"])
     }
@@ -5405,9 +5405,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 idempotencyKey: "other-run"),
         ]
 
-        let reply = NodeAppModel._test_watchChatReplyText(
+        let reply = WatchChatPresentation.replyText(
             from: rawMessages,
-            runId: "watch-run",
+            runID: "watch-run",
             submittedText: "Question",
             submittedAtMs: 1000)
 
@@ -5430,9 +5430,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             makeWatchChatRawMessage(role: "assistant", text: "Queued reply", timestamp: 4000),
         ]
 
-        let reply = NodeAppModel._test_watchChatReplyText(
+        let reply = WatchChatPresentation.replyText(
             from: rawMessages,
-            runId: "watch-run",
+            runID: "watch-run",
             submittedText: "Watch question",
             submittedAtMs: 2500)
 
@@ -5450,9 +5450,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             makeWatchChatRawMessage(role: "assistant", text: "Collected reply", timestamp: 4000),
         ]
 
-        let reply = NodeAppModel._test_watchChatReplyText(
+        let reply = WatchChatPresentation.replyText(
             from: rawMessages,
-            runId: "watch-run",
+            runID: "watch-run",
             submittedText: "Watch question",
             submittedAtMs: 2500)
 
@@ -5474,9 +5474,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 isMessageToolMirror: true),
         ]
 
-        let reply = NodeAppModel._test_watchChatReplyText(
+        let reply = WatchChatPresentation.replyText(
             from: rawMessages,
-            runId: "watch-run",
+            runID: "watch-run",
             submittedText: "Send the update",
             submittedAtMs: 2500)
 
@@ -5501,7 +5501,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             makeWatchChatRawMessage(role: "assistant", text: "Same", timestamp: 1000),
         ]
 
-        let items = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
+        let items = WatchChatPresentation.makeItems(from: rawMessages)
 
         #expect(items.count == 2)
         #expect(items[0].id != items[1].id)
@@ -5522,7 +5522,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 isMessageToolMirror: true),
         ]
 
-        let items = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
+        let items = WatchChatPresentation.makeItems(from: rawMessages)
 
         #expect(items.count == 2)
         #expect(items[0].id != items[1].id)
@@ -5538,24 +5538,24 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                     timestamp: Double(1000 + index)))
         }
 
-        let before = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
+        let before = WatchChatPresentation.makeItems(from: rawMessages)
         try rawMessages.append(
             makeWatchChatRawMessage(
                 role: "user",
                 text: "Next question",
                 timestamp: 2000))
-        let after = NodeAppModel._test_makeWatchChatItems(from: rawMessages)
+        let after = WatchChatPresentation.makeItems(from: rawMessages)
 
         #expect(before.last?.id == after.dropLast().last?.id)
         #expect(after.last?.role == "user")
     }
 
     @Test @MainActor func `watch app command queues chat message when operator offline`() async {
-        NodeAppModel._test_resetPersistedWatchChatQueueState()
-        defer { NodeAppModel._test_resetPersistedWatchChatQueueState() }
+        WatchMessageOutbox.resetPersistedQueue()
+        defer { WatchMessageOutbox.resetPersistedQueue() }
         let (watchService, appModel) = makeWatchModel()
         let gatewayID = "gateway-watch-chat-offline"
-        appModel._test_setConnectedGatewayID(gatewayID)
+        appModel.connectedGatewayID = gatewayID
 
         watchService.emitAppCommand(
             makeWatchAppCommand(
@@ -5566,7 +5566,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 sentAt: 127))
         await Task.yield()
 
-        #expect(appModel._test_queuedWatchChatCommandCount() == 1)
+        #expect(appModel.watchMessageOutbox.queuedCount(kind: .chat) == 1)
 
         watchService.emitAppCommand(
             makeWatchAppCommand(
@@ -5577,12 +5577,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 sentAt: 128))
         await Task.yield()
 
-        #expect(appModel._test_queuedWatchChatCommandCount() == 1)
+        #expect(appModel.watchMessageOutbox.queuedCount(kind: .chat) == 1)
     }
 
     @Test @MainActor func `watch app command queues until cold launch restores its gateway`() async {
-        NodeAppModel._test_resetPersistedWatchChatQueueState()
-        defer { NodeAppModel._test_resetPersistedWatchChatQueueState() }
+        WatchMessageOutbox.resetPersistedQueue()
+        defer { WatchMessageOutbox.resetPersistedQueue() }
         let (watchService, appModel) = makeWatchModel()
 
         watchService.emitAppCommand(
@@ -5593,17 +5593,17 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 text: "Keep this until startup restores the route",
                 sentAt: 127,
                 transport: "transferUserInfo"))
-        await waitForMainActorWork { appModel._test_queuedWatchChatCommandCount() == 1 }
+        await waitForMainActorWork { appModel.watchMessageOutbox.queuedCount(kind: .chat) == 1 }
 
-        #expect(appModel._test_queuedWatchChatCommandCount() == 1)
+        #expect(appModel.watchMessageOutbox.queuedCount(kind: .chat) == 1)
         #expect(watchService.lastSentAppSnapshot == nil)
     }
 
     @Test @MainActor func `watch app command drops chat message for stale gateway snapshot`() async {
-        NodeAppModel._test_resetPersistedWatchChatQueueState()
-        defer { NodeAppModel._test_resetPersistedWatchChatQueueState() }
+        WatchMessageOutbox.resetPersistedQueue()
+        defer { WatchMessageOutbox.resetPersistedQueue() }
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_setConnectedGatewayID("gateway-current")
+        appModel.connectedGatewayID = "gateway-current"
 
         watchService.emitAppCommand(
             makeWatchAppCommand(
@@ -5615,17 +5615,17 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 transport: "transferUserInfo"))
         await Task.yield()
 
-        #expect(appModel._test_queuedWatchChatCommandCount() == 0)
+        #expect(appModel.watchMessageOutbox.queuedCount(kind: .chat) == 0)
     }
 
     @Test @MainActor func `watch app command restores queued chat message after model restart`() async {
-        NodeAppModel._test_resetPersistedWatchChatQueueState()
-        defer { NodeAppModel._test_resetPersistedWatchChatQueueState() }
+        WatchMessageOutbox.resetPersistedQueue()
+        defer { WatchMessageOutbox.resetPersistedQueue() }
 
         let gatewayID = "gateway-watch-chat-restore"
         let firstWatchService = MockWatchMessagingService()
         let firstAppModel = NodeAppModel(watchMessagingService: firstWatchService)
-        firstAppModel._test_setConnectedGatewayID(gatewayID)
+        firstAppModel.connectedGatewayID = gatewayID
         firstWatchService.emitAppCommand(
             makeWatchAppCommand(
                 "watch-send-chat-restore",
@@ -5635,13 +5635,13 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 sentAt: 129))
         await Task.yield()
 
-        #expect(firstAppModel._test_queuedWatchChatCommandIds() == ["watch-send-chat-restore"])
+        #expect(firstAppModel.watchMessageOutbox.queuedMessageIDs(kind: .chat) == ["watch-send-chat-restore"])
 
         let secondWatchService = MockWatchMessagingService()
         let secondAppModel = NodeAppModel(watchMessagingService: secondWatchService)
-        secondAppModel._test_setConnectedGatewayID(gatewayID)
+        secondAppModel.connectedGatewayID = gatewayID
 
-        #expect(secondAppModel._test_queuedWatchChatCommandIds() == ["watch-send-chat-restore"])
+        #expect(secondAppModel.watchMessageOutbox.queuedMessageIDs(kind: .chat) == ["watch-send-chat-restore"])
 
         secondWatchService.emitAppCommand(
             makeWatchAppCommand(
@@ -5653,7 +5653,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 transport: "transferUserInfo"))
         await Task.yield()
 
-        #expect(secondAppModel._test_queuedWatchChatCommandIds() == ["watch-send-chat-restore"])
+        #expect(secondAppModel.watchMessageOutbox.queuedMessageIDs(kind: .chat) == ["watch-send-chat-restore"])
     }
 
     @Test @MainActor func `watch chat queue scopes and orders commands by gateway`() throws {
@@ -5735,17 +5735,17 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let appModel = NodeAppModel(watchMessagingService: MockWatchMessagingService())
         let messageID = "watch-message-exhausted"
 
-        appModel._test_setWatchMessageRetryAttempts(3, messageID: messageID)
-        appModel._test_setOperatorConnected(true)
-        #expect(appModel._test_watchMessageRetryAttempts(messageID: messageID) == nil)
+        appModel.watchMessageRetryAttempts[messageID] = 3
+        appModel.setOperatorConnected(true)
+        #expect(appModel.watchMessageRetryAttempts[messageID] == nil)
 
-        appModel._test_setWatchMessageRetryAttempts(2, messageID: messageID)
-        appModel._test_setOperatorConnected(true)
-        #expect(appModel._test_watchMessageRetryAttempts(messageID: messageID) == 2)
+        appModel.watchMessageRetryAttempts[messageID] = 2
+        appModel.setOperatorConnected(true)
+        #expect(appModel.watchMessageRetryAttempts[messageID] == 2)
 
-        appModel._test_setOperatorConnected(false)
-        appModel._test_setOperatorConnected(true)
-        #expect(appModel._test_watchMessageRetryAttempts(messageID: messageID) == nil)
+        appModel.setOperatorConnected(false)
+        appModel.setOperatorConnected(true)
+        #expect(appModel.watchMessageRetryAttempts[messageID] == nil)
     }
 
     @Test @MainActor func `watch message outbox prioritizes replies over queued chat`() throws {
@@ -5985,12 +5985,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         appModel._test_recordPendingWatchExecApprovalRecoveryID(
             decomposedRecovery.approvalId,
             gatewayDeviceId: decomposedOwner)
-        var recoveryPushes = appModel._test_pendingWatchExecApprovalRecoveryPushes()
+        var recoveryPushes = appModel.pendingWatchExecApprovalRecoveryPushes
         #expect(recoveryPushes.count == 2)
         #expect(Set(recoveryPushes.compactMap { GatewayStableIdentifier.key($0.gatewayDeviceId) }).count == 2)
 
-        appModel._test_removePendingWatchExecApprovalRecoveryPush(composedRecovery)
-        recoveryPushes = appModel._test_pendingWatchExecApprovalRecoveryPushes()
+        appModel.removePendingWatchExecApprovalRecoveryPush(composedRecovery)
+        recoveryPushes = appModel.pendingWatchExecApprovalRecoveryPushes
         #expect(recoveryPushes.count == 1)
         #expect(GatewayStableIdentifier.key(recoveryPushes.first?.gatewayDeviceId) ==
             GatewayStableIdentifier.key(decomposedOwner))
@@ -6003,12 +6003,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             gatewayDeviceId: decomposedOwner)
         #expect(await appModel.handleExecApprovalResolvedRemotePush(composedResolved))
         #expect(await appModel.handleExecApprovalResolvedRemotePush(decomposedResolved))
-        var resolvedPushes = appModel._test_pendingExecApprovalResolvedPushes()
+        var resolvedPushes = appModel.pendingExecApprovalResolvedPushes
         #expect(resolvedPushes.count == 2)
         #expect(Set(resolvedPushes.compactMap { GatewayStableIdentifier.key($0.gatewayDeviceId) }).count == 2)
 
-        appModel._test_removePendingExecApprovalResolvedPush(composedResolved)
-        resolvedPushes = appModel._test_pendingExecApprovalResolvedPushes()
+        appModel.removePendingExecApprovalResolvedPush(composedResolved)
+        resolvedPushes = appModel.pendingExecApprovalResolvedPushes
         #expect(resolvedPushes.count == 1)
         #expect(GatewayStableIdentifier.key(resolvedPushes.first?.gatewayDeviceId) ==
             GatewayStableIdentifier.key(decomposedOwner))
@@ -6044,17 +6044,17 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         appModel._test_setUnifiedExecApprovalGetResponse(makePendingExecApprovalJSON(
             "approval-shipped-cache",
             commandText: "canonical command"))
-        appModel._test_setConnectedGatewayID("gateway-b")
-        await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
+        appModel.connectedGatewayID = "gateway-b"
+        await appModel.reconcileWatchExecApprovalCache(reason: "operator_reconnected")
         #expect(appModel._test_watchExecApprovalCacheIDs().isEmpty)
-        #expect(appModel._test_pendingExecApprovalPrompt() == nil)
+        #expect(appModel.pendingExecApprovalPrompt == nil)
         #expect(appModel._test_pendingPersistedExecApprovalReadbacks().count == 1)
 
-        appModel._test_setConnectedGatewayID("gateway-a")
-        await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
+        appModel.connectedGatewayID = "gateway-a"
+        await appModel.reconcileWatchExecApprovalCache(reason: "operator_reconnected")
         #expect(appModel._test_watchExecApprovalCacheIDs() == ["approval-shipped-cache"])
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-shipped-cache")
-        #expect(appModel._test_pendingExecApprovalPrompt()?.commandText == "canonical command")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-shipped-cache")
+        #expect(appModel.pendingExecApprovalPrompt?.commandText == "canonical command")
         readbacks = appModel._test_pendingPersistedExecApprovalReadbacks()
         #expect(readbacks.isEmpty)
     }
@@ -6085,7 +6085,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             message: "gateway error",
             details: ["reason": AnyCodable("APPROVAL_NOT_FOUND")])
 
-        #expect(NodeAppModel._test_isApprovalNotificationStaleError(staleError))
+        #expect(NodeAppModel.isApprovalNotificationStaleError(staleError))
     }
 
     @Test func `approval RPC family requires a complete route catalog family`() {
@@ -6126,23 +6126,23 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test func `background aware exec approval reconnect covers watch and push paths`() {
         #expect(
-            NodeAppModel._test_shouldUseBackgroundAwareExecApprovalReconnect(
+            NodeAppModel.shouldUseBackgroundAwareExecApprovalReconnect(
                 sourceReason: "watch_request",
                 isBackgrounded: true))
         #expect(
-            NodeAppModel._test_shouldUseBackgroundAwareExecApprovalReconnect(
+            NodeAppModel.shouldUseBackgroundAwareExecApprovalReconnect(
                 sourceReason: "push_request",
                 isBackgrounded: true))
         #expect(
-            NodeAppModel._test_shouldUseBackgroundAwareExecApprovalReconnect(
+            NodeAppModel.shouldUseBackgroundAwareExecApprovalReconnect(
                 sourceReason: "watch_resolve",
                 isBackgrounded: true))
         #expect(
-            !NodeAppModel._test_shouldUseBackgroundAwareExecApprovalReconnect(
+            !NodeAppModel.shouldUseBackgroundAwareExecApprovalReconnect(
                 sourceReason: "direct",
                 isBackgrounded: true))
         #expect(
-            !NodeAppModel._test_shouldUseBackgroundAwareExecApprovalReconnect(
+            !NodeAppModel.shouldUseBackgroundAwareExecApprovalReconnect(
                 sourceReason: "watch_request",
                 isBackgrounded: false))
     }
@@ -6150,17 +6150,17 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test func `exec approval event ID decodes gateway payload`() {
         let controlPrefixedID = "\u{001C}approval-1"
         #expect(NodeAppModel
-            ._test_execApprovalEventID(from: AnyCodable(["id": controlPrefixedID])) == controlPrefixedID)
+            .execApprovalEventID(from: AnyCodable(["id": controlPrefixedID])) == controlPrefixedID)
         #expect(NodeAppModel
-            ._test_execApprovalEventID(from: AnyCodable(["id": " approval-1 "])) == " approval-1 ")
+            .execApprovalEventID(from: AnyCodable(["id": " approval-1 "])) == " approval-1 ")
         #expect(NodeAppModel
-            ._test_execApprovalEventID(from: AnyCodable(["id": "\tapproval-1"])) == "\tapproval-1")
+            .execApprovalEventID(from: AnyCodable(["id": "\tapproval-1"])) == "\tapproval-1")
         #expect(NodeAppModel
-            ._test_execApprovalEventID(from: AnyCodable(["id": "\u{FEFF}approval-1"])) == "\u{FEFF}approval-1")
-        #expect(NodeAppModel._test_execApprovalEventID(from: AnyCodable(["id": "."])) == nil)
-        #expect(NodeAppModel._test_execApprovalEventID(from: AnyCodable(["id": ".."])) == nil)
-        #expect(NodeAppModel._test_execApprovalEventID(from: AnyCodable(["id": "   "])) == "   ")
-        #expect(NodeAppModel._test_execApprovalEventID(from: AnyCodable(["other": "approval-1"])) == nil)
+            .execApprovalEventID(from: AnyCodable(["id": "\u{FEFF}approval-1"])) == "\u{FEFF}approval-1")
+        #expect(NodeAppModel.execApprovalEventID(from: AnyCodable(["id": "."])) == nil)
+        #expect(NodeAppModel.execApprovalEventID(from: AnyCodable(["id": ".."])) == nil)
+        #expect(NodeAppModel.execApprovalEventID(from: AnyCodable(["id": "   "])) == "   ")
+        #expect(NodeAppModel.execApprovalEventID(from: AnyCodable(["other": "approval-1"])) == nil)
     }
 
     @Test @MainActor func `operator gateway resolved event waits for canonical readback`() async throws {
@@ -6188,19 +6188,19 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                     agentId: nil,
                     expiresAtMs: Int64(Date().timeIntervalSince1970 * 1000) + 60000)))
 
-        await appModel._test_handleOperatorGatewayServerEvent(EventFrame(
+        await appModel.handleOperatorGatewayServerEvent(EventFrame(
             type: "event",
             event: ExecApprovalNotificationBridge.resolvedKind,
             payload: AnyCodable(["id": "approval-event-resolved"]),
             seq: nil,
             stateversion: nil))
 
-        #expect(appModel._test_pendingExecApprovalPrompt()?.id == "approval-event-resolved")
+        #expect(appModel.pendingExecApprovalPrompt?.id == "approval-event-resolved")
         #expect(appModel._test_pendingWatchExecApprovalRecoveryIDs() == ["approval-event-resolved"])
         let pendingResolvedPush = ExecApprovalNotificationPrompt(
             approvalId: "approval-event-resolved",
             gatewayDeviceId: nil)
-        #expect(appModel._test_pendingExecApprovalResolvedPushes() == [pendingResolvedPush])
+        #expect(appModel.pendingExecApprovalResolvedPushes == [pendingResolvedPush])
         #expect(!notificationCenter.deliveredRemovedIdentifiers.contains([
             "approval-event-notification",
         ]))
@@ -6210,7 +6210,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let appModel = NodeAppModel(notificationCenter: MockBootstrapNotificationCenter())
-        appModel._test_setConnectedGatewayID("gateway-a")
+        appModel.connectedGatewayID = "gateway-a"
         let gatewayA = ExecApprovalNotificationPrompt(
             approvalId: "shared-approval-id",
             gatewayDeviceId: "gateway-device-a")
@@ -6224,18 +6224,18 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             gatewayB.approvalId,
             gatewayDeviceId: "gateway-device-b")
 
-        await appModel._test_handleExecApprovalResolvedForCurrentGateway(
+        await appModel.handleExecApprovalResolvedForCurrentGateway(
             approvalId: gatewayA.approvalId,
             recoveryPushGatewayDeviceID: gatewayA.gatewayDeviceId)
 
-        #expect(appModel._test_pendingWatchExecApprovalRecoveryPushes() == [gatewayA, gatewayB])
+        #expect(appModel.pendingWatchExecApprovalRecoveryPushes == [gatewayA, gatewayB])
     }
 
     @Test func `watch exec approval hydrate preserves exact missing I ds`() {
         let controlPrefixedID = "\u{001C}pending"
         let composedID = "pending-\u{00E9}"
         let decomposedID = "pending-e\u{0301}"
-        let idsToFetch = NodeAppModel._test_watchExecApprovalIDsNeedingFetch(
+        let idsToFetch = NodeAppModel.watchExecApprovalIDsNeedingFetch(
             candidateIDs: [
                 "cached",
                 controlPrefixedID,
@@ -6264,7 +6264,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let composedID = "approval-\u{00E9}"
         let decomposedID = "approval-e\u{0301}"
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
 
         for approvalID in [composedID, decomposedID] {
             try appModel._test_presentExecApprovalPrompt(#require(
@@ -6292,25 +6292,25 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test func `operator loop waits for bootstrap handoff before using stored token`() {
         #expect(
-            !NodeAppModel._test_shouldStartOperatorGatewayLoop(
+            !NodeAppModel.shouldStartOperatorGatewayLoop(
                 token: nil,
                 bootstrapToken: "fresh-bootstrap-token",
                 password: nil,
                 hasStoredOperatorToken: true))
         #expect(
-            !NodeAppModel._test_shouldStartOperatorGatewayLoop(
+            !NodeAppModel.shouldStartOperatorGatewayLoop(
                 token: nil,
                 bootstrapToken: nil,
                 password: nil,
                 hasStoredOperatorToken: false))
         #expect(
-            NodeAppModel._test_shouldStartOperatorGatewayLoop(
+            NodeAppModel.shouldStartOperatorGatewayLoop(
                 token: nil,
                 bootstrapToken: nil,
                 password: nil,
                 hasStoredOperatorToken: true))
         #expect(
-            NodeAppModel._test_shouldStartOperatorGatewayLoop(
+            NodeAppModel.shouldStartOperatorGatewayLoop(
                 token: "shared-token",
                 bootstrapToken: "fresh-bootstrap-token",
                 password: nil,
@@ -6318,19 +6318,19 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test func `credential handoff is required only for bootstrap authentication`() {
-        #expect(NodeAppModel._test_usesBootstrapCredential(
+        #expect(NodeAppModel.usesBootstrapCredential(
             token: nil,
             bootstrapToken: "fresh-bootstrap-token",
             password: nil))
-        #expect(!NodeAppModel._test_usesBootstrapCredential(
+        #expect(!NodeAppModel.usesBootstrapCredential(
             token: "shared-token",
             bootstrapToken: "fresh-bootstrap-token",
             password: nil))
-        #expect(!NodeAppModel._test_usesBootstrapCredential(
+        #expect(!NodeAppModel.usesBootstrapCredential(
             token: nil,
             bootstrapToken: "fresh-bootstrap-token",
             password: "shared-password"))
-        #expect(!NodeAppModel._test_usesBootstrapCredential(
+        #expect(!NodeAppModel.usesBootstrapCredential(
             token: nil,
             bootstrapToken: nil,
             password: nil))
@@ -6338,17 +6338,17 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `operator gateway requested event shows notification guidance when notifications off`() async throws {
         let (center, appModel) = makeNotificationModel(status: .notDetermined)
-        appModel._test_resetExecApprovalNotificationGuidanceSuppression()
-        defer { appModel._test_resetExecApprovalNotificationGuidanceSuppression() }
+        appModel.resetExecApprovalNotificationGuidanceSuppression()
+        defer { appModel.resetExecApprovalNotificationGuidanceSuppression() }
 
-        await appModel._test_handleOperatorGatewayServerEvent(EventFrame(
+        await appModel.handleOperatorGatewayServerEvent(EventFrame(
             type: "event",
             event: ExecApprovalNotificationBridge.requestedKind,
             payload: AnyCodable(["id": "approval-notifications-off"]),
             seq: nil,
             stateversion: nil))
 
-        let prompt = try #require(appModel._test_pendingNotificationPermissionGuidancePrompt())
+        let prompt = try #require(appModel.pendingNotificationPermissionGuidancePrompt)
         #expect(prompt.approvalId == "approval-notifications-off")
     }
 
@@ -6360,10 +6360,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let appModel = NodeAppModel(
             notificationCenter: center,
             watchMessagingService: MockWatchMessagingService())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        appModel.connectedGatewayID = "test-gateway"
         appModel._test_setExecApprovalPromptFetchFailure("route_changed")
 
-        await appModel._test_handleOperatorGatewayServerEvent(EventFrame(
+        await appModel.handleOperatorGatewayServerEvent(EventFrame(
             type: "event",
             event: ExecApprovalNotificationBridge.requestedKind,
             payload: AnyCodable(["id": "approval-requested-retry"]),
@@ -6375,7 +6375,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         ])
         appModel._test_setUnifiedExecApprovalGetResponse(
             makePendingExecApprovalJSON("approval-requested-retry"))
-        await appModel._test_reconcileWatchExecApprovalCache(reason: "operator_reconnected")
+        await appModel.reconcileWatchExecApprovalCache(reason: "operator_reconnected")
 
         #expect(appModel._test_pendingPersistedExecApprovalReadbacks().isEmpty)
         #expect(appModel._test_pendingExecApprovalInboxItems().map(\.id) == [
@@ -6388,8 +6388,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let authorizationGate = NotificationAuthorizationGate()
         center.authorizationStatusHandler = { await authorizationGate.wait() }
         let appModel = NodeAppModel(notificationCenter: center)
-        appModel._test_resetExecApprovalNotificationGuidanceSuppression()
-        defer { appModel._test_resetExecApprovalNotificationGuidanceSuppression() }
+        appModel.resetExecApprovalNotificationGuidanceSuppression()
+        defer { appModel.resetExecApprovalNotificationGuidanceSuppression() }
         var routeIsCurrent = true
         let event = EventFrame(
             type: "event",
@@ -6399,7 +6399,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             stateversion: nil)
 
         let handling = Task { @MainActor in
-            await appModel._test_handleOperatorGatewayServerEvent(
+            await appModel.handleOperatorGatewayServerEvent(
                 event,
                 shouldContinue: { routeIsCurrent })
         }
@@ -6411,48 +6411,48 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         await authorizationGate.resume(returning: .denied)
         await handling.value
 
-        #expect(appModel._test_pendingNotificationPermissionGuidancePrompt() == nil)
-        #expect(appModel._test_pendingExecApprovalPrompt() == nil)
+        #expect(appModel.pendingNotificationPermissionGuidancePrompt == nil)
+        #expect(appModel.pendingExecApprovalPrompt == nil)
     }
 
     @Test @MainActor func `suppressed operator gateway requested event does not show notification guidance`() async {
         let (center, appModel) = makeNotificationModel(status: .denied)
-        appModel._test_resetExecApprovalNotificationGuidanceSuppression()
-        defer { appModel._test_resetExecApprovalNotificationGuidanceSuppression() }
+        appModel.resetExecApprovalNotificationGuidanceSuppression()
+        defer { appModel.resetExecApprovalNotificationGuidanceSuppression() }
         appModel.dismissNotificationPermissionGuidancePrompt(suppressFuture: true)
 
-        await appModel._test_handleOperatorGatewayServerEvent(EventFrame(
+        await appModel.handleOperatorGatewayServerEvent(EventFrame(
             type: "event",
             event: ExecApprovalNotificationBridge.requestedKind,
             payload: AnyCodable(["id": "approval-suppressed"]),
             seq: nil,
             stateversion: nil))
 
-        #expect(appModel._test_pendingNotificationPermissionGuidancePrompt() == nil)
+        #expect(appModel.pendingNotificationPermissionGuidancePrompt == nil)
     }
 
     @Test @MainActor func `canonical resolved readback clears notification guidance prompt`() async throws {
         let (center, appModel) = makeNotificationModel(status: .denied)
-        appModel._test_resetExecApprovalNotificationGuidanceSuppression()
-        defer { appModel._test_resetExecApprovalNotificationGuidanceSuppression() }
+        appModel.resetExecApprovalNotificationGuidanceSuppression()
+        defer { appModel.resetExecApprovalNotificationGuidanceSuppression() }
 
-        await appModel._test_handleOperatorGatewayServerEvent(EventFrame(
+        await appModel.handleOperatorGatewayServerEvent(EventFrame(
             type: "event",
             event: ExecApprovalNotificationBridge.requestedKind,
             payload: AnyCodable(["id": "approval-guidance-resolved"]),
             seq: nil,
             stateversion: nil))
-        _ = try #require(appModel._test_pendingNotificationPermissionGuidancePrompt())
-        appModel._test_setConnectedGatewayID("test-gateway")
+        _ = try #require(appModel.pendingNotificationPermissionGuidancePrompt)
+        appModel.connectedGatewayID = "test-gateway"
         appModel._test_setUnifiedExecApprovalGetResponse(makeDeniedExecApprovalJSON(
             "approval-guidance-resolved",
             commandText: "echo guarded"))
 
-        await appModel._test_handleExecApprovalResolvedForCurrentGateway(
+        await appModel.handleExecApprovalResolvedForCurrentGateway(
             approvalId: "approval-guidance-resolved",
             recoveryPushGatewayDeviceID: nil)
 
-        #expect(appModel._test_pendingNotificationPermissionGuidancePrompt() == nil)
+        #expect(appModel.pendingNotificationPermissionGuidancePrompt == nil)
     }
 
     @Test @MainActor func `handle invoke rejects background commands`() async {
@@ -6460,11 +6460,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         appModel.setScenePhase(.background)
 
         let req = BridgeInvokeRequest(id: "bg", command: OpenClawCanvasCommand.present.rawValue)
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
         #expect(res.ok == false)
         #expect(res.error?.code == .backgroundUnavailable)
 
-        let talk = await appModel._test_handleInvoke(talkRequest(id: "bg-talk", command: .pttStart))
+        let talk = await appModel.handleInvoke(talkRequest(id: "bg-talk", command: .pttStart))
         #expect(talk.ok == false)
         #expect(talk.error?.message.contains("/talk") == true)
     }
@@ -6485,7 +6485,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             }
         }
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
         #expect(res.ok == false)
         #expect(res.error?.code == .unavailable)
         #expect(res.error?.message.contains("CAMERA_DISABLED") == true)
@@ -6506,7 +6506,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let appModel = NodeAppModel(camera: CancellingCameraService())
         let request = BridgeInvokeRequest(id: "cancelled-camera", command: OpenClawCameraCommand.snap.rawValue)
 
-        let response = await appModel._test_handleInvoke(request)
+        let response = await appModel.handleInvoke(request)
 
         #expect(response.ok == false)
         #expect(response.error?.code == .unavailable)
@@ -6534,14 +6534,14 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             secondStarted: secondStarted.continuation)
         let appModel = NodeAppModel(camera: camera)
         let firstTask = Task {
-            await appModel._test_handleInvoke(
+            await appModel.handleInvoke(
                 BridgeInvokeRequest(id: "camera-first", command: OpenClawCameraCommand.snap.rawValue))
         }
         for await _ in firstStarted.stream {
             break
         }
         let secondTask = Task {
-            await appModel._test_handleInvoke(
+            await appModel.handleInvoke(
                 BridgeInvokeRequest(id: "camera-second", command: OpenClawCameraCommand.snap.rawValue))
         }
         for await _ in secondStarted.stream {
@@ -6566,7 +6566,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawSystemCommand.notify.rawValue,
             params: OpenClawSystemNotifyParams(title: "Approval", body: "Review request"))
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
 
         #expect(res.ok == false)
         #expect(res.error?.code == .unavailable)
@@ -6583,7 +6583,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawSystemCommand.notify.rawValue,
             params: OpenClawSystemNotifyParams(title: "Approval", body: "Review request"))
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
 
         #expect(res.ok)
         #expect(center.addCalls == 1)
@@ -6598,7 +6598,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawSystemCommand.notify.rawValue,
             params: OpenClawSystemNotifyParams(title: "Approval", body: "Review request"))
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
 
         #expect(res.ok == false)
         #expect(res.error?.code == .unavailable)
@@ -6613,18 +6613,18 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         PushEnrollmentConsent.reset()
         defer { PushEnrollmentConsent.reset() }
 
-        #expect(await appModel._test_canPublishAPNsRegistration() == false)
-        #expect(await appModel._test_canPublishAPNsRegistration(usesRelayTransport: false))
+        #expect(await appModel.canPublishAPNsRegistration() == false)
+        #expect(await appModel.canPublishAPNsRegistration(usesRelayTransport: false))
 
         PushEnrollmentConsent.markDisclosureAccepted()
         center.status = .notDetermined
-        #expect(await appModel._test_canPublishAPNsRegistration() == false)
+        #expect(await appModel.canPublishAPNsRegistration() == false)
 
         center.status = .authorized
-        #expect(await appModel._test_canPublishAPNsRegistration())
+        #expect(await appModel.canPublishAPNsRegistration())
 
         UserDefaults.standard.set(false, forKey: NotificationServingPreference.storageKey)
-        #expect(await appModel._test_canPublishAPNsRegistration() == false)
+        #expect(await appModel.canPublishAPNsRegistration() == false)
     }
 
     @Test @MainActor func `chat push without speech returns unavailable when notifications off`() async throws {
@@ -6634,7 +6634,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawChatCommand.push.rawValue,
             params: OpenClawChatPushParams(text: "Build finished", speak: false))
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
 
         #expect(res.ok == false)
         #expect(res.error?.code == .unavailable)
@@ -6651,7 +6651,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawChatCommand.push.rawValue,
             params: OpenClawChatPushParams(text: "Build finished", speak: false))
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
 
         #expect(res.ok)
         #expect(center.addCalls == 1)
@@ -6668,7 +6668,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawScreenCommand.record.rawValue,
             paramsJSON: json)
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
         #expect(res.ok == false)
         #expect(res.error?.message.contains("screen format must be mp4") == true)
     }
@@ -6681,7 +6681,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         appModel.screen.navigate(to: "http://example.com")
 
         let present = BridgeInvokeRequest(id: "present", command: OpenClawCanvasCommand.present.rawValue)
-        let presentRes = await appModel._test_handleInvoke(present)
+        let presentRes = await appModel.handleInvoke(present)
         #expect(presentRes.ok == true)
         #expect(appModel.screen.urlString.isEmpty)
 
@@ -6690,7 +6690,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             id: "nav",
             command: OpenClawCanvasCommand.navigate.rawValue,
             params: OpenClawCanvasNavigateParams(url: "http://example.com/"))
-        let navRes = await appModel._test_handleInvoke(navigate)
+        let navRes = await appModel.handleInvoke(navigate)
         #expect(navRes.ok == true)
         #expect(appModel.screen.urlString == "http://example.com/")
 
@@ -6698,11 +6698,11 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             id: "eval",
             command: OpenClawCanvasCommand.evalJS.rawValue,
             params: OpenClawCanvasEvalParams(javaScript: "1+1"))
-        var evalRes = await appModel._test_handleInvoke(eval)
+        var evalRes = await appModel.handleInvoke(eval)
         let deadline = ContinuousClock().now.advanced(by: .seconds(3))
         while evalRes.ok != true, ContinuousClock().now < deadline {
             try? await Task.sleep(nanoseconds: 100_000_000)
-            evalRes = await appModel._test_handleInvoke(eval)
+            evalRes = await appModel.handleInvoke(eval)
         }
         #expect(evalRes.ok == true)
         let payloadData = try #require(evalRes.payloadJSON?.data(using: .utf8))
@@ -6747,7 +6747,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let appModel = NodeAppModel()
 
         let reset = BridgeInvokeRequest(id: "reset", command: OpenClawCanvasA2UICommand.reset.rawValue)
-        let resetRes = await appModel._test_handleInvoke(reset)
+        let resetRes = await appModel.handleInvoke(reset)
         #expect(resetRes.ok == false)
         #expect(resetRes.error?.message.contains("A2UI_HOST_UNAVAILABLE") == true)
 
@@ -6756,7 +6756,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             id: "push",
             command: OpenClawCanvasA2UICommand.pushJSONL.rawValue,
             params: OpenClawCanvasA2UIPushJSONLParams(jsonl: jsonl))
-        let pushRes = await appModel._test_handleInvoke(push)
+        let pushRes = await appModel.handleInvoke(push)
         #expect(pushRes.ok == false)
         #expect(pushRes.error?.message.contains("A2UI_HOST_UNAVAILABLE") == true)
     }
@@ -6764,7 +6764,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     @Test @MainActor func `handle invoke unknown command returns invalid request`() async {
         let appModel = NodeAppModel()
         let req = BridgeInvokeRequest(id: "unknown", command: "nope")
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
         #expect(res.ok == false)
         #expect(res.error?.code == .invalidRequest)
     }
@@ -6780,7 +6780,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         let appModel = NodeAppModel(watchMessagingService: watchService)
         let req = BridgeInvokeRequest(id: "watch-status", command: OpenClawWatchCommand.status.rawValue)
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
         #expect(res.ok == true)
 
         let payloadData = try #require(res.payloadJSON?.data(using: .utf8))
@@ -6828,7 +6828,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             queuedForDelivery: true,
             transport: "transferUserInfo")
         let appModel = NodeAppModel(watchMessagingService: watchService)
-        appModel._test_setConnectedGatewayID("gateway-watch-notify")
+        appModel.connectedGatewayID = "gateway-watch-notify"
         let params = OpenClawWatchNotifyParams(
             title: "OpenClaw",
             body: "Meeting with Peter is at 4pm",
@@ -6838,7 +6838,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawWatchCommand.notify.rawValue,
             params: params)
 
-        let res = await appModel._test_handleInvoke(req, gatewayStableID: "gateway-a")
+        let res = await appModel.handleInvoke(req, gatewayStableID: "gateway-a")
         #expect(res.ok == true)
         #expect(watchService.lastSent?.params.title == "OpenClaw")
         #expect(watchService.lastSent?.params.body == "Meeting with Peter is at 4pm")
@@ -7150,7 +7150,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawWatchCommand.notify.rawValue,
             params: params)
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
         #expect(res.ok == false)
         #expect(res.error?.code == .invalidRequest)
         #expect(watchService.lastSent == nil)
@@ -7168,7 +7168,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawWatchCommand.notify.rawValue,
             params: params)
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
         #expect(res.ok == true)
         #expect(watchService.lastSent?.params.risk == .low)
         let actionIDs = watchService.lastSent?.params.actions?.map(\.id)
@@ -7177,7 +7177,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `legacy watch reply binds to latest prompt owner`() async throws {
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_setConnectedGatewayID("gateway-a")
+        appModel.connectedGatewayID = "gateway-a"
         let params = OpenClawWatchNotifyParams(
             title: "Task",
             body: "Action needed",
@@ -7186,7 +7186,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             id: "watch-notify-legacy-owner",
             command: OpenClawWatchCommand.notify.rawValue,
             params: params)
-        #expect(await appModel._test_handleInvoke(request, gatewayStableID: "gateway-a").ok)
+        #expect(await appModel.handleInvoke(request, gatewayStableID: "gateway-a").ok)
 
         watchService.emitReply(WatchQuickReplyEvent(
             replyId: "legacy-reply",
@@ -7200,7 +7200,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             transport: "transferUserInfo"))
         await Task.yield()
 
-        #expect(appModel._test_queuedWatchReplyCount() == 1)
+        #expect(appModel.watchMessageOutbox.queuedCount(kind: .quickReply) == 1)
     }
 
     @Test @MainActor func `handle invoke watch notify adds approval defaults`() async throws {
@@ -7215,7 +7215,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawWatchCommand.notify.rawValue,
             params: params)
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
         #expect(res.ok == true)
         let actionIDs = watchService.lastSent?.params.actions?.map(\.id)
         #expect(actionIDs == ["approve", "decline", "open_phone", "escalate"])
@@ -7240,7 +7240,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawWatchCommand.notify.rawValue,
             params: params)
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
         #expect(res.ok == true)
         #expect(watchService.lastSent?.params.priority == .timeSensitive)
         #expect(watchService.lastSent?.params.risk == .high)
@@ -7261,17 +7261,17 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             command: OpenClawWatchCommand.notify.rawValue,
             params: params)
 
-        let res = await appModel._test_handleInvoke(req)
+        let res = await appModel.handleInvoke(req)
         #expect(res.ok == false)
         #expect(res.error?.code == .unavailable)
         #expect(res.error?.message.contains("WATCH_UNAVAILABLE") == true)
     }
 
     @Test @MainActor func `watch reply queues when gateway offline`() async {
-        NodeAppModel._test_resetPersistedWatchReplyQueueState()
-        defer { NodeAppModel._test_resetPersistedWatchReplyQueueState() }
+        WatchMessageOutbox.resetPersistedQueue()
+        defer { WatchMessageOutbox.resetPersistedQueue() }
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_setConnectedGatewayID("gateway-watch-reply")
+        appModel.connectedGatewayID = "gateway-watch-reply"
         watchService.emitReply(
             WatchQuickReplyEvent(
                 replyId: "reply-offline-1",
@@ -7284,15 +7284,15 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 sentAtMs: 1234,
                 transport: "transferUserInfo"))
         await Task.yield()
-        #expect(appModel._test_queuedWatchReplyCount() == 1)
+        #expect(appModel.watchMessageOutbox.queuedCount(kind: .quickReply) == 1)
     }
 
     @Test @MainActor func `watch chat and reply preserve boundary whitespace gateway owner`() async {
-        NodeAppModel._test_resetPersistedWatchChatQueueState()
-        defer { NodeAppModel._test_resetPersistedWatchChatQueueState() }
+        WatchMessageOutbox.resetPersistedQueue()
+        defer { WatchMessageOutbox.resetPersistedQueue() }
         let gatewayID = " gateway-boundary "
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_setConnectedGatewayID(gatewayID)
+        appModel.connectedGatewayID = gatewayID
 
         watchService.emitAppCommand(makeWatchAppCommand(
             "watch-boundary-chat",
@@ -7310,10 +7310,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             note: nil,
             sentAtMs: 2,
             transport: "sendMessage"))
-        await waitForMainActorWork { appModel._test_queuedWatchReplyCount() == 1 }
+        await waitForMainActorWork { appModel.watchMessageOutbox.queuedCount(kind: .quickReply) == 1 }
 
-        #expect(appModel._test_queuedWatchChatCommandIds() == ["watch-boundary-chat"])
-        #expect(appModel._test_queuedWatchReplyCount() == 1)
+        #expect(appModel.watchMessageOutbox.queuedMessageIDs(kind: .chat) == ["watch-boundary-chat"])
+        #expect(appModel.watchMessageOutbox.queuedCount(kind: .quickReply) == 1)
 
         watchService.emitAppCommand(makeWatchAppCommand(
             "watch-trimmed-owner-chat",
@@ -7322,7 +7322,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             text: "Wrong owner",
             sentAt: 3))
         await Task.yield()
-        #expect(appModel._test_queuedWatchChatCommandIds() == ["watch-boundary-chat"])
+        #expect(appModel.watchMessageOutbox.queuedMessageIDs(kind: .chat) == ["watch-boundary-chat"])
     }
 
     @Test @MainActor func `watch message outbox restores queued reply after restart`() throws {
@@ -7431,10 +7431,10 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 
     @Test @MainActor func `watch reply drops stale gateway target`() async {
-        NodeAppModel._test_resetPersistedWatchReplyQueueState()
-        defer { NodeAppModel._test_resetPersistedWatchReplyQueueState() }
+        WatchMessageOutbox.resetPersistedQueue()
+        defer { WatchMessageOutbox.resetPersistedQueue() }
         let (watchService, appModel) = makeWatchModel()
-        appModel._test_setConnectedGatewayID("gateway-current")
+        appModel.connectedGatewayID = "gateway-current"
 
         watchService.emitReply(
             WatchQuickReplyEvent(
@@ -7449,16 +7449,16 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 transport: "transferUserInfo"))
         await Task.yield()
 
-        #expect(appModel._test_queuedWatchReplyCount() == 0)
+        #expect(appModel.watchMessageOutbox.queuedCount(kind: .quickReply) == 0)
         #expect(appModel.openChatRequestID == 0)
     }
 
     @Test @MainActor func `watch reply uses idempotent chat outbox`() async {
-        NodeAppModel._test_resetPersistedWatchReplyQueueState()
-        defer { NodeAppModel._test_resetPersistedWatchReplyQueueState() }
+        WatchMessageOutbox.resetPersistedQueue()
+        defer { WatchMessageOutbox.resetPersistedQueue() }
         let (watchService, appModel) = makeWatchModel()
         appModel.enterAppleReviewDemoMode()
-        appModel._test_recordWatchPromptRoute(
+        appModel.watchMessageOutbox.recordPromptRoute(
             promptID: "prompt-idempotent",
             gatewayStableID: AppleReviewDemoMode.gatewayID)
         let initialOpenChatRequestID = appModel.openChatRequestID
@@ -7476,15 +7476,15 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         watchService.emitReply(event)
         await waitForMainActorWork { appModel.openChatRequestID == initialOpenChatRequestID + 1 }
         watchService.emitReply(event)
-        await waitForMainActorWork { appModel._test_queuedWatchReplyCount() == 0 }
+        await waitForMainActorWork { appModel.watchMessageOutbox.queuedCount(kind: .quickReply) == 0 }
 
         #expect(appModel.openChatRequestID == initialOpenChatRequestID + 1)
-        #expect(appModel._test_queuedWatchReplyCount() == 0)
+        #expect(appModel.watchMessageOutbox.queuedCount(kind: .quickReply) == 0)
     }
 
     @Test @MainActor func `watch reply rejects legacy prompt without a gateway owner`() async {
-        NodeAppModel._test_resetPersistedWatchReplyQueueState()
-        defer { NodeAppModel._test_resetPersistedWatchReplyQueueState() }
+        WatchMessageOutbox.resetPersistedQueue()
+        defer { WatchMessageOutbox.resetPersistedQueue() }
         let (watchService, appModel) = makeWatchModel()
         appModel.enterAppleReviewDemoMode()
         let initialOpenChatRequestID = appModel.openChatRequestID
@@ -7505,7 +7505,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         await Task.yield()
 
         #expect(appModel.openChatRequestID == initialOpenChatRequestID)
-        #expect(appModel._test_queuedWatchReplyCount() == 0)
+        #expect(appModel.watchMessageOutbox.queuedCount(kind: .quickReply) == 0)
     }
 
     @Test @MainActor func `handle deep link sets error when not connected`() async throws {
@@ -7525,8 +7525,8 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `handle deep link requires confirmation when connected and unkeyed`() async {
         let appModel = NodeAppModel()
-        appModel._test_setGatewayConnected(true)
-        appModel._test_setAgentRequestHandler { _ in }
+        appModel.gatewayConnected = true
+        appModel.testAgentRequestHandler = { _ in }
         let url = makeAgentDeepLinkURL(message: "hello from deep link")
 
         await appModel.handleDeepLink(url: url)
@@ -7541,7 +7541,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `handle deep link coalesces prompt when rate limited`() async throws {
         let appModel = NodeAppModel()
-        appModel._test_setGatewayConnected(true)
+        appModel.gatewayConnected = true
 
         await appModel.handleDeepLink(url: makeAgentDeepLinkURL(message: "first prompt"))
         let firstPrompt = try #require(appModel.pendingAgentDeepLinkPrompt)
@@ -7555,7 +7555,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `handle deep link strips delivery fields when unkeyed`() async throws {
         let appModel = NodeAppModel()
-        appModel._test_setGatewayConnected(true)
+        appModel.gatewayConnected = true
         let url = makeAgentDeepLinkURL(
             message: "route this",
             deliver: true,
@@ -7571,7 +7571,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `handle deep link rejects long unkeyed message when connected`() async {
         let appModel = NodeAppModel()
-        appModel._test_setGatewayConnected(true)
+        appModel.gatewayConnected = true
         let message = String(repeating: "x", count: 241)
         let url = makeAgentDeepLinkURL(message: message)
 
@@ -7582,9 +7582,9 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 
     @Test @MainActor func `handle deep link bypasses prompt with valid key`() async {
         let appModel = NodeAppModel()
-        appModel._test_setGatewayConnected(true)
-        appModel._test_setAgentRequestHandler { _ in }
-        let key = NodeAppModel._test_currentDeepLinkKey()
+        appModel.gatewayConnected = true
+        appModel.testAgentRequestHandler = { _ in }
+        let key = NodeAppModel.expectedDeepLinkKey()
         let url = makeAgentDeepLinkURL(message: "trusted request", key: key)
 
         await appModel.handleDeepLink(url: url)
@@ -7639,7 +7639,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             token: "operator-token",
             scopes: ["operator.read", "operator.admin", "operator.approvals"],
             gatewayID: authenticationOwnerID)
-        appModel._test_refreshOperatorAdminScopeFromStore()
+        appModel.refreshOperatorAdminScopeFromStore()
         #expect(appModel.hasOperatorAdminScope == true)
         #expect(appModel._test_shouldRequestStoredOperatorAdminScope(gatewayID: authenticationOwnerID))
         #expect(appModel._test_shouldRequestStoredOperatorApprovalScope(
@@ -7656,7 +7656,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             deviceId: identity.deviceId,
             role: "operator",
             gatewayID: authenticationOwnerID)
-        appModel._test_refreshOperatorAdminScopeFromStore()
+        appModel.refreshOperatorAdminScopeFromStore()
         #expect(appModel.hasOperatorAdminScope == false)
     }
 
@@ -7678,7 +7678,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
                 "context": ["value": "ok"],
             ],
         ]
-        await appModel._test_handleCanvasA2UIAction(body: body)
+        await appModel.handleCanvasA2UIAction(body: body)
         #expect(appModel.screen.urlString.isEmpty)
     }
 }

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -6224,7 +6224,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             gatewayB.approvalId,
             gatewayDeviceId: "gateway-device-b")
 
-        await appModel.handleExecApprovalResolvedForCurrentGateway(
+        await appModel._test_handleExecApprovalResolvedForCurrentGateway(
             approvalId: gatewayA.approvalId,
             recoveryPushGatewayDeviceID: gatewayA.gatewayDeviceId)
 
@@ -6448,7 +6448,7 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             "approval-guidance-resolved",
             commandText: "echo guarded"))
 
-        await appModel.handleExecApprovalResolvedForCurrentGateway(
+        await appModel._test_handleExecApprovalResolvedForCurrentGateway(
             approvalId: "approval-guidance-resolved",
             recoveryPushGatewayDeviceID: nil)
 

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -620,7 +620,7 @@ struct SwiftUIRenderSmokeTests {
 
     @Test @MainActor func `root prompt alert stack still presents deep link prompt`() async throws {
         let appModel = NodeAppModel()
-        appModel._test_setGatewayConnected(true)
+        appModel.gatewayConnected = true
         let gatewayController = Self.gatewayControllerWithCapturedTLSFingerprint(appModel: appModel)
         let root = Color.clear
             .gatewayTrustPromptAlert()


### PR DESCRIPTION
## What Problem This Solves

The iOS node model accumulated a parallel DEBUG-only accessor layer for behavior that its tests can already exercise through the canonical owner with `@testable import`. Keeping both paths made the model harder to navigate and created duplicate signatures that could drift.

## Why This Change Was Made

Remove 64 exact pass-through overloads and update their tests to call the same internal methods and state directly. Semantic fixtures remain in place: persistence and transport stubs, normalization adapters, snapshot projections, hydration waits, task-generation helpers, multi-step outcome helpers, and the exact bridges required by intentional private route-context, talk-permission state, and operator-options source boundaries are unchanged.

The change adds no public or package API and does not alter runtime branches, signing, project configuration, test declarations, test names, assertion intent, or ordering.

## User Impact

No user-visible behavior changes. This is an iOS maintenance cleanup that removes 326 net production lines while preserving the existing test coverage.

## Evidence

- `./scripts/format-swift.sh ios` — passed
- `./scripts/lint-swift.sh ios` — passed
- `swiftformat --lint --config config/swiftformat apps/ios/Sources/Model/NodeAppModel.swift` — passed
- `node scripts/check-changed.mjs -- <six changed iOS paths>` — passed on Blacksmith Testbox `tbx_01kz2p6k1ks3yczmyy80zvk3w5` ([run 30778661481](https://github.com/openclaw/openclaw/actions/runs/30778661481))
- Xcode 26 compile proof caught and fixed the one canonical method constrained by private `GatewaySessionRouteContext`; its exact DEBUG bridge remains
- Post-repair changed-path proof passed on Blacksmith Testbox `tbx_01kz2s6frwt2pdd09pcgg9rm31` ([run 30780785167](https://github.com/openclaw/openclaw/actions/runs/30780785167))
- Xcode 26 compile proof exposed Swift operator precedence in one mechanically rewritten optional-task assertion; parentheses preserve the original negated existence check, and a full changed-assertion audit found no other boolean/optional artifacts
- Post-assertion-repair changed-path proof passed on Blacksmith Testbox `tbx_01kz2t7grgw2evh8zn2cpy4brr` ([run 30781601477](https://github.com/openclaw/openclaw/actions/runs/30781601477))
- Xcode 26 build-for-testing proved the talk-permission handshake flag must remain private; its exact DEBUG getter and original two test calls remain, and a comprehensive direct-target audit found no other inaccessible private/fileprivate target or private signature type
- Final six-path changed gate passed on Blacksmith Testbox `tbx_01kz2vgwndky3b9fsw6a0zwf1a` ([run 30782524245](https://github.com/openclaw/openclaw/actions/runs/30782524245))
- Exact-head Xcode 26 CI compiled Debug and Release before its untouched source guard proved `makeOperatorConnectOptions` must remain private; its exact bridge and original four test calls remain, and all 50 widened declarations were audited against every iOS access-boundary literal/regex with no other conflicts
- Final six-path changed gate after the source-boundary restoration passed on Blacksmith Testbox `tbx_01kz2x7erwnq3z6gy04s012x04` ([run 30783806137](https://github.com/openclaw/openclaw/actions/runs/30783806137))
- Per-file declaration hashes confirm all affected test declarations and names are byte-identical before and after
- Fresh autoreview before and after both compiler repairs: `gpt-5.6-sol`, `xhigh`, no findings, 0.99 confidence each
- Exact-head Xcode 26 CI passed Swift lint, Debug and Release builds, the focused 306-test lifecycle suite including `OpenClawTests/NodeAppModelInvokeTests`, and screenshot evidence ([run 30784074275](https://github.com/openclaw/openclaw/actions/runs/30784074275))
- Exact-head iOS Periphery passed ([run 30784074245](https://github.com/openclaw/openclaw/actions/runs/30784074245)); shared iOS/macOS Periphery intersection passed ([run 30784074244](https://github.com/openclaw/openclaw/actions/runs/30784074244))
