### PR TITLE
improve(tests): reuse approval inference fixture

### DIFF
--- a/src/system-agent/approval-intent.test.ts
+++ b/src/system-agent/approval-intent.test.ts
@@ -1,16 +1,22 @@
 // Approval-intent tests: closed-list fast path plus model-judged classification.
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   classifySystemAgentApprovalIntent,
   classifySystemAgentApprovalText,
   type SystemAgentApprovalIntentDeps,
 } from "./approval-intent.js";
-import { createSystemAgentVerifiedInferenceTestFixture } from "./system-agent.test-helpers.js";
+import {
+  createSystemAgentVerifiedInferenceTestFixture,
+  installSystemAgentPluginMetadataTestSnapshot,
+  type SystemAgentPluginMetadataTestSnapshot,
+} from "./system-agent.test-helpers.js";
 import type { SystemAgentVerifiedInferenceBinding } from "./verified-inference.js";
 
-async function verifiedInference(
-  model = "openai/gpt-5.5@openai:p2",
-): Promise<SystemAgentVerifiedInferenceBinding> {
+const DEFAULT_MODEL = "openai/gpt-5.5@openai:p2";
+const CLI_MODEL = "claude-cli/claude-opus-4-8";
+
+function verifiedInferenceConfig(model: string): OpenClawConfig {
   const openClawRuntime = model.startsWith("openai/")
     ? {
         models: {
@@ -18,18 +24,51 @@ async function verifiedInference(
         },
       }
     : {};
-  return (
-    await createSystemAgentVerifiedInferenceTestFixture({
-      agents: { defaults: { model, ...openClawRuntime } },
-      auth: {
-        order: { openai: ["openai:p1", "openai:p2"] },
-        profiles: {
-          "openai:p1": { provider: "openai", mode: "api_key" },
-          "openai:p2": { provider: "openai", mode: "api_key" },
-        },
+  return {
+    agents: { defaults: { model, ...openClawRuntime } },
+    auth: {
+      order: { openai: ["openai:p1", "openai:p2"] },
+      profiles: {
+        "openai:p1": { provider: "openai", mode: "api_key" },
+        "openai:p2": { provider: "openai", mode: "api_key" },
       },
-    })
-  ).binding;
+    },
+  };
+}
+
+async function createVerifiedInference(
+  model = "openai/gpt-5.5@openai:p2",
+): Promise<SystemAgentVerifiedInferenceBinding> {
+  return (await createSystemAgentVerifiedInferenceTestFixture(verifiedInferenceConfig(model)))
+    .binding;
+}
+
+let sharedVerifiedInference: SystemAgentVerifiedInferenceBinding | undefined;
+let cliPluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
+
+beforeAll(async () => {
+  const defaultSnapshot = installSystemAgentPluginMetadataTestSnapshot(
+    verifiedInferenceConfig(DEFAULT_MODEL),
+  );
+  try {
+    sharedVerifiedInference = await createVerifiedInference(DEFAULT_MODEL);
+  } finally {
+    defaultSnapshot.restore();
+  }
+  cliPluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(
+    verifiedInferenceConfig(CLI_MODEL),
+  );
+});
+
+afterAll(() => {
+  cliPluginMetadataSnapshot?.restore();
+});
+
+function requireSharedVerifiedInference(): SystemAgentVerifiedInferenceBinding {
+  if (!sharedVerifiedInference) {
+    throw new Error("shared verified inference fixture was not initialized");
+  }
+  return sharedVerifiedInference;
 }
 
 function completionDeps(replyText: string, binding: SystemAgentVerifiedInferenceBinding) {
@@ -87,7 +126,7 @@ describe("classifySystemAgentApprovalText", () => {
 
 describe("classifySystemAgentApprovalIntent", () => {
   it("short-circuits closed-list answers without a model call", async () => {
-    const binding = await verifiedInference();
+    const binding = requireSharedVerifiedInference();
     const deps = completionDeps("approve", binding);
     await expect(
       classifySystemAgentApprovalIntent({ message: "yes", verifiedInference: binding }, deps),
@@ -97,7 +136,7 @@ describe("classifySystemAgentApprovalIntent", () => {
   });
 
   it("pins ambiguous approvals to the verified model and profile", async () => {
-    const binding = await verifiedInference();
+    const binding = requireSharedVerifiedInference();
     const deps = completionDeps("approve", binding);
     await expect(
       classifySystemAgentApprovalIntent(
@@ -120,7 +159,7 @@ describe("classifySystemAgentApprovalIntent", () => {
   });
 
   it("fails closed to other on unexpected model output", async () => {
-    const binding = await verifiedInference();
+    const binding = requireSharedVerifiedInference();
     const deps = completionDeps("I think the user probably agrees", binding);
     await expect(
       classifySystemAgentApprovalIntent(
@@ -131,7 +170,7 @@ describe("classifySystemAgentApprovalIntent", () => {
   });
 
   it("fails closed to other when no model is usable", async () => {
-    const binding = await verifiedInference();
+    const binding = requireSharedVerifiedInference();
     const deps = {
       ...completionDeps("approve", binding),
       prepareSimpleCompletionModelForAgent: vi.fn(async () => ({ error: "no model" })) as never,
@@ -145,7 +184,7 @@ describe("classifySystemAgentApprovalIntent", () => {
   });
 
   it("rejects a prepared auth owner that differs from the verified profile", async () => {
-    const binding = await verifiedInference();
+    const binding = requireSharedVerifiedInference();
     const deps = completionDeps("approve", binding);
     deps.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce({
       model: {},
@@ -168,7 +207,7 @@ describe("classifySystemAgentApprovalIntent", () => {
   });
 
   it("rejects a same-profile credential rotation during preparation", async () => {
-    const binding = await verifiedInference();
+    const binding = requireSharedVerifiedInference();
     const deps = completionDeps("approve", binding);
     deps.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce({
       model: {},
@@ -192,7 +231,7 @@ describe("classifySystemAgentApprovalIntent", () => {
   });
 
   it("keeps ambiguous CLI approvals on the exact-text path", async () => {
-    const binding = await verifiedInference("claude-cli/claude-opus-4-8");
+    const binding = await createVerifiedInference(CLI_MODEL);
     const deps = completionDeps("approve", binding);
 
     await expect(
@@ -205,7 +244,7 @@ describe("classifySystemAgentApprovalIntent", () => {
   });
 
   it("rejects a verdict when the verified owner drifts during classification", async () => {
-    const binding = await verifiedInference();
+    const binding = await createVerifiedInference(DEFAULT_MODEL);
     const deps = completionDeps("approve", binding);
     deps.resolveVerifiedInferenceRoute
       .mockResolvedValueOnce(binding.execution)


### PR DESCRIPTION
## What Problem This Solves

The approval-intent suite rebuilt the same immutable default verified-inference binding for ordinary classifier cases. That repeated plugin metadata and route preparation dominated a small but critical compact-large-8 file.

## Why This Change Was Made

Build one real default OpenAI binding under the canonical metadata snapshot and reuse it only for six ordinary cases. The CLI-compatible case still creates a real CLI binding, and the owner-drift case still creates a fresh default binding against an intentionally incompatible snapshot. Snapshot state is restored at suite teardown.

## User Impact

No runtime or user-visible behavior changes. The same real binding, CLI, and drift assertions complete faster with lower memory use.

## Evidence

- Paired Vitest: 26.85s -> 20.07s (25.3% faster).
- Test bodies: 20.14s -> 17.06s; max RSS: 1.54GB -> 1.29GB.
- Test count unchanged: 11/11; sibling proof: 73/73.
- The real CLI and owner-drift paths remain unchanged in cost and behavior.
- Formatting, targeted lint, `git diff --check`, focused type diagnostics, and autoreview are clean.
- Test-only diff: +63/-24; production LOC delta: 0.
