### PR TITLE
refactor(swift): reduce chat test maintenance overhead

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -138,60 +138,13 @@ private func lifecycleSessionEntry(
 private func sessionEntry(
     key: String,
     updatedAt: Double,
+    sessionId: String? = nil,
     displayName: String? = nil,
     label: String? = nil,
     pinned: Bool = false,
     pinnedAt: Double? = nil,
     archived: Bool = false,
-    totalTokens: Int? = nil,
-    totalTokensFresh: Bool? = nil,
-    contextTokens: Int? = nil) -> OpenClawChatSessionEntry
-{
-    OpenClawChatSessionEntry(
-        key: key,
-        kind: nil,
-        displayName: displayName,
-        surface: nil,
-        subject: nil,
-        room: nil,
-        space: nil,
-        updatedAt: updatedAt,
-        sessionId: nil,
-        systemSent: nil,
-        abortedLastRun: nil,
-        thinkingLevel: nil,
-        verboseLevel: nil,
-        inputTokens: nil,
-        outputTokens: nil,
-        totalTokens: totalTokens,
-        totalTokensFresh: totalTokensFresh,
-        modelProvider: nil,
-        model: nil,
-        contextTokens: contextTokens,
-        label: label,
-        pinned: pinned ? true : nil,
-        pinnedAt: pinnedAt ?? (pinned ? updatedAt : nil),
-        archived: archived ? true : nil,
-        archivedAt: archived ? updatedAt : nil)
-}
-
-private func sessionsListResponse(_ sessions: [OpenClawChatSessionEntry]) -> OpenClawChatSessionsListResponse {
-    OpenClawChatSessionsListResponse(
-        ts: nil,
-        path: nil,
-        count: sessions.count,
-        defaults: nil,
-        sessions: sessions)
-}
-
-private func thinkingOption(_ id: String, label: String? = nil) -> OpenClawChatThinkingLevelOption {
-    OpenClawChatThinkingLevelOption(id: id, label: label ?? id)
-}
-
-private func sessionEntry(
-    key: String,
-    updatedAt: Double,
-    model: String?,
+    model: String? = nil,
     modelProvider: String? = nil,
     thinkingLevel: String? = nil,
     thinkingLevels: [OpenClawChatThinkingLevelOption]? = nil,
@@ -207,13 +160,13 @@ private func sessionEntry(
     OpenClawChatSessionEntry(
         key: key,
         kind: nil,
-        displayName: nil,
+        displayName: displayName,
         surface: nil,
         subject: nil,
         room: nil,
         space: nil,
         updatedAt: updatedAt,
-        sessionId: nil,
+        sessionId: sessionId,
         systemSent: nil,
         abortedLastRun: nil,
         thinkingLevel: thinkingLevel,
@@ -228,8 +181,30 @@ private func sessionEntry(
         thinkingLevels: thinkingLevels,
         thinkingOptions: thinkingOptions,
         thinkingDefault: thinkingDefault,
+        label: label,
+        pinned: pinned ? true : nil,
+        pinnedAt: pinnedAt ?? (pinned ? updatedAt : nil),
+        archived: archived ? true : nil,
+        archivedAt: archived ? updatedAt : nil,
         fastMode: fastMode,
         effectiveFastMode: effectiveFastMode)
+}
+
+private func sessionsResponse(
+    _ sessions: [OpenClawChatSessionEntry],
+    ts: Double? = nil,
+    defaults: OpenClawChatSessionsDefaults? = nil) -> OpenClawChatSessionsListResponse
+{
+    OpenClawChatSessionsListResponse(
+        ts: ts,
+        path: nil,
+        count: sessions.count,
+        defaults: defaults,
+        sessions: sessions)
+}
+
+private func thinkingOption(_ id: String, label: String? = nil) -> OpenClawChatThinkingLevelOption {
+    OpenClawChatThinkingLevelOption(id: id, label: label ?? id)
 }
 
 private func modelChoice(
@@ -246,16 +221,37 @@ private func modelChoice(
         reasoning: reasoning)
 }
 
+private func openAIModelPatchResult(
+    _ model: String,
+    thinking: String?,
+    levels: [OpenClawChatThinkingLevelOption]? = nil) -> OpenClawChatModelPatchResult
+{
+    OpenClawChatModelPatchResult(
+        modelProvider: "openai",
+        model: model,
+        thinkingLevel: thinking,
+        thinkingLevels: levels)
+}
+
 private func sessionsResponse(
     _ session: OpenClawChatSessionEntry,
+    ts: Double? = 1,
     defaults: OpenClawChatSessionsDefaults? = nil) -> OpenClawChatSessionsListResponse
 {
-    OpenClawChatSessionsListResponse(
-        ts: 1,
-        path: nil,
-        count: 1,
-        defaults: defaults,
-        sessions: [session])
+    sessionsResponse([session], ts: ts, defaults: defaults)
+}
+
+private func historyPayloadWithoutRunState(
+    sessionKey: String = "main",
+    sessionId: String? = "sess-main",
+    messages: [AnyCodable] = [],
+    thinkingLevel: String = "off") -> OpenClawChatHistoryPayload
+{
+    OpenClawChatHistoryPayload(
+        sessionKey: sessionKey,
+        sessionId: sessionId,
+        messages: messages,
+        thinkingLevel: thinkingLevel)
 }
 
 private func commandChoice(
@@ -6532,17 +6528,14 @@ struct ChatViewModelTests {
         let recentOlder = now - (5 * 60 * 60 * 1000)
         let stale = now - (26 * 60 * 60 * 1000)
         let history = historyPayload()
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 4,
-            defaults: nil,
-            sessions: [
+        let sessions = sessionsResponse(
+            [
                 sessionEntry(key: "recent-1", updatedAt: recent),
                 sessionEntry(key: "main", updatedAt: stale),
                 sessionEntry(key: "recent-2", updatedAt: recentOlder),
                 sessionEntry(key: "old-1", updatedAt: stale),
-            ])
+            ],
+            ts: now)
 
         let (_, vm) = await makeViewModel(historyResponses: [history], sessionsResponses: [sessions])
         await MainActor.run { vm.load() }
@@ -6553,25 +6546,20 @@ struct ChatViewModelTests {
     }
 
     @Test func `context usage follows active session switches`() async throws {
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: 1,
-            path: nil,
-            count: 2,
-            defaults: nil,
-            sessions: [
-                sessionEntry(
-                    key: "main",
-                    updatedAt: 2,
-                    totalTokens: 20,
-                    totalTokensFresh: true,
-                    contextTokens: 100),
-                sessionEntry(
-                    key: "other",
-                    updatedAt: 1,
-                    totalTokens: 80,
-                    totalTokensFresh: true,
-                    contextTokens: 100),
-            ])
+        let sessions = sessionsResponse([
+            sessionEntry(
+                key: "main",
+                updatedAt: 2,
+                totalTokens: 20,
+                totalTokensFresh: true,
+                contextTokens: 100),
+            sessionEntry(
+                key: "other",
+                updatedAt: 1,
+                totalTokens: 80,
+                totalTokensFresh: true,
+                contextTokens: 100),
+        ], ts: 1)
         let (_, vm) = await makeViewModel(
             historyResponses: [
                 historyPayload(sessionKey: "main", sessionId: "sess-main"),
@@ -6594,14 +6582,9 @@ struct ChatViewModelTests {
         let now = Date().timeIntervalSince1970 * 1000
         let recent = now - (30 * 60 * 1000)
         let history = historyPayload(sessionKey: "custom", sessionId: "sess-custom")
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 1,
-            defaults: nil,
-            sessions: [
-                sessionEntry(key: "main", updatedAt: recent),
-            ])
+        let sessions = sessionsResponse(
+            sessionEntry(key: "main", updatedAt: recent),
+            ts: now)
 
         let (_, vm) = await makeViewModel(
             sessionKey: "custom",
@@ -6619,37 +6602,19 @@ struct ChatViewModelTests {
         let recent = now - (30 * 60 * 1000)
         let recentOlder = now - (90 * 60 * 1000)
         let history = historyPayload(sessionKey: "Luke’s MacBook Pro", sessionId: "sess-main")
-        let sessions = OpenClawChatSessionsListResponse(
+        let sessions = sessionsResponse(
+            [
+                sessionEntry(
+                    key: "Luke’s MacBook Pro",
+                    updatedAt: recent,
+                    displayName: "Luke’s MacBook Pro"),
+                sessionEntry(key: "recent-1", updatedAt: recentOlder),
+            ],
             ts: now,
-            path: nil,
-            count: 2,
             defaults: OpenClawChatSessionsDefaults(
                 model: nil,
                 contextTokens: nil,
-                mainSessionKey: "Luke’s MacBook Pro"),
-            sessions: [
-                OpenClawChatSessionEntry(
-                    key: "Luke’s MacBook Pro",
-                    kind: nil,
-                    displayName: "Luke’s MacBook Pro",
-                    surface: nil,
-                    subject: nil,
-                    room: nil,
-                    space: nil,
-                    updatedAt: recent,
-                    sessionId: nil,
-                    systemSent: nil,
-                    abortedLastRun: nil,
-                    thinkingLevel: nil,
-                    verboseLevel: nil,
-                    inputTokens: nil,
-                    outputTokens: nil,
-                    totalTokens: nil,
-                    modelProvider: nil,
-                    model: nil,
-                    contextTokens: nil),
-                sessionEntry(key: "recent-1", updatedAt: recentOlder),
-            ])
+                mainSessionKey: "Luke’s MacBook Pro"))
 
         let (_, vm) = await makeViewModel(
             sessionKey: "Luke’s MacBook Pro",
@@ -6667,56 +6632,22 @@ struct ChatViewModelTests {
         let recent = now - (2 * 60 * 1000)
         let recentOlder = now - (5 * 60 * 1000)
         let history = historyPayload(sessionKey: "agent:main:main", sessionId: "sess-main")
-        let sessions = OpenClawChatSessionsListResponse(
+        let sessions = sessionsResponse(
+            [
+                sessionEntry(
+                    key: "agent:main:onboarding",
+                    updatedAt: recent,
+                    displayName: "Luke’s MacBook Pro"),
+                sessionEntry(
+                    key: "agent:main:main",
+                    updatedAt: recentOlder,
+                    displayName: "Luke’s MacBook Pro"),
+            ],
             ts: now,
-            path: nil,
-            count: 2,
             defaults: OpenClawChatSessionsDefaults(
                 model: nil,
                 contextTokens: nil,
-                mainSessionKey: "agent:main:main"),
-            sessions: [
-                OpenClawChatSessionEntry(
-                    key: "agent:main:onboarding",
-                    kind: nil,
-                    displayName: "Luke’s MacBook Pro",
-                    surface: nil,
-                    subject: nil,
-                    room: nil,
-                    space: nil,
-                    updatedAt: recent,
-                    sessionId: nil,
-                    systemSent: nil,
-                    abortedLastRun: nil,
-                    thinkingLevel: nil,
-                    verboseLevel: nil,
-                    inputTokens: nil,
-                    outputTokens: nil,
-                    totalTokens: nil,
-                    modelProvider: nil,
-                    model: nil,
-                    contextTokens: nil),
-                OpenClawChatSessionEntry(
-                    key: "agent:main:main",
-                    kind: nil,
-                    displayName: "Luke’s MacBook Pro",
-                    surface: nil,
-                    subject: nil,
-                    room: nil,
-                    space: nil,
-                    updatedAt: recentOlder,
-                    sessionId: nil,
-                    systemSent: nil,
-                    abortedLastRun: nil,
-                    thinkingLevel: nil,
-                    verboseLevel: nil,
-                    inputTokens: nil,
-                    outputTokens: nil,
-                    totalTokens: nil,
-                    modelProvider: nil,
-                    model: nil,
-                    contextTokens: nil),
-            ])
+                mainSessionKey: "agent:main:main"))
 
         let (_, vm) = await makeViewModel(
             sessionKey: "agent:main:main",
@@ -6735,17 +6666,13 @@ struct ChatViewModelTests {
                 chatTextMessage(role: "assistant", text: "before new", timestamp: 1),
             ])
         let after = historyPayload(sessionKey: "agent:aiden:ios-new", sessionId: nil, messages: [])
-        let sessions = OpenClawChatSessionsListResponse(
+        let sessions = sessionsResponse(
+            sessionEntry(key: "agent:aiden:main", updatedAt: 1),
             ts: nil,
-            path: nil,
-            count: 1,
             defaults: OpenClawChatSessionsDefaults(
                 model: nil,
                 contextTokens: nil,
-                mainSessionKey: "agent:aiden:main"),
-            sessions: [
-                sessionEntry(key: "agent:aiden:main", updatedAt: 1),
-            ])
+                mainSessionKey: "agent:aiden:main"))
 
         let (transport, vm) = await makeViewModel(
             historyResponses: [before, after],
@@ -7188,14 +7115,10 @@ struct ChatViewModelTests {
     @Test func `bootstraps model selection from session and defaults`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let history = historyPayload()
-        let sessions = OpenClawChatSessionsListResponse(
+        let sessions = sessionsResponse(
+            sessionEntry(key: "main", updatedAt: now, model: "anthropic/claude-opus-4-6"),
             ts: now,
-            path: nil,
-            count: 1,
-            defaults: OpenClawChatSessionsDefaults(model: "openai/gpt-4.1-mini", contextTokens: nil),
-            sessions: [
-                sessionEntry(key: "main", updatedAt: now, model: "anthropic/claude-opus-4-6"),
-            ])
+            defaults: OpenClawChatSessionsDefaults(model: "openai/gpt-4.1-mini", contextTokens: nil))
         let models = [
             modelChoice(id: "anthropic/claude-opus-4-6", name: "Claude Opus 4.6"),
             modelChoice(id: "openai/gpt-4.1-mini", name: "GPT-4.1 mini", provider: "openai"),
@@ -7223,14 +7146,10 @@ struct ChatViewModelTests {
     @Test func `selecting default model patches nil and updates selection`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let history = historyPayload()
-        let sessions = OpenClawChatSessionsListResponse(
+        let sessions = sessionsResponse(
+            sessionEntry(key: "main", updatedAt: now, model: "anthropic/claude-opus-4-6"),
             ts: now,
-            path: nil,
-            count: 1,
-            defaults: OpenClawChatSessionsDefaults(model: "openai/gpt-4.1-mini", contextTokens: nil),
-            sessions: [
-                sessionEntry(key: "main", updatedAt: now, model: "anthropic/claude-opus-4-6"),
-            ])
+            defaults: OpenClawChatSessionsDefaults(model: "openai/gpt-4.1-mini", contextTokens: nil))
         let models = [
             modelChoice(id: "anthropic/claude-opus-4-6", name: "Claude Opus 4.6"),
             modelChoice(id: "openai/gpt-4.1-mini", name: "GPT-4.1 mini", provider: "openai"),
@@ -7264,12 +7183,9 @@ struct ChatViewModelTests {
             modelChoice(id: "gpt-5.4", name: "GPT-5.4", provider: "openai"),
             modelChoice(id: "claude-opus-4-6", name: "Claude Opus 4.6"),
         ]
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 1,
-            defaults: nil,
-            sessions: [sessionEntry(key: "main", updatedAt: now, model: nil)])
+        let sessions = sessionsResponse(
+            sessionEntry(key: "main", updatedAt: now, model: nil),
+            ts: now)
         let (transport, vm) = await makeViewModel(
             historyResponses: [historyPayload()],
             sessionsResponses: [sessions],
@@ -7293,14 +7209,14 @@ struct ChatViewModelTests {
     @Test func `selecting provider qualified model disambiguates duplicate model I ds`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let history = historyPayload()
-        let sessions = OpenClawChatSessionsListResponse(
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: now,
+                model: "gpt-4.1-mini",
+                modelProvider: "openrouter"),
             ts: now,
-            path: nil,
-            count: 1,
-            defaults: OpenClawChatSessionsDefaults(model: "openrouter/gpt-4.1-mini", contextTokens: nil),
-            sessions: [
-                sessionEntry(key: "main", updatedAt: now, model: "gpt-4.1-mini", modelProvider: "openrouter"),
-            ])
+            defaults: OpenClawChatSessionsDefaults(model: "openrouter/gpt-4.1-mini", contextTokens: nil))
         let models = [
             modelChoice(id: "gpt-4.1-mini", name: "GPT-4.1 mini", provider: "openai"),
             modelChoice(id: "gpt-4.1-mini", name: "GPT-4.1 mini", provider: "openrouter"),
@@ -7326,14 +7242,9 @@ struct ChatViewModelTests {
     @Test func `slash model I ds stay provider qualified in selection and patch`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let history = historyPayload()
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 1,
-            defaults: nil,
-            sessions: [
-                sessionEntry(key: "agent:main:main", updatedAt: now, model: nil),
-            ])
+        let sessions = sessionsResponse(
+            sessionEntry(key: "agent:main:main", updatedAt: now, model: nil),
+            ts: now)
         let models = [
             modelChoice(
                 id: "openai/gpt-5.4",
@@ -7363,14 +7274,9 @@ struct ChatViewModelTests {
         let modelPickerStore = ChatModelPickerStore(defaults: defaults)
         let now = Date().timeIntervalSince1970 * 1000
         let history = historyPayload()
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 1,
-            defaults: nil,
-            sessions: [
-                sessionEntry(key: "main", updatedAt: now, model: nil),
-            ])
+        let sessions = sessionsResponse(
+            sessionEntry(key: "main", updatedAt: now, model: nil),
+            ts: now)
         let models = [
             modelChoice(id: "gpt-5.4", name: "GPT-5.4", provider: "openai"),
             modelChoice(id: "gpt-5.4-pro", name: "GPT-5.4 Pro", provider: "openai"),
@@ -7420,14 +7326,8 @@ struct ChatViewModelTests {
             sessionsResponses: [sessions],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "gpt-first",
-                    thinkingLevel: "high"),
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "gpt-second",
-                    thinkingLevel: "medium"),
+                openAIModelPatchResult("gpt-first", thinking: "high"),
+                openAIModelPatchResult("gpt-second", thinking: "medium"),
             ],
             setSessionModelHook: { model in
                 if model == "openai/gpt-first" {
@@ -7472,11 +7372,10 @@ struct ChatViewModelTests {
             sessionsResponses: [sessions],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "gpt-5.6-sol",
-                    thinkingLevel: "high",
-                    thinkingLevels: [thinkingOption("off"), thinkingOption("high"), thinkingOption("ultra")]),
+                openAIModelPatchResult(
+                    "gpt-5.6-sol",
+                    thinking: "high",
+                    levels: [thinkingOption("off"), thinkingOption("high"), thinkingOption("ultra")]),
             ],
             setSessionModelHook: { model in
                 if model == "openai/gpt-5.6-sol" {
@@ -7507,14 +7406,9 @@ struct ChatViewModelTests {
     @Test func `send waits for in flight model patch to finish`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let history = historyPayload()
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 1,
-            defaults: nil,
-            sessions: [
-                sessionEntry(key: "main", updatedAt: now, model: nil),
-            ])
+        let sessions = sessionsResponse(
+            sessionEntry(key: "main", updatedAt: now, model: nil),
+            ts: now)
         let models = [
             modelChoice(id: "gpt-5.4", name: "GPT-5.4", provider: "openai"),
         ]
@@ -7560,14 +7454,9 @@ struct ChatViewModelTests {
     @Test func `failed latest model selection does not replay after older completion finishes`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let history = historyPayload()
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 1,
-            defaults: nil,
-            sessions: [
-                sessionEntry(key: "main", updatedAt: now, model: nil),
-            ])
+        let sessions = sessionsResponse(
+            sessionEntry(key: "main", updatedAt: now, model: nil),
+            ts: now)
         let models = [
             modelChoice(id: "gpt-5.4", name: "GPT-5.4", provider: "openai"),
             modelChoice(id: "gpt-5.4-pro", name: "GPT-5.4 Pro", provider: "openai"),
@@ -7611,14 +7500,9 @@ struct ChatViewModelTests {
     @Test func `failed latest model selection restores earlier success without replay`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let history = historyPayload()
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 1,
-            defaults: nil,
-            sessions: [
-                sessionEntry(key: "main", updatedAt: now, model: nil),
-            ])
+        let sessions = sessionsResponse(
+            sessionEntry(key: "main", updatedAt: now, model: nil),
+            ts: now)
         let models = [
             modelChoice(id: "gpt-5.4", name: "GPT-5.4", provider: "openai"),
             modelChoice(id: "gpt-5.4-pro", name: "GPT-5.4 Pro", provider: "openai"),
@@ -8271,12 +8155,9 @@ struct ChatViewModelTests {
         let bootstrapHistoryGate = SessionSubscribeGate()
         let mainHistoryCount = AsyncCounter()
         let bootstrapHistoryReleasedCount = AsyncCounter()
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: Date().timeIntervalSince1970 * 1000,
-            path: nil,
-            count: 1,
-            defaults: nil,
-            sessions: [sessionEntry(key: "main", updatedAt: Date().timeIntervalSince1970 * 1000)])
+        let sessions = sessionsResponse(
+            sessionEntry(key: "main", updatedAt: Date().timeIntervalSince1970 * 1000),
+            ts: Date().timeIntervalSince1970 * 1000)
         let (transport, vm) = await makeViewModel(
             historyResponses: [
                 historyPayload(
@@ -8777,15 +8658,12 @@ struct ChatViewModelTests {
 
     @Test func `switching sessions ignores late model patch completion from previous session`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 2,
-            defaults: nil,
-            sessions: [
+        let sessions = sessionsResponse(
+            [
                 sessionEntry(key: "main", updatedAt: now, model: nil),
                 sessionEntry(key: "other", updatedAt: now - 1000, model: nil),
-            ])
+            ],
+            ts: now)
         let models = [
             modelChoice(id: "gpt-5.4", name: "GPT-5.4", provider: "openai"),
         ]
@@ -8836,14 +8714,9 @@ struct ChatViewModelTests {
     @Test func `late model patch updates captured canonical alias after agent switch`() async throws {
         let patchGate = AsyncGate()
         let now = Date().timeIntervalSince1970 * 1000
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 1,
-            defaults: nil,
-            sessions: [
-                sessionEntry(key: "agent:alpha:main", updatedAt: now, model: nil),
-            ])
+        let sessions = sessionsResponse(
+            sessionEntry(key: "agent:alpha:main", updatedAt: now, model: nil),
+            ts: now)
         let models = [
             modelChoice(id: "gpt-5.4", name: "GPT-5.4", provider: "openai"),
         ]
@@ -8969,14 +8842,8 @@ struct ChatViewModelTests {
             sessionsResponses: [alphaSessions, betaSessions],
             modelResponses: [models, models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "gpt-alpha",
-                    thinkingLevel: "high"),
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "gpt-beta",
-                    thinkingLevel: "medium"),
+                openAIModelPatchResult("gpt-alpha", thinking: "high"),
+                openAIModelPatchResult("gpt-beta", thinking: "medium"),
             ],
             setSessionModelHook: { model in
                 if model == "openai/gpt-alpha" {
@@ -9113,28 +8980,22 @@ struct ChatViewModelTests {
 
     @Test func `late model completion does not replay current session selection into previous session`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
-        let initialSessions = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 2,
-            defaults: nil,
-            sessions: [
+        let initialSessions = sessionsResponse(
+            [
                 sessionEntry(key: "main", updatedAt: now, model: nil),
                 sessionEntry(key: "other", updatedAt: now - 1000, model: nil),
-            ])
-        let sessionsAfterOtherSelection = OpenClawChatSessionsListResponse(
-            ts: now,
-            path: nil,
-            count: 2,
-            defaults: nil,
-            sessions: [
+            ],
+            ts: now)
+        let sessionsAfterOtherSelection = sessionsResponse(
+            [
                 sessionEntry(
                     key: "main",
                     updatedAt: now,
                     model: "gpt-5.4",
                     modelProvider: "openai"),
                 sessionEntry(key: "other", updatedAt: now - 1000, model: "openai/gpt-5.4-pro"),
-            ])
+            ],
+            ts: now)
         let models = [
             modelChoice(id: "gpt-5.4", name: "GPT-5.4", provider: "openai"),
             modelChoice(id: "gpt-5.4-pro", name: "GPT-5.4 Pro", provider: "openai"),
@@ -9197,11 +9058,7 @@ struct ChatViewModelTests {
     }
 
     @Test func `explicit thinking level wins over history and persists changes`() async throws {
-        let history = OpenClawChatHistoryPayload(
-            sessionKey: "main",
-            sessionId: "sess-main",
-            messages: [],
-            thinkingLevel: "off")
+        let history = historyPayloadWithoutRunState()
         let callbackState = await MainActor.run { CallbackBox() }
 
         let (transport, vm) = await makeViewModel(
@@ -9310,16 +9167,8 @@ struct ChatViewModelTests {
             sessionsResponses: [initialSessions],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "gpt-5.6-luna",
-                    thinkingLevel: "max",
-                    thinkingLevels: lunaLevels),
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "gpt-5.6-terra",
-                    thinkingLevel: "max",
-                    thinkingLevels: solLevels),
+                openAIModelPatchResult("gpt-5.6-luna", thinking: "max", levels: lunaLevels),
+                openAIModelPatchResult("gpt-5.6-terra", thinking: "max", levels: solLevels),
             ],
             listSessionsHook: { _ in
                 guard await gateNextList.current() > 0 else { return nil }
@@ -9396,10 +9245,7 @@ struct ChatViewModelTests {
             sessionsResponses: [sessions],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "legacy-reasoning",
-                    thinkingLevel: nil),
+                openAIModelPatchResult("legacy-reasoning", thinking: nil),
             ],
             initialThinkingLevel: "ultra")
 
@@ -9478,11 +9324,7 @@ struct ChatViewModelTests {
     }
 
     @Test func `server provided thinking levels outside menu are preserved for send`() async throws {
-        let history = OpenClawChatHistoryPayload(
-            sessionKey: "main",
-            sessionId: "sess-main",
-            messages: [],
-            thinkingLevel: "xhigh")
+        let history = historyPayloadWithoutRunState(thinkingLevel: "xhigh")
 
         let (transport, vm) = await makeViewModel(historyResponses: [history])
 
@@ -9544,15 +9386,22 @@ struct ChatViewModelTests {
     }
 
     @Test func `session thinking levels drive picker options`() async throws {
-        let history = OpenClawChatHistoryPayload(
-            sessionKey: "main",
-            sessionId: "sess-main",
-            messages: [],
-            thinkingLevel: "adaptive")
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: 1,
-            path: nil,
-            count: 1,
+        let history = historyPayloadWithoutRunState(thinkingLevel: "adaptive")
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                sessionId: "sess-main",
+                model: "claude-opus-4-7",
+                modelProvider: "anthropic",
+                thinkingLevel: "adaptive",
+                thinkingLevels: [
+                    thinkingOption("off"),
+                    thinkingOption("adaptive"),
+                    thinkingOption("max", label: "maximum"),
+                ],
+                thinkingOptions: ["off", "adaptive", "maximum"],
+                thinkingDefault: "adaptive"),
             defaults: OpenClawChatSessionsDefaults(
                 modelProvider: "openai",
                 model: "gpt-5.5",
@@ -9564,36 +9413,7 @@ struct ChatViewModelTests {
                     thinkingOption("max", label: "maximum"),
                 ],
                 thinkingOptions: ["off", "low", "xhigh", "maximum"],
-                thinkingDefault: "xhigh"),
-            sessions: [
-                OpenClawChatSessionEntry(
-                    key: "main",
-                    kind: nil,
-                    displayName: nil,
-                    surface: nil,
-                    subject: nil,
-                    room: nil,
-                    space: nil,
-                    updatedAt: 1,
-                    sessionId: "sess-main",
-                    systemSent: nil,
-                    abortedLastRun: nil,
-                    thinkingLevel: "adaptive",
-                    verboseLevel: nil,
-                    inputTokens: nil,
-                    outputTokens: nil,
-                    totalTokens: nil,
-                    modelProvider: "anthropic",
-                    model: "claude-opus-4-7",
-                    contextTokens: nil,
-                    thinkingLevels: [
-                        thinkingOption("off"),
-                        thinkingOption("adaptive"),
-                        thinkingOption("max", label: "maximum"),
-                    ],
-                    thinkingOptions: ["off", "adaptive", "maximum"],
-                    thinkingDefault: "adaptive"),
-            ])
+                thinkingDefault: "xhigh"))
 
         let (_, vm) = await makeViewModel(
             historyResponses: [history],
@@ -10018,41 +9838,16 @@ struct ChatViewModelTests {
     }
 
     @Test func `thinking options fallback and current unsupported level stay visible`() async throws {
-        let history = OpenClawChatHistoryPayload(
-            sessionKey: "main",
+        let history = historyPayloadWithoutRunState(thinkingLevel: "xhigh")
+        let sessions = sessionsResponse(sessionEntry(
+            key: "main",
+            updatedAt: 1,
             sessionId: "sess-main",
-            messages: [],
-            thinkingLevel: "xhigh")
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: 1,
-            path: nil,
-            count: 1,
-            defaults: nil,
-            sessions: [
-                OpenClawChatSessionEntry(
-                    key: "main",
-                    kind: nil,
-                    displayName: nil,
-                    surface: nil,
-                    subject: nil,
-                    room: nil,
-                    space: nil,
-                    updatedAt: 1,
-                    sessionId: "sess-main",
-                    systemSent: nil,
-                    abortedLastRun: nil,
-                    thinkingLevel: "xhigh",
-                    verboseLevel: nil,
-                    inputTokens: nil,
-                    outputTokens: nil,
-                    totalTokens: nil,
-                    modelProvider: "openrouter",
-                    model: "deepseek/deepseek-v4",
-                    contextTokens: nil,
-                    thinkingLevels: nil,
-                    thinkingOptions: ["off", "max"],
-                    thinkingDefault: "max"),
-            ])
+            model: "deepseek/deepseek-v4",
+            modelProvider: "openrouter",
+            thinkingLevel: "xhigh",
+            thinkingOptions: ["off", "max"],
+            thinkingDefault: "max"))
 
         let (_, vm) = await makeViewModel(
             historyResponses: [history],
@@ -10066,15 +9861,17 @@ struct ChatViewModelTests {
     }
 
     @Test func `matching default thinking levels beat legacy row thinking options`() async throws {
-        let history = OpenClawChatHistoryPayload(
-            sessionKey: "main",
-            sessionId: "sess-main",
-            messages: [],
-            thinkingLevel: "adaptive")
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: 1,
-            path: nil,
-            count: 1,
+        let history = historyPayloadWithoutRunState(thinkingLevel: "adaptive")
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                sessionId: "sess-main",
+                model: "claude-opus-4-7",
+                modelProvider: "anthropic",
+                thinkingLevel: "adaptive",
+                thinkingOptions: ["off"],
+                thinkingDefault: "off"),
             defaults: OpenClawChatSessionsDefaults(
                 modelProvider: "anthropic",
                 model: "claude-opus-4-7",
@@ -10085,32 +9882,7 @@ struct ChatViewModelTests {
                     thinkingOption("max"),
                 ],
                 thinkingOptions: ["off", "adaptive", "max"],
-                thinkingDefault: "adaptive"),
-            sessions: [
-                OpenClawChatSessionEntry(
-                    key: "main",
-                    kind: nil,
-                    displayName: nil,
-                    surface: nil,
-                    subject: nil,
-                    room: nil,
-                    space: nil,
-                    updatedAt: 1,
-                    sessionId: "sess-main",
-                    systemSent: nil,
-                    abortedLastRun: nil,
-                    thinkingLevel: "adaptive",
-                    verboseLevel: nil,
-                    inputTokens: nil,
-                    outputTokens: nil,
-                    totalTokens: nil,
-                    modelProvider: "anthropic",
-                    model: "claude-opus-4-7",
-                    contextTokens: nil,
-                    thinkingLevels: nil,
-                    thinkingOptions: ["off"],
-                    thinkingDefault: "off"),
-            ])
+                thinkingDefault: "adaptive"))
 
         let (_, vm) = await makeViewModel(
             historyResponses: [history],
@@ -10122,15 +9894,15 @@ struct ChatViewModelTests {
     }
 
     @Test func `default thinking levels do not leak to different session model`() async throws {
-        let history = OpenClawChatHistoryPayload(
-            sessionKey: "main",
-            sessionId: "sess-main",
-            messages: [],
-            thinkingLevel: "max")
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: 1,
-            path: nil,
-            count: 1,
+        let history = historyPayloadWithoutRunState(thinkingLevel: "max")
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                sessionId: "sess-main",
+                model: "gpt-5.4",
+                modelProvider: "openai",
+                thinkingLevel: "max"),
             defaults: OpenClawChatSessionsDefaults(
                 modelProvider: "anthropic",
                 model: "claude-opus-4-7",
@@ -10141,29 +9913,7 @@ struct ChatViewModelTests {
                     thinkingOption("max"),
                 ],
                 thinkingOptions: ["off", "adaptive", "max"],
-                thinkingDefault: "adaptive"),
-            sessions: [
-                OpenClawChatSessionEntry(
-                    key: "main",
-                    kind: nil,
-                    displayName: nil,
-                    surface: nil,
-                    subject: nil,
-                    room: nil,
-                    space: nil,
-                    updatedAt: 1,
-                    sessionId: "sess-main",
-                    systemSent: nil,
-                    abortedLastRun: nil,
-                    thinkingLevel: "max",
-                    verboseLevel: nil,
-                    inputTokens: nil,
-                    outputTokens: nil,
-                    totalTokens: nil,
-                    modelProvider: "openai",
-                    model: "gpt-5.4",
-                    contextTokens: nil),
-            ])
+                thinkingDefault: "adaptive"))
 
         let (_, vm) = await makeViewModel(
             historyResponses: [history],
@@ -10177,11 +9927,7 @@ struct ChatViewModelTests {
     }
 
     @Test func `thinking patches are serialized without replay`() async throws {
-        let history = OpenClawChatHistoryPayload(
-            sessionKey: "main",
-            sessionId: "sess-main",
-            messages: [],
-            thinkingLevel: "off")
+        let history = historyPayloadWithoutRunState()
 
         let (transport, vm) = await makeViewModel(
             historyResponses: [history],
@@ -10259,7 +10005,7 @@ struct ChatViewModelTests {
         let patchStarted = AsyncGate()
         let patchGate = AsyncGate()
         let preferenceChanges = await MainActor.run { OptionalCallbackBox() }
-        let sessions = sessionsListResponse([
+        let sessions = sessionsResponse([
             sessionEntry(key: "main", updatedAt: 2, model: nil, thinkingLevel: "high"),
             sessionEntry(key: "other", updatedAt: 1, model: nil, thinkingLevel: "off"),
         ])
@@ -10299,7 +10045,7 @@ struct ChatViewModelTests {
     @Test func `older pending thinking choice becomes preference fallback`() async throws {
         let firstPatchGate = AsyncGate()
         let callbacks = await MainActor.run { CallbackBox() }
-        let sessions = sessionsListResponse([
+        let sessions = sessionsResponse([
             sessionEntry(key: "main", updatedAt: 2, model: nil, thinkingLevel: "off"),
             sessionEntry(key: "other", updatedAt: 1, model: nil, thinkingLevel: "off"),
         ])
@@ -10500,15 +10246,12 @@ struct ChatViewModelTests {
         let firstPatchGate = AsyncGate()
         let patchCount = AsyncCounter()
         let callbacks = await MainActor.run { CallbackBox() }
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: 1,
-            path: nil,
-            count: 2,
-            defaults: nil,
-            sessions: [
+        let sessions = sessionsResponse(
+            [
                 sessionEntry(key: "main", updatedAt: 2, model: nil, verboseLevel: "off"),
                 sessionEntry(key: "other", updatedAt: 1, model: nil, verboseLevel: "off"),
-            ])
+            ],
+            ts: 1)
         let (_, vm) = await makeViewModel(
             historyResponses: [
                 historyPayload(sessionKey: "main", sessionId: "sess-main"),
@@ -10557,15 +10300,12 @@ struct ChatViewModelTests {
     @Test func `failed verbosity choices restore confirmed preference across sessions`() async throws {
         let firstPatchGate = AsyncGate()
         let callbacks = await MainActor.run { CallbackBox() }
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: 1,
-            path: nil,
-            count: 2,
-            defaults: nil,
-            sessions: [
+        let sessions = sessionsResponse(
+            [
                 sessionEntry(key: "main", updatedAt: 2, model: nil),
                 sessionEntry(key: "other", updatedAt: 1, model: nil),
-            ])
+            ],
+            ts: 1)
         let (_, vm) = await makeViewModel(
             historyResponses: [
                 historyPayload(sessionKey: "main", sessionId: "sess-main"),
@@ -10778,11 +10518,7 @@ struct ChatViewModelTests {
             historyResponses: [historyPayload(sessionId: "sess-main")],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "model-b",
-                    thinkingLevel: "off",
-                    thinkingLevels: levels),
+                openAIModelPatchResult("model-b", thinking: "off", levels: levels),
             ],
             setSessionThinkingHook: { _ in
                 throw NSError(
@@ -10842,11 +10578,7 @@ struct ChatViewModelTests {
             historyResponses: [historyPayload(sessionId: "sess-main")],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "model-b",
-                    thinkingLevel: "high",
-                    thinkingLevels: levels),
+                openAIModelPatchResult("model-b", thinking: "high", levels: levels),
             ],
             setSessionModelHook: { _ in
                 await modelPatchStarted.open()
@@ -10905,18 +10637,10 @@ struct ChatViewModelTests {
             historyResponses: [historyPayload(sessionId: "sess-main")],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "model-b",
-                    thinkingLevel: "off",
-                    thinkingLevels: levels),
+                openAIModelPatchResult("model-b", thinking: "off", levels: levels),
             ],
             thinkingPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "model-b",
-                    thinkingLevel: "high",
-                    thinkingLevels: levels),
+                openAIModelPatchResult("model-b", thinking: "high", levels: levels),
             ],
             setSessionThinkingHook: { _ in
                 await thinkingPatchStarted.open()
@@ -11041,11 +10765,7 @@ struct ChatViewModelTests {
             historyResponses: [historyPayload(sessionId: "sess-main")],
             sessionsResponses: [sessions],
             thinkingPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "gpt-sol",
-                    thinkingLevel: "high",
-                    thinkingLevels: levels),
+                openAIModelPatchResult("gpt-sol", thinking: "high", levels: levels),
             ],
             onThinkingLevelChanged: { level in
                 callbackState.values.append(level)
@@ -11081,11 +10801,7 @@ struct ChatViewModelTests {
             sessionsResponses: [sessions],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "gpt-luna",
-                    thinkingLevel: "max",
-                    thinkingLevels: lunaLevels),
+                openAIModelPatchResult("gpt-luna", thinking: "max", levels: lunaLevels),
             ],
             setSessionThinkingHook: { _ in
                 throw NSError(
@@ -11141,11 +10857,7 @@ struct ChatViewModelTests {
             sessionsResponses: [initialSessions, refreshedSessions],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "model-b",
-                    thinkingLevel: "high",
-                    thinkingLevels: oldLevels),
+                openAIModelPatchResult("model-b", thinking: "high", levels: oldLevels),
             ])
 
         try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
@@ -11186,11 +10898,7 @@ struct ChatViewModelTests {
             sessionsResponses: [sessions],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "model-b",
-                    thinkingLevel: "high",
-                    thinkingLevels: levels),
+                openAIModelPatchResult("model-b", thinking: "high", levels: levels),
             ],
             setSessionModelHook: { model in
                 guard model == "openai/model-b" else { return }
@@ -11244,11 +10952,7 @@ struct ChatViewModelTests {
             sessionsResponses: [sessions],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "model-b",
-                    thinkingLevel: "off",
-                    thinkingLevels: levels),
+                openAIModelPatchResult("model-b", thinking: "off", levels: levels),
             ],
             acquireSessionSettingsRouteLeaseHook: {
                 guard await captureCount.increment() == 1 else { return }
@@ -11287,10 +10991,7 @@ struct ChatViewModelTests {
             sessionsResponses: [sessions],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "model-b",
-                    thinkingLevel: "off"),
+                openAIModelPatchResult("model-b", thinking: "off"),
             ],
             setSessionModelHook: { model in
                 guard model == "openai/model-b" else { return }
@@ -11341,11 +11042,7 @@ struct ChatViewModelTests {
             sessionsResponses: [sessions],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "model-b",
-                    thinkingLevel: "off",
-                    thinkingLevels: levels),
+                openAIModelPatchResult("model-b", thinking: "off", levels: levels),
             ],
             setSessionModelHook: { model in
                 guard model == "openai/model-b" else { return }
@@ -11386,12 +11083,8 @@ struct ChatViewModelTests {
     @Test func `stale settings lease rolls back an inactive session target`() async throws {
         let modelPatchGate = AsyncGate()
         let modelPatchStarted = AsyncGate()
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: 2,
-            path: nil,
-            count: 2,
-            defaults: nil,
-            sessions: [
+        let sessions = sessionsResponse(
+            [
                 sessionEntry(
                     key: "main",
                     updatedAt: 2,
@@ -11399,7 +11092,8 @@ struct ChatViewModelTests {
                     modelProvider: "openai",
                     thinkingLevel: "off"),
                 sessionEntry(key: "other", updatedAt: 1, model: nil, thinkingLevel: "off"),
-            ])
+            ],
+            ts: 2)
         let models = [
             modelChoice(id: "model-a", name: "A", provider: "openai", reasoning: true),
             modelChoice(id: "model-b", name: "B", provider: "openai", reasoning: true),
@@ -11412,10 +11106,7 @@ struct ChatViewModelTests {
             sessionsResponses: [sessions, sessions],
             modelResponses: [models],
             modelPatchResults: [
-                OpenClawChatModelPatchResult(
-                    modelProvider: "openai",
-                    model: "model-b",
-                    thinkingLevel: "off"),
+                openAIModelPatchResult("model-b", thinking: "off"),
             ],
             setSessionModelHook: { model in
                 guard model == "openai/model-b" else { return }
@@ -11451,7 +11142,7 @@ struct ChatViewModelTests {
         let mainKey = "agent:alpha:main"
         let otherKey = "agent:alpha:other"
         let contract = "per-sender|main|alpha"
-        let sessions = sessionsListResponse([
+        let sessions = sessionsResponse([
             sessionEntry(key: mainKey, updatedAt: 2, model: nil, thinkingLevel: "off"),
             sessionEntry(key: otherKey, updatedAt: 1, model: nil, thinkingLevel: "off"),
         ])
@@ -11494,15 +11185,12 @@ struct ChatViewModelTests {
 
     @Test func `late thinking completion does not replace the current session choice`() async throws {
         let firstPatchGate = AsyncGate()
-        let sessions = OpenClawChatSessionsListResponse(
-            ts: 2,
-            path: nil,
-            count: 2,
-            defaults: nil,
-            sessions: [
+        let sessions = sessionsResponse(
+            [
                 sessionEntry(key: "main", updatedAt: 2, model: nil, thinkingLevel: "off"),
                 sessionEntry(key: "other", updatedAt: 1, model: nil, thinkingLevel: "off"),
-            ])
+            ],
+            ts: 2)
         let (transport, vm) = await makeViewModel(
             historyResponses: [
                 historyPayload(sessionKey: "main", sessionId: "sess-main"),
@@ -11543,7 +11231,7 @@ struct ChatViewModelTests {
         let firstPatchGate = AsyncGate()
         let alphaSessions = sessionsResponse(
             sessionEntry(key: "agent:alpha:main", updatedAt: 1, model: nil, thinkingLevel: "off"))
-        let betaSessions = sessionsListResponse([
+        let betaSessions = sessionsResponse([
             sessionEntry(key: "agent:beta:main", updatedAt: 3, model: nil, thinkingLevel: "high"),
             sessionEntry(key: "agent:beta:other", updatedAt: 2, model: nil, thinkingLevel: "off"),
         ])
@@ -11635,9 +11323,7 @@ struct ChatViewModelTests {
     }
 
     @Test func `strips inbound metadata from history messages`() async throws {
-        let history = OpenClawChatHistoryPayload(
-            sessionKey: "main",
-            sessionId: "sess-main",
+        let history = historyPayloadWithoutRunState(
             messages: [
                 AnyCodable([
                     "role": "user",
@@ -11651,8 +11337,7 @@ struct ChatViewModelTests {
                     """]],
                     "timestamp": Date().timeIntervalSince1970 * 1000,
                 ]),
-            ],
-            thinkingLevel: "off")
+            ])
         let transport = TestChatTransport(historyResponses: [history])
         let vm = await MainActor.run { OpenClawChatViewModel(sessionKey: "main", transport: transport) }
 
@@ -11723,11 +11408,11 @@ struct ChatViewModelSessionManagementTests {
     }
 
     @Test func `pin patches transport and reorders optimistically`() async throws {
-        let initial = sessionsListResponse([
+        let initial = sessionsResponse([
             sessionEntry(key: "agent:main:topic-a", updatedAt: 200),
             sessionEntry(key: "agent:main:topic-b", updatedAt: 100),
         ])
-        let pinned = sessionsListResponse([
+        let pinned = sessionsResponse([
             sessionEntry(key: "agent:main:topic-b", updatedAt: 100, pinned: true, pinnedAt: 300),
             sessionEntry(key: "agent:main:topic-a", updatedAt: 200),
         ])
@@ -11754,12 +11439,12 @@ struct ChatViewModelSessionManagementTests {
     }
 
     @Test func `rename patches label optimistically and reverts on failure`() async throws {
-        let initial = sessionsListResponse([
+        let initial = sessionsResponse([
             sessionEntry(key: "agent:main:topic-a", updatedAt: 200, displayName: "Old name"),
         ])
         // The post-rename refresh must return the renamed row; otherwise the
         // refetch legitimately repaints the old name and races the assertions.
-        let renamed = sessionsListResponse([
+        let renamed = sessionsResponse([
             sessionEntry(
                 key: "agent:main:topic-a",
                 updatedAt: 200,
@@ -11801,11 +11486,11 @@ struct ChatViewModelSessionManagementTests {
     }
 
     @Test func `archive removes the session from the active list`() async throws {
-        let initial = sessionsListResponse([
+        let initial = sessionsResponse([
             sessionEntry(key: "agent:main:topic-a", updatedAt: 200),
             sessionEntry(key: "agent:main:topic-b", updatedAt: 100),
         ])
-        let afterArchive = sessionsListResponse([
+        let afterArchive = sessionsResponse([
             sessionEntry(key: "agent:main:topic-a", updatedAt: 200),
         ])
         let (transport, vm) = await makeViewModel(
@@ -11830,7 +11515,7 @@ struct ChatViewModelSessionManagementTests {
         let (transport, vm) = await makeViewModel(
             historyResponses: [historyPayload()],
             listSessionsHook: { query in
-                query.archived == true ? sessionsListResponse([archivedEntry]) : nil
+                query.archived == true ? sessionsResponse([archivedEntry]) : nil
             })
 
         let archivedRows = await vm.fetchSessionList(search: nil, archived: true)
@@ -11862,7 +11547,7 @@ struct ChatViewModelSessionManagementTests {
     }
 
     @Test func `fetchSessionList falls back to local filtering when the server is unreachable`() async throws {
-        let cached = sessionsListResponse([
+        let cached = sessionsResponse([
             sessionEntry(key: "agent:main:topic-a", updatedAt: 2, displayName: "Trip planning"),
             sessionEntry(key: "agent:main:topic-b", updatedAt: 1, displayName: "Groceries"),
         ])


### PR DESCRIPTION
## What Problem This Solves

The ChatViewModel test suite had regrown hundreds of lines of repeated low-level session, history, and model-patch constructors. That duplication made fixture contract changes require many parallel edits and increased the chance that semantically identical tests would drift.

This is part of the maintainer-directed 50k cleanup campaign.

## Why This Change Was Made

Consolidates repeated setup into canonical local fixture helpers while preserving every test declaration, assertion, explicit response timestamp, session identifier, and absence or presence of run-state metadata. The change is confined to test code.

## User Impact

No runtime behavior changes. Maintainers get a smaller, more consistent ChatViewModel test surface with 315 fewer net lines.

## Evidence

- Exact rebased-head focused test: `swift test --package-path apps/shared/OpenClawKit --filter ChatViewModelTests` — 271 tests in 2 suites passed.
- Structural conservation: 271 test declarations before and after (SHA-256 `0af74aa7c55453d33fc5bf249cca8238e2902db82941f21ea7a8e3e07a3f54de`); 592 assertion markers before and after (SHA-256 `5f2c0fa6afa7750dfdc93bf6edc75881d4b2ad67c2b940d6cf7eb175eab33d80`); no changed `@Test`, `#expect`, or `#require` lines.
- Blacksmith Testbox changed gate passed: lease `tbx_01kz2qgfskc1ntmca0s3qvpdjr`, [run 30779592524](https://github.com/openclaw/openclaw/actions/runs/30779592524).
- Fresh branch review: Codex `gpt-5.6-sol`, xhigh reasoning, no actionable findings, confidence 0.99.
- Diff: test code +251/−566 (net −315); production code 0.
- `swiftformat` and `git diff --check` passed.

AI-assisted: yes. I reviewed the complete diff and understand the fixture equivalence and preserved async ordering.