### PR TITLE
fix(agents): answer /btw side questions on gateway-hosted sessions

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -18,6 +18,7 @@ const parseSessionEntriesMock = vi.fn();
 const migrateSessionEntriesMock = vi.fn();
 const buildSessionContextMock = vi.fn();
 const ensureOpenClawModelsJsonMock = vi.fn();
+const loadPreparedModelRuntimeSnapshotMock = vi.fn();
 const discoverAuthStorageMock = vi.fn();
 const discoverModelsMock = vi.fn();
 const getModelRegistryRuntimeMock = vi.fn();
@@ -95,7 +96,9 @@ vi.mock("./prepared-model-runtime.js", () => ({
     config: unknown;
     inheritedAuthDir?: string;
     workspaceDir?: string;
+    allowGatewaySubagentBinding?: boolean;
   }) => {
+    loadPreparedModelRuntimeSnapshotMock(params);
     const workspaceOptions = params.workspaceDir ? { workspaceDir: params.workspaceDir } : {};
     await ensureOpenClawModelsJsonMock(params.config, params.agentDir, workspaceOptions);
     const authStorage = discoverAuthStorageMock(params.agentDir, {
@@ -575,6 +578,7 @@ describe("runBtwSideQuestion", () => {
     migrateSessionEntriesMock.mockReset();
     buildSessionContextMock.mockReset();
     ensureOpenClawModelsJsonMock.mockReset();
+    loadPreparedModelRuntimeSnapshotMock.mockReset();
     discoverAuthStorageMock.mockReset();
     discoverModelsMock.mockReset();
     getModelRegistryRuntimeMock.mockReset();
@@ -750,6 +754,35 @@ describe("runBtwSideQuestion", () => {
       config: ensureArgs?.[0],
       workspaceDir: "/tmp/workspace",
     });
+  });
+
+  it("resolves the prepared runtime the way gateway-published owners are keyed", async () => {
+    // Gateway startup publishes configured owners with allowGatewaySubagentBinding
+    // (server-startup-post-attach.ts), and that flag is part of the owner key
+    // (prepared-model-runtime.owner.ts). A gateway-hosted BTW request that omits
+    // it matches no owner, and standalone activation is refused while the gateway
+    // lifecycle is active, so the side question fails with "owner was not published".
+    mockDoneAnswer("Final answer.");
+
+    await runSideQuestion({ allowGatewaySubagentBinding: true });
+
+    expect(mockCall(loadPreparedModelRuntimeSnapshotMock)?.[0]).toMatchObject({
+      agentDir: DEFAULT_AGENT_DIR,
+      allowGatewaySubagentBinding: true,
+    });
+  });
+
+  it("keeps gateway subagent binding off for local callers such as the embedded TUI", async () => {
+    // The embedded TUI calls runBtwSideQuestion directly and must not borrow the
+    // active registry's subagent and node capabilities, so the flag stays unset
+    // unless a gateway-hosted caller opts in.
+    mockDoneAnswer("Final answer.");
+
+    await runSideQuestion();
+
+    expect(mockCall(loadPreparedModelRuntimeSnapshotMock)?.[0]).not.toHaveProperty(
+      "allowGatewaySubagentBinding",
+    );
   });
 
   it("routes Codex-selected BTW questions through the harness side-question hook", async () => {

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -591,6 +591,12 @@ type RunBtwSideQuestionParams = {
   sessionStore?: Record<string, StoredSessionEntry>;
   sessionKey?: string;
   sandboxSessionKey?: string;
+  /**
+   * Set by gateway-hosted callers so the prepared runtime resolves the owner the
+   * gateway published. Left unset by local callers such as the embedded TUI,
+   * which must not borrow the active registry's subagent and node capabilities.
+   */
+  allowGatewaySubagentBinding?: boolean;
   storePath?: string;
   resolvedThinkLevel?: ThinkLevel;
   resolvedReasoningLevel: ReasoningLevel;
@@ -715,6 +721,9 @@ export async function runBtwSideQuestion(
     agentDir: params.agentDir,
     inheritedAuthDir: resolveDefaultAgentDir(params.cfg),
     workspaceDir: requestedWorkspaceDir,
+    // Gateway-published owners are keyed with this flag, so a gateway-hosted
+    // request that omits it can never match one.
+    ...(params.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true as const } : {}),
   });
   const sessionAgentId =
     preparedModelRuntime.agentId ??

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -136,6 +136,7 @@ vi.mock("../logging/subsystem.js", () => ({
 import {
   acquireAgentRunPreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
+  loadPreparedModelRuntimeSnapshot,
   prepareModelRuntimeSnapshot,
   publishPreparedModelRuntimeSnapshot,
   refreshPreparedModelRuntimeSnapshots,
@@ -245,6 +246,34 @@ describe("prepared model runtime owner selection", () => {
 
     expect(snapshot.workspaceDir).toBe("/tmp/gateway-launch-workspace");
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+  });
+
+  it("resolves a gateway-published owner only for requests carrying the binding flag", async () => {
+    // Gateway startup publishes configured owners with allowGatewaySubagentBinding,
+    // and that flag is part of the owner key. A request that omits it matches no
+    // owner, and standalone activation stays refused while the lifecycle is active.
+    mocks.configuredAgentIds = ["default"];
+    const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      allowGatewaySubagentBinding: true,
+      catalogMode: "static",
+      gatewayLifecycle: true,
+      defaultWorkspaceDir: "/tmp/gateway-launch-workspace",
+    });
+    const request = {
+      config,
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      workspaceDir: "/tmp/gateway-launch-workspace",
+    };
+
+    await expect(
+      loadPreparedModelRuntimeSnapshot({ ...request, allowGatewaySubagentBinding: true }),
+    ).resolves.toMatchObject({ config });
+    await expect(loadPreparedModelRuntimeSnapshot(request)).rejects.toThrow(
+      "prepared model runtime owner was not published",
+    );
   });
 
   it("reuses the configured owner for its prepared plugin harness selections", async () => {

--- a/src/auto-reply/reply/commands-btw.ts
+++ b/src/auto-reply/reply/commands-btw.ts
@@ -87,6 +87,7 @@ export const handleBtwCommand: CommandHandler = defineAuthorizedTextCommand(
           sessionEntry: targetSessionEntry,
           sessionStore: params.sessionStore,
           sessionKey: params.sessionKey,
+          allowGatewaySubagentBinding: true,
           ...(params.ctx.RuntimePolicySessionKey
             ? { sandboxSessionKey: params.ctx.RuntimePolicySessionKey }
             : {}),

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -958,6 +958,35 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
+  it("keeps gateway subagent binding off for embedded /btw side questions", async () => {
+    // The embedded TUI runs the side question locally, so it must not borrow the
+    // active registry's subagent and node capabilities. Only gateway-hosted
+    // callers opt into allowGatewaySubagentBinding.
+    loadSessionEntryMock.mockReturnValue({
+      cfg: {},
+      canonicalKey: "global",
+      storePath: "/tmp/openclaw-btw-sessions.json",
+      store: {},
+      entry: { sessionId: "session-btw-local" },
+    });
+    runBtwSideQuestionMock.mockResolvedValueOnce({ text: "side done" });
+
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "global",
+      message: "/btw local only",
+      runId: "run-btw-local",
+    });
+    await vi.waitFor(() => expect(runBtwSideQuestionMock).toHaveBeenCalledTimes(1));
+    await backend.stop();
+
+    expect(runBtwSideQuestionMock.mock.calls[0]?.[0]).not.toHaveProperty(
+      "allowGatewaySubagentBinding",
+    );
+  });
+
   it("reports the newest matching non-BTW local run in embedded history", async () => {
     loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
       cfg: {},


### PR DESCRIPTION
Closes #118395

## What Problem This Solves

Fixes an issue where users running a gateway would see every `/btw` side question fail
instantly with `⚠️ /btw failed: prepared model runtime owner was not published for <agentDir>`,
while the main agent turn on the same session kept working. This affected every gateway-hosted
session on current main, regardless of provider or model; only the embedded TUI was unaffected.

## Why This Change Was Made

`/btw` resolved its prepared model runtime without `allowGatewaySubagentBinding`, but that flag
became part of the prepared-runtime owner identity in #117587, and gateway startup publishes
configured owners with it set. The request therefore matched no published owner, and standalone
activation is deliberately refused while the gateway lifecycle owns configured identities — so
resolution failed before any side-question work was dispatched. The fix passes the flag,
matching what the gateway publishes and what the agent RPC path already sends; the two paths
now resolve the same owner. No owner-keying or lifecycle behavior is changed.

## User Impact

`/btw` answers side questions again on gateway-hosted sessions, using the same prepared runtime
as the main conversation. Embedded TUI behavior is unchanged.

## Evidence

Two focused tests, both of which fail without the one-line change:

- `src/agents/btw.test.ts` — "resolves the prepared runtime the way gateway-published owners
  are keyed" pins the input `/btw` sends, which is the regression itself. This is the test that
  goes red when the fix is reverted.
- `src/agents/prepared-model-runtime.owner-selection.test.ts` — "resolves a gateway-published
  owner only for requests carrying the binding flag" exercises real owner resolution: it
  publishes configured owners the way gateway startup does (`gatewayLifecycle: true`,
  `allowGatewaySubagentBinding: true`, static catalog), then asserts the request resolves with
  the flag and still throws `prepared model runtime owner was not published` without it. This
  documents the constraint that was silently broken.

Neither test needs a model or network.

```
# fix reverted
× resolves the prepared runtime the way gateway-published owners are keyed
  Tests  1 failed | 74 passed (75)

# fix applied
  Tests  75 passed (75)
```

The blind spot that let this ship is that gateway tests mock `runBtwSideQuestion`
(`src/gateway/test-helpers.mocks.ts:256-261`) and `btw.test.ts` mocks the whole
`prepared-model-runtime` module, so nothing exercised real owner resolution on this path. The
second test closes that gap at the owner-selection layer.


### Review follow-up: the binding grant is scoped to the gateway caller

The prepared-runtime binding grant is scoped to the caller that actually needs it.
`runBtwSideQuestion` is shared: the gateway `/btw` command handler reaches it through
channel ingress, while the embedded TUI calls it directly and in-process. Granting
`allowGatewaySubagentBinding` inside the shared helper would have let embedded-TUI side
questions borrow the active registry's subagent and node capabilities, which the local
path must not gain by default. The flag is therefore an explicit optional parameter on
`runBtwSideQuestion`, passed as `true` only from `src/auto-reply/reply/commands-btw.ts`
and left unset by `src/tui/embedded-backend.ts`. The auto-reply command handler is the
right place for that grant because it is already the repo's gateway-scoped authority
layer — sibling handlers `commands-compact.ts:270` and `commands-system-prompt.ts:207`
set the same flag at the same layer — so the grant stays visible in the caller's own
source rather than being inferred from global lifecycle state, and any future
non-gateway caller inherits the safe default.

Three regression pins, each red in a different direction: the gateway case must pass the
flag (`btw.test.ts`), the helper must not add it on its own (`btw.test.ts`, the P1), and
the embedded TUI call site must not pass it (`embedded-backend.test.ts`):

```text
unconditional grant restored -> keeps gateway subagent binding off for local callers   FAIL
TUI caller wrongly opts in   -> keeps gateway subagent binding off for embedded /btw   FAIL
flag dropped entirely        -> resolves the prepared runtime the way gateway owners.. FAIL
as submitted                 -> agents-core 76/76, tui 88/88, owner-selection 40/40    PASS
```

## After-fix live proof (real gateway, real Codex app-server)

Same lane as the issue repro: an in-process gateway (token auth, codex plugin, real
`codex-cli 0.146.0` app-server behind a transparent stdio tee that captures the JSON-RPC
stream), one real attempt turn, then `/btw` in the same session. Recorded **before** on the
unmodified base and **after** with only this PR's one-line change applied. Paths/ids
redacted.

**Before** — `/btw` fails instantly; the side question never reaches the app-server
(`thread/fork`: 0 occurrences in the capture):

```json
{"type":"event","event":"chat.side_result","payload":{"kind":"btw",
 "runId":"idem-[UUID]-relay-proof-side","sessionKey":"agent:dev:relay-proof-baseline",
 "question":"Reply with exactly RELAY-SIDE-BASELINE-[NONCE] and nothing else.",
 "text":"⚠️ /btw failed: prepared model runtime owner was not published for [STATE_DIR]/agents/dev/agent",
 "isError":true,"ts":"[TS]","seq":1},"seq":83}
```

```text
FAIL src/gateway/... > sends the resolved native hook relay overlay to a real Codex app-server
Error: timed out waiting for side-question echo RELAY-SIDE-BASELINE-[NONCE]
```

**After** — the same `/btw` answers; the reply surfaces as a success `chat.side_result`
frame and the fork reaches the app-server:

```text
receipt.sideQuestion: {"echoToken":"RELAY-SIDE-BASELINE-D744BA","source":"gateway-side-result",
                      "text":"RELAY-SIDE-BASELINE-D744BA"}
```

`thread/fork` present in the app-server JSON-RPC capture (was 0 before the fix):

```text
method=thread/fork id=8
params keys: [approvalPolicy, approvalsReviewer, config, cwd, developerInstructions,
              ephemeral, model, sandbox, threadId, threadSource]
config keys: [..., features.hooks, hooks.PermissionRequest, hooks.PostToolUse,
              hooks.PreToolUse, hooks.Stop, hooks.state, ...]
```

Repeated across four independent gateway sessions (four modes of a live capture lane);
all four completed their `/btw` round trip and echoed their nonce:

```text
baseline         Tests 1 passed — side echo RELAY-SIDE-BASELINE-D744BA
disabled-never   Tests 1 passed
disabled-active  Tests 1 passed — side echo RELAY-SIDE-DISABLED-ACTIVE-28C0B5 (via app-server capture)
scoped-active    Tests 1 passed
```

The only delta between the failing and passing recordings is this PR's one-line change in
`src/agents/btw.ts`.

### For the reviewer's environment

- Submitted head: `eb510cbd3d` (single commit over current `main`).
- The repository's sibling-checkout gate for Codex-related work:

```bash
git clone --filter=blob:none https://github.com/openai/codex.git ../codex
```

(This PR touches no Codex protocol surface — the fix and its tests live entirely in
OpenClaw's prepared-runtime owner selection and `/btw` plumbing; the app-server capture in
the proof merely demonstrates the side question reaching the harness.)
