### PR TITLE
perf(agents): carry prepared plugin load context into per-attempt tool construction

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -1059,6 +1059,7 @@ describe("createOpenClawCodingTools", () => {
     const resolvePluginToolsSpy = vi
       .spyOn(openClawPluginTools, "resolveOpenClawPluginToolsForOptions")
       .mockReturnValue([]);
+    const preparedModelRuntime = { metadataSnapshot: {} } as never;
 
     try {
       createOpenClawCodingTools({
@@ -1069,6 +1070,7 @@ describe("createOpenClawCodingTools", () => {
         modelId: "openrouter/auto",
         nativeChannelId: "oc_native_chat",
         clientCaps: ["inline-widgets"],
+        preparedModelRuntime,
         toolConstructionPlan: {
           includeBaseCodingTools: false,
           includeShellTools: false,
@@ -1085,6 +1087,7 @@ describe("createOpenClawCodingTools", () => {
       expect(pluginToolOptions?.modelId).toBe("openrouter/auto");
       expect(pluginToolOptions?.nativeChannelId).toBe("oc_native_chat");
       expect(pluginToolOptions?.clientCaps).toEqual(["inline-widgets"]);
+      expect(pluginToolOptions?.preparedModelRuntime).toBe(preparedModelRuntime);
     } finally {
       resolvePluginToolsSpy.mockRestore();
     }

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -887,6 +887,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             agentThreadId: options?.messageThreadId,
             nativeChannelId: options?.nativeChannelId,
             agentDir: options?.agentDir,
+            preparedModelRuntime: options?.preparedModelRuntime,
             workspaceDir: workspaceRoot,
             config: options?.config,
             fsPolicy,

--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -19,11 +19,14 @@ import {
   type OpenClawPluginToolOptions,
 } from "./openclaw-tools.plugin-context.js";
 import { applyPluginToolDeliveryDefaults } from "./plugin-tool-delivery-defaults.js";
+import { getPreparedPluginRuntimeLoadContext } from "./prepared-model-runtime.plugin-context.js";
+import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.types.js";
 import { resolveAgentRuntimeToolConfig } from "./tool-runtime-config.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { hasProviderAuthForTool } from "./tools/model-config.helpers.js";
 
 type ResolveOpenClawPluginToolsOptions = OpenClawPluginToolOptions & {
+  preparedModelRuntime?: PreparedModelRuntimeSnapshot;
   pluginToolAllowlist?: string[];
   pluginToolDenylist?: string[];
   currentThreadTs?: string;
@@ -134,6 +137,7 @@ export function resolveOpenClawPluginToolsForOptions(params: {
       }
     : undefined;
   const existingToolNames = new Set(params.existingToolNames ?? []);
+  const preparedModelRuntime = params.options?.preparedModelRuntime;
   const pluginTools = resolvePluginTools({
     ...pluginToolInputs,
     context: {
@@ -147,6 +151,15 @@ export function resolveOpenClawPluginToolsForOptions(params: {
     toolDenylist: params.options?.pluginToolDenylist,
     allowGatewaySubagentBinding: params.options?.allowGatewaySubagentBinding,
     ...(hasAuthForProvider ? { hasAuthForProvider } : {}),
+    ...(preparedModelRuntime
+      ? {
+          preparedRuntime: {
+            loadContext: getPreparedPluginRuntimeLoadContext(preparedModelRuntime.pluginRegistry),
+            metadataSnapshot: preparedModelRuntime.metadataSnapshot,
+            registry: preparedModelRuntime.pluginRegistry,
+          },
+        }
+      : {}),
   });
   for (const tool of pluginTools) {
     existingToolNames.add(tool.name);

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -8,11 +8,15 @@ import {
   createPluginMetadataSnapshot,
   makeRegistry,
 } from "../config/plugin-auto-enable.test-helpers.js";
+import * as pluginMetadata from "../plugins/plugin-metadata-snapshot.js";
 import { activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "./auth-profiles/runtime-snapshots.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
-import { preparePluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
+import {
+  getPreparedPluginRuntimeLoadContext,
+  prepareOwnedPluginLoadContext,
+} from "./prepared-model-runtime.plugin-context.js";
 
 const hoisted = vi.hoisted(() => ({
   resolvePluginTools: vi.fn(),
@@ -170,12 +174,24 @@ describe("createOpenClawTools browser plugin integration", () => {
       manifestRegistry: makeRegistry([]),
       workspaceDir: "/tmp",
     });
-    const loadContext = preparePluginLoadContext(
-      { agentDir: "/tmp/agent", config, workspaceDir: "/tmp" },
-      process.env,
-      pluginRegistry,
-      metadataSnapshot,
-    );
+    const resolveMetadata = vi
+      .spyOn(pluginMetadata, "resolvePluginMetadataSnapshot")
+      .mockReturnValue(metadataSnapshot);
+    try {
+      expect(
+        prepareOwnedPluginLoadContext(
+          { agentDir: "/tmp/agent", config, workspaceDir: "/tmp" },
+          process.env,
+          pluginRegistry,
+        ),
+      ).toBe(metadataSnapshot);
+    } finally {
+      resolveMetadata.mockRestore();
+    }
+    const loadContext = getPreparedPluginRuntimeLoadContext(pluginRegistry);
+    if (!loadContext) {
+      throw new Error("expected prepared plugin load context");
+    }
 
     resolveOpenClawPluginToolsForOptions({
       options: {

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -8,7 +8,7 @@ import { activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } from "../
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "./auth-profiles/runtime-snapshots.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
-import { setPreparedPluginRuntimeLoadContext } from "./prepared-model-runtime.plugin-context.js";
+import { preparePluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
 
 const hoisted = vi.hoisted(() => ({
   resolvePluginTools: vi.fn(),
@@ -160,18 +160,13 @@ describe("createOpenClawTools browser plugin integration", () => {
   it("forwards lifecycle-prepared plugin facts to plugin resolution", () => {
     hoisted.resolvePluginTools.mockReturnValue([]);
     const config = { plugins: { enabled: true } } as OpenClawConfig;
-    const metadataSnapshot = { plugins: [], index: {} } as never;
     const pluginRegistry = { tools: [] } as never;
-    const loadContext = {
-      rawConfig: config,
-      config,
-      activationSourceConfig: config,
-      autoEnabledReasons: {},
-      workspaceDir: "/tmp",
-      env: process.env,
-      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    };
-    setPreparedPluginRuntimeLoadContext(pluginRegistry, loadContext);
+    const loadContext = preparePluginLoadContext(
+      { agentDir: "/tmp/agent", config, workspaceDir: "/tmp" },
+      process.env,
+      pluginRegistry,
+    );
+    const { metadataSnapshot } = loadContext;
 
     resolveOpenClawPluginToolsForOptions({
       options: {

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import {
+  createPluginMetadataSnapshot,
+  makeRegistry,
+} from "../config/plugin-auto-enable.test-helpers.js";
 import { activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "./auth-profiles/runtime-snapshots.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
@@ -161,12 +165,17 @@ describe("createOpenClawTools browser plugin integration", () => {
     hoisted.resolvePluginTools.mockReturnValue([]);
     const config = { plugins: { enabled: true } } as OpenClawConfig;
     const pluginRegistry = { tools: [] } as never;
+    const metadataSnapshot = createPluginMetadataSnapshot({
+      config,
+      manifestRegistry: makeRegistry([]),
+      workspaceDir: "/tmp",
+    });
     const loadContext = preparePluginLoadContext(
       { agentDir: "/tmp/agent", config, workspaceDir: "/tmp" },
       process.env,
       pluginRegistry,
+      metadataSnapshot,
     );
-    const { metadataSnapshot } = loadContext;
 
     resolveOpenClawPluginToolsForOptions({
       options: {

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -8,6 +8,7 @@ import { activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } from "../
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "./auth-profiles/runtime-snapshots.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
+import { setPreparedPluginRuntimeLoadContext } from "./prepared-model-runtime.plugin-context.js";
 
 const hoisted = vi.hoisted(() => ({
   resolvePluginTools: vi.fn(),
@@ -154,6 +155,50 @@ describe("createOpenClawTools browser plugin integration", () => {
 
     expect(hoisted.resolvePluginTools).toHaveBeenCalledTimes(1);
     expect(firstResolvePluginToolsParams().allowGatewaySubagentBinding).toBe(true);
+  });
+
+  it("forwards lifecycle-prepared plugin facts to plugin resolution", () => {
+    hoisted.resolvePluginTools.mockReturnValue([]);
+    const config = { plugins: { enabled: true } } as OpenClawConfig;
+    const metadataSnapshot = { plugins: [], index: {} } as never;
+    const pluginRegistry = { tools: [] } as never;
+    const loadContext = {
+      rawConfig: config,
+      config,
+      activationSourceConfig: config,
+      autoEnabledReasons: {},
+      workspaceDir: "/tmp",
+      env: process.env,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    };
+    setPreparedPluginRuntimeLoadContext(pluginRegistry, loadContext);
+
+    resolveOpenClawPluginToolsForOptions({
+      options: {
+        config,
+        workspaceDir: "/tmp",
+        preparedModelRuntime: {
+          agentDir: "/tmp/agent",
+          workspaceDir: "/tmp",
+          activeProjectKeys: [],
+          config,
+          metadataSnapshot,
+          pluginRegistry,
+          allowGatewaySubagentBinding: false,
+          modelCatalog: { entries: [], routeVariants: [] },
+          configuredRuntimeModels: [],
+          inlineProviderModels: [],
+          createStores: vi.fn(),
+        },
+      },
+      resolvedConfig: config,
+    });
+
+    expect(firstResolvePluginToolsParams().preparedRuntime).toEqual({
+      loadContext,
+      metadataSnapshot,
+      registry: pluginRegistry,
+    });
   });
 
   it("forwards auth profile helpers to plugin resolution and context", async () => {

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -8,6 +8,7 @@ import type { PreparedMessageToolCatalog } from "../channels/plugins/message-act
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { prepareMediaCapabilityProviders } from "../plugins/capability-provider-runtime.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   getPreparedMessageToolCatalog,
@@ -228,6 +229,7 @@ export async function prepareWorkspaceBuildGroup(
   const runtimePluginRegistry = !input.readOnly
     ? loadAgentRuntimePluginRegistryHandle({
         config: input.config,
+        env,
         ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
         ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
         selections: input.runtimePluginSelections,
@@ -236,8 +238,12 @@ export async function prepareWorkspaceBuildGroup(
   const runtimePluginMs = performance.now() - runtimePluginStartedAt;
   return await withPluginRuntimeRegistryScope(runtimePluginRegistry, async () => {
     const pluginMetadataStartedAt = performance.now();
-    const pluginRuntimeLoadContext = preparePluginLoadContext(input, env, runtimePluginRegistry);
-    const pluginMetadataSnapshot = pluginRuntimeLoadContext.metadataSnapshot;
+    const pluginMetadataSnapshot = resolvePluginMetadataSnapshot({
+      config: input.config,
+      env,
+      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+    });
+    preparePluginLoadContext(input, env, runtimePluginRegistry, pluginMetadataSnapshot);
     const pluginMetadataMs = performance.now() - pluginMetadataStartedAt;
     const matchesStaticModelId = createStaticModelIdMatcher({
       manifestPlugins: pluginMetadataSnapshot.plugins,

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -8,7 +8,6 @@ import type { PreparedMessageToolCatalog } from "../channels/plugins/message-act
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { prepareMediaCapabilityProviders } from "../plugins/capability-provider-runtime.js";
-import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   getPreparedMessageToolCatalog,
@@ -53,6 +52,7 @@ import {
   toStaticCatalogEntry,
   type PreparedConfiguredRuntimeModel,
 } from "./prepared-model-runtime.configured.js";
+import { preparePluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
 import type {
   PreparedModelRuntimeBuildStats,
   PreparedModelRuntimeCatalogMode,
@@ -236,11 +236,8 @@ export async function prepareWorkspaceBuildGroup(
   const runtimePluginMs = performance.now() - runtimePluginStartedAt;
   return await withPluginRuntimeRegistryScope(runtimePluginRegistry, async () => {
     const pluginMetadataStartedAt = performance.now();
-    const pluginMetadataSnapshot = resolvePluginMetadataSnapshot({
-      config: input.config,
-      env,
-      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-    });
+    const pluginRuntimeLoadContext = preparePluginLoadContext(input, env, runtimePluginRegistry);
+    const pluginMetadataSnapshot = pluginRuntimeLoadContext.metadataSnapshot;
     const pluginMetadataMs = performance.now() - pluginMetadataStartedAt;
     const matchesStaticModelId = createStaticModelIdMatcher({
       manifestPlugins: pluginMetadataSnapshot.plugins,

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -8,7 +8,6 @@ import type { PreparedMessageToolCatalog } from "../channels/plugins/message-act
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { prepareMediaCapabilityProviders } from "../plugins/capability-provider-runtime.js";
-import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   getPreparedMessageToolCatalog,
@@ -53,7 +52,7 @@ import {
   toStaticCatalogEntry,
   type PreparedConfiguredRuntimeModel,
 } from "./prepared-model-runtime.configured.js";
-import { preparePluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
+import { prepareOwnedPluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
 import type {
   PreparedModelRuntimeBuildStats,
   PreparedModelRuntimeCatalogMode,
@@ -238,12 +237,7 @@ export async function prepareWorkspaceBuildGroup(
   const runtimePluginMs = performance.now() - runtimePluginStartedAt;
   return await withPluginRuntimeRegistryScope(runtimePluginRegistry, async () => {
     const pluginMetadataStartedAt = performance.now();
-    const pluginMetadataSnapshot = resolvePluginMetadataSnapshot({
-      config: input.config,
-      env,
-      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-    });
-    preparePluginLoadContext(input, env, runtimePluginRegistry, pluginMetadataSnapshot);
+    const pluginMetadataSnapshot = prepareOwnedPluginLoadContext(input, env, runtimePluginRegistry);
     const pluginMetadataMs = performance.now() - pluginMetadataStartedAt;
     const matchesStaticModelId = createStaticModelIdMatcher({
       manifestPlugins: pluginMetadataSnapshot.plugins,

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -23,7 +23,7 @@ function setPreparedPluginRuntimeLoadContext(
   (registry as PreparedPluginRegistry)[preparedPluginRuntimeLoadContext] = context;
 }
 
-export function preparePluginLoadContext(
+function preparePluginLoadContext(
   input: PreparedModelRuntimeInput,
   env: NodeJS.ProcessEnv,
   registry: PluginRegistry | undefined,

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -1,5 +1,6 @@
 import type { PluginDiscoveryResult } from "../plugins/discovery.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import {
@@ -50,6 +51,21 @@ export function preparePluginLoadContext(
     setPreparedPluginRuntimeLoadContext(registry, context);
   }
   return context;
+}
+
+/** Resolves and attaches the plugin facts owned by one prepared workspace generation. */
+export function prepareOwnedPluginLoadContext(
+  input: PreparedModelRuntimeInput,
+  env: NodeJS.ProcessEnv,
+  registry: PluginRegistry | undefined,
+): PluginMetadataSnapshot {
+  const metadataSnapshot = resolvePluginMetadataSnapshot({
+    config: input.config,
+    env,
+    ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+  });
+  preparePluginLoadContext(input, env, registry, metadataSnapshot);
+  return metadataSnapshot;
 }
 
 /** Reads plugin facts carried by a lifecycle-owned prepared runtime snapshot. */

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -13,7 +13,7 @@ type PreparedPluginRegistry = PluginRegistry & {
   [preparedPluginRuntimeLoadContext]?: PluginRuntimeLoadContext;
 };
 
-export function setPreparedPluginRuntimeLoadContext(
+function setPreparedPluginRuntimeLoadContext(
   registry: PluginRegistry,
   context: PluginRuntimeLoadContext,
 ): void {

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -1,0 +1,45 @@
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import {
+  resolvePluginRuntimeLoadContext,
+  type PluginRuntimeLoadContext,
+} from "../plugins/runtime/load-context.js";
+import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
+
+const preparedPluginRuntimeLoadContext = Symbol("preparedPluginRuntimeLoadContext");
+
+type PreparedPluginRegistry = PluginRegistry & {
+  [preparedPluginRuntimeLoadContext]?: PluginRuntimeLoadContext;
+};
+
+export function setPreparedPluginRuntimeLoadContext(
+  registry: PluginRegistry,
+  context: PluginRuntimeLoadContext,
+): void {
+  (registry as PreparedPluginRegistry)[preparedPluginRuntimeLoadContext] = context;
+}
+
+export function preparePluginLoadContext(
+  input: PreparedModelRuntimeInput,
+  env: NodeJS.ProcessEnv,
+  registry: PluginRegistry | undefined,
+): PluginRuntimeLoadContext & { metadataSnapshot: PluginMetadataSnapshot } {
+  const { config, workspaceDir } = input;
+  const metadataSnapshot = resolvePluginMetadataSnapshot({ config, env, workspaceDir });
+  const context = {
+    ...resolvePluginRuntimeLoadContext({ config, env, workspaceDir, metadataSnapshot }),
+    metadataSnapshot,
+  };
+  if (registry) {
+    // The prepared registry is the lifecycle-owned carrier; standalone callers keep the cold path.
+    setPreparedPluginRuntimeLoadContext(registry, context);
+  }
+  return context;
+}
+
+/** Reads plugin facts carried by a lifecycle-owned prepared runtime snapshot. */
+export const getPreparedPluginRuntimeLoadContext = (
+  registry: PluginRegistry | undefined,
+): PluginRuntimeLoadContext | undefined =>
+  (registry as PreparedPluginRegistry | undefined)?.[preparedPluginRuntimeLoadContext];

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -1,4 +1,5 @@
-import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import type { PluginDiscoveryResult } from "../plugins/discovery.js";
+import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import {
@@ -8,6 +9,7 @@ import {
 import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
 
 const preparedPluginRuntimeLoadContext = Symbol("preparedPluginRuntimeLoadContext");
+const emptyPluginDiscovery: PluginDiscoveryResult = { candidates: [], diagnostics: [] };
 
 type PreparedPluginRegistry = PluginRegistry & {
   [preparedPluginRuntimeLoadContext]?: PluginRuntimeLoadContext;
@@ -24,12 +26,24 @@ export function preparePluginLoadContext(
   input: PreparedModelRuntimeInput,
   env: NodeJS.ProcessEnv,
   registry: PluginRegistry | undefined,
+  metadataSnapshot: PluginMetadataSnapshot,
 ): PluginRuntimeLoadContext & { metadataSnapshot: PluginMetadataSnapshot } {
   const { config, workspaceDir } = input;
-  const metadataSnapshot = resolvePluginMetadataSnapshot({ config, env, workspaceDir });
+  // The prepared owner already resolved metadata for this exact config/env/workspace tuple.
+  // Missing discovery facts stay empty here instead of reopening cold channel discovery.
+  const preparedMetadataSnapshot = metadataSnapshot.discovery
+    ? metadataSnapshot
+    : { ...metadataSnapshot, discovery: emptyPluginDiscovery };
   const context = {
-    ...resolvePluginRuntimeLoadContext({ config, env, workspaceDir, metadataSnapshot }),
+    ...resolvePluginRuntimeLoadContext({
+      config,
+      env,
+      workspaceDir,
+      metadataSnapshot: preparedMetadataSnapshot,
+      manifestRegistry: metadataSnapshot.manifestRegistry,
+    }),
     metadataSnapshot,
+    installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index),
   };
   if (registry) {
     // The prepared registry is the lifecycle-owned carrier; standalone callers keep the cold path.

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -101,6 +101,7 @@ const mocks = vi.hoisted(() => {
 });
 
 vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  isPluginMetadataSnapshotCompatible: () => true,
   loadPluginMetadataSnapshot: () => mocks.metadataSnapshot,
   resolvePluginMetadataSnapshot: mocks.resolvePluginMetadataSnapshot,
 }));

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -128,6 +128,7 @@ describe("prepared model runtime snapshots", () => {
 
     expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledWith({
       config: {},
+      env: process.env,
       workspaceDir: "/tmp/prepared-model-runtime-plugin-workspace",
       selections: undefined,
     });

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -14,6 +14,7 @@ import {
   rejectPendingPreparedModelRuntimeReplacement,
   refreshPreparedModelRuntimeSnapshots,
 } from "./prepared-model-runtime.js";
+import { getPreparedPluginRuntimeLoadContext } from "./prepared-model-runtime.plugin-context.js";
 import {
   getPreparedModelRuntimeMocks,
   resetPreparedModelRuntimeHarness,
@@ -138,14 +139,20 @@ describe("prepared model runtime snapshots", () => {
 
   it("uses an explicit lifecycle environment for catalog and auth discovery", async () => {
     const env = { NVIDIA_API_KEY: "test-nvidia-api-key" };
-    await publishPreparedModelRuntimeSnapshot({
-      config: {},
+    const config = {};
+    const snapshot = await publishPreparedModelRuntimeSnapshot({
+      config,
       agentDir: "/tmp/prepared-model-runtime-explicit-env",
       env,
     });
 
+    expect(getPreparedPluginRuntimeLoadContext(snapshot.pluginRegistry)).toMatchObject({
+      rawConfig: config,
+      env,
+    });
+
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledWith(
-      {},
+      config,
       "/tmp/prepared-model-runtime-explicit-env",
       expect.objectContaining({ env }),
     );

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -33,16 +33,23 @@ describe("agent runtime plugin registries", () => {
 
   it("returns a non-activating handle for a prepared runtime", () => {
     const config = {} as never;
+    const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" };
     const selections = [{ provider: "openai", modelId: "gpt-5.5", runtime: "codex" }];
 
     expect(
       loadAgentRuntimePluginRegistryHandle({
         config,
+        env,
         workspaceDir: "/tmp/workspace",
         allowGatewaySubagentBinding: true,
         selections,
       }),
     ).toEqual({ handle: true });
+    expect(hoisted.getCurrentPluginMetadataSnapshot).toHaveBeenCalledWith({
+      config,
+      env,
+      workspaceDir: "/tmp/workspace",
+    });
     expect(hoisted.resolveAgentRuntimePluginLoadPlan).toHaveBeenCalledWith({
       config,
       workspaceDir: "/tmp/workspace",
@@ -52,6 +59,7 @@ describe("agent runtime plugin registries", () => {
       activate: false,
       config,
       activationSourceConfig: config,
+      env,
       workspaceDir: "/tmp/workspace",
       runtimeOptions: { allowGatewaySubagentBinding: true },
     });

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -20,10 +20,12 @@ type StartupScopedPluginSnapshot = NonNullable<
 
 function resolveStartupPluginIdsFromCurrentSnapshot(params: {
   config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
   workspaceDir?: string;
 }): string[] | undefined {
   const snapshot = getCurrentPluginMetadataSnapshot({
     config: params.config,
+    env: params.env,
     workspaceDir: params.workspaceDir,
   }) as StartupScopedPluginSnapshot | undefined;
   const pluginIds = snapshot?.startup?.pluginIds;
@@ -35,6 +37,7 @@ function resolveStartupPluginIdsFromCurrentSnapshot(params: {
 
 type AgentRuntimePluginRegistryParams = {
   config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
   workspaceDir?: string | null;
   allowGatewaySubagentBinding?: boolean;
   selections?: readonly AgentHarnessPluginSelection[];
@@ -51,6 +54,7 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
       loadOptions: {
         config: params.config,
         activationSourceConfig: params.config,
+        ...(params.env ? { env: params.env } : {}),
         workspaceDir,
         onlyPluginIds: [],
         runtimeOptions: params.allowGatewaySubagentBinding
@@ -61,6 +65,7 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
   }
   const startupPluginIds = resolveStartupPluginIdsFromCurrentSnapshot({
     config: params.config,
+    env: params.env,
     workspaceDir,
   });
   const plan = resolveAgentRuntimePluginLoadPlan({
@@ -81,6 +86,7 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
     loadOptions: {
       config: plan.config,
       ...(plan.config ? { activationSourceConfig: plan.config } : {}),
+      ...(params.env ? { env: params.env } : {}),
       workspaceDir,
       ...(startupPluginIds === undefined || plan.pluginIds === undefined
         ? {}

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -41,14 +41,8 @@ const PLUGIN_METADATA_ENV_KEYS = [
   "XDG_CONFIG_HOME",
 ] as const;
 export type {
-  LoadPluginMetadataSnapshotParams,
-  PluginMetadataManifestView,
-  PluginMetadataRegistryView,
   PluginMetadataSnapshot,
-  PluginMetadataSnapshotMetrics,
   PluginMetadataSnapshotOwnerMaps,
-  PluginMetadataSnapshotRegistryDiagnostic,
-  ResolvePluginMetadataSnapshotParams,
 } from "./plugin-metadata-snapshot.types.js";
 
 function pickPluginMetadataEnv(env: NodeJS.ProcessEnv): Record<string, string> {

--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -27,7 +27,7 @@ export type PluginMetadataSnapshotOwnerMaps = {
   providerRequests?: ReadonlyMap<string, PluginManifestProviderRequestProvider>;
 };
 
-export type PluginMetadataSnapshotMetrics = {
+type PluginMetadataSnapshotMetrics = {
   registrySnapshotMs: number;
   manifestRegistryMs: number;
   ownerMapsMs: number;
@@ -36,7 +36,7 @@ export type PluginMetadataSnapshotMetrics = {
   manifestPluginCount: number;
 };
 
-export type PluginMetadataSnapshotRegistryDiagnostic = {
+type PluginMetadataSnapshotRegistryDiagnostic = {
   level: "info" | "warn";
   code:
     | "persisted-registry-missing"

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -133,6 +133,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
       env,
       logger: context.logger,
       manifestRegistry,
+      metadataSnapshot,
       installRecords: {},
     });
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledWith({
@@ -154,6 +155,21 @@ describe("resolvePluginRuntimeLoadContext", () => {
     });
     expect(resolveDefaultAgentIdMock).toHaveBeenCalledWith(resolvedConfig);
     expect(resolveAgentWorkspaceDirMock).toHaveBeenCalledWith(resolvedConfig, "default");
+  });
+
+  it("reuses a prepared metadata snapshot without resolving metadata again", () => {
+    const config = { plugins: {} };
+    const env = { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv;
+
+    const context = resolvePluginRuntimeLoadContext({
+      config,
+      env,
+      metadataSnapshot: metadataSnapshot as never,
+      workspaceDir: "/resolved-workspace",
+    });
+
+    expect(context.metadataSnapshot).toBe(metadataSnapshot);
+    expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
   it("stores derived metadata as the reusable runtime snapshot", () => {

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -19,6 +19,7 @@ import {
   isPluginMetadataSnapshotCompatible,
   resolvePluginMetadataSnapshot,
 } from "../plugin-metadata-snapshot.js";
+import type { PluginMetadataSnapshot } from "../plugin-metadata-snapshot.types.js";
 import type { PluginLogger } from "../types.js";
 
 const log = createSubsystemLogger("plugins");
@@ -133,6 +134,7 @@ export type PluginRuntimeLoadContext = {
   env: NodeJS.ProcessEnv;
   logger: PluginLogger;
   manifestRegistry?: PluginManifestRegistry;
+  metadataSnapshot?: PluginMetadataSnapshot;
   installRecords?: Record<string, PluginInstallRecord>;
 };
 
@@ -158,6 +160,7 @@ type PluginRuntimeLoadContextOptions = {
   onlyPluginIds?: readonly string[];
   logger?: PluginLogger;
   manifestRegistry?: PluginManifestRegistry;
+  metadataSnapshot?: PluginMetadataSnapshot;
 };
 
 /** Creates the default plugin runtime loader logger. */
@@ -179,7 +182,8 @@ export function resolvePluginRuntimeLoadContext(
   const rawWorkspaceDir =
     options?.workspaceDir ?? resolveAgentWorkspaceDir(rawConfig, resolveDefaultAgentId(rawConfig));
   const initialMetadataSnapshot =
-    options?.manifestRegistry === undefined
+    options?.metadataSnapshot ??
+    (options?.manifestRegistry === undefined
       ? resolvePluginMetadataSnapshot({
           config: rawConfig,
           env,
@@ -187,7 +191,7 @@ export function resolvePluginRuntimeLoadContext(
           allowWorkspaceScopedCurrent: true,
           ...(options?.onlyPluginIds !== undefined ? { pluginIds: options.onlyPluginIds } : {}),
         })
-      : undefined;
+      : undefined);
   const manifestRegistry = options?.manifestRegistry ?? initialMetadataSnapshot?.manifestRegistry;
   const activationSourceConfig = resolvePluginActivationSourceConfig({
     config: rawConfig,
@@ -245,6 +249,7 @@ export function resolvePluginRuntimeLoadContext(
     env,
     logger: options?.logger ?? createPluginRuntimeLoaderLogger(),
     ...(finalManifestRegistry ? { manifestRegistry: finalManifestRegistry } : {}),
+    ...(metadataSnapshot ? { metadataSnapshot } : {}),
     installRecords,
   };
 }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -21,6 +21,12 @@ type MockRegistryToolEntry = {
 const loadOpenClawPluginsMock = vi.fn();
 const resolveCompatibleRuntimePluginRegistryMock = vi.fn();
 const applyPluginAutoEnableMock = vi.fn();
+const loadContextMocks = vi.hoisted(() => ({
+  actualResolve: undefined as
+    | typeof import("./runtime/load-context.js").resolvePluginRuntimeLoadContext
+    | undefined,
+  resolve: vi.fn(),
+}));
 
 vi.mock("./loader.js", () => ({
   loadOpenClawPlugins: (params: unknown) => loadOpenClawPluginsMock(params),
@@ -35,6 +41,15 @@ vi.mock("./loader.js", () => ({
 vi.mock("../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: (params: unknown) => applyPluginAutoEnableMock(params),
 }));
+
+vi.mock("./runtime/load-context.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./runtime/load-context.js")>();
+  loadContextMocks.actualResolve = actual.resolvePluginRuntimeLoadContext;
+  return {
+    ...actual,
+    resolvePluginRuntimeLoadContext: (...args: unknown[]) => loadContextMocks.resolve(...args),
+  };
+});
 
 let resolvePluginTools: typeof import("./tools.js").resolvePluginTools;
 let ensureStandalonePluginToolRegistryLoaded: typeof import("./tools.js").ensureStandalonePluginToolRegistryLoaded;
@@ -313,64 +328,63 @@ function installToolManifestSnapshots(params: {
   plugins: Record<string, unknown>[];
 }) {
   const plugins = params.plugins;
-  setCurrentPluginMetadataSnapshot(
-    {
-      policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
-      workspaceDir: "/tmp",
-      index: {
-        version: 1,
-        hostContractVersion: "test",
-        compatRegistryVersion: "test",
-        migrationVersion: 1,
-        policyHash: "test",
-        generatedAtMs: 0,
-        installRecords: {},
-        plugins: plugins.map((plugin) => ({
-          pluginId: String(plugin.id),
-          origin: plugin.origin,
-          enabled: true,
-          enabledByDefault: plugin.enabledByDefault,
-          startup: {
-            sidecar: false,
-            memory: false,
-            agentHarnesses: [],
-          },
-          compat: [],
-        })),
-        diagnostics: [],
-      },
-      registryDiagnostics: [],
-      manifestRegistry: { plugins, diagnostics: [] },
-      plugins,
+  const snapshot = {
+    policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
+    workspaceDir: "/tmp",
+    index: {
+      version: 1,
+      hostContractVersion: "test",
+      compatRegistryVersion: "test",
+      migrationVersion: 1,
+      policyHash: "test",
+      generatedAtMs: 0,
+      installRecords: {},
+      plugins: plugins.map((plugin) => ({
+        pluginId: String(plugin.id),
+        origin: plugin.origin,
+        enabled: true,
+        enabledByDefault: plugin.enabledByDefault,
+        startup: {
+          sidecar: false,
+          memory: false,
+          agentHarnesses: [],
+        },
+        compat: [],
+      })),
       diagnostics: [],
-      byPluginId: new Map(plugins.map((plugin) => [String(plugin.id), plugin])),
-      normalizePluginId: (id: string) => id,
-      owners: {
-        channels: new Map(),
-        channelConfigs: new Map(),
-        providers: new Map(),
-        modelCatalogProviders: new Map(),
-        cliBackends: new Map(),
-        setupProviders: new Map(),
-        commandAliases: new Map(),
-        contracts: new Map(),
-      },
-      metrics: {
-        registrySnapshotMs: 0,
-        manifestRegistryMs: 0,
-        ownerMapsMs: 0,
-        totalMs: 0,
-        indexPluginCount: plugins.length,
-        manifestPluginCount: plugins.length,
-      },
-    } as never,
-    {
-      config: params.config,
-      compatibleConfigs: params.compatibleConfigs,
-      env: params.env ?? process.env,
-      workspaceDir: "/tmp",
     },
-  );
+    registryDiagnostics: [],
+    manifestRegistry: { plugins, diagnostics: [] },
+    plugins,
+    diagnostics: [],
+    byPluginId: new Map(plugins.map((plugin) => [String(plugin.id), plugin])),
+    normalizePluginId: (id: string) => id,
+    owners: {
+      channels: new Map(),
+      channelConfigs: new Map(),
+      providers: new Map(),
+      modelCatalogProviders: new Map(),
+      cliBackends: new Map(),
+      setupProviders: new Map(),
+      commandAliases: new Map(),
+      contracts: new Map(),
+    },
+    metrics: {
+      registrySnapshotMs: 0,
+      manifestRegistryMs: 0,
+      ownerMapsMs: 0,
+      totalMs: 0,
+      indexPluginCount: plugins.length,
+      manifestPluginCount: plugins.length,
+    },
+  };
+  setCurrentPluginMetadataSnapshot(snapshot as never, {
+    config: params.config,
+    compatibleConfigs: params.compatibleConfigs,
+    env: params.env ?? process.env,
+    workspaceDir: "/tmp",
+  });
+  return snapshot;
 }
 
 function createXaiToolManifest() {
@@ -513,6 +527,13 @@ describe("resolvePluginTools optional tools", () => {
       config,
       changes: [],
     }));
+    loadContextMocks.resolve.mockReset();
+    loadContextMocks.resolve.mockImplementation((...args: unknown[]) => {
+      if (!loadContextMocks.actualResolve) {
+        throw new Error("load-context mock was not initialized");
+      }
+      return loadContextMocks.actualResolve(...(args as [never]));
+    });
     resetPluginRuntimeStateForTest?.();
     clearCurrentPluginMetadataSnapshot?.();
     resetPluginToolDescriptorCacheForTest?.();
@@ -969,6 +990,44 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(tools, ["optional_tool"]);
     expectLoaderSelectedOnlyPluginIds(["optional-demo"]);
+  });
+
+  it("uses owner-prepared load facts without invoking the cold resolver", () => {
+    const context = createContext();
+    const config = context.config;
+    const registry = createToolRegistry([createOptionalDemoEntry()]);
+    const metadataSnapshot = installToolManifestSnapshots({
+      config,
+      plugins: [
+        createToolManifest("optional-demo", ["optional_tool"], {
+          toolMetadata: { optional_tool: { optional: true } },
+        }),
+      ],
+    });
+
+    const tools = resolvePluginTools({
+      ...createResolveToolsParams({ context, toolAllowlist: ["optional_tool"] }),
+      preparedRuntime: {
+        loadContext: {
+          rawConfig: config,
+          config,
+          activationSourceConfig: config,
+          autoEnabledReasons: {},
+          workspaceDir: "/tmp",
+          env: process.env,
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+          manifestRegistry: metadataSnapshot.manifestRegistry as never,
+          metadataSnapshot: metadataSnapshot as never,
+          installRecords: {},
+        },
+        metadataSnapshot: metadataSnapshot as never,
+        registry: registry as never,
+      },
+    });
+
+    expectResolvedToolNames(tools, ["optional_tool"]);
+    expect(loadContextMocks.resolve).not.toHaveBeenCalled();
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
   it("auto-loads cold registry for path-based config-origin plugins without pre-warming (#76598)", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1109,6 +1109,12 @@ function registryHasScopedPluginTools(
   return Array.from(scopedPluginIds).every((pluginId) => registryPluginIds.has(pluginId));
 }
 
+type PreparedPluginToolRuntime = {
+  loadContext?: ReturnType<typeof resolvePluginRuntimeLoadContext>;
+  metadataSnapshot: PluginMetadataManifestView;
+  registry?: PluginRegistry;
+};
+
 function resolvePluginToolLoadState(params: {
   context: OpenClawPluginToolContext;
   toolAllowlist?: string[];
@@ -1116,6 +1122,7 @@ function resolvePluginToolLoadState(params: {
   allowGatewaySubagentBinding?: boolean;
   hasAuthForProvider?: (providerId: string) => boolean;
   env?: NodeJS.ProcessEnv;
+  preparedRuntime?: PreparedPluginToolRuntime;
 }):
   | {
       context: ReturnType<typeof resolvePluginRuntimeLoadContext>;
@@ -1128,11 +1135,19 @@ function resolvePluginToolLoadState(params: {
   | undefined {
   const env = params.env ?? process.env;
   const baseConfig = applyTestPluginDefaults(params.context.config ?? {}, env);
-  const context = resolvePluginRuntimeLoadContext({
-    config: baseConfig,
-    env,
-    workspaceDir: params.context.workspaceDir,
-  });
+  const preparedLoadContext = params.preparedRuntime?.loadContext;
+  const usePreparedRuntime =
+    preparedLoadContext !== undefined &&
+    (baseConfig === preparedLoadContext.rawConfig || baseConfig === preparedLoadContext.config) &&
+    env === preparedLoadContext.env &&
+    params.context.workspaceDir === preparedLoadContext.workspaceDir;
+  const context = usePreparedRuntime
+    ? preparedLoadContext
+    : resolvePluginRuntimeLoadContext({
+        config: baseConfig,
+        env,
+        workspaceDir: params.context.workspaceDir,
+      });
   const normalized = normalizePluginsConfig(context.config.plugins);
   if (!normalized.enabled) {
     return undefined;
@@ -1141,11 +1156,14 @@ function resolvePluginToolLoadState(params: {
   const runtimeOptions = params.allowGatewaySubagentBinding
     ? { allowGatewaySubagentBinding: true as const }
     : undefined;
-  const snapshot = loadManifestContractSnapshot({
-    config: context.config,
-    workspaceDir: context.workspaceDir,
-    env,
-  });
+  const snapshot =
+    usePreparedRuntime && params.preparedRuntime
+      ? params.preparedRuntime.metadataSnapshot
+      : loadManifestContractSnapshot({
+          config: context.config,
+          workspaceDir: context.workspaceDir,
+          env,
+        });
   const onlyPluginIds = resolvePluginToolRuntimePluginIds({
     config: context.config,
     availabilityConfig: params.context.runtimeConfig ?? context.config,
@@ -1198,6 +1216,7 @@ export function resolvePluginTools(params: {
   hasAuthForProvider?: (providerId: string) => boolean;
   env?: NodeJS.ProcessEnv;
   runtimeRegistry?: PluginRegistry;
+  preparedRuntime?: PreparedPluginToolRuntime;
 }): AnyAgentTool[] {
   // Fast path: when plugins are effectively disabled, avoid discovery/jiti entirely.
   // This matters a lot for unit tests and for tool construction hot paths.
@@ -1258,8 +1277,12 @@ export function resolvePluginTools(params: {
     onlyPluginIds: runtimePluginIds,
     runtimeOptions,
   });
-  let registry = registryHasScopedPluginTools(params.runtimeRegistry, runtimePluginIds)
-    ? params.runtimeRegistry
+  const preparedOrExplicitRegistry =
+    context === params.preparedRuntime?.loadContext
+      ? params.preparedRuntime.registry
+      : params.runtimeRegistry;
+  let registry = registryHasScopedPluginTools(preparedOrExplicitRegistry, runtimePluginIds)
+    ? preparedOrExplicitRegistry
     : undefined;
   if (!registry) {
     registry = resolvePluginToolRegistry({


### PR DESCRIPTION
## What Problem This Solves

The follow-up named in #118334: per-attempt plugin tool construction still re-ran the plugin load-context resolver + auto-enable orchestration once per tool-constructing attempt (call chain run-orchestrator → attempt-tool-base-prepare → agent-tools → openclaw-plugin-tools → plugins/tools → runtime/load-context). Measured at 14.0-15.6 ms per attempt, 117 ms aggregate in an N=8 bench (~1.8% of turn time), repeated again on retries.

## Why This Change Was Made

Prepared facts now travel with the lifecycle owner instead of being rediscovered (#117768's seam, extended): prepared-runtime acquisition resolves the plugin load context once after registry construction and attaches it to the lifecycle-owned plugin registry via a module-private symbol (`prepared-model-runtime.plugin-context.ts`) — no Plugin SDK type changes; all 149 SDK subpaths unchanged. Tool construction uses the prepared context only under strict reference-identity compatibility (raw/resolved config, env, workspaceDir all identical), falling back to the cold resolver otherwise. Incompatible, standalone, CLI, status, and sandbox paths keep the original cold path; one resolution implementation remains.

## User Impact

No behavior change (same plugins, same tools, same registries — six ownership/forwarding/metadata-reuse regressions incl. zero per-attempt resolution under a prepared owner). Configured turns stop paying per-attempt load-context resolution: bench A/B turns 6391 → 6219 ms (−2.7%), in-load readyz/sessions p50 38.7/38.5 → 7.6/7.4 ms.

## Evidence

- Focused Vitest: 8 files, 315 tests passed. Targeted lint/type boundaries clean; full build clean.
- Autoreview (Codex gpt-5.6-sol, high): clean, 0.98.
- Bench A/B (N=8, same machine): above. Production delta +84 net (lifecycle ownership boundary), tests +131.

Completes the follow-up track from #118027 (#118192, #118207, #118193, #118334, #118349, #118364).
