### PR TITLE
refactor(auto-reply): consolidate session rollover state

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -72,102 +72,10 @@ type ForkSessionParamsForTest = {
   sessionKey: string;
 };
 
-vi.mock("./session-fork.js", () => ({
-  forkSessionEntryFromParent: async (params: {
-    fallbackEntry?: SessionEntry;
-    parentSessionKey: string;
-    storePath: string;
-    patch?: (patchParams: {
-      entry: SessionEntry;
-      parentEntry: SessionEntry;
-      fork: { sessionId: string; sessionFile: string };
-      decision: { status: "fork"; maxTokens: number; parentTokens?: number };
-    }) => Partial<SessionEntry>;
-    decisionSkipPatch?: (patchParams: {
-      decision: {
-        status: "skip";
-        reason: "parent-too-large";
-        maxTokens: number;
-        parentTokens: number;
-        message: string;
-      };
-      entry: SessionEntry;
-      parentEntry: SessionEntry;
-    }) => Partial<SessionEntry>;
-    sessionKey?: string;
-  }) => {
-    const parentEntry = loadSessionEntry({
-      sessionKey: params.parentSessionKey,
-      storePath: params.storePath,
-      readConsistency: "latest",
-    });
-    if (!parentEntry?.sessionId) {
-      return { status: "missing-parent" };
-    }
-    const maxTokens = 100_000;
-    const parentTokens = await sessionForkMocks.resolveParentForkTokenCount({
-      parentEntry,
-      storePath: params.storePath,
-    });
-    if (typeof parentTokens === "number" && parentTokens > maxTokens) {
-      const entry = params.fallbackEntry ?? { sessionId: "", updatedAt: Date.now() };
-      const decision = {
-        status: "skip" as const,
-        reason: "parent-too-large" as const,
-        maxTokens,
-        parentTokens,
-        message: `Parent context is too large to fork (${parentTokens}/${maxTokens} tokens); starting with isolated context instead.`,
-      };
-      return {
-        status: "skipped",
-        reason: "decision-skip",
-        parentEntry,
-        sessionEntry: {
-          ...entry,
-          ...params.decisionSkipPatch?.({ decision, entry, parentEntry }),
-        },
-        decision,
-      };
-    }
-    const fork = await sessionForkMocks.forkSessionFromParent({
-      parentEntry,
-      storePath: params.storePath,
-    });
-    if (!fork) {
-      return { status: "failed" };
-    }
-    const entry = params.fallbackEntry ?? { sessionId: "", updatedAt: Date.now() };
-    return {
-      status: "forked",
-      fork,
-      parentEntry,
-      sessionEntry: {
-        ...entry,
-        ...params.patch?.({
-          entry,
-          parentEntry,
-          fork,
-          decision: {
-            status: "fork",
-            maxTokens,
-            ...(typeof parentTokens === "number" ? { parentTokens } : {}),
-          },
-        }),
-        sessionId: fork.sessionId,
-        sessionFile: fork.sessionFile,
-        forkedFromParent: true,
-      },
-      decision: {
-        status: "fork",
-        maxTokens,
-        ...(typeof parentTokens === "number" ? { parentTokens } : {}),
-      },
-    };
-  },
+vi.mock("./session-fork.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./session-fork.js")>()),
   forkSessionFromParent: (...args: [ForkSessionParamsForTest]) =>
     sessionForkMocks.forkSessionFromParent(...args),
-  resolveParentForkTokenCount: (...args: [{ parentEntry: SessionEntry; storePath: string }]) =>
-    sessionForkMocks.resolveParentForkTokenCount(...args),
   resolveParentForkDecision: async (params: { parentEntry: SessionEntry; storePath: string }) => {
     const maxTokens = 100_000;
     const parentTokens = await sessionForkMocks.resolveParentForkTokenCount({
@@ -559,7 +467,6 @@ describe("initSessionState guarded initialization", () => {
           SessionKey: sessionKey,
         },
         cfg: { session: { store: storePath } } as OpenClawConfig,
-        commandAuthorized: true,
       }),
     ).rejects.toThrow(
       'Session "agent:main:telegram:chat:archived" is archived. Restore it before starting new work.',
@@ -597,7 +504,6 @@ describe("initSessionState guarded initialization", () => {
           SessionKey: sessionKey,
         },
         cfg,
-        commandAuthorized: true,
       }),
     );
 
@@ -612,37 +518,8 @@ describe("initSessionState thread forking", () => {
   it("forks a new SQLite session from the parent session", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const root = await makeCaseDir("openclaw-thread-session-");
-    const sessionsDir = path.join(root, "sessions");
-    await fs.mkdir(sessionsDir);
-
     const parentSessionId = "parent-session";
-    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
-    const header = {
-      type: "session",
-      version: 3,
-      id: parentSessionId,
-      timestamp: new Date().toISOString(),
-      cwd: process.cwd(),
-    };
-    const message = {
-      type: "message",
-      id: "m1",
-      parentId: null,
-      timestamp: new Date().toISOString(),
-      message: { role: "user", content: "Parent prompt" },
-    };
-    const assistantMessage = {
-      type: "message",
-      id: "m2",
-      parentId: "m1",
-      timestamp: new Date().toISOString(),
-      message: { role: "assistant", content: "Parent reply" },
-    };
-    await fs.writeFile(
-      parentSessionFile,
-      `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(assistantMessage)}\n`,
-      "utf-8",
-    );
+    const parentSessionFile = path.join(root, "parent.jsonl");
 
     const storePath = path.join(root, "sessions.json");
     const parentSessionKey = "agent:main:slack:channel:c1";
@@ -668,7 +545,6 @@ describe("initSessionState thread forking", () => {
         ThreadLabel: threadLabel,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.sessionKey).toBe(threadSessionKey);
@@ -738,7 +614,6 @@ describe("initSessionState thread forking", () => {
         ParentSessionKey: parentSessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(first.sessionEntry.sessionId).not.toBe("preseed-thread-session");
@@ -760,7 +635,6 @@ describe("initSessionState thread forking", () => {
         ParentSessionKey: parentSessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(second.sessionEntry.sessionId).toBe(first.sessionEntry.sessionId);
@@ -774,37 +648,8 @@ describe("initSessionState thread forking", () => {
 
   it("skips fork and creates fresh session when parent tokens exceed threshold", async () => {
     const root = await makeCaseDir("openclaw-thread-session-overflow-");
-    const sessionsDir = path.join(root, "sessions");
-    await fs.mkdir(sessionsDir);
-
     const parentSessionId = "parent-overflow";
-    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
-    const header = {
-      type: "session",
-      version: 3,
-      id: parentSessionId,
-      timestamp: new Date().toISOString(),
-      cwd: process.cwd(),
-    };
-    const message = {
-      type: "message",
-      id: "m1",
-      parentId: null,
-      timestamp: new Date().toISOString(),
-      message: { role: "user", content: "Parent prompt" },
-    };
-    const assistantMessage = {
-      type: "message",
-      id: "m2",
-      parentId: "m1",
-      timestamp: new Date().toISOString(),
-      message: { role: "assistant", content: "Parent reply" },
-    };
-    await fs.writeFile(
-      parentSessionFile,
-      `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(assistantMessage)}\n`,
-      "utf-8",
-    );
+    const parentSessionFile = path.join(root, "parent.jsonl");
 
     const storePath = path.join(root, "sessions.json");
     const parentSessionKey = "agent:main:slack:channel:c1";
@@ -830,7 +675,6 @@ describe("initSessionState thread forking", () => {
         ParentSessionKey: parentSessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     // Should be marked as forked (to prevent re-attempts) but NOT actually forked from parent
@@ -846,22 +690,8 @@ describe("initSessionState thread forking", () => {
 
   it("skips fork when resolved parent token estimate exceeds threshold", async () => {
     const root = await makeCaseDir("openclaw-thread-session-overflow-estimated-");
-    const sessionsDir = path.join(root, "sessions");
-    await fs.mkdir(sessionsDir);
-
     const parentSessionId = "parent-overflow-estimated";
-    const parentSessionFile = path.join(sessionsDir, "parent.jsonl");
-    await fs.writeFile(
-      parentSessionFile,
-      `${JSON.stringify({
-        type: "session",
-        version: 3,
-        id: parentSessionId,
-        timestamp: new Date().toISOString(),
-        cwd: process.cwd(),
-      })}\n`,
-      "utf-8",
-    );
+    const parentSessionFile = path.join(root, "parent.jsonl");
 
     const storePath = path.join(root, "sessions.json");
     const parentSessionKey = "agent:main:slack:channel:c1";
@@ -888,7 +718,6 @@ describe("initSessionState thread forking", () => {
         ParentSessionKey: parentSessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     const tokenCountCall = requireMockCallArg(
@@ -920,7 +749,6 @@ describe("initSessionState thread forking", () => {
         MessageThreadId: 456,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.sessionEntry.lastThreadId).toBe(456);
@@ -943,7 +771,6 @@ describe("initSessionState thread forking", () => {
           SessionKey: "agent:main:telegram:group:123:topic:456",
         },
         cfg,
-        commandAuthorized: true,
       });
 
       expect(result.sessionKey).toBe("agent:main:telegram:group:123:topic:456");
@@ -968,7 +795,6 @@ describe("initSessionState RawBody", () => {
         SessionKey: "agent:main:whatsapp:group:g1",
       },
       cfg,
-      commandAuthorized: true,
     });
     expect(statusResult.triggerBodyNormalized).toBe("/status");
 
@@ -980,7 +806,6 @@ describe("initSessionState RawBody", () => {
         SessionKey: "agent:main:whatsapp:group:g1",
       },
       cfg,
-      commandAuthorized: true,
     });
     expect(resetResult.isNewSession).toBe(true);
     expect(resetResult.bodyStripped).toBe("");
@@ -1006,7 +831,6 @@ describe("initSessionState RawBody", () => {
     const result = await initSessionState({
       ctx,
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -1051,7 +875,6 @@ describe("initSessionState RawBody", () => {
           resetTriggers: ["/new"],
         },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -1082,7 +905,6 @@ describe("initSessionState RawBody", () => {
             },
           },
         } as OpenClawConfig,
-        commandAuthorized: true,
       });
 
       expect(result.isNewSession).toBe(true);
@@ -1141,7 +963,6 @@ describe("initSessionState RawBody", () => {
             },
           },
         } as OpenClawConfig,
-        commandAuthorized: true,
       });
 
       expect(result.isNewSession).toBe(true);
@@ -1167,7 +988,6 @@ describe("initSessionState RawBody", () => {
           resetTriggers: ["/new"],
         },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -1191,7 +1011,6 @@ describe("initSessionState RawBody", () => {
           resetTriggers: ["/new"],
         },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -1233,7 +1052,6 @@ describe("initSessionState RawBody", () => {
       cfg: {
         session: { store: storePath, resetTriggers: ["/new"] },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(ctx).toMatchObject({
@@ -1259,7 +1077,6 @@ describe("initSessionState RawBody", () => {
         SessionKey: "agent:main:telegram:dm:legacy",
       },
       cfg,
-      commandAuthorized: true,
     });
     expect(legacy.resetTriggered).toBe(true);
     expect(legacy.bodyStripped).toBe("keep [Q3]\nline 2");
@@ -1277,7 +1094,6 @@ describe("initSessionState RawBody", () => {
         SessionKey: "agent:main:telegram:dm:flat-history",
       },
       cfg,
-      commandAuthorized: true,
     });
     expect(flatHistory.resetTriggered).toBe(false);
     expect(flatHistory.bodyStripped).toBeUndefined();
@@ -1297,7 +1113,6 @@ describe("initSessionState RawBody", () => {
         SessionKey: "agent:main:whatsapp:dm:audio-transcript",
       },
       cfg,
-      commandAuthorized: true,
     });
     expect(transcriptOnly.resetTriggered).toBe(false);
 
@@ -1310,7 +1125,6 @@ describe("initSessionState RawBody", () => {
         SessionKey: "agent:main:whatsapp:dm:audio-empty-raw",
       },
       cfg,
-      commandAuthorized: true,
     });
     expect(explicitEmptyRaw.triggerBodyNormalized).toBe("");
     expect(explicitEmptyRaw.resetTriggered).toBe(false);
@@ -1324,7 +1138,6 @@ describe("initSessionState RawBody", () => {
         SessionKey: "agent:main:whatsapp:dm:command-empty-raw",
       },
       cfg,
-      commandAuthorized: true,
     });
     expect(explicitCommandWithEmptyRaw.triggerBodyNormalized).toBe("/new spoken payload");
     expect(explicitCommandWithEmptyRaw.resetTriggered).toBe(false);
@@ -1406,7 +1219,6 @@ describe("initSessionState RawBody", () => {
         SessionKey: sessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -1471,7 +1283,6 @@ describe("initSessionState RawBody", () => {
         SessionKey: sessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -1528,7 +1339,6 @@ describe("initSessionState RawBody", () => {
         SessionKey: sessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     // The session rolled over implicitly (stale), not via /new.
@@ -1567,7 +1377,6 @@ describe("initSessionState RawBody", () => {
             },
           },
           cfg: { session: { store: storePath } } as OpenClawConfig,
-          commandAuthorized: true,
         });
         expect(listSessionStateEventsSince(sessionKey, "main", 0, 20).events).toContainEqual(
           expect.objectContaining({
@@ -1629,7 +1438,6 @@ describe("initSessionState RawBody", () => {
       cfg: {
         session: { store: storePath, reset: { mode: "daily", atHour: 4 } },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -1731,7 +1539,6 @@ describe("initSessionState RawBody", () => {
       cfg: {
         session: { store: storePath, reset: { mode: "daily", atHour: 4 } },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -1822,7 +1629,6 @@ describe("initSessionState RawBody", () => {
         ...(bindings ? { bindings } : {}),
         channels: { discord: { allowFrom: ["*"] } },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.resetTriggered).toBe(true);
@@ -1904,7 +1710,6 @@ describe("initSessionState RawBody", () => {
           SessionKey: sessionKey,
         },
         cfg,
-        commandAuthorized: true,
       });
 
       expect(result.resetTriggered).toBe(true);
@@ -1964,7 +1769,6 @@ describe("initSessionState RawBody", () => {
         SessionKey: fallbackSessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.resetTriggered).toBe(true);
@@ -2012,7 +1816,6 @@ describe("initSessionState RawBody", () => {
         CommandTargetSessionKey: targetSessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.sessionKey).toBe(targetSessionKey);
@@ -2048,7 +1851,6 @@ describe("initSessionState RawBody", () => {
           SessionKey: sessionKey,
         },
         cfg,
-        commandAuthorized: true,
       });
 
       expect(result.sessionEntry.sessionId).toBe(sessionId);
@@ -2133,7 +1935,6 @@ describe("initSessionState RawBody", () => {
       cfg: {
         session: { store: storePath },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.sessionKey).toBe(boundSessionKey);
@@ -2177,7 +1978,6 @@ describe("initSessionState RawBody", () => {
         ChatType: "direct",
       },
       cfg: { session: { store: storePath } } as OpenClawConfig,
-      commandAuthorized: true,
       expectedExistingSessionId: sourceSessionId,
       pinExpectedExistingSession: true,
     });
@@ -2283,7 +2083,6 @@ describe("initSessionState reset policy", () => {
     const result = await initSessionState({
       ctx: { Body: "hello", SessionKey: sessionKey, Provider: "internal", Surface: "internal" },
       cfg: { session: { store: storePath, ...scenario.session } } as OpenClawConfig,
-      commandAuthorized: true,
       requestedSessionId:
         "requestedSessionId" in scenario && scenario.requestedSessionId === "existing"
           ? existingSessionId
@@ -2334,7 +2133,6 @@ describe("initSessionState reset policy", () => {
     const result = await initSessionState({
       ctx: { Body: "hello", SessionKey: sessionKey },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -2372,7 +2170,6 @@ describe("initSessionState reset policy", () => {
     const result = await initSessionState({
       ctx: { Body: "hello", SessionKey: sessionKey },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(false);
@@ -2462,7 +2259,6 @@ describe("initSessionState reset policy", () => {
     const result = await initSessionState({
       ctx: { Body: "hello", SessionKey: scenario.sessionKey },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(scenario.expectNewSession);
@@ -2521,7 +2317,6 @@ describe("initSessionState reset policy", () => {
         BotUsername: "openclaw",
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(false);
@@ -2582,7 +2377,6 @@ describe("initSessionState reset policy", () => {
         SessionKey: sessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.resetTriggered).toBe(false);
@@ -2616,7 +2410,6 @@ describe("initSessionState reset policy", () => {
         SessionKey: sessionKey,
       },
       cfg: { session: { store: storePath } } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.resetTriggered).toBe(false);
@@ -2721,7 +2514,6 @@ describe("initSessionState reset policy", () => {
     const result = await initSessionState({
       ctx: { SessionKey: scenario.sessionKey, ...scenario.ctx },
       cfg: { session: { store: storePath, ...scenario.session } } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(false);
@@ -2758,7 +2550,6 @@ describe("initSessionState browser tab cleanup", () => {
     const result = await initSessionState({
       ctx: { Body: "hello", SessionKey: sessionKey },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -2802,7 +2593,6 @@ describe("initSessionState browser tab cleanup", () => {
     const result = await initSessionState({
       ctx: { Body: "hello", SessionKey: sessionKey },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -2832,7 +2622,6 @@ describe("initSessionState browser tab cleanup", () => {
         SessionKey: sessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -2856,7 +2645,6 @@ describe("initSessionState browser tab cleanup", () => {
         SessionKey: sessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -2885,7 +2673,6 @@ describe("initSessionState browser tab cleanup", () => {
         ChatType: "direct",
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -2932,7 +2719,6 @@ describe("initSessionState channel reset overrides", () => {
         Provider: "discord",
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(false);
@@ -3018,7 +2804,6 @@ describe("initSessionState reset triggers in WhatsApp groups", () => {
           SenderId: testCase.senderId,
         },
         cfg,
-        commandAuthorized: true,
       });
 
       expect(result.triggerBodyNormalized, testCase.name).toBe("/new");
@@ -3121,7 +2906,6 @@ describe("initSessionState reset triggers in Slack channels", () => {
         WasMentioned: true,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -3182,7 +2966,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
           cfg: {
             session: { store: storePath, idleMinutes: 999 },
           } as OpenClawConfig,
-          commandAuthorized: true,
         }),
       ).rejects.toThrow(MODEL_SELECTION_LOCKED_RESET_MESSAGE);
 
@@ -3228,7 +3011,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       cfg: {
         session: { store: storePath, idleMinutes: 1 },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(false);
@@ -3463,7 +3245,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
           },
         },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -3600,7 +3381,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
           Surface: "telegram",
         },
         cfg,
-        commandAuthorized: true,
       });
 
       expect(result.isNewSession, testCase.name).toBe(true);
@@ -3639,7 +3419,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         SessionKey: sessionKey,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.resetTriggered).toBe(false);
@@ -3687,7 +3466,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         SessionKey: sessionKey,
       },
       cfg: { session: { store: storePath, idleMinutes: 999 } } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expect(result.resetTriggered).toBe(false);
@@ -3730,7 +3508,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         Surface: "telegram",
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -3785,7 +3562,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         Surface: "telegram",
       },
       cfg: { session: { store: storePath, idleMinutes: 999 } } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     try {
@@ -3837,7 +3613,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
               Surface: "telegram",
             },
             cfg: { session: { store: storePath, idleMinutes: 999 } } as OpenClawConfig,
-            commandAuthorized: true,
           }),
       );
       expect(result.sessionId).toBe(existingSessionId);
@@ -3885,7 +3660,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
                 Surface: "telegram",
               },
               cfg: { session: { store: storePath, idleMinutes: 999 } } as OpenClawConfig,
-              commandAuthorized: true,
               signal: controller.signal,
             }),
         );
@@ -4037,7 +3811,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       cfg: {
         session: { store: storePath, reset: { mode: "idle", idleMinutes: 1 } },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
     const replaceSession = runExclusiveSessionStoreWrite(storePath, async () => {
       await writeSessionStoreFast(storePath, {
@@ -4113,7 +3886,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
           Surface: "telegram",
         },
         cfg,
-        commandAuthorized: true,
       });
 
       expect(result.isNewSession).toBe(true);
@@ -4171,7 +3943,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
           Surface: "telegram",
         },
         cfg,
-        commandAuthorized: true,
       });
 
       expect(result.isNewSession).toBe(false);
@@ -4229,7 +4000,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
           Surface: "telegram",
         },
         cfg,
-        commandAuthorized: true,
       });
 
       expect(operation.phase).toBe("queued");
@@ -4288,7 +4058,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
           Surface: "telegram",
         },
         cfg,
-        commandAuthorized: true,
       });
 
       expect(result.isNewSession).toBe(true);
@@ -4351,7 +4120,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
           Surface: "telegram",
         },
         cfg,
-        commandAuthorized: true,
       });
 
       expect(result.isNewSession).toBe(false);
@@ -4407,7 +4175,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         Surface: "telegram",
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -4455,7 +4222,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         Surface: "telegram",
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(sessionMcpTesting.getCachedSessionIds()).not.toContain(existingSessionId);
@@ -4482,7 +4248,6 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         Surface: "telegram",
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
@@ -5253,7 +5018,6 @@ describe("initSessionState stale threadId fallback", () => {
         MessageThreadId: 42,
       },
       cfg,
-      commandAuthorized: true,
     });
     expect(threadResult.sessionEntry.lastThreadId).toBe(42);
 
@@ -5265,7 +5029,6 @@ describe("initSessionState stale threadId fallback", () => {
         SessionKey: "agent:main:main",
       },
       cfg,
-      commandAuthorized: true,
     });
     expect(mainResult.sessionEntry.lastThreadId).toBeUndefined();
     expect(mainResult.sessionEntry.deliveryContext?.threadId).toBeUndefined();
@@ -5285,7 +5048,6 @@ describe("initSessionState stale threadId fallback", () => {
         TransportThreadId: "650.000",
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.sessionEntry.lastThreadId).toBe("650.000");
@@ -5304,7 +5066,6 @@ describe("initSessionState stale threadId fallback", () => {
         MessageThreadId: 99,
       },
       cfg,
-      commandAuthorized: true,
     });
 
     // Second message in same thread (MessageThreadId still present)
@@ -5315,7 +5076,6 @@ describe("initSessionState stale threadId fallback", () => {
         MessageThreadId: 99,
       },
       cfg,
-      commandAuthorized: true,
     });
     expect(result.sessionEntry.lastThreadId).toBe(99);
   });
@@ -5356,7 +5116,6 @@ describe("initSessionState dmScope delivery migration", () => {
       cfg: {
         session: { store: storePath, dmScope: "per-channel-peer" },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     const persisted = readSessionStoreFast(storePath);
@@ -5422,7 +5181,6 @@ describe("initSessionState internal channel routing preservation", () => {
         To: "heartbeat",
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.sessionEntry.lastChannel).toBe("mattermost");
@@ -5483,7 +5241,6 @@ describe("initSessionState internal channel routing preservation", () => {
         To: "heartbeat",
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.sessionEntry.lastChannel).toBeUndefined();
@@ -5528,7 +5285,6 @@ describe("initSessionState internal channel routing preservation", () => {
         AccountId: "default",
       },
       cfg,
-      commandAuthorized: true,
     });
 
     expect(result.sessionEntry.lastChannel).toBe("feishu");
@@ -5679,7 +5435,6 @@ describe("initSessionState internal channel routing preservation", () => {
         ...("config" in scenario ? scenario.config : {}),
         session: { store: storePath, ...("session" in scenario ? scenario.session : {}) },
       } as OpenClawConfig,
-      commandAuthorized: true,
     });
 
     expectEntryFields(result.sessionEntry, scenario.expected, scenario.name);

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -50,7 +50,6 @@ import {
   type SessionScope,
 } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { TtsAutoMode } from "../../config/types.tts.js";
 import {
   forgetActiveSessionForShutdown,
   noteActiveSessionForShutdown,
@@ -378,6 +377,36 @@ function selectSessionModelOverride(
   };
 }
 
+function resolveReplySessionRolloverState(entry: SessionEntry): Partial<SessionEntry> {
+  const preservedSelection = resolveResetPreservedSelection({ entry });
+  return {
+    thinkingLevel: entry.thinkingLevel,
+    verboseLevel: entry.verboseLevel,
+    traceLevel: entry.traceLevel,
+    reasoningLevel: entry.reasoningLevel,
+    ttsAuto: entry.ttsAuto,
+    responseUsage: entry.responseUsage,
+    ...selectSessionModelOverride(preservedSelection),
+    authProfileOverride: preservedSelection.authProfileOverride,
+    authProfileOverrideSource: preservedSelection.authProfileOverrideSource,
+    authProfileOverrideCompactionCount: preservedSelection.authProfileOverrideCompactionCount,
+    label: entry.label,
+    displayName: entry.displayName,
+    spawnedBy: entry.spawnedBy,
+    spawnedWorkspaceDir: entry.spawnedWorkspaceDir,
+    spawnedCwd: entry.spawnedCwd,
+    parentSessionKey: entry.parentSessionKey,
+    forkedFromParent: entry.forkedFromParent,
+    forkSource: entry.forkSource,
+    createdVia: entry.createdVia,
+    createdActor: entry.createdActor,
+    createdAt: entry.createdAt,
+    spawnDepth: entry.spawnDepth,
+    subagentRole: entry.subagentRole,
+    subagentControlScope: entry.subagentControlScope,
+  };
+}
+
 export async function initSessionState(params: InitSessionStateParams): Promise<SessionInitResult> {
   return await runWithSessionInitConflictRetry(
     async () => await initSessionStateAttempt(params, false),
@@ -491,30 +520,7 @@ async function initSessionStateAttemptLocked(
   let abortedLastRun;
   let resetTriggered = false;
 
-  let persistedThinking: string | undefined;
-  let persistedVerbose: string | undefined;
-  let persistedTrace: string | undefined;
-  let persistedReasoning: string | undefined;
-  let persistedTtsAuto: TtsAutoMode | undefined;
-  let persistedResponseUsage: SessionEntry["responseUsage"];
-  let persistedModelSelection: SessionModelOverrideSelection | undefined;
-  let persistedAuthProfileOverride: string | undefined;
-  let persistedAuthProfileOverrideSource: SessionEntry["authProfileOverrideSource"];
-  let persistedAuthProfileOverrideCompactionCount: number | undefined;
-  let persistedLabel: string | undefined;
-  let persistedSpawnedBy: SessionEntry["spawnedBy"];
-  let persistedSpawnedWorkspaceDir: SessionEntry["spawnedWorkspaceDir"];
-  let persistedSpawnedCwd: SessionEntry["spawnedCwd"];
-  let persistedParentSessionKey: SessionEntry["parentSessionKey"];
-  let persistedForkedFromParent: SessionEntry["forkedFromParent"];
-  let persistedForkSource: SessionEntry["forkSource"];
-  let persistedCreatedVia: SessionEntry["createdVia"];
-  let persistedCreatedActor: SessionEntry["createdActor"];
-  let persistedCreatedAt: SessionEntry["createdAt"];
-  let persistedSpawnDepth: SessionEntry["spawnDepth"];
-  let persistedSubagentRole: SessionEntry["subagentRole"];
-  let persistedSubagentControlScope: SessionEntry["subagentControlScope"];
-  let persistedDisplayName: SessionEntry["displayName"];
+  let preservedState: Partial<SessionEntry> | undefined;
 
   const normalizedChatType = normalizeChatType(ctx.ChatType);
   const isGroup =
@@ -747,17 +753,7 @@ async function initSessionStateAttemptLocked(
     sessionId = reusableEntry.sessionId;
     systemSent = reusableEntry.systemSent ?? false;
     abortedLastRun = reusableEntry.abortedLastRun ?? false;
-    persistedThinking = reusableEntry.thinkingLevel;
-    persistedVerbose = reusableEntry.verboseLevel;
-    persistedTrace = reusableEntry.traceLevel;
-    persistedReasoning = reusableEntry.reasoningLevel;
-    persistedTtsAuto = reusableEntry.ttsAuto;
-    persistedResponseUsage = reusableEntry.responseUsage;
-    persistedModelSelection = selectSessionModelOverride(reusableEntry);
-    persistedAuthProfileOverride = reusableEntry.authProfileOverride;
-    persistedAuthProfileOverrideSource = reusableEntry.authProfileOverrideSource;
-    persistedAuthProfileOverrideCompactionCount = reusableEntry.authProfileOverrideCompactionCount;
-    persistedLabel = reusableEntry.label;
+    preservedState = selectSessionModelOverride(reusableEntry);
   } else {
     // Durable resets retain their transcript identity for cursor continuity; ACP
     // resets still rotate the local session id that owns provider conversation state.
@@ -778,46 +774,19 @@ async function initSessionStateAttemptLocked(
     // resetTriggered === false), reverting the session to the default model
     // despite the `Model set to ... for this session` ack (#90119, #69301).
     if (entry) {
-      const preservedSelection = resolveResetPreservedSelection({ entry });
-      persistedModelSelection = selectSessionModelOverride(preservedSelection);
-      persistedAuthProfileOverride = preservedSelection.authProfileOverride;
-      persistedAuthProfileOverrideSource = preservedSelection.authProfileOverrideSource;
-      persistedAuthProfileOverrideCompactionCount =
-        preservedSelection.authProfileOverrideCompactionCount;
       // Behavior overrides carry across ANY new-session mint (explicit /new AND
       // implicit daily/idle rollover), mirroring the model/auth carry above
       // (#90119). Any persisted level is safe to forward — user `/think` or a
       // spawn-applied default (subagent-spawn-thinking.ts) — so unlike model
       // overrides these need no fallback-provenance filtering (#92562).
-      persistedThinking = entry.thinkingLevel;
-      persistedVerbose = entry.verboseLevel;
-      persistedTrace = entry.traceLevel;
-      persistedReasoning = entry.reasoningLevel;
-      persistedTtsAuto = entry.ttsAuto;
-      persistedResponseUsage = entry.responseUsage;
-      persistedLabel = entry.label;
-      persistedDisplayName = entry.displayName;
       // Explicit /new and /reset rotate CLI conversation bindings elsewhere.
       // Lineage/control facts belong to the session node and survive ANY rollover
       // from an existing entry, following the #90119 carry pattern.
-      persistedSpawnedBy = entry.spawnedBy;
-      persistedSpawnedWorkspaceDir = entry.spawnedWorkspaceDir;
-      persistedSpawnedCwd = entry.spawnedCwd;
-      persistedParentSessionKey = entry.parentSessionKey;
-      persistedForkedFromParent = entry.forkedFromParent;
-      persistedForkSource = entry.forkSource;
-      persistedCreatedVia = entry.createdVia;
-      persistedCreatedActor = entry.createdActor;
-      persistedCreatedAt = entry.createdAt;
-      persistedSpawnDepth = entry.spawnDepth;
-      persistedSubagentRole = entry.subagentRole;
-      persistedSubagentControlScope = entry.subagentControlScope;
+      preservedState = resolveReplySessionRolloverState(entry);
     }
   }
 
   const baseEntry = !isNewSession && effectiveFreshEntry ? reusableEntry : undefined;
-  const modelSelection =
-    persistedModelSelection ?? (baseEntry ? selectSessionModelOverride(baseEntry) : undefined);
   const usageFamilyKey = previousSessionEntry
     ? (previousSessionEntry.usageFamilyKey ?? sessionKey)
     : baseEntry?.usageFamilyKey;
@@ -897,6 +866,7 @@ async function initSessionStateAttemptLocked(
     !entry && ctx.SessionCreation ? buildSessionCreationStamp(ctx.SessionCreation) : undefined;
   sessionEntry = {
     ...baseEntry,
+    ...preservedState,
     sessionId,
     lifecycleRevision: isNewSession ? crypto.randomUUID() : baseEntry?.lifecycleRevision,
     updatedAt: Date.now(),
@@ -907,48 +877,22 @@ async function initSessionStateAttemptLocked(
     agentStatus: isSystemEvent ? baseEntry?.agentStatus : undefined,
     systemSent,
     abortedLastRun: recoveredTerminalEntry ? undefined : abortedLastRun,
-    // Persist previously stored thinking/verbose levels when present.
-    thinkingLevel: persistedThinking ?? baseEntry?.thinkingLevel,
-    verboseLevel: persistedVerbose ?? baseEntry?.verboseLevel,
-    traceLevel: persistedTrace ?? baseEntry?.traceLevel,
-    reasoningLevel: persistedReasoning ?? baseEntry?.reasoningLevel,
-    ttsAuto: persistedTtsAuto ?? baseEntry?.ttsAuto,
-    responseUsage: persistedResponseUsage ?? baseEntry?.responseUsage,
     pinnedAt: entry?.pinnedAt,
     usageFamilyKey,
     usageFamilySessionIds,
     previousSessionId: baseEntry?.previousSessionId,
-    modelOverride: modelSelection?.modelOverride,
-    providerOverride: modelSelection?.providerOverride,
-    modelOverrideSource: modelSelection?.modelOverrideSource,
-    modelOverrideRouteResolution: modelSelection?.modelOverrideRouteResolution,
-    authProfileOverride: persistedAuthProfileOverride ?? baseEntry?.authProfileOverride,
-    authProfileOverrideSource:
-      persistedAuthProfileOverrideSource ?? baseEntry?.authProfileOverrideSource,
-    authProfileOverrideCompactionCount:
-      persistedAuthProfileOverrideCompactionCount ?? baseEntry?.authProfileOverrideCompactionCount,
     cliSessionIds: baseEntry?.cliSessionIds,
     cliSessionBindings: baseEntry?.cliSessionBindings,
     claudeCliSessionId: baseEntry?.claudeCliSessionId,
-    label: persistedLabel ?? baseEntry?.label,
-    spawnedBy: persistedSpawnedBy ?? baseEntry?.spawnedBy,
-    spawnedWorkspaceDir: persistedSpawnedWorkspaceDir ?? baseEntry?.spawnedWorkspaceDir,
-    spawnedCwd: persistedSpawnedCwd ?? baseEntry?.spawnedCwd,
-    parentSessionKey: persistedParentSessionKey ?? baseEntry?.parentSessionKey,
-    forkedFromParent: persistedForkedFromParent ?? baseEntry?.forkedFromParent,
-    forkSource: persistedForkSource ?? baseEntry?.forkSource,
-    createdVia: persistedCreatedVia ?? baseEntry?.createdVia ?? creationStamp?.createdVia,
-    createdActor: persistedCreatedActor ?? baseEntry?.createdActor ?? creationStamp?.createdActor,
-    createdAt: persistedCreatedAt ?? baseEntry?.createdAt ?? creationStamp?.createdAt,
-    spawnDepth: persistedSpawnDepth ?? baseEntry?.spawnDepth,
-    subagentRole: persistedSubagentRole ?? baseEntry?.subagentRole,
-    subagentControlScope: persistedSubagentControlScope ?? baseEntry?.subagentControlScope,
+    createdVia: preservedState?.createdVia ?? baseEntry?.createdVia ?? creationStamp?.createdVia,
+    createdActor:
+      preservedState?.createdActor ?? baseEntry?.createdActor ?? creationStamp?.createdActor,
+    createdAt: preservedState?.createdAt ?? baseEntry?.createdAt ?? creationStamp?.createdAt,
     sendPolicy: baseEntry?.sendPolicy,
     queueMode: baseEntry?.queueMode,
     queueDebounceMs: baseEntry?.queueDebounceMs,
     queueCap: baseEntry?.queueCap,
     queueDrop: baseEntry?.queueDrop,
-    displayName: persistedDisplayName ?? baseEntry?.displayName,
     chatType: baseEntry?.chatType,
     delivery,
     groupId: baseEntry?.groupId,

--- a/src/auto-reply/reply/test/session.test-support.ts
+++ b/src/auto-reply/reply/test/session.test-support.ts
@@ -21,11 +21,16 @@ function projectSessionEntry(entry: SessionEntry): ProjectedSessionEntry {
 }
 
 export const initSessionState = async (
-  params: Omit<Parameters<typeof initSessionStateRaw>[0], "ctx"> & {
+  params: Omit<Parameters<typeof initSessionStateRaw>[0], "ctx" | "commandAuthorized"> & {
     ctx: Record<string, unknown>;
+    commandAuthorized?: boolean;
   },
 ) => {
-  const result = await initSessionStateRaw({ ...params, ctx: finalizeInboundContext(params.ctx) });
+  const result = await initSessionStateRaw({
+    ...params,
+    commandAuthorized: params.commandAuthorized ?? true,
+    ctx: finalizeInboundContext(params.ctx),
+  });
   return { ...result, sessionEntry: projectSessionEntry(result.sessionEntry) };
 };
 


### PR DESCRIPTION
## What Problem This Solves

Reply-session initialization preserved rollover state through more than twenty independent temporary variables, while fresh-session reuse rebuilt the same state a second way. This made the reset/reuse invariant difficult to audit and made future session fields easy to preserve on one path but miss on another.

## Why This Change Was Made

The session owner now carries rollover facts as one typed partial `SessionEntry`, while reusable sessions keep their canonical base entry and explicitly normalize model selection exactly as before. The session tests also use the real fork-entry implementation behind two focused boundary mocks, and their shared helper defaults authorized commands instead of repeating that fixture value in every case.

This is AI-assisted, maintainer-requested cleanup. It changes no public API, config, persistence schema, or user-visible behavior.

Production delta: +38/-94 (net -56). Test/support delta: +12/-252 (net -240). Total: +50/-346 (net -296).

## User Impact

No user-visible behavior changes. Fresh reuse, explicit reset, and implicit rollover continue to preserve the same model/provider/auth, behavior, delivery, label, compaction, and lineage facts; the owning flow is smaller and easier to extend safely.

## Evidence

- Direct after-fix runtime proof on Blacksmith Testbox used the production `initSessionState` path against an isolated persisted session store. Both an idle-expired implicit rollover and an authorized `/new` returned `verdict: true` while retaining thinking/verbosity/usage, explicit provider/model/auth selection, label, parent/spawn lineage, and spawn depth. Proof run: https://github.com/openclaw/openclaw/actions/runs/30781424014

  ```json
  {
    "verdict": true,
    "implicit": { "isNewSession": true, "resetTriggered": false },
    "explicit": { "isNewSession": true, "resetTriggered": true },
    "preserved": {
      "thinkingLevel": "medium",
      "verboseLevel": "on",
      "responseUsage": "full",
      "providerOverride": "openai",
      "modelOverride": "gpt-5",
      "modelOverrideSource": "user",
      "authProfileOverride": "openai:proof",
      "authProfileOverrideSource": "user",
      "label": "Runtime proof",
      "spawnedBy": "agent:main:main",
      "parentSessionKey": "agent:main:main",
      "spawnDepth": 1
    }
  }
  ```

- Fresh Blacksmith Testbox exact-tree run: 4 files and 188 tests passed (`session.test.ts` 160 plus 28 adjacent lifecycle/conflict/hook tests).
- `pnpm check:changed` passed on the same rebased tree, including formatting, lint, core and core-test typechecks, dependency/plugin boundaries, dead exports, import cycles, and repository guards.
- GitHub Actions proof run: https://github.com/openclaw/openclaw/actions/runs/30779816937
- Fresh post-rebase `autoreview`: clean, no findings; patch judged correct with 0.96 confidence.
- Direct history/source comparison preserved the reuse-path normalization that drops an invalid provider-only override, and all rollover-preservation assertions remain in the focused suite.
