### PR TITLE
fix: start QA Gateway children from fresh source checkouts

### DIFF
--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -369,19 +369,22 @@ describe("Gateway child fixture helpers", () => {
     });
   });
 
-  it("resolves source and built Gateway CLI commands", async () => {
+  it("resolves the repo runner before a built Gateway CLI fallback", async () => {
     const repoRoot = await tempDirs.makeTempDir("qa-gateway-command-");
-    await mkdir(path.join(repoRoot, "src"), { recursive: true });
-    await writeFile(path.join(repoRoot, "src", "entry.ts"), "export {};\n", "utf8");
+    await mkdir(path.join(repoRoot, "scripts"), { recursive: true });
+    const runnerPath = path.join(repoRoot, "scripts", "run-node.mjs");
+    await writeFile(runnerPath, "export {};\n", "utf8");
 
     expect(testing.resolveQaGatewayChildCommand(repoRoot)).toEqual({
       executablePath: process.execPath,
-      argsPrefix: ["--import", "tsx", path.join(repoRoot, "src", "entry.ts")],
+      argsPrefix: [runnerPath],
       cwd: repoRoot,
+      usePackagedPlugins: true,
     });
 
     await mkdir(path.join(repoRoot, "dist"), { recursive: true });
     await writeFile(path.join(repoRoot, "dist", "index.js"), "export {};\n", "utf8");
+    await rm(path.join(repoRoot, "scripts"), { recursive: true });
     expect(testing.resolveQaGatewayChildCommand(repoRoot)).toEqual({
       executablePath: process.execPath,
       argsPrefix: [path.join(repoRoot, "dist", "index.js")],
@@ -463,6 +466,7 @@ describe("buildQaRuntimeEnv", () => {
       "/repo/.artifacts/qa-runtime/openclaw-qa-suite-test",
     );
     expect(env.OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER).toBe("1");
+    expect(env.OPENCLAW_BUILD_PRIVATE_QA).toBe("1");
     expect(env.OPENCLAW_ALLOW_SLOW_REPLY_TESTS).toBe("1");
     expect(env.OPENCLAW_BUNDLED_PLUGINS_DIR).toBe("/tmp/openclaw-qa/bundled-plugins");
     expect(env.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBe("2026.4.8");

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -144,7 +144,7 @@ function createQaGatewayEmptyTransport() {
 }
 
 function resolveQaGatewayChildCommand(repoRoot: string): QaGatewayChildCommand {
-  for (const relativePath of ["dist/index.mjs", "dist/index.js"]) {
+  for (const relativePath of ["scripts/run-node.mjs", "dist/index.mjs", "dist/index.js"]) {
     const entryPath = path.join(repoRoot, relativePath);
     if (existsSync(entryPath)) {
       return {
@@ -156,16 +156,9 @@ function resolveQaGatewayChildCommand(repoRoot: string): QaGatewayChildCommand {
     }
   }
 
-  const sourceEntryPath = path.join(repoRoot, "src/entry.ts");
-  if (existsSync(sourceEntryPath)) {
-    return {
-      executablePath: process.execPath,
-      argsPrefix: ["--import", "tsx", sourceEntryPath],
-      cwd: repoRoot,
-    };
-  }
-
-  throw new Error("OpenClaw CLI entry not found: expected dist/index.(m)js or src/entry.ts");
+  throw new Error(
+    "OpenClaw CLI entry not found: expected scripts/run-node.mjs or dist/index.(m)js",
+  );
 }
 
 async function runQaGatewayCliCommand(params: {
@@ -450,6 +443,7 @@ export function buildQaRuntimeEnv(params: {
   };
   const normalizedEnv = normalizeQaProviderModeEnv(env, params.providerMode);
   Object.assign(normalizedEnv, params.runtimeEnvPatch);
+  normalizedEnv.OPENCLAW_BUILD_PRIVATE_QA = "1";
   delete normalizedEnv[QA_LIVE_ANTHROPIC_SETUP_TOKEN_ENV];
   delete normalizedEnv[QA_LIVE_SETUP_TOKEN_VALUE_ENV];
   return scrubQaGatewayChildSecretEnv(normalizedEnv);


### PR DESCRIPTION
Closes #118400

## What Problem This Solves

Fixes an issue where maintainers running QA Gateway-child product proofs from a fresh source checkout would wait for the full 120-second listener deadline and then fail before the Gateway emitted any logs. The account-routing proof hit this twice in one file, and the requester-delivery proof shared the same launcher.

## Why This Change Was Made

`useRepoCli` fell back to launching the complete TypeScript entrypoint through `tsx` whenever `dist/` was absent. That bypassed the repository's supported CLI runner and compiled the bundled plugin graph inside the Gateway startup budget.

The QA Gateway owner now tries `scripts/run-node.mjs` first, then keeps the direct built-dist entries as the package-style fallback. The QA runtime environment requires private-QA build output, so the runner can build or refresh the exact QA Lab and QA channel artifacts before starting the dist CLI. The duplicate source-entry launcher is removed.

Increasing the listener timeout, special-casing the hook test, or requiring callers to prebuild were rejected because they leave the shared launcher on an unsupported execution path.

## User Impact

There is no shipped product-runtime behavior change. Maintainers and CI/release QA lanes can start real isolated Gateway children from a clean source checkout and reach the hook, channel-routing, requester-lineage, and delivery assertions they are intended to prove.

Production delta: +5/-11 (net -6) in the private QA launcher. Test delta: +8/-4. No compatibility path, config key, dependency, protocol, or user state changed.

Provenance: the source-entry fallback originated in https://github.com/openclaw/openclaw/pull/101091; the current hook account-routing proof landed through https://github.com/openclaw/openclaw/pull/116095 and made the unsupported fresh-checkout path deterministic.

## Evidence

Source: trusted maintainer branch based on `d347cd10974726281baaec98f7935a46c3fdd609`.

Blacksmith Testbox: `tbx_01kz2qk7e59fv3kpya5c2w1mdc` (`blacksmith-testbox`), https://github.com/openclaw/openclaw/actions/runs/30779657024

Before:

```text
pnpm test extensions/qa-lab/src/hook-agent-account-routing.e2e.test.ts

2 failed
rejects invalid explicit accounts before running the agent 121167ms
delivers exactly once through the selected qa-channel account 120553ms
QaSuiteInfraError: gateway failed to listen before timeout
```

After, exact final tree:

```text
pnpm test \
  extensions/qa-lab/src/gateway-child.test.ts \
  extensions/qa-lab/src/hook-agent-account-routing.e2e.test.ts \
  extensions/qa-lab/src/plugin-subagent-current-requester.e2e.test.ts

91 passed across two Vitest shards
- 3/3 real Gateway-child E2E assertions passed in 62.70s
- 88/88 launcher unit assertions passed in 2.56s

pnpm check:changed
passed: formatting, API baselines, extension prod/test typecheck, lint,
dependency pins, plugin boundaries, dead exports, database-first guards,
runtime-sidecar checks, and import-cycle checks
```

The E2E proof uses a real isolated Gateway child, hooks endpoint, QA channel bus, local deterministic provider, selected/default account delivery, and requester-lineage rejection. It is the real-behavior boundary for this private QA launcher repair.

Fresh autoreview:

```text
.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output
gpt-5.6-sol, xhigh: no findings; patch is correct; confidence 0.97
```

Public model identifier audit: PASS. The candidate diff and public proof contain no model identifiers.
