### PR TITLE
fix(agents): stop runaway shell retry loops whose error text keeps changing

### DIFF
--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -74,8 +74,11 @@ You can also enable the global rolling-history detectors in **Settings -> Labs**
 
 For `exec`, no-progress hashing compares stable command outcomes (status,
 exit code, timed-out flag, output) and ignores volatile runtime metadata such
-as duration, PID, session ID, and working directory. Outbound message-send
-results are hashed with volatile per-call ids (message id, file id, timestamp)
+as duration, PID, session ID, and working directory.
+For typed terminal failures, it also ignores diagnostic timestamps, explicit
+attempt or retry counters, elapsed durations, and labeled process IDs. Other
+text and numbers remain significant, so a new failure cause resets the streak.
+Outbound message-send results are hashed with volatile per-call ids (message id, file id, timestamp)
 stripped, so delivery IDs alone do not make repeated equivalent sends look like
 progress. When a run id is available, history is evaluated only within that run,
 so scheduled heartbeat cycles and fresh runs do not inherit stale loop counts

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { GatewayClientRequestError } from "../gateway/client.js";
 import {
@@ -56,6 +57,7 @@ import { callGatewayTool } from "./tools/gateway.js";
 
 const CRITICAL_THRESHOLD = 20;
 const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function currentNodeEvalCommand(source: string): string {
   const shellQuote = (value: string) =>
@@ -504,7 +506,7 @@ describe("before_tool_call loop detection behavior", () => {
   });
 
   it("blocks real exec failures whose process ids drift across a session alias merge", async () => {
-    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-exec-loop-merge-"));
+    const workspace = tempDirs.make("openclaw-exec-loop-merge-");
     const sessionId = "exec-loop-merge-session";
     const sessionKey = "agent:main:exec-loop-merge";
     const sessionIdAlias = "agent:main:exec-loop-merge-id";
@@ -518,55 +520,51 @@ describe("before_tool_call loop detection behavior", () => {
       cwd: workspace,
       allowBackground: false,
     };
-    try {
-      const sessionIdTool = wrapToolWithBeforeToolCallHook(createExecTool(execDefaults), {
-        agentId: "main",
-        sessionId,
-        sessionKey: sessionIdAlias,
-        runId,
-        loopDetection: { enabled: true },
-      });
-      const sessionKeyTool = wrapToolWithBeforeToolCallHook(createExecTool(execDefaults), {
-        agentId: "main",
-        sessionKey,
-        runId,
-        loopDetection: { enabled: true },
-      });
-      const outputs = new Set<string>();
+    const sessionIdTool = wrapToolWithBeforeToolCallHook(createExecTool(execDefaults), {
+      agentId: "main",
+      sessionId,
+      sessionKey: sessionIdAlias,
+      runId,
+      loopDetection: { enabled: true },
+    });
+    const sessionKeyTool = wrapToolWithBeforeToolCallHook(createExecTool(execDefaults), {
+      agentId: "main",
+      sessionKey,
+      runId,
+      loopDetection: { enabled: true },
+    });
+    const outputs = new Set<string>();
 
-      for (const [alias, tool] of [
-        ["id", sessionIdTool],
-        ["key", sessionKeyTool],
-      ] as const) {
-        for (let index = 0; index < CRITICAL_THRESHOLD / 2; index += 1) {
-          const result = await tool.execute(`exec-loop-${alias}-${index}`, { command });
-          const details = requireRecord(result.details, "exec result details");
-          expect(details).toMatchObject({ status: "completed", exitCode: 1 });
-          const aggregated = details.aggregated;
-          expect(aggregated).toBeTypeOf("string");
-          if (typeof aggregated !== "string") {
-            throw new Error("exec result details.aggregated was not a string");
-          }
-          outputs.add(aggregated);
+    for (const [alias, tool] of [
+      ["id", sessionIdTool],
+      ["key", sessionKeyTool],
+    ] as const) {
+      for (let index = 0; index < CRITICAL_THRESHOLD / 2; index += 1) {
+        const result = await tool.execute(`exec-loop-${alias}-${index}`, { command });
+        const details = requireRecord(result.details, "exec result details");
+        expect(details).toMatchObject({ status: "completed", exitCode: 1 });
+        const aggregated = details.aggregated;
+        expect(aggregated).toBeTypeOf("string");
+        if (typeof aggregated !== "string") {
+          throw new Error("exec result details.aggregated was not a string");
         }
+        outputs.add(aggregated);
       }
-      expect(outputs.size).toBeGreaterThan(1);
-
-      const merged = getDiagnosticSessionState({ sessionId, sessionKey });
-      expect(merged.toolCallHistory).toHaveLength(CRITICAL_THRESHOLD);
-
-      const mergedTool = wrapToolWithBeforeToolCallHook(createExecTool(execDefaults), {
-        agentId: "main",
-        sessionId,
-        sessionKey,
-        runId,
-        loopDetection: { enabled: true },
-      });
-      const blocked = await mergedTool.execute("exec-loop-blocked", { command });
-      expectToolLoopBlockedResult(blocked, "identical outcomes");
-    } finally {
-      await fs.rm(workspace, { recursive: true, force: true });
     }
+    expect(outputs.size).toBeGreaterThan(1);
+
+    const merged = getDiagnosticSessionState({ sessionId, sessionKey });
+    expect(merged.toolCallHistory).toHaveLength(CRITICAL_THRESHOLD);
+
+    const mergedTool = wrapToolWithBeforeToolCallHook(createExecTool(execDefaults), {
+      agentId: "main",
+      sessionId,
+      sessionKey,
+      runId,
+      loopDetection: { enabled: true },
+    });
+    const blocked = await mergedTool.execute("exec-loop-blocked", { command });
+    expectToolLoopBlockedResult(blocked, "identical outcomes");
   });
 
   it("blocks changing-argument terminal exec failures and escalates vetoes", async () => {

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -49,12 +49,20 @@ import {
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
+import { createExecTool } from "./bash-tools.exec-run.js";
 import { createWriteTool } from "./sessions/index.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 const CRITICAL_THRESHOLD = 20;
 const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
+
+function currentNodeEvalCommand(source: string): string {
+  const shellQuote = (value: string) =>
+    `'${value.replaceAll("'", process.platform === "win32" ? "''" : "'\\''")}'`;
+  const command = `${shellQuote(process.execPath)} -e ${shellQuote(source)}`;
+  return process.platform === "win32" ? `& ${command}` : command;
+}
 
 vi.mock("../plugins/hook-runner-global.js", async () => {
   const actual = await vi.importActual<typeof import("../plugins/hook-runner-global.js")>(
@@ -493,6 +501,72 @@ describe("before_tool_call loop detection behavior", () => {
 
     const result = await tool.execute(`read-${CRITICAL_THRESHOLD}`, params, undefined, undefined);
     expectToolLoopBlockedResult(result, "identical outcomes");
+  });
+
+  it("blocks real exec failures whose process ids drift across a session alias merge", async () => {
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-exec-loop-merge-"));
+    const sessionId = "exec-loop-merge-session";
+    const sessionKey = "agent:main:exec-loop-merge";
+    const sessionIdAlias = "agent:main:exec-loop-merge-id";
+    const runId = "exec-loop-merge-run";
+    const script = "process.stderr.write(`retry pid ${process.pid}\\n`); process.exit(1)";
+    const command = currentNodeEvalCommand(script);
+    const execDefaults = {
+      host: "gateway" as const,
+      security: "full" as const,
+      ask: "off" as const,
+      cwd: workspace,
+      allowBackground: false,
+    };
+    try {
+      const sessionIdTool = wrapToolWithBeforeToolCallHook(createExecTool(execDefaults), {
+        agentId: "main",
+        sessionId,
+        sessionKey: sessionIdAlias,
+        runId,
+        loopDetection: { enabled: true },
+      });
+      const sessionKeyTool = wrapToolWithBeforeToolCallHook(createExecTool(execDefaults), {
+        agentId: "main",
+        sessionKey,
+        runId,
+        loopDetection: { enabled: true },
+      });
+      const outputs = new Set<string>();
+
+      for (const [alias, tool] of [
+        ["id", sessionIdTool],
+        ["key", sessionKeyTool],
+      ] as const) {
+        for (let index = 0; index < CRITICAL_THRESHOLD / 2; index += 1) {
+          const result = await tool.execute(`exec-loop-${alias}-${index}`, { command });
+          const details = requireRecord(result.details, "exec result details");
+          expect(details).toMatchObject({ status: "completed", exitCode: 1 });
+          const aggregated = details.aggregated;
+          expect(aggregated).toBeTypeOf("string");
+          if (typeof aggregated !== "string") {
+            throw new Error("exec result details.aggregated was not a string");
+          }
+          outputs.add(aggregated);
+        }
+      }
+      expect(outputs.size).toBeGreaterThan(1);
+
+      const merged = getDiagnosticSessionState({ sessionId, sessionKey });
+      expect(merged.toolCallHistory).toHaveLength(CRITICAL_THRESHOLD);
+
+      const mergedTool = wrapToolWithBeforeToolCallHook(createExecTool(execDefaults), {
+        agentId: "main",
+        sessionId,
+        sessionKey,
+        runId,
+        loopDetection: { enabled: true },
+      });
+      const blocked = await mergedTool.execute("exec-loop-blocked", { command });
+      expectToolLoopBlockedResult(blocked, "identical outcomes");
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
   });
 
   it("blocks changing-argument terminal exec failures and escalates vetoes", async () => {

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1316,7 +1316,7 @@ describe("tool-loop-detection", () => {
       },
     );
 
-    it("resets the terminal-failure tail before returning to an earlier command", () => {
+    it("keeps an intervening command as a reset after the first command resumes", () => {
       const state = createState();
       const first = { command: "node first.js" };
 
@@ -1339,6 +1339,20 @@ describe("tool-loop-detection", () => {
         { command: "node second.js" },
         createExecLoopResult({ status: "completed", exitCode: 1, output: "failed in pid=2000" }),
         CRITICAL_THRESHOLD,
+      );
+
+      expect(detectToolCallLoop(state, "exec", first, enabledLoopDetectionConfig)).toMatchObject({
+        stuck: true,
+        level: "warning",
+        detector: "generic_repeat",
+      });
+
+      recordSuccessfulCall(
+        state,
+        "exec",
+        first,
+        createExecLoopResult({ status: "completed", exitCode: 1, output: "failed in pid=3000" }),
+        CRITICAL_THRESHOLD + 1,
       );
 
       expect(detectToolCallLoop(state, "exec", first, enabledLoopDetectionConfig)).toMatchObject({

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1221,6 +1221,133 @@ describe("tool-loop-detection", () => {
       });
     });
 
+    it.each([
+      {
+        label: "ISO timestamps",
+        output: (index: number) => `failed at 2026-08-30T10:20:${10 + index}Z`,
+      },
+      { label: "clock timestamps", output: (index: number) => `failed at 12:00:${10 + index}` },
+      { label: "attempt counters", output: (index: number) => `failed on attempt ${index}` },
+      { label: "retry counters", output: (index: number) => `failed on retry=${index}` },
+      { label: "elapsed durations", output: (index: number) => `failed after ${index + 1}ms` },
+      { label: "process ids", output: (index: number) => `failed in pid=${1000 + index}` },
+    ])("blocks terminal exec failures with drifting $label", ({ output }) => {
+      const state = createState();
+      const params = { command: "node retry.js" };
+
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+        recordSuccessfulCall(
+          state,
+          "exec",
+          params,
+          createExecLoopResult({ status: "completed", exitCode: 1, output: output(index) }),
+          index,
+        );
+      }
+
+      expect(detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig)).toMatchObject({
+        stuck: true,
+        level: "critical",
+        detector: "generic_repeat",
+        count: CRITICAL_THRESHOLD,
+      });
+    });
+
+    it.each([
+      {
+        label: "exit code",
+        beforeExitCode: 1,
+        beforeOutput: () => "command failed",
+        afterExitCode: 2,
+        afterOutput: "command failed",
+      },
+      {
+        label: "diagnostic text",
+        beforeExitCode: 1,
+        beforeOutput: () => "dependency missing",
+        afterExitCode: 1,
+        afterOutput: "syntax error",
+      },
+      {
+        label: "diagnostic number",
+        beforeExitCode: 1,
+        beforeOutput: (index: number) => `errno 111 at 12:00:${10 + index}`,
+        afterExitCode: 1,
+        afterOutput: "errno 113 at 12:00:39",
+      },
+    ])(
+      "resets a drifting terminal-failure streak after a new $label",
+      ({ beforeExitCode, beforeOutput, afterExitCode, afterOutput }) => {
+        const state = createState();
+        const params = { command: "node retry.js" };
+
+        for (let index = 0; index < CRITICAL_THRESHOLD - 1; index += 1) {
+          recordSuccessfulCall(
+            state,
+            "exec",
+            params,
+            createExecLoopResult({
+              status: "completed",
+              exitCode: beforeExitCode,
+              output: beforeOutput(index),
+            }),
+            index,
+          );
+        }
+        recordSuccessfulCall(
+          state,
+          "exec",
+          params,
+          createExecLoopResult({
+            status: "completed",
+            exitCode: afterExitCode,
+            output: afterOutput,
+          }),
+          CRITICAL_THRESHOLD,
+        );
+
+        expect(detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig)).toMatchObject(
+          {
+            stuck: true,
+            level: "warning",
+            detector: "generic_repeat",
+          },
+        );
+      },
+    );
+
+    it("resets the terminal-failure tail before returning to an earlier command", () => {
+      const state = createState();
+      const first = { command: "node first.js" };
+
+      for (let index = 0; index < CRITICAL_THRESHOLD - 1; index += 1) {
+        recordSuccessfulCall(
+          state,
+          "exec",
+          first,
+          createExecLoopResult({
+            status: "completed",
+            exitCode: 1,
+            output: `failed in pid=${1000 + index}`,
+          }),
+          index,
+        );
+      }
+      recordSuccessfulCall(
+        state,
+        "exec",
+        { command: "node second.js" },
+        createExecLoopResult({ status: "completed", exitCode: 1, output: "failed in pid=2000" }),
+        CRITICAL_THRESHOLD,
+      );
+
+      expect(detectToolCallLoop(state, "exec", first, enabledLoopDetectionConfig)).toMatchObject({
+        stuck: true,
+        level: "warning",
+        detector: "generic_repeat",
+      });
+    });
+
     it("anchors changing-argument exec vetoes until the global circuit breaker", () => {
       const state = createState();
       const result = createExecLoopResult({

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1230,6 +1230,7 @@ describe("tool-loop-detection", () => {
       { label: "attempt counters", output: (index: number) => `failed on attempt ${index}` },
       { label: "retry counters", output: (index: number) => `failed on retry=${index}` },
       { label: "elapsed durations", output: (index: number) => `failed after ${index + 1}ms` },
+      { label: "short elapsed durations", output: (index: number) => `failed after ${index + 1}s` },
       { label: "process ids", output: (index: number) => `failed in pid=${1000 + index}` },
     ])("blocks terminal exec failures with drifting $label", ({ output }) => {
       const state = createState();

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1275,6 +1275,13 @@ describe("tool-loop-detection", () => {
         afterExitCode: 1,
         afterOutput: "errno 113 at 12:00:39",
       },
+      {
+        label: "calendar date",
+        beforeExitCode: 1,
+        beforeOutput: () => "certificate becomes valid on 2026-08-30",
+        afterExitCode: 1,
+        afterOutput: "certificate becomes valid on 2026-08-31",
+      },
     ])(
       "resets a drifting terminal-failure streak after a new $label",
       ({ beforeExitCode, beforeOutput, afterExitCode, afterOutput }) => {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -170,6 +170,34 @@ function hashExecToolOutcome(details: Record<string, unknown>, text: string): st
   return undefined;
 }
 
+// These spans describe when an exec failed, not why. Preserve every other
+// diagnostic token so a new error, exit code, or cause resets the streak.
+const VOLATILE_EXEC_FAILURE_PATTERNS = [
+  /\d{4}-\d{2}-\d{2}[t ]\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:z|[+-]\d{2}:\d{2})?/giu,
+  /\d{4}-\d{2}-\d{2}/gu,
+  /\d{1,2}:\d{2}:\d{2}(?:\.\d{1,6})?/gu,
+  /\b(?:attempt|retry)\b[\s#:=]*\d+/giu,
+  /\b\d+(?:\.\d+)?\s?(?:ns|us|ms|seconds?|minutes?|hours?)\b/giu,
+  /\b(?:pid|ppid)\b[\s#:=]*\d+/giu,
+] as const;
+
+function hashExecFailureIdentity(
+  details: Record<string, unknown>,
+  exitCode: number,
+  output: string,
+): string {
+  let outputShape = output;
+  for (const pattern of VOLATILE_EXEC_FAILURE_PATTERNS) {
+    outputShape = outputShape.replace(pattern, "#");
+  }
+  return digestToolOutcome({
+    status: details.status,
+    exitCode,
+    timedOut: details.timedOut === true,
+    output: outputShape,
+  });
+}
+
 // Delivery results carry fresh per-call ids (messageId/runId) in details and text, so
 // hashing them defeats no-progress loop blocking (#89090). Hash only id-stripped facts
 // for outbound-message actions; other `message` actions keep full hashing (real progress).
@@ -259,12 +287,17 @@ function isLoopVetoResult(details: Record<string, unknown>): boolean {
   return details.status === "blocked" && details.deniedReason === "tool-loop";
 }
 
+type ToolCallOutcome = Pick<
+  ToolCallRecord,
+  "failureIdentityHash" | "outcomeKind" | "resultHash" | "noProgress" | "unknownToolName"
+>;
+
 function hashToolOutcome(
   toolName: string,
   params: unknown,
   result: unknown,
   error: unknown,
-): Pick<ToolCallRecord, "outcomeKind" | "resultHash" | "noProgress" | "unknownToolName"> {
+): ToolCallOutcome {
   if (error !== undefined) {
     const unknownToolName = extractUnknownToolName(error);
     return {
@@ -299,7 +332,11 @@ function hashToolOutcome(
         output !== "" &&
         output !== `(Command exited with code ${exitCode})`;
       return terminalFailure
-        ? { resultHash: execHash, outcomeKind: "terminal-exec-failure" }
+        ? {
+            resultHash: execHash,
+            outcomeKind: "terminal-exec-failure",
+            failureIdentityHash: hashExecFailureIdentity(details, exitCode, output),
+          }
         : { resultHash: execHash };
     }
   }
@@ -704,6 +741,7 @@ export function recordToolCallOutcome(
     }
     call.outcomeKind = outcome.outcomeKind;
     call.resultHash = outcome.resultHash;
+    call.failureIdentityHash = outcome.failureIdentityHash;
     if (outcome.noProgress) {
       call.noProgress = true;
     } else {
@@ -723,6 +761,7 @@ export function recordToolCallOutcome(
       ...(runId && { runId }),
       outcomeKind: outcome.outcomeKind,
       resultHash: outcome.resultHash,
+      failureIdentityHash: outcome.failureIdentityHash,
       ...(outcome.noProgress ? { noProgress: true as const } : {}),
       unknownToolName: outcome.unknownToolName,
       timestamp: Date.now(),

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -176,7 +176,7 @@ const VOLATILE_EXEC_FAILURE_PATTERNS = [
   /\d{4}-\d{2}-\d{2}[t ]\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:z|[+-]\d{2}:\d{2})?/giu,
   /\d{1,2}:\d{2}:\d{2}(?:\.\d{1,6})?/gu,
   /\b(?:attempt|retry)\b[\s#:=]*\d+/giu,
-  /\b\d+(?:\.\d+)?\s?(?:ns|us|ms|seconds?|minutes?|hours?)\b/giu,
+  /\b\d+(?:\.\d+)?\s?(?:ns|us|ms|seconds?|minutes?|hours?|s)\b/giu,
   /\b(?:pid|ppid)\b[\s#:=]*\d+/giu,
 ] as const;
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -174,7 +174,6 @@ function hashExecToolOutcome(details: Record<string, unknown>, text: string): st
 // diagnostic token so a new error, exit code, or cause resets the streak.
 const VOLATILE_EXEC_FAILURE_PATTERNS = [
   /\d{4}-\d{2}-\d{2}[t ]\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:z|[+-]\d{2}:\d{2})?/giu,
-  /\d{4}-\d{2}-\d{2}/gu,
   /\d{1,2}:\d{2}:\d{2}(?:\.\d{1,6})?/gu,
   /\b(?:attempt|retry)\b[\s#:=]*\d+/giu,
   /\b\d+(?:\.\d+)?\s?(?:ns|us|ms|seconds?|minutes?|hours?)\b/giu,

--- a/src/agents/tool-loop-no-progress.ts
+++ b/src/agents/tool-loop-no-progress.ts
@@ -21,7 +21,7 @@ function countNoProgressStreak(
   terminalExecFailuresOnly: boolean,
 ): { count: number; latestResultHash?: string } {
   let streak = 0;
-  let latestResultHash: string | undefined;
+  let latestOutcome: ToolCallRecord | undefined;
   // Vetoes are provisional until an older concrete outcome anchors them; a newer
   // changed outcome must reset vetoes from the previous no-progress streak.
   let pendingLoopVetoes = 0;
@@ -50,13 +50,26 @@ function countNoProgressStreak(
     if (terminalExecFailuresOnly && record.outcomeKind !== "terminal-exec-failure") {
       break;
     }
-    if (!latestResultHash) {
-      latestResultHash = record.resultHash;
+    if (!latestOutcome) {
+      latestOutcome = record;
       streak = pendingLoopVetoes + 1;
       pendingLoopVetoes = 0;
       continue;
     }
-    if (record.resultHash !== latestResultHash) {
+    // A return to an earlier command starts a new tail. Changing arguments can
+    // still count when each new command keeps failing in the same typed way.
+    if (
+      terminalExecFailuresOnly &&
+      latestOutcome.argsHash !== argsHash &&
+      record.argsHash === argsHash
+    ) {
+      break;
+    }
+    const repeatsSameFailure =
+      terminalExecFailuresOnly &&
+      record.failureIdentityHash !== undefined &&
+      record.failureIdentityHash === latestOutcome.failureIdentityHash;
+    if (record.resultHash !== latestOutcome.resultHash && !repeatsSameFailure) {
       break;
     }
     streak += pendingLoopVetoes + 1;
@@ -64,7 +77,7 @@ function countNoProgressStreak(
   }
 
   return {
-    count: latestResultHash ? streak : terminalExecFailuresOnly ? 0 : pendingLoopVetoes,
-    latestResultHash,
+    count: latestOutcome ? streak : terminalExecFailuresOnly ? 0 : pendingLoopVetoes,
+    latestResultHash: latestOutcome?.resultHash,
   };
 }

--- a/src/agents/tool-loop-no-progress.ts
+++ b/src/agents/tool-loop-no-progress.ts
@@ -22,6 +22,7 @@ function countNoProgressStreak(
 ): { count: number; latestResultHash?: string } {
   let streak = 0;
   let latestOutcome: ToolCallRecord | undefined;
+  let crossedArgumentBoundary = false;
   // Vetoes are provisional until an older concrete outcome anchors them; a newer
   // changed outcome must reset vetoes from the previous no-progress streak.
   let pendingLoopVetoes = 0;
@@ -52,18 +53,20 @@ function countNoProgressStreak(
     }
     if (!latestOutcome) {
       latestOutcome = record;
+      crossedArgumentBoundary = record.argsHash !== argsHash;
       streak = pendingLoopVetoes + 1;
       pendingLoopVetoes = 0;
       continue;
     }
-    // A return to an earlier command starts a new tail. Changing arguments can
-    // still count when each new command keeps failing in the same typed way.
-    if (
-      terminalExecFailuresOnly &&
-      latestOutcome.argsHash !== argsHash &&
-      record.argsHash === argsHash
-    ) {
-      break;
+    if (terminalExecFailuresOnly) {
+      // Once the scan crosses away from the requested command, finding it again
+      // belongs to an older tail. Unique changing arguments can still count together.
+      if (crossedArgumentBoundary && record.argsHash === argsHash) {
+        break;
+      }
+      if (record.argsHash !== argsHash) {
+        crossedArgumentBoundary = true;
+      }
     }
     const repeatsSameFailure =
       terminalExecFailuresOnly &&

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -26,6 +26,9 @@ export type ToolCallRecord = {
   runId?: string;
   outcomeKind?: "tool-loop-veto" | "terminal-exec-failure";
   resultHash?: string;
+  // Keep the raw result identity while this bounded identity survives alias
+  // merges and lets the no-progress owner ignore diagnostic drift.
+  failureIdentityHash?: string;
   noProgress?: true;
   unknownToolName?: string;
   timestamp: number;


### PR DESCRIPTION
Fixes #93917

## What Problem This Solves

Repeated `exec` calls can fail for the same reason while timestamps, retry counters, durations, or process IDs change in the diagnostic text. The raw result hash changes on every call, so the critical loop guard never reaches its threshold. The agent keeps executing the same failing action after warning text appears.

## Root cause

`src/agents/tool-loop-detection.ts` records the complete exec output in `resultHash`. `src/agents/tool-loop-no-progress.ts` treats any different result hash as progress, including bounded diagnostic drift from one terminal failure.

## Fix

- Keep the raw result hash unchanged for existing consumers.
- Record a bounded identity for typed terminal exec failures at the outcome producer.
- Ignore only diagnostic timestamps, explicit attempt or retry counters, elapsed durations, and labeled process IDs.
- Preserve other text and numbers so a different failure cause resets the streak.
- Preserve standalone calendar dates; only full date-time values count as timestamps.
- Keep the identity on the history record so session ID and session-key alias merges cannot lose it.
- Preserve that reset after the earlier command resumes, including `A -> B -> A -> A`.

Maintainer decision: accept bounded normalization for enabled loop detection. This trades a narrow false-equivalence risk for a deterministic stop on repeated terminal failures, while preserving meaningful error text and numbers.

## Evidence

The same real `createExecTool()` and before-tool admission flow ran this command:

```sh
printf "retry pid $$\n" >&2; exit 1
```

- Current main `c7e48bd32515da843fca2020f7c76477988b3bc4`: 20 child shells produced 20 distinct PID-bearing outputs, then call 21 executed and returned exit code 1. This is the expected red result.
- Proposed head `04b506e2d04ad807c86a6db7e2c9540d5ec9ddb4`: 20 child shells produced 20 distinct PID-bearing outputs, then call 21 was rejected before execution with `status=blocked` and `deniedReason=tool-loop`.
- Main later advanced to `ecb0386e89b330884512a193dec116e6c4e14444` before the repair branch was created, with no change to any affected owner path.

## Validation

- `node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts`: 135 passed.
- Docs MDX, Oxfmt, Oxlint, no-conflict, max-lines, assertion-safety, coercion, test-temp, import-cycle, and diff checks passed.
- Final Codex autoreview: clean, no accepted or actionable finding.
- Hosted CI owns type checking and the committed real-exec end-to-end test.

## Review shape

- Owner: exec outcome classification, compact diagnostic history, and the no-progress streak owner.
- Modes before: byte-identical terminal failure, changed raw output.
- Modes after: byte-identical terminal failure, bounded diagnostic drift, meaningful new failure.
- Production source: +65/-8, net +57. The growth records one lifecycle-stable identity while preserving the raw hash and the resumed-command reset boundary.
- Tests: +221. Docs: +5/-2.

Native Codex built-in tools use a separate post-tool bridge and do not yet record outcomes into this history. That bridge remains a named follow-up; OpenClaw-wrapped tools use the repaired owner in this change.

AI-assisted; I reviewed and understand the change.
