### PR TITLE
refactor(test): consolidate project routing assertions

### DIFF
--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -204,6 +204,32 @@ function withTinyFileTree(files: Record<string, string>, test: (cwd: string) => 
   }
 }
 
+function expectChangedTargets(changedPaths: string[], targets: string[]): void {
+  expect(resolveChangedTestTargetPlan(changedPaths), changedPaths.join(", ")).toEqual({
+    mode: "targets",
+    targets,
+  });
+}
+
+function expectSingleVitestRunPlan(
+  actual: ReturnType<typeof buildVitestRunPlans>,
+  expected: {
+    config: string;
+    forwardedArgs?: string[];
+    includePatterns?: string[] | null;
+    watchMode?: boolean;
+  },
+): void {
+  expect(actual).toEqual([
+    {
+      config: expected.config,
+      forwardedArgs: expected.forwardedArgs ?? [],
+      includePatterns: expected.includePatterns ?? null,
+      watchMode: expected.watchMode ?? false,
+    },
+  ]);
+}
+
 describe("scripts/test-projects changed-target routing", () => {
   beforeAll(() => {
     buildVitestRunPlans(["src/commands/onboard-non-interactive.test-helpers.ts"]);
@@ -229,13 +255,13 @@ describe("scripts/test-projects changed-target routing", () => {
   ])(
     "routes setup inference transcript ownership changes through both regressions for %s",
     (targetPath) => {
-      expect(resolveChangedTestTargetPlan([targetPath])).toEqual({
-        mode: "targets",
-        targets: [
+      expectChangedTargets(
+        [targetPath],
+        [
           "src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts",
           "src/commands/onboard-guided.inference.e2e.test.ts",
         ],
-      });
+      );
     },
   );
 
@@ -281,282 +307,230 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps test runner implementation edits on runner tests", () => {
-    expect(
-      resolveChangedTestTargetPlan([
+    expectChangedTargets(
+      [
         "scripts/check-changed.mjs",
         "scripts/test-projects.test-support.d.mts",
         "scripts/test-projects.test-support.mjs",
         "test/scripts/changed-lanes.test.ts",
-      ]),
-    ).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/changed-lanes.test.ts", "test/scripts/test-projects.test.ts"],
-    });
+      ],
+      ["test/scripts/changed-lanes.test.ts", "test/scripts/test-projects.test.ts"],
+    );
   });
 
   it("routes Docker pull retry helper changes through its regression test", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/ci-docker-pull-retry.sh"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/ci-docker-pull-retry.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/ci-docker-pull-retry.sh"],
+      ["test/scripts/ci-docker-pull-retry.test.ts"],
+    );
   });
 
   it("routes live command retry helper changes through its regression test", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/ci-live-command-retry.sh"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/ci-live-command-retry.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/ci-live-command-retry.sh"],
+      ["test/scripts/ci-live-command-retry.test.ts"],
+    );
   });
 
   it.each(["extensions/codex/package.json", "extensions/codex/src/app-server/version.ts"])(
     "routes Codex version changes through cross-plugin contract tests for %s",
     (changedPath) => {
-      expect(resolveChangedTestTargetPlan([changedPath])).toEqual({
-        mode: "targets",
-        targets: [
+      expectChangedTargets(
+        [changedPath],
+        [
           "extensions/codex/src/manifest.test.ts",
           "extensions/openai/openai-provider.test.ts",
           "test/scripts/codex-client-version-contract.test.ts",
         ],
-      });
+      );
     },
   );
 
   it("routes release wrapper changes through their owner tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/apple-release-source-check.sh"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/apple-release-source-check.test.ts"],
-    });
-    expect(resolveChangedTestTargetPlan(["scripts/ios-release-prepare.sh"])).toEqual({
-      mode: "targets",
-      targets: [
-        "test/scripts/ios-release-prepare.test.ts",
-        "test/scripts/ios-release-wrapper-args.test.ts",
-      ],
-    });
-    expect(resolveChangedTestTargetPlan(["scripts/android-release.sh"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/android-release-wrapper-args.test.ts"],
-    });
-    expect(resolveChangedTestTargetPlan(["scripts/android-release-upload.sh"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/android-release-wrapper-args.test.ts"],
-    });
-    expect(
-      resolveChangedTestTargetPlan(["apps/android/scripts/build-release-artifacts.ts"]),
-    ).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/android-release-artifacts.test.ts"],
-    });
-    expect(resolveChangedTestTargetPlan([".github/workflows/android-release.yml"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["scripts/apple-release-source-check.sh"],
+      ["test/scripts/apple-release-source-check.test.ts"],
+    );
+    expectChangedTargets(
+      ["scripts/ios-release-prepare.sh"],
+      ["test/scripts/ios-release-prepare.test.ts", "test/scripts/ios-release-wrapper-args.test.ts"],
+    );
+    expectChangedTargets(
+      ["scripts/android-release.sh"],
+      ["test/scripts/android-release-wrapper-args.test.ts"],
+    );
+    expectChangedTargets(
+      ["scripts/android-release-upload.sh"],
+      ["test/scripts/android-release-wrapper-args.test.ts"],
+    );
+    expectChangedTargets(
+      ["apps/android/scripts/build-release-artifacts.ts"],
+      ["test/scripts/android-release-artifacts.test.ts"],
+    );
+    expectChangedTargets(
+      [".github/workflows/android-release.yml"],
+      [
         "test/scripts/package-acceptance-workflow.test.ts",
         "test/scripts/ci-workflow-guards.test.ts",
       ],
-    });
-    expect(resolveChangedTestTargetPlan(["scripts/release-fast-pretag-check.sh"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/package-acceptance-workflow.test.ts"],
-    });
+    );
+    expectChangedTargets(
+      ["scripts/release-fast-pretag-check.sh"],
+      ["test/scripts/package-acceptance-workflow.test.ts"],
+    );
   });
 
   it("routes control UI i18n script changes through its regression test", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/control-ui-i18n.ts"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/control-ui-i18n.test.ts", "src/scripts/control-ui-i18n.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/control-ui-i18n.ts"],
+      ["test/scripts/control-ui-i18n.test.ts", "src/scripts/control-ui-i18n.test.ts"],
+    );
   });
 
   it("routes top-level scripts through conventional owner tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/bench-test-changed.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/bench-test-changed.test.ts"],
-    });
-    expect(resolveChangedTestTargetPlan(["scripts/control-ui-i18n-report.ts"])).toEqual({
-      mode: "targets",
-      targets: ["src/scripts/control-ui-i18n-report.test.ts"],
-    });
-    expect(resolveChangedTestTargetPlan(["scripts/check-file-utils.ts"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/check-file-utils.test.ts"],
-    });
-    expect(resolveChangedTestTargetPlan(["scripts/install-trufflehog.sh"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/install-trufflehog.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/bench-test-changed.mjs"],
+      ["test/scripts/bench-test-changed.test.ts"],
+    );
+    expectChangedTargets(
+      ["scripts/control-ui-i18n-report.ts"],
+      ["src/scripts/control-ui-i18n-report.test.ts"],
+    );
+    expectChangedTargets(
+      ["scripts/check-file-utils.ts"],
+      ["test/scripts/check-file-utils.test.ts"],
+    );
+    expectChangedTargets(
+      ["scripts/install-trufflehog.sh"],
+      ["test/scripts/install-trufflehog.test.ts"],
+    );
   });
 
   it("routes nested scripts through conventional owner tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/e2e/openwebui-probe.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts"],
-    });
-    expect(resolveChangedTestTargetPlan(["scripts/lib/docker-e2e-plan.mjs"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["scripts/e2e/openwebui-probe.mjs"],
+      ["test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts"],
+    );
+    expectChangedTargets(
+      ["scripts/lib/docker-e2e-plan.mjs"],
+      [
         "test/scripts/docker-e2e-plan.test.ts",
         "test/scripts/docker-all-scheduler.test.ts",
         "test/scripts/plugin-prerelease-test-plan.test.ts",
       ],
-    });
-    expect(resolveChangedTestTargetPlan(["scripts/github/real-behavior-proof-check.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/vitest/vitest.tooling.config.ts"],
-    });
-    expect(resolveChangedTestTargetPlan(["scripts/github/resolve-openclaw-ref.sh"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/resolve-openclaw-ref.test.ts"],
-    });
+    );
+    expectChangedTargets(
+      ["scripts/github/real-behavior-proof-check.mjs"],
+      ["test/vitest/vitest.tooling.config.ts"],
+    );
+    expectChangedTargets(
+      ["scripts/github/resolve-openclaw-ref.sh"],
+      ["test/scripts/resolve-openclaw-ref.test.ts"],
+    );
   });
 
   it("routes nested e2e library helpers through owner tests", () => {
-    const expectedTargets = new Map([
-      [
-        "scripts/e2e/lib/bundled-plugin-install-uninstall/probe.mjs",
-        ["test/scripts/bundled-plugin-install-uninstall-probe.test.ts"],
+    const expectedTargets = Object.entries({
+      "scripts/e2e/lib/bundled-plugin-install-uninstall/probe.mjs": [
+        "test/scripts/bundled-plugin-install-uninstall-probe.test.ts",
       ],
-      [
-        "scripts/e2e/lib/browser-cdp-snapshot/assert-snapshot.mjs",
-        ["test/scripts/browser-cdp-snapshot.test.ts"],
+      "scripts/e2e/lib/browser-cdp-snapshot/assert-snapshot.mjs": [
+        "test/scripts/browser-cdp-snapshot.test.ts",
       ],
-      [
-        "scripts/e2e/lib/browser-cdp-snapshot/fixture-server.mjs",
-        ["test/scripts/browser-cdp-snapshot.test.ts"],
+      "scripts/e2e/lib/browser-cdp-snapshot/fixture-server.mjs": [
+        "test/scripts/browser-cdp-snapshot.test.ts",
       ],
-      [
-        "scripts/e2e/lib/codex-app-server-fixture.mjs",
-        [
-          "test/scripts/codex-media-path-client.test.ts",
-          "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
-        ],
+      "scripts/e2e/lib/codex-app-server-fixture.mjs": [
+        "test/scripts/codex-media-path-client.test.ts",
+        "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
       ],
-      [
-        "scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs",
-        ["test/scripts/codex-media-path-client.test.ts"],
+      "scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs": [
+        "test/scripts/codex-media-path-client.test.ts",
       ],
-      [
-        "scripts/e2e/lib/codex-media-path/scenario.sh",
-        ["test/scripts/codex-media-path-client.test.ts"],
+      "scripts/e2e/lib/codex-media-path/scenario.sh": [
+        "test/scripts/codex-media-path-client.test.ts",
       ],
-      [
-        "scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs",
-        [
-          "test/scripts/codex-media-path-client.test.ts",
-          "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
-        ],
+      "scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs": [
+        "test/scripts/codex-media-path-client.test.ts",
+        "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
       ],
-      [
-        "scripts/e2e/lib/codex-media-path/limits.mjs",
-        ["test/scripts/codex-media-path-client.test.ts"],
+      "scripts/e2e/lib/codex-media-path/limits.mjs": [
+        "test/scripts/codex-media-path-client.test.ts",
       ],
-      [
-        "scripts/e2e/lib/codex-media-path/write-config.mjs",
-        ["test/scripts/codex-media-path-client.test.ts"],
+      "scripts/e2e/lib/codex-media-path/write-config.mjs": [
+        "test/scripts/codex-media-path-client.test.ts",
       ],
-      [
-        "scripts/e2e/lib/gateway-network/limits.mjs",
-        ["test/scripts/gateway-network-client.test.ts"],
+      "scripts/e2e/lib/gateway-network/limits.mjs": ["test/scripts/gateway-network-client.test.ts"],
+      "scripts/e2e/lib/gateway-network/ws-frames.mjs": [
+        "test/scripts/gateway-network-client.test.ts",
       ],
-      [
-        "scripts/e2e/lib/gateway-network/ws-frames.mjs",
-        ["test/scripts/gateway-network-client.test.ts"],
+      "scripts/e2e/lib/npm-telegram-live/prepare-package.mjs": [
+        "test/scripts/npm-telegram-live.test.ts",
       ],
-      [
-        "scripts/e2e/lib/npm-telegram-live/prepare-package.mjs",
-        ["test/scripts/npm-telegram-live.test.ts"],
+      "scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs": [
+        "test/scripts/kitchen-sink-plugin-assertions.test.ts",
       ],
-      [
-        "scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs",
-        ["test/scripts/kitchen-sink-plugin-assertions.test.ts"],
+      "scripts/e2e/lib/live-plugin-tool/assertions.mjs": [
+        "test/scripts/live-plugin-tool-assertions.test.ts",
       ],
-      [
-        "scripts/e2e/lib/live-plugin-tool/assertions.mjs",
-        ["test/scripts/live-plugin-tool-assertions.test.ts"],
+      "scripts/e2e/lib/plugins/assertions.mjs": ["test/scripts/plugins-assertions.test.ts"],
+      "scripts/e2e/lib/release-user-journey/assertions.mjs": [
+        "test/scripts/release-user-journey-assertions.test.ts",
       ],
-      ["scripts/e2e/lib/plugins/assertions.mjs", ["test/scripts/plugins-assertions.test.ts"]],
-      [
-        "scripts/e2e/lib/release-user-journey/assertions.mjs",
-        ["test/scripts/release-user-journey-assertions.test.ts"],
+      "scripts/e2e/lib/release-assertion-files.mjs": [
+        "test/scripts/release-scenarios-assertions.test.ts",
+        "test/scripts/release-user-journey-assertions.test.ts",
       ],
-      [
-        "scripts/e2e/lib/release-assertion-files.mjs",
-        [
-          "test/scripts/release-scenarios-assertions.test.ts",
-          "test/scripts/release-user-journey-assertions.test.ts",
-        ],
+      "scripts/e2e/lib/openai-chat-tools/write-config.mjs": [
+        "test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts",
       ],
-      [
-        "scripts/e2e/lib/openai-chat-tools/write-config.mjs",
-        ["test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts"],
+      "scripts/e2e/lib/openai-chat-tools/scenario.sh": [
+        "test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts",
       ],
-      [
-        "scripts/e2e/lib/openai-chat-tools/scenario.sh",
-        ["test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts"],
+      "scripts/e2e/openai-chat-tools-docker.sh": [
+        "test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
       ],
-      [
-        "scripts/e2e/openai-chat-tools-docker.sh",
-        [
-          "test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-        ],
+      "scripts/e2e/lib/openai-web-search-minimal/mock-server.mjs": [
+        "test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts",
+        "test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts",
       ],
-      [
-        "scripts/e2e/lib/openai-web-search-minimal/mock-server.mjs",
-        [
-          "test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts",
-          "test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts",
-        ],
+      "scripts/e2e/openai-web-search-minimal-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts",
+        "test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts",
       ],
-      [
-        "scripts/e2e/openai-web-search-minimal-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts",
-          "test/e2e/qa-lab/runtime/openai-web-search-minimal-assertions.e2e.test.ts",
-        ],
+      "scripts/e2e/openwebui-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts",
+        "test/scripts/fixture-config.test.ts",
       ],
-      [
-        "scripts/e2e/openwebui-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts",
-          "test/scripts/fixture-config.test.ts",
-        ],
+      "scripts/e2e/lib/openwebui/http-probe.mjs": [
+        "test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts",
       ],
-      [
-        "scripts/e2e/lib/openwebui/http-probe.mjs",
-        ["test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts"],
+      "test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts": [
+        "test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts",
       ],
-      [
-        "test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts",
-        ["test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts"],
+      "scripts/e2e/lib/text-file-utils.mjs": ["test/scripts/e2e-text-file-utils.test.ts"],
+      "scripts/e2e/lib/plugins/npm-registry-server.mjs": [
+        "test/scripts/plugins-assertions.test.ts",
       ],
-      ["scripts/e2e/lib/text-file-utils.mjs", ["test/scripts/e2e-text-file-utils.test.ts"]],
-      [
-        "scripts/e2e/lib/plugins/npm-registry-server.mjs",
-        ["test/scripts/plugins-assertions.test.ts"],
+      "scripts/e2e/lib/release-scenarios/write-cli-plugin.mjs": [
+        "test/scripts/release-scenarios-assertions.test.ts",
       ],
-      [
-        "scripts/e2e/lib/release-scenarios/write-cli-plugin.mjs",
-        ["test/scripts/release-scenarios-assertions.test.ts"],
+      "scripts/e2e/lib/release-user-journey/clickclack-fixture.mjs": [
+        "test/scripts/release-user-journey-assertions.test.ts",
       ],
-      [
-        "scripts/e2e/lib/release-user-journey/clickclack-fixture.mjs",
-        ["test/scripts/release-user-journey-assertions.test.ts"],
+      "scripts/e2e/lib/upgrade-survivor/run.sh": [
+        "test/scripts/upgrade-survivor-assertions.test.ts",
       ],
-      [
-        "scripts/e2e/lib/upgrade-survivor/run.sh",
-        ["test/scripts/upgrade-survivor-assertions.test.ts"],
+      "scripts/e2e/lib/upgrade-survivor/config-recipe/plugins-configured-installs.json": [
+        "test/scripts/upgrade-survivor-config-recipe.test.ts",
       ],
-      [
-        "scripts/e2e/lib/upgrade-survivor/config-recipe/plugins-configured-installs.json",
-        ["test/scripts/upgrade-survivor-config-recipe.test.ts"],
-      ],
-      ["scripts/e2e/lib/run-with-pty.mjs", ["test/scripts/e2e-run-with-pty.test.ts"]],
-    ]);
+      "scripts/e2e/lib/run-with-pty.mjs": ["test/scripts/e2e-run-with-pty.test.ts"],
+    });
 
     for (const [source, targets] of expectedTargets) {
       expect(resolveChangedTestTargetPlan([source]), source).toEqual({
@@ -567,491 +541,339 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps shared PR worktree helper edits on the full tooling owner suite", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/pr-lib/worktree.sh"])).toEqual({
-      mode: "targets",
-      targets: ["test/vitest/vitest.tooling.config.ts"],
-    });
+    expectChangedTargets(["scripts/pr-lib/worktree.sh"], ["test/vitest/vitest.tooling.config.ts"]);
   });
 
   it("routes nested e2e shell helpers through their sourced owner tests", () => {
-    const expectedTargets = new Map([
-      [
-        "scripts/e2e/lib/bun-global-install/assertions.mjs",
-        ["test/scripts/test-install-sh-docker.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs",
-        ["test/scripts/bundled-plugin-install-uninstall-probe.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/bundled-plugin-install-uninstall/sweep.sh",
-        ["test/scripts/bundled-plugin-install-uninstall-probe.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/auth-profile-store-assertions.mjs",
-        [
-          "test/scripts/release-scenarios-assertions.test.ts",
-          "test/scripts/npm-onboard-channel-agent-assertions.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs",
-        [
-          "test/scripts/codex-install-assertions.test.ts",
-          "test/scripts/docker-build-helper.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/lib/codex-install-utils.mjs",
-        ["test/scripts/codex-install-assertions.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/codex-on-demand/assertions.mjs",
-        ["test/scripts/codex-install-assertions.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/clawhub-fixture-server.cjs",
-        [
-          "test/scripts/clawhub-fixture-server.test.ts",
-          "test/scripts/plugin-prerelease-test-plan.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/lib/config-reload/assert-log.mjs",
-        ["test/scripts/e2e-mock-config-limits.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/config-reload/mutate-metadata.mjs",
-        ["test/scripts/config-reload-mutate-metadata.test.ts"],
-      ],
-      ["scripts/e2e/lib/env-limits.mjs", ["test/scripts/e2e-helper-env-limits.test.ts"]],
-      [
-        "scripts/e2e/lib/docker-stats/assert-resource-ceiling.mjs",
-        ["test/scripts/docker-stats-resource-ceiling.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/doctor-install-switch/scenario.sh",
-        ["test/scripts/docker-build-helper.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/doctor-install-switch/write-wrapper.mjs",
-        ["test/scripts/doctor-install-switch-wrapper.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/doctor-install-switch/shims/loginctl",
-        ["test/scripts/docker-build-helper.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/doctor-install-switch/shims/systemctl",
-        ["test/scripts/docker-build-helper.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/fixture.mjs",
-        [
-          "test/scripts/fixture-config.test.ts",
-          "test/scripts/fixtures-workspace.test.ts",
-          "test/scripts/fixture-plugin-commands.test.ts",
-        ],
-      ],
-      ["scripts/e2e/lib/fixtures/config.mjs", ["test/scripts/fixture-config.test.ts"]],
-      ["scripts/e2e/lib/fixtures/common.mjs", ["test/scripts/fixture-common.test.ts"]],
-      [
-        "scripts/e2e/lib/fixtures/mock-openai-config.mjs",
-        ["test/scripts/mock-openai-config.test.ts"],
-      ],
-      ["scripts/e2e/lib/fixtures/plugins.mjs", ["test/scripts/fixture-plugin-commands.test.ts"]],
-      [
-        "scripts/e2e/lib/incremental-line-reader.mjs",
-        [
-          "test/scripts/incremental-line-reader.test.ts",
-          "test/scripts/config-reload-log-scanner.test.ts",
-          "test/scripts/codex-media-path-client.test.ts",
-          "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/lib/kitchen-sink-plugin/sweep.sh",
-        ["test/scripts/kitchen-sink-plugin-assertions.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/mcp-code-mode-validation.ts",
-        ["test/scripts/mcp-code-mode-gateway-client.test.ts"],
-      ],
-      [
-        "scripts/e2e/codex-media-path-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/codex-media-path-client.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/codex-npm-plugin-live-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/codex-on-demand-docker.sh",
-        ["test/scripts/docker-build-helper.test.ts", "test/scripts/docker-e2e-plan.test.ts"],
-      ],
-      [
-        "scripts/e2e/system-agent-first-run-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/docker-e2e-system-agent.test.ts",
-        ],
-      ],
-      [
-        "test/e2e/qa-lab/runtime/system-agent-first-run-docker-client.ts",
-        [
-          "test/scripts/docker-e2e-system-agent.test.ts",
-          "src/cli/program/register.onboard.test.ts",
-          "src/cli/run-main.test.ts",
-          "src/cli/run-main.exit.test.ts",
-          "src/commands/system-agent-with-inference.test.ts",
-          "src/system-agent/assistant.configured.test.ts",
-          "src/system-agent/assistant.test.ts",
-          "src/system-agent/system-agent.test.ts",
-          "src/system-agent/operations.test.ts",
-          "src/system-agent/overview.test.ts",
-          "src/system-agent/setup-inference.test.ts",
-          "src/system-agent/audit.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/system-agent-first-run-spec.json",
-        [
-          "test/scripts/docker-e2e-system-agent.test.ts",
-          "src/system-agent/operations.test.ts",
-          "src/system-agent/audit.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/system-agent-rescue-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/docker-e2e-system-agent.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/system-agent-rescue-docker-client.ts",
-        [
-          "test/scripts/docker-e2e-system-agent.test.ts",
-          "src/system-agent/rescue-policy.test.ts",
-          "src/system-agent/rescue-message.test.ts",
-          "src/system-agent/operations.test.ts",
-          "src/system-agent/audit.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/commitments-safety-docker-client.ts",
-        [
-          "test/scripts/docker-e2e-clients.test.ts",
-          "src/commitments/runtime.test.ts",
-          "src/commitments/store.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/commitments-safety-docker.sh",
-        [
-          "test/scripts/docker-e2e-clients.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "src/commitments/runtime.test.ts",
-          "src/commitments/store.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/session-runtime-context-docker-client.ts",
-        [
-          "test/scripts/docker-e2e-clients.test.ts",
-          "src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts",
-          "src/agents/embedded-agent-runner/transcript-rewrite.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/session-runtime-context-docker.sh",
-        [
-          "test/scripts/docker-e2e-clients.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts",
-          "src/agents/embedded-agent-runner/transcript-rewrite.test.ts",
-        ],
-      ],
-      ["scripts/e2e/mcp-channels-seed.ts", ["test/scripts/docker-e2e-seeds.test.ts"]],
-      ["scripts/e2e/docker-openai-seed.ts", ["test/scripts/docker-e2e-seeds.test.ts"]],
-      ["scripts/e2e/mcp-code-mode-gateway-seed.ts", ["test/scripts/docker-e2e-seeds.test.ts"]],
-      ["scripts/e2e/mock-openai-server.mjs", ["test/scripts/e2e-mock-config-limits.test.ts"]],
-      [
-        "scripts/e2e/cron-mcp-cleanup-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-observability.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/plugin-prerelease-test-plan.test.ts",
-          "test/scripts/cron-mcp-cleanup-docker-client.test.ts",
-          "test/scripts/docker-e2e-seeds.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/cron-mcp-cleanup-docker-client.ts",
-        [
-          "test/scripts/cron-mcp-cleanup-docker-client.test.ts",
-          "src/gateway/server.cron.test.ts",
-          "src/gateway/server-methods/agent.test.ts",
-          "src/cron/isolated-agent/run.fast-mode.test.ts",
-          "src/cron/active-jobs-manual-run.test.ts",
-        ],
-      ],
-      ["scripts/e2e/cron-mcp-cleanup-seed.ts", ["test/scripts/docker-e2e-seeds.test.ts"]],
-      [
-        "scripts/e2e/lib/onboard/scenario.sh",
-        ["test/scripts/e2e-shell-tempfiles.test.ts", "test/scripts/openclaw-test-state.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/onboard/assert-config.mjs",
-        ["test/scripts/onboard-config-fixtures.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/onboard/write-config.mjs",
-        ["test/scripts/onboard-config-fixtures.test.ts"],
-      ],
-      ["scripts/e2e/lib/package-compat.mjs", ["test/scripts/docker-build-helper.test.ts"]],
-      [
-        "scripts/e2e/agents-delete-shared-workspace-docker.sh",
-        [
-          "test/scripts/docker-e2e-plan.test.ts",
-          "src/scripts/ci-changed-scope.test.ts",
-          "src/commands/agents.delete.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/browser-cdp-snapshot-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/browser-cdp-snapshot.test.ts",
-          "test/scripts/e2e-helper-env-limits.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/config-reload-source-docker.sh",
-        [
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/fixture-config.test.ts",
-          "test/scripts/e2e-mock-config-limits.test.ts",
-          "src/gateway/config-reload.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/gateway-network-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/gateway-network-client.test.ts",
-          "src/scripts/ci-changed-scope.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/npm-onboard-channel-agent-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/npm-onboard-channel-agent-assertions.test.ts",
-          "test/scripts/plugin-prerelease-test-plan.test.ts",
-        ],
-      ],
-      ["scripts/e2e/npm-telegram-live-docker.sh", ["test/scripts/npm-telegram-live.test.ts"]],
-      ["scripts/e2e/npm-telegram-live-runner.ts", ["test/scripts/npm-telegram-live.test.ts"]],
-      [
-        "scripts/e2e/multi-node-update-docker.sh",
-        ["test/scripts/docker-build-helper.test.ts", "test/scripts/docker-e2e-plan.test.ts"],
-      ],
-      [
-        "scripts/e2e/doctor-install-switch-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/update-channel-switch-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/skill-install-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/e2e-shell-tempfiles.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/upgrade-survivor-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/upgrade-survivor-probe-gateway.test.ts",
-          "test/scripts/upgrade-survivor-assertions.test.ts",
-          "test/scripts/openclaw-test-state.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/bundled-plugin-install-uninstall-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/plugin-prerelease-test-plan.test.ts",
-          "test/scripts/bundled-plugin-install-uninstall-probe.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh",
-        ["test/scripts/plugin-update-unchanged-docker.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/plugin-update/probe.mjs",
-        ["test/scripts/plugin-update-unchanged-docker.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/plugin-update/registry-server.mjs",
-        ["test/scripts/plugin-update-unchanged-docker.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/plugin-update/unchanged-scenario.sh",
-        ["test/scripts/plugin-update-unchanged-docker.test.ts"],
-      ],
-      [
-        "scripts/e2e/plugin-update-unchanged-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/plugin-prerelease-test-plan.test.ts",
-          "test/scripts/plugin-update-unchanged-docker.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/update-corrupt-plugin-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/plugin-update-unchanged-docker.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/plugins-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/plugins-assertions.test.ts",
-        ],
-      ],
-      ["scripts/e2e/lib/plugins/clawhub.sh", ["test/scripts/plugins-assertions.test.ts"]],
-      ["scripts/e2e/lib/plugins/fixtures.sh", ["test/scripts/plugins-assertions.test.ts"]],
-      ["scripts/e2e/lib/plugins/marketplace.sh", ["test/scripts/plugins-assertions.test.ts"]],
-      ["scripts/e2e/lib/plugins/sweep.sh", ["test/scripts/plugins-assertions.test.ts"]],
-      [
-        "scripts/e2e/lib/release-plugin-marketplace/scenario.sh",
-        ["test/scripts/docker-build-helper.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/release-typed-onboarding/scenario.sh",
-        ["test/scripts/docker-build-helper.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/release-upgrade-user-journey/scenario.sh",
-        ["test/scripts/docker-build-helper.test.ts"],
-      ],
-      [
-        "scripts/e2e/release-plugin-marketplace-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/release-typed-onboarding-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/release-upgrade-user-journey-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/release-user-journey-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/release-user-journey-assertions.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/lib/skills/clawhub-install-proof.sh",
-        ["test/scripts/e2e-shell-tempfiles.test.ts"],
-      ],
-      [
-        "scripts/e2e/lib/update-channel-switch/assertions.mjs",
-        ["test/scripts/docker-build-helper.test.ts"],
-      ],
-      [
-        "scripts/e2e/live-plugin-tool-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/live-plugin-tool-assertions.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/openai-image-auth-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/openai-image-auth-docker-client.test.ts",
-          "extensions/openai/image-generation-provider.test.ts",
-        ],
-      ],
-      [
-        "test/e2e/qa-lab/runtime/openai-image-auth-docker-client.ts",
-        [
-          "test/scripts/openai-image-auth-docker-client.test.ts",
-          "extensions/openai/image-generation-provider.test.ts",
-          "src/image-generation/openai-compatible-image-provider.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/plugin-binding-command-escape-docker.sh",
-        [
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-        ],
-      ],
-      ["scripts/e2e/qr-import-docker.sh", ["test/scripts/docker-build-helper.test.ts"]],
-    ]);
+    const expectedTargets = Object.entries({
+      "scripts/e2e/lib/bun-global-install/assertions.mjs": [
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      "scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs": [
+        "test/scripts/bundled-plugin-install-uninstall-probe.test.ts",
+      ],
+      "scripts/e2e/lib/bundled-plugin-install-uninstall/sweep.sh": [
+        "test/scripts/bundled-plugin-install-uninstall-probe.test.ts",
+      ],
+      "scripts/e2e/lib/auth-profile-store-assertions.mjs": [
+        "test/scripts/release-scenarios-assertions.test.ts",
+        "test/scripts/npm-onboard-channel-agent-assertions.test.ts",
+      ],
+      "scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs": [
+        "test/scripts/codex-install-assertions.test.ts",
+        "test/scripts/docker-build-helper.test.ts",
+      ],
+      "scripts/e2e/lib/codex-install-utils.mjs": ["test/scripts/codex-install-assertions.test.ts"],
+      "scripts/e2e/lib/codex-on-demand/assertions.mjs": [
+        "test/scripts/codex-install-assertions.test.ts",
+      ],
+      "scripts/e2e/lib/clawhub-fixture-server.cjs": [
+        "test/scripts/clawhub-fixture-server.test.ts",
+        "test/scripts/plugin-prerelease-test-plan.test.ts",
+      ],
+      "scripts/e2e/lib/config-reload/assert-log.mjs": [
+        "test/scripts/e2e-mock-config-limits.test.ts",
+      ],
+      "scripts/e2e/lib/config-reload/mutate-metadata.mjs": [
+        "test/scripts/config-reload-mutate-metadata.test.ts",
+      ],
+      "scripts/e2e/lib/env-limits.mjs": ["test/scripts/e2e-helper-env-limits.test.ts"],
+      "scripts/e2e/lib/docker-stats/assert-resource-ceiling.mjs": [
+        "test/scripts/docker-stats-resource-ceiling.test.ts",
+      ],
+      "scripts/e2e/lib/doctor-install-switch/scenario.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+      ],
+      "scripts/e2e/lib/doctor-install-switch/write-wrapper.mjs": [
+        "test/scripts/doctor-install-switch-wrapper.test.ts",
+      ],
+      "scripts/e2e/lib/doctor-install-switch/shims/loginctl": [
+        "test/scripts/docker-build-helper.test.ts",
+      ],
+      "scripts/e2e/lib/doctor-install-switch/shims/systemctl": [
+        "test/scripts/docker-build-helper.test.ts",
+      ],
+      "scripts/e2e/lib/fixture.mjs": [
+        "test/scripts/fixture-config.test.ts",
+        "test/scripts/fixtures-workspace.test.ts",
+        "test/scripts/fixture-plugin-commands.test.ts",
+      ],
+      "scripts/e2e/lib/fixtures/config.mjs": ["test/scripts/fixture-config.test.ts"],
+      "scripts/e2e/lib/fixtures/common.mjs": ["test/scripts/fixture-common.test.ts"],
+      "scripts/e2e/lib/fixtures/mock-openai-config.mjs": [
+        "test/scripts/mock-openai-config.test.ts",
+      ],
+      "scripts/e2e/lib/fixtures/plugins.mjs": ["test/scripts/fixture-plugin-commands.test.ts"],
+      "scripts/e2e/lib/incremental-line-reader.mjs": [
+        "test/scripts/incremental-line-reader.test.ts",
+        "test/scripts/config-reload-log-scanner.test.ts",
+        "test/scripts/codex-media-path-client.test.ts",
+        "test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts",
+      ],
+      "scripts/e2e/lib/kitchen-sink-plugin/sweep.sh": [
+        "test/scripts/kitchen-sink-plugin-assertions.test.ts",
+      ],
+      "scripts/e2e/lib/mcp-code-mode-validation.ts": [
+        "test/scripts/mcp-code-mode-gateway-client.test.ts",
+      ],
+      "scripts/e2e/codex-media-path-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/codex-media-path-client.test.ts",
+      ],
+      "scripts/e2e/codex-npm-plugin-live-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+      ],
+      "scripts/e2e/codex-on-demand-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+      ],
+      "scripts/e2e/system-agent-first-run-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/docker-e2e-system-agent.test.ts",
+      ],
+      "test/e2e/qa-lab/runtime/system-agent-first-run-docker-client.ts": [
+        "test/scripts/docker-e2e-system-agent.test.ts",
+        "src/cli/program/register.onboard.test.ts",
+        "src/cli/run-main.test.ts",
+        "src/cli/run-main.exit.test.ts",
+        "src/commands/system-agent-with-inference.test.ts",
+        "src/system-agent/assistant.configured.test.ts",
+        "src/system-agent/assistant.test.ts",
+        "src/system-agent/system-agent.test.ts",
+        "src/system-agent/operations.test.ts",
+        "src/system-agent/overview.test.ts",
+        "src/system-agent/setup-inference.test.ts",
+        "src/system-agent/audit.test.ts",
+      ],
+      "scripts/e2e/system-agent-first-run-spec.json": [
+        "test/scripts/docker-e2e-system-agent.test.ts",
+        "src/system-agent/operations.test.ts",
+        "src/system-agent/audit.test.ts",
+      ],
+      "scripts/e2e/system-agent-rescue-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/docker-e2e-system-agent.test.ts",
+      ],
+      "scripts/e2e/system-agent-rescue-docker-client.ts": [
+        "test/scripts/docker-e2e-system-agent.test.ts",
+        "src/system-agent/rescue-policy.test.ts",
+        "src/system-agent/rescue-message.test.ts",
+        "src/system-agent/operations.test.ts",
+        "src/system-agent/audit.test.ts",
+      ],
+      "scripts/e2e/commitments-safety-docker-client.ts": [
+        "test/scripts/docker-e2e-clients.test.ts",
+        "src/commitments/runtime.test.ts",
+        "src/commitments/store.test.ts",
+      ],
+      "scripts/e2e/commitments-safety-docker.sh": [
+        "test/scripts/docker-e2e-clients.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "src/commitments/runtime.test.ts",
+        "src/commitments/store.test.ts",
+      ],
+      "scripts/e2e/session-runtime-context-docker-client.ts": [
+        "test/scripts/docker-e2e-clients.test.ts",
+        "src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts",
+        "src/agents/embedded-agent-runner/transcript-rewrite.test.ts",
+      ],
+      "scripts/e2e/session-runtime-context-docker.sh": [
+        "test/scripts/docker-e2e-clients.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts",
+        "src/agents/embedded-agent-runner/transcript-rewrite.test.ts",
+      ],
+      "scripts/e2e/mcp-channels-seed.ts": ["test/scripts/docker-e2e-seeds.test.ts"],
+      "scripts/e2e/docker-openai-seed.ts": ["test/scripts/docker-e2e-seeds.test.ts"],
+      "scripts/e2e/mcp-code-mode-gateway-seed.ts": ["test/scripts/docker-e2e-seeds.test.ts"],
+      "scripts/e2e/mock-openai-server.mjs": ["test/scripts/e2e-mock-config-limits.test.ts"],
+      "scripts/e2e/cron-mcp-cleanup-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-observability.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/plugin-prerelease-test-plan.test.ts",
+        "test/scripts/cron-mcp-cleanup-docker-client.test.ts",
+        "test/scripts/docker-e2e-seeds.test.ts",
+      ],
+      "scripts/e2e/cron-mcp-cleanup-docker-client.ts": [
+        "test/scripts/cron-mcp-cleanup-docker-client.test.ts",
+        "src/gateway/server.cron.test.ts",
+        "src/gateway/server-methods/agent.test.ts",
+        "src/cron/isolated-agent/run.fast-mode.test.ts",
+        "src/cron/active-jobs-manual-run.test.ts",
+      ],
+      "scripts/e2e/cron-mcp-cleanup-seed.ts": ["test/scripts/docker-e2e-seeds.test.ts"],
+      "scripts/e2e/lib/onboard/scenario.sh": [
+        "test/scripts/e2e-shell-tempfiles.test.ts",
+        "test/scripts/openclaw-test-state.test.ts",
+      ],
+      "scripts/e2e/lib/onboard/assert-config.mjs": ["test/scripts/onboard-config-fixtures.test.ts"],
+      "scripts/e2e/lib/onboard/write-config.mjs": ["test/scripts/onboard-config-fixtures.test.ts"],
+      "scripts/e2e/lib/package-compat.mjs": ["test/scripts/docker-build-helper.test.ts"],
+      "scripts/e2e/agents-delete-shared-workspace-docker.sh": [
+        "test/scripts/docker-e2e-plan.test.ts",
+        "src/scripts/ci-changed-scope.test.ts",
+        "src/commands/agents.delete.test.ts",
+      ],
+      "scripts/e2e/browser-cdp-snapshot-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/browser-cdp-snapshot.test.ts",
+        "test/scripts/e2e-helper-env-limits.test.ts",
+      ],
+      "scripts/e2e/config-reload-source-docker.sh": [
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/fixture-config.test.ts",
+        "test/scripts/e2e-mock-config-limits.test.ts",
+        "src/gateway/config-reload.test.ts",
+      ],
+      "scripts/e2e/gateway-network-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/gateway-network-client.test.ts",
+        "src/scripts/ci-changed-scope.test.ts",
+      ],
+      "scripts/e2e/npm-onboard-channel-agent-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/npm-onboard-channel-agent-assertions.test.ts",
+        "test/scripts/plugin-prerelease-test-plan.test.ts",
+      ],
+      "scripts/e2e/npm-telegram-live-docker.sh": ["test/scripts/npm-telegram-live.test.ts"],
+      "scripts/e2e/npm-telegram-live-runner.ts": ["test/scripts/npm-telegram-live.test.ts"],
+      "scripts/e2e/multi-node-update-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+      ],
+      "scripts/e2e/doctor-install-switch-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+      ],
+      "scripts/e2e/update-channel-switch-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+      ],
+      "scripts/e2e/skill-install-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/e2e-shell-tempfiles.test.ts",
+      ],
+      "scripts/e2e/upgrade-survivor-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/upgrade-survivor-probe-gateway.test.ts",
+        "test/scripts/upgrade-survivor-assertions.test.ts",
+        "test/scripts/openclaw-test-state.test.ts",
+      ],
+      "scripts/e2e/bundled-plugin-install-uninstall-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/plugin-prerelease-test-plan.test.ts",
+        "test/scripts/bundled-plugin-install-uninstall-probe.test.ts",
+      ],
+      "scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh": [
+        "test/scripts/plugin-update-unchanged-docker.test.ts",
+      ],
+      "scripts/e2e/lib/plugin-update/probe.mjs": [
+        "test/scripts/plugin-update-unchanged-docker.test.ts",
+      ],
+      "scripts/e2e/lib/plugin-update/registry-server.mjs": [
+        "test/scripts/plugin-update-unchanged-docker.test.ts",
+      ],
+      "scripts/e2e/lib/plugin-update/unchanged-scenario.sh": [
+        "test/scripts/plugin-update-unchanged-docker.test.ts",
+      ],
+      "scripts/e2e/plugin-update-unchanged-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/plugin-prerelease-test-plan.test.ts",
+        "test/scripts/plugin-update-unchanged-docker.test.ts",
+      ],
+      "scripts/e2e/update-corrupt-plugin-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/plugin-update-unchanged-docker.test.ts",
+      ],
+      "scripts/e2e/plugins-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/plugins-assertions.test.ts",
+      ],
+      "scripts/e2e/lib/plugins/clawhub.sh": ["test/scripts/plugins-assertions.test.ts"],
+      "scripts/e2e/lib/plugins/fixtures.sh": ["test/scripts/plugins-assertions.test.ts"],
+      "scripts/e2e/lib/plugins/marketplace.sh": ["test/scripts/plugins-assertions.test.ts"],
+      "scripts/e2e/lib/plugins/sweep.sh": ["test/scripts/plugins-assertions.test.ts"],
+      "scripts/e2e/lib/release-plugin-marketplace/scenario.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+      ],
+      "scripts/e2e/lib/release-typed-onboarding/scenario.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+      ],
+      "scripts/e2e/lib/release-upgrade-user-journey/scenario.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+      ],
+      "scripts/e2e/release-plugin-marketplace-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+      ],
+      "scripts/e2e/release-typed-onboarding-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+      ],
+      "scripts/e2e/release-upgrade-user-journey-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+      ],
+      "scripts/e2e/release-user-journey-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/release-user-journey-assertions.test.ts",
+      ],
+      "scripts/e2e/lib/skills/clawhub-install-proof.sh": [
+        "test/scripts/e2e-shell-tempfiles.test.ts",
+      ],
+      "scripts/e2e/lib/update-channel-switch/assertions.mjs": [
+        "test/scripts/docker-build-helper.test.ts",
+      ],
+      "scripts/e2e/live-plugin-tool-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/live-plugin-tool-assertions.test.ts",
+      ],
+      "scripts/e2e/openai-image-auth-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/openai-image-auth-docker-client.test.ts",
+        "extensions/openai/image-generation-provider.test.ts",
+      ],
+      "test/e2e/qa-lab/runtime/openai-image-auth-docker-client.ts": [
+        "test/scripts/openai-image-auth-docker-client.test.ts",
+        "extensions/openai/image-generation-provider.test.ts",
+        "src/image-generation/openai-compatible-image-provider.test.ts",
+      ],
+      "scripts/e2e/plugin-binding-command-escape-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+      ],
+      "scripts/e2e/qr-import-docker.sh": ["test/scripts/docker-build-helper.test.ts"],
+    });
 
     for (const [source, targets] of expectedTargets) {
       expect(resolveChangedTestTargetPlan([source]), source).toEqual({
@@ -1064,38 +886,24 @@ describe("scripts/test-projects changed-target routing", () => {
   it("routes unmatched script changes to the tooling suite instead of skipping tests", () => {
     const targets = ["scripts/check-no-raw-http2-imports.mjs"];
 
-    expect(resolveChangedTestTargetPlan(targets)).toEqual({
-      mode: "targets",
-      targets: ["test/vitest/vitest.tooling.config.ts"],
-    });
-    expect(buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => targets)).toEqual(
-      [
-        {
-          config: "test/vitest/vitest.tooling.config.ts",
-          forwardedArgs: [],
-          includePatterns: null,
-          watchMode: false,
-        },
-      ],
+    expectChangedTargets(targets, ["test/vitest/vitest.tooling.config.ts"]);
+    expectSingleVitestRunPlan(
+      buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => targets),
+      { config: "test/vitest/vitest.tooling.config.ts" },
     );
   });
 
   it("routes Z.AI fallback repro script changes through its regression test", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/zai-fallback-repro.ts"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/zai-fallback-repro.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/zai-fallback-repro.ts"],
+      ["test/scripts/zai-fallback-repro.test.ts"],
+    );
   });
 
   it("routes group visible reply config changes through channel delivery regressions", () => {
-    expect(
-      resolveChangedTestTargetPlan([
-        "src/config/types.messages.ts",
-        "src/config/zod-schema.core.ts",
-      ]),
-    ).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["src/config/types.messages.ts", "src/config/zod-schema.core.ts"],
+      [
         "src/auto-reply/reply/dispatch-acp.test.ts",
         "src/auto-reply/reply/dispatch-from-config.test.ts",
         "src/auto-reply/reply/followup-runner.test.ts",
@@ -1103,13 +911,13 @@ describe("scripts/test-projects changed-target routing", () => {
         "extensions/discord/src/monitor/message-handler.process.test.ts",
         "extensions/slack/src/monitor.tool-result.test.ts",
       ],
-    });
+    );
   });
 
   it("routes source reply prompt changes through prompt and channel delivery regressions", () => {
-    expect(resolveChangedTestTargetPlan(["src/agents/system-prompt.ts"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["src/agents/system-prompt.ts"],
+      [
         "src/agents/system-prompt.test.ts",
         "src/auto-reply/reply/dispatch-acp.test.ts",
         "src/auto-reply/reply/dispatch-from-config.test.ts",
@@ -1118,15 +926,13 @@ describe("scripts/test-projects changed-target routing", () => {
         "extensions/discord/src/monitor/message-handler.process.test.ts",
         "extensions/slack/src/monitor.tool-result.test.ts",
       ],
-    });
+    );
   });
 
   it("routes source reply delivery mode changes through channel delivery regressions", () => {
-    expect(
-      resolveChangedTestTargetPlan(["src/auto-reply/reply/source-reply-delivery-mode.ts"]),
-    ).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["src/auto-reply/reply/source-reply-delivery-mode.ts"],
+      [
         "src/auto-reply/reply/dispatch-acp.test.ts",
         "src/auto-reply/reply/dispatch-from-config.test.ts",
         "src/auto-reply/reply/followup-runner.test.ts",
@@ -1134,13 +940,13 @@ describe("scripts/test-projects changed-target routing", () => {
         "extensions/discord/src/monitor/message-handler.process.test.ts",
         "extensions/slack/src/monitor.tool-result.test.ts",
       ],
-    });
+    );
   });
 
   it("routes channel reply pipeline SDK changes through SDK and channel delivery regressions", () => {
-    expect(resolveChangedTestTargetPlan(["src/plugin-sdk/channel-reply-pipeline.ts"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["src/plugin-sdk/channel-reply-pipeline.ts"],
+      [
         "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
         "src/auto-reply/reply/dispatch-acp.test.ts",
         "src/auto-reply/reply/dispatch-from-config.test.ts",
@@ -1149,98 +955,68 @@ describe("scripts/test-projects changed-target routing", () => {
         "extensions/discord/src/monitor/message-handler.process.test.ts",
         "extensions/slack/src/monitor.tool-result.test.ts",
       ],
-    });
+    );
   });
 
   it("routes reply runtime SDK exports through plugin SDK contract tests", () => {
-    expect(resolveChangedTestTargetPlan(["src/plugin-sdk/reply-runtime.ts"])).toEqual({
-      mode: "targets",
-      targets: ["src/plugins/contracts/plugin-sdk-subpaths.test.ts"],
-    });
+    expectChangedTargets(
+      ["src/plugin-sdk/reply-runtime.ts"],
+      ["src/plugins/contracts/plugin-sdk-subpaths.test.ts"],
+    );
   });
 
   it("keeps extension batch runner edits on extension script tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/test-extension-batch.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/test-extension.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/test-extension-batch.mjs"],
+      ["test/scripts/test-extension.test.ts"],
+    );
   });
 
   it("keeps check runner edits on check runner tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/check.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/check.test.ts"],
-    });
+    expectChangedTargets(["scripts/check.mjs"], ["test/scripts/check.test.ts"]);
   });
 
   it("keeps build runner edits on build runner tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/build-all.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/build-all.test.ts"],
-    });
+    expectChangedTargets(["scripts/build-all.mjs"], ["test/scripts/build-all.test.ts"]);
   });
 
   it("keeps force-test runner edits on its safe CLI tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/test-force.ts"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/test-force.test.ts"],
-    });
+    expectChangedTargets(["scripts/test-force.ts"], ["test/scripts/test-force.test.ts"]);
   });
 
   it("keeps live-test runner edits on live-test runner tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/test-live.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/test-live.test.ts"],
-    });
+    expectChangedTargets(["scripts/test-live.mjs"], ["test/scripts/test-live.test.ts"]);
   });
 
   it("keeps tsdown build runner edits on tsdown build tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/tsdown-build.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/tsdown-build.test.ts"],
-    });
+    expectChangedTargets(["scripts/tsdown-build.mjs"], ["test/scripts/tsdown-build.test.ts"]);
   });
 
   it("keeps verify runner edits on verify runner tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/verify.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/verify.test.ts"],
-    });
+    expectChangedTargets(["scripts/verify.mjs"], ["test/scripts/verify.test.ts"]);
   });
 
   it("keeps sharded oxlint runner edits on oxlint runner tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/run-oxlint-shards.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/run-oxlint.test.ts"],
-    });
+    expectChangedTargets(["scripts/run-oxlint-shards.mjs"], ["test/scripts/run-oxlint.test.ts"]);
   });
 
   it("keeps env wrapper edits on env wrapper tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/run-with-env.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/run-with-env.test.ts"],
-    });
+    expectChangedTargets(["scripts/run-with-env.mjs"], ["test/scripts/run-with-env.test.ts"]);
   });
 
   it("keeps Crabbox config edits on package acceptance tests", () => {
-    expect(resolveChangedTestTargetPlan([".crabbox.yaml"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/package-acceptance-workflow.test.ts"],
-    });
+    expectChangedTargets([".crabbox.yaml"], ["test/scripts/package-acceptance-workflow.test.ts"]);
   });
 
   it("keeps scripts tsconfig edits on oxlint config tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/tsconfig.json"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/oxlint-config.test.ts"],
-    });
+    expectChangedTargets(["scripts/tsconfig.json"], ["test/scripts/oxlint-config.test.ts"]);
   });
 
   it("keeps the scripts typecheck project on its routing tests", () => {
-    expect(resolveChangedTestTargetPlan(["tsconfig.scripts.json"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/changed-lanes.test.ts", "test/scripts/test-projects.test.ts"],
-    });
+    expectChangedTargets(
+      ["tsconfig.scripts.json"],
+      ["test/scripts/changed-lanes.test.ts", "test/scripts/test-projects.test.ts"],
+    );
   });
 
   it("keeps docs i18n behavior fixture edits on behavior baseline tests", () => {
@@ -1248,10 +1024,7 @@ describe("scripts/test-projects changed-target routing", () => {
       "scripts/docs-i18n/testdata/behavior/fenced-singleton-retry/case.json",
       "scripts/docs-i18n/testdata/behavior/fenced-singleton-retry/source.txt",
     ]) {
-      expect(resolveChangedTestTargetPlan([fixturePath]), fixturePath).toEqual({
-        mode: "targets",
-        targets: ["test/scripts/docs-i18n.test.ts"],
-      });
+      expectChangedTargets([fixturePath], ["test/scripts/docs-i18n.test.ts"]);
     }
   });
 
@@ -1273,10 +1046,10 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps k8s manifest edits on manifest tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/k8s/manifests/configmap.yaml"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/k8s-manifests.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/k8s/manifests/configmap.yaml"],
+      ["test/scripts/k8s-manifests.test.ts"],
+    );
   });
 
   it("keeps Crabbox runner script edits on their regression tests", () => {
@@ -1284,31 +1057,25 @@ describe("scripts/test-projects changed-target routing", () => {
       "scripts/crabbox-wrapper.mjs",
       "scripts/crabbox-wrapper-providers.mjs",
     ]) {
-      expect(resolveChangedTestTargetPlan([scriptPath]), scriptPath).toEqual({
-        mode: "targets",
-        targets: ["test/scripts/crabbox-wrapper.test.ts"],
-      });
+      expectChangedTargets([scriptPath], ["test/scripts/crabbox-wrapper.test.ts"]);
     }
   });
 
   it("keeps build stamp script edits on the build stamp regression test", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/build-stamp.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["src/infra/build-stamp.test.ts"],
-    });
+    expectChangedTargets(["scripts/build-stamp.mjs"], ["src/infra/build-stamp.test.ts"]);
   });
 
   it("keeps bundled plugin metadata copier edits on runtime owner tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/copy-bundled-plugin-metadata.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["src/plugins/copy-bundled-plugin-metadata.test.ts", "src/infra/run-node.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/copy-bundled-plugin-metadata.mjs"],
+      ["src/plugins/copy-bundled-plugin-metadata.test.ts", "src/infra/run-node.test.ts"],
+    );
   });
 
   it("keeps CI workflow edits on workflow guard tests", () => {
-    expect(resolveChangedTestTargetPlan([".github/workflows/ci.yml"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      [".github/workflows/ci.yml"],
+      [
         "test/scripts/ci-workflow-guards.test.ts",
         "test/scripts/changed-lanes.test.ts",
         "test/scripts/check-workflows.test.ts",
@@ -1316,19 +1083,19 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/plugin-prerelease-test-plan.test.ts",
         "test/scripts/verify-pr-hosted-gates.test.ts",
       ],
-    });
+    );
   });
 
   it("keeps npm release workflow edits on the preflight cache guard", () => {
-    expect(resolveChangedTestTargetPlan([".github/workflows/openclaw-npm-release.yml"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      [".github/workflows/openclaw-npm-release.yml"],
+      [
         "test/openclaw-npm-postpublish-verify.test.ts",
         "test/scripts/openclaw-npm-extended-stable-workflow.test.ts",
         "test/scripts/package-acceptance-workflow.test.ts",
         "test/scripts/ci-workflow-guards.test.ts",
       ],
-    });
+    );
   });
 
   it("keeps generated locale publisher and inventory edits on workflow guards", () => {
@@ -1336,15 +1103,12 @@ describe("scripts/test-projects changed-target routing", () => {
       ".github/actions/create-generated-pr-tokens/action.yml",
       ".github/actions/publish-generated-pr/action.yml",
     ]) {
-      expect(resolveChangedTestTargetPlan([actionPath])).toEqual({
-        mode: "targets",
-        targets: ["test/scripts/ci-workflow-guards.test.ts"],
-      });
+      expectChangedTargets([actionPath], ["test/scripts/ci-workflow-guards.test.ts"]);
     }
-    expect(resolveChangedTestTargetPlan(["scripts/native-app-i18n.ts"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/native-app-i18n.test.ts", "test/scripts/ci-workflow-guards.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/native-app-i18n.ts"],
+      ["test/scripts/native-app-i18n.test.ts", "test/scripts/ci-workflow-guards.test.ts"],
+    );
   });
 
   it("keeps PR automation workflow edits on workflow guard tests", () => {
@@ -1355,23 +1119,18 @@ describe("scripts/test-projects changed-target routing", () => {
       ".github/workflows/real-behavior-proof.yml",
       ".github/workflows/stale.yml",
     ]) {
-      expect(resolveChangedTestTargetPlan([workflowPath])).toEqual({
-        mode: "targets",
-        targets: ["test/scripts/ci-workflow-guards.test.ts"],
-      });
+      expectChangedTargets([workflowPath], ["test/scripts/ci-workflow-guards.test.ts"]);
     }
   });
 
   it("keeps security-sensitive guard workflow edits on guard workflow tests", () => {
-    expect(
-      resolveChangedTestTargetPlan([".github/workflows/security-sensitive-guard.yml"]),
-    ).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      [".github/workflows/security-sensitive-guard.yml"],
+      [
         "test/scripts/security-sensitive-guard-workflow.test.ts",
         "test/scripts/ci-workflow-guards.test.ts",
       ],
-    });
+    );
   });
 
   it("keeps Crabbox and Testbox workflow edits on workflow regression tests", () => {
@@ -1490,213 +1249,182 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps release-check workflow edits on release workflow regression tests", () => {
-    expect(resolveChangedTestTargetPlan([".github/workflows/openclaw-release-checks.yml"])).toEqual(
-      {
-        mode: "targets",
-        targets: [
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/openclaw-cross-os-release-checks.test.ts",
-          "test/scripts/plugin-prerelease-test-plan.test.ts",
-          "test/scripts/test-install-sh-docker.test.ts",
-          "test/scripts/ci-workflow-guards.test.ts",
-        ],
-      },
+    expectChangedTargets(
+      [".github/workflows/openclaw-release-checks.yml"],
+      [
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/openclaw-cross-os-release-checks.test.ts",
+        "test/scripts/plugin-prerelease-test-plan.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
     );
   });
 
   it("keeps workflow sanity script edits on workflow guard tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/check-workflows.mjs"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["scripts/check-workflows.mjs"],
+      [
         "test/scripts/check-composite-action-input-interpolation.test.ts",
         "test/scripts/check-no-conflict-markers.test.ts",
         "test/scripts/ci-workflow-guards.test.ts",
         "test/scripts/check-workflows.test.ts",
       ],
-    });
+    );
   });
 
   it("keeps workflow helper guard edits on their regression tests", () => {
-    expect(
-      resolveChangedTestTargetPlan(["scripts/check-composite-action-input-interpolation.py"]),
-    ).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/check-composite-action-input-interpolation.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/check-composite-action-input-interpolation.py"],
+      ["test/scripts/check-composite-action-input-interpolation.test.ts"],
+    );
 
-    expect(resolveChangedTestTargetPlan(["scripts/check-no-conflict-markers.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/check-no-conflict-markers.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/check-no-conflict-markers.mjs"],
+      ["test/scripts/check-no-conflict-markers.test.ts"],
+    );
   });
 
   it("keeps CI, dependency, and docs tooling edits on owner tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/ci-changed-scope.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["src/scripts/ci-changed-scope.test.ts", "test/scripts/control-ui-i18n.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/ci-changed-scope.mjs"],
+      ["src/scripts/ci-changed-scope.test.ts", "test/scripts/control-ui-i18n.test.ts"],
+    );
 
-    expect(resolveChangedTestTargetPlan(["scripts/check-dependency-pins.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/check-dependency-pins.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/check-dependency-pins.mjs"],
+      ["test/scripts/check-dependency-pins.test.ts"],
+    );
 
-    expect(resolveChangedTestTargetPlan(["scripts/dependency-vulnerability-gate.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/dependency-vulnerability-gate.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/dependency-vulnerability-gate.mjs"],
+      ["test/scripts/dependency-vulnerability-gate.test.ts"],
+    );
 
-    expect(resolveChangedTestTargetPlan(["scripts/dependency-changes-report.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/dependency-changes-report.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/dependency-changes-report.mjs"],
+      ["test/scripts/dependency-changes-report.test.ts"],
+    );
 
-    expect(resolveChangedTestTargetPlan(["scripts/github/dependency-guard.mjs"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["scripts/github/dependency-guard.mjs"],
+      [
         "test/scripts/dependency-guard-script.test.ts",
         "test/scripts/dependency-guard-workflow.test.ts",
       ],
-    });
+    );
 
-    expect(resolveChangedTestTargetPlan(["scripts/github/guard-shared.mjs"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["scripts/github/guard-shared.mjs"],
+      [
         "test/scripts/dependency-guard-script.test.ts",
         "test/scripts/dependency-guard-workflow.test.ts",
         "test/scripts/security-sensitive-guard-script.test.ts",
         "test/scripts/security-sensitive-guard-workflow.test.ts",
       ],
-    });
+    );
 
-    expect(
-      resolveChangedTestTargetPlan(["scripts/github/run-openclaw-cross-os-release-checks.sh"]),
-    ).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/openclaw-cross-os-release-workflow.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/github/run-openclaw-cross-os-release-checks.sh"],
+      ["test/scripts/openclaw-cross-os-release-workflow.test.ts"],
+    );
 
-    expect(resolveChangedTestTargetPlan(["scripts/github/security-sensitive-guard.mjs"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["scripts/github/security-sensitive-guard.mjs"],
+      [
         "test/scripts/security-sensitive-guard-script.test.ts",
         "test/scripts/security-sensitive-guard-workflow.test.ts",
       ],
-    });
+    );
 
-    expect(
-      resolveChangedTestTargetPlan(["scripts/dependency-ownership-surface-report.mjs"]),
-    ).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/dependency-ownership-surface-report.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/dependency-ownership-surface-report.mjs"],
+      ["test/scripts/dependency-ownership-surface-report.test.ts"],
+    );
 
-    expect(resolveChangedTestTargetPlan(["scripts/clawtributors-map.json"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/update-clawtributors.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/clawtributors-map.json"],
+      ["test/scripts/update-clawtributors.test.ts"],
+    );
 
-    expect(resolveChangedTestTargetPlan(["scripts/docs-list.js"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/docs-list.test.ts"],
-    });
+    expectChangedTargets(["scripts/docs-list.js"], ["test/scripts/docs-list.test.ts"]);
 
-    expect(resolveChangedTestTargetPlan(["scripts/docs-link-audit.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["src/scripts/docs-link-audit.test.ts"],
-    });
+    expectChangedTargets(["scripts/docs-link-audit.mjs"], ["src/scripts/docs-link-audit.test.ts"]);
 
-    expect(resolveChangedTestTargetPlan(["scripts/check-changelog-attributions.mjs"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/check-changelog-attributions.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/check-changelog-attributions.mjs"],
+      ["test/scripts/check-changelog-attributions.test.ts"],
+    );
   });
 
   it("keeps package, release, and install tooling edits on owner tests", () => {
-    const expectedTargets = new Map([
-      ["scripts/generate-npm-package-lock.mjs", ["test/scripts/generate-npm-package-lock.test.ts"]],
-      ["scripts/npm-runner.d.mts", ["test/scripts/npm-runner.test.ts"]],
-      ["scripts/pnpm-runner.d.mts", ["test/scripts/pnpm-runner.test.ts"]],
-      [
-        "scripts/lib/cross-os-release-checks/runtime.ts",
-        ["test/scripts/openclaw-cross-os-release-checks.test.ts"],
+    const expectedTargets = Object.entries({
+      "scripts/generate-npm-package-lock.mjs": ["test/scripts/generate-npm-package-lock.test.ts"],
+      "scripts/npm-runner.d.mts": ["test/scripts/npm-runner.test.ts"],
+      "scripts/pnpm-runner.d.mts": ["test/scripts/pnpm-runner.test.ts"],
+      "scripts/lib/cross-os-release-checks/runtime.ts": [
+        "test/scripts/openclaw-cross-os-release-checks.test.ts",
       ],
-      [
-        "scripts/install.sh",
-        [
-          "test/scripts/install-sh.test.ts",
-          "test/scripts/test-install-sh-docker.test.ts",
-          "test/scripts/website-installer-sync-workflow.test.ts",
-          "test/scripts/openclaw-cross-os-release-checks.test.ts",
-          "src/scripts/ci-changed-scope.test.ts",
-        ],
+      "scripts/install.sh": [
+        "test/scripts/install-sh.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
+        "test/scripts/website-installer-sync-workflow.test.ts",
+        "test/scripts/openclaw-cross-os-release-checks.test.ts",
+        "src/scripts/ci-changed-scope.test.ts",
       ],
-      [
-        "scripts/install.ps1",
-        [
-          "test/scripts/install-ps1.test.ts",
-          "test/scripts/website-installer-sync-workflow.test.ts",
-          "test/scripts/openclaw-cross-os-release-checks.test.ts",
-          "src/scripts/ci-changed-scope.test.ts",
-        ],
+      "scripts/install.ps1": [
+        "test/scripts/install-ps1.test.ts",
+        "test/scripts/website-installer-sync-workflow.test.ts",
+        "test/scripts/openclaw-cross-os-release-checks.test.ts",
+        "src/scripts/ci-changed-scope.test.ts",
       ],
-      ["scripts/podman/openclaw.container.in", ["test/scripts/test-install-sh-docker.test.ts"]],
-      [
-        "scripts/package-openclaw-for-docker.mjs",
-        ["test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts"],
+      "scripts/podman/openclaw.container.in": ["test/scripts/test-install-sh-docker.test.ts"],
+      "scripts/package-openclaw-for-docker.mjs": [
+        "test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts",
       ],
-      ["scripts/ios-run.sh", ["test/scripts/ios-run.test.ts"]],
-      ["scripts/ios-write-version-xcconfig.sh", ["test/scripts/ios-version.test.ts"]],
-      ["scripts/create-dmg.sh", ["test/scripts/create-dmg.test.ts"]],
-      ["scripts/make_appcast.sh", ["test/scripts/make-appcast.test.ts"]],
-      ["scripts/package-mac-app.sh", ["test/scripts/package-mac-app.test.ts"]],
-      ["scripts/package-mac-dist.sh", ["test/scripts/package-mac-dist.test.ts"]],
-      [
-        "scripts/lib/build-metadata.sh",
-        [
-          "src/docker-setup.e2e.test.ts",
-          "test/scripts/apple-release-source-check.test.ts",
-          "test/scripts/ios-version.test.ts",
-          "test/scripts/package-mac-app.test.ts",
-          "test/scripts/test-install-sh-docker.test.ts",
-        ],
+      "scripts/ios-run.sh": ["test/scripts/ios-run.test.ts"],
+      "scripts/ios-write-version-xcconfig.sh": ["test/scripts/ios-version.test.ts"],
+      "scripts/create-dmg.sh": ["test/scripts/create-dmg.test.ts"],
+      "scripts/make_appcast.sh": ["test/scripts/make-appcast.test.ts"],
+      "scripts/package-mac-app.sh": ["test/scripts/package-mac-app.test.ts"],
+      "scripts/package-mac-dist.sh": ["test/scripts/package-mac-dist.test.ts"],
+      "scripts/lib/build-metadata.sh": [
+        "src/docker-setup.e2e.test.ts",
+        "test/scripts/apple-release-source-check.test.ts",
+        "test/scripts/ios-version.test.ts",
+        "test/scripts/package-mac-app.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
       ],
-      [
-        "scripts/lib/swift-toolchain.sh",
-        ["test/scripts/package-mac-app.test.ts", "test/scripts/package-mac-dist.test.ts"],
+      "scripts/lib/swift-toolchain.sh": [
+        "test/scripts/package-mac-app.test.ts",
+        "test/scripts/package-mac-dist.test.ts",
       ],
-      ["scripts/e2e/bun-global-install-smoke.sh", ["test/scripts/test-install-sh-docker.test.ts"]],
-      [
-        "scripts/sparkle-build.ts",
-        [
-          "test/appcast.test.ts",
-          "test/release-check.test.ts",
-          "test/scripts/package-mac-app.test.ts",
-          "test/scripts/package-mac-dist.test.ts",
-        ],
+      "scripts/e2e/bun-global-install-smoke.sh": ["test/scripts/test-install-sh-docker.test.ts"],
+      "scripts/sparkle-build.ts": [
+        "test/appcast.test.ts",
+        "test/release-check.test.ts",
+        "test/scripts/package-mac-app.test.ts",
+        "test/scripts/package-mac-dist.test.ts",
       ],
-      ["scripts/package-changelog.mjs", ["test/scripts/package-changelog.test.ts"]],
-      [
-        "scripts/test-install-sh-e2e-docker.sh",
-        ["test/scripts/docker-build-helper.test.ts", "test/scripts/test-install-sh-docker.test.ts"],
+      "scripts/package-changelog.mjs": ["test/scripts/package-changelog.test.ts"],
+      "scripts/test-install-sh-e2e-docker.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
       ],
-      ["scripts/openclaw-prepack.ts", ["test/openclaw-prepack.test.ts"]],
-      ["scripts/openclaw-npm-release-check.ts", ["test/openclaw-npm-release-check.test.ts"]],
-      [
-        "scripts/openclaw-npm-postpublish-verify.ts",
-        ["test/openclaw-npm-postpublish-verify.test.ts"],
+      "scripts/openclaw-prepack.ts": ["test/openclaw-prepack.test.ts"],
+      "scripts/openclaw-npm-release-check.ts": ["test/openclaw-npm-release-check.test.ts"],
+      "scripts/openclaw-npm-postpublish-verify.ts": [
+        "test/openclaw-npm-postpublish-verify.test.ts",
       ],
-      ["scripts/verify-pr-hosted-gates.mjs", ["test/scripts/verify-pr-hosted-gates.test.ts"]],
-      [
-        "scripts/postinstall-bundled-plugins.mjs",
-        ["test/scripts/postinstall-bundled-plugins.test.ts"],
+      "scripts/verify-pr-hosted-gates.mjs": ["test/scripts/verify-pr-hosted-gates.test.ts"],
+      "scripts/postinstall-bundled-plugins.mjs": [
+        "test/scripts/postinstall-bundled-plugins.test.ts",
       ],
-      ["scripts/prepare-git-hooks.mjs", ["test/scripts/prepare-git-hooks.test.ts"]],
-      [
-        "scripts/preinstall-package-manager-warning.mjs",
-        ["test/scripts/preinstall-package-manager-warning.test.ts"],
+      "scripts/prepare-git-hooks.mjs": ["test/scripts/prepare-git-hooks.test.ts"],
+      "scripts/preinstall-package-manager-warning.mjs": [
+        "test/scripts/preinstall-package-manager-warning.test.ts",
       ],
-    ]);
+    });
 
     for (const [source, targets] of expectedTargets) {
       expect(resolveChangedTestTargetPlan([source]), source).toEqual({
@@ -1762,31 +1490,28 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps QA Lab gateway smoke script edits on QA e2e tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/dev/gateway-smoke.ts"])).toEqual({
-      mode: "targets",
-      targets: ["test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/dev/gateway-smoke.ts"],
+      ["test/e2e/qa-lab/runtime/gateway-smoke.e2e.test.ts"],
+    );
   });
 
   it("keeps extensionless helper script edits on owner tests", () => {
-    const expectedTargets = new Map([
-      ["scripts/committer", ["test/scripts/committer.test.ts"]],
-      ["scripts/gh-read", ["test/scripts/gh-read.test.ts"]],
-      [
-        "scripts/pr",
-        [
-          "test/scripts/pr-merge.test.ts",
-          "test/scripts/pr-operation-lock.test.ts",
-          "test/scripts/pr-wrappers.test.ts",
-        ],
+    const expectedTargets = Object.entries({
+      "scripts/committer": ["test/scripts/committer.test.ts"],
+      "scripts/gh-read": ["test/scripts/gh-read.test.ts"],
+      "scripts/pr": [
+        "test/scripts/pr-merge.test.ts",
+        "test/scripts/pr-operation-lock.test.ts",
+        "test/scripts/pr-wrappers.test.ts",
       ],
-      ["scripts/pr-lib/merge.sh", ["test/scripts/pr-merge.test.ts"]],
-      ["scripts/pr-lib/operation-lock.sh", ["test/scripts/pr-operation-lock.test.ts"]],
-      ["scripts/pr-lib/process-group-runner.mjs", ["test/scripts/pr-operation-lock.test.ts"]],
-      ["scripts/pr-merge", ["test/scripts/pr-wrappers.test.ts"]],
-      ["scripts/pr-prepare", ["test/scripts/pr-wrappers.test.ts"]],
-      ["scripts/pr-review", ["test/scripts/pr-wrappers.test.ts"]],
-    ]);
+      "scripts/pr-lib/merge.sh": ["test/scripts/pr-merge.test.ts"],
+      "scripts/pr-lib/operation-lock.sh": ["test/scripts/pr-operation-lock.test.ts"],
+      "scripts/pr-lib/process-group-runner.mjs": ["test/scripts/pr-operation-lock.test.ts"],
+      "scripts/pr-merge": ["test/scripts/pr-wrappers.test.ts"],
+      "scripts/pr-prepare": ["test/scripts/pr-wrappers.test.ts"],
+      "scripts/pr-review": ["test/scripts/pr-wrappers.test.ts"],
+    });
 
     for (const [source, targets] of expectedTargets) {
       expect(resolveChangedTestTargetPlan([source]), source).toEqual({
@@ -1797,17 +1522,17 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps auth monitoring helper edits on owner tests", () => {
-    const expectedTargets = new Map([
-      ["scripts/auth-monitor.sh", ["test/scripts/auth-monitor.test.ts"]],
-      ["scripts/mobile-reauth.sh", ["test/scripts/auth-monitor.test.ts"]],
-      ["scripts/setup-auth-system.sh", ["test/scripts/auth-monitor.test.ts"]],
-      ["scripts/systemd/openclaw-auth-monitor.service", ["test/scripts/auth-monitor.test.ts"]],
-      ["scripts/systemd/openclaw-auth-monitor.timer", ["test/scripts/auth-monitor.test.ts"]],
-      ["scripts/termux-auth-widget.sh", ["test/scripts/auth-monitor.test.ts"]],
-      ["scripts/termux-quick-auth.sh", ["test/scripts/auth-monitor.test.ts"]],
-      ["scripts/termux-sync-widget.sh", ["test/scripts/auth-monitor.test.ts"]],
-      ["test/scripts/auth-monitor.test.ts", ["test/scripts/auth-monitor.test.ts"]],
-    ]);
+    const expectedTargets = Object.entries({
+      "scripts/auth-monitor.sh": ["test/scripts/auth-monitor.test.ts"],
+      "scripts/mobile-reauth.sh": ["test/scripts/auth-monitor.test.ts"],
+      "scripts/setup-auth-system.sh": ["test/scripts/auth-monitor.test.ts"],
+      "scripts/systemd/openclaw-auth-monitor.service": ["test/scripts/auth-monitor.test.ts"],
+      "scripts/systemd/openclaw-auth-monitor.timer": ["test/scripts/auth-monitor.test.ts"],
+      "scripts/termux-auth-widget.sh": ["test/scripts/auth-monitor.test.ts"],
+      "scripts/termux-quick-auth.sh": ["test/scripts/auth-monitor.test.ts"],
+      "scripts/termux-sync-widget.sh": ["test/scripts/auth-monitor.test.ts"],
+      "test/scripts/auth-monitor.test.ts": ["test/scripts/auth-monitor.test.ts"],
+    });
 
     for (const [source, targets] of expectedTargets) {
       expect(resolveChangedTestTargetPlan([source]), source).toEqual({
@@ -1818,12 +1543,12 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps docs spellcheck config edits on owner tests", () => {
-    const expectedTargets = new Map([
-      ["scripts/codespell-dictionary.txt", ["test/scripts/docs-spellcheck.test.ts"]],
-      ["scripts/codespell-ignore.txt", ["test/scripts/docs-spellcheck.test.ts"]],
-      ["scripts/docs-spellcheck.sh", ["test/scripts/docs-spellcheck.test.ts"]],
-      ["test/scripts/docs-spellcheck.test.ts", ["test/scripts/docs-spellcheck.test.ts"]],
-    ]);
+    const expectedTargets = Object.entries({
+      "scripts/codespell-dictionary.txt": ["test/scripts/docs-spellcheck.test.ts"],
+      "scripts/codespell-ignore.txt": ["test/scripts/docs-spellcheck.test.ts"],
+      "scripts/docs-spellcheck.sh": ["test/scripts/docs-spellcheck.test.ts"],
+      "test/scripts/docs-spellcheck.test.ts": ["test/scripts/docs-spellcheck.test.ts"],
+    });
 
     for (const [source, targets] of expectedTargets) {
       expect(resolveChangedTestTargetPlan([source]), source).toEqual({
@@ -1834,535 +1559,401 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps shared script library edits on owner tests", () => {
-    const expectedTargets = new Map([
-      [
-        "scripts/lib/local-heavy-check-runtime.d.mts",
-        ["test/scripts/local-heavy-check-runtime.test.ts"],
-      ],
-      [
-        "scripts/lib/local-heavy-check-runtime.mjs",
-        ["test/scripts/local-heavy-check-runtime.test.ts"],
-      ],
-      ["scripts/lib/managed-child-process.mjs", ["test/scripts/managed-child-process.test.ts"]],
-      [
-        "scripts/lib/failed-trailer.mjs",
-        [
-          "test/scripts/run-oxlint.test.ts",
-          "test/scripts/run-tsgo.test.ts",
-          "test/scripts/run-vitest.test.ts",
-          "test/scripts/changed-lanes.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/windows-taskkill.mjs",
-        ["test/scripts/managed-child-process.test.ts", "test/scripts/run-with-env.test.ts"],
-      ],
-      [
-        "scripts/lib/windows-taskkill.d.mts",
-        ["test/scripts/managed-child-process.test.ts", "test/scripts/run-with-env.test.ts"],
-      ],
-      ["scripts/lib/source-file-scan-cache.mjs", ["test/scripts/source-file-scan-cache.test.ts"]],
-      ["scripts/lib/dev-tooling-safety.ts", ["test/scripts/dev-tooling-safety.test.ts"]],
-      [
-        "scripts/lib/local-build-metadata.mjs",
-        [
-          "src/infra/build-stamp.test.ts",
-          "test/scripts/runtime-postbuild-stamp.test.ts",
-          "src/infra/run-node.test.ts",
-          "src/infra/package-dist-inventory.test.ts",
-          "test/release-check.test.ts",
-          "test/openclaw-npm-release-check.test.ts",
-          "test/scripts/check-gateway-watch-regression.test.ts",
-          "test/scripts/check-openclaw-package-tarball.test.ts",
-          "test/scripts/openclaw-cross-os-release-checks.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/local-build-metadata-paths.mjs",
-        [
-          "src/infra/build-stamp.test.ts",
-          "test/scripts/runtime-postbuild-stamp.test.ts",
-          "src/infra/run-node.test.ts",
-          "src/infra/package-dist-inventory.test.ts",
-          "test/release-check.test.ts",
-          "test/openclaw-npm-release-check.test.ts",
-          "test/scripts/check-gateway-watch-regression.test.ts",
-          "test/scripts/check-openclaw-package-tarball.test.ts",
-          "test/scripts/openclaw-cross-os-release-checks.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/deprecated-plugin-sdk-usage.mjs",
-        ["test/scripts/check-deprecated-api-usage.test.ts"],
-      ],
-      [
-        "scripts/lib/dependency-ownership.json",
-        ["test/scripts/dependency-ownership-surface-report.test.ts"],
-      ],
-      [
-        "scripts/lib/plugin-sdk-deprecated-barrel-subpaths.json",
-        [
-          "src/plugins/contracts/plugin-sdk-index.bundle.test.ts",
-          "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
-          "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
-          "src/plugins/contracts/extension-package-project-boundaries.test.ts",
-          "test/scripts/plugin-sdk-surface-report.test.ts",
-          "test/scripts/build-all.test.ts",
-          "test/release-check.test.ts",
-          "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
-          "test/scripts/ts-topology.test.ts",
-          "test/vitest/vitest.tooling.config.ts",
-        ],
-      ],
-      [
-        "scripts/lib/plugin-sdk-deprecated-public-subpaths.json",
-        [
-          "test/scripts/check-deprecated-api-usage.test.ts",
-          "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
-          "test/scripts/plugin-sdk-surface-report.test.ts",
-          "test/scripts/build-all.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/plugin-sdk-entrypoints.json",
-        [
-          "src/plugins/contracts/plugin-sdk-index.bundle.test.ts",
-          "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
-          "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
-          "src/plugins/contracts/extension-package-project-boundaries.test.ts",
-          "test/scripts/plugin-sdk-surface-report.test.ts",
-          "test/scripts/build-all.test.ts",
-          "test/release-check.test.ts",
-          "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
-          "test/scripts/ts-topology.test.ts",
-          "test/vitest/vitest.tooling.config.ts",
-        ],
-      ],
-      [
-        "scripts/lib/plugin-sdk-entries.mjs",
-        [
-          "src/plugins/contracts/plugin-sdk-index.bundle.test.ts",
-          "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
-          "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
-          "src/plugins/contracts/extension-package-project-boundaries.test.ts",
-          "test/scripts/plugin-sdk-surface-report.test.ts",
-          "test/scripts/build-all.test.ts",
-          "test/release-check.test.ts",
-          "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
-          "test/scripts/ts-topology.test.ts",
-          "test/vitest/vitest.tooling.config.ts",
-        ],
-      ],
-      [
-        "scripts/lib/plugin-sdk-private-local-only-subpaths.json",
-        [
-          "src/plugins/contracts/plugin-sdk-index.bundle.test.ts",
-          "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
-          "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
-          "src/plugins/contracts/extension-package-project-boundaries.test.ts",
-          "test/scripts/plugin-sdk-surface-report.test.ts",
-          "test/scripts/build-all.test.ts",
-          "test/release-check.test.ts",
-          "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
-          "test/scripts/ts-topology.test.ts",
-          "test/vitest/vitest.tooling.config.ts",
-        ],
-      ],
-      [
-        "scripts/lib/official-external-channel-catalog.json",
-        [
-          "src/plugins/official-external-plugin-catalog.test.ts",
-          "test/release-check.test.ts",
-          "test/official-channel-catalog.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/official-external-plugin-catalog.json",
-        ["src/plugins/official-external-plugin-catalog.test.ts", "test/release-check.test.ts"],
-      ],
-      [
-        "scripts/lib/official-external-provider-catalog.json",
-        ["src/plugins/official-external-plugin-catalog.test.ts", "test/release-check.test.ts"],
-      ],
-      [
-        "scripts/lib/recommended-tool-installs.json",
-        ["src/plugins/recommended-tool-installs.test.ts", "test/release-check.test.ts"],
-      ],
-      ["scripts/lib/direct-run.mjs", ["test/scripts/changed-lanes.test.ts"]],
-      ["scripts/lib/npm-verify-exec.ts", ["test/scripts/npm-verify-exec.test.ts"]],
-      [
-        "scripts/lib/plugin-npm-runtime-build.mjs",
-        [
-          "test/scripts/plugin-npm-runtime-build-args.test.ts",
-          "test/plugin-npm-runtime-build.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/plugin-npm-package-manifest.mjs",
-        [
-          "test/scripts/plugin-npm-package-manifest-args.test.ts",
-          "test/plugin-npm-package-manifest.test.ts",
-        ],
-      ],
-      ["scripts/lib/arg-utils.mjs", ["test/scripts/arg-utils.test.ts"]],
-      [
-        "scripts/lib/android-version.ts",
-        ["test/scripts/android-version.test.ts", "test/scripts/android-pin-version.test.ts"],
-      ],
-      ["scripts/lib/ios-version.ts", ["test/scripts/ios-version.test.ts"]],
-      [
-        ".github/images/live-media-runner/Dockerfile",
-        ["test/scripts/package-acceptance-workflow.test.ts"],
-      ],
-      [
-        ".github/actions/detect-docs-changes/action.yml",
-        ["test/scripts/ci-workflow-guards.test.ts"],
-      ],
-      [
-        ".github/actions/ensure-base-commit/action.yml",
-        ["test/scripts/ci-workflow-guards.test.ts"],
-      ],
-      [
-        ".github/actions/setup-node-env/action.yml",
-        [
-          "test/scripts/install-trufflehog.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/ci-workflow-guards.test.ts",
-        ],
-      ],
-      [
-        ".github/actions/setup-node-env/dependency-fingerprint.mjs",
-        ["test/scripts/ci-workflow-guards.test.ts"],
-      ],
-      [
-        ".github/actions/setup-node-env/verify-importers.mjs",
-        ["test/scripts/ci-workflow-guards.test.ts"],
-      ],
-      [
-        ".github/actions/setup-pnpm-store-cache/action.yml",
-        [
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/ci-workflow-guards.test.ts",
-        ],
-      ],
-      [
-        ".github/actions/setup-pnpm-store-cache/ensure-node.sh",
-        ["test/scripts/setup-pnpm-store-cache-ensure-node.test.ts"],
-      ],
-      [
-        ".github/workflows/live-media-runner-image.yml",
-        [
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/ci-workflow-guards.test.ts",
-        ],
-      ],
-      [
-        ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml",
-        [
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/ci-workflow-guards.test.ts",
-          "test/scripts/release-workflow-matrix-plan.test.ts",
-          "test/scripts/test-install-sh-docker.test.ts",
-        ],
-      ],
-      [
-        ".github/workflows/package-acceptance.yml",
-        [
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/ci-workflow-guards.test.ts",
-        ],
-      ],
-      [".github/workflows/workflow-sanity.yml", ["test/scripts/ci-workflow-guards.test.ts"]],
-      [
-        ".github/workflows/docker-release.yml",
-        ["src/dockerfile.test.ts", "test/scripts/ci-workflow-guards.test.ts"],
-      ],
-      [
-        ".github/workflows/full-release-validation.yml",
-        [
-          "src/dockerfile.test.ts",
-          "test/scripts/package-acceptance-workflow.test.ts",
-          "test/scripts/plugin-prerelease-test-plan.test.ts",
-          "test/scripts/ci-workflow-guards.test.ts",
-        ],
-      ],
-      [
-        "Dockerfile",
-        [
-          "src/docker-build-cache.test.ts",
-          "src/docker-image-digests.test.ts",
-          "src/dockerfile.test.ts",
-          "test/scripts/test-install-sh-docker.test.ts",
-        ],
-      ],
-      [
-        "scripts/docker/cleanup-smoke/Dockerfile",
-        [
-          "src/docker-build-cache.test.ts",
-          "src/docker-image-digests.test.ts",
-          "test/scripts/docker-build-helper.test.ts",
-        ],
-      ],
-      ["scripts/docker/cleanup-smoke/run.sh", ["test/scripts/docker-build-helper.test.ts"]],
-      [
-        "scripts/docker/install-sh-e2e/Dockerfile",
-        [
-          "src/docker-build-cache.test.ts",
-          "src/docker-image-digests.test.ts",
-          "test/scripts/test-install-sh-docker.test.ts",
-        ],
-      ],
-      [
-        "scripts/docker/install-sh-e2e/run.sh",
-        ["test/scripts/docker-build-helper.test.ts", "test/scripts/test-install-sh-docker.test.ts"],
-      ],
-      [
-        "scripts/docker/install-sh-common/cli-verify.sh",
-        ["test/scripts/test-install-sh-docker.test.ts"],
-      ],
-      [
-        "scripts/docker/install-sh-common/version-parse.sh",
-        ["test/scripts/test-install-sh-docker.test.ts"],
-      ],
-      [
-        "scripts/docker/install-sh-nonroot/Dockerfile",
-        [
-          "src/docker-build-cache.test.ts",
-          "src/docker-image-digests.test.ts",
-          "test/scripts/test-install-sh-docker.test.ts",
-        ],
-      ],
-      ["scripts/docker/install-sh-nonroot/run.sh", ["test/scripts/test-install-sh-docker.test.ts"]],
-      [
-        "scripts/docker/install-sh-smoke/Dockerfile",
-        [
-          "src/docker-build-cache.test.ts",
-          "src/docker-image-digests.test.ts",
-          "test/scripts/test-install-sh-docker.test.ts",
-        ],
-      ],
-      ["scripts/docker/install-sh-smoke/run.sh", ["test/scripts/test-install-sh-docker.test.ts"]],
-      [
-        "scripts/docker/sandbox/Dockerfile",
-        [
-          "src/docker-build-cache.test.ts",
-          "src/docker-image-digests.test.ts",
-          "src/dockerfile.test.ts",
-        ],
-      ],
-      [
-        "scripts/docker/sandbox/Dockerfile.browser",
-        [
-          "src/docker-build-cache.test.ts",
-          "src/docker-image-digests.test.ts",
-          "src/agents/sandbox/browser.create.test.ts",
-        ],
-      ],
-      ["scripts/docker/sandbox/Dockerfile.common", ["src/docker-build-cache.test.ts"]],
-      [
-        "scripts/e2e/Dockerfile",
-        [
-          "src/docker-build-cache.test.ts",
-          "src/docker-image-digests.test.ts",
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/Dockerfile.qr-import",
-        [
-          "src/docker-build-cache.test.ts",
-          "src/docker-image-digests.test.ts",
-          "test/scripts/docker-build-helper.test.ts",
-        ],
-      ],
-      [
-        "scripts/e2e/plugin-binding-command-escape.Dockerfile",
-        [
-          "src/docker-image-digests.test.ts",
-          "test/scripts/docker-build-helper.test.ts",
-          "test/scripts/docker-e2e-plan.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/package-dist-imports.mjs",
-        [
-          "test/scripts/check-package-dist-imports.test.ts",
-          "test/scripts/check-openclaw-package-tarball.test.ts",
-          "test/scripts/postinstall-bundled-plugins.test.ts",
-          "test/release-check.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/build-metadata.sh",
-        [
-          "src/docker-setup.e2e.test.ts",
-          "test/scripts/apple-release-source-check.test.ts",
-          "test/scripts/ios-version.test.ts",
-          "test/scripts/package-mac-app.test.ts",
-          "test/scripts/test-install-sh-docker.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/plistbuddy.sh",
-        [
-          "test/scripts/create-dmg.test.ts",
-          "test/scripts/package-mac-app.test.ts",
-          "test/scripts/package-mac-dist.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/swift-toolchain.sh",
-        ["test/scripts/package-mac-app.test.ts", "test/scripts/package-mac-dist.test.ts"],
-      ],
-      [
-        "scripts/lib/npm-publish-plan.mjs",
-        [
-          "test/npm-publish-plan.test.ts",
-          "test/openclaw-npm-release-check.test.ts",
-          "test/openclaw-npm-postpublish-verify.test.ts",
-          "test/plugin-npm-release.test.ts",
-          "test/plugin-clawhub-release.test.ts",
-          "test/scripts/release-upgrade-baseline.test.ts",
-          "test/scripts/android-version.test.ts",
-          "test/scripts/ios-version.test.ts",
-          "test/scripts/upgrade-survivor-baselines.test.ts",
-          "test/scripts/upgrade-survivor-config-recipe.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/release-version.mjs",
-        [
-          "test/release-version.test.ts",
-          "test/npm-publish-plan.test.ts",
-          "test/openclaw-npm-release-check.test.ts",
-          "test/openclaw-npm-postpublish-verify.test.ts",
-          "test/plugin-npm-release.test.ts",
-          "test/plugin-clawhub-release.test.ts",
-          "test/scripts/android-version.test.ts",
-          "test/scripts/android-pin-version.test.ts",
-          "test/scripts/docker-release-policy.test.ts",
-          "test/scripts/ios-version.test.ts",
-          "test/scripts/openclaw-npm-extended-stable-release.test.ts",
-          "test/scripts/openclaw-npm-publish.test.ts",
-          "test/scripts/release-preflight.test.ts",
-          "test/scripts/release-prepare.test.ts",
-          "test/scripts/release-upgrade-baseline.test.ts",
-          "test/scripts/release-version.test.ts",
-          "test/scripts/upgrade-survivor-baselines.test.ts",
-          "test/scripts/upgrade-survivor-config-recipe.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/npm-pack-budget.mjs",
-        ["test/release-check.test.ts", "test/scripts/test-install-sh-docker.test.ts"],
-      ],
-      [
-        "scripts/lib/npm-pack-budget.d.mts",
-        ["test/release-check.test.ts", "test/scripts/test-install-sh-docker.test.ts"],
-      ],
-      [
-        "scripts/lib/workspace-bootstrap-smoke.mjs",
-        ["test/release-check.test.ts", "test/openclaw-npm-release-check.test.ts"],
-      ],
-      [
-        "scripts/openclaw-release-clawhub-runtime-state.ts",
-        ["test/scripts/openclaw-release-clawhub-runtime-state.test.ts"],
-      ],
-      [
-        "scripts/openclaw-release-clawhub-plan.ts",
-        ["test/scripts/release-wrapper-scripts.test.ts"],
-      ],
-      ["scripts/lib/openclaw-release-clawhub-plan.ts", ["test/plugin-clawhub-release.test.ts"]],
-      [
-        "scripts/lib/plugin-clawhub-release.ts",
-        ["test/plugin-clawhub-release.test.ts", "test/plugin-npm-release.test.ts"],
-      ],
-      [
-        "scripts/lib/plugin-npm-release.ts",
-        ["test/plugin-npm-release.test.ts", "test/plugin-clawhub-release.test.ts"],
-      ],
-      ["scripts/plugin-clawhub-release-check.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
-      ["scripts/plugin-clawhub-release-plan.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
-      ["scripts/plugin-npm-release-check.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
-      ["scripts/plugin-npm-release-plan.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
-      [
-        "scripts/plugin-release-pretag-pack-check.ts",
-        ["test/scripts/plugin-release-pretag-pack-check.test.ts"],
-      ],
-      [
-        "scripts/plan-release-workflow-matrix.mjs",
-        ["test/scripts/release-workflow-matrix-plan.test.ts"],
-      ],
-      ["scripts/release-verify-beta.ts", ["test/scripts/release-wrapper-scripts.test.ts"]],
-      [
-        "scripts/validate-release-publish-approval.mjs",
-        ["test/scripts/validate-release-publish-approval.test.ts"],
-      ],
-      [
-        "scripts/lib/plugin-package-dependencies.mjs",
-        ["test/scripts/plugin-package-dependencies.test.ts"],
-      ],
-      [
-        "scripts/lib/plugin-npm-runtime-assets.mjs",
-        ["test/scripts/plugin-npm-runtime-build-args.test.ts"],
-      ],
-      [
-        "scripts/lib/generated-text-asset.mjs",
-        [
-          "extensions/browser/scripts/build-copilot-runtime.test.ts",
-          "test/scripts/build-diffs-viewer-runtime.test.ts",
-          "test/scripts/bundled-plugin-assets.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/static-extension-assets.mjs",
-        [
-          "test/scripts/bundled-plugin-assets.test.ts",
-          "test/scripts/runtime-postbuild.test.ts",
-          "src/infra/run-node.test.ts",
-          "test/scripts/plugin-npm-runtime-build-args.test.ts",
-        ],
-      ],
-      ["scripts/lib/test-group-report.mjs", ["test/scripts/test-group-report.test.ts"]],
-      ["scripts/lib/stable-release-closeout.mjs", ["test/stable-release-closeout.test.ts"]],
-      [
-        "scripts/lib/extension-source-classifier.mjs",
-        [
-          "test/scripts/extension-source-classifier.test.ts",
-          "src/channels/plugins/contracts/channel-import-guardrails.test.ts",
-        ],
-      ],
-      ["scripts/lib/ts-topology/analyze.ts", ["test/scripts/ts-topology.test.ts"]],
-      ["scripts/lib/ts-topology/reports.ts", ["test/scripts/ts-topology.test.ts"]],
-      ["scripts/lib/ts-topology/scope.ts", ["test/scripts/ts-topology.test.ts"]],
-      ["scripts/lib/ts-guard-utils.mjs", ["test/scripts/ts-guard-utils.test.ts"]],
-      [
-        "scripts/lib/tsgo-sparse-guard.mjs",
-        ["test/scripts/run-tsgo.test.ts", "test/scripts/changed-lanes.test.ts"],
-      ],
-      ["scripts/write-package-dist-inventory.ts", ["test/scripts/test-install-sh-docker.test.ts"]],
-      ["scripts/lib/format-generated-module.mjs", ["test/scripts/format-generated-module.test.ts"]],
-      [
-        "scripts/lib/bundled-plugin-source-utils.mjs",
-        ["test/scripts/bundled-plugin-source-utils.test.ts"],
-      ],
-      [
-        "scripts/lib/bundled-runtime-sidecar-paths.json",
-        [
-          "src/plugins/bundled-plugin-metadata.test.ts",
-          "src/infra/update-global.test.ts",
-          "src/infra/update-runner.test.ts",
-          "test/openclaw-npm-postpublish-verify.test.ts",
-        ],
-      ],
-      [
-        "scripts/lib/bundled-plugin-build-entries.mjs",
-        ["test/scripts/bundled-plugin-build-entries.test.ts", "test/release-check.test.ts"],
-      ],
-      ["scripts/lib/changed-extensions.mjs", ["test/scripts/test-extension.test.ts"]],
-      ["scripts/lib/extension-vitest-paths.mjs", ["test/scripts/test-extension.test.ts"]],
-    ]);
+    const expectedTargets = Object.entries({
+      "scripts/lib/local-heavy-check-runtime.d.mts": [
+        "test/scripts/local-heavy-check-runtime.test.ts",
+      ],
+      "scripts/lib/local-heavy-check-runtime.mjs": [
+        "test/scripts/local-heavy-check-runtime.test.ts",
+      ],
+      "scripts/lib/managed-child-process.mjs": ["test/scripts/managed-child-process.test.ts"],
+      "scripts/lib/failed-trailer.mjs": [
+        "test/scripts/run-oxlint.test.ts",
+        "test/scripts/run-tsgo.test.ts",
+        "test/scripts/run-vitest.test.ts",
+        "test/scripts/changed-lanes.test.ts",
+      ],
+      "scripts/lib/windows-taskkill.mjs": [
+        "test/scripts/managed-child-process.test.ts",
+        "test/scripts/run-with-env.test.ts",
+      ],
+      "scripts/lib/windows-taskkill.d.mts": [
+        "test/scripts/managed-child-process.test.ts",
+        "test/scripts/run-with-env.test.ts",
+      ],
+      "scripts/lib/source-file-scan-cache.mjs": ["test/scripts/source-file-scan-cache.test.ts"],
+      "scripts/lib/dev-tooling-safety.ts": ["test/scripts/dev-tooling-safety.test.ts"],
+      "scripts/lib/local-build-metadata.mjs": [
+        "src/infra/build-stamp.test.ts",
+        "test/scripts/runtime-postbuild-stamp.test.ts",
+        "src/infra/run-node.test.ts",
+        "src/infra/package-dist-inventory.test.ts",
+        "test/release-check.test.ts",
+        "test/openclaw-npm-release-check.test.ts",
+        "test/scripts/check-gateway-watch-regression.test.ts",
+        "test/scripts/check-openclaw-package-tarball.test.ts",
+        "test/scripts/openclaw-cross-os-release-checks.test.ts",
+      ],
+      "scripts/lib/local-build-metadata-paths.mjs": [
+        "src/infra/build-stamp.test.ts",
+        "test/scripts/runtime-postbuild-stamp.test.ts",
+        "src/infra/run-node.test.ts",
+        "src/infra/package-dist-inventory.test.ts",
+        "test/release-check.test.ts",
+        "test/openclaw-npm-release-check.test.ts",
+        "test/scripts/check-gateway-watch-regression.test.ts",
+        "test/scripts/check-openclaw-package-tarball.test.ts",
+        "test/scripts/openclaw-cross-os-release-checks.test.ts",
+      ],
+      "scripts/lib/deprecated-plugin-sdk-usage.mjs": [
+        "test/scripts/check-deprecated-api-usage.test.ts",
+      ],
+      "scripts/lib/dependency-ownership.json": [
+        "test/scripts/dependency-ownership-surface-report.test.ts",
+      ],
+      "scripts/lib/plugin-sdk-deprecated-barrel-subpaths.json": [
+        "src/plugins/contracts/plugin-sdk-index.bundle.test.ts",
+        "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
+        "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
+        "src/plugins/contracts/extension-package-project-boundaries.test.ts",
+        "test/scripts/plugin-sdk-surface-report.test.ts",
+        "test/scripts/build-all.test.ts",
+        "test/release-check.test.ts",
+        "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
+        "test/scripts/ts-topology.test.ts",
+        "test/vitest/vitest.tooling.config.ts",
+      ],
+      "scripts/lib/plugin-sdk-deprecated-public-subpaths.json": [
+        "test/scripts/check-deprecated-api-usage.test.ts",
+        "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
+        "test/scripts/plugin-sdk-surface-report.test.ts",
+        "test/scripts/build-all.test.ts",
+      ],
+      "scripts/lib/plugin-sdk-entrypoints.json": [
+        "src/plugins/contracts/plugin-sdk-index.bundle.test.ts",
+        "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
+        "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
+        "src/plugins/contracts/extension-package-project-boundaries.test.ts",
+        "test/scripts/plugin-sdk-surface-report.test.ts",
+        "test/scripts/build-all.test.ts",
+        "test/release-check.test.ts",
+        "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
+        "test/scripts/ts-topology.test.ts",
+        "test/vitest/vitest.tooling.config.ts",
+      ],
+      "scripts/lib/plugin-sdk-entries.mjs": [
+        "src/plugins/contracts/plugin-sdk-index.bundle.test.ts",
+        "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
+        "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
+        "src/plugins/contracts/extension-package-project-boundaries.test.ts",
+        "test/scripts/plugin-sdk-surface-report.test.ts",
+        "test/scripts/build-all.test.ts",
+        "test/release-check.test.ts",
+        "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
+        "test/scripts/ts-topology.test.ts",
+        "test/vitest/vitest.tooling.config.ts",
+      ],
+      "scripts/lib/plugin-sdk-private-local-only-subpaths.json": [
+        "src/plugins/contracts/plugin-sdk-index.bundle.test.ts",
+        "src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts",
+        "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
+        "src/plugins/contracts/extension-package-project-boundaries.test.ts",
+        "test/scripts/plugin-sdk-surface-report.test.ts",
+        "test/scripts/build-all.test.ts",
+        "test/release-check.test.ts",
+        "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
+        "test/scripts/ts-topology.test.ts",
+        "test/vitest/vitest.tooling.config.ts",
+      ],
+      "scripts/lib/official-external-channel-catalog.json": [
+        "src/plugins/official-external-plugin-catalog.test.ts",
+        "test/release-check.test.ts",
+        "test/official-channel-catalog.test.ts",
+      ],
+      "scripts/lib/official-external-plugin-catalog.json": [
+        "src/plugins/official-external-plugin-catalog.test.ts",
+        "test/release-check.test.ts",
+      ],
+      "scripts/lib/official-external-provider-catalog.json": [
+        "src/plugins/official-external-plugin-catalog.test.ts",
+        "test/release-check.test.ts",
+      ],
+      "scripts/lib/recommended-tool-installs.json": [
+        "src/plugins/recommended-tool-installs.test.ts",
+        "test/release-check.test.ts",
+      ],
+      "scripts/lib/direct-run.mjs": ["test/scripts/changed-lanes.test.ts"],
+      "scripts/lib/npm-verify-exec.ts": ["test/scripts/npm-verify-exec.test.ts"],
+      "scripts/lib/plugin-npm-runtime-build.mjs": [
+        "test/scripts/plugin-npm-runtime-build-args.test.ts",
+        "test/plugin-npm-runtime-build.test.ts",
+      ],
+      "scripts/lib/plugin-npm-package-manifest.mjs": [
+        "test/scripts/plugin-npm-package-manifest-args.test.ts",
+        "test/plugin-npm-package-manifest.test.ts",
+      ],
+      "scripts/lib/arg-utils.mjs": ["test/scripts/arg-utils.test.ts"],
+      "scripts/lib/android-version.ts": [
+        "test/scripts/android-version.test.ts",
+        "test/scripts/android-pin-version.test.ts",
+      ],
+      "scripts/lib/ios-version.ts": ["test/scripts/ios-version.test.ts"],
+      ".github/images/live-media-runner/Dockerfile": [
+        "test/scripts/package-acceptance-workflow.test.ts",
+      ],
+      ".github/actions/detect-docs-changes/action.yml": ["test/scripts/ci-workflow-guards.test.ts"],
+      ".github/actions/ensure-base-commit/action.yml": ["test/scripts/ci-workflow-guards.test.ts"],
+      ".github/actions/setup-node-env/action.yml": [
+        "test/scripts/install-trufflehog.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+      ".github/actions/setup-node-env/dependency-fingerprint.mjs": [
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+      ".github/actions/setup-node-env/verify-importers.mjs": [
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+      ".github/actions/setup-pnpm-store-cache/action.yml": [
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+      ".github/actions/setup-pnpm-store-cache/ensure-node.sh": [
+        "test/scripts/setup-pnpm-store-cache-ensure-node.test.ts",
+      ],
+      ".github/workflows/live-media-runner-image.yml": [
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+      ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml": [
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+        "test/scripts/release-workflow-matrix-plan.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      ".github/workflows/package-acceptance.yml": [
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+      ".github/workflows/workflow-sanity.yml": ["test/scripts/ci-workflow-guards.test.ts"],
+      ".github/workflows/docker-release.yml": [
+        "src/dockerfile.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+      ".github/workflows/full-release-validation.yml": [
+        "src/dockerfile.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/plugin-prerelease-test-plan.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+      Dockerfile: [
+        "src/docker-build-cache.test.ts",
+        "src/docker-image-digests.test.ts",
+        "src/dockerfile.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      "scripts/docker/cleanup-smoke/Dockerfile": [
+        "src/docker-build-cache.test.ts",
+        "src/docker-image-digests.test.ts",
+        "test/scripts/docker-build-helper.test.ts",
+      ],
+      "scripts/docker/cleanup-smoke/run.sh": ["test/scripts/docker-build-helper.test.ts"],
+      "scripts/docker/install-sh-e2e/Dockerfile": [
+        "src/docker-build-cache.test.ts",
+        "src/docker-image-digests.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      "scripts/docker/install-sh-e2e/run.sh": [
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      "scripts/docker/install-sh-common/cli-verify.sh": [
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      "scripts/docker/install-sh-common/version-parse.sh": [
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      "scripts/docker/install-sh-nonroot/Dockerfile": [
+        "src/docker-build-cache.test.ts",
+        "src/docker-image-digests.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      "scripts/docker/install-sh-nonroot/run.sh": ["test/scripts/test-install-sh-docker.test.ts"],
+      "scripts/docker/install-sh-smoke/Dockerfile": [
+        "src/docker-build-cache.test.ts",
+        "src/docker-image-digests.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      "scripts/docker/install-sh-smoke/run.sh": ["test/scripts/test-install-sh-docker.test.ts"],
+      "scripts/docker/sandbox/Dockerfile": [
+        "src/docker-build-cache.test.ts",
+        "src/docker-image-digests.test.ts",
+        "src/dockerfile.test.ts",
+      ],
+      "scripts/docker/sandbox/Dockerfile.browser": [
+        "src/docker-build-cache.test.ts",
+        "src/docker-image-digests.test.ts",
+        "src/agents/sandbox/browser.create.test.ts",
+      ],
+      "scripts/docker/sandbox/Dockerfile.common": ["src/docker-build-cache.test.ts"],
+      "scripts/e2e/Dockerfile": [
+        "src/docker-build-cache.test.ts",
+        "src/docker-image-digests.test.ts",
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+      ],
+      "scripts/e2e/Dockerfile.qr-import": [
+        "src/docker-build-cache.test.ts",
+        "src/docker-image-digests.test.ts",
+        "test/scripts/docker-build-helper.test.ts",
+      ],
+      "scripts/e2e/plugin-binding-command-escape.Dockerfile": [
+        "src/docker-image-digests.test.ts",
+        "test/scripts/docker-build-helper.test.ts",
+        "test/scripts/docker-e2e-plan.test.ts",
+      ],
+      "scripts/lib/package-dist-imports.mjs": [
+        "test/scripts/check-package-dist-imports.test.ts",
+        "test/scripts/check-openclaw-package-tarball.test.ts",
+        "test/scripts/postinstall-bundled-plugins.test.ts",
+        "test/release-check.test.ts",
+      ],
+      "scripts/lib/build-metadata.sh": [
+        "src/docker-setup.e2e.test.ts",
+        "test/scripts/apple-release-source-check.test.ts",
+        "test/scripts/ios-version.test.ts",
+        "test/scripts/package-mac-app.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      "scripts/lib/plistbuddy.sh": [
+        "test/scripts/create-dmg.test.ts",
+        "test/scripts/package-mac-app.test.ts",
+        "test/scripts/package-mac-dist.test.ts",
+      ],
+      "scripts/lib/swift-toolchain.sh": [
+        "test/scripts/package-mac-app.test.ts",
+        "test/scripts/package-mac-dist.test.ts",
+      ],
+      "scripts/lib/npm-publish-plan.mjs": [
+        "test/npm-publish-plan.test.ts",
+        "test/openclaw-npm-release-check.test.ts",
+        "test/openclaw-npm-postpublish-verify.test.ts",
+        "test/plugin-npm-release.test.ts",
+        "test/plugin-clawhub-release.test.ts",
+        "test/scripts/release-upgrade-baseline.test.ts",
+        "test/scripts/android-version.test.ts",
+        "test/scripts/ios-version.test.ts",
+        "test/scripts/upgrade-survivor-baselines.test.ts",
+        "test/scripts/upgrade-survivor-config-recipe.test.ts",
+      ],
+      "scripts/lib/release-version.mjs": [
+        "test/release-version.test.ts",
+        "test/npm-publish-plan.test.ts",
+        "test/openclaw-npm-release-check.test.ts",
+        "test/openclaw-npm-postpublish-verify.test.ts",
+        "test/plugin-npm-release.test.ts",
+        "test/plugin-clawhub-release.test.ts",
+        "test/scripts/android-version.test.ts",
+        "test/scripts/android-pin-version.test.ts",
+        "test/scripts/docker-release-policy.test.ts",
+        "test/scripts/ios-version.test.ts",
+        "test/scripts/openclaw-npm-extended-stable-release.test.ts",
+        "test/scripts/openclaw-npm-publish.test.ts",
+        "test/scripts/release-preflight.test.ts",
+        "test/scripts/release-prepare.test.ts",
+        "test/scripts/release-upgrade-baseline.test.ts",
+        "test/scripts/release-version.test.ts",
+        "test/scripts/upgrade-survivor-baselines.test.ts",
+        "test/scripts/upgrade-survivor-config-recipe.test.ts",
+      ],
+      "scripts/lib/npm-pack-budget.mjs": [
+        "test/release-check.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      "scripts/lib/npm-pack-budget.d.mts": [
+        "test/release-check.test.ts",
+        "test/scripts/test-install-sh-docker.test.ts",
+      ],
+      "scripts/lib/workspace-bootstrap-smoke.mjs": [
+        "test/release-check.test.ts",
+        "test/openclaw-npm-release-check.test.ts",
+      ],
+      "scripts/openclaw-release-clawhub-runtime-state.ts": [
+        "test/scripts/openclaw-release-clawhub-runtime-state.test.ts",
+      ],
+      "scripts/openclaw-release-clawhub-plan.ts": ["test/scripts/release-wrapper-scripts.test.ts"],
+      "scripts/lib/openclaw-release-clawhub-plan.ts": ["test/plugin-clawhub-release.test.ts"],
+      "scripts/lib/plugin-clawhub-release.ts": [
+        "test/plugin-clawhub-release.test.ts",
+        "test/plugin-npm-release.test.ts",
+      ],
+      "scripts/lib/plugin-npm-release.ts": [
+        "test/plugin-npm-release.test.ts",
+        "test/plugin-clawhub-release.test.ts",
+      ],
+      "scripts/plugin-clawhub-release-check.ts": ["test/scripts/release-wrapper-scripts.test.ts"],
+      "scripts/plugin-clawhub-release-plan.ts": ["test/scripts/release-wrapper-scripts.test.ts"],
+      "scripts/plugin-npm-release-check.ts": ["test/scripts/release-wrapper-scripts.test.ts"],
+      "scripts/plugin-npm-release-plan.ts": ["test/scripts/release-wrapper-scripts.test.ts"],
+      "scripts/plugin-release-pretag-pack-check.ts": [
+        "test/scripts/plugin-release-pretag-pack-check.test.ts",
+      ],
+      "scripts/plan-release-workflow-matrix.mjs": [
+        "test/scripts/release-workflow-matrix-plan.test.ts",
+      ],
+      "scripts/release-verify-beta.ts": ["test/scripts/release-wrapper-scripts.test.ts"],
+      "scripts/validate-release-publish-approval.mjs": [
+        "test/scripts/validate-release-publish-approval.test.ts",
+      ],
+      "scripts/lib/plugin-package-dependencies.mjs": [
+        "test/scripts/plugin-package-dependencies.test.ts",
+      ],
+      "scripts/lib/plugin-npm-runtime-assets.mjs": [
+        "test/scripts/plugin-npm-runtime-build-args.test.ts",
+      ],
+      "scripts/lib/generated-text-asset.mjs": [
+        "extensions/browser/scripts/build-copilot-runtime.test.ts",
+        "test/scripts/build-diffs-viewer-runtime.test.ts",
+        "test/scripts/bundled-plugin-assets.test.ts",
+      ],
+      "scripts/lib/static-extension-assets.mjs": [
+        "test/scripts/bundled-plugin-assets.test.ts",
+        "test/scripts/runtime-postbuild.test.ts",
+        "src/infra/run-node.test.ts",
+        "test/scripts/plugin-npm-runtime-build-args.test.ts",
+      ],
+      "scripts/lib/test-group-report.mjs": ["test/scripts/test-group-report.test.ts"],
+      "scripts/lib/stable-release-closeout.mjs": ["test/stable-release-closeout.test.ts"],
+      "scripts/lib/extension-source-classifier.mjs": [
+        "test/scripts/extension-source-classifier.test.ts",
+        "src/channels/plugins/contracts/channel-import-guardrails.test.ts",
+      ],
+      "scripts/lib/ts-topology/analyze.ts": ["test/scripts/ts-topology.test.ts"],
+      "scripts/lib/ts-topology/reports.ts": ["test/scripts/ts-topology.test.ts"],
+      "scripts/lib/ts-topology/scope.ts": ["test/scripts/ts-topology.test.ts"],
+      "scripts/lib/ts-guard-utils.mjs": ["test/scripts/ts-guard-utils.test.ts"],
+      "scripts/lib/tsgo-sparse-guard.mjs": [
+        "test/scripts/run-tsgo.test.ts",
+        "test/scripts/changed-lanes.test.ts",
+      ],
+      "scripts/write-package-dist-inventory.ts": ["test/scripts/test-install-sh-docker.test.ts"],
+      "scripts/lib/format-generated-module.mjs": ["test/scripts/format-generated-module.test.ts"],
+      "scripts/lib/bundled-plugin-source-utils.mjs": [
+        "test/scripts/bundled-plugin-source-utils.test.ts",
+      ],
+      "scripts/lib/bundled-runtime-sidecar-paths.json": [
+        "src/plugins/bundled-plugin-metadata.test.ts",
+        "src/infra/update-global.test.ts",
+        "src/infra/update-runner.test.ts",
+        "test/openclaw-npm-postpublish-verify.test.ts",
+      ],
+      "scripts/lib/bundled-plugin-build-entries.mjs": [
+        "test/scripts/bundled-plugin-build-entries.test.ts",
+        "test/release-check.test.ts",
+      ],
+      "scripts/lib/changed-extensions.mjs": ["test/scripts/test-extension.test.ts"],
+      "scripts/lib/extension-vitest-paths.mjs": ["test/scripts/test-extension.test.ts"],
+    });
 
     for (const [source, targets] of expectedTargets) {
       expect(resolveChangedTestTargetPlan([source]), source).toEqual({
@@ -2373,59 +1964,44 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps plugin SDK boundary tooling edits on owner tests", () => {
-    const expectedTargets = new Map([
-      [
-        "scripts/check-extension-plugin-sdk-boundary.mjs",
-        ["test/extension-import-boundaries.test.ts"],
+    const expectedTargets = Object.entries({
+      "scripts/check-extension-plugin-sdk-boundary.mjs": [
+        "test/extension-import-boundaries.test.ts",
       ],
-      [
-        "scripts/check-sdk-package-extension-import-boundary.mjs",
-        ["test/extension-import-boundaries.test.ts"],
+      "scripts/check-sdk-package-extension-import-boundary.mjs": [
+        "test/extension-import-boundaries.test.ts",
       ],
-      [
-        "scripts/check-plugin-extension-import-boundary.mjs",
-        ["test/plugin-extension-import-boundary.test.ts"],
+      "scripts/check-plugin-extension-import-boundary.mjs": [
+        "test/plugin-extension-import-boundary.test.ts",
       ],
-      [
-        "scripts/lib/config-boundary-guard.mjs",
-        [
-          "src/plugins/contracts/config-boundary-guard.test.ts",
-          "src/plugins/contracts/deprecated-internal-config-api.test.ts",
-        ],
+      "scripts/lib/config-boundary-guard.mjs": [
+        "src/plugins/contracts/config-boundary-guard.test.ts",
+        "src/plugins/contracts/deprecated-internal-config-api.test.ts",
       ],
-      [
-        "scripts/lib/extension-package-boundary.ts",
-        ["src/plugins/contracts/extension-package-project-boundaries.test.ts"],
+      "scripts/lib/extension-package-boundary.ts": [
+        "src/plugins/contracts/extension-package-project-boundaries.test.ts",
       ],
-      [
-        "scripts/check-src-extension-import-boundary.mjs",
-        ["test/extension-import-boundaries.test.ts"],
+      "scripts/check-src-extension-import-boundary.mjs": [
+        "test/extension-import-boundaries.test.ts",
       ],
-      [
-        "scripts/lib/guard-inventory-utils.mjs",
-        [
-          "test/extension-import-boundaries.test.ts",
-          "test/plugin-extension-import-boundary.test.ts",
-          "test/architecture-smells.test.ts",
-          "test/web-provider-boundary.test.ts",
-          "test/test-helper-extension-import-boundary.test.ts",
-          "test/scripts/extension-import-boundary-checker.test.ts",
-          "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
-        ],
+      "scripts/lib/guard-inventory-utils.mjs": [
+        "test/extension-import-boundaries.test.ts",
+        "test/plugin-extension-import-boundary.test.ts",
+        "test/architecture-smells.test.ts",
+        "test/web-provider-boundary.test.ts",
+        "test/test-helper-extension-import-boundary.test.ts",
+        "test/scripts/extension-import-boundary-checker.test.ts",
+        "src/plugins/contracts/plugin-sdk-subpaths.test.ts",
       ],
-      [
-        "scripts/check-test-helper-extension-import-boundary.mjs",
-        ["test/test-helper-extension-import-boundary.test.ts"],
+      "scripts/check-test-helper-extension-import-boundary.mjs": [
+        "test/test-helper-extension-import-boundary.test.ts",
       ],
-      [
-        "scripts/write-plugin-sdk-entry-dts.ts",
-        [
-          "test/scripts/build-all.test.ts",
-          "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
-        ],
+      "scripts/write-plugin-sdk-entry-dts.ts": [
+        "test/scripts/build-all.test.ts",
+        "test/scripts/prepare-extension-package-boundary-artifacts.test.ts",
       ],
-      ["scripts/fixtures/packed-plugin-sdk-type-smoke.ts", ["test/release-check.test.ts"]],
-    ]);
+      "scripts/fixtures/packed-plugin-sdk-type-smoke.ts": ["test/release-check.test.ts"],
+    });
 
     for (const [source, targets] of expectedTargets) {
       expect(resolveChangedTestTargetPlan([source]), source).toEqual({
@@ -2484,41 +2060,30 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("routes explicit source files through precise owner tests before broad globs", () => {
-    expect(buildVitestRunPlans(["src/gateway/server-startup-early.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.gateway.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/gateway/server-startup-early.test.ts"],
-        watchMode: false,
-      },
-    ]);
-    expect(buildVitestRunPlans(["src/commands/onboarding-plugin-install.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.commands.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/commands/onboarding-plugin-install.test.ts"],
-        watchMode: false,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans(["src/gateway/server-startup-early.ts"]), {
+      config: "test/vitest/vitest.gateway.config.ts",
+      includePatterns: ["src/gateway/server-startup-early.test.ts"],
+    });
+    expectSingleVitestRunPlan(buildVitestRunPlans(["src/commands/onboarding-plugin-install.ts"]), {
+      config: "test/vitest/vitest.commands.config.ts",
+      includePatterns: ["src/commands/onboarding-plugin-install.test.ts"],
+    });
   });
 
   it("routes gateway package targets through the gateway-client lane", () => {
-    expect(
+    expectSingleVitestRunPlan(
       buildVitestRunPlans([
         "packages/gateway-client/src/timeouts.test.ts",
         "packages/gateway-protocol/src/frame-guards.test.ts",
       ]),
-    ).toEqual([
       {
         config: "test/vitest/vitest.gateway-client.config.ts",
-        forwardedArgs: [],
         includePatterns: [
           "packages/gateway-client/src/timeouts.test.ts",
           "packages/gateway-protocol/src/frame-guards.test.ts",
         ],
-        watchMode: false,
       },
-    ]);
+    );
   });
 
   it("routes explicit imported source files through import-graph tests", () => {
@@ -2597,82 +2162,57 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("does not route live tests through the normal changed-test lane", () => {
-    expect(
-      resolveChangedTestTargetPlan(["src/gateway/gateway-codex-harness.live.test.ts"]),
-    ).toEqual({
-      mode: "targets",
-      targets: [],
-    });
+    expectChangedTargets(["src/gateway/gateway-codex-harness.live.test.ts"], []);
   });
 
   it("routes changed extension vitest configs to their own shard", () => {
-    expect(
+    expectSingleVitestRunPlan(
       buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
         "test/vitest/vitest.extension-discord.config.ts",
       ]),
-    ).toEqual([
-      {
-        config: "test/vitest/vitest.extension-discord.config.ts",
-        forwardedArgs: [],
-        includePatterns: null,
-        watchMode: false,
-      },
-    ]);
+      { config: "test/vitest/vitest.extension-discord.config.ts" },
+    );
   });
 
   it("routes the shell helper test to the isolated tooling shard", () => {
-    expect(
+    expectSingleVitestRunPlan(
       buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
         "test/scripts/openclaw-e2e-instance.test.ts",
       ]),
-    ).toEqual([
       {
         config: "test/vitest/vitest.tooling-isolated.config.ts",
-        forwardedArgs: [],
         includePatterns: ["test/scripts/openclaw-e2e-instance.test.ts"],
-        watchMode: false,
       },
-    ]);
+    );
   });
 
   it("routes the bundled provider auth parity test to the isolated tooling shard", () => {
-    expect(
+    expectSingleVitestRunPlan(
       buildVitestRunPlans(["test/plugins/bundled-provider-auth-literal-parity.test.ts"]),
-    ).toEqual([
       {
         config: "test/vitest/vitest.tooling-isolated.config.ts",
-        forwardedArgs: [],
         includePatterns: ["test/plugins/bundled-provider-auth-literal-parity.test.ts"],
-        watchMode: false,
       },
-    ]);
+    );
   });
 
   it.each([
     "test/scripts/check-extension-package-tsc-boundary.test.ts",
     "test/scripts/control-ui-i18n.test.ts",
   ])("routes process-group test %s to the isolated tooling shard", (testFile) => {
-    expect(buildVitestRunPlans([testFile])).toEqual([
-      {
-        config: "test/vitest/vitest.tooling-isolated.config.ts",
-        forwardedArgs: [],
-        includePatterns: [testFile],
-        watchMode: false,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans([testFile]), {
+      config: "test/vitest/vitest.tooling-isolated.config.ts",
+      includePatterns: [testFile],
+    });
   });
 
   it.each(agentVitestProjectOwners.coreIsolated.include)(
     "routes isolated agent test %s to the isolated agents-core shard",
     (testFile) => {
-      expect(buildVitestRunPlans([testFile])).toEqual([
-        {
-          config: "test/vitest/vitest.agents-core-isolated.config.ts",
-          forwardedArgs: [],
-          includePatterns: [testFile],
-          watchMode: false,
-        },
-      ]);
+      expectSingleVitestRunPlan(buildVitestRunPlans([testFile]), {
+        config: "test/vitest/vitest.agents-core-isolated.config.ts",
+        includePatterns: [testFile],
+      });
     },
   );
 
@@ -2770,14 +2310,10 @@ describe("scripts/test-projects changed-target routing", () => {
   it("keeps the broad agent test glob in the all-agents shard", () => {
     const target = "src/agents/**/*.test.ts";
 
-    expect(buildVitestRunPlans([target])).toEqual([
-      {
-        config: "test/vitest/vitest.agents.config.ts",
-        forwardedArgs: [],
-        includePatterns: [target],
-        watchMode: false,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans([target]), {
+      config: "test/vitest/vitest.agents.config.ts",
+      includePatterns: [target],
+    });
   });
 
   it.each([
@@ -2859,7 +2395,7 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("routes changed Parallels process helpers to their owner tooling tests", () => {
-    expect(
+    expectSingleVitestRunPlan(
       buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
         "scripts/e2e/parallels/filesystem.ts",
         "scripts/e2e/parallels/guest-transports.ts",
@@ -2878,25 +2414,22 @@ describe("scripts/test-projects changed-target routing", () => {
         "scripts/e2e/parallels/windows-smoke.ts",
         "scripts/e2e/parallels-windows-smoke.sh",
       ]),
-    ).toEqual([
       {
         config: "test/vitest/vitest.tooling.config.ts",
-        forwardedArgs: [],
         includePatterns: [
           "test/scripts/parallels-smoke-model.test.ts",
           "test/scripts/parallels-npm-update-smoke.test.ts",
           "test/scripts/parallels-update-job-timeout.test.ts",
         ],
-        watchMode: false,
       },
-    ]);
+    );
   });
 
   it("routes mac restart helpers through restart-mac owner tests", () => {
-    expect(resolveChangedTestTargetPlan(["scripts/lib/restart-mac-gateway.sh"])).toEqual({
-      mode: "targets",
-      targets: ["test/scripts/restart-mac.test.ts"],
-    });
+    expectChangedTargets(
+      ["scripts/lib/restart-mac-gateway.sh"],
+      ["test/scripts/restart-mac.test.ts"],
+    );
   });
 
   it("routes MCP and cron Docker E2E script targets instead of skipping changed tests", () => {
@@ -2920,26 +2453,23 @@ describe("scripts/test-projects changed-target routing", () => {
     ];
 
     expect(findUnmatchedExplicitTestTargets(targets)).toEqual([]);
-    expect(resolveChangedTestTargetPlan(targets)).toEqual({
-      mode: "targets",
-      targets: [
-        "test/scripts/docker-build-helper.test.ts",
-        "test/scripts/docker-e2e-observability.test.ts",
-        "test/scripts/docker-e2e-plan.test.ts",
-        "test/scripts/plugin-prerelease-test-plan.test.ts",
-        "test/e2e/qa-lab/runtime/mcp-gateway-transport.e2e.test.ts",
-        "test/scripts/cron-mcp-cleanup-docker-client.test.ts",
-        "test/scripts/docker-e2e-seeds.test.ts",
-        "test/scripts/mcp-code-mode-gateway-client.test.ts",
-        "test/scripts/session-log-mentions.test.ts",
-        "src/agents/agent-bundle-mcp-runtime.test.ts",
-        "src/agents/agent-bundle-mcp-tools.materialize.test.ts",
-        "src/gateway/server.cron.test.ts",
-        "src/gateway/server-methods/agent.test.ts",
-        "src/cron/isolated-agent/run.fast-mode.test.ts",
-        "src/cron/active-jobs-manual-run.test.ts",
-      ],
-    });
+    expectChangedTargets(targets, [
+      "test/scripts/docker-build-helper.test.ts",
+      "test/scripts/docker-e2e-observability.test.ts",
+      "test/scripts/docker-e2e-plan.test.ts",
+      "test/scripts/plugin-prerelease-test-plan.test.ts",
+      "test/e2e/qa-lab/runtime/mcp-gateway-transport.e2e.test.ts",
+      "test/scripts/cron-mcp-cleanup-docker-client.test.ts",
+      "test/scripts/docker-e2e-seeds.test.ts",
+      "test/scripts/mcp-code-mode-gateway-client.test.ts",
+      "test/scripts/session-log-mentions.test.ts",
+      "src/agents/agent-bundle-mcp-runtime.test.ts",
+      "src/agents/agent-bundle-mcp-tools.materialize.test.ts",
+      "src/gateway/server.cron.test.ts",
+      "src/gateway/server-methods/agent.test.ts",
+      "src/cron/isolated-agent/run.fast-mode.test.ts",
+      "src/cron/active-jobs-manual-run.test.ts",
+    ]);
   });
 
   it("routes OpenAI image auth Docker E2E script targets instead of skipping changed tests", () => {
@@ -2949,16 +2479,13 @@ describe("scripts/test-projects changed-target routing", () => {
     ];
 
     expect(findUnmatchedExplicitTestTargets(targets)).toEqual([]);
-    expect(resolveChangedTestTargetPlan(targets)).toEqual({
-      mode: "targets",
-      targets: [
-        "test/scripts/docker-build-helper.test.ts",
-        "test/scripts/docker-e2e-plan.test.ts",
-        "test/scripts/openai-image-auth-docker-client.test.ts",
-        "extensions/openai/image-generation-provider.test.ts",
-        "src/image-generation/openai-compatible-image-provider.test.ts",
-      ],
-    });
+    expectChangedTargets(targets, [
+      "test/scripts/docker-build-helper.test.ts",
+      "test/scripts/docker-e2e-plan.test.ts",
+      "test/scripts/openai-image-auth-docker-client.test.ts",
+      "extensions/openai/image-generation-provider.test.ts",
+      "src/image-generation/openai-compatible-image-provider.test.ts",
+    ]);
   });
 
   it("routes package-backed Docker shell targets instead of skipping changed tests", () => {
@@ -2972,16 +2499,13 @@ describe("scripts/test-projects changed-target routing", () => {
     ];
 
     expect(findUnmatchedExplicitTestTargets(targets)).toEqual([]);
-    expect(resolveChangedTestTargetPlan(targets)).toEqual({
-      mode: "targets",
-      targets: [
-        "test/scripts/docker-build-helper.test.ts",
-        "test/scripts/docker-e2e-plan.test.ts",
-        "test/scripts/codex-media-path-client.test.ts",
-        "test/scripts/package-acceptance-workflow.test.ts",
-        "test/scripts/live-plugin-tool-assertions.test.ts",
-      ],
-    });
+    expectChangedTargets(targets, [
+      "test/scripts/docker-build-helper.test.ts",
+      "test/scripts/docker-e2e-plan.test.ts",
+      "test/scripts/codex-media-path-client.test.ts",
+      "test/scripts/package-acceptance-workflow.test.ts",
+      "test/scripts/live-plugin-tool-assertions.test.ts",
+    ]);
   });
 
   it("routes OpenClaw Docker E2E script targets instead of skipping changed tests", () => {
@@ -2994,27 +2518,24 @@ describe("scripts/test-projects changed-target routing", () => {
     ];
 
     expect(findUnmatchedExplicitTestTargets(targets)).toEqual([]);
-    expect(resolveChangedTestTargetPlan(targets)).toEqual({
-      mode: "targets",
-      targets: [
-        "test/scripts/docker-build-helper.test.ts",
-        "test/scripts/docker-e2e-plan.test.ts",
-        "test/scripts/docker-e2e-system-agent.test.ts",
-        "src/cli/program/register.onboard.test.ts",
-        "src/cli/run-main.test.ts",
-        "src/cli/run-main.exit.test.ts",
-        "src/commands/system-agent-with-inference.test.ts",
-        "src/system-agent/assistant.configured.test.ts",
-        "src/system-agent/assistant.test.ts",
-        "src/system-agent/system-agent.test.ts",
-        "src/system-agent/operations.test.ts",
-        "src/system-agent/overview.test.ts",
-        "src/system-agent/setup-inference.test.ts",
-        "src/system-agent/audit.test.ts",
-        "src/system-agent/rescue-policy.test.ts",
-        "src/system-agent/rescue-message.test.ts",
-      ],
-    });
+    expectChangedTargets(targets, [
+      "test/scripts/docker-build-helper.test.ts",
+      "test/scripts/docker-e2e-plan.test.ts",
+      "test/scripts/docker-e2e-system-agent.test.ts",
+      "src/cli/program/register.onboard.test.ts",
+      "src/cli/run-main.test.ts",
+      "src/cli/run-main.exit.test.ts",
+      "src/commands/system-agent-with-inference.test.ts",
+      "src/system-agent/assistant.configured.test.ts",
+      "src/system-agent/assistant.test.ts",
+      "src/system-agent/system-agent.test.ts",
+      "src/system-agent/operations.test.ts",
+      "src/system-agent/overview.test.ts",
+      "src/system-agent/setup-inference.test.ts",
+      "src/system-agent/audit.test.ts",
+      "src/system-agent/rescue-policy.test.ts",
+      "src/system-agent/rescue-message.test.ts",
+    ]);
   });
 
   it("chunks the broad shell helper tooling shard after isolated targets", () => {
@@ -3078,14 +2599,10 @@ describe("scripts/test-projects changed-target routing", () => {
 
   it("routes the src scripts test root to the tooling shard", () => {
     expect(findUnmatchedExplicitTestTargets(["src/scripts"], process.cwd())).toEqual([]);
-    expect(buildVitestRunPlans(["src/scripts"], process.cwd())).toEqual([
-      {
-        config: "test/vitest/vitest.tooling.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/scripts/**/*.test.ts"],
-        watchMode: false,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans(["src/scripts"], process.cwd()), {
+      config: "test/vitest/vitest.tooling.config.ts",
+      includePatterns: ["src/scripts/**/*.test.ts"],
+    });
   });
 
   it("routes exact source directory roots to their owning shards", () => {
@@ -3178,14 +2695,10 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("routes CLI process tests through their isolated project", () => {
-    expect(buildVitestRunPlans(["src/cli/help-exit.process.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.cli-process.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["src/cli/help-exit.process.test.ts"],
-        watchMode: false,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans(["src/cli/help-exit.process.test.ts"]), {
+      config: "test/vitest/vitest.cli-process.config.ts",
+      includePatterns: ["src/cli/help-exit.process.test.ts"],
+    });
   });
 
   it("adds the CLI process project for broad CLI targets", () => {
@@ -3270,14 +2783,11 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps broad shell helper watch targets in one tooling shard", () => {
-    expect(buildVitestRunPlans(["--watch", "test/scripts"], process.cwd())).toEqual([
-      {
-        config: "test/vitest/vitest.tooling.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["test/scripts/**/*.test.ts"],
-        watchMode: true,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans(["--watch", "test/scripts"], process.cwd()), {
+      config: "test/vitest/vitest.tooling.config.ts",
+      includePatterns: ["test/scripts/**/*.test.ts"],
+      watchMode: true,
+    });
   });
 
   it("preserves post-separator Vitest args without parsing them as targets", () => {
@@ -3297,14 +2807,10 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps pnpm-style leading separators out of target routing", () => {
-    expect(buildVitestRunPlans(["--", "test/scripts/run-vitest.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.tooling.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["test/scripts/run-vitest.test.ts"],
-        watchMode: false,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans(["--", "test/scripts/run-vitest.test.ts"]), {
+      config: "test/vitest/vitest.tooling.config.ts",
+      includePatterns: ["test/scripts/run-vitest.test.ts"],
+    });
   });
 
   it("prints wrapper help without starting a broad local suite", () => {
@@ -3346,14 +2852,13 @@ describe("scripts/test-projects changed-target routing", () => {
       findUnmatchedExplicitTestTargets(["src/commands/onboard-non-interactive.test-helpers.ts"]),
     ).toEqual([]);
 
-    expect(buildVitestRunPlans(["src/commands/onboard-non-interactive.test-helpers.ts"])).toEqual([
+    expectSingleVitestRunPlan(
+      buildVitestRunPlans(["src/commands/onboard-non-interactive.test-helpers.ts"]),
       {
         config: "test/vitest/vitest.commands.config.ts",
-        forwardedArgs: [],
         includePatterns: ["src/commands/onboard-non-interactive.gateway.test.ts"],
-        watchMode: false,
       },
-    ]);
+    );
   });
 
   it("rejects explicit test-support helper files with no importing tests", () => {
@@ -3525,14 +3030,14 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("routes channel SDK helper edits through the tests that import them", () => {
-    expect(resolveChangedTestTargetPlan(["src/plugin-sdk/test-helpers/directory-ids.ts"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["src/plugin-sdk/test-helpers/directory-ids.ts"],
+      [
         "extensions/discord/src/directory-contract.test.ts",
         "extensions/slack/src/directory-contract.test.ts",
         "extensions/telegram/src/directory-contract.test.ts",
       ],
-    });
+    );
   });
 
   it("routes channel contract helper edits through contract shards", () => {
@@ -3760,19 +3265,13 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("keeps a grouped Matrix config target in the unsplit plan", () => {
-    expect(
+    expectSingleVitestRunPlan(
       buildVitestRunPlans(
         ["extensions/matrix", "test/vitest/vitest.extension-matrix.config.ts"],
         process.cwd(),
       ),
-    ).toEqual([
-      {
-        config: "test/vitest/vitest.extension-matrix.config.ts",
-        forwardedArgs: [],
-        includePatterns: null,
-        watchMode: false,
-      },
-    ]);
+      { config: "test/vitest/vitest.extension-matrix.config.ts" },
+    );
   });
 
   it("keeps explicit Matrix files and watch runs unchunked", () => {
@@ -3780,14 +3279,14 @@ describe("scripts/test-projects changed-target routing", () => {
     expect(testFile).toBeDefined();
 
     expect(buildVitestRunPlans([testFile!], process.cwd())).toHaveLength(1);
-    expect(buildVitestRunPlans(["--watch", "extensions/matrix"], process.cwd())).toEqual([
+    expectSingleVitestRunPlan(
+      buildVitestRunPlans(["--watch", "extensions/matrix"], process.cwd()),
       {
         config: "test/vitest/vitest.extension-matrix.config.ts",
-        forwardedArgs: [],
         includePatterns: ["extensions/matrix/**/*.test.ts"],
         watchMode: true,
       },
-    ]);
+    );
   });
 
   it("narrows default-lane changed source files to affected tests", () => {
@@ -3877,14 +3376,10 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("routes isolated ui test targets to the isolated project", () => {
-    expect(buildVitestRunPlans(["ui/src/pages/workboard/view.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.ui-isolated.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["ui/src/pages/workboard/view.test.ts"],
-        watchMode: false,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans(["ui/src/pages/workboard/view.test.ts"]), {
+      config: "test/vitest/vitest.ui-isolated.config.ts",
+      includePatterns: ["ui/src/pages/workboard/view.test.ts"],
+    });
   });
 
   it("adds the isolated project for broad ui targets", () => {
@@ -3926,46 +3421,31 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("routes control ui e2e tests to the ui e2e lane", () => {
-    expect(buildVitestRunPlans(["ui/src/e2e/chat-flow.e2e.test.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.ui-e2e.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["ui/src/e2e/chat-flow.e2e.test.ts"],
-        watchMode: false,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans(["ui/src/e2e/chat-flow.e2e.test.ts"]), {
+      config: "test/vitest/vitest.ui-e2e.config.ts",
+      includePatterns: ["ui/src/e2e/chat-flow.e2e.test.ts"],
+    });
 
-    expect(buildVitestRunPlans(["ui/src/test-helpers/control-ui-e2e.ts"])).toEqual([
-      {
-        config: "test/vitest/vitest.ui-e2e.config.ts",
-        forwardedArgs: [],
-        includePatterns: null,
-        watchMode: false,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans(["ui/src/test-helpers/control-ui-e2e.ts"]), {
+      config: "test/vitest/vitest.ui-e2e.config.ts",
+    });
 
-    expect(buildVitestRunPlans(["ui/src/e2e"])).toEqual([
-      {
-        config: "test/vitest/vitest.ui-e2e.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["ui/src/e2e/**/*.test.ts"],
-        watchMode: false,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans(["ui/src/e2e"]), {
+      config: "test/vitest/vitest.ui-e2e.config.ts",
+      includePatterns: ["ui/src/e2e/**/*.test.ts"],
+    });
 
     expect(buildVitestArgs(["ui/src/e2e"])).toContain("--configLoader");
   });
 
   it("routes auto-reply route source files to route regression tests", () => {
-    expect(
-      resolveChangedTestTargetPlan([
+    expectChangedTargets(
+      [
         "src/auto-reply/reply/dispatch-from-config.ts",
         "src/auto-reply/reply/effective-reply-route.ts",
         "src/auto-reply/reply/effective-reply-route.test.ts",
-      ]),
-    ).toEqual({
-      mode: "targets",
-      targets: [
+      ],
+      [
         "src/auto-reply/reply/dispatch-acp.test.ts",
         "src/auto-reply/reply/dispatch-from-config.test.ts",
         "src/auto-reply/reply/followup-runner.test.ts",
@@ -3974,98 +3454,89 @@ describe("scripts/test-projects changed-target routing", () => {
         "extensions/slack/src/monitor.tool-result.test.ts",
         "src/auto-reply/reply/effective-reply-route.test.ts",
       ],
-    });
+    );
   });
 
   it("routes ACP command source files to ACP command regression tests", () => {
-    expect(
-      resolveChangedTestTargetPlan([
+    expectChangedTargets(
+      [
         "src/auto-reply/reply/commands-acp.ts",
         "src/auto-reply/reply/commands-acp.test.ts",
         "src/auto-reply/reply/dispatch-acp-command-bypass.ts",
         "src/auto-reply/reply/dispatch-acp-command-bypass.test.ts",
-      ]),
-    ).toEqual({
-      mode: "targets",
-      targets: [
+      ],
+      [
         "src/auto-reply/reply/commands-acp.test.ts",
         "src/auto-reply/reply/dispatch-acp-command-bypass.test.ts",
       ],
-    });
+    );
   });
 
   it("routes Google Meet CLI edits to the lightweight CLI tests", () => {
-    expect(resolveChangedTestTargetPlan(["extensions/google-meet/src/cli.ts"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["extensions/google-meet/src/cli.ts"],
+      [
         "extensions/google-meet/src/cli-artifacts.test.ts",
         "extensions/google-meet/src/cli-runtime.test.ts",
         "extensions/google-meet/src/cli.test.ts",
       ],
-    });
+    );
   });
 
   it("routes Google Meet OAuth edits to the lightweight OAuth tests", () => {
-    expect(resolveChangedTestTargetPlan(["extensions/google-meet/src/oauth.ts"])).toEqual({
-      mode: "targets",
-      targets: ["extensions/google-meet/src/oauth.test.ts"],
-    });
+    expectChangedTargets(
+      ["extensions/google-meet/src/oauth.ts"],
+      ["extensions/google-meet/src/oauth.test.ts"],
+    );
   });
 
   it("routes Google Meet entry edits to the plugin entry tests", () => {
-    expect(resolveChangedTestTargetPlan(["extensions/google-meet/index.ts"])).toEqual({
-      mode: "targets",
-      targets: ["extensions/google-meet/index.test.ts"],
-    });
+    expectChangedTargets(
+      ["extensions/google-meet/index.ts"],
+      ["extensions/google-meet/index.test.ts"],
+    );
   });
 
   it("routes memory doctor and embedding default edits to focused tests", () => {
-    expect(
-      resolveChangedTestTargetPlan([
+    expectChangedTargets(
+      [
         "src/commands/doctor-memory-search.ts",
         "packages/memory-host-sdk/src/host/embedding-defaults.ts",
-      ]),
-    ).toEqual({
-      mode: "targets",
-      targets: [
+      ],
+      [
         "src/commands/doctor-memory-search.test.ts",
         "packages/memory-host-sdk/src/host/embeddings.test.ts",
       ],
-    });
+    );
   });
 
   it("routes commitment model-selection runtime edits away from broad gateway dependents", () => {
-    expect(
-      resolveChangedTestTargetPlan([
+    expectChangedTargets(
+      [
         "src/agents/model-selection.test.ts",
         "src/commitments/model-selection.runtime.ts",
         "src/commitments/runtime.test.ts",
         "src/commitments/runtime.ts",
-      ]),
-    ).toEqual({
-      mode: "targets",
-      targets: ["src/agents/model-selection.test.ts", "src/commitments/runtime.test.ts"],
-    });
+      ],
+      ["src/agents/model-selection.test.ts", "src/commitments/runtime.test.ts"],
+    );
   });
 
   it("routes provider auth choice edits to focused auth-choice tests", () => {
-    expect(resolveChangedTestTargetPlan(["src/plugins/provider-auth-choice.ts"])).toEqual({
-      mode: "targets",
-      targets: [
+    expectChangedTargets(
+      ["src/plugins/provider-auth-choice.ts"],
+      [
         "src/commands/auth-choice.apply.plugin-provider.test.ts",
         "src/commands/auth-choice.test.ts",
       ],
-    });
+    );
   });
 
   it("routes provider env var edits to focused secret tests", () => {
-    expect(resolveChangedTestTargetPlan(["src/secrets/provider-env-vars.ts"])).toEqual({
-      mode: "targets",
-      targets: [
-        "src/secrets/provider-env-vars.dynamic.test.ts",
-        "src/secrets/provider-env-vars.test.ts",
-      ],
-    });
+    expectChangedTargets(
+      ["src/secrets/provider-env-vars.ts"],
+      ["src/secrets/provider-env-vars.dynamic.test.ts", "src/secrets/provider-env-vars.test.ts"],
+    );
   });
 
   it("routes changed utils and shared files to their light scoped lanes", () => {
@@ -4380,10 +3851,7 @@ describe("scripts/test-projects changed-target routing", () => {
       "test/fixtures/agents/prompt-snapshots/codex-model-catalog/gpt-5.5.pragmatic.source.json",
       "test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md",
     ]) {
-      expect(resolveChangedTestTargetPlan([target])).toEqual({
-        mode: "targets",
-        targets: ["test/scripts/prompt-snapshots.test.ts"],
-      });
+      expectChangedTargets([target], ["test/scripts/prompt-snapshots.test.ts"]);
     }
   });
 
@@ -4392,33 +3860,30 @@ describe("scripts/test-projects changed-target routing", () => {
       "scripts/generate-runtime-sidecar-paths-baseline.ts",
       "src/plugins/runtime-sidecar-paths-baseline.ts",
     ]) {
-      expect(resolveChangedTestTargetPlan([target])).toEqual({
-        mode: "targets",
-        targets: ["src/plugins/bundled-plugin-metadata.test.ts"],
-      });
+      expectChangedTargets([target], ["src/plugins/bundled-plugin-metadata.test.ts"]);
     }
 
     for (const target of [
       "scripts/lib/bundled-runtime-sidecar-paths.json",
       "src/plugins/runtime-sidecar-paths.ts",
     ]) {
-      expect(resolveChangedTestTargetPlan([target])).toEqual({
-        mode: "targets",
-        targets: [
+      expectChangedTargets(
+        [target],
+        [
           "src/plugins/bundled-plugin-metadata.test.ts",
           "src/infra/update-global.test.ts",
           "src/infra/update-runner.test.ts",
           "test/openclaw-npm-postpublish-verify.test.ts",
         ],
-      });
+      );
     }
   });
 
   it("routes appcast edits to appcast owner tests", () => {
-    expect(resolveChangedTestTargetPlan(["appcast.xml"])).toEqual({
-      mode: "targets",
-      targets: ["test/appcast.test.ts", "test/scripts/make-appcast.test.ts"],
-    });
+    expectChangedTargets(
+      ["appcast.xml"],
+      ["test/appcast.test.ts", "test/scripts/make-appcast.test.ts"],
+    );
   });
 
   it.each([
@@ -5244,14 +4709,10 @@ describe("scripts/test-projects full-suite sharding", () => {
         includePattern: "test/vitest/**/*.test.ts",
       },
     ]);
-    expect(buildVitestRunPlans(args, process.cwd())).toEqual([
-      {
-        config: "test/vitest/vitest.tooling.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["test/vitest/**/*.test.ts"],
-        watchMode: false,
-      },
-    ]);
+    expectSingleVitestRunPlan(buildVitestRunPlans(args, process.cwd()), {
+      config: "test/vitest/vitest.tooling.config.ts",
+      includePatterns: ["test/vitest/**/*.test.ts"],
+    });
   });
 
   it("rejects typoed explicit leaf project config targets", () => {


### PR DESCRIPTION
## What Problem This Solves

The project-routing test suite repeats the same deep-equality assertion shape and stores large source-to-owner tables as tuple-heavy Maps. That makes an already large owner test harder to scan and maintain.

## Why This Change Was Made

Consolidates the exact changed-target and single-plan assertions into two test-local helpers, and expresses eight source-to-target fixtures as ordered object entries. Test names, source diagnostics, assertion semantics, iteration order, and all 276 routing cases remain unchanged.

## User Impact

No user-visible behavior changes. This removes 539 net lines from test tooling while preserving coverage.

## Evidence

- Blacksmith Testbox `tbx_01kz2qwd44yfwvjw7p16jeq0ze`: `CI=1 node scripts/run-vitest.mjs test/scripts/test-projects.test.ts` — 260/260 tests passed.
- Same Testbox: `node scripts/check-changed.mjs -- test/scripts/test-projects.test.ts` — formatting, script declarations, test-root typecheck, lint, dependency guards, and repository guards passed.
- Structural equivalence check: all 222 test names, 91 changed-target cases, 23 single-plan cases, and 276 source-to-target fixture entries match the pre-change AST values.
- Autoreview: clean, no accepted/actionable P0 findings; overall correctness 0.99.
- Hosted run: https://github.com/openclaw/openclaw/actions/runs/30779854663
