### PR TITLE
improve(tests): isolate cold plugin import probes

### DIFF
--- a/src/cli/cold-command-plugin-imports.process.test.ts
+++ b/src/cli/cold-command-plugin-imports.process.test.ts
@@ -147,6 +147,8 @@ it.each(cases)(
         cwd: path.resolve("."),
         env: {
           ...process.env,
+          // This fixture owns command imports, not entrypoint respawn or compile-cache behavior.
+          NODE_DISABLE_COMPILE_CACHE: "1",
           NODE_ENV: undefined,
           VITEST: undefined,
           OPENCLAW_CLAWHUB_URL: clawHubUrl,
@@ -155,6 +157,7 @@ it.each(cases)(
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
           OPENCLAW_DEV_SOURCE_ROOT: path.resolve("."),
           OPENCLAW_HOME: path.join(root, "home"),
+          OPENCLAW_NO_RESPAWN: "1",
           OPENCLAW_STATE_DIR: stateDir,
         },
         maxBuffer: 4 * 1024 * 1024,


### PR DESCRIPTION
## What Problem This Solves

The cold plugin-import process suite launched each command through unrelated compile-cache and entrypoint-respawn behavior before reaching the plugin import boundary it owns. That doubled wrapper work across five fresh-process probes.

## Why This Change Was Made

Disable compile cache and entrypoint respawn only inside this process fixture. All five commands still execute in distinct real fresh processes, retain selected-owner and unrelated-plugin sentinels, and keep their output/exit assertions. Compile-cache and respawn behavior remain covered by their dedicated owner suites.

## User Impact

No runtime or user-visible behavior changes. The same cold plugin-import contracts complete faster with lower memory use.

## Evidence

- Paired file: 24.75s -> 17.21s (30.5% faster); real wall 27.68s -> 21.31s.
- Test bodies: 23.84s -> 16.67s; max RSS: 648.8MB -> 546.4MB.
- All 5 cold-process cases retained.
- Help-exit 25/25, ACP/Gateway exit 8/8, and entry-respawn 21/21 pass.
- Formatting, typed targeted lint, `git diff --check`, and autoreview are clean.
- Test-only diff: +3 lines; production LOC delta: 0.
