### PR TITLE
fix(release): restore cross-os baseline preparation

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -638,6 +638,7 @@ jobs:
       - name: Capture baseline metadata
         if: ${{ inputs.mode != 'fresh' }}
         id: baseline_metadata
+        working-directory: workflow
         env:
           BASELINE_PACK_JSON: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/baseline/pack.json
         run: |

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -19,6 +19,7 @@ type WorkflowStep = {
   run?: string;
   uses?: string;
   with?: Record<string, unknown>;
+  "working-directory"?: string;
 };
 
 type WorkflowJob = {
@@ -62,13 +63,17 @@ describe("cross-OS release checks workflow", () => {
   });
 
   it("bounds npm baseline packing during prepare", () => {
-    const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+    const workflow = readWorkflow(WORKFLOW_PATH);
+    const baselineMetadata = step(job(workflow, "prepare"), "Capture baseline metadata");
 
-    expect(workflow).toContain("timeout --preserve-status 300s npm pack --ignore-scripts");
-    expect(workflow).toContain(
+    expect(readFileSync(WORKFLOW_PATH, "utf8")).toContain(
+      "timeout --preserve-status 300s npm pack --ignore-scripts",
+    );
+    expect(baselineMetadata["working-directory"]).toBe("workflow");
+    expect(baselineMetadata.run).toContain(
       'import { resolveNpmJsonEntries } from "./scripts/lib/npm-json-output.mjs";',
     );
-    expect(workflow).toContain("const entry = resolveNpmJsonEntries(payload).at(-1);");
+    expect(baselineMetadata.run).toContain("const entry = resolveNpmJsonEntries(payload).at(-1);");
   });
 
   it("keeps release artifact tarball filenames local before upload paths use them", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release validation could not start cross-OS package checks when the baseline package metadata step ran against an artifact-backed candidate.

## Why This Change Was Made

The reusable workflow checks out trusted release tooling under `workflow/`, so the baseline metadata step now runs from that directory. Its existing relative import then resolves the checked-out `npm-json-output.mjs` helper instead of looking in the empty workspace root.

## User Impact

Release operators can complete cross-OS candidate validation instead of failing during package preparation before any OS matrix jobs start.

## Evidence

- Reproduced in [Full Release Validation 30779583489](https://github.com/openclaw/openclaw/actions/runs/30779583489), child [Release Checks 30780088302](https://github.com/openclaw/openclaw/actions/runs/30780088302), job `cross_os_release_checks / prepare`: `ERR_MODULE_NOT_FOUND` for the workspace-root `scripts/lib/npm-json-output.mjs`
- Exact rebased `check:changed` passed on Blacksmith Testbox: [30780766979](https://github.com/openclaw/openclaw/actions/runs/30780766979)
- Focused workflow contract test passed: 1 file, 6 tests on Blacksmith Testbox [30781003504](https://github.com/openclaw/openclaw/actions/runs/30781003504)
- Fresh branch autoreview: clean at 0.99
- `git diff --check`
