### PR TITLE
refactor(update): canonicalize subprocess step recording

### DIFF
--- a/src/infra/update-runner-command.ts
+++ b/src/infra/update-runner-command.ts
@@ -46,7 +46,7 @@ export async function runStep(opts: RunStepOptions): Promise<UpdateStepResult> {
     termination: result.termination,
   });
 
-  return {
+  const stepResult: UpdateStepResult = {
     name,
     command,
     cwd,
@@ -58,6 +58,8 @@ export async function runStep(opts: RunStepOptions): Promise<UpdateStepResult> {
     killed: result.killed,
     termination: result.termination,
   };
+  opts.results?.push(stepResult);
+  return stepResult;
 }
 
 export function normalizeFallbackFailureReason(

--- a/src/infra/update-runner-git-preflight.ts
+++ b/src/infra/update-runner-git-preflight.ts
@@ -138,7 +138,6 @@ async function resolveExplicitTarget(params: {
       const remoteStep = await runStep(
         params.step("git remote", ["git", "-C", params.gitRoot, "remote"], params.gitRoot),
       );
-      params.steps.push(remoteStep);
       const remotes = normalizeStringEntries((remoteStep.stdoutTail ?? "").split("\n"));
       let fetchedTag = false;
       for (const remote of remotes) {
@@ -149,7 +148,6 @@ async function resolveExplicitTarget(params: {
             params.gitRoot,
           ),
         );
-        params.steps.push(fetchStep);
         if (fetchStep.exitCode === 0) {
           fetchedTag = true;
           break;
@@ -166,7 +164,6 @@ async function resolveExplicitTarget(params: {
         params.gitRoot,
       ),
     );
-    params.steps.push(shaStep);
     const sha = shaStep.stdoutTail?.trim();
     if (shaStep.exitCode === 0 && sha) {
       return sha;
@@ -200,14 +197,12 @@ async function resolveUpstreamCandidates(params: {
         params.gitRoot,
       ),
     );
-    params.steps.push(localMainStep);
     localDevBranchExists = localMainStep.exitCode === 0;
   }
   if (params.needsCheckoutMain && localDevBranchExists === false) {
     const remoteStep = await runStep(
       params.step("git remote", ["git", "-C", params.gitRoot, "remote"], params.gitRoot),
     );
-    params.steps.push(remoteStep);
     if (remoteStep.exitCode === 0) {
       remoteBranchRefs = normalizeStringEntries((remoteStep.stdoutTail ?? "").split("\n")).map(
         (remote) => `refs/remotes/${remote}/${DEV_BRANCH}`,
@@ -237,7 +232,6 @@ async function resolveUpstreamCandidates(params: {
           params.gitRoot,
         ),
       );
-      params.steps.push(upstreamStep);
       if (upstreamStep.exitCode !== 0) {
         continue;
       }
@@ -250,7 +244,6 @@ async function resolveUpstreamCandidates(params: {
         params.gitRoot,
       ),
     );
-    params.steps.push(shaStep);
     const sha = shaStep.stdoutTail?.trim();
     if (shaStep.exitCode === 0 && sha) {
       upstreamSha = sha;
@@ -280,7 +273,6 @@ async function resolveUpstreamCandidates(params: {
       params.gitRoot,
     ),
   );
-  params.steps.push(revListStep);
   if (revListStep.exitCode !== 0) {
     return { status: "error", reason: "preflight-revlist-failed" };
   }
@@ -323,7 +315,6 @@ async function testPreflightCandidates(params: {
         params.worktreeDir,
       ),
     );
-    params.steps.push(checkoutStep);
     if (checkoutStep.exitCode !== 0) {
       sawOtherFailure = true;
       continue;
@@ -364,7 +355,6 @@ async function testPreflightCandidates(params: {
       let installStep = await runStep(
         params.step(installName, installArgv, params.worktreeDir, installEnv),
       );
-      params.steps.push(installStep);
       if (
         installStep.exitCode !== 0 &&
         !preferIgnoreScripts &&
@@ -380,7 +370,6 @@ async function testPreflightCandidates(params: {
               installEnv,
             ),
           );
-          params.steps.push(installStep);
         }
       }
       if (installStep.exitCode !== 0) {
@@ -395,7 +384,6 @@ async function testPreflightCandidates(params: {
           resolveBuildEnv(manager.env, path.join(params.gitRoot, ".artifacts", "build-all-cache")),
         ),
       );
-      params.steps.push(buildStep);
       if (buildStep.exitCode !== 0) {
         sawOtherFailure = true;
         continue;
@@ -409,7 +397,6 @@ async function testPreflightCandidates(params: {
             resolveDevPreflightLintEnv(manager.env),
           ),
         );
-        params.steps.push(lintStep);
         if (lintStep.exitCode !== 0) {
           sawOtherFailure = true;
           continue;
@@ -466,7 +453,6 @@ export async function runGitDevPreflight(params: {
       params.gitRoot,
     ),
   );
-  params.steps.push(worktreeStep);
   if (worktreeStep.exitCode !== 0) {
     await removePathRecursive(preflightRoot);
     return { status: "error", reason: "preflight-worktree-failed" };
@@ -495,7 +481,6 @@ export async function runGitDevPreflight(params: {
         MAX_LOG_CHARS,
       );
     }
-    params.steps.push(removeStep);
     await params
       .runCommand(["git", "-C", params.gitRoot, "worktree", "prune"], {
         cwd: params.gitRoot,

--- a/src/infra/update-runner-git-recovery.ts
+++ b/src/infra/update-runner-git-recovery.ts
@@ -1,14 +1,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveControlUiDistIndexHealth } from "./control-ui-assets.js";
-import { trimLogTail } from "./restart-sentinel.js";
 import type { UpdateChannel } from "./update-channels.js";
 import {
   managerInstallArgs,
   managerScriptArgs,
   resolveUpdateBuildManager,
 } from "./update-package-manager.js";
-import { MAX_LOG_CHARS } from "./update-runner-command.js";
+import { runStep } from "./update-runner-command.js";
 import {
   resolveBuildEnv,
   resolveInstallEnv,
@@ -46,22 +45,18 @@ export async function rebuildRolledBackGitRuntime(params: {
   steps: UpdateStepResult[];
 }): Promise<GitRuntimeRecovery> {
   const appendStep = async (name: string, argv: string[], env?: NodeJS.ProcessEnv) => {
-    const started = Date.now();
-    const result = await params.runCommand(argv, {
+    const result = await runStep({
+      runCommand: params.runCommand,
+      name,
+      argv,
       cwd: params.gitRoot,
       timeoutMs: params.timeoutMs,
       env,
+      stepIndex: 0,
+      totalSteps: 1,
+      results: params.steps,
     });
-    params.steps.push({
-      name,
-      command: argv.join(" "),
-      cwd: params.gitRoot,
-      durationMs: Date.now() - started,
-      exitCode: result.code,
-      stdoutTail: trimLogTail(result.stdout, MAX_LOG_CHARS),
-      stderrTail: trimLogTail(result.stderr, MAX_LOG_CHARS),
-    });
-    return result.code === 0;
+    return result.exitCode === 0;
   };
   const appendFailure = (reason: RecoveryReason, detail: string): GitRuntimeRecovery => {
     params.steps.push({

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -5,7 +5,6 @@ import {
   resolveControlUiDistIndexPathForRoot,
 } from "./control-ui-assets.js";
 import { readPackageVersion } from "./package-json.js";
-import { trimLogTail } from "./restart-sentinel.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import { DEV_BRANCH, type UpdateChannel } from "./update-channels.js";
 import {
@@ -13,7 +12,7 @@ import {
   managerScriptArgs,
   resolveUpdateBuildManager,
 } from "./update-package-manager.js";
-import { MAX_LOG_CHARS, normalizeFallbackFailureReason, runStep } from "./update-runner-command.js";
+import { normalizeFallbackFailureReason, runStep } from "./update-runner-command.js";
 import {
   buildUpdateDoctorEnv,
   resolveUpdateDoctorExecutionPolicy,
@@ -89,6 +88,7 @@ export async function runGitUpdate(params: {
     progress: opts.progress,
     stepIndex: stepIndex++,
     totalSteps,
+    results: steps,
   });
 
   let allowGatewayServiceRepair = opts.allowGatewayServiceRepair !== false;
@@ -128,44 +128,40 @@ export async function runGitUpdate(params: {
   });
   const runRequiredStep = async (name: string, argv: string[], reason: string) => {
     const result = await runStep(step(name, argv, gitRoot));
-    steps.push(result);
     return result.exitCode === 0 ? null : buildError(reason);
   };
   const appendRecoveryStep = async (name: string, argv: string[]) => {
-    const started = Date.now();
-    const result = await runCommand(argv, { cwd: gitRoot, timeoutMs });
-    steps.push({
+    const result = await runStep({
+      runCommand,
       name,
-      command: argv.join(" "),
+      argv,
       cwd: gitRoot,
-      durationMs: Date.now() - started,
-      exitCode: result.code,
-      stdoutTail: trimLogTail(result.stdout, MAX_LOG_CHARS),
-      stderrTail: trimLogTail(result.stderr, MAX_LOG_CHARS),
+      timeoutMs,
+      stepIndex: 0,
+      totalSteps: 1,
+      results: steps,
     });
-    return result.code === 0;
+    return result.exitCode === 0;
   };
   const verifyRollbackHead = async () => {
     if (!beforeSha) {
       return false;
     }
-    const started = Date.now();
-    const result = await runCommand(["git", "-C", gitRoot, "rev-parse", "HEAD"], {
+    const result = await runStep({
+      runCommand,
+      name: "git rollback verify HEAD",
+      argv: ["git", "-C", gitRoot, "rev-parse", "HEAD"],
       cwd: gitRoot,
       timeoutMs,
+      stepIndex: 0,
+      totalSteps: 1,
+      results: steps,
     });
-    const verified = result.code === 0 && result.stdout.trim() === beforeSha;
-    steps.push({
-      name: "git rollback verify HEAD",
-      command: `git -C ${gitRoot} rev-parse HEAD`,
-      cwd: gitRoot,
-      durationMs: Date.now() - started,
-      exitCode: verified ? 0 : 1,
-      stdoutTail: trimLogTail(result.stdout, MAX_LOG_CHARS),
-      stderrTail: verified
-        ? trimLogTail(result.stderr, MAX_LOG_CHARS)
-        : `expected ${beforeSha}, found ${result.stdout.trim() || "unreadable HEAD"}`,
-    });
+    const verified = result.exitCode === 0 && result.stdoutTail?.trim() === beforeSha;
+    result.exitCode = verified ? 0 : 1;
+    if (!verified) {
+      result.stderrTail = `expected ${beforeSha}, found ${result.stdoutTail?.trim() || "unreadable HEAD"}`;
+    }
     return verified;
   };
   const rollback = async () => {
@@ -274,7 +270,6 @@ export async function runGitUpdate(params: {
       gitRoot,
     ),
   );
-  steps.push(statusCheck);
   if (statusCheck.stdoutTail?.trim()) {
     return buildError("dirty", "skipped");
   }
@@ -361,20 +356,16 @@ export async function runGitUpdate(params: {
         const rebaseStep = await runStep(
           step("git rebase", ["git", "-C", gitRoot, "rebase", preflight.selectedSha], gitRoot),
         );
-        steps.push(rebaseStep);
         if (rebaseStep.exitCode !== 0) {
-          const abort = await runCommand(["git", "-C", gitRoot, "rebase", "--abort"], {
+          await runStep({
+            runCommand,
+            name: "git rebase --abort",
+            argv: ["git", "-C", gitRoot, "rebase", "--abort"],
             cwd: gitRoot,
             timeoutMs,
-          });
-          steps.push({
-            name: "git rebase --abort",
-            command: "git rebase --abort",
-            cwd: gitRoot,
-            durationMs: 0,
-            exitCode: abort.code,
-            stdoutTail: trimLogTail(abort.stdout, MAX_LOG_CHARS),
-            stderrTail: trimLogTail(abort.stderr, MAX_LOG_CHARS),
+            stepIndex: 0,
+            totalSteps: 1,
+            results: steps,
           });
           return buildError("rebase-failed");
         }
@@ -426,14 +417,12 @@ export async function runGitUpdate(params: {
         installEnv,
       ),
     );
-    steps.push(installStep);
     if (installStep.exitCode !== 0 && shouldRetryWindowsInstallIgnoringScripts(manager.manager)) {
       const retryArgv = resolveRetryInstallArgs(manager.manager);
       if (retryArgv) {
         installStep = await runStep(
           step("deps install (ignore scripts)", retryArgv, gitRoot, installEnv),
         );
-        steps.push(installStep);
       }
     }
     if (installStep.exitCode !== 0) {
@@ -451,7 +440,6 @@ export async function runGitUpdate(params: {
         ),
       ),
     );
-    steps.push(buildStep);
     if (buildStep.exitCode !== 0) {
       return await rollbackError("build-failed");
     }
@@ -462,7 +450,6 @@ export async function runGitUpdate(params: {
         gitRoot,
       ),
     );
-    steps.push(buildCleanCheck);
     if (buildCleanCheck.exitCode !== 0) {
       return await rollbackError("build-failed");
     }
@@ -479,7 +466,6 @@ export async function runGitUpdate(params: {
           manager.env,
         ),
       );
-      steps.push(uiBuildStep);
       if (uiBuildStep.exitCode !== 0) {
         return await rollbackError("ui-build-failed");
       }
@@ -526,7 +512,6 @@ export async function runGitUpdate(params: {
         }),
       ),
     );
-    steps.push(doctorStep);
     if (doctorStep.exitCode !== 0) {
       return await rollbackError("doctor-failed");
     }
@@ -534,22 +519,18 @@ export async function runGitUpdate(params: {
     const uiIndexHealth = await resolveControlUiDistIndexHealth({ root: gitRoot });
     if (!uiIndexHealth.exists) {
       const repairArgv = managerScriptArgs(manager.manager, "ui:build");
-      const repairStarted = Date.now();
-      const repairResult = await runCommand(repairArgv, {
+      const repairStep = await runStep({
+        runCommand,
+        name: "ui:build (post-doctor repair)",
+        argv: repairArgv,
         cwd: gitRoot,
         timeoutMs,
         env: manager.env,
+        stepIndex: 0,
+        totalSteps: 1,
+        results: steps,
       });
-      steps.push({
-        name: "ui:build (post-doctor repair)",
-        command: repairArgv.join(" "),
-        cwd: gitRoot,
-        durationMs: Date.now() - repairStarted,
-        exitCode: repairResult.code,
-        stdoutTail: trimLogTail(repairResult.stdout, MAX_LOG_CHARS),
-        stderrTail: trimLogTail(repairResult.stderr, MAX_LOG_CHARS),
-      });
-      if (repairResult.code !== 0) {
+      if (repairStep.exitCode !== 0) {
         return await rollbackError("ui-build-failed");
       }
       const repairedHealth = await resolveControlUiDistIndexHealth({ root: gitRoot });
@@ -572,7 +553,6 @@ export async function runGitUpdate(params: {
     const afterShaStep = await runStep(
       step("git rev-parse HEAD (after)", ["git", "-C", gitRoot, "rev-parse", "HEAD"], gitRoot),
     );
-    steps.push(afterShaStep);
     return {
       status: failedStep ? "error" : "ok",
       mode: "git",

--- a/src/infra/update-runner-types.ts
+++ b/src/infra/update-runner-types.ts
@@ -160,4 +160,5 @@ export type RunStepOptions = {
   progress?: UpdateStepProgress;
   stepIndex: number;
   totalSteps: number;
+  results?: UpdateStepResult[];
 };

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -36,7 +36,7 @@ function toCommandResult(response?: CommandResponse): CommandResult {
   return {
     stdout: response?.stdout ?? "",
     stderr: response?.stderr ?? "",
-    code: response?.code ?? 0,
+    code: response?.code === undefined ? 0 : response.code,
   };
 }
 
@@ -393,6 +393,123 @@ describe("runGatewayUpdate", () => {
     };
 
     return { calls, runCommand };
+  }
+
+  type TestCommandOptions = {
+    env?: NodeJS.ProcessEnv;
+    cwd?: string;
+    timeoutMs?: number;
+  };
+
+  async function createDevGitRunner(params?: {
+    targetSha?: string;
+    targetRef?: string;
+    packageManager?: string;
+    onCommand?: (
+      key: string,
+      options: TestCommandOptions | undefined,
+      calls: readonly string[],
+    ) => Promise<CommandResponse | undefined> | CommandResponse | undefined;
+  }) {
+    const calls: string[] = [];
+    const targetSha = params?.targetSha ?? "upstream123";
+    const doctorNodePath = await resolveStableNodePath(process.execPath);
+    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
+    const targetRef = params?.targetRef;
+    const targetCandidate = targetRef
+      ? targetRef === targetSha
+        ? targetSha
+        : `refs/remotes/origin/${targetRef}`
+      : null;
+
+    const runCommand = async (argv: string[], options?: TestCommandOptions) => {
+      const key = argv.join(" ");
+      calls.push(key);
+      const override = await params?.onCommand?.(key, options, calls);
+      if (override !== undefined) {
+        return toCommandResult(override);
+      }
+      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
+        return toCommandResult({ stdout: tempDir });
+      }
+      if (key === `git -C ${tempDir} rev-parse HEAD`) {
+        const updated =
+          calls.includes(`git -C ${tempDir} rebase ${targetSha}`) ||
+          calls.includes(`git -C ${tempDir} checkout --detach ${targetSha}`);
+        return toCommandResult({ stdout: `${updated ? targetSha : "abc123"}\n` });
+      }
+      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
+        return toCommandResult({ stdout: "main" });
+      }
+      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
+        return toCommandResult();
+      }
+      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
+        return toCommandResult();
+      }
+      if (
+        !targetRef &&
+        key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`
+      ) {
+        return toCommandResult({ stdout: "origin/main" });
+      }
+      if (!targetRef && key === `git -C ${tempDir} rev-parse @{upstream}`) {
+        return toCommandResult({ stdout: targetSha });
+      }
+      if (!targetRef && key === `git -C ${tempDir} rev-list --max-count=10 ${targetSha}`) {
+        return toCommandResult({ stdout: `${targetSha}\n` });
+      }
+      if (targetCandidate && key === `git -C ${tempDir} rev-parse ${targetCandidate}`) {
+        return toCommandResult({ stdout: `${targetSha}\n` });
+      }
+      if (key === "pnpm --version") {
+        return toCommandResult({ stdout: "10.0.0" });
+      }
+      if (
+        key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
+        key.endsWith(` ${targetSha}`) &&
+        preflightPrefixPattern.test(key)
+      ) {
+        await writePreflightPackageManagerFixtureFromWorktreeAdd(
+          key,
+          params?.packageManager ?? "pnpm@8.0.0",
+        );
+        return toCommandResult({ stdout: `HEAD is now at ${targetSha}` });
+      }
+      if (
+        key.startsWith("git -C ") &&
+        preflightPrefixPattern.test(key) &&
+        key.includes(` checkout --detach ${targetSha}`)
+      ) {
+        return toCommandResult();
+      }
+      if (
+        key === "pnpm install" ||
+        key === "pnpm install --ignore-scripts" ||
+        key === "pnpm build" ||
+        key === "pnpm lint" ||
+        key === "pnpm ui:build" ||
+        key === doctorCommand
+      ) {
+        return toCommandResult();
+      }
+      if (
+        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
+        preflightPrefixPattern.test(key)
+      ) {
+        return toCommandResult();
+      }
+      if (
+        key === `git -C ${tempDir} worktree prune` ||
+        key === `git -C ${tempDir} rebase ${targetSha}` ||
+        key === `git -C ${tempDir} checkout --detach ${targetSha}`
+      ) {
+        return toCommandResult();
+      }
+      return toCommandResult();
+    };
+
+    return { calls, runCommand, targetSha };
   }
 
   async function removeControlUiAssets() {
@@ -1857,86 +1974,15 @@ describe("runGatewayUpdate", () => {
 
   it("runs dev preflight lint in constrained mode when explicitly enabled", async () => {
     await setupGitPackageManagerFixture();
-    const calls: string[] = [];
     const lintEnv: NodeJS.ProcessEnv[] = [];
-    const upstreamSha = "upstream123";
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
-
-    const runCommand = async (
-      argv: string[],
-      options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
-    ) => {
-      const key = argv.join(" ");
-      calls.push(key);
-
-      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-        return { stdout: tempDir, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse HEAD`) {
-        return { stdout: "abc123", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-        return { stdout: "main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
-        return { stdout: "origin/main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
-        return { stdout: upstreamSha, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-list --max-count=10 ${upstreamSha}`) {
-        return { stdout: `${upstreamSha}\n`, stderr: "", code: 0 };
-      }
-      if (key === "pnpm --version") {
-        return { stdout: "10.0.0", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
-        key.endsWith(` ${upstreamSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
-        return { stdout: `HEAD is now at ${upstreamSha}`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith("git -C ") &&
-        preflightPrefixPattern.test(key) &&
-        key.includes(" checkout --detach ") &&
-        key.endsWith(upstreamSha)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm install" || key === "pnpm build" || key === "pnpm ui:build") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm lint") {
-        lintEnv.push(options?.env ?? {});
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} worktree prune`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rebase ${upstreamSha}`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === doctorCommand) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      return { stdout: "", stderr: "", code: 0 };
-    };
+    const { calls, runCommand } = await createDevGitRunner({
+      onCommand: (key, options) => {
+        if (key === "pnpm lint") {
+          lintEnv.push(options?.env ?? {});
+        }
+        return undefined;
+      },
+    });
 
     const result = await withEnvAsync({ OPENCLAW_UPDATE_PREFLIGHT_LINT: "1" }, async () =>
       runWithCommand(runCommand, { channel: "dev" }),
@@ -1951,106 +1997,33 @@ describe("runGatewayUpdate", () => {
 
   it("retries windows pnpm git installs with --ignore-scripts for dev updates", async () => {
     await setupGitPackageManagerFixture();
-    const calls: string[] = [];
-    const upstreamSha = "upstream123";
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
     let preflightInstallAttempts = 0;
     let preflightIgnoreScriptsAttempts = 0;
     let finalInstallAttempts = 0;
-
-    await withMockedWindowsPlatform(async () => {
-      const runCommand = async (
-        argv: string[],
-        options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
-      ) => {
-        const key = argv.join(" ");
-        calls.push(key);
-
-        if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-          return { stdout: tempDir, stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rev-parse HEAD`) {
-          return { stdout: "abc123", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-          return { stdout: "main", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
-          return { stdout: "origin/main", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
-          return { stdout: upstreamSha, stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rev-list --max-count=10 ${upstreamSha}`) {
-          return { stdout: `${upstreamSha}\n`, stderr: "", code: 0 };
-        }
-        if (key === "pnpm --version") {
-          return { stdout: "10.0.0", stderr: "", code: 0 };
-        }
-        if (
-          key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
-          key.endsWith(` ${upstreamSha}`) &&
-          preflightPrefixPattern.test(key)
-        ) {
-          await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
-          return { stdout: `HEAD is now at ${upstreamSha}`, stderr: "", code: 0 };
-        }
-        if (
-          key.startsWith("git -C ") &&
-          preflightPrefixPattern.test(key) &&
-          key.includes(" checkout --detach ") &&
-          key.endsWith(upstreamSha)
-        ) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
+    const { calls, runCommand } = await createDevGitRunner({
+      onCommand: (key, options) => {
         if (key === "pnpm install") {
-          if (options?.cwd && /(?:openclaw-update-preflight-|ocu-pf-)/.test(options.cwd)) {
+          if (options?.cwd && preflightPrefixPattern.test(options.cwd)) {
             preflightInstallAttempts += 1;
-            return preflightInstallAttempts === 1
-              ? { stdout: "", stderr: "sharp: Please add node-gyp to your dependencies", code: 1 }
-              : { stdout: "", stderr: "", code: 0 };
-          }
-          if (options?.cwd === tempDir) {
+          } else if (options?.cwd === tempDir) {
             finalInstallAttempts += 1;
             return finalInstallAttempts === 1
-              ? { stdout: "", stderr: "sharp: Please add node-gyp to your dependencies", code: 1 }
-              : { stdout: "", stderr: "", code: 0 };
+              ? { stderr: "sharp: Please add node-gyp to your dependencies", code: 1 }
+              : undefined;
           }
-        }
-        if (key === "pnpm install --ignore-scripts") {
-          if (options?.cwd && /(?:openclaw-update-preflight-|ocu-pf-)/.test(options.cwd)) {
-            preflightIgnoreScriptsAttempts += 1;
-          }
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        if (key === "pnpm build" || key === "pnpm lint" || key === "pnpm ui:build") {
-          return { stdout: "", stderr: "", code: 0 };
         }
         if (
-          key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-          preflightPrefixPattern.test(key)
+          key === "pnpm install --ignore-scripts" &&
+          options?.cwd &&
+          preflightPrefixPattern.test(options.cwd)
         ) {
-          return { stdout: "", stderr: "", code: 0 };
+          preflightIgnoreScriptsAttempts += 1;
         }
-        if (key === `git -C ${tempDir} worktree prune`) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rebase ${upstreamSha}`) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        if (key === doctorCommand) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        return { stdout: "", stderr: "", code: 0 };
-      };
+        return undefined;
+      },
+    });
 
+    await withMockedWindowsPlatform(async () => {
       const result = await runWithCommand(runCommand, { channel: "dev" });
 
       expect(result.status).toBe("ok");
@@ -2068,92 +2041,24 @@ describe("runGatewayUpdate", () => {
 
   it("does not fail a good windows dev preflight only because worktree cleanup hit long paths", async () => {
     await setupGitPackageManagerFixture();
-    const calls: string[] = [];
     const cleanupTimeouts: Array<number | undefined> = [];
-    const upstreamSha = "upstream123";
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
-
-    await withMockedWindowsPlatform(async () => {
-      const runCommand = async (
-        argv: string[],
-        options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
-      ) => {
-        const key = argv.join(" ");
-        calls.push(key);
-
-        if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-          return { stdout: tempDir, stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rev-parse HEAD`) {
-          return { stdout: "abc123", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-          return { stdout: "main", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
-          return { stdout: "origin/main", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
-          return { stdout: upstreamSha, stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rev-list --max-count=10 ${upstreamSha}`) {
-          return { stdout: `${upstreamSha}\n`, stderr: "", code: 0 };
-        }
-        if (key === "pnpm --version") {
-          return { stdout: "10.0.0", stderr: "", code: 0 };
-        }
-        if (
-          key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
-          key.endsWith(` ${upstreamSha}`) &&
-          preflightPrefixPattern.test(key)
-        ) {
-          await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
-          return { stdout: `HEAD is now at ${upstreamSha}`, stderr: "", code: 0 };
-        }
-        if (
-          key.startsWith("git -C ") &&
-          preflightPrefixPattern.test(key) &&
-          key.includes(" checkout --detach ") &&
-          key.endsWith(upstreamSha)
-        ) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        if (key === "pnpm install" || key === "pnpm build" || key === "pnpm lint") {
-          return { stdout: "", stderr: "", code: 0 };
-        }
+    const { runCommand } = await createDevGitRunner({
+      onCommand: (key, options) => {
         if (
           key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
           preflightPrefixPattern.test(key)
         ) {
           cleanupTimeouts.push(options?.timeoutMs);
           return {
-            stdout: "",
             stderr: "error: failed to delete worktree: Filename too long",
             code: 255,
           };
         }
-        if (key === `git -C ${tempDir} worktree prune`) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        if (key === `git -C ${tempDir} rebase ${upstreamSha}`) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        if (key === doctorCommand) {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        if (key === "pnpm ui:build") {
-          return { stdout: "", stderr: "", code: 0 };
-        }
-        return { stdout: "", stderr: "", code: 0 };
-      };
+        return undefined;
+      },
+    });
 
+    await withMockedWindowsPlatform(async () => {
       const result = await runWithCommand(runCommand, { channel: "dev" });
 
       expect(result.status).toBe("ok");
@@ -2168,90 +2073,19 @@ describe("runGatewayUpdate", () => {
 
   it("falls back when dev preflight worktree cleanup times out", async () => {
     await setupGitPackageManagerFixture();
-    const calls: string[] = [];
     const cleanupTimeouts: Array<number | undefined> = [];
-    const upstreamSha = "upstream123";
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
-
-    const runCommand = async (
-      argv: string[],
-      options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
-    ) => {
-      const key = argv.join(" ");
-      calls.push(key);
-
-      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-        return { stdout: tempDir, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse HEAD`) {
-        return { stdout: "abc123", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-        return { stdout: "main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
-        return { stdout: "origin/main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
-        return { stdout: upstreamSha, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-list --max-count=10 ${upstreamSha}`) {
-        return { stdout: `${upstreamSha}\n`, stderr: "", code: 0 };
-      }
-      if (key === "pnpm --version") {
-        return { stdout: "10.0.0", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
-        key.endsWith(` ${upstreamSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
-        return { stdout: `HEAD is now at ${upstreamSha}`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith("git -C ") &&
-        preflightPrefixPattern.test(key) &&
-        key.includes(" checkout --detach ") &&
-        key.endsWith(upstreamSha)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm install" || key === "pnpm build" || key === "pnpm lint") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        cleanupTimeouts.push(options?.timeoutMs);
-        return {
-          stdout: "",
-          stderr: "Command timed out after 60000ms",
-          code: null,
-        };
-      }
-      if (key === `git -C ${tempDir} worktree prune`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rebase ${upstreamSha}`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === doctorCommand) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm ui:build") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      return { stdout: "", stderr: "", code: 0 };
-    };
+    const { runCommand } = await createDevGitRunner({
+      onCommand: (key, options) => {
+        if (
+          key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
+          preflightPrefixPattern.test(key)
+        ) {
+          cleanupTimeouts.push(options?.timeoutMs);
+          return { stderr: "Command timed out after 60000ms", code: null };
+        }
+        return undefined;
+      },
+    });
 
     const result = await runWithCommand(runCommand, { channel: "dev" });
 
@@ -2264,90 +2098,17 @@ describe("runGatewayUpdate", () => {
 
   it("shares the build cache while adding heap headroom to dev builds", async () => {
     await setupGitPackageManagerFixture();
-    const upstreamSha = "upstream123";
     const buildNodeOptions: string[] = [];
     const buildCacheRoots: string[] = [];
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
-
-    const runCommand = async (
-      argv: string[],
-      options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
-    ) => {
-      const key = argv.join(" ");
-
-      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-        return { stdout: tempDir, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse HEAD`) {
-        return { stdout: "abc123", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-        return { stdout: "main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
-        return { stdout: "origin/main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
-        return { stdout: upstreamSha, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-list --max-count=10 ${upstreamSha}`) {
-        return { stdout: `${upstreamSha}\n`, stderr: "", code: 0 };
-      }
-      if (key === "pnpm --version") {
-        return { stdout: "10.0.0", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
-        key.endsWith(` ${upstreamSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
-        return { stdout: `HEAD is now at ${upstreamSha}`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith("git -C ") &&
-        preflightPrefixPattern.test(key) &&
-        key.includes(" checkout --detach ") &&
-        key.endsWith(upstreamSha)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key === "pnpm install --ignore-scripts" ||
-        key === "pnpm lint" ||
-        key === "pnpm ui:build"
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm build") {
-        buildNodeOptions.push(options?.env?.NODE_OPTIONS ?? "");
-        buildCacheRoots.push(options?.env?.BUILD_ALL_CACHE_ROOT ?? "");
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} worktree prune`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rebase ${upstreamSha}`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === doctorCommand) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      return { stdout: "", stderr: "", code: 0 };
-    };
+    const { calls, runCommand } = await createDevGitRunner({
+      onCommand: (key, options) => {
+        if (key === "pnpm build") {
+          buildNodeOptions.push(options?.env?.NODE_OPTIONS ?? "");
+          buildCacheRoots.push(options?.env?.BUILD_ALL_CACHE_ROOT ?? "");
+        }
+        return undefined;
+      },
+    });
 
     const result = await runWithCommand(runCommand, { channel: "dev" });
 
@@ -2358,7 +2119,9 @@ describe("runGatewayUpdate", () => {
       path.join(tempDir, ".artifacts", "build-all-cache"),
       path.join(tempDir, ".artifacts", "build-all-cache"),
     ]);
+    expect(calls.filter((call) => call === "pnpm build")).toHaveLength(2);
   });
+
   it("pins dev updates to an explicit target ref when requested", async () => {
     await setupGitPackageManagerFixture();
     const calls: string[] = [];


### PR DESCRIPTION
## What Problem This Solves

The Git updater had one canonical subprocess recorder for forward update steps, but callers still had to append every returned result manually and rollback/recovery commands rebuilt result records independently. That split ownership could omit a step or lose signal and termination diagnostics as the paths evolved.

## Why This Change Was Made

The update command runner now records each completed subprocess result into its supplied result sink. Git preflight, forward update, rollback, and runtime recovery use that one owner for command text, cwd, timing, truncated output, exit status, signal, killed state, and termination reason. Synthetic verification outcomes remain explicit because they are not direct subprocess results.

The update-runner tests also use one dev-update command fixture for the shared forward path while retaining case-specific Windows retry, cleanup fallback, lint, and build-cache assertions.

Root cause: result construction and result-list mutation had separate owners. Architectural owner: `src/infra/update-runner-command.ts`. Canonical fix: record real subprocess results where they are constructed. Removed paths: manual append calls and two hand-built rollback/recovery recorders.

Production LOC: +50/-87 (-37 net). Test LOC: +169/-406 (-237 net). Total: +219/-493 (-274 net).

## User Impact

No intended user-visible behavior change. Operators keep the same update and rollback ordering and failure text, while subprocess diagnostics now flow through one consistent recorder.

## Evidence

- `node scripts/run-vitest.mjs src/infra/update-runner.test.ts`: 66/66 passed.
- Converted fixture cases: 5/5 passed (Windows retry, both cleanup fallbacks, preflight lint, and build-cache ordering).
- `node scripts/check-changed.mjs -- src/infra/update-runner-command.ts src/infra/update-runner-git-preflight.ts src/infra/update-runner-git-recovery.ts src/infra/update-runner-git.ts src/infra/update-runner-types.ts src/infra/update-runner.test.ts`: passed on Blacksmith Testbox `tbx_01kz2rs7dpr43ydnqnp2dvk81g` ([run](https://github.com/openclaw/openclaw/actions/runs/30780488874)).
- Max-lines ratchet stayed clean at 996 grandfathered suppressions; no baseline change.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`: clean, no accepted/actionable findings (0.99 confidence).
- Sibling coverage: dev preflight target resolution, candidate checkout/install/build/lint, stable/dev forward updates, rollback source repair, runtime rebuild recovery, UI repair, doctor, and final HEAD recording remain covered by the focused suite.

### Disposable real updater proof

ClawSweeper rank-up moves are applied: the required real disposable-checkout runtime evidence is attached below, and required CI is complete on the reviewed head. The prior `needs proof` finding is therefore addressed with durable evidence rather than bypassed.

A trusted Blacksmith Testbox cloned exact PR head `6cfdfcbb157fa7220e630ac9c637b4701227730f`, created an empty descendant commit, switched back to the PR head, verified a clean checkout, and ran the real dist-backed command:

```text
OPENCLAW_STATE_DIR=<DISPOSABLE_STATE> \
OPENCLAW_UPDATE_DEV_TARGET_REF=<EMPTY_DESCENDANT_SHA> \
pnpm openclaw update --channel dev --yes --no-restart --json
```

The updater completed successfully, moved HEAD to the disposable target, and `git diff --name-only <PR_HEAD> <TARGET_HEAD>` was empty, proving the run changed no source. All capture and state files were outside the checkout. Paths below are redacted.

- Provider: Blacksmith Testbox `tbx_01kz2vfzy4tfhzrj0khe1y25j4`
- [Delegated proof run](https://github.com/openclaw/openclaw/actions/runs/30782504703)
- Result: exit 0, `status: ok`, `mode: git`, 14 subprocess records

```json
{
  "runtimeSourceHead": "6cfdfcbb157fa7220e630ac9c637b4701227730f",
  "beforeHead": "6cfdfcbb157fa7220e630ac9c637b4701227730f",
  "targetHead": "34b38a58d89c986015c6a7a97b219800300f4db0",
  "finalHead": "34b38a58d89c986015c6a7a97b219800300f4db0",
  "sourceDiffNames": [],
  "status": "ok",
  "mode": "git",
  "steps": [
    { "name": "clean check", "cwd": "<DISPOSABLE_CHECKOUT>", "exitCode": 0, "termination": "exit" },
    { "name": "git fetch", "cwd": "<DISPOSABLE_CHECKOUT>", "exitCode": 0, "termination": "exit" },
    { "name": "git rev-parse 34b38a58d89c986015c6a7a97b219800300f4db0", "cwd": "<DISPOSABLE_CHECKOUT>", "exitCode": 0, "termination": "exit" },
    { "name": "preflight worktree", "cwd": "<DISPOSABLE_CHECKOUT>", "exitCode": 0, "termination": "exit" },
    { "name": "preflight checkout (34b38a58)", "cwd": "<DISPOSABLE_PREFLIGHT>", "exitCode": 0, "termination": "exit" },
    { "name": "preflight deps install (34b38a58)", "cwd": "<DISPOSABLE_PREFLIGHT>", "exitCode": 0, "termination": "exit" },
    { "name": "preflight build (34b38a58)", "cwd": "<DISPOSABLE_PREFLIGHT>", "exitCode": 0, "termination": "exit" },
    { "name": "preflight cleanup", "cwd": "<DISPOSABLE_CHECKOUT>", "exitCode": 0, "termination": "exit" },
    { "name": "git checkout 34b38a58d89c986015c6a7a97b219800300f4db0", "cwd": "<DISPOSABLE_CHECKOUT>", "exitCode": 0, "termination": "exit" },
    { "name": "deps install", "cwd": "<DISPOSABLE_CHECKOUT>", "exitCode": 0, "termination": "exit" },
    { "name": "build", "cwd": "<DISPOSABLE_CHECKOUT>", "exitCode": 0, "termination": "exit" },
    { "name": "build clean check", "cwd": "<DISPOSABLE_CHECKOUT>", "exitCode": 0, "termination": "exit" },
    { "name": "openclaw doctor", "cwd": "<DISPOSABLE_CHECKOUT>", "exitCode": 0, "termination": "exit" },
    { "name": "git rev-parse HEAD (after)", "cwd": "<DISPOSABLE_CHECKOUT>", "exitCode": 0, "termination": "exit" }
  ]
}
```
