### PR TITLE
refactor(google-meet): consolidate create and node host test fixtures

### DIFF
--- a/extensions/google-meet/index.create.test.ts
+++ b/extensions/google-meet/index.create.test.ts
@@ -107,50 +107,24 @@ async function runCreateMeetBrowserScript(params: { buttonText: string }) {
       chromeNode: { node: "parallels-macos" },
     },
     {
-      nodesInvokeHandler: async (invokeParams) => {
-        const proxy = invokeParams.params as {
-          path?: string;
-          body?: { fn?: string; url?: string };
-        };
-        if (proxy.path === "/tabs") {
-          return { payload: { result: { tabs: [] } } };
-        }
-        if (proxy.path === "/tabs/open") {
-          return {
-            payload: {
-              result: {
-                targetId: "create-script-tab",
-                title: "Meet",
-                url: proxy.body?.url,
-              },
-            },
-          };
-        }
-        if (proxy.path === "/act") {
-          if (typeof proxy.body?.fn !== "string") {
+      nodesInvokeHandler: createBrowserProxyHandler({
+        openedTargetId: "create-script-tab",
+        act: async (body) => {
+          if (typeof body.fn !== "string") {
             throw new Error("expected browser create script");
           }
-          const fn = (0, eval)(`(${proxy.body.fn})`) as () => Promise<BrowserScriptResult>;
+          const fn = (0, eval)(`(${body.fn})`) as () => Promise<BrowserScriptResult>;
           scriptResult = await fn();
           return {
-            payload: {
-              result: {
-                ok: true,
-                targetId: "create-script-tab",
-                result: {
-                  manualAction: {
-                    reason: "meet-permission-required",
-                    message: "Stop after exercising the browser script.",
-                  },
-                  browserUrl: location.href,
-                  browserTitle: document.title,
-                },
-              },
+            manualAction: {
+              reason: "meet-permission-required",
+              message: "Stop after exercising the browser script.",
             },
+            browserUrl: location.href,
+            browserTitle: document.title,
           };
-        }
-        throw new Error(`unexpected browser proxy path ${proxy.path}`);
-      },
+        },
+      }),
     },
   );
   const tool = tools[0] as {
@@ -168,6 +142,77 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
     throw new Error(`expected ${label}`);
   }
   return value as Record<string, unknown>;
+}
+
+type BrowserProxyBody = {
+  fn?: string;
+  targetId?: string;
+  url?: string;
+};
+
+type BrowserProxyTab = {
+  targetId: string;
+  title?: string;
+  url?: string;
+};
+
+function browserProxyPayload(result: unknown) {
+  return { payload: { result } };
+}
+
+function browserCreateResult(meetingUri: string) {
+  return { meetingUri, browserUrl: meetingUri, browserTitle: "Meet" };
+}
+
+function createBrowserProxyHandler(options: {
+  act: (body: BrowserProxyBody) => unknown;
+  handleChromeStart?: boolean;
+  navigateTo?: BrowserProxyTab;
+  openedTargetId?: string | ((url: string | undefined) => string);
+  openedTitle?: string;
+  tabs?: BrowserProxyTab[];
+}) {
+  return async (params: { command: string; params?: unknown }) => {
+    if (params.command === "googlemeet.chrome" && options.handleChromeStart) {
+      return { payload: { launched: true } };
+    }
+    if (params.command !== "browser.proxy") {
+      throw new Error(`unexpected node command ${params.command}`);
+    }
+    const proxy = params.params as { path?: string; body?: BrowserProxyBody };
+    switch (proxy.path) {
+      case "/tabs":
+        return browserProxyPayload({ tabs: options.tabs ?? [] });
+      case "/tabs/open": {
+        const targetId =
+          typeof options.openedTargetId === "function"
+            ? options.openedTargetId(proxy.body?.url)
+            : (options.openedTargetId ?? "tab-1");
+        return browserProxyPayload({
+          targetId,
+          title: options.openedTitle ?? "Meet",
+          url: proxy.body?.url,
+        });
+      }
+      case "/tabs/focus":
+      case "/permissions/grant":
+        return browserProxyPayload({ ok: true });
+      case "/navigate":
+        if (options.navigateTo) {
+          return browserProxyPayload(options.navigateTo);
+        }
+        break;
+      case "/act":
+        return browserProxyPayload({
+          ok: true,
+          targetId: proxy.body?.targetId,
+          result: await options.act(proxy.body ?? {}),
+        });
+      case undefined:
+        break;
+    }
+    throw new Error(`unexpected browser proxy path ${proxy.path}`);
+  };
 }
 
 function mockCalls(mock: unknown, label: string): Array<Array<unknown>> {
@@ -214,6 +259,42 @@ function findNodeInvokeParams(
     return predicate(value as Record<string, unknown>);
   });
   return requireRecord(call[0], label);
+}
+
+function readBrowserProxyRequest(
+  value: unknown,
+): { path?: string; body?: BrowserProxyBody } | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const params = value as Record<string, unknown>;
+  if (params.command !== "browser.proxy" || !params.params || typeof params.params !== "object") {
+    return null;
+  }
+  return params.params as { path?: string; body?: BrowserProxyBody };
+}
+
+function hasBrowserProxyCall(nodesInvoke: unknown, path: string): boolean {
+  return mockCalls(nodesInvoke, "nodes invoke").some(
+    ([value]) => readBrowserProxyRequest(value)?.path === path,
+  );
+}
+
+function findBrowserProxyCall(
+  nodesInvoke: unknown,
+  label: string,
+  path: string,
+  body: BrowserProxyBody = {},
+) {
+  return findMockCall(nodesInvoke, label, ([value]) => {
+    const request = readBrowserProxyRequest(value);
+    return (
+      request?.path === path &&
+      Object.entries(body).every(
+        ([key, expected]) => request.body?.[key as keyof BrowserProxyBody] === expected,
+      )
+    );
+  });
 }
 
 describe("google-meet create flow", () => {
@@ -303,39 +384,9 @@ describe("google-meet create flow", () => {
         chromeNode: { node: "parallels-macos" },
       },
       {
-        nodesInvokeHandler: async (params) => {
-          const proxy = params.params as { path?: string; body?: { url?: string } };
-          if (proxy.path === "/tabs") {
-            return { payload: { result: { tabs: [] } } };
-          }
-          if (proxy.path === "/tabs/open") {
-            return {
-              payload: {
-                result: {
-                  targetId: "tab-1",
-                  title: "Meet",
-                  url: proxy.body?.url,
-                },
-              },
-            };
-          }
-          if (proxy.path === "/act") {
-            return {
-              payload: {
-                result: {
-                  ok: true,
-                  targetId: "tab-1",
-                  result: {
-                    meetingUri: "https://meet.google.com/browser-made-url",
-                    browserUrl: "https://meet.google.com/browser-made-url",
-                    browserTitle: "Meet",
-                  },
-                },
-              },
-            };
-          }
-          return { payload: { result: { ok: true } } };
-        },
+        nodesInvokeHandler: createBrowserProxyHandler({
+          act: () => browserCreateResult("https://meet.google.com/browser-made-url"),
+        }),
       },
     );
     const handler = methods.get("googlemeet.create") as
@@ -355,19 +406,8 @@ describe("google-meet create flow", () => {
     const browser = requireRecord(payload.browser, "browser payload");
     expect(browser.nodeId).toBe("node-1");
     expect(browser.targetId).toBe("tab-1");
-    findNodeInvokeParams(nodesInvoke, "open create tab", (params) => {
-      if (params.command !== "browser.proxy") {
-        return false;
-      }
-      if (!params.params || typeof params.params !== "object") {
-        return false;
-      }
-      const proxy = params.params as Record<string, unknown>;
-      if (!proxy.body || typeof proxy.body !== "object") {
-        return false;
-      }
-      const body = proxy.body as Record<string, unknown>;
-      return proxy.path === "/tabs/open" && body.url === "https://meet.google.com/new?hl=en";
+    findBrowserProxyCall(nodesInvoke, "open create tab", "/tabs/open", {
+      url: "https://meet.google.com/new?hl=en",
     });
   });
 
@@ -399,44 +439,20 @@ describe("google-meet create flow", () => {
         chromeNode: { node: "parallels-macos" },
       },
       {
-        nodesInvokeHandler: async (params) => {
-          const proxy = params.params as { path?: string; body?: { url?: string } };
-          if (proxy.path === "/tabs") {
-            return { payload: { result: { tabs: [] } } };
-          }
-          if (proxy.path === "/tabs/open") {
-            return {
-              payload: {
-                result: {
-                  targetId: "login-tab",
-                  title: "New Tab",
-                  url: proxy.body?.url,
-                },
-              },
-            };
-          }
-          if (proxy.path === "/act") {
-            return {
-              payload: {
-                result: {
-                  ok: true,
-                  targetId: "login-tab",
-                  result: {
-                    manualAction: {
-                      reason: "google-login-required",
-                      message:
-                        "Sign in to Google in the OpenClaw browser profile, then retry meeting creation.",
-                    },
-                    browserUrl: "https://accounts.google.com/signin",
-                    browserTitle: "Sign in - Google Accounts",
-                    notes: ["Sign-in page detected."],
-                  },
-                },
-              },
-            };
-          }
-          throw new Error(`unexpected browser proxy path ${proxy.path}`);
-        },
+        nodesInvokeHandler: createBrowserProxyHandler({
+          openedTargetId: "login-tab",
+          openedTitle: "New Tab",
+          act: () => ({
+            manualAction: {
+              reason: "google-login-required",
+              message:
+                "Sign in to Google in the OpenClaw browser profile, then retry meeting creation.",
+            },
+            browserUrl: "https://accounts.google.com/signin",
+            browserTitle: "Sign in - Google Accounts",
+            notes: ["Sign-in page detected."],
+          }),
+        }),
       },
     );
     const handler = methods.get("googlemeet.create") as
@@ -474,64 +490,20 @@ describe("google-meet create flow", () => {
         chromeNode: { node: "parallels-macos" },
       },
       {
-        nodesInvokeHandler: async (params) => {
-          if (params.command === "googlemeet.chrome") {
-            return { payload: { launched: true } };
-          }
-          const proxy = params.params as {
-            path?: string;
-            body?: { url?: string; targetId?: string; fn?: string };
-          };
-          if (proxy.path === "/tabs") {
-            return { payload: { result: { tabs: [] } } };
-          }
-          if (proxy.path === "/tabs/open") {
-            return {
-              payload: {
-                result: {
-                  targetId:
-                    proxy.body?.url === "https://meet.google.com/new?hl=en"
-                      ? "create-tab"
-                      : "join-tab",
-                  title: "Meet",
-                  url: proxy.body?.url,
-                },
-              },
-            };
-          }
-          if (proxy.path === "/act" && proxy.body?.fn?.includes("meetUrlPattern")) {
-            return {
-              payload: {
-                result: {
-                  ok: true,
-                  targetId: "create-tab",
-                  result: {
-                    meetingUri: "https://meet.google.com/new-abcd-xyz",
-                    browserUrl: "https://meet.google.com/new-abcd-xyz",
-                    browserTitle: "Meet",
-                  },
-                },
-              },
-            };
-          }
-          if (proxy.path === "/act") {
-            return {
-              payload: {
-                result: {
-                  ok: true,
-                  targetId: "join-tab",
-                  result: JSON.stringify({
-                    inCall: true,
-                    micMuted: false,
-                    title: "Meet call",
-                    url: "https://meet.google.com/new-abcd-xyz",
-                  }),
-                },
-              },
-            };
-          }
-          return { payload: { result: { ok: true } } };
-        },
+        nodesInvokeHandler: createBrowserProxyHandler({
+          handleChromeStart: true,
+          openedTargetId: (url) =>
+            url === "https://meet.google.com/new?hl=en" ? "create-tab" : "join-tab",
+          act: (body) =>
+            body.fn?.includes("meetUrlPattern")
+              ? browserCreateResult("https://meet.google.com/new-abcd-xyz")
+              : JSON.stringify({
+                  inCall: true,
+                  micMuted: false,
+                  title: "Meet call",
+                  url: "https://meet.google.com/new-abcd-xyz",
+                }),
+        }),
       },
     );
     const tool = tools[0] as {
@@ -574,43 +546,18 @@ describe("google-meet create flow", () => {
         chromeNode: { node: "parallels-macos" },
       },
       {
-        nodesInvokeHandler: async (params) => {
-          const proxy = params.params as { path?: string; body?: { url?: string } };
-          if (proxy.path === "/tabs") {
-            return { payload: { result: { tabs: [] } } };
-          }
-          if (proxy.path === "/tabs/open") {
-            return {
-              payload: {
-                result: {
-                  targetId: "permission-tab",
-                  title: "Meet",
-                  url: proxy.body?.url,
-                },
-              },
-            };
-          }
-          if (proxy.path === "/act") {
-            return {
-              payload: {
-                result: {
-                  ok: true,
-                  targetId: "permission-tab",
-                  result: {
-                    manualAction: {
-                      reason: "meet-permission-required",
-                      message:
-                        "Allow microphone/camera permissions for Meet in the OpenClaw browser profile, then retry meeting creation.",
-                    },
-                    browserUrl: "https://meet.google.com/new",
-                    browserTitle: "Meet",
-                  },
-                },
-              },
-            };
-          }
-          throw new Error(`unexpected browser proxy path ${proxy.path}`);
-        },
+        nodesInvokeHandler: createBrowserProxyHandler({
+          openedTargetId: "permission-tab",
+          act: () => ({
+            manualAction: {
+              reason: "meet-permission-required",
+              message:
+                "Allow microphone/camera permissions for Meet in the OpenClaw browser profile, then retry meeting creation.",
+            },
+            browserUrl: "https://meet.google.com/new",
+            browserTitle: "Meet",
+          }),
+        }),
       },
     );
     const tool = tools[0] as {
@@ -639,53 +586,20 @@ describe("google-meet create flow", () => {
         chromeNode: { node: "parallels-macos" },
       },
       {
-        nodesInvokeHandler: async (params) => {
-          const proxy = params.params as { path?: string; body?: { targetId?: string } };
-          if (proxy.path === "/tabs") {
-            return {
-              payload: {
-                result: {
-                  tabs: [
-                    {
-                      targetId: "existing-create-tab",
-                      title: "Meet",
-                      url: "https://meet.google.com/new",
-                    },
-                  ],
-                },
-              },
-            };
-          }
-          if (proxy.path === "/tabs/focus") {
-            return { payload: { result: { ok: true } } };
-          }
-          if (proxy.path === "/navigate") {
-            return {
-              payload: {
-                result: {
-                  targetId: "navigated-create-tab",
-                  url: "https://meet.google.com/new?hl=en",
-                },
-              },
-            };
-          }
-          if (proxy.path === "/act") {
-            return {
-              payload: {
-                result: {
-                  ok: true,
-                  targetId: proxy.body?.targetId ?? "existing-create-tab",
-                  result: {
-                    meetingUri: "https://meet.google.com/reu-sedx-tab",
-                    browserUrl: "https://meet.google.com/reu-sedx-tab",
-                    browserTitle: "Meet",
-                  },
-                },
-              },
-            };
-          }
-          throw new Error(`unexpected browser proxy path ${proxy.path}`);
-        },
+        nodesInvokeHandler: createBrowserProxyHandler({
+          tabs: [
+            {
+              targetId: "existing-create-tab",
+              title: "Meet",
+              url: "https://meet.google.com/new",
+            },
+          ],
+          navigateTo: {
+            targetId: "navigated-create-tab",
+            url: "https://meet.google.com/new?hl=en",
+          },
+          act: () => browserCreateResult("https://meet.google.com/reu-sedx-tab"),
+        }),
       },
     );
     const handler = methods.get("googlemeet.create") as
@@ -704,54 +618,17 @@ describe("google-meet create flow", () => {
     const browser = requireRecord(payload.browser, "browser payload");
     expect(browser.nodeId).toBe("node-1");
     expect(browser.targetId).toBe("navigated-create-tab");
-    findNodeInvokeParams(nodesInvoke, "focus existing tab", (params) => {
-      if (!params.params || typeof params.params !== "object") {
-        return false;
-      }
-      const proxy = params.params as Record<string, unknown>;
-      if (!proxy.body || typeof proxy.body !== "object") {
-        return false;
-      }
-      const body = proxy.body as Record<string, unknown>;
-      return proxy.path === "/tabs/focus" && body.targetId === "existing-create-tab";
+    findBrowserProxyCall(nodesInvoke, "focus existing tab", "/tabs/focus", {
+      targetId: "existing-create-tab",
     });
-    findNodeInvokeParams(nodesInvoke, "navigate reused tab to English UI", (params) => {
-      if (!params.params || typeof params.params !== "object") {
-        return false;
-      }
-      const proxy = params.params as Record<string, unknown>;
-      if (!proxy.body || typeof proxy.body !== "object") {
-        return false;
-      }
-      const body = proxy.body as Record<string, unknown>;
-      return (
-        proxy.path === "/navigate" &&
-        body.targetId === "existing-create-tab" &&
-        body.url === "https://meet.google.com/new?hl=en"
-      );
+    findBrowserProxyCall(nodesInvoke, "navigate reused tab to English UI", "/navigate", {
+      targetId: "existing-create-tab",
+      url: "https://meet.google.com/new?hl=en",
     });
-    findNodeInvokeParams(nodesInvoke, "act uses navigated target id", (params) => {
-      if (!params.params || typeof params.params !== "object") {
-        return false;
-      }
-      const proxy = params.params as Record<string, unknown>;
-      if (!proxy.body || typeof proxy.body !== "object") {
-        return false;
-      }
-      const body = proxy.body as Record<string, unknown>;
-      return proxy.path === "/act" && body.targetId === "navigated-create-tab";
+    findBrowserProxyCall(nodesInvoke, "act uses navigated target id", "/act", {
+      targetId: "navigated-create-tab",
     });
-    const openedCreateTab = mockCalls(nodesInvoke, "nodes invoke").some(([value]) => {
-      if (!value || typeof value !== "object") {
-        return false;
-      }
-      const params = value as Record<string, unknown>;
-      if (!params.params || typeof params.params !== "object") {
-        return false;
-      }
-      const proxy = params.params as Record<string, unknown>;
-      return proxy.path === "/tabs/open";
-    });
+    const openedCreateTab = hasBrowserProxyCall(nodesInvoke, "/tabs/open");
     expect(openedCreateTab).toBe(false);
   });
 
@@ -762,43 +639,16 @@ describe("google-meet create flow", () => {
         chromeNode: { node: "parallels-macos" },
       },
       {
-        nodesInvokeHandler: async (params) => {
-          const proxy = params.params as { path?: string; body?: { targetId?: string } };
-          if (proxy.path === "/tabs") {
-            return {
-              payload: {
-                result: {
-                  tabs: [
-                    {
-                      targetId: "english-create-tab",
-                      title: "Meet",
-                      url: "https://meet.google.com/new?hl=en",
-                    },
-                  ],
-                },
-              },
-            };
-          }
-          if (proxy.path === "/tabs/focus") {
-            return { payload: { result: { ok: true } } };
-          }
-          if (proxy.path === "/act") {
-            return {
-              payload: {
-                result: {
-                  ok: true,
-                  targetId: proxy.body?.targetId ?? "english-create-tab",
-                  result: {
-                    meetingUri: "https://meet.google.com/eng-lish-tab",
-                    browserUrl: "https://meet.google.com/eng-lish-tab",
-                    browserTitle: "Meet",
-                  },
-                },
-              },
-            };
-          }
-          throw new Error(`unexpected browser proxy path ${proxy.path}`);
-        },
+        nodesInvokeHandler: createBrowserProxyHandler({
+          tabs: [
+            {
+              targetId: "english-create-tab",
+              title: "Meet",
+              url: "https://meet.google.com/new?hl=en",
+            },
+          ],
+          act: () => browserCreateResult("https://meet.google.com/eng-lish-tab"),
+        }),
       },
     );
     const handler = methods.get("googlemeet.create") as
@@ -811,17 +661,7 @@ describe("google-meet create flow", () => {
 
     await handler?.({ params: { join: false }, respond });
 
-    const navigated = mockCalls(nodesInvoke, "nodes invoke").some(([value]) => {
-      if (!value || typeof value !== "object") {
-        return false;
-      }
-      const params = value as Record<string, unknown>;
-      if (!params.params || typeof params.params !== "object") {
-        return false;
-      }
-      const proxy = params.params as Record<string, unknown>;
-      return proxy.path === "/navigate";
-    });
+    const navigated = hasBrowserProxyCall(nodesInvoke, "/navigate");
     expect(navigated).toBe(false);
   });
 

--- a/extensions/google-meet/node-host.test.ts
+++ b/extensions/google-meet/node-host.test.ts
@@ -1,7 +1,7 @@
 // Google Meet tests cover node host plugin behavior.
 import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type MockChild = EventEmitter & {
   exitCode: number | null;
@@ -15,6 +15,25 @@ type MockChild = EventEmitter & {
 
 const children: MockChild[] = [];
 let handleGoogleMeetNodeHostCommand: typeof import("./src/node-host.js").handleGoogleMeetNodeHostCommand;
+let originalPlatform: NodeJS.Platform;
+
+const MEET_URL = "https://meet.google.com/xyz-abcd-uvw";
+const REALTIME_START = {
+  action: "start",
+  url: MEET_URL,
+  mode: "realtime",
+  launch: false,
+  audioInputCommand: ["mock-rec"],
+  audioOutputCommand: ["mock-play"],
+};
+
+async function invokeNodeHost(params: Record<string, unknown>) {
+  return await handleGoogleMeetNodeHostCommand(JSON.stringify(params));
+}
+
+async function invokeNodeHostJson(params: Record<string, unknown>) {
+  return JSON.parse(await invokeNodeHost(params));
+}
 
 vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
@@ -62,7 +81,14 @@ describe("google-meet node host bridge sessions", () => {
     ({ handleGoogleMeetNodeHostCommand } = await import("./src/node-host.js"));
   });
 
+  beforeEach(() => {
+    originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    vi.mocked(spawnSync).mockClear();
+  });
+
   afterEach(() => {
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
     vi.useRealTimers();
     children.length = 0;
   });
@@ -79,97 +105,43 @@ describe("google-meet node host bridge sessions", () => {
   });
 
   it("rejects non-Meet start URLs before local Chrome side effects", async () => {
-    const originalPlatform = process.platform;
-    children.length = 0;
-    vi.mocked(spawnSync).mockClear();
+    await expect(
+      invokeNodeHost({
+        ...REALTIME_START,
+        url: "https://example.com/private-call",
+        launch: true,
+      }),
+    ).rejects.toThrow("url must be an explicit https://meet.google.com/... URL");
 
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      await expect(
-        handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "start",
-            url: "https://example.com/private-call",
-            mode: "realtime",
-            launch: true,
-            audioInputCommand: ["mock-rec"],
-            audioOutputCommand: ["mock-play"],
-          }),
-        ),
-      ).rejects.toThrow("url must be an explicit https://meet.google.com/... URL");
-
-      expect(spawnSync).not.toHaveBeenCalled();
-      expect(children).toHaveLength(0);
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
-    }
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(children).toHaveLength(0);
   });
 
   it("starts observe-only Chrome without BlackHole or bridge processes", async () => {
-    const originalPlatform = process.platform;
-    children.length = 0;
-    vi.mocked(spawnSync).mockClear();
+    const start = await invokeNodeHostJson({ ...REALTIME_START, mode: "transcribe" });
 
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      const start = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "start",
-            url: "https://meet.google.com/xyz-abcd-uvw",
-            mode: "transcribe",
-            launch: false,
-            audioInputCommand: ["mock-rec"],
-            audioOutputCommand: ["mock-play"],
-          }),
-        ),
-      );
-
-      expect(start).toEqual({ launched: false });
-      expect(spawnSync).not.toHaveBeenCalled();
-      expect(children).toHaveLength(0);
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
-    }
+    expect(start).toEqual({ launched: false });
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(children).toHaveLength(0);
   });
 
   it("passes the Meet URL before Chrome profile args when launching a profiled browser", async () => {
-    const originalPlatform = process.platform;
-    children.length = 0;
-    vi.mocked(spawnSync).mockClear();
+    const start = await invokeNodeHostJson({
+      action: "start",
+      url: MEET_URL,
+      mode: "transcribe",
+      browserProfile: "Profile 2",
+    });
 
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      const start = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "start",
-            url: "https://meet.google.com/xyz-abcd-uvw",
-            mode: "transcribe",
-            browserProfile: "Profile 2",
-          }),
-        ),
-      );
-
-      expect(start.launched).toBe(true);
-      expect(spawnSync).toHaveBeenCalledWith(
-        "open",
-        [
-          "-a",
-          "Google Chrome",
-          "https://meet.google.com/xyz-abcd-uvw",
-          "--args",
-          "--profile-directory=Profile 2",
-        ],
-        expect.objectContaining({ encoding: "utf8" }),
-      );
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
-    }
+    expect(start.launched).toBe(true);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "open",
+      ["-a", "Google Chrome", MEET_URL, "--args", "--profile-directory=Profile 2"],
+      expect.objectContaining({ encoding: "utf8" }),
+    );
   });
 
   it("rejects Chrome launch when the command exits by signal", async () => {
-    const originalPlatform = process.platform;
     vi.mocked(spawnSync).mockImplementationOnce(() => ({
       pid: 123,
       output: [null, "", ""],
@@ -179,24 +151,12 @@ describe("google-meet node host bridge sessions", () => {
       signal: "SIGTERM",
     }));
 
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      await expect(
-        handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "start",
-            url: "https://meet.google.com/xyz-abcd-uvw",
-            mode: "transcribe",
-          }),
-        ),
-      ).rejects.toThrow("failed to launch Chrome for Meet: terminated by SIGTERM");
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
-    }
+    await expect(
+      invokeNodeHost({ action: "start", url: MEET_URL, mode: "transcribe" }),
+    ).rejects.toThrow("failed to launch Chrome for Meet: terminated by SIGTERM");
   });
 
   it("preserves timeout diagnostics when Chrome launch stderr is empty", async () => {
-    const originalPlatform = process.platform;
     const error = Object.assign(new Error("spawnSync open ETIMEDOUT"), { code: "ETIMEDOUT" });
     vi.mocked(spawnSync).mockImplementationOnce(() => ({
       pid: 123,
@@ -208,24 +168,12 @@ describe("google-meet node host bridge sessions", () => {
       error,
     }));
 
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      await expect(
-        handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "start",
-            url: "https://meet.google.com/xyz-abcd-uvw",
-            mode: "transcribe",
-          }),
-        ),
-      ).rejects.toThrow("failed to launch Chrome for Meet: spawnSync open ETIMEDOUT");
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
-    }
+    await expect(
+      invokeNodeHost({ action: "start", url: MEET_URL, mode: "transcribe" }),
+    ).rejects.toThrow("failed to launch Chrome for Meet: spawnSync open ETIMEDOUT");
   });
 
   it("preserves timeout diagnostics when Chrome launch also writes stderr", async () => {
-    const originalPlatform = process.platform;
     const error = Object.assign(new Error("spawnSync open ETIMEDOUT"), { code: "ETIMEDOUT" });
     vi.mocked(spawnSync).mockImplementationOnce(() => ({
       pid: 123,
@@ -237,374 +185,195 @@ describe("google-meet node host bridge sessions", () => {
       error,
     }));
 
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      await expect(
-        handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "start",
-            url: "https://meet.google.com/xyz-abcd-uvw",
-            mode: "transcribe",
-          }),
-        ),
-      ).rejects.toThrow(
-        "failed to launch Chrome for Meet: spawnSync open ETIMEDOUT: child warning",
-      );
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
-    }
+    await expect(
+      invokeNodeHost({ action: "start", url: MEET_URL, mode: "transcribe" }),
+    ).rejects.toThrow("failed to launch Chrome for Meet: spawnSync open ETIMEDOUT: child warning");
   });
 
   it("clears output playback without closing the active bridge when the old output exits", async () => {
-    const originalPlatform = process.platform;
-    children.length = 0;
+    const start = await invokeNodeHostJson(REALTIME_START);
 
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      const start = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "start",
-            url: "https://meet.google.com/xyz-abcd-uvw",
-            mode: "realtime",
-            launch: false,
-            audioInputCommand: ["mock-rec"],
-            audioOutputCommand: ["mock-play"],
-          }),
-        ),
-      );
+    expect(children).toHaveLength(2);
+    const firstOutput = children[0];
 
-      expect(children).toHaveLength(2);
-      const firstOutput = children[0];
+    const cleared = await invokeNodeHostJson({ action: "clearAudio", bridgeId: start.bridgeId });
 
-      const cleared = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "clearAudio",
-            bridgeId: start.bridgeId,
-          }),
-        ),
-      );
+    expect(cleared).toEqual({ bridgeId: start.bridgeId, ok: true, clearCount: 1 });
+    expect(children).toHaveLength(3);
+    expect(firstOutput?.kill).toHaveBeenCalledWith("SIGTERM");
 
-      expect(cleared).toEqual({ bridgeId: start.bridgeId, ok: true, clearCount: 1 });
-      expect(children).toHaveLength(3);
-      expect(firstOutput?.kill).toHaveBeenCalledWith("SIGTERM");
+    firstOutput?.emit("error", new Error("stale output failed after clear"));
+    firstOutput?.emit("exit", 0, "SIGTERM");
 
-      firstOutput?.emit("error", new Error("stale output failed after clear"));
-      firstOutput?.emit("exit", 0, "SIGTERM");
+    const status = await invokeNodeHostJson({ action: "status", bridgeId: start.bridgeId });
 
-      const status = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "status",
-            bridgeId: start.bridgeId,
-          }),
-        ),
-      );
+    expect(status.bridge.bridgeId).toBe(start.bridgeId);
+    expect(status.bridge.closed).toBe(false);
+    expect(status.bridge.clearCount).toBe(1);
+    expect(typeof status.bridge.createdAt).toBe("string");
 
-      expect(status.bridge.bridgeId).toBe(start.bridgeId);
-      expect(status.bridge.closed).toBe(false);
-      expect(status.bridge.clearCount).toBe(1);
-      expect(typeof status.bridge.createdAt).toBe("string");
+    const audio = Buffer.from([1, 2, 3]);
+    await invokeNodeHost({
+      action: "pushAudio",
+      bridgeId: start.bridgeId,
+      base64: audio.toString("base64"),
+    });
 
-      const audio = Buffer.from([1, 2, 3]);
-      await handleGoogleMeetNodeHostCommand(
-        JSON.stringify({
-          action: "pushAudio",
-          bridgeId: start.bridgeId,
-          base64: audio.toString("base64"),
-        }),
-      );
+    expect(children[2]?.stdin?.write).toHaveBeenCalledWith(audio, expect.any(Function));
+    expect(firstOutput?.stdin?.write).not.toHaveBeenCalled();
 
-      expect(children[2]?.stdin?.write).toHaveBeenCalledWith(audio, expect.any(Function));
-      expect(firstOutput?.stdin?.write).not.toHaveBeenCalled();
+    await expect(
+      invokeNodeHost({ action: "pushAudio", bridgeId: start.bridgeId, base64: "not-base64!" }),
+    ).rejects.toThrow("pushAudio base64 must be a valid audio payload");
+    expect(children[2]?.stdin?.write).toHaveBeenCalledTimes(1);
 
-      await expect(
-        handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "pushAudio",
-            bridgeId: start.bridgeId,
-            base64: "not-base64!",
-          }),
-        ),
-      ).rejects.toThrow("pushAudio base64 must be a valid audio payload");
-      expect(children[2]?.stdin?.write).toHaveBeenCalledTimes(1);
-
-      await handleGoogleMeetNodeHostCommand(
-        JSON.stringify({
-          action: "stop",
-          bridgeId: start.bridgeId,
-        }),
-      );
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
-    }
+    await invokeNodeHost({ action: "stop", bridgeId: start.bridgeId });
   });
 
   it("waits for cleared SIGTERM-resistant output before acknowledging stop", async () => {
-    const originalPlatform = process.platform;
-    children.length = 0;
     vi.useFakeTimers();
 
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      const start = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "start",
-            url: "https://meet.google.com/xyz-abcd-uvw",
-            mode: "realtime",
-            launch: false,
-            audioInputCommand: ["mock-rec"],
-            audioOutputCommand: ["mock-play"],
-          }),
-        ),
-      );
-      const [retiredOutput] = children;
-      if (!retiredOutput) {
-        throw new Error("expected Google Meet node host output process");
-      }
-      retiredOutput.ignoreSigterm = true;
-
-      await handleGoogleMeetNodeHostCommand(
-        JSON.stringify({ action: "clearAudio", bridgeId: start.bridgeId }),
-      );
-      let settled = false;
-      const stopPromise = handleGoogleMeetNodeHostCommand(
-        JSON.stringify({ action: "stop", bridgeId: start.bridgeId }),
-      ).finally(() => {
-        settled = true;
-      });
-
-      await vi.advanceTimersByTimeAsync(1_999);
-      expect(settled).toBe(false);
-      expect(retiredOutput.kill.mock.calls).toEqual([["SIGTERM"]]);
-
-      await vi.advanceTimersByTimeAsync(1);
-      await stopPromise;
-      expect(retiredOutput.signalCode).toBe("SIGKILL");
-      expect(retiredOutput.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    const start = await invokeNodeHostJson(REALTIME_START);
+    const [retiredOutput] = children;
+    if (!retiredOutput) {
+      throw new Error("expected Google Meet node host output process");
     }
+    retiredOutput.ignoreSigterm = true;
+
+    await invokeNodeHost({ action: "clearAudio", bridgeId: start.bridgeId });
+    let settled = false;
+    const stopPromise = invokeNodeHost({ action: "stop", bridgeId: start.bridgeId }).finally(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(settled).toBe(false);
+    expect(retiredOutput.kill.mock.calls).toEqual([["SIGTERM"]]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await stopPromise;
+    expect(retiredOutput.signalCode).toBe("SIGKILL");
+    expect(retiredOutput.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
   });
 
   it("closes once when command-pair streams fail together", async () => {
-    const originalPlatform = process.platform;
-    children.length = 0;
-
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      const start = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "start",
-            url: "https://meet.google.com/xyz-abcd-uvw",
-            mode: "realtime",
-            launch: false,
-            audioInputCommand: ["mock-rec"],
-            audioOutputCommand: ["mock-play"],
-          }),
-        ),
-      );
-      const [outputProcess, inputProcess] = children;
-      if (!outputProcess || !inputProcess) {
-        throw new Error("expected Google Meet node host command-pair processes");
-      }
-
-      outputProcess.stderr?.emit("error", new Error("output stderr failed"));
-      inputProcess.stdout?.emit("error", new Error("input stdout failed"));
-      inputProcess.stderr?.emit("error", new Error("input stderr failed"));
-
-      const status = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({ action: "status", bridgeId: start.bridgeId }),
-        ),
-      );
-      expect(status.bridge.closed).toBe(true);
-      expect(outputProcess.kill).toHaveBeenCalledTimes(1);
-      expect(inputProcess.kill).toHaveBeenCalledTimes(1);
-      expect(outputProcess.kill).toHaveBeenCalledWith("SIGTERM");
-      expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    const start = await invokeNodeHostJson(REALTIME_START);
+    const [outputProcess, inputProcess] = children;
+    if (!outputProcess || !inputProcess) {
+      throw new Error("expected Google Meet node host command-pair processes");
     }
+
+    outputProcess.stderr?.emit("error", new Error("output stderr failed"));
+    inputProcess.stdout?.emit("error", new Error("input stdout failed"));
+    inputProcess.stderr?.emit("error", new Error("input stderr failed"));
+
+    const status = await invokeNodeHostJson({ action: "status", bridgeId: start.bridgeId });
+    expect(status.bridge.closed).toBe(true);
+    expect(outputProcess.kill).toHaveBeenCalledTimes(1);
+    expect(inputProcess.kill).toHaveBeenCalledTimes(1);
+    expect(outputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
   it("waits for SIGTERM-resistant command-pair processes before acknowledging stop", async () => {
-    const originalPlatform = process.platform;
-    children.length = 0;
     vi.useFakeTimers();
 
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      const start = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "start",
-            url: "https://meet.google.com/xyz-abcd-uvw",
-            mode: "realtime",
-            launch: false,
-            audioInputCommand: ["mock-rec"],
-            audioOutputCommand: ["mock-play"],
-          }),
-        ),
-      );
-      const [outputProcess, inputProcess] = children;
-      if (!outputProcess || !inputProcess) {
-        throw new Error("expected Google Meet node host command-pair processes");
-      }
-      outputProcess.ignoreSigterm = true;
-      inputProcess.ignoreSigterm = true;
-      let settled = false;
-      const stopPromise = handleGoogleMeetNodeHostCommand(
-        JSON.stringify({ action: "stop", bridgeId: start.bridgeId }),
-      ).finally(() => {
-        settled = true;
-      });
-
-      await vi.advanceTimersByTimeAsync(1_999);
-      expect(settled).toBe(false);
-      expect(outputProcess.kill).toHaveBeenCalledWith("SIGTERM");
-      expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
-
-      await vi.advanceTimersByTimeAsync(1);
-      await stopPromise;
-      expect(outputProcess.signalCode).toBe("SIGKILL");
-      expect(inputProcess.signalCode).toBe("SIGKILL");
-      expect(outputProcess.kill).toHaveBeenCalledWith("SIGKILL");
-      expect(inputProcess.kill).toHaveBeenCalledWith("SIGKILL");
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    const start = await invokeNodeHostJson(REALTIME_START);
+    const [outputProcess, inputProcess] = children;
+    if (!outputProcess || !inputProcess) {
+      throw new Error("expected Google Meet node host command-pair processes");
     }
+    outputProcess.ignoreSigterm = true;
+    inputProcess.ignoreSigterm = true;
+    let settled = false;
+    const stopPromise = invokeNodeHost({ action: "stop", bridgeId: start.bridgeId }).finally(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(settled).toBe(false);
+    expect(outputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+
+    await vi.advanceTimersByTimeAsync(1);
+    await stopPromise;
+    expect(outputProcess.signalCode).toBe("SIGKILL");
+    expect(inputProcess.signalCode).toBe("SIGKILL");
+    expect(outputProcess.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(inputProcess.kill).toHaveBeenCalledWith("SIGKILL");
   });
 
   it("shares SIGTERM-resistant cleanup across concurrent stopByUrl calls", async () => {
-    const originalPlatform = process.platform;
-    children.length = 0;
     vi.useFakeTimers();
 
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      await handleGoogleMeetNodeHostCommand(
-        JSON.stringify({
-          action: "start",
-          url: "https://meet.google.com/xyz-abcd-uvw",
-          mode: "realtime",
-          launch: false,
-          audioInputCommand: ["mock-rec"],
-          audioOutputCommand: ["mock-play"],
-        }),
-      );
-      const [outputProcess, inputProcess] = children;
-      if (!outputProcess || !inputProcess) {
-        throw new Error("expected Google Meet node host command-pair processes");
-      }
-      outputProcess.ignoreSigterm = true;
-      inputProcess.ignoreSigterm = true;
-      let firstSettled = false;
-      let secondSettled = false;
-      const stopParams = JSON.stringify({
-        action: "stopByUrl",
-        url: "https://meet.google.com/xyz-abcd-uvw",
-        mode: "realtime",
-      });
-      const firstStop = handleGoogleMeetNodeHostCommand(stopParams).finally(() => {
-        firstSettled = true;
-      });
-      const secondStop = handleGoogleMeetNodeHostCommand(stopParams).finally(() => {
-        secondSettled = true;
-      });
-
-      await vi.advanceTimersByTimeAsync(1_999);
-      expect(firstSettled).toBe(false);
-      expect(secondSettled).toBe(false);
-
-      await vi.advanceTimersByTimeAsync(1);
-      const [firstResult, secondResult] = await Promise.all([firstStop, secondStop]);
-      expect(JSON.parse(firstResult)).toEqual({ ok: true, stopped: 1 });
-      expect(JSON.parse(secondResult)).toEqual({ ok: true, stopped: 0 });
-      expect(outputProcess.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
-      expect(inputProcess.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    await invokeNodeHost(REALTIME_START);
+    const [outputProcess, inputProcess] = children;
+    if (!outputProcess || !inputProcess) {
+      throw new Error("expected Google Meet node host command-pair processes");
     }
+    outputProcess.ignoreSigterm = true;
+    inputProcess.ignoreSigterm = true;
+    let firstSettled = false;
+    let secondSettled = false;
+    const stopParams = { action: "stopByUrl", url: MEET_URL, mode: "realtime" };
+    const firstStop = invokeNodeHostJson(stopParams).finally(() => {
+      firstSettled = true;
+    });
+    const secondStop = invokeNodeHostJson(stopParams).finally(() => {
+      secondSettled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(firstSettled).toBe(false);
+    expect(secondSettled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const [firstResult, secondResult] = await Promise.all([firstStop, secondStop]);
+    expect(firstResult).toEqual({ ok: true, stopped: 1 });
+    expect(secondResult).toEqual({ ok: true, stopped: 0 });
+    expect(outputProcess.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
+    expect(inputProcess.kill.mock.calls).toEqual([["SIGTERM"], ["SIGKILL"]]);
   });
 
   it("lists active bridge sessions and hides closed sessions", async () => {
-    const originalPlatform = process.platform;
-    children.length = 0;
+    const listParams = {
+      action: "list",
+      url: "https://meet.google.com/abc-defg-hij",
+      mode: "realtime",
+    };
+    const start = await invokeNodeHostJson({
+      ...REALTIME_START,
+      url: "https://meet.google.com/abc-defg-hij?authuser=1",
+    });
 
-    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
-    try {
-      const start = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "start",
-            url: "https://meet.google.com/abc-defg-hij?authuser=1",
-            mode: "realtime",
-            launch: false,
-            audioInputCommand: ["mock-rec"],
-            audioOutputCommand: ["mock-play"],
-          }),
-        ),
-      );
+    expect(typeof start.bridgeId).toBe("string");
+    expect(start.bridgeId.length).toBeGreaterThan(0);
+    expect(start).toEqual({
+      audioBridge: { type: "node-command-pair", outputGeneration: true },
+      bridgeId: start.bridgeId,
+      launched: false,
+    });
 
-      expect(typeof start.bridgeId).toBe("string");
-      expect(start.bridgeId.length).toBeGreaterThan(0);
-      expect(start).toEqual({
-        audioBridge: { type: "node-command-pair", outputGeneration: true },
-        bridgeId: start.bridgeId,
-        launched: false,
-      });
+    const activeList = await invokeNodeHostJson(listParams);
 
-      const activeList = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "list",
-            url: "https://meet.google.com/abc-defg-hij",
-            mode: "realtime",
-          }),
-        ),
-      );
+    expect(activeList.bridges).toHaveLength(1);
+    expect(activeList.bridges[0]?.bridgeId).toBe(start.bridgeId);
+    expect(activeList.bridges[0]?.closed).toBe(false);
+    expect(activeList.bridges[0]?.mode).toBe("realtime");
+    expect(activeList.bridges[0]?.url).toBe("https://meet.google.com/abc-defg-hij?authuser=1");
+    expect(typeof activeList.bridges[0]?.createdAt).toBe("string");
 
-      expect(activeList.bridges).toHaveLength(1);
-      expect(activeList.bridges[0]?.bridgeId).toBe(start.bridgeId);
-      expect(activeList.bridges[0]?.closed).toBe(false);
-      expect(activeList.bridges[0]?.mode).toBe("realtime");
-      expect(activeList.bridges[0]?.url).toBe("https://meet.google.com/abc-defg-hij?authuser=1");
-      expect(typeof activeList.bridges[0]?.createdAt).toBe("string");
-
-      if (children[1]) {
-        children[1].exitCode = 0;
-        children[1].emit("exit", 0, null);
-      }
-
-      const afterExitList = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "list",
-            url: "https://meet.google.com/abc-defg-hij",
-            mode: "realtime",
-          }),
-        ),
-      );
-
-      expect(afterExitList).toEqual({ bridges: [] });
-
-      const stopped = JSON.parse(
-        await handleGoogleMeetNodeHostCommand(
-          JSON.stringify({
-            action: "stopByUrl",
-            url: "https://meet.google.com/abc-defg-hij",
-            mode: "realtime",
-          }),
-        ),
-      );
-
-      expect(stopped).toEqual({ ok: true, stopped: 0 });
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    if (children[1]) {
+      children[1].exitCode = 0;
+      children[1].emit("exit", 0, null);
     }
+
+    const afterExitList = await invokeNodeHostJson(listParams);
+
+    expect(afterExitList).toEqual({ bridges: [] });
+
+    const stopped = await invokeNodeHostJson({ ...listParams, action: "stopByUrl" });
+
+    expect(stopped).toEqual({ ok: true, stopped: 0 });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The Google Meet create-flow and node-host regression suites repeated large browser-proxy, node-command, platform, and process-lifecycle fixtures across neighboring cases. That duplication made equivalent scenarios harder to compare and easier to let drift as the production contracts evolved.

## Why This Change Was Made

Consolidate the repeated setup into file-local test helpers while keeping each scenario's URLs, proxy paths, process events, timeout behavior, response assertions, and cleanup expectations explicit. The change is test-only: production ownership, runtime behavior, configuration, dependencies, and public contracts are unchanged.

## User Impact

No user-visible behavior changes. The Google Meet regression coverage is smaller and easier to maintain while preserving the same create-flow and node-host behaviors.

## Evidence

- Exact rebased source: `cf0528fb4f064ce7e469ab15efb3637d8f71dc4c`.
- Blacksmith Testbox `tbx_01kz2sfkvwz5cb6myz4kjt4nsf`: both focused files passed, 23/23 tests. Run: https://github.com/openclaw/openclaw/actions/runs/30781017011
- Fresh autoreview against current `origin/main`: secret scan clean, no findings, patch correct with 0.99 confidence.
- `git diff --check` passed.
- Before/after static parity: identical ordered test-title hashes and matcher-kind hashes in both files (9 declaration lines/41 expectations for create; 13 declaration lines/57 expectations for node host).
- Rebase verification: current-main had not changed either target blob; final rebased blobs exactly match the original cleanup commit.
