### PR TITLE
fix: keep sandboxed gateway locks out of live state dirs (#118371)

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -403,10 +403,10 @@ export const DEFAULT_GATEWAY_PORT = 18789;
 
 /**
  * Gateway lock directory (ephemeral).
- * Default: os.tmpdir()/openclaw-<uid> (uid suffix when available).
+ * Default: <state-dir>/tmp/openclaw-<uid> (uid suffix when available).
  */
-export function resolveGatewayLockDir(tmpdir: () => string = os.tmpdir): string {
-  const base = tmpdir();
+export function resolveGatewayLockDir(env: NodeJS.ProcessEnv = process.env): string {
+  const base = path.join(resolveStateDir(env), "tmp");
   const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
   const suffix = uid != null ? `openclaw-${uid}` : "openclaw";
   return path.join(base, suffix);

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -401,15 +401,22 @@ export function resolveDefaultConfigCandidates(
 
 export const DEFAULT_GATEWAY_PORT = 18789;
 
+function resolveGatewayLockDirName(): string {
+  const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+  return uid != null ? `openclaw-${uid}` : "openclaw";
+}
+
+/** Lock directory used by releases before locks moved under the configured state directory. */
+export function resolveLegacyGatewayLockDir(tmpdir: () => string = os.tmpdir): string {
+  return path.join(tmpdir(), resolveGatewayLockDirName());
+}
+
 /**
  * Gateway lock directory (ephemeral).
  * Default: <state-dir>/tmp/openclaw-<uid> (uid suffix when available).
  */
 export function resolveGatewayLockDir(env: NodeJS.ProcessEnv = process.env): string {
-  const base = path.join(resolveStateDir(env), "tmp");
-  const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
-  const suffix = uid != null ? `openclaw-${uid}` : "openclaw";
-  return path.join(base, suffix);
+  return path.join(resolveStateDir(env), "tmp", resolveGatewayLockDirName());
 }
 
 /**

--- a/src/infra/device-identity-coordinator.ts
+++ b/src/infra/device-identity-coordinator.ts
@@ -57,7 +57,7 @@ function ensurePrivateCoordinatorDirectory(lockDir: string): void {
       throw error;
     }
     try {
-      fs.mkdirSync(lockDir, { mode: 0o700 });
+      fs.mkdirSync(lockDir, { recursive: true, mode: 0o700 });
     } catch (mkdirError) {
       if ((mkdirError as NodeJS.ErrnoException).code !== "EEXIST") {
         throw mkdirError;
@@ -90,9 +90,13 @@ function ensurePrivateCoordinatorDirectory(lockDir: string): void {
 export function acquireDeviceIdentityCoordinator(params: {
   databasePath: string;
   busyTimeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
   lockDir?: string;
 }): { release: () => void } {
-  const coordinatorPath = resolveDeviceIdentityCoordinatorPath(params.databasePath, params.lockDir);
+  const coordinatorPath = resolveDeviceIdentityCoordinatorPath(
+    params.databasePath,
+    params.lockDir ?? resolveGatewayLockDir(params.env),
+  );
   ensurePrivateCoordinatorDirectory(path.dirname(coordinatorPath));
   const database = openNodeSqliteDatabase(coordinatorPath);
   try {

--- a/src/infra/device-identity.state-dir.test.ts
+++ b/src/infra/device-identity.state-dir.test.ts
@@ -31,12 +31,25 @@ describe("device identity state dir defaults", () => {
     });
   });
 
+  it("keeps the identity coordinator under the overridden state directory", async () => {
+    await withStateDirEnv("openclaw-identity-state-", async ({ stateDir }) => {
+      loadOrCreateDeviceIdentity();
+
+      const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+      const lockDir = path.join(stateDir, "tmp", uid != null ? `openclaw-${uid}` : "openclaw");
+      expect(fs.readdirSync(lockDir)).toContainEqual(
+        expect.stringMatching(/^device-identity\..+\.lock\.sqlite$/u),
+      );
+    });
+  });
+
   it("keeps read-only lookup non-creating when the default database is absent", async () => {
     await withStateDirEnv("openclaw-identity-state-", async ({ stateDir }) => {
       const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
 
       expect(loadDeviceIdentityIfPresent()).toBeNull();
       expect(fs.existsSync(databasePath)).toBe(false);
+      expect(fs.existsSync(path.join(stateDir, "tmp"))).toBe(false);
     });
   });
 });

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -55,6 +55,18 @@ function pathMayExist(filePath: string): boolean {
   }
 }
 
+function isMissingPath(filePath: string): boolean {
+  try {
+    fs.lstatSync(filePath);
+    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return true;
+    }
+    throw error;
+  }
+}
+
 function resolveLegacyStateDir(options: DeviceIdentityStoreOptions): string {
   if (options.env?.OPENCLAW_STATE_DIR?.trim()) {
     return resolveStateDir(options.env);
@@ -100,7 +112,10 @@ function withDeviceIdentityCoordinator<T>(
     path: resolved.databasePath,
     identityKey: resolved.identityKey,
   };
-  const coordinator = acquireDeviceIdentityCoordinator({ databasePath: resolved.databasePath });
+  const coordinator = acquireDeviceIdentityCoordinator({
+    databasePath: resolved.databasePath,
+    env: options.env,
+  });
   let result: T;
   try {
     result = operation(resolved, resolvedOptions);
@@ -168,6 +183,10 @@ export function loadOrCreateProcessDeviceIdentity(
 export function loadDeviceIdentityIfPresent(
   options: DeviceIdentityStoreOptions = {},
 ): DeviceIdentity | null {
+  assertNoPendingLegacyIdentity(options);
+  if (isMissingPath(resolveDeviceIdentityStore(options).databasePath)) {
+    return null;
+  }
   return withDeviceIdentityCoordinator(options, (_resolved, resolvedOptions) => {
     assertNoPendingLegacyIdentity(resolvedOptions);
     const stored = readStoredDeviceIdentityReadOnly(resolvedOptions);

--- a/src/infra/gateway-lock.state-dir.test.ts
+++ b/src/infra/gateway-lock.state-dir.test.ts
@@ -1,0 +1,83 @@
+// Covers state-scoped Gateway lock roots and the one-way legacy transition.
+import { createHash } from "node:crypto";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveConfigPath, resolveGatewayLockDir, resolveStateDir } from "../config/paths.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
+
+function stateLockPath(lockDir: string, stateDir: string): string {
+  const canonicalStateDir = fsSync.realpathSync.native(path.resolve(stateDir));
+  const stateHash = createHash("sha256").update(canonicalStateDir).digest("hex").slice(0, 8);
+  return path.join(lockDir, `gateway.state.${stateHash}.lock`);
+}
+
+describe("Gateway lock state directory", () => {
+  it("keeps default locks inside an overridden state directory", async () => {
+    await withStateDirEnv("openclaw-gateway-lock-state-", async ({ stateDir }) => {
+      const configPath = path.join(stateDir, "openclaw.json");
+      await fs.writeFile(configPath, "{}\n");
+      const env = {
+        ...process.env,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+      };
+      const lock = await acquireGatewayLock({ allowInTests: true, env, timeoutMs: 30 });
+      if (!lock) {
+        throw new Error("Expected Gateway lock");
+      }
+
+      try {
+        const expectedLockDir = resolveGatewayLockDir(env);
+        expect(path.dirname(lock.lockPath)).toBe(expectedLockDir);
+        expect(path.dirname(lock.stateLockPath)).toBe(expectedLockDir);
+      } finally {
+        await lock.release();
+      }
+    });
+  });
+
+  it("does not bypass an active legacy lock during an in-place upgrade", async () => {
+    await withStateDirEnv("openclaw-gateway-lock-transition-", async ({ stateDir }) => {
+      const configPath = path.join(stateDir, "openclaw.json");
+      const legacyLockDir = path.join(stateDir, "legacy-temp");
+      await fs.writeFile(configPath, "{}\n");
+      await fs.mkdir(legacyLockDir, { recursive: true });
+      const env = {
+        ...process.env,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+      };
+      const legacyStateLockPath = stateLockPath(legacyLockDir, stateDir);
+      await fs.writeFile(
+        legacyStateLockPath,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+          configPath: resolveConfigPath(env, stateDir),
+          startTime: 123,
+          stateDir,
+        }),
+      );
+
+      await expect(
+        acquireGatewayLock({
+          allowInTests: true,
+          env,
+          legacyLockDir,
+          platform: "darwin",
+          readProcessCmdline: () => ["openclaw-gateway"],
+          readProcessStartTime: () => 123,
+          timeoutMs: 30,
+        }),
+      ).rejects.toBeInstanceOf(GatewayLockError);
+      await expect(
+        fs.access(stateLockPath(resolveGatewayLockDir(env), stateDir)),
+      ).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+});

--- a/src/infra/gateway-lock.state-dir.test.ts
+++ b/src/infra/gateway-lock.state-dir.test.ts
@@ -6,7 +6,11 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveConfigPath, resolveGatewayLockDir } from "../config/paths.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
-import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
+import {
+  acquireGatewayLock,
+  GatewayLockError,
+  readActiveGatewayLockIdentity,
+} from "./gateway-lock.js";
 
 function stateLockPath(lockDir: string, stateDir: string): string {
   const canonicalStateDir = fsSync.realpathSync.native(path.resolve(stateDir));
@@ -33,6 +37,99 @@ describe("Gateway lock state directory", () => {
         const expectedLockDir = resolveGatewayLockDir(env);
         expect(path.dirname(lock.lockPath)).toBe(expectedLockDir);
         expect(path.dirname(lock.stateLockPath)).toBe(expectedLockDir);
+      } finally {
+        await lock.release();
+      }
+    });
+  });
+
+  it("discovers an active legacy state lock during an in-place upgrade", async () => {
+    await withStateDirEnv("openclaw-gateway-lock-reader-", async ({ stateDir }) => {
+      const configPath = path.join(stateDir, "openclaw.json");
+      const legacyLockDir = path.join(stateDir, "legacy-temp");
+      const expectedPort = 48123;
+      await fs.writeFile(configPath, "{}\n");
+      await fs.mkdir(legacyLockDir, { recursive: true });
+      const env = {
+        ...process.env,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+      };
+      await fs.writeFile(
+        stateLockPath(legacyLockDir, stateDir),
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+          configPath: resolveConfigPath(env, stateDir),
+          port: expectedPort,
+          role: "gateway",
+          stateDir,
+        }),
+      );
+
+      await expect(
+        readActiveGatewayLockIdentity({
+          env,
+          legacyLockDir,
+          platform: "darwin",
+          readProcessCmdline: () => ["openclaw-gateway"],
+        }),
+      ).resolves.toMatchObject({
+        pid: process.pid,
+        port: expectedPort,
+      });
+    });
+  });
+
+  it("prefers a state-local lock over a legacy state lock during an upgrade", async () => {
+    await withStateDirEnv("openclaw-gateway-lock-reader-precedence-", async ({ stateDir }) => {
+      const configPath = path.join(stateDir, "openclaw.json");
+      const legacyLockDir = path.join(stateDir, "legacy-temp");
+      const currentPort = 48124;
+      await fs.writeFile(configPath, "{}\n");
+      await fs.mkdir(legacyLockDir, { recursive: true });
+      const env = {
+        ...process.env,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+      };
+      const lock = await acquireGatewayLock({
+        allowInTests: true,
+        env,
+        legacyLockDir,
+        platform: "darwin",
+        port: currentPort,
+        readProcessCmdline: () => ["openclaw-gateway"],
+        timeoutMs: 30,
+      });
+      if (!lock) {
+        throw new Error("Expected Gateway lock");
+      }
+
+      try {
+        await fs.writeFile(
+          stateLockPath(legacyLockDir, stateDir),
+          JSON.stringify({
+            pid: process.pid,
+            createdAt: new Date().toISOString(),
+            configPath: resolveConfigPath(env, stateDir),
+            port: 48123,
+            role: "gateway",
+            stateDir,
+          }),
+        );
+
+        await expect(
+          readActiveGatewayLockIdentity({
+            env,
+            legacyLockDir,
+            platform: "darwin",
+            readProcessCmdline: () => ["openclaw-gateway"],
+          }),
+        ).resolves.toMatchObject({
+          pid: process.pid,
+          port: currentPort,
+        });
       } finally {
         await lock.release();
       }

--- a/src/infra/gateway-lock.state-dir.test.ts
+++ b/src/infra/gateway-lock.state-dir.test.ts
@@ -4,7 +4,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveConfigPath, resolveGatewayLockDir, resolveStateDir } from "../config/paths.js";
+import { resolveConfigPath, resolveGatewayLockDir } from "../config/paths.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { acquireGatewayLock, GatewayLockError } from "./gateway-lock.js";
 

--- a/src/infra/gateway-lock.state-dir.test.ts
+++ b/src/infra/gateway-lock.state-dir.test.ts
@@ -10,12 +10,18 @@ import {
   acquireGatewayLock,
   GatewayLockError,
   readActiveGatewayLockIdentity,
+  readActiveGatewayLockPort,
 } from "./gateway-lock.js";
 
 function stateLockPath(lockDir: string, stateDir: string): string {
   const canonicalStateDir = fsSync.realpathSync.native(path.resolve(stateDir));
   const stateHash = createHash("sha256").update(canonicalStateDir).digest("hex").slice(0, 8);
   return path.join(lockDir, `gateway.state.${stateHash}.lock`);
+}
+
+function configLockPath(lockDir: string, configPath: string): string {
+  const configHash = createHash("sha256").update(configPath).digest("hex").slice(0, 8);
+  return path.join(lockDir, `gateway.${configHash}.lock`);
 }
 
 describe("Gateway lock state directory", () => {
@@ -40,6 +46,40 @@ describe("Gateway lock state directory", () => {
       } finally {
         await lock.release();
       }
+    });
+  });
+
+  it("discovers an active stable-release config lock during an in-place upgrade", async () => {
+    await withStateDirEnv("openclaw-gateway-lock-stable-reader-", async ({ stateDir }) => {
+      const configPath = path.join(stateDir, "openclaw.json");
+      const legacyLockDir = path.join(stateDir, "legacy-temp");
+      const expectedPort = 48122;
+      await fs.writeFile(configPath, "{}\n");
+      await fs.mkdir(legacyLockDir, { recursive: true });
+      const env = {
+        ...process.env,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+      };
+      const resolvedConfigPath = resolveConfigPath(env, stateDir);
+      await fs.writeFile(
+        configLockPath(legacyLockDir, resolvedConfigPath),
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+          configPath: resolvedConfigPath,
+          port: expectedPort,
+        }),
+      );
+
+      await expect(
+        readActiveGatewayLockPort({
+          env,
+          legacyLockDir,
+          platform: "darwin",
+          readProcessCmdline: () => ["openclaw-gateway"],
+        }),
+      ).resolves.toBe(expectedPort);
     });
   });
 
@@ -133,6 +173,50 @@ describe("Gateway lock state directory", () => {
       } finally {
         await lock.release();
       }
+    });
+  });
+
+  it("does not bypass an active stable-release config lock during an in-place upgrade", async () => {
+    await withStateDirEnv("openclaw-gateway-lock-stable-transition-", async ({ stateDir }) => {
+      const configPath = path.join(stateDir, "openclaw.json");
+      const legacyLockDir = path.join(stateDir, "legacy-temp");
+      await fs.writeFile(configPath, "{}\n");
+      await fs.mkdir(legacyLockDir, { recursive: true });
+      const env = {
+        ...process.env,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+      };
+      const resolvedConfigPath = resolveConfigPath(env, stateDir);
+      await fs.writeFile(
+        configLockPath(legacyLockDir, resolvedConfigPath),
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+          configPath: resolvedConfigPath,
+          port: 48122,
+        }),
+      );
+
+      await expect(
+        acquireGatewayLock({
+          allowInTests: true,
+          env,
+          legacyLockDir,
+          platform: "darwin",
+          readProcessCmdline: () => ["openclaw-gateway"],
+          timeoutMs: 30,
+        }),
+      ).rejects.toBeInstanceOf(GatewayLockError);
+      const currentLockDir = resolveGatewayLockDir(env);
+      await expect(
+        fs.access(configLockPath(currentLockDir, resolvedConfigPath)),
+      ).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(fs.access(stateLockPath(currentLockDir, stateDir))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
     });
   });
 

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -173,30 +173,6 @@ describe("gateway lock", () => {
     vi.restoreAllMocks();
   });
 
-  it("keeps default locks inside an overridden state directory", async () => {
-    const env = await makeEnv();
-    const lock = expectGatewayLock(
-      await acquireGatewayLock({
-        allowInTests: true,
-        env,
-        timeoutMs: 30,
-      }),
-    );
-    const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
-    const expectedLockDir = path.join(
-      resolveStateDir(env),
-      "tmp",
-      uid != null ? `openclaw-${uid}` : "openclaw",
-    );
-
-    try {
-      expect(path.dirname(lock.lockPath)).toBe(expectedLockDir);
-      expect(path.dirname(lock.stateLockPath)).toBe(expectedLockDir);
-    } finally {
-      await lock.release();
-    }
-  });
-
   it("blocks concurrent acquisition until release", async () => {
     // Fake timers can hang on Windows CI when combined with fs open loops.
     // Keep this test on real timers and use small timeouts.

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -173,6 +173,30 @@ describe("gateway lock", () => {
     vi.restoreAllMocks();
   });
 
+  it("keeps default locks inside an overridden state directory", async () => {
+    const env = await makeEnv();
+    const lock = expectGatewayLock(
+      await acquireGatewayLock({
+        allowInTests: true,
+        env,
+        timeoutMs: 30,
+      }),
+    );
+    const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+    const expectedLockDir = path.join(
+      resolveStateDir(env),
+      "tmp",
+      uid != null ? `openclaw-${uid}` : "openclaw",
+    );
+
+    try {
+      expect(path.dirname(lock.lockPath)).toBe(expectedLockDir);
+      expect(path.dirname(lock.stateLockPath)).toBe(expectedLockDir);
+    } finally {
+      await lock.release();
+    }
+  });
+
   it("blocks concurrent acquisition until release", async () => {
     // Fake timers can hang on Windows CI when combined with fs open loops.
     // Keep this test on real timers and use small timeouts.

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -370,7 +370,7 @@ async function assertLegacyGatewayLockIsNotActive(params: {
 export async function readActiveGatewayLockPort(
   opts: Pick<
     GatewayLockOptions,
-    "env" | "lockDir" | "platform" | "readProcessCmdline" | "readProcessStartTime"
+    "env" | "lockDir" | "legacyLockDir" | "platform" | "readProcessCmdline" | "readProcessStartTime"
   > = {},
 ): Promise<number | undefined> {
   return (await readActiveGatewayLockIdentity(opts))?.port;
@@ -379,13 +379,22 @@ export async function readActiveGatewayLockPort(
 export async function readActiveGatewayLockIdentity(
   opts: Pick<
     GatewayLockOptions,
-    "env" | "lockDir" | "platform" | "readProcessCmdline" | "readProcessStartTime"
+    "env" | "lockDir" | "legacyLockDir" | "platform" | "readProcessCmdline" | "readProcessStartTime"
   > = {},
 ): Promise<GatewayLockIdentity | undefined> {
   const env = opts.env ?? process.env;
-  const { configLockPath, stateLockPath } = resolveGatewayLockPaths(env, opts.lockDir);
+  const { configLockPath, legacyStateLockPath, stateLockPath } = resolveGatewayLockPaths(
+    env,
+    opts.lockDir,
+    opts.legacyLockDir ?? (opts.lockDir ? opts.lockDir : undefined),
+  );
   const configIdentity = await readVerifiedGatewayLockIdentity(configLockPath, opts);
-  return configIdentity ?? (await readVerifiedGatewayLockIdentity(stateLockPath, opts));
+  const stateIdentity = await readVerifiedGatewayLockIdentity(stateLockPath, opts);
+  return (
+    configIdentity ??
+    stateIdentity ??
+    (await readVerifiedGatewayLockIdentity(legacyStateLockPath, opts))
+  );
 }
 
 async function readVerifiedGatewayLockIdentity(

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -293,7 +293,7 @@ function canonicalizeStateDir(stateDir: string): string {
   }
 }
 
-function resolveGatewayLockPaths(env: NodeJS.ProcessEnv, lockDir = resolveGatewayLockDir()) {
+function resolveGatewayLockPaths(env: NodeJS.ProcessEnv, lockDir = resolveGatewayLockDir(env)) {
   const resolvedStateDir = resolveStateDir(env);
   const stateDir = canonicalizeStateDir(resolvedStateDir);
   const configPath = resolveConfigPath(env, resolvedStateDir);

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -10,7 +10,12 @@ import {
   resolveTimestampMsToIsoString,
 } from "@openclaw/normalization-core/number-coercion";
 import { z } from "zod";
-import { resolveConfigPath, resolveGatewayLockDir, resolveStateDir } from "../config/paths.js";
+import {
+  resolveConfigPath,
+  resolveGatewayLockDir,
+  resolveLegacyGatewayLockDir,
+  resolveStateDir,
+} from "../config/paths.js";
 import { getFileLockProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import { safeParseJsonWithSchema } from "../utils/zod-parse.js";
 import { sha256HexPrefix } from "./crypto-digest.js";
@@ -91,6 +96,8 @@ export type GatewayLockOptions = {
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
   lockDir?: string;
+  /** Test seam for the previous release's temporary lock root. */
+  legacyLockDir?: string;
   role?: GatewayLockRole;
   /** Override process command-line reader (testing seam). */
   readProcessCmdline?: (pid: number) => string[] | null;
@@ -293,7 +300,11 @@ function canonicalizeStateDir(stateDir: string): string {
   }
 }
 
-function resolveGatewayLockPaths(env: NodeJS.ProcessEnv, lockDir = resolveGatewayLockDir(env)) {
+function resolveGatewayLockPaths(
+  env: NodeJS.ProcessEnv,
+  lockDir = resolveGatewayLockDir(env),
+  legacyLockDir = resolveLegacyGatewayLockDir(),
+) {
   const resolvedStateDir = resolveStateDir(env);
   const stateDir = canonicalizeStateDir(resolvedStateDir);
   const configPath = resolveConfigPath(env, resolvedStateDir);
@@ -302,9 +313,58 @@ function resolveGatewayLockPaths(env: NodeJS.ProcessEnv, lockDir = resolveGatewa
   return {
     configLockPath: path.join(lockDir, `gateway.${configHash}.lock`),
     configPath,
+    legacyStateLockPath: path.join(legacyLockDir, `gateway.state.${stateHash}.lock`),
     stateDir,
     stateLockPath: path.join(lockDir, `gateway.state.${stateHash}.lock`),
   };
+}
+
+async function assertLegacyGatewayLockIsNotActive(params: {
+  legacyStateLockPath: string;
+  stateLockPath: string;
+  staleMs: number;
+  now: () => number;
+  platform: NodeJS.Platform;
+  readProcessCmdline?: (pid: number) => string[] | null;
+  readProcessStartTime?: (pid: number) => number | null;
+}): Promise<void> {
+  if (params.legacyStateLockPath === params.stateLockPath) {
+    return;
+  }
+  let stat: fsSync.Stats;
+  try {
+    stat = await fs.stat(params.legacyStateLockPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw new GatewayLockError(
+      `failed to inspect legacy gateway lock at ${params.legacyStateLockPath}`,
+      error,
+    );
+  }
+
+  const payload = await readLockPayload(params.legacyStateLockPath);
+  if (payload?.pid) {
+    const ownerStatus = await resolveGatewayOwnerStatus(
+      payload.pid,
+      payload,
+      params.platform,
+      params.readProcessCmdline,
+      params.readProcessStartTime,
+    );
+    if (ownerStatus === "dead") {
+      return;
+    }
+    throw new GatewayLockError(
+      `gateway already running (pid ${payload.pid}); legacy lock remains active during state-lock upgrade`,
+    );
+  }
+  if (params.now() - stat.mtimeMs <= params.staleMs) {
+    throw new GatewayLockError(
+      `gateway already running; legacy lock remains active during state-lock upgrade`,
+    );
+  }
 }
 
 export async function readActiveGatewayLockPort(
@@ -366,7 +426,20 @@ export async function acquireGatewayLock(
   }
   const role = opts.role ?? "gateway";
   const ownerId = randomUUID();
-  const paths = resolveGatewayLockPaths(env, opts.lockDir);
+  const paths = resolveGatewayLockPaths(
+    env,
+    opts.lockDir,
+    opts.legacyLockDir ?? (opts.lockDir ? opts.lockDir : undefined),
+  );
+  await assertLegacyGatewayLockIsNotActive({
+    legacyStateLockPath: paths.legacyStateLockPath,
+    stateLockPath: paths.stateLockPath,
+    staleMs: resolveTimerTimeoutMs(opts.staleMs, DEFAULT_STALE_MS, 0),
+    now: opts.now ?? Date.now,
+    platform: opts.platform ?? process.platform,
+    readProcessCmdline: opts.readProcessCmdline,
+    readProcessStartTime: opts.readProcessStartTime,
+  });
   const stateLock = await acquireLockFile({
     ...opts,
     configPath: paths.configPath,

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -313,6 +313,7 @@ function resolveGatewayLockPaths(
   return {
     configLockPath: path.join(lockDir, `gateway.${configHash}.lock`),
     configPath,
+    legacyConfigLockPath: path.join(legacyLockDir, `gateway.${configHash}.lock`),
     legacyStateLockPath: path.join(legacyLockDir, `gateway.state.${stateHash}.lock`),
     stateDir,
     stateLockPath: path.join(lockDir, `gateway.state.${stateHash}.lock`),
@@ -320,31 +321,31 @@ function resolveGatewayLockPaths(
 }
 
 async function assertLegacyGatewayLockIsNotActive(params: {
-  legacyStateLockPath: string;
-  stateLockPath: string;
+  currentLockPath: string;
+  legacyLockPath: string;
   staleMs: number;
   now: () => number;
   platform: NodeJS.Platform;
   readProcessCmdline?: (pid: number) => string[] | null;
   readProcessStartTime?: (pid: number) => number | null;
 }): Promise<void> {
-  if (params.legacyStateLockPath === params.stateLockPath) {
+  if (params.legacyLockPath === params.currentLockPath) {
     return;
   }
   let stat: fsSync.Stats;
   try {
-    stat = await fs.stat(params.legacyStateLockPath);
+    stat = await fs.stat(params.legacyLockPath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return;
     }
     throw new GatewayLockError(
-      `failed to inspect legacy gateway lock at ${params.legacyStateLockPath}`,
+      `failed to inspect legacy gateway lock at ${params.legacyLockPath}`,
       error,
     );
   }
 
-  const payload = await readLockPayload(params.legacyStateLockPath);
+  const payload = await readLockPayload(params.legacyLockPath);
   if (payload?.pid) {
     const ownerStatus = await resolveGatewayOwnerStatus(
       payload.pid,
@@ -357,12 +358,12 @@ async function assertLegacyGatewayLockIsNotActive(params: {
       return;
     }
     throw new GatewayLockError(
-      `gateway already running (pid ${payload.pid}); legacy lock remains active during state-lock upgrade`,
+      `gateway already running (pid ${payload.pid}); legacy lock remains active during lock-root upgrade`,
     );
   }
   if (params.now() - stat.mtimeMs <= params.staleMs) {
     throw new GatewayLockError(
-      `gateway already running; legacy lock remains active during state-lock upgrade`,
+      `gateway already running; legacy lock remains active during upgrade`,
     );
   }
 }
@@ -383,16 +384,18 @@ export async function readActiveGatewayLockIdentity(
   > = {},
 ): Promise<GatewayLockIdentity | undefined> {
   const env = opts.env ?? process.env;
-  const { configLockPath, legacyStateLockPath, stateLockPath } = resolveGatewayLockPaths(
-    env,
-    opts.lockDir,
-    opts.legacyLockDir ?? (opts.lockDir ? opts.lockDir : undefined),
-  );
+  const { configLockPath, legacyConfigLockPath, legacyStateLockPath, stateLockPath } =
+    resolveGatewayLockPaths(
+      env,
+      opts.lockDir,
+      opts.legacyLockDir ?? (opts.lockDir ? opts.lockDir : undefined),
+    );
   const configIdentity = await readVerifiedGatewayLockIdentity(configLockPath, opts);
   const stateIdentity = await readVerifiedGatewayLockIdentity(stateLockPath, opts);
   return (
     configIdentity ??
     stateIdentity ??
+    (await readVerifiedGatewayLockIdentity(legacyConfigLockPath, opts)) ??
     (await readVerifiedGatewayLockIdentity(legacyStateLockPath, opts))
   );
 }
@@ -440,14 +443,24 @@ export async function acquireGatewayLock(
     opts.lockDir,
     opts.legacyLockDir ?? (opts.lockDir ? opts.lockDir : undefined),
   );
-  await assertLegacyGatewayLockIsNotActive({
-    legacyStateLockPath: paths.legacyStateLockPath,
-    stateLockPath: paths.stateLockPath,
+  // This bridge is deliberately one-way: detect an already-running predecessor without
+  // recreating artifacts outside the configured state directory.
+  const legacyLockCheckOptions = {
     staleMs: resolveTimerTimeoutMs(opts.staleMs, DEFAULT_STALE_MS, 0),
     now: opts.now ?? Date.now,
     platform: opts.platform ?? process.platform,
     readProcessCmdline: opts.readProcessCmdline,
     readProcessStartTime: opts.readProcessStartTime,
+  };
+  await assertLegacyGatewayLockIsNotActive({
+    ...legacyLockCheckOptions,
+    currentLockPath: paths.configLockPath,
+    legacyLockPath: paths.legacyConfigLockPath,
+  });
+  await assertLegacyGatewayLockIsNotActive({
+    ...legacyLockCheckOptions,
+    currentLockPath: paths.stateLockPath,
+    legacyLockPath: paths.legacyStateLockPath,
   });
   const stateLock = await acquireLockFile({
     ...opts,

--- a/src/infra/state-migrations.device-identity.ts
+++ b/src/infra/state-migrations.device-identity.ts
@@ -535,6 +535,7 @@ export async function migrateLegacyDeviceIdentity(params: {
       try {
         identityCoordinator = acquireDeviceIdentityCoordinator({
           databasePath: resolveDeviceIdentityStore({ env, identityKey: IDENTITY_KEY }).databasePath,
+          env,
         });
       } catch (error) {
         return {


### PR DESCRIPTION
Closes #118371

## What Problem This Solves

Fixes an issue where users running a sandboxed gateway with `OPENCLAW_STATE_DIR` would still create Gateway and device-identity coordinator locks in the live user's shared temporary directory. This broke full state isolation and could leave sandbox artifacts beside a production instance.

## Why This Change Was Made

The lock root now derives from the resolved state directory and retains the existing per-user suffix. Gateway locking and device-identity coordination both receive the effective environment. During an in-place upgrade, a new process checks both the stable release's former temporary config lock and the later beta temporary state lock before acquiring state-local locks; this compatibility check never creates legacy-root artifacts. Read-only identity lookup still returns without creating a lock directory when its database is absent.

## User Impact

Sandboxed, canary, and test gateways keep their ephemeral lock files inside their own state directory. They no longer write lock artifacts into a live instance's temporary directory. On a same-host upgrade, the new process also discovers the active port from an already-running stable predecessor and refuses to bypass its lock.

### Compatibility boundary

The legacy bridge is intentionally read-only and one-way: it detects a predecessor that already owns a visible legacy lock without recreating that artifact outside the configured state directory. A predecessor started after the new process checks the old root cannot observe the relocated locks. Separate old and new containers with private `/tmp` mounts also cannot see each other's legacy files, so rolling upgrades across that topology must stop the old Gateway before starting the new release.

## Evidence

- `node scripts/run-vitest.mjs src/infra/gateway-lock.state-dir.test.ts src/infra/gateway-lock.test.ts src/infra/device-identity.state-dir.test.ts src/config/paths.test.ts` (91 tests passed)
- `./node_modules/.bin/oxfmt --check src/infra/gateway-lock.ts src/infra/gateway-lock.state-dir.test.ts`
- `./node_modules/.bin/oxlint src/infra/gateway-lock.ts src/infra/gateway-lock.state-dir.test.ts`
- `git diff --check`
- Added stable `v2026.7.1`-shape regressions proving active-port discovery and acquisition refusal from `gateway.<configHash>.lock`.
- Retained coverage for the later `gateway.state.<stateHash>.lock` transition and current state-local precedence.
- Moved the state-dir coverage into `gateway-lock.state-dir.test.ts`; this keeps the existing large suite below its max-lines gate.

### Redacted real runtime proof

A foreground Gateway was started directly from the source runtime with a fresh temporary `OPENCLAW_STATE_DIR`, loopback binding, a temporary token, and channel/provider startup disabled. It reached `starting HTTP server...`; before shutdown, the only lock artifacts observed were:

```text
<state-dir>/tmp/openclaw-501/gateway.<config-hash>.lock
<state-dir>/tmp/openclaw-501/gateway.state.<state-hash>.lock
<state-dir>/tmp/openclaw-501/device-identity.<database-hash>.lock.sqlite
```

A scan of the host temporary root found no matching gateway or device-identity lock artifacts. The temporary Gateway and state directory were then stopped and removed.

The repository changed-check wrapper still cannot complete locally because its Testbox delegation exits 137 before starting a remote run. The focused tests and runtime proof above completed locally.

## AI-assisted

- [x] AI-assisted implementation; reviewed the lock owner paths, shipped stable lock contract, upgrade boundary, current tests, and runtime output before submission.
