### PR TITLE
refactor(agents): compact main-session recovery fixtures

### DIFF
--- a/src/agents/main-session-recovery-state.test.ts
+++ b/src/agents/main-session-recovery-state.test.ts
@@ -44,6 +44,46 @@ function observe(entry: SessionEntry, lifecycleGeneration: string) {
   return result.view;
 }
 
+function claimForeground(
+  entry: SessionEntry,
+  overrides: Partial<{
+    claimId: string;
+    cycleId: string;
+    lifecycleGeneration: string;
+    sessionId: string;
+    sessionKey: string;
+  }> = {},
+) {
+  return transitionMainSessionRecovery(entry, {
+    kind: "claim_foreground",
+    cycleId: "unused",
+    lifecycleGeneration: "generation-1",
+    sessionId: "session-1",
+    sessionKey,
+    claimId: "foreground-1",
+    ...overrides,
+  });
+}
+
+type LifecycleProjectionParams = Parameters<typeof projectMainSessionRecoveryLifecycle>[0];
+
+function projectLifecycle(
+  entry: LifecycleProjectionParams["entry"],
+  event: LifecycleProjectionParams["event"],
+  snapshotPatch: LifecycleProjectionParams["snapshotPatch"],
+  currentLifecycleGeneration = event.lifecycleGeneration,
+) {
+  if (!currentLifecycleGeneration) {
+    throw new Error("expected lifecycle generation");
+  }
+  return projectMainSessionRecoveryLifecycle({
+    currentLifecycleGeneration,
+    entry,
+    event,
+    snapshotPatch,
+  });
+}
+
 describe("main session recovery state", () => {
   it("gives a legacy interrupted row a stable cycle before exposing it to a scan", () => {
     const entry = interruptedEntry({ mainRestartRecovery: undefined });
@@ -154,14 +194,7 @@ describe("main session recovery state", () => {
       attempt: 1,
     });
 
-    const claim = transitionMainSessionRecovery(entry, {
-      kind: "claim_foreground",
-      cycleId: "unused",
-      lifecycleGeneration: "generation-1",
-      sessionId: "session-1",
-      sessionKey,
-      claimId: "foreground-1",
-    });
+    const claim = claimForeground(entry);
     expect(claim.kind).toBe("foreground_claimed");
 
     expect(
@@ -187,16 +220,7 @@ describe("main session recovery state", () => {
     });
     const before = structuredClone(entry);
 
-    expect(
-      transitionMainSessionRecovery(entry, {
-        kind: "claim_foreground",
-        cycleId: "unused",
-        lifecycleGeneration: "generation-1",
-        sessionId: "session-1",
-        sessionKey,
-        claimId: "foreground-1",
-      }),
-    ).toEqual({ kind: "rejected", reason: "recovery_exhausted" });
+    expect(claimForeground(entry)).toEqual({ kind: "rejected", reason: "recovery_exhausted" });
     expect(entry).toEqual(before);
   });
 
@@ -207,16 +231,7 @@ describe("main session recovery state", () => {
       restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "stale-generation" }],
     });
 
-    expect(
-      transitionMainSessionRecovery(entry, {
-        kind: "claim_foreground",
-        cycleId: "unused",
-        lifecycleGeneration: "generation-1",
-        sessionId: "session-1",
-        sessionKey,
-        claimId: "foreground-1",
-      }),
-    ).toEqual({ kind: "applied" });
+    expect(claimForeground(entry)).toEqual({ kind: "applied" });
     expect(entry).toMatchObject({
       status: "running",
       abortedLastRun: false,
@@ -238,16 +253,7 @@ describe("main session recovery state", () => {
       ],
     });
 
-    expect(
-      transitionMainSessionRecovery(entry, {
-        kind: "claim_foreground",
-        cycleId: "unused",
-        lifecycleGeneration: "generation-1",
-        sessionId: "session-1",
-        sessionKey,
-        claimId: "foreground-1",
-      }),
-    ).toEqual({ kind: "applied" });
+    expect(claimForeground(entry)).toEqual({ kind: "applied" });
     expect(entry.restartRecoveryRuns).toBeUndefined();
     expect(entry.mainRestartRecovery).toBeUndefined();
     expect(entry.abortedLastRun).toBe(false);
@@ -260,16 +266,7 @@ describe("main session recovery state", () => {
       restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "dead-generation" }],
     });
 
-    expect(
-      transitionMainSessionRecovery(entry, {
-        kind: "claim_foreground",
-        cycleId: "unused",
-        lifecycleGeneration: "generation-1",
-        sessionId: "session-1",
-        sessionKey,
-        claimId: "foreground-1",
-      }),
-    ).toEqual({ kind: "applied" });
+    expect(claimForeground(entry)).toEqual({ kind: "applied" });
     expect(entry).toMatchObject({ status: "failed", abortedLastRun: false });
     expect(entry.restartRecoveryRuns).toBeUndefined();
     expect(entry.mainRestartRecovery).toBeUndefined();
@@ -285,16 +282,7 @@ describe("main session recovery state", () => {
       restartRecoveryDeliveryRunId: "pending-delivery",
     });
 
-    expect(
-      transitionMainSessionRecovery(entry, {
-        kind: "claim_foreground",
-        cycleId: "unused",
-        lifecycleGeneration: "generation-1",
-        sessionId: "session-1",
-        sessionKey,
-        claimId: "foreground-1",
-      }),
-    ).toEqual({ kind: "applied" });
+    expect(claimForeground(entry)).toEqual({ kind: "applied" });
     expect(entry.abortedLastRun).toBe(false);
     expect(entry.mainRestartRecovery).toBeUndefined();
     // The delivery claim is owned by the delivery path, not recovery cleanup.
@@ -307,16 +295,9 @@ describe("main session recovery state", () => {
       restartRecoveryRuns: [{ runId: "pending-run", lifecycleGeneration: "generation-1" }],
     });
 
-    expect(
-      transitionMainSessionRecovery(entry, {
-        kind: "claim_foreground",
-        cycleId: "cycle-2",
-        lifecycleGeneration: "generation-1",
-        sessionId: "session-1",
-        sessionKey,
-        claimId: "foreground-1",
-      }),
-    ).toMatchObject({ kind: "foreground_claimed" });
+    expect(claimForeground(entry, { cycleId: "cycle-2" })).toMatchObject({
+      kind: "foreground_claimed",
+    });
     expect(entry.abortedLastRun).toBe(true);
     expect(entry.restartRecoveryRuns).toEqual([
       { runId: "pending-run", lifecycleGeneration: "generation-1" },
@@ -339,16 +320,7 @@ describe("main session recovery state", () => {
     });
     const before = structuredClone(entry);
 
-    expect(
-      transitionMainSessionRecovery(entry, {
-        kind: "claim_foreground",
-        cycleId: "unused",
-        lifecycleGeneration: "generation-1",
-        sessionId: "session-1",
-        sessionKey,
-        claimId: "foreground-1",
-      }),
-    ).toEqual({ kind: "no_change" });
+    expect(claimForeground(entry)).toEqual({ kind: "no_change" });
     expect(entry).toEqual(before);
   });
 
@@ -365,16 +337,7 @@ describe("main session recovery state", () => {
       }),
     });
 
-    expect(
-      transitionMainSessionRecovery(entry, {
-        kind: "claim_foreground",
-        cycleId: "unused",
-        lifecycleGeneration: "generation-1",
-        sessionId: "session-1",
-        sessionKey,
-        claimId: "foreground-1",
-      }),
-    ).toMatchObject({ kind: "foreground_claimed" });
+    expect(claimForeground(entry)).toMatchObject({ kind: "foreground_claimed" });
     expect(entry.mainRestartRecovery).toMatchObject({
       chargedAttempts: 1,
       foregroundClaims: {
@@ -718,29 +681,27 @@ describe("main session recovery state", () => {
       ],
     });
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-1",
+      projectLifecycle(
         entry,
-        event: {
+        {
           runId: "interrupted",
           lifecycleGeneration: "generation-1",
           data: { phase: "error", stopReason: "restart" },
         },
-        snapshotPatch: { status: "failed" },
-      }),
+        { status: "failed" },
+      ),
     ).toEqual({ action: "suppress" });
 
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-1",
+      projectLifecycle(
         entry,
-        event: {
+        {
           runId: "recovery",
           lifecycleGeneration: "generation-1",
           data: { phase: "end" },
         },
-        snapshotPatch: { status: "done", abortedLastRun: false },
-      }),
+        { status: "done", abortedLastRun: false },
+      ),
     ).toEqual({
       action: "apply",
       patch: {
@@ -752,16 +713,15 @@ describe("main session recovery state", () => {
     });
 
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-1",
+      projectLifecycle(
         entry,
-        event: {
+        {
           runId: "recovery",
           lifecycleGeneration: "generation-1",
           data: { phase: "error", error: "provider failed" },
         },
-        snapshotPatch: { status: "failed", abortedLastRun: false },
-      }),
+        { status: "failed", abortedLastRun: false },
+      ),
     ).toEqual({
       action: "apply",
       patch: {
@@ -787,16 +747,16 @@ describe("main session recovery state", () => {
     });
 
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-2",
+      projectLifecycle(
         entry,
-        event: {
+        {
           runId: "old-run",
           lifecycleGeneration: "generation-1",
           data: { phase: "end" },
         },
-        snapshotPatch: { status: "done", abortedLastRun: false },
-      }),
+        { status: "done", abortedLastRun: false },
+        "generation-2",
+      ),
     ).toEqual({
       action: "apply",
       patch: {
@@ -821,16 +781,16 @@ describe("main session recovery state", () => {
     });
 
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-2",
+      projectLifecycle(
         entry,
-        event: {
+        {
           runId: "old-run",
           lifecycleGeneration: "generation-1",
           data: { phase: "end" },
         },
-        snapshotPatch: { status: "done", abortedLastRun: false },
-      }),
+        { status: "done", abortedLastRun: false },
+        "generation-2",
+      ),
     ).toEqual({
       action: "apply",
       patch: {
@@ -858,21 +818,20 @@ describe("main session recovery state", () => {
     });
 
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-1",
+      projectLifecycle(
         entry,
-        event: {
+        {
           runId: "recovery-1",
           lifecycleGeneration: "generation-1",
           data: { phase: "end" },
         },
-        snapshotPatch: {
+        {
           status: "done",
           abortedLastRun: false,
           restartRecoveryRuns: undefined,
           mainRestartRecovery: undefined,
         },
-      }),
+      ),
     ).toEqual({
       action: "apply",
       patch: {
@@ -893,16 +852,15 @@ describe("main session recovery state", () => {
     });
 
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-1",
+      projectLifecycle(
         entry,
-        event: {
+        {
           runId: "recovery-1",
           lifecycleGeneration: "generation-1",
           data: { phase: "end" },
         },
-        snapshotPatch: { status: "done", abortedLastRun: false },
-      }),
+        { status: "done", abortedLastRun: false },
+      ),
     ).toEqual({
       action: "apply",
       patch: {
@@ -920,21 +878,20 @@ describe("main session recovery state", () => {
     });
 
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-1",
+      projectLifecycle(
         entry,
-        event: {
+        {
           runId: "ordinary-run",
           lifecycleGeneration: "generation-1",
           data: { phase: "end" },
         },
-        snapshotPatch: {
+        {
           status: "done",
           abortedLastRun: false,
           restartRecoveryRuns: undefined,
           mainRestartRecovery: undefined,
         },
-      }),
+      ),
     ).toEqual({ action: "suppress" });
   });
 
@@ -950,31 +907,29 @@ describe("main session recovery state", () => {
     });
 
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-1",
+      projectLifecycle(
         entry,
-        event: {
+        {
           runId: "unrelated-run",
           lifecycleGeneration: "generation-1",
           data: { phase: "end" },
         },
-        snapshotPatch: { status: "done", abortedLastRun: false },
-      }),
+        { status: "done", abortedLastRun: false },
+      ),
     ).toEqual({ action: "suppress" });
   });
 
   it("applies ordinary lifecycle completion without recovery metadata", () => {
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-1",
-        entry: { abortedLastRun: false },
-        event: {
+      projectLifecycle(
+        { abortedLastRun: false },
+        {
           runId: "ordinary-run",
           lifecycleGeneration: "generation-1",
           data: { phase: "end" },
         },
-        snapshotPatch: { status: "done", abortedLastRun: false },
-      }),
+        { status: "done", abortedLastRun: false },
+      ),
     ).toEqual({
       action: "apply",
       patch: { status: "done", abortedLastRun: false },
@@ -994,16 +949,15 @@ describe("main session recovery state", () => {
     });
 
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-2",
+      projectLifecycle(
         entry,
-        event: {
+        {
           runId: "recovery",
           lifecycleGeneration: "generation-2",
           data: { phase: "end" },
         },
-        snapshotPatch: { status: "done", abortedLastRun: false },
-      }),
+        { status: "done", abortedLastRun: false },
+      ),
     ).toEqual({
       action: "apply",
       patch: {
@@ -1028,16 +982,15 @@ describe("main session recovery state", () => {
     });
 
     expect(
-      projectMainSessionRecoveryLifecycle({
-        currentLifecycleGeneration: "generation-1",
+      projectLifecycle(
         entry,
-        event: {
+        {
           runId: "old-run",
           lifecycleGeneration: "generation-1",
           data: { phase: "end" },
         },
-        snapshotPatch: { status: "done", abortedLastRun: false },
-      }),
+        { status: "done", abortedLastRun: false },
+      ),
     ).toEqual({
       action: "apply",
       patch: {

--- a/src/agents/main-session-recovery-store.test.ts
+++ b/src/agents/main-session-recovery-store.test.ts
@@ -74,6 +74,27 @@ describe("main session recovery store", () => {
     };
   }
 
+  type ClaimParams = Parameters<typeof claimMainSessionRecoveryOwner>[0];
+  type CommitParams = Parameters<typeof commitMainSessionRecovery>[0];
+
+  function commitRecovery(
+    command: CommitParams["command"],
+    options: Omit<CommitParams, "command" | "target"> = {},
+  ) {
+    return commitMainSessionRecovery({ command, target: { sessionKey, storePath }, ...options });
+  }
+
+  function claimRecovery(
+    overrides: Omit<ClaimParams, "lifecycleGeneration" | "sessionId" | "target"> = {},
+  ) {
+    return claimMainSessionRecoveryOwner({
+      lifecycleGeneration,
+      sessionId: "session-1",
+      target: { sessionKey, storePath },
+      ...overrides,
+    });
+  }
+
   async function reserve(targetSessionKey = sessionKey) {
     const result = await commitMainSessionRecovery({
       command: {
@@ -100,16 +121,15 @@ describe("main session recovery store", () => {
       abortedLastRun: true,
     });
 
-    const result = await commitMainSessionRecovery({
-      command: {
+    const result = await commitRecovery(
+      {
         kind: "observe",
         cycleId: "cycle-1",
         lifecycleGeneration,
         sessionKey,
       },
-      requireWriteSuccess: true,
-      target: { sessionKey, storePath },
-    });
+      { requireWriteSuccess: true },
+    );
 
     expect(result.transition).toMatchObject({
       kind: "observed",
@@ -124,22 +144,16 @@ describe("main session recovery store", () => {
   it("preserves a concurrent foreground claim while cancelling its reservation", async () => {
     await write(interruptedEntry());
     const reservation = await reserve();
-    await commitMainSessionRecovery({
-      command: {
-        kind: "claim_foreground",
-        cycleId: "unused",
-        lifecycleGeneration,
-        sessionId: "session-1",
-        sessionKey,
-        claimId: "foreground-1",
-      },
-      target: { sessionKey, storePath },
+    await commitRecovery({
+      kind: "claim_foreground",
+      cycleId: "unused",
+      lifecycleGeneration,
+      sessionId: "session-1",
+      sessionKey,
+      claimId: "foreground-1",
     });
 
-    await commitMainSessionRecovery({
-      command: { kind: "cancel_reservation", reservation },
-      target: { sessionKey, storePath },
-    });
+    await commitRecovery({ kind: "cancel_reservation", reservation });
 
     expect(read().mainRestartRecovery).toMatchObject({
       chargedAttempts: 0,
@@ -163,15 +177,12 @@ describe("main session recovery store", () => {
       }),
     );
 
-    const admitted = await commitMainSessionRecovery({
-      command: {
-        kind: "admit_recovery",
-        lifecycleGeneration,
-        now: 300,
-        runId: "recovery-1",
-        sessionId: "session-1",
-      },
-      target: { sessionKey, storePath },
+    const admitted = await commitRecovery({
+      kind: "admit_recovery",
+      lifecycleGeneration,
+      now: 300,
+      runId: "recovery-1",
+      sessionId: "session-1",
     });
 
     expect(admitted.transition).toEqual({ kind: "admitted_recovery" });
@@ -192,16 +203,13 @@ describe("main session recovery store", () => {
       },
     });
 
-    const result = await commitMainSessionRecovery({
-      command: {
-        kind: "prepare_attempt",
-        attempt: 1,
-        lifecycleGeneration,
-        now: 400,
-        observation: { sessionId: "session-1", cycleId: "cycle-1", revision: 1 },
-        runId: "stale-recovery",
-      },
-      target: { sessionKey, storePath },
+    const result = await commitRecovery({
+      kind: "prepare_attempt",
+      attempt: 1,
+      lifecycleGeneration,
+      now: 400,
+      observation: { sessionId: "session-1", cycleId: "cycle-1", revision: 1 },
+      runId: "stale-recovery",
     });
 
     expect(result.transition).toEqual({ kind: "rejected", reason: "session_replaced" });
@@ -224,10 +232,7 @@ describe("main session recovery store", () => {
       },
     });
 
-    const cancelled = await commitMainSessionRecovery({
-      command: { kind: "cancel_reservation", reservation },
-      target: { sessionKey, storePath },
-    });
+    const cancelled = await commitRecovery({ kind: "cancel_reservation", reservation });
 
     expect(cancelled.transition).toEqual({ kind: "rejected", reason: "stale_reservation" });
     expect(read()).toMatchObject({
@@ -243,19 +248,10 @@ describe("main session recovery store", () => {
   it("does not let an old reservation survive healthy clear and immediate re-wedge", async () => {
     await write(interruptedEntry());
     const reservation = await reserve();
-    await commitMainSessionRecovery({
-      command: { kind: "clear" },
-      target: { sessionKey, storePath },
-    });
-    await commitMainSessionRecovery({
-      command: { kind: "mark_interrupted", cycleId: "cycle-2", now: 300 },
-      target: { sessionKey, storePath },
-    });
+    await commitRecovery({ kind: "clear" });
+    await commitRecovery({ kind: "mark_interrupted", cycleId: "cycle-2", now: 300 });
 
-    const cancelled = await commitMainSessionRecovery({
-      command: { kind: "cancel_reservation", reservation },
-      target: { sessionKey, storePath },
-    });
+    const cancelled = await commitRecovery({ kind: "cancel_reservation", reservation });
 
     expect(cancelled.transition).toEqual({ kind: "rejected", reason: "stale_reservation" });
     expect(read().mainRestartRecovery).toMatchObject({
@@ -268,11 +264,7 @@ describe("main session recovery store", () => {
     await write(interruptedEntry());
     const accessorSpy = vi.spyOn(sessionAccessor, "applySessionEntryReplacements");
 
-    const claim = await claimMainSessionRecoveryOwner({
-      lifecycleGeneration,
-      sessionId: "session-1",
-      target: { sessionKey, storePath },
-    });
+    const claim = await claimRecovery();
 
     expect(claim.kind).toBe("claimed");
     expect(accessorSpy).toHaveBeenCalledOnce();
@@ -288,13 +280,7 @@ describe("main session recovery store", () => {
       }),
     );
 
-    await expect(
-      claimMainSessionRecoveryOwner({
-        lifecycleGeneration,
-        sessionId: "session-1",
-        target: { sessionKey, storePath },
-      }),
-    ).resolves.toEqual({ kind: "not_required" });
+    await expect(claimRecovery()).resolves.toEqual({ kind: "not_required" });
     expect(read()).toMatchObject({
       sessionId: "session-1",
       status: "running",
@@ -313,13 +299,7 @@ describe("main session recovery store", () => {
       }),
     );
 
-    await expect(
-      claimMainSessionRecoveryOwner({
-        lifecycleGeneration,
-        sessionId: "session-1",
-        target: { sessionKey, storePath },
-      }),
-    ).resolves.toEqual({ kind: "not_required" });
+    await expect(claimRecovery()).resolves.toEqual({ kind: "not_required" });
     expect(read()).toMatchObject({
       sessionId: "session-1",
       status: "failed",
@@ -352,13 +332,7 @@ describe("main session recovery store", () => {
     });
     expect(read().mainRestartRecovery).toBeUndefined();
 
-    await expect(
-      claimMainSessionRecoveryOwner({
-        lifecycleGeneration,
-        sessionId: "session-1",
-        target: { sessionKey, storePath },
-      }),
-    ).resolves.toEqual({ kind: "not_required" });
+    await expect(claimRecovery()).resolves.toEqual({ kind: "not_required" });
     expect(read()).toMatchObject({ status: "done", abortedLastRun: false });
     expect(read().restartRecoveryRuns).toBeUndefined();
   });
@@ -366,12 +340,7 @@ describe("main session recovery store", () => {
   it("binds a foreground claim to its lifecycle run", async () => {
     await write(interruptedEntry());
 
-    const claim = await claimMainSessionRecoveryOwner({
-      lifecycleGeneration,
-      runId: "foreground-run",
-      sessionId: "session-1",
-      target: { sessionKey, storePath },
-    });
+    const claim = await claimRecovery({ runId: "foreground-run" });
 
     if (claim.kind !== "claimed") {
       throw new Error("expected foreground owner claim");
@@ -389,11 +358,7 @@ describe("main session recovery store", () => {
 
   it("releases an owner after the durable row session id rotates", async () => {
     await write(interruptedEntry());
-    const claim = await claimMainSessionRecoveryOwner({
-      lifecycleGeneration,
-      sessionId: "session-1",
-      target: { sessionKey, storePath },
-    });
+    const claim = await claimRecovery();
     if (claim.kind !== "claimed") {
       throw new Error("expected foreground owner claim");
     }
@@ -409,11 +374,7 @@ describe("main session recovery store", () => {
     vi.useFakeTimers();
     try {
       await write(interruptedEntry());
-      const claim = await claimMainSessionRecoveryOwner({
-        lifecycleGeneration,
-        sessionId: "session-1",
-        target: { sessionKey, storePath },
-      });
+      const claim = await claimRecovery();
       if (claim.kind !== "claimed") {
         throw new Error("expected foreground owner claim");
       }
@@ -474,14 +435,10 @@ describe("main session recovery store", () => {
       }),
     );
 
-    await expect(
-      claimMainSessionRecoveryOwner({
-        lifecycleGeneration,
-        replacementSessionId: "session-2",
-        sessionId: "session-1",
-        target: { sessionKey, storePath },
-      }),
-    ).resolves.toEqual({ kind: "invalidated", reason: "state_changed" });
+    await expect(claimRecovery({ replacementSessionId: "session-2" })).resolves.toEqual({
+      kind: "invalidated",
+      reason: "state_changed",
+    });
   });
 
   it("does not let foreground work bypass an exhausted predecessor", async () => {
@@ -495,23 +452,16 @@ describe("main session recovery store", () => {
       }),
     );
 
-    await expect(
-      claimMainSessionRecoveryOwner({
-        lifecycleGeneration,
-        sessionId: "session-1",
-        target: { sessionKey, storePath },
-      }),
-    ).resolves.toEqual({ kind: "invalidated", reason: "recovery_exhausted" });
+    await expect(claimRecovery()).resolves.toEqual({
+      kind: "invalidated",
+      reason: "recovery_exhausted",
+    });
     expect(read().mainRestartRecovery?.foregroundClaims).toBeUndefined();
   });
 
   it("validates a transferred owner against the latest durable row", async () => {
     await write(interruptedEntry());
-    const claim = await claimMainSessionRecoveryOwner({
-      lifecycleGeneration,
-      sessionId: "session-1",
-      target: { sessionKey, storePath },
-    });
+    const claim = await claimRecovery();
     if (claim.kind !== "claimed") {
       throw new Error("expected foreground owner claim");
     }
@@ -523,16 +473,8 @@ describe("main session recovery store", () => {
 
   it("returns a retry target only when the final foreground owner releases", async () => {
     await write(interruptedEntry());
-    const first = await claimMainSessionRecoveryOwner({
-      lifecycleGeneration,
-      sessionId: "session-1",
-      target: { sessionKey, storePath },
-    });
-    const second = await claimMainSessionRecoveryOwner({
-      lifecycleGeneration,
-      sessionId: "session-1",
-      target: { sessionKey, storePath },
-    });
+    const first = await claimRecovery();
+    const second = await claimRecovery();
     if (first.kind !== "claimed" || second.kind !== "claimed") {
       throw new Error("expected foreground owner claims");
     }
@@ -552,32 +494,19 @@ describe("main session recovery store", () => {
 
   it("does not let an old lease release a same-token claim from a new cycle", async () => {
     await write(interruptedEntry());
-    const oldClaim = await claimMainSessionRecoveryOwner({
-      lifecycleGeneration,
-      sessionId: "session-1",
-      target: { sessionKey, storePath },
-    });
+    const oldClaim = await claimRecovery();
     if (oldClaim.kind !== "claimed") {
       throw new Error("expected foreground owner claim");
     }
-    await commitMainSessionRecovery({
-      command: { kind: "clear" },
-      target: { sessionKey, storePath },
-    });
-    await commitMainSessionRecovery({
-      command: { kind: "mark_interrupted", cycleId: "cycle-2", now: 300 },
-      target: { sessionKey, storePath },
-    });
-    await commitMainSessionRecovery({
-      command: {
-        kind: "claim_foreground",
-        cycleId: "unused",
-        lifecycleGeneration,
-        sessionId: "session-1",
-        sessionKey,
-        claimId: oldClaim.lease.claimId,
-      },
-      target: { sessionKey, storePath },
+    await commitRecovery({ kind: "clear" });
+    await commitRecovery({ kind: "mark_interrupted", cycleId: "cycle-2", now: 300 });
+    await commitRecovery({
+      kind: "claim_foreground",
+      cycleId: "unused",
+      lifecycleGeneration,
+      sessionId: "session-1",
+      sessionKey,
+      claimId: oldClaim.lease.claimId,
     });
 
     await releaseMainSessionRecoveryOwner(oldClaim.lease);
@@ -593,11 +522,7 @@ describe("main session recovery store", () => {
 
   it("retries a transient owner release write failure", async () => {
     await write(interruptedEntry());
-    const claim = await claimMainSessionRecoveryOwner({
-      lifecycleGeneration,
-      sessionId: "session-1",
-      target: { sessionKey, storePath },
-    });
+    const claim = await claimRecovery();
     if (claim.kind !== "claimed") {
       throw new Error("expected foreground owner claim");
     }
@@ -634,23 +559,17 @@ describe("main session recovery store", () => {
     });
     await writerEntered;
 
-    const staleClaim = commitMainSessionRecovery({
-      command: {
-        kind: "claim_foreground",
-        cycleId: "unused",
-        lifecycleGeneration,
-        sessionId: "session-1",
-        sessionKey,
-        claimId: "stale-owner",
-      },
-      target: { sessionKey, storePath },
-    });
-    const staleOwnerClaim = claimMainSessionRecoveryOwner({
-      allowMissingSession: true,
+    const staleClaim = commitRecovery({
+      kind: "claim_foreground",
+      cycleId: "unused",
       lifecycleGeneration,
-      replacementSessionId: "session-2",
       sessionId: "session-1",
-      target: { sessionKey, storePath },
+      sessionKey,
+      claimId: "stale-owner",
+    });
+    const staleOwnerClaim = claimRecovery({
+      allowMissingSession: true,
+      replacementSessionId: "session-2",
     });
     const staleInspection = inspectMainSessionRecoveryRequired({
       expectedSessionId: "session-1",
@@ -659,16 +578,13 @@ describe("main session recovery store", () => {
     });
     await Promise.resolve();
     const currentGeneration = rotateAgentEventLifecycleGeneration();
-    const currentClaim = commitMainSessionRecovery({
-      command: {
-        kind: "claim_foreground",
-        cycleId: "unused",
-        lifecycleGeneration: currentGeneration,
-        sessionId: "session-1",
-        sessionKey,
-        claimId: "current-owner",
-      },
-      target: { sessionKey, storePath },
+    const currentClaim = commitRecovery({
+      kind: "claim_foreground",
+      cycleId: "unused",
+      lifecycleGeneration: currentGeneration,
+      sessionId: "session-1",
+      sessionKey,
+      claimId: "current-owner",
     });
     releaseWriter();
 
@@ -704,15 +620,12 @@ describe("main session recovery store", () => {
     );
     rotateAgentEventLifecycleGeneration();
 
-    const result = await commitMainSessionRecovery({
-      command: {
-        kind: "mark_admitted_recovery_interrupted",
-        lifecycleGeneration,
-        now: 300,
-        runId: "recovery-1",
-        sessionId: "session-1",
-      },
-      target: { sessionKey, storePath },
+    const result = await commitRecovery({
+      kind: "mark_admitted_recovery_interrupted",
+      lifecycleGeneration,
+      now: 300,
+      runId: "recovery-1",
+      sessionId: "session-1",
     });
 
     expect(result.transition).toEqual({ kind: "rejected", reason: "stale_generation" });
@@ -725,11 +638,7 @@ describe("main session recovery store", () => {
 
   it("rejects a transferred foreground lease after lifecycle rotation", async () => {
     await write(interruptedEntry());
-    const claim = await claimMainSessionRecoveryOwner({
-      lifecycleGeneration,
-      sessionId: "session-1",
-      target: { sessionKey, storePath },
-    });
+    const claim = await claimRecovery();
     if (claim.kind !== "claimed") {
       throw new Error("expected foreground owner claim");
     }

--- a/src/agents/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-restart-dispatch.ts
@@ -40,6 +40,7 @@ import {
   type MainSessionRecoveryReservation,
 } from "./main-session-recovery-state.js";
 import { commitMainSessionRecovery } from "./main-session-recovery-store.js";
+import { normalizeFiniteTimestamp } from "./main-session-restart-recovery-shared.js";
 import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
 
 const log = createSubsystemLogger("main-session-restart-recovery");
@@ -49,10 +50,6 @@ const RESTART_RECOVERY_RESUME_MESSAGE =
   "transcript and finish the interrupted response.";
 
 type RestartRecoveryTerminalStatus = "error" | "ok" | "timeout";
-
-function normalizeFiniteTimestamp(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
 
 export function hasRestartRecoveryMessageActionAuthority(entry: SessionEntry): boolean {
   const authority = resolveRestartRecoveryChannelAuthority(entry);

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -266,7 +266,7 @@ function readStore(storePath: string): Record<string, SessionEntry> {
 async function writeTranscript(
   sessionsDir: string,
   sessionId: string,
-  messages: unknown[],
+  messages: readonly unknown[],
 ): Promise<void> {
   const storePath = path.join(sessionsDir, "sessions.json");
   const sessionKey = Object.entries(readStore(storePath)).find(
@@ -284,6 +284,16 @@ async function writeTranscript(
       },
     );
   }
+}
+
+async function writeMainSessionTranscript(
+  messages: readonly unknown[],
+  entry: SessionEntryFixture = {},
+): Promise<string> {
+  const sessionsDir = await makeSessionsDir();
+  await writeMainSession({ sessionsDir, ...entry });
+  await writeTranscript(sessionsDir, "main-session", messages);
+  return sessionsDir;
 }
 
 async function writeCompletedToolTranscript(sessionsDir: string): Promise<void> {
@@ -1589,9 +1599,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails marked sessions with stale approval-pending exec tool results", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    const sessionsDir = await writeMainSessionTranscript([
       { role: "user", content: "run a command that needs approval" },
       { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
       {
@@ -1706,29 +1714,29 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("retains restart safety when the first restart follows pending final persistence", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeMainSession({
-      sessionsDir,
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "Safe work finished.",
-        createdAt: Date.now() - 5_000,
-      },
-    });
-    await writeTranscript(sessionsDir, "main-session", [
-      { role: "user", content: "do the thing" },
+    const sessionsDir = await writeMainSessionTranscript(
+      [
+        { role: "user", content: "do the thing" },
+        {
+          role: "toolResult",
+          toolName: "exec",
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ status: "completed", value: "done", replaySafe: true }),
+            },
+          ],
+        },
+        { role: "assistant", content: [{ type: "text", text: "Safe work finished." }] },
+      ],
       {
-        role: "toolResult",
-        toolName: "exec",
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({ status: "completed", value: "done", replaySafe: true }),
-          },
-        ],
+        pendingFinalDelivery: {
+          kind: "replayable",
+          text: "Safe work finished.",
+          createdAt: Date.now() - 5_000,
+        },
       },
-      { role: "assistant", content: [{ type: "text", text: "Safe work finished." }] },
-    ]);
+    );
 
     await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
     expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
@@ -1795,19 +1803,19 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("resumes pending final delivery even when the transcript tail is assistant output", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeMainSession({
-      sessionsDir,
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text: "assistant final was already captured",
-        createdAt: Date.now() - 5_000,
+    const sessionsDir = await writeMainSessionTranscript(
+      [
+        { role: "user", content: "finish" },
+        { role: "assistant", content: "assistant final was already captured" },
+      ],
+      {
+        pendingFinalDelivery: {
+          kind: "replayable",
+          text: "assistant final was already captured",
+          createdAt: Date.now() - 5_000,
+        },
       },
-    });
-    await writeTranscript(sessionsDir, "main-session", [
-      { role: "user", content: "finish" },
-      { role: "assistant", content: "assistant final was already captured" },
-    ]);
+    );
 
     await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
     expect(callGateway).toHaveBeenCalledOnce();
@@ -3316,9 +3324,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("fails marked sessions without a meaningful transcript tail", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    const sessionsDir = await writeMainSessionTranscript([
       { role: "system", content: "session metadata only" },
     ]);
 
@@ -4379,12 +4385,7 @@ describe("main-session-restart-recovery", () => {
       },
     ],
   ])("does not resume %s at the transcript tail", async (_label, assistantMessage) => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
-      { role: "user", content: "do the thing" },
-      assistantMessage,
-    ]);
+    await writeMainSessionTranscript([{ role: "user", content: "do the thing" }, assistantMessage]);
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
     expect(callGateway).not.toHaveBeenCalled();
@@ -4399,9 +4400,7 @@ describe("main-session-restart-recovery", () => {
     async (errorMessage) => {
       // The process that wrote this tail predates errorCode propagation, and it
       // can be the very process replaced by the upgrade running recovery now.
-      const sessionsDir = await makeSessionsDir();
-      await writeStore(sessionsDir, mainSessionStore());
-      await writeTranscript(sessionsDir, "main-session", [
+      await writeMainSessionTranscript([
         { role: "user", content: "do the thing" },
         { role: "assistant", content: [], stopReason: "error", errorMessage },
       ]);
@@ -4444,9 +4443,7 @@ describe("main-session-restart-recovery", () => {
   ])(
     "resumes an aborted tail persisted with %s",
     async (_label, assistantMessage, forceRestartSafeTools) => {
-      const sessionsDir = await makeSessionsDir();
-      await writeStore(sessionsDir, mainSessionStore());
-      await writeTranscript(sessionsDir, "main-session", [
+      await writeMainSessionTranscript([
         { role: "user", content: "do the thing" },
         assistantMessage,
       ]);
@@ -4784,9 +4781,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("reads a provider-native Code Mode wait input", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       codeModeCheckpointMessage("exec"),
       createAssistantToolCallMessage([
@@ -4820,14 +4815,7 @@ describe("main-session-restart-recovery", () => {
   ])(
     "classifies a direct waiting checkpoint with replaySafe=$replaySafe",
     async ({ replaySafe, expected, gatewayCalls }) => {
-      const sessionsDir = await makeSessionsDir();
-      await writeStore(sessionsDir, {
-        "agent:main:main": {
-          ...runningSessionEntry("main-session"),
-          abortedLastRun: true,
-        },
-      });
-      await writeTranscript(sessionsDir, "main-session", [
+      await writeMainSessionTranscript([
         { role: "user", content: "do the thing" },
         {
           role: "toolResult",
@@ -4856,14 +4844,7 @@ describe("main-session-restart-recovery", () => {
   it.each(["completed", "failed"] as const)(
     "keeps restart safety after a terminal Code Mode %s result",
     async (status) => {
-      const sessionsDir = await makeSessionsDir();
-      await writeStore(sessionsDir, {
-        "agent:main:main": {
-          ...runningSessionEntry("main-session"),
-          abortedLastRun: true,
-        },
-      });
-      await writeTranscript(sessionsDir, "main-session", [
+      await writeMainSessionTranscript([
         { role: "user", content: "do the thing" },
         {
           role: "toolResult",
@@ -4935,9 +4916,7 @@ describe("main-session-restart-recovery", () => {
   ])(
     "preserves the restart-safe boundary after an ordinary tool result with $label",
     async ({ messages, forceRestartSafeTools }) => {
-      const sessionsDir = await makeSessionsDir();
-      await writeStore(sessionsDir, mainSessionStore());
-      await writeTranscript(sessionsDir, "main-session", messages);
+      await writeMainSessionTranscript(messages);
 
       await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
       if (forceRestartSafeTools) {
@@ -4949,93 +4928,83 @@ describe("main-session-restart-recovery", () => {
   );
 
   it("keeps restart safety across a second restart of the recovery turn", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeMainSession({
-      sessionsDir,
-      restartRecoveryForceSafeTools: true,
-    });
-    await writeTranscript(sessionsDir, "main-session", [
-      { role: "user", content: "do the thing" },
-      {
-        role: "user",
-        content:
-          "[System] Your previous turn was interrupted by a gateway restart while OpenClaw was waiting on tool/model work. Continue from the existing transcript and finish the interrupted response.",
-      },
-      createAssistantToolCallMessage([
+    await writeMainSessionTranscript(
+      [
+        { role: "user", content: "do the thing" },
         {
-          type: "toolCall",
-          id: "call-read-1",
-          name: "read",
-          arguments: { path: "README.md" },
+          role: "user",
+          content:
+            "[System] Your previous turn was interrupted by a gateway restart while OpenClaw was waiting on tool/model work. Continue from the existing transcript and finish the interrupted response.",
         },
-      ]),
-      {
-        role: "toolResult",
-        toolName: "read",
-        content: [{ type: "text", text: "read result" }],
-      },
-    ]);
+        createAssistantToolCallMessage([
+          {
+            type: "toolCall",
+            id: "call-read-1",
+            name: "read",
+            arguments: { path: "README.md" },
+          },
+        ]),
+        {
+          role: "toolResult",
+          toolName: "read",
+          content: [{ type: "text", text: "read result" }],
+        },
+      ],
+      { restartRecoveryForceSafeTools: true },
+    );
 
     await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
     expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
   });
 
   it("keeps restart safety after the recovery prompt leaves the recent transcript window", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeMainSession({
-      sessionsDir,
-      restartRecoveryForceSafeTools: true,
-    });
-    await writeTranscript(sessionsDir, "main-session", [
-      { role: "user", content: "do the thing" },
-      ...Array.from({ length: 24 }, (_, index) => ({
-        role: "toolResult",
-        toolName: "read",
-        content: [{ type: "text", text: `read result ${index}` }],
-      })),
-    ]);
+    await writeMainSessionTranscript(
+      [
+        { role: "user", content: "do the thing" },
+        ...Array.from({ length: 24 }, (_, index) => ({
+          role: "toolResult",
+          toolName: "read",
+          content: [{ type: "text", text: `read result ${index}` }],
+        })),
+      ],
+      { restartRecoveryForceSafeTools: true },
+    );
 
     await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
     expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
   });
 
   it("resumes an in-flight safe tool call across a repeated restart", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeMainSession({
-      sessionsDir,
-      restartRecoveryForceSafeTools: true,
-    });
-    await writeTranscript(sessionsDir, "main-session", [
-      { role: "user", content: "do the thing" },
-      createAssistantToolCallMessage([
-        { type: "thinking", thinking: "I need one more read." },
-        { type: "toolCall", id: "call-read-2", name: "read", arguments: { path: "README.md" } },
-      ]),
-    ]);
+    await writeMainSessionTranscript(
+      [
+        { role: "user", content: "do the thing" },
+        createAssistantToolCallMessage([
+          { type: "thinking", thinking: "I need one more read." },
+          { type: "toolCall", id: "call-read-2", name: "read", arguments: { path: "README.md" } },
+        ]),
+      ],
+      { restartRecoveryForceSafeTools: true },
+    );
 
     await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
     expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
   });
 
   it("does not resume completed assistant output just because the restart-safe guard remains", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeMainSession({
-      sessionsDir,
-      restartRecoveryForceSafeTools: true,
-    });
-    await writeTranscript(sessionsDir, "main-session", [
-      { role: "user", content: "do the thing" },
-      { role: "assistant", content: [{ type: "text", text: "Done already." }] },
-    ]);
+    await writeMainSessionTranscript(
+      [
+        { role: "user", content: "do the thing" },
+        { role: "assistant", content: [{ type: "text", text: "Done already." }] },
+      ],
+      { restartRecoveryForceSafeTools: true },
+    );
 
     await expectRecovery({ recovered: 0, failed: 1, skipped: 0 });
     expect(callGateway).not.toHaveBeenCalled();
   });
 
   it("does not treat a historical recovery prompt as current recovery state", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       {
         role: "user",
         content:
@@ -5051,9 +5020,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("does not replay visible assistant text beside a Code Mode wait", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       codeModeCheckpointMessage("exec"),
       createAssistantToolCallMessage([
@@ -5087,14 +5054,7 @@ describe("main-session-restart-recovery", () => {
   ])(
     "handles $label without discarding assistant output",
     async ({ content, expected, gatewayCalls }) => {
-      const sessionsDir = await makeSessionsDir();
-      await writeStore(sessionsDir, {
-        "agent:main:main": {
-          ...runningSessionEntry("main-session"),
-          abortedLastRun: true,
-        },
-      });
-      await writeTranscript(sessionsDir, "main-session", [
+      await writeMainSessionTranscript([
         { role: "user", content: "do the thing" },
         codeModeCheckpointMessage("exec"),
         codeModeWaitCallMessage(),
@@ -5114,9 +5074,7 @@ describe("main-session-restart-recovery", () => {
   );
 
   it("resumes a partial streamed answer interrupted by a restart", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       {
         role: "assistant",
@@ -5132,9 +5090,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("resumes an abort artifact persisted with the gateway restart reason", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       {
         role: "assistant",
@@ -5149,9 +5105,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("resumes a side-effecting tool call restricted to restart-safe tools", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       createAssistantToolCallMessage([
         { type: "text", text: "Running the check now." },
@@ -5165,9 +5119,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("keeps a dangling side-effecting call in an aborted tail restricted", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       {
         role: "assistant",
@@ -5186,9 +5138,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("resumes an interrupted replay-safe tool call without restricting tools", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       createAssistantToolCallMessage([
         { type: "text", text: "Let me look that up." },
@@ -5202,9 +5152,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("resumes through the shutdown error persisted for an interrupted Code Mode wait", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       codeModeCheckpointMessage(),
       codeModeWaitCallMessage(),
@@ -5236,9 +5184,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("resumes through the current Code Mode abort persisted for an interrupted wait", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       codeModeCheckpointMessage(),
       codeModeWaitCallMessage(),
@@ -5281,9 +5227,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("keeps an unmatched failed wait restricted when its checkpoint is replay-safe", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       codeModeCheckpointMessage(),
       codeModeWaitCallMessage(),
@@ -5328,9 +5272,7 @@ describe("main-session-restart-recovery", () => {
       },
     },
   ])("does not resume a Code Mode wait after a $label", async ({ checkpoint }) => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       codeModeCheckpointMessage("wait", checkpoint),
       codeModeWaitCallMessage(),
@@ -5341,9 +5283,7 @@ describe("main-session-restart-recovery", () => {
   });
 
   it("does not resume a mixed Code Mode wait and side-effecting tool tail", async () => {
-    const sessionsDir = await makeSessionsDir();
-    await writeStore(sessionsDir, mainSessionStore());
-    await writeTranscript(sessionsDir, "main-session", [
+    await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       codeModeCheckpointMessage("exec"),
       createAssistantToolCallMessage([


### PR DESCRIPTION
## What Problem This Solves

The main-session restart-recovery owner repeated the same durable transcript, foreground-claim, commit, and lifecycle-projection setup across its focused tests. The dispatch path also kept a private copy of finite-timestamp normalization already owned by the shared recovery helper.

## Why This Change Was Made

This keeps main-session recovery as one canonical lifecycle owner: dispatch now imports the shared timestamp normalizer, while the state, store, and restart-recovery suites use small owner-level fixture helpers. Every existing test identity and assertion remains intact; no runtime behavior, schema, protocol, config, or public contract changes.

Architectural owner: `src/agents/main-session-*` restart-recovery lifecycle. Removed paths: the duplicate dispatch normalizer and repeated test-only setup wrappers. Production delta is +1/-4 (net -3); total delta is +320/-521 (net -201).

## User Impact

No user-visible behavior changes. The recovery lifecycle has less duplicate policy and its tests express scenario-specific state instead of repeated plumbing.

## Evidence

- Focused exact-head proof: 207/207 tests passed across `main-session-recovery-state.test.ts`, `main-session-recovery-store.test.ts`, and `main-session-restart-recovery.test.ts`.
- Full changed-file gate passed on Blacksmith Testbox, including core/core-test typechecks, changed-file lint, formatting, dead-export scans, import-cycle checks, and repository ratchets: https://github.com/openclaw/openclaw/actions/runs/30781058048
- Fresh branch autoreview on `b419efa89b0` reported no accepted/actionable findings.
- `git diff --check` and targeted `oxfmt` passed.
- Sibling coverage: pure state transitions, durable store ownership, startup/restart recovery integration, repeated lifecycle generations, and exact foreground-owner release paths remain covered.
