### PR TITLE
refactor(macos): consolidate gateway lifecycle state

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -133,16 +133,29 @@ actor GatewayConnection {
     private let clientShutdown: @Sendable (GatewayChannelActor) async -> Void
     private let decoder = JSONDecoder()
 
-    private var client: GatewayChannelActor?
-    private var configuredURL: URL?
-    private var configuredToken: String?
-    private var configuredPassword: String?
-    private var configuredTLS: GatewayTLSRoute?
-    private var configuredTLSMetadataProvider: (any GatewayTLSRouteMetadataProviding)?
-    private var configuredDeviceAuthGatewayID: String?
-    private var configuredRouteAuthority: UInt64?
-    private var configuredShutdownGeneration: UInt64?
-    private var configuredActivationBindingKey: SymmetricKey?
+    private struct ConfiguredConnection {
+        let client: GatewayChannelActor
+        let endpoint: EndpointSnapshot
+        let tlsMetadataProvider: (any GatewayTLSRouteMetadataProviding)?
+        let shutdownGeneration: UInt64
+        let activationBindingKey: SymmetricKey?
+
+        func matches(endpoint: EndpointSnapshot, shutdownGeneration: UInt64? = nil) -> Bool {
+            self.endpoint.config.url == endpoint.config.url &&
+                self.endpoint.config.token == endpoint.config.token &&
+                self.endpoint.config.password == endpoint.config.password &&
+                GatewayTLSRoute.hasSameConnectionIdentity(self.endpoint.tls, endpoint.tls) &&
+                self.endpoint.deviceAuthGatewayID == endpoint.deviceAuthGatewayID &&
+                self.endpoint.routeAuthority == endpoint.routeAuthority &&
+                shutdownGeneration.map { self.shutdownGeneration == $0 } ?? true
+        }
+
+        func matches(route: Route) -> Bool {
+            route.matches(self.endpoint)
+        }
+    }
+
+    private var configuredConnection: ConfiguredConnection?
     private var highestEndpointRevision: UInt64?
     private var routeGeneration: UInt64 = 0
     /// Unbound operations capture this before their first suspension. Shutdown
@@ -256,12 +269,7 @@ actor GatewayConnection {
         let endpoint = try await currentEndpoint()
         let cfg = endpoint.config
         let client = try await configure(
-            url: cfg.url,
-            token: cfg.token,
-            password: cfg.password,
-            tls: endpoint.tls,
-            deviceAuthGatewayID: endpoint.deviceAuthGatewayID,
-            routeAuthority: endpoint.routeAuthority,
+            endpoint: endpoint,
             shutdownGeneration: shutdownGeneration)
 
         do {
@@ -298,49 +306,36 @@ actor GatewayConnection {
                 await MainActor.run { GatewayProcessManager.shared.setActive(true) }
                 try requireCurrentShutdownGeneration(shutdownGeneration)
 
-                var lastError: Error = error
-                for delayMs in [150, 400, 900] {
-                    try await Task.sleep(nanoseconds: UInt64(delayMs) * 1_000_000)
-                    try requireCurrentShutdownGeneration(shutdownGeneration)
-                    do {
-                        return try await client.request(method: method, params: params, timeoutMs: timeoutMs)
-                    } catch {
-                        try requireCurrentShutdownGeneration(shutdownGeneration)
-                        lastError = error
-                    }
+                let lastError: Error
+                do {
+                    return try await self.retryRequest(
+                        client: client,
+                        method: method,
+                        params: params,
+                        timeoutMs: timeoutMs,
+                        after: error,
+                        shutdownGeneration: shutdownGeneration)
+                } catch {
+                    lastError = error
                 }
 
                 let nsError = lastError as NSError
-                try requireCurrentShutdownGeneration(shutdownGeneration)
                 if nsError.domain == URLError.errorDomain,
                    let fallback = await GatewayEndpointStore.shared.maybeFallbackToTailnet(from: cfg.url)
                 {
                     try acceptEndpointRevision(fallback)
-                    let fallbackConfig = fallback.config
                     let fallbackClient = try await configure(
-                        url: fallbackConfig.url,
-                        token: fallbackConfig.token,
-                        password: fallbackConfig.password,
-                        tls: fallback.tls,
-                        deviceAuthGatewayID: fallback.deviceAuthGatewayID,
-                        routeAuthority: fallback.routeAuthority,
+                        endpoint: fallback,
                         shutdownGeneration: shutdownGeneration)
-                    for delayMs in [150, 400, 900] {
-                        try await Task.sleep(nanoseconds: UInt64(delayMs) * 1_000_000)
-                        try requireCurrentShutdownGeneration(shutdownGeneration)
-                        do {
-                            return try await fallbackClient.request(
-                                method: method,
-                                params: params,
-                                timeoutMs: timeoutMs)
-                        } catch {
-                            try requireCurrentShutdownGeneration(shutdownGeneration)
-                            lastError = error
-                        }
-                    }
+                    return try await self.retryRequest(
+                        client: fallbackClient,
+                        method: method,
+                        params: params,
+                        timeoutMs: timeoutMs,
+                        after: lastError,
+                        shutdownGeneration: shutdownGeneration)
                 }
 
-                try requireCurrentShutdownGeneration(shutdownGeneration)
                 throw lastError
             case .remote:
                 let nsError = error as NSError
@@ -362,14 +357,8 @@ actor GatewayConnection {
                     try requireCurrentShutdownGeneration(shutdownGeneration)
                     do {
                         let endpoint = try await currentEndpoint()
-                        let cfg = endpoint.config
                         let client = try await configure(
-                            url: cfg.url,
-                            token: cfg.token,
-                            password: cfg.password,
-                            tls: endpoint.tls,
-                            deviceAuthGatewayID: endpoint.deviceAuthGatewayID,
-                            routeAuthority: endpoint.routeAuthority,
+                            endpoint: endpoint,
                             shutdownGeneration: shutdownGeneration)
                         return try await client.request(method: method, params: params, timeoutMs: timeoutMs)
                     } catch {
@@ -386,6 +375,28 @@ actor GatewayConnection {
         }
     }
 
+    private func retryRequest(
+        client: GatewayChannelActor,
+        method: String,
+        params: [String: AnyCodable]?,
+        timeoutMs: Double?,
+        after initialError: Error,
+        shutdownGeneration: UInt64) async throws -> Data
+    {
+        var lastError = initialError
+        for delayMs in [150, 400, 900] {
+            try await Task.sleep(nanoseconds: UInt64(delayMs) * 1_000_000)
+            try requireCurrentShutdownGeneration(shutdownGeneration)
+            do {
+                return try await client.request(method: method, params: params, timeoutMs: timeoutMs)
+            } catch {
+                try requireCurrentShutdownGeneration(shutdownGeneration)
+                lastError = error
+            }
+        }
+        throw lastError
+    }
+
     /// Route-bound requests never reconfigure or retry on another endpoint.
     /// Durable outbox rows must remain owned by the gateway that created them.
     func request(
@@ -396,15 +407,8 @@ actor GatewayConnection {
         distinguishPreDispatchRouteChange: Bool = false) async throws -> Data
     {
         let endpoint = try await currentEndpoint()
-        guard route.generation == self.routeGeneration,
-              route.matches(endpoint),
-              self.configuredURL == route.url,
-              self.configuredToken == route.token,
-              self.configuredPassword == route.password,
-              GatewayTLSRoute.hasSameConnectionIdentity(self.configuredTLS, route.tls),
-              self.configuredDeviceAuthGatewayID == route.deviceAuthGatewayID,
-              self.configuredRouteAuthority == route.authority,
-              let client
+        guard self.routeMatchesCurrentState(route, endpoint: endpoint),
+              let client = self.configuredConnection?.client
         else {
             if distinguishPreDispatchRouteChange {
                 throw OpenClawChatTransportSendError.notDispatched
@@ -412,7 +416,7 @@ actor GatewayConnection {
             throw CancellationError()
         }
         let data = try await client.request(method: method, params: params, timeoutMs: timeoutMs)
-        guard await self.isCurrentRoute(route), self.client === client else {
+        guard await self.isCurrentRoute(route), self.configuredConnection?.client === client else {
             throw CancellationError()
         }
         return data
@@ -593,14 +597,8 @@ extension GatewayConnection {
     func refresh() async throws {
         let shutdownGeneration = shutdownGeneration
         let endpoint = try await currentEndpoint()
-        let cfg = endpoint.config
         _ = try await self.configure(
-            url: cfg.url,
-            token: cfg.token,
-            password: cfg.password,
-            tls: endpoint.tls,
-            deviceAuthGatewayID: endpoint.deviceAuthGatewayID,
-            routeAuthority: endpoint.routeAuthority,
+            endpoint: endpoint,
             shutdownGeneration: shutdownGeneration)
     }
 
@@ -613,12 +611,7 @@ extension GatewayConnection {
         let endpoint = try await currentEndpoint()
         let cfg = endpoint.config
         _ = try await self.configure(
-            url: cfg.url,
-            token: cfg.token,
-            password: cfg.password,
-            tls: endpoint.tls,
-            deviceAuthGatewayID: endpoint.deviceAuthGatewayID,
-            routeAuthority: endpoint.routeAuthority,
+            endpoint: endpoint,
             shutdownGeneration: shutdownGeneration)
         return Route(
             generation: self.routeGeneration,
@@ -630,7 +623,7 @@ extension GatewayConnection {
             deviceAuthGatewayID: endpoint.deviceAuthGatewayID,
             activationOwnershipFingerprint: Self.activationOwnershipFingerprint(
                 config: cfg,
-                key: self.configuredActivationBindingKey))
+                key: self.configuredConnection?.activationBindingKey))
     }
 
     /// Connect and bind subsequent work to the hello snapshot's physical
@@ -645,7 +638,7 @@ extension GatewayConnection {
     /// reconnecting. Queued mutations use this so waiting cannot retarget them.
     func captureServerLease() async -> ServerLease? {
         guard let route = await self.captureRoute(),
-              let client = self.client,
+              let client = self.configuredConnection?.client,
               let socketGeneration = self.activeSocketGeneration
         else { return nil }
         let lease = ServerLease(route: route, socketGeneration: socketGeneration, client: client)
@@ -667,12 +660,7 @@ extension GatewayConnection {
         let endpoint = try await currentEndpoint()
         let cfg = endpoint.config
         guard let client = configuredClient(
-            url: cfg.url,
-            token: cfg.token,
-            password: cfg.password,
-            tls: endpoint.tls,
-            deviceAuthGatewayID: endpoint.deviceAuthGatewayID,
-            routeAuthority: endpoint.routeAuthority,
+            endpoint: endpoint,
             shutdownGeneration: shutdownGeneration)
         else {
             throw OpenClawChatTransportSendError.notDispatched
@@ -697,7 +685,7 @@ extension GatewayConnection {
                 activationOwnershipFingerprint: Self.activationOwnershipFingerprint(
                     config: cfg,
                     authBinding: authBinding,
-                    key: self.configuredActivationBindingKey)),
+                    key: self.configuredConnection?.activationBindingKey)),
             socketGeneration: socketGeneration,
             client: client)
         guard await self.isCurrentServerLease(lease) else {
@@ -734,14 +722,7 @@ extension GatewayConnection {
 
     func isCurrentRoute(_ route: Route) async -> Bool {
         guard let endpoint = try? await currentEndpoint() else { return false }
-        return route.generation == self.routeGeneration &&
-            route.matches(endpoint) &&
-            self.configuredURL == route.url &&
-            self.configuredToken == route.token &&
-            self.configuredPassword == route.password &&
-            GatewayTLSRoute.hasSameConnectionIdentity(self.configuredTLS, route.tls) &&
-            self.configuredDeviceAuthGatewayID == route.deviceAuthGatewayID &&
-            self.configuredRouteAuthority == route.authority
+        return self.routeMatchesCurrentState(route, endpoint: endpoint)
     }
 
     func supportsServerCapability(
@@ -749,16 +730,8 @@ extension GatewayConnection {
         ifCurrentRoute route: Route) async -> Bool?
     {
         guard let endpoint = try? await currentEndpoint() else { return nil }
-        guard
-            route.generation == self.routeGeneration,
-            route.matches(endpoint),
-            self.configuredURL == route.url,
-            self.configuredToken == route.token,
-            self.configuredPassword == route.password,
-            GatewayTLSRoute.hasSameConnectionIdentity(self.configuredTLS, route.tls),
-            self.configuredDeviceAuthGatewayID == route.deviceAuthGatewayID,
-            self.configuredRouteAuthority == route.authority,
-            let snapshot = lastSnapshot
+        guard self.routeMatchesCurrentState(route, endpoint: endpoint),
+              let snapshot = lastSnapshot
         else { return nil }
         return snapshot.supportsServerCapability(capability)
     }
@@ -804,16 +777,19 @@ extension GatewayConnection {
     }
 
     private func serverLeaseMatchesCurrentState(_ lease: ServerLease) -> Bool {
-        lease.route.generation == self.routeGeneration &&
-            lease.route.url == self.configuredURL &&
-            lease.route.token == self.configuredToken &&
-            lease.route.password == self.configuredPassword &&
-            GatewayTLSRoute.hasSameConnectionIdentity(lease.route.tls, self.configuredTLS) &&
-            lease.route.deviceAuthGatewayID == self.configuredDeviceAuthGatewayID &&
-            lease.route.authority == self.configuredRouteAuthority &&
-            self.client === lease.client &&
+        self.routeMatchesConfiguredConnection(lease.route) &&
+            self.configuredConnection?.client === lease.client &&
             self.activeSocketGeneration == lease.socketGeneration &&
             self.lastSnapshot != nil
+    }
+
+    private func routeMatchesCurrentState(_ route: Route, endpoint: EndpointSnapshot) -> Bool {
+        route.matches(endpoint) && self.routeMatchesConfiguredConnection(route)
+    }
+
+    private func routeMatchesConfiguredConnection(_ route: Route) -> Bool {
+        route.generation == self.routeGeneration &&
+            self.configuredConnection?.matches(route: route) == true
     }
 
     func sessionRoutingIdentity(
@@ -826,91 +802,47 @@ extension GatewayConnection {
     }
 
     func configuredGatewayURL() -> URL? {
-        self.configuredURL
+        self.configuredConnection?.endpoint.config.url
     }
 
     func configuredTLSFingerprintSHA256() -> String? {
-        self.configuredTLSMetadataProvider?.effectiveTLSFingerprintSHA256
+        self.configuredConnection?.tlsMetadataProvider?.effectiveTLSFingerprintSHA256
     }
 
     func authSource() async -> GatewayAuthSource? {
-        guard let client else { return nil }
-        return await client.authSource()
+        guard let connection = self.configuredConnection else { return nil }
+        return await connection.client.authSource()
     }
 
     func shutdown() async {
         self.shutdownGeneration &+= 1
-        self.routeGeneration &+= 1
-        resetSocketGeneration()
-        self.lastSnapshot = nil
-        self.resetCanvasPluginSurfaceState()
-        let client = client
-        self.client = nil
-        self.configuredURL = nil
-        self.configuredToken = nil
-        self.configuredPassword = nil
-        self.configuredTLS = nil
-        self.configuredTLSMetadataProvider = nil
-        self.configuredDeviceAuthGatewayID = nil
-        self.configuredRouteAuthority = nil
-        self.configuredShutdownGeneration = nil
-        self.configuredActivationBindingKey = nil
+        let client = self.retireConfiguredConnection()
         if let client {
             await self.clientShutdown(client)
         }
     }
 
     private func configure(
-        url: URL,
-        token: String?,
-        password: String?,
-        tls: GatewayTLSRoute?,
-        deviceAuthGatewayID: String?,
-        routeAuthority: UInt64?,
+        endpoint: EndpointSnapshot,
         shutdownGeneration: UInt64) async throws -> GatewayChannelActor
     {
         try self.requireCurrentShutdownGeneration(shutdownGeneration)
+        let config = endpoint.config
         if let client = configuredClient(
-            url: url,
-            token: token,
-            password: password,
-            tls: tls,
-            deviceAuthGatewayID: deviceAuthGatewayID,
-            routeAuthority: routeAuthority,
+            endpoint: endpoint,
             shutdownGeneration: shutdownGeneration)
         {
             return client
         }
-        // Invalidate captured routes before suspension so no reentrant caller
-        // can continue an old-gateway outbox flush during replacement.
-        self.routeGeneration &+= 1
-        resetSocketGeneration()
-        self.lastSnapshot = nil
-        self.resetCanvasPluginSurfaceState()
+        let previousClient = self.retireConfiguredConnection()
         let configuredRouteGeneration = self.routeGeneration
-        let previousClient = client
-        client = nil
-        self.configuredURL = nil
-        self.configuredToken = nil
-        self.configuredPassword = nil
-        self.configuredTLS = nil
-        self.configuredTLSMetadataProvider = nil
-        self.configuredDeviceAuthGatewayID = nil
-        self.configuredRouteAuthority = nil
-        self.configuredShutdownGeneration = nil
-        self.configuredActivationBindingKey = nil
         if let previousClient {
             await self.clientShutdown(previousClient)
         }
         try self.requireCurrentShutdownGeneration(shutdownGeneration)
         if self.routeGeneration != configuredRouteGeneration {
             if let client = configuredClient(
-                url: url,
-                token: token,
-                password: password,
-                tls: tls,
-                deviceAuthGatewayID: deviceAuthGatewayID,
-                routeAuthority: routeAuthority,
+                endpoint: endpoint,
                 shutdownGeneration: shutdownGeneration)
             {
                 return client
@@ -918,11 +850,11 @@ extension GatewayConnection {
             throw CancellationError()
         }
         let activationBindingKey = self.activationBindingKeyProvider()
-        let sessionBox = self.sessionProvider(tls)
+        let sessionBox = self.sessionProvider(endpoint.tls)
         let client = GatewayChannelActor(
-            url: url,
-            token: token,
-            password: password,
+            url: config.url,
+            token: config.token,
+            password: config.password,
             authBindingKey: activationBindingKey,
             session: sessionBox,
             connectSnapshotAdmissionHandler: { [weak self] snapshot, socketGeneration in
@@ -947,44 +879,44 @@ extension GatewayConnection {
                 clientMode: "ui",
                 clientDisplayName: InstanceIdentity.displayName,
                 includeDeviceIdentity: self.includeDeviceIdentity,
-                allowStoredDeviceAuth: deviceAuthGatewayID != nil,
-                deviceAuthGatewayID: deviceAuthGatewayID),
+                allowStoredDeviceAuth: endpoint.deviceAuthGatewayID != nil,
+                deviceAuthGatewayID: endpoint.deviceAuthGatewayID),
             disconnectHandler: { [weak self] _, socketGeneration in
                 await self?.handleDisconnect(
                     routeGeneration: configuredRouteGeneration,
                     socketGeneration: socketGeneration)
             })
-        self.client = client
-        self.configuredURL = url
-        self.configuredToken = token
-        self.configuredPassword = password
-        self.configuredTLS = tls
-        self.configuredTLSMetadataProvider = sessionBox?.session as? GatewayTLSRouteMetadataProviding
-        self.configuredDeviceAuthGatewayID = deviceAuthGatewayID
-        self.configuredRouteAuthority = routeAuthority
-        self.configuredShutdownGeneration = shutdownGeneration
-        self.configuredActivationBindingKey = activationBindingKey
+        self.configuredConnection = ConfiguredConnection(
+            client: client,
+            endpoint: endpoint,
+            tlsMetadataProvider: sessionBox?.session as? GatewayTLSRouteMetadataProviding,
+            shutdownGeneration: shutdownGeneration,
+            activationBindingKey: activationBindingKey)
         return client
     }
 
     private func configuredClient(
-        url: URL,
-        token: String?,
-        password: String?,
-        tls: GatewayTLSRoute?,
-        deviceAuthGatewayID: String?,
-        routeAuthority: UInt64?,
+        endpoint: EndpointSnapshot,
         shutdownGeneration: UInt64) -> GatewayChannelActor?
     {
-        guard self.configuredShutdownGeneration == shutdownGeneration,
-              self.configuredURL == url,
-              self.configuredToken == token,
-              self.configuredPassword == password,
-              GatewayTLSRoute.hasSameConnectionIdentity(self.configuredTLS, tls),
-              self.configuredDeviceAuthGatewayID == deviceAuthGatewayID,
-              self.configuredRouteAuthority == routeAuthority
+        guard let connection = self.configuredConnection,
+              connection.matches(
+                  endpoint: endpoint,
+                  shutdownGeneration: shutdownGeneration)
         else { return nil }
-        return self.client
+        return connection.client
+    }
+
+    /// Invalidate every route-owned fact before shutdown can suspend; otherwise
+    /// reentrant work could continue on a client whose replacement is in flight.
+    private func retireConfiguredConnection() -> GatewayChannelActor? {
+        self.routeGeneration &+= 1
+        self.resetSocketGeneration()
+        self.lastSnapshot = nil
+        self.resetCanvasPluginSurfaceState()
+        let client = self.configuredConnection?.client
+        self.configuredConnection = nil
+        return client
     }
 
     private func requireCurrentShutdownGeneration(_ shutdownGeneration: UInt64) throws {
@@ -1068,7 +1000,7 @@ extension GatewayConnection {
     }
 
     func _test_configuredURL() -> URL? {
-        self.configuredURL
+        self.configuredConnection?.endpoint.config.url
     }
 
     func _test_handlePush(
@@ -1143,30 +1075,21 @@ extension GatewayConnection {
               endpoint.config.url == config.url,
               endpoint.config.token == config.token,
               endpoint.config.password == config.password,
-              let client,
+              let client = self.configuredConnection?.client,
               let socketGeneration = activeSocketGeneration,
               controlUiRouteIsLive(
-                  config: config,
-                  tls: endpoint.tls,
-                  routeAuthority: endpoint.routeAuthority,
-                  deviceAuthGatewayID: endpoint.deviceAuthGatewayID,
+                  endpoint: endpoint,
                   client: client,
                   socketGeneration: socketGeneration),
               await client.currentConnectionGeneration() == socketGeneration,
               controlUiRouteIsLive(
-                  config: config,
-                  tls: endpoint.tls,
-                  routeAuthority: endpoint.routeAuthority,
-                  deviceAuthGatewayID: endpoint.deviceAuthGatewayID,
+                  endpoint: endpoint,
                   client: client,
                   socketGeneration: socketGeneration),
               let authBinding = await client.authBinding(
                   ifCurrentConnectionGeneration: socketGeneration),
               controlUiRouteIsLive(
-                  config: config,
-                  tls: endpoint.tls,
-                  routeAuthority: endpoint.routeAuthority,
-                  deviceAuthGatewayID: endpoint.deviceAuthGatewayID,
+                  endpoint: endpoint,
                   client: client,
                   socketGeneration: socketGeneration)
         else { return nil }
@@ -1175,7 +1098,7 @@ extension GatewayConnection {
         case .sharedToken:
             return config.token?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
         case .deviceToken:
-            guard let gatewayID = configuredDeviceAuthGatewayID?
+            guard let gatewayID = configuredConnection?.endpoint.deviceAuthGatewayID?
                 .trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
             else { return nil }
             if let deviceToken = lastSnapshot?.auth["deviceToken"]?.value as? String,
@@ -1195,21 +1118,14 @@ extension GatewayConnection {
     }
 
     private func controlUiRouteIsLive(
-        config: Config,
-        tls: GatewayTLSRoute?,
-        routeAuthority: UInt64?,
-        deviceAuthGatewayID: String?,
+        endpoint: EndpointSnapshot,
         client: GatewayChannelActor,
         socketGeneration: UInt64) -> Bool
     {
-        self.configuredURL == config.url &&
-            self.configuredToken == config.token &&
-            self.configuredPassword == config.password &&
-            GatewayTLSRoute.hasSameConnectionIdentity(self.configuredTLS, tls) &&
-            self.configuredRouteAuthority == routeAuthority &&
-            self.configuredDeviceAuthGatewayID == deviceAuthGatewayID &&
-            self.configuredShutdownGeneration == self.shutdownGeneration &&
-            self.client === client &&
+        self.configuredConnection?.matches(
+            endpoint: endpoint,
+            shutdownGeneration: self.shutdownGeneration) == true &&
+            self.configuredConnection?.client === client &&
             self.activeSocketGeneration == socketGeneration &&
             self.lastSnapshot != nil
     }
@@ -1393,27 +1309,6 @@ extension GatewayConnection {
         } catch {
             return (false, error.localizedDescription)
         }
-    }
-
-    func sendAgent(
-        message: String,
-        thinking: String?,
-        sessionKey: String,
-        deliver: Bool,
-        to: String?,
-        channel: GatewayAgentChannel = .last,
-        timeoutSeconds: Int? = nil,
-        idempotencyKey: String = UUID().uuidString) async -> (ok: Bool, error: String?)
-    {
-        await self.sendAgent(GatewayAgentInvocation(
-            message: message,
-            sessionKey: sessionKey,
-            thinking: thinking,
-            deliver: deliver,
-            to: to,
-            channel: channel,
-            timeoutSeconds: timeoutSeconds,
-            idempotencyKey: idempotencyKey))
     }
 
     // MARK: - Health

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
@@ -44,25 +44,11 @@ struct GatewayConnectionTests {
                             try await Task.sleep(nanoseconds: UInt64(helloDelayMs) * 1_000_000)
                         }
                         let id = task.snapshotConnectRequestID() ?? "connect"
-                        return .data(Self.connectOkData(id: id, capabilities: serverCapabilities))
+                        return .data(GatewayWebSocketTestSupport.connectOkData(
+                            id: id,
+                            capabilities: serverCapabilities))
                     })
             })
-    }
-
-    private static func connectOkData(id: String, capabilities: [String]) -> Data {
-        let encodedCapabilities = capabilities.map { "\"\($0)\"" }.joined(separator: ",")
-        return Data(
-            """
-            {
-              "type":"res","id":"\(id)","ok":true,"payload":{
-                "type":"hello-ok","protocol":4,
-                "server":{"version":"test","connId":"test"},
-                "features":{"methods":[],"events":[],"capabilities":[\(encodedCapabilities)]},
-                "snapshot":{"presence":[],"health":{},"stateVersion":{"presence":0,"health":0},"uptimeMs":0},
-                "auth":{},"policy":{}
-              }
-            }
-            """.utf8)
     }
 
     private final class ConfigSource: @unchecked Sendable {
@@ -162,7 +148,7 @@ struct GatewayConnectionTests {
                             return .data(GatewayWebSocketTestSupport.connectChallengeData())
                         }
                         let id = task.snapshotConnectRequestID() ?? "connect"
-                        return .data(Self.connectOkData(
+                        return .data(GatewayWebSocketTestSupport.connectOkData(
                             id: id,
                             capabilities: ["openclaw-setup-model-ref"]))
                     })

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -35,87 +35,6 @@ private func gatewayGenerationSnapshotVersion(_ push: GatewayPush?) -> String? {
     return snapshot.server["version"]?.value as? String
 }
 
-private final class FakeWebSocketTask: WebSocketTasking, @unchecked Sendable {
-    var state: URLSessionTask.State = .running
-    var autoRespond = false
-    private(set) var sentMessages: [URLSessionWebSocketTask.Message] = []
-    private var sentChallenge = false
-    private var respondedRequestIds = Set<String>()
-
-    func resume() {}
-
-    func cancel(with _: URLSessionWebSocketTask.CloseCode, reason _: Data?) {
-        state = .canceling
-    }
-
-    func send(_ message: URLSessionWebSocketTask.Message) async throws {
-        sentMessages.append(message)
-    }
-
-    func receive() async throws -> URLSessionWebSocketTask.Message {
-        if autoRespond {
-            if !sentChallenge {
-                sentChallenge = true
-                return .string("""
-                {"type":"event","event":"connect.challenge","payload":{"nonce":"test-nonce","ts":1777777777000}}
-                """)
-            }
-            if let request = latestUnrespondedRequest() {
-                respondedRequestIds.insert(request.id)
-                if request.method == "connect" {
-                    return .string("""
-                    {"type":"res","id":"\(request
-                        .id)","ok":true,"payload":{"type":"hello","protocol":3,"server":{},"features":{},"snapshot":{"presence":[],"health":{},"stateVersion":{"presence":0,"health":0},"uptimeMs":0},"auth":{},"policy":{}}}
-                    """)
-                }
-                return .string("""
-                {"type":"res","id":"\(request.id)","ok":true,"payload":{}}
-                """)
-            }
-        }
-        throw URLError(.cannotConnectToHost)
-    }
-
-    func receive(completionHandler: @escaping @Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void) {
-        completionHandler(.failure(URLError(.cannotConnectToHost)))
-    }
-
-    private func latestUnrespondedRequest() -> (id: String, method: String)? {
-        for message in sentMessages.reversed() {
-            let data: Data? = switch message {
-            case let .string(text):
-                Data(text.utf8)
-            case let .data(raw):
-                raw
-            @unknown default:
-                nil
-            }
-            guard let data,
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let id = json["id"] as? String,
-                  let method = json["method"] as? String,
-                  !self.respondedRequestIds.contains(id)
-            else {
-                continue
-            }
-            return (id, method)
-        }
-        return nil
-    }
-}
-
-private final class FakeWebSocketSession: WebSocketSessioning, @unchecked Sendable {
-    let task = FakeWebSocketTask()
-
-    func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
-        makeWebSocketTask(request: URLRequest(url: url))
-    }
-
-    func makeWebSocketTask(request _: URLRequest) -> WebSocketTaskBox {
-        WebSocketTaskBox(task: task)
-    }
-}
-
 private final class WebSocketMessageRecorder: @unchecked Sendable {
     private let lock = NSLock()
     private var messages: [URLSessionWebSocketTask.Message] = []
@@ -133,12 +52,18 @@ private final class WebSocketMessageRecorder: @unchecked Sendable {
     }
 }
 
-private final class GatewayConnectionEndpointSource: @unchecked Sendable {
+final class GatewayConnectionEndpointSource: @unchecked Sendable {
     private let lock = NSLock()
     private var endpoint: GatewayConnection.EndpointSnapshot
 
     init(endpoint: GatewayConnection.EndpointSnapshot) {
         self.endpoint = endpoint
+    }
+
+    convenience init(url: URL, token: String? = nil, password: String? = nil) {
+        self.init(endpoint: GatewayConnection.EndpointSnapshot(
+            config: (url: url, token: token, password: password),
+            routeAuthority: nil))
     }
 
     func setEndpoint(_ endpoint: GatewayConnection.EndpointSnapshot) {
@@ -152,36 +77,24 @@ private final class GatewayConnectionEndpointSource: @unchecked Sendable {
         defer { self.lock.unlock() }
         return endpoint
     }
-}
-
-private final class GatewayConnectionRouteConfigSource: @unchecked Sendable {
-    private let lock = NSLock()
-    private var url: URL
-
-    init(url: URL) {
-        self.url = url
-    }
 
     func setURL(_ url: URL) {
         lock.lock()
-        self.url = url
+        let config = self.endpoint.config
+        self.endpoint = GatewayConnection.EndpointSnapshot(
+            config: (url: url, token: config.token, password: config.password),
+            routeAuthority: nil)
         lock.unlock()
     }
-
-    func snapshotURL() -> URL {
-        lock.lock()
-        defer { self.lock.unlock() }
-        return url
-    }
 }
 
-private actor GatewayConnectionClientShutdownGate {
+private actor GatewayConnectionSuspensionGate {
     private var didStart = false
     private var isOpen = false
     private var startWaiters: [CheckedContinuation<Void, Never>] = []
     private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
 
-    func run(_ client: GatewayChannelActor) async {
+    func suspend() async {
         didStart = true
         startWaiters.forEach { $0.resume() }
         startWaiters.removeAll()
@@ -190,7 +103,6 @@ private actor GatewayConnectionClientShutdownGate {
                 self.releaseWaiters.append(continuation)
             }
         }
-        await client.shutdown()
     }
 
     func waitUntilStarted() async {
@@ -207,45 +119,12 @@ private actor GatewayConnectionClientShutdownGate {
     }
 }
 
-private actor GatewayConnectionConfigProviderGate {
-    private let config: GatewayConnection.Config
-    private var didStart = false
-    private var isOpen = false
-    private var startWaiters: [CheckedContinuation<Void, Never>] = []
-    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
-
-    init(config: GatewayConnection.Config) {
-        self.config = config
-    }
-
-    func provide() async -> GatewayConnection.Config {
-        didStart = true
-        startWaiters.forEach { $0.resume() }
-        startWaiters.removeAll()
-        if !isOpen {
-            await withCheckedContinuation { continuation in
-                self.releaseWaiters.append(continuation)
-            }
-        }
-        return config
-    }
-
-    func waitUntilStarted() async {
-        guard !didStart else { return }
-        await withCheckedContinuation { continuation in
-            self.startWaiters.append(continuation)
-        }
-    }
-
-    func open() {
-        isOpen = true
-        releaseWaiters.forEach { $0.resume() }
-        releaseWaiters.removeAll()
-    }
-}
-
-private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSession) {
-    let session = FakeWebSocketSession()
+private func makeTestGatewayConnection() -> (GatewayConnection, GatewayTestWebSocketSession) {
+    let session = GatewayTestWebSocketSession(taskFactory: {
+        GatewayTestWebSocketTask(receiveHook: { _, _ in
+            throw URLError(.cannotConnectToHost)
+        })
+    })
     let connection = GatewayConnection(
         configProvider: {
             (url: URL(string: "ws://127.0.0.1:1")!, token: nil, password: nil)
@@ -253,6 +132,95 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
         sessionBox: WebSocketSessionBox(session: session)
     )
     return (connection, session)
+}
+
+private func makeRecordingGatewayConnection(
+    responseData: @escaping @Sendable (String) -> Data
+) -> (GatewayConnection, WebSocketMessageRecorder) {
+    let recorder = WebSocketMessageRecorder()
+    let session = GatewayTestWebSocketSession(taskFactory: {
+        GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
+            recorder.append(message)
+            guard sendIndex > 0,
+                  let id = GatewayWebSocketTestSupport.requestID(from: message)
+            else { return }
+            task.emitReceiveSuccess(.data(responseData(id)))
+        })
+    })
+    let connection = GatewayConnection(
+        configProvider: {
+            (url: URL(string: "ws://127.0.0.1:1")!, token: nil, password: nil)
+        },
+        sessionBox: WebSocketSessionBox(session: session)
+    )
+    return (connection, recorder)
+}
+
+private func makeRouteLifecycleConnection(
+    url: URL,
+    token: String? = nil,
+    password: String? = nil
+) -> (GatewayConnectionEndpointSource, GatewayConnectionSuspensionGate, GatewayConnection) {
+    let source = GatewayConnectionEndpointSource(url: url, token: token, password: password)
+    let gate = GatewayConnectionSuspensionGate()
+    let connection = GatewayConnection(
+        configProvider: { source.snapshot().config },
+        sessionBox: WebSocketSessionBox(session: GatewayTestWebSocketSession()),
+        clientShutdown: { client in
+            await gate.suspend()
+            await client.shutdown()
+        }
+    )
+    return (source, gate, connection)
+}
+
+private enum SuspendedConfigOperation {
+    case request
+    case refresh
+    case captureRoute
+}
+
+private func assertConfigLookupCannotRecreateRoute(
+    url: URL,
+    operation: SuspendedConfigOperation
+) async {
+    let gate = GatewayConnectionSuspensionGate()
+    let config: GatewayConnection.Config = (url: url, token: nil, password: nil)
+    let connection = GatewayConnection(
+        configProvider: {
+            await gate.suspend()
+            return config
+        },
+        sessionBox: WebSocketSessionBox(session: GatewayTestWebSocketSession())
+    )
+    let operationTask = Task {
+        switch operation {
+        case .request:
+            do {
+                _ = try await connection.request(
+                    method: "status",
+                    params: nil,
+                    retryTransportFailures: false)
+                Issue.record("expected stale request cancellation")
+            } catch is CancellationError {} catch {
+                Issue.record("unexpected stale request error: \(error)")
+            }
+        case .refresh:
+            do {
+                try await connection.refresh()
+                Issue.record("expected stale refresh cancellation")
+            } catch is CancellationError {} catch {
+                Issue.record("unexpected stale refresh error: \(error)")
+            }
+        case .captureRoute:
+            #expect(await connection.captureRoute() == nil)
+        }
+    }
+    await gate.waitUntilStarted()
+    await connection.shutdown()
+    await gate.open()
+    await operationTask.value
+    #expect(await connection._test_configuredURL() == nil)
 }
 
 @Suite(.serialized) struct GatewayConnectionControlTests {
@@ -495,17 +463,7 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
 
     @Test func `older reconfigure cannot install after newer route`() async throws {
         let initialURL = try #require(URL(string: "ws://route-a.invalid"))
-        let source = GatewayConnectionRouteConfigSource(url: initialURL)
-        let gate = GatewayConnectionClientShutdownGate()
-        let connection = GatewayConnection(
-            configProvider: {
-                (url: source.snapshotURL(), token: nil, password: nil)
-            },
-            sessionBox: WebSocketSessionBox(session: FakeWebSocketSession()),
-            clientShutdown: { client in
-                await gate.run(client)
-            }
-        )
+        let (source, gate, connection) = makeRouteLifecycleConnection(url: initialURL)
         try await connection.refresh()
 
         let intermediateURL = try #require(URL(string: "ws://route-b.invalid"))
@@ -529,17 +487,10 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
 
     @Test func `same route reconfigure joins newer client`() async throws {
         let initialURL = try #require(URL(string: "ws://route-a.invalid"))
-        let source = GatewayConnectionRouteConfigSource(url: initialURL)
-        let gate = GatewayConnectionClientShutdownGate()
-        let connection = GatewayConnection(
-            configProvider: {
-                (url: source.snapshotURL(), token: "same-token", password: "same-password")
-            },
-            sessionBox: WebSocketSessionBox(session: FakeWebSocketSession()),
-            clientShutdown: { client in
-                await gate.run(client)
-            }
-        )
+        let (source, gate, connection) = makeRouteLifecycleConnection(
+            url: initialURL,
+            token: "same-token",
+            password: "same-password")
         try await connection.refresh()
 
         let replacementURL = try #require(URL(string: "ws://route-b.invalid"))
@@ -560,17 +511,10 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
 
     @Test func `reconfigure cannot join same route installed after shutdown`() async throws {
         let initialURL = try #require(URL(string: "ws://route-a.invalid"))
-        let source = GatewayConnectionRouteConfigSource(url: initialURL)
-        let gate = GatewayConnectionClientShutdownGate()
-        let connection = GatewayConnection(
-            configProvider: {
-                (url: source.snapshotURL(), token: "same-token", password: "same-password")
-            },
-            sessionBox: WebSocketSessionBox(session: FakeWebSocketSession()),
-            clientShutdown: { client in
-                await gate.run(client)
-            }
-        )
+        let (source, gate, connection) = makeRouteLifecycleConnection(
+            url: initialURL,
+            token: "same-token",
+            password: "same-password")
         try await connection.refresh()
 
         let replacementURL = try #require(URL(string: "ws://route-b.invalid"))
@@ -595,84 +539,22 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
 
     @Test func `request suspended in config lookup cannot recreate route after shutdown`() async throws {
         let url = try #require(URL(string: "ws://stale-request.invalid"))
-        let gate = GatewayConnectionConfigProviderGate(config: (url: url, token: nil, password: nil))
-        let connection = GatewayConnection(
-            configProvider: { await gate.provide() },
-            sessionBox: WebSocketSessionBox(session: FakeWebSocketSession())
-        )
-
-        let request = Task {
-            try await connection.request(
-                method: "status",
-                params: nil,
-                retryTransportFailures: false
-            )
-        }
-        await gate.waitUntilStarted()
-        await connection.shutdown()
-        await gate.open()
-
-        do {
-            _ = try await request.value
-            Issue.record("expected stale request cancellation")
-        } catch is CancellationError {} catch {
-            Issue.record("unexpected stale request error: \(error)")
-        }
-        #expect(await connection._test_configuredURL() == nil)
+        await assertConfigLookupCannotRecreateRoute(url: url, operation: .request)
     }
 
     @Test func `refresh suspended in config lookup cannot recreate route after shutdown`() async throws {
         let url = try #require(URL(string: "ws://stale-refresh.invalid"))
-        let gate = GatewayConnectionConfigProviderGate(config: (url: url, token: nil, password: nil))
-        let connection = GatewayConnection(
-            configProvider: { await gate.provide() },
-            sessionBox: WebSocketSessionBox(session: FakeWebSocketSession())
-        )
-
-        let refresh = Task { try await connection.refresh() }
-        await gate.waitUntilStarted()
-        await connection.shutdown()
-        await gate.open()
-
-        do {
-            try await refresh.value
-            Issue.record("expected stale refresh cancellation")
-        } catch is CancellationError {} catch {
-            Issue.record("unexpected stale refresh error: \(error)")
-        }
-        #expect(await connection._test_configuredURL() == nil)
+        await assertConfigLookupCannotRecreateRoute(url: url, operation: .refresh)
     }
 
     @Test func `capture route suspended in config lookup cannot recreate route after shutdown`() async throws {
         let url = try #require(URL(string: "ws://stale-capture.invalid"))
-        let gate = GatewayConnectionConfigProviderGate(config: (url: url, token: nil, password: nil))
-        let connection = GatewayConnection(
-            configProvider: { await gate.provide() },
-            sessionBox: WebSocketSessionBox(session: FakeWebSocketSession())
-        )
-
-        let capture = Task { await connection.captureRoute() }
-        await gate.waitUntilStarted()
-        await connection.shutdown()
-        await gate.open()
-
-        #expect(await capture.value == nil)
-        #expect(await connection._test_configuredURL() == nil)
+        await assertConfigLookupCannotRecreateRoute(url: url, operation: .captureRoute)
     }
 
     @Test func `older shutdown cannot clear newer route`() async throws {
         let initialURL = try #require(URL(string: "ws://route-a.invalid"))
-        let source = GatewayConnectionRouteConfigSource(url: initialURL)
-        let gate = GatewayConnectionClientShutdownGate()
-        let connection = GatewayConnection(
-            configProvider: {
-                (url: source.snapshotURL(), token: nil, password: nil)
-            },
-            sessionBox: WebSocketSessionBox(session: FakeWebSocketSession()),
-            clientShutdown: { client in
-                await gate.run(client)
-            }
-        )
+        let (source, gate, connection) = makeRouteLifecycleConnection(url: initialURL)
         try await connection.refresh()
 
         let olderShutdown = Task { await connection.shutdown() }
@@ -699,33 +581,20 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
 
     @Test func `reject empty message`() async {
         let (connection, _) = makeTestGatewayConnection()
-        let result = await connection.sendAgent(
+        let result = await connection.sendAgent(GatewayAgentInvocation(
             message: "",
-            thinking: nil,
             sessionKey: "main",
+            thinking: nil,
             deliver: false,
-            to: nil
-        )
+            to: nil,
+            channel: .last))
         #expect(result.ok == false)
     }
 
     @Test func `send agent keeps empty voice wake trigger field`() async throws {
-        let recorder = WebSocketMessageRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                recorder.append(message)
-                guard sendIndex > 0,
-                      let id = GatewayWebSocketTestSupport.requestID(from: message)
-                else { return }
-                task.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
-            })
-        })
-        let connection = GatewayConnection(
-            configProvider: {
-                (url: URL(string: "ws://127.0.0.1:1")!, token: nil, password: nil)
-            },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+        let (connection, recorder) = makeRecordingGatewayConnection {
+            GatewayWebSocketTestSupport.okResponseData(id: $0)
+        }
         let result = await connection.sendAgent(GatewayAgentInvocation(
             message: "test",
             sessionKey: "main",
@@ -762,24 +631,9 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
     }
 
     @Test func `chat send carries routing precondition and omits inherited thinking`() async throws {
-        let recorder = WebSocketMessageRecorder()
-        let session = GatewayTestWebSocketSession(taskFactory: {
-            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
-                recorder.append(message)
-                guard sendIndex > 0,
-                      let data = Self.messageData(message),
-                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      let id = json["id"] as? String
-                else { return }
-                task.emitReceiveSuccess(.data(Self.chatSendOkResponseData(id: id)))
-            })
-        })
-        let connection = GatewayConnection(
-            configProvider: {
-                (url: URL(string: "ws://127.0.0.1:1")!, token: nil, password: nil)
-            },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+        let (connection, recorder) = makeRecordingGatewayConnection {
+            Self.chatSendOkResponseData(id: $0)
+        }
 
         _ = try await connection.chatSend(
             sessionKey: "main",

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlUIAuthTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlUIAuthTests.swift
@@ -3,27 +3,6 @@ import Testing
 @testable import OpenClaw
 @testable import OpenClawKit
 
-private final class ControlUIEndpointSource: @unchecked Sendable {
-    private let lock = NSLock()
-    private var endpoint: GatewayConnection.EndpointSnapshot
-
-    init(_ endpoint: GatewayConnection.EndpointSnapshot) {
-        self.endpoint = endpoint
-    }
-
-    func set(_ endpoint: GatewayConnection.EndpointSnapshot) {
-        self.lock.lock()
-        self.endpoint = endpoint
-        self.lock.unlock()
-    }
-
-    func snapshot() -> GatewayConnection.EndpointSnapshot {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        return self.endpoint
-    }
-}
-
 private func makeControlUIAuthSession(
     issuedDeviceToken: String? = nil) -> GatewayTestWebSocketSession
 {
@@ -47,14 +26,18 @@ private func makeControlUIAuthSession(
     })
 }
 
+private func controlUIRoute(_ rawURL: String, token: String? = nil) throws -> GatewayConnection.Config {
+    (
+        url: try #require(URL(string: rawURL)),
+        token: token,
+        password: nil)
+}
+
 @Suite(.serialized)
 struct GatewayConnectionControlUIAuthTests {
     @Test func `shared token requires the current live route and socket`() async throws {
-        let routeA: GatewayConnection.Config = (
-            url: try #require(URL(string: "ws://route-a.invalid")),
-            token: " shared-token ",
-            password: nil)
-        let source = ControlUIEndpointSource(.init(
+        let routeA = try controlUIRoute("ws://route-a.invalid", token: " shared-token ")
+        let source = GatewayConnectionEndpointSource(endpoint: .init(
             config: routeA,
             routeAuthority: 1,
             deviceAuthGatewayID: "route-a"))
@@ -69,11 +52,8 @@ struct GatewayConnectionControlUIAuthTests {
             retryTransportFailures: false)
         #expect(await connection.controlUiAutoAuthToken(config: routeA) == "shared-token")
 
-        let routeB: GatewayConnection.Config = (
-            url: try #require(URL(string: "ws://route-b.invalid")),
-            token: routeA.token,
-            password: nil)
-        source.set(.init(
+        let routeB = try controlUIRoute("ws://route-b.invalid", token: routeA.token)
+        source.setEndpoint(.init(
             config: routeB,
             routeAuthority: 2,
             deviceAuthGatewayID: "route-b"))
@@ -103,10 +83,7 @@ struct GatewayConnectionControlUIAuthTests {
                 token: "route-a-device-token",
                 gatewayID: "route-a")
 
-            let routeA: GatewayConnection.Config = (
-                url: try #require(URL(string: "ws://route-a.invalid")),
-                token: nil,
-                password: nil)
+            let routeA = try controlUIRoute("ws://route-a.invalid")
             let routeAConnection = GatewayConnection(
                 endpointProvider: {
                     .init(
@@ -124,10 +101,7 @@ struct GatewayConnectionControlUIAuthTests {
                     "route-a-device-token")
             await routeAConnection.shutdown()
 
-            let routeB: GatewayConnection.Config = (
-                url: try #require(URL(string: "ws://route-b.invalid")),
-                token: nil,
-                password: nil)
+            let routeB = try controlUIRoute("ws://route-b.invalid")
             let routeBConnection = GatewayConnection(
                 endpointProvider: {
                     .init(
@@ -158,11 +132,8 @@ struct GatewayConnectionControlUIAuthTests {
                 role: "operator",
                 token: "route-a-device-token",
                 gatewayID: "route-a")
-            let routeA: GatewayConnection.Config = (
-                url: try #require(URL(string: "ws://route-a.invalid")),
-                token: nil,
-                password: nil)
-            let source = ControlUIEndpointSource(.init(
+            let routeA = try controlUIRoute("ws://route-a.invalid")
+            let source = GatewayConnectionEndpointSource(endpoint: .init(
                 config: routeA,
                 routeAuthority: 1,
                 deviceAuthGatewayID: "route-a"))
@@ -179,17 +150,14 @@ struct GatewayConnectionControlUIAuthTests {
                 await connection.controlUiAutoAuthToken(config: routeA) ==
                     "route-a-issued-token")
 
-            source.set(.init(
+            source.setEndpoint(.init(
                 config: routeA,
                 routeAuthority: 1,
                 deviceAuthGatewayID: "route-b"))
             #expect(await connection.controlUiAutoAuthToken(config: routeA) == nil)
 
-            let routeB: GatewayConnection.Config = (
-                url: try #require(URL(string: "ws://route-b.invalid")),
-                token: nil,
-                password: nil)
-            source.set(.init(
+            let routeB = try controlUIRoute("ws://route-b.invalid")
+            source.setEndpoint(.init(
                 config: routeB,
                 routeAuthority: 2,
                 deviceAuthGatewayID: "route-b"))


### PR DESCRIPTION
## What Problem This Solves

The macOS gateway connection lifecycle carried one logical configured route across many parallel fields and repeated the same route/client checks in several request and authentication paths. That duplication made shutdown and reconfiguration behavior harder to audit and increased the risk that future changes would invalidate only part of the live route state.

## Why This Change Was Made

This consolidates the configured client and its route-owned facts into one value, uses one retirement boundary before any suspending shutdown, and centralizes matching/retry policy without changing connection sequencing, retry delays, TLS identity, route authority, or device-auth binding. The accompanying tests reuse the canonical websocket fixtures and shared lifecycle gates while retaining the existing cases.

## User Impact

No intentional user-visible behavior change. The macOS app keeps the same gateway routing, retry, shutdown, and control-UI authentication behavior with 105 fewer production lines and 192 fewer test lines.

AI-assisted: yes. I reviewed the final implementation and validation results.

## Evidence

- `swift test --package-path apps/macos --build-system native -j 4 --filter GatewayConnectionControlTests` — 21 tests passed.
- `swift test --package-path apps/macos --build-system native -j 4 --filter GatewayConnectionTests` — 11 tests passed.
- `swift test --package-path apps/macos --build-system native -j 4 --filter 'OpenClawIPCTests.GatewayConnectionControlUIAuthTests/'` — 3 tests passed.
- `PATH=/private/tmp/openclaw-swift-tools-2d45:$PATH ./scripts/format-swift.sh macos` — clean.
- `PATH=/private/tmp/openclaw-swift-tools-2d45:$PATH ./scripts/lint-swift.sh macos` — 0 violations.
- `node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/GatewayConnection.swift apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlUIAuthTests.swift` — Blacksmith Testbox `tbx_01kz2seq0qcq2ycnpsxt1ydtjd` passed ([run](https://github.com/openclaw/openclaw/actions/runs/30780993674)).
- Fresh autoreview: `gpt-5.6-sol`, xhigh, no findings, correctness 0.98 (thread `019fc5a2-46c9-7270-924d-f24a2d3a2e82`).
- Diff: 290 additions, 587 deletions; production 140/245 (net -105), tests 150/342 (net -192), total net -297.
