### PR TITLE
test(agents): consolidate runtime auth fixtures

### DIFF
--- a/src/agents/runtime-plan/prepare-auth.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.test.ts
@@ -30,20 +30,96 @@ function authStore(
   return { version: 1, profiles, ...(order ? { order } : {}) };
 }
 
-function allCooldownOpenAIStore(): AuthProfileStore {
-  const store = authStore(
-    {
-      "openai:cooldown": {
-        type: "api_key",
-        provider: "openai",
-        key: "cooldown-key",
+function providerConfig(provider: string, config: Record<string, unknown>): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        [provider]: { baseUrl: "", models: [], ...config },
       },
     },
+  } as OpenClawConfig;
+}
+
+function openAIConfig(config: Record<string, unknown>): OpenClawConfig {
+  return providerConfig("openai", config);
+}
+
+function openAIAuthFixture() {
+  return { provider: "openai", modelId: "gpt-5.5" } as const;
+}
+
+function openAIPlatformAuthFixture() {
+  return {
+    ...openAIAuthFixture(),
+    modelApi: "openai-responses",
+    modelBaseUrl: "https://api.openai.com/v1",
+  } as const;
+}
+
+function codexPlatformAuthFixture() {
+  return {
+    ...openAIPlatformAuthFixture(),
+    env: {},
+    harnessId: "codex",
+    harnessRuntime: "codex",
+  } as const;
+}
+
+function openAIChatGptAuthFixture() {
+  return {
+    ...openAIAuthFixture(),
+    modelApi: "openai-chatgpt-responses",
+    modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+  } as const;
+}
+
+function virtualCodexAuthFixture() {
+  return {
+    provider: "codex",
+    modelId: "gpt-5.4",
+    env: {},
+    harnessId: "codex",
+    harnessRuntime: "codex",
+  } as const;
+}
+
+function apiKeyProfile(provider: string, key: string) {
+  return { type: "api_key" as const, provider, key };
+}
+
+function openAIApiKeyProfile(key: string) {
+  return apiKeyProfile("openai", key);
+}
+
+function openAITokenProfile(token: string, expires?: number) {
+  return {
+    type: "token" as const,
+    provider: "openai",
+    token,
+    ...(expires === undefined ? {} : { expires }),
+  };
+}
+
+function openAIOAuthProfile(access: string, refresh: string, expires: number) {
+  return { type: "oauth" as const, provider: "openai", access, refresh, expires };
+}
+
+function setProfileCooldown(
+  store: AuthProfileStore,
+  profileId: string,
+  details: Omit<NonNullable<AuthProfileStore["usageStats"]>[string], "cooldownUntil"> = {},
+) {
+  store.usageStats = {
+    [profileId]: { cooldownUntil: Date.now() + 60_000, ...details },
+  };
+}
+
+function allCooldownOpenAIStore(): AuthProfileStore {
+  const store = authStore(
+    { "openai:cooldown": openAIApiKeyProfile("cooldown-key") },
     { openai: ["openai:cooldown"] },
   );
-  store.usageStats = {
-    "openai:cooldown": { cooldownUntil: Date.now() + 60_000 },
-  };
+  setProfileCooldown(store, "openai:cooldown");
   return store;
 }
 
@@ -70,26 +146,12 @@ describe("prepareAgentRuntimeAuthPlan", () => {
     const plan = prepareAgentRuntimeAuthPlan({
       provider: "xai",
       modelId: "grok-4",
-      config: {
-        models: {
-          providers: {
-            xai: { apiKey: "xai:bound", baseUrl: "", models: [] },
-          },
-        },
-      } as OpenClawConfig,
+      config: providerConfig("xai", { apiKey: "xai:bound" }),
       env: {},
       authProfileStore: authStore(
         {
-          "xai:bound": {
-            type: "api_key",
-            provider: "xai",
-            key: "bound-key",
-          },
-          "xai:backup": {
-            type: "api_key",
-            provider: "xai",
-            key: "backup-key",
-          },
+          "xai:bound": apiKeyProfile("xai", "bound-key"),
+          "xai:backup": apiKeyProfile("xai", "backup-key"),
         },
         { xai: ["xai:backup", "xai:bound"] },
       ),
@@ -110,34 +172,18 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("rejects a cooldowned generic provider-entry binding instead of using a backup", () => {
     const store = authStore(
       {
-        "xai:bound": {
-          type: "api_key",
-          provider: "xai",
-          key: "bound-key",
-        },
-        "xai:backup": {
-          type: "api_key",
-          provider: "xai",
-          key: "backup-key",
-        },
+        "xai:bound": apiKeyProfile("xai", "bound-key"),
+        "xai:backup": apiKeyProfile("xai", "backup-key"),
       },
       { xai: ["xai:backup", "xai:bound"] },
     );
-    store.usageStats = {
-      "xai:bound": { cooldownUntil: Date.now() + 60_000 },
-    };
+    setProfileCooldown(store, "xai:bound");
 
     expect(() =>
       prepareAgentRuntimeAuthPlan({
         provider: "xai",
         modelId: "grok-4",
-        config: {
-          models: {
-            providers: {
-              xai: { apiKey: "xai:bound", baseUrl: "", models: [] },
-            },
-          },
-        } as OpenClawConfig,
+        config: providerConfig("xai", { apiKey: "xai:bound" }),
         env: {},
         authProfileStore: store,
         sessionAuthProfileId: "xai:backup",
@@ -150,30 +196,11 @@ describe("prepareAgentRuntimeAuthPlan", () => {
     const plan = prepareAgentRuntimeAuthPlan({
       provider: "xai",
       modelId: "grok-4",
-      config: {
-        models: {
-          providers: {
-            xai: {
-              auth: "aws-sdk",
-              apiKey: "xai:bound",
-              baseUrl: "",
-              models: [],
-            },
-          },
-        },
-      } as OpenClawConfig,
+      config: providerConfig("xai", { auth: "aws-sdk", apiKey: "xai:bound" }),
       env: {},
       authProfileStore: authStore({
-        "xai:bound": {
-          type: "api_key",
-          provider: "xai",
-          key: "bound-key",
-        },
-        "xai:backup": {
-          type: "api_key",
-          provider: "xai",
-          key: "backup-key",
-        },
+        "xai:bound": apiKeyProfile("xai", "bound-key"),
+        "xai:backup": apiKeyProfile("xai", "backup-key"),
       }),
       sessionAuthProfileId: "xai:backup",
       sessionAuthProfileSource: "auto",
@@ -188,31 +215,16 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("rotates a generic automatic profile past a model cooldown", () => {
     const store = authStore(
       {
-        "xai:p1": {
-          type: "api_key",
-          provider: "xai",
-          key: "p1-key",
-        },
-        "xai:p2": {
-          type: "api_key",
-          provider: "xai",
-          key: "p2-key",
-        },
-        "xai:p3": {
-          type: "api_key",
-          provider: "xai",
-          key: "p3-key",
-        },
+        "xai:p1": apiKeyProfile("xai", "p1-key"),
+        "xai:p2": apiKeyProfile("xai", "p2-key"),
+        "xai:p3": apiKeyProfile("xai", "p3-key"),
       },
       { xai: ["xai:p1", "xai:p2", "xai:p3"] },
     );
-    store.usageStats = {
-      "xai:p1": {
-        cooldownUntil: Date.now() + 60_000,
-        cooldownReason: "rate_limit",
-        cooldownModel: "grok-4",
-      },
-    };
+    setProfileCooldown(store, "xai:p1", {
+      cooldownReason: "rate_limit",
+      cooldownModel: "grok-4",
+    });
 
     const plan = prepareAgentRuntimeAuthPlan({
       provider: "xai",
@@ -239,8 +251,8 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       env: {},
       authProfileStore: authStore(
         {
-          "xai:p1": { type: "api_key", provider: "xai", key: "p1-key" },
-          "xai:p2": { type: "api_key", provider: "xai", key: "p2-key" },
+          "xai:p1": apiKeyProfile("xai", "p1-key"),
+          "xai:p2": apiKeyProfile("xai", "p2-key"),
         },
         { xai: ["xai:p1", "xai:p2"] },
       ),
@@ -273,16 +285,8 @@ describe("prepareAgentRuntimeAuthPlan", () => {
             provider: "xai",
             keyRef: { source: "env", provider: "vault", id: "XAI_API_KEY" },
           },
-          "xai:p2": {
-            type: "api_key",
-            provider: "xai",
-            key: "p2-key",
-          },
-          "xai:p3": {
-            type: "api_key",
-            provider: "xai",
-            key: "p3-key",
-          },
+          "xai:p2": apiKeyProfile("xai", "p2-key"),
+          "xai:p3": apiKeyProfile("xai", "p3-key"),
         },
         { xai: ["xai:missing", "xai:p2", "xai:p3"] },
       ),
@@ -300,23 +304,13 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("fails closed before resolving an all-cooldown generic order", () => {
     const store = authStore(
       {
-        "xai:p1": {
-          type: "api_key",
-          provider: "xai",
-          key: "p1-key",
-        },
-        "xai:p2": {
-          type: "api_key",
-          provider: "xai",
-          key: "p2-key",
-        },
+        "xai:p1": apiKeyProfile("xai", "p1-key"),
+        "xai:p2": apiKeyProfile("xai", "p2-key"),
       },
       { xai: ["xai:p1", "xai:p2"] },
     );
-    store.usageStats = {
-      "xai:p1": { cooldownUntil: Date.now() + 60_000 },
-      "xai:p2": { cooldownUntil: Date.now() + 60_000 },
-    };
+    setProfileCooldown(store, "xai:p1");
+    store.usageStats!["xai:p2"] = { cooldownUntil: Date.now() + 60_000 };
 
     expect(() =>
       prepareAgentRuntimeAuthPlan({
@@ -340,11 +334,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
         } as OpenClawConfig,
         env: {},
         authProfileStore: authStore({
-          "xai:backup": {
-            type: "api_key",
-            provider: "xai",
-            key: "backup-key",
-          },
+          "xai:backup": apiKeyProfile("xai", "backup-key"),
         }),
       }),
     ).toThrow(/explicit auth order.*no usable profiles/iu);
@@ -360,11 +350,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
         } as OpenClawConfig,
         env: {},
         authProfileStore: authStore({
-          "xai:backup": {
-            type: "api_key",
-            provider: "xai",
-            key: "backup-key",
-          },
+          "xai:backup": apiKeyProfile("xai", "backup-key"),
         }),
       }),
     ).toThrow(/explicit auth order.*no usable profiles/iu);
@@ -373,22 +359,12 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("keeps a generic user lock as a singleton despite cooldown", () => {
     const store = authStore(
       {
-        "xai:p1": {
-          type: "api_key",
-          provider: "xai",
-          key: "p1-key",
-        },
-        "xai:p2": {
-          type: "api_key",
-          provider: "xai",
-          key: "p2-key",
-        },
+        "xai:p1": apiKeyProfile("xai", "p1-key"),
+        "xai:p2": apiKeyProfile("xai", "p2-key"),
       },
       { xai: ["xai:p1", "xai:p2"] },
     );
-    store.usageStats = {
-      "xai:p1": { cooldownUntil: Date.now() + 60_000 },
-    };
+    setProfileCooldown(store, "xai:p1");
 
     const plan = prepareAgentRuntimeAuthPlan({
       provider: "xai",
@@ -409,10 +385,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("defers an ambiguous route when native Codex owns auth", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-chatgpt-responses",
-      modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+      ...openAIChatGptAuthFixture(),
       env: {},
       harnessId: "codex",
       harnessRuntime: "codex",
@@ -431,27 +404,14 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("falls through an unusable env marker to an ordered API-key profile", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
-      config: {
-        models: {
-          providers: {
-            openai: { apiKey: "OPENAI_API_KEY", baseUrl: "", models: [] },
-          },
-        },
-      } as OpenClawConfig,
+      ...openAIPlatformAuthFixture(),
+      config: openAIConfig({ apiKey: "OPENAI_API_KEY" }),
       env: {},
       harnessId: "codex",
       harnessRuntime: "codex",
       authProfileStore: authStore(
         {
-          "openai:backup": {
-            type: "api_key",
-            provider: "openai",
-            key: "backup-key",
-          },
+          "openai:backup": openAIApiKeyProfile("backup-key"),
         },
         { openai: ["openai:backup"] },
       ),
@@ -464,17 +424,8 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("rejects a concrete route when an env marker has no usable credential", () => {
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-responses",
-        modelBaseUrl: "https://api.openai.com/v1",
-        config: {
-          models: {
-            providers: {
-              openai: { apiKey: "OPENAI_API_KEY", baseUrl: "", models: [] },
-            },
-          },
-        } as OpenClawConfig,
+        ...openAIPlatformAuthFixture(),
+        config: openAIConfig({ apiKey: "OPENAI_API_KEY" }),
         env: {},
         harnessId: "codex",
         harnessRuntime: "codex",
@@ -486,31 +437,15 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("skips cooldowned automatic profiles before selecting a healthy backup", () => {
     const store = authStore(
       {
-        "openai:cooldown": {
-          type: "api_key",
-          provider: "openai",
-          key: "cooldown-key",
-        },
-        "openai:backup": {
-          type: "api_key",
-          provider: "openai",
-          key: "backup-key",
-        },
+        "openai:cooldown": openAIApiKeyProfile("cooldown-key"),
+        "openai:backup": openAIApiKeyProfile("backup-key"),
       },
       { openai: ["openai:cooldown", "openai:backup"] },
     );
-    store.usageStats = {
-      "openai:cooldown": { cooldownUntil: Date.now() + 60_000 },
-    };
+    setProfileCooldown(store, "openai:cooldown");
 
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
-      env: {},
-      harnessId: "codex",
-      harnessRuntime: "codex",
+      ...codexPlatformAuthFixture(),
       authProfileStore: store,
       sessionAuthProfileId: "openai:cooldown",
       sessionAuthProfileSource: "auto",
@@ -523,10 +458,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("does not bypass an all-cooldown auth order through native Codex auth", () => {
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-responses",
-        modelBaseUrl: "https://api.openai.com/v1",
+        ...openAIPlatformAuthFixture(),
         env: {},
         harnessId: "codex",
         harnessRuntime: "codex",
@@ -538,10 +470,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("does not bypass an all-cooldown auth order through direct provider auth", () => {
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-responses",
-        modelBaseUrl: "https://api.openai.com/v1",
+        ...openAIPlatformAuthFixture(),
         config: {
           models: {
             providers: {
@@ -565,18 +494,8 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("does not let clear OAuth auth hide a cooldown Platform tier before literal fallback", () => {
     const store = authStore(
       {
-        "openai:chatgpt": {
-          type: "oauth",
-          provider: "openai",
-          access: "oauth-access",
-          refresh: "oauth-refresh",
-          expires: Date.now() + 60_000,
-        },
-        "openai:platform": {
-          type: "api_key",
-          provider: "openai",
-          key: "platform-key",
-        },
+        "openai:chatgpt": openAIOAuthProfile("oauth-access", "oauth-refresh", Date.now() + 60_000),
+        "openai:platform": openAIApiKeyProfile("platform-key"),
       },
       { openai: ["openai:chatgpt", "openai:platform"] },
     );
@@ -629,11 +548,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
         harnessId: "codex",
         harnessRuntime: "codex",
         authProfileStore: authStore({
-          "relay:key": {
-            type: "api_key",
-            provider: "relay",
-            key: "relay-secret",
-          },
+          "relay:key": apiKeyProfile("relay", "relay-secret"),
         }),
       }),
     ).toThrow(/has no usable credentials/u);
@@ -663,11 +578,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
         harnessId: "codex",
         harnessRuntime: "codex",
         authProfileStore: authStore({
-          "relay:key": {
-            type: "api_key",
-            provider: "relay",
-            key: "relay-secret",
-          },
+          "relay:key": apiKeyProfile("relay", "relay-secret"),
         }),
       }),
     ).toThrow(/has no usable credentials/u);
@@ -675,26 +586,14 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("selects the first compatible auth.order profile with its exact route", () => {
     const preparation = prepareAgentRuntimeAuth({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
+      ...openAIPlatformAuthFixture(),
       env: {},
       harnessId: "codex",
       harnessRuntime: "codex",
       authProfileStore: authStore(
         {
-          "openai:chatgpt": {
-            type: "token",
-            provider: "openai",
-            token: "subscription-token",
-            expires: Date.now() + 60_000,
-          },
-          "openai:platform": {
-            type: "api_key",
-            provider: "openai",
-            key: "platform-key",
-          },
+          "openai:chatgpt": openAITokenProfile("subscription-token", Date.now() + 60_000),
+          "openai:platform": openAIApiKeyProfile("platform-key"),
         },
         { openai: ["openai:chatgpt", "openai:platform"] },
       ),
@@ -725,17 +624,8 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("prepares every ordered same-route profile as an exhaustive fallback set", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
-      config: {
-        models: {
-          providers: {
-            openai: { baseUrl: "https://api.openai.com/v1", models: [] },
-          },
-        },
-      } as OpenClawConfig,
+      ...openAIPlatformAuthFixture(),
+      config: openAIConfig({ baseUrl: "https://api.openai.com/v1" }),
       env: {},
       harnessId: "codex",
       harnessRuntime: "codex",
@@ -750,11 +640,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
               id: "OPENCLAW_TEST_MISSING_PREPARED_AUTH",
             },
           },
-          "openai:backup": {
-            type: "api_key",
-            provider: "openai",
-            key: "backup-key",
-          },
+          "openai:backup": openAIApiKeyProfile("backup-key"),
         },
         { openai: ["openai:missing", "openai:backup"] },
       ),
@@ -771,10 +657,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("keeps same-route native candidates ahead of interleaved route fallbacks", () => {
     const preparation = prepareAgentRuntimeAuth({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
+      ...openAIPlatformAuthFixture(),
       config: {
         secrets: {
           providers: {
@@ -792,16 +675,8 @@ describe("prepareAgentRuntimeAuthPlan", () => {
             provider: "openai",
             tokenRef: { source: "file", provider: "vault", id: "/chatgpt/token" },
           },
-          "openai:platform": {
-            type: "api_key",
-            provider: "openai",
-            key: "platform-key",
-          },
-          "openai:subscription-backup": {
-            type: "token",
-            provider: "openai",
-            token: "subscription-token",
-          },
+          "openai:platform": openAIApiKeyProfile("platform-key"),
+          "openai:subscription-backup": openAITokenProfile("subscription-token"),
         },
         {
           openai: ["openai:subscription-missing", "openai:platform", "openai:subscription-backup"],
@@ -827,10 +702,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("skips a definitively invalid ordered profile before selecting a sibling route", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
+      ...openAIPlatformAuthFixture(),
       config: {
         auth: { order: { openai: ["openai:bad-key", "openai:chatgpt"] } },
         secrets: {
@@ -849,13 +721,11 @@ describe("prepareAgentRuntimeAuthPlan", () => {
             provider: "openai",
             keyRef: { source: "env", provider: "vault", id: "OPENAI_API_KEY" },
           },
-          "openai:chatgpt": {
-            type: "oauth",
-            provider: "openai",
-            access: "access-token",
-            refresh: "refresh-token",
-            expires: Date.now() + 10 * 60_000,
-          },
+          "openai:chatgpt": openAIOAuthProfile(
+            "access-token",
+            "refresh-token",
+            Date.now() + 10 * 60_000,
+          ),
         },
         { openai: ["openai:bad-key", "openai:chatgpt"] },
       ),
@@ -872,10 +742,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("rejects an all-invalid auth order before configured direct auth", () => {
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-responses",
-        modelBaseUrl: "https://api.openai.com/v1",
+        ...openAIPlatformAuthFixture(),
         config: {
           auth: { order: { openai: ["openai:ordered"] } },
           secrets: {
@@ -914,10 +781,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("keeps a user-locked profile authoritative and rejects the wrong route class", () => {
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-chatgpt-responses",
-        modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+        ...openAIChatGptAuthFixture(),
         env: {},
         config: {
           models: {
@@ -933,11 +797,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
         sessionAuthProfileId: "openai:platform",
         sessionAuthProfileSource: "user",
         authProfileStore: authStore({
-          "openai:platform": {
-            type: "api_key",
-            provider: "openai",
-            key: "platform-key",
-          },
+          "openai:platform": openAIApiKeyProfile("platform-key"),
         }),
       }),
     ).toThrow(/requires subscription authentication/u);
@@ -958,20 +818,15 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       },
     } as OpenClawConfig;
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-chatgpt-responses",
-      modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+      ...openAIChatGptAuthFixture(),
       config,
       env: {},
       authProfileStore: authStore({
-        "openai:chatgpt": {
-          type: "oauth",
-          provider: "openai",
-          access: "subscription-token",
-          refresh: "refresh-token",
-          expires: Date.now() + 60_000,
-        },
+        "openai:chatgpt": openAIOAuthProfile(
+          "subscription-token",
+          "refresh-token",
+          Date.now() + 60_000,
+        ),
       }),
     });
 
@@ -986,10 +841,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("rejects an official authored route with unvalidated native auth", () => {
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-responses",
-        modelBaseUrl: "https://api.openai.com/v1",
+        ...openAIPlatformAuthFixture(),
         config: {
           models: {
             providers: {
@@ -1005,13 +857,11 @@ describe("prepareAgentRuntimeAuthPlan", () => {
         env: { OPENAI_API_KEY: "ambient-platform-key" },
         authProfileStore: authStore(
           {
-            "openai:chatgpt": {
-              type: "oauth",
-              provider: "openai",
-              access: "subscription-token",
-              refresh: "refresh-token",
-              expires: Date.now() + 60_000,
-            },
+            "openai:chatgpt": openAIOAuthProfile(
+              "subscription-token",
+              "refresh-token",
+              Date.now() + 60_000,
+            ),
           },
           { openai: ["openai:chatgpt"] },
         ),
@@ -1028,17 +878,10 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("rejects a user-locked profile when the harness cannot accept host auth", () => {
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-responses",
-        modelBaseUrl: "https://api.openai.com/v1",
+        ...openAIPlatformAuthFixture(),
         env: {},
         authProfileStore: authStore({
-          "openai:work": {
-            type: "api_key",
-            provider: "openai",
-            key: "platform-key",
-          },
+          "openai:work": openAIApiKeyProfile("platform-key"),
         }),
         sessionAuthProfileId: "openai:work",
         sessionAuthProfileSource: "user",
@@ -1053,16 +896,10 @@ describe("prepareAgentRuntimeAuthPlan", () => {
     const plan = prepareAgentRuntimeAuthPlan({
       provider: "xai",
       modelId: "grok-4",
-      config: {
-        models: {
-          providers: {
-            xai: { auth: "api-key", apiKey: "xai-key", baseUrl: "", models: [] },
-          },
-        },
-      } as OpenClawConfig,
+      config: providerConfig("xai", { auth: "api-key", apiKey: "xai-key" }),
       env: {},
       authProfileStore: authStore({
-        "xai:auto": { type: "api_key", provider: "xai", key: "profile-key" },
+        "xai:auto": apiKeyProfile("xai", "profile-key"),
       }),
       sessionAuthProfileId: "xai:auto",
       sessionAuthProfileSource: "auto",
@@ -1077,10 +914,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("lets a provider-entry token profile binding outrank configured auth and auth.order", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
+      ...openAIPlatformAuthFixture(),
       config: {
         models: {
           providers: {
@@ -1096,17 +930,8 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       env: {},
       authProfileStore: authStore(
         {
-          "openai:bound": {
-            type: "token",
-            provider: "openai",
-            token: "subscription-token",
-            expires: Date.now() + 60_000,
-          },
-          "openai:platform": {
-            type: "api_key",
-            provider: "openai",
-            key: "platform-key",
-          },
+          "openai:bound": openAITokenProfile("subscription-token", Date.now() + 60_000),
+          "openai:platform": openAIApiKeyProfile("platform-key"),
         },
         { openai: ["openai:platform", "openai:bound"] },
       ),
@@ -1142,11 +967,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
         } as OpenClawConfig,
         env: {},
         authProfileStore: authStore({
-          "openai:bound": {
-            type: "api_key",
-            provider: "openai",
-            key: "bound-platform-key",
-          },
+          "openai:bound": openAIApiKeyProfile("bound-platform-key"),
         }),
       }),
     ).toThrow(/no usable credentials/u);
@@ -1155,10 +976,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("rejects an incompatible provider-entry profile without borrowing auth.order", () => {
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-responses",
-        modelBaseUrl: "https://api.openai.com/v1",
+        ...openAIPlatformAuthFixture(),
         config: {
           models: {
             providers: {
@@ -1173,18 +991,12 @@ describe("prepareAgentRuntimeAuthPlan", () => {
         env: {},
         authProfileStore: authStore(
           {
-            "openai:oauth": {
-              type: "oauth",
-              provider: "openai",
-              access: "subscription-token",
-              refresh: "refresh-token",
-              expires: Date.now() + 60_000,
-            },
-            "openai:platform": {
-              type: "api_key",
-              provider: "openai",
-              key: "platform-key",
-            },
+            "openai:oauth": openAIOAuthProfile(
+              "subscription-token",
+              "refresh-token",
+              Date.now() + 60_000,
+            ),
+            "openai:platform": openAIApiKeyProfile("platform-key"),
           },
           { openai: ["openai:platform"] },
         ),
@@ -1194,23 +1006,13 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("does not forward a cooldowned provider-entry profile", () => {
     const store = authStore({
-      "openai:bound": {
-        type: "token",
-        provider: "openai",
-        token: "subscription-token",
-        expires: Date.now() + 60_000,
-      },
+      "openai:bound": openAITokenProfile("subscription-token", Date.now() + 60_000),
     });
-    store.usageStats = {
-      "openai:bound": { cooldownUntil: Date.now() + 60_000 },
-    };
+    setProfileCooldown(store, "openai:bound");
 
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-responses",
-        modelBaseUrl: "https://api.openai.com/v1",
+        ...openAIPlatformAuthFixture(),
         config: {
           models: {
             providers: {
@@ -1226,10 +1028,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("keeps an explicit AWS SDK auth mode ahead of provider-entry profile bindings", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
+      ...openAIPlatformAuthFixture(),
       config: {
         models: {
           providers: {
@@ -1244,12 +1043,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       } as OpenClawConfig,
       env: {},
       authProfileStore: authStore({
-        "openai:bound": {
-          type: "token",
-          provider: "openai",
-          token: "subscription-token",
-          expires: Date.now() + 60_000,
-        },
+        "openai:bound": openAITokenProfile("subscription-token", Date.now() + 60_000),
       }),
     });
 
@@ -1263,10 +1057,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("keeps AWS SDK auth terminal when an API-key SecretRef and ordered profile also exist", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
+      ...openAIPlatformAuthFixture(),
       config: {
         models: {
           providers: {
@@ -1287,11 +1078,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       env: {},
       authProfileStore: authStore(
         {
-          "openai:platform": {
-            type: "api_key",
-            provider: "openai",
-            key: "platform-key",
-          },
+          "openai:platform": openAIApiKeyProfile("platform-key"),
         },
         { openai: ["openai:platform"] },
       ),
@@ -1308,10 +1095,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("keeps an explicit SecretRef API key ahead of ordered API-key profiles", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-chatgpt-responses",
-      modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+      ...openAIChatGptAuthFixture(),
       config: {
         models: {
           providers: {
@@ -1336,18 +1120,12 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       env: {},
       authProfileStore: authStore(
         {
-          "openai:chatgpt": {
-            type: "oauth",
-            provider: "openai",
-            access: "subscription-token",
-            refresh: "refresh-token",
-            expires: Date.now() + 60_000,
-          },
-          "openai:platform": {
-            type: "api_key",
-            provider: "openai",
-            key: "platform-key",
-          },
+          "openai:chatgpt": openAIOAuthProfile(
+            "subscription-token",
+            "refresh-token",
+            Date.now() + 60_000,
+          ),
+          "openai:platform": openAIApiKeyProfile("platform-key"),
         },
         { openai: ["openai:chatgpt", "openai:platform"] },
       ),
@@ -1377,19 +1155,12 @@ describe("prepareAgentRuntimeAuthPlan", () => {
     } as OpenClawConfig;
     const store = authStore(
       {
-        "openai:platform-backup": {
-          type: "api_key",
-          provider: "openai",
-          key: "profile-platform-key",
-        },
+        "openai:platform-backup": openAIApiKeyProfile("profile-platform-key"),
       },
       { openai: ["openai:platform-backup"] },
     );
     const prepared = prepareAgentRuntimeAuth({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-chatgpt-responses",
-      modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+      ...openAIChatGptAuthFixture(),
       config,
       env: {},
       authProfileStore: store,
@@ -1588,10 +1359,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       } as OpenClawConfig;
       const store = authStore({});
       const prepared = prepareAgentRuntimeAuth({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-chatgpt-responses",
-        modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+        ...openAIChatGptAuthFixture(),
         config,
         env: process.env,
         authProfileStore: store,
@@ -1647,10 +1415,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("keeps a provider apiKey SecretRef after API-key-compatible profiles", () => {
     const prepared = prepareAgentRuntimeAuth({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-chatgpt-responses",
-      modelBaseUrl: "https://chatgpt.com/backend-api/codex",
+      ...openAIChatGptAuthFixture(),
       config: {
         models: {
           providers: {
@@ -1670,18 +1435,12 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       env: {},
       authProfileStore: authStore(
         {
-          "openai:chatgpt": {
-            type: "oauth",
-            provider: "openai",
-            access: "subscription-token",
-            refresh: "refresh-token",
-            expires: Date.now() + 10 * 60_000,
-          },
-          "openai:platform": {
-            type: "api_key",
-            provider: "openai",
-            key: "platform-key",
-          },
+          "openai:chatgpt": openAIOAuthProfile(
+            "subscription-token",
+            "refresh-token",
+            Date.now() + 10 * 60_000,
+          ),
+          "openai:platform": openAIApiKeyProfile("platform-key"),
         },
         { openai: ["openai:chatgpt", "openai:platform"] },
       ),
@@ -1707,10 +1466,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("uses explicit OAuth mode for literal provider material", () => {
     const prepared = prepareAgentRuntimeAuth({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
+      ...openAIPlatformAuthFixture(),
       config: {
         models: {
           providers: {
@@ -1761,11 +1517,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
       } as OpenClawConfig,
       env: {},
       authProfileStore: authStore({
-        "openai:platform": {
-          type: "api_key",
-          provider: "openai",
-          key: "profile-platform-key",
-        },
+        "openai:platform": openAIApiKeyProfile("profile-platform-key"),
       }),
     });
 
@@ -1786,10 +1538,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("preserves explicit provider token auth before auth.order or route defaults", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
+      ...openAIPlatformAuthFixture(),
       config: {
         models: {
           providers: {
@@ -1866,10 +1615,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("rejects configured provider auth that contradicts an authored route", () => {
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        modelApi: "openai-responses",
-        modelBaseUrl: "https://api.openai.com/v1",
+        ...openAIPlatformAuthFixture(),
         config: {
           models: {
             providers: {
@@ -1890,10 +1636,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("preserves an explicit environment endpoint in the selected route", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "openai",
-      modelId: "gpt-5.5",
-      modelApi: "openai-responses",
-      modelBaseUrl: "https://api.openai.com/v1",
+      ...openAIPlatformAuthFixture(),
       env: {
         OPENAI_API_KEY: "platform-key",
         OPENAI_BASE_URL: "https://relay.example.test/v1",
@@ -1914,17 +1657,13 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("keeps the live codex virtual provider on a generic either-auth plan", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "codex",
-      modelId: "gpt-5.4",
-      env: {},
+      ...virtualCodexAuthFixture(),
       authProfileStore: authStore({
-        "openai:account": {
-          type: "oauth",
-          provider: "openai",
-          access: "subscription-token",
-          refresh: "refresh-token",
-          expires: Date.now() + 60_000,
-        },
+        "openai:account": openAIOAuthProfile(
+          "subscription-token",
+          "refresh-token",
+          Date.now() + 60_000,
+        ),
       }),
       sessionAuthProfileId: "openai:account",
       sessionAuthProfileSource: "user",
@@ -1943,28 +1682,16 @@ describe("prepareAgentRuntimeAuthPlan", () => {
 
   it("resolves automatic virtual Codex profiles from the OpenAI auth order", () => {
     const plan = prepareAgentRuntimeAuthPlan({
-      provider: "codex",
-      modelId: "gpt-5.4",
-      env: {},
+      ...virtualCodexAuthFixture(),
       authProfileStore: authStore(
         {
-          "openai:p1": {
-            type: "token",
-            provider: "openai",
-            token: "p1-token",
-          },
-          "openai:p2": {
-            type: "api_key",
-            provider: "openai",
-            key: "p2-key",
-          },
+          "openai:p1": openAITokenProfile("p1-token"),
+          "openai:p2": openAIApiKeyProfile("p2-key"),
         },
         { openai: ["openai:p1", "openai:p2"] },
       ),
       sessionAuthProfileId: "openai:p1",
       sessionAuthProfileSource: "auto",
-      harnessId: "codex",
-      harnessRuntime: "codex",
     });
 
     expect(plan).toMatchObject({
@@ -1981,20 +1708,12 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("rejects a user-locked non-OpenAI profile on the virtual Codex provider", () => {
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "codex",
-        modelId: "gpt-5.4",
-        env: {},
+        ...virtualCodexAuthFixture(),
         authProfileStore: authStore({
-          "anthropic:work": {
-            type: "api_key",
-            provider: "anthropic",
-            key: "anthropic-key",
-          },
+          "anthropic:work": apiKeyProfile("anthropic", "anthropic-key"),
         }),
         sessionAuthProfileId: "anthropic:work",
         sessionAuthProfileSource: "user",
-        harnessId: "codex",
-        harnessRuntime: "codex",
       }),
     ).toThrow(/not configured for openai/u);
   });
@@ -2002,9 +1721,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   it("rejects unavailable user-locked OpenAI profiles on the virtual Codex provider", () => {
     expect(() =>
       prepareAgentRuntimeAuthPlan({
-        provider: "codex",
-        modelId: "gpt-5.4",
-        env: {},
+        ...virtualCodexAuthFixture(),
         config: {
           auth: {
             profiles: {
@@ -2015,8 +1732,6 @@ describe("prepareAgentRuntimeAuthPlan", () => {
         authProfileStore: authStore({}),
         sessionAuthProfileId: "openai:missing",
         sessionAuthProfileSource: "user",
-        harnessId: "codex",
-        harnessRuntime: "codex",
       }),
     ).toThrow(/not configured for openai/u);
   });


### PR DESCRIPTION
## What Problem This Solves

`src/agents/runtime-plan/prepare-auth.test.ts` repeated the same provider config, OpenAI Platform/ChatGPT route, auth profile, and cooldown records throughout a large planner suite. That fixture duplication obscured the auth behavior each case was meant to prove and made equivalent route literals easier to drift.

## Why This Change Was Made

The test-local fixture layer is the architectural owner. This change consolidates those repeated literals into small typed helpers while keeping every case-specific override and expectation at its original test. A production abstraction or cross-suite fixture would widen the API and couple tests that exercise different boundaries.

Removed paths are duplicated test fixture literals only. Production behavior is unchanged: `prepareAgentRuntimeAuth` remains the canonical planner and its callers/callees are untouched.

Upstream contract audit: `openai/codex@07490c7` distinguishes API-key auth from ChatGPT/backend auth in `codex-rs/protocol/src/auth.rs:6-55`, persists `OPENAI_API_KEY` separately in `codex-rs/login/src/auth/{storage.rs:38-61,manager.rs:250-348,838-928}`, and selects `https://api.openai.com/v1` versus `https://chatgpt.com/backend-api/codex` in `codex-rs/model-provider-info/src/lib.rs:35-38,244-262`. The consolidated fixtures preserve those values exactly.

## User Impact

No runtime or user-visible behavior changes. Test LOC changes by +218/-503 (net -285); production LOC delta is 0. All 55 test-definition call sites remain in the same order, expanding to the same 58 cases, with the same 100 expectation sites.

## Evidence

- Fresh autoreview: clean, patch correct, confidence 0.99.
- Blacksmith Testbox `tbx_01kz2swxq5s6jj8nntdx1a0hmh`: 4 files and 80 tests passed, including all 58 changed-suite cases and 22 sibling auth tests.
- Static parity: identical test-definition sequence and identical expectation count before/after; `git diff --check` passed.
- Owner/sibling audit: `prepare-auth.ts`, `resolve-auth.ts`, embedded-runner and compaction callers, plus `auth.test.ts`, `prepare-auth.setup-provider.test.ts`, and `resolve-auth.test.ts` show no competing abstraction or lost invariant coverage.
