### PR TITLE
refactor(agents): unify prepared runtime publication

### DIFF
--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -1,132 +1,5 @@
+import "./prepared-model-runtime.test-harness.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
-
-type LoadStaticCatalog =
-  typeof import("./embedded-agent-runner/model.static-catalog.js").loadBundledProviderStaticCatalogContextModels;
-
-const mocks = vi.hoisted(() => ({
-  authStorage: {
-    getAll: vi.fn(() => ({ custom: { type: "api_key", key: "test-key" } })),
-    getOAuthProviders: vi.fn(() => []),
-  },
-  modelRegistry: {
-    fork: vi.fn((authStorage: unknown) => ({ authStorage })),
-    getAll: vi.fn(() => []),
-    find: vi.fn(() => null),
-  },
-  resolveAmbientCredentials: vi.fn((..._args: unknown[]) => ({})),
-  discoverAuthStorage: vi.fn((..._args: unknown[]) => undefined as unknown),
-  discoverModels: vi.fn(),
-  ensureOpenClawModelsJson: vi.fn(async (..._args: unknown[]) => ({
-    agentDir: "/tmp/agent",
-    wrote: false,
-  })),
-  planOpenClawModelsJsonSource: vi.fn(async (...args: unknown[]) => ({
-    agentDir: String(args[1]),
-    modelsJsonContents: null,
-    pluginCatalogs: [],
-  })),
-  buildPreparedModelCatalogSnapshot: vi.fn(async (..._args: unknown[]) => ({
-    entries: [],
-    routeVariants: [],
-  })),
-  loadAgentRuntimePluginRegistryHandle: vi.fn(),
-  loadStaticCatalog: vi.fn<LoadStaticCatalog>(async () => []),
-  prepareStaticCatalog: vi.fn(async (..._args: unknown[]) => ({ entries: [] })),
-  resolveStaticCatalogModel: vi.fn(() => undefined),
-  configuredAgentIds: [] as string[],
-  configuredAgentDirs: new Map<string, string>(),
-  configuredWorkspaces: new Map<string, string>(),
-  warn: vi.fn(),
-  mutationListener: undefined as
-    | ((event: { agentDir?: string; affectsInheritedStores: boolean }) => void)
-    | undefined,
-}));
-
-vi.mock("./model-catalog.js", () => ({
-  buildPreparedModelCatalogSnapshot: (...args: unknown[]) =>
-    mocks.buildPreparedModelCatalogSnapshot(...args),
-}));
-
-vi.mock("./agent-auth-discovery.js", () => ({
-  resolveAmbientAgentCredentialsForDiscovery: (...args: unknown[]) =>
-    mocks.resolveAmbientCredentials(...args),
-}));
-
-vi.mock("./agent-model-discovery.js", () => ({
-  discoverAuthStorage: (...args: unknown[]) => {
-    return mocks.discoverAuthStorage(...args) ?? mocks.authStorage;
-  },
-  discoverModels: (...args: unknown[]) => {
-    mocks.discoverModels(...args);
-    return mocks.modelRegistry;
-  },
-  discoverModelsFromCapturedSources: (...args: unknown[]) => {
-    mocks.discoverModels(...args);
-    return mocks.modelRegistry;
-  },
-}));
-
-vi.mock("../plugins/synthetic-auth.runtime.js", () => ({
-  resolveRuntimeSyntheticAuthProviderRefs: () => [],
-}));
-
-vi.mock("./agent-scope.js", () => ({
-  listAgentEntries: (config: { agents?: { list?: unknown[] } }) => config.agents?.list ?? [],
-  listAgentIds: () => mocks.configuredAgentIds,
-  resolveAgentDir: (_config: unknown, agentId: string) =>
-    mocks.configuredAgentDirs.get(agentId) ??
-    (agentId === "default" ? "/tmp/unused-agent" : `/tmp/configured-${agentId}`),
-  resolveAgentWorkspaceDir: (_config: unknown, agentId: string) =>
-    mocks.configuredWorkspaces.get(agentId) ??
-    (agentId === "default" ? "/tmp/unused-workspace" : `/tmp/workspace-${agentId}`),
-  resolveDefaultAgentDir: () => "/tmp/unused-agent",
-  resolveDefaultAgentId: () => "default",
-  resolveAgentEffectiveModelPrimary: () => undefined,
-  resolveRunModelFallbacksOverride: () => undefined,
-  resolveSessionAgentIds: ({ agentId }: { agentId?: string }) => ({
-    defaultAgentId: "default",
-    sessionAgentId: agentId ?? "default",
-  }),
-}));
-
-vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
-  registerRuntimeAuthProfileStoreMutationListener: (
-    listener: (event: { agentDir?: string; affectsInheritedStores: boolean }) => void,
-  ) => {
-    mocks.mutationListener = listener;
-    return () => {};
-  },
-}));
-
-vi.mock("./model-discovery-context.js", () => ({
-  resolveModelPluginMetadataSnapshot: () => undefined,
-}));
-
-vi.mock("./models-config.js", () => ({
-  ensureOpenClawModelsJson: (...args: unknown[]) => mocks.ensureOpenClawModelsJson(...args),
-  planOpenClawModelsJsonSource: (...args: unknown[]) => mocks.planOpenClawModelsJsonSource(...args),
-}));
-
-vi.mock("./models-config.providers.implicit.js", () => ({
-  prepareImplicitProviderStaticCatalog: (...args: unknown[]) => mocks.prepareStaticCatalog(...args),
-}));
-
-vi.mock("./runtime-plugins.js", () => ({
-  loadAgentRuntimePluginRegistryHandle: (...args: unknown[]) =>
-    mocks.loadAgentRuntimePluginRegistryHandle(...args),
-}));
-
-vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
-  loadBundledProviderStaticCatalogContextModels: (...args: Parameters<LoadStaticCatalog>) =>
-    mocks.loadStaticCatalog(...args),
-  createBundledStaticCatalogModelResolver: () => mocks.resolveStaticCatalogModel,
-}));
-
-vi.mock("../logging/subsystem.js", () => ({
-  createSubsystemLogger: () => ({ warn: mocks.warn }),
-}));
-
 import {
   acquireAgentRunPreparedModelRuntime,
   acquireReadOnlyPreparedModelRuntime,
@@ -136,43 +9,17 @@ import {
   publishPreparedModelRuntimeSnapshot,
   refreshPreparedModelRuntimeSnapshots,
 } from "./prepared-model-runtime.js";
+import {
+  getPreparedModelRuntimeMocks,
+  getPreparedModelRuntimeTestApi,
+  resetPreparedModelRuntimeHarness,
+} from "./prepared-model-runtime.test-harness.js";
+
+const mocks = getPreparedModelRuntimeMocks();
 
 describe("prepared model runtime snapshots", () => {
-  const getTesting = () =>
-    (globalThis as Record<PropertyKey, unknown>)[
-      Symbol.for("openclaw.preparedModelRuntimeTestApi")
-    ] as {
-      resetPreparedModelRuntimeSnapshotsForTest: () => void;
-      setModelRuntimeBuildTimeoutMsForTest: (timeoutMs: number) => void;
-    };
-
   beforeEach(() => {
-    getTesting().resetPreparedModelRuntimeSnapshotsForTest();
-    mocks.discoverAuthStorage.mockClear();
-    mocks.resolveAmbientCredentials.mockClear();
-    mocks.discoverAuthStorage.mockImplementation(() => mocks.authStorage);
-    mocks.discoverModels.mockClear();
-    mocks.ensureOpenClawModelsJson.mockReset();
-    mocks.ensureOpenClawModelsJson.mockResolvedValue({ agentDir: "/tmp/agent", wrote: false });
-    mocks.planOpenClawModelsJsonSource.mockReset();
-    mocks.planOpenClawModelsJsonSource.mockImplementation(async (_config, agentDir) => ({
-      agentDir: String(agentDir),
-      modelsJsonContents: null,
-      pluginCatalogs: [],
-    }));
-    mocks.buildPreparedModelCatalogSnapshot.mockClear();
-    mocks.loadAgentRuntimePluginRegistryHandle
-      .mockReset()
-      .mockReturnValue(createEmptyPluginRegistry());
-    mocks.loadStaticCatalog.mockClear();
-    mocks.prepareStaticCatalog.mockClear();
-    mocks.resolveStaticCatalogModel.mockClear();
-    mocks.modelRegistry.fork.mockClear();
-    mocks.modelRegistry.find.mockClear();
-    mocks.warn.mockClear();
-    mocks.configuredAgentIds = [];
-    mocks.configuredAgentDirs.clear();
-    mocks.configuredWorkspaces.clear();
+    resetPreparedModelRuntimeHarness();
   });
 
   it("does not discover missing owners from a gateway request", async () => {
@@ -637,7 +484,7 @@ describe("prepared model runtime snapshots", () => {
   });
 
   it("fails a timed-out publication without overlapping its late build with a retry", async () => {
-    getTesting().setModelRuntimeBuildTimeoutMsForTest(1);
+    getPreparedModelRuntimeTestApi().setModelRuntimeBuildTimeoutMsForTest(1);
     let finishTimedOutBuild: (() => void) | undefined;
     mocks.ensureOpenClawModelsJson.mockImplementationOnce(
       async () =>
@@ -799,7 +646,7 @@ describe("prepared model runtime snapshots", () => {
   });
 
   it("does not replay an auth mutation that occurs before the first owner is registered", async () => {
-    getTesting().setModelRuntimeBuildTimeoutMsForTest(100);
+    getPreparedModelRuntimeTestApi().setModelRuntimeBuildTimeoutMsForTest(100);
     mocks.configuredAgentIds = ["default"];
     mocks.prepareStaticCatalog.mockImplementationOnce(async () => {
       mocks.mutationListener?.({ affectsInheritedStores: true });

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -1,138 +1,8 @@
+import "./prepared-model-runtime.test-harness.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
-
-type CreateStaticCatalogResolver =
-  typeof import("./embedded-agent-runner/model.static-catalog.js").createBundledStaticCatalogModelResolver;
-type StaticCatalogResolver = ReturnType<CreateStaticCatalogResolver>;
-
-const mocks = vi.hoisted(() => ({
-  authStorage: {
-    getAll: vi.fn(() => ({ custom: { type: "api_key", key: "test-key" } })),
-    getOAuthProviders: vi.fn(() => []),
-  },
-  modelRegistry: {
-    fork: vi.fn((authStorage: unknown) => ({ authStorage })),
-    getAll: vi.fn(() => []),
-    find: vi.fn(() => null),
-  },
-  configuredAgentIds: [] as string[],
-  configuredAgentIdsError: undefined as Error | undefined,
-  configuredAgentDirs: new Map<string, string>(),
-  configuredWorkspaces: new Map<string, string>(),
-  buildPreparedModelCatalogSnapshot: vi.fn(async (..._args: unknown[]) => ({
-    entries: [],
-    routeVariants: [],
-  })),
-  discoverAuthStorage: vi.fn((..._args: unknown[]) => undefined as unknown),
-  discoverModels: vi.fn(),
-  ensureOpenClawModelsJson: vi.fn(async (..._args: unknown[]) => ({
-    agentDir: "/tmp/agent",
-    wrote: false,
-  })),
-  loadAgentRuntimePluginRegistryHandle: vi.fn(),
-  planOpenClawModelsJsonSource: vi.fn(async (...args: unknown[]) => ({
-    agentDir: String(args[1]),
-    modelsJsonContents: null,
-    pluginCatalogs: [],
-  })),
-  prepareStaticCatalog: vi.fn(async (..._args: unknown[]) => ({ entries: [] })),
-  resolveAmbientCredentials: vi.fn((..._args: unknown[]) => ({})),
-  resolveStaticCatalogModel: vi.fn<StaticCatalogResolver>(() => undefined),
-  mutationListener: undefined as
-    | ((event: { agentDir?: string; affectsInheritedStores: boolean }) => void)
-    | undefined,
-}));
-
-vi.mock("./model-catalog.js", () => ({
-  buildPreparedModelCatalogSnapshot: (...args: unknown[]) =>
-    mocks.buildPreparedModelCatalogSnapshot(...args),
-}));
-
-vi.mock("./agent-auth-discovery.js", () => ({
-  resolveAmbientAgentCredentialsForDiscovery: (...args: unknown[]) =>
-    mocks.resolveAmbientCredentials(...args),
-}));
-
-vi.mock("./agent-model-discovery.js", () => ({
-  discoverAuthStorage: (...args: unknown[]) =>
-    mocks.discoverAuthStorage(...args) ?? mocks.authStorage,
-  discoverModels: (...args: unknown[]) => {
-    mocks.discoverModels(...args);
-    return mocks.modelRegistry;
-  },
-  discoverModelsFromCapturedSources: (...args: unknown[]) => {
-    mocks.discoverModels(...args);
-    return mocks.modelRegistry;
-  },
-}));
-
-vi.mock("../plugins/synthetic-auth.runtime.js", () => ({
-  resolveRuntimeSyntheticAuthProviderRefs: () => [],
-}));
-
-vi.mock("./agent-scope.js", () => ({
-  listAgentEntries: (config: { agents?: { list?: unknown[] } }) => config.agents?.list ?? [],
-  listAgentIds: () => {
-    if (mocks.configuredAgentIdsError) {
-      throw mocks.configuredAgentIdsError;
-    }
-    return mocks.configuredAgentIds;
-  },
-  resolveAgentDir: (_config: unknown, agentId: string) =>
-    mocks.configuredAgentDirs.get(agentId) ??
-    (agentId === "default" ? "/tmp/unused-agent" : `/tmp/configured-${agentId}`),
-  resolveAgentWorkspaceDir: (_config: unknown, agentId: string) =>
-    mocks.configuredWorkspaces.get(agentId) ??
-    (agentId === "default" ? "/tmp/unused-workspace" : `/tmp/workspace-${agentId}`),
-  resolveDefaultAgentDir: () => "/tmp/unused-agent",
-  resolveDefaultAgentId: () => "default",
-  resolveAgentEffectiveModelPrimary: () => undefined,
-  resolveRunModelFallbacksOverride: () => undefined,
-  resolveSessionAgentIds: ({ agentId }: { agentId?: string }) => ({
-    defaultAgentId: "default",
-    sessionAgentId: agentId ?? "default",
-  }),
-}));
-
-vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
-  registerRuntimeAuthProfileStoreMutationListener: (
-    listener: (event: { agentDir?: string; affectsInheritedStores: boolean }) => void,
-  ) => {
-    mocks.mutationListener = listener;
-    return () => {};
-  },
-}));
-
-vi.mock("./model-discovery-context.js", () => ({
-  resolveModelPluginMetadataSnapshot: () => undefined,
-}));
-
-vi.mock("./models-config.js", () => ({
-  ensureOpenClawModelsJson: (...args: unknown[]) => mocks.ensureOpenClawModelsJson(...args),
-  planOpenClawModelsJsonSource: (...args: unknown[]) => mocks.planOpenClawModelsJsonSource(...args),
-}));
-
-vi.mock("./models-config.providers.implicit.js", () => ({
-  prepareImplicitProviderStaticCatalog: (...args: unknown[]) => mocks.prepareStaticCatalog(...args),
-}));
-
-vi.mock("./runtime-plugins.js", () => ({
-  loadAgentRuntimePluginRegistryHandle: (...args: unknown[]) =>
-    mocks.loadAgentRuntimePluginRegistryHandle(...args),
-}));
-
-vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
-  loadBundledProviderStaticCatalogContextModels: async () => [],
-  createBundledStaticCatalogModelResolver: () => mocks.resolveStaticCatalogModel,
-}));
-
-vi.mock("../logging/subsystem.js", () => ({
-  createSubsystemLogger: () => ({ warn: vi.fn() }),
-}));
-
 import {
   acquireAgentRunPreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
@@ -140,41 +10,17 @@ import {
   publishPreparedModelRuntimeSnapshot,
   refreshPreparedModelRuntimeSnapshots,
 } from "./prepared-model-runtime.js";
+import {
+  getPreparedModelRuntimeMocks,
+  getPreparedModelRuntimeTestApi,
+  resetPreparedModelRuntimeHarness,
+} from "./prepared-model-runtime.test-harness.js";
+
+const mocks = getPreparedModelRuntimeMocks();
 
 describe("prepared model runtime owner selection", () => {
-  const getTesting = () =>
-    (globalThis as Record<PropertyKey, unknown>)[
-      Symbol.for("openclaw.preparedModelRuntimeTestApi")
-    ] as {
-      getPreparedModelRuntimeOwnerCountForTest: () => number;
-      resetPreparedModelRuntimeSnapshotsForTest: () => void;
-    };
-
   beforeEach(() => {
-    getTesting().resetPreparedModelRuntimeSnapshotsForTest();
-    mocks.configuredAgentIds = [];
-    mocks.configuredAgentIdsError = undefined;
-    mocks.configuredAgentDirs.clear();
-    mocks.configuredWorkspaces.clear();
-    mocks.buildPreparedModelCatalogSnapshot.mockClear();
-    mocks.discoverAuthStorage.mockReset();
-    mocks.discoverAuthStorage.mockImplementation(() => mocks.authStorage);
-    mocks.discoverModels.mockClear();
-    mocks.ensureOpenClawModelsJson.mockReset();
-    mocks.ensureOpenClawModelsJson.mockResolvedValue({ agentDir: "/tmp/agent", wrote: false });
-    mocks.loadAgentRuntimePluginRegistryHandle
-      .mockReset()
-      .mockReturnValue(createEmptyPluginRegistry());
-    mocks.modelRegistry.fork.mockClear();
-    mocks.planOpenClawModelsJsonSource.mockReset();
-    mocks.planOpenClawModelsJsonSource.mockImplementation(async (_config, agentDir) => ({
-      agentDir: String(agentDir),
-      modelsJsonContents: null,
-      pluginCatalogs: [],
-    }));
-    mocks.prepareStaticCatalog.mockClear();
-    mocks.resolveAmbientCredentials.mockClear();
-    mocks.resolveStaticCatalogModel.mockClear();
+    resetPreparedModelRuntimeHarness();
   });
 
   it("serializes live catalog sources for owners sharing one agent directory", async () => {
@@ -365,13 +211,13 @@ describe("prepared model runtime owner selection", () => {
       });
       lease.release();
     }
-    expect(getTesting().getPreparedModelRuntimeOwnerCountForTest()).toBe(4);
+    expect(getPreparedModelRuntimeTestApi().getPreparedModelRuntimeOwnerCountForTest()).toBe(4);
 
     const refreshError = new Error("configured owner discovery failed");
     mocks.configuredAgentIdsError = refreshError;
     await expect(refreshPreparedModelRuntimeSnapshots(config)).rejects.toBe(refreshError);
 
-    expect(getTesting().getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+    expect(getPreparedModelRuntimeTestApi().getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
   });
 
   it("does not substitute a configured owner captured from another environment", async () => {

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -27,6 +27,7 @@ import {
   toPreparedModelRuntimeError,
 } from "./prepared-model-runtime.errors.js";
 import type {
+  PreparedModelRuntimeBuildStats,
   PreparedModelRuntimeCatalogMode,
   PreparedModelRuntimeInput,
   PreparedModelRuntimeOwner,
@@ -34,7 +35,6 @@ import type {
   PreparedModelRuntimeSnapshot,
 } from "./prepared-model-runtime.types.js";
 
-export { startSerializedSnapshotBuildBatch };
 export type {
   PreparedModelRuntimeInput,
   PreparedModelRuntimeLease,
@@ -389,6 +389,10 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
   owners: Map<string, PreparedModelRuntimeOwner>;
   agentBuildCompletions: Map<string, Promise<void>>;
   buildTimeoutMs: number;
+  isPublicationCurrent?: () => boolean;
+  isBuildCurrent?: () => boolean;
+  onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void;
+  registerEntriesAfterBuildStart?: boolean;
 }): Promise<void> {
   const candidates = params.entries.map(({ owner, input }) => {
     owner.input = input;
@@ -398,10 +402,24 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
     owner.refreshError = undefined;
     const generation = owner.generation;
     const key = ownerKey(input);
+    let registered = params.owners.get(key) === owner;
     return {
       catalogMode: owner.catalogMode,
       input,
-      isCurrent: () => owner.generation === generation && params.owners.get(key) === owner,
+      isEligible: () =>
+        (params.isPublicationCurrent?.() ?? true) &&
+        owner.generation === generation &&
+        (registered
+          ? params.owners.get(key) === owner
+          : params.registerEntriesAfterBuildStart === true),
+      isCurrent: () =>
+        (params.isPublicationCurrent?.() ?? true) &&
+        owner.generation === generation &&
+        params.owners.get(key) === owner,
+      key,
+      markRegistered: () => {
+        registered = true;
+      },
       owner,
     };
   });
@@ -419,7 +437,7 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
     try {
       while (true) {
         const attempt = candidates.filter(
-          (candidate) => candidate.isCurrent() && !snapshots.has(candidate.owner),
+          (candidate) => candidate.isEligible() && !snapshots.has(candidate.owner),
         );
         if (attempt.length === 0) {
           break;
@@ -429,7 +447,7 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
           // so one mutation cannot reintroduce broad plugin/catalog fanout on constrained hosts.
           for (const [catalogMode, group] of groups) {
             const currentGroup = group.filter(
-              (candidate) => candidate.isCurrent() && !snapshots.has(candidate.owner),
+              (candidate) => candidate.isEligible() && !snapshots.has(candidate.owner),
             );
             if (currentGroup.length === 0) {
               continue;
@@ -439,10 +457,17 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
               params.agentBuildCompletions,
               params.buildTimeoutMs,
               catalogMode,
-              undefined,
+              params.onBuildStats,
               new Map(currentGroup.map((candidate) => [candidate.input, candidate.isCurrent])),
+              params.isBuildCurrent,
             );
             for (const candidate of currentGroup) {
+              if (params.registerEntriesAfterBuildStart === true) {
+                // First-build hooks may emit auth mutations. Publish the owner only after those
+                // hooks start so an event cannot refresh a generation that was not visible yet.
+                params.owners.set(candidate.key, candidate.owner);
+                candidate.markRegistered();
+              }
               candidate.owner.buildCompletion = build.completion;
               void build.completion.then(() => {
                 if (candidate.owner.buildCompletion === build.completion) {
@@ -461,6 +486,7 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
           const lostCandidate = attempt.some((candidate) => !candidate.isCurrent());
           if (
             !(refreshError instanceof PreparedModelRuntimePublicationSupersededError) ||
+            !(params.isPublicationCurrent?.() ?? true) ||
             !lostCandidate
           ) {
             throw refreshError;

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -1,0 +1,202 @@
+import { vi } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+
+type LoadStaticCatalog =
+  typeof import("./embedded-agent-runner/model.static-catalog.js").loadBundledProviderStaticCatalogContextModels;
+type CreateStaticCatalogResolver =
+  typeof import("./embedded-agent-runner/model.static-catalog.js").createBundledStaticCatalogModelResolver;
+type StaticCatalogResolver = ReturnType<CreateStaticCatalogResolver>;
+
+const preparedModelRuntimeMocks = vi.hoisted(() => ({
+  authStorage: {
+    getAll: vi.fn(() => ({ custom: { type: "api_key", key: "test-key" } })),
+    getOAuthProviders: vi.fn(() => []),
+  },
+  modelRegistry: {
+    fork: vi.fn((authStorage: unknown) => ({ authStorage })),
+    getAll: vi.fn(() => []),
+    find: vi.fn(() => null),
+  },
+  buildPreparedModelCatalogSnapshot: vi.fn(async (..._args: unknown[]) => ({
+    entries: [],
+    routeVariants: [],
+  })),
+  configuredAgentIds: [] as string[],
+  configuredAgentIdsError: undefined as Error | undefined,
+  configuredAgentDirs: new Map<string, string>(),
+  configuredWorkspaces: new Map<string, string>(),
+  createStaticCatalogResolver: vi.fn<CreateStaticCatalogResolver>(),
+  discoverAuthStorage: vi.fn((..._args: unknown[]) => undefined as unknown),
+  discoverModels: vi.fn(),
+  ensureOpenClawModelsJson: vi.fn(async (..._args: unknown[]) => ({
+    agentDir: "/tmp/agent",
+    wrote: false,
+  })),
+  loadAgentRuntimePluginRegistryHandle: vi.fn(),
+  loadStaticCatalog: vi.fn<LoadStaticCatalog>(async () => []),
+  planOpenClawModelsJsonSource: vi.fn(async (...args: unknown[]) => ({
+    agentDir: String(args[1]),
+    modelsJsonContents: null,
+    pluginCatalogs: [],
+  })),
+  prepareStaticCatalog: vi.fn(async (..._args: unknown[]) => ({ entries: [] })),
+  resolveAmbientCredentials: vi.fn((..._args: unknown[]) => ({})),
+  resolveStaticCatalogModel: vi.fn<StaticCatalogResolver>(() => undefined),
+  warn: vi.fn(),
+  mutationListener: undefined as
+    | ((event: { agentDir?: string; affectsInheritedStores: boolean }) => void)
+    | undefined,
+}));
+
+vi.mock("./model-catalog.js", () => ({
+  buildPreparedModelCatalogSnapshot: (...args: unknown[]) =>
+    preparedModelRuntimeMocks.buildPreparedModelCatalogSnapshot(...args),
+}));
+
+vi.mock("./agent-auth-discovery.js", () => ({
+  resolveAmbientAgentCredentialsForDiscovery: (...args: unknown[]) =>
+    preparedModelRuntimeMocks.resolveAmbientCredentials(...args),
+}));
+
+vi.mock("./agent-model-discovery.js", () => ({
+  discoverAuthStorage: (...args: unknown[]) =>
+    preparedModelRuntimeMocks.discoverAuthStorage(...args) ?? preparedModelRuntimeMocks.authStorage,
+  discoverModels: (...args: unknown[]) => {
+    preparedModelRuntimeMocks.discoverModels(...args);
+    return preparedModelRuntimeMocks.modelRegistry;
+  },
+  discoverModelsFromCapturedSources: (...args: unknown[]) => {
+    preparedModelRuntimeMocks.discoverModels(...args);
+    return preparedModelRuntimeMocks.modelRegistry;
+  },
+}));
+
+vi.mock("../plugins/synthetic-auth.runtime.js", () => ({
+  resolveRuntimeSyntheticAuthProviderRefs: () => [],
+}));
+
+vi.mock("./agent-scope.js", () => ({
+  listAgentEntries: (config: { agents?: { list?: unknown[] } }) => config.agents?.list ?? [],
+  listAgentIds: () => {
+    if (preparedModelRuntimeMocks.configuredAgentIdsError) {
+      throw preparedModelRuntimeMocks.configuredAgentIdsError;
+    }
+    return preparedModelRuntimeMocks.configuredAgentIds;
+  },
+  resolveAgentDir: (_config: unknown, agentId: string) =>
+    preparedModelRuntimeMocks.configuredAgentDirs.get(agentId) ??
+    (agentId === "default" ? "/tmp/unused-agent" : `/tmp/configured-${agentId}`),
+  resolveAgentWorkspaceDir: (_config: unknown, agentId: string) =>
+    preparedModelRuntimeMocks.configuredWorkspaces.get(agentId) ??
+    (agentId === "default" ? "/tmp/unused-workspace" : `/tmp/workspace-${agentId}`),
+  resolveDefaultAgentDir: () => "/tmp/unused-agent",
+  resolveDefaultAgentId: () => "default",
+  resolveAgentEffectiveModelPrimary: () => undefined,
+  resolveRunModelFallbacksOverride: () => undefined,
+  resolveSessionAgentIds: ({ agentId }: { agentId?: string }) => ({
+    defaultAgentId: "default",
+    sessionAgentId: agentId ?? "default",
+  }),
+}));
+
+vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
+  registerRuntimeAuthProfileStoreMutationListener: (
+    listener: (event: { agentDir?: string; affectsInheritedStores: boolean }) => void,
+  ) => {
+    preparedModelRuntimeMocks.mutationListener = listener;
+    return () => {};
+  },
+}));
+
+vi.mock("./model-discovery-context.js", () => ({
+  resolveModelPluginMetadataSnapshot: () => undefined,
+}));
+
+vi.mock("./models-config.js", () => ({
+  ensureOpenClawModelsJson: (...args: unknown[]) =>
+    preparedModelRuntimeMocks.ensureOpenClawModelsJson(...args),
+  planOpenClawModelsJsonSource: (...args: unknown[]) =>
+    preparedModelRuntimeMocks.planOpenClawModelsJsonSource(...args),
+}));
+
+vi.mock("./models-config.providers.implicit.js", () => ({
+  prepareImplicitProviderStaticCatalog: (...args: unknown[]) =>
+    preparedModelRuntimeMocks.prepareStaticCatalog(...args),
+}));
+
+vi.mock("./runtime-plugins.js", () => ({
+  loadAgentRuntimePluginRegistryHandle: (...args: unknown[]) =>
+    preparedModelRuntimeMocks.loadAgentRuntimePluginRegistryHandle(...args),
+}));
+
+vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
+  loadBundledProviderStaticCatalogContextModels: (...args: Parameters<LoadStaticCatalog>) =>
+    preparedModelRuntimeMocks.loadStaticCatalog(...args),
+  createBundledStaticCatalogModelResolver: (...args: Parameters<CreateStaticCatalogResolver>) =>
+    preparedModelRuntimeMocks.createStaticCatalogResolver(...args),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ warn: preparedModelRuntimeMocks.warn }),
+}));
+
+type PreparedModelRuntimeTestApi = {
+  getPreparedModelRuntimeOwnerCountForTest(): number;
+  resetPreparedModelRuntimeSnapshotsForTest(): void;
+  setModelRuntimeBuildTimeoutMsForTest(timeoutMs: number): void;
+};
+
+export function getPreparedModelRuntimeMocks(): typeof preparedModelRuntimeMocks {
+  return preparedModelRuntimeMocks;
+}
+
+export function getPreparedModelRuntimeTestApi(): PreparedModelRuntimeTestApi {
+  return (globalThis as Record<PropertyKey, unknown>)[
+    Symbol.for("openclaw.preparedModelRuntimeTestApi")
+  ] as PreparedModelRuntimeTestApi;
+}
+
+export function resetPreparedModelRuntimeHarness(): void {
+  getPreparedModelRuntimeTestApi().resetPreparedModelRuntimeSnapshotsForTest();
+  preparedModelRuntimeMocks.authStorage.getAll.mockReset().mockReturnValue({
+    custom: { type: "api_key", key: "test-key" },
+  });
+  preparedModelRuntimeMocks.authStorage.getOAuthProviders.mockReset().mockReturnValue([]);
+  preparedModelRuntimeMocks.modelRegistry.fork
+    .mockReset()
+    .mockImplementation((authStorage: unknown) => ({ authStorage }));
+  preparedModelRuntimeMocks.modelRegistry.getAll.mockReset().mockReturnValue([]);
+  preparedModelRuntimeMocks.modelRegistry.find.mockReset().mockReturnValue(null);
+  preparedModelRuntimeMocks.buildPreparedModelCatalogSnapshot
+    .mockReset()
+    .mockResolvedValue({ entries: [], routeVariants: [] });
+  preparedModelRuntimeMocks.discoverAuthStorage
+    .mockReset()
+    .mockImplementation(() => preparedModelRuntimeMocks.authStorage);
+  preparedModelRuntimeMocks.discoverModels.mockReset();
+  preparedModelRuntimeMocks.ensureOpenClawModelsJson
+    .mockReset()
+    .mockResolvedValue({ agentDir: "/tmp/agent", wrote: false });
+  preparedModelRuntimeMocks.loadAgentRuntimePluginRegistryHandle
+    .mockReset()
+    .mockReturnValue(createEmptyPluginRegistry());
+  preparedModelRuntimeMocks.loadStaticCatalog.mockReset().mockResolvedValue([]);
+  preparedModelRuntimeMocks.planOpenClawModelsJsonSource
+    .mockReset()
+    .mockImplementation(async (_config, agentDir) => ({
+      agentDir: String(agentDir),
+      modelsJsonContents: null,
+      pluginCatalogs: [],
+    }));
+  preparedModelRuntimeMocks.prepareStaticCatalog.mockReset().mockResolvedValue({ entries: [] });
+  preparedModelRuntimeMocks.resolveAmbientCredentials.mockReset().mockReturnValue({});
+  preparedModelRuntimeMocks.resolveStaticCatalogModel.mockReset().mockReturnValue(undefined);
+  preparedModelRuntimeMocks.createStaticCatalogResolver
+    .mockReset()
+    .mockReturnValue(preparedModelRuntimeMocks.resolveStaticCatalogModel);
+  preparedModelRuntimeMocks.warn.mockReset();
+  preparedModelRuntimeMocks.configuredAgentIds = [];
+  preparedModelRuntimeMocks.configuredAgentIdsError = undefined;
+  preparedModelRuntimeMocks.configuredAgentDirs.clear();
+  preparedModelRuntimeMocks.configuredWorkspaces.clear();
+}

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -1,129 +1,7 @@
+import "./prepared-model-runtime.test-harness.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { requireActivePluginRegistry } from "../plugins/runtime.js";
-
-type LoadStaticCatalog =
-  typeof import("./embedded-agent-runner/model.static-catalog.js").loadBundledProviderStaticCatalogContextModels;
-type CreateStaticCatalogResolver =
-  typeof import("./embedded-agent-runner/model.static-catalog.js").createBundledStaticCatalogModelResolver;
-type StaticCatalogResolver = ReturnType<CreateStaticCatalogResolver>;
-
-const mocks = vi.hoisted(() => ({
-  authStorage: {
-    getAll: vi.fn(() => ({ custom: { type: "api_key", key: "test-key" } })),
-    getOAuthProviders: vi.fn(() => []),
-  },
-  modelRegistry: {
-    fork: vi.fn((authStorage: unknown) => ({ authStorage })),
-    getAll: vi.fn(() => []),
-    find: vi.fn(() => null),
-  },
-  resolveAmbientCredentials: vi.fn((..._args: unknown[]) => ({})),
-  discoverAuthStorage: vi.fn(),
-  discoverModels: vi.fn(),
-  ensureOpenClawModelsJson: vi.fn(async (..._args: unknown[]) => ({
-    agentDir: "/tmp/agent",
-    wrote: false,
-  })),
-  planOpenClawModelsJsonSource: vi.fn(async (...args: unknown[]) => ({
-    agentDir: String(args[1]),
-    modelsJsonContents: null,
-    pluginCatalogs: [],
-  })),
-  buildPreparedModelCatalogSnapshot: vi.fn(async (..._args: unknown[]) => ({
-    entries: [],
-    routeVariants: [],
-  })),
-  loadAgentRuntimePluginRegistryHandle: vi.fn(),
-  loadStaticCatalog: vi.fn<LoadStaticCatalog>(async () => []),
-  resolveStaticCatalogModel: vi.fn<StaticCatalogResolver>(() => undefined),
-  createStaticCatalogResolver: vi.fn<CreateStaticCatalogResolver>(),
-  configuredAgentIds: [] as string[],
-  mutationListener: undefined as
-    | ((event: { agentDir?: string; affectsInheritedStores: boolean }) => void)
-    | undefined,
-}));
-
-vi.mock("./model-catalog.js", () => ({
-  buildPreparedModelCatalogSnapshot: (...args: unknown[]) =>
-    mocks.buildPreparedModelCatalogSnapshot(...args),
-}));
-
-vi.mock("./agent-auth-discovery.js", () => ({
-  resolveAmbientAgentCredentialsForDiscovery: (...args: unknown[]) =>
-    mocks.resolveAmbientCredentials(...args),
-}));
-
-vi.mock("./agent-model-discovery.js", () => ({
-  discoverAuthStorage: (...args: unknown[]) => {
-    mocks.discoverAuthStorage(...args);
-    return mocks.authStorage;
-  },
-  discoverModels: (...args: unknown[]) => {
-    mocks.discoverModels(...args);
-    return mocks.modelRegistry;
-  },
-  discoverModelsFromCapturedSources: (...args: unknown[]) => {
-    mocks.discoverModels(...args);
-    return mocks.modelRegistry;
-  },
-}));
-
-vi.mock("../plugins/synthetic-auth.runtime.js", () => ({
-  resolveRuntimeSyntheticAuthProviderRefs: () => [],
-}));
-
-vi.mock("./agent-scope.js", () => ({
-  listAgentEntries: (config: { agents?: { list?: unknown[] } }) => config.agents?.list ?? [],
-  listAgentIds: () => mocks.configuredAgentIds,
-  resolveAgentDir: (_config: unknown, agentId: string) =>
-    agentId === "default" ? "/tmp/unused-agent" : `/tmp/configured-${agentId}`,
-  resolveAgentWorkspaceDir: (_config: unknown, agentId: string) =>
-    agentId === "default" ? "/tmp/unused-workspace" : `/tmp/workspace-${agentId}`,
-  resolveDefaultAgentDir: () => "/tmp/unused-agent",
-  resolveDefaultAgentId: () => "default",
-  resolveAgentEffectiveModelPrimary: () => undefined,
-  resolveRunModelFallbacksOverride: () => undefined,
-  resolveSessionAgentIds: ({ agentId }: { agentId?: string }) => ({
-    defaultAgentId: "default",
-    sessionAgentId: agentId ?? "default",
-  }),
-}));
-
-vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
-  registerRuntimeAuthProfileStoreMutationListener: (
-    listener: (event: { agentDir?: string; affectsInheritedStores: boolean }) => void,
-  ) => {
-    mocks.mutationListener = listener;
-    return () => {};
-  },
-}));
-
-vi.mock("./model-discovery-context.js", () => ({
-  resolveModelPluginMetadataSnapshot: () => undefined,
-}));
-
-vi.mock("./models-config.js", () => ({
-  ensureOpenClawModelsJson: (...args: unknown[]) => mocks.ensureOpenClawModelsJson(...args),
-  planOpenClawModelsJsonSource: (...args: unknown[]) => mocks.planOpenClawModelsJsonSource(...args),
-}));
-
-vi.mock("./runtime-plugins.js", () => ({
-  loadAgentRuntimePluginRegistryHandle: (...args: unknown[]) =>
-    mocks.loadAgentRuntimePluginRegistryHandle(...args),
-}));
-
-vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
-  loadBundledProviderStaticCatalogContextModels: (...args: Parameters<LoadStaticCatalog>) =>
-    mocks.loadStaticCatalog(...args),
-  createBundledStaticCatalogModelResolver: (...args: Parameters<CreateStaticCatalogResolver>) =>
-    mocks.createStaticCatalogResolver(...args),
-}));
-
-vi.mock("../logging/subsystem.js", () => ({
-  createSubsystemLogger: () => ({ warn: vi.fn() }),
-}));
-
 import { startSerializedSnapshotBuild } from "./prepared-model-runtime.build.js";
 import {
   acquireReadOnlyPreparedModelRuntime,
@@ -136,32 +14,16 @@ import {
   rejectPendingPreparedModelRuntimeReplacement,
   refreshPreparedModelRuntimeSnapshots,
 } from "./prepared-model-runtime.js";
+import {
+  getPreparedModelRuntimeMocks,
+  resetPreparedModelRuntimeHarness,
+} from "./prepared-model-runtime.test-harness.js";
+
+const mocks = getPreparedModelRuntimeMocks();
 
 describe("prepared model runtime snapshots", () => {
-  const getTesting = () =>
-    (globalThis as Record<PropertyKey, unknown>)[
-      Symbol.for("openclaw.preparedModelRuntimeTestApi")
-    ] as {
-      resetPreparedModelRuntimeSnapshotsForTest: () => void;
-      setModelRuntimeBuildTimeoutMsForTest: (timeoutMs: number) => void;
-    };
-
   beforeEach(() => {
-    getTesting().resetPreparedModelRuntimeSnapshotsForTest();
-    mocks.discoverAuthStorage.mockClear();
-    mocks.resolveAmbientCredentials.mockClear();
-    mocks.discoverModels.mockClear();
-    mocks.ensureOpenClawModelsJson.mockClear();
-    mocks.buildPreparedModelCatalogSnapshot.mockClear();
-    mocks.loadAgentRuntimePluginRegistryHandle
-      .mockReset()
-      .mockReturnValue(createEmptyPluginRegistry());
-    mocks.loadStaticCatalog.mockClear();
-    mocks.resolveStaticCatalogModel.mockReset();
-    mocks.createStaticCatalogResolver.mockReset();
-    mocks.createStaticCatalogResolver.mockReturnValue(mocks.resolveStaticCatalogModel);
-    mocks.modelRegistry.fork.mockClear();
-    mocks.configuredAgentIds = [];
+    resetPreparedModelRuntimeHarness();
   });
 
   it("allows a direct serialized build without a lifecycle generation guard", async () => {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -21,7 +21,6 @@ import {
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
   resolvePublishedOwner,
-  startSerializedSnapshotBuildBatch,
   toError,
   type PreparedModelRuntimeOwner,
   type PreparedModelRuntimeInput,
@@ -548,74 +547,20 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
     owner.environmentFingerprint = effectiveEnvironmentFingerprint(input);
     owner.catalogMode = catalogMode;
     owner.provenance = "configured";
-    owner.generation += 1;
-    owner.needsRefresh = true;
-    owner.refreshError = undefined;
-    const generation = owner.generation;
-    const isCurrent = () =>
-      publicationEpoch === refreshRequestEpoch &&
-      owner.generation === generation &&
-      owners.get(ownerKey(input)) === owner;
-    return { input, isCurrent, owner };
+    return { input, owner };
   });
-  const build = startSerializedSnapshotBuildBatch(
-    candidates.map(({ input }) => input),
+  await publishPreparedModelRuntimeOwnerBatch({
+    entries: candidates,
+    owners,
     agentBuildCompletions,
-    modelRuntimeBuildTimeoutMs,
-    catalogMode,
-    options.onBuildStats,
-    new Map(candidates.map((candidate) => [candidate.input, candidate.isCurrent])),
-    () => publicationEpoch === refreshRequestEpoch,
-  );
-  for (const candidate of candidates) {
-    owners.set(ownerKey(candidate.input), candidate.owner);
-    candidate.owner.buildCompletion = build.completion;
-    void build.completion.then(() => {
-      if (candidate.owner.buildCompletion === build.completion) {
-        candidate.owner.buildCompletion = undefined;
-      }
-    });
-  }
-  const publication = (async () => {
-    try {
-      const snapshots = await build.pending;
-      for (const [index, candidate] of candidates.entries()) {
-        if (!candidate.isCurrent()) {
-          continue;
-        }
-        candidate.owner.snapshot = snapshots[index]!;
-        candidate.owner.pending = undefined;
-        candidate.owner.needsRefresh = false;
-      }
-      return snapshots;
-    } catch (error) {
-      const refreshError = toError(error);
-      for (const candidate of candidates) {
-        if (!candidate.isCurrent()) {
-          continue;
-        }
-        candidate.owner.pending = undefined;
-        candidate.owner.needsRefresh = true;
-        candidate.owner.refreshError = refreshError;
-      }
-      throw refreshError;
-    }
-  })();
-  for (const [index, candidate] of candidates.entries()) {
-    const pending = publication.then((snapshots) => {
-      // Config publication is atomic, including callers deduplicated against an individual owner.
-      // A superseded batch must not leak its unpublished snapshot through that pending promise.
-      if (!candidate.isCurrent()) {
-        throw new PreparedModelRuntimePublicationSupersededError(
-          `prepared model runtime publication was superseded for ${candidate.input.agentDir}`,
-        );
-      }
-      return snapshots[index]!;
-    });
-    candidate.owner.pending = pending;
-    void pending.catch(() => undefined);
-  }
-  await publication;
+    buildTimeoutMs: modelRuntimeBuildTimeoutMs,
+    isPublicationCurrent: () => publicationEpoch === refreshRequestEpoch,
+    // Config replacement is one transaction. Per-owner auth supersession may retire individual
+    // candidates, while a newer config epoch stops every remaining build in this publication.
+    isBuildCurrent: () => publicationEpoch === refreshRequestEpoch,
+    onBuildStats: options.onBuildStats,
+    registerEntriesAfterBuildStart: true,
+  });
 }
 
 /** Serializes config/plugin publications so only the latest completed refresh retires owners. */


### PR DESCRIPTION
## What Problem This Solves

Prepared model runtime config reloads and auth mutations maintained parallel owner-publication flows. The duplication made generation guards, atomic commit behavior, build statistics, and owner-registration timing easier to drift apart.

## Why This Change Was Made

Route configured-owner rebuilds through the existing batch publication owner while preserving config-epoch cancellation and the boundary that publishes first-time owners only after their build starts. Consolidate the three prepared-runtime suites on one shared mock/reset harness and remove the resulting dead re-export.

Production code is net -29 lines; the complete change is net -272 lines.

## User Impact

No intended user-visible behavior change. Gateway config reload and auth-refresh publications keep the same atomicity, supersession, and lifecycle behavior with one canonical implementation.

## Evidence

- Blacksmith Testbox `tbx_01kz2s20dcrjs0qb3fbjkdycxj`: 91/91 focused prepared-runtime tests passed ([run](https://github.com/openclaw/openclaw/actions/runs/30780681145)).
- Blacksmith Testbox `tbx_01kz2shazynrmmta0e0rs7y0kp`: `pnpm check:changed` passed, including dead-code, core/core-test typecheck, lint, formatting, import cycles, and runtime/storage guards ([run](https://github.com/openclaw/openclaw/actions/runs/30781061610)).
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- `git diff --check`: passed.
