### PR TITLE
improve(tests): fixture wizard model auth policy

### DIFF
--- a/src/wizard/setup.model-auth.test.ts
+++ b/src/wizard/setup.model-auth.test.ts
@@ -5,6 +5,11 @@ import type { RuntimeEnv } from "../runtime.js";
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
 import { runSetupModelAuthStep } from "./setup.model-auth.js";
 
+type ResolveManifestProviderAuthChoice =
+  typeof import("../plugins/provider-auth-choices.js").resolveManifestProviderAuthChoice;
+type ResolvePluginSetupProvider =
+  typeof import("../plugins/setup-registry.js").resolvePluginSetupProvider;
+
 const applyAuthChoice = vi.hoisted(() => vi.fn());
 const warnIfModelConfigLooksOff = vi.hoisted(() => vi.fn());
 const resolvePreferredProviderForAuthChoice = vi.hoisted(() => vi.fn());
@@ -12,6 +17,18 @@ const promptDefaultModel = vi.hoisted(() => vi.fn());
 const applyPrimaryModel = vi.hoisted(() => vi.fn((config: unknown) => config));
 const promptAuthChoiceGrouped = vi.hoisted(() => vi.fn());
 const ensureAuthProfileStore = vi.hoisted(() => vi.fn(() => ({ profiles: {} })));
+const resolveManifestProviderAuthChoice = vi.hoisted(() =>
+  vi.fn<ResolveManifestProviderAuthChoice>(() => ({
+    pluginId: "anthropic",
+    providerId: "anthropic",
+    methodId: "anthropic-cli",
+    choiceId: "anthropic-cli",
+    choiceLabel: "Anthropic CLI",
+  })),
+);
+const resolvePluginSetupProvider = vi.hoisted(() =>
+  vi.fn<ResolvePluginSetupProvider>(() => undefined),
+);
 
 vi.mock("../commands/auth-choice.js", () => ({
   applyAuthChoice,
@@ -32,6 +49,14 @@ vi.mock("../commands/auth-choice-prompt.js", () => ({
 
 vi.mock("../agents/auth-profiles.runtime.js", () => ({
   ensureAuthProfileStore,
+}));
+
+vi.mock("../plugins/provider-auth-choices.js", () => ({
+  resolveManifestProviderAuthChoice,
+}));
+
+vi.mock("../plugins/setup-registry.js", () => ({
+  resolvePluginSetupProvider,
 }));
 
 function createPrompter(): WizardPrompter {


### PR DESCRIPTION
## What Problem This Solves

One default-agent model-auth wizard case accidentally entered real plugin manifest and setup-provider discovery after its auth/model owners were already mocked. That unrelated inventory work consumed virtually the entire test file.

## Why This Change Was Made

Provide narrow hoisted fixtures for the manifest auth-choice identity and the absence of an explicit setup-provider policy. The real wizard target-selection branch and every default-agent assertion remain unchanged; manifest policy, provider auth, setup registry, and agent targeting retain dedicated owner coverage.

## User Impact

No runtime or user-visible behavior changes. The same wizard coverage completes much faster with lower memory use.

## Evidence

- Median wall: 21.21s -> 3.51s (83.5% faster).
- Vitest: 18.04s -> 783ms; test bodies: 17.21s -> 81ms.
- Max RSS: about 1.006GB -> 341MB.
- Target: 6/6; manifest-policy owner: 1/1; provider-auth/setup-registry/default-agent owners: 43/43.
- Formatting, typed targeted lint, `git diff --check`, and autoreview are clean.
- Test-only diff: +25 lines; production LOC delta: 0.
