### PR TITLE
improve(tests): avoid bundled scans in config CLI

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -35,6 +35,31 @@ const mockReadBestEffortRuntimeConfigSchema = vi.fn();
 const mockLoadPluginMetadataSnapshot = vi.fn((_configForTest: unknown) =>
   createPluginMetadataSnapshot(),
 );
+const mockLoadChannelSecretContractApi = vi.hoisted(() =>
+  vi.fn(({ channelId }: { channelId: string }) => {
+    const fields: Record<string, readonly string[]> = {
+      discord: ["token"],
+      slack: ["appToken", "botToken"],
+      telegram: ["botToken"],
+    };
+    return {
+      secretTargetRegistryEntries: (fields[channelId] ?? []).map((field) => {
+        const pathPattern = `channels.${channelId}.${field}`;
+        return {
+          id: pathPattern,
+          targetType: pathPattern,
+          configFile: "openclaw.json" as const,
+          pathPattern,
+          secretShape: "secret_input" as const,
+          expectedResolvedValue: "string" as const,
+          includeInPlan: true,
+          includeInConfigure: true,
+          includeInAudit: true,
+        };
+      }),
+    };
+  }),
+);
 
 vi.mock("../config/config.js", () => ({
   readConfigFileSnapshot: (...args: Parameters<typeof mockReadConfigFileSnapshot>) =>
@@ -109,6 +134,15 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
   loadPluginMetadataSnapshot: (config: unknown) => mockLoadPluginMetadataSnapshot(config),
   resolvePluginMetadataSnapshot: (params: { config?: unknown }) =>
     mockLoadPluginMetadataSnapshot(params.config),
+}));
+
+vi.mock("../plugins/bundled-plugin-metadata.js", () => ({
+  listBundledPluginMetadata: () => [],
+}));
+
+vi.mock("../secrets/channel-contract-api.js", () => ({
+  loadChannelSecretContractApi: mockLoadChannelSecretContractApi,
+  loadChannelSecretContractApiForRecord: () => undefined,
 }));
 
 const { defaultRuntime, resetRuntimeCapture } = createCliRuntimeCapture();
@@ -465,8 +499,6 @@ let ExitError: new (code: number, message?: string) => Error;
 describe("config cli", () => {
   beforeAll(async () => {
     ({ parseConfigSetPath, registerConfigCli } = await import("./config-cli.js"));
-    const { resolveConfigSecretTargetByPath } = await import("../secrets/target-registry.js");
-    resolveConfigSecretTargetByPath(["channels", "googlechat", "serviceAccount"]);
     sharedProgram = new Command();
     sharedProgram.exitOverride();
     registerConfigCli(sharedProgram);


### PR DESCRIPTION
## What Problem This Solves

The config CLI suite exercised real target-registry matching but paid to discover the complete bundled plugin and channel inventory during cold setup. No individual assertion was slow; unrelated inventory loading dominated all 183 cases.

## Why This Change Was Made

Provide empty bundled metadata plus tiny Discord, Slack, and Telegram channel-contract fixtures while retaining the real target-registry compile, match, and discovery logic. Dedicated registry and integration suites continue to prove real catalog loading. Sharding, concurrency, production behavior, and assertion count are unchanged.

## User Impact

No runtime or user-visible behavior changes. Config CLI coverage completes much faster with a narrower owner fixture.

## Evidence

- Same AWS lease median: 22.20s -> 1.84s (91.7% faster).
- Test count unchanged: 183/183.
- Config CLI integration plus fast/real target-registry owners: 17/17.
- Rebased focused/sibling proof: 200/200.
- Remote changed gate passed formatting, core test types, lint, boundaries, and dead code; final autoreview is clean.
- Test-only diff: +34/-2; production LOC delta: 0.
