### PR TITLE
test(ollama): consolidate stream runtime fixtures

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -89,6 +89,36 @@ function expectIteratorEvent(
   }
 }
 
+function convertAssistantContent(
+  content: Array<Record<string, unknown>>,
+  options?: Parameters<typeof convertToOllamaMessages>[2],
+) {
+  return convertToOllamaMessages([{ role: "assistant", content }] as never, undefined, options);
+}
+
+type AssistantResponse = Parameters<typeof buildAssistantMessage>[0];
+type AssistantResponseMessage = AssistantResponse["message"];
+
+function createAssistantResponse(
+  message: Omit<AssistantResponseMessage, "role">,
+  overrides: Partial<Omit<AssistantResponse, "message">> = {},
+): AssistantResponse {
+  return {
+    model: "qwen3:32b",
+    created_at: "2026-01-01T00:00:00Z",
+    message: { role: "assistant", ...message },
+    done: true,
+    ...overrides,
+  };
+}
+
+function createToolCallResponse(
+  toolCalls: NonNullable<AssistantResponseMessage["tool_calls"]>,
+  overrides: Partial<Omit<AssistantResponse, "message">> = {},
+): AssistantResponse {
+  return createAssistantResponse({ content: "", tool_calls: toolCalls }, overrides);
+}
+
 afterEach(() => {
   fetchWithSsrFGuardMock.mockReset();
   ollamaStreamWarnMock.mockReset();
@@ -560,16 +590,10 @@ describe("convertToOllamaMessages", () => {
   });
 
   it("converts assistant messages with toolCall content blocks", () => {
-    const messages = [
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Let me check." },
-          { type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } },
-        ],
-      },
-    ];
-    const result = convertToOllamaMessages(messages);
+    const result = convertAssistantContent([
+      { type: "text", text: "Let me check." },
+      { type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } },
+    ]);
     expect(requireEntry(result, 0, "first converted Ollama message").role).toBe("assistant");
     expect(requireEntry(result, 0, "first converted Ollama message").content).toBe("Let me check.");
     expect(requireEntry(result, 0, "first converted Ollama message").tool_calls).toEqual([
@@ -578,36 +602,24 @@ describe("convertToOllamaMessages", () => {
   });
 
   it("preserves assistant tool-call ids before Ollama replay", () => {
-    const messages = [
+    const result = convertAssistantContent([
       {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "fc_ollama_123",
-            name: "bash",
-            arguments: { command: "pwd" },
-          },
-        ],
+        type: "toolCall",
+        id: "fc_ollama_123",
+        name: "bash",
+        arguments: { command: "pwd" },
       },
-    ];
-    const result = convertToOllamaMessages(messages);
+    ]);
     expect(requireEntry(result, 0, "first converted Ollama message").tool_calls).toEqual([
       { id: "fc_ollama_123", function: { name: "bash", arguments: { command: "pwd" } } },
     ]);
   });
 
   it("normalizes provider-prefixed tool-call names before Ollama replay", () => {
-    const messages = [
-      {
-        role: "assistant",
-        content: [
-          { type: "toolCall", id: "call_1", name: "functions.exec", arguments: { command: "pwd" } },
-          { type: "tool_use", id: "call_2", name: "tools/read", input: { path: "README.md" } },
-        ],
-      },
-    ];
-    const result = convertToOllamaMessages(messages);
+    const result = convertAssistantContent([
+      { type: "toolCall", id: "call_1", name: "functions.exec", arguments: { command: "pwd" } },
+      { type: "tool_use", id: "call_2", name: "tools/read", input: { path: "README.md" } },
+    ]);
     expect(requireEntry(result, 0, "first converted Ollama message").tool_calls).toEqual([
       { id: "call_1", function: { name: "exec", arguments: { command: "pwd" } } },
       { id: "call_2", function: { name: "read", arguments: { path: "README.md" } } },
@@ -615,19 +627,16 @@ describe("convertToOllamaMessages", () => {
   });
 
   it("preserves exact allowlisted tool-prefix names before Ollama replay", () => {
-    const messages = [
+    const result = convertAssistantContent(
+      [
+        { type: "toolCall", id: "call_1", name: "tool_a", arguments: { value: 1 } },
+        { type: "tool_use", id: "call_2", name: "tools_invoke_test", input: { value: 2 } },
+        { type: "toolCall", id: "call_3", name: "function-run", arguments: { value: 3 } },
+      ],
       {
-        role: "assistant",
-        content: [
-          { type: "toolCall", id: "call_1", name: "tool_a", arguments: { value: 1 } },
-          { type: "tool_use", id: "call_2", name: "tools_invoke_test", input: { value: 2 } },
-          { type: "toolCall", id: "call_3", name: "function-run", arguments: { value: 3 } },
-        ],
+        availableToolNames: new Set(["tool_a", "tools_invoke_test", "function-run"]),
       },
-    ];
-    const result = convertToOllamaMessages(messages, undefined, {
-      availableToolNames: new Set(["tool_a", "tools_invoke_test", "function-run"]),
-    });
+    );
     expect(requireEntry(result, 0, "first converted Ollama message").tool_calls).toEqual([
       { id: "call_1", function: { name: "tool_a", arguments: { value: 1 } } },
       { id: "call_2", function: { name: "tools_invoke_test", arguments: { value: 2 } } },
@@ -636,19 +645,16 @@ describe("convertToOllamaMessages", () => {
   });
 
   it("strips underscore and dash provider prefixes only when the suffix is allowlisted", () => {
-    const messages = [
+    const result = convertAssistantContent(
+      [
+        { type: "toolCall", id: "call_1", name: "tools_exec", arguments: { command: "pwd" } },
+        { type: "tool_use", id: "call_2", name: "function-read", input: { path: "." } },
+        { type: "toolCall", id: "call_3", name: "tool_missing", arguments: {} },
+      ],
       {
-        role: "assistant",
-        content: [
-          { type: "toolCall", id: "call_1", name: "tools_exec", arguments: { command: "pwd" } },
-          { type: "tool_use", id: "call_2", name: "function-read", input: { path: "." } },
-          { type: "toolCall", id: "call_3", name: "tool_missing", arguments: {} },
-        ],
+        availableToolNames: new Set(["exec", "read"]),
       },
-    ];
-    const result = convertToOllamaMessages(messages, undefined, {
-      availableToolNames: new Set(["exec", "read"]),
-    });
+    );
     expect(requireEntry(result, 0, "first converted Ollama message").tool_calls).toEqual([
       { id: "call_1", function: { name: "exec", arguments: { command: "pwd" } } },
       { id: "call_2", function: { name: "read", arguments: { path: "." } } },
@@ -657,18 +663,12 @@ describe("convertToOllamaMessages", () => {
   });
 
   it("keeps non-prefixed Ollama replay tool names intact", () => {
-    const messages = [
-      {
-        role: "assistant",
-        content: [
-          { type: "toolCall", id: "call_1", name: "functionshell", arguments: {} },
-          { type: "toolCall", id: "call_2", name: "tooling", arguments: {} },
-          { type: "toolCall", id: "call_3", name: "tools", arguments: {} },
-          { type: "toolCall", id: "call_4", name: "tool_a", arguments: {} },
-        ],
-      },
-    ];
-    const result = convertToOllamaMessages(messages);
+    const result = convertAssistantContent([
+      { type: "toolCall", id: "call_1", name: "functionshell", arguments: {} },
+      { type: "toolCall", id: "call_2", name: "tooling", arguments: {} },
+      { type: "toolCall", id: "call_3", name: "tools", arguments: {} },
+      { type: "toolCall", id: "call_4", name: "tool_a", arguments: {} },
+    ]);
     expect(requireEntry(result, 0, "first converted Ollama message").tool_calls).toEqual([
       { id: "call_1", function: { name: "functionshell", arguments: {} } },
       { id: "call_2", function: { name: "tooling", arguments: {} } },
@@ -680,55 +680,37 @@ describe("convertToOllamaMessages", () => {
   it("deserializes string arguments back to objects for Ollama (round-trip fix)", () => {
     // When tool calls round-trip through OpenAI-format storage, arguments
     // are serialized as a JSON string.  Ollama expects an object.
-    const messages = [
+    const result = convertAssistantContent([
       {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call_2",
-            name: "Read",
-            arguments: '{"file_path":"/tmp/test.txt"}',
-          },
-        ],
+        type: "toolCall",
+        id: "call_2",
+        name: "Read",
+        arguments: '{"file_path":"/tmp/test.txt"}',
       },
-    ];
-    const result = convertToOllamaMessages(messages);
+    ]);
     expect(requireEntry(result, 0, "first converted Ollama message").tool_calls).toEqual([
       { id: "call_2", function: { name: "Read", arguments: { file_path: "/tmp/test.txt" } } },
     ]);
   });
 
   it("handles tool_use blocks with string input (Anthropic format round-trip)", () => {
-    const messages = [
-      {
-        role: "assistant",
-        content: [
-          { type: "tool_use", id: "toolu_1", name: "exec", input: '{"command":"echo hello"}' },
-        ],
-      },
-    ];
-    const result = convertToOllamaMessages(messages);
+    const result = convertAssistantContent([
+      { type: "tool_use", id: "toolu_1", name: "exec", input: '{"command":"echo hello"}' },
+    ]);
     expect(requireEntry(result, 0, "first converted Ollama message").tool_calls).toEqual([
       { id: "toolu_1", function: { name: "exec", arguments: { command: "echo hello" } } },
     ]);
   });
 
   it("preserves unsafe integers as strings when replay args are deserialized", () => {
-    const messages = [
+    const result = convertAssistantContent([
       {
-        role: "assistant",
-        content: [
-          {
-            type: "toolCall",
-            id: "call_3",
-            name: "read",
-            arguments: '{"path":9223372036854775807,"nested":{"thread":1234567890123456789}}',
-          },
-        ],
+        type: "toolCall",
+        id: "call_3",
+        name: "read",
+        arguments: '{"path":9223372036854775807,"nested":{"thread":1234567890123456789}}',
       },
-    ];
-    const result = convertToOllamaMessages(messages);
+    ]);
     expect(requireEntry(result, 0, "first converted Ollama message").tool_calls).toEqual([
       {
         id: "call_3",
@@ -779,14 +761,13 @@ describe("buildAssistantMessage", () => {
   const modelInfo = { api: "ollama", provider: "ollama", id: "qwen3:32b" };
 
   it("builds text-only response", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: { role: "assistant" as const, content: "Hello!" },
-      done: true,
-      prompt_eval_count: 10,
-      eval_count: 5,
-    };
+    const response = createAssistantResponse(
+      { content: "Hello!" },
+      {
+        prompt_eval_count: 10,
+        eval_count: 5,
+      },
+    );
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.role).toBe("assistant");
     expect(result.content).toEqual([{ type: "text", text: "Hello!" }]);
@@ -797,50 +778,28 @@ describe("buildAssistantMessage", () => {
   });
 
   it("keeps thinking-only output when content is empty", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        thinking: "Thinking output",
-      },
-      done: true,
-    };
+    const response = createAssistantResponse({ content: "", thinking: "Thinking output" });
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.stopReason).toBe("stop");
     expect(result.content).toEqual([{ type: "thinking", thinking: "Thinking output" }]);
   });
 
   it("keeps reasoning-only output when content and thinking are empty", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        reasoning: "Reasoning output",
-      },
-      done: true,
-    };
+    const response = createAssistantResponse({ content: "", reasoning: "Reasoning output" });
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.stopReason).toBe("stop");
     expect(result.content).toEqual([{ type: "thinking", thinking: "Reasoning output" }]);
   });
 
   it("drops provider-returned thinking for non-reasoning models", () => {
-    const response = {
-      model: "minimax-m2.7:cloud",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        thinking: "Thinking output",
+    const response = createAssistantResponse(
+      { content: "", thinking: "Thinking output" },
+      {
+        model: "minimax-m2.7:cloud",
+        prompt_eval_count: 10,
+        eval_count: 6,
       },
-      done: true,
-      prompt_eval_count: 10,
-      eval_count: 6,
-    };
+    );
     const result = buildAssistantMessage(response, {
       ...modelInfo,
       id: "minimax-m2.7:cloud",
@@ -883,47 +842,33 @@ describe("buildAssistantMessage", () => {
       separator: "️ ",
     },
   ])("$name", ({ id, answer, separator }) => {
-    const response = {
-      model: "kimi-k2.6:cloud",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
+    const response = createAssistantResponse(
+      {
         content:
           "I should think privately and not leak this planning text in the answer. " +
           `I need to keep deciding what to say next. ${separator}${answer}`,
       },
-      done: true,
-    };
+      { model: "kimi-k2.6:cloud" },
+    );
     expect(
       buildAssistantMessage(response, { api: "ollama", provider: "ollama", id }).content,
     ).toEqual(answer ? [{ type: "text", text: answer }] : []);
   });
 
   it("does not strip inline boundary marker on non-kimi models", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "intro ️keep this intact",
-      },
-      done: true,
-    };
+    const response = createAssistantResponse({ content: "intro ️keep this intact" });
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.content).toEqual([{ type: "text", text: "intro ️keep this intact" }]);
   });
 
   it("does not treat emoji variation selectors as Kimi inline-reasoning boundaries", () => {
-    const response = {
-      model: "kimi-k2.6:cloud",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
+    const response = createAssistantResponse(
+      {
         content:
           "This is a normal Kimi cloud answer with enough length to cross the prefix threshold and no hidden reasoning leak. ☀️sunshine should remain visible to the user.",
       },
-      done: true,
-    };
+      { model: "kimi-k2.6:cloud" },
+    );
     const result = buildAssistantMessage(response, {
       api: "ollama",
       provider: "ollama",
@@ -938,12 +883,7 @@ describe("buildAssistantMessage", () => {
   });
 
   it("estimates usage when Ollama omits eval counters", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: { role: "assistant" as const, content: "Estimated output" },
-      done: true,
-    };
+    const response = createAssistantResponse({ content: "Estimated output" });
     const result = buildAssistantMessage(response, modelInfo, { input: 11, output: 4 });
     expect(result.usage.input).toBe(11);
     expect(result.usage.output).toBe(4);
@@ -951,14 +891,13 @@ describe("buildAssistantMessage", () => {
   });
 
   it("preserves explicit zero usage counters from Ollama", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: { role: "assistant" as const, content: "" },
-      done: true,
-      prompt_eval_count: 0,
-      eval_count: 0,
-    };
+    const response = createAssistantResponse(
+      { content: "" },
+      {
+        prompt_eval_count: 0,
+        eval_count: 0,
+      },
+    );
     const result = buildAssistantMessage(response, modelInfo, { input: 11, output: 4 });
     expect(result.usage.input).toBe(0);
     expect(result.usage.output).toBe(0);
@@ -966,18 +905,13 @@ describe("buildAssistantMessage", () => {
   });
 
   it("builds response with tool calls", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        tool_calls: [{ function: { name: "bash", arguments: { command: "ls -la" } } }],
+    const response = createToolCallResponse(
+      [{ function: { name: "bash", arguments: { command: "ls -la" } } }],
+      {
+        prompt_eval_count: 20,
+        eval_count: 10,
       },
-      done: true,
-      prompt_eval_count: 20,
-      eval_count: 10,
-    };
+    );
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.stopReason).toBe("toolUse");
     expect(result.content.length).toBe(1); // toolCall only (empty content is skipped)
@@ -994,18 +928,10 @@ describe("buildAssistantMessage", () => {
   });
 
   it("preserves Ollama response tool-call ids", () => {
-    const response = {
-      model: "gemini-3-flash-preview:cloud",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        tool_calls: [
-          { id: "fc_ollama_real_1", function: { name: "bash", arguments: { command: "pwd" } } },
-        ],
-      },
-      done: true,
-    };
+    const response = createToolCallResponse(
+      [{ id: "fc_ollama_real_1", function: { name: "bash", arguments: { command: "pwd" } } }],
+      { model: "gemini-3-flash-preview:cloud" },
+    );
     const result = buildAssistantMessage(response, modelInfo);
     expectToolCallContent(requireEntry(result.content, 0, "Ollama tool-call content"), {
       name: "bash",
@@ -1017,19 +943,13 @@ describe("buildAssistantMessage", () => {
   });
 
   it("preserves parallel Ollama response tool-call ids independently", () => {
-    const response = {
-      model: "gemini-3-flash-preview:cloud",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        tool_calls: [
-          { id: "fc_ollama_real_1", function: { name: "read", arguments: { path: "a.txt" } } },
-          { id: "fc_ollama_real_2", function: { name: "exec", arguments: { command: "date" } } },
-        ],
-      },
-      done: true,
-    };
+    const response = createToolCallResponse(
+      [
+        { id: "fc_ollama_real_1", function: { name: "read", arguments: { path: "a.txt" } } },
+        { id: "fc_ollama_real_2", function: { name: "exec", arguments: { command: "date" } } },
+      ],
+      { model: "gemini-3-flash-preview:cloud" },
+    );
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.content.map((part) => (part as { id?: string }).id)).toEqual([
       "fc_ollama_real_1",
@@ -1043,19 +963,10 @@ describe("buildAssistantMessage", () => {
   });
 
   it("normalizes provider-prefixed tool-call names in Ollama responses", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        tool_calls: [
-          { function: { name: "functions.exec", arguments: { command: "pwd" } } },
-          { function: { name: "tools/read", arguments: { path: "README.md" } } },
-        ],
-      },
-      done: true,
-    };
+    const response = createToolCallResponse([
+      { function: { name: "functions.exec", arguments: { command: "pwd" } } },
+      { function: { name: "tools/read", arguments: { path: "README.md" } } },
+    ]);
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.content).toHaveLength(2);
     expectToolCallContent(requireEntry(result.content, 0, "Ollama tool-call content"), {
@@ -1066,20 +977,11 @@ describe("buildAssistantMessage", () => {
   });
 
   it("preserves exact allowlisted tool-prefix names in Ollama responses", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        tool_calls: [
-          { function: { name: "tool_a", arguments: { value: 1 } } },
-          { function: { name: "tools_invoke_test", arguments: { value: 2 } } },
-          { function: { name: "function-run", arguments: { value: 3 } } },
-        ],
-      },
-      done: true,
-    };
+    const response = createToolCallResponse([
+      { function: { name: "tool_a", arguments: { value: 1 } } },
+      { function: { name: "tools_invoke_test", arguments: { value: 2 } } },
+      { function: { name: "function-run", arguments: { value: 3 } } },
+    ]);
     const result = buildAssistantMessage(response, modelInfo, undefined, {
       availableToolNames: new Set(["tool_a", "tools_invoke_test", "function-run"]),
     });
@@ -1096,21 +998,12 @@ describe("buildAssistantMessage", () => {
   });
 
   it("keeps non-prefixed Ollama response tool names intact", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        tool_calls: [
-          { function: { name: "functionshell", arguments: {} } },
-          { function: { name: "tooling", arguments: {} } },
-          { function: { name: "tools", arguments: {} } },
-          { function: { name: "tool_a", arguments: {} } },
-        ],
-      },
-      done: true,
-    };
+    const response = createToolCallResponse([
+      { function: { name: "functionshell", arguments: {} } },
+      { function: { name: "tooling", arguments: {} } },
+      { function: { name: "tools", arguments: {} } },
+      { function: { name: "tool_a", arguments: {} } },
+    ]);
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.content).toHaveLength(4);
     expectToolCallContent(requireEntry(result.content, 0, "Ollama tool-call content"), {
@@ -1123,16 +1016,9 @@ describe("buildAssistantMessage", () => {
   });
 
   it("parses stringified tool call arguments from Ollama responses", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        tool_calls: [{ function: { name: "bash", arguments: '{"command":"ls","path":"/tmp"}' } }],
-      },
-      done: true,
-    };
+    const response = createToolCallResponse([
+      { function: { name: "bash", arguments: '{"command":"ls","path":"/tmp"}' } },
+    ]);
     const result = buildAssistantMessage(response, modelInfo);
     expectToolCallContent(requireEntry(result.content, 0, "Ollama tool-call content"), {
       name: "bash",
@@ -1141,23 +1027,14 @@ describe("buildAssistantMessage", () => {
   });
 
   it("preserves unsafe integers in stringified tool call arguments", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        tool_calls: [
-          {
-            function: {
-              name: "send",
-              arguments: '{"target":9223372036854775807,"nested":{"thread":1234567890123456789}}',
-            },
-          },
-        ],
+    const response = createToolCallResponse([
+      {
+        function: {
+          name: "send",
+          arguments: '{"target":9223372036854775807,"nested":{"thread":1234567890123456789}}',
+        },
       },
-      done: true,
-    };
+    ]);
     const result = buildAssistantMessage(response, modelInfo);
     expectToolCallContent(requireEntry(result.content, 0, "Ollama tool-call content"), {
       name: "send",
@@ -1169,16 +1046,9 @@ describe("buildAssistantMessage", () => {
   });
 
   it("falls back to empty arguments for malformed stringified tool call arguments", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: {
-        role: "assistant" as const,
-        content: "",
-        tool_calls: [{ function: { name: "bash", arguments: '{"command":"ls"' } }],
-      },
-      done: true,
-    };
+    const response = createToolCallResponse([
+      { function: { name: "bash", arguments: '{"command":"ls"' } },
+    ]);
     const result = buildAssistantMessage(response, modelInfo);
     expectToolCallContent(requireEntry(result.content, 0, "Ollama tool-call content"), {
       name: "bash",
@@ -1187,12 +1057,7 @@ describe("buildAssistantMessage", () => {
   });
 
   it("sets all costs to zero for local models", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: { role: "assistant" as const, content: "ok" },
-      done: true,
-    };
+    const response = createAssistantResponse({ content: "ok" });
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.usage.cost).toEqual({
       input: 0,
@@ -1204,14 +1069,13 @@ describe("buildAssistantMessage", () => {
   });
 
   it("records unavailable cache telemetry when Ollama omits the cache split", () => {
-    const response = {
-      model: "qwen3:32b",
-      created_at: "2026-01-01T00:00:00Z",
-      message: { role: "assistant" as const, content: "ok" },
-      done: true,
-      prompt_eval_count: 10,
-      eval_count: 2,
-    };
+    const response = createAssistantResponse(
+      { content: "ok" },
+      {
+        prompt_eval_count: 10,
+        eval_count: 2,
+      },
+    );
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.usage.cacheTelemetry).toEqual({ state: "unavailable" });
   });
@@ -1278,17 +1142,12 @@ function createClosedNdjsonStream(lines: string[]) {
 }
 
 async function expectDoneEventContent(lines: string[], expectedContent: unknown) {
-  await withMockNdjsonFetch(lines, async () => {
-    const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
-    const events = await collectStreamEvents(stream);
-
-    const doneEvent = events.at(-1);
-    if (!doneEvent || doneEvent.type !== "done") {
-      throw new Error("Expected done event");
-    }
-
-    expect(doneEvent.message.content).toEqual(expectedContent);
-  });
+  const events = await collectMockedOllamaEvents(lines);
+  const doneEvent = events.at(-1);
+  if (!doneEvent || doneEvent.type !== "done") {
+    throw new Error("Expected done event");
+  }
+  expect(doneEvent.message.content).toEqual(expectedContent);
 }
 
 async function expectNoParsedChunks(reader: ReadableStreamDefaultReader<Uint8Array>) {
@@ -1655,6 +1514,24 @@ async function collectStreamEvents<T>(stream: AsyncIterable<T>): Promise<T[]> {
   return events;
 }
 
+type OllamaStreamEvent =
+  Awaited<ReturnType<typeof createOllamaTestStream>> extends AsyncIterable<infer Event>
+    ? Event
+    : never;
+
+async function collectMockedOllamaEvents(
+  lines: string[],
+  params: Parameters<typeof createOllamaTestStream>[0] = {
+    baseUrl: "http://ollama-host:11434",
+  },
+): Promise<OllamaStreamEvent[]> {
+  let events: OllamaStreamEvent[] | undefined;
+  await withMockNdjsonFetch(lines, async () => {
+    events = await collectStreamEvents(await createOllamaTestStream(params));
+  });
+  return expectDefined(events, "mocked Ollama stream events");
+}
+
 async function expectSuccessfulOllamaRequest(
   params: Parameters<typeof createOllamaTestStream>[0],
   verify: (observation: {
@@ -1695,293 +1572,218 @@ async function nextEventWithin<T>(
 
 describe("createOllamaStreamFn streaming events", () => {
   it("emits start, text_start, text_delta, text_end, done for text responses", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"Hello"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":" world"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":5,"eval_count":2}',
-      ],
-      async () => {
-        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
-        const events = await collectStreamEvents(stream);
+    const events = await collectMockedOllamaEvents([
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"Hello"},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":" world"},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":5,"eval_count":2}',
+    ]);
 
-        const types = events.map((e) => e.type);
-        expect(types).toEqual([
-          "start",
-          "text_start",
-          "text_delta",
-          "text_delta",
-          "text_end",
-          "done",
-        ]);
+    const types = events.map((e) => e.type);
+    expect(types).toEqual(["start", "text_start", "text_delta", "text_delta", "text_end", "done"]);
 
-        // text_delta events carry incremental deltas
-        const deltas = events.filter((e) => e.type === "text_delta");
-        expect(deltas[0]?.contentIndex).toBe(0);
-        expect(deltas[0]?.delta).toBe("Hello");
-        expect(deltas[1]?.contentIndex).toBe(0);
-        expect(deltas[1]?.delta).toBe(" world");
+    // text_delta events carry incremental deltas
+    const deltas = events.filter((e) => e.type === "text_delta");
+    expect(deltas[0]?.contentIndex).toBe(0);
+    expect(deltas[0]?.delta).toBe("Hello");
+    expect(deltas[1]?.contentIndex).toBe(0);
+    expect(deltas[1]?.delta).toBe(" world");
 
-        // text_end carries the full accumulated content
-        const textEnd = events.find((e) => e.type === "text_end");
-        expect(textEnd?.contentIndex).toBe(0);
-        expect(textEnd?.content).toBe("Hello world");
+    // text_end carries the full accumulated content
+    const textEnd = events.find((e) => e.type === "text_end");
+    expect(textEnd?.contentIndex).toBe(0);
+    expect(textEnd?.content).toBe("Hello world");
 
-        // start/text_start carry empty partials (before any content accumulates)
-        const startEvent = events.find((e) => e.type === "start");
-        expect(startEvent?.partial.content).toStrictEqual([]);
-        const textStartEvent = events.find((e) => e.type === "text_start");
-        expect(textStartEvent?.partial.content).toStrictEqual([]);
+    // start/text_start carry empty partials (before any content accumulates)
+    const startEvent = events.find((e) => e.type === "start");
+    expect(startEvent?.partial.content).toStrictEqual([]);
+    const textStartEvent = events.find((e) => e.type === "text_start");
+    expect(textStartEvent?.partial.content).toStrictEqual([]);
 
-        // text_delta events stay lightweight; text_end/done carry the full snapshot.
-        expect(deltas[0]).not.toHaveProperty("partial");
-        expect(deltas[1]).not.toHaveProperty("partial");
+    // text_delta events stay lightweight; text_end/done carry the full snapshot.
+    expect(deltas[0]).not.toHaveProperty("partial");
+    expect(deltas[1]).not.toHaveProperty("partial");
 
-        // done event contains the final message
-        const doneEvent = events.at(-1);
-        expect(doneEvent?.type).toBe("done");
-        if (doneEvent?.type === "done") {
-          expect(doneEvent.message.content).toEqual([{ type: "text", text: "Hello world" }]);
-        }
-      },
-    );
+    // done event contains the final message
+    const doneEvent = events.at(-1);
+    expect(doneEvent?.type).toBe("done");
+    if (doneEvent?.type === "done") {
+      expect(doneEvent.message.content).toEqual([{ type: "text", text: "Hello world" }]);
+    }
   });
 
   it("streams the complete lifecycle for tool-call-only responses", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":10,"eval_count":5}',
-      ],
-      async () => {
-        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
-        const events = await collectStreamEvents(stream);
+    const events = await collectMockedOllamaEvents([
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":10,"eval_count":5}',
+    ]);
 
-        const types = events.map((e) => e.type);
-        expect(types).toEqual([
-          "start",
-          "toolcall_start",
-          "toolcall_delta",
-          "toolcall_end",
-          "done",
-        ]);
-        expect(events[1]).toMatchObject({
-          type: "toolcall_start",
-          contentIndex: 0,
-          partial: { content: [{ type: "toolCall", name: "bash", arguments: {} }] },
-        });
-        expect(events[2]).toMatchObject({
-          type: "toolcall_delta",
-          contentIndex: 0,
-          delta: '{"command":"ls"}',
-        });
-        expect(events[3]).toMatchObject({
-          type: "toolcall_end",
-          contentIndex: 0,
-          toolCall: { name: "bash", arguments: { command: "ls" } },
-        });
-        const doneEvent = requireEntry(events, 4, "tool-call-only done event");
-        if (doneEvent.type === "done") {
-          expect(doneEvent.reason).toBe("toolUse");
-          expect(doneEvent.message.content[0]).toMatchObject({
-            type: "toolCall",
-            id: events[3]?.type === "toolcall_end" ? events[3].toolCall.id : undefined,
-          });
-        }
-      },
-    );
+    const types = events.map((e) => e.type);
+    expect(types).toEqual(["start", "toolcall_start", "toolcall_delta", "toolcall_end", "done"]);
+    expect(events[1]).toMatchObject({
+      type: "toolcall_start",
+      contentIndex: 0,
+      partial: { content: [{ type: "toolCall", name: "bash", arguments: {} }] },
+    });
+    expect(events[2]).toMatchObject({
+      type: "toolcall_delta",
+      contentIndex: 0,
+      delta: '{"command":"ls"}',
+    });
+    expect(events[3]).toMatchObject({
+      type: "toolcall_end",
+      contentIndex: 0,
+      toolCall: { name: "bash", arguments: { command: "ls" } },
+    });
+    const doneEvent = requireEntry(events, 4, "tool-call-only done event");
+    if (doneEvent.type === "done") {
+      expect(doneEvent.reason).toBe("toolUse");
+      expect(doneEvent.message.content[0]).toMatchObject({
+        type: "toolCall",
+        id: events[3]?.type === "toolcall_end" ? events[3].toolCall.id : undefined,
+      });
+    }
   });
 
   it("estimates usage when the final Ollama chunk omits counters", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"Estimated answer"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
-      ],
-      async () => {
-        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
-        const events = await collectStreamEvents(stream);
+    const events = await collectMockedOllamaEvents([
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"Estimated answer"},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
+    ]);
 
-        const doneEvent = events.at(-1);
-        expect(doneEvent?.type).toBe("done");
-        if (doneEvent?.type === "done") {
-          expect(doneEvent.message.usage.input).toBeGreaterThan(0);
-          expect(doneEvent.message.usage.output).toBeGreaterThan(0);
-          expect(doneEvent.message.usage.totalTokens).toBeGreaterThan(0);
-        }
-      },
-    );
+    const doneEvent = events.at(-1);
+    expect(doneEvent?.type).toBe("done");
+    if (doneEvent?.type === "done") {
+      expect(doneEvent.message.usage.input).toBeGreaterThan(0);
+      expect(doneEvent.message.usage.output).toBeGreaterThan(0);
+      expect(doneEvent.message.usage.totalTokens).toBeGreaterThan(0);
+    }
   });
 
   it("counts image payloads in prompt usage estimates when Ollama omits counters", async () => {
-    await withMockNdjsonFetch(
+    const events = await collectMockedOllamaEvents(
       [
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":"vision answer"},"done":false}',
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
       ],
-      async () => {
-        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
-        const stream = await Promise.resolve(
-          streamFn(
-            {
-              id: "llava",
-              api: "ollama",
-              provider: "custom-ollama",
-              contextWindow: 131072,
-            } as never,
-            {
-              messages: [
-                {
-                  role: "user",
-                  content: [{ type: "image", data: "a".repeat(400) }],
-                },
-              ],
-            } as never,
-            {} as never,
-          ),
-        );
-        const events = await collectStreamEvents(stream);
-
-        const doneEvent = events.at(-1);
-        expect(doneEvent?.type).toBe("done");
-        if (doneEvent?.type === "done") {
-          expect(doneEvent.message.usage.input).toBeGreaterThan(50);
-        }
+      {
+        baseUrl: "http://ollama-host:11434",
+        model: { id: "llava" },
+        context: {
+          messages: [{ role: "user", content: [{ type: "image", data: "a".repeat(400) }] }],
+        },
       },
     );
+    const doneEvent = events.at(-1);
+    expect(doneEvent?.type).toBe("done");
+    if (doneEvent?.type === "done") {
+      expect(doneEvent.message.usage.input).toBeGreaterThan(50);
+    }
   });
 
   it("emits text streaming events before done for mixed text + tool responses", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"Let me check."},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":10,"eval_count":5}',
-      ],
-      async () => {
-        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
-        const events = await collectStreamEvents(stream);
+    const events = await collectMockedOllamaEvents([
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"Let me check."},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":10,"eval_count":5}',
+    ]);
 
-        const types = events.map((e) => e.type);
-        expect(types).toEqual([
-          "start",
-          "text_start",
-          "text_delta",
-          "text_end",
-          "toolcall_start",
-          "toolcall_delta",
-          "toolcall_end",
-          "done",
-        ]);
-        expect(events[5]).toMatchObject({
-          type: "toolcall_delta",
-          contentIndex: 1,
-          delta: '{"command":"ls"}',
-        });
-        const doneEvent = events.at(-1);
-        if (doneEvent?.type === "done") {
-          expect(doneEvent.reason).toBe("toolUse");
-        }
-      },
-    );
+    const types = events.map((e) => e.type);
+    expect(types).toEqual([
+      "start",
+      "text_start",
+      "text_delta",
+      "text_end",
+      "toolcall_start",
+      "toolcall_delta",
+      "toolcall_end",
+      "done",
+    ]);
+    expect(events[5]).toMatchObject({
+      type: "toolcall_delta",
+      contentIndex: 1,
+      delta: '{"command":"ls"}',
+    });
+    const doneEvent = events.at(-1);
+    if (doneEvent?.type === "done") {
+      expect(doneEvent.reason).toBe("toolUse");
+    }
   });
 
   it("streams multiple native calls with stable provider ids across chunks", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"id":"call-read","function":{"name":"read","arguments":{"path":"/tmp/a"}}}]},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"id":"call-bash","function":{"name":"bash","arguments":"{\\"command\\":\\"ls\\"}"}}]},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
-      ],
-      async () => {
-        const events = await collectStreamEvents(
-          await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" }),
-        );
+    const events = await collectMockedOllamaEvents([
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"id":"call-read","function":{"name":"read","arguments":{"path":"/tmp/a"}}}]},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"id":"call-bash","function":{"name":"bash","arguments":"{\\"command\\":\\"ls\\"}"}}]},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
+    ]);
 
-        expect(events.map((event) => event.type)).toEqual([
-          "start",
-          "toolcall_start",
-          "toolcall_delta",
-          "toolcall_end",
-          "toolcall_start",
-          "toolcall_delta",
-          "toolcall_end",
-          "done",
-        ]);
-        const toolCallEnds = events.filter((event) => event.type === "toolcall_end");
-        expect(toolCallEnds).toMatchObject([
-          {
-            contentIndex: 0,
-            toolCall: { id: "call-read", name: "read", arguments: { path: "/tmp/a" } },
-          },
-          {
-            contentIndex: 1,
-            toolCall: { id: "call-bash", name: "bash", arguments: { command: "ls" } },
-          },
-        ]);
-        expect(events.filter((event) => event.type === "toolcall_delta")).toMatchObject([
-          { contentIndex: 0, delta: '{"path":"/tmp/a"}' },
-          { contentIndex: 1, delta: '{"command":"ls"}' },
-        ]);
-        expect(events.filter((event) => event.type === "toolcall_start")).toMatchObject([
-          { partial: { content: [{ arguments: {} }] } },
-          {
-            partial: {
-              content: [{ arguments: { path: "/tmp/a" } }, { arguments: {} }],
-            },
-          },
-        ]);
-        const done = events.at(-1);
-        if (done?.type !== "done") {
-          throw new Error("missing terminal Ollama message");
-        }
-        expect(done.message.content).toMatchObject([
-          { type: "toolCall", id: "call-read" },
-          { type: "toolCall", id: "call-bash" },
-        ]);
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "toolcall_start",
+      "toolcall_delta",
+      "toolcall_end",
+      "toolcall_start",
+      "toolcall_delta",
+      "toolcall_end",
+      "done",
+    ]);
+    const toolCallEnds = events.filter((event) => event.type === "toolcall_end");
+    expect(toolCallEnds).toMatchObject([
+      {
+        contentIndex: 0,
+        toolCall: { id: "call-read", name: "read", arguments: { path: "/tmp/a" } },
       },
-    );
+      {
+        contentIndex: 1,
+        toolCall: { id: "call-bash", name: "bash", arguments: { command: "ls" } },
+      },
+    ]);
+    expect(events.filter((event) => event.type === "toolcall_delta")).toMatchObject([
+      { contentIndex: 0, delta: '{"path":"/tmp/a"}' },
+      { contentIndex: 1, delta: '{"command":"ls"}' },
+    ]);
+    expect(events.filter((event) => event.type === "toolcall_start")).toMatchObject([
+      { partial: { content: [{ arguments: {} }] } },
+      {
+        partial: {
+          content: [{ arguments: { path: "/tmp/a" } }, { arguments: {} }],
+        },
+      },
+    ]);
+    const done = events.at(-1);
+    if (done?.type !== "done") {
+      throw new Error("missing terminal Ollama message");
+    }
+    expect(done.message.content).toMatchObject([
+      { type: "toolCall", id: "call-read" },
+      { type: "toolCall", id: "call-bash" },
+    ]);
   });
 
   it("does not stream non-executable calls from a token-limited final chunk", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":true,"done_reason":"length"}',
-      ],
-      async () => {
-        const events = await collectStreamEvents(
-          await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" }),
-        );
+    const events = await collectMockedOllamaEvents([
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":true,"done_reason":"length"}',
+    ]);
 
-        expect(events.map((event) => event.type)).toEqual(["done"]);
-        expect(events[0]).toMatchObject({
-          type: "done",
-          reason: "length",
-          message: { content: [], stopReason: "length" },
-        });
-      },
-    );
+    expect(events.map((event) => event.type)).toEqual(["done"]);
+    expect(events[0]).toMatchObject({
+      type: "done",
+      reason: "length",
+      message: { content: [], stopReason: "length" },
+    });
   });
 
   it("never exposes an intermediate native call invalidated by a later length terminal", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"done_reason":"length"}',
-      ],
-      async () => {
-        const events = await collectStreamEvents(
-          await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" }),
-        );
+    const events = await collectMockedOllamaEvents([
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"done_reason":"length"}',
+    ]);
 
-        expect(events.map((event) => event.type)).toEqual(["done"]);
-        expect(events[0]).toMatchObject({
-          type: "done",
-          reason: "length",
-          message: { content: [], stopReason: "length" },
-        });
-      },
-    );
+    expect(events.map((event) => event.type)).toEqual(["done"]);
+    expect(events[0]).toMatchObject({
+      type: "done",
+      reason: "length",
+      message: { content: [], stopReason: "length" },
+    });
   });
 
   it("emits text_end as soon as Ollama switches from text to tool calls", async () => {
@@ -2069,31 +1871,25 @@ describe("createOllamaStreamFn streaming events", () => {
   it("emits error without text_end when stream fails mid-response", async () => {
     // Simulate a stream that sends one content chunk then ends without done:true.
     // The stream function throws "Ollama API stream ended without a final response".
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"partial"},"done":false}',
-      ],
-      async () => {
-        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
-        const events = await collectStreamEvents(stream);
+    const events = await collectMockedOllamaEvents([
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"partial"},"done":false}',
+    ]);
 
-        const types = events.map((e) => e.type);
-        // Should have streaming events for the partial content, then error (no text_end).
-        expect(types).toEqual(["start", "text_start", "text_delta", "error"]);
-        const errorEvent = events.at(-1);
-        expect(errorEvent?.type).toBe("error");
-        if (errorEvent?.type === "error") {
-          expect(errorEvent.error.errorMessage).toBe(OLLAMA_INCOMPLETE_STREAM_ERROR);
-        }
-      },
-    );
+    const types = events.map((e) => e.type);
+    // Should have streaming events for the partial content, then error (no text_end).
+    expect(types).toEqual(["start", "text_start", "text_delta", "error"]);
+    const errorEvent = events.at(-1);
+    expect(errorEvent?.type).toBe("error");
+    if (errorEvent?.type === "error") {
+      expect(errorEvent.error.errorMessage).toBe(OLLAMA_INCOMPLETE_STREAM_ERROR);
+    }
   });
 
   it("emits an error instead of accepting garbled Kimi visible text", async () => {
     const garbled =
       '$$"##"%#"##"####""$""""##""$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$' +
       '#"$"$"""$""""#$"""$"""%"%###"""#%""""&"#"""$"""#"#""""%#""""&"#"""$"""$"""#%"""';
-    await withMockNdjsonFetch(
+    const events = await collectMockedOllamaEvents(
       [
         JSON.stringify({
           model: "kimi-k2.5:cloud",
@@ -2103,22 +1899,18 @@ describe("createOllamaStreamFn streaming events", () => {
         }),
         '{"model":"kimi-k2.5:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":20,"eval_count":40}',
       ],
-      async () => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: { id: "kimi-k2.5:cloud", provider: "ollama" },
-        });
-        const events = await collectStreamEvents(stream);
-
-        const types = events.map((e) => e.type);
-        expect(types).toEqual(["error"]);
-        const errorEvent = events.at(-1);
-        expect(errorEvent?.type).toBe("error");
-        if (errorEvent?.type === "error") {
-          expect(errorEvent.error.errorMessage).toContain("garbled visible text");
-        }
+      {
+        baseUrl: "http://ollama-host:11434",
+        model: { id: "kimi-k2.5:cloud", provider: "ollama" },
       },
     );
+    const types = events.map((e) => e.type);
+    expect(types).toEqual(["error"]);
+    const errorEvent = events.at(-1);
+    expect(errorEvent?.type).toBe("error");
+    if (errorEvent?.type === "error") {
+      expect(errorEvent.error.errorMessage).toContain("garbled visible text");
+    }
   });
 
   it("buffers Kimi inline reasoning until the streaming boundary is safe", async () => {
@@ -2278,7 +2070,7 @@ describe("createOllamaStreamFn streaming events", () => {
 
   it("keeps Kimi deltas append-only after the bounded sanitizer window is bypassed", async () => {
     const longPrefix = "This Kimi cloud output has streamed past the sanitizer window. ".repeat(10);
-    await withMockNdjsonFetch(
+    const events = await collectMockedOllamaEvents(
       [
         JSON.stringify({
           model: "kimi-k2.6:cloud",
@@ -2294,76 +2086,61 @@ describe("createOllamaStreamFn streaming events", () => {
         }),
         '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":20,"eval_count":40}',
       ],
-      async () => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: { id: "kimi-k2.6:cloud", provider: "ollama" },
-        });
-        const events = await collectStreamEvents(stream);
-        const deltas = events.filter((event) => event.type === "text_delta");
-        expect(deltas.map((event) => event.delta)).toEqual([longPrefix, " ️ OK."]);
-
-        const rawText = `${longPrefix} ️ OK.`;
-        const textEnd = events.find((event) => event.type === "text_end");
-        expect(textEnd?.content).toBe(rawText);
-        const doneEvent = events.find((event) => event.type === "done");
-        expect(doneEvent?.message.content).toEqual([{ type: "text", text: rawText }]);
+      {
+        baseUrl: "http://ollama-host:11434",
+        model: { id: "kimi-k2.6:cloud", provider: "ollama" },
       },
     );
+    const deltas = events.filter((event) => event.type === "text_delta");
+    expect(deltas.map((event) => event.delta)).toEqual([longPrefix, " ️ OK."]);
+
+    const rawText = `${longPrefix} ️ OK.`;
+    const textEnd = events.find((event) => event.type === "text_end");
+    expect(textEnd?.content).toBe(rawText);
+    const doneEvent = events.find((event) => event.type === "done");
+    expect(doneEvent?.message.content).toEqual([{ type: "text", text: rawText }]);
   });
 
   it("does not reject punctuation-heavy text from unrelated Ollama models", async () => {
     const punctuationHeavy =
       '$$"##"%#"##"####""$""""##""$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$' +
       '#"$"$"""$""""#$"""$"""%"%###"""#%""""&"#"""$"""#"#""""%#""""&"#"""$"""$"""#%"""';
-    await withMockNdjsonFetch(
-      [
-        JSON.stringify({
-          model: "qwen3:32b",
-          created_at: "t",
-          message: { role: "assistant", content: punctuationHeavy },
-          done: false,
-        }),
-        '{"model":"qwen3:32b","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":20,"eval_count":40}',
-      ],
-      async () => {
-        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
-        const events = await collectStreamEvents(stream);
+    const events = await collectMockedOllamaEvents([
+      JSON.stringify({
+        model: "qwen3:32b",
+        created_at: "t",
+        message: { role: "assistant", content: punctuationHeavy },
+        done: false,
+      }),
+      '{"model":"qwen3:32b","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":20,"eval_count":40}',
+    ]);
 
-        expect(events.map((e) => e.type)).toEqual([
-          "start",
-          "text_start",
-          "text_delta",
-          "text_end",
-          "done",
-        ]);
-      },
-    );
+    expect(events.map((e) => e.type)).toEqual([
+      "start",
+      "text_start",
+      "text_delta",
+      "text_end",
+      "done",
+    ]);
   });
 
   it("emits a single text_delta for single-chunk responses", async () => {
-    await withMockNdjsonFetch(
-      [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"one shot"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
-      ],
-      async () => {
-        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
-        const events = await collectStreamEvents(stream);
+    const events = await collectMockedOllamaEvents([
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":"one shot"},"done":false}',
+      '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+    ]);
 
-        const types = events.map((e) => e.type);
-        expect(types).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
+    const types = events.map((e) => e.type);
+    expect(types).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
 
-        const textStart = events.find((e) => e.type === "text_start");
-        expect(textStart?.partial.content).toEqual([]);
-        const delta = events.find((e) => e.type === "text_delta");
-        expect(delta?.delta).toBe("one shot");
-      },
-    );
+    const textStart = events.find((e) => e.type === "text_start");
+    expect(textStart?.partial.content).toEqual([]);
+    const delta = events.find((e) => e.type === "text_delta");
+    expect(delta?.delta).toBe("one shot");
   });
 
   it("sanitizes Kimi inline reasoning in text_delta, text_end, and done output", async () => {
-    await withMockNdjsonFetch(
+    const events = await collectMockedOllamaEvents(
       [
         JSON.stringify({
           model: "kimi-k2.6:cloud",
@@ -2383,48 +2160,38 @@ describe("createOllamaStreamFn streaming events", () => {
         }),
         '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":3,"eval_count":4}',
       ],
-      async () => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: { id: "kimi-k2.6:cloud", provider: "ollama" },
-        });
-        const events = await collectStreamEvents(stream);
-        const types = events.map((e) => e.type);
-        expect(types).toEqual([
-          "start",
-          "text_start",
-          "text_delta",
-          "text_delta",
-          "text_end",
-          "done",
-        ]);
-
-        const textStart = events.find((e) => e.type === "text_start");
-        expect(textStart?.partial.content).toEqual([]);
-        const deltas = events.filter((e) => e.type === "text_delta");
-        expect(deltas).toHaveLength(2);
-        expect(deltas[0]?.delta).toBe("Final answer");
-        expect(deltas[1]?.delta).toBe(" only.");
-        expect(deltas[0]).not.toHaveProperty("partial");
-        expect(deltas[1]).not.toHaveProperty("partial");
-
-        const textEnd = events.find((e) => e.type === "text_end");
-        expect(textEnd?.content).toBe("Final answer only.");
-        expect(textEnd?.partial.content).toEqual([{ type: "text", text: "Final answer only." }]);
-
-        const doneEvent = events.at(-1);
-        expect(doneEvent?.type).toBe("done");
-        if (doneEvent?.type === "done") {
-          expect(doneEvent.message.content).toEqual([{ type: "text", text: "Final answer only." }]);
-        }
+      {
+        baseUrl: "http://ollama-host:11434",
+        model: { id: "kimi-k2.6:cloud", provider: "ollama" },
       },
     );
+    const types = events.map((e) => e.type);
+    expect(types).toEqual(["start", "text_start", "text_delta", "text_delta", "text_end", "done"]);
+
+    const textStart = events.find((e) => e.type === "text_start");
+    expect(textStart?.partial.content).toEqual([]);
+    const deltas = events.filter((e) => e.type === "text_delta");
+    expect(deltas).toHaveLength(2);
+    expect(deltas[0]?.delta).toBe("Final answer");
+    expect(deltas[1]?.delta).toBe(" only.");
+    expect(deltas[0]).not.toHaveProperty("partial");
+    expect(deltas[1]).not.toHaveProperty("partial");
+
+    const textEnd = events.find((e) => e.type === "text_end");
+    expect(textEnd?.content).toBe("Final answer only.");
+    expect(textEnd?.partial.content).toEqual([{ type: "text", text: "Final answer only." }]);
+
+    const doneEvent = events.at(-1);
+    expect(doneEvent?.type).toBe("done");
+    if (doneEvent?.type === "done") {
+      expect(doneEvent.message.content).toEqual([{ type: "text", text: "Final answer only." }]);
+    }
   });
 
   it("does not re-sanitize visible Kimi stream output before done", async () => {
     const visibleAnswer =
       "This visible answer is intentionally long enough to look like a reasoning prefix if it is sanitized a second time. ️ keep this marker visible.";
-    await withMockNdjsonFetch(
+    const events = await collectMockedOllamaEvents(
       [
         JSON.stringify({
           model: "kimi-k2.6:cloud",
@@ -2444,29 +2211,26 @@ describe("createOllamaStreamFn streaming events", () => {
         }),
         '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":3,"eval_count":4}',
       ],
-      async () => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: { id: "kimi-k2.6:cloud", provider: "ollama" },
-        });
-        const events = await collectStreamEvents(stream);
-        const textEnd = events.find((event) => event.type === "text_end");
-        const doneEvent = events.at(-1);
-
-        expect(textEnd?.content).toBe(visibleAnswer);
-        expect(doneEvent?.type).toBe("done");
-        if (doneEvent?.type === "done") {
-          expect(doneEvent.message.content).toEqual([{ type: "text", text: visibleAnswer }]);
-        }
+      {
+        baseUrl: "http://ollama-host:11434",
+        model: { id: "kimi-k2.6:cloud", provider: "ollama" },
       },
     );
+    const textEnd = events.find((event) => event.type === "text_end");
+    const doneEvent = events.at(-1);
+
+    expect(textEnd?.content).toBe(visibleAnswer);
+    expect(doneEvent?.type).toBe("done");
+    if (doneEvent?.type === "done") {
+      expect(doneEvent.message.content).toEqual([{ type: "text", text: visibleAnswer }]);
+    }
   });
 
   it("does not leak Kimi inline reasoning when a boundary is followed by tool calls only", async () => {
     const hiddenPrefix =
       "I should think privately and not leak this planning text in the answer. " +
       "I need to keep deciding what tool to call before showing any visible text.";
-    await withMockNdjsonFetch(
+    const events = await collectMockedOllamaEvents(
       [
         JSON.stringify({
           model: "kimi-k2.6:cloud",
@@ -2486,84 +2250,77 @@ describe("createOllamaStreamFn streaming events", () => {
         }),
         '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":20,"eval_count":40}',
       ],
-      async () => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: { id: "kimi-k2.6:cloud", provider: "ollama" },
-        });
-        const events = await collectStreamEvents(stream);
-
-        expect(events.map((event) => event.type)).toEqual([
-          "start",
-          "toolcall_start",
-          "toolcall_delta",
-          "toolcall_end",
-          "done",
-        ]);
-        expect(JSON.stringify(events)).not.toContain("I should think privately");
-        const doneEvent = events.at(-1);
-        expect(doneEvent?.type).toBe("done");
-        if (doneEvent?.type === "done") {
-          expect(doneEvent.message.content).toEqual([
-            {
-              type: "toolCall",
-              id: expect.any(String),
-              name: "bash",
-              arguments: { command: "ls" },
-            },
-          ]);
-          expect(JSON.stringify(doneEvent)).not.toContain("I should think privately");
-        }
+      {
+        baseUrl: "http://ollama-host:11434",
+        model: { id: "kimi-k2.6:cloud", provider: "ollama" },
       },
     );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "toolcall_start",
+      "toolcall_delta",
+      "toolcall_end",
+      "done",
+    ]);
+    expect(JSON.stringify(events)).not.toContain("I should think privately");
+    const doneEvent = events.at(-1);
+    expect(doneEvent?.type).toBe("done");
+    if (doneEvent?.type === "done") {
+      expect(doneEvent.message.content).toEqual([
+        {
+          type: "toolCall",
+          id: expect.any(String),
+          name: "bash",
+          arguments: { command: "ls" },
+        },
+      ]);
+      expect(JSON.stringify(doneEvent)).not.toContain("I should think privately");
+    }
   });
 
   it("flushes buffered visible Kimi text before streaming its native tool call", async () => {
-    await withMockNdjsonFetch(
+    const events = await collectMockedOllamaEvents(
       [
         '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":"Visible answer"},"done":false}',
         '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
         '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
       ],
-      async () => {
-        const events = await collectStreamEvents(
-          await createOllamaTestStream({
-            baseUrl: "http://ollama-host:11434",
-            model: { id: "kimi-k2.6:cloud", provider: "ollama" },
-          }),
-        );
-
-        expect(events.map((event) => event.type)).toEqual([
-          "start",
-          "text_start",
-          "text_delta",
-          "text_end",
-          "toolcall_start",
-          "toolcall_delta",
-          "toolcall_end",
-          "done",
-        ]);
-        expect(events[2]).toMatchObject({ type: "text_delta", delta: "Visible answer" });
-        expect(events[4]).toMatchObject({ type: "toolcall_start", contentIndex: 1 });
-        expect(events[6]).toMatchObject({ type: "toolcall_end", contentIndex: 1 });
-        expect(events.at(-1)).toMatchObject({
-          type: "done",
-          message: {
-            content: [
-              { type: "text", text: "Visible answer" },
-              { type: "toolCall", name: "bash" },
-            ],
-          },
-        });
+      {
+        baseUrl: "http://ollama-host:11434",
+        model: { id: "kimi-k2.6:cloud", provider: "ollama" },
       },
     );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "text_start",
+      "text_delta",
+      "text_end",
+      "toolcall_start",
+      "toolcall_delta",
+      "toolcall_end",
+      "done",
+    ]);
+    expect(events[2]).toMatchObject({ type: "text_delta", delta: "Visible answer" });
+    expect(events[4]).toMatchObject({ type: "toolcall_start", contentIndex: 1 });
+    expect(events[6]).toMatchObject({ type: "toolcall_end", contentIndex: 1 });
+    expect(events.at(-1)).toMatchObject({
+      type: "done",
+      message: {
+        content: [
+          { type: "text", text: "Visible answer" },
+          { type: "toolCall", name: "bash" },
+        ],
+      },
+    });
   });
 
   it("does not reveal buffered Kimi reasoning for an empty tool-call chunk", async () => {
     const hiddenPrefix =
       "I should think privately and not leak this planning text in the answer. " +
       "I need to keep deciding what to say next.";
-    await withMockNdjsonFetch(
+    const events = await collectMockedOllamaEvents(
       [
         JSON.stringify({
           model: "kimi-k2.6:cloud",
@@ -2575,25 +2332,21 @@ describe("createOllamaStreamFn streaming events", () => {
         '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":" ️ Visible answer"},"done":false}',
         '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
       ],
-      async () => {
-        const events = await collectStreamEvents(
-          await createOllamaTestStream({
-            baseUrl: "http://ollama-host:11434",
-            model: { id: "kimi-k2.6:cloud", provider: "ollama" },
-          }),
-        );
-
-        expect(events.map((event) => event.type)).toEqual([
-          "start",
-          "text_start",
-          "text_delta",
-          "text_end",
-          "done",
-        ]);
-        expect(events[2]).toMatchObject({ type: "text_delta", delta: "Visible answer" });
-        expect(JSON.stringify(events)).not.toContain("I should think privately");
+      {
+        baseUrl: "http://ollama-host:11434",
+        model: { id: "kimi-k2.6:cloud", provider: "ollama" },
       },
     );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "text_start",
+      "text_delta",
+      "text_end",
+      "done",
+    ]);
+    expect(events[2]).toMatchObject({ type: "text_delta", delta: "Visible answer" });
+    expect(JSON.stringify(events)).not.toContain("I should think privately");
   });
 });
 
@@ -3029,28 +2782,22 @@ describe("createOllamaStreamFn", () => {
   });
 
   it("drops streamed reasoning chunks for non-reasoning models", async () => {
-    await withMockNdjsonFetch(
+    const events = await collectMockedOllamaEvents(
       [
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":"reasoned"},"done":false}',
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":" output"},"done":false}',
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":2}',
       ],
-      async () => {
-        const stream = await createOllamaTestStream({
-          baseUrl: "http://ollama-host:11434",
-          model: { reasoning: false },
-        });
-        const events = await collectStreamEvents(stream);
-        const doneEvent = events.at(-1);
-        if (!doneEvent || doneEvent.type !== "done") {
-          throw new Error("Expected done event");
-        }
-
-        expect(doneEvent.message.content).toEqual([]);
-        expect(doneEvent.message.usage.output).toBeGreaterThan(0);
-        expect(events.some((event) => event.type === "thinking_delta")).toBe(false);
-      },
+      { baseUrl: "http://ollama-host:11434", model: { reasoning: false } },
     );
+    const doneEvent = events.at(-1);
+    if (!doneEvent || doneEvent.type !== "done") {
+      throw new Error("Expected done event");
+    }
+
+    expect(doneEvent.message.content).toEqual([]);
+    expect(doneEvent.message.usage.output).toBeGreaterThan(0);
+    expect(events.some((event) => event.type === "thinking_delta")).toBe(false);
   });
 
   it("keeps streamed content after earlier reasoning chunks", async () => {


### PR DESCRIPTION
## Summary

- centralize repeated Ollama assistant replay and response fixtures
- reuse one stream-event collection harness across NDJSON lifecycle tests
- preserve all test cases and assertions while removing 253 net test lines

## Proof

- Blacksmith Testbox focused suite: 128/128 passed (tbx_01kz2shwh17mf2qep72gxv4by8)
- Blacksmith Testbox exact-head changed gate: passed format, extension test typecheck, lint, plugin boundaries, deadcode, and guard lanes (tbx_01kz2t6apgb367sgk9988ycxx5)
- assertion parity: 269 before / 269 after
- test invocation parity: 107 before / 107 after
- autoreview: clean, correctness 0.99
- git diff --check and oxfmt --check: passed

## Diff metrics

- production: +0/-0
- tests: +547/-800 (net -253)