### PR TITLE
improve(tests): reuse verified inference fixtures

### DIFF
--- a/src/system-agent/assistant.configured.test.ts
+++ b/src/system-agent/assistant.configured.test.ts
@@ -1,5 +1,6 @@
 // Configured OpenClaw assistant tests cover route-owned, tool-free planning.
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import type { RunCliAgentParams } from "../agents/cli-runner/types.js";
 import { fingerprintResolvedProviderAuth } from "../agents/execution-auth-binding.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -8,7 +9,14 @@ import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
 import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
 import type { SystemAgentOverview } from "./overview.js";
 import { createSystemAgentVerifiedInferenceTestFixture } from "./system-agent.test-helpers.js";
-import { createSystemAgentVerifiedInferenceBinding } from "./verified-inference.js";
+import {
+  createSystemAgentVerifiedInferenceBinding,
+  type SystemAgentVerifiedInferenceBinding,
+} from "./verified-inference.js";
+
+const inferenceMocks = vi.hoisted(() => ({
+  fastBindings: new WeakSet<object>(),
+}));
 
 vi.mock("../plugins/providers.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../plugins/providers.js")>()),
@@ -22,6 +30,52 @@ vi.mock("../agents/harness/runtime-plugin.js", async (importOriginal) => ({
     runtime === "codex" ? ["codex"] : [],
   ),
 }));
+
+vi.mock("./verified-inference.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./verified-inference.js")>();
+  return {
+    ...actual,
+    resolveSystemAgentVerifiedInferenceRoute: (
+      ...args: Parameters<typeof actual.resolveSystemAgentVerifiedInferenceRoute>
+    ) => {
+      // These cases own planner dispatch, not repeated inference ownership checks.
+      // Unmarked bindings still exercise the real resolver for every drift boundary.
+      if (inferenceMocks.fastBindings.has(args[0])) {
+        return Promise.resolve(args[0].execution);
+      }
+      return actual.resolveSystemAgentVerifiedInferenceRoute(...args);
+    },
+  };
+});
+
+function useFastVerifiedInference(
+  binding: SystemAgentVerifiedInferenceBinding,
+): SystemAgentVerifiedInferenceBinding {
+  inferenceMocks.fastBindings.add(binding);
+  return binding;
+}
+
+beforeAll(() => {
+  cliBackendsTesting.setDepsForTest({
+    resolvePluginSetupCliBackend: () => undefined,
+    resolvePluginSetupRegistry: () => ({ cliBackends: [] }) as never,
+    resolveRuntimeCliBackends: () => [
+      {
+        id: "claude-cli",
+        pluginId: "anthropic",
+        modelProvider: "anthropic",
+        bundleMcp: true,
+        bundleMcpMode: "claude-config-file",
+        config: { command: "claude" },
+        sideQuestionToolMode: "disabled",
+      },
+    ],
+  });
+});
+
+afterAll(() => {
+  cliBackendsTesting.resetDepsForTest();
+});
 
 function overview(defaultModel?: string): SystemAgentOverview {
   return {
@@ -121,17 +175,19 @@ describe("OpenClaw configured-model planner", () => {
     if (!authFingerprint) {
       throw new Error("missing test auth fingerprint");
     }
-    const binding = await createSystemAgentVerifiedInferenceBinding({
-      configuredRoute,
-      executionRoute: { ...configuredRoute, authProfileId: "openai:p2" },
-      auth: {
-        authProfileId: "openai:p2",
-        authFingerprint,
-        modelId: configuredRoute.model,
-        modelApi: "openai-responses",
-      },
-      deps: authDeps,
-    });
+    const binding = useFastVerifiedInference(
+      await createSystemAgentVerifiedInferenceBinding({
+        configuredRoute,
+        executionRoute: { ...configuredRoute, authProfileId: "openai:p2" },
+        auth: {
+          authProfileId: "openai:p2",
+          authFingerprint,
+          modelId: configuredRoute.model,
+          modelApi: "openai-responses",
+        },
+        deps: authDeps,
+      }),
+    );
     const runEmbeddedAgent = vi.fn(async () => ({
       payloads: [{ text: '{"reply":"Ready.","command":"gateway status"}' }],
     }));
@@ -255,6 +311,7 @@ describe("OpenClaw configured-model planner", () => {
     }));
     const removeTempDir = vi.fn(async () => {});
     const { binding, deps } = await createSystemAgentVerifiedInferenceTestFixture(config);
+    useFastVerifiedInference(binding);
 
     const result = await planSystemAgentCommandWithConfiguredModel({
       input: "please finish setup",
@@ -311,6 +368,7 @@ describe("OpenClaw configured-model planner", () => {
       payloads: [{ text: '{"reply":"Ready.","command":"gateway status"}' }],
     }));
     const { binding, deps } = await createSystemAgentVerifiedInferenceTestFixture(config);
+    useFastVerifiedInference(binding);
 
     const result = await planSystemAgentCommandWithConfiguredModel({
       input: "is the gateway healthy",
@@ -367,6 +425,7 @@ describe("OpenClaw configured-model planner", () => {
       },
     } satisfies OpenClawConfig;
     const { binding, deps } = await createSystemAgentVerifiedInferenceTestFixture(config);
+    useFastVerifiedInference(binding);
     const runEmbeddedAgent = vi.fn(async () => ({
       payloads: [{ text: '{"reply":"Ready.","command":"gateway status"}' }],
     }));

--- a/src/system-agent/system-agent.test.ts
+++ b/src/system-agent/system-agent.test.ts
@@ -1,5 +1,5 @@
 // OpenClaw tests cover main rescue and audit command behavior.
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
 import type { SystemAgentCommandDeps } from "./operations.js";
@@ -9,12 +9,34 @@ import {
   createSystemAgentTestRuntime,
   createSystemAgentVerifiedInferenceTestFixture,
 } from "./system-agent.test-helpers.js";
+import type { SystemAgentVerifiedInferenceBinding } from "./verified-inference.js";
+
+const inferenceMocks = vi.hoisted(() => ({
+  sharedVerifiedInference: undefined as SystemAgentVerifiedInferenceBinding | undefined,
+}));
 
 vi.mock("../plugins/providers.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../plugins/providers.js")>()),
   resolveOwningPluginIdsForModelRefs: vi.fn(() => []),
   resolveOwningPluginIdsForProviderRef: vi.fn(() => []),
 }));
+
+vi.mock("./verified-inference.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./verified-inference.js")>();
+  return {
+    ...actual,
+    resolveSystemAgentVerifiedInferenceRoute: (
+      ...args: Parameters<typeof actual.resolveSystemAgentVerifiedInferenceRoute>
+    ) => {
+      // Ordinary runner cases share one immutable verified fixture. Distinct
+      // bindings still use the real resolver for route and apply-boundary drift.
+      if (args[0] === inferenceMocks.sharedVerifiedInference) {
+        return Promise.resolve(args[0].execution);
+      }
+      return actual.resolveSystemAgentVerifiedInferenceRoute(...args);
+    },
+  };
+});
 
 const overview: SystemAgentOverview = {
   defaultAgentId: "main",
@@ -71,10 +93,22 @@ function configSnapshot(config: OpenClawConfig) {
   };
 }
 
-async function createVerifiedRunOptions(deps: SystemAgentCommandDeps = {}) {
-  const fixture = await createSystemAgentVerifiedInferenceTestFixture(verifiedConfig);
+let sharedVerifiedFixture: Awaited<
+  ReturnType<typeof createSystemAgentVerifiedInferenceTestFixture>
+>;
+
+beforeAll(async () => {
+  sharedVerifiedFixture = await createSystemAgentVerifiedInferenceTestFixture(verifiedConfig);
+  inferenceMocks.sharedVerifiedInference = sharedVerifiedFixture.binding;
+});
+
+function createVerifiedRunOptions(
+  deps: SystemAgentCommandDeps = {},
+  options: { revalidate?: boolean } = {},
+) {
+  const fixture = sharedVerifiedFixture;
   return {
-    verifiedInference: fixture.binding,
+    verifiedInference: options.revalidate ? { ...fixture.binding } : fixture.binding,
     deps: {
       ...fixture.deps,
       readConfigFileSnapshot: vi.fn(async () => configSnapshot(verifiedConfig)) as never,
@@ -166,10 +200,13 @@ describe("runSystemAgent", () => {
       .mockResolvedValueOnce(configSnapshot(verifiedConfig))
       .mockResolvedValue(configSnapshot(changedConfig));
     const runGatewayRestart = vi.fn(async () => {});
-    const verified = await createVerifiedRunOptions({
-      readConfigFileSnapshot: readConfigFileSnapshot as never,
-      runGatewayRestart,
-    });
+    const verified = await createVerifiedRunOptions(
+      {
+        readConfigFileSnapshot: readConfigFileSnapshot as never,
+        runGatewayRestart,
+      },
+      { revalidate: true },
+    );
 
     await expect(
       runSystemAgent(
@@ -195,12 +232,16 @@ describe("runSystemAgent", () => {
       .fn()
       .mockResolvedValueOnce(configSnapshot(verifiedConfig))
       .mockResolvedValueOnce(configSnapshot(verifiedConfig))
+      .mockResolvedValueOnce(configSnapshot(verifiedConfig))
       .mockResolvedValue(configSnapshot(changedConfig));
     const runGatewayRestart = vi.fn(async () => {});
-    const verified = await createVerifiedRunOptions({
-      readConfigFileSnapshot: readConfigFileSnapshot as never,
-      runGatewayRestart,
-    });
+    const verified = await createVerifiedRunOptions(
+      {
+        readConfigFileSnapshot: readConfigFileSnapshot as never,
+        runGatewayRestart,
+      },
+      { revalidate: true },
+    );
 
     await expect(
       runSystemAgent(
@@ -215,7 +256,7 @@ describe("runSystemAgent", () => {
       ),
     ).rejects.toBeInstanceOf(SystemAgentInferenceUnavailableError);
 
-    expect(readConfigFileSnapshot).toHaveBeenCalledTimes(3);
+    expect(readConfigFileSnapshot).toHaveBeenCalledTimes(4);
     expect(runGatewayRestart).not.toHaveBeenCalled();
   });
 
@@ -306,9 +347,12 @@ describe("runSystemAgent", () => {
       agents: { defaults: { model: "anthropic/claude-opus-4-8" } },
     } satisfies OpenClawConfig;
     let currentConfig: OpenClawConfig = verifiedConfig;
-    const verified = await createVerifiedRunOptions({
-      readConfigFileSnapshot: vi.fn(async () => configSnapshot(currentConfig)) as never,
-    });
+    const verified = await createVerifiedRunOptions(
+      {
+        readConfigFileSnapshot: vi.fn(async () => configSnapshot(currentConfig)) as never,
+      },
+      { revalidate: true },
+    );
 
     await expect(
       runSystemAgent(

--- a/src/system-agent/system-agent.test.ts
+++ b/src/system-agent/system-agent.test.ts
@@ -157,7 +157,7 @@ describe("runSystemAgent", () => {
     const { runtime, lines } = createSystemAgentTestRuntime();
     let runGatewayRestartCalls = 0;
     let onReadyCalls = 0;
-    const verified = await createVerifiedRunOptions({
+    const verified = createVerifiedRunOptions({
       runGatewayRestart: async () => {
         runGatewayRestartCalls += 1;
       },
@@ -200,7 +200,7 @@ describe("runSystemAgent", () => {
       .mockResolvedValueOnce(configSnapshot(verifiedConfig))
       .mockResolvedValue(configSnapshot(changedConfig));
     const runGatewayRestart = vi.fn(async () => {});
-    const verified = await createVerifiedRunOptions(
+    const verified = createVerifiedRunOptions(
       {
         readConfigFileSnapshot: readConfigFileSnapshot as never,
         runGatewayRestart,
@@ -235,7 +235,7 @@ describe("runSystemAgent", () => {
       .mockResolvedValueOnce(configSnapshot(verifiedConfig))
       .mockResolvedValue(configSnapshot(changedConfig));
     const runGatewayRestart = vi.fn(async () => {});
-    const verified = await createVerifiedRunOptions(
+    const verified = createVerifiedRunOptions(
       {
         readConfigFileSnapshot: readConfigFileSnapshot as never,
         runGatewayRestart,
@@ -264,7 +264,7 @@ describe("runSystemAgent", () => {
     const { runtime, lines } = createSystemAgentTestRuntime();
     let plannerCalls = 0;
     let onReadyCalls = 0;
-    const verified = await createVerifiedRunOptions();
+    const verified = createVerifiedRunOptions();
 
     await runSystemAgent(
       {
@@ -289,7 +289,7 @@ describe("runSystemAgent", () => {
 
   it("prints an explicit one-shot overview exactly once", async () => {
     const { runtime, lines } = createSystemAgentTestRuntime();
-    const verified = await createVerifiedRunOptions();
+    const verified = createVerifiedRunOptions();
 
     await runSystemAgent(
       {
@@ -309,7 +309,7 @@ describe("runSystemAgent", () => {
     { name: "invalid command", plan: { command: "invent a new operation" } },
   ])("fails a fuzzy one-shot when inference returns $name", async ({ plan }) => {
     const { runtime } = createSystemAgentTestRuntime();
-    const verified = await createVerifiedRunOptions();
+    const verified = createVerifiedRunOptions();
 
     await expect(
       runSystemAgent(
@@ -326,7 +326,7 @@ describe("runSystemAgent", () => {
 
   it("prints a valid reply-only one-shot plan", async () => {
     const { runtime, lines } = createSystemAgentTestRuntime();
-    const verified = await createVerifiedRunOptions();
+    const verified = createVerifiedRunOptions();
 
     await runSystemAgent(
       {
@@ -347,7 +347,7 @@ describe("runSystemAgent", () => {
       agents: { defaults: { model: "anthropic/claude-opus-4-8" } },
     } satisfies OpenClawConfig;
     let currentConfig: OpenClawConfig = verifiedConfig;
-    const verified = await createVerifiedRunOptions(
+    const verified = createVerifiedRunOptions(
       {
         readConfigFileSnapshot: vi.fn(async () => configSnapshot(currentConfig)) as never,
       },
@@ -375,7 +375,7 @@ describe("runSystemAgent", () => {
     const { runtime, lines } = createSystemAgentTestRuntime();
     let runInteractiveTuiCalls = 0;
     let onReadyCalls = 0;
-    const verified = await createVerifiedRunOptions();
+    const verified = createVerifiedRunOptions();
 
     await runSystemAgent(
       {
@@ -401,7 +401,7 @@ describe("runSystemAgent", () => {
     const { runtime, lines } = createSystemAgentTestRuntime();
     let loadOverviewCalls = 0;
     let runInteractiveTuiCalls = 0;
-    const verified = await createVerifiedRunOptions();
+    const verified = createVerifiedRunOptions();
 
     await runSystemAgent(
       {
@@ -440,7 +440,7 @@ describe("runSystemAgent", () => {
   ])("exits non-zero when $name", async ({ input, output, interactive }) => {
     const { runtime, lines } = createSystemAgentTestRuntime();
     let runInteractiveTuiCalls = 0;
-    const verified = await createVerifiedRunOptions();
+    const verified = createVerifiedRunOptions();
 
     await expect(
       runSystemAgent(


### PR DESCRIPTION
## What Problem This Solves

The configured-assistant and OpenClaw runner tests repeatedly rebuilt and revalidated identical inference ownership, plugin, backend, auth, and runtime metadata. In the measured compact-large-8 run, those two small suites consumed 38.425 seconds even though most cases own planner or CLI behavior rather than discovery.

## Why This Change Was Made

Reuse one immutable verified route for ordinary runner cases, install a deterministic test CLI backend, and bypass repeated verification only for explicitly marked happy-path bindings. The two planner security paths and three runner drift/apply paths still use distinct bindings and the real verifier. The persistent-apply regression now supplies three stable reads and drifts on the fourth, so it reaches the boundary named by the test.

## User Impact

No runtime or user-visible behavior changes. The test suite does less unrelated discovery work while retaining inference-owner, auth, runtime-artifact, route-drift, and persistent-apply coverage.

## Evidence

- Baseline CI: `assistant.configured.test.ts` 24.449s and `system-agent.test.ts` 13.976s in compact-large-8 ([job 91583236765](https://github.com/openclaw/openclaw/actions/runs/30780187759/job/91583236765)).
- Dedicated verifier and persistent-apply owner suites remain unchanged.
- Test-only diff; production LOC delta: 0.
- Targeted formatting, Oxlint, `git diff --check`, and autoreview are clean.
- Fresh changed-target CI: 7/7 assistant tests and 14/14 runner tests passed. Test bodies were 4.03s and 4.57s; cold per-file process durations were 14.24s and 14.31s ([run 30782206866](https://github.com/openclaw/openclaw/actions/runs/30782206866)).
- Lint, test types, production types, changed-boundary tests, and the aggregate PR gate passed on the current head.
- Exact-SHA full CI timing run: [30782354057](https://github.com/openclaw/openclaw/actions/runs/30782354057).
- Exact full-run file timings: `assistant.configured.test.ts` 24.449s -> 5.326s and `system-agent.test.ts` 13.976s -> 4.568s. Combined 38.425s -> 9.894s, saving 28.531s (74.3%) with all 21 tests retained.
- The current enclosing `core-unit-fast-isolated` group contains a substantially expanded file set versus the baseline run, so its whole-group wall is not used as an apples-to-apples speedup claim.
- Local execution was unavailable because the linked worktree has no dependency install; Blacksmith Testbox was unavailable and direct AWS hydration failed in the repository install hook.
