### PR TITLE
fix(memory-core): report vector store ready from persisted chunks on fast path

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -3087,6 +3087,46 @@ describe("memory index", () => {
     expect(status.vector?.available).toBeUndefined();
   });
 
+  it("reports vector store ready from persisted semantic chunks on the unprobed fast path (#92102)", async () => {
+    const cfg = createCfg({ vectorEnabled: true });
+    const manager = await getPersistentManager(cfg);
+    const db = Reflect.get(manager, "db") as DatabaseSync;
+    const vector = Reflect.get(manager, "vector") as { available: boolean | null };
+
+    // The CLI status fast path never live-probes sqlite-vec, so vector.available
+    // stays null (the lazy-init default set in the constructor).
+    vector.available = null;
+
+    // No persisted chunks yet -> still unknown (undefined); the fix does not
+    // fabricate readiness when nothing has been indexed.
+    expect(manager.status().vector?.storeAvailable).toBeUndefined();
+
+    // Persist a real semantic (non-fts-only) chunk as a prior indexing would.
+    db.exec(
+      `INSERT INTO memory_index_chunks
+         (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+       VALUES
+         ('chunk-1', 'memory/2026-01-12.md', 'memory', 1, 2, 'h1',
+          'mock-embed', 'semantic chunk body', '[]', 0)`,
+    );
+
+    // Unprobed fast path now reports ready, mirroring --deep, instead of the
+    // misleading "unknown" that made operators think vector search was down.
+    expect(manager.status().vector?.storeAvailable).toBe(true);
+
+    // fts-only chunks are not semantic vectors and must not count as ready.
+    db.exec(
+      `DELETE FROM memory_index_chunks;
+       INSERT INTO memory_index_chunks
+         (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+       VALUES
+         ('chunk-fts', 'memory/2026-01-12.md', 'memory', 1, 2, 'h2',
+          'fts-only', 'fts only body', '[]', 0)`,
+    );
+    vector.available = null;
+    expect(manager.status().vector?.storeAvailable).toBeUndefined();
+  });
+
   it("keeps current vector indexes clean after vector store probing", async () => {
     const cfg = createCfg({ provider: "gemini" });
     const manager = await getFreshManager(cfg);

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -3087,46 +3087,6 @@ describe("memory index", () => {
     expect(status.vector?.available).toBeUndefined();
   });
 
-  it("reports vector store ready from persisted semantic chunks on the unprobed fast path (#92102)", async () => {
-    const cfg = createCfg({ vectorEnabled: true });
-    const manager = await getPersistentManager(cfg);
-    const db = Reflect.get(manager, "db") as DatabaseSync;
-    const vector = Reflect.get(manager, "vector") as { available: boolean | null };
-
-    // The CLI status fast path never live-probes sqlite-vec, so vector.available
-    // stays null (the lazy-init default set in the constructor).
-    vector.available = null;
-
-    // No persisted chunks yet -> still unknown (undefined); the fix does not
-    // fabricate readiness when nothing has been indexed.
-    expect(manager.status().vector?.storeAvailable).toBeUndefined();
-
-    // Persist a real semantic (non-fts-only) chunk as a prior indexing would.
-    db.exec(
-      `INSERT INTO memory_index_chunks
-         (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
-       VALUES
-         ('chunk-1', 'memory/2026-01-12.md', 'memory', 1, 2, 'h1',
-          'mock-embed', 'semantic chunk body', '[]', 0)`,
-    );
-
-    // Unprobed fast path now reports ready, mirroring --deep, instead of the
-    // misleading "unknown" that made operators think vector search was down.
-    expect(manager.status().vector?.storeAvailable).toBe(true);
-
-    // fts-only chunks are not semantic vectors and must not count as ready.
-    db.exec(
-      `DELETE FROM memory_index_chunks;
-       INSERT INTO memory_index_chunks
-         (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
-       VALUES
-         ('chunk-fts', 'memory/2026-01-12.md', 'memory', 1, 2, 'h2',
-          'fts-only', 'fts only body', '[]', 0)`,
-    );
-    vector.available = null;
-    expect(manager.status().vector?.storeAvailable).toBeUndefined();
-  });
-
   it("keeps current vector indexes clean after vector store probing", async () => {
     const cfg = createCfg({ provider: "gemini" });
     const manager = await getFreshManager(cfg);

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -2190,7 +2190,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         : undefined,
       vector: {
         enabled: this.vector.enabled,
-        storeAvailable: this.vector.available ?? undefined,
+        storeAvailable: this.vector.available ?? (this.hasSemanticChunks() ? true : undefined),
         semanticAvailable: this.vector.semanticAvailable,
         available: this.vector.semanticAvailable,
         extensionPath: this.vector.extensionPath,

--- a/extensions/memory-core/src/memory/manager.vector-status.test.ts
+++ b/extensions/memory-core/src/memory/manager.vector-status.test.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetEmbeddingMocks } from "./embedding.test-mocks.js";
+import type { MemoryIndexManager } from "./index.js";
+
+// Regression coverage for #92102 lives in its own small file so the memory-core
+// vitest shard does not have to transform the full index.test.ts graph to run it.
+
+describe("memory manager vector store status (#92102)", () => {
+  let fixtureRoot = "";
+  let workspaceDir = "";
+
+  beforeEach(async () => {
+    resetEmbeddingMocks();
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-vector-status-"));
+    workspaceDir = path.join(fixtureRoot, "workspace");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(fixtureRoot, "state"));
+  });
+
+  afterEach(async () => {
+    const { closeAllMemorySearchManagers } = await import("./index.js");
+    await closeAllMemorySearchManagers();
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  async function openManager(): Promise<MemoryIndexManager> {
+    const cfg: OpenClawConfig = {
+      memory: {
+        backend: "builtin",
+        search: {
+          provider: "none",
+          model: "mock-embed",
+          store: { vector: { enabled: true } },
+          cache: { enabled: false },
+        },
+      },
+      agents: {
+        defaults: { workspace: workspaceDir },
+        list: [{ id: "main", default: true }],
+      },
+    };
+    const { getMemorySearchManager } = await import("./index.js");
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    if (!result.manager) {
+      throw new Error(result.error ?? "manager missing");
+    }
+    return result.manager as unknown as MemoryIndexManager;
+  }
+
+  it("reports vector store ready from persisted semantic chunks on the unprobed fast path", async () => {
+    const manager = await openManager();
+    const db = Reflect.get(manager, "db") as DatabaseSync;
+    const vector = Reflect.get(manager, "vector") as { available: boolean | null };
+
+    // The CLI status fast path never live-probes sqlite-vec, so vector.available
+    // stays null (the lazy-init default set in the constructor).
+    vector.available = null;
+
+    // No persisted chunks yet -> still unknown (undefined); the fix does not
+    // fabricate readiness when nothing has been indexed.
+    expect(manager.status().vector?.storeAvailable).toBeUndefined();
+
+    // Persist a real semantic (non-fts-only) chunk as a prior indexing would.
+    db.exec(
+      `INSERT INTO memory_index_chunks
+         (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+       VALUES
+         ('chunk-1', 'memory/2026-01-12.md', 'memory', 1, 2, 'h1',
+          'mock-embed', 'semantic chunk body', '[]', 0)`,
+    );
+
+    // Unprobed fast path now reports ready, mirroring --deep, instead of the
+    // misleading "unknown" that made operators think vector search was down.
+    expect(manager.status().vector?.storeAvailable).toBe(true);
+
+    // fts-only chunks are not semantic vectors and must not count as ready.
+    db.exec(
+      `DELETE FROM memory_index_chunks;
+       INSERT INTO memory_index_chunks
+         (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+       VALUES
+         ('chunk-fts', 'memory/2026-01-12.md', 'memory', 1, 2, 'h2',
+          'fts-only', 'fts only body', '[]', 0)`,
+    );
+    vector.available = null;
+    expect(manager.status().vector?.storeAvailable).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`openclaw memory status` (without `--deep` / `--index`) always prints **`Vector store: unknown`** on the first CLI invocation, even when the index is built and vectors are present in the DB. Operators read "unknown" and falsely conclude vector search is unavailable (#92102).

Root cause: the CLI status fast path constructs a fresh `MemoryManager` whose `vector.available` stays `null` (lazy init — `loadVectorExtension()` / `ensureVectorReady()` only run during `--deep` / `--index`). `status()` rendered `storeAvailable: this.vector.available ?? undefined`, so the unprobed fast path always yields `undefined` → "unknown".

## Why This Change Was Made

On the unprobed fast path, fall back to the existing `hasSemanticChunks()` helper (`SELECT 1 ... FROM memory_index_chunks WHERE model != 'fts-only' LIMIT 1`) when `vector.available` is still `null`:

- persisted **semantic** chunks present → `storeAvailable: true` → "ready" (mirrors `--deep`)
- no chunks, or only `fts-only` chunks → `undefined` → "unknown" (unchanged, honest)

This is **narrower than the issue's literal suggestion** (which queried the bare `chunks` table and would report "ready" for `fts-only` rows that carry no real vectors), and **smaller than adding a separate status line**: it corrects the existing misleading `Vector store` line in one expression, reusing the `hasSemanticChunks()` pattern already used elsewhere in the class for the same "are there real vectors" question.

Probed-path behavior is unchanged — `this.vector.available` (`true`/`false`) short-circuits via `??`.

```diff
- storeAvailable: this.vector.available ?? undefined,
+ storeAvailable: this.vector.available ?? (this.hasSemanticChunks() ? true : undefined),
```

## User Impact

`openclaw memory status` no longer falsely reports "Vector store: unknown" when vectors are indexed and working. No state change; the only runtime change is the displayed status string on the unprobed fast path.

## Evidence

Real-runtime regression test (`extensions/memory-core/src/memory/index.test.ts`, "reports vector store ready from persisted semantic chunks on the unprobed fast path") — constructs a **real** `MemoryManager` against a **real** SQLite DB, leaves `vector.available` unprobed (`null`), and asserts `status().vector.storeAvailable` across all three branches of the fix (no mocking of the code under test; only the embedding *provider* is stubbed, which the fast-path `status()` never touches):

| state | `storeAvailable` | CLI label |
|---|---|---|
| unprobed + no chunks | `undefined` | "unknown" (unchanged) |
| unprobed + semantic chunk | `true` | **"ready"** ← the fix |
| unprobed + fts-only-only chunk | `undefined` | "unknown" (unchanged) |

- `oxlint` / `oxfmt --check` on changed files: clean.
- CI: check-prod-types, check-test-types, check-lint, check-additional-extension-package-boundary, Real behavior proof (run pending).

## Note on approach vs #117572

Open PR #117572 targets the same issue with a different shape: it adds a **separate** `Vector index: ready (persisted)` line rather than correcting the existing `Vector store` line. This PR takes the minimal, issue-aligned shape (correct the misleading existing line, reuse `hasSemanticChunks()`, exclude `fts-only`), which keeps the operator-facing output structure unchanged while making it truthful. Either resolves #92102; happy to defer to maintainer preference on the shape.

Closes #92102.

AI-assisted: Codex
