### PR TITLE
perf(tests): bound compaction identifier scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Compaction safeguard identifier scans:** require host/port token boundaries so very long non-identifier text cannot trigger quadratic regex retries while preserving valid endpoint identifiers.
 - **Telegram durable ingress:** preserve pre-identity control-lane ownership during replay and attempt each drain snapshot row only once per pass, preventing targeted commands from spinning the spool and blocking polling shutdown.
 - **Control UI operator session permissions:** honor Gateway-advertised operator scopes for new-thread creation, thread management, checkpoints, and sharing controls while preserving read-only navigation and legacy Gateway compatibility. Fixes #117786. Thanks @shakkernerd.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Compaction safeguard identifier scans:** require host/port token boundaries so very long non-identifier text cannot trigger quadratic regex retries while preserving valid endpoint identifiers.
 - **Telegram durable ingress:** preserve pre-identity control-lane ownership during replay and attempt each drain snapshot row only once per pass, preventing targeted commands from spinning the spool and blocking polling shutdown.
 - **Control UI operator session permissions:** honor Gateway-advertised operator scopes for new-thread creation, thread management, checkpoints, and sharing controls while preserving read-only navigation and legacy Gateway compatibility. Fixes #117786. Thanks @shakkernerd.
 - **Control UI archived session deletion:** send archive-gated delete requests from Sessions-page row and mixed-selection actions so write-scoped operators can remove archived threads while active-session deletion remains admin-only. Thanks @shakkernerd.

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -146,9 +146,11 @@ function summaryIncludesIdentifier(summary: string, identifier: string): boolean
 
 /** Extracts likely exact identifiers that summaries should preserve literally. */
 export function extractOpaqueIdentifiers(text: string): string[] {
+  // Host/port candidates start at token boundaries so a long non-identifier
+  // does not retry the greedy branch at every character.
   const matches =
     text.match(
-      /([A-Fa-f0-9]{8,}|https?:\/\/\S+|\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5}|\b\d{6,}\b)/g,
+      /([A-Fa-f0-9]{8,}|https?:\/\/\S+|\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5}|\b\d{6,}\b)/g,
     ) ?? [];
   return uniqueStrings(
     matches

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1096,6 +1096,20 @@ describe("compaction-safeguard recent-turn preservation", () => {
     ).toBe(1);
   });
 
+  it("keeps valid host/port identifiers after a long non-identifier token", () => {
+    const identifiers = extractOpaqueIdentifiers(
+      `${"x".repeat(120_000)} host.local:18789 ` +
+        "api.example.com/v1:443 127.0.0.1:8080 sub-domain.example.test:65535",
+    );
+
+    expect(identifiers).toStrictEqual([
+      "host.local:18789",
+      "api.example.com/v1:443",
+      "127.0.0.1:8080",
+      "sub-domain.example.test:65535",
+    ]);
+  });
+
   it("dedupes identifiers before applying the result cap", () => {
     const noisyPrefix = Array.from({ length: 10 }, () => "a0b0c0d0").join(" ");
     const uniqueTail = Array.from(


### PR DESCRIPTION
## What Problem This Solves

The compaction safeguard's opaque-identifier extractor could retry the greedy host/port alternative at every character of a very long non-identifier token. That made otherwise simple safeguard tests spend quadratic time scanning input.

## Fix

Require the host/port alternative to start at an identifier token boundary. The regression fixture combines a 120 KB non-identifier token with valid hostname, path, IP, and dashed-host endpoints so the fast path and accepted endpoint forms stay covered.

## Evidence

- focused real time: 20.72s before, 9.97s after
- Vitest duration: 17.89s before, 6.80s after
- test bodies: 9.78s before, 1.80s after
- rebased focused proof: 120 safeguard tests and 4 embedded-runner composition tests passed
- final branch autoreview: clean, no accepted/actionable findings
- production delta: +3/-1 lines; tests: +14 lines

No test sharding, concurrency, or coverage configuration changed.
