### PR TITLE
fix(qa): reject incomplete character judge rankings

### DIFF
--- a/extensions/qa-lab/src/character-eval.test.ts
+++ b/extensions/qa-lab/src/character-eval.test.ts
@@ -335,6 +335,70 @@ describe("runQaCharacterEval", () => {
     expect(report).toContain("1. codex-cli/test-model - 9.1 - Better vibes.");
   });
 
+  it.each([
+    {
+      description: "a missing candidate",
+      rankings: [{ model: "openai/gpt-5.6-luna", rank: 1, score: 8, summary: "ok" }],
+    },
+    {
+      description: "a duplicated candidate",
+      rankings: [
+        { model: "openai/gpt-5.6-luna", rank: 1, score: 8, summary: "ok" },
+        { model: "openai/gpt-5.6-luna", rank: 2, score: 7, summary: "again" },
+      ],
+    },
+    {
+      description: "duplicated ranks",
+      rankings: [
+        { model: "openai/gpt-5.6-luna", rank: 1, score: 8, summary: "ok" },
+        { model: "moonshot/kimi-k2.5", rank: 1, score: 7, summary: "ok" },
+      ],
+    },
+    {
+      description: "a missing rank",
+      rankings: [
+        { model: "openai/gpt-5.6-luna", rank: 1, score: 8, summary: "ok" },
+        { model: "moonshot/kimi-k2.5", rank: 3, score: 7, summary: "ok" },
+      ],
+    },
+    {
+      description: "a fractional rank",
+      rankings: [
+        { model: "openai/gpt-5.6-luna", rank: 1, score: 8, summary: "ok" },
+        { model: "moonshot/kimi-k2.5", rank: 1.5, score: 7, summary: "ok" },
+      ],
+    },
+    {
+      description: "a non-positive rank",
+      rankings: [
+        { model: "openai/gpt-5.6-luna", rank: 0, score: 8, summary: "ok" },
+        { model: "moonshot/kimi-k2.5", rank: 1, score: 7, summary: "ok" },
+      ],
+    },
+    {
+      description: "an unknown candidate",
+      rankings: [
+        { model: "openai/gpt-5.6-luna", rank: 1, score: 8, summary: "ok" },
+        { model: "unknown/candidate", rank: 2, score: 7, summary: "unknown" },
+      ],
+    },
+  ])("marks a judge with $description as failed", async ({ rankings }) => {
+    const result = await runQaCharacterEval({
+      repoRoot: tempRoot,
+      outputDir: path.join(tempRoot, "character"),
+      models: ["openai/gpt-5.6-luna", "moonshot/kimi-k2.5"],
+      judgeModels: ["openai/gpt-5.6-luna"],
+      runSuite: makeRunSuite(),
+      runJudge: makeRunJudge(rankings),
+    });
+
+    expect(result.runs.map((run) => run.status)).toEqual(["pass", "pass"]);
+    expect(result.judgments[0]).toMatchObject({
+      rankings: [],
+      error: "judge reply must rank every candidate exactly once with consecutive ranks",
+    });
+  });
+
   it("defaults to the character eval model panel when no models are provided", async () => {
     const runSuite = makeRunSuite();
     const runJudge = makeRunJudge([
@@ -694,6 +758,7 @@ describe("runQaCharacterEval", () => {
     const runSuite = makeRunSuite();
     const runJudge = makeRunJudge([
       { model: "openai/gpt-5.6-luna", rank: 1, score: 8, summary: "ok" },
+      { model: "moonshot/kimi-k2.5", rank: 2, score: 7, summary: "ok" },
     ]);
 
     await runQaCharacterEval({
@@ -740,7 +805,10 @@ describe("runQaCharacterEval", () => {
     });
     const runJudge = vi.fn(async (_params: CharacterRunJudgeParams) =>
       JSON.stringify({
-        rankings: [{ model: "openai/gpt-5.6-luna", rank: 1, score: 8, summary: "ok" }],
+        rankings: [
+          { model: "openai/gpt-5.6-luna", rank: 1, score: 8, summary: "ok" },
+          { model: "codex-cli/test-model", rank: 2, score: 0, summary: "failed" },
+        ],
       }),
     );
 

--- a/extensions/qa-lab/src/character-eval.ts
+++ b/extensions/qa-lab/src/character-eval.ts
@@ -377,6 +377,13 @@ function parseJudgeReply(reply: string | null, allowedModels: Set<string>) {
   if (rankings.length === 0) {
     throw new Error("judge reply did not contain valid rankings");
   }
+  if (
+    rankings.length !== allowedModels.size ||
+    new Set(rankings.map(({ model }) => model)).size !== allowedModels.size ||
+    rankings.some(({ rank }, index) => rank !== index + 1)
+  ) {
+    throw new Error("judge reply must rank every candidate exactly once with consecutive ranks");
+  }
   return rankings;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running character evaluations would receive a successful report even when a judge omitted candidates, duplicated models, or returned invalid ranks.

## Why This Change Was Made

Validate the complete judge ranking in its owning parser, requiring every requested candidate exactly once with consecutive ranks while preserving blind labels and existing CLI failure reporting.

## User Impact

Character-evaluation reports now fail visibly when a judge produces incomplete or invalid comparisons instead of presenting misleading successful results.

## Real Behavior Proof

The exact committed production file was rebuilt and verified in private QA dist on an isolated Testbox, then exercised through the real `openclaw qa character-eval` operator command against live OpenAI providers.

- Exact head: ac1bf8cececbd80af783c5fef418cf2b04e9e145.
- Scenario: character-vibes-gollum; exactly one live openai/gpt-5.4 candidate and one separate live openai/gpt-5.4 blind judge.
- Four real user turns and four assistant turns, including workspace-file creation and inspection.
- Candidate: passed in 38.508 seconds; judge: passed in 21.156 seconds.
- Real judge produced one complete valid ranking: rank 1, score 5.9.
- Real command exit: 0; private Testbox run: https://github.com/openclaw/openclaw/actions/runs/30780578123
- Raw judge/candidate transcripts and credentials were intentionally not included.

## Regression Evidence

- Before: seven new missing, duplicate, unknown, fractional, nonpositive, duplicate-rank, and skipped-rank regressions failed.
- After: node scripts/run-vitest.mjs extensions/qa-lab/src/character-eval.test.ts — 24/24 passing.
- Exact-head hosted CI: green.
- Independent structured Sol/high review: clean, confidence 0.91.
- Production delta: +7 lines; no auth, config, schema, public SDK, or provider changes.
- Rank-up disposition: real-judge evidence applied above; moving-main drift is advisory because the PR remains conflict-free and exact-head CI passed.
- AI-assisted implementation and independently verified source review.
