### PR TITLE
fix(codex): restore prerelease media validation

### DIFF
--- a/extensions/codex/media-understanding-provider.test.ts
+++ b/extensions/codex/media-understanding-provider.test.ts
@@ -315,12 +315,14 @@ describe("codex media understanding provider", () => {
       developerInstructions:
         "You are OpenClaw's bounded image-understanding worker. Describe only the provided image content. Do not call tools, edit files, or ask follow-up questions.",
       config: {
+        "agents.enabled": false,
         "features.apps": false,
         "features.goals": false,
         "features.code_mode": false,
         "features.code_mode_only": false,
         "features.image_generation": false,
         "features.multi_agent": false,
+        "features.multi_agent_v2": false,
         "features.plugins": false,
         "features.standalone_web_search": false,
         web_search: "disabled",
@@ -336,7 +338,6 @@ describe("codex media understanding provider", () => {
         { type: "text", text: "Describe briefly.", text_elements: [] },
         { type: "image", url: "data:image/png;base64,aW1hZ2UtYnl0ZXM=" },
       ],
-      cwd: "/tmp/openclaw-agent",
       approvalPolicy: "on-request",
       model: "gpt-5.4",
       effort: "low",
@@ -368,7 +369,7 @@ describe("codex media understanding provider", () => {
       timeoutMs: 30_000,
     });
     expect(requests[1]?.params).toEqual(expect.objectContaining({ cwd: process.cwd() }));
-    expect(requests[2]?.params).toEqual(expect.objectContaining({ cwd: process.cwd() }));
+    expect(requests[2]?.params).not.toHaveProperty("cwd");
   });
 
   it("preserves configured WebSocket transport for media turns", async () => {
@@ -406,7 +407,7 @@ describe("codex media understanding provider", () => {
       timeoutMs: 30_000,
     });
     expect(requests[1]?.params).toEqual(expect.objectContaining({ cwd: "/tmp/openclaw-agent" }));
-    expect(requests[2]?.params).toEqual(expect.objectContaining({ cwd: "/tmp/openclaw-agent" }));
+    expect(requests[2]?.params).not.toHaveProperty("cwd");
   });
 
   it("interrupts a configured app-server turn when the media request aborts", async () => {
@@ -651,12 +652,14 @@ describe("codex media understanding provider", () => {
       developerInstructions:
         "You are OpenClaw's bounded structured-extraction worker. Return only the requested extraction. Do not call tools, edit files, ask follow-up questions, or include secrets.",
       config: {
+        "agents.enabled": false,
         "features.apps": false,
         "features.goals": false,
         "features.code_mode": false,
         "features.code_mode_only": false,
         "features.image_generation": false,
         "features.multi_agent": false,
+        "features.multi_agent_v2": false,
         "features.plugins": false,
         "features.standalone_web_search": false,
         web_search: "disabled",
@@ -672,14 +675,13 @@ describe("codex media understanding provider", () => {
           approvalPolicy?: unknown;
           model?: unknown;
           input?: Array<{ type?: unknown; text?: unknown; text_elements?: unknown; url?: unknown }>;
-          cwd?: unknown;
           effort?: unknown;
         }
       | undefined;
     expect(turnParams?.threadId).toBe("thread-1");
     expect(turnParams?.approvalPolicy).toBe("on-request");
     expect(turnParams?.model).toBe("gpt-5.4");
-    expect(turnParams?.cwd).toBe("/tmp/openclaw-agent");
+    expect(turnParams).not.toHaveProperty("cwd");
     expect(turnParams?.effort).toBe("low");
     expect(turnParams?.input).toHaveLength(3);
     expect(turnParams?.input?.[0]?.type).toBe("text");


### PR DESCRIPTION
Related: #118146

## What Problem This Solves

Fixes an issue where Full Release Validation's plugin prerelease suite failed after bounded Codex media turns tightened their isolation contract. The media-provider tests still expected `turn/start.cwd` and omitted the new delegation-disable fields from `thread/start`.

## Why This Change Was Made

Align the tests with the production contract introduced in #118146: bounded turns disable both Codex delegation backends at thread start, and turn start omits `cwd` so an empty thread environment cannot recreate native tools. This is test-only and does not change runtime behavior.

## User Impact

Maintainers can run plugin prerelease validation without false Codex media failures, while the tests explicitly preserve the bounded worker's no-delegation and no-tool-recreation invariants.

## Evidence

- Full Release Validation plugin prerelease failure: https://github.com/openclaw/openclaw/actions/runs/30780088808
- Focused before-fix reproduction on current main: https://github.com/openclaw/openclaw/actions/runs/30781322174 (4 failed, 12 passed)
- Focused exact-head Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30781577870 (16/16 passed)
- Rebased exact-head focused test plus `check:changed`: https://github.com/openclaw/openclaw/actions/runs/30781942091
- Fresh autoreview: clean, no accepted/actionable findings, confidence 0.99.
- Direct dependency contract checked at `openai/codex` tag `rust-v0.146.0`: `codex-rs/config/src/config_toml.rs:681-686` defines `agents.enabled`; `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:93-94` accepts thread config overrides; `codex-rs/app-server/src/config_manager.rs:192-203` applies request overrides.
- The sibling memory-core timeout from the same prerelease run passed alone in 12.31s: https://github.com/openclaw/openclaw/actions/runs/30781434592. No memory code change was made.
