### PR TITLE
fix(logging): apply quiet-work floor to model_call recovery

### DIFF
--- a/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
+++ b/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
@@ -966,6 +966,44 @@ describe("claude live session provisional results", () => {
     expect(driver.cancel).not.toHaveBeenCalled();
   });
 
+  it("mirrors outstanding background tasks into the diagnostic activity snapshot", async () => {
+    const driver = installLiveStdoutDriver();
+    const resultPromise = startLiveTurn({
+      runId: "run-bg-mirror",
+      timeoutMs: 60_000,
+    });
+    await driver.stdout.waitReady();
+    try {
+      driver.stdout.emit(
+        jsonl([
+          { type: "system", subtype: "init", session_id: "live-bg-mirror" },
+          {
+            type: "system",
+            subtype: "background_tasks_changed",
+            tasks: [{ task_id: "task-mirror", task_type: "local_agent", description: "work" }],
+          },
+        ]),
+      );
+      await waitForDiagnosticEventsDrained();
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:bg" })
+          .hasOutstandingBackgroundWork,
+      ).toBe(true);
+
+      driver.stdout.emit(
+        jsonl([{ type: "system", subtype: "background_tasks_changed", tasks: [] }]),
+      );
+      await waitForDiagnosticEventsDrained();
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:bg" })
+          .hasOutstandingBackgroundWork,
+      ).toBeUndefined();
+    } finally {
+      (driver.cancel as unknown as (reason?: string) => void)();
+      await resultPromise.catch(() => undefined);
+    }
+  });
+
   it("still aborts on overall turn timeout while waiting for a never-finishing background task", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const driver = installLiveStdoutDriver();

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -26,7 +26,10 @@ import {
   type ExecAsk,
   type ExecSecurity,
 } from "../../infra/exec-approvals.js";
-import { BLOCKED_TOOL_CALL_ABORT_FLOOR_MS } from "../../logging/diagnostic-run-activity.js";
+import {
+  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
+  markDiagnosticClaudeBackgroundWorkState,
+} from "../../logging/diagnostic-run-activity.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import type { CliBackendConfig } from "../../plugins/cli-backend.types.js";
 import {
@@ -902,6 +905,7 @@ const CLAUDE_LIVE_RESULT_HOLDING_BACKGROUND_TASK_TYPES = new Set(["local_agent",
 /** Replace outstanding subagent/workflow task ids from background_tasks_changed. */
 function applyBackgroundTasksChanged(
   session: ClaudeLiveSession,
+  turn: ClaudeLiveTurn,
   parsed: Record<string, unknown>,
 ): void {
   if (parsed.type !== "system" || parsed.subtype !== "background_tasks_changed") {
@@ -924,6 +928,12 @@ function applyBackgroundTasksChanged(
       session.outstandingBackgroundTaskIds.add(taskId);
     }
   }
+  // Mirror the outstanding-work fact into session diagnostics so the recovery
+  // watchdog grants a quiet parent model_call the same floor the CLI grants it.
+  markDiagnosticClaudeBackgroundWorkState({
+    ...claudeLiveDiagnosticBase(turn),
+    active: session.outstandingBackgroundTaskIds.size > 0,
+  });
 }
 
 function isClaudeLiveProvisionalSyntheticPlaceholder(parsed: Record<string, unknown>): boolean {
@@ -1420,7 +1430,7 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
     return;
   }
   turn.rawLines.push(trimmed);
-  applyBackgroundTasksChanged(session, parsed);
+  applyBackgroundTasksChanged(session, turn, parsed);
   if (turn.allowSyntheticContinuationGrace && isClaudeLiveProvisionalSyntheticPlaceholder(parsed)) {
     turn.pendingSyntheticPlaceholder = true;
   } else if (turn.pendingSyntheticPlaceholder && isClaudeLiveSubstantiveAssistantProgress(parsed)) {

--- a/src/logging/diagnostic-embedded-run-recovery.ts
+++ b/src/logging/diagnostic-embedded-run-recovery.ts
@@ -1,0 +1,240 @@
+// Stuck-session recovery cleanup: reconciles a session's terminal embedded-run
+// activity when an authority declares the lane idle.
+import {
+  clearArgumentChurnActivity,
+  clearArgumentChurnPolicyWaits,
+} from "./diagnostic-argument-churn-activity.js";
+import {
+  embeddedRunIndex,
+  registerSessionActivityRefs,
+  resolveSessionActivity,
+  touchSessionActivity,
+  type ActiveEmbeddedRun,
+  type SessionActivity,
+} from "./diagnostic-run-activity.js";
+
+function ownerRefsForRecovery(params: {
+  sessionId?: string;
+  activeSessionId?: string;
+}): Set<string> {
+  const refs = [params.activeSessionId?.trim(), params.sessionId?.trim()].filter(
+    (ref): ref is string => Boolean(ref),
+  );
+  return new Set(refs);
+}
+
+function markerBelongsToRecoveredOwner(
+  marker: { runId?: string; sessionId?: string },
+  ownerRefs: Set<string>,
+): boolean {
+  return (
+    (marker.runId !== undefined && ownerRefs.has(marker.runId)) ||
+    (marker.sessionId !== undefined && ownerRefs.has(marker.sessionId))
+  );
+}
+
+function embeddedRunStartedAfter(
+  embeddedRun: ActiveEmbeddedRun,
+  sequence: number | undefined,
+): boolean {
+  return sequence !== undefined && embeddedRun.sequence > sequence;
+}
+
+function activityMarkerStartedAfter(
+  marker: { sequence?: number },
+  sequence: number | undefined,
+): boolean {
+  return sequence !== undefined && marker.sequence !== undefined && marker.sequence > sequence;
+}
+
+function clearRecoveredOwnerEmbeddedRuns(
+  activity: SessionActivity,
+  ownerRefs: Set<string>,
+  recoveryStartedAfterSequence: number | undefined,
+): void {
+  if (ownerRefs.size === 0) {
+    return;
+  }
+  for (const [key, embeddedRun] of activity.activeEmbeddedRuns) {
+    if (
+      embeddedRun.sessionId !== undefined &&
+      ownerRefs.has(embeddedRun.sessionId) &&
+      !embeddedRunStartedAfter(embeddedRun, recoveryStartedAfterSequence)
+    ) {
+      embeddedRunIndex.remove(activity, key);
+    }
+  }
+}
+
+function hasEmbeddedRunStartedAfter(
+  activity: SessionActivity,
+  sequence: number | undefined,
+): boolean {
+  if (sequence === undefined) {
+    return activity.activeEmbeddedRuns.size > 0;
+  }
+  for (const embeddedRun of activity.activeEmbeddedRuns.values()) {
+    if (embeddedRun.sequence > sequence) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function clearRecoveredOwnerMarkers(
+  activity: SessionActivity,
+  ownerRefs: Set<string>,
+  recoveryStartedAfterSequence: number | undefined,
+): void {
+  if (ownerRefs.size === 0) {
+    return;
+  }
+  for (const [key, tool] of activity.activeTools) {
+    if (
+      markerBelongsToRecoveredOwner(tool, ownerRefs) &&
+      !activityMarkerStartedAfter(tool, recoveryStartedAfterSequence)
+    ) {
+      activity.activeTools.delete(key);
+    }
+  }
+  for (const [key, modelCall] of activity.activeModelCalls) {
+    if (
+      markerBelongsToRecoveredOwner(modelCall, ownerRefs) &&
+      !activityMarkerStartedAfter(modelCall, recoveryStartedAfterSequence)
+    ) {
+      activity.activeModelCalls.delete(key);
+    }
+  }
+}
+
+function pruneActivityStartedBeforeRecoveryCutoff(
+  activity: SessionActivity,
+  recoveryStartedAfterEmbeddedRunSequence: number | undefined,
+  recoveryStartedAfterDiagnosticEventSequence: number | undefined,
+): void {
+  if (
+    recoveryStartedAfterEmbeddedRunSequence === undefined &&
+    recoveryStartedAfterDiagnosticEventSequence === undefined
+  ) {
+    return;
+  }
+  for (const [key, embeddedRun] of activity.activeEmbeddedRuns) {
+    if (!embeddedRunStartedAfter(embeddedRun, recoveryStartedAfterEmbeddedRunSequence)) {
+      embeddedRunIndex.remove(activity, key);
+    }
+  }
+  for (const [key, tool] of activity.activeTools) {
+    if (!activityMarkerStartedAfter(tool, recoveryStartedAfterDiagnosticEventSequence)) {
+      activity.activeTools.delete(key);
+    }
+  }
+  for (const [key, modelCall] of activity.activeModelCalls) {
+    if (!activityMarkerStartedAfter(modelCall, recoveryStartedAfterDiagnosticEventSequence)) {
+      activity.activeModelCalls.delete(key);
+    }
+  }
+}
+
+function rememberRecoveredOwnerStartEventCutoffs(
+  activity: SessionActivity,
+  ownerRefs: Set<string>,
+  recoveryStartedAfterSequence: number | undefined,
+): void {
+  if (recoveryStartedAfterSequence === undefined) {
+    return;
+  }
+  for (const ownerRef of ownerRefs) {
+    // Recovery can clear a session before the async diagnostic queue drains.
+    // Remember the queue watermark so older start events cannot recreate stale activity.
+    activity.recoveredOwnerStartEventCutoffs.set(
+      ownerRef,
+      Math.max(
+        recoveryStartedAfterSequence,
+        activity.recoveredOwnerStartEventCutoffs.get(ownerRef) ?? 0,
+      ),
+    );
+  }
+}
+
+// Reconciles a session's terminal embedded-run activity at once. Used when an
+// authority (stuck-session recovery) declares the lane idle and the per-run
+// markDiagnosticEmbeddedRunEnded may have been bypassed. Clears the embedded-run
+// owners AND their tool/model markers, matching the default teardown so the lane
+// cannot be left as idle + orphaned tool/model activity (which
+// isIdleQueuedRecoverableSessionStall still treats as recoverable).
+export function clearDiagnosticEmbeddedRunActivityForSession(params: {
+  sessionId?: string;
+  sessionKey?: string;
+  activeSessionId?: string;
+  recoveryStartedAfterEmbeddedRunSequence?: number;
+  recoveryStartedAfterDiagnosticEventSequence?: number;
+}): { cleared: boolean; blockedByActiveEmbeddedRun: boolean } {
+  const shouldCreateCutoffActivity =
+    params.recoveryStartedAfterDiagnosticEventSequence !== undefined;
+  const activity = resolveSessionActivity({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    runId: params.activeSessionId,
+    create: shouldCreateCutoffActivity,
+  });
+  if (!activity) {
+    return { cleared: false, blockedByActiveEmbeddedRun: false };
+  }
+  if (params.activeSessionId) {
+    registerSessionActivityRefs(activity, {
+      sessionId: params.activeSessionId,
+      sessionKey: params.sessionKey,
+      runId: params.activeSessionId,
+    });
+  }
+  const ownerRefs = ownerRefsForRecovery(params);
+  rememberRecoveredOwnerStartEventCutoffs(
+    activity,
+    ownerRefs,
+    params.recoveryStartedAfterDiagnosticEventSequence,
+  );
+  if (
+    activity.activeEmbeddedRuns.size === 0 &&
+    activity.activeTools.size === 0 &&
+    activity.activeModelCalls.size === 0
+  ) {
+    const clearedChurn = clearArgumentChurnActivity(activity, {
+      runId: params.activeSessionId,
+    });
+    const clearedPolicyWait = clearArgumentChurnPolicyWaits(activity, {
+      runId: params.activeSessionId,
+    });
+    return {
+      cleared: clearedChurn || clearedPolicyWait,
+      blockedByActiveEmbeddedRun: false,
+    };
+  }
+  clearRecoveredOwnerEmbeddedRuns(
+    activity,
+    ownerRefs,
+    params.recoveryStartedAfterEmbeddedRunSequence,
+  );
+  clearRecoveredOwnerMarkers(
+    activity,
+    ownerRefs,
+    params.recoveryStartedAfterDiagnosticEventSequence,
+  );
+  if (activity.activeEmbeddedRuns.size > 0) {
+    if (hasEmbeddedRunStartedAfter(activity, params.recoveryStartedAfterEmbeddedRunSequence)) {
+      pruneActivityStartedBeforeRecoveryCutoff(
+        activity,
+        params.recoveryStartedAfterEmbeddedRunSequence,
+        params.recoveryStartedAfterDiagnosticEventSequence,
+      );
+      touchSessionActivity(activity, "embedded_run:recovery_skipped_active_owner");
+      return { cleared: false, blockedByActiveEmbeddedRun: true };
+    }
+    embeddedRunIndex.clear(activity);
+  }
+  activity.activeTools.clear();
+  activity.activeModelCalls.clear();
+  clearArgumentChurnActivity(activity, { runId: params.activeSessionId });
+  clearArgumentChurnPolicyWaits(activity, { runId: params.activeSessionId });
+  touchSessionActivity(activity, "embedded_run:ended");
+  return { cleared: true, blockedByActiveEmbeddedRun: false };
+}

--- a/src/logging/diagnostic-run-activity.test.ts
+++ b/src/logging/diagnostic-run-activity.test.ts
@@ -7,9 +7,9 @@ import {
   resetDiagnosticEventsForTest,
   waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
+import { clearDiagnosticEmbeddedRunActivityForSession } from "./diagnostic-embedded-run-recovery.js";
 import {
   BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
-  clearDiagnosticEmbeddedRunActivityForSession,
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticArgumentChurnObservation,
   markDiagnosticEmbeddedRunEnded,

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -17,7 +17,7 @@ import {
 } from "./diagnostic-argument-churn-activity.js";
 import { createDiagnosticEmbeddedRunIndex } from "./diagnostic-embedded-run-index.js";
 
-type SessionActivity = DiagnosticArgumentChurnActivity & {
+export type SessionActivity = DiagnosticArgumentChurnActivity & {
   sessionId?: string;
   sessionKey?: string;
   activeEmbeddedRuns: Map<string, ActiveEmbeddedRun>;
@@ -26,9 +26,12 @@ type SessionActivity = DiagnosticArgumentChurnActivity & {
   recoveredOwnerStartEventCutoffs: Map<string, number>;
   lastProgressAt: number;
   lastProgressReason?: string;
+  // CLI-owned fact: the claude-cli session reports outstanding background
+  // subagent/workflow tasks, so a quiet parent model_call is still doing work.
+  hasOutstandingBackgroundWork: boolean;
 };
 
-type ActiveEmbeddedRun = {
+export type ActiveEmbeddedRun = {
   runId: string;
   sessionId?: string;
   sessionKey?: string;
@@ -80,6 +83,7 @@ export const RUN_STALE_TAKEOVER_MS = 10 * 60_000;
 export type DiagnosticSessionActivitySnapshot = {
   activeWorkKind?: DiagnosticSessionActiveWorkKind;
   hasActiveEmbeddedRun?: boolean;
+  hasOutstandingBackgroundWork?: boolean;
   activeToolName?: string;
   activeToolCallId?: string;
   activeToolAgeMs?: number;
@@ -99,7 +103,7 @@ export function resolveRunStaleThresholdMs(
 
 const activityByRef = new Map<string, SessionActivity>();
 const activityByRunId = new Map<string, SessionActivity>();
-const embeddedRunIndex = createDiagnosticEmbeddedRunIndex(activityByRunId);
+export const embeddedRunIndex = createDiagnosticEmbeddedRunIndex(activityByRunId);
 let embeddedRunSequence = 0;
 
 function sessionRefs(params: { sessionId?: string; sessionKey?: string }): string[] {
@@ -115,7 +119,7 @@ function sessionRefs(params: { sessionId?: string; sessionKey?: string }): strin
   return refs;
 }
 
-function registerSessionActivityRefs(
+export function registerSessionActivityRefs(
   activity: SessionActivity,
   params: { sessionId?: string; sessionKey?: string; runId?: string },
 ): void {
@@ -158,6 +162,9 @@ function mergeSessionActivity(target: SessionActivity, source: SessionActivity):
   for (const [key, modelCall] of source.activeModelCalls) {
     target.activeModelCalls.set(key, modelCall);
   }
+  if (source.hasOutstandingBackgroundWork) {
+    target.hasOutstandingBackgroundWork = true;
+  }
   for (const [ownerRef, cutoff] of source.recoveredOwnerStartEventCutoffs) {
     target.recoveredOwnerStartEventCutoffs.set(
       ownerRef,
@@ -178,7 +185,7 @@ function mergeSessionActivity(target: SessionActivity, source: SessionActivity):
   replaceSessionActivityReferences(source, target);
 }
 
-function resolveSessionActivity(params: {
+export function resolveSessionActivity(params: {
   sessionId?: string;
   sessionKey?: string;
   runId?: string;
@@ -220,13 +227,18 @@ function resolveSessionActivity(params: {
     activeTools: new Map(),
     activeModelCalls: new Map(),
     recoveredOwnerStartEventCutoffs: new Map(),
+    hasOutstandingBackgroundWork: false,
     lastProgressAt: Date.now(),
   };
   registerSessionActivityRefs(created, params);
   return created;
 }
 
-function touchSessionActivity(activity: SessionActivity, reason: string, now = Date.now()): void {
+export function touchSessionActivity(
+  activity: SessionActivity,
+  reason: string,
+  now = Date.now(),
+): void {
   activity.lastProgressAt = now;
   activity.lastProgressReason = reason;
   recordDiagnosticActivityProgress(activity);
@@ -333,6 +345,27 @@ export function markDiagnosticRunProgress(params: DiagnosticRunProgressActivityE
   touchSessionActivity(activity, params.reason);
 }
 
+/**
+ * Records the claude-cli-owned background-work fact: while the CLI reports
+ * outstanding subagent/workflow tasks, the parent's quiet model_call is still
+ * doing work and must not be recovered at the bare abort threshold.
+ */
+export function markDiagnosticClaudeBackgroundWorkState(params: {
+  sessionId?: string;
+  sessionKey?: string;
+  runId?: string;
+  active: boolean;
+}): void {
+  const activity = resolveSessionActivity({ ...params, create: params.active });
+  if (!activity) {
+    return;
+  }
+  activity.hasOutstandingBackgroundWork = params.active;
+  if (params.active) {
+    touchSessionActivity(activity, "cli_background_work:active");
+  }
+}
+
 function recordRunCompleted(
   event: Extract<DiagnosticEventPayload, { type: "run.completed" }>,
 ): void {
@@ -343,6 +376,7 @@ function recordRunCompleted(
   activityByRunId.delete(event.runId);
   activity.activeTools.clear();
   activity.activeModelCalls.clear();
+  activity.hasOutstandingBackgroundWork = false;
   embeddedRunIndex.clear(activity);
   clearArgumentChurnActivity(activity, { runId: event.runId });
   clearArgumentChurnPolicyWaits(activity, { runId: event.runId });
@@ -406,153 +440,10 @@ function resolveEmbeddedRunWorkKey(params: { sessionId: string; workKey?: string
   return params.workKey ?? params.sessionId;
 }
 
-function ownerRefsForRecovery(params: {
-  sessionId?: string;
-  activeSessionId?: string;
-}): Set<string> {
-  const refs = [params.activeSessionId?.trim(), params.sessionId?.trim()].filter(
-    (ref): ref is string => Boolean(ref),
-  );
-  return new Set(refs);
-}
-
 function ownerRefsForStartedEvent(event: { runId?: string; sessionId?: string }): string[] {
   return [event.runId?.trim(), event.sessionId?.trim()].filter((ref): ref is string =>
     Boolean(ref),
   );
-}
-
-function markerBelongsToRecoveredOwner(
-  marker: { runId?: string; sessionId?: string },
-  ownerRefs: Set<string>,
-): boolean {
-  return (
-    (marker.runId !== undefined && ownerRefs.has(marker.runId)) ||
-    (marker.sessionId !== undefined && ownerRefs.has(marker.sessionId))
-  );
-}
-
-function embeddedRunStartedAfter(
-  embeddedRun: ActiveEmbeddedRun,
-  sequence: number | undefined,
-): boolean {
-  return sequence !== undefined && embeddedRun.sequence > sequence;
-}
-
-function activityMarkerStartedAfter(
-  marker: { sequence?: number },
-  sequence: number | undefined,
-): boolean {
-  return sequence !== undefined && marker.sequence !== undefined && marker.sequence > sequence;
-}
-
-function clearRecoveredOwnerEmbeddedRuns(
-  activity: SessionActivity,
-  ownerRefs: Set<string>,
-  recoveryStartedAfterSequence: number | undefined,
-): void {
-  if (ownerRefs.size === 0) {
-    return;
-  }
-  for (const [key, embeddedRun] of activity.activeEmbeddedRuns) {
-    if (
-      embeddedRun.sessionId !== undefined &&
-      ownerRefs.has(embeddedRun.sessionId) &&
-      !embeddedRunStartedAfter(embeddedRun, recoveryStartedAfterSequence)
-    ) {
-      embeddedRunIndex.remove(activity, key);
-    }
-  }
-}
-
-function hasEmbeddedRunStartedAfter(
-  activity: SessionActivity,
-  sequence: number | undefined,
-): boolean {
-  if (sequence === undefined) {
-    return activity.activeEmbeddedRuns.size > 0;
-  }
-  for (const embeddedRun of activity.activeEmbeddedRuns.values()) {
-    if (embeddedRun.sequence > sequence) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function clearRecoveredOwnerMarkers(
-  activity: SessionActivity,
-  ownerRefs: Set<string>,
-  recoveryStartedAfterSequence: number | undefined,
-): void {
-  if (ownerRefs.size === 0) {
-    return;
-  }
-  for (const [key, tool] of activity.activeTools) {
-    if (
-      markerBelongsToRecoveredOwner(tool, ownerRefs) &&
-      !activityMarkerStartedAfter(tool, recoveryStartedAfterSequence)
-    ) {
-      activity.activeTools.delete(key);
-    }
-  }
-  for (const [key, modelCall] of activity.activeModelCalls) {
-    if (
-      markerBelongsToRecoveredOwner(modelCall, ownerRefs) &&
-      !activityMarkerStartedAfter(modelCall, recoveryStartedAfterSequence)
-    ) {
-      activity.activeModelCalls.delete(key);
-    }
-  }
-}
-
-function pruneActivityStartedBeforeRecoveryCutoff(
-  activity: SessionActivity,
-  recoveryStartedAfterEmbeddedRunSequence: number | undefined,
-  recoveryStartedAfterDiagnosticEventSequence: number | undefined,
-): void {
-  if (
-    recoveryStartedAfterEmbeddedRunSequence === undefined &&
-    recoveryStartedAfterDiagnosticEventSequence === undefined
-  ) {
-    return;
-  }
-  for (const [key, embeddedRun] of activity.activeEmbeddedRuns) {
-    if (!embeddedRunStartedAfter(embeddedRun, recoveryStartedAfterEmbeddedRunSequence)) {
-      embeddedRunIndex.remove(activity, key);
-    }
-  }
-  for (const [key, tool] of activity.activeTools) {
-    if (!activityMarkerStartedAfter(tool, recoveryStartedAfterDiagnosticEventSequence)) {
-      activity.activeTools.delete(key);
-    }
-  }
-  for (const [key, modelCall] of activity.activeModelCalls) {
-    if (!activityMarkerStartedAfter(modelCall, recoveryStartedAfterDiagnosticEventSequence)) {
-      activity.activeModelCalls.delete(key);
-    }
-  }
-}
-
-function rememberRecoveredOwnerStartEventCutoffs(
-  activity: SessionActivity,
-  ownerRefs: Set<string>,
-  recoveryStartedAfterSequence: number | undefined,
-): void {
-  if (recoveryStartedAfterSequence === undefined) {
-    return;
-  }
-  for (const ownerRef of ownerRefs) {
-    // Recovery can clear a session before the async diagnostic queue drains.
-    // Remember the queue watermark so older start events cannot recreate stale activity.
-    activity.recoveredOwnerStartEventCutoffs.set(
-      ownerRef,
-      Math.max(
-        recoveryStartedAfterSequence,
-        activity.recoveredOwnerStartEventCutoffs.get(ownerRef) ?? 0,
-      ),
-    );
-  }
 }
 
 function shouldIgnoreRecoveredOwnerStartEvent(
@@ -569,89 +460,6 @@ function shouldIgnoreRecoveredOwnerStartEvent(
     }
   }
   return false;
-}
-
-// Reconciles a session's terminal embedded-run activity at once. Used when an
-// authority (stuck-session recovery) declares the lane idle and the per-run
-// markDiagnosticEmbeddedRunEnded may have been bypassed. Clears the embedded-run
-// owners AND their tool/model markers, matching the default teardown so the lane
-// cannot be left as idle + orphaned tool/model activity (which
-// isIdleQueuedRecoverableSessionStall still treats as recoverable).
-export function clearDiagnosticEmbeddedRunActivityForSession(params: {
-  sessionId?: string;
-  sessionKey?: string;
-  activeSessionId?: string;
-  recoveryStartedAfterEmbeddedRunSequence?: number;
-  recoveryStartedAfterDiagnosticEventSequence?: number;
-}): { cleared: boolean; blockedByActiveEmbeddedRun: boolean } {
-  const shouldCreateCutoffActivity =
-    params.recoveryStartedAfterDiagnosticEventSequence !== undefined;
-  const activity = resolveSessionActivity({
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    runId: params.activeSessionId,
-    create: shouldCreateCutoffActivity,
-  });
-  if (!activity) {
-    return { cleared: false, blockedByActiveEmbeddedRun: false };
-  }
-  if (params.activeSessionId) {
-    registerSessionActivityRefs(activity, {
-      sessionId: params.activeSessionId,
-      sessionKey: params.sessionKey,
-      runId: params.activeSessionId,
-    });
-  }
-  const ownerRefs = ownerRefsForRecovery(params);
-  rememberRecoveredOwnerStartEventCutoffs(
-    activity,
-    ownerRefs,
-    params.recoveryStartedAfterDiagnosticEventSequence,
-  );
-  if (
-    activity.activeEmbeddedRuns.size === 0 &&
-    activity.activeTools.size === 0 &&
-    activity.activeModelCalls.size === 0
-  ) {
-    const clearedChurn = clearArgumentChurnActivity(activity, {
-      runId: params.activeSessionId,
-    });
-    const clearedPolicyWait = clearArgumentChurnPolicyWaits(activity, {
-      runId: params.activeSessionId,
-    });
-    return {
-      cleared: clearedChurn || clearedPolicyWait,
-      blockedByActiveEmbeddedRun: false,
-    };
-  }
-  clearRecoveredOwnerEmbeddedRuns(
-    activity,
-    ownerRefs,
-    params.recoveryStartedAfterEmbeddedRunSequence,
-  );
-  clearRecoveredOwnerMarkers(
-    activity,
-    ownerRefs,
-    params.recoveryStartedAfterDiagnosticEventSequence,
-  );
-  if (activity.activeEmbeddedRuns.size > 0) {
-    if (hasEmbeddedRunStartedAfter(activity, params.recoveryStartedAfterEmbeddedRunSequence)) {
-      pruneActivityStartedBeforeRecoveryCutoff(
-        activity,
-        params.recoveryStartedAfterEmbeddedRunSequence,
-        params.recoveryStartedAfterDiagnosticEventSequence,
-      );
-      touchSessionActivity(activity, "embedded_run:recovery_skipped_active_owner");
-      return { cleared: false, blockedByActiveEmbeddedRun: true };
-    }
-    embeddedRunIndex.clear(activity);
-  }
-  activity.activeTools.clear();
-  activity.activeModelCalls.clear();
-  clearArgumentChurnActivity(activity, { runId: params.activeSessionId });
-  clearArgumentChurnPolicyWaits(activity, { runId: params.activeSessionId });
-  touchSessionActivity(activity, "embedded_run:ended");
-  return { cleared: true, blockedByActiveEmbeddedRun: false };
 }
 
 export function getDiagnosticSessionActivitySnapshot(
@@ -686,6 +494,7 @@ export function getDiagnosticSessionActivitySnapshot(
   return {
     activeWorkKind,
     ...(activity.activeEmbeddedRuns.size > 0 ? { hasActiveEmbeddedRun: true } : {}),
+    ...(activity.hasOutstandingBackgroundWork ? { hasOutstandingBackgroundWork: true } : {}),
     activeToolName: activeTool?.toolName,
     activeToolCallId: activeTool?.toolCallId,
     activeToolAgeMs: activeTool ? Math.max(0, now - activeTool.startedAt) : undefined,

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -3,10 +3,8 @@ import {
   emitInternalDiagnosticEvent as emitDiagnosticEvent,
   getInternalDiagnosticEventSequence,
 } from "../infra/diagnostic-events.js";
-import {
-  clearDiagnosticEmbeddedRunActivityForSession,
-  getDiagnosticEmbeddedRunActivitySequence,
-} from "./diagnostic-run-activity.js";
+import { clearDiagnosticEmbeddedRunActivityForSession } from "./diagnostic-embedded-run-recovery.js";
+import { getDiagnosticEmbeddedRunActivitySequence } from "./diagnostic-run-activity.js";
 import { markDiagnosticActivity as markActivity } from "./diagnostic-runtime.js";
 import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
 import {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -16,7 +16,9 @@ import {
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { withDiagnosticPhase } from "./diagnostic-phase.js";
 import {
+  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
   getDiagnosticSessionActivitySnapshot,
+  markDiagnosticClaudeBackgroundWorkState,
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
   resetDiagnosticRunActivityForTest,
@@ -1024,10 +1026,10 @@ describe("stuck session diagnostics threshold", () => {
         model: "gpt-5",
       });
 
-      vi.advanceTimersByTime(stuckSessionAbortMs - 30_000);
+      vi.advanceTimersByTime(stuckSessionAbortMs);
       expect(recoverStuckSession).not.toHaveBeenCalled();
 
-      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(BLOCKED_TOOL_CALL_ABORT_FLOOR_MS - stuckSessionAbortMs);
     } finally {
       unsubscribe();
     }
@@ -1042,6 +1044,62 @@ describe("stuck session diagnostics threshold", () => {
         reason: "active_work_without_progress",
         activeWorkKind: "model_call",
         lastProgressReason: "model_call:started",
+      },
+    );
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
+      ["ageMs", "stateGeneration"],
+    );
+  });
+
+  it("keeps silent model calls with outstanding claude background work alive until the quiet-work floor", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const stuckSessionAbortMs = 60_000;
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticModelStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        provider: "claude",
+        model: "claude-opus-5",
+      });
+      markDiagnosticClaudeBackgroundWorkState({
+        sessionId: "s1",
+        sessionKey: "main",
+        active: true,
+      });
+
+      vi.advanceTimersByTime(stuckSessionAbortMs);
+      expect(recoverStuckSession).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(BLOCKED_TOOL_CALL_ABORT_FLOOR_MS - stuckSessionAbortMs);
+    } finally {
+      unsubscribe();
+    }
+
+    expectRecordFields(
+      requireRecord(
+        events.findLast((event) => event.type === "session.stalled"),
+        "stalled event",
+      ),
+      {
+        classification: "stalled_agent_run",
+        reason: "active_work_without_progress",
+        activeWorkKind: "model_call",
       },
     );
     expectRecoveryCall(
@@ -1153,7 +1211,7 @@ describe("stuck session diagnostics threshold", () => {
     expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
-  it("actively aborts silent local model calls after the stuck timeout", async () => {
+  it("actively aborts silent local model calls after the quiet-work floor", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const stuckSessionAbortMs = 60_000;
@@ -1180,6 +1238,9 @@ describe("stuck session diagnostics threshold", () => {
       });
 
       vi.advanceTimersByTime(stuckSessionAbortMs);
+      expect(recoverStuckSession).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(BLOCKED_TOOL_CALL_ABORT_FLOOR_MS - stuckSessionAbortMs);
     } finally {
       unsubscribe();
     }
@@ -1420,6 +1481,9 @@ describe("stuck session diagnostics threshold", () => {
     vi.advanceTimersByTime(59_000);
     logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test-followup" });
     vi.advanceTimersByTime(1_000);
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(BLOCKED_TOOL_CALL_ABORT_FLOOR_MS - 60_000);
     await Promise.resolve();
 
     expectRecoveryCall(

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -550,15 +550,23 @@ function isStalledModelCallRecoveryEligible(params: {
   stuckSessionAbortMs: number;
 }): boolean {
   const lastProgressAgeMs = params.activity?.lastProgressAgeMs;
-  // Local providers are not blanket-exempt from recovery. Streaming model
-  // chunks refresh run activity while emitted progress events are throttled, so
-  // active streams stay fresh and silent/non-streaming calls can be recovered.
+  // Quiet-but-alive model calls (a parent waiting on an embedded run or on
+  // claude-cli background subagent/workflow work) get the same floor as blocked
+  // tool calls; #88870's floor bounds every quiet-work consumer. Orphaned or
+  // genuinely silent model calls keep the bare abort threshold so #99847
+  // orphaned-lane recovery is not delayed.
+  const hasQuietBackgroundWork =
+    params.activity?.hasActiveEmbeddedRun === true ||
+    params.activity?.hasOutstandingBackgroundWork === true;
+  const abortMs = hasQuietBackgroundWork
+    ? Math.max(params.stuckSessionAbortMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)
+    : params.stuckSessionAbortMs;
   return (
     params.classification?.eventType === "session.stalled" &&
     params.classification.classification === "stalled_agent_run" &&
     params.classification.activeWorkKind === "model_call" &&
     typeof lastProgressAgeMs === "number" &&
-    lastProgressAgeMs >= params.stuckSessionAbortMs
+    lastProgressAgeMs >= abortMs
   );
 }
 


### PR DESCRIPTION
Closes #118386

## What Problem This Solves

Stuck-session recovery aborts healthy long-running turns at the bare 6-minute threshold when the quiet window falls inside a `model_call`, because the 15-minute `BLOCKED_TOOL_CALL_ABORT_FLOOR_MS` is only applied on the `blocked_tool_call` recovery branch. A claude-cli parent turn that delegates to background subagents/workflows stays classified as `model_call` with no parent stdout, so the diagnostic watchdog kills the whole turn at `stuckSessionAbortMs` (6 min default) — while the CLI watchdog itself had already granted the same run a 15-minute quiet budget. Carry the CLI-owned outstanding-background-work fact into session diagnostics and apply the quiet-work floor only for model calls carrying that fact (or an active embedded run), preserving the configured abort threshold for orphaned and genuinely silent model calls.

## Root Cause

`isStalledModelCallRecoveryEligible` in `src/logging/diagnostic.ts` compared `lastProgressAgeMs >= stuckSessionAbortMs` without the 15-minute `BLOCKED_TOOL_CALL_ABORT_FLOOR_MS`, while the adjacent `isBlockedToolCallRecoveryEligible` uses `Math.max(stuckSessionAbortMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)`. Two changes created the gap:

- `b1da734a1e` (fix(logging): recover orphaned stalled lanes, #99847) removed the `hasActiveEmbeddedRun` guard that originally scoped model-call recovery to embedded runs, widening the branch to any silent model call.
- `969efdac4f` / `c2789b52a7` (the #88870 quiet-work floor) introduced `BLOCKED_TOOL_CALL_ABORT_FLOOR_MS` with a comment stating it "bounds every staleness consumer", but applied it only to the `blocked_tool_call` branch, stale takeovers, and steer gates — the model-call recovery predicate was left out.

At runtime, `activeWorkKind` resolves by priority `tool_call > model_call > embedded_run` (`src/logging/diagnostic-run-activity.ts`). A claude-cli parent with outstanding background work has no parent stdout stream, so its run activity is never refreshed and it resolves to `model_call`. The CLI layer independently certifies the run alive (`claude-live-session.ts` extends its no-output budget to the same 15-minute floor while `outstandingBackgroundTaskIds` is non-empty), but that evidence never reached the diagnostic layer — the stricter, less-informed watchdog wins and aborts at 6 minutes.

## Canonical Repair

- Record the CLI-owned fact at its producer: `applyBackgroundTasksChanged` now mirrors `session.outstandingBackgroundTaskIds.size > 0` into the diagnostic activity snapshot via a new `markDiagnosticClaudeBackgroundWorkState` API (`src/logging/diagnostic-run-activity.ts`, `src/agents/cli-runner/claude-live-session.ts`). The snapshot exposes `hasOutstandingBackgroundWork`; the fact is cleared on `run.completed` and propagated across activity merges. The stuck-session recovery cleanup moved into its own module (`src/logging/diagnostic-embedded-run-recovery.ts`) — same functions, behavior-neutral split to keep the activity owner under the repo `max-lines` budget.
- Apply the 15-minute floor only for model calls that carry quiet-background-work evidence — `hasActiveEmbeddedRun === true` (the #88870 embedded-run case) or `hasOutstandingBackgroundWork === true` (the reported claude-cli case). Orphaned or genuinely silent model calls keep the bare configured abort threshold, so #99847 orphaned-lane recovery is not delayed.
- Regression tests cover all four owner cases at the heartbeat boundary, plus a CLI-to-diagnostics mirror test.

Best-fix judgment: recording and consuming the explicit CLI-owned liveness fact is the narrower owner-boundary repair, matching ClawSweeper's review. A blanket model-call floor (issue suggestion 1) was initially tried and rejected because it delayed recovery for orphaned/wedged model calls with no background-work evidence; emitting progress from `background_tasks_changed` (issue suggestion 3) is ineffective because that event only fires on task add/remove, not as a heartbeat, so the parent would still go stale.

## User Impact

- A long-but-active claude-cli turn delegating to background subagents/workflows is no longer killed and discarded at 6 minutes; it now gets the same 15-minute quiet-work floor as tool-call windows, matching the CLI watchdog's own budget.
- Orphaned and genuinely silent model calls are recovered exactly as before (bare configured abort threshold, 6 min default); the #99847 orphaned-lane reclaim behavior is unchanged.
- No config, API, default, protocol, or schema change; existing operator behavior is unchanged except that model-call recovery with background-work evidence now waits for the floor.

## Evidence

- Linux, Node 22 (`node scripts/run-vitest.mjs` wrapper), branch `fix/model-call-abort-floor-118386` based on latest `upstream/main`
- `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts src/logging/diagnostic-run-activity.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-session-attention.test.ts`: 123/123
- `node scripts/run-vitest.mjs src/agents/cli-runner/claude-live-session.background-tasks.test.ts src/agents/cli-runner/claude-live-session-policy.test.ts`: 21/21 (incl. CLI-to-diagnostics mirror test)
- `node_modules/.bin/tsgo --noEmit -p test/tsconfig/tsconfig.core.test.json`: clean (no errors in changed files)
- `node --import tsx scripts/check-import-cycles.ts`: 0 runtime value cycles
- `node_modules/.bin/oxlint <changed src files>`: 0 warnings, 0 errors
- `git diff --check`: clean
- `node_modules/.bin/oxfmt --check <8 changed files>`: correct format

**Matrix-style evidence** — model-call quiet window vs recovery decision (before vs after):

```
Model-call quiet window with evidence        => Before (main)  => After (this fix)
embedded run active (workflow/subagent)      => abort @ 6 min  => no recovery until 15 min floor
claude-cli background task outstanding       => abort @ 6 min  => no recovery until 15 min floor
no embedded run / no background work         => abort @ 6 min  => abort @ 6 min (unchanged)
```

### Regression Tests

Six tests cover the scoped predicate at the heartbeat boundary plus the CLI-to-diagnostics mirror:

Test

Input

Result

`recovers stale model calls through the active embedded-run abort path`

silent `model_call` + embedded run

no recovery at 60s, recovery at 15 min floor

`actively aborts silent local model calls after the quiet-work floor`

silent local `model_call` (vllm) + embedded run

no recovery at 60s, recovery at 15 min floor

`keeps silent model calls with outstanding claude background work alive until the quiet-work floor`

silent `model_call` + `markDiagnosticClaudeBackgroundWorkState(active: true)`

no recovery at 60s, recovery at 15 min floor (reported scenario)

`recovers stale model calls without active embedded-run ownership`

orphaned `model_call`, no embedded run / no background work

recovery at 60s (bare threshold, #99847 behavior preserved)

`recovers idle queued work when embedded ownership is surfaced as a model call`

idle + queued work surfaced as `model_call` + embedded run

no recovery at 60s, recovery at 15 min floor

`claude-live-session.background-tasks.test.ts` "mirrors outstanding background tasks into the diagnostic activity snapshot"

real `background_tasks_changed` events through `runClaudeLiveSessionTurn`

snapshot `hasOutstandingBackgroundWork` true while tasks outstanding, cleared when drained

#### After-Fix Runtime Artifact

```
$ node scripts/run-vitest.mjs src/logging/diagnostic.test.ts src/logging/diagnostic-run-activity.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-session-attention.test.ts
[test] passed 2 Vitest shards in 35.49s
   Tests  123 passed (123)

$ node scripts/run-vitest.mjs src/agents/cli-runner/claude-live-session.background-tasks.test.ts src/agents/cli-runner/claude-live-session-policy.test.ts
[test] passed 2 Vitest shards in 104.07s
   Tests  21 passed (21)

$ node_modules/.bin/tsgo --noEmit -p test/tsconfig/tsconfig.core.test.json
(no errors in changed files)

$ node --import tsx scripts/check-import-cycles.ts
Import cycle check: 0 runtime value cycle(s).

$ node_modules/.bin/oxlint src/logging/diagnostic-run-activity.ts src/logging/diagnostic-embedded-run-recovery.ts src/logging/diagnostic.ts src/agents/cli-runner/claude-live-session.ts
Found 0 warnings and 0 errors.

$ git diff --check
(no output — clean)

$ node_modules/.bin/oxfmt --check src/logging/diagnostic.ts src/logging/diagnostic-run-activity.ts src/logging/diagnostic-embedded-run-recovery.ts src/logging/diagnostic.test.ts src/logging/diagnostic-run-activity.test.ts src/logging/diagnostic-session-recovery-coordinator.ts src/agents/cli-runner/claude-live-session.ts src/agents/cli-runner/claude-live-session.background-tasks.test.ts
All matched files use the correct format.
```

#### Key Invariant Verified

```
Recovery predicate (activeWorkKind)              => Floor applied    => Recovery after floor
blocked_tool_call (unchanged)                    => 15 min           => yes (existing tests)
model_call + embedded run                        => 15 min           => yes (2 tests)
model_call + claude background work (this fix)   => 15 min           => yes (1 test + CLI mirror)
model_call, orphaned (unchanged)                 => bare abortMs     => yes (1 test, #99847)
```

`claude-live-session.background-tasks.test.ts` "does not no-output-abort while a background task is outstanding within the blocked-tool floor" still proves the CLI watchdog grants background work up to `BLOCKED_TOOL_CALL_ABORT_FLOOR_MS`, so the diagnostic and CLI watchdogs now agree on the same boundary for the same evidence.

## Diff Shape

- Production: +307/-242, net +65 lines (`diagnostic-embedded-run-recovery.ts` +240 new module, `diagnostic-run-activity.ts` +41/-232 with the recovery cleanup moved out, `claude-live-session.ts` +12/-2, `diagnostic.ts` +12/-4, `diagnostic-session-recovery-coordinator.ts` +2/-4 import source only).
- Tests: +106/-4 (`diagnostic.test.ts` +67/-3, `claude-live-session.background-tasks.test.ts` +38, `diagnostic-run-activity.test.ts` +1/-1 import source only).
- No config, protocol, schema-version, or public API change. The recovery cleanup module split is behavior-neutral (same functions, moved file) and keeps the activity owner under the repo `max-lines` budget; `knip` dead-code check is clean.

## AI Assistance

- **AI-assisted**: Yes
- **Original model**: deepseek-v4-flash
