### PR TITLE
fix(gateway): preserve terminal voice events under backpressure

### DIFF
--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -46,7 +46,6 @@ import {
   adoptRelayProviderToolCallId,
   broadcastToOwner,
   ensureRelayTurn,
-  relayEventDeliveryOptions,
   relaySessions,
   type CreateTalkRealtimeRelaySessionParams,
   type RelaySession,
@@ -101,15 +100,10 @@ export function createTalkRealtimeRelaySession(
     captureBridgeEvents: false,
   });
   const emit = (event: TalkRealtimeRelayEventPayload, talkEvent?: TalkEventInput) =>
-    broadcastToOwner(
-      params.context,
-      params.connId,
-      {
-        ...event,
-        ...(talkEvent ? { talkEvent: harness.emit(talkEvent) } : {}),
-      },
-      relayEventDeliveryOptions(event),
-    );
+    broadcastToOwner(params.context, params.connId, {
+      ...event,
+      ...(talkEvent ? { talkEvent: harness.emit(talkEvent) } : {}),
+    });
   let currentOutputItemId: string | undefined;
   let currentOutputResponseId: string | undefined;
   let ready = false;
@@ -279,12 +273,10 @@ export function createTalkRealtimeRelaySession(
           return;
         }
         const clearEvent = { relaySessionId, type: "clear" as const };
-        broadcastToOwner(
-          params.context,
-          params.connId,
-          { ...clearEvent, ...(talkEvent ? { talkEvent } : {}) },
-          relayEventDeliveryOptions(clearEvent),
-        );
+        broadcastToOwner(params.context, params.connId, {
+          ...clearEvent,
+          ...(talkEvent ? { talkEvent } : {}),
+        });
         return;
       }
       if (event.direction !== "server") {
@@ -301,12 +293,7 @@ export function createTalkRealtimeRelaySession(
             type: "toolCallCancelled" as const,
             callId: relayCallId,
           };
-          broadcastToOwner(
-            params.context,
-            params.connId,
-            cancelledEvent,
-            relayEventDeliveryOptions(cancelledEvent),
-          );
+          broadcastToOwner(params.context, params.connId, cancelledEvent);
         }
         return;
       }

--- a/src/gateway/talk-realtime-relay-state.ts
+++ b/src/gateway/talk-realtime-relay-state.ts
@@ -186,23 +186,30 @@ export function broadcastToOwner(
   context: GatewayRequestContext,
   connId: string,
   event: TalkRealtimeRelayEvent,
-  options: { dropIfSlow?: boolean } = { dropIfSlow: true },
 ): void {
-  context.broadcastToConnIds(RELAY_EVENT, event, new Set([connId]), options);
+  // Classify the materialized Talk event so final results cannot be mistaken
+  // for transient tool progress by individual provider callback paths.
+  const delivery = relayEventDeliveryOptions(event, event.talkEvent);
+  context.broadcastToConnIds(RELAY_EVENT, event, new Set([connId]), delivery);
 }
 
-export function relayEventDeliveryOptions(event: TalkRealtimeRelayEventPayload): {
+function relayEventDeliveryOptions(
+  event: TalkRealtimeRelayEventPayload,
+  talkEvent?: TalkEvent,
+): {
   dropIfSlow?: boolean;
 } {
   switch (event.type) {
-    case "ready":
-    case "error":
-    case "close":
-    case "mark":
-    case "toolCallCancelled":
-      return { dropIfSlow: false };
-    default:
+    case "audio":
+    case "inputAudio":
       return { dropIfSlow: true };
+    case "transcript":
+      return { dropIfSlow: !event.final };
+    case "toolProgress":
+    case "toolResult":
+      return { dropIfSlow: talkEvent?.final !== true };
+    default:
+      return { dropIfSlow: false };
   }
 }
 

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -1388,6 +1388,7 @@ describe("talk realtime gateway relay", () => {
         bridgeRequest?.onReady?.();
         bridgeRequest?.onAudio(Buffer.from("audio-out"));
         bridgeRequest?.onMark?.("mark-1");
+        bridgeRequest?.onTranscript?.("user", "hel", false);
         bridgeRequest?.onTranscript?.("user", "hello", true);
         bridgeRequest?.onTranscript?.("assistant", "hi there", true);
         bridgeRequest?.onToolCall?.({
@@ -1432,6 +1433,9 @@ describe("talk realtime gateway relay", () => {
         events.push({ event, payload, connIds: [...connIds], opts });
       },
     } as never;
+    const expectDelivery = (payload: Record<string, unknown>, dropIfSlow: boolean) => {
+      expectRecordFields(events.find((entry) => entry.payload === payload)?.opts, { dropIfSlow });
+    };
 
     const session = createTalkRealtimeRelaySession({
       context,
@@ -1483,7 +1487,7 @@ describe("talk realtime gateway relay", () => {
     });
     const readyEvent = events.find((entry) => entry.payload === readyPayload);
     expectRecordFields(readyEvent, { event: "talk.event", connIds: ["conn-1"] });
-    expectRecordFields(readyEvent?.opts, { dropIfSlow: false });
+    expectDelivery(readyPayload, false);
 
     const audioPayload = findEventPayload(events, (payload) => payload.type === "audio");
     expectRecordFields(audioPayload, {
@@ -1492,8 +1496,7 @@ describe("talk realtime gateway relay", () => {
       audioBase64: Buffer.from("audio-out").toString("base64"),
     });
     expectRecordFields(audioPayload.talkEvent, { type: "output.audio.delta" });
-    const audioEvent = events.find((entry) => entry.payload === audioPayload);
-    expectRecordFields(audioEvent?.opts, { dropIfSlow: true });
+    expectDelivery(audioPayload, true);
 
     const markPayload = findEventPayload(events, (payload) => payload.type === "mark");
     expectRecordFields(markPayload, {
@@ -1501,12 +1504,19 @@ describe("talk realtime gateway relay", () => {
       type: "mark",
       markName: "mark-1",
     });
-    const markEvent = events.find((entry) => entry.payload === markPayload);
-    expectRecordFields(markEvent?.opts, { dropIfSlow: false });
+    expectDelivery(markPayload, false);
+
+    const partialTranscript = findEventPayload(
+      events,
+      (payload) =>
+        payload.type === "transcript" && payload.role === "user" && payload.final === false,
+    );
+    expectDelivery(partialTranscript, true);
 
     const userTranscript = findEventPayload(
       events,
-      (payload) => payload.type === "transcript" && payload.role === "user",
+      (payload) =>
+        payload.type === "transcript" && payload.role === "user" && payload.final === true,
     );
     expectRecordFields(userTranscript, {
       relaySessionId: session.relaySessionId,
@@ -1516,6 +1526,7 @@ describe("talk realtime gateway relay", () => {
       final: true,
     });
     expectRecordFields(userTranscript.talkEvent, { type: "transcript.done", final: true });
+    expectDelivery(userTranscript, false);
 
     const assistantTranscript = findEventPayload(
       events,
@@ -1533,6 +1544,7 @@ describe("talk realtime gateway relay", () => {
       final: true,
       payload: { text: "hi there" },
     });
+    expectDelivery(assistantTranscript, false);
 
     const toolCallPayload = findEventPayload(events, (payload) => payload.type === "toolCall");
     expectRecordFields(toolCallPayload, {
@@ -1548,6 +1560,7 @@ describe("talk realtime gateway relay", () => {
       itemId: "item-1",
       callId: "call-1",
     });
+    expectDelivery(toolCallPayload, false);
 
     sendTalkRealtimeRelayAudio({
       relaySessionId: session.relaySessionId,
@@ -1628,6 +1641,7 @@ describe("talk realtime gateway relay", () => {
       byteLength: Buffer.from("audio-in").byteLength,
     });
     expectRecordFields(inputAudioPayload.talkEvent, { type: "input.audio.delta" });
+    expectDelivery(inputAudioPayload, true);
 
     const clearPayload = findEventPayload(events, (payload) => payload.type === "clear");
     expectRecordFields(clearPayload, {
@@ -1639,6 +1653,7 @@ describe("talk realtime gateway relay", () => {
       payload: { reason: "barge-in" },
       final: true,
     });
+    expectDelivery(clearPayload, false);
 
     const toolResultPayloads = events
       .map((entry) => entry.payload)
@@ -1680,6 +1695,9 @@ describe("talk realtime gateway relay", () => {
       callId: "call-1",
       final: true,
     });
+    expect(
+      toolResultPayloads.map((payload) => events.find((event) => event.payload === payload)?.opts),
+    ).toEqual([{ dropIfSlow: true }, { dropIfSlow: true }, { dropIfSlow: false }]);
 
     const closePayload = findEventPayload(events, (payload) => payload.type === "close");
     expectRecordFields(closePayload, {
@@ -1688,6 +1706,7 @@ describe("talk realtime gateway relay", () => {
       reason: "completed",
     });
     expectRecordFields(closePayload.talkEvent, { type: "session.closed", final: true });
+    expectDelivery(closePayload, false);
   });
 
   it("emits generic issue details when relay connect fails", async () => {
@@ -1708,10 +1727,20 @@ describe("talk realtime gateway relay", () => {
         isConnected: vi.fn(() => false),
       }),
     };
-    const events: Array<{ event: string; payload: unknown; connIds: string[] }> = [];
+    const events: Array<{
+      event: string;
+      payload: unknown;
+      connIds: string[];
+      opts?: { dropIfSlow?: boolean };
+    }> = [];
     const context = {
-      broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
-        events.push({ event, payload, connIds: [...connIds] });
+      broadcastToConnIds: (
+        event: string,
+        payload: unknown,
+        connIds: ReadonlySet<string>,
+        opts?: { dropIfSlow?: boolean },
+      ) => {
+        events.push({ event, payload, connIds: [...connIds], opts });
       },
     } as never;
 
@@ -1747,6 +1776,9 @@ describe("talk realtime gateway relay", () => {
       model: "gpt-realtime-2",
       transport: "gateway-relay",
       phase: "connect",
+    });
+    expectRecordFields(events.find((event) => event.payload === errorPayload)?.opts, {
+      dropIfSlow: false,
     });
   });
 

--- a/src/gateway/talk-transcription-relay.test.ts
+++ b/src/gateway/talk-transcription-relay.test.ts
@@ -4,6 +4,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RealtimeTranscriptionProviderPlugin } from "../plugins/types.js";
 import type { RealtimeTranscriptionSessionCreateRequest } from "../realtime-transcription/provider-types.js";
+import { createGatewayBroadcaster } from "./server-broadcast.js";
+import { MAX_BUFFERED_BYTES } from "./server-constants.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
 import { getUnifiedTalkSession, rememberUnifiedTalkSession } from "./talk-session-registry.js";
 import {
   cancelTalkTranscriptionRelayTurn,
@@ -14,7 +17,12 @@ import {
 } from "./talk-transcription-relay.js";
 import { expectRecordFields, isRecord, requireRecord } from "./test-helpers.assertions.js";
 
-type BroadcastEvent = { event: string; payload: unknown; connIds: string[] };
+type BroadcastEvent = {
+  event: string;
+  payload: unknown;
+  connIds: string[];
+  opts?: { dropIfSlow?: boolean };
+};
 
 function createSttSessionMock(connect: () => Promise<void> = async () => {}) {
   return {
@@ -46,8 +54,13 @@ function createBroadcastContext() {
   const context = {
     getRuntimeConfig: () => ({}),
     logGateway,
-    broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
-      events.push({ event, payload, connIds: [...connIds] });
+    broadcastToConnIds: (
+      event: string,
+      payload: unknown,
+      connIds: ReadonlySet<string>,
+      opts?: { dropIfSlow?: boolean },
+    ) => {
+      events.push({ event, payload, connIds: [...connIds], opts });
     },
   } as never;
   return { context, events, logGateway };
@@ -214,6 +227,119 @@ describe("talk transcription gateway relay", () => {
       type: "session.closed",
       final: true,
     });
+    for (const { payload, opts } of events) {
+      const { type } = requireRecord(payload, "transcription relay event");
+      expect(opts, `${String(type)} delivery`).toEqual({
+        dropIfSlow: type === "partial" || type === "inputAudio",
+      });
+    }
+  });
+
+  it("keeps provider errors and terminal close events durable", async () => {
+    let sttRequest: RealtimeTranscriptionSessionCreateRequest | undefined;
+    const { events } = await createStartedRelaySession(createSttSessionMock(), {}, (request) => {
+      sttRequest = request;
+    });
+
+    sttRequest?.onError?.(new Error("transcription provider disconnected"));
+
+    for (const type of ["error", "close"]) {
+      const payload = findPayloadByType(events, type);
+      expect(events.find((event) => event.payload === payload)?.opts).toEqual({
+        dropIfSlow: false,
+      });
+    }
+  });
+
+  it("closes a backpressured owner for final transcripts while healthy owners still receive them", async () => {
+    const createSocket = () => ({
+      bufferedAmount: 0,
+      send: vi.fn<(payload: string) => void>(),
+      close: vi.fn<(code: number, reason: string) => void>(),
+    });
+    const slowSocket = createSocket();
+    const healthySocket = createSocket();
+    const createClient = (
+      connId: string,
+      socket: ReturnType<typeof createSocket>,
+    ): GatewayWsClient =>
+      ({
+        connId,
+        socket: socket as unknown as GatewayWsClient["socket"],
+        connect: { role: "operator", scopes: ["operator.read"] } as GatewayWsClient["connect"],
+        usesSharedGatewayAuth: false,
+      }) satisfies GatewayWsClient;
+    const clients = new Set([
+      createClient("conn-slow", slowSocket),
+      createClient("conn-healthy", healthySocket),
+    ]);
+    const { broadcastToConnIds } = createGatewayBroadcaster({ clients });
+    const context = { broadcastToConnIds, getRuntimeConfig: () => ({}) } as never;
+    const requests = new Map<string, RealtimeTranscriptionSessionCreateRequest>();
+    const createSession = (connId: string) =>
+      createTalkTranscriptionRelaySession({
+        context,
+        connId,
+        provider: createTranscriptionProvider(createSttSessionMock(), (request) => {
+          requests.set(connId, request);
+        }),
+        providerConfig: {},
+      });
+    const slowSession = createSession("conn-slow");
+    const healthySession = createSession("conn-healthy");
+    await Promise.resolve();
+    const slowRequest = requests.get("conn-slow");
+    const healthyRequest = requests.get("conn-healthy");
+    if (!slowRequest || !healthyRequest) {
+      throw new Error("expected transcription providers for both browser connections");
+    }
+
+    try {
+      slowRequest.onSpeechStart?.();
+      healthyRequest.onSpeechStart?.();
+      slowSocket.bufferedAmount = MAX_BUFFERED_BYTES + 1;
+      const slowFramesBeforePartial = slowSocket.send.mock.calls.length;
+
+      slowRequest.onPartial?.("slow draft");
+      healthyRequest.onPartial?.("healthy draft");
+
+      expect(slowSocket.send).toHaveBeenCalledTimes(slowFramesBeforePartial);
+      expect(slowSocket.close).not.toHaveBeenCalled();
+
+      slowRequest.onTranscript?.("slow final");
+      healthyRequest.onTranscript?.("healthy final");
+
+      expect(slowSocket.close).toHaveBeenCalledWith(1008, "slow consumer");
+      const healthyFrames = healthySocket.send.mock.calls.map(
+        ([frame]) => JSON.parse(frame) as { event: string; payload: unknown },
+      );
+      expect(healthyFrames).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: "talk.event",
+            payload: expect.objectContaining({ type: "partial", text: "healthy draft" }),
+          }),
+          expect.objectContaining({
+            event: "talk.event",
+            payload: expect.objectContaining({
+              type: "transcript",
+              text: "healthy final",
+              final: true,
+            }),
+          }),
+        ]),
+      );
+    } finally {
+      slowSocket.bufferedAmount = 0;
+      stopTalkTranscriptionRelaySession({
+        transcriptionSessionId: slowSession.transcriptionSessionId,
+        connId: "conn-slow",
+      });
+      stopTalkTranscriptionRelaySession({
+        transcriptionSessionId: healthySession.transcriptionSessionId,
+        connId: "conn-healthy",
+      });
+    }
   });
 
   it("closes only transcription relays owned by the disconnected connection", async () => {

--- a/src/gateway/talk-transcription-relay.ts
+++ b/src/gateway/talk-transcription-relay.ts
@@ -160,7 +160,9 @@ function broadcastToOwner(
   connId: string,
   event: TalkTranscriptionRelayEvent,
 ): void {
-  context.broadcastToConnIds(TRANSCRIPTION_EVENT, event, new Set([connId]), { dropIfSlow: true });
+  context.broadcastToConnIds(TRANSCRIPTION_EVENT, event, new Set([connId]), {
+    dropIfSlow: event.type === "inputAudio" || event.type === "partial",
+  });
 }
 
 function ensureTranscriptionTurn(session: TranscriptionRelaySession): string {


### PR DESCRIPTION
## What Problem This Solves

Voice-session terminal transcript, error, close, and final tool-result events could silently disappear when a Gateway WebSocket client was under backpressure.

## Why This Change Was Made

The Gateway broadcast owner classifies the complete event once: terminal voice outcomes are durable, while partial transcripts, audio, and progress remain intentionally lossy.

## User Impact

Voice operators receive the final transcript or explicit failure; overloaded clients close visibly rather than losing terminal outcomes silently.

## Real Gateway / WebSocket Proof

The exact committed candidate was exercised through a genuine isolated Gateway, two authenticated real TCP/WebSocket clients, real `talk.session.create` RPC calls, and a local in-memory transcription provider:

```text
slow-client server socket buffered bytes: 52428801
transient draft under pressure: dropped; socket remains open
terminal transcript on slow client: actual WebSocket close 1008, reason "slow consumer"
healthy client: received final transcript over actual WebSocket
healthy client: received provider error and terminal close event
real Gateway/WebSocket scenario: 1/1 passed
```

Both clients communicated with the real server over the network loopback boundary; only the upstream transcription provider was intentionally local. No provider credentials or user channels were used. Testbox run: https://github.com/openclaw/openclaw/actions/runs/30785523517

## Regression Evidence

- node scripts/run-vitest.mjs src/gateway/talk-realtime-relay.test.ts src/gateway/talk-transcription-relay.test.ts — 70/70 passing.
- Exact-head hosted CI and openclaw/ci-gate passed.
- Independent structured Sol/high review clean, confidence 0.94; production delta -4 lines.
- ClawSweeper rank-up satisfied by actual overloaded/healthy real-client wire evidence above.
- No Gateway protocol, authentication, or configuration changes.
- AI-assisted implementation and independently verified source review.
