### PR TITLE
improve(tests): reuse TUI inference fixture

### DIFF
--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -1,5 +1,5 @@
 // OpenClaw TUI backend tests cover rescue status integration with the TUI backend.
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import * as preparedModelCatalog from "../agents/prepared-model-catalog.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -71,11 +71,22 @@ function configSnapshot(config: OpenClawConfig) {
   };
 }
 
+let sharedVerifiedFixture: Awaited<
+  ReturnType<typeof createSystemAgentVerifiedInferenceTestFixture>
+>;
+
+beforeAll(async () => {
+  sharedVerifiedFixture = await createSystemAgentVerifiedInferenceTestFixture(verifiedConfig);
+});
+
 async function createVerifiedTuiOptions(
   deps: SystemAgentCommandDeps = {},
   config: OpenClawConfig = verifiedConfig,
 ) {
-  const fixture = await createSystemAgentVerifiedInferenceTestFixture(config);
+  const fixture =
+    config === verifiedConfig
+      ? sharedVerifiedFixture
+      : await createSystemAgentVerifiedInferenceTestFixture(config);
   return {
     verifiedInference: fixture.binding,
     deps: {
@@ -102,7 +113,7 @@ describe("runSystemAgentTui", () => {
     const planWithAssistant = vi.fn(async () => ({ reply: "ready" }));
     const runTui = vi.fn(async () => ({ exitReason: "exit" as const }));
     const runChannelsAdd = vi.fn(async () => undefined);
-    const fixture = await createSystemAgentVerifiedInferenceTestFixture(verifiedConfig);
+    const fixture = sharedVerifiedFixture;
     const options: SystemAgentTuiOptions = {
       verifiedInference: fixture.binding,
       deps: { loadOverview },


### PR DESCRIPTION
## What Problem This Solves

The OpenClaw TUI backend suite rebuilt the same verified inference binding for nearly every case, even though the file is isolated and most cases use the identical immutable default config. In exact full CI, the ten-test file consumed 12.770 seconds.

## Why This Change Was Made

Create the default verified fixture once per isolated test file and reuse it for default-config cases. The two cases with distinct model/thinking configs continue to build separate verified bindings, and every TUI backend call still performs the production route checks.

## User Impact

No runtime or user-visible behavior changes. The TUI integration tests retain their assertions and inference verification while avoiding repeated fixture discovery.

## Evidence

- Baseline exact full-run timing: 12.770s for 10 tests ([run 30782354057, job 91589456436](https://github.com/openclaw/openclaw/actions/runs/30782354057/job/91589456436)).
- One test file, +14/-3; production LOC delta: 0.
- Formatting, targeted Oxlint, `git diff --check`, and autoreview are clean.
- Fresh current-head CI: 10/10 tests passed; test-body time improved from 12.770s to 3.516s, saving 9.254s (72.5%) ([run 30783008019](https://github.com/openclaw/openclaw/actions/runs/30783008019)).
- Lint, test/prod types, changed-boundary checks, and the aggregate PR gate passed.
- Local execution was unavailable because the linked worktree has no dependency install.
