### PR TITLE
test(openai): centralize GPT-Live delegation contracts

### DIFF
--- a/extensions/openai/realtime-quicksilver-delegation.test.ts
+++ b/extensions/openai/realtime-quicksilver-delegation.test.ts
@@ -172,7 +172,7 @@ describe("GPT-Live sideband protocol", () => {
   });
 
   it("wraps delegated input and appends the raw speakable result", async () => {
-    const runAgentConsult = vi.fn(async ({ prompt }: { prompt: string }) => ({
+    const runAgentConsult = vi.fn<ConsultRunner>(async ({ prompt }) => ({
       text: `Result for ${prompt}`,
     }));
     const { controller, socket } = createDelegationHarness({ runAgentConsult });
@@ -201,7 +201,7 @@ describe("GPT-Live sideband protocol", () => {
   });
 
   it("bounds and chunks delegation output before sideband sends", async () => {
-    const runAgentConsult = vi.fn(async () => ({ text: "x".repeat(10_000) }));
+    const runAgentConsult = vi.fn<ConsultRunner>(async () => ({ text: "x".repeat(10_000) }));
     const { controller, socket } = createDelegationHarness({ runAgentConsult });
 
     delegate(controller, "delegation-large", "summarize everything");
@@ -222,7 +222,7 @@ describe("GPT-Live sideband protocol", () => {
   });
 
   it("consumes bounded transcript context once and in event order", async () => {
-    const runAgentConsult = vi.fn(async () => ({ text: "Done" }));
+    const runAgentConsult = vi.fn<ConsultRunner>(async () => ({ text: "Done" }));
     const { controller } = createDelegationHarness({ runAgentConsult });
     controller.handleEvent({ kind: "transcript-delta", role: "user", text: "hel" });
     controller.handleEvent({ kind: "transcript-done", role: "user", text: "hello" });
@@ -244,8 +244,8 @@ describe("GPT-Live sideband protocol", () => {
 
   it("aborts stale work and retains only the latest pending delegation", async () => {
     const signals: AbortSignal[] = [];
-    const runAgentConsult = vi.fn(
-      async ({ signal }: { signal?: AbortSignal }) =>
+    const runAgentConsult = vi.fn<ConsultRunner>(
+      async ({ signal }) =>
         await new Promise<{ text: string }>((_resolve, reject) => {
           signals.push(signal as AbortSignal);
           signal?.addEventListener(
@@ -269,7 +269,7 @@ describe("GPT-Live sideband protocol", () => {
   });
 
   it("keeps transcript context when it skips an empty delegation", async () => {
-    const runAgentConsult = vi.fn(async () => ({ text: "Done" }));
+    const runAgentConsult = vi.fn<ConsultRunner>(async () => ({ text: "Done" }));
     const { controller } = createDelegationHarness({ runAgentConsult });
     controller.handleEvent({ kind: "transcript-done", role: "user", text: "hello" });
 
@@ -284,7 +284,7 @@ describe("GPT-Live sideband protocol", () => {
   });
 
   it("returns only a fixed speakable failure when the delegated agent fails", async () => {
-    const runAgentConsult = vi.fn(async () => {
+    const runAgentConsult = vi.fn<ConsultRunner>(async () => {
       throw new Error("workspace unavailable");
     });
     const { controller, logger, socket } = createDelegationHarness({ runAgentConsult });
@@ -321,7 +321,7 @@ describe("GPT-Live sideband protocol", () => {
   it("suppresses host cancellation and stops accepting work after teardown", async () => {
     const abortError = new Error("The operation was aborted");
     abortError.name = "AbortError";
-    const runAgentConsult = vi.fn(async () => {
+    const runAgentConsult = vi.fn<ConsultRunner>(async () => {
       throw abortError;
     });
     const { controller, logger, socket } = createDelegationHarness({

--- a/extensions/openai/realtime-quicksilver-delegation.test.ts
+++ b/extensions/openai/realtime-quicksilver-delegation.test.ts
@@ -1,16 +1,45 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { OpenAIQuicksilverDelegationController } from "./realtime-quicksilver-delegation-controller.js";
 import {
   boundOpenAIQuicksilverDelegationResult,
   chunkOpenAIQuicksilverAppendText,
   parseOpenAIQuicksilverEvent,
 } from "./realtime-quicksilver-wire.js";
-import {
-  createRequest,
-  createResponseHarness,
-  parseSent,
-  emitSideband,
-  createBroker,
-} from "./realtime-quicksilver.test-helpers.js";
+import { FakeSocket, parseSent } from "./realtime-quicksilver.test-helpers.js";
+
+type ConsultRunner = (params: {
+  prompt: string;
+  signal?: AbortSignal;
+}) => Promise<{ text: string }>;
+
+function createDelegationHarness(params?: {
+  isCanceledError?: (error: unknown) => boolean;
+  runAgentConsult?: ConsultRunner;
+}) {
+  const socket = new FakeSocket("manual");
+  socket.readyState = 1;
+  const logger = { debug: vi.fn(), warn: vi.fn() };
+  const onFatalError = vi.fn();
+  const sessionController = new AbortController();
+  const runAgentConsult = params?.runAgentConsult ?? vi.fn(async () => ({ text: "Done" }));
+  const controller = new OpenAIQuicksilverDelegationController({
+    getSocket: () => socket,
+    isCanceledError: params?.isCanceledError,
+    logger,
+    onFatalError,
+    runAgentConsult,
+    signal: sessionController.signal,
+  });
+  return { controller, logger, onFatalError, runAgentConsult, sessionController, socket };
+}
+
+function delegate(
+  controller: OpenAIQuicksilverDelegationController,
+  id: string,
+  prompt: string,
+): void {
+  controller.handleEvent({ kind: "delegation", id, prompt });
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -146,365 +175,167 @@ describe("GPT-Live sideband protocol", () => {
     const runAgentConsult = vi.fn(async ({ prompt }: { prompt: string }) => ({
       text: `Result for ${prompt}`,
     }));
-    const { realtime, sockets } = createBroker({ runAgentConsult });
-    try {
-      const reservation = await realtime.broker.createBrowserSession(
-        {
-          providerConfig: {},
-          model: "gpt-live-1",
-          runAgentConsult,
-        },
-        { type: "api-key", token: "platform-key" },
-      );
-      if (reservation.transport !== "webrtc") {
-        throw new Error("Expected WebRTC reservation");
-      }
-      const response = createResponseHarness();
-      await realtime.handler(createRequest({ token: reservation.clientSecret }), response.res);
-      const socket = sockets[0];
-      if (!socket) {
-        throw new Error("Expected sideband socket");
-      }
-      expect(socket.sent).toEqual([]);
-      socket.emit(
-        "message",
-        Buffer.from(
-          JSON.stringify({
-            type: "delegation.created",
-            item: {
-              type: "delegation",
-              target: "client",
-              id: "delegation-1",
-              content: [
-                { type: "input_text", text: "first " },
-                { type: "input_text", text: "task" },
-              ],
-            },
-          }),
-        ),
-        false,
-      );
-      await vi.waitFor(() =>
-        expect(runAgentConsult).toHaveBeenCalledWith({
-          prompt: "<realtime_delegation>\n  <input>first task</input>\n</realtime_delegation>",
-          signal: expect.any(AbortSignal),
-        }),
-      );
-      await vi.waitFor(() =>
-        expect(parseSent(socket)).toContainEqual({
-          type: "delegation.context.append",
-          delegation_item_id: "delegation-1",
-          channel: "speakable",
-          content: [
-            {
-              type: "input_text",
-              text: "Result for <realtime_delegation>\n  <input>first task</input>\n</realtime_delegation>",
-            },
-          ],
-        }),
-      );
-      await realtime.cleanup();
-      expect(parseSent(socket).at(-1)).toEqual({ type: "session.close" });
-      expect(socket.closed).toBe(true);
-    } finally {
-      await realtime.cleanup();
-    }
+    const { controller, socket } = createDelegationHarness({ runAgentConsult });
+
+    delegate(controller, "delegation-1", "first task");
+
+    await vi.waitFor(() =>
+      expect(runAgentConsult).toHaveBeenCalledWith({
+        prompt: "<realtime_delegation>\n  <input>first task</input>\n</realtime_delegation>",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(parseSent(socket)).toContainEqual({
+        type: "delegation.context.append",
+        delegation_item_id: "delegation-1",
+        channel: "speakable",
+        content: [
+          {
+            type: "input_text",
+            text: "Result for <realtime_delegation>\n  <input>first task</input>\n</realtime_delegation>",
+          },
+        ],
+      }),
+    );
   });
 
-  it("bounds browser delegation output before sideband sends", async () => {
+  it("bounds and chunks delegation output before sideband sends", async () => {
     const runAgentConsult = vi.fn(async () => ({ text: "x".repeat(10_000) }));
-    const { realtime, sockets } = createBroker({ runAgentConsult });
-    try {
-      const reservation = await realtime.broker.createBrowserSession(
-        { providerConfig: {}, model: "gpt-live-1", runAgentConsult },
-        { type: "api-key", token: "platform-key" },
-      );
-      if (reservation.transport !== "webrtc") {
-        throw new Error("Expected WebRTC reservation");
-      }
-      await realtime.handler(
-        createRequest({ token: reservation.clientSecret }),
-        createResponseHarness().res,
-      );
-      const socket = sockets[0];
-      if (!socket) {
-        throw new Error("Expected sideband socket");
-      }
+    const { controller, socket } = createDelegationHarness({ runAgentConsult });
 
-      emitSideband(socket, {
-        type: "delegation.created",
-        item: {
-          type: "delegation",
-          target: "client",
-          id: "delegation-large",
-          content: [{ type: "input_text", text: "summarize everything" }],
-        },
-      });
+    delegate(controller, "delegation-large", "summarize everything");
 
-      await vi.waitFor(() => {
-        const appends = parseSent(socket).filter(
-          (event) => event.type === "delegation.context.append",
-        );
-        expect(appends.length).toBeGreaterThan(0);
-        expect(appends.length).toBeLessThanOrEqual(11);
-        expect(
-          appends
-            .map((event) => (event.content as Array<{ text: string }>)[0]?.text ?? "")
-            .join(""),
-        ).toMatch(/^x+ \[truncated\]$/);
-      });
-    } finally {
-      await realtime.cleanup();
-    }
+    await vi.waitFor(() => expect(socket.sent.length).toBeGreaterThan(0));
+    const appends = parseSent(socket).filter((event) => event.type === "delegation.context.append");
+    expect(appends.length).toBeLessThanOrEqual(11);
+    expect(
+      appends.map((event) => (event.content as Array<{ text: string }>)[0]?.text ?? "").join(""),
+    ).toMatch(/^x+ \[truncated\]$/);
+    expect(
+      appends.every((event) =>
+        (event.content as Array<{ text: string }>).every(
+          ({ text }) => Buffer.byteLength(text, "utf8") <= 500,
+        ),
+      ),
+    ).toBe(true);
   });
 
-  it("adds the in-call transcript delta to each delegation and resets it", async () => {
-    const runAgentConsult = vi.fn(async (_params: { prompt: string; signal?: AbortSignal }) => ({
-      text: "Done",
-    }));
-    const { realtime, sockets } = createBroker({ runAgentConsult });
-    try {
-      const reservation = await realtime.broker.createBrowserSession(
-        { providerConfig: {}, model: "gpt-live-1-codex", runAgentConsult },
-        { type: "api-key", token: "platform-key" },
-      );
-      if (reservation.transport !== "webrtc") {
-        throw new Error("Expected WebRTC reservation");
-      }
-      await realtime.handler(
-        createRequest({ token: reservation.clientSecret }),
-        createResponseHarness().res,
-      );
-      const socket = sockets[0];
-      if (!socket) {
-        throw new Error("Expected sideband socket");
-      }
+  it("consumes bounded transcript context once and in event order", async () => {
+    const runAgentConsult = vi.fn(async () => ({ text: "Done" }));
+    const { controller } = createDelegationHarness({ runAgentConsult });
+    controller.handleEvent({ kind: "transcript-delta", role: "user", text: "hel" });
+    controller.handleEvent({ kind: "transcript-done", role: "user", text: "hello" });
+    controller.handleEvent({ kind: "transcript-delta", role: "assistant", text: "ack" });
 
-      emitSideband(socket, { type: "input_transcript.added", item: { text: "hel" } });
-      emitSideband(socket, {
-        type: "turn.done",
-        turn: { role: "user", transcript: "hello" },
-      });
-      emitSideband(socket, { type: "output_transcript.added", item: { text: "ack" } });
-      emitSideband(socket, {
-        type: "delegation.created",
-        item: {
-          type: "delegation",
-          target: "client",
-          id: "delegation-1",
-          content: [{ type: "input_text", text: "check weather" }],
-        },
-      });
-      await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(1));
-      expect(runAgentConsult.mock.calls[0]?.[0]?.prompt).toBe(
-        "<realtime_delegation>\n  <input>check weather</input>\n  <transcript_delta>user: hello\nassistant: ack</transcript_delta>\n</realtime_delegation>",
-      );
+    delegate(controller, "delegation-1", "check weather");
+    await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(1));
+    expect(runAgentConsult.mock.calls[0]?.[0].prompt).toBe(
+      "<realtime_delegation>\n  <input>check weather</input>\n  <transcript_delta>user: hello\nassistant: ack</transcript_delta>\n</realtime_delegation>",
+    );
 
-      emitSideband(socket, {
-        type: "turn.done",
-        turn: { role: "user", transcript: "second context" },
-      });
-      emitSideband(socket, {
-        type: "delegation.created",
-        item: {
-          type: "delegation",
-          target: "client",
-          id: "delegation-2",
-          content: [{ type: "input_text", text: "next task" }],
-        },
-      });
-      await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(2));
-      expect(runAgentConsult.mock.calls[1]?.[0]?.prompt).toBe(
-        "<realtime_delegation>\n  <input>next task</input>\n  <transcript_delta>user: second context</transcript_delta>\n</realtime_delegation>",
-      );
-    } finally {
-      await realtime.cleanup();
-    }
+    controller.handleEvent({ kind: "transcript-done", role: "user", text: "second context" });
+    delegate(controller, "delegation-2", "next task");
+    await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(2));
+    expect(runAgentConsult.mock.calls[1]?.[0].prompt).toBe(
+      "<realtime_delegation>\n  <input>next task</input>\n  <transcript_delta>user: second context</transcript_delta>\n</realtime_delegation>",
+    );
   });
 
-  it("aborts the in-flight consult when a newer delegation arrives", async () => {
+  it("aborts stale work and retains only the latest pending delegation", async () => {
     const signals: AbortSignal[] = [];
-    const resolutions: Array<(value: { text: string }) => void> = [];
     const runAgentConsult = vi.fn(
-      ({ signal }: { prompt: string; signal?: AbortSignal }) =>
-        new Promise<{ text: string }>((resolve) => {
-          if (signal) {
-            signals.push(signal);
-          }
-          resolutions.push(resolve);
+      async ({ signal }: { signal?: AbortSignal }) =>
+        await new Promise<{ text: string }>((_resolve, reject) => {
+          signals.push(signal as AbortSignal);
+          signal?.addEventListener(
+            "abort",
+            () => reject(signal.reason instanceof Error ? signal.reason : new Error("aborted")),
+            { once: true },
+          );
         }),
     );
-    const { realtime, sockets } = createBroker({ runAgentConsult });
-    try {
-      const reservation = await realtime.broker.createBrowserSession(
-        { providerConfig: {}, model: "gpt-live-1-codex", runAgentConsult },
-        { type: "api-key", token: "platform-key" },
-      );
-      if (reservation.transport !== "webrtc") {
-        throw new Error("Expected WebRTC reservation");
-      }
-      await realtime.handler(
-        createRequest({ token: reservation.clientSecret }),
-        createResponseHarness().res,
-      );
-      const socket = sockets[0];
-      if (!socket) {
-        throw new Error("Expected sideband socket");
-      }
+    const { controller } = createDelegationHarness({ runAgentConsult });
 
-      for (const [id, text] of [
-        ["delegation-1", "first"],
-        ["delegation-2", "second"],
-      ] as const) {
-        emitSideband(socket, {
-          type: "delegation.created",
-          item: {
-            type: "delegation",
-            target: "client",
-            id,
-            content: [{ type: "input_text", text }],
-          },
-        });
-        if (id.endsWith("1")) {
-          await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(1));
-        }
-      }
+    delegate(controller, "delegation-1", "first task");
+    delegate(controller, "delegation-2", "second task");
+    delegate(controller, "delegation-3", "latest task");
 
-      expect(signals[0]?.aborted).toBe(true);
-      expect(runAgentConsult).toHaveBeenCalledTimes(1);
-      resolutions[0]?.({ text: "stale" });
-      await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(2));
-      expect(signals[1]?.aborted).toBe(false);
-      resolutions[1]?.({ text: "fresh" });
-      await vi.waitFor(() =>
-        expect(parseSent(socket)).toContainEqual(
-          expect.objectContaining({
-            delegation_item_id: "delegation-2",
-            channel: "speakable",
-          }),
-        ),
-      );
-      expect(parseSent(socket)).not.toContainEqual(
-        expect.objectContaining({ delegation_item_id: "delegation-1" }),
-      );
-    } finally {
-      await realtime.cleanup();
-    }
+    expect(signals[0]?.aborted).toBe(true);
+    await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(2));
+    expect(runAgentConsult.mock.calls[1]?.[0].prompt).toContain("latest task");
+    expect(runAgentConsult.mock.calls[1]?.[0].prompt).not.toContain("second task");
+    controller.stop(new Error("test complete"));
   });
 
-  it("skips empty delegations and keeps their transcript for the next one", async () => {
-    const runAgentConsult = vi.fn(async (_params: { prompt: string; signal?: AbortSignal }) => ({
-      text: "Done",
-    }));
-    const { realtime, sockets } = createBroker({ runAgentConsult });
-    try {
-      const reservation = await realtime.broker.createBrowserSession(
-        { providerConfig: {}, model: "gpt-live-1-codex", runAgentConsult },
-        { type: "api-key", token: "platform-key" },
-      );
-      if (reservation.transport !== "webrtc") {
-        throw new Error("Expected WebRTC reservation");
-      }
-      await realtime.handler(
-        createRequest({ token: reservation.clientSecret }),
-        createResponseHarness().res,
-      );
-      const socket = sockets[0];
-      if (!socket) {
-        throw new Error("Expected sideband socket");
-      }
-      emitSideband(socket, {
-        type: "turn.done",
-        turn: { role: "user", transcript: "hello" },
-      });
-      emitSideband(socket, {
-        type: "delegation.created",
-        item: {
-          type: "delegation",
-          target: "client",
-          id: "empty",
-          content: [{ type: "input_text", text: "  " }],
-        },
-      });
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 0);
-      });
-      expect(runAgentConsult).not.toHaveBeenCalled();
+  it("keeps transcript context when it skips an empty delegation", async () => {
+    const runAgentConsult = vi.fn(async () => ({ text: "Done" }));
+    const { controller } = createDelegationHarness({ runAgentConsult });
+    controller.handleEvent({ kind: "transcript-done", role: "user", text: "hello" });
 
-      emitSideband(socket, {
-        type: "delegation.created",
-        item: {
-          type: "delegation",
-          target: "client",
-          id: "delegation-1",
-          content: [{ type: "input_text", text: "check weather" }],
-        },
-      });
-      await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(1));
-      expect(runAgentConsult.mock.calls[0]?.[0]?.prompt).toBe(
-        "<realtime_delegation>\n  <input>check weather</input>\n  <transcript_delta>user: hello</transcript_delta>\n</realtime_delegation>",
-      );
-    } finally {
-      await realtime.cleanup();
-    }
+    delegate(controller, "empty", "  ");
+    expect(runAgentConsult).not.toHaveBeenCalled();
+    delegate(controller, "delegation-1", "check weather");
+
+    await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(1));
+    expect(runAgentConsult.mock.calls[0]?.[0].prompt).toContain(
+      "<transcript_delta>user: hello</transcript_delta>",
+    );
   });
 
-  it("returns a speakable failure when the delegated agent fails", async () => {
+  it("returns only a fixed speakable failure when the delegated agent fails", async () => {
     const runAgentConsult = vi.fn(async () => {
       throw new Error("workspace unavailable");
     });
-    const { realtime, sockets, logger } = createBroker({ runAgentConsult });
-    try {
-      const reservation = await realtime.broker.createBrowserSession(
-        { providerConfig: {}, model: "gpt-live-1", runAgentConsult },
-        { type: "api-key", token: "platform-key" },
-      );
-      if (reservation.transport !== "webrtc") {
-        throw new Error("Expected WebRTC reservation");
-      }
-      await realtime.handler(
-        createRequest({ token: reservation.clientSecret }),
-        createResponseHarness().res,
-      );
-      const socket = sockets[0];
-      if (!socket) {
-        throw new Error("Expected sideband socket");
-      }
-      socket.emit(
-        "message",
-        Buffer.from(
-          JSON.stringify({
-            type: "delegation.created",
-            item: {
-              type: "delegation",
-              target: "client",
-              id: "delegation-failed",
-              content: [{ type: "input_text", text: "do work" }],
-            },
-          }),
-        ),
-        false,
-      );
-      await vi.waitFor(() => {
-        expect(parseSent(socket)).toContainEqual(
-          expect.objectContaining({
-            type: "delegation.context.append",
-            delegation_item_id: "delegation-failed",
-            channel: "speakable",
-            content: [
-              {
-                type: "input_text",
-                text: "The agent task failed. Tell the user it did not complete and offer to try again.",
-              },
-            ],
-          }),
-        );
-      });
-      // The raw failure detail must stay in Gateway logs, never on the provider sideband.
-      expect(JSON.stringify(parseSent(socket))).not.toContain("workspace unavailable");
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("workspace unavailable"));
-    } finally {
-      await realtime.cleanup();
-    }
+    const { controller, logger, socket } = createDelegationHarness({ runAgentConsult });
+
+    delegate(controller, "delegation-failed", "do work");
+
+    await vi.waitFor(() => expect(socket.sent.length).toBeGreaterThan(0));
+    expect(parseSent(socket)).toContainEqual(
+      expect.objectContaining({
+        delegation_item_id: "delegation-failed",
+        channel: "speakable",
+        content: [
+          {
+            type: "input_text",
+            text: "The agent task failed. Tell the user it did not complete and offer to try again.",
+          },
+        ],
+      }),
+    );
+    expect(socket.sent.join("\n")).not.toContain("workspace unavailable");
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("workspace unavailable"));
+  });
+
+  it("surfaces fatal sideband errors to the lifecycle owner", () => {
+    const { controller, logger, onFatalError } = createDelegationHarness();
+    controller.handleEvent({ kind: "error", message: "token expired", fatalAuth: true });
+
+    expect(logger.warn).toHaveBeenCalledWith("OpenAI GPT-Live sideband error: token expired");
+    expect(onFatalError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "OpenAI GPT-Live sideband error: token expired" }),
+    );
+  });
+
+  it("suppresses host cancellation and stops accepting work after teardown", async () => {
+    const abortError = new Error("The operation was aborted");
+    abortError.name = "AbortError";
+    const runAgentConsult = vi.fn(async () => {
+      throw abortError;
+    });
+    const { controller, logger, socket } = createDelegationHarness({
+      isCanceledError: (error) => error === abortError,
+      runAgentConsult,
+    });
+
+    delegate(controller, "delegation-cancelled", "stop this");
+    await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledOnce());
+    expect(socket.sent).toEqual([]);
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    controller.stop(new Error("session closed"));
+    delegate(controller, "delegation-late", "late task");
+    expect(runAgentConsult).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -60,56 +60,8 @@ type TestableAudioPeer = {
 };
 
 type TestableGatewayBridge = {
-  delegations?: {
-    handleEvent(event: { kind: "delegation"; id: string; prompt: string }): void;
-  };
   pendingAudio: Buffer;
-  sideband?: {
-    socket: FakeSocket;
-    requestIds: { realtimeSessionId: string; sessionId: string; threadId: string };
-  };
 };
-
-function delegate(testBridge: TestableGatewayBridge, id: string, prompt: string): void {
-  const delegations = testBridge.delegations;
-  if (!delegations) {
-    throw new Error("Expected delegation controller");
-  }
-  delegations.handleEvent({ kind: "delegation", id, prompt });
-}
-
-function createDelegationBridge(
-  runAgentConsult: (params: { prompt: string; signal?: AbortSignal }) => Promise<{ text: string }>,
-) {
-  const logger = { debug: vi.fn(), warn: vi.fn() };
-  const bridge = new OpenAIQuicksilverGatewayBridge({
-    providerConfig: {},
-    model: "gpt-live-1-codex",
-    voice: "marin",
-    audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
-    onAudio: vi.fn(),
-    onClearAudio: vi.fn(),
-    runAgentConsult,
-    logger,
-    resolveAuth: vi.fn(async () => ({
-      type: "oauth" as const,
-      token: "oauth-token",
-      accountId: "account-1",
-    })),
-  });
-  const socket = new FakeSocket("manual");
-  socket.readyState = 1;
-  const testBridge = bridge as unknown as TestableGatewayBridge;
-  testBridge.sideband = {
-    socket,
-    requestIds: {
-      realtimeSessionId: "realtime-session",
-      sessionId: "session",
-      threadId: "thread",
-    },
-  };
-  return { bridge, logger, socket, testBridge };
-}
 
 async function createInboundAudioHarness(params?: { onRtpPacket?: () => void }) {
   const { RtpHeader, RtpPacket } = await import("werift");
@@ -752,78 +704,6 @@ describe("GPT-Live gateway relay bridge", () => {
     await expect(connection).rejects.toThrow("sideband overflow observed");
     expect(socket.closeCode).toBe(1009);
     expect(socket.closeReason).toBe("sideband startup buffer exceeded");
-  });
-
-  it("does not append failure text when the host cancels a delegation", async () => {
-    const abortError = new Error("The operation was aborted");
-    abortError.name = "AbortError";
-    const runAgentConsult = vi.fn(async () => {
-      throw abortError;
-    });
-    const { bridge, logger, socket, testBridge } = createDelegationBridge(runAgentConsult);
-    try {
-      delegate(testBridge, "delegation-cancelled", "stop this");
-      await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledOnce());
-
-      expect(socket.sent).toEqual([]);
-      expect(logger.warn).not.toHaveBeenCalled();
-    } finally {
-      bridge.close();
-    }
-  });
-
-  it("keeps only the latest delegation when the superseded consult rejects on abort", async () => {
-    const resolvers: Array<(value: { text: string }) => void> = [];
-    const signals: AbortSignal[] = [];
-    const runAgentConsult = vi.fn(
-      async ({ signal }: { prompt: string; signal?: AbortSignal }) =>
-        await new Promise<{ text: string }>((resolve, reject) => {
-          signals.push(signal as AbortSignal);
-          resolvers.push(resolve);
-          signal?.addEventListener(
-            "abort",
-            () => {
-              reject(signal.reason instanceof Error ? signal.reason : new Error("aborted"));
-            },
-            { once: true },
-          );
-        }),
-    );
-    const { bridge, socket, testBridge } = createDelegationBridge(runAgentConsult);
-    try {
-      delegate(testBridge, "delegation-1", "first task");
-      delegate(testBridge, "delegation-2", "second task");
-      delegate(testBridge, "delegation-3", "latest task");
-
-      expect(runAgentConsult).toHaveBeenCalledOnce();
-      expect(signals[0]?.aborted).toBe(true);
-      await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(2));
-      expect(runAgentConsult.mock.calls[1]?.[0].prompt).toContain("latest task");
-      expect(runAgentConsult.mock.calls[1]?.[0].prompt).not.toContain("second task");
-
-      resolvers[1]?.({ text: "latest result" });
-      await vi.waitFor(() =>
-        expect(parseSent(socket)).toContainEqual({
-          type: "delegation.context.append",
-          delegation_item_id: "delegation-3",
-          channel: "speakable",
-          content: [{ type: "input_text", text: "latest result" }],
-        }),
-      );
-      expect(socket.closed).toBe(false);
-    } finally {
-      bridge.close();
-    }
-  });
-
-  it("ignores delegation work after the bridge closes", () => {
-    const runAgentConsult = vi.fn(async () => ({ text: "unused" }));
-    const { bridge, testBridge } = createDelegationBridge(runAgentConsult);
-
-    bridge.close();
-    delegate(testBridge, "delegation-late", "late task");
-
-    expect(runAgentConsult).not.toHaveBeenCalled();
   });
 
   it("bounds peer creation and closes a peer that resolves after the deadline", async () => {


### PR DESCRIPTION
## What Problem

GPT-Live delegation contracts were still tested through duplicated browser-broker and provider-specific gateway-bridge scaffolding. That repeated transport setup obscured the controller-owned behavior and left equivalent cancellation, latest-only scheduling, and teardown cases spread across multiple test owners.

## Why

- Exercise delegation behavior directly through `OpenAIGptLiveDelegationController`: prompt wrapping, transcript ordering/reset, latest-only scheduling, 500-byte append chunking, bounded output, safe failures, fatal errors, cancellation, and teardown.
- Remove bridge tests that mutated transport-specific delegation and sideband fields to restate the same controller contract.
- Retain the real gateway end-to-end sideband/RTP/teardown integration coverage; browser transport/session integration remains in its dedicated session tests.
- This follows the directly inspected public Codex realtime contract for delegation parsing, bounded context appends, and latest-only handoff ownership.

## User Impact

No production behavior changes. The GPT-Live test suite has one canonical owner for delegation semantics and 289 fewer net test lines, while retaining transport wiring proof.

Production delta: `0` lines. Test delta: `+184/-473` (net `-289`) across two files.

## Evidence

- `pnpm test extensions/openai/realtime-gpt-live-delegation.test.ts extensions/openai/realtime-gpt-live-gateway-bridge.test.ts`: 42 passed, 1 existing Bun-dependent skip.
- Exact-head changed gate passed formatting, extension-test typecheck, lint (0 warnings/errors), boundaries, dead-export checks, and repository ratchets: https://github.com/openclaw/openclaw/actions/runs/30782605513
- Fresh branch autoreview: clean, correctness `0.99`; TruffleHog clean.
- `git diff --check`: clean.

## ClawSweeper Rank-up moves

- **Live GPT-Live proof skipped:** this branch changes test ownership only (`0` production lines/bytes). A live provider session cannot distinguish this refactor from current runtime behavior. The retained gateway integration still exercises real sideband delegation, RTP/audio, append, and teardown wiring, while the dedicated browser session suite retains browser transport coverage.
- **Upstream contract verified directly** against the corresponding public Codex realtime implementation.

