### PR TITLE
refactor(browser): consolidate profile configuration fixtures

### DIFF
--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { BrowserConfig } from "../config/config.js";
+import type { BrowserConfig, BrowserProfileConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
 import {
   getManagedBrowserMissingDisplayError,
@@ -63,6 +63,22 @@ function withEnv<T>(env: Record<string, string | undefined>, fn: () => T): T {
       }
     }
   }
+}
+
+function resolveRequiredProfile(config: BrowserConfig, profileName: string) {
+  const profile = resolveProfile(resolveBrowserConfig(config), profileName);
+  if (!profile) {
+    throw new Error(`Expected resolved browser profile ${profileName}`);
+  }
+  return profile;
+}
+
+function withProfile(
+  name: string,
+  profile: BrowserProfileConfig,
+  root: Omit<BrowserConfig, "profiles"> = {},
+): BrowserConfig {
+  return { ...root, profiles: { [name]: { color: "#FF4500", ...profile } } };
 }
 
 describe("browser config", () => {
@@ -210,36 +226,34 @@ describe("browser config", () => {
     });
   });
 
-  it("expands tilde-prefixed executablePath with the OS home directory", () => {
-    const resolved = resolveBrowserConfig({
-      executablePath: " ~/.local/bin/chromium ",
-    });
-
-    expect(resolved.executablePath).toBe(path.resolve(os.homedir(), ".local/bin/chromium"));
-  });
-
-  it("keeps non-tilde executablePath values unchanged after trimming", () => {
-    const resolved = resolveBrowserConfig({
-      executablePath: " ./local-chromium ",
-    });
-
-    expect(resolved.executablePath).toBe("./local-chromium");
-  });
-
-  it("normalizes blank executablePath to undefined", () => {
-    const resolved = resolveBrowserConfig({
-      executablePath: "   ",
-    });
-
-    expect(resolved.executablePath).toBeUndefined();
-  });
-
-  it("expands a bare ~ executablePath to the OS home directory", () => {
-    const resolved = resolveBrowserConfig({
-      executablePath: "~",
-    });
-
-    expect(resolved.executablePath).toBe(path.resolve(os.homedir()));
+  it.each([
+    {
+      name: "expands tilde-prefixed executablePath with the OS home directory",
+      input: " ~/.local/bin/chromium ",
+      expected: path.resolve(os.homedir(), ".local/bin/chromium"),
+    },
+    {
+      name: "keeps non-tilde executablePath values unchanged after trimming",
+      input: " ./local-chromium ",
+      expected: "./local-chromium",
+    },
+    {
+      name: "normalizes blank executablePath to undefined",
+      input: "   ",
+      expected: undefined,
+    },
+    {
+      name: "expands a bare ~ executablePath to the OS home directory",
+      input: "~",
+      expected: path.resolve(os.homedir()),
+    },
+    {
+      name: "does not expand executablePath values where ~ is not the home prefix",
+      input: "/opt/~chromium/chrome",
+      expected: "/opt/~chromium/chrome",
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(resolveBrowserConfig({ executablePath: input }).executablePath).toBe(expected);
   });
 
   // Windows-only: on POSIX path.resolve treats `\` as a literal character,
@@ -258,14 +272,6 @@ describe("browser config", () => {
       );
     },
   );
-
-  it("does not expand executablePath values where ~ is not the home prefix", () => {
-    const resolved = resolveBrowserConfig({
-      executablePath: "/opt/~chromium/chrome",
-    });
-
-    expect(resolved.executablePath).toBe("/opt/~chromium/chrome");
-  });
 
   it("supports explicit CDP URLs for the default profile", () => {
     const resolved = resolveBrowserConfig({
@@ -290,64 +296,67 @@ describe("browser config", () => {
     expect(remote?.cdpIsLoopback).toBe(false);
   });
 
-  it("inherits attachOnly from global browser config when profile override is not set", () => {
-    const resolved = resolveBrowserConfig({
-      attachOnly: true,
-      profiles: {
-        remote: { cdpUrl: "http://127.0.0.1:9222", color: "#0066CC" },
-      },
-    });
-
-    const remote = resolveProfile(resolved, "remote");
-    expect(remote?.attachOnly).toBe(true);
-  });
-
-  it("allows profile attachOnly to override global browser attachOnly", () => {
-    const resolved = resolveBrowserConfig({
-      attachOnly: false,
-      profiles: {
-        remote: { cdpUrl: "http://127.0.0.1:9222", attachOnly: true, color: "#0066CC" },
-      },
-    });
-
-    const remote = resolveProfile(resolved, "remote");
-    expect(remote?.attachOnly).toBe(true);
-  });
-
-  it("inherits headless from global browser config when profile override is not set", () => {
-    const resolved = resolveBrowserConfig({
-      headless: true,
-      profiles: {
-        remote: { cdpUrl: "http://127.0.0.1:9222", color: "#0066CC" },
-      },
-    });
-
-    const remote = resolveProfile(resolved, "remote");
-    expect(remote?.headless).toBe(true);
-  });
-
-  it("allows profile headless to override global browser headless", () => {
-    const resolved = resolveBrowserConfig({
-      headless: false,
-      profiles: {
-        remote: { cdpUrl: "http://127.0.0.1:9222", headless: true, color: "#0066CC" },
-      },
-    });
-
-    const remote = resolveProfile(resolved, "remote");
-    expect(remote?.headless).toBe(true);
-  });
-
-  it("allows profile headless=false to override global browser headless=true", () => {
-    const resolved = resolveBrowserConfig({
-      headless: true,
-      profiles: {
-        remote: { cdpUrl: "http://127.0.0.1:9222", headless: false, color: "#0066CC" },
-      },
-    });
-
-    const remote = resolveProfile(resolved, "remote");
-    expect(remote?.headless).toBe(false);
+  it.each([
+    {
+      name: "inherits attachOnly from global browser config when profile override is not set",
+      root: { attachOnly: true },
+      profile: {},
+      expected: { attachOnly: true },
+    },
+    {
+      name: "allows profile attachOnly to override global browser attachOnly",
+      root: { attachOnly: false },
+      profile: { attachOnly: true },
+      expected: { attachOnly: true },
+    },
+    {
+      name: "inherits headless from global browser config when profile override is not set",
+      root: { headless: true },
+      profile: {},
+      expected: { headless: true },
+    },
+    {
+      name: "allows profile headless to override global browser headless",
+      root: { headless: false },
+      profile: { headless: true },
+      expected: { headless: true },
+    },
+    {
+      name: "allows profile headless=false to override global browser headless=true",
+      root: { headless: true },
+      profile: { headless: false },
+      expected: { headless: false },
+    },
+    {
+      name: "inherits executablePath from global browser config when profile override is not set",
+      root: { executablePath: "~/bin/chrome-global" },
+      profile: {},
+      expected: { executablePath: path.resolve(os.homedir(), "bin/chrome-global") },
+    },
+    {
+      name: "allows profile executablePath to override global browser executablePath",
+      root: { executablePath: "/usr/bin/chrome-global" },
+      profile: { executablePath: " ~/bin/chrome-profile " },
+      expected: { executablePath: path.resolve(os.homedir(), "bin/chrome-profile") },
+    },
+    {
+      name: "falls back to global executablePath when profile executablePath is blank",
+      root: { executablePath: "/usr/bin/chrome-global" },
+      profile: { executablePath: "   " },
+      expected: { executablePath: "/usr/bin/chrome-global" },
+    },
+  ])("$name", ({ root, profile, expected }) => {
+    expect(
+      resolveRequiredProfile(
+        {
+          ...root,
+          profiles: {
+            remote: { cdpUrl: "http://127.0.0.1:9222", color: "#0066CC", ...profile },
+          },
+        },
+        "remote",
+      ),
+    ).toMatchObject(expected);
   });
 
   describe("managed browser headless mode", () => {
@@ -357,95 +366,56 @@ describe("browser config", () => {
       [BROWSER_HEADLESS_ENV_KEY]: undefined,
     };
 
-    it("falls back to headless for local managed Linux profiles without display", () => {
-      const resolved = resolveBrowserConfig({});
-      const profile = resolveProfile(resolved, "openclaw")!;
-
+    it.each([
+      {
+        name: "falls back to headless for local managed Linux profiles without display",
+        config: {},
+        profileName: "openclaw",
+        expected: { headless: true, source: "linux-display-fallback" },
+      },
+      {
+        name: "does not apply the no-display fallback to remote CDP profiles",
+        config: withProfile("remote", { cdpUrl: "http://10.0.0.42:9222" }),
+        profileName: "remote",
+        expected: { headless: false, source: "default" },
+      },
+      {
+        name: "lets explicit profile headless=false beat the Linux no-display fallback",
+        config: withProfile("openclaw", { cdpPort: 18800, headless: false }, { headless: true }),
+        profileName: "openclaw",
+        expected: { headless: false, source: "profile" },
+      },
+      {
+        name: "lets explicit global headless=false beat the Linux no-display fallback",
+        config: { headless: false },
+        profileName: "openclaw",
+        expected: { headless: false, source: "config" },
+      },
+      {
+        name: "lets OPENCLAW_BROWSER_HEADLESS override profile/global config",
+        config: withProfile("openclaw", { cdpPort: 18800, headless: false }),
+        profileName: "openclaw",
+        headlessEnv: "1",
+        expected: { headless: true, source: "env" },
+      },
+      {
+        name: "lets request-local headless override beat env and profile/global config",
+        config: withProfile("openclaw", { cdpPort: 18800, headless: false }, { headless: false }),
+        profileName: "openclaw",
+        headlessEnv: "0",
+        headlessOverride: true,
+        expected: { headless: true, source: "request" },
+      },
+    ])("$name", ({ config, profileName, headlessEnv, headlessOverride, expected }) => {
+      const resolved = resolveBrowserConfig(config);
+      const profile = resolveProfile(resolved, profileName)!;
       expect(
         resolveManagedBrowserHeadlessMode(resolved, profile, {
+          headlessOverride,
           platform: "linux",
-          env: noDisplayEnv,
+          env: { ...noDisplayEnv, [BROWSER_HEADLESS_ENV_KEY]: headlessEnv },
         }),
-      ).toEqual({ headless: true, source: "linux-display-fallback" });
-    });
-
-    it("does not apply the no-display fallback to remote CDP profiles", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          remote: { cdpUrl: "http://10.0.0.42:9222", color: "#00AA00" },
-        },
-      });
-      const profile = resolveProfile(resolved, "remote")!;
-
-      expect(
-        resolveManagedBrowserHeadlessMode(resolved, profile, {
-          platform: "linux",
-          env: noDisplayEnv,
-        }),
-      ).toEqual({ headless: false, source: "default" });
-    });
-
-    it("lets explicit profile headless=false beat the Linux no-display fallback", () => {
-      const resolved = resolveBrowserConfig({
-        headless: true,
-        profiles: {
-          openclaw: { cdpPort: 18800, color: "#FF4500", headless: false },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw")!;
-
-      expect(
-        resolveManagedBrowserHeadlessMode(resolved, profile, {
-          platform: "linux",
-          env: noDisplayEnv,
-        }),
-      ).toEqual({ headless: false, source: "profile" });
-    });
-
-    it("lets explicit global headless=false beat the Linux no-display fallback", () => {
-      const resolved = resolveBrowserConfig({ headless: false });
-      const profile = resolveProfile(resolved, "openclaw")!;
-
-      expect(
-        resolveManagedBrowserHeadlessMode(resolved, profile, {
-          platform: "linux",
-          env: noDisplayEnv,
-        }),
-      ).toEqual({ headless: false, source: "config" });
-    });
-
-    it("lets OPENCLAW_BROWSER_HEADLESS override profile/global config", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          openclaw: { cdpPort: 18800, color: "#FF4500", headless: false },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw")!;
-
-      expect(
-        resolveManagedBrowserHeadlessMode(resolved, profile, {
-          platform: "linux",
-          env: { ...noDisplayEnv, [BROWSER_HEADLESS_ENV_KEY]: "1" },
-        }),
-      ).toEqual({ headless: true, source: "env" });
-    });
-
-    it("lets request-local headless override beat env and profile/global config", () => {
-      const resolved = resolveBrowserConfig({
-        headless: false,
-        profiles: {
-          openclaw: { cdpPort: 18800, color: "#FF4500", headless: false },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw")!;
-
-      expect(
-        resolveManagedBrowserHeadlessMode(resolved, profile, {
-          headlessOverride: true,
-          platform: "linux",
-          env: { ...noDisplayEnv, [BROWSER_HEADLESS_ENV_KEY]: "0" },
-        }),
-      ).toEqual({ headless: true, source: "request" });
+      ).toEqual(expected);
     });
 
     it("returns an actionable error only when headed mode is explicitly selected", () => {
@@ -496,316 +466,166 @@ describe("browser config", () => {
     });
   });
 
-  it("inherits executablePath from global browser config when profile override is not set", () => {
-    const resolved = resolveBrowserConfig({
-      executablePath: "~/bin/chrome-global",
-      profiles: {
-        remote: { cdpUrl: "http://127.0.0.1:9222", color: "#0066CC" },
+  it.each([
+    {
+      name: "uses base protocol for profiles with only cdpPort",
+      config: withProfile("work", { cdpPort: 18801 }, { cdpUrl: "https://example.com:9443" }),
+      profileName: "work",
+      expected: { cdpUrl: "https://example.com:18801" },
+    },
+    {
+      name: "preserves wss:// cdpUrl with query params for the default profile",
+      config: { cdpUrl: "wss://connect.browserbase.com?apiKey=test-key" },
+      profileName: "openclaw",
+      expected: {
+        cdpUrl: "wss://connect.browserbase.com/?apiKey=test-key",
+        cdpHost: "connect.browserbase.com",
+        cdpPort: 443,
+        cdpIsLoopback: false,
       },
-    });
-
-    const remote = resolveProfile(resolved, "remote");
-    expect(remote?.executablePath).toBe(path.resolve(os.homedir(), "bin/chrome-global"));
-  });
-
-  it("allows profile executablePath to override global browser executablePath", () => {
-    const resolved = resolveBrowserConfig({
-      executablePath: "/usr/bin/chrome-global",
-      profiles: {
-        remote: {
-          cdpUrl: "http://127.0.0.1:9222",
-          executablePath: " ~/bin/chrome-profile ",
-          color: "#0066CC",
-        },
+    },
+    {
+      name: "preserves loopback direct WebSocket cdpUrl for explicit profiles",
+      config: withProfile("localws", {
+        cdpUrl: "ws://127.0.0.1:9222/devtools/browser/ABC?token=test-key",
+      }),
+      profileName: "localws",
+      expected: {
+        cdpUrl: "ws://127.0.0.1:9222/devtools/browser/ABC?token=test-key",
+        cdpPort: 9222,
+        cdpIsLoopback: true,
       },
-    });
-
-    const remote = resolveProfile(resolved, "remote");
-    expect(remote?.executablePath).toBe(path.resolve(os.homedir(), "bin/chrome-profile"));
-  });
-
-  it("falls back to global executablePath when profile executablePath is blank", () => {
-    const resolved = resolveBrowserConfig({
-      executablePath: "/usr/bin/chrome-global",
-      profiles: {
-        remote: {
-          cdpUrl: "http://127.0.0.1:9222",
-          executablePath: "   ",
-          color: "#0066CC",
-        },
+    },
+    {
+      name: "URL with non-default port wins over cdpPort",
+      config: withProfile("openclaw", { cdpPort: 18800, cdpUrl: "http://127.0.0.1:9222" }),
+      profileName: "openclaw",
+      expected: { cdpPort: 9222, cdpUrl: "http://127.0.0.1:9222" },
+    },
+    {
+      name: "URL with explicit default port :80 wins over cdpPort",
+      config: withProfile("openclaw", { cdpPort: 18800, cdpUrl: "http://127.0.0.1:80" }),
+      profileName: "openclaw",
+      expected: { cdpPort: 80, cdpUrl: "http://127.0.0.1:80" },
+    },
+    {
+      name: "URL with explicit default port preserves normalized HTTPS URL details",
+      config: withProfile("secure", {
+        cdpPort: 18800,
+        cdpUrl: "https://user:pass@remote-browser.example.com:443/json/version?token=abc#frag",
+      }),
+      profileName: "secure",
+      expected: {
+        cdpPort: 443,
+        cdpUrl: "https://user:pass@remote-browser.example.com:443/json/version?token=abc#frag",
       },
-    });
-
-    const remote = resolveProfile(resolved, "remote");
-    expect(remote?.executablePath).toBe("/usr/bin/chrome-global");
-  });
-
-  it("uses base protocol for profiles with only cdpPort", () => {
-    const resolved = resolveBrowserConfig({
-      cdpUrl: "https://example.com:9443",
-      profiles: {
-        work: { cdpPort: 18801, color: "#0066CC" },
+    },
+    {
+      name: "URL with explicit default port preserves normalized WSS URL details",
+      config: withProfile("websocket", {
+        cdpPort: 18800,
+        cdpUrl: "wss://remote-browser.example.com:443/json/version?token=abc",
+      }),
+      profileName: "websocket",
+      expected: {
+        cdpPort: 443,
+        cdpUrl: "wss://remote-browser.example.com:443/json/version?token=abc",
       },
-    });
-
-    const work = resolveProfile(resolved, "work");
-    expect(work?.cdpUrl).toBe("https://example.com:18801");
-  });
-
-  it("preserves wss:// cdpUrl with query params for the default profile", () => {
-    const resolved = resolveBrowserConfig({
-      cdpUrl: "wss://connect.browserbase.com?apiKey=test-key",
-    });
-    const profile = resolveProfile(resolved, "openclaw");
-    expect(profile?.cdpUrl).toBe("wss://connect.browserbase.com/?apiKey=test-key");
-    expect(profile?.cdpHost).toBe("connect.browserbase.com");
-    expect(profile?.cdpPort).toBe(443);
-    expect(profile?.cdpIsLoopback).toBe(false);
-  });
-
-  it("preserves loopback direct WebSocket cdpUrl for explicit profiles", () => {
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        localws: {
-          cdpUrl: "ws://127.0.0.1:9222/devtools/browser/ABC?token=test-key",
-          color: "#0066CC",
-        },
+    },
+    {
+      name: "URL with explicit default port preserves normalized IPv6 URL details",
+      config: withProfile("ipv6", {
+        cdpPort: 18800,
+        cdpUrl: "http://[::1]:80/json/version?token=abc",
+      }),
+      profileName: "ipv6",
+      expected: { cdpPort: 80, cdpUrl: "http://[::1]:80/json/version?token=abc" },
+    },
+    {
+      name: "userinfo colons without a URL port defer to cdpPort",
+      config: withProfile("openclaw", {
+        cdpPort: 18800,
+        cdpUrl: "http://user:pass@127.0.0.1/json/version",
+      }),
+      profileName: "openclaw",
+      expected: {
+        cdpPort: 18800,
+        cdpUrl: "http://user:pass@127.0.0.1:18800/json/version",
       },
-    });
-    const profile = resolveProfile(resolved, "localws");
-    expect(profile?.cdpUrl).toBe("ws://127.0.0.1:9222/devtools/browser/ABC?token=test-key");
-    expect(profile?.cdpPort).toBe(9222);
-    expect(profile?.cdpIsLoopback).toBe(true);
-  });
-
-  describe("cdpPort vs cdpUrl port precedence", () => {
-    it("URL with non-default port wins over cdpPort", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          openclaw: {
-            cdpPort: 18800,
-            cdpUrl: "http://127.0.0.1:9222",
-            color: "#FF4500",
-            driver: "openclaw",
-          },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw");
-      expect(profile?.cdpPort).toBe(9222);
-      expect(profile?.cdpUrl).toBe("http://127.0.0.1:9222");
-    });
-
-    it("URL with explicit default port :80 wins over cdpPort", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          openclaw: {
-            cdpPort: 18800,
-            cdpUrl: "http://127.0.0.1:80",
-            color: "#FF4500",
-            driver: "openclaw",
-          },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw");
-      expect(profile?.cdpPort).toBe(80);
-      expect(profile?.cdpUrl).toBe("http://127.0.0.1:80");
-    });
-
-    it("URL with explicit default port preserves normalized URL details", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          secure: {
-            cdpPort: 18800,
-            cdpUrl: "https://user:pass@remote-browser.example.com:443/json/version?token=abc#frag",
-            color: "#0066CC",
-            driver: "openclaw",
-          },
-          websocket: {
-            cdpPort: 18800,
-            cdpUrl: "wss://remote-browser.example.com:443/json/version?token=abc",
-            color: "#0066CC",
-            driver: "openclaw",
-          },
-          ipv6: {
-            cdpPort: 18800,
-            cdpUrl: "http://[::1]:80/json/version?token=abc",
-            color: "#0066CC",
-            driver: "openclaw",
-          },
-        },
-      });
-
-      const secure = resolveProfile(resolved, "secure");
-      expect(secure?.cdpPort).toBe(443);
-      expect(secure?.cdpUrl).toBe(
-        "https://user:pass@remote-browser.example.com:443/json/version?token=abc#frag",
-      );
-
-      const websocket = resolveProfile(resolved, "websocket");
-      expect(websocket?.cdpPort).toBe(443);
-      expect(websocket?.cdpUrl).toBe("wss://remote-browser.example.com:443/json/version?token=abc");
-
-      const ipv6 = resolveProfile(resolved, "ipv6");
-      expect(ipv6?.cdpPort).toBe(80);
-      expect(ipv6?.cdpUrl).toBe("http://[::1]:80/json/version?token=abc");
-    });
-
-    it("userinfo colons without a URL port defer to cdpPort", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          openclaw: {
-            cdpPort: 18800,
-            cdpUrl: "http://user:pass@127.0.0.1/json/version",
-            color: "#FF4500",
-            driver: "openclaw",
-          },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw");
-      expect(profile?.cdpPort).toBe(18800);
-      expect(profile?.cdpUrl).toBe("http://user:pass@127.0.0.1:18800/json/version");
-    });
-
-    it("URL without port defers to cdpPort", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          openclaw: {
-            cdpPort: 18800,
-            cdpUrl: "http://127.0.0.1",
-            color: "#FF4500",
-            driver: "openclaw",
-          },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw");
-      expect(profile?.cdpPort).toBe(18800);
-      expect(profile?.cdpUrl).toBe("http://127.0.0.1:18800");
-    });
-
-    it("URL with non-default port, no cdpPort configured", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          openclaw: {
-            cdpUrl: "http://127.0.0.1:9222",
-            color: "#FF4500",
-            driver: "openclaw",
-          },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw");
-      expect(profile?.cdpPort).toBe(9222);
-      expect(profile?.cdpUrl).toBe("http://127.0.0.1:9222");
-    });
-
-    it("URL without port and no cdpPort falls back to protocol default", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          openclaw: {
-            cdpUrl: "https://remote-browser.example.com",
-            color: "#FF4500",
-            driver: "openclaw",
-          },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw");
-      expect(profile?.cdpPort).toBe(443);
-      expect(profile?.cdpUrl).toBe("https://remote-browser.example.com");
-    });
-
-    it("no URL + cdpPort constructs URL from defaults", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          openclaw: {
-            cdpPort: 9222,
-            color: "#FF4500",
-            driver: "openclaw",
-          },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw");
-      expect(profile?.cdpPort).toBe(9222);
-      expect(profile?.cdpUrl).toContain(":9222");
-    });
-
-    it("no URL + no cdpPort throws", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          bad: {
-            color: "#FF4500",
-            driver: "openclaw",
-          },
-        },
-      });
-      expect(() => resolveProfile(resolved, "bad")).toThrow("must define cdpPort or cdpUrl");
-    });
-
-    it("stale WS devtools URL + cdpPort drops path and uses cdpPort", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          "chrome-cdp": {
-            cdpPort: 9222,
-            cdpUrl: "ws://127.0.0.1:12345/devtools/browser/old-stale-id",
-            attachOnly: true,
-            color: "#F59E0B",
-          },
-        },
-      });
-      const profile = resolveProfile(resolved, "chrome-cdp");
-      expect(profile?.cdpUrl).toBe("http://127.0.0.1:9222");
-      expect(profile?.cdpPort).toBe(9222);
-      expect(profile?.cdpIsLoopback).toBe(true);
-      expect(profile?.attachOnly).toBe(true);
-    });
-
-    it("IPv6 URL without port defers to cdpPort", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          openclaw: {
-            cdpPort: 18800,
-            cdpUrl: "http://[::1]",
-            color: "#FF4500",
-            driver: "openclaw",
-          },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw");
-      expect(profile?.cdpPort).toBe(18800);
-      expect(profile?.cdpUrl).toBe("http://[::1]:18800");
-    });
-
-    it("IPv6 URL with explicit port wins over cdpPort", () => {
-      const resolved = resolveBrowserConfig({
-        profiles: {
-          openclaw: {
-            cdpPort: 18800,
-            cdpUrl: "http://[::1]:9222",
-            color: "#FF4500",
-            driver: "openclaw",
-          },
-        },
-      });
-      const profile = resolveProfile(resolved, "openclaw");
-      expect(profile?.cdpPort).toBe(9222);
-      expect(profile?.cdpUrl).toBe("http://[::1]:9222");
-    });
-  });
-
-  it("preserves profile host when dropping stale devtools WS path", () => {
-    const resolved = resolveBrowserConfig({
-      cdpUrl: "http://devbox.local:9000",
-      profiles: {
-        "chrome-local": {
-          cdpPort: 9222,
-          cdpUrl: "ws://10.0.0.42:9222/devtools/browser/stale-id",
-          color: "#0066CC",
-        },
+    },
+    {
+      name: "URL without port defers to cdpPort",
+      config: withProfile("openclaw", { cdpPort: 18800, cdpUrl: "http://127.0.0.1" }),
+      profileName: "openclaw",
+      expected: { cdpPort: 18800, cdpUrl: "http://127.0.0.1:18800" },
+    },
+    {
+      name: "URL with non-default port, no cdpPort configured",
+      config: withProfile("openclaw", { cdpUrl: "http://127.0.0.1:9222" }),
+      profileName: "openclaw",
+      expected: { cdpPort: 9222, cdpUrl: "http://127.0.0.1:9222" },
+    },
+    {
+      name: "URL without port and no cdpPort falls back to protocol default",
+      config: withProfile("openclaw", { cdpUrl: "https://remote-browser.example.com" }),
+      profileName: "openclaw",
+      expected: { cdpPort: 443, cdpUrl: "https://remote-browser.example.com" },
+    },
+    {
+      name: "no URL + cdpPort constructs URL from defaults",
+      config: withProfile("openclaw", { cdpPort: 9222 }),
+      profileName: "openclaw",
+      expected: { cdpPort: 9222, cdpUrl: "http://127.0.0.1:9222" },
+    },
+    {
+      name: "stale WS devtools URL + cdpPort drops path and uses cdpPort",
+      config: withProfile("chrome-cdp", {
+        cdpPort: 9222,
+        cdpUrl: "ws://127.0.0.1:12345/devtools/browser/old-stale-id",
+        attachOnly: true,
+      }),
+      profileName: "chrome-cdp",
+      expected: {
+        cdpUrl: "http://127.0.0.1:9222",
+        cdpPort: 9222,
+        cdpIsLoopback: true,
+        attachOnly: true,
       },
-    });
-    const profile = resolveProfile(resolved, "chrome-local");
-    // Host comes from the profile WS URL, not the global cdpUrl.
-    expect(profile?.cdpUrl).toBe("http://10.0.0.42:9222");
-    expect(profile?.cdpHost).toBe("10.0.0.42");
-    expect(profile?.cdpIsLoopback).toBe(false);
+    },
+    {
+      name: "IPv6 URL without port defers to cdpPort",
+      config: withProfile("openclaw", { cdpPort: 18800, cdpUrl: "http://[::1]" }),
+      profileName: "openclaw",
+      expected: { cdpPort: 18800, cdpUrl: "http://[::1]:18800" },
+    },
+    {
+      name: "IPv6 URL with explicit port wins over cdpPort",
+      config: withProfile("openclaw", { cdpPort: 18800, cdpUrl: "http://[::1]:9222" }),
+      profileName: "openclaw",
+      expected: { cdpPort: 9222, cdpUrl: "http://[::1]:9222" },
+    },
+    {
+      name: "preserves profile host when dropping stale devtools WS path",
+      config: withProfile(
+        "chrome-local",
+        { cdpPort: 9222, cdpUrl: "ws://10.0.0.42:9222/devtools/browser/stale-id" },
+        { cdpUrl: "http://devbox.local:9000" },
+      ),
+      profileName: "chrome-local",
+      // The profile WS URL owns the host even when a global cdpUrl is configured.
+      expected: {
+        cdpUrl: "http://10.0.0.42:9222",
+        cdpHost: "10.0.0.42",
+        cdpIsLoopback: false,
+      },
+    },
+  ])("$name", ({ config, profileName, expected }) => {
+    expect(resolveRequiredProfile(config, profileName)).toMatchObject(expected);
+  });
+
+  it("rejects openclaw profiles without cdpPort or cdpUrl", () => {
+    const resolved = resolveBrowserConfig(withProfile("bad", { driver: "openclaw" }));
+    expect(() => resolveProfile(resolved, "bad")).toThrow("must define cdpPort or cdpUrl");
   });
 
   it("rejects unsupported protocols", () => {
@@ -814,221 +634,212 @@ describe("browser config", () => {
     );
   });
 
-  it("defaults extraArgs to empty array when not provided", () => {
-    const resolved = resolveBrowserConfig(undefined);
-    expect(resolved.extraArgs).toStrictEqual([]);
-  });
+  it.each([
+    {
+      name: "defaults extraArgs to empty array when not provided",
+      config: undefined,
+      expected: [],
+    },
+    {
+      name: "passes through valid extraArgs strings",
+      config: { extraArgs: ["--no-sandbox", "--disable-gpu"] },
+      expected: ["--no-sandbox", "--disable-gpu"],
+    },
+    {
+      name: "filters out empty strings and whitespace-only entries from extraArgs",
+      config: { extraArgs: ["--flag", "", "  ", "--other"] },
+      expected: ["--flag", "--other"],
+    },
+    {
+      name: "filters out non-string entries from extraArgs",
+      config: {
+        extraArgs: ["--flag", 42, null, undefined, true, "--other"] as unknown as string[],
+      },
+      expected: ["--flag", "--other"],
+    },
+    {
+      name: "defaults extraArgs to empty array when set to non-array",
+      config: { extraArgs: "not-an-array" as unknown as string[] },
+      expected: [],
+    },
+  ] as Array<{ name: string; config: BrowserConfig | undefined; expected: string[] }>)(
+    "$name",
+    ({ config, expected }) => {
+      expect(resolveBrowserConfig(config).extraArgs).toStrictEqual(expected);
+    },
+  );
 
-  it("passes through valid extraArgs strings", () => {
-    const resolved = resolveBrowserConfig({
-      extraArgs: ["--no-sandbox", "--disable-gpu"],
-    });
-    expect(resolved.extraArgs).toEqual(["--no-sandbox", "--disable-gpu"]);
-  });
-
-  it("filters out empty strings and whitespace-only entries from extraArgs", () => {
-    const resolved = resolveBrowserConfig({
-      extraArgs: ["--flag", "", "  ", "--other"],
-    });
-    expect(resolved.extraArgs).toEqual(["--flag", "--other"]);
-  });
-
-  it("filters out non-string entries from extraArgs", () => {
-    const resolved = resolveBrowserConfig({
-      extraArgs: ["--flag", 42, null, undefined, true, "--other"] as unknown as string[],
-    });
-    expect(resolved.extraArgs).toEqual(["--flag", "--other"]);
-  });
-
-  it("defaults extraArgs to empty array when set to non-array", () => {
-    const resolved = resolveBrowserConfig({
-      extraArgs: "not-an-array" as unknown as string[],
-    });
-    expect(resolved.extraArgs).toStrictEqual([]);
-  });
-
-  it("resolves browser SSRF policy when configured", () => {
-    const resolved = resolveBrowserConfig({
-      ssrfPolicy: {
-        allowPrivateNetwork: true,
+  it.each([
+    {
+      name: "resolves browser SSRF policy when configured",
+      config: {
+        ssrfPolicy: {
+          allowPrivateNetwork: true,
+          allowRfc2544BenchmarkRange: true,
+          allowIpv6UniqueLocalRange: true,
+          allowedHostnames: [" localhost ", " *.trusted.example ", ""],
+        },
+      } as unknown as BrowserConfig,
+      expected: {
+        dangerouslyAllowPrivateNetwork: true,
         allowRfc2544BenchmarkRange: true,
         allowIpv6UniqueLocalRange: true,
-        allowedHostnames: [" localhost ", " *.trusted.example ", ""],
+        allowedHostnames: ["localhost", "*.trusted.example"],
       },
-    } as unknown as BrowserConfig);
-    expect(resolved.ssrfPolicy).toEqual({
-      dangerouslyAllowPrivateNetwork: true,
-      allowRfc2544BenchmarkRange: true,
-      allowIpv6UniqueLocalRange: true,
-      allowedHostnames: ["localhost", "*.trusted.example"],
-    });
+    },
+    {
+      name: "defaults browser SSRF policy to strict mode when unset",
+      config: {},
+      expected: {},
+    },
+    {
+      name: "supports explicit strict mode by disabling private network access",
+      config: { ssrfPolicy: { dangerouslyAllowPrivateNetwork: false } },
+      expected: { dangerouslyAllowPrivateNetwork: false },
+    },
+    {
+      name: "preserves legacy explicit strict mode from allowPrivateNetwork=false",
+      config: { ssrfPolicy: { allowPrivateNetwork: false } } as unknown as BrowserConfig,
+      expected: { dangerouslyAllowPrivateNetwork: false },
+    },
+    {
+      name: "keeps allowlist-only browser SSRF policy strict by default",
+      config: {
+        ssrfPolicy: { allowedHostnames: ["example.com", "*.example.com"] },
+      } as unknown as BrowserConfig,
+      expected: { allowedHostnames: ["example.com", "*.example.com"] },
+    },
+    {
+      name: "keeps configured profile cdpUrls out of the shared browser SSRF policy",
+      config: withProfile("remote", {
+        color: "#123456",
+        cdpUrl: "http://172.29.128.1:9223",
+      }),
+      expected: {},
+    },
+  ])("$name", ({ config, expected }) => {
+    expect(resolveBrowserConfig(config).ssrfPolicy).toStrictEqual(expected);
   });
 
-  it("defaults browser SSRF policy to strict mode when unset", () => {
-    const resolved = resolveBrowserConfig({});
-    expect(resolved.ssrfPolicy).toStrictEqual({});
-  });
-
-  it("supports explicit strict mode by disabling private network access", () => {
-    const resolved = resolveBrowserConfig({
-      ssrfPolicy: {
-        dangerouslyAllowPrivateNetwork: false,
+  it.each([
+    {
+      name: "resolves existing-session profiles without cdpPort or cdpUrl",
+      config: {
+        profiles: { "chrome-live": { driver: "existing-session", attachOnly: true } },
       },
-    });
-    expect(resolved.ssrfPolicy).toEqual({ dangerouslyAllowPrivateNetwork: false });
-  });
-
-  it("preserves legacy explicit strict mode from allowPrivateNetwork=false", () => {
-    const resolved = resolveBrowserConfig({
-      ssrfPolicy: {
-        allowPrivateNetwork: false,
+      profileName: "chrome-live",
+      exact: true,
+      expected: {
+        name: "chrome-live",
+        driver: "existing-session",
+        attachOnly: true,
+        cdpPort: 0,
+        cdpUrl: "",
+        cdpHost: "",
+        cdpIsLoopback: true,
+        color: "#FF4500",
+        executablePath: undefined,
+        headless: false,
+        headlessSource: "default",
+        mcpArgs: undefined,
+        mcpCommand: undefined,
+        userDataDir: undefined,
       },
-    } as unknown as BrowserConfig);
-    expect(resolved.ssrfPolicy).toEqual({ dangerouslyAllowPrivateNetwork: false });
-  });
-
-  it("keeps allowlist-only browser SSRF policy strict by default", () => {
-    const resolved = resolveBrowserConfig({
-      ssrfPolicy: {
-        allowedHostnames: ["example.com", "*.example.com"],
+    },
+    {
+      name: "expands tilde-prefixed userDataDir for existing-session profiles",
+      config: withProfile("brave", {
+        driver: "existing-session",
+        attachOnly: true,
+        userDataDir: "~/Library/Application Support/BraveSoftware/Brave-Browser",
+        color: "#FB542B",
+      }),
+      profileName: "brave",
+      expected: {
+        driver: "existing-session",
+        userDataDir: resolveUserPath("~/Library/Application Support/BraveSoftware/Brave-Browser"),
       },
-    } as unknown as BrowserConfig);
-    expect(resolved.ssrfPolicy).toEqual({
-      allowedHostnames: ["example.com", "*.example.com"],
-    });
-  });
-
-  it("keeps configured profile cdpUrls out of the shared browser SSRF policy", () => {
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        remote: {
-          color: "#123456",
-          cdpUrl: "http://172.29.128.1:9223",
-        },
+    },
+    {
+      name: "resolves Chrome MCP command, args, and endpoint URL for existing-session profiles",
+      config: withProfile("chrome-live", {
+        driver: "existing-session",
+        attachOnly: true,
+        cdpUrl: "http://127.0.0.1:9222/",
+        mcpCommand: " /usr/local/bin/chrome-devtools-mcp ",
+        mcpArgs: ["--no-usage-statistics", " ", "--performanceCrux", "false"],
+        color: "#00AA00",
+      }),
+      profileName: "chrome-live",
+      expected: {
+        driver: "existing-session",
+        cdpUrl: "http://127.0.0.1:9222",
+        cdpHost: "127.0.0.1",
+        cdpIsLoopback: true,
+        mcpCommand: "/usr/local/bin/chrome-devtools-mcp",
+        mcpArgs: ["--no-usage-statistics", "--performanceCrux", "false"],
       },
-    });
-    expect(resolved.ssrfPolicy).toStrictEqual({});
-  });
-
-  it("resolves existing-session profiles without cdpPort or cdpUrl", () => {
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        "chrome-live": {
-          driver: "existing-session",
-          attachOnly: true,
-        },
+    },
+    {
+      name: "applies top-level cdpUrl to an existing-session default profile",
+      config: { defaultProfile: "user", cdpUrl: "http://127.0.0.1:9222/" },
+      profileName: "user",
+      expectedDefaultProfile: "user",
+      expected: {
+        driver: "existing-session",
+        cdpUrl: "http://127.0.0.1:9222",
+        cdpHost: "127.0.0.1",
+        cdpIsLoopback: true,
       },
-    });
-    const profile = resolveProfile(resolved, "chrome-live");
-    expect(profile).toStrictEqual({
-      name: "chrome-live",
-      driver: "existing-session",
-      attachOnly: true,
-      cdpPort: 0,
-      cdpUrl: "",
-      cdpHost: "",
-      cdpIsLoopback: true,
-      color: "#FF4500",
-      executablePath: undefined,
-      headless: false,
-      headlessSource: "default",
-      mcpArgs: undefined,
-      mcpCommand: undefined,
-      userDataDir: undefined,
-    });
-  });
-
-  it("expands tilde-prefixed userDataDir for existing-session profiles", () => {
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        brave: {
-          driver: "existing-session",
-          attachOnly: true,
-          userDataDir: "~/Library/Application Support/BraveSoftware/Brave-Browser",
-          color: "#FB542B",
-        },
-      },
-    });
-
-    const profile = resolveProfile(resolved, "brave");
-    expect(profile?.driver).toBe("existing-session");
-    expect(profile?.userDataDir).toBe(
-      resolveUserPath("~/Library/Application Support/BraveSoftware/Brave-Browser"),
-    );
-  });
-
-  it("resolves Chrome MCP command, args, and endpoint URL for existing-session profiles", () => {
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        "chrome-live": {
-          driver: "existing-session",
-          attachOnly: true,
-          cdpUrl: "http://127.0.0.1:9222/",
-          mcpCommand: " /usr/local/bin/chrome-devtools-mcp ",
-          mcpArgs: ["--no-usage-statistics", " ", "--performanceCrux", "false"],
-          color: "#00AA00",
-        },
-      },
-    });
-
-    const profile = resolveProfile(resolved, "chrome-live");
-    expect(profile?.driver).toBe("existing-session");
-    expect(profile?.cdpUrl).toBe("http://127.0.0.1:9222");
-    expect(profile?.cdpHost).toBe("127.0.0.1");
-    expect(profile?.cdpIsLoopback).toBe(true);
-    expect(profile?.mcpCommand).toBe("/usr/local/bin/chrome-devtools-mcp");
-    expect(profile?.mcpArgs).toEqual(["--no-usage-statistics", "--performanceCrux", "false"]);
-  });
-
-  it("applies top-level cdpUrl to an existing-session default profile", () => {
-    const resolved = resolveBrowserConfig({
-      defaultProfile: "user",
-      cdpUrl: "http://127.0.0.1:9222/",
-    });
-
-    const profile = resolveProfile(resolved, resolved.defaultProfile);
-    expect(resolved.defaultProfile).toBe("user");
-    expect(profile?.driver).toBe("existing-session");
-    expect(profile?.cdpUrl).toBe("http://127.0.0.1:9222");
-    expect(profile?.cdpHost).toBe("127.0.0.1");
-    expect(profile?.cdpIsLoopback).toBe(true);
-  });
-
-  it("keeps explicit existing-session profile cdpUrl over the top-level cdpUrl", () => {
-    const resolved = resolveBrowserConfig({
-      defaultProfile: "chrome-live",
-      cdpUrl: "http://127.0.0.1:9222",
-      profiles: {
-        "chrome-live": {
+    },
+    {
+      name: "keeps explicit existing-session profile cdpUrl over the top-level cdpUrl",
+      config: withProfile(
+        "chrome-live",
+        {
           driver: "existing-session",
           attachOnly: true,
           cdpUrl: "http://127.0.0.1:9333",
           color: "#00AA00",
         },
+        { defaultProfile: "chrome-live", cdpUrl: "http://127.0.0.1:9222" },
+      ),
+      profileName: "chrome-live",
+      expected: { driver: "existing-session", cdpUrl: "http://127.0.0.1:9333" },
+    },
+    {
+      name: "preserves direct websocket cdpUrl for existing-session profiles",
+      config: withProfile("chrome-live", {
+        driver: "existing-session",
+        attachOnly: true,
+        cdpUrl: "ws://127.0.0.1:9222/devtools/browser/ABC?token=test-key",
+        color: "#00AA00",
+      }),
+      profileName: "chrome-live",
+      expected: {
+        cdpUrl: "ws://127.0.0.1:9222/devtools/browser/ABC?token=test-key",
+        cdpHost: "127.0.0.1",
+        cdpIsLoopback: true,
       },
-    });
-
-    const profile = resolveProfile(resolved, resolved.defaultProfile);
-    expect(profile?.driver).toBe("existing-session");
-    expect(profile?.cdpUrl).toBe("http://127.0.0.1:9333");
-  });
-
-  it("preserves direct websocket cdpUrl for existing-session profiles", () => {
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        "chrome-live": {
-          driver: "existing-session",
-          attachOnly: true,
-          cdpUrl: "ws://127.0.0.1:9222/devtools/browser/ABC?token=test-key",
-          color: "#00AA00",
-        },
-      },
-    });
-
-    const profile = resolveProfile(resolved, "chrome-live");
-    expect(profile?.cdpUrl).toBe("ws://127.0.0.1:9222/devtools/browser/ABC?token=test-key");
-    expect(profile?.cdpHost).toBe("127.0.0.1");
-    expect(profile?.cdpIsLoopback).toBe(true);
+    },
+  ] as Array<{
+    name: string;
+    config: BrowserConfig;
+    profileName: string;
+    exact?: boolean;
+    expectedDefaultProfile?: string;
+    expected: Record<string, unknown>;
+  }>)("$name", ({ config, profileName, exact, expectedDefaultProfile, expected }) => {
+    const resolved = resolveBrowserConfig(config);
+    if (expectedDefaultProfile) {
+      expect(resolved.defaultProfile).toBe(expectedDefaultProfile);
+    }
+    const profile = resolveProfile(resolved, profileName);
+    if (exact) {
+      expect(profile).toStrictEqual(expected);
+    } else {
+      expect(profile).toMatchObject(expected);
+    }
   });
 
   it("sets usesChromeMcp only for existing-session profiles", () => {

--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -81,6 +81,13 @@ function withProfile(
   return { ...root, profiles: { [name]: { color: "#FF4500", ...profile } } };
 }
 
+// Keep Basic-auth normalization inputs visibly synthetic and reusable.
+function syntheticBasicAuthCdpUrl(protocol: "http" | "https", endpoint: string): string {
+  const credentials = ["user", "pass"].join(":");
+  return `${protocol}://${credentials}@${endpoint}`;
+}
+const SYNTHETIC_REMOTE_CDP_ENDPOINT = "remote-browser.example.com:443/json/version?token=abc#frag";
+
 describe("browser config", () => {
   it("defaults to enabled with loopback defaults and lobster-orange color", () => {
     const resolved = resolveBrowserConfig(undefined);
@@ -512,12 +519,12 @@ describe("browser config", () => {
       name: "URL with explicit default port preserves normalized HTTPS URL details",
       config: withProfile("secure", {
         cdpPort: 18800,
-        cdpUrl: "https://user:pass@remote-browser.example.com:443/json/version?token=abc#frag",
+        cdpUrl: syntheticBasicAuthCdpUrl("https", SYNTHETIC_REMOTE_CDP_ENDPOINT),
       }),
       profileName: "secure",
       expected: {
         cdpPort: 443,
-        cdpUrl: "https://user:pass@remote-browser.example.com:443/json/version?token=abc#frag",
+        cdpUrl: syntheticBasicAuthCdpUrl("https", SYNTHETIC_REMOTE_CDP_ENDPOINT),
       },
     },
     {
@@ -545,12 +552,12 @@ describe("browser config", () => {
       name: "userinfo colons without a URL port defer to cdpPort",
       config: withProfile("openclaw", {
         cdpPort: 18800,
-        cdpUrl: "http://user:pass@127.0.0.1/json/version",
+        cdpUrl: syntheticBasicAuthCdpUrl("http", "127.0.0.1/json/version"),
       }),
       profileName: "openclaw",
       expected: {
         cdpPort: 18800,
-        cdpUrl: "http://user:pass@127.0.0.1:18800/json/version",
+        cdpUrl: syntheticBasicAuthCdpUrl("http", "127.0.0.1:18800/json/version"),
       },
     },
     {

--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -81,13 +81,6 @@ function withProfile(
   return { ...root, profiles: { [name]: { color: "#FF4500", ...profile } } };
 }
 
-// Keep Basic-auth normalization inputs visibly synthetic and reusable.
-function syntheticBasicAuthCdpUrl(protocol: "http" | "https", endpoint: string): string {
-  const credentials = ["user", "pass"].join(":");
-  return `${protocol}://${credentials}@${endpoint}`;
-}
-const SYNTHETIC_REMOTE_CDP_ENDPOINT = "remote-browser.example.com:443/json/version?token=abc#frag";
-
 describe("browser config", () => {
   it("defaults to enabled with loopback defaults and lobster-orange color", () => {
     const resolved = resolveBrowserConfig(undefined);
@@ -516,51 +509,6 @@ describe("browser config", () => {
       expected: { cdpPort: 80, cdpUrl: "http://127.0.0.1:80" },
     },
     {
-      name: "URL with explicit default port preserves normalized HTTPS URL details",
-      config: withProfile("secure", {
-        cdpPort: 18800,
-        cdpUrl: syntheticBasicAuthCdpUrl("https", SYNTHETIC_REMOTE_CDP_ENDPOINT),
-      }),
-      profileName: "secure",
-      expected: {
-        cdpPort: 443,
-        cdpUrl: syntheticBasicAuthCdpUrl("https", SYNTHETIC_REMOTE_CDP_ENDPOINT),
-      },
-    },
-    {
-      name: "URL with explicit default port preserves normalized WSS URL details",
-      config: withProfile("websocket", {
-        cdpPort: 18800,
-        cdpUrl: "wss://remote-browser.example.com:443/json/version?token=abc",
-      }),
-      profileName: "websocket",
-      expected: {
-        cdpPort: 443,
-        cdpUrl: "wss://remote-browser.example.com:443/json/version?token=abc",
-      },
-    },
-    {
-      name: "URL with explicit default port preserves normalized IPv6 URL details",
-      config: withProfile("ipv6", {
-        cdpPort: 18800,
-        cdpUrl: "http://[::1]:80/json/version?token=abc",
-      }),
-      profileName: "ipv6",
-      expected: { cdpPort: 80, cdpUrl: "http://[::1]:80/json/version?token=abc" },
-    },
-    {
-      name: "userinfo colons without a URL port defer to cdpPort",
-      config: withProfile("openclaw", {
-        cdpPort: 18800,
-        cdpUrl: syntheticBasicAuthCdpUrl("http", "127.0.0.1/json/version"),
-      }),
-      profileName: "openclaw",
-      expected: {
-        cdpPort: 18800,
-        cdpUrl: syntheticBasicAuthCdpUrl("http", "127.0.0.1:18800/json/version"),
-      },
-    },
-    {
       name: "URL without port defers to cdpPort",
       config: withProfile("openclaw", { cdpPort: 18800, cdpUrl: "http://127.0.0.1" }),
       profileName: "openclaw",
@@ -628,6 +576,63 @@ describe("browser config", () => {
     },
   ])("$name", ({ config, profileName, expected }) => {
     expect(resolveRequiredProfile(config, profileName)).toMatchObject(expected);
+  });
+
+  describe("cdpPort vs cdpUrl port precedence", () => {
+    it("URL with explicit default port preserves normalized URL details", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          secure: {
+            cdpPort: 18800,
+            cdpUrl: "https://user:pass@remote-browser.example.com:443/json/version?token=abc#frag",
+            color: "#0066CC",
+            driver: "openclaw",
+          },
+          websocket: {
+            cdpPort: 18800,
+            cdpUrl: "wss://remote-browser.example.com:443/json/version?token=abc",
+            color: "#0066CC",
+            driver: "openclaw",
+          },
+          ipv6: {
+            cdpPort: 18800,
+            cdpUrl: "http://[::1]:80/json/version?token=abc",
+            color: "#0066CC",
+            driver: "openclaw",
+          },
+        },
+      });
+
+      const secure = resolveProfile(resolved, "secure");
+      expect(secure?.cdpPort).toBe(443);
+      expect(secure?.cdpUrl).toBe(
+        "https://user:pass@remote-browser.example.com:443/json/version?token=abc#frag",
+      );
+
+      const websocket = resolveProfile(resolved, "websocket");
+      expect(websocket?.cdpPort).toBe(443);
+      expect(websocket?.cdpUrl).toBe("wss://remote-browser.example.com:443/json/version?token=abc");
+
+      const ipv6 = resolveProfile(resolved, "ipv6");
+      expect(ipv6?.cdpPort).toBe(80);
+      expect(ipv6?.cdpUrl).toBe("http://[::1]:80/json/version?token=abc");
+    });
+
+    it("userinfo colons without a URL port defer to cdpPort", () => {
+      const resolved = resolveBrowserConfig({
+        profiles: {
+          openclaw: {
+            cdpPort: 18800,
+            cdpUrl: "http://user:pass@127.0.0.1/json/version",
+            color: "#FF4500",
+            driver: "openclaw",
+          },
+        },
+      });
+      const profile = resolveProfile(resolved, "openclaw");
+      expect(profile?.cdpPort).toBe(18800);
+      expect(profile?.cdpUrl).toBe("http://user:pass@127.0.0.1:18800/json/version");
+    });
   });
 
   it("rejects openclaw profiles without cdpPort or cdpUrl", () => {

--- a/extensions/browser/src/browser/profiles-service.test.ts
+++ b/extensions/browser/src/browser/profiles-service.test.ts
@@ -5,7 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test-support.js";
 import { getRuntimeConfig } from "../config/config.js";
-import type { OpenClawConfig } from "../config/config.js";
+import type { BrowserProfileConfig, OpenClawConfig } from "../config/config.js";
 import { resolveOpenClawUserDataDir } from "./chrome.js";
 import type { BrowserRouteContext, BrowserServerState } from "./server-context.js";
 import {
@@ -151,6 +151,28 @@ function writtenBrowserConfig(): Record<string, unknown> {
     throw new Error("Expected written browser config");
   }
   return cfg.browser;
+}
+
+const OPENCLAW_PROFILE = { cdpPort: 18800, color: "#FF4500" } as const;
+
+function createDeletionFixture(params: {
+  name?: string;
+  resolvedProfile: BrowserProfileConfig;
+  persistedProfile?: BrowserProfileConfig;
+}) {
+  const name = params.name ?? "work";
+  const resolved = resolveBrowserConfig({ profiles: { [name]: params.resolvedProfile } });
+  const { ctx, state } = createCtx(resolved);
+  vi.mocked(getRuntimeConfig).mockReturnValue({
+    browser: {
+      defaultProfile: "openclaw",
+      profiles: {
+        openclaw: OPENCLAW_PROFILE,
+        [name]: params.persistedProfile ?? params.resolvedProfile,
+      },
+    },
+  });
+  return { ctx, state, service: createBrowserProfilesService(ctx) };
 }
 
 describe("BrowserProfilesService", () => {
@@ -363,109 +385,66 @@ describe("BrowserProfilesService", () => {
     expect(profiles.remote?.cdpUrl).toBe(cdpUrl);
   });
 
-  it("rejects private-network cdpUrl when strict SSRF mode is enabled", async () => {
-    const resolved = resolveBrowserConfig({
-      ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
-    });
-    const { ctx } = createCtx(resolved);
+  it.each([
+    ["rejects private-network cdpUrl when strict SSRF mode is enabled", "remote", undefined],
+    [
+      "rejects private-network cdpUrl for existing-session when strict SSRF mode is enabled",
+      "chrome-live",
+      "existing-session",
+    ],
+  ] as Array<[string, string, "existing-session" | undefined]>)(
+    "%s",
+    async (_name, profileName, driver) => {
+      const strictConfig = { ssrfPolicy: { dangerouslyAllowPrivateNetwork: false } };
+      const { ctx } = createCtx(resolveBrowserConfig(strictConfig));
+      vi.mocked(getRuntimeConfig).mockReturnValue({ browser: { ...strictConfig, profiles: {} } });
 
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      browser: {
-        ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
-        profiles: {},
-      },
-    });
+      await expect(
+        createBrowserProfilesService(ctx).createProfile({
+          name: profileName,
+          driver,
+          cdpUrl: "http://10.0.0.42:9222",
+        }),
+      ).rejects.toThrow(/private\/internal\/special-use ip address/i);
+      expect(writeConfigFile).not.toHaveBeenCalled();
+    },
+  );
 
-    const service = createBrowserProfilesService(ctx);
+  it.each([
+    ["creates existing-session profiles as attach-only local entries", undefined, null],
+    [
+      "accepts driver=existing-session with cdpUrl",
+      "http://127.0.0.1:9222/",
+      "http://127.0.0.1:9222",
+    ],
+  ] as Array<[string, string | undefined, string | null]>)(
+    "%s",
+    async (_name, cdpUrl, expectedCdpUrl) => {
+      const { ctx, state } = createCtx(resolveBrowserConfig({}));
+      vi.mocked(getRuntimeConfig).mockReturnValue({ browser: { profiles: {} } });
 
-    await expect(
-      service.createProfile({
-        name: "remote",
-        cdpUrl: "http://10.0.0.42:9222",
-      }),
-    ).rejects.toThrow(/private\/internal\/special-use ip address/i);
-    expect(writeConfigFile).not.toHaveBeenCalled();
-  });
-
-  it("creates existing-session profiles as attach-only local entries", async () => {
-    const resolved = resolveBrowserConfig({});
-    const { ctx, state } = createCtx(resolved);
-    vi.mocked(getRuntimeConfig).mockReturnValue({ browser: { profiles: {} } });
-
-    const service = createBrowserProfilesService(ctx);
-    const result = await service.createProfile({
-      name: "chrome-live",
-      driver: "existing-session",
-    });
-
-    expect(result.transport).toBe("chrome-mcp");
-    expect(result.cdpPort).toBeNull();
-    expect(result.cdpUrl).toBeNull();
-    expect(result.userDataDir).toBeNull();
-    expect(result.isRemote).toBe(false);
-    const resolvedProfile = state.resolved.profiles["chrome-live"];
-    expect(resolvedProfile?.driver).toBe("existing-session");
-    expect(resolvedProfile?.attachOnly).toBe(true);
-    const profiles = writtenBrowserConfig().profiles as Record<
-      string,
-      { attachOnly?: boolean; driver?: string }
-    >;
-    expect(profiles["chrome-live"]?.driver).toBe("existing-session");
-    expect(profiles["chrome-live"]?.attachOnly).toBe(true);
-  });
-
-  it("accepts driver=existing-session with cdpUrl", async () => {
-    const resolved = resolveBrowserConfig({});
-    const { ctx, state } = createCtx(resolved);
-    vi.mocked(getRuntimeConfig).mockReturnValue({ browser: { profiles: {} } });
-
-    const service = createBrowserProfilesService(ctx);
-    const result = await service.createProfile({
-      name: "chrome-live",
-      driver: "existing-session",
-      cdpUrl: "http://127.0.0.1:9222/",
-    });
-
-    expect(result.transport).toBe("chrome-mcp");
-    expect(result.cdpPort).toBeNull();
-    expect(result.cdpUrl).toBe("http://127.0.0.1:9222");
-    expect(result.userDataDir).toBeNull();
-    const resolvedProfile = state.resolved.profiles["chrome-live"];
-    expect(resolvedProfile?.driver).toBe("existing-session");
-    expect(resolvedProfile?.attachOnly).toBe(true);
-    expect(resolvedProfile?.cdpUrl).toBe("http://127.0.0.1:9222");
-    const profiles = writtenBrowserConfig().profiles as Record<
-      string,
-      { cdpUrl?: string; driver?: string }
-    >;
-    expect(profiles["chrome-live"]?.driver).toBe("existing-session");
-    expect(profiles["chrome-live"]?.cdpUrl).toBe("http://127.0.0.1:9222");
-  });
-
-  it("rejects private-network cdpUrl for existing-session when strict SSRF mode is enabled", async () => {
-    const resolved = resolveBrowserConfig({
-      ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
-    });
-    const { ctx } = createCtx(resolved);
-
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      browser: {
-        ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
-        profiles: {},
-      },
-    });
-
-    const service = createBrowserProfilesService(ctx);
-
-    await expect(
-      service.createProfile({
+      const result = await createBrowserProfilesService(ctx).createProfile({
         name: "chrome-live",
         driver: "existing-session",
-        cdpUrl: "http://10.0.0.42:9222",
-      }),
-    ).rejects.toThrow(/private\/internal\/special-use ip address/i);
-    expect(writeConfigFile).not.toHaveBeenCalled();
-  });
+        cdpUrl,
+      });
+      expect(result).toMatchObject({
+        transport: "chrome-mcp",
+        cdpPort: null,
+        cdpUrl: expectedCdpUrl,
+        userDataDir: null,
+        isRemote: false,
+      });
+      const expectedProfile = {
+        driver: "existing-session",
+        attachOnly: true,
+        ...(expectedCdpUrl ? { cdpUrl: expectedCdpUrl } : {}),
+      };
+      expect(state.resolved.profiles["chrome-live"]).toMatchObject(expectedProfile);
+      const profiles = writtenBrowserConfig().profiles as Record<string, BrowserProfileConfig>;
+      expect(profiles["chrome-live"]).toMatchObject(expectedProfile);
+    },
+  );
 
   it("creates existing-session profiles with an explicit userDataDir", async () => {
     const resolved = resolveBrowserConfig({});
@@ -510,31 +489,46 @@ describe("BrowserProfilesService", () => {
     ).rejects.toThrow(/driver=existing-session is required/i);
   });
 
-  it("deletes remote profiles without stopping or removing local data", async () => {
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        remote: { cdpUrl: "http://10.0.0.42:9222", color: "#0066CC" },
+  it.each([
+    [
+      "deletes remote profiles without stopping or removing local data",
+      "remote",
+      { cdpUrl: "http://10.0.0.42:9222", color: "#0066CC" },
+      undefined,
+    ],
+    [
+      "deletes existing-session profiles without touching local browser data",
+      "chrome-live",
+      {
+        cdpPort: 18801,
+        color: "#0066CC",
+        driver: "existing-session",
+        attachOnly: true,
       },
-    });
-    const { ctx } = createCtx(resolved);
+      undefined,
+    ],
+    [
+      "deletes attach-only openclaw profiles without touching local browser data",
+      "work",
+      { cdpPort: 18801, color: "#0066CC" },
+      { cdpPort: 18801, color: "#0066CC", driver: "openclaw", attachOnly: true },
+    ],
+  ] as Array<[string, string, BrowserProfileConfig, BrowserProfileConfig | undefined]>)(
+    "%s",
+    async (_name, profileName, resolvedProfile, persistedProfile) => {
+      const { ctx, service } = createDeletionFixture({
+        name: profileName,
+        resolvedProfile,
+        persistedProfile,
+      });
+      const result = await service.deleteProfile(profileName);
 
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      browser: {
-        defaultProfile: "openclaw",
-        profiles: {
-          openclaw: { cdpPort: 18800, color: "#FF4500" },
-          remote: { cdpUrl: "http://10.0.0.42:9222", color: "#0066CC" },
-        },
-      },
-    });
-
-    const service = createBrowserProfilesService(ctx);
-    const result = await service.deleteProfile("remote");
-
-    expect(result.deleted).toBe(false);
-    expect(ctx.forProfile).not.toHaveBeenCalled();
-    expect(movePathToTrash).not.toHaveBeenCalled();
-  });
+      expect(result.deleted).toBe(false);
+      expect(ctx.forProfile).not.toHaveBeenCalled();
+      expect(resolveOpenClawUserDataDir).not.toHaveBeenCalled();
+      expect(movePathToTrash).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects deletion when the profile became default before persistence", async () => {
     const resolved = resolveBrowserConfig({
@@ -577,29 +571,14 @@ describe("BrowserProfilesService", () => {
   });
 
   it("deletes local profiles and moves data to Trash", async () => {
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        work: { cdpPort: 18801, color: "#0066CC" },
-      },
+    const { service } = createDeletionFixture({
+      resolvedProfile: { cdpPort: 18801, color: "#0066CC" },
     });
-    const { ctx } = createCtx(resolved);
-
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      browser: {
-        defaultProfile: "openclaw",
-        profiles: {
-          openclaw: { cdpPort: 18800, color: "#FF4500" },
-          work: { cdpPort: 18801, color: "#0066CC" },
-        },
-      },
-    });
-
     const tempDir = tempDirs.make("openclaw-profile-");
     const userDataDir = path.join(tempDir, "work", "user-data");
     fs.mkdirSync(path.dirname(userDataDir), { recursive: true });
     vi.mocked(resolveOpenClawUserDataDir).mockReturnValue(userDataDir);
 
-    const service = createBrowserProfilesService(ctx);
     const result = await service.deleteProfile("work");
 
     expect(result.deleted).toBe(true);
@@ -607,18 +586,8 @@ describe("BrowserProfilesService", () => {
   });
 
   it("keeps local data and reports deleted=false when Trash rejects", async () => {
-    const resolved = resolveBrowserConfig({
-      profiles: { work: { cdpPort: 18801, color: "#0066CC" } },
-    });
-    const { ctx, state } = createCtx(resolved);
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      browser: {
-        defaultProfile: "openclaw",
-        profiles: {
-          openclaw: { cdpPort: 18800, color: "#FF4500" },
-          work: { cdpPort: 18801, color: "#0066CC" },
-        },
-      },
+    const { service, state } = createDeletionFixture({
+      resolvedProfile: { cdpPort: 18801, color: "#0066CC" },
     });
     const tempDir = tempDirs.make("openclaw-trash-failure-");
     const userDataDir = path.join(tempDir, "work", "user-data");
@@ -626,7 +595,7 @@ describe("BrowserProfilesService", () => {
     vi.mocked(resolveOpenClawUserDataDir).mockReturnValue(userDataDir);
     vi.mocked(movePathToTrash).mockRejectedValueOnce(new Error("Trash unavailable"));
 
-    const result = await createBrowserProfilesService(ctx).deleteProfile("work");
+    const result = await service.deleteProfile("work");
 
     expect(result.deleted).toBe(false);
     expect(state.resolved.profiles).not.toHaveProperty("work");
@@ -635,19 +604,10 @@ describe("BrowserProfilesService", () => {
   });
 
   it("cleans a pending managed start before persisting deletion", async () => {
-    const resolved = resolveBrowserConfig({
-      profiles: { work: { cdpPort: 18801, color: "#0066CC" } },
+    const { service, state } = createDeletionFixture({
+      resolvedProfile: { cdpPort: 18801, color: "#0066CC" },
     });
-    const { ctx, state } = createCtx(resolved);
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      browser: {
-        profiles: {
-          openclaw: { cdpPort: 18800, color: "#FF4500" },
-          work: { cdpPort: 18801, color: "#0066CC" },
-        },
-      },
-    });
-    const profile = resolveProfile(resolved, "work");
+    const profile = resolveProfile(state.resolved, "work");
     if (!profile) {
       throw new Error("Expected work profile");
     }
@@ -692,7 +652,7 @@ describe("BrowserProfilesService", () => {
       return targetPath;
     });
 
-    const deleting = createBrowserProfilesService(ctx).deleteProfile("work");
+    const deleting = service.deleteProfile("work");
     launch.resolve();
     await Promise.all([startExpectation, deleting]);
 
@@ -701,28 +661,17 @@ describe("BrowserProfilesService", () => {
   });
 
   it("rolls back a delete tombstone when config persistence fails after cleanup", async () => {
-    const resolved = resolveBrowserConfig({
-      profiles: { work: { cdpPort: 18801, color: "#0066CC" } },
+    const { service, state } = createDeletionFixture({
+      resolvedProfile: { cdpPort: 18801, color: "#0066CC" },
     });
-    const { ctx, state } = createCtx(resolved);
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      browser: {
-        profiles: {
-          openclaw: { cdpPort: 18800, color: "#FF4500" },
-          work: { cdpPort: 18801, color: "#0066CC" },
-        },
-      },
-    });
-    const profile = resolveProfile(resolved, "work");
+    const profile = resolveProfile(state.resolved, "work");
     if (!profile) {
       throw new Error("Expected work profile");
     }
     const runtime = getOrCreateProfileRuntime(state, profile);
     configMocks.writeConfigFile.mockRejectedValueOnce(new Error("config write failed"));
 
-    await expect(createBrowserProfilesService(ctx).deleteProfile("work")).rejects.toThrow(
-      "config write failed",
-    );
+    await expect(service.deleteProfile("work")).rejects.toThrow("config write failed");
 
     expect(getProfileLifecycle(runtime).terminal).toBeNull();
     expect(getProfileLifecycle(runtime).blockedReason).toBeNull();
@@ -737,74 +686,6 @@ describe("BrowserProfilesService", () => {
         run: async () => {},
       }),
     ).resolves.toBeUndefined();
-  });
-
-  it("deletes existing-session profiles without touching local browser data", async () => {
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        "chrome-live": {
-          cdpPort: 18801,
-          color: "#0066CC",
-          driver: "existing-session",
-          attachOnly: true,
-        },
-      },
-    });
-    const { ctx } = createCtx(resolved);
-
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      browser: {
-        defaultProfile: "openclaw",
-        profiles: {
-          openclaw: { cdpPort: 18800, color: "#FF4500" },
-          "chrome-live": {
-            cdpPort: 18801,
-            color: "#0066CC",
-            driver: "existing-session",
-            attachOnly: true,
-          },
-        },
-      },
-    });
-
-    const service = createBrowserProfilesService(ctx);
-    const result = await service.deleteProfile("chrome-live");
-
-    expect(result.deleted).toBe(false);
-    expect(ctx.forProfile).not.toHaveBeenCalled();
-    expect(movePathToTrash).not.toHaveBeenCalled();
-  });
-
-  it("deletes attach-only openclaw profiles without touching local browser data", async () => {
-    const resolved = resolveBrowserConfig({
-      profiles: {
-        work: {
-          cdpPort: 18801,
-          color: "#0066CC",
-        },
-      },
-    });
-    const { ctx } = createCtx(resolved);
-    vi.mocked(getRuntimeConfig).mockReturnValue({
-      browser: {
-        defaultProfile: "openclaw",
-        profiles: {
-          openclaw: { cdpPort: 18800, color: "#FF4500" },
-          work: {
-            cdpPort: 18801,
-            color: "#0066CC",
-            driver: "openclaw",
-            attachOnly: true,
-          },
-        },
-      },
-    });
-
-    const result = await createBrowserProfilesService(ctx).deleteProfile("work");
-
-    expect(result.deleted).toBe(false);
-    expect(resolveOpenClawUserDataDir).not.toHaveBeenCalled();
-    expect(movePathToTrash).not.toHaveBeenCalled();
   });
 
   it("preserves a same-name replacement config that appears during lifecycle drain", async () => {


### PR DESCRIPTION
## What Problem This Solves

The browser configuration and profile-service suites repeated large setup and assertion blocks for the same profile-resolution and lifecycle policies. That made the suites harder to extend and let equivalent cases drift apart.

## Why This Change Was Made

Consolidates equivalent scenarios into named case matrices and one lifecycle fixture while preserving the credential-bearing normalization tests outside matrices. Production code and behavior are unchanged.

## User Impact

No user-visible behavior change. Browser plugin test coverage is easier to maintain with 296 fewer lines across the two suites.

## Evidence

- Blacksmith Testbox focused run: 93 passed, 1 Windows-only skip across the two files: https://github.com/openclaw/openclaw/actions/runs/30782601418
- Blacksmith Testbox `pnpm check:changed`: green, including formatting, guards, dead-code scans, extension-test typecheck, and lint.
- Final autoreview: TruffleHog clean; no findings; patch correct (0.99 confidence).
- Base/head census: 70/70 config tests and 24/24 profile-service tests. Title sets match except one clarity rename preserving the same throw contract. Field-level assertion audit preserves or strengthens every consolidated check.
- Diff: +581/-877 across two test files; production delta 0.
