### PR TITLE
refactor(policy): centralize CLI test fixtures

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -190,7 +190,6 @@ extensions/openai/realtime-voice-provider.ts
 extensions/openrouter/index.test.ts
 extensions/openshell/src/backend.ts
 extensions/openshell/src/openshell-core.test.ts
-extensions/policy/src/cli.test.ts
 extensions/policy/src/doctor/register.base.test-utils.ts
 extensions/policy/src/doctor/register.gateway-data-and-approvals.test-utils.ts
 extensions/policy/src/doctor/register.ingress-and-secrets.test-utils.ts

--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -75,6 +75,10 @@ function workspacePath(value: string): string {
   return isAbsolute(value) ? value : join(workspaceDir, value);
 }
 
+async function writeFixture(path: string, value: unknown): Promise<void> {
+  await fs.writeFile(path, typeof value === "string" ? value : JSON.stringify(value), "utf-8");
+}
+
 async function runPolicyCompareJson(options: PolicyCompareCliOptions) {
   return runPolicyCli([
     "compare",
@@ -83,6 +87,12 @@ async function runPolicyCompareJson(options: PolicyCompareCliOptions) {
     workspacePath(options.baseline),
     ...(options.policy === undefined ? [] : ["--policy", workspacePath(options.policy)]),
   ]);
+}
+
+async function runPolicyCompareFixture(baseline: unknown, policy: unknown = {}) {
+  await writeFixture(join(workspaceDir, "baseline.policy.jsonc"), baseline);
+  await writeFixture(join(workspaceDir, "policy.jsonc"), policy);
+  return runPolicyCompareJson({ baseline: "baseline.policy.jsonc" });
 }
 
 describe("policy commands", () => {
@@ -103,7 +113,7 @@ describe("policy commands", () => {
         denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
       },
     };
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
+    await writeFixture(join(workspaceDir, "policy.jsonc"), policy);
     const { exitCode, parsed } = await runPolicyCheckJson();
 
     expect(exitCode).toBe(0);
@@ -133,15 +143,11 @@ describe("policy commands", () => {
   });
 
   it("reports policy findings in policy check output", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        channels: {
-          denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
-        },
-      }),
-      "utf-8",
-    );
+    await writeFixture(join(workspaceDir, "policy.jsonc"), {
+      channels: {
+        denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
+      },
+    });
     const { exitCode, parsed } = await runPolicyCheckJson();
 
     expect(exitCode).toBe(0);
@@ -162,33 +168,25 @@ describe("policy commands", () => {
     const peerId = "+15555550123-private";
     const configPath = join(workspaceDir, "openclaw.jsonc");
     vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        plugins: { entries: { policy: { enabled: true, config: { enabled: true } } } },
-        agents: { entries: { main: { default: true }, family: {} } },
-        channels: { imessage: { enabled: false } },
-        bindings: [],
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        routing: {
-          requireBindings: true,
-          requireConfiguredChannels: true,
-          probes: [
-            {
-              id: "family-dm",
-              route: { channel: "imessage", peer: { kind: "direct", id: peerId } },
-              expect: { agentId: "family", matchedBy: ["binding.peer"] },
-            },
-          ],
-        },
-      }),
-      "utf-8",
-    );
+    await writeFixture(configPath, {
+      plugins: { entries: { policy: { enabled: true, config: { enabled: true } } } },
+      agents: { entries: { main: { default: true }, family: {} } },
+      channels: { imessage: { enabled: false } },
+      bindings: [],
+    });
+    await writeFixture(join(workspaceDir, "policy.jsonc"), {
+      routing: {
+        requireBindings: true,
+        requireConfiguredChannels: true,
+        probes: [
+          {
+            id: "family-dm",
+            route: { channel: "imessage", peer: { kind: "direct", id: peerId } },
+            expect: { agentId: "family", matchedBy: ["binding.peer"] },
+          },
+        ],
+      },
+    });
 
     const { exitCode, parsed, output } = await runPolicyCheckJson();
 
@@ -204,44 +202,30 @@ describe("policy commands", () => {
     expect(output.join("\n")).not.toContain(peerId);
   });
 
-  it("reports malformed policy rules in policy check output", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ channels: { denyRules: [{ when: {} }] } }),
-      "utf-8",
-    );
+  it.each([
+    {
+      name: "reports malformed policy rules in policy check output",
+      policy: { channels: { denyRules: [{ when: {} }] } },
+      target: "oc://policy.jsonc/channels/denyRules/#0",
+    },
+    {
+      name: "reports malformed policy containers in policy check output",
+      policy: { tools: [] },
+      target: "oc://policy.jsonc/tools",
+    },
+  ])("$name", async ({ policy, target }) => {
+    await writeFixture(join(workspaceDir, "policy.jsonc"), policy);
     const { exitCode, parsed } = await runPolicyCheckJson();
 
     expect(exitCode).toBe(1);
     expect(parsed).toMatchObject({
       ok: false,
-      findings: [
-        {
-          checkId: "policy/policy-jsonc-invalid",
-          target: "oc://policy.jsonc/channels/denyRules/#0",
-        },
-      ],
-    });
-  });
-
-  it("reports malformed policy containers in policy check output", async () => {
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify({ tools: [] }), "utf-8");
-    const { exitCode, parsed } = await runPolicyCheckJson();
-
-    expect(exitCode).toBe(1);
-    expect(parsed).toMatchObject({
-      ok: false,
-      findings: [
-        {
-          checkId: "policy/policy-jsonc-invalid",
-          target: "oc://policy.jsonc/tools",
-        },
-      ],
+      findings: [{ checkId: "policy/policy-jsonc-invalid", target }],
     });
   });
 
   it("reports unparseable policy files in policy check output", async () => {
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), "{ channels: ", "utf-8");
+    await writeFixture(join(workspaceDir, "policy.jsonc"), "{ channels: ");
     const { exitCode, parsed } = await runPolicyCheckJson();
 
     expect(exitCode).toBe(1);
@@ -260,27 +244,19 @@ describe("policy commands", () => {
   it("links policy findings to evidence and policy requirement refs", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        plugins: {
-          entries: {
-            policy: { enabled: true, config: { enabled: true } },
-          },
+    await writeFixture(configPath, {
+      plugins: {
+        entries: {
+          policy: { enabled: true, config: { enabled: true } },
         },
-        channels: { telegram: { enabled: true } },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        channels: {
-          denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
-        },
-      }),
-      "utf-8",
-    );
+      },
+      channels: { telegram: { enabled: true } },
+    });
+    await writeFixture(join(workspaceDir, "policy.jsonc"), {
+      channels: {
+        denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
+      },
+    });
     const { exitCode, parsed } = await runPolicyCheckJson();
 
     expect(exitCode).toBe(1);
@@ -336,30 +312,22 @@ describe("policy commands", () => {
   it("attests underlying policy findings when the accepted attestation is stale", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        plugins: {
-          entries: {
-            policy: {
-              enabled: true,
-              config: { enabled: true, expectedAttestationHash: "sha256:not-current" },
-            },
+    await writeFixture(configPath, {
+      plugins: {
+        entries: {
+          policy: {
+            enabled: true,
+            config: { enabled: true, expectedAttestationHash: "sha256:not-current" },
           },
         },
-        channels: { telegram: { enabled: true } },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
-        channels: {
-          denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
-        },
-      }),
-      "utf-8",
-    );
+      },
+      channels: { telegram: { enabled: true } },
+    });
+    await writeFixture(join(workspaceDir, "policy.jsonc"), {
+      channels: {
+        denyRules: [{ id: "no-telegram", when: { provider: "telegram" } }],
+      },
+    });
     const { exitCode, parsed } = await runPolicyCheckJson();
 
     expect(exitCode).toBe(1);
@@ -381,25 +349,17 @@ describe("policy commands", () => {
   it("reports stale accepted attestations in policy watch", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        plugins: {
-          entries: {
-            policy: {
-              enabled: true,
-              config: { enabled: true, expectedAttestationHash: "sha256:not-current" },
-            },
+    await writeFixture(configPath, {
+      plugins: {
+        entries: {
+          policy: {
+            enabled: true,
+            config: { enabled: true, expectedAttestationHash: "sha256:not-current" },
           },
         },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ channels: { denyRules: [] } }),
-      "utf-8",
-    );
+      },
+    });
+    await writeFixture(join(workspaceDir, "policy.jsonc"), { channels: { denyRules: [] } });
 
     const { exitCode, parsed } = await runPolicyWatchJson();
 
@@ -415,22 +375,24 @@ describe("policy commands", () => {
     });
   });
 
-  it("rejects partial policy watch intervals before evaluating policy", async () => {
-    const { exitCode, output } = await runPolicyWatchJson({ intervalMs: "500ms" });
-
-    expect(exitCode).toBe(2);
-    expect(output.join("\n")).toContain("--interval-ms must be an integer >= 250.");
-  });
-
-  it("rejects sub-floor policy watch intervals before evaluating policy", async () => {
-    const { exitCode, output } = await runPolicyWatchJson({ intervalMs: "249" });
+  it.each([
+    {
+      name: "rejects partial policy watch intervals before evaluating policy",
+      intervalMs: "500ms",
+    },
+    {
+      name: "rejects sub-floor policy watch intervals before evaluating policy",
+      intervalMs: "249",
+    },
+  ])("$name", async ({ intervalMs }) => {
+    const { exitCode, output } = await runPolicyWatchJson({ intervalMs });
 
     expect(exitCode).toBe(2);
     expect(output.join("\n")).toContain("--interval-ms must be an integer >= 250.");
   });
 
   it("reports findings instead of stale when policy watch has no attestation to compare", async () => {
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), "{ channels: ", "utf-8");
+    await writeFixture(join(workspaceDir, "policy.jsonc"), "{ channels: ");
 
     const { exitCode, parsed } = await runPolicyWatchJson();
 
@@ -448,21 +410,17 @@ describe("policy commands", () => {
   it("reports findings before stale when accepted attestation exists", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        plugins: {
-          entries: {
-            policy: {
-              enabled: true,
-              config: { enabled: true, expectedAttestationHash: "sha256:not-current" },
-            },
+    await writeFixture(configPath, {
+      plugins: {
+        entries: {
+          policy: {
+            enabled: true,
+            config: { enabled: true, expectedAttestationHash: "sha256:not-current" },
           },
         },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), "{ channels: ", "utf-8");
+      },
+    });
+    await writeFixture(join(workspaceDir, "policy.jsonc"), "{ channels: ");
 
     const { exitCode, parsed } = await runPolicyWatchJson();
 
@@ -498,7 +456,7 @@ describe("policy commands", () => {
   it("fails closed when the OpenClaw config is invalid", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
-    await fs.writeFile(configPath, "{", "utf-8");
+    await writeFixture(configPath, "{");
     const { exitCode, parsed } = await runPolicyCheckJson();
 
     expect(exitCode).toBe(1);
@@ -509,9 +467,8 @@ describe("policy commands", () => {
   });
 
   it("checks policy file conformance with metadata-backed global rules", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      {
         channels: { denyRules: [{ when: { provider: "telegram" } }] },
         mcp: { servers: { allow: ["docs", "audit"], deny: ["untrusted"] } },
         models: { providers: { allow: ["openai", "anthropic"], deny: ["openrouter"] } },
@@ -525,12 +482,8 @@ describe("policy commands", () => {
         tools: { requireMetadata: ["risk"] },
         secrets: { requireManagedProviders: true, denySources: ["env"] },
         auth: { profiles: { allowModes: ["oauth", "token"], requireMetadata: ["provider"] } },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+      },
+      {
         channels: { denyRules: [{ when: { provider: "telegram" } }] },
         mcp: { servers: { allow: ["docs"], deny: ["untrusted", "shadow"] } },
         models: { providers: { allow: ["openai"], deny: ["openrouter", "local"] } },
@@ -544,13 +497,8 @@ describe("policy commands", () => {
         tools: { requireMetadata: ["risk", "owner"] },
         secrets: { requireManagedProviders: true, denySources: ["env", "file"] },
         auth: { profiles: { allowModes: ["oauth"], requireMetadata: ["provider", "mode"] } },
-      }),
-      "utf-8",
+      },
     );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(0);
     expect(parsed).toMatchObject({
@@ -573,16 +521,7 @@ describe("policy commands", () => {
         },
       },
     };
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify(policy),
-      "utf-8",
-    );
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify(policy), "utf-8");
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
+    const { exitCode, parsed } = await runPolicyCompareFixture(policy, policy);
 
     expect(exitCode).toBe(0);
     expect(parsed).toMatchObject({
@@ -597,14 +536,11 @@ describe("policy commands", () => {
       route: { channel: "imessage", peer: { kind: "direct", id: "private-peer" } },
       expect: { agentId: "family", matchedBy: ["binding.peer", "binding.account"] },
     };
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({ routing: { requireBindings: true, probes: [baselineProbe] } }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      {
+        routing: { requireBindings: true, probes: [baselineProbe] },
+      },
+      {
         routing: {
           requireBindings: true,
           probes: [
@@ -619,13 +555,8 @@ describe("policy commands", () => {
             },
           ],
         },
-      }),
-      "utf-8",
+      },
     );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(0);
     expect(parsed).toMatchObject({ ok: true, findings: [] });
@@ -637,14 +568,11 @@ describe("policy commands", () => {
       route: { channel: "imessage", peer: { kind: "direct", id: "private-peer" } },
       expect: { agentId: "family", matchedBy: ["binding.peer"] },
     };
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({ routing: { probes: [baselineProbe] } }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      {
+        routing: { probes: [baselineProbe] },
+      },
+      {
         routing: {
           probes: [
             {
@@ -653,13 +581,8 @@ describe("policy commands", () => {
             },
           ],
         },
-      }),
-      "utf-8",
+      },
     );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(1);
     expect(parsed.findings).toEqual([
@@ -668,29 +591,18 @@ describe("policy commands", () => {
   });
 
   it("treats an empty baseline routing probe list as a no-op", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({ routing: { probes: [] } }),
-      "utf-8",
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      { routing: { probes: [] } },
+      { routing: {} },
     );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({ routing: {} }),
-      "utf-8",
-    );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(0);
     expect(parsed).toMatchObject({ ok: true, findings: [] });
   });
 
   it("rejects unsupported exec approval allowlist requirement keys in policy compare", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      {
         execApprovals: {
           agents: {
             allowlist: {
@@ -698,12 +610,8 @@ describe("policy commands", () => {
             },
           },
         },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+      },
+      {
         execApprovals: {
           agents: {
             allowlist: {
@@ -711,13 +619,8 @@ describe("policy commands", () => {
             },
           },
         },
-      }),
-      "utf-8",
+      },
     );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(1);
     expect(parsed).toMatchObject({
@@ -735,25 +638,17 @@ describe("policy commands", () => {
   });
 
   it("reports missing and weaker policy file conformance rules", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
-        channels: { denyRules: [{ when: { provider: "telegram" } }] },
-        network: { privateNetwork: { allow: false } },
-        gateway: { auth: { requireAuth: true } },
-        secrets: { denySources: ["env"] },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "candidate.policy.jsonc"),
-      JSON.stringify({
-        channels: { denyRules: [{ when: { provider: "Telegram" } }] },
-        network: { privateNetwork: { allow: true } },
-        secrets: { denySources: [] },
-      }),
-      "utf-8",
-    );
+    await writeFixture(join(workspaceDir, "baseline.policy.jsonc"), {
+      channels: { denyRules: [{ when: { provider: "telegram" } }] },
+      network: { privateNetwork: { allow: false } },
+      gateway: { auth: { requireAuth: true } },
+      secrets: { denySources: ["env"] },
+    });
+    await writeFixture(join(workspaceDir, "candidate.policy.jsonc"), {
+      channels: { denyRules: [{ when: { provider: "Telegram" } }] },
+      network: { privateNetwork: { allow: true } },
+      secrets: { denySources: [] },
+    });
 
     const { exitCode, parsed } = await runPolicyCompareJson({
       baseline: "baseline.policy.jsonc",
@@ -784,12 +679,7 @@ describe("policy commands", () => {
   });
 
   it("returns JSON findings for malformed policy compare files", async () => {
-    await fs.writeFile(join(workspaceDir, "baseline.policy.jsonc"), "{", "utf-8");
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify({}), "utf-8");
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
+    const { exitCode, parsed } = await runPolicyCompareFixture("{", {});
 
     expect(exitCode).toBe(1);
     expect(parsed).toMatchObject({
@@ -805,7 +695,7 @@ describe("policy commands", () => {
   });
 
   it("returns JSON findings for missing policy compare files", async () => {
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify({}), "utf-8");
+    await writeFixture(join(workspaceDir, "policy.jsonc"), {});
 
     const { exitCode, parsed } = await runPolicyCompareJson({
       baseline: "missing.policy.jsonc",
@@ -825,19 +715,10 @@ describe("policy commands", () => {
   });
 
   it("does not require candidate keys for baseline rules that impose no restriction", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
-        channels: { denyRules: [] },
-        gateway: { auth: { requireAuth: false } },
-        mcp: { servers: { allow: [] } },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify({}), "utf-8");
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
+    const { exitCode, parsed } = await runPolicyCompareFixture({
+      channels: { denyRules: [] },
+      gateway: { auth: { requireAuth: false } },
+      mcp: { servers: { allow: [] } },
     });
 
     expect(exitCode).toBe(0);
@@ -848,17 +729,8 @@ describe("policy commands", () => {
   });
 
   it("rejects malformed baseline policy rules during policy file conformance", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
-        channels: { denyRules: [{ when: {} }] },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify({}), "utf-8");
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
+    const { exitCode, parsed } = await runPolicyCompareFixture({
+      channels: { denyRules: [{ when: {} }] },
     });
 
     expect(exitCode).toBe(1);
@@ -870,155 +742,87 @@ describe("policy commands", () => {
     ]);
   });
 
-  it("rejects malformed policy containers during policy file conformance", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
-        network: { privateNetwork: "bad" },
-        tools: "bad",
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify({}), "utf-8");
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
-
-    expect(exitCode).toBe(1);
-    expect(parsed.findings).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          checkId: "policy/policy-conformance-invalid",
-          target: "oc://baseline.policy.jsonc/tools",
-        }),
-      ]),
-    );
-  });
-
-  it("rejects scoped policy rules that do not have a valid supported selector", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
+  it.each([
+    {
+      name: "rejects malformed policy containers during policy file conformance",
+      baseline: { network: { privateNetwork: "bad" }, tools: "bad" },
+      policy: undefined,
+      targets: ["oc://baseline.policy.jsonc/tools"],
+    },
+    {
+      name: "rejects scoped policy rules that do not have a valid supported selector",
+      baseline: {
         scopes: {
-          missingSelector: {
-            tools: { exec: { allowHosts: ["sandbox"] } },
-          },
+          missingSelector: { tools: { exec: { allowHosts: ["sandbox"] } } },
           wrongSelector: {
             channelIds: ["telegram"],
             tools: { exec: { allowHosts: ["sandbox"] } },
           },
         },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(join(workspaceDir, "policy.jsonc"), JSON.stringify({}), "utf-8");
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
-
-    expect(exitCode).toBe(1);
-    expect(parsed.findings).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          checkId: "policy/policy-conformance-invalid",
-          target: "oc://baseline.policy.jsonc/scopes/missingSelector/tools/exec/allowHosts",
-        }),
-        expect.objectContaining({
-          checkId: "policy/policy-conformance-invalid",
-          target: "oc://baseline.policy.jsonc/scopes/wrongSelector/tools/exec/allowHosts",
-        }),
-      ]),
-    );
-  });
-
-  it("rejects unsupported enum values during policy file conformance", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
+      },
+      policy: undefined,
+      targets: [
+        "oc://baseline.policy.jsonc/scopes/missingSelector/tools/exec/allowHosts",
+        "oc://baseline.policy.jsonc/scopes/wrongSelector/tools/exec/allowHosts",
+      ],
+    },
+    {
+      name: "rejects unsupported enum values during policy file conformance",
+      baseline: {
         auth: { profiles: { allowModes: ["password"] } },
         gateway: { http: { denyEndpoints: ["bogus"] } },
         tools: { requireMetadata: ["custom"] },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+      },
+      policy: {
         auth: { profiles: { allowModes: ["password"] } },
         gateway: { http: { denyEndpoints: ["bogus"] } },
         tools: { requireMetadata: ["custom"] },
-      }),
-      "utf-8",
-    );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
+      },
+      targets: [
+        "oc://baseline.policy.jsonc/auth/profiles/allowModes",
+        "oc://baseline.policy.jsonc/gateway/http/denyEndpoints",
+        "oc://baseline.policy.jsonc/tools/requireMetadata",
+      ],
+    },
+  ])("$name", async ({ baseline, policy, targets }) => {
+    const { exitCode, parsed } = await runPolicyCompareFixture(baseline, policy);
 
     expect(exitCode).toBe(1);
     expect(parsed.findings).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          checkId: "policy/policy-conformance-invalid",
-          target: "oc://baseline.policy.jsonc/auth/profiles/allowModes",
-        }),
-        expect.objectContaining({
-          checkId: "policy/policy-conformance-invalid",
-          target: "oc://baseline.policy.jsonc/gateway/http/denyEndpoints",
-        }),
-        expect.objectContaining({
-          checkId: "policy/policy-conformance-invalid",
-          target: "oc://baseline.policy.jsonc/tools/requireMetadata",
-        }),
-      ]),
+      expect.arrayContaining(
+        targets.map((target) =>
+          expect.objectContaining({
+            checkId: "policy/policy-conformance-invalid",
+            target,
+          }),
+        ),
+      ),
     );
   });
 
   it("normalizes model provider casing during policy file conformance", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      {
         models: { providers: { allow: ["OpenAI"], deny: ["OpenRouter"] } },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+      },
+      {
         models: { providers: { allow: ["openai"], deny: ["openrouter"] } },
-      }),
-      "utf-8",
+      },
     );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(0);
     expect(parsed.findings).toEqual([]);
   });
 
   it("rejects gateway HTTP endpoint ids with invalid casing during policy file conformance", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      {
         gateway: { http: { denyEndpoints: ["chatCompletions"] } },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+      },
+      {
         gateway: { http: { denyEndpoints: ["chatcompletions"] } },
-      }),
-      "utf-8",
+      },
     );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(1);
     expect(parsed.findings).toEqual(
@@ -1036,32 +840,20 @@ describe("policy commands", () => {
     await fs.mkdir(agentWorkspace, { recursive: true });
     const configPath = join(workspaceDir, "openclaw.jsonc");
     vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        agents: { defaults: { workspace: agentWorkspace } },
-        plugins: {
-          entries: {
-            policy: { enabled: true, config: { enabled: true, path: "policy.jsonc" } },
-          },
+    await writeFixture(configPath, {
+      agents: { defaults: { workspace: agentWorkspace } },
+      plugins: {
+        entries: {
+          policy: { enabled: true, config: { enabled: true, path: "policy.jsonc" } },
         },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
-        network: { privateNetwork: { allow: false } },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(agentWorkspace, "policy.jsonc"),
-      JSON.stringify({
-        network: { privateNetwork: { allow: false } },
-      }),
-      "utf-8",
-    );
+      },
+    });
+    await writeFixture(join(workspaceDir, "baseline.policy.jsonc"), {
+      network: { privateNetwork: { allow: false } },
+    });
+    await writeFixture(join(agentWorkspace, "policy.jsonc"), {
+      network: { privateNetwork: { allow: false } },
+    });
 
     const { exitCode, parsed } = await runPolicyCompareJson({
       baseline: join(workspaceDir, "baseline.policy.jsonc"),
@@ -1076,9 +868,8 @@ describe("policy commands", () => {
   });
 
   it("allows a top-level candidate rule to satisfy a scoped baseline rule", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      {
         scopes: {
           release: {
             agentIds: ["main"],
@@ -1089,42 +880,28 @@ describe("policy commands", () => {
             ingress: { channels: { requireMentionInGroups: true } },
           },
         },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+      },
+      {
         tools: { exec: { allowHosts: ["sandbox"] } },
         ingress: { channels: { requireMentionInGroups: true } },
-      }),
-      "utf-8",
+      },
     );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(0);
     expect(parsed.findings).toEqual([]);
   });
 
   it("rejects a weaker scoped candidate override even when top-level policy satisfies baseline", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      {
         scopes: {
           release: {
             agentIds: ["main"],
             tools: { exec: { allowHosts: ["sandbox"] } },
           },
         },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+      },
+      {
         tools: { exec: { allowHosts: ["sandbox"] } },
         scopes: {
           release: {
@@ -1132,13 +909,8 @@ describe("policy commands", () => {
             tools: { exec: { allowHosts: ["sandbox", "node"] } },
           },
         },
-      }),
-      "utf-8",
+      },
     );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(1);
     expect(parsed.findings).toEqual([
@@ -1151,21 +923,16 @@ describe("policy commands", () => {
   });
 
   it("accepts stricter later scoped candidate overlays during policy compare", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      {
         scopes: {
           release: {
             agentIds: ["main"],
             tools: { exec: { allowHosts: ["sandbox"] } },
           },
         },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+      },
+      {
         scopes: {
           team: {
             agentIds: ["main"],
@@ -1176,34 +943,24 @@ describe("policy commands", () => {
             tools: { exec: { allowHosts: ["sandbox"] } },
           },
         },
-      }),
-      "utf-8",
+      },
     );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(0);
     expect(parsed.findings).toEqual([]);
   });
 
   it("rejects duplicate scoped candidates when any matching scoped value is weaker", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      {
         scopes: {
           release: {
             agentIds: ["main"],
             tools: { exec: { allowHosts: ["sandbox"] } },
           },
         },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+      },
+      {
         scopes: {
           release: {
             agentIds: ["main"],
@@ -1214,13 +971,8 @@ describe("policy commands", () => {
             tools: { exec: { allowHosts: ["sandbox", "node"] } },
           },
         },
-      }),
-      "utf-8",
+      },
     );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(1);
     expect(parsed.findings).toEqual([
@@ -1233,16 +985,11 @@ describe("policy commands", () => {
   });
 
   it("rejects a weaker scoped candidate override for a global baseline rule", async () => {
-    await fs.writeFile(
-      join(workspaceDir, "baseline.policy.jsonc"),
-      JSON.stringify({
+    const { exitCode, parsed } = await runPolicyCompareFixture(
+      {
         tools: { exec: { allowHosts: ["sandbox"] } },
-      }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      join(workspaceDir, "policy.jsonc"),
-      JSON.stringify({
+      },
+      {
         tools: { exec: { allowHosts: ["sandbox"] } },
         scopes: {
           relaxed: {
@@ -1250,13 +997,8 @@ describe("policy commands", () => {
             tools: { exec: { allowHosts: ["sandbox", "node"] } },
           },
         },
-      }),
-      "utf-8",
+      },
     );
-
-    const { exitCode, parsed } = await runPolicyCompareJson({
-      baseline: "baseline.policy.jsonc",
-    });
 
     expect(exitCode).toBe(1);
     expect(parsed.findings).toEqual([
@@ -1268,4 +1010,3 @@ describe("policy commands", () => {
     ]);
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Policy CLI tests repeated serialization, path, and baseline/candidate setup across 61 fixture writes. The repeated mechanics obscured the command scenarios and kept the file above the repository line limit.

## Why This Change Was Made

Adds one test-local fixture serializer and one standard policy-compare fixture runner, then table-drives only cases with identical command, output, and assertion semantics. All 37 CLI scenarios, raw malformed inputs, JSON values, write order, paths, and assertions remain covered. Production CLI, configuration, schemas, protocols, and public contracts are unchanged.

## User Impact

No user-visible behavior changes. Maintainers get one fixture owner for the policy CLI suite, 260 fewer test/tooling lines, and removal of the suite's now-stale max-lines exception.

## Evidence

- Inspectable after-fix proof: [focused Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/30781846477), wrapper exit 0.

```text
Test Files  1 passed (1)
Tests       37 passed (37)
Exit code   0
```

- [Exact-head changed gate on Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30782787259), exit 0: ratchets, formatting, boundaries, dead-code, extension-test typecheck, full extension lint, and script lint passed.
- Autoreview: clean, no accepted/actionable findings; patch correct (0.99 confidence).
- Scenario-title parity: 37 before / 37 after, with no missing or added scenario names.
- Diff: 240 additions, 500 deletions; net -260 test/tooling lines, 0 runtime production lines.
