### PR TITLE
refactor(gateway): consolidate server method test fixtures

### DIFF
--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -95,6 +95,110 @@ function lastMockCallArg(mock: ReturnType<typeof vi.fn>, argIndex = 0) {
   return call[argIndex];
 }
 
+type ChatHistoryTestRole = "assistant" | "custom" | "system" | "toolResult" | "user";
+type ChatHistoryTestMessage = Record<string, unknown>;
+
+function textHistoryMessage(
+  role: ChatHistoryTestRole,
+  text: string,
+  fields: ChatHistoryTestMessage = {},
+): ChatHistoryTestMessage {
+  return { role, content: [{ type: "text", text }], ...fields };
+}
+
+function assistantHistoryMessage(
+  text: string,
+  fields: ChatHistoryTestMessage = {},
+): ChatHistoryTestMessage {
+  return textHistoryMessage("assistant", text, fields);
+}
+
+function userHistoryMessage(
+  text: string,
+  fields: ChatHistoryTestMessage = {},
+): ChatHistoryTestMessage {
+  return textHistoryMessage("user", text, fields);
+}
+
+function sessionsSendProvenance(sourceSessionKey = "agent:main:webchat:source") {
+  return { kind: "inter_session", sourceSessionKey, sourceTool: "sessions_send" };
+}
+
+function sessionsSendHistoryMessage(
+  text: string,
+  timestamp: number,
+  fields: ChatHistoryTestMessage = {},
+): ChatHistoryTestMessage {
+  return userHistoryMessage(text, {
+    provenance: sessionsSendProvenance(),
+    timestamp,
+    ...fields,
+  });
+}
+
+function projectedSessionsSendHistoryMessage(
+  text: string,
+  timestamp: number,
+  fields: ChatHistoryTestMessage = {},
+): ChatHistoryTestMessage {
+  return assistantHistoryMessage(text, {
+    senderLabel: "Forwarded from main",
+    provenance: sessionsSendProvenance(),
+    timestamp,
+    ...fields,
+  });
+}
+
+function assistantAudioAttachmentHistoryMessage(
+  text: string,
+  timestamp: number,
+  fields: ChatHistoryTestMessage = {},
+): ChatHistoryTestMessage {
+  return {
+    role: "assistant",
+    content: [
+      { type: "text", text },
+      {
+        type: "attachment",
+        attachment: {
+          url: "/tmp/tts.mp3",
+          kind: "audio",
+          label: "tts.mp3",
+          mimeType: "audio/mpeg",
+        },
+      },
+    ],
+    timestamp,
+    ...fields,
+  };
+}
+
+function ttsSupplementHistoryMessage(
+  marker: { textSha256: string; spokenText?: string },
+  timestamp: number,
+  text = "Audio reply",
+): ChatHistoryTestMessage {
+  return assistantAudioAttachmentHistoryMessage(text, timestamp, {
+    openclawTtsSupplement: marker,
+  });
+}
+
+function deliveryMirrorHistoryMessage(
+  text: string,
+  sourceMessageId: string,
+  timestamp: number,
+): ChatHistoryTestMessage {
+  return {
+    role: "assistant",
+    provider: "openclaw",
+    model: "delivery-mirror",
+    content: [{ type: "text", text }],
+    idempotencyKey: `channel-final:${sourceMessageId}:0`,
+    openclawDeliveryMirror: { kind: "channel-final", sourceMessageId },
+    timestamp,
+  };
+}
+
 describe("waitForAgentJob", () => {
   async function runLifecycleScenario(params: {
     runIdPrefix: string;
@@ -778,22 +882,12 @@ describe("sanitizeChatHistoryMessages", () => {
   it("truncates display text without splitting surrogate pairs", () => {
     const prefix = "a".repeat(7);
     const result = sanitizeChatHistoryMessages(
-      [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: `${prefix}😀tail` }],
-          timestamp: 1,
-        },
-      ],
+      [assistantHistoryMessage(`${prefix}😀tail`, { timestamp: 1 })],
       8,
     );
 
     expect(result).toEqual([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: `${prefix}\n...(truncated)...` }],
-        timestamp: 1,
-      },
+      assistantHistoryMessage(`${prefix}\n...(truncated)...`, { timestamp: 1 }),
     ]);
   });
 
@@ -927,11 +1021,7 @@ describe("sanitizeChatHistoryMessages", () => {
 
   it("drops commentary-only assistant entries when phase exists only in textSignature", () => {
     const result = sanitizeChatHistoryMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "hello" }],
-        timestamp: 1,
-      },
+      userHistoryMessage("hello", { timestamp: 1 }),
       {
         role: "assistant",
         content: [
@@ -943,24 +1033,12 @@ describe("sanitizeChatHistoryMessages", () => {
         ],
         timestamp: 2,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "real reply" }],
-        timestamp: 3,
-      },
+      assistantHistoryMessage("real reply", { timestamp: 3 }),
     ]);
 
     expect(result).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "hello" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "real reply" }],
-        timestamp: 3,
-      },
+      userHistoryMessage("hello", { timestamp: 1 }),
+      assistantHistoryMessage("real reply", { timestamp: 3 }),
     ]);
   });
 });
@@ -1253,12 +1331,10 @@ describe("projectRecentChatDisplayMessages", () => {
       ]);
 
       expect(result).toEqual([
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "The agent run failed before producing a reply." }],
+        assistantHistoryMessage("The agent run failed before producing a reply.", {
           stopReason: "error",
           timestamp: 1,
-        },
+        }),
       ]);
       expect(JSON.stringify(result)).not.toContain("secret.internal.example");
     },
@@ -1268,23 +1344,19 @@ describe("projectRecentChatDisplayMessages", () => {
     "projects repaired stream errors with errorMessage %j as a generic safe failure",
     (errorMessage) => {
       const result = projectRecentChatDisplayMessages([
-        {
-          role: "assistant",
-          content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+        assistantHistoryMessage(STREAM_ERROR_FALLBACK_TEXT, {
           stopReason: "error",
           ...(errorMessage === undefined ? {} : { errorMessage }),
           errorBody: "private response body from secret.internal.example",
           timestamp: 1,
-        },
+        }),
       ]);
 
       expect(result).toEqual([
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "The agent run failed before producing a reply." }],
+        assistantHistoryMessage("The agent run failed before producing a reply.", {
           stopReason: "error",
           timestamp: 1,
-        },
+        }),
       ]);
       expect(JSON.stringify(result)).not.toContain("secret.internal.example");
     },
@@ -1342,7 +1414,7 @@ describe("projectRecentChatDisplayMessages", () => {
   it("keeps intentional mentions of the internal fallback inside a real assistant reply", () => {
     const text = `Diagnostic note: ${STREAM_ERROR_FALLBACK_TEXT}`;
     const result = projectRecentChatDisplayMessages([
-      { role: "assistant", content: [{ type: "text", text }], stopReason: "error" },
+      assistantHistoryMessage(text, { stopReason: "error" }),
     ]);
 
     expect(result[0]?.content).toEqual([{ type: "text", text }]);
@@ -1353,11 +1425,7 @@ describe("projectRecentChatDisplayMessages", () => {
     (stopReason) => {
       const text = `${STREAM_ERROR_FALLBACK_TEXT} actual quoted text`;
       const result = projectRecentChatDisplayMessages([
-        {
-          role: "assistant",
-          content: [{ type: "text", text }],
-          ...(stopReason ? { stopReason } : {}),
-        },
+        assistantHistoryMessage(text, stopReason ? { stopReason } : {}),
       ]);
 
       expect(result[0]?.content).toEqual([{ type: "text", text }]);
@@ -1383,139 +1451,66 @@ describe("projectRecentChatDisplayMessages", () => {
 
   it("drops a repaired stream-error placeholder before same-turn assistant content", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "hello" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+      userHistoryMessage("hello", { timestamp: 1 }),
+      assistantHistoryMessage(STREAM_ERROR_FALLBACK_TEXT, {
         stopReason: "error",
         errorMessage: "provider failed before content",
         timestamp: 2,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "actual fallback response" }],
-        timestamp: 3,
-      },
+      }),
+      assistantHistoryMessage("actual fallback response", { timestamp: 3 }),
     ]);
 
     expect(result).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "hello" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "actual fallback response" }],
-        timestamp: 3,
-      },
+      userHistoryMessage("hello", { timestamp: 1 }),
+      assistantHistoryMessage("actual fallback response", { timestamp: 3 }),
     ]);
   });
 
   it("keeps a genuine failed turn before a new forwarded inter-session turn", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+      assistantHistoryMessage(STREAM_ERROR_FALLBACK_TEXT, {
         stopReason: "error",
         timestamp: 1,
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "forwarded update" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
-        timestamp: 2,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "actual fallback response" }],
-        timestamp: 3,
-      },
+      }),
+      sessionsSendHistoryMessage("forwarded update", 2),
+      assistantHistoryMessage("actual fallback response", { timestamp: 3 }),
     ]);
 
     expect(result).toHaveLength(3);
-    expect(result[0]).toMatchObject({
-      role: "assistant",
-      content: [{ type: "text", text: "The agent run failed before producing a reply." }],
-    });
-    expect(result[1]).toMatchObject({
-      role: "assistant",
-      content: [{ type: "text", text: "forwarded update" }],
-    });
-    expect(result[2]).toMatchObject({
-      role: "assistant",
-      content: [{ type: "text", text: "actual fallback response" }],
-    });
+    expect(result[0]).toMatchObject(
+      assistantHistoryMessage("The agent run failed before producing a reply."),
+    );
+    expect(result[1]).toMatchObject(assistantHistoryMessage("forwarded update"));
+    expect(result[2]).toMatchObject(assistantHistoryMessage("actual fallback response"));
   });
 
   it("keeps genuine stream-error failures when a hidden assistant row has text", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
-        stopReason: "error",
-      },
-      {
-        role: "assistant",
-        display: false,
-        content: [{ type: "text", text: "internal-only assistant content" }],
-      },
+      assistantHistoryMessage(STREAM_ERROR_FALLBACK_TEXT, { stopReason: "error" }),
+      assistantHistoryMessage("internal-only assistant content", { display: false }),
     ]);
 
     expect(result).toEqual([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "The agent run failed before producing a reply." }],
+      assistantHistoryMessage("The agent run failed before producing a reply.", {
         stopReason: "error",
-      },
+      }),
     ]);
   });
 
   it("keeps a stream-error placeholder when the next user turn starts first", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
-        stopReason: "error",
-        timestamp: 1,
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "retry" }],
-        timestamp: 2,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "fresh answer" }],
-        timestamp: 3,
-      },
+      assistantHistoryMessage(STREAM_ERROR_FALLBACK_TEXT, { stopReason: "error", timestamp: 1 }),
+      userHistoryMessage("retry", { timestamp: 2 }),
+      assistantHistoryMessage("fresh answer", { timestamp: 3 }),
     ]);
 
     expect(result).toEqual([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "The agent run failed before producing a reply." }],
+      assistantHistoryMessage("The agent run failed before producing a reply.", {
         stopReason: "error",
         timestamp: 1,
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "retry" }],
-        timestamp: 2,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "fresh answer" }],
-        timestamp: 3,
-      },
+      }),
+      userHistoryMessage("retry", { timestamp: 2 }),
+      assistantHistoryMessage("fresh answer", { timestamp: 3 }),
     ]);
   });
 
@@ -1543,47 +1538,16 @@ describe("projectRecentChatDisplayMessages", () => {
     ]);
 
     expect(result).toEqual([
-      {
-        role: "assistant",
-        senderLabel: "Forwarded from main",
-        content: [{ type: "text", text: "forwarded report" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:discord:source",
-          sourceTool: "sessions_send",
-        },
-        timestamp: 1,
-      },
+      projectedSessionsSendHistoryMessage("forwarded report", 1, {
+        provenance: sessionsSendProvenance("agent:main:discord:source"),
+      }),
     ]);
   });
 
   it("projects empty sessions_send inter-session turns before empty user filtering", () => {
-    const result = projectRecentChatDisplayMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
-        timestamp: 1,
-      },
-    ]);
+    const result = projectRecentChatDisplayMessages([sessionsSendHistoryMessage("", 1)]);
 
-    expect(result).toEqual([
-      {
-        role: "assistant",
-        senderLabel: "Forwarded from main",
-        content: [{ type: "text", text: "" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
-        timestamp: 1,
-      },
-    ]);
+    expect(result).toEqual([projectedSessionsSendHistoryMessage("", 1)]);
   });
 
   it("does not let sessions_send inter-session turns clear pending message-tool mirrors", () => {
@@ -1601,17 +1565,9 @@ describe("projectRecentChatDisplayMessages", () => {
         __openclaw: { seq: 1 },
         timestamp: 1,
       },
-      {
-        role: "user",
-        content: [{ type: "text", text: "inter-session update" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
+      sessionsSendHistoryMessage("inter-session update", 2, {
         __openclaw: { seq: 2 },
-        timestamp: 2,
-      },
+      }),
       {
         role: "toolResult",
         toolName: "message",
@@ -1620,11 +1576,7 @@ describe("projectRecentChatDisplayMessages", () => {
         details: { sourceReplySink: "internal-ui" },
         timestamp: 3,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
-        timestamp: 4,
-      },
+      assistantHistoryMessage("NO_REPLY", { timestamp: 4 }),
     ]);
 
     expect(result).toEqual([
@@ -1641,18 +1593,9 @@ describe("projectRecentChatDisplayMessages", () => {
         __openclaw: { seq: 1 },
         timestamp: 1,
       },
-      {
-        role: "assistant",
-        senderLabel: "Forwarded from main",
-        content: [{ type: "text", text: "inter-session update" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
+      projectedSessionsSendHistoryMessage("inter-session update", 2, {
         __openclaw: { seq: 2 },
-        timestamp: 2,
-      },
+      }),
       {
         role: "toolResult",
         toolName: "message",
@@ -1660,9 +1603,7 @@ describe("projectRecentChatDisplayMessages", () => {
         content: JSON.stringify({ ok: true }),
         timestamp: 3,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "visible via message tool" }],
+      assistantHistoryMessage("visible via message tool", {
         openclawMessageToolMirror: {
           toolName: "message",
           toolCallId: "call-message",
@@ -1670,7 +1611,7 @@ describe("projectRecentChatDisplayMessages", () => {
           sourceMessageSeq: 1,
         },
         timestamp: 1,
-      },
+      }),
     ]);
   });
 
@@ -1688,126 +1629,45 @@ describe("projectRecentChatDisplayMessages", () => {
             ].join("\n"),
           },
         ],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
+        provenance: sessionsSendProvenance(),
         timestamp: 1,
       },
     ]);
 
-    expect(result).toEqual([
-      {
-        role: "assistant",
-        senderLabel: "Forwarded from main",
-        content: [{ type: "text", text: "NO_REPLY" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
-        timestamp: 1,
-      },
-    ]);
+    expect(result).toEqual([projectedSessionsSendHistoryMessage("NO_REPLY", 1)]);
   });
 
   it("keeps forwarded sessions_send heartbeat-looking text visible", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "HEARTBEAT_OK" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
-        timestamp: 1,
-      },
+      sessionsSendHistoryMessage("HEARTBEAT_OK", 1),
     ]);
 
-    expect(result).toEqual([
-      {
-        role: "assistant",
-        senderLabel: "Forwarded from main",
-        content: [{ type: "text", text: "HEARTBEAT_OK" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
-        timestamp: 1,
-      },
-    ]);
+    expect(result).toEqual([projectedSessionsSendHistoryMessage("HEARTBEAT_OK", 1)]);
   });
 
   it("keeps forwarded sessions_send heartbeat-looking text visible after a heartbeat prompt", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: HEARTBEAT_PROMPT }],
-        timestamp: 1,
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "HEARTBEAT_OK" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
-        timestamp: 2,
-      },
+      userHistoryMessage(HEARTBEAT_PROMPT, { timestamp: 1 }),
+      sessionsSendHistoryMessage("HEARTBEAT_OK", 2),
     ]);
 
     expect(result).toEqual([
-      {
-        role: "assistant",
-        senderLabel: "Forwarded from main",
-        content: [{ type: "text", text: "HEARTBEAT_OK" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
+      projectedSessionsSendHistoryMessage("HEARTBEAT_OK", 2, {
         __openclaw: { turnBoundary: true },
-        timestamp: 2,
-      },
+      }),
     ]);
   });
 
   it("marks only the first visible message after each hidden heartbeat input", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: HEARTBEAT_PROMPT }],
-        __openclaw: { seq: 1 },
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "First run started." }],
-        __openclaw: { seq: 2 },
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "First run finished." }],
-        __openclaw: { seq: 3 },
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: HEARTBEAT_PROMPT }],
-        __openclaw: { seq: 4 },
-      },
-      {
-        role: "system",
-        content: [{ type: "text", text: "Compaction" }],
+      userHistoryMessage(HEARTBEAT_PROMPT, { __openclaw: { seq: 1 } }),
+      assistantHistoryMessage("First run started.", { __openclaw: { seq: 2 } }),
+      assistantHistoryMessage("First run finished.", { __openclaw: { seq: 3 } }),
+      userHistoryMessage(HEARTBEAT_PROMPT, { __openclaw: { seq: 4 } }),
+      textHistoryMessage("system", "Compaction", {
         __openclaw: { kind: "compaction", seq: 5 },
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Second run finished." }],
-        __openclaw: { seq: 6 },
-      },
+      }),
+      assistantHistoryMessage("Second run finished.", { __openclaw: { seq: 6 } }),
     ]);
 
     expect(
@@ -1874,74 +1734,19 @@ describe("projectRecentChatDisplayMessages", () => {
     const textSha256 = createHash("sha256").update(visibleText).digest("hex");
 
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: visibleText }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Audio reply" },
-          {
-            type: "attachment",
-            attachment: {
-              url: "/tmp/tts.mp3",
-              kind: "audio",
-              label: "tts.mp3",
-              mimeType: "audio/mpeg",
-            },
-          },
-        ],
-        openclawTtsSupplement: { textSha256 },
-        timestamp: 2,
-      },
+      sessionsSendHistoryMessage(visibleText, 1),
+      ttsSupplementHistoryMessage({ textSha256 }, 2),
     ]);
 
     expect(result).toEqual([
-      {
-        role: "assistant",
-        senderLabel: "Forwarded from main",
-        content: [{ type: "text", text: visibleText }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Audio reply" },
-          {
-            type: "attachment",
-            attachment: {
-              url: "/tmp/tts.mp3",
-              kind: "audio",
-              label: "tts.mp3",
-              mimeType: "audio/mpeg",
-            },
-          },
-        ],
-        openclawTtsSupplement: { textSha256 },
-        timestamp: 2,
-      },
+      projectedSessionsSendHistoryMessage(visibleText, 1),
+      ttsSupplementHistoryMessage({ textSha256 }, 2),
     ]);
   });
 
   it("preserves structured trace alongside visible assistant progress text", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "fix it" }],
-        timestamp: 1,
-      },
+      userHistoryMessage("fix it", { timestamp: 1 }),
       {
         role: "assistant",
         content: [
@@ -1993,11 +1798,7 @@ describe("projectRecentChatDisplayMessages", () => {
 
   it("keeps pure commentary assistant messages hidden", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "status" }],
-        timestamp: 1,
-      },
+      userHistoryMessage("status", { timestamp: 1 }),
       {
         role: "assistant",
         content: [
@@ -2015,52 +1816,32 @@ describe("projectRecentChatDisplayMessages", () => {
       },
     ]);
 
-    expect(result).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "status" }],
-        timestamp: 1,
-      },
-    ]);
+    expect(result).toEqual([userHistoryMessage("status", { timestamp: 1 })]);
   });
 
   it("drops duplicate ACP gateway-injected assistant replies from chat history", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "good morning" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
+      userHistoryMessage("good morning", { timestamp: 1 }),
+      assistantHistoryMessage("Good morning.", {
         provider: "openclaw",
         model: "acp-runtime",
-        content: [{ type: "text", text: "Good morning." }],
         timestamp: 2,
-      },
-      {
-        role: "assistant",
+      }),
+      assistantHistoryMessage("Good morning.", {
         provider: "openclaw",
         model: "gateway-injected",
-        content: [{ type: "text", text: "Good morning." }],
         idempotencyKey: "run-1",
         timestamp: 3,
-      },
+      }),
     ]);
 
     expect(result).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "good morning" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
+      userHistoryMessage("good morning", { timestamp: 1 }),
+      assistantHistoryMessage("Good morning.", {
         provider: "openclaw",
         model: "acp-runtime",
-        content: [{ type: "text", text: "Good morning." }],
         timestamp: 2,
-      },
+      }),
     ]);
   });
 
@@ -2071,23 +1852,13 @@ describe("projectRecentChatDisplayMessages", () => {
         content: "yo big boy",
         timestamp: 1,
       },
-      {
-        role: "assistant",
+      assistantHistoryMessage("Yo Peter. I’m here.", {
         provider: "openai",
         model: "gpt-5.5",
-        content: [{ type: "text", text: "Yo Peter. I’m here." }],
         __openclaw: { mirrorIdentity: "run-1:assistant" },
         timestamp: 2,
-      },
-      {
-        role: "assistant",
-        provider: "openclaw",
-        model: "delivery-mirror",
-        content: [{ type: "text", text: "Yo Peter. I’m here." }],
-        idempotencyKey: "channel-final:message-1:0",
-        openclawDeliveryMirror: { kind: "channel-final", sourceMessageId: "message-1" },
-        timestamp: 3,
-      },
+      }),
+      deliveryMirrorHistoryMessage("Yo Peter. I’m here.", "message-1", 3),
     ]);
 
     expect(result).toEqual([
@@ -2096,41 +1867,29 @@ describe("projectRecentChatDisplayMessages", () => {
         content: "yo big boy",
         timestamp: 1,
       },
-      {
-        role: "assistant",
+      assistantHistoryMessage("Yo Peter. I’m here.", {
         provider: "openai",
         model: "gpt-5.5",
-        content: [{ type: "text", text: "Yo Peter. I’m here." }],
         __openclaw: { mirrorIdentity: "run-1:assistant" },
         timestamp: 2,
-      },
+      }),
     ]);
   });
 
   it("keeps a channel-final delivery mirror after a filtered user turn", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
+      assistantHistoryMessage("Repeated reply", {
         provider: "openai",
         model: "gpt-5.5",
-        content: [{ type: "text", text: "Repeated reply" }],
         __openclaw: { mirrorIdentity: "run-1:assistant" },
         timestamp: 1,
-      },
+      }),
       {
         role: "user",
         content: "",
         timestamp: 2,
       },
-      {
-        role: "assistant",
-        provider: "openclaw",
-        model: "delivery-mirror",
-        content: [{ type: "text", text: "Repeated reply" }],
-        idempotencyKey: "channel-final:message-2:0",
-        openclawDeliveryMirror: { kind: "channel-final", sourceMessageId: "message-2" },
-        timestamp: 3,
-      },
+      deliveryMirrorHistoryMessage("Repeated reply", "message-2", 3),
     ]);
 
     expect(result).toHaveLength(2);
@@ -2143,19 +1902,9 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("keeps adjacent channel-final delivery mirrors from distinct sends", () => {
-    const deliveryMirror = (sourceMessageId: string, timestamp: number) => ({
-      role: "assistant",
-      provider: "openclaw",
-      model: "delivery-mirror",
-      content: [{ type: "text", text: "Repeated reply" }],
-      idempotencyKey: `channel-final:${sourceMessageId}:0`,
-      openclawDeliveryMirror: { kind: "channel-final", sourceMessageId },
-      timestamp,
-    });
-
     const result = projectRecentChatDisplayMessages([
-      deliveryMirror("message-1", 1),
-      deliveryMirror("message-2", 2),
+      deliveryMirrorHistoryMessage("Repeated reply", "message-1", 1),
+      deliveryMirrorHistoryMessage("Repeated reply", "message-2", 2),
     ]);
 
     expect(result).toHaveLength(2);
@@ -2163,22 +1912,12 @@ describe("projectRecentChatDisplayMessages", () => {
 
   it("keeps channel-final mirrors after unmarked assistant replies", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
+      assistantHistoryMessage("Repeated reply", {
         provider: "openai",
         model: "gpt-5.5",
-        content: [{ type: "text", text: "Repeated reply" }],
         timestamp: 1,
-      },
-      {
-        role: "assistant",
-        provider: "openclaw",
-        model: "delivery-mirror",
-        content: [{ type: "text", text: "Repeated reply" }],
-        idempotencyKey: "channel-final:message-unmarked:0",
-        openclawDeliveryMirror: { kind: "channel-final", sourceMessageId: "message-unmarked" },
-        timestamp: 2,
-      },
+      }),
+      deliveryMirrorHistoryMessage("Repeated reply", "message-unmarked", 2),
     ]);
 
     expect(result).toHaveLength(2);
@@ -2186,28 +1925,8 @@ describe("projectRecentChatDisplayMessages", () => {
 
   it("keeps channel-final mirrors after forwarded sessions_send messages", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "Forwarded status" }],
-        provenance: {
-          kind: "inter_session",
-          sourceSessionKey: "agent:main:webchat:source",
-          sourceTool: "sessions_send",
-        },
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        provider: "openclaw",
-        model: "delivery-mirror",
-        content: [{ type: "text", text: "Forwarded status" }],
-        idempotencyKey: "channel-final:message-forwarded:0",
-        openclawDeliveryMirror: {
-          kind: "channel-final",
-          sourceMessageId: "message-forwarded",
-        },
-        timestamp: 2,
-      },
+      sessionsSendHistoryMessage("Forwarded status", 1),
+      deliveryMirrorHistoryMessage("Forwarded status", "message-forwarded", 2),
     ]);
 
     expect(result).toHaveLength(2);
@@ -2227,37 +1946,29 @@ describe("projectRecentChatDisplayMessages", () => {
 
   it("keeps gateway-injected assistant replies when they are not duplicate ACP text", () => {
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
+      assistantHistoryMessage("First answer.", {
         provider: "openclaw",
         model: "acp-runtime",
-        content: [{ type: "text", text: "First answer." }],
         timestamp: 1,
-      },
-      {
-        role: "assistant",
+      }),
+      assistantHistoryMessage("Second answer.", {
         provider: "openclaw",
         model: "gateway-injected",
-        content: [{ type: "text", text: "Second answer." }],
         timestamp: 2,
-      },
+      }),
     ]);
 
     expect(result).toEqual([
-      {
-        role: "assistant",
+      assistantHistoryMessage("First answer.", {
         provider: "openclaw",
         model: "acp-runtime",
-        content: [{ type: "text", text: "First answer." }],
         timestamp: 1,
-      },
-      {
-        role: "assistant",
+      }),
+      assistantHistoryMessage("Second answer.", {
         provider: "openclaw",
         model: "gateway-injected",
-        content: [{ type: "text", text: "Second answer." }],
         timestamp: 2,
-      },
+      }),
     ]);
   });
 
@@ -2323,67 +2034,16 @@ describe("projectRecentChatDisplayMessages", () => {
     const textSha256 = createHash("sha256").update(visibleText).digest("hex");
 
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "user",
-        content: [{ type: "text", text: "first" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: visibleText }],
-        timestamp: 2,
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "second" }],
-        timestamp: 3,
-      },
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Audio reply" },
-          {
-            type: "attachment",
-            attachment: {
-              url: "/tmp/tts.mp3",
-              kind: "audio",
-              label: "tts.mp3",
-              mimeType: "audio/mpeg",
-            },
-          },
-        ],
-        openclawTtsSupplement: { textSha256, spokenText },
-        timestamp: 4,
-      },
+      userHistoryMessage("first", { timestamp: 1 }),
+      assistantHistoryMessage(visibleText, { timestamp: 2 }),
+      userHistoryMessage("second", { timestamp: 3 }),
+      ttsSupplementHistoryMessage({ textSha256, spokenText }, 4),
     ]);
 
     expect(result).toEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "first" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: visibleText },
-          {
-            type: "attachment",
-            attachment: {
-              url: "/tmp/tts.mp3",
-              kind: "audio",
-              label: "tts.mp3",
-              mimeType: "audio/mpeg",
-            },
-          },
-        ],
-        timestamp: 2,
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "second" }],
-        timestamp: 3,
-      },
+      userHistoryMessage("first", { timestamp: 1 }),
+      assistantAudioAttachmentHistoryMessage(visibleText, 2),
+      userHistoryMessage("second", { timestamp: 3 }),
     ]);
   });
 
@@ -2393,48 +2053,11 @@ describe("projectRecentChatDisplayMessages", () => {
     const textSha256 = createHash("sha256").update(projectedVisibleText).digest("hex");
 
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: rawVisibleText }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Audio reply" },
-          {
-            type: "attachment",
-            attachment: {
-              url: "/tmp/tts.mp3",
-              kind: "audio",
-              label: "tts.mp3",
-              mimeType: "audio/mpeg",
-            },
-          },
-        ],
-        openclawTtsSupplement: { textSha256 },
-        timestamp: 2,
-      },
+      assistantHistoryMessage(rawVisibleText, { timestamp: 1 }),
+      ttsSupplementHistoryMessage({ textSha256 }, 2),
     ]);
 
-    expect(result).toEqual([
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: projectedVisibleText },
-          {
-            type: "attachment",
-            attachment: {
-              url: "/tmp/tts.mp3",
-              kind: "audio",
-              label: "tts.mp3",
-              mimeType: "audio/mpeg",
-            },
-          },
-        ],
-        timestamp: 1,
-      },
-    ]);
+    expect(result).toEqual([assistantAudioAttachmentHistoryMessage(projectedVisibleText, 1)]);
   });
 
   it("merges delayed TTS supplements before display truncation", () => {
@@ -2444,49 +2067,17 @@ describe("projectRecentChatDisplayMessages", () => {
 
     const result = projectRecentChatDisplayMessages(
       [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: rawVisibleText }],
-          timestamp: 1,
-        },
-        {
-          role: "assistant",
-          content: [
-            { type: "text", text: "Audio reply" },
-            {
-              type: "attachment",
-              attachment: {
-                url: "/tmp/tts.mp3",
-                kind: "audio",
-                label: "tts.mp3",
-                mimeType: "audio/mpeg",
-              },
-            },
-          ],
-          openclawTtsSupplement: { textSha256 },
-          timestamp: 2,
-        },
+        assistantHistoryMessage(rawVisibleText, { timestamp: 1 }),
+        ttsSupplementHistoryMessage({ textSha256 }, 2),
       ],
       { maxChars: 24 },
     );
 
     expect(result).toEqual([
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: `${projectedVisibleText.slice(0, 24)}\n...(truncated)...` },
-          {
-            type: "attachment",
-            attachment: {
-              url: "/tmp/tts.mp3",
-              kind: "audio",
-              label: "tts.mp3",
-              mimeType: "audio/mpeg",
-            },
-          },
-        ],
-        timestamp: 1,
-      },
+      assistantAudioAttachmentHistoryMessage(
+        `${projectedVisibleText.slice(0, 24)}\n...(truncated)...`,
+        1,
+      ),
     ]);
   });
 
@@ -2496,63 +2087,15 @@ describe("projectRecentChatDisplayMessages", () => {
     const ttsSupplement = { textSha256 };
 
     const result = projectRecentChatDisplayMessages([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: visibleText }],
-        timestamp: 1,
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "again" }],
-        timestamp: 2,
-      },
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: visibleText },
-          {
-            type: "attachment",
-            attachment: {
-              url: "/tmp/tts.mp3",
-              kind: "audio",
-              label: "tts.mp3",
-              mimeType: "audio/mpeg",
-            },
-          },
-        ],
-        openclawTtsSupplement: ttsSupplement,
-        timestamp: 3,
-      },
+      assistantHistoryMessage(visibleText, { timestamp: 1 }),
+      userHistoryMessage("again", { timestamp: 2 }),
+      ttsSupplementHistoryMessage(ttsSupplement, 3, visibleText),
     ]);
 
     expect(result).toEqual([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: visibleText }],
-        timestamp: 1,
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "again" }],
-        timestamp: 2,
-      },
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: visibleText },
-          {
-            type: "attachment",
-            attachment: {
-              url: "/tmp/tts.mp3",
-              kind: "audio",
-              label: "tts.mp3",
-              mimeType: "audio/mpeg",
-            },
-          },
-        ],
-        openclawTtsSupplement: ttsSupplement,
-        timestamp: 3,
-      },
+      assistantHistoryMessage(visibleText, { timestamp: 1 }),
+      userHistoryMessage("again", { timestamp: 2 }),
+      ttsSupplementHistoryMessage(ttsSupplement, 3, visibleText),
     ]);
   });
 });
@@ -2861,6 +2404,21 @@ describe("exec approval handlers", () => {
     } as unknown as ExecApprovalRequestArgs["client"];
   }
 
+  function createApprovalRuntimeClient(
+    connId: string,
+    deviceId?: string,
+    agentRuntimeIdentity?: { agentId: string; sessionKey: string },
+  ) {
+    return createExecApprovalClient({
+      connId,
+      clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+      deviceId,
+      scopes: ["operator.approvals"],
+      approvalRuntime: true,
+      agentRuntimeIdentity,
+    });
+  }
+
   function toExecApprovalRequestContext(context: {
     broadcast: (event: string, payload: unknown) => void;
     hasExecApprovalClients?: () => boolean;
@@ -2995,6 +2553,14 @@ describe("exec approval handlers", () => {
     });
   }
 
+  async function resolveExecApprovalForTest(
+    params: Omit<Parameters<typeof resolveExecApproval>[0], "respond">,
+  ) {
+    const respond = vi.fn();
+    await resolveExecApproval({ ...params, respond });
+    return respond;
+  }
+
   async function waitExecApproval(params: {
     handlers: ExecApprovalHandlers;
     id: string;
@@ -3059,24 +2625,59 @@ describe("exec approval handlers", () => {
     return getRequestedExecApprovalPayload(broadcasts);
   }
 
-  async function startAcceptedExecApproval(params: {
-    handlers: ExecApprovalHandlers;
-    respond: ReturnType<typeof vi.fn>;
-    context: ReturnType<typeof createExecApprovalFixture>["context"];
+  async function createAcceptedExecApproval(params: {
     request: Record<string, unknown>;
     client?: ExecApprovalRequestArgs["client"];
   }) {
+    const fixture = createExecApprovalFixture();
     const requestPromise = requestExecApproval({
-      handlers: params.handlers,
-      respond: params.respond,
-      context: params.context,
+      handlers: fixture.handlers,
+      respond: fixture.respond,
+      context: fixture.context,
       params: params.request,
       client: params.client,
     });
     await waitForFast(() => {
-      expect(params.respond.mock.calls.some((call) => call[1]?.status === "accepted")).toBe(true);
+      expect(fixture.respond.mock.calls.some((call) => call[1]?.status === "accepted")).toBe(true);
     });
-    return { requestPromise };
+    return {
+      ...fixture,
+      ...getRequestedExecApprovalPayload(fixture.broadcasts),
+      requestPromise,
+    };
+  }
+
+  async function createRequestedExecApproval(
+    params: {
+      request?: Record<string, unknown>;
+      client?: ExecApprovalRequestArgs["client"];
+      fixtureOptions?: Parameters<typeof createExecApprovalFixture>[0];
+    } = {},
+  ) {
+    const fixture = createExecApprovalFixture(params.fixtureOptions);
+    const requestPromise = requestExecApproval({
+      handlers: fixture.handlers,
+      respond: fixture.respond,
+      context: fixture.context,
+      params: params.request,
+      client: params.client,
+    });
+    const requested = await waitForRequestedExecApprovalPayload(fixture.broadcasts);
+    return { ...fixture, ...requested, requestPromise };
+  }
+
+  async function requestExecApprovalForTest(
+    request: Record<string, unknown>,
+    fixtureOptions?: Parameters<typeof createExecApprovalFixture>[0],
+  ) {
+    const fixture = createExecApprovalFixture(fixtureOptions);
+    await requestExecApproval({
+      handlers: fixture.handlers,
+      respond: fixture.respond,
+      context: fixture.context,
+      params: request,
+    });
+    return { ...fixture, ...getRequestedExecApprovalPayload(fixture.broadcasts) };
   }
 
   async function expectRejectedExecApprovalRequest(
@@ -3102,12 +2703,10 @@ describe("exec approval handlers", () => {
       params: requestParams,
     });
     const { id } = await waitForRequestedExecApprovalPayload(broadcasts);
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id,
       decision: "allow-always",
-      respond: resolveRespond,
       context,
     });
     expect(mockCallArg(resolveRespond)).toBe(false);
@@ -3116,12 +2715,10 @@ describe("exec approval handlers", () => {
       message: "allow-always is unavailable for this command",
     });
 
-    const fallbackRespond = vi.fn();
-    await resolveExecApproval({
+    const fallbackRespond = await resolveExecApprovalForTest({
       handlers,
       id,
       decision: fallbackDecision,
-      respond: fallbackRespond,
       context,
     });
     await requestPromise;
@@ -3129,14 +2726,8 @@ describe("exec approval handlers", () => {
   }
 
   async function expectDroppedApprovalCommandSpans(config?: OpenClawConfig) {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture(
-      config ? { config } : undefined,
-    );
-    await requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
+    const { request } = await requestExecApprovalForTest(
+      {
         timeoutMs: 10,
         command: "ls | python -c 'print(1)'",
         commandSpans: [
@@ -3144,8 +2735,8 @@ describe("exec approval handlers", () => {
           { startIndex: 5, endIndex: 11 },
         ],
       },
-    });
-    const { request } = getRequestedExecApprovalPayload(broadcasts);
+      config ? { config } : undefined,
+    );
     expectRecordFields(request["commandAnalysis"], { commandCount: 1, nestedCommandCount: 0 });
     expect(request["commandSpans"]).toBeUndefined();
   }
@@ -3180,6 +2771,16 @@ describe("exec approval handlers", () => {
       iosPushDelivery: opts?.iosPushDelivery,
       respond,
       context,
+    };
+  }
+
+  function createIosPushDelivery(
+    handleRequested: ReturnType<typeof vi.fn> = vi.fn(async () => true),
+  ) {
+    return {
+      handleRequested,
+      handleResolved: vi.fn(async () => {}),
+      handleExpired: vi.fn(async () => {}),
     };
   }
 
@@ -3348,13 +2949,8 @@ describe("exec approval handlers", () => {
   });
 
   it("returns pending approval details for exec.approval.get", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-
-    const requestPromise = requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
+    const { handlers, context, requestPromise, id } = await createRequestedExecApproval({
+      request: {
         twoPhase: true,
         host: "gateway",
         command: "echo ok",
@@ -3363,7 +2959,6 @@ describe("exec approval handlers", () => {
         nodeId: undefined,
       },
     });
-    const { id } = await waitForRequestedExecApprovalPayload(broadcasts);
 
     const getRespond = vi.fn();
     await getExecApproval({ handlers, id, respond: getRespond });
@@ -3380,24 +2975,17 @@ describe("exec approval handlers", () => {
     expect(approval.allowedDecisions).toEqual(["allow-once", "allow-always", "deny"]);
     expect(mockCallArg(getRespond, 0, 2)).toBeUndefined();
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    await resolveExecApprovalForTest({
       handlers,
       id,
-      respond: resolveRespond,
       context,
     });
     await requestPromise;
   });
 
   it("escapes unpaired surrogates before broadcasting an exec approval", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-
-    const requestPromise = requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
+    const { handlers, context, requestPromise, id, request } = await createRequestedExecApproval({
+      request: {
         twoPhase: true,
         host: "gateway",
         command: "echo \uD83D \uDE00 😀",
@@ -3406,24 +2994,17 @@ describe("exec approval handlers", () => {
         nodeId: undefined,
       },
     });
-    const { id, request } = await waitForRequestedExecApprovalPayload(broadcasts);
 
     expect(request.command).toBe("echo \\u{D83D} \\u{DE00} 😀");
     expect(() => encodeURIComponent(String(request.command))).not.toThrow();
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({ handlers, id, respond: resolveRespond, context });
+    await resolveExecApprovalForTest({ handlers, id, context });
     await requestPromise;
   });
 
   it("attaches shared command analysis to gateway exec approval requests", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-
-    const requestPromise = requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
+    const { handlers, context, requestPromise, id, request } = await createRequestedExecApproval({
+      request: {
         twoPhase: true,
         host: "gateway",
         command: "python3 -c 'print(1)'",
@@ -3432,28 +3013,21 @@ describe("exec approval handlers", () => {
         nodeId: undefined,
       },
     });
-    const request = await waitForRequestedExecApprovalPayload(broadcasts);
-    const commandAnalysis = request.request?.commandAnalysis as Record<string, unknown>;
+    const commandAnalysis = request.commandAnalysis as Record<string, unknown>;
     expect(commandAnalysis.commandCount).toBe(1);
     expect(commandAnalysis.riskKinds).toEqual(["inline-eval"]);
     expect(commandAnalysis.warningLines).toEqual(["Contains inline-eval: python3 -c"]);
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    await resolveExecApprovalForTest({
       handlers,
-      id: request.id ?? "",
-      respond: resolveRespond,
+      id,
       context,
     });
     await requestPromise;
   });
 
   it("lists pending exec approvals", async () => {
-    const { handlers, respond, context } = createExecApprovalFixture();
-    const { requestPromise } = await startAcceptedExecApproval({
-      handlers,
-      respond,
-      context,
+    const { handlers, context, requestPromise } = await createAcceptedExecApproval({
       request: {
         id: "approval-list-1",
         twoPhase: true,
@@ -3473,11 +3047,9 @@ describe("exec approval handlers", () => {
     expectRecordFields((approval as Record<string, unknown>).request, { command: "echo ok" });
     expect(mockCallArg(listRespond, 0, 2)).toBeUndefined();
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    await resolveExecApprovalForTest({
       handlers,
       id: "approval-list-1",
-      respond: resolveRespond,
       context,
     });
     await requestPromise;
@@ -3522,11 +3094,9 @@ describe("exec approval handlers", () => {
     const approvals = mockCallArg(listRespond, 0, 1) as Array<Record<string, unknown>>;
     expect(approvals.map((entry) => entry.id)).toEqual(["approval-abcd-visible"]);
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id: "approval-abcd",
-      respond: resolveRespond,
       context,
       client: ownerClient,
     });
@@ -3534,11 +3104,9 @@ describe("exec approval handlers", () => {
     expect(manager.getSnapshot(visible.id)?.decision).toBe("allow-once");
     expect(manager.getSnapshot(hidden.id)?.decision).toBeUndefined();
 
-    const hiddenRespond = vi.fn();
-    await resolveExecApproval({
+    const hiddenRespond = await resolveExecApprovalForTest({
       handlers,
       id: hidden.id,
-      respond: hiddenRespond,
       context,
       client: ownerClient,
     });
@@ -3549,11 +3117,9 @@ describe("exec approval handlers", () => {
     });
     expect(manager.getSnapshot(hidden.id)?.decision).toBeUndefined();
 
-    const otherRespond = vi.fn();
-    await resolveExecApproval({
+    const otherRespond = await resolveExecApprovalForTest({
       handlers,
       id: hidden.id,
-      respond: otherRespond,
       context,
       client: otherClient,
     });
@@ -3561,7 +3127,6 @@ describe("exec approval handlers", () => {
   });
 
   it("ignores approval reviewer devices from non-runtime approval request clients", async () => {
-    const { manager, handlers, respond, context } = createExecApprovalFixture();
     const requesterClient = createExecApprovalClient({
       connId: "conn-gateway-client",
       clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
@@ -3575,10 +3140,7 @@ describe("exec approval handlers", () => {
       scopes: ["operator.approvals"],
     });
 
-    const { requestPromise } = await startAcceptedExecApproval({
-      handlers,
-      respond,
-      context,
+    const { manager, handlers, requestPromise } = await createAcceptedExecApproval({
       client: requesterClient,
       request: {
         id: "approval-reviewer-untrusted",
@@ -3618,14 +3180,10 @@ describe("exec approval handlers", () => {
   });
 
   it("allows the internal approval runtime to bind the initiating mobile approval reviewer device", async () => {
-    const { manager, handlers, respond, context } = createExecApprovalFixture();
-    const requesterClient = createExecApprovalClient({
-      connId: "conn-gateway-runtime",
-      clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-      deviceId: "device-gateway-runtime",
-      scopes: ["operator.approvals"],
-      approvalRuntime: true,
-    });
+    const requesterClient = createApprovalRuntimeClient(
+      "conn-gateway-runtime",
+      "device-gateway-runtime",
+    );
     const reviewerClient = createExecApprovalClient({
       connId: "conn-ios-reviewer",
       clientId: GATEWAY_CLIENT_IDS.IOS_APP,
@@ -3633,10 +3191,7 @@ describe("exec approval handlers", () => {
       scopes: ["operator.approvals"],
     });
 
-    const { requestPromise } = await startAcceptedExecApproval({
-      handlers,
-      respond,
-      context,
+    const { manager, handlers, context, requestPromise } = await createAcceptedExecApproval({
       client: requesterClient,
       request: {
         id: "approval-reviewer-runtime",
@@ -3672,11 +3227,9 @@ describe("exec approval handlers", () => {
       commandText: "echo ok",
     });
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id: "approval-reviewer-runtime",
-      respond: resolveRespond,
       context,
       client: reviewerClient,
     });
@@ -3687,14 +3240,10 @@ describe("exec approval handlers", () => {
   });
 
   it("allows admin clients to resolve reviewer-targeted runtime approvals", async () => {
-    const { manager, handlers, respond, context } = createExecApprovalFixture();
-    const requesterClient = createExecApprovalClient({
-      connId: "conn-gateway-runtime",
-      clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-      deviceId: "device-gateway-runtime",
-      scopes: ["operator.approvals"],
-      approvalRuntime: true,
-    });
+    const requesterClient = createApprovalRuntimeClient(
+      "conn-gateway-runtime",
+      "device-gateway-runtime",
+    );
     const adminClient = createExecApprovalClient({
       connId: "conn-admin",
       clientId: GATEWAY_CLIENT_IDS.CONTROL_UI,
@@ -3702,10 +3251,7 @@ describe("exec approval handlers", () => {
       scopes: ["operator.admin"],
     });
 
-    const { requestPromise } = await startAcceptedExecApproval({
-      handlers,
-      respond,
-      context,
+    const { manager, handlers, context, requestPromise } = await createAcceptedExecApproval({
       client: requesterClient,
       request: {
         id: "approval-reviewer-runtime-admin",
@@ -3714,11 +3260,9 @@ describe("exec approval handlers", () => {
       },
     });
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id: "approval-reviewer-runtime-admin",
-      respond: resolveRespond,
       context,
       client: adminClient,
     });
@@ -3729,26 +3273,16 @@ describe("exec approval handlers", () => {
   });
 
   it("allows the internal approval runtime to resolve reviewer-targeted runtime approvals", async () => {
-    const { manager, handlers, respond, context } = createExecApprovalFixture();
-    const requesterClient = createExecApprovalClient({
-      connId: "conn-gateway-runtime-requester",
-      clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-      deviceId: "device-gateway-runtime-requester",
-      scopes: ["operator.approvals"],
-      approvalRuntime: true,
-    });
-    const runtimeResolverClient = createExecApprovalClient({
-      connId: "conn-gateway-runtime-resolver",
-      clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-      deviceId: "device-gateway-runtime-resolver",
-      scopes: ["operator.approvals"],
-      approvalRuntime: true,
-    });
+    const requesterClient = createApprovalRuntimeClient(
+      "conn-gateway-runtime-requester",
+      "device-gateway-runtime-requester",
+    );
+    const runtimeResolverClient = createApprovalRuntimeClient(
+      "conn-gateway-runtime-resolver",
+      "device-gateway-runtime-resolver",
+    );
 
-    const { requestPromise } = await startAcceptedExecApproval({
-      handlers,
-      respond,
-      context,
+    const { manager, handlers, context, requestPromise } = await createAcceptedExecApproval({
       client: requesterClient,
       request: {
         id: "approval-reviewer-runtime-runtime",
@@ -3757,11 +3291,9 @@ describe("exec approval handlers", () => {
       },
     });
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id: "approval-reviewer-runtime-runtime",
-      respond: resolveRespond,
       context,
       client: runtimeResolverClient,
     });
@@ -3775,26 +3307,16 @@ describe("exec approval handlers", () => {
   });
 
   it("records matching trusted agent-runtime resolutions with default agent binding", async () => {
-    const { manager, handlers, respond, context } = createExecApprovalFixture();
-    const requesterClient = createExecApprovalClient({
-      connId: "conn-auto-review-requester",
-      clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-      deviceId: "device-auto-review-requester",
-      scopes: ["operator.approvals"],
-      approvalRuntime: true,
-    });
-    const resolverClient = createExecApprovalClient({
-      connId: "conn-auto-review-resolver",
-      clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-      deviceId: "device-auto-review-resolver",
-      scopes: ["operator.approvals"],
-      approvalRuntime: true,
-      agentRuntimeIdentity: { agentId: "main", sessionKey: "agent:main:main" },
-    });
-    const { requestPromise } = await startAcceptedExecApproval({
-      handlers,
-      respond,
-      context,
+    const requesterClient = createApprovalRuntimeClient(
+      "conn-auto-review-requester",
+      "device-auto-review-requester",
+    );
+    const resolverClient = createApprovalRuntimeClient(
+      "conn-auto-review-resolver",
+      "device-auto-review-resolver",
+      { agentId: "main", sessionKey: "agent:main:main" },
+    );
+    const { manager, handlers, context, requestPromise } = await createAcceptedExecApproval({
       client: requesterClient,
       request: {
         id: "approval-auto-review",
@@ -3806,11 +3328,9 @@ describe("exec approval handlers", () => {
       },
     });
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id: "approval-auto-review",
-      respond: resolveRespond,
       context,
       client: resolverClient,
     });
@@ -3824,34 +3344,23 @@ describe("exec approval handlers", () => {
   });
 
   it("rejects auto-review resolution when trusted agent identity mismatches the request", async () => {
-    const { manager, handlers, respond, context } = createExecApprovalFixture();
-    const requesterClient = createExecApprovalClient({
-      connId: "conn-auto-review-mismatch-requester",
-      clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-      deviceId: "device-auto-review-mismatch-requester",
-      scopes: ["operator.approvals"],
-      approvalRuntime: true,
-    });
-    const resolverClient = createExecApprovalClient({
-      connId: "conn-auto-review-mismatch-resolver",
-      clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-      scopes: ["operator.approvals"],
-      approvalRuntime: true,
-      agentRuntimeIdentity: { agentId: "other", sessionKey: "agent:other:main" },
-    });
-    const { requestPromise } = await startAcceptedExecApproval({
-      handlers,
-      respond,
-      context,
+    const requesterClient = createApprovalRuntimeClient(
+      "conn-auto-review-mismatch-requester",
+      "device-auto-review-mismatch-requester",
+    );
+    const resolverClient = createApprovalRuntimeClient(
+      "conn-auto-review-mismatch-resolver",
+      undefined,
+      { agentId: "other", sessionKey: "agent:other:main" },
+    );
+    const { manager, handlers, context, requestPromise } = await createAcceptedExecApproval({
       client: requesterClient,
       request: { id: "approval-auto-review-mismatch", twoPhase: true },
     });
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id: "approval-auto-review-mismatch",
-      respond: resolveRespond,
       context,
       client: resolverClient,
     });
@@ -3868,14 +3377,10 @@ describe("exec approval handlers", () => {
   });
 
   it("does not allow reviewer devices without approval scope to resolve runtime approvals", async () => {
-    const { manager, handlers, respond, context } = createExecApprovalFixture();
-    const requesterClient = createExecApprovalClient({
-      connId: "conn-gateway-runtime",
-      clientId: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-      deviceId: "device-gateway-runtime",
-      scopes: ["operator.approvals"],
-      approvalRuntime: true,
-    });
+    const requesterClient = createApprovalRuntimeClient(
+      "conn-gateway-runtime",
+      "device-gateway-runtime",
+    );
     const reviewerClient = createExecApprovalClient({
       connId: "conn-ios-reviewer",
       clientId: GATEWAY_CLIENT_IDS.IOS_APP,
@@ -3883,10 +3388,7 @@ describe("exec approval handlers", () => {
       scopes: ["operator.read"],
     });
 
-    const { requestPromise } = await startAcceptedExecApproval({
-      handlers,
-      respond,
-      context,
+    const { manager, handlers, context, requestPromise } = await createAcceptedExecApproval({
       client: requesterClient,
       request: {
         id: "approval-reviewer-runtime-no-scope",
@@ -3895,11 +3397,9 @@ describe("exec approval handlers", () => {
       },
     });
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id: "approval-reviewer-runtime-no-scope",
-      respond: resolveRespond,
       context,
       client: reviewerClient,
     });
@@ -3916,31 +3416,19 @@ describe("exec approval handlers", () => {
   });
 
   it("returns not found for stale exec.approval.get ids", async () => {
-    const { handlers, respond, context } = createExecApprovalFixture();
-
-    const requestPromise = requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: { twoPhase: true, host: "gateway", systemRunPlan: undefined, nodeId: undefined },
+    const { handlers, context, requestPromise, id } = await createAcceptedExecApproval({
+      request: { twoPhase: true, host: "gateway", systemRunPlan: undefined, nodeId: undefined },
     });
-    await waitForFast(() => {
-      expect(respond.mock.calls.some((call) => call[1]?.status === "accepted")).toBe(true);
-    });
-    const acceptedId = respond.mock.calls.find((call) => call[1]?.status === "accepted")?.[1]?.id;
-    expect(typeof acceptedId).toBe("string");
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    await resolveExecApprovalForTest({
       handlers,
-      id: acceptedId as string,
-      respond: resolveRespond,
+      id,
       context,
     });
     await requestPromise;
 
     const getRespond = vi.fn();
-    await getExecApproval({ handlers, id: acceptedId as string, respond: getRespond });
+    await getExecApproval({ handlers, id, respond: getRespond });
     expect(mockCallArg(getRespond)).toBe(false);
     expect(mockCallArg(getRespond, 0, 1)).toBeUndefined();
     expectRecordFields(mockCallArg(getRespond, 0, 2), {
@@ -3950,25 +3438,16 @@ describe("exec approval handlers", () => {
   });
 
   it("broadcasts request + resolve", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-
-    const requestPromise = requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: { twoPhase: true },
-    });
-    const { id } = await waitForRequestedExecApprovalPayload(broadcasts);
+    const { handlers, broadcasts, respond, context, requestPromise, id } =
+      await createRequestedExecApproval({ request: { twoPhase: true } });
 
     expect(mockCallArg(respond)).toBe(true);
     expectRecordFields(mockCallArg(respond, 0, 1), { status: "accepted", id });
     expect(mockCallArg(respond, 0, 2)).toBeUndefined();
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id,
-      respond: resolveRespond,
       context,
     });
 
@@ -4047,27 +3526,19 @@ describe("exec approval handlers", () => {
   });
 
   it("keeps baseline decisions available when allow-always is unavailable", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-
-    const requestPromise = requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
+    const { handlers, context, requestPromise, id, request } = await createRequestedExecApproval({
+      request: {
         twoPhase: true,
         unavailableDecisions: ["allow-always"],
       },
     });
-    const { id, request } = await waitForRequestedExecApprovalPayload(broadcasts);
 
     expect(request.allowedDecisions).toEqual(["allow-once", "deny"]);
 
-    const denyRespond = vi.fn();
-    await resolveExecApproval({
+    const denyRespond = await resolveExecApprovalForTest({
       handlers,
       id,
       decision: "deny",
-      respond: denyRespond,
       context,
     });
 
@@ -4089,21 +3560,14 @@ describe("exec approval handlers", () => {
   });
 
   it("stores versioned system.run binding and sorted env keys on approval request", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-    await requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
-        timeoutMs: 10,
-        commandArgv: ["echo", "ok"],
-        env: {
-          Z_VAR: "z",
-          A_VAR: "a",
-        },
+    const { request } = await requestExecApprovalForTest({
+      timeoutMs: 10,
+      commandArgv: ["echo", "ok"],
+      env: {
+        Z_VAR: "z",
+        A_VAR: "a",
       },
     });
-    const { request } = getRequestedExecApprovalPayload(broadcasts);
     expect(request["envKeys"]).toEqual(["A_VAR", "Z_VAR"]);
     expect(request["systemRunBinding"]).toEqual(
       buildSystemRunApprovalBinding({
@@ -4115,21 +3579,14 @@ describe("exec approval handlers", () => {
   });
 
   it("includes Windows-compatible env keys in approval env bindings", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-    await requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
-        timeoutMs: 10,
-        commandArgv: ["cmd.exe", "/c", "echo", "ok"],
-        command: "cmd.exe /c echo ok",
-        env: {
-          "ProgramFiles(x86)": "C:\\Program Files (x86)",
-        },
+    const { request } = await requestExecApprovalForTest({
+      timeoutMs: 10,
+      commandArgv: ["cmd.exe", "/c", "echo", "ok"],
+      command: "cmd.exe /c echo ok",
+      env: {
+        "ProgramFiles(x86)": "C:\\Program Files (x86)",
       },
     });
-    const { request } = getRequestedExecApprovalPayload(broadcasts);
     const envBinding = buildSystemRunApprovalEnvBinding({
       "ProgramFiles(x86)": "C:\\Program Files (x86)",
     });
@@ -4144,23 +3601,16 @@ describe("exec approval handlers", () => {
   });
 
   it("stores sorted env keys for gateway approvals without node-only binding", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-    await requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
-        timeoutMs: 10,
-        host: "gateway",
-        nodeId: undefined,
-        systemRunPlan: undefined,
-        env: {
-          Z_VAR: "z",
-          A_VAR: "a",
-        },
+    const { request } = await requestExecApprovalForTest({
+      timeoutMs: 10,
+      host: "gateway",
+      nodeId: undefined,
+      systemRunPlan: undefined,
+      env: {
+        Z_VAR: "z",
+        A_VAR: "a",
       },
     });
-    const { request } = getRequestedExecApprovalPayload(broadcasts);
     expect(request["envKeys"]).toEqual(
       buildSystemRunApprovalEnvBinding({ A_VAR: "a", Z_VAR: "z" }).envKeys,
     );
@@ -4168,34 +3618,27 @@ describe("exec approval handlers", () => {
   });
 
   it("prefers systemRunPlan canonical command/cwd when present", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-    await requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
-        timeoutMs: 10,
-        command: "echo stale",
-        commandArgv: ["echo", "stale"],
-        cwd: "/tmp/link/sub",
-        systemRunPlan: {
-          argv: ["/usr/bin/echo", "ok"],
-          cwd: "/real/cwd",
-          commandText: "/usr/bin/echo ok",
-          commandPreview: "echo ok",
-          agentId: "main",
-          sessionKey: "agent:main:main",
-          policySnapshot: {
-            security: "allowlist",
-            ask: "on-miss",
-            askFallback: "deny",
-            autoAllowSkills: false,
-            allowlistRules: [{ pattern: "/usr/bin/echo" }],
-          },
+    const { request } = await requestExecApprovalForTest({
+      timeoutMs: 10,
+      command: "echo stale",
+      commandArgv: ["echo", "stale"],
+      cwd: "/tmp/link/sub",
+      systemRunPlan: {
+        argv: ["/usr/bin/echo", "ok"],
+        cwd: "/real/cwd",
+        commandText: "/usr/bin/echo ok",
+        commandPreview: "echo ok",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        policySnapshot: {
+          security: "allowlist",
+          ask: "on-miss",
+          askFallback: "deny",
+          autoAllowSkills: false,
+          allowlistRules: [{ pattern: "/usr/bin/echo" }],
         },
       },
     });
-    const { request } = getRequestedExecApprovalPayload(broadcasts);
     expect(request["command"]).toBe("/usr/bin/echo ok");
     expect(request["commandPreview"]).toBeUndefined();
     expect(request["commandArgv"]).toBeUndefined();
@@ -4220,25 +3663,18 @@ describe("exec approval handlers", () => {
   });
 
   it("derives a command preview from the fallback command for older node plans", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-    await requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
-        timeoutMs: 10,
-        command: "jq --version",
-        commandArgv: ["./env", "sh", "-c", "jq --version"],
-        systemRunPlan: {
-          argv: ["./env", "sh", "-c", "jq --version"],
-          cwd: "/real/cwd",
-          commandText: './env sh -c "jq --version"',
-          agentId: "main",
-          sessionKey: "agent:main:main",
-        },
+    const { request } = await requestExecApprovalForTest({
+      timeoutMs: 10,
+      command: "jq --version",
+      commandArgv: ["./env", "sh", "-c", "jq --version"],
+      systemRunPlan: {
+        argv: ["./env", "sh", "-c", "jq --version"],
+        cwd: "/real/cwd",
+        commandText: './env sh -c "jq --version"',
+        agentId: "main",
+        sessionKey: "agent:main:main",
       },
     });
-    const { request } = getRequestedExecApprovalPayload(broadcasts);
     expect(request["command"]).toBe('./env sh -c "jq --version"');
     expect(request["commandPreview"]).toBeUndefined();
     expect((request["systemRunPlan"] as { commandPreview?: string }).commandPreview).toBe(
@@ -4247,25 +3683,18 @@ describe("exec approval handlers", () => {
   });
 
   it("sanitizes invisible Unicode format chars in approval display text without changing node bindings", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-    await requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
-        timeoutMs: 10,
-        command: "bash safe\u200B.sh",
-        commandArgv: ["bash", "safe\u200B.sh"],
-        systemRunPlan: {
-          argv: ["bash", "safe\u200B.sh"],
-          cwd: "/real/cwd",
-          commandText: "bash safe\u200B.sh",
-          agentId: "main",
-          sessionKey: "agent:main:main",
-        },
+    const { request } = await requestExecApprovalForTest({
+      timeoutMs: 10,
+      command: "bash safe\u200B.sh",
+      commandArgv: ["bash", "safe\u200B.sh"],
+      systemRunPlan: {
+        argv: ["bash", "safe\u200B.sh"],
+        cwd: "/real/cwd",
+        commandText: "bash safe\u200B.sh",
+        agentId: "main",
+        sessionKey: "agent:main:main",
       },
     });
-    const { request } = getRequestedExecApprovalPayload(broadcasts);
     expect(request["command"]).toBe("bash safe\\u{200B}.sh");
     expect((request["systemRunPlan"] as { commandText?: string }).commandText).toBe(
       "bash safe\u200B.sh",
@@ -4273,17 +3702,10 @@ describe("exec approval handlers", () => {
   });
 
   it("preserves approval warning line breaks while sanitizing hidden characters", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-    await requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
-        timeoutMs: 10,
-        warningText: "Diagnostics line one\r\n\r\nOpenAI Codex harness:\nSend feedback\u200B",
-      },
+    const { request } = await requestExecApprovalForTest({
+      timeoutMs: 10,
+      warningText: "Diagnostics line one\r\n\r\nOpenAI Codex harness:\nSend feedback\u200B",
     });
-    const { request } = getRequestedExecApprovalPayload(broadcasts);
     expect(request["warningText"]).toBe(
       "Diagnostics line one\n\nOpenAI Codex harness:\nSend feedback\\u{200B}",
     );
@@ -4291,14 +3713,8 @@ describe("exec approval handlers", () => {
   });
 
   it("preserves command analysis and normalizes command spans", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture({
-      config: { tools: { exec: { commandHighlighting: true } } },
-    });
-    await requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
+    const { request } = await requestExecApprovalForTest(
+      {
         timeoutMs: 10,
         command: "ls | python -c 'print(1)'",
         commandSpans: [
@@ -4309,10 +3725,8 @@ describe("exec approval handlers", () => {
           { startIndex: 11, endIndex: 11 },
         ],
       },
-    });
-    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
-    expectRecordFields(requested, { event: "exec.approval.requested" });
-    const request = (requested?.payload as { request?: Record<string, unknown> })?.request ?? {};
+      { config: { tools: { exec: { commandHighlighting: true } } } },
+    );
     expectRecordFields(request["commandAnalysis"], { commandCount: 1, nestedCommandCount: 0 });
     expect(request["commandSpans"]).toEqual([
       { startIndex: 0, endIndex: 2 },
@@ -4331,14 +3745,8 @@ describe("exec approval handlers", () => {
   });
 
   it("drops command spans when command display sanitization changes offsets", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture({
-      config: { tools: { exec: { commandHighlighting: true } } },
-    });
-    await requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: {
+    const { request } = await requestExecApprovalForTest(
+      {
         timeoutMs: 10,
         command: "ls\u0000 | python -c 'print(1)'",
         commandSpans: [
@@ -4346,9 +3754,8 @@ describe("exec approval handlers", () => {
           { startIndex: 6, endIndex: 12 },
         ],
       },
-    });
-    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
-    const request = (requested?.payload as { request?: Record<string, unknown> })?.request ?? {};
+      { config: { tools: { exec: { commandHighlighting: true } } } },
+    );
     expect(request["command"]).not.toBe("ls\u0000 | python -c 'print(1)'");
     expect(request["commandSpans"]).toBeUndefined();
   });
@@ -4391,22 +3798,14 @@ describe("exec approval handlers", () => {
   });
 
   it("accepts explicit approval ids", async () => {
-    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
-
-    const requestPromise = requestExecApproval({
-      handlers,
-      respond,
-      context,
-      params: { id: "approval-123", host: "gateway" },
+    const { handlers, respond, context, requestPromise, id } = await createRequestedExecApproval({
+      request: { id: "approval-123", host: "gateway" },
     });
-    const { id } = await waitForRequestedExecApprovalPayload(broadcasts);
     expect(id).toBe("approval-123");
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id,
-      respond: resolveRespond,
       context,
     });
 
@@ -4573,11 +3972,9 @@ describe("exec approval handlers", () => {
     void manager.register(manager.create({ command: "echo one" }, 60_000, "approval-one"), 60_000);
     void manager.register(manager.create({ command: "echo two" }, 60_000, "approval-two"), 60_000);
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id: "approval-one",
-      respond: resolveRespond,
       context,
     });
 
@@ -4657,11 +4054,9 @@ describe("exec approval handlers", () => {
       expect(respond.mock.calls.some((call) => call[1]?.status === "accepted")).toBe(true);
     });
 
-    const resolveRespond = vi.fn();
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id: "approval-control-ui-multichannel",
-      respond: resolveRespond,
       context: requestContext,
     });
     await requestPromise;
@@ -4712,11 +4107,7 @@ describe("exec approval handlers", () => {
   });
 
   it("keeps approvals pending when iOS push delivery accepted the request", async () => {
-    const iosPushDelivery = {
-      handleRequested: vi.fn(async () => true),
-      handleResolved: vi.fn(async () => {}),
-      handleExpired: vi.fn(async () => {}),
-    };
+    const iosPushDelivery = createIosPushDelivery();
     const { manager, handlers, forwarder, respond, context } = createForwardingExecApprovalFixture({
       iosPushDelivery,
     });
@@ -4752,8 +4143,8 @@ describe("exec approval handlers", () => {
   });
 
   it("does not count iOS push delivery to hidden approval targets as a route", async () => {
-    const iosPushDelivery = {
-      handleRequested: vi.fn(
+    const iosPushDelivery = createIosPushDelivery(
+      vi.fn(
         async (
           _request: unknown,
           opts?: {
@@ -4765,9 +4156,7 @@ describe("exec approval handlers", () => {
             scopes: ["operator.approvals"],
           }) ?? true,
       ),
-      handleResolved: vi.fn(async () => {}),
-      handleExpired: vi.fn(async () => {}),
-    };
+    );
     const { manager, handlers, respond, context } = createForwardingExecApprovalFixture({
       iosPushDelivery,
     });
@@ -4803,14 +4192,8 @@ describe("exec approval handlers", () => {
   });
 
   it("sends iOS cleanup delivery on resolve", async () => {
-    const iosPushDelivery = {
-      handleRequested: vi.fn(async () => true),
-      handleResolved: vi.fn(async () => {}),
-      handleExpired: vi.fn(async () => {}),
-    };
+    const iosPushDelivery = createIosPushDelivery();
     const { handlers, respond, context } = createForwardingExecApprovalFixture({ iosPushDelivery });
-    const resolveRespond = vi.fn();
-
     const requestPromise = requestExecApproval({
       handlers,
       respond,
@@ -4821,10 +4204,9 @@ describe("exec approval handlers", () => {
       expect(iosPushDelivery.handleRequested).toHaveBeenCalledTimes(1);
     });
 
-    await resolveExecApproval({
+    await resolveExecApprovalForTest({
       handlers,
       id: "approval-ios-cleanup",
-      respond: resolveRespond,
       context,
     });
     await requestPromise;
@@ -4840,11 +4222,7 @@ describe("exec approval handlers", () => {
   it("sends iOS cleanup delivery on expiration", async () => {
     vi.useFakeTimers();
     try {
-      const iosPushDelivery = {
-        handleRequested: vi.fn(async () => true),
-        handleResolved: vi.fn(async () => {}),
-        handleExpired: vi.fn(async () => {}),
-      };
+      const iosPushDelivery = createIosPushDelivery();
       const { handlers, respond, context } = createForwardingExecApprovalFixture({
         iosPushDelivery,
       });
@@ -4918,7 +4296,6 @@ describe("exec approval handlers", () => {
     const { manager, handlers, forwarder, respond, context } =
       createForwardingExecApprovalFixture();
     const expireSpy = vi.spyOn(manager, "expire");
-    const resolveRespond = vi.fn();
     forwarder.handleRequested.mockResolvedValueOnce(true);
 
     const requestPromise = requestExecApproval({
@@ -4932,10 +4309,9 @@ describe("exec approval handlers", () => {
     });
     expect(expireSpy).not.toHaveBeenCalled();
 
-    await resolveExecApproval({
+    const resolveRespond = await resolveExecApprovalForTest({
       handlers,
       id: "approval-forwarded",
-      respond: resolveRespond,
       context,
     });
     await requestPromise;
@@ -5038,6 +4414,47 @@ describe("gateway healthHandlers.health cache freshness", () => {
       sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
       ...overrides,
     };
+  }
+
+  function channelHealthAccount(params: {
+    accountId?: string;
+    running: boolean;
+    connected: boolean;
+    lifecycle?: string;
+  }) {
+    return {
+      accountId: params.accountId ?? "default",
+      configured: true,
+      running: params.running,
+      connected: params.connected,
+      ...(params.lifecycle ? { lifecycle: params.lifecycle } : {}),
+    };
+  }
+
+  function createSingleChannelHealthSnapshot<TChannelId extends string>(params: {
+    channelId: TChannelId;
+    label: string;
+    running: boolean;
+    connected: boolean;
+    lifecycle?: string;
+    channelAccountId?: string;
+    ts?: number;
+  }) {
+    const account = channelHealthAccount(params);
+    const channel = {
+      ...(params.channelAccountId ? { accountId: params.channelAccountId } : {}),
+      configured: true,
+      running: params.running,
+      connected: params.connected,
+      ...(params.lifecycle ? { lifecycle: params.lifecycle } : {}),
+      accounts: { default: account },
+    };
+    return createHealthSnapshot({
+      ...(params.ts === undefined ? {} : { ts: params.ts }),
+      channels: { [params.channelId]: channel } as Record<TChannelId, typeof channel>,
+      channelOrder: [params.channelId],
+      channelLabels: { [params.channelId]: params.label },
+    });
   }
 
   async function requestHealthSnapshot(params: {
@@ -5153,43 +4570,19 @@ describe("gateway healthHandlers.health cache freshness", () => {
   });
 
   it("refreshes cached health when runtime channel lifecycle has changed", async () => {
-    const cached = createHealthSnapshot({
-      channels: {
-        discord: {
-          configured: true,
-          running: false,
-          connected: false,
-          accounts: {
-            default: {
-              accountId: "default",
-              configured: true,
-              running: false,
-              connected: false,
-            },
-          },
-        },
-      },
-      channelOrder: ["discord"],
-      channelLabels: { discord: "Discord" },
+    const cached = createSingleChannelHealthSnapshot({
+      channelId: "discord",
+      label: "Discord",
+      running: false,
+      connected: false,
     });
-    const fresh = {
-      ...cached,
+    const fresh = createSingleChannelHealthSnapshot({
+      channelId: "discord",
+      label: "Discord",
+      running: true,
+      connected: true,
       ts: cached.ts + 1,
-      channels: {
-        discord: {
-          ...cached.channels.discord,
-          running: true,
-          connected: true,
-          accounts: {
-            default: {
-              ...cached.channels.discord.accounts.default,
-              running: true,
-              connected: true,
-            },
-          },
-        },
-      },
-    };
+    });
     const { respond, refreshHealthSnapshot } = await requestHealthSnapshot({
       cached,
       fresh,
@@ -5211,27 +4604,13 @@ describe("gateway healthHandlers.health cache freshness", () => {
   });
 
   it("refreshes cached health when recorded lifecycle changes without socket churn", async () => {
-    const cached = createHealthSnapshot({
-      channels: {
-        slack: {
-          accountId: "default",
-          configured: true,
-          running: true,
-          connected: true,
-          lifecycle: "ready",
-          accounts: {
-            default: {
-              accountId: "default",
-              configured: true,
-              running: true,
-              connected: true,
-              lifecycle: "ready",
-            },
-          },
-        },
-      },
-      channelOrder: ["slack"],
-      channelLabels: { slack: "Slack" },
+    const cached = createSingleChannelHealthSnapshot({
+      channelId: "slack",
+      label: "Slack",
+      running: true,
+      connected: true,
+      lifecycle: "ready",
+      channelAccountId: "default",
     });
     const fresh = { ...cached, ts: cached.ts + 1 };
     const { refreshHealthSnapshot } = await requestHealthSnapshot({
@@ -5414,24 +4793,11 @@ describe("gateway healthHandlers.health cache freshness", () => {
   });
 
   it("refreshes cached health when a runtime account is missing from the cached account summary", async () => {
-    const cached = createHealthSnapshot({
-      channels: {
-        discord: {
-          configured: true,
-          running: true,
-          connected: true,
-          accounts: {
-            default: {
-              accountId: "default",
-              configured: true,
-              running: true,
-              connected: true,
-            },
-          },
-        },
-      },
-      channelOrder: ["discord"],
-      channelLabels: { discord: "Discord" },
+    const cached = createSingleChannelHealthSnapshot({
+      channelId: "discord",
+      label: "Discord",
+      running: true,
+      connected: true,
     });
     const fresh = {
       ...cached,
@@ -5441,12 +4807,7 @@ describe("gateway healthHandlers.health cache freshness", () => {
           ...cached.channels.discord,
           accounts: {
             ...cached.channels.discord.accounts,
-            work: {
-              accountId: "work",
-              configured: true,
-              running: true,
-              connected: true,
-            },
+            work: channelHealthAccount({ accountId: "work", running: true, connected: true }),
           },
         },
       },


### PR DESCRIPTION
## What Problem This Solves

Reduces repeated inline gateway test fixtures that made the server-method test suite harder to review and maintain.

## Why This Change Was Made

Introduces narrow test-only factories for repeated chat-history, exec-approval, iOS push-delivery, and health-snapshot fixtures while preserving every test registration, assertion, mock interaction, cleanup path, and runtime behavior. No production code or public contract changes.

## User Impact

No user-visible behavior changes. The gateway server-method suite is 639 net lines smaller and its repeated fixture setup now has canonical test-only builders.

## Evidence

- Exact registration title/order parity against the rebased base: 170 before / 170 after.
- Exact focused test count parity on the immutable starting SHA: 211/211 baseline and 211/211 patched.
- Rebased focused proof: 211/211 passed on Blacksmith Testbox.
- `pnpm check:changed`: passed formatting, core-test typecheck, lint, dead-code, dependency, and plugin-boundary checks on Blacksmith Testbox.
- Fresh `gpt-5.6-sol` xhigh autoreview: clean, no actionable findings.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30782071385
