### PR TITLE
fix(diagnostic): apply 15-min abort floor to model_call recovery eligibility

### DIFF
--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -550,6 +550,7 @@ function isStalledModelCallRecoveryEligible(params: {
   stuckSessionAbortMs: number;
 }): boolean {
   const lastProgressAgeMs = params.activity?.lastProgressAgeMs;
+  const abortMs = Math.max(params.stuckSessionAbortMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS);
   // Local providers are not blanket-exempt from recovery. Streaming model
   // chunks refresh run activity while emitted progress events are throttled, so
   // active streams stay fresh and silent/non-streaming calls can be recovered.
@@ -558,7 +559,7 @@ function isStalledModelCallRecoveryEligible(params: {
     params.classification.classification === "stalled_agent_run" &&
     params.classification.activeWorkKind === "model_call" &&
     typeof lastProgressAgeMs === "number" &&
-    lastProgressAgeMs >= params.stuckSessionAbortMs
+    lastProgressAgeMs >= abortMs
   );
 }
 


### PR DESCRIPTION
Fixes #118386

**Problem:** Stuck-session recovery aborted healthy runs at 6 minutes when the quiet window was a `model_call` (e.g., claude-cli delegating to background subagents). The `tool_call` branch had a 15-minute floor via `BLOCKED_TOOL_CALL_ABORT_FLOOR_MS` but the `model_call` branch did not.

**Fix:** Apply the same floor to `isStalledModelCallRecoveryEligible` by using `Math.max(params.stuckSessionAbortMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)`.

**Testing:** Existing stuck-session recovery tests should cover this change; it only relaxes the abort threshold for model_call to match tool_call.