### PR TITLE
refactor(gateway): compact call test fixtures

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HelloOk } from "../../packages/gateway-protocol/src/schema/frames.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import type { DeviceIdentity } from "../infra/device-identity.js";
@@ -12,6 +13,7 @@ import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { DeviceAuthEntry } from "../shared/device-auth.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import type { GatewayClientOptions, GatewayClientRequestOptions } from "./client.js";
 import {
   loadConfigMock as getRuntimeConfig,
   pickPrimaryLanIPv4Mock as pickPrimaryLanIPv4,
@@ -70,32 +72,11 @@ const connectAssemblyErrorState = vi.hoisted(() => {
   };
 });
 
-let lastClientOptions: {
-  url?: string;
-  token?: string;
-  password?: string;
-  tlsFingerprint?: string;
-  preauthHandshakeTimeoutMs?: number;
-  clientName?: string;
-  clientDisplayName?: string;
-  mode?: string;
-  approvalRuntimeToken?: string;
-  agentRuntimeIdentityToken?: string;
-  scopes?: string[];
-  deviceIdentity?: unknown;
-  onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
-  onClose?: (code: number, reason: string, info?: StubGatewayClientCloseInfo) => void;
-  onConnectError?: (err: Error) => void;
-} | null = null;
+let lastClientOptions: GatewayClientOptions | null = null;
 let lastRequestOptions: {
   method?: string;
   params?: unknown;
-  opts?: {
-    expectFinal?: boolean;
-    timeoutMs?: number | null;
-    signal?: AbortSignal;
-    onAccepted?: (payload: unknown) => void;
-  };
+  opts?: GatewayClientRequestOptions;
 } | null = null;
 type StartMode =
   | "hello"
@@ -105,10 +86,6 @@ type StartMode =
   | "startup-retry-then-hello"
   | "clean-prehello-close-then-hello"
   | "repeated-clean-prehello-close";
-type StubGatewayClientCloseInfo = {
-  phase: "pre-hello" | "post-hello";
-  transientPreHelloCleanClose: boolean;
-};
 let startMode: StartMode = "hello";
 let startCalls = 0;
 let closeCode = 1006;
@@ -116,37 +93,48 @@ let closeReason = "";
 let helloMethods: string[] | undefined = ["health", "secrets.resolve"];
 let connectError: Error | null = null;
 
+function makeStubGatewayHello(): HelloOk {
+  return {
+    type: "hello-ok",
+    protocol: 1,
+    server: { version: "test", connId: "test-connection" },
+    features: { methods: helloMethods ?? [], events: [] },
+    snapshot: {
+      presence: [],
+      health: {},
+      stateVersion: { presence: 0, health: 0 },
+      uptimeMs: 0,
+    },
+    auth: { role: "operator", scopes: [] },
+    policy: { maxPayload: 1, maxBufferedBytes: 1, tickIntervalMs: 1 },
+  };
+}
+
 function startStubGatewayClient() {
   startCalls += 1;
   if (startMode === "hello") {
-    void lastClientOptions?.onHelloOk?.({
-      features: {
-        methods: helloMethods,
-      },
-    });
+    lastClientOptions?.onHelloOk?.(makeStubGatewayHello());
   } else if (startMode === "startup-retry-then-hello") {
-    void lastClientOptions?.onHelloOk?.({
-      features: {
-        methods: helloMethods,
-      },
-    });
+    lastClientOptions?.onHelloOk?.(makeStubGatewayHello());
   } else if (startMode === "clean-prehello-close-then-hello") {
     lastClientOptions?.onClose?.(1000, "", {
       phase: "pre-hello",
+      socketOpened: true,
+      transportValidated: true,
       transientPreHelloCleanClose: true,
     });
-    void lastClientOptions?.onHelloOk?.({
-      features: {
-        methods: helloMethods,
-      },
-    });
+    lastClientOptions?.onHelloOk?.(makeStubGatewayHello());
   } else if (startMode === "repeated-clean-prehello-close") {
     lastClientOptions?.onClose?.(1000, "", {
       phase: "pre-hello",
+      socketOpened: true,
+      transportValidated: true,
       transientPreHelloCleanClose: true,
     });
     lastClientOptions?.onClose?.(1000, "", {
       phase: "pre-hello",
+      socketOpened: true,
+      transportValidated: true,
       transientPreHelloCleanClose: true,
     });
   } else if (startMode === "connect-error") {
@@ -161,28 +149,10 @@ function startStubGatewayClient() {
 vi.mock("./client.js", () => ({
   isGatewayConnectAssemblyError: (value: unknown) => connectAssemblyErrorState.has(value),
   GatewayClient: class {
-    constructor(opts: {
-      url?: string;
-      token?: string;
-      password?: string;
-      preauthHandshakeTimeoutMs?: number;
-      clientName?: string;
-      clientDisplayName?: string;
-      mode?: string;
-      approvalRuntimeToken?: string;
-      agentRuntimeIdentityToken?: string;
-      scopes?: string[];
-      onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
-      onClose?: (code: number, reason: string, info?: StubGatewayClientCloseInfo) => void;
-      onConnectError?: (err: Error) => void;
-    }) {
+    constructor(opts: GatewayClientOptions) {
       lastClientOptions = opts;
     }
-    async request(
-      method: string,
-      params: unknown,
-      opts?: { expectFinal?: boolean; timeoutMs?: number | null },
-    ) {
+    async request(method: string, params: unknown, opts?: GatewayClientRequestOptions) {
       lastRequestOptions = { method, params, opts };
       return { ok: true };
     }
@@ -219,33 +189,10 @@ const {
 const { GatewaySecretRefUnavailableError } = await import("./credentials.js");
 
 class StubGatewayClient {
-  constructor(opts: {
-    url?: string;
-    token?: string;
-    password?: string;
-    preauthHandshakeTimeoutMs?: number;
-    clientName?: string;
-    clientDisplayName?: string;
-    mode?: string;
-    approvalRuntimeToken?: string;
-    agentRuntimeIdentityToken?: string;
-    scopes?: string[];
-    onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
-    onClose?: (code: number, reason: string, info?: StubGatewayClientCloseInfo) => void;
-    onConnectError?: (err: Error) => void;
-  }) {
+  constructor(opts: GatewayClientOptions) {
     lastClientOptions = opts;
   }
-  async request(
-    method: string,
-    params: unknown,
-    opts?: {
-      expectFinal?: boolean;
-      timeoutMs?: number | null;
-      signal?: AbortSignal;
-      onAccepted?: (payload: unknown) => void;
-    },
-  ) {
+  async request(method: string, params: unknown, opts?: GatewayClientRequestOptions) {
     lastRequestOptions = { method, params, opts };
     return { ok: true };
   }
@@ -284,8 +231,7 @@ function resetGatewayCallMocks() {
     env?: NodeJS.ProcessEnv,
   ) => number;
   testing.setDepsForTests({
-    createGatewayClient: (opts) =>
-      new StubGatewayClient(opts as ConstructorParameters<typeof StubGatewayClient>[0]) as never,
+    createGatewayClient: (opts) => new StubGatewayClient(opts) as never,
     getRuntimeConfig: loadConfigForTests,
     loadOrCreateDeviceIdentity: () => {
       if (deviceIdentityState.throwOnLoad) {
@@ -311,8 +257,20 @@ function setGatewayNetworkDefaults(port = 18789) {
   pickPrimaryTailnetIPv4.mockReturnValue(undefined);
 }
 
+function setGatewayConfig(gateway: NonNullable<OpenClawConfig["gateway"]>) {
+  getRuntimeConfig.mockReturnValue({ gateway });
+}
+
+function setEnvSecretGatewayConfig(gateway: NonNullable<OpenClawConfig["gateway"]>) {
+  const config = {
+    gateway,
+    secrets: { providers: { default: { source: "env" } } },
+  } satisfies OpenClawConfig;
+  getRuntimeConfig.mockReturnValue(config);
+}
+
 function setLocalLoopbackGatewayConfig(port = 18789) {
-  getRuntimeConfig.mockReturnValue({ gateway: { mode: "local", bind: "loopback" } });
+  setGatewayConfig({ mode: "local", bind: "loopback" });
   setGatewayNetworkDefaults(port);
 }
 
@@ -364,7 +322,7 @@ describe("callGateway url resolution", () => {
       tailnetIp: undefined,
     },
   ])("local auto-bind: $label", async ({ tailnetIp }) => {
-    getRuntimeConfig.mockReturnValue({ gateway: { mode: "local", bind: "auto" } });
+    setGatewayConfig({ mode: "local", bind: "auto" });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryTailnetIPv4.mockReturnValue(tailnetIp);
 
@@ -421,9 +379,7 @@ describe("callGateway url resolution", () => {
   });
 
   it("uses url override in remote mode even when remote url is missing", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: { mode: "remote", bind: "loopback", remote: {} },
-    });
+    setGatewayConfig({ mode: "remote", bind: "loopback", remote: {} });
     resolveGatewayPort.mockReturnValue(18789);
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
 
@@ -469,9 +425,7 @@ describe("callGateway url resolution", () => {
   });
 
   it("fails before opening a websocket when backend token auth has no shared or paired credential", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: { mode: "local", bind: "loopback", auth: { mode: "token" } },
-    });
+    setGatewayConfig({ mode: "local", bind: "loopback", auth: { mode: "token" } });
     setGatewayNetworkDefaults();
     loadDeviceAuthTokenMock.mockReturnValue(null);
 
@@ -489,9 +443,7 @@ describe("callGateway url resolution", () => {
   });
 
   it("fails before opening a websocket when default token auth has no shared or paired credential", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: { mode: "local", bind: "loopback" },
-    });
+    setGatewayConfig({ mode: "local", bind: "loopback" });
     setGatewayNetworkDefaults();
     loadDeviceAuthTokenMock.mockReturnValue(null);
 
@@ -504,9 +456,7 @@ describe("callGateway url resolution", () => {
   });
 
   it("allows paired backend device auth without explicit shared credentials", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: { mode: "local", bind: "loopback", auth: { mode: "token" } },
-    });
+    setGatewayConfig({ mode: "local", bind: "loopback", auth: { mode: "token" } });
     setGatewayNetworkDefaults();
     loadDeviceAuthTokenMock.mockReturnValue({
       token: "paired-device-token",
@@ -523,12 +473,10 @@ describe("callGateway url resolution", () => {
   });
 
   it("allows Tailscale-authenticated backend calls without client-side credentials", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        remote: { url: "wss://openclaw.example.test" },
-        auth: { mode: "token", allowTailscale: true },
-      },
+    setGatewayConfig({
+      mode: "remote",
+      remote: { url: "wss://openclaw.example.test" },
+      auth: { mode: "token", allowTailscale: true },
     });
     setGatewayNetworkDefaults();
 
@@ -540,13 +488,11 @@ describe("callGateway url resolution", () => {
   });
 
   it("allows Tailscale Serve backend calls without explicit allowTailscale", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        remote: { url: "wss://openclaw.example.test" },
-        auth: { mode: "token" },
-        tailscale: { mode: "serve" },
-      },
+    setGatewayConfig({
+      mode: "remote",
+      remote: { url: "wss://openclaw.example.test" },
+      auth: { mode: "token" },
+      tailscale: { mode: "serve" },
     });
     setGatewayNetworkDefaults();
 
@@ -573,9 +519,7 @@ describe("callGateway url resolution", () => {
   });
 
   it("keeps CLI device identity when an ambient token is inactive under auth mode none", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: { mode: "local", bind: "loopback", auth: { mode: "none" } },
-    });
+    setGatewayConfig({ mode: "local", bind: "loopback", auth: { mode: "none" } });
     setGatewayNetworkDefaults();
     process.env.OPENCLAW_GATEWAY_TOKEN = "inactive-env-token";
 
@@ -631,9 +575,7 @@ describe("callGateway url resolution", () => {
   });
 
   it("uses OPENCLAW_GATEWAY_URL env override in remote mode when remote URL is missing", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: { mode: "remote", bind: "loopback", remote: {} },
-    });
+    setGatewayConfig({ mode: "remote", bind: "loopback", remote: {} });
     resolveGatewayPort.mockReturnValue(18789);
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
     process.env.OPENCLAW_GATEWAY_URL = "wss://gateway-in-container.internal:9443/ws";
@@ -649,9 +591,7 @@ describe("callGateway url resolution", () => {
   });
 
   it("lets an explicit local port override bypass gateway env URL and port", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: { mode: "local", bind: "loopback" },
-    });
+    setGatewayConfig({ mode: "local", bind: "loopback" });
     resolveGatewayPort.mockImplementation((_config?: unknown, env?: unknown) => {
       const candidateEnv = env as NodeJS.ProcessEnv | undefined;
       return Number(candidateEnv?.OPENCLAW_GATEWAY_PORT ?? 18789);
@@ -672,20 +612,13 @@ describe("callGateway url resolution", () => {
   });
 
   it("uses env URL override credentials without resolving local password SecretRefs", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        auth: {
-          mode: "password",
-          password: { source: "env", provider: "default", id: "MISSING_LOCAL_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      auth: {
+        mode: "password",
+        password: { source: "env", provider: "default", id: "MISSING_LOCAL_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
     resolveGatewayPort.mockReturnValue(18789);
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
     process.env.OPENCLAW_GATEWAY_URL = "wss://gateway-in-container.internal:9443/ws";
@@ -701,13 +634,11 @@ describe("callGateway url resolution", () => {
   });
 
   it("uses remote tlsFingerprint with env URL override", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        remote: {
-          url: "wss://remote.example:9443/ws",
-          tlsFingerprint: "remote-fingerprint",
-        },
+    setGatewayConfig({
+      mode: "remote",
+      remote: {
+        url: "wss://remote.example:9443/ws",
+        tlsFingerprint: "remote-fingerprint",
       },
     });
     setGatewayNetworkDefaults(18789);
@@ -723,13 +654,11 @@ describe("callGateway url resolution", () => {
   });
 
   it("does not apply remote tlsFingerprint for CLI url override", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        remote: {
-          url: "wss://remote.example:9443/ws",
-          tlsFingerprint: "remote-fingerprint",
-        },
+    setGatewayConfig({
+      mode: "remote",
+      remote: {
+        url: "wss://remote.example:9443/ws",
+        tlsFingerprint: "remote-fingerprint",
       },
     });
     setGatewayNetworkDefaults(18789);
@@ -842,12 +771,10 @@ describe("callGateway url resolution", () => {
   });
 
   it("prefers stored device auth over configured local credentials", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: { mode: "token", token: "configured-token" },
-      },
+    setGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: { mode: "token", token: "configured-token" },
     });
     setGatewayNetworkDefaults();
 
@@ -858,21 +785,14 @@ describe("callGateway url resolution", () => {
   });
 
   it("does not resolve configured local SecretRefs when using stored device auth", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: {
-          mode: "password",
-          password: { source: "env", provider: "default", id: "MISSING_LOCAL_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: {
+        mode: "password",
+        password: { source: "env", provider: "default", id: "MISSING_LOCAL_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
     setGatewayNetworkDefaults();
 
     await callGatewayCli({ method: "node.list", useStoredDeviceAuth: true });
@@ -913,9 +833,7 @@ describe("callGateway url resolution", () => {
   });
 
   it("fails before connecting when stored device auth is unavailable", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: { mode: "local", bind: "loopback", auth: { mode: "none" } },
-    });
+    setGatewayConfig({ mode: "local", bind: "loopback", auth: { mode: "none" } });
     setGatewayNetworkDefaults();
     loadDeviceAuthTokenMock.mockReturnValue(null);
 
@@ -944,9 +862,7 @@ describe("callGateway url resolution", () => {
   });
 
   it("uses local backend auth-none without a device identity when required", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: { mode: "local", bind: "loopback", auth: { mode: "none" } },
-    });
+    setGatewayConfig({ mode: "local", bind: "loopback", auth: { mode: "none" } });
     setGatewayNetworkDefaults();
 
     await callGateway({
@@ -992,13 +908,11 @@ describe("callGateway url resolution", () => {
   });
 
   it("rejects required local backend shared auth for remote-mode loopback tunnels", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        remote: {
-          url: "ws://127.0.0.1:18789",
-          token: "remote-token",
-        },
+    setGatewayConfig({
+      mode: "remote",
+      remote: {
+        url: "ws://127.0.0.1:18789",
+        token: "remote-token",
       },
     });
     setGatewayNetworkDefaults();
@@ -1252,9 +1166,7 @@ describe("buildGatewayConnectionDetails", () => {
   });
 
   it("emits a remote fallback note when remote url is missing", () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: { mode: "remote", bind: "loopback", remote: {} },
-    });
+    setGatewayConfig({ mode: "remote", bind: "loopback", remote: {} });
     resolveGatewayPort.mockReturnValue(18789);
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
 
@@ -1294,12 +1206,10 @@ describe("buildGatewayConnectionDetails", () => {
   });
 
   it("prefers remote url when configured", () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        bind: "tailnet",
-        remote: { url: "wss://remote.example.com/ws" },
-      },
+    setGatewayConfig({
+      mode: "remote",
+      bind: "tailnet",
+      remote: { url: "wss://remote.example.com/ws" },
     });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryTailnetIPv4.mockReturnValue("100.64.0.9");
@@ -1313,7 +1223,7 @@ describe("buildGatewayConnectionDetails", () => {
   });
 
   it("uses env OPENCLAW_GATEWAY_URL when set", () => {
-    getRuntimeConfig.mockReturnValue({ gateway: { mode: "local", bind: "loopback" } });
+    setGatewayConfig({ mode: "local", bind: "loopback" });
     resolveGatewayPort.mockReturnValue(18800);
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
     const prevUrl = process.env.OPENCLAW_GATEWAY_URL;
@@ -1335,7 +1245,7 @@ describe("buildGatewayConnectionDetails", () => {
   });
 
   it("lets a local port override bypass gateway env URL and port in connection details", () => {
-    getRuntimeConfig.mockReturnValue({ gateway: { mode: "local", bind: "loopback" } });
+    setGatewayConfig({ mode: "local", bind: "loopback" });
     resolveGatewayPort.mockImplementation((_config?: unknown, env?: unknown) => {
       const candidateEnv = env as NodeJS.ProcessEnv | undefined;
       return Number(candidateEnv?.OPENCLAW_GATEWAY_PORT ?? 18789);
@@ -1371,7 +1281,7 @@ describe("buildGatewayConnectionDetails", () => {
     setTestEnvValue("OPENCLAW_STATE_DIR", tempStateDir);
     setTestEnvValue("OPENCLAW_CONFIG_PATH", path.join(tempStateDir, "missing-config.json"));
     try {
-      getRuntimeConfig.mockReturnValue({ gateway: { mode: "local", bind: "loopback" } });
+      setGatewayConfig({ mode: "local", bind: "loopback" });
       resolveGatewayPort.mockReturnValue(18800);
       testing.setDepsForTests({
         getRuntimeConfig: {} as never,
@@ -1461,12 +1371,10 @@ describe("buildGatewayConnectionDetails", () => {
   });
 
   it("throws for insecure ws:// remote URLs (CWE-319)", () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        bind: "loopback",
-        remote: { url: "ws://remote.example.com:18789" },
-      },
+    setGatewayConfig({
+      mode: "remote",
+      bind: "loopback",
+      remote: { url: "ws://remote.example.com:18789" },
     });
     resolveGatewayPort.mockReturnValue(18789);
     pickPrimaryTailnetIPv4.mockReturnValue(undefined);
@@ -1486,12 +1394,10 @@ describe("buildGatewayConnectionDetails", () => {
   });
 
   it("redacts credential-bearing target URLs from insecure ws:// errors", () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        bind: "loopback",
-        remote: { url: "ws://user:pass@remote.example.com:18789/ws?token=secret-token" },
-      },
+    setGatewayConfig({
+      mode: "remote",
+      bind: "loopback",
+      remote: { url: "ws://user:pass@remote.example.com:18789/ws?token=secret-token" },
     });
     resolveGatewayPort.mockReturnValue(18789);
 
@@ -1508,12 +1414,10 @@ describe("buildGatewayConnectionDetails", () => {
   });
 
   it("allows ws:// private remote URLs for trusted LAN and Tailnet configs", () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        bind: "loopback",
-        remote: { url: "ws://10.0.0.8:18789" },
-      },
+    setGatewayConfig({
+      mode: "remote",
+      bind: "loopback",
+      remote: { url: "ws://10.0.0.8:18789" },
     });
     resolveGatewayPort.mockReturnValue(18789);
 
@@ -1525,12 +1429,10 @@ describe("buildGatewayConnectionDetails", () => {
 
   it("allows ws:// hostname remote URLs when OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1", () => {
     process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS = "1";
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        bind: "loopback",
-        remote: { url: "ws://openclaw-gateway.ai:18789" },
-      },
+    setGatewayConfig({
+      mode: "remote",
+      bind: "loopback",
+      remote: { url: "ws://openclaw-gateway.ai:18789" },
     });
     resolveGatewayPort.mockReturnValue(18789);
 
@@ -2317,9 +2219,7 @@ describe("callGateway error details", () => {
   });
 
   it("fails fast when remote mode is missing remote url", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: { mode: "remote", bind: "loopback", remote: {} },
-    });
+    setGatewayConfig({ mode: "remote", bind: "loopback", remote: {} });
     await expect(
       callGateway({
         method: "health",
@@ -2365,11 +2265,9 @@ describe("callGateway url override auth requirements", () => {
   it("throws when url override is set without explicit credentials", async () => {
     process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
     process.env.OPENCLAW_GATEWAY_PASSWORD = "env-password";
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        auth: { token: "local-token", password: "local-password" },
-      },
+    setGatewayConfig({
+      mode: "local",
+      auth: { token: "local-token", password: "local-password" },
     });
 
     await expect(
@@ -2379,11 +2277,9 @@ describe("callGateway url override auth requirements", () => {
 
   it("throws when env URL override is set without env credentials", async () => {
     process.env.OPENCLAW_GATEWAY_URL = "wss://override.example/ws";
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        auth: { token: "local-token", password: "local-password" },
-      },
+    setGatewayConfig({
+      mode: "local",
+      auth: { token: "local-token", password: "local-password" },
     });
 
     await expect(callGateway({ method: "health" })).rejects.toThrow(
@@ -2486,21 +2382,14 @@ describe("callGateway password resolution", () => {
 
   it("resolves gateway.auth.password SecretInput refs for gateway calls", async () => {
     process.env.LOCAL_REF_PASSWORD = "resolved-local-ref-password"; // pragma: allowlist secret
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: {
-          mode: "password",
-          password: { source: "env", provider: "default", id: "LOCAL_REF_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: {
+        mode: "password",
+        password: { source: "env", provider: "default", id: "LOCAL_REF_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2509,42 +2398,28 @@ describe("callGateway password resolution", () => {
 
   it("does not let env password mask an unresolved local password ref", async () => {
     process.env.OPENCLAW_GATEWAY_PASSWORD = "from-env";
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: {
-          mode: "password",
-          password: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: {
+        mode: "password",
+        password: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await expect(callGateway({ method: "health" })).rejects.toThrow("gateway.auth.password");
   });
 
   it("does not resolve local password ref when token auth can win", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: {
-          mode: "token",
-          token: "token-auth",
-          password: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: {
+        mode: "token",
+        token: "token-auth",
+        password: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2553,21 +2428,14 @@ describe("callGateway password resolution", () => {
 
   it("resolves local password ref before unresolved local token ref can block auth", async () => {
     process.env.LOCAL_FALLBACK_PASSWORD = "resolved-local-fallback-password"; // pragma: allowlist secret
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: {
-          token: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_TOKEN" },
-          password: { source: "env", provider: "default", id: "LOCAL_FALLBACK_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: {
+        token: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_TOKEN" },
+        password: { source: "env", provider: "default", id: "LOCAL_FALLBACK_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2577,44 +2445,30 @@ describe("callGateway password resolution", () => {
 
   it("fails closed when unresolved local token SecretRef would otherwise fall back to remote token", async () => {
     process.env.LOCAL_REMOTE_FALLBACK_TOKEN = "resolved-local-remote-fallback-token";
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: {
-          mode: "token",
-          token: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_TOKEN" },
-        },
-        remote: {
-          token: { source: "env", provider: "default", id: "LOCAL_REMOTE_FALLBACK_TOKEN" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: {
+        mode: "token",
+        token: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_TOKEN" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
+      remote: {
+        token: { source: "env", provider: "default", id: "LOCAL_REMOTE_FALLBACK_TOKEN" },
       },
-    } as unknown as OpenClawConfig);
+    });
 
     await expect(callGateway({ method: "health" })).rejects.toThrow("gateway.auth.token");
   });
 
   it("ignores unresolved local password ref when auth mode is none", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: {
-          mode: "none",
-          password: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: {
+        mode: "none",
+        password: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2624,21 +2478,14 @@ describe("callGateway password resolution", () => {
 
   it("resolves local password refs when auth mode is trusted-proxy", async () => {
     process.env.LOCAL_TRUSTED_PROXY_PASSWORD = "resolved-trusted-proxy-password";
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: {
-          mode: "trusted-proxy",
-          password: { source: "env", provider: "default", id: "LOCAL_TRUSTED_PROXY_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: {
+        mode: "trusted-proxy",
+        password: { source: "env", provider: "default", id: "LOCAL_TRUSTED_PROXY_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2647,45 +2494,31 @@ describe("callGateway password resolution", () => {
   });
 
   it("fails closed when trusted-proxy local password ref cannot resolve", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: {
-          mode: "trusted-proxy",
-          password: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: {
+        mode: "trusted-proxy",
+        password: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await expect(callGateway({ method: "health" })).rejects.toThrow("gateway.auth.password");
   });
 
   it("does not resolve local password ref when remote password is already configured", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        bind: "loopback",
-        auth: {
-          mode: "password",
-          password: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_PASSWORD" },
-        },
-        remote: {
-          url: "wss://remote.example:18789",
-          password: "remote-secret",
-        },
+    setEnvSecretGatewayConfig({
+      mode: "remote",
+      bind: "loopback",
+      auth: {
+        mode: "password",
+        password: { source: "env", provider: "default", id: "MISSING_LOCAL_REF_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
+      remote: {
+        url: "wss://remote.example:18789",
+        password: "remote-secret",
       },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2694,22 +2527,15 @@ describe("callGateway password resolution", () => {
 
   it("resolves gateway.remote.token SecretInput refs when remote token is required", async () => {
     process.env.REMOTE_REF_TOKEN = "resolved-remote-ref-token";
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        bind: "loopback",
-        auth: {},
-        remote: {
-          url: "wss://remote.example:18789",
-          token: { source: "env", provider: "default", id: "REMOTE_REF_TOKEN" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "remote",
+      bind: "loopback",
+      auth: {},
+      remote: {
+        url: "wss://remote.example:18789",
+        token: { source: "env", provider: "default", id: "REMOTE_REF_TOKEN" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2718,22 +2544,15 @@ describe("callGateway password resolution", () => {
 
   it("resolves gateway.remote.password SecretInput refs when remote password is required", async () => {
     process.env.REMOTE_REF_PASSWORD = "resolved-remote-ref-password"; // pragma: allowlist secret
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        bind: "loopback",
-        auth: {},
-        remote: {
-          url: "wss://remote.example:18789",
-          password: { source: "env", provider: "default", id: "REMOTE_REF_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "remote",
+      bind: "loopback",
+      auth: {},
+      remote: {
+        url: "wss://remote.example:18789",
+        password: { source: "env", provider: "default", id: "REMOTE_REF_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2741,23 +2560,16 @@ describe("callGateway password resolution", () => {
   });
 
   it("does not resolve remote token ref when remote password already wins", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        bind: "loopback",
-        auth: {},
-        remote: {
-          url: "wss://remote.example:18789",
-          token: { source: "env", provider: "default", id: "MISSING_REMOTE_TOKEN" },
-          password: "remote-password", // pragma: allowlist secret
-        },
+    setEnvSecretGatewayConfig({
+      mode: "remote",
+      bind: "loopback",
+      auth: {},
+      remote: {
+        url: "wss://remote.example:18789",
+        token: { source: "env", provider: "default", id: "MISSING_REMOTE_TOKEN" },
+        password: "remote-password", // pragma: allowlist secret
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2767,23 +2579,16 @@ describe("callGateway password resolution", () => {
 
   it("resolves remote token ref before unresolved remote password ref can block auth", async () => {
     process.env.REMOTE_REF_TOKEN = "resolved-remote-ref-token";
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        bind: "loopback",
-        auth: {},
-        remote: {
-          url: "wss://remote.example:18789",
-          token: { source: "env", provider: "default", id: "REMOTE_REF_TOKEN" },
-          password: { source: "env", provider: "default", id: "MISSING_REMOTE_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "remote",
+      bind: "loopback",
+      auth: {},
+      remote: {
+        url: "wss://remote.example:18789",
+        token: { source: "env", provider: "default", id: "REMOTE_REF_TOKEN" },
+        password: { source: "env", provider: "default", id: "MISSING_REMOTE_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2792,23 +2597,16 @@ describe("callGateway password resolution", () => {
   });
 
   it("does not resolve remote password ref when remote token already wins", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "remote",
-        bind: "loopback",
-        auth: {},
-        remote: {
-          url: "wss://remote.example:18789",
-          token: "remote-token",
-          password: { source: "env", provider: "default", id: "MISSING_REMOTE_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "remote",
+      bind: "loopback",
+      auth: {},
+      remote: {
+        url: "wss://remote.example:18789",
+        token: "remote-token",
+        password: { source: "env", provider: "default", id: "MISSING_REMOTE_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2818,22 +2616,15 @@ describe("callGateway password resolution", () => {
 
   it("resolves remote token refs on local-mode calls when fallback token can win", async () => {
     process.env.LOCAL_FALLBACK_REMOTE_TOKEN = "resolved-local-fallback-remote-token";
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: {},
-        remote: {
-          token: { source: "env", provider: "default", id: "LOCAL_FALLBACK_REMOTE_TOKEN" },
-          password: { source: "env", provider: "default", id: "MISSING_REMOTE_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: {},
+      remote: {
+        token: { source: "env", provider: "default", id: "LOCAL_FALLBACK_REMOTE_TOKEN" },
+        password: { source: "env", provider: "default", id: "MISSING_REMOTE_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2842,23 +2633,16 @@ describe("callGateway password resolution", () => {
   });
 
   it("does not resolve remote refs on non-remote gateway calls when auth mode is none", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: { mode: "none" },
-        remote: {
-          url: "wss://remote.example:18789",
-          token: { source: "env", provider: "default", id: "MISSING_REMOTE_TOKEN" },
-          password: { source: "env", provider: "default", id: "MISSING_REMOTE_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: { mode: "none" },
+      remote: {
+        url: "wss://remote.example:18789",
+        token: { source: "env", provider: "default", id: "MISSING_REMOTE_TOKEN" },
+        password: { source: "env", provider: "default", id: "MISSING_REMOTE_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2867,23 +2651,16 @@ describe("callGateway password resolution", () => {
   });
 
   it("does not resolve remote refs on non-remote gateway calls when auth mode is trusted-proxy", async () => {
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: { mode: "trusted-proxy" },
-        remote: {
-          url: "wss://remote.example:18789",
-          token: { source: "env", provider: "default", id: "MISSING_REMOTE_TOKEN" },
-          password: { source: "env", provider: "default", id: "MISSING_REMOTE_PASSWORD" },
-        },
+    setEnvSecretGatewayConfig({
+      mode: "local",
+      bind: "loopback",
+      auth: { mode: "trusted-proxy" },
+      remote: {
+        url: "wss://remote.example:18789",
+        token: { source: "env", provider: "default", id: "MISSING_REMOTE_TOKEN" },
+        password: { source: "env", provider: "default", id: "MISSING_REMOTE_PASSWORD" },
       },
-      secrets: {
-        providers: {
-          default: { source: "env" },
-        },
-      },
-    } as unknown as OpenClawConfig);
+    });
 
     await callGateway({ method: "health" });
 
@@ -2897,12 +2674,7 @@ describe("callGateway password resolution", () => {
       password?: string;
       token?: string;
     };
-    getRuntimeConfig.mockReturnValue({
-      gateway: {
-        mode: "local",
-        auth,
-      },
-    });
+    setGatewayConfig({ mode: "local", auth });
 
     await callGateway({
       method: "health",


### PR DESCRIPTION
<!-- AI-assisted: implemented and reviewed with Codex. Maintainer-requested bounded refactor; no linked issue. -->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

`src/gateway/call.test.ts` repeated complete gateway, SecretRef, client-option, and hello fixtures across cases. That repetition obscured the per-case fields under test and kept an already oversized owner test unnecessarily large.

## Why This Change Was Made

This maintainer-requested cleanup introduces typed local fixture builders and reuses the real gateway client and protocol types. It preserves every test title and order, assertion and error line, request sequence, auth case, timeout/abort path, WebSocket lifecycle, mock, and cleanup boundary.

## User Impact

No user-visible or production behavior changes. The gateway call suite is 228 lines smaller and its fixtures are easier to audit against the production contracts.

## Evidence

- Baseline/post focused gateway suite: 123/123 tests passed.
- Blacksmith Testbox `tbx_01kz2tk756a7q4nx5374m5k91x`: `node scripts/run-vitest.mjs src/gateway/call.test.ts` passed 123/123.
- Same Testbox: full `pnpm check:changed` passed, including format, dead-export scan, core-test typecheck, and oxlint.
- Exact title/order parity and exact assertion/error-line parity against the parent commit.
- Fresh Sol xhigh autoreview: 0 findings, patch correct (0.99 confidence), thread `019fc5c6-cbf7-7310-bf30-c67058f86fb5`.
- Diff: one test file, 269 insertions / 497 deletions (net -228); production LOC delta 0.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30781863698
