### PR TITLE
refactor(ai): consolidate legacy function-call test fixtures

### DIFF
--- a/packages/ai/src/providers/openai-completions.legacy-function-call.test.ts
+++ b/packages/ai/src/providers/openai-completions.legacy-function-call.test.ts
@@ -1,8 +1,8 @@
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { configureAiTransportHost, getAiTransportHost } from "../host.js";
 import { createOpenAICompletionsTransportStreamFn } from "../transports/openai-completions-transport.js";
-import type { AssistantMessageEventStreamLike, Context, Model } from "../types.js";
+import type { AssistantMessageEvent, Context, Model } from "../types.js";
 import { streamOpenAICompletions } from "./openai-completions.js";
 
 const model = {
@@ -46,34 +46,71 @@ function chunk(
   };
 }
 
+type ToolCallFixture = {
+  index?: number;
+  id?: string;
+  name?: string;
+  arguments: string;
+};
+
+function toolCallDelta({
+  index = 0,
+  id,
+  name,
+  arguments: rawArguments,
+}: ToolCallFixture): ChatCompletionChunk.Choice.Delta.ToolCall {
+  return {
+    index,
+    ...(id !== undefined ? { id, type: "function" as const } : {}),
+    function: {
+      ...(name !== undefined ? { name } : {}),
+      arguments: rawArguments,
+    },
+  };
+}
+
+const modernCallChunk = (
+  rawArguments: string,
+  { id = "call_modern", index = 0, name = "lookup" } = {},
+): ChatCompletionChunk =>
+  chunk({ tool_calls: [toolCallDelta({ id, index, name, arguments: rawArguments })] });
+
+const confirmedModernCallChunks = (
+  rawArguments: string,
+  options?: Parameters<typeof modernCallChunk>[1],
+): ChatCompletionChunk[] => [modernCallChunk(rawArguments, options), chunk({}, "tool_calls")];
+
+function confirmedLegacyCallChunks(rawArguments: string, name = "lookup"): ChatCompletionChunk[] {
+  return [chunk({ function_call: { name, arguments: rawArguments } }), chunk({}, "function_call")];
+}
+
 function installStream(chunks: ChatCompletionChunk[]): void {
   const body = `${chunks.map((value) => `data: ${JSON.stringify(value)}\n\n`).join("")}data: [DONE]\n\n`;
-  const fetch = vi.fn<typeof globalThis.fetch>(async () => {
-    return new Response(body, {
-      status: 200,
-      headers: { "content-type": "text/event-stream" },
-    });
+  configureAiTransportHost({
+    buildModelFetch: () => async () =>
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
   });
-  configureAiTransportHost({ buildModelFetch: () => fetch });
 }
 
 let previousHost: ReturnType<typeof getAiTransportHost>;
 
-beforeEach(() => {
-  previousHost = getAiTransportHost();
-});
+beforeEach(() => (previousHost = getAiTransportHost()));
 
-afterEach(() => {
-  configureAiTransportHost(previousHost);
-});
+afterEach(() => configureAiTransportHost(previousHost));
 
 const createManagedStream = createOpenAICompletionsTransportStreamFn();
+type FixtureOptions = { apiKey: string; reasoningEffort?: "medium"; signal?: AbortSignal };
+
+const FIXTURE_OPTIONS = { apiKey: "fixture-token" } satisfies FixtureOptions;
 
 function createManagedFixtureStream(
   fixtureModel: Model<"openai-completions">,
   fixtureContext: Context,
-  fixtureOptions?: Parameters<typeof createManagedStream>[2],
-): AssistantMessageEventStreamLike {
+  fixtureOptions?: FixtureOptions,
+) {
   const stream = createManagedStream(fixtureModel, fixtureContext, fixtureOptions);
   if (stream instanceof Promise) {
     throw new Error("OpenAI Chat transport must return its event stream synchronously");
@@ -85,20 +122,50 @@ describe.each([
   { name: "package", createStream: streamOpenAICompletions },
   { name: "managed", createStream: createManagedFixtureStream },
 ])("$name OpenAI Chat Completions stream", ({ createStream }) => {
+  const startFixture = (
+    chunks: ChatCompletionChunk[],
+    options: FixtureOptions = FIXTURE_OPTIONS,
+    fixtureModel: Model<"openai-completions"> = model,
+  ) => {
+    installStream(chunks);
+    return createStream(fixtureModel, context, options);
+  };
+  const fixtureResult = (...args: Parameters<typeof startFixture>) =>
+    startFixture(...args).result();
+  const collectFixture = async (...args: Parameters<typeof startFixture>) => {
+    const stream = startFixture(...args);
+    const events: Array<{ type: AssistantMessageEvent["type"]; toolCallId?: string }> = [];
+    const starts: Array<{ id: string; name: string }> = [];
+    const argumentDeltas: string[] = [];
+    for await (const event of stream) {
+      events.push({
+        type: event.type,
+        ...(event.type === "toolcall_end" ? { toolCallId: event.toolCall.id } : {}),
+      });
+      if (event.type === "toolcall_start") {
+        const block = event.partial.content[event.contentIndex];
+        if (block?.type === "toolCall") {
+          starts.push({ id: block.id, name: block.name });
+        }
+      } else if (event.type === "toolcall_delta" && event.delta) {
+        argumentDeltas.push(event.delta);
+      }
+    }
+    return {
+      events,
+      eventTypes: events.map((event) => event.type),
+      starts,
+      argumentDeltas,
+      result: await stream.result(),
+    };
+  };
   it("preserves legacy function_call deltas and reassembles split arguments", async () => {
-    installStream([
+    const { eventTypes, result } = await collectFixture([
       chunk({ role: "assistant", function_call: { name: "lookup" } }),
       chunk({ function_call: { arguments: '{"query":"ca' } }),
       chunk({ function_call: { arguments: 'ts"}' } }),
       chunk({}, "function_call"),
     ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const eventTypes: string[] = [];
-    for await (const event of stream) {
-      eventTypes.push(event.type);
-    }
-    const result = await stream.result();
 
     expect(result.stopReason).toBe("toolUse");
     expect(result.content).toHaveLength(1);
@@ -115,18 +182,11 @@ describe.each([
   });
 
   it("preserves a confirmed legacy call before later visible text", async () => {
-    installStream([
+    const { eventTypes, result } = await collectFixture([
       chunk({ function_call: { name: "lookup", arguments: '{"query":"cats"}' } }),
       chunk({ content: "Trailing commentary." }),
       chunk({}, "function_call"),
     ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const eventTypes: string[] = [];
-    for await (const event of stream) {
-      eventTypes.push(event.type);
-    }
-    const result = await stream.result();
 
     expect(result.stopReason).toBe("toolUse");
     expect(result.content.map((block) => block.type)).toEqual(["toolCall", "text"]);
@@ -135,7 +195,7 @@ describe.each([
   });
 
   it("keeps content preceding a legacy call in the same provider delta", async () => {
-    installStream([
+    const result = await fixtureResult([
       chunk({
         content: "Commentary before the call.",
         function_call: { name: "lookup", arguments: '{"query":"cats"}' },
@@ -143,29 +203,23 @@ describe.each([
       chunk({}, "function_call"),
     ]);
 
-    const result = await createStream(model, context, { apiKey: "fixture-token" }).result();
-
     expect(result.stopReason).toBe("toolUse");
     expect(result.content.map((block) => block.type)).toEqual(["text", "toolCall"]);
     expect(result.content[0]).toMatchObject({ text: "Commentary before the call." });
   });
 
   it("preserves a confirmed legacy call before later streamed reasoning", async () => {
-    installStream([
-      chunk({ function_call: { name: "lookup", arguments: '{"query":"cats"}' } }),
-      chunk({ reasoning_content: "Reasoning after the call." } as ChatCompletionChunk.Choice.Delta),
-      chunk({}, "function_call"),
-    ]);
-
-    const stream = createStream({ ...model, reasoning: true }, context, {
-      apiKey: "fixture-token",
-      reasoningEffort: "medium",
-    });
-    const eventTypes: string[] = [];
-    for await (const event of stream) {
-      eventTypes.push(event.type);
-    }
-    const result = await stream.result();
+    const { eventTypes, result } = await collectFixture(
+      [
+        chunk({ function_call: { name: "lookup", arguments: '{"query":"cats"}' } }),
+        chunk({
+          reasoning_content: "Reasoning after the call.",
+        } as ChatCompletionChunk.Choice.Delta),
+        chunk({}, "function_call"),
+      ],
+      { ...FIXTURE_OPTIONS, reasoningEffort: "medium" },
+      { ...model, reasoning: true },
+    );
 
     expect(result.stopReason).toBe("toolUse");
     expect(result.content.map((block) => block.type)).toEqual(["toolCall", "thinking"]);
@@ -173,48 +227,25 @@ describe.each([
   });
 
   it("replays buffered visible text before a superseding modern call", async () => {
-    installStream([
+    const { starts, result } = await collectFixture([
       chunk({ function_call: { name: "legacy", arguments: '{"query":"wrong"}' } }),
       chunk({ content: "Visible before the modern call." }),
-      chunk({
-        tool_calls: [
-          {
-            index: 0,
-            id: "call_modern",
-            type: "function",
-            function: { name: "lookup", arguments: '{"query":"cats"}' },
-          },
-        ],
-      }),
+      modernCallChunk('{"query":"cats"}'),
       chunk({}, "tool_calls"),
     ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const observedStarts: string[] = [];
-    for await (const event of stream) {
-      if (event.type === "toolcall_start") {
-        const block = event.partial.content[event.contentIndex];
-        if (block?.type === "toolCall") {
-          observedStarts.push(block.id);
-        }
-      }
-    }
-    const result = await stream.result();
 
     expect(result.stopReason).toBe("toolUse");
     expect(result.content.map((block) => block.type)).toEqual(["text", "toolCall"]);
     expect(result.content[0]).toMatchObject({ text: "Visible before the modern call." });
-    expect(observedStarts).toEqual(["call_modern"]);
+    expect(starts.map(({ id }) => id)).toEqual(["call_modern"]);
   });
 
   it("releases buffered visible text when a legacy call is not confirmed", async () => {
-    installStream([
+    const result = await fixtureResult([
       chunk({ function_call: { name: "legacy", arguments: '{"query":"discard"}' } }),
       chunk({ content: "The provider supplied an answer instead." }),
       chunk({}, "stop"),
     ]);
-
-    const result = await createStream(model, context, { apiKey: "fixture-token" }).result();
 
     expect(result.stopReason).toBe("stop");
     expect(result.content).toEqual([
@@ -222,82 +253,41 @@ describe.each([
     ]);
   });
 
-  it("keeps modern tool_calls authoritative when legacy data is also present", async () => {
-    installStream([
-      chunk({
-        function_call: { name: "legacy", arguments: '{"query":"wrong"}' },
-        tool_calls: [
-          {
-            index: 0,
-            id: "call_modern",
-            type: "function",
-            function: { name: "lookup", arguments: '{"query":"ca' },
-          },
-        ],
-      }),
-      chunk({ function_call: { arguments: "ignore this legacy continuation" } }),
-      chunk({ tool_calls: [{ index: 0, function: { arguments: 'ts"}' } }] }),
-      chunk({}, "tool_calls"),
-    ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const observedStarts: Array<{ id: string; name: string }> = [];
-    const observedArgumentDeltas: string[] = [];
-    for await (const event of stream) {
-      if (event.type === "toolcall_start") {
-        const block = event.partial.content[event.contentIndex];
-        if (block?.type === "toolCall") {
-          observedStarts.push({ id: block.id, name: block.name });
-        }
-      } else if (event.type === "toolcall_delta" && event.delta) {
-        observedArgumentDeltas.push(event.delta);
-      }
-    }
-    const result = await stream.result();
-
-    expect(result.stopReason).toBe("toolUse");
-    expect(result.content).toHaveLength(1);
-    expect(result.content[0]).toMatchObject({
-      type: "toolCall",
-      id: "call_modern",
-      name: "lookup",
-      arguments: { query: "cats" },
-    });
-    expect(observedStarts).toEqual([{ id: "call_modern", name: "lookup" }]);
-    expect(observedArgumentDeltas).toEqual(['{"query":"ca', 'ts"}']);
-  });
-
-  it("replaces an earlier legacy function_call when modern tool_calls arrive later", async () => {
-    installStream([
-      chunk({ function_call: { name: "legacy", arguments: '{"query":"wrong"}' } }),
-      chunk({
-        tool_calls: [
-          {
-            index: 1,
-            id: "call_modern",
-            type: "function",
-            function: { name: "lookup", arguments: '{"query":"ca' },
-          },
-        ],
-      }),
-      chunk({ tool_calls: [{ index: 1, function: { arguments: 'ts"}' } }] }),
-      chunk({}, "tool_calls"),
-    ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const observedStarts: Array<{ id: string; name: string }> = [];
-    const observedArgumentDeltas: string[] = [];
-    for await (const event of stream) {
-      if (event.type === "toolcall_start") {
-        const block = event.partial.content[event.contentIndex];
-        if (block?.type === "toolCall") {
-          observedStarts.push({ id: block.id, name: block.name });
-        }
-      } else if (event.type === "toolcall_delta" && event.delta) {
-        observedArgumentDeltas.push(event.delta);
-      }
-    }
-    const result = await stream.result();
+  it.each<[string, ChatCompletionChunk[]]>([
+    [
+      "keeps modern tool_calls authoritative when legacy data is also present",
+      [
+        chunk({
+          function_call: { name: "legacy", arguments: '{"query":"wrong"}' },
+          tool_calls: [
+            toolCallDelta({ id: "call_modern", name: "lookup", arguments: '{"query":"ca' }),
+          ],
+        }),
+        chunk({ function_call: { arguments: "ignore this legacy continuation" } }),
+        chunk({ tool_calls: [toolCallDelta({ arguments: 'ts"}' })] }),
+        chunk({}, "tool_calls"),
+      ],
+    ],
+    [
+      "replaces an earlier legacy function_call when modern tool_calls arrive later",
+      [
+        chunk({ function_call: { name: "legacy", arguments: '{"query":"wrong"}' } }),
+        chunk({
+          tool_calls: [
+            toolCallDelta({
+              index: 1,
+              id: "call_modern",
+              name: "lookup",
+              arguments: '{"query":"ca',
+            }),
+          ],
+        }),
+        chunk({ tool_calls: [toolCallDelta({ index: 1, arguments: 'ts"}' })] }),
+        chunk({}, "tool_calls"),
+      ],
+    ],
+  ])("%s", async (_title, chunks) => {
+    const { starts, argumentDeltas, result } = await collectFixture(chunks);
 
     expect(result.stopReason).toBe("toolUse");
     expect(result.content).toHaveLength(1);
@@ -307,14 +297,15 @@ describe.each([
       name: "lookup",
       arguments: { query: "cats" },
     });
-    expect(observedStarts).toEqual([{ id: "call_modern", name: "lookup" }]);
-    expect(observedArgumentDeltas).toEqual(['{"query":"ca', 'ts"}']);
+    expect(starts).toEqual([{ id: "call_modern", name: "lookup" }]);
+    expect(argumentDeltas).toEqual(['{"query":"ca', 'ts"}']);
   });
 
   it("keeps ordinary text and stop finish reasons outside the tool-call lane", async () => {
-    installStream([chunk({ role: "assistant", content: "No tool needed." }), chunk({}, "stop")]);
-
-    const result = await createStream(model, context, { apiKey: "fixture-token" }).result();
+    const result = await fixtureResult([
+      chunk({ role: "assistant", content: "No tool needed." }),
+      chunk({}, "stop"),
+    ]);
 
     expect(result.stopReason).toBe("stop");
     expect(result.content).toEqual([{ type: "text", text: "No tool needed." }]);
@@ -327,28 +318,11 @@ describe.each([
   ] as const)(
     "does not publish completed modern calls discarded by a $finishReason terminal",
     async ({ finishReason, visibleText, stopReason }) => {
-      installStream([
+      const { eventTypes, result } = await collectFixture([
         ...(visibleText ? [chunk({ content: "Visible final answer." })] : []),
-        chunk({
-          tool_calls: [
-            {
-              index: 0,
-              id: "call_unconfirmed",
-              type: "function",
-              function: { name: "lookup", arguments: '{"query":"discard"}' },
-            },
-          ],
-        }),
+        modernCallChunk('{"query":"discard"}', { id: "call_unconfirmed" }),
         chunk({}, finishReason),
       ]);
-
-      const stream = createStream(model, context, { apiKey: "fixture-token" });
-      const eventTypes: string[] = [];
-      for await (const event of stream) {
-        eventTypes.push(event.type);
-      }
-
-      const result = await stream.result();
       expect(result.stopReason).toBe(stopReason);
       expect(result.content.filter((block) => block.type === "toolCall")).toHaveLength(0);
       expect(eventTypes).not.toContain("toolcall_end");
@@ -366,27 +340,9 @@ describe.each([
   ] as const)(
     "rejects an authoritative modern tool terminal with $reason",
     async ({ name, arguments: rawArguments }) => {
-      installStream([
-        chunk({
-          tool_calls: [
-            {
-              index: 0,
-              id: "call_malformed",
-              type: "function",
-              function: { name, arguments: rawArguments },
-            },
-          ],
-        }),
-        chunk({}, "tool_calls"),
-      ]);
-
-      const stream = createStream(model, context, { apiKey: "fixture-token" });
-      const eventTypes: string[] = [];
-      for await (const event of stream) {
-        eventTypes.push(event.type);
-      }
-
-      const result = await stream.result();
+      const { eventTypes, result } = await collectFixture(
+        confirmedModernCallChunks(rawArguments, { id: "call_malformed", name }),
+      );
       expect(result.stopReason).toBe("error");
       expect(result.errorMessage).toContain("incomplete or malformed tool call");
       expect(result.content.filter((block) => block.type === "toolCall")).toHaveLength(0);
@@ -399,18 +355,7 @@ describe.each([
     { reason: "invalid string escape", arguments: String.raw`{"query":"cats\q"}` },
     { reason: "unescaped control character", arguments: '{"query":"cats\n"}' },
   ] as const)("rejects an authoritative legacy function terminal with $reason", async (value) => {
-    installStream([
-      chunk({ function_call: { name: "lookup", arguments: value.arguments } }),
-      chunk({}, "function_call"),
-    ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const eventTypes: string[] = [];
-    for await (const event of stream) {
-      eventTypes.push(event.type);
-    }
-
-    const result = await stream.result();
+    const { eventTypes, result } = await collectFixture(confirmedLegacyCallChunks(value.arguments));
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("incomplete or malformed tool call");
     expect(result.content.filter((block) => block.type === "toolCall")).toHaveLength(0);
@@ -418,55 +363,31 @@ describe.each([
   });
 
   it("rejects every parallel call when a sibling has incomplete arguments", async () => {
-    installStream([
+    const { eventTypes, result } = await collectFixture([
       chunk({
         tool_calls: [
-          {
-            index: 0,
-            id: "call_valid",
-            type: "function",
-            function: { name: "lookup", arguments: '{"query":"cats"}' },
-          },
-          {
+          toolCallDelta({ id: "call_valid", name: "lookup", arguments: '{"query":"cats"}' }),
+          toolCallDelta({
             index: 1,
             id: "call_invalid",
-            type: "function",
-            function: { name: "lookup", arguments: '{"query":"dogs"' },
-          },
+            name: "lookup",
+            arguments: '{"query":"dogs"',
+          }),
         ],
       }),
       chunk({}, "tool_calls"),
     ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const eventTypes: string[] = [];
-    for await (const event of stream) {
-      eventTypes.push(event.type);
-    }
-
-    const result = await stream.result();
     expect(result.stopReason).toBe("error");
     expect(result.content.filter((block) => block.type === "toolCall")).toHaveLength(0);
     expect(eventTypes).not.toContain("toolcall_end");
   });
 
   it("removes provisional calls when the response is aborted mid-stream", async () => {
-    installStream([
-      chunk({
-        tool_calls: [
-          {
-            index: 0,
-            id: "call_aborted",
-            type: "function",
-            function: { name: "lookup", arguments: '{"query":"cats"}' },
-          },
-        ],
-      }),
-      chunk({}, "tool_calls"),
-    ]);
-
     const abort = new AbortController();
-    const stream = createStream(model, context, { apiKey: "fixture-token", signal: abort.signal });
+    const stream = startFixture(
+      confirmedModernCallChunks('{"query":"cats"}', { id: "call_aborted" }),
+      { ...FIXTURE_OPTIONS, signal: abort.signal },
+    );
     const eventTypes: string[] = [];
     for await (const event of stream) {
       eventTypes.push(event.type);
@@ -482,30 +403,10 @@ describe.each([
   });
 
   it("retains an executable modern call after its confirmed tool terminal", async () => {
-    installStream([
-      chunk({
-        tool_calls: [
-          {
-            index: 0,
-            id: "call_confirmed",
-            type: "function",
-            function: { name: "lookup", arguments: '{"query":"cats"}' },
-          },
-        ],
-      }),
-      chunk({}, "tool_calls"),
-    ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const events: Array<{ type: string; toolCallId?: string }> = [];
-    for await (const event of stream) {
-      events.push({
-        type: event.type,
-        ...(event.type === "toolcall_end" ? { toolCallId: event.toolCall.id } : {}),
-      });
-    }
-
-    const result = await stream.result();
+    const collected = await collectFixture(
+      confirmedModernCallChunks('{"query":"cats"}', { id: "call_confirmed" }),
+    );
+    const { events, result } = collected;
     expect(result.stopReason).toBe("toolUse");
     expect(result.content).toContainEqual({
       type: "toolCall",
@@ -519,28 +420,12 @@ describe.each([
   });
 
   it("preserves confirmed tool completion before following text blocks close", async () => {
-    installStream([
-      chunk({
-        tool_calls: [
-          {
-            index: 0,
-            id: "call_before_text",
-            type: "function",
-            function: { name: "lookup", arguments: '{"query":"cats"}' },
-          },
-        ],
-      }),
+    const { eventTypes, result } = await collectFixture([
+      modernCallChunk('{"query":"cats"}', { id: "call_before_text" }),
       chunk({ content: "Trailing commentary." }),
       chunk({}, "tool_calls"),
     ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const eventTypes: string[] = [];
-    for await (const event of stream) {
-      eventTypes.push(event.type);
-    }
-
-    expect((await stream.result()).stopReason).toBe("toolUse");
+    expect(result.stopReason).toBe("toolUse");
     const toolEndIndex = eventTypes.indexOf("toolcall_end");
     expect(toolEndIndex).toBeGreaterThanOrEqual(0);
     expect(toolEndIndex).toBeLessThan(eventTypes.indexOf("done"));
@@ -559,17 +444,10 @@ describe.each([
   ] as const)(
     "discards provisional legacy fragments when the provider finishes with $finishReason",
     async ({ finishReason, stopReason }) => {
-      installStream([
+      const { eventTypes, result } = await collectFixture([
         chunk({ function_call: { name: "lookup", arguments: '{"query":"discard"}' } }),
         chunk({}, finishReason),
       ]);
-
-      const stream = createStream(model, context, { apiKey: "fixture-token" });
-      const eventTypes: string[] = [];
-      for await (const event of stream) {
-        eventTypes.push(event.type);
-      }
-      const result = await stream.result();
 
       expect(result.stopReason).toBe(stopReason);
       expect(result.content.filter((block) => block.type === "toolCall")).toHaveLength(0);
@@ -578,37 +456,21 @@ describe.each([
     },
   );
 
-  it("rejects oversized legacy arguments without publishing a provisional tool call", async () => {
-    installStream([
-      chunk({ function_call: { name: "lookup", arguments: "x".repeat(256_001) } }),
-      chunk({}, "function_call"),
-    ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const eventTypes: string[] = [];
-    for await (const event of stream) {
-      eventTypes.push(event.type);
-    }
-    const result = await stream.result();
-
-    expect(result.stopReason).toBe("error");
-    expect(result.errorMessage).toContain("Exceeded tool-call argument buffer limit");
-    expect(eventTypes).not.toContain("toolcall_start");
-  });
-
-  it("rejects an oversized legacy function name before publishing a provisional call", async () => {
-    installStream([
-      chunk({ function_call: { name: "x".repeat(256_001), arguments: "{}" } }),
-      chunk({}, "function_call"),
-    ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const eventTypes: string[] = [];
-    for await (const event of stream) {
-      eventTypes.push(event.type);
-    }
-    const result = await stream.result();
-
+  it.each<[string, string, string]>([
+    [
+      "rejects oversized legacy arguments without publishing a provisional tool call",
+      "x".repeat(256_001),
+      "lookup",
+    ],
+    [
+      "rejects an oversized legacy function name before publishing a provisional call",
+      "{}",
+      "x".repeat(256_001),
+    ],
+  ])("%s", async (_title, rawArguments, name) => {
+    const { eventTypes, result } = await collectFixture(
+      confirmedLegacyCallChunks(rawArguments, name),
+    );
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("Exceeded tool-call argument buffer limit");
     expect(eventTypes).not.toContain("toolcall_start");
@@ -616,7 +478,7 @@ describe.each([
 
   it("coalesces tiny provisional legacy fragments into one bounded executable delta", async () => {
     const query = "x".repeat(1_100);
-    installStream([
+    const { argumentDeltas, result } = await collectFixture([
       chunk({ function_call: { name: "lookup", arguments: '{"query":"' } }),
       ...Array.from(query, (character) =>
         chunk({
@@ -630,15 +492,6 @@ describe.each([
       chunk({}, "function_call"),
     ]);
 
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const argumentDeltas: string[] = [];
-    for await (const event of stream) {
-      if (event.type === "toolcall_delta" && event.delta) {
-        argumentDeltas.push(event.delta);
-      }
-    }
-    const result = await stream.result();
-
     expect(result.stopReason).toBe("toolUse");
     expect(result.content[0]).toMatchObject({
       type: "toolCall",
@@ -649,18 +502,11 @@ describe.each([
   });
 
   it("bounds visible content buffered behind a provisional legacy call", async () => {
-    installStream([
+    const { eventTypes, result } = await collectFixture([
       chunk({ function_call: { name: "lookup", arguments: '{"query":"cats"}' } }),
       chunk({ content: "x".repeat(256_001) }),
       chunk({}, "function_call"),
     ]);
-
-    const stream = createStream(model, context, { apiKey: "fixture-token" });
-    const eventTypes: string[] = [];
-    for await (const event of stream) {
-      eventTypes.push(event.type);
-    }
-    const result = await stream.result();
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("Exceeded legacy tool-call content buffer limit");
@@ -669,13 +515,11 @@ describe.each([
   });
 
   it("bounds the number of tiny deltas buffered behind a provisional legacy call", async () => {
-    installStream([
+    const result = await fixtureResult([
       chunk({ function_call: { name: "lookup", arguments: '{"query":"cats"}' } }),
       ...Array.from({ length: 1_025 }, () => chunk({ content: "x" })),
       chunk({}, "function_call"),
     ]);
-
-    const result = await createStream(model, context, { apiKey: "fixture-token" }).result();
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("Exceeded legacy tool-call content buffer limit");
@@ -683,13 +527,9 @@ describe.each([
   });
 
   it("generates a distinct legacy call id for each assistant response", async () => {
-    installStream([
-      chunk({ function_call: { name: "lookup", arguments: '{"query":"cats"}' } }),
-      chunk({}, "function_call"),
-    ]);
-
-    const first = await createStream(model, context, { apiKey: "fixture-token" }).result();
-    const second = await createStream(model, context, { apiKey: "fixture-token" }).result();
+    const chunks = confirmedLegacyCallChunks('{"query":"cats"}');
+    const first = await fixtureResult(chunks);
+    const second = await fixtureResult(chunks);
 
     expect(first.content[0]).toMatchObject({ type: "toolCall" });
     expect(second.content[0]).toMatchObject({ type: "toolCall" });


### PR DESCRIPTION
## What Problem This Solves

The OpenAI Chat Completions legacy-function-call parity suite repeated the same SSE setup, stream collection, modern/legacy tool-call fixtures, and terminal assertions across both package and managed transports. That made the authoritative-terminal coverage unnecessarily large and harder to extend consistently.

## Why This Change Was Made

Consolidates those repeated test-only fixtures behind typed local helpers and table-drives identical cases. The 36 scenarios still run against both transport implementations, preserving all 72 cases, input wire shapes, ordering, and assertions without changing production code.

## User Impact

No user-visible behavior changes. Maintainers get a smaller, clearer parity suite for legacy `function_call` and modern `tool_calls` compatibility.

## Evidence

- Blacksmith Testbox `tbx_01kz2w5nxxqcaypj5ca26kd16e`: focused Vitest file passed, 1 file / 72 tests — https://github.com/openclaw/openclaw/actions/runs/30782995486
- Fresh structured autoreview: clean, no accepted/actionable findings, confidence 0.99.
- Static parity review: all 36 effective cases per transport remain in the same order with the same inputs, matchers, and assertions.
- OpenAI SDK 6.49.0 types confirm legacy streamed `function_call`/`finish_reason: "function_call"` remains a distinct deprecated Chat Completions contract alongside modern `tool_calls`.
- Direct sibling Codex inspection confirms Codex uses the separate Responses endpoint and `ResponseItem::FunctionCall` protocol; this test-only cleanup does not affect that runtime contract.
- Source recovery: original `7fafdff00fea4a6878b88011016f79576f021a5c`, rebased source `d2ffe0cfd97782cc8b0f933307c61776569935ba`; recovered file blob is byte-identical.
