### PR TITLE
fix(slack): finalize the actual delivered question card

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -484,6 +484,11 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
       accountId,
       payload,
     }),
+  // Core sees this facade, not its lazy owner; forward finalization or question cards stay live.
+  afterDeliverPayload: async (ctx) => {
+    const { slackOutbound } = await loadSlackOutboundAdapterModule();
+    await slackOutbound.afterDeliverPayload!(ctx);
+  },
   presentationCapabilities: SLACK_PRESENTATION_CAPABILITIES,
   ...createRuntimeOutboundDelegates({
     getRuntime: loadSlackOutboundAdapterModule,

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -379,9 +379,15 @@ export const slackOutbound: ChannelOutboundAdapter = {
     if (!channelId) {
       return;
     }
+    // Aggregate fallback receipts retain their last platform id separately
+    // from the actual card whose question controls need finalization.
+    const questionMessageId =
+      typeof result.meta?.slackQuestionMessageId === "string"
+        ? result.meta.slackQuestionMessageId
+        : result.messageId;
     questionGatewayRuntime.registerChannelDelivery({
       questionId,
-      deliveryId: `slack:${target.accountId ?? "default"}:${channelId}:${result.messageId}`,
+      deliveryId: `slack:${target.accountId ?? "default"}:${channelId}:${questionMessageId}`,
       finalize: async (statusLine) => {
         const { updateMessageSlack } = await loadSlackSendRuntime();
         const escapedStatusLine = escapeSlackMrkdwn(statusLine);
@@ -393,7 +399,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
           cfg,
           accountId: target.accountId ?? undefined,
           channelId,
-          messageTs: result.messageId,
+          messageTs: questionMessageId,
           text: `${deliveryMessage.text}\n\n${escapedStatusLine}`,
           blocks,
         });

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -27,6 +27,7 @@ import {
 import { SLACK_TEXT_LIMIT } from "./limits.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 import { SLACK_PRESENTATION_CAPABILITIES } from "./presentation.js";
+import { resolveSlackQuestionActionIds } from "./reply-action-ids.js";
 import {
   parseSlackReplyBlockSegments,
   resolveSlackReplyBlockResolution,
@@ -358,12 +359,18 @@ export const slackOutbound: ChannelOutboundAdapter = {
       segments: resolution.segments,
       text: payload.text,
     });
-    const blockMessageIndex = deliveryMessages.findIndex((message) =>
-      message.blocks?.some((block) => block.type === "actions"),
+    const deliveryMessage = deliveryMessages.find(
+      (message) => resolveSlackQuestionActionIds(message.blocks).length > 0,
     );
-    const deliveryMessage = deliveryMessages[blockMessageIndex];
-    const result =
-      results[blockMessageIndex] ?? results.find((candidate) => candidate.channel === "slack");
+    const questionActionIds = resolveSlackQuestionActionIds(deliveryMessage?.blocks);
+    const result = results.find(
+      ({ channel, meta }) =>
+        channel === "slack" &&
+        Array.isArray(meta?.slackQuestionActionIds) &&
+        meta.slackQuestionActionIds.some(
+          (actionId) => typeof actionId === "string" && questionActionIds.includes(actionId),
+        ),
+    );
     const deliveryBlocks = deliveryMessage?.blocks;
     if (!deliveryMessage || !deliveryBlocks || !result?.messageId) {
       return;

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -27,7 +27,10 @@ import {
 import { SLACK_TEXT_LIMIT } from "./limits.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 import { SLACK_PRESENTATION_CAPABILITIES } from "./presentation.js";
-import { resolveSlackQuestionActionIds } from "./reply-action-ids.js";
+import {
+  resolveSlackQuestionActionIds,
+  SLACK_QUESTION_FINALIZATION_BLOCKS,
+} from "./reply-action-ids.js";
 import {
   parseSlackReplyBlockSegments,
   resolveSlackReplyBlockResolution,
@@ -35,7 +38,7 @@ import {
   type SlackReplyBlockResolution,
   type SlackReplyBlockSegment,
 } from "./reply-blocks.js";
-import type { SlackSendIdentity } from "./send.js";
+import type { SlackSendIdentity, SlackSendResult } from "./send.js";
 import { resolveSlackThreadTsValue } from "./thread-ts.js";
 
 type SlackSendFn = typeof import("./send.runtime.js").sendMessageSlack;
@@ -371,8 +374,10 @@ export const slackOutbound: ChannelOutboundAdapter = {
           (actionId) => typeof actionId === "string" && questionActionIds.includes(actionId),
         ),
     );
-    const deliveryBlocks = deliveryMessage?.blocks;
-    if (!deliveryMessage || !deliveryBlocks || !result?.messageId) {
+    const deliveredDisplayBlocks = (result?.meta as SlackSendResult["meta"] | undefined)?.[
+      SLACK_QUESTION_FINALIZATION_BLOCKS
+    ];
+    if (!deliveryMessage || !deliveredDisplayBlocks || !result?.messageId) {
       return;
     }
     const channelId = result.channelId;
@@ -392,7 +397,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
         const { updateMessageSlack } = await loadSlackSendRuntime();
         const escapedStatusLine = escapeSlackMrkdwn(statusLine);
         const blocks = [
-          ...deliveryBlocks.filter((block) => block.type !== "actions"),
+          ...deliveredDisplayBlocks,
           { type: "context", elements: [{ type: "mrkdwn", text: escapedStatusLine }] },
         ];
         await updateMessageSlack({

--- a/extensions/slack/src/question-finalization.test.ts
+++ b/extensions/slack/src/question-finalization.test.ts
@@ -212,7 +212,8 @@ describe("Slack question finalization", () => {
 
     const client = createSlackSendTestClient();
     let messageCount = 0;
-    client.chat.postMessage.mockImplementation(async () => ({
+    client.chat.postMessage = vi.fn(async () => ({
+      ok: true,
       ts: `171234.${String(++messageCount).padStart(3, "0")}`,
     }));
     const results: OutboundDeliveryResult[] = [];

--- a/extensions/slack/src/question-finalization.test.ts
+++ b/extensions/slack/src/question-finalization.test.ts
@@ -1,6 +1,14 @@
 // Covers Slack question delivery capture and Block Kit final edit.
+import { sendDurableMessageBatch } from "openclaw/plugin-sdk/channel-outbound";
 import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/channel-send-result";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createOutboundTestPlugin,
+  createTestRegistry,
+  resetGlobalHookRunner,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSlackSendTestClient } from "./blocks.test-helpers.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -39,6 +47,11 @@ describe("Slack question finalization", () => {
   beforeEach(() => {
     hoisted.update.mockReset();
     hoisted.registration = undefined;
+  });
+
+  afterEach(() => {
+    resetGlobalHookRunner();
+    resetPluginRuntimeStateForTest();
   });
 
   it("removes action blocks and appends terminal context", async () => {
@@ -270,5 +283,123 @@ describe("Slack question finalization", () => {
         messageTs: questionDelivery?.messageId,
       }),
     );
+  });
+
+  it("keeps the actual fallback question card through durable result reconciliation", async () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const cfg = { channels: { slack: { botToken: "xoxb-test" } } };
+    const payload = {
+      text: "Pick one",
+      channelData: { askUser: { questionId } },
+      presentation: {
+        blocks: [
+          {
+            type: "table" as const,
+            caption: "Choices",
+            headers: ["Label"],
+            rows: [["A useful answer"]],
+          },
+          {
+            type: "buttons" as const,
+            buttons: [
+              {
+                label: "One",
+                action: { type: "question" as const, questionId, optionValue: "One" },
+              },
+            ],
+          },
+          {
+            type: "text" as const,
+            text: "Trailing context intentionally arrives after the question card.",
+          },
+        ],
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          plugin: createOutboundTestPlugin({ id: "slack", outbound: slackOutbound }),
+          source: "test",
+        },
+      ]),
+    );
+
+    const client = createSlackSendTestClient();
+    let messageCount = 0;
+    let questionMessageId: string | undefined;
+    let trailingMessageId: string | undefined;
+    client.chat.postMessage = vi.fn(async (request: unknown) => {
+      const blocks = (request as { blocks?: Array<{ elements?: unknown[]; type?: string }> })
+        .blocks;
+      if (blocks?.some((block) => block.type === "data_table")) {
+        throw Object.assign(new Error("invalid_blocks"), { data: { error: "invalid_blocks" } });
+      }
+      const ts = `171234.${String(++messageCount).padStart(3, "0")}`;
+      const hasQuestion = blocks?.some(
+        (block) =>
+          block.type === "actions" &&
+          block.elements?.some((element) =>
+            String((element as { action_id?: string }).action_id).startsWith(
+              "openclaw:question_button",
+            ),
+          ),
+      );
+      if (hasQuestion) {
+        questionMessageId = ts;
+      } else if (questionMessageId) {
+        trailingMessageId = ts;
+      }
+      return { ok: true, channel: "C123", ts };
+    });
+    const sendSlack: typeof sendMessageSlack = async (to, text, options) =>
+      await sendMessageSlack(to, text, {
+        ...options,
+        cfg,
+        token: "xoxb-test",
+        client,
+        textLimit: 72,
+      });
+
+    const batch = await sendDurableMessageBatch({
+      cfg,
+      channel: "slack",
+      to: "C123",
+      accountId: "default",
+      payloads: [payload],
+      deps: { sendSlack },
+    });
+
+    if (batch.status !== "sent") {
+      throw batch.status === "failed"
+        ? batch.error
+        : new Error("Expected the Slack question fallback to be delivered");
+    }
+    expect(questionMessageId).toBeDefined();
+    expect(trailingMessageId).toBeDefined();
+    expect(trailingMessageId).not.toBe(questionMessageId);
+    expect(batch.results).toHaveLength(1);
+    expect(batch.results[0]).toMatchObject({
+      messageId: trailingMessageId,
+      meta: {
+        slackQuestionActionIds: ["openclaw:question_button:1:1"],
+        slackQuestionMessageId: questionMessageId,
+      },
+    });
+    expect(hoisted.registration?.deliveryId).toBe(`slack:default:C123:${questionMessageId}`);
+
+    await hoisted.registration?.finalize("Answered: One");
+
+    expect(hoisted.update).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: "C123", messageTs: questionMessageId }),
+    );
+    expect(
+      client.chat.postMessage.mock.calls.filter(([request]) =>
+        (request as { blocks?: Array<{ elements?: Array<{ action_id?: string }> }> }).blocks?.some(
+          (block) =>
+            block.elements?.some((element) => element.action_id?.startsWith("openclaw:question_")),
+        ),
+      ),
+    ).toHaveLength(2);
   });
 });

--- a/extensions/slack/src/question-finalization.test.ts
+++ b/extensions/slack/src/question-finalization.test.ts
@@ -36,6 +36,7 @@ vi.mock("./send.js", async (importOriginal) => ({
 
 import { slackPlugin } from "./channel.js";
 import { slackOutbound } from "./outbound-adapter.js";
+import { SLACK_QUESTION_FINALIZATION_BLOCKS } from "./reply-action-ids.js";
 import { sendMessageSlack } from "./send.js";
 
 function jsonRoundTrip<T>(value: T): T {
@@ -104,7 +105,10 @@ describe("Slack question finalization", () => {
           channel: "slack",
           messageId: "55",
           channelId: "C123",
-          meta: { slackQuestionActionIds: ["openclaw:question_button:1:1"] },
+          meta: {
+            slackQuestionActionIds: ["openclaw:question_button:1:1"],
+            [SLACK_QUESTION_FINALIZATION_BLOCKS]: [],
+          },
         },
       ],
     });
@@ -173,7 +177,10 @@ describe("Slack question finalization", () => {
           channel: "slack",
           messageId: "actual-question",
           channelId: "C123",
-          meta: { slackQuestionActionIds: [questionActionId] },
+          meta: {
+            slackQuestionActionIds: [questionActionId],
+            [SLACK_QUESTION_FINALIZATION_BLOCKS]: [],
+          },
         },
       ],
     });
@@ -328,6 +335,7 @@ describe("Slack question finalization", () => {
     const client = createSlackSendTestClient();
     let messageCount = 0;
     let questionMessageId: string | undefined;
+    let acceptedQuestionBlocks: Array<{ elements?: unknown[]; type?: string }> | undefined;
     let trailingMessageId: string | undefined;
     client.chat.postMessage = vi.fn(async (request: unknown) => {
       const blocks = (request as { blocks?: Array<{ elements?: unknown[]; type?: string }> })
@@ -347,6 +355,7 @@ describe("Slack question finalization", () => {
       );
       if (hasQuestion) {
         questionMessageId = ts;
+        acceptedQuestionBlocks = blocks;
       } else if (questionMessageId) {
         trailingMessageId = ts;
       }
@@ -394,6 +403,10 @@ describe("Slack question finalization", () => {
     expect(hoisted.update).toHaveBeenCalledWith(
       expect.objectContaining({ channelId: "C123", messageTs: questionMessageId }),
     );
+    expect(hoisted.update.mock.calls[0]?.[0]?.blocks).toEqual([
+      ...(acceptedQuestionBlocks ?? []).filter((block) => block.type !== "actions"),
+      { type: "context", elements: [{ type: "mrkdwn", text: "Answered: One" }] },
+    ]);
     expect(
       client.chat.postMessage.mock.calls.filter(([request]) =>
         (request as { blocks?: Array<{ elements?: Array<{ action_id?: string }> }> }).blocks?.some(

--- a/extensions/slack/src/question-finalization.test.ts
+++ b/extensions/slack/src/question-finalization.test.ts
@@ -2,7 +2,6 @@
 import { sendDurableMessageBatch } from "openclaw/plugin-sdk/channel-outbound";
 import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/channel-send-result";
 import {
-  createOutboundTestPlugin,
   createTestRegistry,
   resetGlobalHookRunner,
   resetPluginRuntimeStateForTest,
@@ -35,6 +34,7 @@ vi.mock("./send.js", async (importOriginal) => ({
   updateMessageSlack: hoisted.update,
 }));
 
+import { slackPlugin } from "./channel.js";
 import { slackOutbound } from "./outbound-adapter.js";
 import { sendMessageSlack } from "./send.js";
 
@@ -319,7 +319,7 @@ describe("Slack question finalization", () => {
       createTestRegistry([
         {
           pluginId: "slack",
-          plugin: createOutboundTestPlugin({ id: "slack", outbound: slackOutbound }),
+          plugin: slackPlugin,
           source: "test",
         },
       ]),
@@ -390,6 +390,7 @@ describe("Slack question finalization", () => {
 
     await hoisted.registration?.finalize("Answered: One");
 
+    expect(hoisted.update).toHaveBeenCalledOnce();
     expect(hoisted.update).toHaveBeenCalledWith(
       expect.objectContaining({ channelId: "C123", messageTs: questionMessageId }),
     );

--- a/extensions/slack/src/question-finalization.test.ts
+++ b/extensions/slack/src/question-finalization.test.ts
@@ -1,5 +1,7 @@
 // Covers Slack question delivery capture and Block Kit final edit.
-import { describe, expect, it, vi } from "vitest";
+import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/channel-send-result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSlackSendTestClient } from "./blocks.test-helpers.js";
 
 const hoisted = vi.hoisted(() => ({
   update: vi.fn(),
@@ -20,9 +22,13 @@ vi.mock("openclaw/plugin-sdk/question-gateway-runtime", async (importOriginal) =
     },
   };
 });
-vi.mock("./send.js", () => ({ updateMessageSlack: hoisted.update }));
+vi.mock("./send.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./send.js")>()),
+  updateMessageSlack: hoisted.update,
+}));
 
 import { slackOutbound } from "./outbound-adapter.js";
+import { sendMessageSlack } from "./send.js";
 
 function jsonRoundTrip<T>(value: T): T {
   // oxlint-disable-next-line unicorn/prefer-structured-clone -- This test exercises JSON transport.
@@ -30,6 +36,11 @@ function jsonRoundTrip<T>(value: T): T {
 }
 
 describe("Slack question finalization", () => {
+  beforeEach(() => {
+    hoisted.update.mockReset();
+    hoisted.registration = undefined;
+  });
+
   it("removes action blocks and appends terminal context", async () => {
     const questionId = "ask_0123456789abcdef0123456789abcdef";
     const headers = Array.from({ length: 21 }, (_value, index) => `Column ${String(index)}`);
@@ -76,7 +87,12 @@ describe("Slack question finalization", () => {
       payload: renderedAfterTransport!,
       results: [
         { channel: "slack", messageId: "44", channelId: "C123" },
-        { channel: "slack", messageId: "55", channelId: "C123" },
+        {
+          channel: "slack",
+          messageId: "55",
+          channelId: "C123",
+          meta: { slackQuestionActionIds: ["openclaw:question_button:1:1"] },
+        },
       ],
     });
 
@@ -96,5 +112,162 @@ describe("Slack question finalization", () => {
     );
     const blocks = hoisted.update.mock.calls[0]?.[0]?.blocks as Array<{ type?: string }>;
     expect(blocks.some((block) => block.type === "actions")).toBe(false);
+  });
+
+  it("finalizes the delivered question card after uploads, text chunks, and other cards", async () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const questionActionId = "openclaw:question_button:1:1";
+    const payload = {
+      text: "Pick one",
+      mediaUrl: "https://example.invalid/question-context.png",
+      channelData: { askUser: { questionId } },
+      presentation: {
+        blocks: [
+          {
+            type: "buttons" as const,
+            buttons: [
+              {
+                label: "One",
+                action: { type: "question" as const, questionId, optionValue: "One" },
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation,
+      ctx: { cfg: {}, to: "C123", text: payload.text, payload },
+    });
+    expect(JSON.stringify(rendered)).toContain(questionActionId);
+
+    await slackOutbound.afterDeliverPayload?.({
+      cfg: {},
+      target: { channel: "slack", to: "C123", accountId: "default" },
+      payload: jsonRoundTrip(rendered)!,
+      results: [
+        { channel: "slack", messageId: "upload", channelId: "C123" },
+        { channel: "slack", messageId: "preface-1", channelId: "C123" },
+        { channel: "slack", messageId: "preface-2", channelId: "C123" },
+        {
+          channel: "slack",
+          messageId: "another-question",
+          channelId: "C123",
+          meta: { slackQuestionActionIds: ["openclaw:question_button:9:1"] },
+        },
+        {
+          channel: "slack",
+          messageId: "actual-question",
+          channelId: "C123",
+          meta: { slackQuestionActionIds: [questionActionId] },
+        },
+      ],
+    });
+
+    await hoisted.registration?.finalize("Answered: One");
+
+    expect(hoisted.registration?.deliveryId).toBe("slack:default:C123:actual-question");
+    expect(hoisted.update).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: "C123", messageTs: "actual-question" }),
+    );
+  });
+
+  it("carries the real WebClient question-card identity through upload and chunk progress", async () => {
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const headers = Array.from({ length: 21 }, (_value, index) => `Column ${String(index)}`);
+    const payload = {
+      text: "Pick one",
+      mediaUrl: "https://example.invalid/question-context.png",
+      channelData: { askUser: { questionId } },
+      presentation: {
+        blocks: [
+          {
+            type: "table" as const,
+            caption: "Option metadata",
+            headers,
+            rows: [headers.map((_header, index) => `Value ${String(index)}`)],
+          },
+          {
+            type: "buttons" as const,
+            buttons: [
+              {
+                label: "One",
+                action: { type: "question" as const, questionId, optionValue: "One" },
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const cfg = { channels: { slack: { botToken: "xoxb-test" } } };
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation,
+      ctx: { cfg, to: "C123", text: payload.text, payload },
+    });
+    if (!rendered) {
+      throw new Error("Expected rendered Slack question presentation");
+    }
+
+    const client = createSlackSendTestClient();
+    let messageCount = 0;
+    client.chat.postMessage.mockImplementation(async () => ({
+      ts: `171234.${String(++messageCount).padStart(3, "0")}`,
+    }));
+    const results: OutboundDeliveryResult[] = [];
+    const sendSlack: typeof sendMessageSlack = async (to, text, options) => {
+      if (options.mediaUrl) {
+        const upload = {
+          messageId: "F001",
+          channelId: "C123",
+          receipt: {
+            platformMessageIds: ["F001"],
+            parts: [{ platformMessageId: "F001", kind: "media" as const, index: 0 }],
+            sentAt: Date.now(),
+          },
+        };
+        await options.onDeliveryResult?.(upload);
+        return upload;
+      }
+      return await sendMessageSlack(to, text, {
+        ...options,
+        cfg,
+        token: "xoxb-test",
+        client,
+        textLimit: 32,
+      });
+    };
+
+    await slackOutbound.sendPayload?.({
+      cfg,
+      to: "channel:C123",
+      text: payload.text,
+      payload: rendered,
+      deps: { sendSlack },
+      onDeliveryResult: (result) => {
+        results.push(result);
+      },
+    });
+    const questionDelivery = results.find((result) => result.meta?.slackQuestionActionIds);
+    expect(results.map((result) => result.receipt?.parts[0]?.kind)).toEqual(
+      expect.arrayContaining(["media", "text", "card"]),
+    );
+    expect(questionDelivery?.messageId).not.toBe("F001");
+
+    await slackOutbound.afterDeliverPayload?.({
+      cfg,
+      target: { channel: "slack", to: "C123", accountId: "default" },
+      payload: rendered,
+      results,
+    });
+    await hoisted.registration?.finalize("Answered: One");
+
+    expect(hoisted.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: "C123",
+        messageTs: questionDelivery?.messageId,
+      }),
+    );
   });
 });

--- a/extensions/slack/src/reply-action-ids.ts
+++ b/extensions/slack/src/reply-action-ids.ts
@@ -9,6 +9,10 @@ export const SLACK_CALLBACK_SELECT_ACTION_ID = "openclaw:callback_select";
 export const SLACK_APPROVAL_BUTTON_ACTION_ID = "openclaw:approval_button";
 export const SLACK_APPROVAL_SELECT_ACTION_ID = "openclaw:approval_select";
 export const SLACK_QUESTION_BUTTON_ACTION_ID = "openclaw:question_button";
+// Keep accepted display blocks plugin-private; string-keyed receipts are serialized.
+export const SLACK_QUESTION_FINALIZATION_BLOCKS: unique symbol = Symbol(
+  "slackQuestionFinalizationBlocks",
+);
 
 export function isSlackQuestionActionId(actionId: string): boolean {
   return (

--- a/extensions/slack/src/reply-action-ids.ts
+++ b/extensions/slack/src/reply-action-ids.ts
@@ -1,4 +1,6 @@
 // Slack plugin module implements reply action ids behavior.
+import type { Block, KnownBlock } from "@slack/web-api";
+
 export const SLACK_REPLY_BUTTON_ACTION_ID = "openclaw:reply_button";
 export const SLACK_REPLY_LINK_ACTION_ID = "openclaw:reply_link";
 export const SLACK_REPLY_SELECT_ACTION_ID = "openclaw:reply_select";
@@ -13,6 +15,19 @@ export function isSlackQuestionActionId(actionId: string): boolean {
     actionId === SLACK_QUESTION_BUTTON_ACTION_ID ||
     actionId.startsWith(`${SLACK_QUESTION_BUTTON_ACTION_ID}:`)
   );
+}
+
+/** Read only question control identities from the blocks actually sent to Slack. */
+export function resolveSlackQuestionActionIds(blocks?: readonly (Block | KnownBlock)[]): string[] {
+  return (blocks ?? []).flatMap((block) => {
+    if (block.type !== "actions") {
+      return [];
+    }
+    const elements = (block as { elements?: readonly { action_id?: string }[] }).elements ?? [];
+    return elements.flatMap(({ action_id }) =>
+      action_id && isSlackQuestionActionId(action_id) ? [action_id] : [],
+    );
+  });
 }
 
 export function isSlackApprovalActionId(actionId: string): boolean {

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createSlackSendTestClient } from "./blocks.test-helpers.js";
 import { SLACK_MESSAGE_TEXT_RECOMMENDED_LIMIT } from "./limits.js";
+import { SLACK_QUESTION_FINALIZATION_BLOCKS } from "./reply-action-ids.js";
 import {
   clearSlackThreadParticipationCache,
   hasSlackThreadParticipation,
@@ -379,6 +380,7 @@ describe("sendMessageSlack blocks", () => {
       client,
       onDeliveryResult,
       blocks: [
+        { type: "section", text: { type: "mrkdwn", text: "Private displayed question" } },
         {
           type: "actions",
           elements: [
@@ -397,11 +399,18 @@ describe("sendMessageSlack blocks", () => {
       ],
     });
 
-    expect(result.meta).toEqual({ slackQuestionActionIds: [questionActionId] });
+    expect(result.meta).toMatchObject({ slackQuestionActionIds: [questionActionId] });
+    expect(result.meta?.[SLACK_QUESTION_FINALIZATION_BLOCKS]).toEqual([
+      { type: "section", text: { type: "mrkdwn", text: "Private displayed question" } },
+    ]);
+    expect(Object.keys(result.meta ?? {})).toEqual(["slackQuestionActionIds"]);
+    expect(JSON.parse(JSON.stringify(result.meta))).toEqual({
+      slackQuestionActionIds: [questionActionId],
+    });
     expect(onDeliveryResult).toHaveBeenCalledWith(
       expect.objectContaining({
         messageId: "171234.567",
-        meta: { slackQuestionActionIds: [questionActionId] },
+        meta: expect.objectContaining({ slackQuestionActionIds: [questionActionId] }),
       }),
     );
   });
@@ -434,17 +443,27 @@ describe("sendMessageSlack blocks", () => {
     const delivered = onDeliveryResult.mock.calls.map(([result]) => result);
     expect(delivered.length).toBeGreaterThan(1);
     expect(delivered.filter((result) => result.meta)).toEqual([
-      expect.objectContaining({ meta: { slackQuestionActionIds: [questionActionId] } }),
+      expect.objectContaining({
+        meta: expect.objectContaining({ slackQuestionActionIds: [questionActionId] }),
+      }),
     ]);
     expect(
       delivered.some((result) => result.receipt.parts[0]?.kind === "card" && !result.meta),
     ).toBe(true);
     const questionDelivery = delivered.find((delivery) => delivery.meta);
     expect(questionDelivery?.messageId).not.toBe(aggregateResult.messageId);
-    expect(aggregateResult.meta).toEqual({
+    expect(JSON.parse(JSON.stringify(aggregateResult.meta))).toEqual({
       slackQuestionActionIds: [questionActionId],
       slackQuestionMessageId: questionDelivery?.messageId,
     });
+    expect(aggregateResult.meta?.[SLACK_QUESTION_FINALIZATION_BLOCKS]).toBe(
+      questionDelivery?.meta?.[SLACK_QUESTION_FINALIZATION_BLOCKS],
+    );
+    expect(
+      aggregateResult.meta?.[SLACK_QUESTION_FINALIZATION_BLOCKS]?.some(
+        (block) => block.type === "actions" || block.type === "data_table",
+      ),
+    ).toBe(false);
   });
 
   it("includes sibling block text in top-level fallback for raw block sends", async () => {

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -369,6 +369,72 @@ describe("sendMessageSlack blocks", () => {
     expect((receiptPart?.raw as Record<string, unknown> | undefined)?.channelId).toBe("C123");
   });
 
+  it("records question action identities on the exact delivered Block Kit card", async () => {
+    const client = createSlackSendTestClient();
+    const onDeliveryResult = vi.fn();
+    const questionActionId = "openclaw:question_button:2:1";
+    const result = await sendMessageSlack("channel:C123", "Pick one", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      onDeliveryResult,
+      blocks: [
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              action_id: "openclaw:reply_button:1:1",
+              text: { type: "plain_text", text: "Reply" },
+            },
+            {
+              type: "button",
+              action_id: questionActionId,
+              text: { type: "plain_text", text: "Answer" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.meta).toEqual({ slackQuestionActionIds: [questionActionId] });
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "171234.567",
+        meta: { slackQuestionActionIds: [questionActionId] },
+      }),
+    );
+  });
+
+  it("marks only the fallback card that actually contains the question controls", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+    const questionActionId = "openclaw:question_button:2:1";
+    const blocks = interleavedNativeDataBlocks();
+    const actionBlock = blocks.at(-1) as { elements: Array<{ action_id: string }> };
+    actionBlock.elements[0]!.action_id = questionActionId;
+    const onDeliveryResult = vi.fn();
+
+    await sendMessageSlack("channel:C123", "Outside", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      blocks: blocks as never,
+      nativeDataFallbackBaseText: "Outside",
+      textLimit: 25,
+      onDeliveryResult,
+    });
+
+    const delivered = onDeliveryResult.mock.calls.map(([result]) => result);
+    expect(delivered.length).toBeGreaterThan(1);
+    expect(delivered.filter((result) => result.meta)).toEqual([
+      expect.objectContaining({ meta: { slackQuestionActionIds: [questionActionId] } }),
+    ]);
+    expect(
+      delivered.some((result) => result.receipt.parts[0]?.kind === "card" && !result.meta),
+    ).toBe(true);
+  });
+
   it("includes sibling block text in top-level fallback for raw block sends", async () => {
     const client = createSlackSendTestClient();
 

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -404,9 +404,9 @@ describe("sendMessageSlack blocks", () => {
       { type: "section", text: { type: "mrkdwn", text: "Private displayed question" } },
     ]);
     expect(Object.keys(result.meta ?? {})).toEqual(["slackQuestionActionIds"]);
-    expect(JSON.parse(JSON.stringify(result.meta))).toEqual({
-      slackQuestionActionIds: [questionActionId],
-    });
+    expect(JSON.stringify(result.meta)).toBe(
+      JSON.stringify({ slackQuestionActionIds: [questionActionId] }),
+    );
     expect(onDeliveryResult).toHaveBeenCalledWith(
       expect.objectContaining({
         messageId: "171234.567",
@@ -452,10 +452,12 @@ describe("sendMessageSlack blocks", () => {
     ).toBe(true);
     const questionDelivery = delivered.find((delivery) => delivery.meta);
     expect(questionDelivery?.messageId).not.toBe(aggregateResult.messageId);
-    expect(JSON.parse(JSON.stringify(aggregateResult.meta))).toEqual({
-      slackQuestionActionIds: [questionActionId],
-      slackQuestionMessageId: questionDelivery?.messageId,
-    });
+    expect(JSON.stringify(aggregateResult.meta)).toBe(
+      JSON.stringify({
+        slackQuestionActionIds: [questionActionId],
+        slackQuestionMessageId: questionDelivery?.messageId,
+      }),
+    );
     expect(aggregateResult.meta?.[SLACK_QUESTION_FINALIZATION_BLOCKS]).toBe(
       questionDelivery?.meta?.[SLACK_QUESTION_FINALIZATION_BLOCKS],
     );

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -408,14 +408,20 @@ describe("sendMessageSlack blocks", () => {
 
   it("marks only the fallback card that actually contains the question controls", async () => {
     const client = createSlackSendTestClient();
+    let messageCount = 0;
+    client.chat.postMessage = vi.fn(async () => ({
+      ok: true,
+      ts: `171234.${String(++messageCount).padStart(3, "0")}`,
+    }));
     client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
     const questionActionId = "openclaw:question_button:2:1";
     const blocks = interleavedNativeDataBlocks();
     const actionBlock = blocks.at(-1) as { elements: Array<{ action_id: string }> };
     actionBlock.elements[0]!.action_id = questionActionId;
+    blocks.push({ type: "section", text: { type: "mrkdwn", text: "After question" } });
     const onDeliveryResult = vi.fn();
 
-    await sendMessageSlack("channel:C123", "Outside", {
+    const aggregateResult = await sendMessageSlack("channel:C123", "Outside", {
       token: "xoxb-test",
       cfg: SLACK_TEST_CFG,
       client,
@@ -433,6 +439,12 @@ describe("sendMessageSlack blocks", () => {
     expect(
       delivered.some((result) => result.receipt.parts[0]?.kind === "card" && !result.meta),
     ).toBe(true);
+    const questionDelivery = delivered.find((delivery) => delivery.meta);
+    expect(questionDelivery?.messageId).not.toBe(aggregateResult.messageId);
+    expect(aggregateResult.meta).toEqual({
+      slackQuestionActionIds: [questionActionId],
+      slackQuestionMessageId: questionDelivery?.messageId,
+    });
   });
 
   it("includes sibling block text in top-level fallback for raw block sends", async () => {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -49,6 +49,7 @@ import {
   isSlackInvalidBlocksError,
 } from "./native-data-blocks.js";
 import { buildSlackNativeDataDeliveryPlan } from "./native-data-fallback.js";
+import { resolveSlackQuestionActionIds } from "./reply-action-ids.js";
 import { recordSlackThreadParticipation } from "./sent-thread-cache.js";
 import { canonicalizeSlackApiTargetId, parseSlackTarget } from "./target-parsing.js";
 import { normalizeSlackThreadTsCandidate, resolveSlackThreadTsValue } from "./thread-ts.js";
@@ -261,6 +262,7 @@ export type SlackSendResult = {
   channelId: string;
   receipt: MessageReceipt;
   threadTs?: string;
+  meta?: { slackQuestionActionIds: string[] };
 };
 
 export async function updateMessageSlack(params: {
@@ -1111,9 +1113,18 @@ async function sendMessageSlackQueuedInner(params: {
         accountId: account.accountId,
         token,
       });
-  const reportDelivery = async (result: SlackSendResult) => {
-    await opts.onDeliveryResult?.(result);
-    return result;
+  const reportDelivery = async (
+    result: SlackSendResult,
+    deliveredBlocks?: (Block | KnownBlock)[],
+  ) => {
+    // Fallback can split blocks across several sends; identify controls on the
+    // actual posted card so uploads and text chunks cannot steal finalization.
+    const slackQuestionActionIds = resolveSlackQuestionActionIds(deliveredBlocks);
+    const deliveryResult = slackQuestionActionIds.length
+      ? { ...result, meta: { ...result.meta, slackQuestionActionIds } }
+      : result;
+    await opts.onDeliveryResult?.(deliveryResult);
+    return deliveryResult;
   };
   let didDispatch = false;
   const dispatchOnce = async () => {
@@ -1222,17 +1233,20 @@ async function sendMessageSlackQueuedInner(params: {
         deliveredChannelId = resolvePostedMessageChannelId(response, channelId);
         const deliveredThreadTs =
           resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
-        return await reportDelivery({
-          messageId,
-          channelId: deliveredChannelId,
-          threadTs: deliveredThreadTs,
-          receipt: createSlackSendReceipt({
-            platformMessageIds: [messageId],
+        return await reportDelivery(
+          {
+            messageId,
             channelId: deliveredChannelId,
-            kind: "card",
             threadTs: deliveredThreadTs,
-          }),
-        });
+            receipt: createSlackSendReceipt({
+              platformMessageIds: [messageId],
+              channelId: deliveredChannelId,
+              kind: "card",
+              threadTs: deliveredThreadTs,
+            }),
+          },
+          blocks,
+        );
       } catch (error) {
         if (!hasNativeData || !isSlackInvalidBlocksError(error)) {
           throw error;
@@ -1284,17 +1298,20 @@ async function sendMessageSlackQueuedInner(params: {
         sentMessageIds.push(response.ts);
         const deliveredThreadTs =
           resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
-        await reportDelivery({
-          messageId: response.ts,
-          channelId: deliveredChannelId,
-          threadTs: deliveredThreadTs,
-          receipt: createSlackSendReceipt({
-            platformMessageIds: [response.ts],
+        await reportDelivery(
+          {
+            messageId: response.ts,
             channelId: deliveredChannelId,
-            kind: fallback.blocks ? "card" : "text",
             threadTs: deliveredThreadTs,
-          }),
-        });
+            receipt: createSlackSendReceipt({
+              platformMessageIds: [response.ts],
+              channelId: deliveredChannelId,
+              kind: fallback.blocks ? "card" : "text",
+              threadTs: deliveredThreadTs,
+            }),
+          },
+          fallback.blocks,
+        );
       }
       const messageId = lastMessageId || "unknown";
       const deliveredThreadTs =

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -49,7 +49,10 @@ import {
   isSlackInvalidBlocksError,
 } from "./native-data-blocks.js";
 import { buildSlackNativeDataDeliveryPlan } from "./native-data-fallback.js";
-import { resolveSlackQuestionActionIds } from "./reply-action-ids.js";
+import {
+  resolveSlackQuestionActionIds,
+  SLACK_QUESTION_FINALIZATION_BLOCKS,
+} from "./reply-action-ids.js";
 import { recordSlackThreadParticipation } from "./sent-thread-cache.js";
 import { canonicalizeSlackApiTargetId, parseSlackTarget } from "./target-parsing.js";
 import { normalizeSlackThreadTsCandidate, resolveSlackThreadTsValue } from "./thread-ts.js";
@@ -262,7 +265,11 @@ export type SlackSendResult = {
   channelId: string;
   receipt: MessageReceipt;
   threadTs?: string;
-  meta?: { slackQuestionActionIds: string[]; slackQuestionMessageId?: string };
+  meta?: {
+    slackQuestionActionIds: string[];
+    slackQuestionMessageId?: string;
+    [SLACK_QUESTION_FINALIZATION_BLOCKS]?: (Block | KnownBlock)[];
+  };
 };
 
 export async function updateMessageSlack(params: {
@@ -1119,9 +1126,19 @@ async function sendMessageSlackQueuedInner(params: {
   ) => {
     // Fallback can split blocks across several sends; identify controls on the
     // actual posted card so uploads and text chunks cannot steal finalization.
+    // Preserve only accepted display blocks; actions contain private callback data.
     const slackQuestionActionIds = resolveSlackQuestionActionIds(deliveredBlocks);
     const deliveryResult = slackQuestionActionIds.length
-      ? { ...result, meta: { ...result.meta, slackQuestionActionIds } }
+      ? {
+          ...result,
+          meta: {
+            ...result.meta,
+            slackQuestionActionIds,
+            [SLACK_QUESTION_FINALIZATION_BLOCKS]: deliveredBlocks!.filter(
+              (block) => block.type !== "actions",
+            ),
+          },
+        }
       : result;
     await opts.onDeliveryResult?.(deliveryResult);
     return deliveryResult;

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -262,7 +262,7 @@ export type SlackSendResult = {
   channelId: string;
   receipt: MessageReceipt;
   threadTs?: string;
-  meta?: { slackQuestionActionIds: string[] };
+  meta?: { slackQuestionActionIds: string[]; slackQuestionMessageId?: string };
 };
 
 export async function updateMessageSlack(params: {
@@ -1257,6 +1257,7 @@ async function sendMessageSlackQueuedInner(params: {
     }
     if (pendingBlockFallback) {
       const fallbackMessages = pendingBlockFallback.fallbackMessages;
+      let questionDelivery: SlackSendResult | undefined;
       for (const [partIndex, fallback] of fallbackMessages.entries()) {
         const metadata = withSlackDeliveryMetadata(partIndex === 0 ? opts.metadata : undefined, {
           queueId: opts.deliveryQueueId,
@@ -1298,7 +1299,7 @@ async function sendMessageSlackQueuedInner(params: {
         sentMessageIds.push(response.ts);
         const deliveredThreadTs =
           resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
-        await reportDelivery(
+        const fallbackDelivery = await reportDelivery(
           {
             messageId: response.ts,
             channelId: deliveredChannelId,
@@ -1312,6 +1313,9 @@ async function sendMessageSlackQueuedInner(params: {
           },
           fallback.blocks,
         );
+        if (fallbackDelivery.meta?.slackQuestionActionIds.length) {
+          questionDelivery = fallbackDelivery;
+        }
       }
       const messageId = lastMessageId || "unknown";
       const deliveredThreadTs =
@@ -1320,6 +1324,16 @@ async function sendMessageSlackQueuedInner(params: {
         messageId,
         channelId: deliveredChannelId,
         threadTs: deliveredThreadTs,
+        // Core replaces per-card progress with this aggregate; retain the
+        // actual question-card identity even when a later fallback part wins.
+        ...(questionDelivery?.meta
+          ? {
+              meta: {
+                ...questionDelivery.meta,
+                slackQuestionMessageId: questionDelivery.messageId,
+              },
+            }
+          : {}),
         receipt: createSlackSendReceipt({
           platformMessageIds: sentMessageIds.length ? sentMessageIds : [messageId],
           channelId: deliveredChannelId,

--- a/src/channels/message/outbound-bridge.test.ts
+++ b/src/channels/message/outbound-bridge.test.ts
@@ -115,6 +115,81 @@ describe("createChannelMessageAdapterFromOutbound", () => {
     });
   });
 
+  it("preserves contracted delivery facts without exposing private provider fields", async () => {
+    const sourceResult = (messageId: string) => ({
+      channel: "forged-channel",
+      messageId,
+      chatId: "chat-1",
+      channelId: "channel-1",
+      roomId: "room-1",
+      conversationId: "conversation-1",
+      toJid: "recipient@example.invalid",
+      pollId: "poll-1",
+      timestamp: 123,
+      meta: { questionActionIds: ["question:1"], questionMessageId: "question-card" },
+      receipt: {
+        primaryPlatformMessageId: messageId,
+        platformMessageIds: [messageId],
+        parts: [{ platformMessageId: messageId, kind: "text" as const, index: 0 }],
+        sentAt: 123,
+      },
+      accessToken: "private-access-token",
+      content: "private-provider-content",
+      primaryMessageId: "private-primary-id",
+      threadTs: "private-thread-ts",
+      blocks: [{ text: "private-block" }],
+      callback: { value: "private-callback" },
+      action: { value: "private-action" },
+    });
+    const onDeliveryResult = vi.fn();
+    const adapter = createChannelMessageAdapterFromOutbound({
+      outbound: {
+        sendText: async ({ onDeliveryResult: reportProgress }) => {
+          await reportProgress?.(sourceResult("progress-1"));
+          return sourceResult("final-1");
+        },
+      },
+    });
+
+    const result = await adapter.send?.text?.({
+      cfg,
+      to: "room-1",
+      text: "hello",
+      onDeliveryResult,
+    });
+
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    const progress = onDeliveryResult.mock.calls[0]?.[0];
+    for (const [delivery, messageId] of [
+      [progress, "progress-1"],
+      [result, "final-1"],
+    ] as const) {
+      expect(delivery).toMatchObject({
+        messageId,
+        chatId: "chat-1",
+        channelId: "channel-1",
+        roomId: "room-1",
+        conversationId: "conversation-1",
+        toJid: "recipient@example.invalid",
+        pollId: "poll-1",
+        timestamp: 123,
+        meta: { questionActionIds: ["question:1"], questionMessageId: "question-card" },
+      });
+      for (const privateField of [
+        "channel",
+        "accessToken",
+        "content",
+        "primaryMessageId",
+        "threadTs",
+        "blocks",
+        "callback",
+        "action",
+      ]) {
+        expect(delivery).not.toHaveProperty(privateField);
+      }
+    }
+  });
+
   it("preserves an outbound receipt instead of rebuilding it", async () => {
     const receipt: MessageReceipt = {
       primaryPlatformMessageId: "receipt-1",

--- a/src/channels/message/outbound-bridge.ts
+++ b/src/channels/message/outbound-bridge.ts
@@ -101,6 +101,16 @@ function toMessageSendResult(
         replyToId: params.replyToId ?? undefined,
       });
   return {
+    // Preserve sanctioned owner facts for delivery hooks without exposing private
+    // provider fields or trusting a provider-authored channel identity.
+    ...(result.chatId !== undefined ? { chatId: result.chatId } : {}),
+    ...(result.channelId !== undefined ? { channelId: result.channelId } : {}),
+    ...(result.roomId !== undefined ? { roomId: result.roomId } : {}),
+    ...(result.conversationId !== undefined ? { conversationId: result.conversationId } : {}),
+    ...(result.toJid !== undefined ? { toJid: result.toJid } : {}),
+    ...(result.pollId !== undefined ? { pollId: result.pollId } : {}),
+    ...(result.timestamp !== undefined ? { timestamp: result.timestamp } : {}),
+    ...(result.meta !== undefined ? { meta: result.meta } : {}),
     receipt,
     ...(resolveResultMessageId({ ...result, receipt })
       ? {

--- a/src/infra/question-channel-runtime.test.ts
+++ b/src/infra/question-channel-runtime.test.ts
@@ -1,6 +1,8 @@
 // Covers question message finalization lifecycle and delivery races.
+import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import type { QuestionRecord } from "../../packages/gateway-protocol/src/schema/questions.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
 import { createQuestionChannelRuntime } from "./question-channel-runtime-internal.js";
 
 const record: QuestionRecord = {
@@ -19,6 +21,64 @@ const record: QuestionRecord = {
 };
 
 describe("question channel runtime", () => {
+  it("shares finalizers between separately evaluated gateway and plugin runtime modules", async () => {
+    const gateway = await importFreshModule<typeof import("./question-channel-runtime.js")>(
+      import.meta.url,
+      "./question-channel-runtime.js?scope=question-gateway-owner",
+    );
+    const plugin = await importFreshModule<typeof import("./question-channel-runtime.js")>(
+      import.meta.url,
+      "./question-channel-runtime.js?scope=question-plugin-sdk",
+    );
+    const finalize = vi.fn();
+
+    try {
+      gateway.handleQuestionChannelRequested(record);
+      plugin.registerQuestionChannelDelivery({
+        questionId: record.id,
+        deliveryId: "slack:default:C123:171234.001",
+        finalize,
+      });
+      gateway.handleQuestionChannelResolved({
+        id: record.id,
+        status: "answered",
+        answers: { answers: { target: ["Production"] } },
+      });
+
+      expect(finalize).toHaveBeenCalledExactlyOnceWith("Answered: Production");
+    } finally {
+      await drainGlobalSingletonLifecycleState("restart");
+    }
+  });
+
+  it("clears shared callbacks and retention timers when the gateway restarts", async () => {
+    vi.useFakeTimers();
+    try {
+      const gateway = await importFreshModule<typeof import("./question-channel-runtime.js")>(
+        import.meta.url,
+        "./question-channel-runtime.js?scope=question-gateway-lifecycle",
+      );
+      const staleFinalize = vi.fn();
+      gateway.handleQuestionChannelRequested(record);
+      gateway.registerQuestionChannelDelivery({
+        questionId: record.id,
+        deliveryId: "slack:default:C123:171234.002",
+        finalize: staleFinalize,
+      });
+      gateway.handleQuestionChannelResolved({ id: "ask_terminal", status: "expired" });
+
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
+      await drainGlobalSingletonLifecycleState("restart");
+      expect(vi.getTimerCount()).toBe(0);
+
+      gateway.handleQuestionChannelResolved({ id: record.id, status: "cancelled" });
+      expect(staleFinalize).not.toHaveBeenCalled();
+    } finally {
+      await drainGlobalSingletonLifecycleState("restart");
+      vi.useRealTimers();
+    }
+  });
+
   it("finalizes delivered messages once with canonical answer labels", async () => {
     const finalize = vi.fn();
     const runtime = createQuestionChannelRuntime();

--- a/src/infra/question-channel-runtime.ts
+++ b/src/infra/question-channel-runtime.ts
@@ -1,15 +1,23 @@
 // Tracks delivered native question controls until the Gateway resolves them.
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { createQuestionChannelRuntime } from "./question-channel-runtime-internal.js";
 
 const log = createSubsystemLogger("gateway/questions");
-const questionChannelRuntime = createQuestionChannelRuntime({
-  onFinalizeError: (error, questionId, deliveryId) => {
-    log.warn(`question message finalization failed id=${questionId} delivery=${deliveryId}`, {
-      error: String(error),
-    });
-  },
-});
+// Source-loaded plugin SDK chunks and Gateway chunks must share one delivery owner.
+// Clear its pending callbacks and retention timers when the Gateway closes or restarts.
+const questionChannelRuntime = resolveGlobalSingleton(
+  Symbol.for("openclaw.questionChannelRuntime"),
+  () =>
+    createQuestionChannelRuntime({
+      onFinalizeError: (error, questionId, deliveryId) => {
+        log.warn(`question message finalization failed id=${questionId} delivery=${deliveryId}`, {
+          error: String(error),
+        });
+      },
+    }),
+  (runtime) => runtime.clear(),
+);
 
 export const handleQuestionChannelRequested = questionChannelRuntime.handleRequested;
 export const handleQuestionChannelResolved = questionChannelRuntime.handleResolved;


### PR DESCRIPTION
## What Problem This Solves

Slack question controls remained active or the wrong Slack message was edited after uploads, chunking, invalid_blocks fallback, and multi-message delivery. Real ephemeral-Gateway testing uncovered two additional owner-boundary defects: externally loaded plugins registered question callbacks in a duplicated SDK runtime, and the original finalizer reconstructed Slack blocks the provider had already rejected.

## Canonical Owner-Boundary Repairs

- The question-runtime owner uses the existing lifecycle-managed process singleton, so Gateway resolution and externally loaded Slack, Signal, and iMessage plugins share one finalization registry. Its canonical close/restart reset clears callbacks and retention timers.
- The real registered Slack outbound facade forwards finalization; the generic delivery bridge preserves only existing safe contracted identity/meta fields.
- Slack records the accepted question-card timestamp even when a trailing fallback message owns the aggregate receipt.
- A Slack-private, unguessable, non-serialized symbol retains only the actual accepted card's non-action display blocks. The finalizer edits those accepted fallback blocks rather than resurrecting an invalid native table/chart.
- No generic plugin-loader behavior, public SDK shape, configuration, credentials, or externally serialized metadata changes.

## Exact-Head Real Gateway / Slack Transport Proof

The exact published commit 6bfb5ed23efa6dd2235108d0a29c48b3e4f78a95 passed a fresh remote private-QA build and a real ephemeral Gateway with a mock OpenAI model, the actual registered Slack plugin, installed Crabline Slack-compatible transport, and a fault proxy that rejects unsupported native data blocks for BOTH chat.postMessage and chat.update.

The complete sanitized machine verdict was:

```json
{"status":"pass","gateway":"real-ephemeral","provider":"mock-openai","providerRequests":1,"channel":"slack","channelApi":"installed-crabline-local+fault-proxy","nativeRejected":"invalid_blocks","acceptedQuestionCards":1,"questionTs":"171234.001","trailingTs":"171234.002","updatedTs":"171234.001","updateCount":1,"rejectedUpdateDataTables":0,"duplicateQuestionCards":0}
```

The Gateway really resolved the question, updated the accepted 171234.001 card exactly once rather than trailing 171234.002, removed its actions, retained the exact provider-accepted fallback display blocks, and rendered Answered: One. No external Slack workspace or real user account was accessed. Full private build validated 149 SDK entrypoints and Control UI assets/performance gates. Remote proof action: https://github.com/openclaw/openclaw/actions/runs/30793152102

## Regression Evidence

- True RED: separately evaluated Gateway/plugin question-runtime modules produced zero callbacks; shared owner now passes duplicate-instance and close/restart timer-cleanup tests.
- True RED: the previous finalizer reconstructed Slack's rejected native data_table; final accepted-card snapshot now preserves only supported provider-accepted blocks.
- Final combined focused owner and Slack suites: 64/64 passing; final full Slack block suite: 52/52 passing.
- Actual Gateway + Slack-compatible transport scenario: 1/1 passing on exact published head.
- Private accepted-card metadata survives result aggregation but is absent from Object.keys and JSON; actions/callback values are excluded.
- Generic plugin-loader workaround rejected after dependency tests proved it would execute failing TypeScript twice and break SDK capability overrides.
- Independent full lifecycle/sibling/security review clean; hosted lint and real-behavior checks pass.
- ClawSweeper rank-up applied: redacted exact-head Gateway/proxy evidence proves precisely one final update at 171234.001 with the actual accepted card.
- AI-assisted implementation and independently verified source review.
