### PR TITLE
fix(tui): settle failed local shell commands exactly once

### DIFF
--- a/src/tui/tui-local-shell.test.ts
+++ b/src/tui/tui-local-shell.test.ts
@@ -1,5 +1,7 @@
 // Verifies local shell process handling for TUI local mode.
+import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { join } from "node:path";
 import type { OverlayHandle } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import { createLocalShellRunner } from "./tui-local-shell.js";
@@ -240,6 +242,28 @@ describe("createLocalShellRunner", () => {
     expect(harness.messages).toContain(
       "local shell: working directory was deleted; cd to an existing directory first",
     );
+  });
+
+  it("finishes a failed child before reporting the next local command", async () => {
+    const harness = createShellHarness({
+      spawnCommand: spawn,
+      getCwd: vi
+        .fn(() => process.cwd())
+        .mockReturnValueOnce(join(process.cwd(), ".missing-openclaw-local-shell-directory")),
+    });
+
+    const failedRun = harness.runLocalShellLine("!echo first");
+    harness.getLastSelector()?.onSelect?.({ value: "yes", label: "Yes" });
+    await failedRun;
+    await harness.runLocalShellLine("!echo second");
+
+    expect(harness.messages.filter((message) => message.startsWith("[local]"))).toEqual([
+      "[local] $ echo first",
+      expect.stringContaining("[local] error: "),
+      "[local] $ echo second",
+      "[local] second",
+      "[local] exit 0",
+    ]);
   });
 
   it("does not crash when stdout or stderr emit an error event", async () => {

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -131,9 +131,10 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
 
       let stdout = "";
       let stderr = "";
+      let error: Error | undefined;
       const stdoutDecoder = new StringDecoder("utf8");
       const stderrDecoder = new StringDecoder("utf8");
-      // Output pipes may fail independently; child close/error remains authoritative.
+      // Pipe errors are incidental; close owns completion after any recorded spawn error.
       const ignoreOutputStreamError = () => {};
       child.stdout.on("error", ignoreOutputStreamError);
       child.stderr.on("error", ignoreOutputStreamError);
@@ -160,15 +161,14 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
             deps.chatLog.addSystem(`[local] ${lineLocal}`);
           }
         }
-        deps.chatLog.addSystem(`[local] exit ${code ?? "?"}${signal ? ` (signal ${signal})` : ""}`);
+        const status = error ? `error: ${formatTuiErrorMessage(error)}` : `exit ${code ?? "?"}`;
+        deps.chatLog.addSystem(`[local] ${status}${signal ? ` (signal ${signal})` : ""}`);
         deps.tui.requestRender();
         resolve();
       });
 
       child.on("error", (err) => {
-        deps.chatLog.addSystem(`[local] error: ${formatTuiErrorMessage(err)}`);
-        deps.tui.requestRender();
-        resolve();
+        error = err;
       });
     });
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running local shell commands from the terminal UI could see a failed command finish out of order, display a stale extra exit message, or have that stale completion appear after the next command started when its working directory no longer existed.

## Why This Change Was Made

Node emits a child-process `error` event before its terminal `close` event when spawning from a missing working directory fails with `ENOENT`. The local-shell owner previously resolved the command from the early `error` handler, then emitted another terminal outcome when `close` eventually arrived. The owner now records the spawn failure and lets `close` settle the command exactly once, preserving output ordering, signal reporting, and the existing approval boundary without adding production lines.

## User Impact

A failed local shell command reports one understandable terminal error before the next command can start. Successful command output, signal termination, UTF-8 streaming, output limits, deleted-working-directory guidance, and the existing per-session approval flow retain their established behavior.

## Evidence

- Frozen candidate: `b7894b1e1cdec1e92aebc54fd7d1917f1ce95b4f`; original base/direct parent: `57732647d16d3ad8629a4bef708a2bef343f9190`.
- Exact reviewed paths: `src/tui/tui-local-shell.ts` and `src/tui/tui-local-shell.test.ts`. Production delta: **0 lines** (`5` added, `5` removed); existing focused regression coverage: `24` test lines added.
- Four distinct, independent, nonauthor hostile whole-branch reviews approved the exact frozen candidate; genuine official Sol review is clean at confidence **0.96**.
- The committed owner regression invokes real `node:child_process.spawn` against a missing working directory, then checks that the failed command's single terminal error precedes the next real command and its successful exit.
- The unchanged original owner failed the committed regression using real `node:child_process.spawn`, a missing working directory, and the actual `ENOENT`-before-`close` event sequence; the frozen candidate then passed **58/58 focused tests** across the local-shell owner, submit handler, submit state, and real PTY process/signal lifecycle.
- The **complete exact-two-path changed-code gate passed**, including core production and test typechecks, formatting, lint, import-cycle, SDK, dependency, architecture, and state guards. A full production build is not required for this narrow TUI owner refactor.
- Remote validation completed with `exitCode=0` on owned Blacksmith Testbox lease `tbx_01kz2wq0qekhq4vanng698hsjf`; the lease was stopped after completion. Workflow: [OpenClaw remote TUI validation](https://github.com/openclaw/openclaw/actions/runs/30783402857).
- **Named Pathfinder follow-up — TUI local-shell session teardown and process-tree ownership:** unmerged commit `991eae1bab68935a1f7c884d1e1e6f451ebf1685` identifies pending-approval cancellation, active local-shell session teardown, and owned process-tree cleanup work. Any future owner-level repair must preserve this change's single, `close`-owned final settlement and must not reintroduce early completion or duplicate terminal messages.
- Protected maintainer next step resolved: authenticated repository administrator `@steipete` explicitly authorized autonomous maintainer review and landing of individually verified low-risk QA refactors. Exact-head hosted PR checks and the latest completed ClawSweeper review must still pass before repository-native landing.
- ClawSweeper merge-risk and rank-up move resolved at landing: refresh exact-head hosted checks and mergeability immediately before repository-native landing; require every current required context to be green, the reviewed head to remain unchanged, and GitHub to report the PR mergeable. The native landing gate independently refuses any pending or failing exact-head check.
