### PR TITLE
test(agents): fixture model runtime collaborators

### DIFF
--- a/extensions/openai/openclaw.plugin.test.ts
+++ b/extensions/openai/openclaw.plugin.test.ts
@@ -175,6 +175,24 @@ describe("OpenAI plugin manifest", () => {
     });
   });
 
+  it("keeps the Azure transport alias and Spark suppression owned by the manifest", () => {
+    expect(manifest.modelCatalog?.aliases?.["azure-openai-responses"]).toEqual({
+      provider: "openai",
+      api: "azure-openai-responses",
+    });
+    const azureSparkSuppression = manifest.modelCatalog?.suppressions?.find(
+      (suppression) =>
+        suppression.provider === "azure-openai-responses" &&
+        suppression.model === "gpt-5.3-codex-spark",
+    );
+
+    expect(azureSparkSuppression).toMatchObject({
+      provider: "azure-openai-responses",
+      model: "gpt-5.3-codex-spark",
+    });
+    expect(azureSparkSuppression).not.toHaveProperty("when");
+  });
+
   it("keeps auth choice copy aligned with provider wizard metadata", () => {
     const wizards = providerWizardByKey();
 

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -4,20 +4,45 @@ import type { ModelProviderConfig } from "../../config/config.js";
 import { discoverModels } from "../agent-model-discovery.js";
 import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
 
-vi.mock("../../plugins/provider-runtime.js", async () => {
-  const actual = await vi.importActual<typeof import("../../plugins/provider-runtime.js")>(
-    "../../plugins/provider-runtime.js",
-  );
-  return {
-    ...actual,
-    applyProviderResolvedTransportWithPlugin: () => undefined,
-    buildProviderUnknownModelHintWithPlugin: () => undefined,
-    normalizeProviderTransportWithPlugin: () => undefined,
-    normalizeProviderResolvedModelWithPlugin: () => undefined,
-    prepareProviderDynamicModel: async () => {},
-    runProviderDynamicModel: () => undefined,
-  };
-});
+vi.mock("../../plugins/provider-runtime.js", () => ({
+  applyProviderResolvedTransportWithPlugin: () => undefined,
+  buildProviderUnknownModelHintWithPlugin: () => undefined,
+  normalizeProviderResolvedModelWithPlugin: () => undefined,
+  normalizeProviderTransportWithPlugin: () => undefined,
+  prepareProviderDynamicModel: async () => {},
+  resolveExternalAuthProfilesWithPlugins: () => [],
+  runProviderDynamicModel: () => undefined,
+  shouldPreferProviderRuntimeResolvedModel: () => false,
+}));
+
+vi.mock("../auth-profiles.js", () => ({
+  ensureAuthProfileStore: () => ({ version: 1, profiles: {} }),
+  resolveAuthProfileOrder: () => [],
+}));
+
+vi.mock("./model.static-catalog.js", () => ({
+  resolveBundledProviderStaticCatalogModel: () => undefined,
+  resolveBundledStaticCatalogModel: () => undefined,
+  resolveManifestModelCatalogProviderAliasMetadata: ({
+    provider,
+    modelId,
+    cfg,
+  }: {
+    provider: string;
+    modelId?: string;
+    cfg?: { models?: { providers?: Record<string, { baseUrl?: string }> } };
+  }) => ({
+    provider:
+      provider === "azure-openai-responses" && modelId === "gpt-5.3-codex-spark"
+        ? "openai"
+        : provider,
+    ...(provider === "azure-openai-responses" &&
+    modelId !== "gpt-5.3-codex-spark" &&
+    cfg?.models?.providers?.[provider]?.baseUrl
+      ? { transport: { api: "azure-openai-responses" as const } }
+      : {}),
+  }),
+}));
 
 vi.mock("../model-suppression.js", () => ({
   shouldSuppressBuiltInModel: ({

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -43,6 +43,17 @@ const preparedSnapshotState = vi.hoisted(() => ({
   inlineProviderModels: [] as PreparedModelRuntimeSnapshot["inlineProviderModels"],
 }));
 
+vi.mock("../../plugins/provider-runtime.js", () => ({
+  applyProviderResolvedTransportWithPlugin: () => undefined,
+  buildProviderUnknownModelHintWithPlugin: () => undefined,
+  normalizeProviderResolvedModelWithPlugin: () => undefined,
+  normalizeProviderTransportWithPlugin: () => undefined,
+  prepareProviderDynamicModel: async () => {},
+  resolveExternalAuthProfilesWithPlugins: () => [],
+  runProviderDynamicModel: () => undefined,
+  shouldPreferProviderRuntimeResolvedModel: () => false,
+}));
+
 vi.mock("../model-suppression.js", () => {
   // Mirrors the canonical manifest-driven suppression in
   // extensions/qwen/openclaw.plugin.json and src/plugins/manifest-model-suppression.ts.


### PR DESCRIPTION
## Summary

- replace broad provider-runtime imports in the embedded model resolver suites with explicit collaborator fixtures
- keep auth-profile and static-catalog owner behavior outside the resolver fixture graph
- add direct OpenAI manifest assertions for the Azure transport alias and Spark suppression retained by those fixtures

## Performance

Paired local runs from the same pre-change head:

| Suites | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| model resolver + forward compatibility (wall) | 72.88s | 43.01s | 41.0% |
| test bodies | 61.14s | 35.79s | 41.5% |

The change leaves Vitest sharding, worker configuration, and production code untouched.

## Proof

- model.test.ts: 149/149
- model.forward-compat.errors-and-overrides.test.ts: 32/32
- openclaw.plugin.test.ts: 11/11
- sibling owner suites: 68/68 across static catalog, forward compatibility, prepared runtime selection/startup, external OAuth, and synthetic auth discovery
- formatting, oxlint, and diff checks clean
- autoreview clean with no accepted/actionable findings

The changed-file gate attempted direct AWS Crabbox run run_2a7507eac0a1, but remote setup failed because postinstall could not import TypeScript. The documented local fallback reached both relevant typecheck graphs; only unrelated stale-dependency errors in untouched terminal-core, UI, and cua-computer files were reported.
