### PR TITLE
test(xai): consolidate catalog discovery setup

### DIFF
--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -116,6 +116,59 @@ function createXaiBilledToolConfig(name: XaiBilledToolName, enabled?: boolean) {
   };
 }
 
+function mockXaiRuntimeOAuth() {
+  providerAuthRuntimeMocks.resolveApiKeyForProvider.mockResolvedValue({
+    apiKey: "xai-oauth-token",
+    mode: "oauth",
+    source: "profile:xai-profile",
+    profileId: "xai-profile",
+  });
+}
+
+function stubXaiFetch(respond: (url: string) => Response | Promise<Response>) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    return await respond(url);
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+  return fetchMock;
+}
+
+function findXaiFetchInit(
+  fetchMock: ReturnType<typeof stubXaiFetch>,
+  url: string,
+): RequestInit | undefined {
+  return fetchMock.mock.calls.find(([input]) => input === url)?.[1];
+}
+
+async function runXaiCatalog(options: { auth?: "none"; apiKey?: false } = {}) {
+  const provider = await registerSingleProviderPlugin(plugin);
+  const result = await provider.catalog?.run({
+    config: { models: {} },
+    agentDir: "/agent",
+    workspaceDir: "/workspace",
+    env: {},
+    resolveProviderAuth: () =>
+      options.auth === "none"
+        ? { apiKey: undefined, discoveryApiKey: undefined, mode: "none", source: "none" }
+        : {
+            apiKey: undefined,
+            discoveryApiKey: "stale-oauth-token",
+            mode: "oauth",
+            source: "profile",
+            profileId: "xai-profile",
+          },
+    resolveProviderApiKey: () => ({
+      apiKey: options.apiKey === false ? undefined : "env-xai-key",
+      discoveryApiKey: options.apiKey === false ? undefined : "env-xai-key",
+    }),
+  });
+  if (!result || !("provider" in result)) {
+    throw new Error("expected xAI catalog provider result");
+  }
+  return { provider, result: result.provider };
+}
+
 describe("xai provider plugin", () => {
   beforeEach(() => {
     clearLiveCatalogCacheForTests();
@@ -186,14 +239,8 @@ describe("xai provider plugin", () => {
   });
 
   it("uses the Grok OAuth proxy catalog for xAI OAuth discovery", async () => {
-    providerAuthRuntimeMocks.resolveApiKeyForProvider.mockResolvedValue({
-      apiKey: "xai-oauth-token",
-      mode: "oauth",
-      source: "profile:xai-profile",
-      profileId: "xai-profile",
-    });
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    mockXaiRuntimeOAuth();
+    const fetchMock = stubXaiFetch((url) => {
       if (url.endsWith("/settings")) {
         return Response.json({ default_model: "grok-build" });
       }
@@ -222,39 +269,17 @@ describe("xai provider plugin", () => {
         ],
       });
     });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-    const provider = await registerSingleProviderPlugin(plugin);
+    const { provider, result } = await runXaiCatalog();
 
-    const result = await provider.catalog?.run({
-      config: { models: {} },
-      agentDir: "/agent",
-      workspaceDir: "/workspace",
-      env: {},
-      resolveProviderAuth: () => ({
-        apiKey: undefined,
-        discoveryApiKey: "stale-oauth-token",
-        mode: "oauth",
-        source: "profile",
-        profileId: "xai-profile",
-      }),
-      resolveProviderApiKey: () => ({
-        apiKey: "env-xai-key",
-        discoveryApiKey: "env-xai-key",
-      }),
-    });
-
-    if (!result || !("provider" in result)) {
-      throw new Error("expected xAI catalog provider result");
-    }
-    expect(result.provider.baseUrl).toBe("https://cli-chat-proxy.grok.com/v1");
-    expect(result.provider.auth).toBe("oauth");
-    expect(result.provider.apiKey).toBeUndefined();
-    expect(result.provider.models.map((model) => model.id)).toEqual([
+    expect(result.baseUrl).toBe("https://cli-chat-proxy.grok.com/v1");
+    expect(result.auth).toBe("oauth");
+    expect(result.apiKey).toBeUndefined();
+    expect(result.models.map((model) => model.id)).toEqual([
       "auto",
       "grok-composer-2.5-fast",
       "grok-build",
     ]);
-    const auto = result.provider.models.find((model) => model.id === "auto");
+    const auto = result.models.find((model) => model.id === "auto");
     expect(auto?.params?.canonicalModelId).toBe("grok-build");
     const normalizedAuto = provider.normalizeResolvedModel?.({
       provider: "xai",
@@ -262,12 +287,12 @@ describe("xai provider plugin", () => {
       model: { ...auto, provider: "xai" },
     } as never);
     expect(normalizedAuto?.id).toBe("grok-build");
-    const composer = result.provider.models.find((model) => model.id === "grok-composer-2.5-fast");
+    const composer = result.models.find((model) => model.id === "grok-composer-2.5-fast");
     if (!composer) {
       throw new Error("expected OAuth Composer model");
     }
     expect(composer.reasoning).toBe(true);
-    expect(result.provider.models.find((model) => model.id === "grok-build")?.reasoning).toBe(true);
+    expect(result.models.find((model) => model.id === "grok-build")?.reasoning).toBe(true);
     const normalizedComposer = provider.normalizeResolvedModel?.({
       provider: "xai",
       modelId: composer.id,
@@ -297,16 +322,15 @@ describe("xai provider plugin", () => {
       profileId: "xai-profile",
       lockedProfile: true,
     });
-    const modelFetchCall = fetchMock.mock.calls.find(
-      ([input]) => input === "https://cli-chat-proxy.grok.com/v1/models",
-    ) as unknown as [string, RequestInit] | undefined;
-    const settingsFetchCall = fetchMock.mock.calls.find(
-      ([input]) => input === "https://cli-chat-proxy.grok.com/v1/settings",
-    ) as unknown as [string, RequestInit] | undefined;
-    expect(new Headers(modelFetchCall?.[1]?.headers).get("Authorization")).toBe(
+    const modelFetchInit = findXaiFetchInit(fetchMock, "https://cli-chat-proxy.grok.com/v1/models");
+    const settingsFetchInit = findXaiFetchInit(
+      fetchMock,
+      "https://cli-chat-proxy.grok.com/v1/settings",
+    );
+    expect(new Headers(modelFetchInit?.headers).get("Authorization")).toBe(
       "Bearer xai-oauth-token",
     );
-    expect(new Headers(settingsFetchCall?.[1]?.headers).get("Authorization")).toBe(
+    expect(new Headers(settingsFetchInit?.headers).get("Authorization")).toBe(
       "Bearer xai-oauth-token",
     );
   });
@@ -347,44 +371,21 @@ describe("xai provider plugin", () => {
   });
 
   it("uses runtime OAuth profiles when xAI catalog auth resolution is empty", async () => {
-    providerAuthRuntimeMocks.resolveApiKeyForProvider.mockResolvedValue({
-      apiKey: "xai-oauth-token",
-      mode: "oauth",
-      source: "profile:xai-profile",
-      profileId: "xai-profile",
-    });
-    const fetchMock = vi.fn(async () =>
+    mockXaiRuntimeOAuth();
+    stubXaiFetch(() =>
       Response.json({
         data: [{ id: "grok-build", model: "grok-build", api_backend: "responses" }],
       }),
     );
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-    const provider = await registerSingleProviderPlugin(plugin);
-
-    const result = await provider.catalog?.run({
-      config: { models: {} },
-      agentDir: "/agent",
-      workspaceDir: "/workspace",
-      env: {},
-      resolveProviderAuth: () => ({
-        apiKey: undefined,
-        discoveryApiKey: undefined,
-        mode: "none",
-        source: "none",
-      }),
-      resolveProviderApiKey: () => ({
-        apiKey: undefined,
-        discoveryApiKey: undefined,
-      }),
+    const { result } = await runXaiCatalog({
+      auth: "none",
+      apiKey: false,
     });
 
-    if (!result || !("provider" in result)) {
-      throw new Error("expected xAI catalog provider result");
-    }
-    expect(result.provider.baseUrl).toBe("https://cli-chat-proxy.grok.com/v1");
-    expect(result.provider.auth).toBe("oauth");
-    expect(result.provider.models.map((model) => model.id)).toEqual(["auto", "grok-build"]);
-    expect(result.provider.models[0]?.params?.canonicalModelId).toBe("grok-build");
+    expect(result.baseUrl).toBe("https://cli-chat-proxy.grok.com/v1");
+    expect(result.auth).toBe("oauth");
+    expect(result.models.map((model) => model.id)).toEqual(["auto", "grok-build"]);
+    expect(result.models[0]?.params?.canonicalModelId).toBe("grok-build");
     expect(providerAuthRuntimeMocks.resolveApiKeyForProvider).toHaveBeenCalledWith({
       provider: "xai",
       cfg: { models: {} },
@@ -394,120 +395,51 @@ describe("xai provider plugin", () => {
   });
 
   it("keeps the Grok OAuth transport when xAI OAuth discovery is unavailable", async () => {
-    providerAuthRuntimeMocks.resolveApiKeyForProvider.mockResolvedValue({
-      apiKey: "xai-oauth-token",
-      mode: "oauth",
-      source: "profile:xai-profile",
-      profileId: "xai-profile",
-    });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () => new Response("temporarily unavailable", { status: 503 }),
-      ) as unknown as typeof fetch,
-    );
-    const provider = await registerSingleProviderPlugin(plugin);
+    mockXaiRuntimeOAuth();
+    stubXaiFetch(() => new Response("temporarily unavailable", { status: 503 }));
+    const { result } = await runXaiCatalog();
 
-    const result = await provider.catalog?.run({
-      config: { models: {} },
-      agentDir: "/agent",
-      workspaceDir: "/workspace",
-      env: {},
-      resolveProviderAuth: () => ({
-        apiKey: undefined,
-        discoveryApiKey: "stale-oauth-token",
-        mode: "oauth",
-        source: "profile",
-        profileId: "xai-profile",
-      }),
-      resolveProviderApiKey: () => ({
-        apiKey: "env-xai-key",
-        discoveryApiKey: "env-xai-key",
-      }),
-    });
-
-    if (!result || !("provider" in result)) {
-      throw new Error("expected xAI catalog provider result");
-    }
-    expect(result.provider.baseUrl).toBe("https://cli-chat-proxy.grok.com/v1");
-    expect(result.provider.auth).toBe("oauth");
-    expect(result.provider.apiKey).toBeUndefined();
-    expect(result.provider.models.map((model) => model.id)).toContain("auto");
-    expect(result.provider.models.map((model) => model.id)).toContain("grok-build-0.1");
+    expect(result.baseUrl).toBe("https://cli-chat-proxy.grok.com/v1");
+    expect(result.auth).toBe("oauth");
+    expect(result.apiKey).toBeUndefined();
+    expect(result.models.map((model) => model.id)).toContain("auto");
+    expect(result.models.map((model) => model.id)).toContain("grok-build-0.1");
   });
 
   it("falls back to API-key discovery when xAI OAuth credential resolution fails", async () => {
     providerAuthRuntimeMocks.resolveApiKeyForProvider.mockRejectedValue(
       new Error("expired oauth profile"),
     );
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = stubXaiFetch(() =>
       Response.json({
         data: [{ id: "grok-4.3", object: "model" }],
       }),
     );
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-    const provider = await registerSingleProviderPlugin(plugin);
+    const { result } = await runXaiCatalog();
 
-    const result = await provider.catalog?.run({
-      config: { models: {} },
-      agentDir: "/agent",
-      workspaceDir: "/workspace",
-      env: {},
-      resolveProviderAuth: () => ({
-        apiKey: undefined,
-        discoveryApiKey: "stale-oauth-token",
-        mode: "oauth",
-        source: "profile",
-        profileId: "xai-profile",
-      }),
-      resolveProviderApiKey: () => ({
-        apiKey: "env-xai-key",
-        discoveryApiKey: "env-xai-key",
-      }),
-    });
-
-    if (!result || !("provider" in result)) {
-      throw new Error("expected xAI catalog provider result");
-    }
-    expect(result.provider.baseUrl).toBe("https://api.x.ai/v1");
-    expect(result.provider.apiKey).toBe("env-xai-key");
-    expect(result.provider.auth).toBeUndefined();
-    expect(result.provider.models.map((model) => model.id)).toEqual(["grok-4.3"]);
-    expect(result.provider.models.some((model) => model.id === "auto")).toBe(false);
-    const fetchCall = fetchMock.mock.calls[0] as unknown as [string, RequestInit] | undefined;
-    expect(fetchCall?.[0]).toBe("https://api.x.ai/v1/models");
-    expect(new Headers(fetchCall?.[1]?.headers).get("Authorization")).toBe("Bearer env-xai-key");
+    expect(result.baseUrl).toBe("https://api.x.ai/v1");
+    expect(result.apiKey).toBe("env-xai-key");
+    expect(result.auth).toBeUndefined();
+    expect(result.models.map((model) => model.id)).toEqual(["grok-4.3"]);
+    expect(result.models.some((model) => model.id === "auto")).toBe(false);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.x.ai/v1/models");
+    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("Authorization")).toBe(
+      "Bearer env-xai-key",
+    );
   });
 
   it("uses fallback API-key credentials consistently for xAI live discovery", async () => {
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = stubXaiFetch(() =>
       Response.json({
         data: [{ id: "grok-4.3", object: "model" }],
       }),
     );
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-    const provider = await registerSingleProviderPlugin(plugin);
+    const { result } = await runXaiCatalog({ auth: "none" });
 
-    const result = await provider.catalog?.run({
-      resolveProviderAuth: () => ({
-        apiKey: undefined,
-        discoveryApiKey: undefined,
-        mode: "none",
-        source: "none",
-      }),
-      resolveProviderApiKey: () => ({
-        apiKey: "env-xai-key",
-        discoveryApiKey: "env-xai-key",
-      }),
-    } as never);
-
-    if (!result || !("provider" in result)) {
-      throw new Error("expected xAI catalog provider result");
-    }
-    expect(result.provider.apiKey).toBe("env-xai-key");
-    const fetchCall = fetchMock.mock.calls[0] as unknown as [string, RequestInit] | undefined;
-    const fetchInit = fetchCall?.[1];
-    expect(new Headers(fetchInit?.headers).get("Authorization")).toBe("Bearer env-xai-key");
+    expect(result.apiKey).toBe("env-xai-key");
+    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("Authorization")).toBe(
+      "Bearer env-xai-key",
+    );
   });
 
   it("classifies Grok usage and spending limit errors", async () => {


### PR DESCRIPTION
## Summary
- centralize repeated xAI catalog discovery context and OAuth runtime fixtures
- centralize fetch stubbing while preserving all catalog assertions and test titles
- leave production behavior and realtime-voice coverage unchanged

## Testing
- Blacksmith focused: pnpm test extensions/xai/index.test.ts (44 passed)
- Blacksmith changed gate: node scripts/check-changed.mjs -- extensions/xai/index.test.ts
- autoreview: clean (0.99)