### PR TITLE
improve(tests): narrow shared runner resets

### DIFF
--- a/src/agents/embedded-agent-runner/run.before-agent-finalize.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-finalize.test-support.ts
@@ -11,7 +11,7 @@ import {
   mockedRunEmbeddedAttempt,
   mockedSleepWithAbort,
   overflowBaseRunParams,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
   useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
@@ -78,7 +78,7 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
   });
 
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
     useOpenAIPlatformAuthFixture();
     mockedGlobalHookRunner.hasHooks.mockImplementation(
       (hookName: string) => hookName === "before_agent_finalize",

--- a/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test-support.ts
@@ -6,7 +6,7 @@ import {
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
@@ -54,7 +54,7 @@ describe("runEmbeddedAgent before_agent_reply seam", () => {
   });
 
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
   });
 
   it("lets before_agent_reply claim cron runs before the embedded attempt starts", async () => {

--- a/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test-support.ts
@@ -9,7 +9,7 @@ import {
   mockedMarkAuthProfileFailure,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 import { hasCodexAppServerRecoveryRetryBudget } from "./run/codex-app-server-recovery.js";
@@ -98,7 +98,7 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
   });
 
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
     mockedClassifyFailoverReason.mockReturnValue(null);
   });
 

--- a/src/agents/embedded-agent-runner/run.codex-server-error-fallback.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.codex-server-error-fallback.test-support.ts
@@ -11,7 +11,7 @@ import {
   mockedIsFailoverAssistantError,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
   useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
@@ -24,7 +24,7 @@ describe("runEmbeddedAgent Codex server_error fallback handoff", () => {
   });
 
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
     useOpenAIPlatformAuthFixture();
     mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
   });

--- a/src/agents/embedded-agent-runner/run.compaction-loop-guard.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.compaction-loop-guard.test-support.ts
@@ -25,7 +25,7 @@ import {
   mockedIsCompactionFailureError,
   mockedIsLikelyContextOverflowError,
   mockedRunEmbeddedAttempt,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
@@ -111,7 +111,7 @@ describe("post-compaction loop guard wired into runEmbeddedAgent", () => {
   beforeEach(() => {
     liveToolCallSeq = 0;
     diagnosticSessionStates.clear();
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
     mockedIsCompactionFailureError.mockImplementation((msg?: string) => {
       if (!msg) {
         return false;

--- a/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test-support.ts
@@ -15,7 +15,7 @@ import {
   mockedRunEmbeddedAttempt,
   mockedResolveAuthProfileOrder,
   overflowBaseRunParams,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
   warmRunOverflowCompactionHarness,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
@@ -174,7 +174,7 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
   });
 
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
     useCrossProviderAuthFixture();
     mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
   });

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test-support.ts
@@ -10,7 +10,7 @@ import {
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 import { buildEmbeddedRunPayloads as realBuildEmbeddedRunPayloads } from "./run/payloads.js";
@@ -67,7 +67,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
   });
 
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
     mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
     mockedClassifyFailoverReason.mockReturnValue(null);
   });

--- a/src/agents/embedded-agent-runner/run.fast-mode-auto.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.fast-mode-auto.test-support.ts
@@ -11,7 +11,7 @@ import {
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
@@ -57,7 +57,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
   });
 
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
     mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
     mockedClassifyFailoverReason.mockReturnValue(null);
   });

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -668,7 +668,10 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
   runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
 }> {
   resetRunOverflowCompactionHarnessMocks();
-  vi.resetModules();
+
+  // This harness has one aggregate consumer, which references run.js only as a
+  // type before this loader. Resetting the worker graph here recompiles every
+  // runner dependency without changing which module instance the mocks own.
 
   vi.doMock("../../plugins/hook-runner-global.js", () => ({
     getGlobalHookRunner: vi.fn(() => mockedGlobalHookRunner),

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -447,10 +447,7 @@ export const overflowBaseRunParams = {
   runId: "run-1",
 } as const;
 
-/** Reset every mocked runner dependency to the default successful no-op state. */
-export function resetRunOverflowCompactionHarnessMocks(): void {
-  vi.unstubAllEnvs();
-  resetCommandQueueStateForTest();
+function resetMockAgentHarness(): void {
   clearAgentHarnesses();
   registerAgentHarness({
     id: "codex",
@@ -472,6 +469,13 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
       return { assistant, ...(result.attemptUsage ? { usage: result.attemptUsage } : {}) };
     },
   });
+}
+
+/** Reset every mocked runner dependency to the default successful no-op state. */
+export function resetRunOverflowCompactionHarnessMocks(): void {
+  vi.unstubAllEnvs();
+  resetCommandQueueStateForTest();
+  resetMockAgentHarness();
   mockedGlobalHookRunner.hasHooks.mockReset();
   mockedGlobalHookRunner.hasHooks.mockReturnValue(false);
   mockedGlobalHookRunner.runBeforeAgentReply.mockReset();
@@ -663,15 +667,86 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedSleepWithAbort.mockResolvedValue(undefined);
 }
 
+/** Reset only the seams mutated by the shared public-entry integration suites. */
+export function resetSharedRunIntegrationHarnessMocks(): void {
+  vi.unstubAllEnvs();
+  resetCommandQueueStateForTest();
+  resetMockAgentHarness();
+
+  mockedBuildEmbeddedRunPayloads.mockReset();
+  mockedBuildEmbeddedRunPayloads.mockReturnValue([]);
+  mockedClassifyFailoverReason.mockReset();
+  mockedClassifyFailoverReason.mockReturnValue(null);
+  mockedClassifyAssistantFailoverReason.mockReset();
+  mockedClassifyAssistantFailoverReason.mockImplementation(
+    (assistant?: { errorMessage?: string | null }): FailoverReason | null =>
+      mockedClassifyFailoverReason(assistant?.errorMessage ?? ""),
+  );
+  mockedCompactDirect.mockReset();
+  mockedCompactDirect.mockResolvedValue({
+    ok: false,
+    compacted: false,
+    reason: "nothing to compact",
+  });
+  mockedEnsureAuthProfileStore.mockReset();
+  mockedEnsureAuthProfileStore.mockReturnValue({ version: 1, profiles: {} });
+  mockedEnsureAuthProfileStoreWithoutExternalProfiles.mockReset();
+  mockedEnsureAuthProfileStoreWithoutExternalProfiles.mockReturnValue({
+    version: 1,
+    profiles: {},
+  });
+  mockedFormatAssistantErrorText.mockReset();
+  mockedFormatAssistantErrorText.mockReturnValue("");
+  mockedGetApiKeyForModel.mockReset();
+  mockedGetApiKeyForModel.mockImplementation(
+    async ({ profileId }: MockGetApiKeyForModelParams = {}) => ({
+      apiKey: "test-key",
+      profileId: profileId ?? "test-profile",
+      source: "test",
+      mode: "api-key",
+    }),
+  );
+  mockedGlobalHookRunner.hasHooks.mockReset();
+  mockedGlobalHookRunner.hasHooks.mockReturnValue(false);
+  mockedGlobalHookRunner.runBeforeAgentReply.mockReset();
+  mockedGlobalHookRunner.runBeforeAgentReply.mockResolvedValue(undefined);
+  mockedIsCompactionFailureError.mockReset();
+  mockedIsCompactionFailureError.mockReturnValue(false);
+  mockedIsFailoverAssistantError.mockReset();
+  mockedIsFailoverAssistantError.mockReturnValue(false);
+  mockedIsLikelyContextOverflowError.mockReset();
+  mockedIsLikelyContextOverflowError.mockImplementation((msg?: string) => {
+    const lower = normalizeLowercaseStringOrEmpty(msg ?? "");
+    return (
+      lower.includes("request_too_large") ||
+      lower.includes("context window exceeded") ||
+      (lower.includes("context window") && lower.includes("ran out of room")) ||
+      lower.includes("prompt is too long")
+    );
+  });
+  mockedIsRateLimitAssistantError.mockReset();
+  mockedIsRateLimitAssistantError.mockReturnValue(false);
+  mockedResolveAuthProfileOrder.mockReset();
+  mockedResolveAuthProfileOrder.mockReturnValue([]);
+  mockedResolveModelAsync.mockReset();
+  mockedResolveModelAsync.mockImplementation(
+    async (provider?: string, modelId?: string, _agentDir?: string, cfg?: unknown) =>
+      createMockResolvedModel(provider, modelId, cfg),
+  );
+  mockedRunEmbeddedAttempt.mockReset();
+
+  mockedAcquireAgentRunPreparedModelRuntime.mockClear();
+  mockedLog.warn.mockClear();
+  mockedMarkAuthProfileFailure.mockClear();
+  mockedSleepWithAbort.mockClear();
+}
+
 /** Install module mocks, import the runner, and return the mocked entrypoint. */
 export async function loadRunOverflowCompactionHarness(): Promise<{
   runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
 }> {
   resetRunOverflowCompactionHarnessMocks();
-
-  // This harness has one aggregate consumer, which references run.js only as a
-  // type before this loader. Resetting the worker graph here recompiles every
-  // runner dependency without changing which module instance the mocks own.
+  vi.resetModules();
 
   vi.doMock("../../plugins/hook-runner-global.js", () => ({
     getGlobalHookRunner: vi.fn(() => mockedGlobalHookRunner),

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -472,7 +472,7 @@ function resetMockAgentHarness(): void {
 }
 
 /** Reset every mocked runner dependency to the default successful no-op state. */
-export function resetRunOverflowCompactionHarnessMocks(): void {
+function resetRunOverflowCompactionHarnessMocks(): void {
   vi.unstubAllEnvs();
   resetCommandQueueStateForTest();
   resetMockAgentHarness();

--- a/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
@@ -7,7 +7,7 @@ import {
   mockedClassifyFailoverReason,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
   useOpenAIPlatformAuthFixture,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
@@ -20,7 +20,7 @@ describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
   });
 
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
     useOpenAIPlatformAuthFixture();
   });
 

--- a/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test-support.ts
@@ -7,7 +7,7 @@ import {
   mockedResolveAuthProfileOrder,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 
@@ -34,7 +34,7 @@ describe("runEmbeddedAgent timeout recovery composition", () => {
   });
 
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
   });
 
   it("adopts a compacted transcript and retries with the complete runtime context", async () => {

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test-support.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test-support.ts
@@ -10,7 +10,7 @@ import {
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 import { isEmbeddedAgentRunActive, queueEmbeddedAgentMessageWithOutcome } from "./runs.js";
@@ -23,7 +23,7 @@ describe("sessions_yield orchestration", () => {
   });
 
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
     mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
   });
 

--- a/src/agents/embedded-agent-runner/usage-reporting.test-support.ts
+++ b/src/agents/embedded-agent-runner/usage-reporting.test-support.ts
@@ -7,7 +7,7 @@ import {
   mockedAcquireAgentRunPreparedModelRuntime,
   mockedResolveModelAsync,
   mockedRunEmbeddedAttempt,
-  resetRunOverflowCompactionHarnessMocks,
+  resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
@@ -48,7 +48,7 @@ describe("runEmbeddedAgent usage reporting", () => {
   });
 
   beforeEach(() => {
-    resetRunOverflowCompactionHarnessMocks();
+    resetSharedRunIntegrationHarnessMocks();
   });
 
   it("bootstraps runtime plugins with the resolved workspace before running", async () => {


### PR DESCRIPTION
## What Problem This Solves

The shared embedded-runner integration suite spent 428.935 seconds running 111 mocked orchestration scenarios. Named test bodies account for about 93.2 seconds; the remaining 335.7 seconds is predominantly per-case fixture and hook work. Every case reset 62 mock seams even though these twelve suites mutate only 17 of them.

## Why This Change Was Made

Keep the required module reset, dynamic mocks, warmup, all 111 scenarios, and per-case isolation. Add a shared-suite reset that restores only the 17 mutable seams and clears four assertion-only histories. Environment stubs, command queues, harness registration, diagnostics, timers, and events continue to reset at their existing ownership boundaries.

## User Impact

No runtime or user-visible behavior changes. The same integration coverage executes with substantially less unrelated mock cleanup.

## Evidence

- Baseline: 111/111 tests, 428.935s file time in exact full run [30782354057](https://github.com/openclaw/openclaw/actions/runs/30782354057), [job 91589453611](https://github.com/openclaw/openclaw/actions/runs/30782354057/job/91589453611).
- Named test bodies total about 93.2s; the remaining 335.7s belongs predominantly to fixture/hooks.
- Per-case mock resets: 62 -> 17, removing about 4,995 unnecessary reset operations across 111 cases; four assertion-only mocks retain call-history clearing.
- All 111 scenarios, queue cleanup, env cleanup, harness restoration, diagnostic cleanup, timer cleanup, and event cleanup remain unchanged.
- Thirteen test-support files, production LOC delta: 0.
- Formatting, targeted Oxlint, `git diff --check`, and autoreview are clean.
- An initial experiment confirmed the module reset is required for cached auth-module identity; the current head restores that boundary.
- Fresh current-head PR CI is the execution and timing authority because the linked worktree has no dependency install.
- Full compact proof on the reset patch: 111/111 shared scenarios passed; shared file 428.935s -> 212.089s, saving 216.846s (50.6%). The complete embedded base config improved 533.54s -> 247.37s, saving 286.17s (53.6%) ([run 30784990040](https://github.com/openclaw/openclaw/actions/runs/30784990040), [job 91596857003](https://github.com/openclaw/openclaw/actions/runs/30784990040/job/91596857003)).
