### PR TITLE
fix(agents): reject error-only subagent completion delivery

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1072,6 +1072,22 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expectsMessageToolMode: false,
     },
     {
+      name: "directly delivers direct-message subagent text when the announce agent only reports a tool error",
+      payloads: [{ text: "Yield failed before completion.", isError: true }],
+      event: { childSessionId: "child-session-id" },
+      content: "child completion output",
+      fullTarget: true,
+      expectsMessageToolMode: true,
+    },
+    {
+      name: "directly delivers direct-message subagent text when the announce agent only emits reasoning",
+      payloads: [{ text: "Waiting for the delegated task.", isReasoning: true }],
+      event: { childSessionId: "child-session-id" },
+      content: "child completion output",
+      fullTarget: true,
+      expectsMessageToolMode: true,
+    },
+    {
       name: "directly delivers direct-message subagent text when the announce agent omits the result",
       payloads: [{ text: "TG88042_NO_REOUTPUT" }],
       event: { childSessionId: "child-session-id", result: "TG88042_CHILD" },
@@ -1353,6 +1369,14 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
   it.each([
     { name: "no payloads", result: { payloads: [] } },
     {
+      name: "only a failed-tool warning",
+      result: { payloads: [{ text: "Yield failed before completion.", isError: true }] },
+    },
+    {
+      name: "only hidden reasoning",
+      result: { payloads: [{ text: "Waiting for the delegated task.", isReasoning: true }] },
+    },
+    {
       name: "attachment payload without a usable media reference",
       result: { payloads: [{ attachments: [{}] }] },
     },
@@ -1397,6 +1421,56 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         channel: undefined,
         to: undefined,
         bestEffortDeliver: true,
+      });
+    },
+  );
+
+  it.each([
+    {
+      name: "only a failed-tool warning",
+      payloads: [{ text: "Yield failed before completion.", isError: true }],
+      delivered: false,
+    },
+    {
+      name: "only hidden reasoning",
+      payloads: [{ text: "Waiting for the delegated task.", isReasoning: true }],
+      delivered: false,
+    },
+    {
+      name: "a failed-tool warning and a successful visible reply",
+      payloads: [
+        { text: "Yield failed before completion.", isError: true },
+        { text: "The delegated task completed." },
+      ],
+      delivered: true,
+    },
+    {
+      name: "hidden reasoning and a successful visible reply",
+      payloads: [
+        { text: "Waiting for the delegated task.", isReasoning: true },
+        { text: "The delegated task completed." },
+      ],
+      delivered: true,
+    },
+  ])(
+    "requires a successful visible grouped completion reply when the agent returns $name",
+    async ({ payloads, delivered }) => {
+      const callGateway = createGatewayMock({ result: { payloads } });
+      const result = await deliverSlackThreadAnnouncement({
+        callGateway,
+        directIdempotencyKey: "announce-thread-completion-payload-visibility",
+        sourceTool: "agent_harness_task",
+      });
+
+      expectRecordFields(result, {
+        delivered,
+        path: "direct",
+        ...(!delivered
+          ? {
+              reason: "visible_reply_missing",
+              error: "completion agent did not produce a visible reply",
+            }
+          : {}),
       });
     },
   );
@@ -1491,6 +1565,24 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       result: {
         payloads: [],
         successfulCronAdds: 1,
+      },
+    },
+    {
+      name: "a successful visible reply alongside a failed-tool warning",
+      result: {
+        payloads: [
+          { text: "Yield failed before completion.", isError: true },
+          { text: "The delegated task completed." },
+        ],
+      },
+    },
+    {
+      name: "a successful visible reply alongside hidden reasoning",
+      result: {
+        payloads: [
+          { text: "Waiting for the delegated task.", isReasoning: true },
+          { text: "The delegated task completed." },
+        ],
       },
     },
   ])("accepts session-only completion handoff with $name evidence", async ({ result }) => {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1065,9 +1065,14 @@ async function sendSubagentAnnounceDirectly(params: {
       directAnnounceResult &&
       hasMessagingToolDeliveryToSource(directAnnounceResult, deliveryTarget),
     );
+    const completionPayloadVisibility = {
+      includeErrorPayloads: false,
+      includeReasoningPayloads: false,
+    };
     const hasVisibleGatewayPayload = Boolean(
       directAnnounceResult &&
-      (hasVisibleAgentPayload(directAnnounceResult) || hasMessagingToolDelivery),
+      (hasVisibleAgentPayload(directAnnounceResult, completionPayloadVisibility) ||
+        hasMessagingToolDelivery),
     );
     const hasIntentionalSilentCompletionReply = Boolean(
       directAnnounceResult && hasIntentionalSilentAgentPayload(directAnnounceResult),
@@ -1122,7 +1127,10 @@ async function sendSubagentAnnounceDirectly(params: {
     const hasVisibleCompletionReply = Boolean(
       directAnnounceResult &&
       (hasMessagingToolDelivery ||
-        hasVisibleAgentPayload(directAnnounceResult, { includeSilentReplyPayloads: false })),
+        hasVisibleAgentPayload(directAnnounceResult, {
+          ...completionPayloadVisibility,
+          includeSilentReplyPayloads: false,
+        })),
     );
     const hasCompletionSideEffect = Boolean(
       directAnnounceResult && hasCommittedOutboundDeliveryEvidence(directAnnounceResult),


### PR DESCRIPTION
## What Problem This Solves

Subagent session and grouped completion delivery counted error-only or reasoning-only parent responses as successful visible completions. Durable delivery could falsely claim success without an actual answer.

## Why This Change Was Made

Both completion visibility decisions now apply the error/reasoning exclusions already enforced by the canonical delivery-evidence owner. Successful replies, message-tool receipts, intentional silence, mixed payloads, and direct-message recovery keep existing semantics.

## User Impact

Subagent completion no longer silently treats an error-only or reasoning-only response as a successful user-visible answer.

## Real Gateway / Subagent Runtime Proof

The exact committed delivery owner was exercised against a genuine isolated Gateway with a real authenticated WebSocket connection, real Gateway `agent` RPC dispatch/admission, and three deterministic model-boundary responses:

```text
error-only parent payload -> delivered: false, reason: visible_reply_missing, actual Gateway agent dispatches: 1
reasoning-only parent payload -> delivered: false, reason: visible_reply_missing, actual Gateway agent dispatches: 1
mixed error + reasoning + successful reply -> delivered: true, actual Gateway agent dispatches: 1
duplicate dispatches: 0
real Gateway/subagent runtime scenario: 1/1 passed
```

The Gateway transport, admission, requester routing, and completion owner were real; only the external model-generation response was fixed for deterministic coverage. Testbox run: https://github.com/openclaw/openclaw/actions/runs/30785523517

## Regression Evidence

- Red-first owner proof: four session/group regressions failed before repair.
- node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts — 118/118 passing.
- Intentional silence, mixed real reply, message-tool evidence, and protected direct-message recovery remain covered.
- Exact-head hosted CI and openclaw/ci-gate passed.
- Independent structured Sol/high review clean, confidence 0.94; production +8 lines.
- ClawSweeper rank-up satisfied by actual Gateway runtime output above; this separate repair does not claim to solve the distinct live direct-message requester-wake issue.
- No auth, configuration, routing-security, or public-contract changes.
- AI-assisted implementation and independently verified source review.
