### PR TITLE
fix(chat): restore active turns after navigation and reconnect

### DIFF
--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../infra/agent-run-registry.js";
+import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import {
   abortChatRunById,
   abortChatRunsForProvider,
@@ -949,5 +950,41 @@ describe("resolveInFlightRunSnapshot", () => {
         maxBytes: 200,
       }),
     ).toEqual({ runId: "run-1", text: "short answer", plan: { steps: [] } });
+  });
+
+  it("prioritizes active progress and explicitly clears budget-dropped projections", () => {
+    const event = {
+      runId: "run-1",
+      seq: 2,
+      stream: "tool" as const,
+      ts: 1_000,
+      data: { phase: "start", name: "read", toolCallId: "tool-1", args: {} },
+    };
+    const expected = {
+      runId: "run-1",
+      text: "",
+      events: [event],
+      plan: { steps: [] },
+    };
+    expect(
+      boundInFlightRunSnapshotForChatHistory({
+        snapshot: {
+          runId: "run-1",
+          text: "x".repeat(1_000),
+          events: [event],
+          plan: { steps: [{ step: "y".repeat(1_000), status: "in_progress" }] },
+        },
+        messages: [],
+        maxBytes: jsonUtf8Bytes([]) + jsonUtf8Bytes(expected),
+      }),
+    ).toEqual(expected);
+
+    expect(
+      boundInFlightRunSnapshotForChatHistory({
+        snapshot: { runId: "run-1", text: "", events: [event] },
+        messages: [],
+        maxBytes: jsonUtf8Bytes([]) + jsonUtf8Bytes({ runId: "run-1", text: "", events: [] }),
+      }),
+    ).toEqual({ runId: "run-1", text: "", events: [] });
   });
 });

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -10,7 +10,11 @@ import { createAgentRunRestartAbortError } from "../agents/run-termination.js";
 import { readToolValidationErrorSummary } from "../agents/tool-error-summary.js";
 import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { emitAgentEvent, getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
+import {
+  emitAgentEvent,
+  getAgentEventLifecycleGeneration,
+  type AgentEventPayload,
+} from "../infra/agent-events.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
@@ -79,6 +83,13 @@ export type RestartRecoveryCandidate = {
   sessionKey: string;
   sessionId: string;
   observedAt?: number;
+};
+
+type InFlightRunSnapshot = {
+  runId: string;
+  text: string;
+  plan?: ChatRunPlanSnapshot;
+  events?: AgentEventPayload[];
 };
 
 type RegisteredChatAbortController = {
@@ -269,7 +280,7 @@ export function resolveInFlightRunSnapshot(params: {
   canonicalSessionKey: string;
   agentId?: string;
   defaultAgentId?: string;
-}): { runId: string; text: string; plan?: ChatRunPlanSnapshot } | undefined {
+}): InFlightRunSnapshot | undefined {
   const matchesKey = (entry: ChatAbortControllerEntry, key: string): boolean => {
     if (entry.sessionKey !== key) {
       return false;
@@ -335,18 +346,20 @@ export function resolveInFlightRunSnapshot(params: {
     { suppressLeadFragments: true },
   );
   const plan = run?.planSnapshot;
+  const events = run?.progressSnapshot?.events;
   return {
     runId: best.runId,
     text: projected.suppress ? "" : projected.text,
     ...(plan ? { plan } : {}),
+    ...(events?.length ? { events } : {}),
   };
 }
 
 export function boundInFlightRunSnapshotForChatHistory(params: {
-  snapshot: { runId: string; text: string; plan?: ChatRunPlanSnapshot } | undefined;
+  snapshot: InFlightRunSnapshot | undefined;
   messages: unknown[];
   maxBytes: number;
-}): { runId: string; text: string; plan?: ChatRunPlanSnapshot } | undefined {
+}): InFlightRunSnapshot | undefined {
   if (!params.snapshot) {
     return undefined;
   }
@@ -355,30 +368,42 @@ export function boundInFlightRunSnapshotForChatHistory(params: {
   if (messagesBytes + snapshotBytes <= params.maxBytes) {
     return params.snapshot;
   }
-  // Recovery priority is run adoption, then plan replay, then opportunistic text.
-  const withoutText = {
+  // Recovery priority is run adoption, then active progress, plan replay, and
+  // opportunistic text. Explicit empty projections authoritatively clear any
+  // stale client state when a richer snapshot cannot fit the history budget.
+  let bounded: InFlightRunSnapshot = {
     runId: params.snapshot.runId,
     text: "",
-    ...(params.snapshot.plan ? { plan: params.snapshot.plan } : {}),
+    ...(params.snapshot.events ? { events: [] } : {}),
+    ...(params.snapshot.plan ? { plan: { steps: [] } } : {}),
   };
-  if (params.snapshot.plan && messagesBytes + jsonUtf8Bytes(withoutText) <= params.maxBytes) {
-    return withoutText;
+
+  if (params.snapshot.events) {
+    const events = [...params.snapshot.events];
+    while (events.length > 0) {
+      const candidate = { ...bounded, events };
+      if (messagesBytes + jsonUtf8Bytes(candidate) <= params.maxBytes) {
+        bounded = candidate;
+        break;
+      }
+      events.shift();
+    }
   }
-  // An oversized plan must not also cost the deliverable buffered text. Clients
-  // treat an ABSENT plan as legacy-gateway unknown and preserve retained state,
-  // so a budget-dropped plan is sent as an explicit empty snapshot (authoritative
-  // clear) — accepted tradeoff: the checklist blanks until the next live plan
-  // event instead of showing a possibly obsolete retained plan indefinitely.
-  const droppedPlan = params.snapshot.plan ? { plan: { steps: [] } } : {};
-  const withoutPlan = {
-    runId: params.snapshot.runId,
-    text: params.snapshot.text,
-    ...droppedPlan,
-  };
-  if (params.snapshot.text && messagesBytes + jsonUtf8Bytes(withoutPlan) <= params.maxBytes) {
-    return withoutPlan;
+
+  if (params.snapshot.plan) {
+    const candidate = { ...bounded, plan: params.snapshot.plan };
+    if (messagesBytes + jsonUtf8Bytes(candidate) <= params.maxBytes) {
+      bounded = candidate;
+    }
   }
-  return { runId: params.snapshot.runId, text: "", ...droppedPlan };
+
+  if (params.snapshot.text) {
+    const candidate = { ...bounded, text: params.snapshot.text };
+    if (messagesBytes + jsonUtf8Bytes(candidate) <= params.maxBytes) {
+      bounded = candidate;
+    }
+  }
+  return bounded;
 }
 
 export type ChatAbortOps = {

--- a/src/gateway/server-chat-progress-snapshot.ts
+++ b/src/gateway/server-chat-progress-snapshot.ts
@@ -1,0 +1,125 @@
+import type { AgentEventPayload } from "../infra/agent-events.js";
+import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+
+const CHAT_RUN_PROGRESS_MAX_EVENTS = 50;
+const CHAT_RUN_PROGRESS_MAX_BYTES = 128 * 1024;
+const CHAT_RUN_PROGRESS_MAX_EVENT_BYTES = 64 * 1024;
+
+export type ChatRunProgressSnapshot = {
+  events: AgentEventPayload[];
+  byteLength: number;
+  lastSeq: number;
+};
+
+export function updateChatRunProgressSnapshot(
+  snapshot: ChatRunProgressSnapshot | undefined,
+  event: AgentEventPayload,
+): ChatRunProgressSnapshot | undefined {
+  const data = event.data ?? {};
+  const phase = typeof data.phase === "string" ? data.phase : "";
+  const toolCallId = typeof data.toolCallId === "string" ? data.toolCallId.trim() : "";
+  const preambleItemId =
+    typeof data.itemId === "string" && data.itemId.trim()
+      ? data.itemId.trim()
+      : typeof data.id === "string" && data.id.trim()
+        ? data.id.trim()
+        : "";
+  const isTool =
+    event.stream === "tool" && Boolean(toolCallId) && ["start", "update", "result"].includes(phase);
+  const isPreamble = event.stream === "item" && data.kind === "preamble";
+  if (!isTool && !isPreamble) {
+    return snapshot;
+  }
+
+  const next = snapshot ?? { events: [], byteLength: 0, lastSeq: 0 };
+  // Agent events are run-sequenced. Reject delayed duplicates so reconnect
+  // state cannot resurrect a tool that a newer result already completed.
+  if (event.seq <= next.lastSeq) {
+    return next;
+  }
+  next.lastSeq = event.seq;
+
+  const removeWhere = (predicate: (candidate: AgentEventPayload) => boolean) => {
+    next.events = next.events.filter((candidate) => {
+      if (!predicate(candidate)) {
+        return true;
+      }
+      next.byteLength -= jsonUtf8Bytes(candidate);
+      return false;
+    });
+  };
+
+  if (isTool) {
+    removeWhere((candidate) => {
+      if (candidate.stream !== "tool" || candidate.data?.toolCallId !== toolCallId) {
+        return false;
+      }
+      return phase !== "update" || candidate.data?.phase === "update";
+    });
+    if (phase === "result") {
+      return next;
+    }
+  } else {
+    const progressText = typeof data.progressText === "string" ? data.progressText.trim() : "";
+    if (!progressText) {
+      if (preambleItemId) {
+        removeWhere((candidate) => {
+          if (candidate.stream !== "item" || candidate.data?.kind !== "preamble") {
+            return false;
+          }
+          return candidate.data.itemId === preambleItemId;
+        });
+      }
+      return next;
+    }
+    removeWhere((candidate) => candidate.stream === "item" && candidate.data?.kind === "preamble");
+  }
+
+  const storedData: Record<string, unknown> = isTool
+    ? {
+        phase,
+        ...(typeof data.name === "string" ? { name: data.name } : {}),
+        toolCallId,
+        ...(phase === "start" && Object.hasOwn(data, "args") ? { args: data.args } : {}),
+        ...(phase === "update" && Object.hasOwn(data, "partialResult")
+          ? { partialResult: data.partialResult }
+          : {}),
+      }
+    : {
+        kind: "preamble",
+        ...(preambleItemId ? { itemId: preambleItemId } : {}),
+        progressText: data.progressText,
+      };
+  let storedEvent: AgentEventPayload = {
+    runId: event.runId,
+    seq: event.seq,
+    stream: event.stream,
+    ts: event.ts,
+    data: storedData,
+    ...(event.sessionKey ? { sessionKey: event.sessionKey } : {}),
+    ...(event.agentId ? { agentId: event.agentId } : {}),
+  };
+  let eventBytes = jsonUtf8Bytes(storedEvent);
+  if (eventBytes > CHAT_RUN_PROGRESS_MAX_EVENT_BYTES && isTool) {
+    delete storedData.args;
+    delete storedData.partialResult;
+    storedEvent = { ...storedEvent, data: storedData };
+    eventBytes = jsonUtf8Bytes(storedEvent);
+  }
+  if (eventBytes > CHAT_RUN_PROGRESS_MAX_EVENT_BYTES) {
+    return next;
+  }
+  next.events.push(storedEvent);
+  next.byteLength += eventBytes;
+  while (
+    next.events.length > CHAT_RUN_PROGRESS_MAX_EVENTS ||
+    next.byteLength > CHAT_RUN_PROGRESS_MAX_BYTES
+  ) {
+    const removed = next.events.shift();
+    if (!removed) {
+      break;
+    }
+    next.byteLength -= jsonUtf8Bytes(removed);
+  }
+  return next;
+}

--- a/src/gateway/server-chat-state.test.ts
+++ b/src/gateway/server-chat-state.test.ts
@@ -22,6 +22,13 @@ describe("createChatRunState", () => {
       agentText: { assistant: { lastSentAt: 3 } },
       abortMarker: createChatAbortMarker(4),
     });
+    state.recordProgressEvent("run-1", {
+      runId: "run-1",
+      seq: 1,
+      stream: "item",
+      ts: 1,
+      data: { kind: "preamble", progressText: "Inspecting" },
+    });
 
     state.clearRun("run-1");
 
@@ -44,6 +51,64 @@ describe("createChatRunState", () => {
     expect([...state.runs.keys()]).toEqual(["run-b", "run-a"]);
     expect(state.registry.shift("run-b")?.clientRunId).toBe("client-b-1");
     expect(state.registry.shift("run-b")?.clientRunId).toBe("client-b-2");
+  });
+
+  it("keeps bounded active progress ordered and removes completed tools", () => {
+    const state = createChatRunState();
+    const event = (seq: number, stream: "item" | "tool", data: Record<string, unknown>) =>
+      state.recordProgressEvent("run-1", {
+        runId: "run-1",
+        seq,
+        stream,
+        ts: 1_000 + seq,
+        sessionKey: "main",
+        data,
+      });
+
+    event(1, "item", { kind: "preamble", itemId: "p-1", progressText: "Inspecting" });
+    event(2, "tool", {
+      phase: "start",
+      name: "read",
+      toolCallId: "active",
+      args: { path: "a" },
+    });
+    event(3, "tool", {
+      phase: "update",
+      name: "read",
+      toolCallId: "active",
+      partialResult: "halfway",
+    });
+    event(4, "tool", { phase: "start", name: "exec", toolCallId: "done", args: {} });
+    event(5, "tool", {
+      phase: "result",
+      name: "exec",
+      toolCallId: "done",
+      result: "x".repeat(256_000),
+    });
+    event(3, "tool", { phase: "result", name: "read", toolCallId: "active" });
+
+    expect(state.runs.get("run-1")?.progressSnapshot?.events).toMatchObject([
+      { seq: 1, stream: "item", data: { itemId: "p-1", progressText: "Inspecting" } },
+      { seq: 2, stream: "tool", data: { phase: "start", toolCallId: "active" } },
+      { seq: 3, stream: "tool", data: { phase: "update", toolCallId: "active" } },
+    ]);
+
+    for (let seq = 6; seq <= 70; seq += 1) {
+      event(seq, "tool", {
+        phase: "start",
+        name: "read",
+        toolCallId: `tool-${seq}`,
+        args: { payload: "y".repeat(80_000) },
+      });
+    }
+    const snapshot = state.runs.get("run-1")?.progressSnapshot;
+    expect(snapshot?.events).toHaveLength(50);
+    expect(snapshot?.byteLength).toBeLessThanOrEqual(128 * 1024);
+    expect(snapshot?.events.at(-1)?.data).toEqual({
+      phase: "start",
+      name: "read",
+      toolCallId: "tool-70",
+    });
   });
 });
 

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -6,6 +6,8 @@ import {
   normalizeLiveAssistantBufferedText,
   projectLiveAssistantBufferedText,
 } from "./live-chat-projector.js";
+import type { ChatRunProgressSnapshot } from "./server-chat-progress-snapshot.js";
+import { updateChatRunProgressSnapshot } from "./server-chat-progress-snapshot.js";
 
 export type ChatRunTiming = {
   ackedAtMs: number;
@@ -109,6 +111,7 @@ type ChatRunRecord = {
   /** Projection stays valid only while source matches rawBuffer; readers refresh it lazily. */
   bufferProjection?: { source: string; suppress: boolean };
   planSnapshot?: ChatRunPlanSnapshot;
+  progressSnapshot?: ChatRunProgressSnapshot;
   /** Last time any buffered assistant text changed, including suppressed raw buffers. */
   bufferUpdatedAt?: number;
   deltaSentAt?: number;
@@ -236,6 +239,7 @@ export type ChatRunState = {
   resolveBuffer: (runId: string) => { text: string; suppress: boolean };
   hasAbortMarker: (runId: string) => boolean;
   deleteAbortMarker: (runId: string) => void;
+  recordProgressEvent: (runId: string, event: AgentEventPayload) => void;
   clearRun: (runId: string) => void;
   clear: () => void;
 };
@@ -246,6 +250,16 @@ export function createChatRunState(): ChatRunState {
   const registry = createChatRunRegistryForStore(store);
   const toolEventRecipients = createToolEventRecipientRegistryForStore(store);
 
+  const recordProgressEvent = (runId: string, event: AgentEventPayload) => {
+    const progressSnapshot = updateChatRunProgressSnapshot(
+      store.runs.get(runId)?.progressSnapshot,
+      event,
+    );
+    if (progressSnapshot) {
+      store.getOrCreate(runId).progressSnapshot = progressSnapshot;
+    }
+  };
+
   const clearRun = (runId: string) => {
     const record = store.runs.get(runId);
     if (!record) {
@@ -255,6 +269,7 @@ export function createChatRunState(): ChatRunState {
     delete record.buffer;
     delete record.bufferProjection;
     delete record.planSnapshot;
+    delete record.progressSnapshot;
     delete record.bufferUpdatedAt;
     delete record.deltaSentAt;
     delete record.deltaLastBroadcastLen;
@@ -306,6 +321,7 @@ export function createChatRunState(): ChatRunState {
       delete record.abortMarker;
       store.releaseIfEmpty(runId);
     },
+    recordProgressEvent,
     clearRun,
     clear,
   };

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1417,6 +1417,17 @@ export function createAgentEventHandler({
         ...(explanation ? { explanation } : {}),
       };
     }
+    if (
+      chatLink &&
+      isControlUiVisible &&
+      !isAborted &&
+      ((isToolEvent && !suppressHeartbeatToolEvents) || isItemEvent)
+    ) {
+      // Persist the client-facing identity after run/session remapping. Route
+      // changes discard transient UI rows, so history replay must use the same
+      // payload identity as live delivery or tool results cannot reconcile.
+      chatRunState.recordProgressEvent(clientRunId, agentPayload);
+    }
     if (evt.stream === "run_status") {
       const phase = readChatRunStartupPhase(evt.data?.phase);
       if (phase && chatLink && isControlUiVisible && sessionKey && !isAborted) {

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -35,11 +35,6 @@ import {
   createDirectChatContext,
   createTextTranscriptEvent,
 } from "./server-chat.agent-events.test-helpers.js";
-import {
-  createAgentEventHandler,
-  createSessionEventSubscriberRegistry,
-  createSessionMessageSubscriberRegistry,
-} from "./server-chat.js";
 import { getMaxChatHistoryMessagesBytes } from "./server-constants.js";
 import type {
   GatewayRequestContext,
@@ -533,6 +528,11 @@ describe("gateway server chat", () => {
   test.each(["chat.history", "chat.startup"] as const)(
     "%s replays bounded active progress events in inFlightRun",
     async (method) => {
+      const {
+        createAgentEventHandler,
+        createSessionEventSubscriberRegistry,
+        createSessionMessageSubscriberRegistry,
+      } = await import("./server-chat.js");
       openDirectChatSession();
       const context = createDirectChatContext();
       const handler = createAgentEventHandler({

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -35,6 +35,11 @@ import {
   createDirectChatContext,
   createTextTranscriptEvent,
 } from "./server-chat.agent-events.test-helpers.js";
+import {
+  createAgentEventHandler,
+  createSessionEventSubscriberRegistry,
+  createSessionMessageSubscriberRegistry,
+} from "./server-chat.js";
 import { getMaxChatHistoryMessagesBytes } from "./server-constants.js";
 import type {
   GatewayRequestContext,
@@ -519,6 +524,158 @@ describe("gateway server chat", () => {
           },
         });
       } finally {
+        testState.sessionStorePath = undefined;
+        clearConfigCache();
+      }
+    },
+  );
+
+  test.each(["chat.history", "chat.startup"] as const)(
+    "%s replays bounded active progress events in inFlightRun",
+    async (method) => {
+      openDirectChatSession();
+      const context = createDirectChatContext();
+      const handler = createAgentEventHandler({
+        broadcast: context.broadcast,
+        broadcastToConnIds: context.broadcastToConnIds,
+        nodeSendToSession: context.nodeSendToSession,
+        agentRunSeq: context.agentRunSeq,
+        chatRunState: context.chatRunState,
+        resolveSessionKeyForRun: () => "main",
+        clearAgentRunContext: vi.fn(),
+        toolEventRecipients: context.chatRunState.toolEventRecipients,
+        sessionEventSubscribers: createSessionEventSubscriberRegistry(),
+        sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
+      });
+      try {
+        await writeMainSessionStore();
+        const controller = new AbortController();
+        context.chatAbortControllers.set("run-active", {
+          controller,
+          sessionId: "sess-main",
+          sessionKey: "main",
+          startedAtMs: 1_000,
+          expiresAtMs: 10_000,
+          projectSessionActive: true,
+        });
+        context.chatRunState.registry.add("provider-run", {
+          sessionKey: "main",
+          clientRunId: "run-active",
+        });
+
+        handler({
+          runId: "provider-run",
+          seq: 1,
+          stream: "item",
+          ts: 1_001,
+          data: { kind: "preamble", itemId: "preamble-1", progressText: "Checking files" },
+        });
+        handler({
+          runId: "provider-run",
+          seq: 2,
+          stream: "tool",
+          ts: 1_002,
+          data: { phase: "start", name: "read", toolCallId: "tool-active", args: { path: "a" } },
+        });
+        handler({
+          runId: "provider-run",
+          seq: 3,
+          stream: "tool",
+          ts: 1_003,
+          data: {
+            phase: "update",
+            name: "read",
+            toolCallId: "tool-active",
+            partialResult: "halfway",
+          },
+        });
+        handler({
+          runId: "provider-run",
+          seq: 4,
+          stream: "tool",
+          ts: 1_004,
+          data: { phase: "start", name: "exec", toolCallId: "tool-finished", args: {} },
+        });
+        handler({
+          runId: "provider-run",
+          seq: 5,
+          stream: "tool",
+          ts: 1_005,
+          data: {
+            phase: "result",
+            name: "exec",
+            toolCallId: "tool-finished",
+            result: "x".repeat(256_000),
+          },
+        });
+        // A delayed result older than the latest accepted progress event must
+        // not remove the active tool from the reconnect projection.
+        handler({
+          runId: "provider-run",
+          seq: 3,
+          stream: "tool",
+          ts: 1_006,
+          data: { phase: "result", name: "read", toolCallId: "tool-active", result: "stale" },
+        });
+
+        const responses: Array<{ ok: boolean; payload?: unknown }> = [];
+        await callDirectChat(method, {
+          id: method,
+          params: { sessionKey: "main" },
+          respond: ((ok, payload) => responses.push({ ok, payload })) as RespondFn,
+          context,
+        });
+
+        expect(responses).toHaveLength(1);
+        expect(responses[0]?.ok).toBe(true);
+        expect(
+          (responses[0]?.payload as { inFlightRun?: unknown } | undefined)?.inFlightRun,
+        ).toEqual({
+          runId: "run-active",
+          text: "",
+          events: [
+            {
+              runId: "run-active",
+              seq: 1,
+              stream: "item",
+              ts: 1_001,
+              sessionKey: "main",
+              data: {
+                kind: "preamble",
+                itemId: "preamble-1",
+                progressText: "Checking files",
+              },
+            },
+            {
+              runId: "run-active",
+              seq: 2,
+              stream: "tool",
+              ts: 1_002,
+              sessionKey: "main",
+              data: {
+                phase: "start",
+                name: "read",
+                toolCallId: "tool-active",
+                args: { path: "a" },
+              },
+            },
+            {
+              runId: "run-active",
+              seq: 3,
+              stream: "tool",
+              ts: 1_003,
+              sessionKey: "main",
+              data: {
+                phase: "update",
+                name: "read",
+                toolCallId: "tool-active",
+                partialResult: "halfway",
+              },
+            },
+          ],
+        });
+      } finally {
+        handler.dispose();
         testState.sessionStorePath = undefined;
         clearConfigCache();
       }

--- a/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
@@ -1,0 +1,294 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, type Page } from "playwright/test";
+import { it } from "vitest";
+import {
+  installMockGateway,
+  type MockGatewayControls,
+  waitForControlUiRoute,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "active turn recovery",
+  trackBrowserContexts: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is required for active-turn recovery proof at ${executablePath}`,
+});
+
+const proofDir = path.resolve(".artifacts/control-ui-e2e/active-turn-recovery");
+const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+
+async function capture(page: Page, name: string): Promise<void> {
+  if (!captureProof) {
+    return;
+  }
+  await mkdir(proofDir, { recursive: true });
+  await page.screenshot({ path: path.join(proofDir, `${name}.png`), fullPage: true });
+}
+
+function activeRunSnapshot(
+  runId: string,
+  prompt: string,
+  streamText: string,
+  opts?: { persistedToolCall?: boolean },
+) {
+  return {
+    inFlightRun: {
+      runId,
+      text: streamText,
+      events: [
+        {
+          runId,
+          seq: 1,
+          stream: "tool",
+          ts: 1_000,
+          sessionKey: "main",
+          data: {
+            toolCallId: "tool-active-turn-recovery",
+            name: "read",
+            phase: "start",
+            args: { path: "README.md" },
+          },
+        },
+      ],
+    },
+    messages: [
+      {
+        __openclaw: { idempotencyKey: `${runId}:user` },
+        content: [{ text: prompt, type: "text" }],
+        role: "user",
+        timestamp: 900,
+      },
+      ...(opts?.persistedToolCall
+        ? [
+            {
+              content: [
+                {
+                  type: "toolCall",
+                  id: "tool-active-turn-recovery",
+                  name: "read",
+                  arguments: { path: "README.md" },
+                },
+              ],
+              role: "assistant",
+              timestamp: 950,
+            },
+          ]
+        : []),
+    ],
+    sessionId: "active-turn-recovery-session",
+    sessionInfo: {
+      activeRunIds: [runId],
+      hasActiveRun: true,
+      key: "main",
+      kind: "direct",
+      status: "running",
+      updatedAt: 1_000,
+    },
+    thinkingLevel: null,
+  };
+}
+
+async function startActiveTurn(
+  page: Page,
+  gateway: MockGatewayControls,
+  prompt: string,
+  streamText: string,
+): Promise<string> {
+  await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+  await page.getByRole("button", { name: "Send message" }).click();
+  const send = await gateway.waitForRequest("chat.send");
+  const runId = (send.params as { idempotencyKey?: unknown }).idempotencyKey;
+  expect(typeof runId).toBe("string");
+
+  await gateway.emitGatewayEvent("agent", {
+    runId,
+    seq: 1,
+    stream: "tool",
+    ts: 1_000,
+    sessionKey: "main",
+    data: {
+      toolCallId: "tool-active-turn-recovery",
+      name: "read",
+      phase: "start",
+      args: { path: "README.md" },
+    },
+  });
+  await page.waitForTimeout(200);
+  await gateway.emitGatewayEvent("chat", {
+    deltaText: streamText,
+    message: {
+      content: [{ text: streamText, type: "text" }],
+      role: "assistant",
+      timestamp: 1_100,
+    },
+    runId,
+    sessionKey: "main",
+    state: "delta",
+  });
+  await assertActiveTurnVisible(page, streamText);
+  return runId as string;
+}
+
+async function installActiveRunSnapshot(
+  gateway: MockGatewayControls,
+  runId: string,
+  prompt: string,
+  streamText: string,
+  opts?: { persistedToolCall?: boolean },
+): Promise<void> {
+  const snapshot = activeRunSnapshot(runId, prompt, streamText, opts);
+  await gateway.setMethodResponse("chat.startup", snapshot);
+  await gateway.setMethodResponse("chat.history", snapshot);
+  await gateway.setMethodResponse("sessions.list", {
+    count: 1,
+    defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+    path: "",
+    sessions: [snapshot.sessionInfo],
+    ts: 1_000,
+  });
+}
+
+async function assertActiveTurnVisible(page: Page, streamText: string): Promise<void> {
+  await page.getByText(streamText, { exact: true }).waitFor({ timeout: 10_000 });
+  await page.locator(".chat-tool-row--running").waitFor({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Stop generating" }).waitFor({ timeout: 10_000 });
+  await expect
+    .poll(() =>
+      page
+        .getByText(
+          "Delivery could not be confirmed after reconnect. Check the conversation before retrying.",
+          { exact: true },
+        )
+        .count(),
+    )
+    .toBe(0);
+}
+
+async function waitForGatewayConnected(page: Page): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const app = document.querySelector("openclaw-app") as HTMLElement & {
+            runtime?: { context: { gateway: { snapshot: { phase: string } } } };
+          };
+          return app.runtime?.context.gateway.snapshot.phase;
+        }),
+      { timeout: 15_000 },
+    )
+    .toBe("connected");
+}
+
+async function finishRecoveredTurn(
+  page: Page,
+  gateway: MockGatewayControls,
+  runId: string,
+  finalText: string,
+): Promise<void> {
+  await gateway.emitGatewayEvent("agent", {
+    runId,
+    seq: 2,
+    stream: "tool",
+    ts: 1_200,
+    sessionKey: "main",
+    data: {
+      toolCallId: "tool-active-turn-recovery",
+      name: "read",
+      phase: "result",
+      result: { content: [{ type: "text", text: "README recovered" }] },
+    },
+  });
+  await expect.poll(() => page.locator(".chat-tool-row--running").count()).toBe(0);
+  await expect.poll(() => page.locator(".chat-tool-row").count()).toBe(1);
+  await gateway.emitChatFinal({ runId, text: finalText });
+  const visibleFinal = page.getByRole("paragraph").filter({ hasText: finalText });
+  await visibleFinal.waitFor({ timeout: 10_000 });
+  await expect.poll(() => page.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
+  expect(await visibleFinal.count()).toBe(1);
+}
+
+async function openActiveTurn() {
+  const context = await suite.newBrowserContext({
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport: { height: 900, width: 1280 },
+  });
+  const page = await context.newPage();
+  const gateway = await installMockGateway(page);
+  await page.goto(`${suite.server.baseUrl}chat`);
+  await page.locator(".agent-chat__composer-combobox textarea").waitFor({ timeout: 10_000 });
+  return { context, page, gateway };
+}
+
+suite.define(() => {
+  it("restores the active assistant and tool across SPA navigation", async () => {
+    const { context, page, gateway } = await openActiveTurn();
+    try {
+      const prompt = "navigation active turn";
+      const streamText = "Navigation progress is still running.";
+      const runId = await startActiveTurn(page, gateway, prompt, streamText);
+      await installActiveRunSnapshot(gateway, runId, prompt, streamText);
+      await capture(page, "01-navigation-before");
+
+      const sidebar = page.locator("openclaw-app-sidebar");
+      await sidebar.locator(".sidebar-identity-card").click();
+      await sidebar
+        .locator('wa-dropdown.sidebar-identity-menu wa-dropdown-item[value="command:usage"]')
+        .click();
+      await waitForControlUiRoute(page, { pathname: "/usage", routeId: "usage" });
+      await sidebar.getByRole("link", { name: "Home" }).click();
+      await waitForControlUiRoute(page, { pathname: "/chat/main", routeId: "chat" });
+      await assertActiveTurnVisible(page, streamText);
+      await capture(page, "02-navigation-after");
+      await finishRecoveredTurn(page, gateway, runId, "Navigation delivery complete.");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("restores the active assistant and tool after socket reconnect", async () => {
+    const { context, page, gateway } = await openActiveTurn();
+    try {
+      const prompt = "reconnect active turn";
+      const streamText = "Reconnect progress is still running.";
+      const runId = await startActiveTurn(page, gateway, prompt, streamText);
+      await installActiveRunSnapshot(gateway, runId, prompt, streamText);
+      await capture(page, "03-reconnect-before");
+
+      const startupCount = (await gateway.getRequests("chat.startup")).length;
+      await gateway.closeLatest(1001, "active-turn recovery reconnect");
+      await expect.poll(() => gateway.getSocketCount(), { timeout: 15_000 }).toBe(2);
+      await expect
+        .poll(async () => (await gateway.getRequests("chat.startup")).length, { timeout: 15_000 })
+        .toBeGreaterThan(startupCount);
+      await waitForGatewayConnected(page);
+      await assertActiveTurnVisible(page, streamText);
+      await capture(page, "04-reconnect-after");
+      await finishRecoveredTurn(page, gateway, runId, "Reconnect delivery complete.");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("restores the active assistant and tool after a full reload", async () => {
+    const { context, page, gateway } = await openActiveTurn();
+    try {
+      const prompt = "reload active turn";
+      const streamText = "Reload progress is still running.";
+      const runId = await startActiveTurn(page, gateway, prompt, streamText);
+      await installActiveRunSnapshot(gateway, runId, prompt, streamText, {
+        persistedToolCall: true,
+      });
+      await capture(page, "05-reload-before");
+
+      await page.reload();
+      await assertActiveTurnVisible(page, streamText);
+      await capture(page, "06-reload-after");
+      await finishRecoveredTurn(page, gateway, runId, "Reload delivery complete.");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -3,8 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { handleChatGatewayEvent } from "./chat-gateway.ts";
 import { loadChatHistory, type ChatHistoryResult, type ChatState } from "./chat-history.ts";
+import { getChatSessionProjection, setChatSessionProjection } from "./history-merge.ts";
+import { handleAgentEvent, type ToolStreamEntry } from "./tool-stream.ts";
 
-function createState(result: ChatHistoryResult): ChatState {
+type TestState = ChatState & Parameters<typeof handleAgentEvent>[0];
+
+function createState(result: ChatHistoryResult): TestState {
   return {
     client: { request: vi.fn().mockResolvedValue(result) } as unknown as GatewayBrowserClient,
     connected: true,
@@ -21,12 +25,35 @@ function createState(result: ChatHistoryResult): ChatState {
     chatRunId: null,
     chatStream: null,
     chatStreamStartedAt: null,
+    chatStreamSegments: [],
+    toolStreamById: new Map<string, ToolStreamEntry>(),
+    toolStreamOrder: [],
+    chatToolMessages: [],
+    toolStreamSyncTimer: null,
     planStatus: null,
     lastError: null,
     hello: null,
     sessions: { setModelOverride: vi.fn(), reconcileRunTerminal: vi.fn() },
     requestUpdate: vi.fn(),
   };
+}
+
+async function loadHistoryWithBrowserTimers(state: TestState): Promise<void> {
+  const globalWithWindow = globalThis as typeof globalThis & {
+    window?: Window & typeof globalThis;
+  };
+  const previousWindow = globalWithWindow.window;
+  globalWithWindow.window = globalThis as unknown as Window & typeof globalThis;
+  try {
+    await loadChatHistory(state);
+    await vi.waitFor(() => expect(state.chatToolMessages).toHaveLength(1));
+  } finally {
+    if (previousWindow) {
+      globalWithWindow.window = previousWindow;
+    } else {
+      Reflect.deleteProperty(globalWithWindow, "window");
+    }
+  }
 }
 
 function activeHistory(runId: string): ChatHistoryResult {
@@ -45,6 +72,91 @@ function activeHistory(runId: string): ChatHistoryResult {
 }
 
 describe("chat history in-flight assistant recovery", () => {
+  it("restores active tool state from the in-flight run snapshot", async () => {
+    const history = activeHistory("run-live");
+    (history.inFlightRun as { events?: unknown[] }).events = [
+      {
+        runId: "run-live",
+        seq: 1,
+        stream: "item",
+        ts: 900,
+        sessionKey: "main",
+        data: {
+          kind: "preamble",
+          itemId: "preamble-restored",
+          progressText: "Checking the workspace",
+        },
+      },
+      {
+        runId: "run-live",
+        seq: 2,
+        stream: "tool",
+        ts: 1_000,
+        sessionKey: "main",
+        data: {
+          toolCallId: "call-restored",
+          name: "read",
+          phase: "start",
+          args: { path: "README.md" },
+        },
+      },
+    ];
+    const state = createState(history);
+
+    await loadHistoryWithBrowserTimers(state);
+
+    expect(state.chatToolMessages[0]).toMatchObject({
+      runId: "run-live",
+      toolCallId: "call-restored",
+      content: [expect.objectContaining({ type: "toolcall", name: "read" })],
+    });
+    expect(state.chatStreamSegments).toContainEqual(
+      expect.objectContaining({
+        itemId: "preamble-restored",
+        runId: "run-live",
+        text: "Checking the workspace",
+      }),
+    );
+  });
+
+  it("restores cleared activity for an already-owned run after reconnect", async () => {
+    const history = activeHistory("run-live");
+    (history.inFlightRun as { events?: unknown[] }).events = [
+      {
+        runId: "run-live",
+        seq: 2,
+        stream: "tool",
+        ts: 1_000,
+        sessionKey: "main",
+        data: {
+          toolCallId: "call-reconnected",
+          name: "read",
+          phase: "start",
+          args: { path: "README.md" },
+        },
+      },
+    ];
+    const state = createState(history);
+    state.chatRunId = "run-live";
+    state.chatStream = "The active response survived reconnect.";
+
+    await loadHistoryWithBrowserTimers(state);
+
+    expect(state.chatRunId).toBe("run-live");
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamSegments).toContainEqual(
+      expect.objectContaining({
+        runId: "run-live",
+        text: "The active response survived reconnect.",
+        toolCallId: "call-reconnected",
+      }),
+    );
+    expect(state.chatToolMessages[0]).toMatchObject({
+      runId: "run-live",
+      toolCallId: "call-reconnected",
+    });
+  });
+
   it("restores an unpersisted assistant response from the active run snapshot", async () => {
     const history = activeHistory("run-reconnected");
     history.messages = [{ role: "user", content: "Continue working." }];
@@ -57,6 +169,21 @@ describe("chat history in-flight assistant recovery", () => {
     expect(state.chatStream).toBe("The response survived the reconnect.");
     expect(state.chatStreamStartedAt).toEqual(expect.any(Number));
     expect(state.chatRunStartup).toEqual({ state: "activity", runId: "run-reconnected" });
+  });
+
+  it("adopts an active snapshot while binding its durable session identity", async () => {
+    const history = activeHistory("run-reconnected");
+    history.sessionId = "current-session";
+    history.messages = [{ role: "user", content: "Continue working." }];
+    history.inFlightRun!.text = "The response survived navigation.";
+    const state = createState(history);
+    state.currentSessionId = "previous-session";
+
+    await loadChatHistory(state);
+
+    expect(state.currentSessionId).toBe("current-session");
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBe("The response survived navigation.");
   });
 
   it("restores only the active response after its persisted assistant prefix", async () => {
@@ -235,6 +362,28 @@ describe("chat history in-flight assistant recovery", () => {
 
     expect(state.chatRunId).toBe("run-newer");
     expect(state.chatStream).toBe("A newer live response.");
+  });
+
+  it("adopts the snapshot when remount reconciliation replaces an unchanged run map", async () => {
+    let resolveHistory!: (result: ChatHistoryResult) => void;
+    const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
+      resolveHistory = resolve;
+    });
+    const request = vi.fn().mockReturnValue(historyPromise);
+    const history = activeHistory("run-reconnected");
+    history.inFlightRun!.text = "The response survived navigation.";
+    const state = createState(history);
+    state.client = { request } as unknown as GatewayBrowserClient;
+
+    const loadPromise = loadChatHistory(state);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    const projection = getChatSessionProjection(state);
+    setChatSessionProjection(state, { ...projection, runs: { ...projection.runs } });
+    resolveHistory(history);
+    await loadPromise;
+
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBe("The response survived navigation.");
   });
 
   it.each([

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -85,7 +85,7 @@ import {
   visibleCurrentAssistantStreamTail,
 } from "./stream-reconciliation.ts";
 import { reconcileAuthoritativeTerminalHistory } from "./terminal-message-identity.ts";
-import { normalizePlanSnapshot, type PlanStatus } from "./tool-stream.ts";
+import { handleAgentEvent, normalizePlanSnapshot, type PlanStatus } from "./tool-stream.ts";
 
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
@@ -339,12 +339,36 @@ export type ChatHistoryResult = {
   inFlightRun?: {
     runId: string;
     text?: string;
+    events?: Array<{
+      runId: string;
+      seq: number;
+      stream: string;
+      ts: number;
+      sessionKey?: string;
+      agentId?: string;
+      data: Record<string, unknown>;
+    }>;
     plan?: {
       steps: Array<PlanStatus["steps"][number] | string>;
       explanation?: string;
     };
   };
 };
+
+function replayInFlightRunEvents(
+  state: ChatState,
+  run: NonNullable<ChatHistoryResult["inFlightRun"]>,
+): void {
+  if (state.chatRunId !== run.runId || !Array.isArray(run.events)) {
+    return;
+  }
+  for (const event of run.events) {
+    if (!event || event.runId !== run.runId) {
+      continue;
+    }
+    handleAgentEvent(state as never, event as never);
+  }
+}
 
 function resolveInFlightAssistantTail(
   messages: unknown[],
@@ -450,6 +474,17 @@ function onlyInFlightRunProjectionChanged(
     }
   }
   return true;
+}
+
+function runProjectionsUnchanged(
+  previous: ReturnType<typeof getChatSessionProjection>["runs"],
+  current: ReturnType<typeof getChatSessionProjection>["runs"],
+): boolean {
+  const previousEntries = Object.entries(previous);
+  return (
+    previousEntries.length === Object.keys(current).length &&
+    previousEntries.every(([runId, run]) => current[runId] === run)
+  );
 }
 
 function mergeInFlightAssistantTails(
@@ -1486,6 +1521,16 @@ async function loadChatHistoryUncached(
       });
       return undefined;
     }
+    // Fence concurrent run lifecycle before applying the response. A remount
+    // may replace the map itself, so compare its canonical run entries.
+    const runProjectionsBeforeApply = getChatSessionProjection(
+      state,
+      state.chatMessages,
+      readChatSessionProjectionScope(state, {
+        sessionKey,
+        ...(requestAgentId ? { agentId: requestAgentId } : {}),
+      }),
+    ).runs;
     const messages = Array.isArray(res.messages) ? res.messages : [];
     const nextPagination = resolveChatHistoryPagination(res);
     const nextSessionId = resolveChatHistorySessionId(res);
@@ -1560,6 +1605,7 @@ async function loadChatHistoryUncached(
     state.chatQueueModeOverride = res.sessionInfo?.queueMode;
     state.chatEffectiveQueueMode = res.sessionInfo?.effectiveQueueMode;
     const planStatusBeforeStreamReset = state.planStatus ?? null;
+    const activeStreamBeforeReset = state.chatRunId ? state.chatStream : null;
     const resetStream = !state.chatRunId || state.chatRunId === previousRunId;
     if (resetStream) {
       const streamReconciliation = {
@@ -1649,17 +1695,27 @@ async function loadChatHistoryUncached(
         inFlightRunId,
       ),
     );
-    if (
+    const inFlightRunIsActive = Boolean(
       inFlightRunId &&
       isSessionRunActive(res.sessionInfo ?? {}) &&
       (!Array.isArray(activeRunIds) || activeRunIds.includes(inFlightRunId)) &&
-      (!projectedInFlightRun || projectedInFlightRun.status === "streaming") &&
-      ((resetStream && !state.chatRunId && historyProjection.runs === previousRunProjections) ||
-        sameRunContinued)
-    ) {
+      (!projectedInFlightRun || projectedInFlightRun.status === "streaming"),
+    );
+    const canAdoptInFlightRun = Boolean(
+      inFlightRunId &&
+      inFlightRunIsActive &&
+      ((resetStream &&
+        !state.chatRunId &&
+        runProjectionsUnchanged(previousRunProjections, runProjectionsBeforeApply)) ||
+        sameRunContinued),
+    );
+    if (inFlightRunId && canAdoptInFlightRun) {
       // Canonical run projections change on every live delta or terminal.
       // Their identity fences ABA races where a run starts and finishes while
       // history is pending; deltas from this same live run must still merge.
+      state.chatRunId = inFlightRunId;
+    }
+    if (inFlightRunIsActive && res.inFlightRun && state.chatRunId === inFlightRunId) {
       const snapshotTail = resolveInFlightAssistantTail(
         state.chatMessages,
         res.inFlightRun?.text,
@@ -1671,12 +1727,15 @@ async function loadChatHistoryUncached(
             extractText(projectedInFlightRun?.message),
             inFlightRunId,
           )
-        : null;
+        : activeStreamBeforeReset;
       const tail = mergeInFlightAssistantTails(snapshotTail, liveTail);
-      state.chatRunId = inFlightRunId;
       state.chatStream = tail;
       state.chatStreamStartedAt = tail ? (state.chatStreamStartedAt ?? Date.now()) : null;
       state.chatRunStartup = { state: "activity", runId: inFlightRunId };
+      // Disconnect cleanup intentionally removes transient activity rows while
+      // retaining the owned run. Replay fills that gap; per-identity sequence
+      // fences keep a delayed snapshot from replacing newer live progress.
+      replayInFlightRunEvents(state, res.inFlightRun);
     }
 
     // Plan reconciliation shares stream adoption: rejected history cannot clobber newer live state.

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -243,8 +243,14 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     }
     if (sourceChanged && snapshot.phase === "connected" && state.sessionKey && !clientChanged) {
       // A logical reconnect can retain the browser client and skip full startup.
-      // The existing transcript is already authoritative, so rehydrate after its next commit.
-      this.deferSessionHydrationUntilTranscript(state.sessionKey, Promise.resolve());
+      // Disconnect cleanup drops transient tool rows, so reload this pane's
+      // active-run snapshot before secondary session surfaces hydrate.
+      const historyRefresh = refreshPageChat(state, {
+        startup: true,
+        awaitHistory: true,
+        deferBranches: true,
+      });
+      this.deferSessionHydrationUntilTranscript(state.sessionKey, historyRefresh);
     }
     state.terminalAvailable =
       this.context.config.current.terminalEnabled &&

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -864,7 +864,7 @@ describe("chat pane connection lifecycle", () => {
     expect(state.realtimeTalkCameraError).toBe(false);
   });
 
-  it("advances session ownership once per same-client connection transition", () => {
+  it("advances session ownership once per same-client connection transition", async () => {
     const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
     const initialGeneration = pane.connectionGeneration;
@@ -889,7 +889,7 @@ describe("chat pane connection lifecycle", () => {
 
     expect(pane.connectionGeneration).toBe(initialGeneration + 2);
     expect(state.connectionEpoch).toBe(initialGeneration + 2);
-    expect(state.chatLoading).toBe(false);
+    await vi.waitFor(() => expect(state.chatLoading).toBe(false));
 
     state.chatLoading = true;
     pane.applyGatewaySnapshot({ ...snapshot, phase: "connected" });
@@ -899,9 +899,10 @@ describe("chat pane connection lifecycle", () => {
     expect(state.chatLoading).toBe(true);
   });
 
-  it("rehydrates secondary session state after a same-client logical reconnect", () => {
+  it("refreshes the transcript before secondary hydration after a same-client reconnect", () => {
+    const request = vi.fn(() => new Promise<never>(() => {}));
     const client = {
-      request: vi.fn(() => new Promise<never>(() => {})),
+      request,
     } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
     const deferHydration = vi.spyOn(pane, "deferSessionHydrationUntilTranscript");
@@ -914,6 +915,10 @@ describe("chat pane connection lifecycle", () => {
       phase: "connected",
     });
 
+    expect(request).toHaveBeenCalledWith(
+      "chat.history",
+      expect.objectContaining({ limit: 100, sessionKey: state.sessionKey }),
+    );
     expect(deferHydration).toHaveBeenCalledWith(state.sessionKey, expect.any(Promise));
   });
 

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -624,12 +624,15 @@ export abstract class ChatPaneLifecycle extends ChatPaneBoard {
         // after its transcript commit in deferSessionHydrationUntilTranscript.
         this.sessionDiscussionStates.delete(nextSessionKey);
       }
-      if (nextSessionKey && nextSessionKey !== this.state.sessionKey) {
+      if (nextSessionKey && !areUiSessionKeysEquivalent(nextSessionKey, this.state.sessionKey)) {
         this.switchPaneSession(nextSessionKey);
       } else if (catalogKey && this.catalogRequestedSessionKey !== this.sessionKey) {
         this.catalogLoadGeneration += 1;
         this.openCatalogSession(catalogKey, this.state);
       } else if (nextSessionKey) {
+        // Route aliases name the same conversation. Adopt the canonical spelling
+        // without clearing the active stream and tool state as a session switch.
+        this.state.sessionKey = nextSessionKey;
         // A pane routed straight onto the created session never runs the switch
         // path, so its one-shot handoffs would expire unclaimed: the rejected turn
         // would vanish instead of offering a retry, and the accepted prompt would

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -515,6 +515,53 @@ describe("chat pane initialization", () => {
       expect.objectContaining({ sessionKey: canonicalSessionKey }),
     );
   });
+
+  it("keeps active turn state when re-entry canonicalizes the main route alias", () => {
+    const canonicalSessionKey = "agent:main:main";
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({
+      client,
+      sessions: {} as SessionCapability,
+    });
+    const hello = {
+      snapshot: {
+        sessionDefaults: {
+          defaultAgentId: "main",
+          mainKey: "main",
+          mainSessionKey: canonicalSessionKey,
+        },
+      },
+    } as unknown as NonNullable<ApplicationContext["gateway"]["snapshot"]["hello"]>;
+    pane.context = {
+      ...pane.context,
+      gateway: {
+        ...pane.context.gateway,
+        snapshot: { ...pane.context.gateway.snapshot, hello },
+      },
+    } as unknown as ApplicationContext;
+    state.sessionKey = "main";
+    state.hello = hello;
+    state.initialUserMessage = createInitialUserMessageHandoff();
+    state.chatRunId = "run-reconnected";
+    state.chatStream = "The response survived navigation.";
+    pane.sessionKey = canonicalSessionKey;
+    const switchPaneSession = vi.spyOn(pane, "switchPaneSession").mockImplementation((next) => {
+      state.sessionKey = next;
+      state.chatRunId = null;
+      state.chatStream = null;
+    });
+
+    (
+      pane as TestChatPane & {
+        willUpdate: (changedProperties: Map<PropertyKey, unknown>) => void;
+      }
+    ).willUpdate(new Map([["sessionKey", "main"]]));
+
+    expect(state.sessionKey).toBe(canonicalSessionKey);
+    expect(switchPaneSession).not.toHaveBeenCalled();
+    expect(state.chatRunId).toBe("run-reconnected");
+    expect(state.chatStream).toBe("The response survived navigation.");
+  });
 });
 
 describe("chat pane keyboard shortcuts", () => {

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -743,6 +743,44 @@ describe("refreshChat", () => {
     expect(requestUpdate).toHaveBeenCalled();
   });
 
+  it("keeps an active run adopted from history over newer stale catalog metadata", async () => {
+    const runId = "run-restored";
+    const host = makeHost({
+      requestHandlers: {
+        "chat.history": {
+          messages: [],
+          inFlightRun: { runId, text: "Still working after navigation." },
+          sessionInfo: row("main", {
+            activeRunIds: [runId],
+            hasActiveRun: true,
+            status: "running",
+            updatedAt: 1,
+          }),
+        },
+      },
+      sessionKey: "main",
+      sessionsResult: createSessionsResult([
+        row("main", { hasActiveRun: false, status: "done", updatedAt: 10 }),
+      ]),
+    });
+
+    await refreshPageChat(asChatPageHost(host), {
+      awaitHistory: true,
+      scheduleScroll: false,
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(host.chatRunId).toBe(runId);
+    expect(host.chatStream).toBe("Still working after navigation.");
+    expect(host.sessionsResult?.sessions[0]).toMatchObject({
+      hasActiveRun: false,
+      status: "done",
+      updatedAt: 10,
+    });
+  });
+
   it.each([
     {
       name: "drains a restored queue after history proves the selected session is idle",

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -231,6 +231,7 @@ export function createPageState(
     imageLightboxRequestVersion: 0,
     toolStreamById: new Map(),
     toolStreamOrder: [],
+    activityEventSeqById: new Map(),
     toolStreamSyncTimer: null,
     ...createInitialChatRealtimeState(),
     renderLifecycle,

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -2,6 +2,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { loadModelAuthStatus } from "../../lib/model-auth.ts";
+import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import {
   areUiSessionKeysEquivalent,
   resolveUiDefaultAgentId,
@@ -323,6 +324,19 @@ async function refreshChat(
     const sessionsResult = reconciled ? host.sessions.state.result : host.sessionsResult;
     if (reconciled) {
       host.sessionsResult = sessionsResult;
+    }
+    const snapshotRunId = history.inFlightRun?.runId?.trim();
+    const activeRunIds = history.sessionInfo.activeRunIds;
+    const snapshotConfirmsCurrentRun = Boolean(
+      snapshotRunId &&
+      host.chatRunId === snapshotRunId &&
+      isSessionRunActive(history.sessionInfo) &&
+      (!Array.isArray(activeRunIds) || activeRunIds.includes(snapshotRunId)),
+    );
+    if (snapshotConfirmsCurrentRun) {
+      // History just adopted this authoritative active run. A newer catalog
+      // timestamp may still describe its prior terminal state during remount.
+      return;
     }
     const sessionInfo = sessionsResult?.sessions.find(
       (row: GatewaySessionRow) =>

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -1,4 +1,9 @@
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  isToolCallContentType,
+  isToolResultContentType,
+  resolveToolUseId,
+} from "../../../../src/chat/tool-content.js";
 import type { QuestionPrompt } from "../../app/question-prompt.ts";
 import type { ChatItem, ChatQueueItem, MessageGroup } from "../../lib/chat/chat-types.ts";
 import {
@@ -14,6 +19,7 @@ import {
 import { extractTextCached } from "../../lib/chat/message-extract.ts";
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
+import { normalizeOptionalString } from "../../lib/string-coerce.ts";
 import {
   buildCompactionDividerItem,
   clearWorkingProgress,
@@ -52,6 +58,11 @@ import {
 } from "./chat-thread-items.ts";
 import { chatMessagesContainQueuedSend } from "./steer-lifecycle.ts";
 import { isLiveTerminalForRun } from "./terminal-message-identity.ts";
+import {
+  extractToolMessageRefs,
+  resolveMatchingLiveToolIdentity,
+  type LiveToolStreamRef,
+} from "./tool-stream-identity.ts";
 import type { PlanStatus } from "./tool-stream.ts";
 
 export type BuildChatItemsProps = {
@@ -134,14 +145,58 @@ function resolveRunInsertionBounds(
   );
 }
 
+function liveRenderedToolRefs(toolMessages: unknown[]): LiveToolStreamRef[] {
+  const refs: LiveToolStreamRef[] = [];
+  const seen = new Set<string>();
+  for (const [index, message] of toolMessages.entries()) {
+    for (const ref of extractToolMessageRefs(message)) {
+      const key = JSON.stringify([ref.runId ?? null, ref.id]);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      refs.push({ ...ref, identity: `live:${index}:${key}` });
+    }
+  }
+  return refs;
+}
+
+function removeLiveToolBlocksFromHistory(
+  message: unknown,
+  liveToolRefs: LiveToolStreamRef[],
+): unknown {
+  const record = asRecord(message);
+  if (!record || !Array.isArray(record.content) || liveToolRefs.length === 0) {
+    return message;
+  }
+  const topLevelToolId = resolveToolUseId({ ...record, id: undefined });
+  const topLevelRunId = normalizeOptionalString(record.runId);
+  const content = record.content.filter((block) => {
+    const entry = asRecord(block);
+    if (!entry || (!isToolCallContentType(entry.type) && !isToolResultContentType(entry.type))) {
+      return true;
+    }
+    const id = resolveToolUseId(entry) ?? topLevelToolId;
+    if (!id) {
+      return true;
+    }
+    const runId = normalizeOptionalString(entry.runId) ?? topLevelRunId;
+    return !resolveMatchingLiveToolIdentity({ id, ...(runId ? { runId } : {}) }, liveToolRefs);
+  });
+  return content.length === record.content.length ? message : { ...record, content };
+}
+
 export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGroup> {
   let items: ChatItem[] = [];
-  const history = props.messages.filter(
-    (message) =>
-      !isAssistantHeartbeatAckForDisplay(message) &&
-      (props.persistCommentary !== false || !isKeyedAssistantStreamFallbackMessage(message)),
-  );
   const tools = props.toolMessages.filter((message) => asRecord(message) !== null);
+  const liveToolRefs = liveRenderedToolRefs(tools);
+  const history = props.messages
+    .filter(
+      (message) =>
+        !isAssistantHeartbeatAckForDisplay(message) &&
+        (props.persistCommentary !== false || !isKeyedAssistantStreamFallbackMessage(message)),
+    )
+    .map((message) => removeLiveToolBlocksFromHistory(message, liveToolRefs));
   const historyKeys = buildMessageKeys(history);
   const toolKeys = buildMessageKeys(tools, history.length);
   const liftedCanvasSources = tools.flatMap((message, index) => {

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -2586,6 +2586,48 @@ describe("buildCachedChatItems", () => {
     expect(messageRecord(requireGroup(items[1])).toolCallId).toBe("call-read");
   });
 
+  it("renders one live card when active history contains the same tool call block", () => {
+    const groups = messageGroups({
+      runId: "run-live",
+      messages: [
+        { role: "user", content: "Read the file.", timestamp: 1 },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I will read it." },
+            {
+              type: "toolCall",
+              id: "call-read",
+              name: "read",
+              arguments: { path: "README.md" },
+            },
+          ],
+          timestamp: 2,
+        },
+      ],
+      toolMessages: [
+        {
+          role: "assistant",
+          runId: "run-live",
+          toolCallId: "call-read",
+          content: [{ type: "toolcall", name: "read", arguments: { path: "README.md" } }],
+          timestamp: 3,
+        },
+      ],
+    });
+
+    const cards = groups.flatMap((group, index) =>
+      group.messages.flatMap((entry) => extractToolCards(entry.message, `restored-${index}`)),
+    );
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({ callId: "call-read", name: "read" });
+    expect(
+      groups.some((group) =>
+        firstMessageContent(group).some((block) => requireRecord(block).text === "I will read it."),
+      ),
+    ).toBe(true);
+  });
+
   it("keeps same-millisecond stream segments interleaved with their matching tool cards", () => {
     const items = buildCachedChatItems(
       createProps({

--- a/ui/src/pages/chat/tool-stream-identity.ts
+++ b/ui/src/pages/chat/tool-stream-identity.ts
@@ -12,7 +12,7 @@ type ToolMessageRef = {
   runId?: string;
 };
 
-type LiveToolStreamRef = ToolMessageRef & {
+export type LiveToolStreamRef = ToolMessageRef & {
   identity: string;
 };
 

--- a/ui/src/pages/chat/tool-stream.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.node.test.ts
@@ -341,6 +341,49 @@ describe("app-tool-stream throttled projections", () => {
       }
     },
   );
+
+  it("does not let an older replay replace newer live tool progress", () => {
+    useToolStreamFakeTimers();
+    try {
+      const host = createHost();
+      const toolCallId = "call-sequenced";
+      handleAgentEvent(
+        host,
+        agentEvent("run-1", 1, "tool", {
+          phase: "start",
+          name: "read",
+          toolCallId,
+          args: { path: "README.md" },
+        }),
+      );
+      handleAgentEvent(
+        host,
+        agentEvent("run-1", 3, "tool", {
+          phase: "update",
+          name: "read",
+          toolCallId,
+          partialResult: "newer live progress",
+        }),
+      );
+      handleAgentEvent(
+        host,
+        agentEvent("run-1", 2, "tool", {
+          phase: "update",
+          name: "read",
+          toolCallId,
+          partialResult: "older replayed progress",
+        }),
+      );
+      vi.advanceTimersByTime(80);
+
+      expect(host.chatToolMessages[0]?.content).toEqual([
+        { type: "toolcall", name: "read", arguments: { path: "README.md" } },
+        { type: "toolresult", name: "read", text: "newer live progress" },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("app-tool-stream result blocks", () => {

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -64,6 +64,7 @@ type ToolStreamHost = {
   chatStreamSegments: ChatStreamSegment[];
   toolStreamById: Map<string, ToolStreamEntry>;
   toolStreamOrder: string[];
+  activityEventSeqById?: Map<string, number>;
   chatToolMessages: Record<string, unknown>[];
   toolStreamSyncTimer: number | null;
   planStatus?: PlanStatus | null;
@@ -327,6 +328,7 @@ export function resetToolStream(host: ToolStreamHost) {
   }
   host.toolStreamById.clear();
   host.toolStreamOrder = [];
+  host.activityEventSeqById?.clear();
   host.chatToolMessages = [];
   host.chatStreamSegments = [];
   host.planStatus = null;
@@ -334,6 +336,34 @@ export function resetToolStream(host: ToolStreamHost) {
   host.waitingApprovalStatuses?.clear();
   // Resolution can beat the overlay queue update. Keep tombstones across transient stream resets
   // until snapshot reconciliation observes the approval leaving the queue.
+}
+
+function activityEventIdentity(payload: AgentEventPayload): string | null {
+  if (payload.stream === "tool") {
+    const toolCallId = toTrimmedString(payload.data?.toolCallId);
+    return toolCallId ? `tool:${payload.runId}:${toolCallId}` : null;
+  }
+  if (payload.stream === "item" && payload.data?.kind === "preamble") {
+    const itemId =
+      toTrimmedString(payload.data?.itemId) ?? toTrimmedString(payload.data?.id) ?? "latest";
+    return `preamble:${payload.runId}:${itemId}`;
+  }
+  return null;
+}
+
+function acceptActivityEvent(host: ToolStreamHost, payload: AgentEventPayload): boolean {
+  const identity = activityEventIdentity(payload);
+  if (!identity) {
+    return true;
+  }
+  const seq = Number.isSafeInteger(payload.seq) ? payload.seq : 0;
+  const previous = host.activityEventSeqById?.get(identity);
+  if (previous !== undefined && seq <= previous) {
+    return false;
+  }
+  const sequences = (host.activityEventSeqById ??= new Map());
+  sequences.set(identity, seq);
+  return true;
 }
 
 export type CompactionStatus = {
@@ -923,6 +953,12 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   // active chat run; individual run-owned projections apply their own match.
   const sessionKey = typeof payload.sessionKey === "string" ? payload.sessionKey : undefined;
   if (sessionKey && !uiSessionEventMatches(host, sessionKey, toTrimmedString(payload.agentId))) {
+    return;
+  }
+  // History can replay an older active-run snapshot after newer live activity.
+  // Fence each tool/preamble identity by Gateway sequence so restore fills gaps
+  // without regressing a result or newer progress already rendered by this pane.
+  if (!acceptActivityEvent(host, payload)) {
     return;
   }
   if (payload.stream === "lifecycle" || payload.stream === "tool") {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -202,7 +202,7 @@ export type ControlUiMockGatewayScenario = {
   /** Static payloads, parameter-matched cases, or call-ordered sequences. */
   methodResponses?: Record<string, unknown>;
   /** Replayed in-flight run snapshot served by chat.history and chat.startup. */
-  inFlightRun?: { runId: string; text?: string; plan?: unknown } | null;
+  inFlightRun?: { runId: string; text?: string; events?: unknown[]; plan?: unknown } | null;
   /** Online users included in the connect snapshot's presence list. The entry
    * flagged `self` adopts the connecting client's instanceId so presence
    * surfaces (footer facepile, who's-online roster) resolve "you". */


### PR DESCRIPTION
## Summary

- retain a bounded Gateway snapshot of active assistant, preamble, plan, and tool progress
- replay and adopt that snapshot after Control UI navigation, socket reconnect, and reload with run/sequence fencing
- deduplicate replayed tool progress against persisted transcript tool calls

## Root cause

The Control UI correctly clears route-local streaming state when leaving a chat, but `chat.history` / `chat.startup` could only restore the active run id, assistant text, and plan. Tool and preamble progress existed only in live WebSocket events, so navigation or reconnect silently erased it and could leave delivery ambiguous.

This is distinct from #117687, which fixed transcript row measurement after panel resizing and did not change Gateway recovery state.

## Proof

- Current-main red reproduction: [Blacksmith Testbox run 30783081344](https://github.com/openclaw/openclaw/actions/runs/30783081344), 3/3 navigation/reconnect/reload scenarios failed before the fix.
- Fixed Chromium proof: [Blacksmith Testbox run 30784709239](https://github.com/openclaw/openclaw/actions/runs/30784709239), 3/3 scenarios passed; focused Gateway/UI tests also passed. Six before/after screenshots were captured and visually inspected.
- Final changed-file gate: [Blacksmith Testbox run 30785052923](https://github.com/openclaw/openclaw/actions/runs/30785052923), full `pnpm check:changed` passed after dead-export cleanup.
- Autoreview: clean, confidence 0.98.

The final push is the same patch rebased over unrelated newer `main` commits; hosted PR CI is the exact rebased-head gate.

## Scope

This is not a small UI-only repair. The invariant crosses Gateway event capture/budgeting/terminal cleanup, history RPC recovery, UI navigation/reconnect lifecycle, sequence fencing, and persisted-tool deduplication. Snapshot bounds are 50 events, 128 KiB total, and 64 KiB per event.