### PR TITLE
fix(openai): support the current speech model snapshot

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -812,9 +812,10 @@ compatibility fallback when the shared
     | Base URL     | `tts.providers.openai.baseUrl`                | `https://api.openai.com/v1`      |
     | Extra body   | `tts.providers.openai.extraBody` / `extra_body` | (unset)                        |
 
-    Available models: `gpt-4o-mini-tts`, `tts-1`, `tts-1-hd`. Available voices:
-    `alloy`, `ash`, `ballad`, `cedar`, `coral`, `echo`, `fable`, `juniper`,
-    `marin`, `onyx`, `nova`, `sage`, `shimmer`, `verse`.
+    Available models: `gpt-4o-mini-tts`, `gpt-4o-mini-tts-2025-12-15`, `tts-1`,
+    `tts-1-hd`. Available voices: `alloy`, `ash`, `ballad`, `cedar`, `coral`,
+    `echo`, `fable`, `juniper`, `marin`, `onyx`, `nova`, `sage`, `shimmer`,
+    `verse`.
 
     `extraBody` is merged into `/audio/speech` request JSON after OpenClaw's
     generated fields, so use it for OpenAI-compatible endpoints that require

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -806,7 +806,7 @@ compatibility fallback when the shared
     | Model        | `tts.providers.openai.model`                  | `gpt-4o-mini-tts`                |
     | Voice        | `tts.providers.openai.speakerVoice`           | `coral`                          |
     | Speed        | `tts.providers.openai.speed`                  | (unset)                          |
-    | Instructions | `tts.providers.openai.instructions`           | (unset, `gpt-4o-mini-tts` only)  |
+    | Instructions | `tts.providers.openai.instructions`           | (unset, `gpt-4o-mini-tts` family only)  |
     | Format       | `tts.providers.openai.responseFormat`         | `opus` for voice notes, `mp3` for files |
     | API key      | `tts.providers.openai.apiKey`                 | Falls back to `OPENAI_API_KEY`   |
     | Base URL     | `tts.providers.openai.baseUrl`                | `https://api.openai.com/v1`      |

--- a/extensions/openai/speech-provider.test.ts
+++ b/extensions/openai/speech-provider.test.ts
@@ -1,6 +1,9 @@
 // Openai tests cover speech provider plugin behavior.
+import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAISpeechProvider } from "./speech-provider.js";
+
+const OPENAI_TTS_SNAPSHOT = "gpt-4o-mini-tts-2025-12-15";
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: async ({
@@ -60,6 +63,13 @@ describe("buildOpenAISpeechProvider", () => {
     globalThis.fetch = originalFetch;
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
+  });
+
+  it("advertises official speech snapshots without changing the default model", () => {
+    const provider = buildOpenAISpeechProvider();
+
+    expect(provider.defaultModel).toBe("gpt-4o-mini-tts");
+    expect(provider.models).toContain(OPENAI_TTS_SNAPSHOT);
   });
 
   it("normalizes provider-owned speech config from raw provider config", () => {
@@ -179,6 +189,23 @@ describe("buildOpenAISpeechProvider", () => {
 
     expect(
       provider.parseDirectiveToken?.({
+        key: "openai_model",
+        value: OPENAI_TTS_SNAPSHOT,
+        policy: {
+          allowVoice: true,
+          allowModelId: true,
+        },
+        providerConfig: {
+          baseUrl: "https://api.openai.com/v1/",
+        },
+      } as never),
+    ).toEqual({
+      handled: true,
+      overrides: { model: OPENAI_TTS_SNAPSHOT },
+    });
+
+    expect(
+      provider.parseDirectiveToken?.({
         key: "model",
         value: "kokoro-custom-model",
         policy: {
@@ -192,6 +219,76 @@ describe("buildOpenAISpeechProvider", () => {
     ).toEqual({
       handled: false,
     });
+  });
+
+  it("sends dated speech snapshots through a real loopback HTTP request", async () => {
+    const provider = buildOpenAISpeechProvider();
+    let receivedRequest:
+      | {
+          method: string | undefined;
+          url: string | undefined;
+          body: unknown;
+        }
+      | undefined;
+    const server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("end", () => {
+        receivedRequest = {
+          method: request.method,
+          url: request.url,
+          body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown,
+        };
+        response.writeHead(200, { "content-type": "audio/mpeg" });
+        response.end(Buffer.from("snapshot-audio"));
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.removeListener("error", reject);
+        resolve();
+      });
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected a loopback server address");
+      }
+
+      const result = await provider.synthesize({
+        text: "snapshot request",
+        cfg: {} as never,
+        providerConfig: {
+          apiKey: "sk-test",
+          baseUrl: `http://127.0.0.1:${address.port}/v1`,
+          model: OPENAI_TTS_SNAPSHOT,
+          voice: "alloy",
+          instructions: " Speak warmly ",
+        },
+        target: "audio-file",
+        timeoutMs: 1_000,
+      });
+
+      expect(receivedRequest).toEqual({
+        method: "POST",
+        url: "/v1/audio/speech",
+        body: {
+          model: OPENAI_TTS_SNAPSHOT,
+          input: "snapshot request",
+          voice: "alloy",
+          response_format: "mp3",
+          instructions: "Speak warmly",
+        },
+      });
+      expect(result.audioBuffer).toEqual(Buffer.from("snapshot-audio"));
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("parses preferred-OpenAI speed directive within the supported range", () => {

--- a/extensions/openai/tts.test.ts
+++ b/extensions/openai/tts.test.ts
@@ -101,13 +101,15 @@ describe("openai tts", () => {
   describe("isValidOpenAIModel", () => {
     it("matches the supported model set and rejects unsupported values", () => {
       expect(OPENAI_TTS_MODELS).toContain("gpt-4o-mini-tts");
+      expect(OPENAI_TTS_MODELS).toContain("gpt-4o-mini-tts-2025-12-15");
       expect(OPENAI_TTS_MODELS).toContain("tts-1");
       expect(OPENAI_TTS_MODELS).toContain("tts-1-hd");
-      expect(OPENAI_TTS_MODELS).toHaveLength(3);
+      expect(OPENAI_TTS_MODELS).toHaveLength(4);
       expect(Array.isArray(OPENAI_TTS_MODELS)).toBe(true);
       expect(OPENAI_TTS_MODELS.length).toBeGreaterThan(0);
       const cases = [
         { model: "gpt-4o-mini-tts", expected: true },
+        { model: "gpt-4o-mini-tts-2025-12-15", expected: true },
         { model: "tts-1", expected: true },
         { model: "tts-1-hd", expected: true },
         { model: "invalid", expected: false },

--- a/extensions/openai/tts.ts
+++ b/extensions/openai/tts.ts
@@ -17,7 +17,12 @@ import {
 export const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const DEFAULT_TTS_MAX_BYTES = 16 * 1024 * 1024;
 
-export const OPENAI_TTS_MODELS = ["gpt-4o-mini-tts", "tts-1", "tts-1-hd"] as const;
+export const OPENAI_TTS_MODELS = [
+  "gpt-4o-mini-tts",
+  "gpt-4o-mini-tts-2025-12-15",
+  "tts-1",
+  "tts-1-hd",
+] as const;
 
 export const OPENAI_TTS_VOICES = [
   "alloy",


### PR DESCRIPTION
## What Problem This Solves

The OpenAI speech provider rejected the officially supported gpt-4o-mini-tts-2025-12-15 model snapshot in both configuration and per-request directives.

## Why This Change Was Made

The provider-owned speech inventory includes the official snapshot while keeping the existing default unchanged. Public provider documentation now lists the same supported models.

## User Impact

Operators can explicitly select the supported current OpenAI speech snapshot without unexpected validation errors.

## Real Provider Proof

The exact committed provider was exercised through the genuine packaged OpenClaw speech CLI against the live authenticated OpenAI Speech API:

```text
node openclaw.mjs infer tts convert --local --provider openai --model openai/gpt-4o-mini-tts-2025-12-15 --voice alloy --text OK --output snapshot.mp3 --json
provider: openai
model: gpt-4o-mini-tts-2025-12-15
real generated MP3: 45696 bytes
natural exit: 0
```

Exactly one authenticated provider request was made; no credentials or audio data are disclosed. Testbox: https://github.com/openclaw/openclaw/actions/runs/30785523517

## Regression Evidence

- Focused provider/directive tests: 47/47 passing, including an actual loopback speech HTTP request.
- Current official OpenAI model reference and installed openai@6.49.0 speech source confirm the snapshot and endpoint.
- Independent structured Sol/high review clean, confidence 0.96.
- Production +5 lines; docs updated; no auth, config-shape, or default changes.
- AI-assisted implementation and independently verified source review.
