### PR TITLE
refactor(gateway): consolidate doctor test fixtures

### DIFF
--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -73,137 +73,6 @@ import { doctorHandlers } from "./doctor.js";
 
 const makeRuntimeContext = () => ({ getRuntimeConfig: () => getRuntimeConfig() });
 
-const invokeDoctorMemoryStatus = async (
-  respond: ReturnType<typeof vi.fn>,
-  options?: { cron?: { list?: ReturnType<typeof vi.fn> }; params?: unknown },
-) => {
-  const cronList =
-    options?.cron?.list ??
-    vi.fn(async () => {
-      return [];
-    });
-  await expectDefined(
-    doctorHandlers["doctor.memory.status"],
-    'doctorHandlers["doctor.memory.status"] test invariant',
-  )({
-    req: {} as never,
-    params: (options?.params ?? {}) as never,
-    respond: respond as never,
-    context: {
-      ...makeRuntimeContext(),
-      cron: {
-        list: cronList,
-      },
-    } as never,
-    client: null,
-    isWebchatConnect: () => false,
-  });
-};
-
-const invokeDoctorMemoryDreamDiary = async (
-  respond: ReturnType<typeof vi.fn>,
-  params: unknown = {},
-) => {
-  await expectDefined(
-    doctorHandlers["doctor.memory.dreamDiary"],
-    'doctorHandlers["doctor.memory.dreamDiary"] test invariant',
-  )({
-    req: {} as never,
-    params: params as never,
-    respond: respond as never,
-    context: makeRuntimeContext() as never,
-    client: null,
-    isWebchatConnect: () => false,
-  });
-};
-
-const invokeDoctorMemoryBackfillDreamDiary = async (respond: ReturnType<typeof vi.fn>) => {
-  await expectDefined(
-    doctorHandlers["doctor.memory.backfillDreamDiary"],
-    'doctorHandlers["doctor.memory.backfillDreamDiary"] test invariant',
-  )({
-    req: {} as never,
-    params: {} as never,
-    respond: respond as never,
-    context: makeRuntimeContext() as never,
-    client: null,
-    isWebchatConnect: () => false,
-  });
-};
-
-const invokeDoctorMemoryResetDreamDiary = async (respond: ReturnType<typeof vi.fn>) => {
-  await expectDefined(
-    doctorHandlers["doctor.memory.resetDreamDiary"],
-    'doctorHandlers["doctor.memory.resetDreamDiary"] test invariant',
-  )({
-    req: {} as never,
-    params: {} as never,
-    respond: respond as never,
-    context: makeRuntimeContext() as never,
-    client: null,
-    isWebchatConnect: () => false,
-  });
-};
-
-const invokeDoctorMemoryResetGroundedShortTerm = async (respond: ReturnType<typeof vi.fn>) => {
-  await expectDefined(
-    doctorHandlers["doctor.memory.resetGroundedShortTerm"],
-    'doctorHandlers["doctor.memory.resetGroundedShortTerm"] test invariant',
-  )({
-    req: {} as never,
-    params: {} as never,
-    respond: respond as never,
-    context: makeRuntimeContext() as never,
-    client: null,
-    isWebchatConnect: () => false,
-  });
-};
-
-const invokeDoctorMemoryRepairDreamingArtifacts = async (respond: ReturnType<typeof vi.fn>) => {
-  await expectDefined(
-    doctorHandlers["doctor.memory.repairDreamingArtifacts"],
-    'doctorHandlers["doctor.memory.repairDreamingArtifacts"] test invariant',
-  )({
-    req: {} as never,
-    params: {} as never,
-    respond: respond as never,
-    context: makeRuntimeContext() as never,
-    client: null,
-    isWebchatConnect: () => false,
-  });
-};
-
-const invokeDoctorMemoryDedupeDreamDiary = async (respond: ReturnType<typeof vi.fn>) => {
-  await expectDefined(
-    doctorHandlers["doctor.memory.dedupeDreamDiary"],
-    'doctorHandlers["doctor.memory.dedupeDreamDiary"] test invariant',
-  )({
-    req: {} as never,
-    params: {} as never,
-    respond: respond as never,
-    context: makeRuntimeContext() as never,
-    client: null,
-    isWebchatConnect: () => false,
-  });
-};
-
-const invokeDoctorMemoryRemHarness = async (
-  respond: ReturnType<typeof vi.fn>,
-  params: Record<string, unknown> = {},
-) => {
-  await expectDefined(
-    doctorHandlers["doctor.memory.remHarness"],
-    'doctorHandlers["doctor.memory.remHarness"] test invariant',
-  )({
-    req: {} as never,
-    params: params as never,
-    respond: respond as never,
-    context: makeRuntimeContext() as never,
-    client: null,
-    isWebchatConnect: () => false,
-  });
-};
-
 const DOCTOR_MEMORY_TARGET_METHODS = [
   "doctor.memory.status",
   "doctor.memory.dreamDiary",
@@ -214,22 +83,32 @@ const DOCTOR_MEMORY_TARGET_METHODS = [
   "doctor.memory.dedupeDreamDiary",
 ] as const;
 
-const invokeDoctorMemoryTargetMethod = async (
-  method: (typeof DOCTOR_MEMORY_TARGET_METHODS)[number],
+type DoctorMemoryMethod =
+  | (typeof DOCTOR_MEMORY_TARGET_METHODS)[number]
+  | "doctor.memory.remHarness";
+
+const invokeDoctorMemory = async (
+  method: DoctorMemoryMethod,
   respond: ReturnType<typeof vi.fn>,
-  params: Record<string, unknown>,
+  options: {
+    params?: Record<string, unknown>;
+    cronList?: ReturnType<typeof vi.fn>;
+    includeCron?: boolean;
+  } = {},
 ) => {
+  const cronList = options.cronList ?? vi.fn(async () => []);
+  const context =
+    method === "doctor.memory.status" || options.includeCron
+      ? { ...makeRuntimeContext(), cron: { list: cronList } }
+      : makeRuntimeContext();
   await expectDefined(
     doctorHandlers[method],
-    `doctorHandlers[${method}] test invariant`,
+    `doctorHandlers["${method}"] test invariant`,
   )({
     req: {} as never,
-    params: params as never,
+    params: (options.params ?? {}) as never,
     respond: respond as never,
-    context: {
-      ...makeRuntimeContext(),
-      cron: { list: vi.fn(async () => []) },
-    } as never,
+    context: context as never,
     client: null,
     isWebchatConnect: () => false,
   });
@@ -290,6 +169,67 @@ function makeDreamingStats(overrides: Record<string, unknown> = {}): Record<stri
   };
 }
 
+type DreamingEntryFixture = {
+  key: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  snippet: string;
+  recallCount: number;
+  dailyCount: number;
+  groundedCount: number;
+  totalSignalCount: number;
+  lightHits: number;
+  remHits: number;
+  phaseHitCount: number;
+  promotedAt?: string;
+  lastRecalledAt?: string;
+};
+
+function makeDreamingEntry(
+  entryPath: string,
+  overrides: Partial<DreamingEntryFixture> = {},
+): DreamingEntryFixture {
+  return {
+    key: `memory:${entryPath}:1:2`,
+    path: entryPath,
+    startLine: 1,
+    endLine: 2,
+    snippet: entryPath,
+    recallCount: 0,
+    dailyCount: 0,
+    groundedCount: 0,
+    totalSignalCount: 0,
+    lightHits: 0,
+    remHits: 0,
+    phaseHitCount: 0,
+    ...overrides,
+  };
+}
+
+type MemoryManagerFixtureOptions = {
+  status: () => Record<string, unknown>;
+  probeEmbeddingAvailability?: ReturnType<typeof vi.fn>;
+  getCachedEmbeddingAvailability?: ReturnType<typeof vi.fn>;
+};
+
+function useMemoryManagerFixture(options: MemoryManagerFixtureOptions) {
+  const close = vi.fn().mockResolvedValue(undefined);
+  const probeEmbeddingAvailability =
+    options.probeEmbeddingAvailability ?? vi.fn().mockResolvedValue({ ok: true });
+  getMemorySearchManager.mockResolvedValue({
+    manager: {
+      status: options.status,
+      probeEmbeddingAvailability,
+      ...(options.getCachedEmbeddingAvailability
+        ? { getCachedEmbeddingAvailability: options.getCachedEmbeddingAvailability }
+        : {}),
+      close,
+    },
+  });
+  return { close, probeEmbeddingAvailability };
+}
+
 const expectEmbeddingErrorResponse = (respond: ReturnType<typeof vi.fn>, error: string) => {
   const payload = respondPayload(respond);
   expectRecordFields(payload, {
@@ -326,7 +266,10 @@ describe("doctor.memory agent targeting", () => {
     async (method) => {
       const respond = vi.fn();
 
-      await invokeDoctorMemoryTargetMethod(method, respond, { agentId: "invented" });
+      await invokeDoctorMemory(method, respond, {
+        params: { agentId: "invented" },
+        includeCron: true,
+      });
 
       expect(respond).toHaveBeenCalledWith(
         false,
@@ -343,7 +286,10 @@ describe("doctor.memory agent targeting", () => {
     async (method) => {
       const respond = vi.fn();
 
-      await invokeDoctorMemoryTargetMethod(method, respond, { agentId: 42 });
+      await invokeDoctorMemory(method, respond, {
+        params: { agentId: 42 },
+        includeCron: true,
+      });
 
       expect(respond).toHaveBeenCalledWith(
         false,
@@ -375,17 +321,12 @@ describe("doctor.memory.status", () => {
   });
 
   it("returns gateway embedding probe status for the default agent", async () => {
-    const close = vi.fn().mockResolvedValue(undefined);
-    getMemorySearchManager.mockResolvedValue({
-      manager: {
-        status: () => ({ provider: "gemini" }),
-        probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
-        close,
-      },
+    const { close } = useMemoryManagerFixture({
+      status: () => ({ provider: "gemini" }),
     });
     const respond = vi.fn();
 
-    await invokeDoctorMemoryStatus(respond, { params: { probe: true } });
+    await invokeDoctorMemory("doctor.memory.status", respond, { params: { probe: true } });
 
     const managerInput = mockCallArg(getMemorySearchManager);
     if (managerInput.cfg === undefined) {
@@ -420,17 +361,12 @@ describe("doctor.memory.status", () => {
   });
 
   it("returns gateway embedding probe status for the requested agent", async () => {
-    const close = vi.fn().mockResolvedValue(undefined);
-    getMemorySearchManager.mockResolvedValue({
-      manager: {
-        status: () => ({ provider: "gemini", workspaceDir: "/tmp/research-workspace" }),
-        probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
-        close,
-      },
+    useMemoryManagerFixture({
+      status: () => ({ provider: "gemini", workspaceDir: "/tmp/research-workspace" }),
     });
     const respond = vi.fn();
 
-    await invokeDoctorMemoryStatus(respond, {
+    await invokeDoctorMemory("doctor.memory.status", respond, {
       params: { agentId: "research-analyst", probe: true },
     });
 
@@ -447,44 +383,40 @@ describe("doctor.memory.status", () => {
   });
 
   it("returns llama.cpp runtime facts created by the deep embedding probe", async () => {
-    const close = vi.fn().mockResolvedValue(undefined);
     let probed = false;
-    getMemorySearchManager.mockResolvedValue({
-      manager: {
-        status: () => ({
-          provider: "local",
-          ...(probed
-            ? {
-                custom: {
-                  llamaCppRuntime: {
-                    engine: "llama.cpp",
-                    state: "ready",
-                    backend: "cuda",
-                    buildType: "prebuilt",
-                    deviceNames: ["NVIDIA Test GPU"],
-                    offload: {
-                      supported: true,
-                      offloadedLayers: 24,
-                      totalLayers: 24,
-                    },
-                    context: {
-                      requestedSize: 4096,
-                    },
+    const { close } = useMemoryManagerFixture({
+      status: () => ({
+        provider: "local",
+        ...(probed
+          ? {
+              custom: {
+                llamaCppRuntime: {
+                  engine: "llama.cpp",
+                  state: "ready",
+                  backend: "cuda",
+                  buildType: "prebuilt",
+                  deviceNames: ["NVIDIA Test GPU"],
+                  offload: {
+                    supported: true,
+                    offloadedLayers: 24,
+                    totalLayers: 24,
+                  },
+                  context: {
+                    requestedSize: 4096,
                   },
                 },
-              }
-            : {}),
-        }),
-        probeEmbeddingAvailability: vi.fn(async () => {
-          probed = true;
-          return { ok: true };
-        }),
-        close,
-      },
+              },
+            }
+          : {}),
+      }),
+      probeEmbeddingAvailability: vi.fn(async () => {
+        probed = true;
+        return { ok: true };
+      }),
     });
     const respond = vi.fn();
 
-    await invokeDoctorMemoryStatus(respond, { params: { probe: true } });
+    await invokeDoctorMemory("doctor.memory.status", respond, { params: { probe: true } });
 
     expect(respondPayload(respond).embeddingRuntime).toMatchObject({
       state: "ready",
@@ -502,18 +434,12 @@ describe("doctor.memory.status", () => {
   });
 
   it("does not live-probe embedding readiness by default", async () => {
-    const close = vi.fn().mockResolvedValue(undefined);
-    const probeEmbeddingAvailability = vi.fn().mockResolvedValue({ ok: true });
-    getMemorySearchManager.mockResolvedValue({
-      manager: {
-        status: () => ({ provider: "gemini" }),
-        probeEmbeddingAvailability,
-        close,
-      },
+    const { close, probeEmbeddingAvailability } = useMemoryManagerFixture({
+      status: () => ({ provider: "gemini" }),
     });
     const respond = vi.fn();
 
-    await invokeDoctorMemoryStatus(respond);
+    await invokeDoctorMemory("doctor.memory.status", respond);
 
     expect(probeEmbeddingAvailability).not.toHaveBeenCalled();
     const payload = respondPayload(respond);
@@ -522,25 +448,20 @@ describe("doctor.memory.status", () => {
   });
 
   it("returns cached embedding readiness without a live probe", async () => {
-    const close = vi.fn().mockResolvedValue(undefined);
-    const probeEmbeddingAvailability = vi.fn().mockResolvedValue({ ok: false });
-    getMemorySearchManager.mockResolvedValue({
-      manager: {
-        status: () => ({ provider: "gemini" }),
-        getCachedEmbeddingAvailability: vi.fn(() => ({
-          ok: true,
-          checked: true,
-          cached: true,
-          checkedAtMs: 123,
-          cacheExpiresAtMs: 456,
-        })),
-        probeEmbeddingAvailability,
-        close,
-      },
+    const { close, probeEmbeddingAvailability } = useMemoryManagerFixture({
+      status: () => ({ provider: "gemini" }),
+      probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: false }),
+      getCachedEmbeddingAvailability: vi.fn(() => ({
+        ok: true,
+        checked: true,
+        cached: true,
+        checkedAtMs: 123,
+        cacheExpiresAtMs: 456,
+      })),
     });
     const respond = vi.fn();
 
-    await invokeDoctorMemoryStatus(respond);
+    await invokeDoctorMemory("doctor.memory.status", respond);
 
     expect(probeEmbeddingAvailability).not.toHaveBeenCalled();
     const payload = respondPayload(respond);
@@ -555,23 +476,19 @@ describe("doctor.memory.status", () => {
     });
     const respond = vi.fn();
 
-    await invokeDoctorMemoryStatus(respond, { params: { probe: true } });
+    await invokeDoctorMemory("doctor.memory.status", respond, { params: { probe: true } });
 
     expectEmbeddingErrorResponse(respond, "memory search unavailable");
   });
 
   it("returns probe failure when manager probe throws", async () => {
-    const close = vi.fn().mockResolvedValue(undefined);
-    getMemorySearchManager.mockResolvedValue({
-      manager: {
-        status: () => ({ provider: "openai" }),
-        probeEmbeddingAvailability: vi.fn().mockRejectedValue(new Error("timeout")),
-        close,
-      },
+    const { close } = useMemoryManagerFixture({
+      status: () => ({ provider: "openai" }),
+      probeEmbeddingAvailability: vi.fn().mockRejectedValue(new Error("timeout")),
     });
     const respond = vi.fn();
 
-    await invokeDoctorMemoryStatus(respond, { params: { probe: true } });
+    await invokeDoctorMemory("doctor.memory.status", respond, { params: { probe: true } });
 
     expectEmbeddingErrorResponse(respond, "gateway memory probe failed: timeout");
     expect(close).toHaveBeenCalled();
@@ -768,36 +685,20 @@ describe("doctor.memory.status", () => {
               promotedTotal: 2,
               promotedToday: 1,
               promotedEntries: [
-                {
-                  key: "memory:memory/2026-04-01.md:1:2",
-                  path: "memory/2026-04-01.md",
-                  startLine: 1,
-                  endLine: 2,
+                makeDreamingEntry("memory/2026-04-01.md", {
                   snippet: "Bunji lives in London.",
                   recallCount: 7,
                   dailyCount: 4,
-                  groundedCount: 0,
                   totalSignalCount: 11,
-                  lightHits: 0,
-                  remHits: 0,
-                  phaseHitCount: 0,
                   promotedAt: olderIso,
-                },
-                {
-                  key: "memory:memory/notes/2026-04-04-0800.md:1:2",
-                  path: "memory/notes/2026-04-04-0800.md",
-                  startLine: 1,
-                  endLine: 2,
+                }),
+                makeDreamingEntry("memory/notes/2026-04-04-0800.md", {
                   snippet: "Always book the covered valet option at Park & Greet BCN.",
                   recallCount: 8,
                   dailyCount: 3,
-                  groundedCount: 0,
                   totalSignalCount: 11,
-                  lightHits: 0,
-                  remHits: 0,
-                  phaseHitCount: 0,
                   promotedAt: recentIso,
-                },
+                }),
               ],
               lastPromotedAt: recentIso,
             })
@@ -812,67 +713,44 @@ describe("doctor.memory.status", () => {
               promotedTotal: 1,
               promotedToday: 1,
               shortTermEntries: [
-                {
-                  key: "memory:memory/2026-04-03-1503.md:1:2",
-                  path: "memory/2026-04-03-1503.md",
-                  startLine: 1,
-                  endLine: 2,
+                makeDreamingEntry("memory/2026-04-03-1503.md", {
                   snippet: "Emma prefers shorter, lower-pressure check-ins.",
                   recallCount: 2,
                   dailyCount: 1,
-                  groundedCount: 0,
                   totalSignalCount: 3,
                   lightHits: 2,
                   remHits: 3,
                   phaseHitCount: 5,
                   lastRecalledAt: recentIso,
-                },
+                }),
               ],
               signalEntries: [
-                {
-                  key: "memory:memory/2026-04-03-1503.md:1:2",
-                  path: "memory/2026-04-03-1503.md",
-                  startLine: 1,
-                  endLine: 2,
+                makeDreamingEntry("memory/2026-04-03-1503.md", {
                   snippet: "Emma prefers shorter, lower-pressure check-ins.",
                   recallCount: 2,
                   dailyCount: 1,
-                  groundedCount: 0,
                   totalSignalCount: 3,
                   lightHits: 2,
                   remHits: 3,
                   phaseHitCount: 5,
                   lastRecalledAt: recentIso,
-                },
+                }),
               ],
               promotedEntries: [
-                {
-                  key: "memory:memory/daily/2026-04-02-1015.md:1:2",
-                  path: "memory/daily/2026-04-02-1015.md",
-                  startLine: 1,
-                  endLine: 2,
+                makeDreamingEntry("memory/daily/2026-04-02-1015.md", {
                   snippet: "Use the Happy Together calendar for flights.",
                   recallCount: 9,
                   dailyCount: 5,
-                  groundedCount: 0,
                   totalSignalCount: 14,
-                  lightHits: 0,
-                  remHits: 0,
-                  phaseHitCount: 0,
                   promotedAt: recentIso,
-                },
+                }),
               ],
               lastPromotedAt: recentIso,
             }),
     );
 
-    const close = vi.fn().mockResolvedValue(undefined);
-    getMemorySearchManager.mockResolvedValue({
-      manager: {
-        status: () => ({ provider: "gemini", workspaceDir: mainWorkspaceDir }),
-        probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
-        close,
-      },
+    const { close } = useMemoryManagerFixture({
+      status: () => ({ provider: "gemini", workspaceDir: mainWorkspaceDir }),
     });
 
     const cronList = vi.fn(async () => [
@@ -890,7 +768,7 @@ describe("doctor.memory.status", () => {
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryStatus(respond, { cron: { list: cronList } });
+      await invokeDoctorMemory("doctor.memory.status", respond, { cronList });
       const payload = respondPayload(respond);
       expectRecordFields(payload, {
         agentId: "main",
@@ -985,22 +863,11 @@ describe("doctor.memory.status", () => {
         makeDreamingStats({
           promotedTotal: 1,
           promotedEntries: [
-            {
-              key: "memory:memory/2026-04-04.md:1:2",
-              path: "memory/2026-04-04.md",
-              startLine: 1,
-              endLine: 2,
+            makeDreamingEntry("memory/2026-04-04.md", {
               snippet:
                 workspaceDir === alphaWorkspaceDir ? "alpha agent memory" : "main agent memory",
-              recallCount: 0,
-              dailyCount: 0,
-              groundedCount: 0,
-              totalSignalCount: 0,
-              lightHits: 0,
-              remHits: 0,
-              phaseHitCount: 0,
               promotedAt: "2026-04-04T00:00:00.000Z",
-            },
+            }),
           ],
           lastPromotedAt: "2026-04-04T00:00:00.000Z",
         }),
@@ -1026,18 +893,13 @@ describe("doctor.memory.status", () => {
       return mainWorkspaceDir;
     });
 
-    const close = vi.fn().mockResolvedValue(undefined);
-    getMemorySearchManager.mockResolvedValue({
-      manager: {
-        status: () => ({ provider: "gemini", workspaceDir: alphaWorkspaceDir }),
-        probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
-        close,
-      },
+    useMemoryManagerFixture({
+      status: () => ({ provider: "gemini", workspaceDir: alphaWorkspaceDir }),
     });
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryStatus(respond, { params: { agentId: "alpha" } });
+      await invokeDoctorMemory("doctor.memory.status", respond, { params: { agentId: "alpha" } });
       const payload = respondPayload(respond);
       expectRecordFields(payload, {
         agentId: "alpha",
@@ -1082,21 +944,10 @@ describe("doctor.memory.status", () => {
       makeDreamingStats({
         promotedTotal: 1,
         promotedEntries: [
-          {
-            key: "memory:memory/2026-04-03.md:1:2",
-            path: "memory/2026-04-03.md",
-            startLine: 1,
+          makeDreamingEntry("memory/2026-04-03.md", {
             endLine: 1,
-            snippet: "memory/2026-04-03.md",
-            recallCount: 0,
-            dailyCount: 0,
-            groundedCount: 0,
-            totalSignalCount: 0,
-            lightHits: 0,
-            remHits: 0,
-            phaseHitCount: 0,
             promotedAt: "2026-04-04T00:00:00.000Z",
-          },
+          }),
         ],
         lastPromotedAt: "2026-04-04T00:00:00.000Z",
       }),
@@ -1113,18 +964,13 @@ describe("doctor.memory.status", () => {
       },
     } as OpenClawConfig);
 
-    const close = vi.fn().mockResolvedValue(undefined);
-    getMemorySearchManager.mockResolvedValue({
-      manager: {
-        status: () => ({ provider: "gemini", workspaceDir }),
-        probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
-        close,
-      },
+    useMemoryManagerFixture({
+      status: () => ({ provider: "gemini", workspaceDir }),
     });
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryStatus(respond);
+      await invokeDoctorMemory("doctor.memory.status", respond);
       const payload = respondPayload(respond);
       const dreaming = expectRecordFields(payload.dreaming, {
         shortTermCount: 0,
@@ -1165,17 +1011,12 @@ describe("doctor.memory.status", () => {
       },
     } as OpenClawConfig);
 
-    const close = vi.fn().mockResolvedValue(undefined);
-    getMemorySearchManager.mockResolvedValue({
-      manager: {
-        status: () => ({ provider: "gemini" }),
-        probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
-        close,
-      },
+    const { close } = useMemoryManagerFixture({
+      status: () => ({ provider: "gemini" }),
     });
     const respond = vi.fn();
 
-    await invokeDoctorMemoryStatus(respond);
+    await invokeDoctorMemory("doctor.memory.status", respond);
 
     const payload = respondPayload(respond);
     const dreaming = expectRecordFields(payload.dreaming, {
@@ -1244,18 +1085,13 @@ describe("doctor.memory.status", () => {
 
     loadShortTermPromotionDreamingStats.mockRejectedValue(new Error("denied"));
 
-    const close = vi.fn().mockResolvedValue(undefined);
-    getMemorySearchManager.mockResolvedValue({
-      manager: {
-        status: () => ({ provider: "gemini", workspaceDir: mainWorkspaceDir }),
-        probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
-        close,
-      },
+    useMemoryManagerFixture({
+      status: () => ({ provider: "gemini", workspaceDir: mainWorkspaceDir }),
     });
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryStatus(respond);
+      await invokeDoctorMemory("doctor.memory.status", respond);
       const payload = respondPayload(respond);
       expectRecordFields(payload.dreaming, {
         shortTermCount: 0,
@@ -1277,7 +1113,7 @@ describe("doctor.memory dream actions", () => {
     });
     const respond = vi.fn();
 
-    await invokeDoctorMemoryResetGroundedShortTerm(respond);
+    await invokeDoctorMemory("doctor.memory.resetGroundedShortTerm", respond);
 
     expect(removeGroundedShortTermCandidates).toHaveBeenCalledWith({
       workspaceDir: "/tmp/openclaw",
@@ -1306,7 +1142,7 @@ describe("doctor.memory dream actions", () => {
     });
     const respond = vi.fn();
 
-    await invokeDoctorMemoryRepairDreamingArtifacts(respond);
+    await invokeDoctorMemory("doctor.memory.repairDreamingArtifacts", respond);
 
     expect(repairDreamingArtifacts).toHaveBeenCalledWith({
       workspaceDir: "/tmp/openclaw",
@@ -1336,7 +1172,7 @@ describe("doctor.memory dream actions", () => {
     });
     const respond = vi.fn();
 
-    await invokeDoctorMemoryDedupeDreamDiary(respond);
+    await invokeDoctorMemory("doctor.memory.dedupeDreamDiary", respond);
 
     expect(dedupeDreamDiaryEntries).toHaveBeenCalledWith({
       workspaceDir: "/tmp/openclaw",
@@ -1375,7 +1211,7 @@ describe("doctor.memory.dreamDiary", () => {
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryDreamDiary(respond);
+      await invokeDoctorMemory("doctor.memory.dreamDiary", respond);
       const payload = respondPayload(respond);
       expectRecordFields(payload, {
         agentId: "main",
@@ -1398,7 +1234,9 @@ describe("doctor.memory.dreamDiary", () => {
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryDreamDiary(respond, { agentId: "research-analyst" });
+      await invokeDoctorMemory("doctor.memory.dreamDiary", respond, {
+        params: { agentId: "research-analyst" },
+      });
       expect(resolveAgentWorkspaceDir).toHaveBeenCalledWith(expect.anything(), "research-analyst");
       const payload = respondPayload(respond);
       expectRecordFields(payload, {
@@ -1419,7 +1257,7 @@ describe("doctor.memory.dreamDiary", () => {
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryDreamDiary(respond);
+      await invokeDoctorMemory("doctor.memory.dreamDiary", respond);
       const payload = respondPayload(respond);
       expectRecordFields(payload, {
         agentId: "main",
@@ -1439,7 +1277,7 @@ describe("doctor.memory.dreamDiary", () => {
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryDreamDiary(respond);
+      await invokeDoctorMemory("doctor.memory.dreamDiary", respond);
       expectRecordFields(respondPayload(respond), {
         agentId: "main",
         found: false,
@@ -1473,7 +1311,7 @@ describe("doctor.memory.dreamDiary", () => {
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryBackfillDreamDiary(respond);
+      await invokeDoctorMemory("doctor.memory.backfillDreamDiary", respond);
       expect(previewGroundedRemMarkdown).toHaveBeenCalledWith({
         workspaceDir,
         inputPaths: [path.join(workspaceDir, "memory", "2026-02-19.md")],
@@ -1523,7 +1361,7 @@ describe("doctor.memory.dreamDiary", () => {
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryBackfillDreamDiary(respond);
+      await invokeDoctorMemory("doctor.memory.backfillDreamDiary", respond);
       expect(previewGroundedRemMarkdown).toHaveBeenCalledWith({
         workspaceDir,
         inputPaths: [sourcePath],
@@ -1558,7 +1396,7 @@ describe("doctor.memory.dreamDiary", () => {
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryBackfillDreamDiary(respond);
+      await invokeDoctorMemory("doctor.memory.backfillDreamDiary", respond);
       expect(previewGroundedRemMarkdown).not.toHaveBeenCalled();
       expect(writeBackfillDiaryEntries).not.toHaveBeenCalled();
       expectRecordFields(respondPayload(respond), {
@@ -1584,7 +1422,7 @@ describe("doctor.memory.dreamDiary", () => {
     const respond = vi.fn();
 
     try {
-      await invokeDoctorMemoryResetDreamDiary(respond);
+      await invokeDoctorMemory("doctor.memory.resetDreamDiary", respond);
       expect(removeBackfillDiaryEntries).toHaveBeenCalledWith({ workspaceDir });
       expectRecordFields(respondPayload(respond), {
         agentId: "main",
@@ -1657,7 +1495,7 @@ describe("doctor.memory.remHarness", () => {
   it("returns an empty preview payload for an empty workspace", async () => {
     const respond = vi.fn();
 
-    await invokeDoctorMemoryRemHarness(respond);
+    await invokeDoctorMemory("doctor.memory.remHarness", respond);
 
     expectRecordFields(mockCallArg(previewRemHarness), {
       workspaceDir: "/tmp/openclaw",
@@ -1722,7 +1560,7 @@ describe("doctor.memory.remHarness", () => {
     );
     const respond = vi.fn();
 
-    await invokeDoctorMemoryRemHarness(respond);
+    await invokeDoctorMemory("doctor.memory.remHarness", respond);
 
     const payload = respondPayload(respond);
     expectRecordFields(payload, { ok: true });
@@ -1760,7 +1598,9 @@ describe("doctor.memory.remHarness", () => {
     );
     const respond = vi.fn();
 
-    await invokeDoctorMemoryRemHarness(respond, { grounded: true });
+    await invokeDoctorMemory("doctor.memory.remHarness", respond, {
+      params: { grounded: true },
+    });
 
     expectRecordFields(mockCallArg(previewRemHarness), { grounded: true });
     const payload = respondPayload(respond);
@@ -1776,7 +1616,9 @@ describe("doctor.memory.remHarness", () => {
   it("passes bounded grounded and REM preview limits to the shared harness", async () => {
     const respond = vi.fn();
 
-    await invokeDoctorMemoryRemHarness(respond, { grounded: true });
+    await invokeDoctorMemory("doctor.memory.remHarness", respond, {
+      params: { grounded: true },
+    });
 
     expectRecordFields(mockCallArg(previewRemHarness), {
       grounded: true,
@@ -1788,7 +1630,9 @@ describe("doctor.memory.remHarness", () => {
   it("maps requested empty grounded preview into an empty payload", async () => {
     const respond = vi.fn();
 
-    await invokeDoctorMemoryRemHarness(respond, { grounded: true });
+    await invokeDoctorMemory("doctor.memory.remHarness", respond, {
+      params: { grounded: true },
+    });
 
     expectRecordFields(respondPayload(respond), {
       grounded: { scannedFiles: 0, files: [] },
@@ -1799,7 +1643,7 @@ describe("doctor.memory.remHarness", () => {
     previewRemHarness.mockRejectedValue(new Error("disk boom"));
     const respond = vi.fn();
 
-    await invokeDoctorMemoryRemHarness(respond);
+    await invokeDoctorMemory("doctor.memory.remHarness", respond);
 
     const payload = respondPayload(respond);
     expectRecordFields(payload, {
@@ -1839,7 +1683,7 @@ describe("doctor.memory.remHarness", () => {
     );
     const respond = vi.fn();
 
-    await invokeDoctorMemoryRemHarness(respond);
+    await invokeDoctorMemory("doctor.memory.remHarness", respond);
 
     expectRecordFields(mockCallArg(previewRemHarness), { candidateLimit: 25 });
     const payload = respondPayload(respond) as {
@@ -1855,7 +1699,7 @@ describe("doctor.memory.remHarness", () => {
   it("clamps caller-supplied limit within [1, REM_HARNESS_MAX_CANDIDATE_LIMIT]", async () => {
     const respond = vi.fn();
 
-    await invokeDoctorMemoryRemHarness(respond, { limit: 500 });
+    await invokeDoctorMemory("doctor.memory.remHarness", respond, { params: { limit: 500 } });
 
     expectRecordFields(mockCallArg(previewRemHarness), { candidateLimit: 100 });
     const payload = respondPayload(respond) as {


### PR DESCRIPTION
## What Problem This Solves

The 1,867-line doctor RPC test suite repeated method invocation plumbing, memory-manager mocks, and dense dreaming-entry fixtures. That repetition made the suite harder to audit while extending doctor memory behavior.

## Why This Change Was Made

This maintainer-requested cleanup replaces the repeated setup with one typed doctor invocation helper plus typed memory-manager and dreaming-entry fixture builders. It preserves all 45 test titles and their order, exact request parameters, cron-context presence, response assertions, status/error strings, mocks, environment handling, and cleanup. Production code and product behavior are unchanged.

AI-assisted: yes. The diff was implemented and verified with Codex, including an isolated `gpt-5.6-sol` xhigh autoreview.

## User Impact

No user-visible impact. Maintainers get the same doctor RPC coverage with 156 fewer net test lines and fewer fixture shapes to keep synchronized.

## Evidence

- Current-main gate: the target file was byte-identical between the starting SHA and refreshed `origin/main` before rebase.
- Baseline Blacksmith Testbox: 45/45 passed — https://github.com/openclaw/openclaw/actions/runs/30784425790
- Post-change local repository Node Vitest wrapper: 45/45 passed.
- Post-change Blacksmith Testbox: 45/45 passed — https://github.com/openclaw/openclaw/actions/runs/30785484296
- Post-rebase local repository Node Vitest wrapper: 45/45 passed.
- `git diff --check` passed; all 45 `describe`/`it` titles and order compare exactly with `origin/main`.
- Fresh autoreview: `gpt-5.6-sol`, xhigh, one pass, TruffleHog clean, no findings, patch correct at 0.99 confidence.
- Diff: one test file, +197/-353 (net -156); production LOC delta: 0.
