### PR TITLE
fix(parallels): recover Windows smoke after guest transport loss

### DIFF
--- a/scripts/e2e/parallels/guest-transports.ts
+++ b/scripts/e2e/parallels/guest-transports.ts
@@ -92,6 +92,8 @@ function throwIfParallelsVmStopped(label: string, result: CommandResult): void {
 const POSIX_GUEST_SCRIPT_CLEANUP_TIMEOUT_MS = 30_000;
 const POSIX_BACKGROUND_LOG_MAX_BYTES = 8 * 1024 * 1024;
 const WINDOWS_BACKGROUND_LOG_MAX_BYTES = 8 * 1024 * 1024;
+const WINDOWS_BACKGROUND_CLEANUP_RESERVE_MS = 120_000;
+const WINDOWS_BACKGROUND_POLL_FAILURE_LIMIT = 3;
 
 function appendCommandResult(phases: PhaseRunner, result: CommandResult): void {
   phases.append(result.stdout);
@@ -324,7 +326,22 @@ export async function runWindowsBackgroundPowerShell(
   const windowsLogPath = `%WINDIR%\\Temp\\${guestRunDir}\\run.log`;
   const backgroundExitPrefix = `__OPENCLAW_BACKGROUND_EXIT__:${nonce}:`;
   const backgroundDoneMarker = `__OPENCLAW_BACKGROUND_DONE__:${nonce}`;
-  const deadline = Date.now() + options.timeoutMs;
+  // PhaseRunner cannot cancel an in-flight callback. Keep cleanup inside the
+  // helper budget so a timed-out lane cannot overlap the next snapshot restore.
+  const deadline =
+    Date.now() + Math.max(1, options.timeoutMs - WINDOWS_BACKGROUND_CLEANUP_RESERVE_MS);
+  let consecutivePollFailures = 0;
+  const recordPollFailure = (stage: string, result: CommandResult): void => {
+    consecutivePollFailures++;
+    options.onLaunchRetry?.(
+      `${options.label} ${stage} transport failure ${consecutivePollFailures}/${WINDOWS_BACKGROUND_POLL_FAILURE_LIMIT} (exit ${result.status})`,
+    );
+    if (consecutivePollFailures >= WINDOWS_BACKGROUND_POLL_FAILURE_LIMIT) {
+      throw new Error(
+        `${options.label} ${stage} failed after ${WINDOWS_BACKGROUND_POLL_FAILURE_LIMIT} consecutive guest transport errors`,
+      );
+    }
+  };
   const pathsScript = `$runDir = Join-Path (Join-Path $env:WINDIR 'Temp\\openclaw-parallels') ${psSingleQuote(nonce)}
 $scriptPath = Join-Path $runDir 'run.ps1'
 $logPath = Join-Path $runDir 'run.log'
@@ -506,9 +523,18 @@ cmd.exe /d /s /c start "" /b powershell.exe -NoProfile -ExecutionPolicy Bypass -
       appendOutput(append, doneProbe);
       throwIfParallelsVmStopped(options.label, doneProbe);
       if (doneProbe.stdout.split(/\r?\n/u).some((line) => line.trim() === "done")) {
+        consecutivePollFailures = 0;
         doneFileSeen = true;
         completedLogDrainDeadline ||= Date.now() + completedLogDrainGraceMs;
+      } else if (
+        doneProbe.status === 0 &&
+        doneProbe.stdout.split(/\r?\n/u).some((line) => line.trim() === "wait")
+      ) {
+        consecutivePollFailures = 0;
+        await sleep(pollIntervalMs);
+        continue;
       } else {
+        recordPollFailure("done poll", doneProbe);
         await sleep(pollIntervalMs);
         continue;
       }
@@ -529,6 +555,7 @@ cmd.exe /d /s /c start "" /b powershell.exe -NoProfile -ExecutionPolicy Bypass -
       appendOutput(append, poll);
       throwIfParallelsVmStopped(options.label, poll);
       if (hasControlLine(poll.stdout, backgroundDoneMarker)) {
+        consecutivePollFailures = 0;
         doneSeen = true;
         const backgroundExit = findControlValue(poll.stdout, backgroundExitPrefix) ?? "0";
         if (backgroundExit !== "0" || (poll.status !== 0 && poll.status !== 124)) {
@@ -536,6 +563,7 @@ cmd.exe /d /s /c start "" /b powershell.exe -NoProfile -ExecutionPolicy Bypass -
         }
         return;
       }
+      recordPollFailure("log poll", poll);
       await sleep(Math.min(pollIntervalMs, 100));
     }
     if (doneSeen) {

--- a/scripts/e2e/parallels/host-command.ts
+++ b/scripts/e2e/parallels/host-command.ts
@@ -79,17 +79,33 @@ function signalHostCommandProcess(pid: number | undefined, signal: NodeJS.Signal
   if (!pid) {
     return;
   }
-  try {
-    if (process.platform === "win32") {
+  if (process.platform === "win32") {
+    try {
       process.kill(pid, signal);
-    } else {
-      process.kill(-pid, signal);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ESRCH") {
+        warn(`failed to send ${signal} to host command process ${pid}: ${code ?? String(error)}`);
+      }
     }
+    return;
+  }
+  try {
+    process.kill(-pid, signal);
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    if (code !== "ESRCH") {
+    if (code === "ESRCH") {
+      return;
+    }
+    try {
+      process.kill(pid, signal);
+    } catch (fallbackError) {
+      const fallbackCode = (fallbackError as NodeJS.ErrnoException).code;
+      if (fallbackCode === "ESRCH") {
+        return;
+      }
       warn(
-        `failed to send ${signal} to timed host command process ${pid}: ${code ?? String(error)}`,
+        `failed to send ${signal} to host command process ${pid}: group ${code ?? String(error)}, leader ${fallbackCode ?? String(fallbackError)}`,
       );
     }
   }
@@ -115,8 +131,8 @@ writeSync(
 );
 
 let timedOut = false;
-let killTimer;
 let killDeadlineAt = 0;
+let timedOutCleanupStarted = false;
 let outputExceeded = false;
 let forwardedSignal;
 let forwardedSignalKillTimer;
@@ -137,9 +153,17 @@ function signalGroup(signal) {
   }
   try {
     process.kill(-child.pid, signal);
+    return;
   } catch (error) {
-    if (error && error.code !== "ESRCH") {
-      process.stderr.write("failed to send " + signal + " to timed host command process " + child.pid + ": " + (error.code || String(error)) + "\n");
+    if (error && error.code === "ESRCH") {
+      return;
+    }
+    try {
+      process.kill(child.pid, signal);
+    } catch (fallbackError) {
+      if (!fallbackError || fallbackError.code !== "ESRCH") {
+        process.stderr.write("failed to send " + signal + " to host command process " + child.pid + ": group " + ((error && error.code) || String(error)) + ", leader " + ((fallbackError && fallbackError.code) || String(fallbackError)) + "\n");
+      }
     }
   }
 }
@@ -152,19 +176,31 @@ function groupAlive() {
     process.kill(-child.pid, 0);
     return true;
   } catch (error) {
-    return Boolean(error && error.code === "EPERM");
+    if (!error || error.code !== "EPERM") {
+      return false;
+    }
+    if (child.exitCode !== null || child.signalCode !== null) {
+      return false;
+    }
+    try {
+      process.kill(child.pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
   }
 }
 
 function finishTimedOut() {
-  if (killTimer) {
-    clearTimeout(killTimer);
-  }
   writeSync(3, ${JSON.stringify(HOST_COMMAND_TIMEOUT_PREFIX)} + "{}\n");
   process.exit(124);
 }
 
 function finishTimedOutAfterCleanup() {
+  if (timedOutCleanupStarted) {
+    return;
+  }
+  timedOutCleanupStarted = true;
   if (!groupAlive()) {
     finishTimedOut();
     return;
@@ -273,8 +309,7 @@ const timeout = setTimeout(() => {
   timedOut = true;
   signalGroup("SIGTERM");
   killDeadlineAt = Date.now() + payload.timeoutKillGraceMs;
-  killTimer = setTimeout(() => signalGroup("SIGKILL"), payload.timeoutKillGraceMs);
-  killTimer.unref();
+  finishTimedOutAfterCleanup();
 }, payload.timeoutMs);
 timeout.unref();
 
@@ -287,9 +322,6 @@ child.stdin.on("error", (error) => {
 });
 child.on("error", (error) => {
   clearTimeout(timeout);
-  if (killTimer) {
-    clearTimeout(killTimer);
-  }
   writeSync(
     3,
     ${JSON.stringify(HOST_COMMAND_SPAWN_ERROR_PREFIX)} + JSON.stringify({
@@ -309,9 +341,6 @@ child.on("close", (code, signal) => {
   if (timedOut) {
     finishTimedOutAfterCleanup();
     return;
-  }
-  if (killTimer) {
-    clearTimeout(killTimer);
   }
   if (outputExceeded) {
     process.exit(1);
@@ -583,7 +612,18 @@ export async function runStreaming(
         process.kill(-childPid, 0);
         return true;
       } catch (error) {
-        return (error as NodeJS.ErrnoException).code === "EPERM";
+        if ((error as NodeJS.ErrnoException).code !== "EPERM") {
+          return false;
+        }
+        if (child.exitCode !== null || child.signalCode !== null) {
+          return false;
+        }
+        try {
+          process.kill(childPid, 0);
+          return true;
+        } catch {
+          return false;
+        }
       }
     };
     const waitForStreamingProcessGroupExit = async (timeoutBudgetMs: number): Promise<boolean> => {
@@ -703,6 +743,7 @@ export async function runStreaming(
     let timedOut = false;
     let killTimer: NodeJS.Timeout | undefined;
     let killDeadlineAt = 0;
+    let forceKillSent = false;
     const waitForStreamingTimeoutCleanup = async (): Promise<void> => {
       if (!detached) {
         signalStreamingChild("SIGKILL");
@@ -712,7 +753,12 @@ export async function runStreaming(
       if (remainingGraceMs > 0) {
         await waitForStreamingProcessGroupExit(remainingGraceMs);
       }
-      if (streamingProcessGroupAlive()) {
+      if (streamingProcessGroupAlive() && !forceKillSent) {
+        if (killTimer) {
+          clearTimeout(killTimer);
+          killTimer = undefined;
+        }
+        forceKillSent = true;
         signalStreamingChild("SIGKILL");
         await waitForStreamingProcessGroupExit(HOST_COMMAND_POST_FORCE_KILL_WAIT_MS);
       }
@@ -724,10 +770,10 @@ export async function runStreaming(
             timedOut = true;
             signalHostCommandProcess(childPid, "SIGTERM");
             killDeadlineAt = Date.now() + HOST_COMMAND_STREAMING_TIMEOUT_KILL_GRACE_MS;
-            killTimer = setTimeout(
-              () => signalHostCommandProcess(childPid, "SIGKILL"),
-              HOST_COMMAND_STREAMING_TIMEOUT_KILL_GRACE_MS,
-            );
+            killTimer = setTimeout(() => {
+              forceKillSent = true;
+              signalHostCommandProcess(childPid, "SIGKILL");
+            }, HOST_COMMAND_STREAMING_TIMEOUT_KILL_GRACE_MS);
             killTimer.unref();
           }, timeoutMs);
 

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -1621,6 +1621,41 @@ kill -TERM "$$"`,
     expect(runCommand).toHaveBeenCalledTimes(1);
   });
 
+  it("fails boundedly when Windows background polling loses guest transport", async () => {
+    const retries: string[] = [];
+    let donePolls = 0;
+    const runCommand = vi.fn((_command: string, args: string[], options?: { input?: string }) => {
+      const command = args.at(-1) ?? "";
+      if (options?.input) {
+        return { status: 0, stderr: "", stdout: "" };
+      }
+      if (args.includes("--current-user")) {
+        return { status: 0, stderr: "", stdout: "started\n" };
+      }
+      if (args.includes("cmd.exe") && command.includes("echo wait")) {
+        donePolls++;
+        return { status: 124, stderr: "", stdout: "" };
+      }
+      return { status: 0, stderr: "", stdout: "" };
+    });
+
+    await expect(
+      runWindowsBackgroundPowerShell({
+        label: "ref-onboard",
+        onLaunchRetry: (message) => retries.push(message),
+        pollIntervalMs: 1,
+        runCommand,
+        script: "Write-Output ok",
+        timeoutMs: 720_000,
+        vmName: "Windows 11",
+      }),
+    ).rejects.toThrow("ref-onboard done poll failed after 3 consecutive guest transport errors");
+
+    expect(donePolls).toBe(3);
+    expect(retries).toHaveLength(3);
+    expect(retries.at(-1)).toContain("transport failure 3/3");
+  });
+
   it("returns timed-out host command status when check is disabled", () => {
     const result = runNode("process.stdout.write('partial'); setTimeout(() => {}, 1000);", {
       check: false,
@@ -1703,6 +1738,52 @@ kill -TERM "$$"`,
       } finally {
         if (grandchildPid && isProcessAlive(grandchildPid)) {
           process.kill(grandchildPid, "SIGKILL");
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "settles timed host commands when an escaped descendant retains child pipes",
+    () => {
+      const tempDir = makeTempDir(tempDirs, "openclaw-parallels-host-command-pipes-");
+      const grandchildPidPath = join(tempDir, "grandchild.pid");
+      let grandchildPid = 0;
+      const grandchildScript = [
+        "const { writeFileSync } = require('node:fs');",
+        "writeFileSync(process.env.GRANDCHILD_PID_PATH, String(process.pid));",
+        "setInterval(() => {}, 1000);",
+      ].join("\n");
+      const parentScript = [
+        "const { spawn } = require('node:child_process');",
+        `const child = spawn(process.execPath, ['-e', ${JSON.stringify(grandchildScript)}], {`,
+        "  detached: true,",
+        "  env: process.env,",
+        "  stdio: ['ignore', 'inherit', 'inherit'],",
+        "});",
+        "child.unref();",
+        "setInterval(() => {}, 1000);",
+      ].join("\n");
+      const startedAt = Date.now();
+
+      try {
+        const result = run(process.execPath, ["-e", parentScript], {
+          check: false,
+          env: {
+            ...process.env,
+            GRANDCHILD_PID_PATH: grandchildPidPath,
+          },
+          quiet: true,
+          timeoutMs: 100,
+        });
+
+        expect(result.status).toBe(124);
+        expect(Date.now() - startedAt).toBeLessThan(2_000);
+        grandchildPid = Number.parseInt(readFileSync(grandchildPidPath, "utf8"), 10);
+        expect(Number.isInteger(grandchildPid)).toBe(true);
+      } finally {
+        if (grandchildPid && isProcessAlive(grandchildPid)) {
+          process.kill(-grandchildPid, "SIGKILL");
         }
       }
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Windows Parallels validation lane could spend its full phase timeout treating broken `prlctl` polls as healthy waits, then overlap the next retry with unfinished host-command cleanup. The observed Beta 8 validation failure timed out `fresh.onboard-ref` after 721 seconds and emitted repeated `SIGKILL ... EPERM` cleanup errors.

## Why This Change Was Made

The Windows background runner now reserves cleanup time inside the phase budget and fails after three consecutive broken or empty poll transports, allowing the native lane retry to recover promptly. The host-command owner now uses one bounded timeout cleanup state machine and falls back from POSIX process-group signaling to the owned leader PID when Parallels-owned group members reject group signaling.

This repairs the lifecycle owners instead of adding a longer timeout, a consumer-side retry, or provider-specific behavior.

Architectural owner: `scripts/e2e/parallels/guest-transports.ts` for guest poll lifecycle and `scripts/e2e/parallels/host-command.ts` for host process cleanup.

Production LOC: +102/-28 across the two owner modules, net +74. Tests: +81. The added production code expresses the bounded transport-loss and process-cleanup invariants; no parallel execution path or compatibility shim was added.

## User Impact

Maintainers running macOS and Windows Parallels release validation now get bounded recovery from transient guest transport loss instead of a misleading 12-minute hang followed by cleanup interference. There is no shipped runtime or end-user behavior change.

AI-assisted: yes. The change was manually scoped to the test-proved failure and passed a fresh repository autoreview.

## Evidence

- Reproduction: Windows `fresh.onboard-ref` timed out after 721,443 ms; a same-head Windows run had already proved OpenClaw onboarding itself worked, isolating the failure to Parallels transport and cleanup ownership.
- Focused Vitest on the final branch: 6 host-command/transport regressions passed; 3 Windows npm-update background tests passed.
- `git diff --check`: passed.
- Blacksmith Testbox changed gate: passed on lease `tbx_01kz2x05g2eyp3msta5ssc9vmp`, run https://github.com/openclaw/openclaw/actions/runs/30783618056.
- Fresh autoreview against `origin/main`: no findings; patch correct, confidence 0.98.
- Focused Windows E2E: install, version, ref onboarding, gateway restart/status, and live Anthropic agent turn passed.
- Full Parallels aggregate on candidate `6c84837e92b`:
  - macOS fresh: pass, 2m 59s
  - Windows fresh: pass, 7m 38s
  - macOS same-guest `openclaw update`: pass, 4m 4s
  - Windows same-guest `openclaw update`: pass, 12m 58s
  - total: 21m 11s
  - artifact summary: `.artifacts/parallels/openclaw-parallels-npm-update.Z4gXx7/summary.md`
- Both guests were stopped after validation.

No changelog entry: this is release-validation harness reliability only.
