### PR TITLE
refactor: consolidate PR operation lock lifecycle fixtures

### DIFF
--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -112,6 +112,34 @@ function setSparseCheckout(repoDir: string) {
   });
 }
 
+function enterPrWorktree(repoDir: string, pr: number) {
+  const result = runLockShell(repoDir, [
+    "ensure_gh_api_auth() { return 0; }",
+    `enter_worktree ${pr}`,
+  ]);
+  expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  return { result, worktreeDir: join(repoDir, ".worktrees", `pr-${pr}`) };
+}
+
+function expectWorktreeBranch(worktreeDir: string, branch: string) {
+  expect(
+    execFileSync("git", ["branch", "--show-current"], {
+      cwd: worktreeDir,
+      encoding: "utf8",
+    }).trim(),
+  ).toBe(branch);
+}
+
+function expectMaterializedWorktree(worktreeDir: string) {
+  expect(existsSync(join(worktreeDir, "ui", "config", "control-ui-chunking.ts"))).toBe(true);
+  expect(
+    execFileSync("git", ["config", "--bool", "core.sparseCheckout"], {
+      cwd: worktreeDir,
+      encoding: "utf8",
+    }).trim(),
+  ).toBe("false");
+}
+
 function bashSource(repoDir: string, supervised = false) {
   return [
     "set -euo pipefail",
@@ -125,10 +153,16 @@ function bashSource(repoDir: string, supervised = false) {
   ];
 }
 
-function writeOperationFixture(repoDir: string, name: string, commands: string[]) {
+function writeFixtureFile(repoDir: string, name: string, contents: string | readonly string[]) {
   const fixture = join(repoDir, name);
-  writeFileSync(
-    fixture,
+  writeFileSync(fixture, typeof contents === "string" ? contents : contents.join("\n"));
+  return fixture;
+}
+
+function writeOperationFixture(repoDir: string, name: string, commands: string[]) {
+  const fixture = writeFixtureFile(
+    repoDir,
+    name,
     ["#!/usr/bin/env bash", ...bashSource(repoDir, true), ...commands].join("\n"),
   );
   chmodSync(fixture, 0o755);
@@ -159,7 +193,6 @@ function installPrCliFixture(repoDir: string) {
   }
   const cli = join(repoDir, "scripts/pr");
   chmodSync(cli, 0o755);
-
   const binDir = join(repoDir, "isolated-bin");
   mkdirSync(binDir);
   for (const command of ["bash", "basename", "dirname", "git"]) {
@@ -169,15 +202,17 @@ function installPrCliFixture(repoDir: string) {
   return { binDir, cli };
 }
 
+interface SupervisedFixtureOptions {
+  accelerateTimeouts?: boolean;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runner?: string;
+}
+
 async function runSupervisedFixture(
   repoDir: string,
   fixture: string,
-  options: {
-    accelerateTimeouts?: boolean;
-    cwd?: string;
-    env?: NodeJS.ProcessEnv;
-    runner?: string;
-  } = {},
+  options: SupervisedFixtureOptions = {},
 ) {
   const controller = spawn(
     process.execPath,
@@ -238,6 +273,15 @@ async function runSupervisedFixture(
   return { status: controller.exitCode, signal: controller.signalCode, stdout, stderr };
 }
 
+function runSupervisedOperation(
+  repoDir: string,
+  name: string,
+  commands: string[],
+  options?: SupervisedFixtureOptions,
+) {
+  return runSupervisedFixture(repoDir, writeOperationFixture(repoDir, name, commands), options);
+}
+
 function runLockShell(repoDir: string, commands: string[]) {
   return spawnSync("bash", ["-c", [...bashSource(repoDir), ...commands].join("\n")], {
     cwd: repoDir,
@@ -245,6 +289,25 @@ function runLockShell(repoDir: string, commands: string[]) {
     encoding: "utf8",
     timeout: 10_000,
   } as { cwd: string; encoding: "utf8"; timeout: number });
+}
+
+function probeOperationLock(repoDir: string, command: "blocking" | "try" = "try") {
+  return runLockShell(repoDir, [
+    "set +e",
+    command === "try" ? "try_acquire_pr_operation_lock 42" : "acquire_pr_operation_lock 42",
+    "lock_status=$?",
+    "set -e",
+    'printf "%s\\n" "$lock_status"',
+  ]);
+}
+
+function recoverOperationLock(repoDir: string, ownerOid: string, commands: string[] = []) {
+  const result = runLockShell(repoDir, [
+    `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
+    ...commands,
+  ]);
+  expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  expect(refExists(repoDir)).toBe(false);
 }
 
 function spawnHolder(repoDir: string, statusFile: string, pr = 42, trapTerm = true) {
@@ -438,6 +501,13 @@ async function cleanupProcessGroup(pgid: number) {
   }
 }
 
+async function cleanupRecordedProcessGroup(path: string, pgid?: number) {
+  const recordedPgid = pgid ?? readProcessIdFile(path);
+  if (recordedPgid) {
+    await cleanupProcessGroup(recordedPgid);
+  }
+}
+
 function readOperationProcessGroup(repoDir: string) {
   if (!refExists(repoDir)) {
     return undefined;
@@ -465,7 +535,6 @@ async function cleanupController(
     await cleanupProcessGroup(pgid);
   }
   await cleanupChildren(controller);
-
   pgid = operationPgidFile ? readProcessIdFile(operationPgidFile) : undefined;
   pgid ??= readOperationProcessGroup(repoDir);
   if (pgid) {
@@ -526,7 +595,6 @@ describe("scripts/pr process-group platform guard", () => {
     if (process.platform !== "win32") {
       return;
     }
-
     const result = spawnSync(process.execPath, [processGroupRunner, repoRoot, "unused"], {
       encoding: "utf8",
     });
@@ -546,7 +614,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
     let waiter: ChildProcess | undefined;
     try {
       expect(await waitFor(() => existsSync(held))).toBe(true);
-
       waiter = spawnDetached(
         "bash",
         [
@@ -563,7 +630,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       );
       expect(await waitFor(() => existsSync(blocked))).toBe(true);
       expect(existsSync(acquired)).toBe(false);
-
       await stopChild(holder, "SIGTERM");
       expect(await waitFor(() => existsSync(acquired))).toBe(true);
       await waitForExit(waiter);
@@ -571,7 +637,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       await cleanupChildren(waiter, holder);
     }
   });
-
   it("allows different PRs to proceed concurrently", async () => {
     const repoDir = createRepo();
     const held = join(repoDir, "held");
@@ -587,7 +652,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       await cleanupChildren(holder);
     }
   });
-
   it("does not publish a candidate paused before the create CAS", async () => {
     const repoDir = createRepo();
     const prepared = join(repoDir, "prepared");
@@ -603,7 +667,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       await cleanupChildren(candidate);
     }
   });
-
   it("requires exact recovery after a SIGKILL owner disappears", async () => {
     const repoDir = createRepo();
     const held = join(repoDir, "held");
@@ -612,31 +675,18 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(await waitFor(() => existsSync(held))).toBe(true);
       const ownerOid = refOid(repoDir);
       await stopChild(holder, "SIGKILL");
-
-      const blocked = runLockShell(repoDir, [
-        "set +e",
-        "acquire_pr_operation_lock 42",
-        "lock_status=$?",
-        "set -e",
-        'printf "%s\\n" "$lock_status"',
-      ]);
+      const blocked = probeOperationLock(repoDir, "blocking");
       expect(blocked.status).toBe(0);
       expect(blocked.stdout.trim()).toBe("2");
       expect(blocked.stderr).toContain(
         `scripts/pr lock-recover 42 ${ownerOid} --confirmed-no-running-tools`,
       );
       expect(refOid(repoDir)).toBe(ownerOid);
-
-      const recovered = runLockShell(repoDir, [
-        `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-      ]);
-      expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-      expect(refExists(repoDir)).toBe(false);
+      recoverOperationLock(repoDir, ownerOid);
     } finally {
       await cleanupChildren(holder);
     }
   });
-
   it("makes an exact-OID late release harmless after a successor acquires", async () => {
     const repoDir = createRepo();
     const firstHeld = join(repoDir, "first-held");
@@ -647,11 +697,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
       const oldOid = refOid(repoDir);
       await stopChild(first, "SIGKILL");
       expect(await waitFor(() => !processGroupExists(first.pid!))).toBe(true);
-      const recovered = runLockShell(repoDir, [
-        `recover_pr_operation_lock 42 '${oldOid}' --confirmed-no-running-tools`,
-      ]);
-      expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-
+      recoverOperationLock(repoDir, oldOid);
       const secondHeld = join(repoDir, "second-held");
       second = spawnHolder(repoDir, secondHeld);
       expect(await waitFor(() => existsSync(secondHeld))).toBe(true);
@@ -667,7 +713,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       await cleanupChildren(second, first);
     }
   });
-
   it("requires confirmation and the current exact OID for recovery", async () => {
     const repoDir = createRepo();
     const held = join(repoDir, "held");
@@ -679,7 +724,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
         cwd: repoDir,
         encoding: "utf8",
       }).trim();
-
       const unconfirmed = runLockShell(repoDir, [
         "set +e",
         `recover_pr_operation_lock 42 '${ownerOid}'`,
@@ -691,7 +735,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(unconfirmed.stdout.trim()).toBe("2");
       expect(unconfirmed.stderr).toContain("Recovery requires --confirmed-no-running-tools");
       expect(refOid(repoDir)).toBe(ownerOid);
-
       const wrongOwner = runLockShell(repoDir, [
         "set +e",
         `recover_pr_operation_lock 42 '${wrongOid}' --confirmed-no-running-tools`,
@@ -706,7 +749,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       await cleanupChildren(holder);
     }
   });
-
   it("preserves a successor when recovery loses its exact-OID CAS", () => {
     const repoDir = createRepo();
     const result = runLockShell(repoDir, [
@@ -731,12 +773,10 @@ describePosix("scripts/pr per-PR operation lock", () => {
       input: "successor-lock\n",
       encoding: "utf8",
     }).trim();
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout.trim()).toBe(`1\t${successorOid}`);
     expect(result.stderr).toContain("owner changed during recovery");
   });
-
   it("runs lock recovery without the normal PR toolchain", () => {
     const repoDir = createRepo();
     const { binDir, cli } = installPrCliFixture(repoDir);
@@ -745,7 +785,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       encoding: "utf8",
     }).trim();
     execFileSync("git", ["update-ref", lockRef, ownerOid], { cwd: repoDir });
-
     const result = spawnSync(
       cli,
       ["lock-recover", "42", ownerOid, "--confirmed-no-running-tools"],
@@ -755,38 +794,24 @@ describePosix("scripts/pr per-PR operation lock", () => {
         env: { ...process.env, PATH: binDir },
       },
     );
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout.trim()).toBe("Recovered the stale operation lock for PR #42.");
     expect(refExists(repoDir)).toBe(false);
   });
-
-  it("does not lock an unsupported command that shares a known prefix", () => {
+  it.each([
+    ["does not lock an unsupported command that shares a known prefix", "review-not-a-command"],
+    ["does not lock review-tests before validating its required target", "review-tests"],
+  ])("%s", (_title, command) => {
     const repoDir = createRepo();
     const { cli } = installPrCliFixture(repoDir);
-    const result = spawnSync(cli, ["review-not-a-command", "42"], {
+    const result = spawnSync(cli, [command, "42"], {
       cwd: repoDir,
       encoding: "utf8",
     });
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(2);
     expect(result.stdout).toContain("Usage:");
     expect(refExists(repoDir)).toBe(false);
   });
-
-  it("does not lock review-tests before validating its required target", () => {
-    const repoDir = createRepo();
-    const { cli } = installPrCliFixture(repoDir);
-    const result = spawnSync(cli, ["review-tests", "42"], {
-      cwd: repoDir,
-      encoding: "utf8",
-    });
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(2);
-    expect(result.stdout).toContain("Usage:");
-    expect(refExists(repoDir)).toBe(false);
-  });
-
   it("does not trust an ambient dedicated-process-group marker", () => {
     const repoDir = createRepo();
     const { binDir, cli } = installPrCliFixture(repoDir);
@@ -804,17 +829,14 @@ describePosix("scripts/pr per-PR operation lock", () => {
     };
     delete env.OPENCLAW_PR_LOCK_NOTIFY_FD;
     delete env.OPENCLAW_PR_LOCK_SUPERVISOR_PID;
-
     const result = spawnSync(cli, ["review-init", "42"], {
       cwd: repoDir,
       encoding: "utf8",
       env,
     });
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(refExists(repoDir)).toBe(false);
   });
-
   it.each([["--dryrun"], ["--dry-run", "extra"]])(
     "rejects invalid gc arguments before cleanup: %s",
     (...args: string[]) => {
@@ -824,13 +846,11 @@ describePosix("scripts/pr per-PR operation lock", () => {
         cwd: repoDir,
         encoding: "utf8",
       });
-
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(2);
       expect(result.stdout).toContain("Usage:");
       expect(refExists(repoDir)).toBe(false);
     },
   );
-
   it("recovers an exact owner despite an unrelated reused live PGID", async () => {
     const repoDir = createRepo();
     const unrelated = spawnDetached("sleep", ["30"], { stdio: "ignore" });
@@ -846,7 +866,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
         'printf "%s\\t%s\\n" "$lock_status" "$owner_oid"',
         'recover_pr_operation_lock 42 "$owner_oid" --confirmed-no-running-tools',
       ]);
-
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
       const blockedLine = expectDefined(
         result.stdout.trim().split("\n")[0],
@@ -864,7 +883,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       await cleanupChildren(unrelated);
     }
   });
-
   it("retries when the prior owner releases between failed create CAS and ref read", () => {
     const repoDir = createRepo();
     const raceTriggered = join(repoDir, "race-triggered");
@@ -886,7 +904,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
     expect(result.status).toBe(0);
     expect(existsSync(raceTriggered)).toBe(true);
   });
-
   it("retries when the finishing supervisor releases before an orphan verdict", () => {
     const repoDir = createRepo();
     const result = runLockShell(repoDir, [
@@ -901,11 +918,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
       "try_acquire_pr_operation_lock 42",
       "release_pr_operation_lock",
     ]);
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(refExists(repoDir)).toBe(false);
   });
-
   it("keeps a live orphaned operation group sticky and surfaces recovery", async () => {
     const repoDir = createRepo();
     const held = join(repoDir, "held");
@@ -916,7 +931,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       const ownerOid = refOid(repoDir);
       // Leave the same-group child alive to model a controller-only failure.
       await stopChildLeader(holder, "SIGKILL");
-
       const blocked = runLockShell(repoDir, [
         "set +e",
         "try_acquire_pr_operation_lock 42",
@@ -928,28 +942,17 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(blocked.stdout.trim()).toBe(`2\torphaned\t${ownerOid}`);
       killProcessGroup(holder.pid!, "SIGTERM");
       expect(await waitFor(() => !processGroupExists(holder.pid!))).toBe(true);
-
-      const stillBlocked = runLockShell(repoDir, [
-        "set +e",
-        "acquire_pr_operation_lock 42",
-        "lock_status=$?",
-        "set -e",
-        'printf "%s\\n" "$lock_status"',
-      ]);
+      const stillBlocked = probeOperationLock(repoDir, "blocking");
       expect(stillBlocked.status).toBe(0);
       expect(stillBlocked.stdout.trim()).toBe("2");
-
-      const recovered = runLockShell(repoDir, [
-        `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
+      recoverOperationLock(repoDir, ownerOid, [
         "acquire_pr_operation_lock 42",
         "release_pr_operation_lock",
       ]);
-      expect(recovered.status, `${recovered.stdout}\\n${recovered.stderr}`).toBe(0);
     } finally {
       await cleanupChildren(holder);
     }
   });
-
   it("rejects noncanonical aliases for the same PR number", () => {
     const repoDir = createRepo();
     const result = runLockShell(repoDir, [
@@ -961,11 +964,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
       "set -e",
       'printf "%s\t%s\n" "$lock_status" "$parse_status"',
     ]);
-
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe("2\t1");
   });
-
   it("retries release while the owner ref is unchanged", () => {
     const repoDir = createRepo();
     const result = runLockShell(repoDir, [
@@ -984,11 +985,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
       `if command git show-ref --verify --quiet '${lockRef}'; then ref_status=present; else ref_status=absent; fi`,
       'printf "%s\t%s\n" "$delete_attempts" "$ref_status"',
     ]);
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout.trim()).toBe("3\tabsent");
   });
-
   it("fails release when the owner ref stays unchanged", () => {
     const repoDir = createRepo();
     const result = runLockShell(repoDir, [
@@ -1009,142 +1008,90 @@ describePosix("scripts/pr per-PR operation lock", () => {
       "set -e",
       'printf "%s\t%s\t%s\n" "$release_status" "$PR_OPERATION_LOCK_OWNER_OID" "$delete_attempts"',
     ]);
-
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe(`1\t${refOid(repoDir)}\t20`);
     expect(result.stderr).toContain("Unable to release the operation lock for 42");
   });
-
-  it("has the process-group supervisor release the exact owner ref", async () => {
+  it.each([
+    {
+      title: "has the process-group supervisor release the exact owner ref",
+      fixture: "acquire-once.sh",
+      commands: ["acquire_pr_operation_lock 42"],
+      status: 0,
+      retained: false,
+    },
+    {
+      title: "releases a failed lock while the child is still in validation phase",
+      fixture: "failed-validation.sh",
+      commands: ["acquire_pr_operation_lock 42", "begin_pr_operation_validation_phase", "exit 3"],
+      status: 3,
+      retained: false,
+    },
+    {
+      title: "retains a failed lock after the child leaves validation phase",
+      fixture: "failed-after-side-effects.sh",
+      commands: [
+        "acquire_pr_operation_lock 42",
+        "begin_pr_operation_validation_phase",
+        "mark_pr_operation_side_effects_started",
+        "exit 3",
+      ],
+      status: 3,
+      retained: true,
+    },
+    {
+      title: "reports the child exit code when retaining a failed operation",
+      fixture: "failed-operation.sh",
+      commands: ["acquire_pr_operation_lock 42", "exit 3"],
+      status: 3,
+      retained: true,
+    },
+    {
+      title: "does not re-enter validation after side effects have started",
+      fixture: "failed-after-forged-validation.sh",
+      commands: [
+        "acquire_pr_operation_lock 42",
+        "begin_pr_operation_validation_phase",
+        "mark_pr_operation_side_effects_started",
+        "notify_pr_operation_phase validation-started",
+        "exit 3",
+      ],
+      status: 3,
+      retained: true,
+    },
+    {
+      title: "retains a validation-phase lock when the child exits through a trapped signal",
+      fixture: "signaled-validation.sh",
+      commands: [
+        "trap 'exit 143' TERM",
+        "acquire_pr_operation_lock 42",
+        "begin_pr_operation_validation_phase",
+        "kill -TERM $$",
+      ],
+      status: 143,
+      retained: true,
+    },
+    {
+      title: "retains a validation-phase lock for untrapped signal exit statuses",
+      fixture: "killed-validation.sh",
+      commands: ["acquire_pr_operation_lock 42", "begin_pr_operation_validation_phase", "exit 137"],
+      status: 137,
+      retained: true,
+    },
+  ])("$title", async ({ fixture, commands, status, retained }) => {
     const repoDir = createRepo();
-    const fixture = writeOperationFixture(repoDir, "acquire-once.sh", [
-      "acquire_pr_operation_lock 42",
-    ]);
-    const result = await runSupervisedFixture(repoDir, fixture);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-    expect(refExists(repoDir)).toBe(false);
-    expect(result.stderr).not.toContain("Retaining the operation lock");
+    const result = await runSupervisedOperation(repoDir, fixture, commands);
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(status);
+    if (retained) {
+      const ownerOid = refOid(repoDir);
+      expect(result.stderr).toContain(`reason: child exited with code ${status}`);
+      expect(refOid(repoDir)).toBe(ownerOid);
+      recoverOperationLock(repoDir, ownerOid);
+    } else {
+      expect(refExists(repoDir)).toBe(false);
+      expect(result.stderr).not.toContain("Retaining the operation lock");
+    }
   });
-
-  it("releases a failed lock while the child is still in validation phase", async () => {
-    const repoDir = createRepo();
-    const fixture = writeOperationFixture(repoDir, "failed-validation.sh", [
-      "acquire_pr_operation_lock 42",
-      "begin_pr_operation_validation_phase",
-      "exit 3",
-    ]);
-    const result = await runSupervisedFixture(repoDir, fixture);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(3);
-    expect(refExists(repoDir)).toBe(false);
-    expect(result.stderr).not.toContain("Retaining the operation lock");
-  });
-
-  it("retains a failed lock after the child leaves validation phase", async () => {
-    const repoDir = createRepo();
-    const fixture = writeOperationFixture(repoDir, "failed-after-side-effects.sh", [
-      "acquire_pr_operation_lock 42",
-      "begin_pr_operation_validation_phase",
-      "mark_pr_operation_side_effects_started",
-      "exit 3",
-    ]);
-    const result = await runSupervisedFixture(repoDir, fixture);
-    const ownerOid = refOid(repoDir);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(3);
-    expect(result.stderr).toContain("reason: child exited with code 3");
-    expect(refOid(repoDir)).toBe(ownerOid);
-
-    const recovered = runLockShell(repoDir, [
-      `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-    ]);
-    expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-  });
-
-  it("reports the child exit code when retaining a failed operation", async () => {
-    const repoDir = createRepo();
-    const fixture = writeOperationFixture(repoDir, "failed-operation.sh", [
-      "acquire_pr_operation_lock 42",
-      "exit 3",
-    ]);
-    const result = await runSupervisedFixture(repoDir, fixture);
-    const ownerOid = refOid(repoDir);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(3);
-    expect(result.stderr).toContain("reason: child exited with code 3");
-    expect(refOid(repoDir)).toBe(ownerOid);
-
-    const recovered = runLockShell(repoDir, [
-      `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-    ]);
-    expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-    expect(refExists(repoDir)).toBe(false);
-  });
-
-  it("does not re-enter validation after side effects have started", async () => {
-    const repoDir = createRepo();
-    const fixture = writeOperationFixture(repoDir, "failed-after-forged-validation.sh", [
-      "acquire_pr_operation_lock 42",
-      "begin_pr_operation_validation_phase",
-      "mark_pr_operation_side_effects_started",
-      "notify_pr_operation_phase validation-started",
-      "exit 3",
-    ]);
-    const result = await runSupervisedFixture(repoDir, fixture);
-    const ownerOid = refOid(repoDir);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(3);
-    expect(result.stderr).toContain("reason: child exited with code 3");
-    expect(refOid(repoDir)).toBe(ownerOid);
-
-    const recovered = runLockShell(repoDir, [
-      `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-    ]);
-    expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-  });
-
-  it("retains a validation-phase lock when the child exits through a trapped signal", async () => {
-    const repoDir = createRepo();
-    const fixture = writeOperationFixture(repoDir, "signaled-validation.sh", [
-      "trap 'exit 143' TERM",
-      "acquire_pr_operation_lock 42",
-      "begin_pr_operation_validation_phase",
-      "kill -TERM $$",
-    ]);
-    const result = await runSupervisedFixture(repoDir, fixture);
-    const ownerOid = refOid(repoDir);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(143);
-    expect(result.stderr).toContain("reason: child exited with code 143");
-    expect(refOid(repoDir)).toBe(ownerOid);
-
-    const recovered = runLockShell(repoDir, [
-      `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-    ]);
-    expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-  });
-
-  it("retains a validation-phase lock for untrapped signal exit statuses", async () => {
-    const repoDir = createRepo();
-    const fixture = writeOperationFixture(repoDir, "killed-validation.sh", [
-      "acquire_pr_operation_lock 42",
-      "begin_pr_operation_validation_phase",
-      "exit 137",
-    ]);
-    const result = await runSupervisedFixture(repoDir, fixture);
-    const ownerOid = refOid(repoDir);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(137);
-    expect(result.stderr).toContain("reason: child exited with code 137");
-    expect(refOid(repoDir)).toBe(ownerOid);
-
-    const recovered = runLockShell(repoDir, [
-      `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-    ]);
-    expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-  });
-
   it("releases the lock after the operation deletes its runner worktree", async () => {
     const repoDir = createRepo();
     const doomedDir = tempDirs.make("openclaw-pr-self-deleting-runner-");
@@ -1169,19 +1116,16 @@ describePosix("scripts/pr per-PR operation lock", () => {
       ].join("\n"),
     );
     chmodSync(fixture, 0o755);
-
     const result = await runSupervisedFixture(repoDir, fixture, {
       cwd: doomedDir,
       runner: copiedRunner,
     });
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout).toContain("fixture: lock acquired");
     expect(result.stdout).toContain("fixture: runner worktree deleted");
     expect(result.stderr).not.toContain("Retaining the operation lock");
     expect(refExists(repoDir)).toBe(false);
   });
-
   it("retains the exact owner when supervisor release cannot take the ref lock", async () => {
     const repoDir = createRepo();
     // Retry counts are covered above; this integration case only needs the real ref-lock failure.
@@ -1192,30 +1136,22 @@ describePosix("scripts/pr per-PR operation lock", () => {
     writeFileSync(sleepPath, "#!/bin/sh\nexit 0\n");
     chmodSync(sleepPath, 0o755);
     const refLock = join(repoDir, ".git/refs/openclaw/pr-operation-locks/42.lock");
-    const fixture = writeOperationFixture(repoDir, "blocked-release.sh", [
-      "acquire_pr_operation_lock 42",
-      `: >'${refLock}'`,
-    ]);
-    const result = await runSupervisedFixture(repoDir, fixture, {
-      env: { PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}` },
-    });
+    const result = await runSupervisedOperation(
+      repoDir,
+      "blocked-release.sh",
+      ["acquire_pr_operation_lock 42", `: >'${refLock}'`],
+      { env: { PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}` } },
+    );
     const ownerOid = refOid(repoDir);
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
     expect(result.stderr).toContain("Unable to release the operation lock for 42");
     expect(result.stderr).toContain(
       `scripts/pr lock-recover 42 ${ownerOid} --confirmed-no-running-tools`,
     );
     expect(refOid(repoDir)).toBe(ownerOid);
-
     unlinkSync(refLock);
-    const recovered = runLockShell(repoDir, [
-      `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-    ]);
-    expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-    expect(refExists(repoDir)).toBe(false);
+    recoverOperationLock(repoDir, ownerOid);
   });
-
   it("reports exact recovery when lock notification fails", () => {
     const repoDir = createRepo();
     const result = runLockShell(repoDir, [
@@ -1226,21 +1162,14 @@ describePosix("scripts/pr per-PR operation lock", () => {
       "set -e",
       'printf "%s\\n" "$lock_status"',
     ]);
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout.trim()).toBe("2");
     const ownerOid = refOid(repoDir);
     expect(result.stderr).toContain(
       `scripts/pr lock-recover 42 ${ownerOid} --confirmed-no-running-tools`,
     );
-
-    const recovered = runLockShell(repoDir, [
-      `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-    ]);
-    expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-    expect(refExists(repoDir)).toBe(false);
+    recoverOperationLock(repoDir, ownerOid);
   });
-
   it("rejects a notification for a lock owned by another process group", async () => {
     const repoDir = createRepo();
     const foreignRef = "refs/openclaw/pr-operation-locks/43";
@@ -1249,119 +1178,90 @@ describePosix("scripts/pr per-PR operation lock", () => {
     try {
       expect(await waitFor(() => existsSync(foreignHeld))).toBe(true);
       const foreignOid = refOid(repoDir, foreignRef);
-      const fixture = writeOperationFixture(repoDir, "forged-notification.sh", [
+      const result = await runSupervisedOperation(repoDir, "forged-notification.sh", [
         "acquire_pr_operation_lock 42",
         `printf '%s\\t%s\\n' '${foreignRef}' '${foreignOid}' >&"$OPENCLAW_PR_LOCK_NOTIFY_FD"`,
       ]);
-      const result = await runSupervisedFixture(repoDir, fixture);
-
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
       expect(refOid(repoDir, foreignRef)).toBe(foreignOid);
       expect(refExists(repoDir)).toBe(true);
       expect(result.stderr).toContain("operation lock owned by another process group");
-
       const ownerOid = refOid(repoDir);
-      const recovered = runLockShell(repoDir, [
-        `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-      ]);
-      expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
+      recoverOperationLock(repoDir, ownerOid);
     } finally {
       await cleanupChildren(foreignHolder);
     }
   });
-
   it.each([
-    ["newline-terminated", "printf 'not-lock-metadata\\n'"],
-    ["unterminated", "printf 'not-lock-metadata'"],
-  ])("retains the lock after %s malformed supervisor metadata", async (_name, command) => {
+    [
+      "retains the lock after newline-terminated malformed supervisor metadata",
+      "malformed-notification.sh",
+      "printf 'not-lock-metadata\\n'",
+      "malformed operation-lock metadata",
+    ],
+    [
+      "retains the lock after unterminated malformed supervisor metadata",
+      "malformed-notification.sh",
+      "printf 'not-lock-metadata'",
+      "malformed operation-lock metadata",
+    ],
+    [
+      "bounds an oversized unterminated supervisor metadata line",
+      "oversized-notification.sh",
+      `node -e 'process.stdout.write("x".repeat(8192))'`,
+      "operation-lock metadata line is too large",
+    ],
+  ])("%s", async (_title, fixture, command, expectedError) => {
     const repoDir = createRepo();
-    const fixture = writeOperationFixture(repoDir, "malformed-notification.sh", [
+    const result = await runSupervisedOperation(repoDir, fixture, [
       "acquire_pr_operation_lock 42",
       `${command} >&"$OPENCLAW_PR_LOCK_NOTIFY_FD"`,
     ]);
-    const result = await runSupervisedFixture(repoDir, fixture);
     const ownerOid = refOid(repoDir);
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
-    expect(result.stderr).toContain("malformed operation-lock metadata");
+    expect(result.stderr).toContain(expectedError);
     expect(result.stderr).toContain(
       `scripts/pr lock-recover 42 ${ownerOid} --confirmed-no-running-tools`,
     );
     expect(refOid(repoDir)).toBe(ownerOid);
-
-    const recovered = runLockShell(repoDir, [
-      `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-    ]);
-    expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-    expect(refExists(repoDir)).toBe(false);
+    recoverOperationLock(repoDir, ownerOid);
   });
-
-  it("bounds an oversized unterminated supervisor metadata line", async () => {
-    const repoDir = createRepo();
-    const fixture = writeOperationFixture(repoDir, "oversized-notification.sh", [
-      "acquire_pr_operation_lock 42",
-      `node -e 'process.stdout.write("x".repeat(8192))' >&"$OPENCLAW_PR_LOCK_NOTIFY_FD"`,
-    ]);
-    const result = await runSupervisedFixture(repoDir, fixture);
-    const ownerOid = refOid(repoDir);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
-    expect(result.stderr).toContain("operation-lock metadata line is too large");
-    expect(result.stderr).toContain(
-      `scripts/pr lock-recover 42 ${ownerOid} --confirmed-no-running-tools`,
-    );
-    expect(refOid(repoDir)).toBe(ownerOid);
-
-    const recovered = runLockShell(repoDir, [
-      `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-    ]);
-    expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-    expect(refExists(repoDir)).toBe(false);
-  });
-
   it("uses successful command return as the trusted completion contract", async () => {
     const repoDir = createRepo();
     const daemonPidFile = join(repoDir, "unrelated-daemon-pgid");
-    const daemonScript = join(repoDir, "unrelated-daemon.mjs");
-    const launcherScript = join(repoDir, "unrelated-daemon-launcher.mjs");
-    writeFileSync(daemonScript, "setInterval(() => {}, 1000);\n");
-    writeFileSync(
-      launcherScript,
-      [
-        'import { spawn } from "node:child_process";',
-        'import fs from "node:fs";',
-        `const child = spawn(process.execPath, [${JSON.stringify(daemonScript)}], {`,
-        "  detached: true,",
-        '  stdio: "ignore",',
-        "});",
-        `fs.writeFileSync(${JSON.stringify(daemonPidFile)}, String(child.pid));`,
-        "child.unref();",
-      ].join("\n"),
+    const daemonScript = writeFixtureFile(
+      repoDir,
+      "unrelated-daemon.mjs",
+      "setInterval(() => {}, 1000);\n",
     );
-    const fixture = writeOperationFixture(repoDir, "clean-detached-launcher.sh", [
-      "acquire_pr_operation_lock 42",
-      `node '${launcherScript}'`,
+    const launcherScript = writeFixtureFile(repoDir, "unrelated-daemon-launcher.mjs", [
+      'import { spawn } from "node:child_process";',
+      'import fs from "node:fs";',
+      `const child = spawn(process.execPath, [${JSON.stringify(daemonScript)}], {`,
+      "  detached: true,",
+      '  stdio: "ignore",',
+      "});",
+      `fs.writeFileSync(${JSON.stringify(daemonPidFile)}, String(child.pid));`,
+      "child.unref();",
     ]);
     let daemonPgid: number | undefined;
     try {
-      const result = await runSupervisedFixture(repoDir, fixture);
+      const result = await runSupervisedOperation(repoDir, "clean-detached-launcher.sh", [
+        "acquire_pr_operation_lock 42",
+        `node '${launcherScript}'`,
+      ]);
       daemonPgid = await waitForProcessId(daemonPidFile);
-
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
       expect(processGroupExists(daemonPgid)).toBe(true);
       expect(refExists(repoDir)).toBe(false);
     } finally {
-      daemonPgid ??= readProcessIdFile(daemonPidFile);
-      if (daemonPgid) {
-        await cleanupProcessGroup(daemonPgid);
-      }
+      await cleanupRecordedProcessGroup(daemonPidFile, daemonPgid);
     }
   });
-
   it("joins worktree-list producers before releasing a successful operation lock", async () => {
     const repoDir = createRepo();
     const producerExited = join(repoDir, "worktree-producer-exited");
-    const fixture = writeOperationFixture(repoDir, "joined-worktree-operation.sh", [
+    const result = await runSupervisedOperation(repoDir, "joined-worktree-operation.sh", [
       "acquire_pr_operation_lock 42",
       "git() {",
       '  if [ "$1" = worktree ] && [ "$2" = list ]; then',
@@ -1380,44 +1280,34 @@ describePosix("scripts/pr per-PR operation lock", () => {
       'test "$resolved" = "$PWD"',
       "test -f worktree-producer-exited",
     ]);
-
-    const result = await runSupervisedFixture(repoDir, fixture);
-
     expect(result.status, result.stdout + "\n" + result.stderr).toBe(0);
     expect(existsSync(producerExited)).toBe(true);
     expect(refExists(repoDir)).toBe(false);
     expect(result.stderr).not.toContain("process group remained active after wrapper exit");
   });
-
   it("retains a failed operation lock when a detached child outlives its launcher", async () => {
     const repoDir = createRepo();
     const nestedPidFile = join(repoDir, "failed-nested-pgid");
-    const nestedScript = join(repoDir, "failed-nested.mjs");
-    const launcherScript = join(repoDir, "failing-launcher.mjs");
-    writeFileSync(
-      nestedScript,
-      ['process.on("SIGTERM", () => {});', "setInterval(() => {}, 1000);"].join("\n"),
-    );
-    writeFileSync(
-      launcherScript,
-      [
-        'import { spawn } from "node:child_process";',
-        'import fs from "node:fs";',
-        `const child = spawn(process.execPath, [${JSON.stringify(nestedScript)}], {`,
-        "  detached: true,",
-        '  stdio: "ignore",',
-        "});",
-        `fs.writeFileSync(${JSON.stringify(nestedPidFile)}, String(child.pid));`,
-        "process.exit(1);",
-      ].join("\n"),
-    );
-    const fixture = writeOperationFixture(repoDir, "failed-operation.sh", [
-      "acquire_pr_operation_lock 42",
-      `node '${launcherScript}'`,
+    const nestedScript = writeFixtureFile(repoDir, "failed-nested.mjs", [
+      'process.on("SIGTERM", () => {});',
+      "setInterval(() => {}, 1000);",
+    ]);
+    const launcherScript = writeFixtureFile(repoDir, "failing-launcher.mjs", [
+      'import { spawn } from "node:child_process";',
+      'import fs from "node:fs";',
+      `const child = spawn(process.execPath, [${JSON.stringify(nestedScript)}], {`,
+      "  detached: true,",
+      '  stdio: "ignore",',
+      "});",
+      `fs.writeFileSync(${JSON.stringify(nestedPidFile)}, String(child.pid));`,
+      "process.exit(1);",
     ]);
     let nestedPgid: number | undefined;
     try {
-      const result = await runSupervisedFixture(repoDir, fixture);
+      const result = await runSupervisedOperation(repoDir, "failed-operation.sh", [
+        "acquire_pr_operation_lock 42",
+        `node '${launcherScript}'`,
+      ]);
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
       nestedPgid = await waitForProcessId(nestedPidFile);
       expect(processGroupExists(nestedPgid!)).toBe(true);
@@ -1425,104 +1315,77 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(result.stderr).toContain(
         `scripts/pr lock-recover 42 ${ownerOid} --confirmed-no-running-tools`,
       );
-
-      const blocked = runLockShell(repoDir, [
-        "set +e",
-        "try_acquire_pr_operation_lock 42",
-        "lock_status=$?",
-        "set -e",
-        'printf "%s\\n" "$lock_status"',
-      ]);
+      const blocked = probeOperationLock(repoDir);
       expect(blocked.status).toBe(0);
       expect(blocked.stdout.trim()).toBe("2");
-
       killProcessGroup(nestedPgid!, "SIGKILL");
       expect(await waitFor(() => !processGroupExists(nestedPgid!))).toBe(true);
-      const recovered = runLockShell(repoDir, [
-        `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-      ]);
-      expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-      expect(refExists(repoDir)).toBe(false);
+      recoverOperationLock(repoDir, ownerOid);
     } finally {
-      nestedPgid ??= readProcessIdFile(nestedPidFile);
-      if (nestedPgid) {
-        await cleanupProcessGroup(nestedPgid);
-      }
+      await cleanupRecordedProcessGroup(nestedPidFile, nestedPgid);
     }
   });
-
   it("exits after a bounded wait when a detached child keeps the notification pipe open", async () => {
     const repoDir = createRepo();
     const nestedPidFile = join(repoDir, "pipe-holder-pgid");
-    const nestedScript = join(repoDir, "pipe-holder.mjs");
-    const launcherScript = join(repoDir, "pipe-holder-launcher.mjs");
-    writeFileSync(nestedScript, "setInterval(() => {}, 1000);\n");
-    writeFileSync(
-      launcherScript,
-      [
-        'import { spawn } from "node:child_process";',
-        'import fs from "node:fs";',
-        `const child = spawn(process.execPath, [${JSON.stringify(nestedScript)}], {`,
-        "  detached: true,",
-        '  stdio: ["ignore", "ignore", "ignore", 3],',
-        "});",
-        `fs.writeFileSync(${JSON.stringify(nestedPidFile)}, String(child.pid));`,
-        "process.exit(1);",
-      ].join("\n"),
+    const nestedScript = writeFixtureFile(
+      repoDir,
+      "pipe-holder.mjs",
+      "setInterval(() => {}, 1000);\n",
     );
-    const fixture = writeOperationFixture(repoDir, "pipe-holder-operation.sh", [
-      "acquire_pr_operation_lock 42",
-      `node '${launcherScript}'`,
+    const launcherScript = writeFixtureFile(repoDir, "pipe-holder-launcher.mjs", [
+      'import { spawn } from "node:child_process";',
+      'import fs from "node:fs";',
+      `const child = spawn(process.execPath, [${JSON.stringify(nestedScript)}], {`,
+      "  detached: true,",
+      '  stdio: ["ignore", "ignore", "ignore", 3],',
+      "});",
+      `fs.writeFileSync(${JSON.stringify(nestedPidFile)}, String(child.pid));`,
+      "process.exit(1);",
     ]);
     let nestedPgid: number | undefined;
     try {
       const startedAt = Date.now();
-      const result = await runSupervisedFixture(repoDir, fixture, { accelerateTimeouts: true });
+      const result = await runSupervisedOperation(
+        repoDir,
+        "pipe-holder-operation.sh",
+        ["acquire_pr_operation_lock 42", `node '${launcherScript}'`],
+        { accelerateTimeouts: true },
+      );
       const elapsed = Date.now() - startedAt;
       nestedPgid = await waitForProcessId(nestedPidFile);
-
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
       expect(elapsed).toBeLessThan(12_000);
       expect(processGroupExists(nestedPgid)).toBe(true);
       expect(result.stderr).toContain("operation lifetime did not drain");
       const ownerOid = refOid(repoDir);
-
       killProcessGroup(nestedPgid, "SIGKILL");
       expect(await waitFor(() => !processGroupExists(nestedPgid!))).toBe(true);
-      const recovered = runLockShell(repoDir, [
-        `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-      ]);
-      expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-      expect(refExists(repoDir)).toBe(false);
+      recoverOperationLock(repoDir, ownerOid);
     } finally {
-      nestedPgid ??= readProcessIdFile(nestedPidFile);
-      if (nestedPgid) {
-        await cleanupProcessGroup(nestedPgid);
-      }
+      await cleanupRecordedProcessGroup(nestedPidFile, nestedPgid);
     }
   }, 15_000);
-
   it("waits while a live supervisor finishes draining a dead operation group", async () => {
     const repoDir = createRepo();
     const operationPgidFile = join(repoDir, "finishing-operation-pgid");
     const holderPidFile = join(repoDir, "finishing-holder-pgid");
     const acquiredFile = join(repoDir, "finishing-waiter-acquired");
-    const holderScript = join(repoDir, "finishing-holder.mjs");
-    const launcherScript = join(repoDir, "finishing-launcher.mjs");
-    writeFileSync(holderScript, "setInterval(() => {}, 1000);\n");
-    writeFileSync(
-      launcherScript,
-      [
-        'import { spawn } from "node:child_process";',
-        'import fs from "node:fs";',
-        `const child = spawn(process.execPath, [${JSON.stringify(holderScript)}], {`,
-        "  detached: true,",
-        '  stdio: ["ignore", "ignore", "ignore", 3],',
-        "});",
-        `fs.writeFileSync(${JSON.stringify(holderPidFile)}, String(child.pid));`,
-        "process.exit(0);",
-      ].join("\n"),
+    const holderScript = writeFixtureFile(
+      repoDir,
+      "finishing-holder.mjs",
+      "setInterval(() => {}, 1000);\n",
     );
+    const launcherScript = writeFixtureFile(repoDir, "finishing-launcher.mjs", [
+      'import { spawn } from "node:child_process";',
+      'import fs from "node:fs";',
+      `const child = spawn(process.execPath, [${JSON.stringify(holderScript)}], {`,
+      "  detached: true,",
+      '  stdio: ["ignore", "ignore", "ignore", 3],',
+      "});",
+      `fs.writeFileSync(${JSON.stringify(holderPidFile)}, String(child.pid));`,
+      "process.exit(0);",
+    ]);
     const fixture = writeOperationFixture(repoDir, "finishing-operation.sh", [
       `printf '%s\\n' "$$" >'${operationPgidFile}'`,
       "acquire_pr_operation_lock 42",
@@ -1539,17 +1402,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
       holderPgid = await waitForProcessId(holderPidFile);
       expect(await waitFor(() => !processGroupExists(operationPgid))).toBe(true);
       expect(refExists(repoDir)).toBe(true);
-
-      const probe = runLockShell(repoDir, [
-        "set +e",
-        "try_acquire_pr_operation_lock 42",
-        "lock_status=$?",
-        "set -e",
-        'printf "%s\\n" "$lock_status"',
-      ]);
+      const probe = probeOperationLock(repoDir);
       expect(probe.status, `${probe.stdout}\n${probe.stderr}`).toBe(0);
       expect(probe.stdout.trim()).toBe("1");
-
       waiter = spawnDetached(
         "bash",
         [
@@ -1576,7 +1431,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(existsSync(acquiredFile)).toBe(false);
       expect(controller.exitCode).toBeNull();
       expect(processGroupExists(holderPgid)).toBe(true);
-
       killProcessGroup(holderPgid, "SIGTERM");
       await waitForExit(controller, 5000);
       await waitForExit(waiter, 5000);
@@ -1585,30 +1439,24 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(existsSync(acquiredFile)).toBe(true);
       expect(refExists(repoDir)).toBe(false);
     } finally {
-      holderPgid ??= readProcessIdFile(holderPidFile);
-      if (holderPgid) {
-        await cleanupProcessGroup(holderPgid);
-      }
+      await cleanupRecordedProcessGroup(holderPidFile, holderPgid);
       await cleanupChildren(waiter);
       await cleanupController(repoDir, controller, operationPgidFile);
     }
   }, 12_000);
-
   it("drains a same-group background job after its wrapper fails", async () => {
     const repoDir = createRepo();
     const operationPgidFile = join(repoDir, "failed-operation-pgid");
     const backgroundPidFile = join(repoDir, "failed-background-pid");
-    const fixture = writeOperationFixture(repoDir, "failed-background-operation.sh", [
-      `printf '%s\\n' "$$" >'${operationPgidFile}'`,
-      "acquire_pr_operation_lock 42",
-      "sleep 30 &",
-      `printf '%s\\n' "$!" >'${backgroundPidFile}'`,
-      "exit 1",
-    ]);
-
     let operationPgid: number | undefined;
     try {
-      const result = await runSupervisedFixture(repoDir, fixture);
+      const result = await runSupervisedOperation(repoDir, "failed-background-operation.sh", [
+        `printf '%s\\n' "$$" >'${operationPgidFile}'`,
+        "acquire_pr_operation_lock 42",
+        "sleep 30 &",
+        `printf '%s\\n' "$!" >'${backgroundPidFile}'`,
+        "exit 1",
+      ]);
       operationPgid = await waitForProcessId(operationPgidFile);
       const ownerOid = refOid(repoDir);
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
@@ -1618,33 +1466,22 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(result.stderr).toContain(
         `scripts/pr lock-recover 42 ${ownerOid} --confirmed-no-running-tools`,
       );
-
-      const recovered = runLockShell(repoDir, [
-        `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-      ]);
-      expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-      expect(refExists(repoDir)).toBe(false);
+      recoverOperationLock(repoDir, ownerOid);
     } finally {
-      operationPgid ??= readProcessIdFile(operationPgidFile);
-      if (operationPgid) {
-        await cleanupProcessGroup(operationPgid);
-      }
+      await cleanupRecordedProcessGroup(operationPgidFile, operationPgid);
     }
   });
-
   it("fails and retains the lock when a clean wrapper leaves same-group work", async () => {
     const repoDir = createRepo();
     const operationPgidFile = join(repoDir, "clean-background-operation-pgid");
-    const fixture = writeOperationFixture(repoDir, "clean-background-operation.sh", [
-      `printf '%s\\n' "$$" >'${operationPgidFile}'`,
-      "acquire_pr_operation_lock 42",
-      "sleep 30 &",
-      "exit 0",
-    ]);
-
     let operationPgid: number | undefined;
     try {
-      const result = await runSupervisedFixture(repoDir, fixture);
+      const result = await runSupervisedOperation(repoDir, "clean-background-operation.sh", [
+        `printf '%s\\n' "$$" >'${operationPgidFile}'`,
+        "acquire_pr_operation_lock 42",
+        "sleep 30 &",
+        "exit 0",
+      ]);
       operationPgid = await waitForProcessId(operationPgidFile);
       const ownerOid = refOid(repoDir);
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
@@ -1656,20 +1493,11 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(result.stderr).toContain(
         `scripts/pr lock-recover 42 ${ownerOid} --confirmed-no-running-tools`,
       );
-
-      const recovered = runLockShell(repoDir, [
-        `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-      ]);
-      expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-      expect(refExists(repoDir)).toBe(false);
+      recoverOperationLock(repoDir, ownerOid);
     } finally {
-      operationPgid ??= readProcessIdFile(operationPgidFile);
-      if (operationPgid) {
-        await cleanupProcessGroup(operationPgid);
-      }
+      await cleanupRecordedProcessGroup(operationPgidFile, operationPgid);
     }
   });
-
   it("keeps gc lock ownership with the supervisor until gc exits", async () => {
     const repoDir = createRepo();
     mkdirSync(join(repoDir, ".worktrees", "pr-42"), { recursive: true });
@@ -1690,16 +1518,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
     });
     try {
       expect(await waitFor(() => existsSync(ghStarted) && refExists(repoDir))).toBe(true);
-      const probe = runLockShell(repoDir, [
-        "set +e",
-        "try_acquire_pr_operation_lock 42",
-        "lock_status=$?",
-        "set -e",
-        'printf "%s\\n" "$lock_status"',
-      ]);
+      const probe = probeOperationLock(repoDir);
       expect(probe.status, `${probe.stdout}\n${probe.stderr}`).toBe(0);
       expect(probe.stdout.trim()).toBe("1");
-
       writeFileSync(ghContinue, "continue\n");
       await waitForExit(controller, 5000);
       expect(controller.exitCode).toBe(0);
@@ -1710,7 +1531,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       await cleanupController(repoDir, controller);
     }
   });
-
   it("fails closed on malformed owner blobs", () => {
     const repoDir = createRepo();
     const result = runLockShell(repoDir, [
@@ -1728,7 +1548,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
     expect(result.stdout.trim().split("\n").at(-1)).toBe("2\t0");
     expect(refExists(repoDir)).toBe(false);
   });
-
   it("rejects special and out-of-range process-group ids", () => {
     for (const pgid of ["1", "2147483648"]) {
       const repoDir = createRepo();
@@ -1746,7 +1565,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(result.stdout.trim()).toBe("2");
     }
   });
-
   it("fails closed when process-group liveness is not permitted", () => {
     const repoDir = createRepo();
     const result = runLockShell(repoDir, [
@@ -1763,12 +1581,10 @@ describePosix("scripts/pr per-PR operation lock", () => {
       "set -e",
       'printf "%s\\t%s\\n" "$lock_status" "$recovery_status"',
     ]);
-
     expect(result.status).toBe(0);
     expect(result.stdout.trim().split("\n").at(-1)).toBe("2\t0");
     expect(refExists(repoDir)).toBe(false);
   });
-
   it.runIf(process.platform === "linux")(
     "conservatively keeps a lock whose process group contains a zombie",
     async () => {
@@ -1802,7 +1618,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
             return state.startsWith("Z");
           }),
         ).toBe(true);
-
         const blocked = runLockShell(repoDir, [
           'supervisor_birth=$(pr_operation_lock_process_birth "$$")',
           `owner_oid=$(printf 'version=3\\nstate=active\\npgid=%s\\nsupervisor_pid=%s\\nsupervisor_birth=%s\\ntoken=11111111-1111-1111-1111-111111111111\\n' '${zombiePgid}' "$$" "$supervisor_birth" | git hash-object -w --stdin)`,
@@ -1815,23 +1630,19 @@ describePosix("scripts/pr per-PR operation lock", () => {
         ]);
         expect(blocked.status).toBe(0);
         expect(blocked.stdout.trim()).toBe("1");
-
         const ownerOid = refOid(repoDir);
         await stopChild(parent, "SIGTERM");
         expect(await waitFor(() => !processGroupExists(zombiePgid!))).toBe(true);
-        const recovered = runLockShell(repoDir, [
-          `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
+        recoverOperationLock(repoDir, ownerOid, [
           "acquire_pr_operation_lock 42",
           "release_pr_operation_lock",
         ]);
-        expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
       } finally {
         await cleanupChildren(parent);
       }
     },
     15_000,
   );
-
   it("keeps a dead owner sticky instead of guessing that detached work ended", () => {
     const repoDir = createRepo();
     const result = runLockShell(repoDir, [
@@ -1843,7 +1654,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       "set -e",
       `printf '%s\t%s\n' "$lock_status" "$(command git rev-parse '${lockRef}')"`,
     ]);
-
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe(`2\t${refOid(repoDir)}`);
     expect(result.stderr).toContain("detached child tools cannot be ruled out");
@@ -1852,7 +1662,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
     );
     expect(result.stderr).toContain("Unable to acquire the operation lock for PR #42.");
   });
-
   it("preserves the exact lock if its controller is killed", async () => {
     const repoDir = createRepo();
     const pidFile = join(repoDir, "operation-pgid");
@@ -1863,7 +1672,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       `printf 'held\\n' >'${held}'`,
       "while :; do sleep 1; done",
     ]);
-
     const controller = spawn(process.execPath, [processGroupRunner, repoDir, fixture], {
       cwd: repoDir,
       stdio: "ignore",
@@ -1874,11 +1682,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
       pgid = await waitForProcessId(pidFile);
       const ownerOid = refOid(repoDir);
       expect(processGroupExists(pgid!)).toBe(true);
-
       await stopChild(controller, "SIGKILL");
       expect(processGroupExists(pgid!)).toBe(true);
       expect(refOid(repoDir)).toBe(ownerOid);
-
       const blockedWhileGroupLives = runLockShell(repoDir, [
         "set +e",
         "try_acquire_pr_operation_lock 42",
@@ -1890,32 +1696,20 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(blockedWhileGroupLives.stdout.trim()).toBe(`2\torphaned\t${ownerOid}`);
       expect(processGroupExists(pgid!)).toBe(true);
       expect(refOid(repoDir)).toBe(ownerOid);
-
       killProcessGroup(pgid!, "SIGTERM");
       expect(await waitFor(() => !processGroupExists(pgid!))).toBe(true);
-      const blocked = runLockShell(repoDir, [
-        "set +e",
-        "acquire_pr_operation_lock 42",
-        "lock_status=$?",
-        "set -e",
-        'printf "%s\\n" "$lock_status"',
-      ]);
+      const blocked = probeOperationLock(repoDir, "blocking");
       expect(blocked.status).toBe(0);
       expect(blocked.stdout.trim()).toBe("2");
       expect(refOid(repoDir)).toBe(ownerOid);
-
-      const recovered = runLockShell(repoDir, [
-        `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
+      recoverOperationLock(repoDir, ownerOid, [
         "acquire_pr_operation_lock 42",
         "release_pr_operation_lock",
       ]);
-      expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-      expect(refExists(repoDir)).toBe(false);
     } finally {
       await cleanupController(repoDir, controller, pidFile);
     }
   });
-
   it("escalates a signal, drains its group, and retains the interrupted lock", async () => {
     const repoDir = createRepo();
     const pidFile = join(repoDir, "operation-pgid");
@@ -1944,50 +1738,35 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(await waitFor(() => existsSync(pidFile) && existsSync(childReady))).toBe(true);
       pgid = await waitForProcessId(pidFile);
       expect(refExists(repoDir)).toBe(true);
-
       controller.kill("SIGTERM");
       await waitForExit(controller, 12_000);
-
       expect(controller.exitCode).toBe(143);
       expect(processGroupExists(pgid!)).toBe(false);
       expect(refExists(repoDir)).toBe(true);
       const ownerOid = refOid(repoDir);
-      const recovered = runLockShell(repoDir, [
-        `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-      ]);
-      expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-      expect(refExists(repoDir)).toBe(false);
+      recoverOperationLock(repoDir, ownerOid);
     } finally {
       await cleanupController(repoDir, controller, pidFile);
     }
   }, 15_000);
-
   it("retains the lock when a nested managed process group escapes cancellation", async () => {
     const repoDir = createRepo();
     const nestedPidFile = join(repoDir, "nested-pgid");
     const signalRelayedFile = join(repoDir, "nested-signal-relayed");
-    const nestedScript = join(repoDir, "nested.mjs");
-    const relayScript = join(repoDir, "relay.mjs");
-    writeFileSync(
-      nestedScript,
-      [
-        'import fs from "node:fs";',
-        "fs.writeFileSync(process.argv[2], String(process.pid));",
-        'process.on("SIGTERM", () => fs.writeFileSync(process.argv[3], "relayed\\n"));',
-        "setInterval(() => {}, 1000);",
-      ].join("\n"),
-    );
-    writeFileSync(
-      relayScript,
-      [
-        `import { runManagedCommand } from ${JSON.stringify(managedChildUrl)};`,
-        "process.exitCode = await runManagedCommand({",
-        "  bin: process.execPath,",
-        `  args: [${JSON.stringify(nestedScript)}, ${JSON.stringify(nestedPidFile)}, ${JSON.stringify(signalRelayedFile)}],`,
-        '  stdio: "ignore",',
-        "});",
-      ].join("\n"),
-    );
+    const nestedScript = writeFixtureFile(repoDir, "nested.mjs", [
+      'import fs from "node:fs";',
+      "fs.writeFileSync(process.argv[2], String(process.pid));",
+      'process.on("SIGTERM", () => fs.writeFileSync(process.argv[3], "relayed\\n"));',
+      "setInterval(() => {}, 1000);",
+    ]);
+    const relayScript = writeFixtureFile(repoDir, "relay.mjs", [
+      `import { runManagedCommand } from ${JSON.stringify(managedChildUrl)};`,
+      "process.exitCode = await runManagedCommand({",
+      "  bin: process.execPath,",
+      `  args: [${JSON.stringify(nestedScript)}, ${JSON.stringify(nestedPidFile)}, ${JSON.stringify(signalRelayedFile)}],`,
+      '  stdio: "ignore",',
+      "});",
+    ]);
     const fixture = writeOperationFixture(repoDir, "nested-operation.sh", [
       "acquire_pr_operation_lock 42",
       `node '${relayScript}'`,
@@ -2002,32 +1781,19 @@ describePosix("scripts/pr per-PR operation lock", () => {
       nestedPgid = await waitForProcessId(nestedPidFile);
       const ownerOid = refOid(repoDir);
       expect(processGroupExists(nestedPgid!)).toBe(true);
-
       controller.kill("SIGTERM");
       expect(await waitFor(() => existsSync(signalRelayedFile))).toBe(true);
       controller.kill("SIGTERM");
       await waitForExit(controller, 8000);
-
       expect(controller.exitCode).toBe(143);
       expect(processGroupExists(nestedPgid!)).toBe(true);
       expect(refOid(repoDir)).toBe(ownerOid);
-      const blocked = runLockShell(repoDir, [
-        "set +e",
-        "try_acquire_pr_operation_lock 42",
-        "lock_status=$?",
-        "set -e",
-        'printf "%s\\n" "$lock_status"',
-      ]);
+      const blocked = probeOperationLock(repoDir);
       expect(blocked.status).toBe(0);
       expect(blocked.stdout.trim()).toBe("2");
-
       killProcessGroup(nestedPgid!, "SIGKILL");
       expect(await waitFor(() => !processGroupExists(nestedPgid!))).toBe(true);
-      const recovered = runLockShell(repoDir, [
-        `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
-      ]);
-      expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
-      expect(refExists(repoDir)).toBe(false);
+      recoverOperationLock(repoDir, ownerOid);
     } finally {
       if (nestedPgid) {
         await cleanupProcessGroup(nestedPgid);
@@ -2035,7 +1801,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       await cleanupController(repoDir, controller);
     }
   });
-
   it("has one dispatcher acquisition for composite prepare-run", () => {
     const script = readFileSync(join(repoRoot, "scripts/pr"), "utf8");
     const runner = readFileSync(processGroupRunner, "utf8");
@@ -2057,7 +1822,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       "acquire_pr_operation_lock",
     );
   });
-
   it("makes gc skip a PR while its operation lock is held", async () => {
     const repoDir = createRepo();
     mkdirSync(join(repoDir, ".worktrees", "pr-42"), { recursive: true });
@@ -2065,7 +1829,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
     const holder = spawnHolder(repoDir, held);
     try {
       expect(await waitFor(() => existsSync(held))).toBe(true);
-
       const result = runLockShell(repoDir, [
         "gh() { if [ \"$1 $2\" = 'repo view' ]; then printf 'openclaw/openclaw\\n'; else printf 'MERGED\\n'; fi; }",
         "gc_pr_worktrees false",
@@ -2077,7 +1840,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       await cleanupChildren(holder);
     }
   });
-
   it("makes gc skip an unreadable lock and report exact recovery", () => {
     const repoDir = createRepo();
     const worktreeDir = join(repoDir, ".worktrees", "pr-42");
@@ -2088,7 +1850,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       "gh() { printf 'MERGED\\n'; }",
       "gc_pr_worktrees false",
     ]);
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout).toContain("operation lock is unreadable");
     expect(result.stderr).toContain(
@@ -2096,7 +1857,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
     );
     expect(existsSync(worktreeDir)).toBe(true);
   });
-
   it("does not report removal when gc cleanup leaves the worktree", () => {
     const repoDir = createRepo();
     const worktreeDir = join(repoDir, ".worktrees", "pr-42");
@@ -2107,13 +1867,11 @@ describePosix("scripts/pr per-PR operation lock", () => {
       "delete_local_branch_if_safe() { return 0; }",
       "gc_pr_worktrees false",
     ]);
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout).toContain("cleanup incomplete");
     expect(result.stdout).not.toContain("removed .worktrees/pr-42");
     expect(existsSync(worktreeDir)).toBe(true);
   });
-
   it("removes a registered relative worktree under a NUL-framed escaped Unicode path", () => {
     const repoDir = createRepo("repo with space \\ backslash\n雪");
     const worktreeDir = join(repoDir, ".worktrees", "pr-42");
@@ -2125,9 +1883,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
     const located = runLockShell(repoDir, ["worktree_path_for_branch pr-42"]);
     expect(located.status, `${located.stdout}\n${located.stderr}`).toBe(0);
     expect(located.stdout.trim()).toBe(canonicalWorktreeDir);
-
     const result = runLockShell(repoDir, ["gh() { printf 'MERGED\\n'; }", "gc_pr_worktrees false"]);
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout).toContain("removed .worktrees/pr-42");
     expect(existsSync(worktreeDir)).toBe(false);
@@ -2143,7 +1899,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       }).status,
     ).toBe(1);
   });
-
   it("propagates producer failures from NUL-framed worktree listings", () => {
     const repoDir = createRepo();
     const result = runLockShell(repoDir, [
@@ -2161,11 +1916,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
       'branch_status="$?"',
       'printf "%s %s\\n" "$registered_status" "$branch_status"',
     ]);
-
     expect(result.status, result.stdout + "\n" + result.stderr).toBe(0);
     expect(result.stdout.trim()).toBe("23 23");
   });
-
   it("accepts only nonempty docs-only file lists", () => {
     const repoDir = createRepo();
     const result = runLockShell(repoDir, [
@@ -2178,11 +1931,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
       'mixed_status="$?"',
       'printf "%s %s %s\\n" "$empty_status" "$docs_status" "$mixed_status"',
     ]);
-
     expect(result.status, result.stdout + "\n" + result.stderr).toBe(0);
     expect(result.stdout.trim()).toBe("1 0 1");
   });
-
   it("prunes a registered worktree whose directory is already gone", () => {
     const repoDir = createRepo();
     const worktreeDir = join(repoDir, ".worktrees", "pr-42");
@@ -2192,9 +1943,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
     });
     const canonicalWorktreeDir = realpathSync(worktreeDir);
     rmSync(worktreeDir, { recursive: true });
-
     const result = runLockShell(repoDir, ['remove_worktree_if_present ".worktrees/pr-42"']);
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(
       execFileSync("git", ["worktree", "list", "--porcelain"], {
@@ -2203,7 +1952,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
       }),
     ).not.toContain(canonicalWorktreeDir);
   });
-
   it("surfaces git worktree remove stderr without making cleanup fatal", () => {
     const repoDir = createRepo();
     const worktreeDir = join(repoDir, ".worktrees", "pr-42");
@@ -2211,7 +1959,6 @@ describePosix("scripts/pr per-PR operation lock", () => {
     execFileSync("git", ["worktree", "add", "-q", "-b", "pr-42", worktreeDir], {
       cwd: repoDir,
     });
-
     const result = runLockShell(repoDir, [
       "git() {",
       "  if [ \"$1 $2\" = 'worktree remove' ]; then",
@@ -2222,14 +1969,12 @@ describePosix("scripts/pr per-PR operation lock", () => {
       "}",
       'remove_worktree_if_present ".worktrees/pr-42"',
     ]);
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout).toContain(
       "Warning: git worktree remove failed for .worktrees/pr-42: fixture remove failure",
     );
     expect(existsSync(worktreeDir)).toBe(true);
   });
-
   it("prunes a missing registration and resets its script-owned branch on worktree add", () => {
     const repoDir = createRepo();
     execFileSync("git", ["remote", "add", "origin", repoDir], { cwd: repoDir });
@@ -2241,66 +1986,27 @@ describePosix("scripts/pr per-PR operation lock", () => {
       cwd: repoDir,
     });
     rmSync(worktreeDir, { recursive: true });
-
-    const result = runLockShell(repoDir, [
-      "ensure_gh_api_auth() { return 0; }",
-      "enter_worktree 42",
-    ]);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    const { result } = enterPrWorktree(repoDir, 42);
     expect(result.stdout).toContain("Pruning stale worktree registration for .worktrees/pr-42");
     expect(existsSync(worktreeDir)).toBe(true);
-    expect(
-      execFileSync("git", ["branch", "--show-current"], {
-        cwd: worktreeDir,
-        encoding: "utf8",
-      }).trim(),
-    ).toBe("temp/pr-42");
+    expectWorktreeBranch(worktreeDir, "temp/pr-42");
   });
-
   it("resets an existing script-owned branch when adding a fresh worktree", () => {
     const repoDir = createRepo();
     execFileSync("git", ["remote", "add", "origin", repoDir], { cwd: repoDir });
     execFileSync("git", ["branch", "temp/pr-43"], { cwd: repoDir });
-    const worktreeDir = join(repoDir, ".worktrees", "pr-43");
-
-    const result = runLockShell(repoDir, [
-      "ensure_gh_api_auth() { return 0; }",
-      "enter_worktree 43",
-    ]);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    const { worktreeDir } = enterPrWorktree(repoDir, 43);
     expect(existsSync(worktreeDir)).toBe(true);
-    expect(
-      execFileSync("git", ["branch", "--show-current"], {
-        cwd: worktreeDir,
-        encoding: "utf8",
-      }).trim(),
-    ).toBe("temp/pr-43");
+    expectWorktreeBranch(worktreeDir, "temp/pr-43");
   });
-
   it("materializes a new PR worktree inherited from a sparse checkout", () => {
     const repoDir = createRepo();
     addTrackedUiConfig(repoDir);
     execFileSync("git", ["remote", "add", "origin", repoDir], { cwd: repoDir });
     setSparseCheckout(repoDir);
-    const worktreeDir = join(repoDir, ".worktrees", "pr-44");
-
-    const result = runLockShell(repoDir, [
-      "ensure_gh_api_auth() { return 0; }",
-      "enter_worktree 44",
-    ]);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-    expect(existsSync(join(worktreeDir, "ui", "config", "control-ui-chunking.ts"))).toBe(true);
-    expect(
-      execFileSync("git", ["config", "--bool", "core.sparseCheckout"], {
-        cwd: worktreeDir,
-        encoding: "utf8",
-      }).trim(),
-    ).toBe("false");
+    const { worktreeDir } = enterPrWorktree(repoDir, 44);
+    expectMaterializedWorktree(worktreeDir);
   });
-
   it("materializes an existing sparse PR worktree before reuse", () => {
     const repoDir = createRepo();
     addTrackedUiConfig(repoDir);
@@ -2311,22 +2017,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
     });
     setSparseCheckout(worktreeDir);
     expect(existsSync(join(worktreeDir, "ui", "config", "control-ui-chunking.ts"))).toBe(false);
-
-    const result = runLockShell(repoDir, [
-      "ensure_gh_api_auth() { return 0; }",
-      "enter_worktree 45",
-    ]);
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-    expect(existsSync(join(worktreeDir, "ui", "config", "control-ui-chunking.ts"))).toBe(true);
-    expect(
-      execFileSync("git", ["config", "--bool", "core.sparseCheckout"], {
-        cwd: worktreeDir,
-        encoding: "utf8",
-      }).trim(),
-    ).toBe("false");
+    enterPrWorktree(repoDir, 45);
+    expectMaterializedWorktree(worktreeDir);
   });
-
   it("refuses a symlink alias to another registered worktree", () => {
     const repoDir = createRepo();
     const worktreesDir = join(repoDir, ".worktrees");
@@ -2338,9 +2031,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
     });
     const canonicalTargetDir = realpathSync(targetDir);
     symlinkSync("pr-99", aliasDir, "dir");
-
     const result = runLockShell(repoDir, ['remove_worktree_if_present ".worktrees/pr-42"']);
-
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(result.stdout).toContain("refusing to remove non-canonical PR-worktree path");
     expect(existsSync(aliasDir)).toBe(true);


### PR DESCRIPTION
## What Problem This Solves

The PR operation-lock lifecycle suite repeated shell fixture setup, exact-OID recovery, process-group cleanup, and worktree materialization assertions across many cases. That duplication made the safety-contract tests longer and harder to update consistently.

## Why This Change Was Made

Consolidates repeated test-only setup behind focused helpers and data-driven cases while retaining every existing runtime test name and the operation-group, notification-phase, side-effect-marker, exact recovery, and worktree contracts. Production code and behavior are unchanged.

## User Impact

No user-visible behavior change. Maintainers get a smaller, more consistent lifecycle suite: 309 net test lines removed.

## Evidence

- Local focused wrapper: 64 passed, 1 platform-skipped (65 total)
- Expanded test-name parity against the branch base: 65/65 exact names preserved
- Blacksmith Testbox focused proof: 65/65 passed ([run](https://github.com/openclaw/openclaw/actions/runs/30785472784))
- Blacksmith Testbox exact-head changed gate: passed formatting, dependency/package guards, script declarations, root-test tsgo, and scripts lint
- Fresh branch autoreview: clean, patch correct (0.99 confidence)
- Test-only diff: +322 / -631, net -309 LOC
