### PR TITLE
test(gateway): await continuation admission drain

### DIFF
--- a/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
+++ b/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
@@ -20,7 +20,10 @@ import {
   resetGatewaySuspendCoordinatorForLifecycleRestart,
   resumeGatewaySuspend,
 } from "../../infra/gateway-suspend-coordinator.js";
-import { resetGatewayWorkAdmission } from "../../process/gateway-work-admission.js";
+import {
+  resetGatewayWorkAdmission,
+  waitForActiveGatewayRootWork,
+} from "../../process/gateway-work-admission.js";
 import { getDetachedTaskLifecycleRuntime } from "../../tasks/detached-task-runtime.js";
 import { findTaskByRunId } from "../../tasks/task-registry.js";
 import { setDetachedTaskLifecycleRuntime } from "../../tasks/task-runtime.test-helpers.js";
@@ -114,6 +117,7 @@ describe("gateway agent handler", () => {
         phase: "continuing",
         ownerRunId: "cron-media-release-rotates",
       });
+      await expect(waitForActiveGatewayRootWork()).resolves.toEqual({ drained: true, active: 0 });
       const readyPrepare = await invokeGatewaySuspendPrepare(
         context,
         "cron-media-release-rotation-complete",

--- a/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
+++ b/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
@@ -8,7 +8,10 @@ import {
   resetGatewaySuspendCoordinatorForLifecycleRestart,
   resumeGatewaySuspend,
 } from "../../infra/gateway-suspend-coordinator.js";
-import { resetGatewayWorkAdmission } from "../../process/gateway-work-admission.js";
+import {
+  resetGatewayWorkAdmission,
+  waitForActiveGatewayRootWork,
+} from "../../process/gateway-work-admission.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
 import { registerSubagentCompletionToolHandoff } from "../subagent-completion-tool-handoff.js";
 import {
@@ -1975,6 +1978,7 @@ describe("gateway agent handler", () => {
         phase: "ready",
         basePersisted: true,
       });
+      await expect(waitForActiveGatewayRootWork()).resolves.toEqual({ drained: true, active: 0 });
       const readyPrepare = await invokeGatewaySuspendPrepare(
         context,
         "cron-media-release-recovered",
@@ -2063,6 +2067,7 @@ describe("gateway agent handler", () => {
       expect(context.logGateway.warn).toHaveBeenCalledWith(
         "cron continuation release recovery exhausted for cron-media-release-exhausts",
       );
+      await expect(waitForActiveGatewayRootWork()).resolves.toEqual({ drained: true, active: 0 });
       const readyPrepare = await invokeGatewaySuspendPrepare(
         context,
         "cron-media-release-exhausted",


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where three gateway continuation-recovery tests could observe durable recovery completion before the detached root admission lease had finished releasing, causing suspension readiness assertions to fail under loaded CI scheduling.

## Why This Change Was Made

The tests now wait on the existing gateway root-work drain contract before asserting that suspension is ready. Runtime behavior is unchanged: suspension remains busy until all tracked root work has actually released.

## User Impact

No user-visible runtime change. Release and full-CI validation no longer race the gateway admission teardown boundary.

## Evidence

- Reproduced in exact candidate CI: https://github.com/openclaw/openclaw/actions/runs/30783382229/job/91592293478
- Patched full agent module: 267/267 tests passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30784503480
- Exact-base rerun after rebasing: 267/267 tests plus `pnpm check:changed` passed: https://github.com/openclaw/openclaw/actions/runs/30785411920
- Exact PR-head CI: 53 required checks passed: https://github.com/openclaw/openclaw/actions/runs/30785806694
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 118481` passed. It retained the reviewed head because behind-main drift is advisory when the branch is conflict-free and exact-head hosted gates are green.
- Fresh branch autoreview: no accepted/actionable findings
- `git diff --check`: passed

AI-assisted: yes.
