### PR TITLE
refactor(swift): reduce gateway session test plumbing

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -729,6 +729,41 @@ private func operatorConnectOptions(
         includeDeviceIdentity: includeDeviceIdentity)
 }
 
+private func testURL(_ value: String) throws -> URL {
+    try #require(URL(string: value))
+}
+
+extension GatewayNodeSession {
+    fileprivate func connectForTest(
+        _ url: URL,
+        credentials: GatewayNodeSessionCredentials = .init(),
+        options: GatewayConnectOptions,
+        session: FakeGatewayWebSocketSession,
+        extraHeadersProvider: (@Sendable () -> [String: String])? = nil,
+        onConnected: @escaping @Sendable () async -> Void = {},
+        onDisconnected: @escaping @Sendable (String) async -> Void = { _ in },
+        onInvoke: @escaping @Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse = {
+            BridgeInvokeResponse(id: $0.id, ok: true)
+        },
+        onInvokeInput: (@Sendable (NodeInvokeInputEvent) async -> Void)? = nil,
+        onInvokeCancel: (@Sendable (String) async -> Void)? = nil,
+        onRouteInvalidated: (@Sendable () async -> Void)? = nil) async throws
+    {
+        try await self.connect(
+            url: url,
+            credentials: credentials,
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            extraHeadersProvider: extraHeadersProvider,
+            onConnected: onConnected,
+            onDisconnected: onDisconnected,
+            onInvoke: onInvoke,
+            onInvokeInput: onInvokeInput,
+            onInvokeCancel: onInvokeCancel,
+            onRouteInvalidated: onRouteInvalidated)
+    }
+}
+
 private func nodeInvokePush(id: String, command: String) -> GatewayPush {
     .event(EventFrame(
         type: "event",
@@ -752,13 +787,7 @@ struct GatewayNodeSessionTests {
             caps: [OpenClawGatewayClientCapability.inlineWidgets],
             clientId: "openclaw-ios")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+        try await gateway.connectForTest(testURL("ws://gateway.example.invalid"), options: options, session: session)
 
         async let refreshed = gateway.refreshCanvasHostUrl(replacing: nil)
         try await waitUntil("operator surface refresh sent") {
@@ -786,13 +815,7 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(caps: ["canvas"], clientId: "openclaw-macos", clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "wss://gateway.example.invalid")),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+        try await gateway.connectForTest(testURL("wss://gateway.example.invalid"), options: options, session: session)
 
         async let first = gateway.refreshCanvasHostUrl(replacing: nil)
         async let second = gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
@@ -828,13 +851,7 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(caps: ["canvas"], clientId: "openclaw-macos", clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+        try await gateway.connectForTest(testURL("ws://gateway.example.invalid"), options: options, session: session)
 
         async let shortWait = gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
         try await waitUntil("single surface refresh sent") {
@@ -869,13 +886,7 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(caps: ["canvas"], clientId: "openclaw-macos", clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+        try await gateway.connectForTest(testURL("ws://gateway.example.invalid"), options: options, session: session)
 
         let first = await gateway.refreshCanvasHostUrl(timeoutSeconds: 1)
         #expect(first == nil)
@@ -905,13 +916,7 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(caps: ["canvas"], clientId: "openclaw-macos", clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+        try await gateway.connectForTest(testURL("ws://gateway.example.invalid"), options: options, session: session)
 
         let stalled = Task { await gateway.refreshCanvasHostUrl(timeoutSeconds: 0) }
         try await waitUntil("first surface refresh sent") {
@@ -945,13 +950,7 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(caps: ["canvas"], clientId: "openclaw-macos", clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+        try await gateway.connectForTest(testURL("ws://gateway.example.invalid"), options: options, session: session)
 
         async let seeded = gateway.refreshCanvasHostUrl(replacing: nil)
         try await waitUntil("seed surface refresh sent") {
@@ -1002,13 +1001,7 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+        try await gateway.connectForTest(testURL("ws://gateway.example.invalid"), options: options, session: session)
 
         let pending = Task {
             try await gateway.request(
@@ -1043,13 +1036,10 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) },
+        try await gateway.connectForTest(
+            testURL("ws://gateway.example.invalid"),
+            options: options,
+            session: session,
             onInvokeInput: { input in await probe.recordInput(input) },
             onInvokeCancel: { invokeId in await probe.recordCancellation(invokeId) })
 
@@ -1190,15 +1180,14 @@ struct GatewayNodeSessionTests {
         let invalidations = DisconnectProbe()
         let options = nodeConnectOptions()
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            credentials: .init(),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
             onDisconnected: { reason in await disconnects.record("first:\(reason)") },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) },
             onRouteInvalidated: { await invalidations.record("first") })
+        // Keep the flat overload in this mixed sequence to cover its credential forwarding
+        // while proving that a same-route connect replaces the owning callbacks.
         try await gateway.connect(
             url: #require(URL(string: "ws://first.example.invalid")),
             token: nil,
@@ -1211,14 +1200,11 @@ struct GatewayNodeSessionTests {
             onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) },
             onRouteInvalidated: { await invalidations.record("same") })
         #expect(await (invalidations.values()).isEmpty)
-        try await gateway.connect(
-            url: #require(URL(string: "ws://second.example.invalid")),
-            credentials: .init(),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
+        try await gateway.connectForTest(
+            testURL("ws://second.example.invalid"),
+            options: options,
+            session: session,
             onDisconnected: { reason in await disconnects.record("second:\(reason)") },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) },
             onRouteInvalidated: { await invalidations.record("second") })
 
         for _ in 0..<20 {
@@ -1246,21 +1232,14 @@ struct GatewayNodeSessionTests {
         let options = nodeConnectOptions()
 
         let connect = Task {
-            try await gateway.connect(
-                url: #require(URL(string: "ws://first.example.invalid")),
-                token: nil,
-                bootstrapToken: nil,
-                password: nil,
-                connectOptions: options,
-                sessionBox: WebSocketSessionBox(session: session),
+            try await gateway.connectForTest(
+                testURL("ws://first.example.invalid"),
+                options: options,
+                session: session,
                 onConnected: {
                     await lifecycle.record("connected-start")
                     await connectedGate.wait()
                     await lifecycle.record("connected-end")
-                },
-                onDisconnected: { _ in },
-                onInvoke: { req in
-                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
                 })
             await lifecycle.record("connect-returned")
         }
@@ -1315,49 +1294,21 @@ struct GatewayNodeSessionTests {
         let invalidationGate = AsyncGate()
         let options = nodeConnectOptions()
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) },
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
             onRouteInvalidated: { await invalidationGate.wait() })
 
         let supersededReplacement = Task {
-            try await gateway.connect(
-                url: #require(URL(string: "ws://second.example.invalid")),
-                token: nil,
-                bootstrapToken: nil,
-                password: nil,
-                connectOptions: options,
-                sessionBox: WebSocketSessionBox(session: session),
-                onConnected: {},
-                onDisconnected: { _ in },
-                onInvoke: { req in
-                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                })
+            try await gateway.connectForTest(testURL("ws://second.example.invalid"), options: options, session: session)
         }
         try await waitUntil("route invalidation started") {
             await invalidationGate.hasStarted()
         }
         let supersededAdmissionGeneration = await gateway._test_admissionGeneration()
         let finalReplacement = Task {
-            try await gateway.connect(
-                url: #require(URL(string: "ws://third.example.invalid")),
-                token: nil,
-                bootstrapToken: nil,
-                password: nil,
-                connectOptions: options,
-                sessionBox: WebSocketSessionBox(session: session),
-                onConnected: {},
-                onDisconnected: { _ in },
-                onInvoke: { req in
-                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                })
+            try await gateway.connectForTest(testURL("ws://third.example.invalid"), options: options, session: session)
         }
         try await waitUntil("final replacement revoked superseded admission") {
             await gateway._test_admissionGeneration() != supersededAdmissionGeneration
@@ -1390,28 +1341,13 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) })
+        try await gateway.connectForTest(testURL("ws://first.example.invalid"), options: options, session: session)
         let oldRoute = try #require(await gateway.currentRoute())
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://replacement.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) })
+        try await gateway.connectForTest(
+            testURL("ws://replacement.example.invalid"),
+            options: options,
+            session: session)
 
         let response = await gateway.invokeIfCurrentRoute(
             BridgeInvokeRequest(id: "stale-computer", command: "computer.act", paramsJSON: "{}"),
@@ -1441,14 +1377,10 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
             onDisconnected: { reason in await disconnects.record(reason) },
             onInvoke: { request in
                 await invokeStarted.wait()
@@ -1499,16 +1431,7 @@ struct GatewayNodeSessionTests {
         let cancellations = DisconnectProbe()
         let options = nodeConnectOptions(caps: ["talk"], commands: ["talk.ptt.start"], clientId: "openclaw-ios")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) })
+        try await gateway.connectForTest(testURL("ws://first.example.invalid"), options: options, session: session)
         let route = try #require(await gateway.currentRoute())
         let invoking = Task {
             await gateway.invokeIfCurrentRoute(
@@ -1532,16 +1455,10 @@ struct GatewayNodeSessionTests {
         }
         await invokeStarted.release()
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://replacement.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) })
+        try await gateway.connectForTest(
+            testURL("ws://replacement.example.invalid"),
+            options: options,
+            session: session)
 
         #expect(await (invoking.value).ok == false)
         #expect(await cancellations.values() == ["stale-ptt"])
@@ -1559,15 +1476,10 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
             onInvoke: { request in
                 await invocations.record(request.id)
                 return BridgeInvokeResponse(id: request.id, ok: true, payloadJSON: nil, error: nil)
@@ -1612,16 +1524,12 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
             onConnected: { await lifecycle.record("connected") },
-            onDisconnected: { _ in await lifecycle.record("disconnected") },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) })
+            onDisconnected: { _ in await lifecycle.record("disconnected") })
         try await waitUntil("initial connected callback completed") {
             await lifecycle.values() == ["connected"]
         }
@@ -1650,18 +1558,12 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
             onConnected: { await lifecycle.record("connected") },
             onDisconnected: { _ in await lifecycle.record("disconnected") },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            },
             onRouteInvalidated: { await invalidationGate.wait() })
         let firstTask = try #require(session.latestTask())
         try await waitUntil("receive loop armed before disconnect") {
@@ -1695,15 +1597,10 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
             onInvoke: { request in
                 await invocations.record(request.id)
                 return BridgeInvokeResponse(id: request.id, ok: true, payloadJSON: nil, error: nil)
@@ -1756,22 +1653,16 @@ struct GatewayNodeSessionTests {
             clientDisplayName: "macOS Test")
 
         let connect = Task {
-            try await gateway.connect(
-                url: #require(URL(string: "ws://first.example.invalid")),
-                token: nil,
-                bootstrapToken: nil,
-                password: nil,
-                connectOptions: options,
-                sessionBox: WebSocketSessionBox(session: session),
+            try await gateway.connectForTest(
+                testURL("ws://first.example.invalid"),
+                options: options,
+                session: session,
                 onConnected: {
                     await lifecycle.record("connected-start")
                     await connectedGate.wait()
                     await lifecycle.record("connected-end")
                 },
                 onDisconnected: { _ in await lifecycle.record("disconnected") },
-                onInvoke: { req in
-                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                },
                 onRouteInvalidated: { await lifecycle.record("invalidated") })
         }
         try await waitUntil("connected callback suspended") {
@@ -1818,13 +1709,10 @@ struct GatewayNodeSessionTests {
             clientDisplayName: "macOS Test")
 
         let connect = Task {
-            try? await gateway.connect(
-                url: #require(URL(string: "ws://first.example.invalid")),
-                token: nil,
-                bootstrapToken: nil,
-                password: nil,
-                connectOptions: options,
-                sessionBox: WebSocketSessionBox(session: session),
+            try? await gateway.connectForTest(
+                testURL("ws://first.example.invalid"),
+                options: options,
+                session: session,
                 onConnected: {
                     await lifecycle.record("connected-start")
                     await gateway.disconnect()
@@ -1833,9 +1721,6 @@ struct GatewayNodeSessionTests {
                     await lifecycle.record("connected-end")
                 },
                 onDisconnected: { _ in await lifecycle.record("disconnected") },
-                onInvoke: { req in
-                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                },
                 onRouteInvalidated: { await lifecycle.record("invalidated") })
         }
         defer { connect.cancel() }
@@ -1845,18 +1730,10 @@ struct GatewayNodeSessionTests {
         }
 
         let replacement = Task {
-            try await gateway.connect(
-                url: #require(URL(string: "ws://second.example.invalid")),
-                token: nil,
-                bootstrapToken: nil,
-                password: nil,
-                connectOptions: options,
-                sessionBox: WebSocketSessionBox(session: session),
-                onConnected: {},
-                onDisconnected: { _ in },
-                onInvoke: { req in
-                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                },
+            try await gateway.connectForTest(
+                testURL("ws://second.example.invalid"),
+                options: options,
+                session: session,
                 onRouteInvalidated: {})
         }
         defer { replacement.cancel() }
@@ -1890,18 +1767,10 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            },
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
             onRouteInvalidated: {
                 await lifecycle.record("invalidation-start")
                 await gateway.disconnect()
@@ -1925,13 +1794,10 @@ struct GatewayNodeSessionTests {
         let options = nodeConnectOptions()
 
         let connect = Task {
-            try? await gateway.connect(
-                url: #require(URL(string: "ws://first.example.invalid")),
-                token: nil,
-                bootstrapToken: nil,
-                password: nil,
-                connectOptions: options,
-                sessionBox: WebSocketSessionBox(session: session),
+            try? await gateway.connectForTest(
+                testURL("ws://first.example.invalid"),
+                options: options,
+                session: session,
                 onConnected: {
                     do {
                         _ = try await gateway.request(
@@ -1942,10 +1808,7 @@ struct GatewayNodeSessionTests {
                         await lifecycle.record("request-failed")
                     }
                 },
-                onDisconnected: { _ in await lifecycle.record("disconnected") },
-                onInvoke: { req in
-                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                })
+                onDisconnected: { _ in await lifecycle.record("disconnected") })
         }
         defer { connect.cancel() }
 
@@ -1977,34 +1840,18 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            },
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
             onRouteInvalidated: { await invalidationGate.wait() })
         let firstTask = try #require(session.latestTask())
 
         let replacement = Task {
-            try await gateway.connect(
-                url: #require(URL(string: "ws://second.example.invalid")),
-                token: nil,
-                bootstrapToken: nil,
-                password: nil,
-                connectOptions: options,
-                sessionBox: WebSocketSessionBox(session: session),
-                onConnected: {},
-                onDisconnected: { _ in },
-                onInvoke: { req in
-                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                },
+            try await gateway.connectForTest(
+                testURL("ws://second.example.invalid"),
+                options: options,
+                session: session,
                 onRouteInvalidated: {})
         }
         defer { replacement.cancel() }
@@ -2037,17 +1884,11 @@ struct GatewayNodeSessionTests {
             ]
         }
         let connectOnce: () async throws -> Void = {
-            try await gateway.connect(
-                url: url,
-                credentials: .init(),
-                connectOptions: options,
-                sessionBox: WebSocketSessionBox(session: session),
-                extraHeadersProvider: provider,
-                onConnected: {},
-                onDisconnected: { _ in },
-                onInvoke: { req in
-                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                })
+            try await gateway.connectForTest(
+                url,
+                options: options,
+                session: session,
+                extraHeadersProvider: provider)
         }
 
         try await connectOnce()
@@ -2074,17 +1915,11 @@ struct GatewayNodeSessionTests {
         let secret = MutableHeaderValue(value: "must-not-be-read")
         let options = nodeConnectOptions()
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
-            credentials: .init(),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            extraHeadersProvider: { [secret] in ["Authorization": secret.get()] },
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+        try await gateway.connectForTest(
+            testURL("ws://gateway.example.invalid"),
+            options: options,
+            session: session,
+            extraHeadersProvider: { [secret] in ["Authorization": secret.get()] })
 
         let request = try #require(session.latestRequest())
         #expect(secret.readCount() == 0)
@@ -2103,16 +1938,7 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = operatorConnectOptions(scopes: [], clientMode: "operator")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) })
+        try await gateway.connectForTest(testURL("ws://gateway.example.invalid"), options: options, session: session)
         let route = try #require(await gateway.currentRoute())
         #expect(await gateway.supportsServerMethod("approval.get", ifCurrentRoute: route) == true)
         #expect(await gateway.supportsServerMethod("missing", ifCurrentRoute: route) == false)
@@ -2127,13 +1953,7 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(clientId: "openclaw-macos-test", clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+        try await gateway.connectForTest(testURL("ws://gateway.example.invalid"), options: options, session: session)
         let route = try #require(await gateway.currentRoute())
         let task = try #require(session.latestTask())
 
@@ -2206,13 +2026,7 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions()
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway.example.invalid")),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) })
+        try await gateway.connectForTest(testURL("ws://gateway.example.invalid"), options: options, session: session)
         let route = try #require(await gateway.currentRoute())
         let socket = try #require(session.latestTask())
         let request = Task {
@@ -2247,14 +2061,7 @@ struct GatewayNodeSessionTests {
         let decomposedGatewayID = "gw-e\u{0301}"
         let options = nodeConnectOptions(deviceAuthGatewayID: composedGatewayID)
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            credentials: .init(),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) })
+        try await gateway.connectForTest(testURL("ws://first.example.invalid"), options: options, session: session)
         let firstRoute = try #require(await gateway.currentRoute(ifGatewayID: composedGatewayID))
         #expect(composedGatewayID == decomposedGatewayID)
         #expect(await gateway.currentRoute(ifGatewayID: decomposedGatewayID) == nil)
@@ -2267,14 +2074,10 @@ struct GatewayNodeSessionTests {
 
         var replacementOptions = options
         replacementOptions.deviceAuthGatewayID = decomposedGatewayID
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
-            credentials: .init(),
-            connectOptions: replacementOptions,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) })
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: replacementOptions,
+            session: session)
 
         #expect(await gateway.currentRoute(ifGatewayID: composedGatewayID) == nil)
         #expect(await gateway.currentRoute(ifGatewayID: decomposedGatewayID) != nil)
@@ -2312,26 +2115,18 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions()
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
             credentials: .init(token: "first-token"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) })
+            options: options,
+            session: session)
 
         let replacement = Task {
-            try await gateway.connect(
-                url: #require(URL(string: "ws://stale.example.invalid")),
+            try await gateway.connectForTest(
+                testURL("ws://stale.example.invalid"),
                 credentials: .init(token: "stale-token"),
-                connectOptions: options,
-                sessionBox: WebSocketSessionBox(session: session),
-                onConnected: {},
-                onDisconnected: { _ in },
-                onInvoke: { req in
-                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                })
+                options: options,
+                session: session)
         }
         let deadline = ContinuousClock().now.advanced(by: .seconds(2))
         while !cancelGate.hasStarted(), ContinuousClock().now < deadline {
@@ -2365,13 +2160,11 @@ struct GatewayNodeSessionTests {
         var startedIterator = invokeStarted.stream.makeAsyncIterator()
         let options = nodeConnectOptions(commands: ["camera.snap"])
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://first.example.invalid")),
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
             credentials: .init(token: "first-token"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
+            options: options,
+            session: session,
             onInvoke: { request in
                 invokeStarted.continuation.yield()
                 for await _ in invokeRelease.stream {
@@ -2387,14 +2180,11 @@ struct GatewayNodeSessionTests {
         firstTask.emitInvokeRequest(id: "invoke-old", command: "camera.snap")
         _ = await startedIterator.next()
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://replacement.example.invalid")),
+        try await gateway.connectForTest(
+            testURL("ws://replacement.example.invalid"),
             credentials: .init(token: "replacement-token"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil) })
+            options: options,
+            session: session)
         let replacementTask = try #require(session.latestTask())
 
         invokeRelease.continuation.yield()
@@ -2420,13 +2210,10 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://example.invalid")),
-            credentials: .init(),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
+        try await gateway.connectForTest(
+            testURL("ws://example.invalid"),
+            options: options,
+            session: session,
             onInvoke: { request in
                 if request.id == "system-run-blocked" {
                     systemRunStarted.continuation.yield()
@@ -2490,13 +2277,10 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://example.invalid")),
-            credentials: .init(),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
+        try await gateway.connectForTest(
+            testURL("ws://example.invalid"),
+            options: options,
+            session: session,
             onInvoke: { request in
                 BridgeInvokeResponse(
                     id: request.id,
@@ -2529,15 +2313,10 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://example.invalid")),
-            token: nil,
-            bootstrapToken: nil,
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
+        try await gateway.connectForTest(
+            testURL("ws://example.invalid"),
+            options: options,
+            session: session,
             onInvoke: { request in await probe.execute(request) })
         let firstTask = try #require(session.latestTask())
         let idempotencyKey = "computer.act:v1:stable-call"
@@ -2759,16 +2538,11 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = operatorConnectOptions(includeDeviceIdentity: true)
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://example.invalid")),
+        try await gateway.connectForTest(
+            testURL("ws://example.invalid"),
             credentials: .init(bootstrapToken: "fresh-bootstrap-token"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+            options: options,
+            session: session)
 
         let auth = try #require(session.latestTask()?.latestConnectAuth())
         #expect(auth["bootstrapToken"] as? String == "fresh-bootstrap-token")
@@ -2790,16 +2564,10 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(includeDeviceIdentity: true, allowStoredDeviceAuth: false)
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://new-gateway.example.invalid")),
-            credentials: .init(),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+        try await gateway.connectForTest(
+            testURL("ws://new-gateway.example.invalid"),
+            options: options,
+            session: session)
 
         let task = try #require(session.latestTask())
         let auth = try #require(task.latestConnectAuth())
@@ -2828,16 +2596,7 @@ struct GatewayNodeSessionTests {
             allowStoredDeviceAuth: true,
             deviceAuthGatewayID: "gateway-b")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://gateway-b.example.invalid")),
-            credentials: .init(),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+        try await gateway.connectForTest(testURL("ws://gateway-b.example.invalid"), options: options, session: session)
 
         let auth = try #require(session.latestTask()?.latestConnectAuth())
         #expect(auth["token"] == nil)
@@ -2870,16 +2629,11 @@ struct GatewayNodeSessionTests {
             deviceIdentityProfile: .shareExtension,
             includeDeviceIdentity: true)
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://example.invalid")),
+        try await gateway.connectForTest(
+            testURL("ws://example.invalid"),
             credentials: .init(password: "shared-password"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+            options: options,
+            session: session)
 
         let shareDevice = try #require(session.latestTask()?.latestConnectDevice())
         let shareDeviceId = try #require(shareDevice["id"] as? String)
@@ -2903,18 +2657,13 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = operatorConnectOptions()
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://example.invalid")),
+        try await gateway.connectForTest(
+            testURL("ws://example.invalid"),
             credentials: .init(
                 bootstrapToken: "stale-bootstrap-token",
                 password: "shared-password"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+            options: options,
+            session: session)
 
         let auth = try #require(session.latestTask()?.latestConnectAuth())
         #expect(auth["password"] as? String == "shared-password")
@@ -2941,16 +2690,11 @@ struct GatewayNodeSessionTests {
         let options = operatorConnectOptions()
 
         do {
-            try await gateway.connect(
-                url: #require(URL(string: "ws://example.invalid")),
+            try await gateway.connectForTest(
+                testURL("ws://example.invalid"),
                 credentials: .init(token: "shared-token"),
-                connectOptions: options,
-                sessionBox: WebSocketSessionBox(session: session),
-                onConnected: {},
-                onDisconnected: { _ in },
-                onInvoke: { req in
-                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                })
+                options: options,
+                session: session)
             Issue.record("connect unexpectedly succeeded")
         } catch let error as GatewayConnectAuthError {
             #expect(error.detail == .protocolMismatch)
@@ -2980,27 +2724,17 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions()
 
-        try await gateway.connect(
-            url: #require(URL(string: "wss://example.invalid")),
+        try await gateway.connectForTest(
+            testURL("wss://example.invalid"),
             credentials: .init(token: "shared-token"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: firstSession),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+            options: options,
+            session: firstSession)
 
-        try await gateway.connect(
-            url: #require(URL(string: "wss://example.invalid")),
+        try await gateway.connectForTest(
+            testURL("wss://example.invalid"),
             credentials: .init(token: "shared-token"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: secondSession),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+            options: options,
+            session: secondSession)
 
         #expect(firstSession.snapshotMakeCount() == 1)
         #expect(secondSession.snapshotMakeCount() == 1)
@@ -3036,16 +2770,11 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(includeDeviceIdentity: true)
 
-        try await gateway.connect(
-            url: #require(URL(string: "wss://example.invalid")),
+        try await gateway.connectForTest(
+            testURL("wss://example.invalid"),
             credentials: .init(bootstrapToken: "fresh-bootstrap-token"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+            options: options,
+            session: session)
 
         let nodeEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node"))
         let operatorEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator"))
@@ -3082,16 +2811,11 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(includeDeviceIdentity: true)
 
-        try await gateway.connect(
-            url: #require(URL(string: "wss://example.invalid")),
+        try await gateway.connectForTest(
+            testURL("wss://example.invalid"),
             credentials: .init(bootstrapToken: "fresh-bootstrap-token"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+            options: options,
+            session: session)
 
         #expect(await gateway.currentIssuedDeviceAuthRoles().isEmpty)
         await gateway.disconnect()
@@ -3115,16 +2839,11 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(includeDeviceIdentity: true)
 
-        try await gateway.connect(
-            url: #require(URL(string: "wss://example.invalid")),
+        try await gateway.connectForTest(
+            testURL("wss://example.invalid"),
             credentials: .init(token: "shared-token"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+            options: options,
+            session: session)
 
         let nodeEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node"))
         #expect(nodeEntry.token == "server-node-token")
@@ -3155,16 +2874,11 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(includeDeviceIdentity: true)
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://example.invalid")),
+        try await gateway.connectForTest(
+            testURL("ws://example.invalid"),
             credentials: .init(bootstrapToken: "fresh-bootstrap-token"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+            options: options,
+            session: session)
 
         #expect(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node") == nil)
         #expect(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator") == nil)
@@ -3194,16 +2908,11 @@ struct GatewayNodeSessionTests {
         let gateway = GatewayNodeSession()
         let options = nodeConnectOptions(includeDeviceIdentity: true)
 
-        try await gateway.connect(
-            url: url,
+        try await gateway.connectForTest(
+            url,
             credentials: .init(bootstrapToken: "fresh-bootstrap-token"),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: bootstrapSession),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+            options: options,
+            session: bootstrapSession)
         await gateway.disconnect()
 
         let nodeEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node"))
@@ -3217,16 +2926,7 @@ struct GatewayNodeSessionTests {
         ])
 
         let reconnectSession = FakeGatewayWebSocketSession()
-        try await gateway.connect(
-            url: url,
-            credentials: .init(),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: reconnectSession),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+        try await gateway.connectForTest(url, options: options, session: reconnectSession)
 
         let reconnectAuth = try #require(reconnectSession.latestTask()?.latestConnectAuth())
         #expect(reconnectAuth["token"] as? String == "lan-node-token")
@@ -3261,16 +2961,11 @@ struct GatewayNodeSessionTests {
 
             for _ in 0..<2 {
                 do {
-                    try await gateway.connect(
-                        url: url,
+                    try await gateway.connectForTest(
+                        url,
                         credentials: .init(token: "shared-gateway-token"),
-                        connectOptions: options,
-                        sessionBox: WebSocketSessionBox(session: session),
-                        onConnected: {},
-                        onDisconnected: { _ in },
-                        onInvoke: { req in
-                            BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-                        })
+                        options: options,
+                        session: session)
                     Issue.record("connect unexpectedly succeeded")
                 } catch let error as GatewayConnectAuthError {
                     #expect(error.detail == .authTokenMismatch)
@@ -3485,11 +3180,10 @@ struct GatewayNodeSessionTests {
         let capturedMainSessionKey = StringCapture()
         let options = nodeConnectOptions(clientId: "openclaw-macos", clientDisplayName: "macOS Test")
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://example.invalid")),
-            credentials: .init(),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
+        try await gateway.connectForTest(
+            testURL("ws://example.invalid"),
+            options: options,
+            session: session,
             onConnected: {
                 let route = await gateway.currentRoute()
                 let key: String? = if let route {
@@ -3498,10 +3192,6 @@ struct GatewayNodeSessionTests {
                     nil
                 }
                 await capturedMainSessionKey.set(key)
-            },
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
             })
 
         let route = try #require(await gateway.currentRoute())
@@ -3532,16 +3222,7 @@ struct GatewayNodeSessionTests {
             }
         }
 
-        try await gateway.connect(
-            url: #require(URL(string: "ws://example.invalid")),
-            credentials: .init(),
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
+        try await gateway.connectForTest(testURL("ws://example.invalid"), options: options, session: session)
 
         let firstTask = try #require(session.latestTask())
         firstTask.emitReceiveFailure()


### PR DESCRIPTION
## What Problem This Solves

Gateway node session tests repeat full connection plumbing across 62 lifecycle, auth, invoke, and routing scenarios. The repeated URL/session-box/credential/no-op callback setup makes the scenario-specific behavior harder to review and maintain.

## Why This Change Was Made

Adds one file-private test connection helper that defaults only empty credentials and exact no-op/success callbacks while requiring the URL, options, and fake session. All custom credentials, headers, lifecycle callbacks, invoke callbacks, route invalidation, session identity, Tasks, gates, and disconnect ordering remain explicit. One direct flat-overload call stays in place to cover the source-compatible credential forwarding contract.

## User Impact

No user-visible or production behavior changes. Maintainers keep the same 72 gateway session tests with 319 fewer test lines and one canonical connection setup.

## Evidence

- `swift test --package-path apps/shared/OpenClawKit --filter GatewayNodeSessionTests`: 72/72 passed in 11.145s.
- Independent ordinal audit: 62/62 logical connects conserved; 61 helper calls plus one direct flat-overload call. All custom callbacks and providers match baseline: connected 7/7, disconnected 9/9, invoke 7/7, route invalidated 12/12, input/cancel 1/1, headers 2/2.
- Structural conservation: all 72 test declarations are byte-identical; all 322 non-URL behavioral assertion lines are byte-identical. The 58 literal URL validations still execute 58 times.
- `node scripts/check-changed.mjs -- apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift`: passed on Blacksmith Testbox `tbx_01kz2zmt949wengwkrysw7yrzn` ([run 30785743720](https://github.com/openclaw/openclaw/actions/runs/30785743720)).
- Fresh Codex autoreview using `gpt-5.6-sol` at `xhigh`: 0 findings, correctness 0.99.
- Diff: +231/-550 test lines (net -319); production delta 0.

AI-assisted: yes.