### PR TITLE
refactor: consolidate kitchen sink RPC walk helpers

### DIFF
--- a/scripts/e2e/kitchen-sink-rpc-walk.d.mts
+++ b/scripts/e2e/kitchen-sink-rpc-walk.d.mts
@@ -69,15 +69,13 @@ export function signalProcessGroup(
     runTaskkill,
     useProcessGroup,
   }?: {
-    platform?: NodeJS.Platform | undefined;
-    runTaskkill?:
-      | ((
-          command: string,
-          args: string[],
-          options: { stdio: "ignore" },
-        ) => { error?: Error; status: number | null })
-      | undefined;
-    useProcessGroup?: boolean | undefined;
+    platform?: NodeJS.Platform;
+    runTaskkill?: (
+      command: string,
+      args: string[],
+      options: { stdio: "ignore" },
+    ) => { error?: Error; status: number | null };
+    useProcessGroup?: boolean;
   },
 ): void;
 export function parseJsonOutput(stdout: string): Record<string, unknown>;
@@ -109,11 +107,6 @@ export function fetchJson(
   status: unknown;
   body: unknown;
 }>;
-export function readBoundedResponseText(
-  response: unknown,
-  byteLimit: number,
-  timeoutPromise?: Promise<never>,
-): Promise<string>;
 export function stopGateway(child: unknown, options?: Record<string, unknown>): Promise<void>;
 export function hasChildExited(child: unknown): boolean;
 export function signalGateway(
@@ -136,11 +129,10 @@ export function assertExpectedKitchenSinkToolEntries(
   {
     requirePluginProvenance,
   }?: {
-    requirePluginProvenance?: boolean | undefined;
+    requirePluginProvenance?: boolean;
   },
 ): unknown;
 export function assertChannelAccountRunning(payload: unknown): unknown;
-export function extractTtsProviderIds(payload: unknown, surface: unknown): unknown[];
 export function assertTtsProviderCoverage(payload: unknown, surface: unknown): void;
 export function assertKitchenSinkSearchInvokeResult(payload: unknown): void;
 export function assertKitchenSinkTextInvokeResult(payload: unknown): void;
@@ -189,7 +181,5 @@ export function sampleWindowsProcessByPort(
 export function assertResourceCeiling(sample: unknown): void;
 export function assertCommandResourceCeiling(sample: unknown): void;
 export function findErrorLogFindings(logPath: string): Array<{ line: string; lineNumber: number }>;
-export function tailFile(file: string, maxBytes?: number): string;
-export function main(): Promise<void>;
 export const MAX_KITCHEN_SINK_TIMER_TIMEOUT_MS: 2147000000;
 declare function defaultKillProcess(pid: unknown, signal: unknown): true;

--- a/scripts/e2e/kitchen-sink-rpc-walk.mjs
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mjs
@@ -9,10 +9,15 @@ import process from "node:process";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
+  createBoundedResponseTooLargeError,
+  readBoundedResponseText,
+} from "../lib/bounded-response.mjs";
+import {
   resolveWindowsPowerShellPath,
   resolveWindowsSystem32Path,
   resolveWindowsTaskkillPath,
 } from "../lib/windows-taskkill.mjs";
+import { readTextFileTail } from "./lib/text-file-utils.mjs";
 
 const PLUGIN_SPEC =
   process.env.OPENCLAW_KITCHEN_SINK_NPM_SPEC || "npm:@openclaw/kitchen-sink@latest";
@@ -632,24 +637,12 @@ export function signalProcessGroup(
     useProcessGroup = platform !== "win32",
   } = {},
 ) {
-  if (useProcessGroup && typeof child.pid === "number") {
-    try {
-      process.kill(-child.pid, signal);
-      return;
-    } catch {}
-  }
-  if (platform === "win32" && typeof child.pid === "number") {
-    if (signalWindowsProcessTreeOrForce(child.pid, signal, runTaskkill)) {
-      return;
-    }
-  }
-  try {
-    child.kill(signal);
-  } catch (error) {
-    if (error?.code !== "ESRCH") {
-      throw error;
-    }
-  }
+  signalChildProcessTree(child, signal, {
+    killProcess: process.kill,
+    platform,
+    runTaskkill,
+    useProcessGroup,
+  });
 }
 
 async function runOpenClaw(runner, args, env, options = {}) {
@@ -1104,7 +1097,10 @@ export async function fetchJson(url, options = {}) {
         ? Promise.race([timeoutPromise, abortPromise])
         : timeoutPromise;
       const text = await Promise.race([
-        readBoundedResponseText(response, maxBodyBytes, bodyAbortPromise),
+        readBoundedResponseText(response, "fetch", maxBodyBytes, {
+          createTooLargeError: createBoundedResponseTooLargeError,
+          timeoutPromise: bodyAbortPromise,
+        }),
         bodyAbortPromise,
       ]);
       let body = null;
@@ -1155,75 +1151,6 @@ async function delayWithAbort(delayMs, signal) {
     }
     throw error;
   }
-}
-
-export async function readBoundedResponseText(response, byteLimit, timeoutPromise) {
-  const resolvedByteLimit = byteLimit ?? resolveKitchenSinkRpcConfig().fetchBodyMaxBytes;
-  const contentLength = response.headers?.get?.("content-length");
-  if (contentLength && /^\d+$/u.test(contentLength)) {
-    const parsedContentLength = Number(contentLength);
-    if (!Number.isSafeInteger(parsedContentLength) || parsedContentLength > resolvedByteLimit) {
-      await response.body?.cancel?.().catch(() => undefined);
-      throw createFetchBodyTooLargeError(resolvedByteLimit);
-    }
-  }
-
-  const reader = response.body?.getReader?.();
-  if (!reader) {
-    const text = await withOptionalTimeout(response.text(), timeoutPromise);
-    if (Buffer.byteLength(text, "utf8") > resolvedByteLimit) {
-      throw createFetchBodyTooLargeError(resolvedByteLimit);
-    }
-    return text;
-  }
-  const chunks = [];
-  let totalBytes = 0;
-  try {
-    for (;;) {
-      const read = reader.read();
-      const { done, value } = await withOptionalTimeout(
-        read,
-        timeoutPromise?.catch((error) => {
-          cancelReaderSoon(reader);
-          throw error;
-        }),
-      );
-      if (done) {
-        break;
-      }
-      const chunk = Buffer.from(value);
-      totalBytes += chunk.byteLength;
-      if (totalBytes > resolvedByteLimit) {
-        await reader.cancel().catch(() => undefined);
-        throw createFetchBodyTooLargeError(resolvedByteLimit);
-      }
-      chunks.push(chunk);
-    }
-  } finally {
-    try {
-      reader.releaseLock?.();
-    } catch {}
-  }
-  return Buffer.concat(chunks, totalBytes).toString("utf8");
-}
-
-function createFetchBodyTooLargeError(byteLimit) {
-  return Object.assign(new Error(`fetch response body exceeded ${byteLimit} bytes`), {
-    code: "ETOOBIG",
-  });
-}
-
-async function withOptionalTimeout(promise, timeoutPromise) {
-  if (!timeoutPromise) {
-    return await promise;
-  }
-  return await Promise.race([promise, timeoutPromise]);
-}
-
-function cancelReaderSoon(reader) {
-  void Promise.resolve()
-    .then(() => reader.cancel())
-    .catch(() => undefined);
 }
 
 function configureKitchenSink(env, port) {
@@ -1378,12 +1305,26 @@ export function signalGateway(child, signal, killProcess = defaultKillProcess, o
     runTaskkill = childProcess.spawnSync,
     useProcessGroup = platform !== "win32",
   } = options;
+  return signalChildProcessTree(child, signal, {
+    groupEsrchMeansExited: true,
+    killProcess,
+    platform,
+    runTaskkill,
+    useProcessGroup,
+  });
+}
+
+function signalChildProcessTree(
+  child,
+  signal,
+  { groupEsrchMeansExited = false, killProcess, platform, runTaskkill, useProcessGroup },
+) {
   if (useProcessGroup && typeof child.pid === "number") {
     try {
       killProcess(-child.pid, signal);
       return true;
     } catch (error) {
-      if (error?.code === "ESRCH") {
+      if (groupEsrchMeansExited && error?.code === "ESRCH") {
         return false;
       }
     }
@@ -1604,16 +1545,6 @@ export function assertChannelAccountRunning(payload) {
   return account;
 }
 
-export function extractTtsProviderIds(payload, surface) {
-  const entries =
-    surface === "providers"
-      ? payload?.providers
-      : surface === "status"
-        ? payload?.providerStates
-        : null;
-  return (Array.isArray(entries) ? entries : []).map((entry) => entry?.id).filter(isNonEmptyString);
-}
-
 export function assertTtsProviderCoverage(payload, surface) {
   const entries =
     surface === "providers"
@@ -1626,7 +1557,7 @@ export function assertTtsProviderCoverage(payload, surface) {
       `tts.${surface} returned invalid provider list: ${boundedJsonPreview(payload)}`,
     );
   }
-  const ids = extractTtsProviderIds(payload, surface);
+  const ids = entries.map((entry) => entry?.id).filter(isNonEmptyString);
   assertIncludesAny(ids, EXPECTED_SPEECH_PROVIDERS, `tts.${surface}`);
   const configuredEntry = entries.find(
     (entry) => EXPECTED_SPEECH_PROVIDERS.includes(entry?.id) && entry.configured === true,
@@ -1881,38 +1812,23 @@ function assertObjectPayload(payload, label) {
 
 export function assertGatewayHealthPayload(payload) {
   const health = assertObjectPayload(payload, "health");
-  const problems = [];
-  if (health.ok !== true) {
-    problems.push("ok=true");
-  }
-  if (!Number.isFinite(health.ts)) {
-    problems.push("numeric ts");
-  }
-  if (!Number.isFinite(health.durationMs)) {
-    problems.push("numeric durationMs");
-  }
-  if (!health.channels || typeof health.channels !== "object" || Array.isArray(health.channels)) {
-    problems.push("channels object");
-  }
-  if (!Array.isArray(health.channelOrder)) {
-    problems.push("channelOrder array");
-  }
-  if (!isNonEmptyString(health.defaultAgentId)) {
-    problems.push("defaultAgentId");
-  }
-  if (!Array.isArray(health.agents)) {
-    problems.push("agents array");
-  }
-  if (
-    !health.sessions ||
-    typeof health.sessions !== "object" ||
-    Array.isArray(health.sessions) ||
-    !isNonEmptyString(health.sessions.path) ||
-    !Number.isFinite(health.sessions.count) ||
-    !Array.isArray(health.sessions.recent)
-  ) {
-    problems.push("sessions summary");
-  }
+  const sessions = health.sessions;
+  const problems = failedPayloadChecks([
+    [health.ok === true, "ok=true"],
+    [Number.isFinite(health.ts), "numeric ts"],
+    [Number.isFinite(health.durationMs), "numeric durationMs"],
+    [isObjectRecord(health.channels), "channels object"],
+    [Array.isArray(health.channelOrder), "channelOrder array"],
+    [isNonEmptyString(health.defaultAgentId), "defaultAgentId"],
+    [Array.isArray(health.agents), "agents array"],
+    [
+      isObjectRecord(sessions) &&
+        isNonEmptyString(sessions.path) &&
+        Number.isFinite(sessions.count) &&
+        Array.isArray(sessions.recent),
+      "sessions summary",
+    ],
+  ]);
   if (problems.length > 0) {
     throw new Error(
       `health payload missing ${problems.join(", ")}: ${boundedJsonPreview(payload)}`,
@@ -1922,52 +1838,42 @@ export function assertGatewayHealthPayload(payload) {
 
 export function assertGatewayStatusPayload(payload) {
   const status = assertObjectPayload(payload, "status");
-  const problems = [];
-  if (
-    !status.heartbeat ||
-    typeof status.heartbeat !== "object" ||
-    Array.isArray(status.heartbeat) ||
-    !isNonEmptyString(status.heartbeat.defaultAgentId) ||
-    !Array.isArray(status.heartbeat.agents)
-  ) {
-    problems.push("heartbeat summary");
-  }
-  if (!Array.isArray(status.channelSummary)) {
-    problems.push("channelSummary array");
-  }
-  if (!Array.isArray(status.queuedSystemEvents)) {
-    problems.push("queuedSystemEvents array");
-  }
-  if (!status.tasks || typeof status.tasks !== "object" || Array.isArray(status.tasks)) {
-    problems.push("tasks summary");
-  }
-  if (
-    !status.taskAudit ||
-    typeof status.taskAudit !== "object" ||
-    Array.isArray(status.taskAudit)
-  ) {
-    problems.push("taskAudit summary");
-  }
-  if (
-    !status.sessions ||
-    typeof status.sessions !== "object" ||
-    Array.isArray(status.sessions) ||
-    !Array.isArray(status.sessions.paths) ||
-    !Number.isFinite(status.sessions.count) ||
-    !Array.isArray(status.sessions.recent) ||
-    !Array.isArray(status.sessions.byAgent) ||
-    !status.sessions.defaults ||
-    typeof status.sessions.defaults !== "object" ||
-    Array.isArray(status.sessions.defaults)
-  ) {
-    problems.push("sessions summary");
-  }
+  const { heartbeat, sessions } = status;
+  const problems = failedPayloadChecks([
+    [
+      isObjectRecord(heartbeat) &&
+        isNonEmptyString(heartbeat.defaultAgentId) &&
+        Array.isArray(heartbeat.agents),
+      "heartbeat summary",
+    ],
+    [Array.isArray(status.channelSummary), "channelSummary array"],
+    [Array.isArray(status.queuedSystemEvents), "queuedSystemEvents array"],
+    [isObjectRecord(status.tasks), "tasks summary"],
+    [isObjectRecord(status.taskAudit), "taskAudit summary"],
+    [
+      isObjectRecord(sessions) &&
+        Array.isArray(sessions.paths) &&
+        Number.isFinite(sessions.count) &&
+        Array.isArray(sessions.recent) &&
+        Array.isArray(sessions.byAgent) &&
+        isObjectRecord(sessions.defaults),
+      "sessions summary",
+    ],
+  ]);
   if (problems.length > 0) {
     throw new Error(
       `status payload missing ${problems.join(", ")}: ${boundedJsonPreview(payload)}`,
     );
   }
 }
+
+function failedPayloadChecks(checks) {
+  return checks.filter(([passed]) => !passed).map(([, label]) => label);
+}
+
+// This plain-Node entrypoint must run before workspace packages are linkable.
+const isObjectRecord = (value) =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
 
 function countDiagnosticEvents(payload, type) {
   const summaryCount = payload.summary?.byType?.[type];
@@ -2023,34 +1929,42 @@ async function samplePosixProcess(pid, run, commandLineNeedles = []) {
 }
 
 async function samplePosixProcessWithDescendants(pid, run) {
-  const safePid = Number(pid);
-  if (!Number.isInteger(safePid) || safePid <= 0) {
+  const snapshot = await readPosixProcessTreeSnapshot(pid, run);
+  if (!snapshot) {
     return null;
   }
-  try {
-    const { stdout } = await run("ps", POSIX_PROCESS_SNAPSHOT_ARGS, {
-      timeoutMs: 5000,
-    });
-    const snapshot = parsePosixProcessRows(stdout);
-    if (!snapshot) {
-      return null;
-    }
-    const { malformedRows, rows } = snapshot;
-    const selected = rows.find((row) => row.processId === safePid);
-    if (!selected) {
-      return null;
-    }
-    const treeRows = collectPosixProcessTree(rows, safePid);
-    if (hasMalformedProcessTreeRows(malformedRows, treeRows)) {
-      return null;
-    }
-    return formatPosixProcessTreeSample(selected, treeRows);
-  } catch {
-    return null;
-  }
+  return formatPosixProcessTreeSample(snapshot.rootRow, snapshot.rootTreeRows);
 }
 
 async function samplePosixProcessTree(pid, run, commandLineNeedles) {
+  const snapshot = await readPosixProcessTreeSnapshot(pid, run);
+  if (!snapshot) {
+    return null;
+  }
+  const { rootRow, rootTreeRows, rows } = snapshot;
+  const descendants = rootTreeRows.filter((row) => row.processId !== rootRow.processId);
+  const matchesCommandNeedles = (row) =>
+    commandLineNeedles.every((needle) => row.command.toLowerCase().includes(needle.toLowerCase()));
+  const commandMatches = descendants.filter(matchesCommandNeedles);
+  const rootCommandMatches = matchesCommandNeedles(rootRow) ? [rootRow] : [];
+  const gatewayTitleMatches = descendants.filter((row) =>
+    row.command.toLowerCase().includes("openclaw-gateway"),
+  );
+  const selected = selectPeakRssProcess(
+    commandMatches.length > 0
+      ? commandMatches
+      : gatewayTitleMatches.length > 0
+        ? gatewayTitleMatches
+        : descendants.length > 0
+          ? descendants
+          : rootCommandMatches,
+  );
+  return selected
+    ? formatPosixProcessTreeSample(selected, collectPosixProcessTree(rows, selected.processId))
+    : null;
+}
+
+async function readPosixProcessTreeSnapshot(pid, run) {
   const safePid = Number(pid);
   if (!Number.isInteger(safePid) || safePid <= 0) {
     return null;
@@ -2065,36 +1979,11 @@ async function samplePosixProcessTree(pid, run, commandLineNeedles) {
     }
     const { malformedRows, rows } = snapshot;
     const rootTreeRows = collectPosixProcessTree(rows, safePid);
-    if (hasMalformedProcessTreeRows(malformedRows, rootTreeRows)) {
+    const rootRow = rootTreeRows.find((row) => row.processId === safePid);
+    if (!rootRow || hasMalformedProcessTreeRows(malformedRows, rootTreeRows)) {
       return null;
     }
-    const rootRow = rootTreeRows.find((row) => row.processId === safePid) ?? null;
-    const descendants = rootTreeRows.filter((row) => row.processId !== safePid);
-    const matchesCommandNeedles = (row) =>
-      commandLineNeedles.every((needle) =>
-        row.command.toLowerCase().includes(needle.toLowerCase()),
-      );
-    const commandMatches = descendants.filter(matchesCommandNeedles);
-    const rootCommandMatches = rootRow && matchesCommandNeedles(rootRow) ? [rootRow] : [];
-    const gatewayTitleMatches = descendants.filter((row) =>
-      row.command.toLowerCase().includes("openclaw-gateway"),
-    );
-    const selected = selectPeakRssProcess(
-      commandMatches.length > 0
-        ? commandMatches
-        : gatewayTitleMatches.length > 0
-          ? gatewayTitleMatches
-          : descendants.length > 0
-            ? descendants
-            : rootCommandMatches,
-    );
-    if (!selected) {
-      return null;
-    }
-    return formatPosixProcessTreeSample(
-      selected,
-      collectPosixProcessTree(rows, selected.processId),
-    );
+    return { rootRow, rootTreeRows, rows };
   } catch {
     return null;
   }
@@ -2535,21 +2424,8 @@ function assertNoErrorLogs(logPath) {
   }
 }
 
-export function tailFile(file, maxBytes = LOG_TAIL_BYTES) {
-  if (!fs.existsSync(file)) {
-    return "";
-  }
-  const stat = fs.statSync(file);
-  const start = Math.max(0, stat.size - Math.max(1, maxBytes));
-  const length = stat.size - start;
-  const fd = fs.openSync(file, "r");
-  try {
-    const buffer = Buffer.alloc(length);
-    const bytesRead = fs.readSync(fd, buffer, 0, length, start);
-    return tailText(buffer.subarray(0, bytesRead).toString("utf8"));
-  } finally {
-    fs.closeSync(fd);
-  }
+function tailFile(file, maxBytes = LOG_TAIL_BYTES) {
+  return tailText(readTextFileTail(file, Math.max(1, maxBytes)));
 }
 
 function tailText(text) {
@@ -2560,7 +2436,7 @@ function isNonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-export async function main() {
+async function main() {
   const config = resolveKitchenSinkRpcConfig();
   let runner = resolveOpenClawRunner();
   const port = await resolveKitchenSinkRpcPort();

--- a/scripts/e2e/kitchen-sink-rpc-walk.mjs
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mjs
@@ -638,7 +638,7 @@ export function signalProcessGroup(
   } = {},
 ) {
   signalChildProcessTree(child, signal, {
-    killProcess: process.kill,
+    killProcess: (pid, childSignal) => process.kill(pid, childSignal),
     platform,
     runTaskkill,
     useProcessGroup,

--- a/test/scripts/kitchen-sink-rpc-walk.test.ts
+++ b/test/scripts/kitchen-sink-rpc-walk.test.ts
@@ -35,7 +35,6 @@ import {
   createGatewayReadyLogScanner,
   createRpcCliRunOptions,
   extractPluginCommandNames,
-  extractTtsProviderIds,
   fetchJson,
   findErrorLogFindings,
   findDistCallGatewayModuleFiles,
@@ -49,7 +48,6 @@ import {
   parseGatewayCliRequestFailure,
   readPositiveInt,
   readPositiveTimerMs,
-  readBoundedResponseText,
   resolveKitchenSinkRpcConfig,
   resolveKitchenSinkRpcPort,
   runCommand,
@@ -60,7 +58,6 @@ import {
   signalProcessGroup,
   stopGateway,
   summarizeProcessSamples,
-  tailFile,
   unwrapRpcPayload,
   usesBuiltOpenClawEntry,
   validateCliArgs,
@@ -76,16 +73,93 @@ import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 const posixIt = process.platform === "win32" ? it.skip : it;
 
-function expectedTaskkillPath(): string {
-  return resolveWindowsTaskkillPath();
+type RunTaskkill = NonNullable<
+  NonNullable<Parameters<typeof signalProcessGroup>[2]>["runTaskkill"]
+>;
+
+function invokeWindowsTreeSignal(
+  owner: "command" | "gateway",
+  signal: NodeJS.Signals,
+  runTaskkill: RunTaskkill,
+) {
+  const child = { kill: vi.fn(), pid: 12345 };
+  const killProcess = vi.fn();
+  const result =
+    owner === "gateway"
+      ? signalGateway(child, signal, killProcess, { platform: "win32", runTaskkill })
+      : signalProcessGroup(child, signal, { platform: "win32", runTaskkill });
+  expect(killProcess).not.toHaveBeenCalled();
+  expect(child.kill).not.toHaveBeenCalled();
+  return result;
 }
 
-function expectedWindowsSystem32Path(executableName: string): string {
-  return resolveWindowsSystem32Path(executableName);
+function expectTaskkillCall(runTaskkill: RunTaskkill, call: number, force: boolean) {
+  expect(runTaskkill).toHaveBeenNthCalledWith(
+    call,
+    resolveWindowsTaskkillPath(),
+    ["/PID", "12345", "/T", ...(force ? ["/F"] : [])],
+    { stdio: "ignore" },
+  );
 }
 
-function expectedPowerShellPath(): string {
-  return resolveWindowsPowerShellPath();
+const commandResult = (stdout: string) => ({ stderr: "", stdout });
+
+function samplePosixSnapshot(
+  stdout: string,
+  options: { commandLineNeedles?: string[]; platform?: NodeJS.Platform } = {},
+) {
+  return sampleProcess(4321, {
+    platform: options.platform ?? "linux",
+    posixCommandLineNeedles: options.commandLineNeedles,
+    runCommand: async (command: string, args: string[]) => {
+      expect(command).toBe("ps");
+      expect(args).toEqual(["-ww", "-axo", "pid=,ppid=,rss=,pcpu=,command="]);
+      return commandResult(stdout);
+    },
+  });
+}
+
+function createWindowsPortSampleRunner(options: {
+  calls?: string[];
+  extraNetstatRows?: string[];
+  powershell: Error | string;
+  tasklist?: string;
+}) {
+  return async (command: string) => {
+    options.calls?.push(command);
+    if (command === resolveWindowsSystem32Path("netstat.exe")) {
+      return commandResult(
+        [
+          "  Proto  Local Address          Foreign Address        State           PID",
+          ...(options.extraNetstatRows ?? []),
+          "  TCP    127.0.0.1:19675        0.0.0.0:0              LISTENING       6789",
+        ].join("\r\n"),
+      );
+    }
+    if (command === resolveWindowsPowerShellPath()) {
+      if (options.powershell instanceof Error) {
+        throw options.powershell;
+      }
+      return commandResult(options.powershell);
+    }
+    if (command === resolveWindowsSystem32Path("tasklist.exe") && options.tasklist) {
+      return commandResult(options.tasklist);
+    }
+    throw new Error(`unexpected command ${command}`);
+  };
+}
+
+async function sampleWindowsSnapshot(stdout: string, commandLineNeedles?: string[]) {
+  const calls: Array<{ args: string[]; command: string }> = [];
+  const sample = await sampleProcess(1234, {
+    platform: "win32",
+    runCommand: async (command: string, args: string[]) => {
+      calls.push({ args, command });
+      return commandResult(stdout);
+    },
+    windowsCommandLineNeedles: commandLineNeedles,
+  });
+  return { calls, sample };
 }
 
 afterEach(() => {
@@ -331,84 +405,37 @@ describe("kitchen-sink RPC gateway teardown", () => {
     expect(child.kill).toHaveBeenCalledOnce();
   });
 
-  it("signals Windows gateway process trees with taskkill", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const killProcess = vi.fn();
-    const runTaskkill = vi.fn(() => ({ error: undefined, status: 0 }));
+  it.each(["gateway", "command"] as const)(
+    "signals Windows %s process trees with taskkill",
+    (owner) => {
+      const runTaskkill = vi.fn<RunTaskkill>(() => ({ error: undefined, status: 0 }));
 
-    expect(
-      signalGateway(child, "SIGTERM", killProcess, {
-        platform: "win32",
-        runTaskkill,
-      }),
-    ).toBe(true);
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
+      expect(invokeWindowsTreeSignal(owner, "SIGTERM", runTaskkill)).toBe(
+        owner === "gateway" ? true : undefined,
+      );
+      expectTaskkillCall(runTaskkill, 1, false);
+      expect(invokeWindowsTreeSignal(owner, "SIGKILL", runTaskkill)).toBe(
+        owner === "gateway" ? true : undefined,
+      );
+      expectTaskkillCall(runTaskkill, 2, true);
+    },
+  );
 
-    expect(
-      signalGateway(child, "SIGKILL", killProcess, {
-        platform: "win32",
-        runTaskkill,
-      }),
-    ).toBe(true);
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(killProcess).not.toHaveBeenCalled();
-    expect(child.kill).not.toHaveBeenCalled();
-  });
+  it.each(["gateway", "command"] as const)(
+    "force-kills Windows %s process trees when graceful taskkill fails",
+    (owner) => {
+      const runTaskkill = vi
+        .fn<RunTaskkill>()
+        .mockReturnValueOnce({ error: undefined, status: 1 })
+        .mockReturnValueOnce({ error: undefined, status: 0 });
 
-  it("force-kills Windows gateway process trees when graceful taskkill fails", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const killProcess = vi.fn();
-    const runTaskkill = vi
-      .fn()
-      .mockReturnValueOnce({ error: undefined, status: 1 })
-      .mockReturnValueOnce({ error: undefined, status: 0 });
-
-    expect(
-      signalGateway(child, "SIGTERM", killProcess, {
-        platform: "win32",
-        runTaskkill,
-      }),
-    ).toBe(true);
-
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(killProcess).not.toHaveBeenCalled();
-    expect(child.kill).not.toHaveBeenCalled();
-  });
+      expect(invokeWindowsTreeSignal(owner, "SIGTERM", runTaskkill)).toBe(
+        owner === "gateway" ? true : undefined,
+      );
+      expectTaskkillCall(runTaskkill, 1, false);
+      expectTaskkillCall(runTaskkill, 2, true);
+    },
+  );
 
   posixIt("does not trust an exited wrapper while the gateway process group is alive", async () => {
     const child = Object.assign(new EventEmitter(), {
@@ -604,40 +631,6 @@ describe("kitchen-sink RPC gateway readiness logs", () => {
     }
   });
 
-  it("tails large gateway logs without returning older content", () => {
-    const root = mkdtempSync(path.join(tmpdir(), "openclaw-kitchen-rpc-log-tail-"));
-    try {
-      const logPath = path.join(root, "gateway.log");
-      writeFileSync(logPath, `old fatal marker\n${"noise\n".repeat(2000)}recent ready\n`);
-
-      const tail = tailFile(logPath, 128);
-
-      expect(tail).toContain("recent ready");
-      expect(tail).not.toContain("old fatal marker");
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it("honors short reads when a gateway log shrinks during tailing", () => {
-    vi.spyOn(fs, "existsSync").mockReturnValue(true);
-    vi.spyOn(fs, "statSync").mockReturnValue({
-      isFile: () => true,
-      size: 64,
-    } as fs.Stats);
-    vi.spyOn(fs, "openSync").mockReturnValue(123 as never);
-    vi.spyOn(fs, "closeSync").mockImplementation(() => undefined);
-    vi.spyOn(fs, "readSync").mockImplementation((_fd, buffer) => {
-      if (!Buffer.isBuffer(buffer)) {
-        throw new Error("expected buffer read");
-      }
-      buffer.write("recent ready");
-      return 12;
-    });
-
-    expect(tailFile("/tmp/truncated-kitchen-rpc.log", 64)).toBe("recent ready");
-  });
-
   it("scans gateway error logs incrementally and keeps the latest findings", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-kitchen-rpc-log-errors-"));
     try {
@@ -798,75 +791,6 @@ setInterval(() => {}, 1000);
       }
       rmSync(root, { recursive: true, force: true });
     }
-  });
-
-  it("signals Windows command process trees with taskkill", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const runTaskkill = vi.fn(() => ({ error: undefined, status: 0 }));
-
-    signalProcessGroup(child, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
-
-    signalProcessGroup(child, "SIGKILL", {
-      platform: "win32",
-      runTaskkill,
-    });
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(child.kill).not.toHaveBeenCalled();
-  });
-
-  it("force-kills Windows command process trees when graceful taskkill fails", () => {
-    const child = {
-      kill: vi.fn(),
-      pid: 12345,
-    };
-    const runTaskkill = vi
-      .fn()
-      .mockReturnValueOnce({ error: undefined, status: 1 })
-      .mockReturnValueOnce({ error: undefined, status: 0 });
-
-    signalProcessGroup(child, "SIGTERM", {
-      platform: "win32",
-      runTaskkill,
-    });
-
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      1,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(runTaskkill).toHaveBeenNthCalledWith(
-      2,
-      expectedTaskkillPath(),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        stdio: "ignore",
-      },
-    );
-    expect(child.kill).not.toHaveBeenCalled();
   });
 
   posixIt("rejects timed commands that exit cleanly after SIGTERM", async () => {
@@ -1459,52 +1383,26 @@ describe("kitchen-sink RPC command catalog assertions", () => {
   });
 
   it("checks TTS providers on the exact response surfaces", () => {
-    expect(extractTtsProviderIds({ providers: [{ id: "nested-miss" }] }, "providers")).toEqual([
-      "nested-miss",
-    ]);
-    expect(
-      extractTtsProviderIds(
-        {
-          metadata: { id: "kitchen-sink-speech" },
-          providers: [{ id: "other", configured: true }],
-        },
+    for (const [payload, surface] of [
+      [{ providers: [{ id: "kitchen-sink-speech", configured: true }] }, "providers"],
+      [{ providerStates: [{ id: "kitchen-sink-speech-provider", configured: true }] }, "status"],
+    ] as const) {
+      expect(() => assertTtsProviderCoverage(payload, surface)).not.toThrow();
+    }
+    for (const [payload, surface, message] of [
+      [
+        { metadata: { id: "kitchen-sink-speech" }, providers: [{ id: "other", configured: true }] },
         "providers",
-      ),
-    ).toEqual(["other"]);
-
-    expect(() =>
-      assertTtsProviderCoverage(
-        {
-          providers: [{ id: "kitchen-sink-speech", configured: true }],
-        },
-        "providers",
-      ),
-    ).not.toThrow();
-    expect(() =>
-      assertTtsProviderCoverage(
-        {
-          providerStates: [{ id: "kitchen-sink-speech-provider", configured: true }],
-        },
+        "tts.providers missing one of",
+      ],
+      [
+        { providerStates: [{ id: "kitchen-sink-speech", configured: false }] },
         "status",
-      ),
-    ).not.toThrow();
-    expect(() =>
-      assertTtsProviderCoverage(
-        {
-          metadata: { id: "kitchen-sink-speech" },
-          providers: [{ id: "other", configured: true }],
-        },
-        "providers",
-      ),
-    ).toThrow("tts.providers missing one of");
-    expect(() =>
-      assertTtsProviderCoverage(
-        {
-          providerStates: [{ id: "kitchen-sink-speech", configured: false }],
-        },
-        "status",
-      ),
-    ).toThrow("did not report a configured Kitchen Sink speech provider");
+        "did not report a configured Kitchen Sink speech provider",
+      ],
+    ] as const) {
+      expect(() => assertTtsProviderCoverage(payload, surface)).toThrow(message);
+    }
   });
 
   it("checks search, text, and image job tool invocation fixtures separately", () => {
@@ -1811,14 +1709,9 @@ describe("kitchen-sink RPC process sampling", () => {
   });
 
   it("samples RSS on Windows instead of silently disabling the resource guard", async () => {
-    const calls: Array<{ command: string; args: string[] }> = [];
-    const sample = await sampleProcess(1234, {
-      platform: "win32",
-      runCommand: async (command: string, args: string[]) => {
-        calls.push({ command, args });
-        return { stdout: `${256 * 1024 * 1024} 1.5 5678 ${288 * 1024 * 1024}`, stderr: "" };
-      },
-    });
+    const { calls, sample } = await sampleWindowsSnapshot(
+      `${256 * 1024 * 1024} 1.5 5678 ${288 * 1024 * 1024}`,
+    );
 
     expect(sample).toEqual({
       aggregateRssMiB: 288,
@@ -1827,21 +1720,16 @@ describe("kitchen-sink RPC process sampling", () => {
       processId: 5678,
       rssMiB: 256,
     });
-    expect(calls[0]?.command).toBe(expectedPowerShellPath());
+    expect(calls[0]?.command).toBe(resolveWindowsPowerShellPath());
     expect(calls[0]?.args.join(" ")).toContain("$rootPid = 1234");
     expect(calls[0]?.args.join(" ")).toContain("ParentProcessId");
   });
 
   it("can locate a Windows gateway process by command line when the launcher is gone", async () => {
-    const calls: Array<{ command: string; args: string[] }> = [];
-    const sample = await sampleProcess(1234, {
-      platform: "win32",
-      runCommand: async (command: string, args: string[]) => {
-        calls.push({ command, args });
-        return { stdout: `${384 * 1024 * 1024} 2.25 6789 ${512 * 1024 * 1024}`, stderr: "" };
-      },
-      windowsCommandLineNeedles: ["gateway", "--port", "19080"],
-    });
+    const { calls, sample } = await sampleWindowsSnapshot(
+      `${384 * 1024 * 1024} 2.25 6789 ${512 * 1024 * 1024}`,
+      ["gateway", "--port", "19080"],
+    );
 
     expect(sample).toEqual({
       aggregateRssMiB: 512,
@@ -1869,18 +1757,14 @@ describe("kitchen-sink RPC process sampling", () => {
       },
     });
 
-    expect(commands).toEqual([expectedPowerShellPath()]);
+    expect(commands).toEqual([resolveWindowsPowerShellPath()]);
     expect(sample).toBeNull();
   });
 
   it("does not truncate malformed Windows PowerShell CPU or id samples", async () => {
-    const sample = await sampleProcess(1234, {
-      platform: "win32",
-      runCommand: async () => ({
-        stdout: `${256 * 1024 * 1024} 2.25oops 6789x ${512 * 1024 * 1024}oops`,
-        stderr: "",
-      }),
-    });
+    const { sample } = await sampleWindowsSnapshot(
+      `${256 * 1024 * 1024} 2.25oops 6789x ${512 * 1024 * 1024}oops`,
+    );
 
     expect(sample).toEqual({
       aggregateRssMiB: 256,
@@ -1892,13 +1776,9 @@ describe("kitchen-sink RPC process sampling", () => {
   });
 
   it("rejects malformed Windows PowerShell RSS samples", async () => {
-    const sample = await sampleProcess(1234, {
-      platform: "win32",
-      runCommand: async () => ({
-        stdout: `${256 * 1024 * 1024}oops 2.25 6789 ${512 * 1024 * 1024}`,
-        stderr: "",
-      }),
-    });
+    const { sample } = await sampleWindowsSnapshot(
+      `${256 * 1024 * 1024}oops 2.25 6789 ${512 * 1024 * 1024}`,
+    );
 
     expect(sample).toBeNull();
   });
@@ -1953,21 +1833,13 @@ describe("kitchen-sink RPC process sampling", () => {
     const sample = await sampleWindowsProcessByPort(19675, {
       runCommand: async (command: string, args: string[]) => {
         calls.push({ command, args });
-        if (command === expectedWindowsSystem32Path("netstat.exe")) {
-          return {
-            stdout: [
-              "  Proto  Local Address          Foreign Address        State           PID",
-              "  TCP    127.0.0.1:196750       0.0.0.0:0              LISTENING       1111",
-              "  TCP    127.0.0.1:1967         0.0.0.0:0              LISTENING       2222",
-              "  TCP    127.0.0.1:19675        0.0.0.0:0              LISTENING       6789",
-            ].join("\r\n"),
-            stderr: "",
-          };
-        }
-        if (command === expectedPowerShellPath()) {
-          return { stdout: `${384 * 1024 * 1024} 2.25 6789 ${512 * 1024 * 1024}`, stderr: "" };
-        }
-        throw new Error(`unexpected command ${command}`);
+        return createWindowsPortSampleRunner({
+          extraNetstatRows: [
+            "  TCP    127.0.0.1:196750       0.0.0.0:0              LISTENING       1111",
+            "  TCP    127.0.0.1:1967         0.0.0.0:0              LISTENING       2222",
+          ],
+          powershell: `${384 * 1024 * 1024} 2.25 6789 ${512 * 1024 * 1024}`,
+        })(command);
       },
     });
 
@@ -1979,9 +1851,9 @@ describe("kitchen-sink RPC process sampling", () => {
       rssMiB: 384,
     });
     expect(calls).toEqual([
-      { command: expectedWindowsSystem32Path("netstat.exe"), args: ["-ano", "-p", "tcp"] },
+      { command: resolveWindowsSystem32Path("netstat.exe"), args: ["-ano", "-p", "tcp"] },
       {
-        command: expectedPowerShellPath(),
+        command: resolveWindowsPowerShellPath(),
         args: expect.arrayContaining(["-Command", expect.stringContaining("$rootPid = 6789")]),
       },
     ]);
@@ -1990,28 +1862,11 @@ describe("kitchen-sink RPC process sampling", () => {
   it("falls back to strict tasklist RSS when Windows PowerShell sampling fails", async () => {
     const calls: string[] = [];
     const sample = await sampleWindowsProcessByPort(19675, {
-      runCommand: async (command: string) => {
-        calls.push(command);
-        if (command === expectedWindowsSystem32Path("netstat.exe")) {
-          return {
-            stdout: [
-              "  Proto  Local Address          Foreign Address        State           PID",
-              "  TCP    127.0.0.1:19675        0.0.0.0:0              LISTENING       6789",
-            ].join("\r\n"),
-            stderr: "",
-          };
-        }
-        if (command === expectedPowerShellPath()) {
-          throw new Error("powershell unavailable");
-        }
-        if (command === expectedWindowsSystem32Path("tasklist.exe")) {
-          return {
-            stdout: '"node.exe","6789","Console","1","262,144 K"',
-            stderr: "",
-          };
-        }
-        throw new Error(`unexpected command ${command}`);
-      },
+      runCommand: createWindowsPortSampleRunner({
+        calls,
+        powershell: new Error("powershell unavailable"),
+        tasklist: '"node.exe","6789","Console","1","262,144 K"',
+      }),
     });
 
     expect(sample).toEqual({
@@ -2021,35 +1876,18 @@ describe("kitchen-sink RPC process sampling", () => {
       rssMiB: 256,
     });
     expect(calls).toEqual([
-      expectedWindowsSystem32Path("netstat.exe"),
-      expectedPowerShellPath(),
-      expectedWindowsSystem32Path("tasklist.exe"),
+      resolveWindowsSystem32Path("netstat.exe"),
+      resolveWindowsPowerShellPath(),
+      resolveWindowsSystem32Path("tasklist.exe"),
     ]);
   });
 
   it("falls back to the known Windows pid when tasklist reports malformed pid text", async () => {
     const sample = await sampleWindowsProcessByPort(19675, {
-      runCommand: async (command: string) => {
-        if (command === expectedWindowsSystem32Path("netstat.exe")) {
-          return {
-            stdout: [
-              "  Proto  Local Address          Foreign Address        State           PID",
-              "  TCP    127.0.0.1:19675        0.0.0.0:0              LISTENING       6789",
-            ].join("\r\n"),
-            stderr: "",
-          };
-        }
-        if (command === expectedPowerShellPath()) {
-          throw new Error("powershell unavailable");
-        }
-        if (command === expectedWindowsSystem32Path("tasklist.exe")) {
-          return {
-            stdout: '"node.exe","9999x","Console","1","262,144 K"',
-            stderr: "",
-          };
-        }
-        throw new Error(`unexpected command ${command}`);
-      },
+      runCommand: createWindowsPortSampleRunner({
+        powershell: new Error("powershell unavailable"),
+        tasklist: '"node.exe","9999x","Console","1","262,144 K"',
+      }),
     });
 
     expect(sample).toEqual({
@@ -2062,47 +1900,22 @@ describe("kitchen-sink RPC process sampling", () => {
 
   it("rejects malformed tasklist RSS instead of stripping digits", async () => {
     const sample = await sampleWindowsProcessByPort(19675, {
-      runCommand: async (command: string) => {
-        if (command === expectedWindowsSystem32Path("netstat.exe")) {
-          return {
-            stdout: [
-              "  Proto  Local Address          Foreign Address        State           PID",
-              "  TCP    127.0.0.1:19675        0.0.0.0:0              LISTENING       6789",
-            ].join("\r\n"),
-            stderr: "",
-          };
-        }
-        if (command === expectedPowerShellPath()) {
-          throw new Error("powershell unavailable");
-        }
-        if (command === expectedWindowsSystem32Path("tasklist.exe")) {
-          return {
-            stdout: '"node.exe","6789","Console","1","262x144 K"',
-            stderr: "",
-          };
-        }
-        throw new Error(`unexpected command ${command}`);
-      },
+      runCommand: createWindowsPortSampleRunner({
+        powershell: new Error("powershell unavailable"),
+        tasklist: '"node.exe","6789","Console","1","262x144 K"',
+      }),
     });
 
     expect(sample).toBeNull();
   });
 
   it("samples direct POSIX gateway RSS with descendants", async () => {
-    const sample = await sampleProcess(4321, {
-      platform: "linux",
-      runCommand: async (command: string, args: string[]) => {
-        expect(command).toBe("ps");
-        expect(args).toEqual(["-ww", "-axo", "pid=,ppid=,rss=,pcpu=,command="]);
-        return {
-          stdout: [
-            " 4321     1  262144  12.5 node dist/index.js gateway --port 19080",
-            " 4322  4321  131072   1.5 node helper.js",
-          ].join("\n"),
-          stderr: "",
-        };
-      },
-    });
+    const sample = await samplePosixSnapshot(
+      [
+        " 4321     1  262144  12.5 node dist/index.js gateway --port 19080",
+        " 4322  4321  131072   1.5 node helper.js",
+      ].join("\n"),
+    );
 
     expect(sample).toEqual({
       aggregateRssMiB: 384,
@@ -2113,13 +1926,9 @@ describe("kitchen-sink RPC process sampling", () => {
   });
 
   it("does not truncate malformed POSIX CPU samples", async () => {
-    const sample = await sampleProcess(4321, {
-      platform: "linux",
-      runCommand: async () => ({
-        stdout: " 4321     1  262144  12.5.6 node dist/index.js gateway --port 19080",
-        stderr: "",
-      }),
-    });
+    const sample = await samplePosixSnapshot(
+      " 4321     1  262144  12.5.6 node dist/index.js gateway --port 19080",
+    );
 
     expect(sample).toEqual({
       aggregateRssMiB: 256,
@@ -2130,13 +1939,9 @@ describe("kitchen-sink RPC process sampling", () => {
   });
 
   it("does not loop forever on self-parenting POSIX process rows", async () => {
-    const sample = await sampleProcess(4321, {
-      platform: "linux",
-      runCommand: async () => ({
-        stdout: " 4321  4321  262144  12.5 node dist/index.js gateway --port 19080",
-        stderr: "",
-      }),
-    });
+    const sample = await samplePosixSnapshot(
+      " 4321  4321  262144  12.5 node dist/index.js gateway --port 19080",
+    );
 
     expect(sample).toEqual({
       aggregateRssMiB: 256,
@@ -2147,22 +1952,14 @@ describe("kitchen-sink RPC process sampling", () => {
   });
 
   it("samples the POSIX gateway child instead of the pnpm launcher", async () => {
-    const sample = await sampleProcess(4321, {
-      platform: "linux",
-      posixCommandLineNeedles: ["gateway", "--port", "19080"],
-      runCommand: async (command: string, args: string[]) => {
-        expect(command).toBe("ps");
-        expect(args).toEqual(["-ww", "-axo", "pid=,ppid=,rss=,pcpu=,command="]);
-        return {
-          stdout: [
-            " 4321     1   16384   0.0 node /usr/local/bin/corepack pnpm openclaw gateway --port 19080",
-            " 4322  4321  262144  12.5 node dist/index.js gateway --port 19080 --bind loopback",
-            " 4323  4322   32768   1.5 node helper.js",
-          ].join("\n"),
-          stderr: "",
-        };
-      },
-    });
+    const sample = await samplePosixSnapshot(
+      [
+        " 4321     1   16384   0.0 node /usr/local/bin/corepack pnpm openclaw gateway --port 19080",
+        " 4322  4321  262144  12.5 node dist/index.js gateway --port 19080 --bind loopback",
+        " 4323  4322   32768   1.5 node helper.js",
+      ].join("\n"),
+      { commandLineNeedles: ["gateway", "--port", "19080"] },
+    );
 
     expect(sample).toEqual({
       aggregateRssMiB: 288,
@@ -2173,15 +1970,10 @@ describe("kitchen-sink RPC process sampling", () => {
   });
 
   it("samples the POSIX gateway root when command-line needles match", async () => {
-    const sample = await sampleProcess(4321, {
-      platform: "darwin",
-      posixCommandLineNeedles: ["gateway", "--port", "19080"],
-      runCommand: async () => ({
-        stdout:
-          " 4321     1  262144  12.5 node dist/index.js gateway --port 19080 --bind loopback\n",
-        stderr: "",
-      }),
-    });
+    const sample = await samplePosixSnapshot(
+      " 4321     1  262144  12.5 node dist/index.js gateway --port 19080 --bind loopback\n",
+      { commandLineNeedles: ["gateway", "--port", "19080"], platform: "darwin" },
+    );
 
     expect(sample).toEqual({
       aggregateRssMiB: 256,
@@ -2192,18 +1984,14 @@ describe("kitchen-sink RPC process sampling", () => {
   });
 
   it("falls back to the POSIX gateway process title when the port arg is rewritten", async () => {
-    const sample = await sampleProcess(4321, {
-      platform: "darwin",
-      posixCommandLineNeedles: ["gateway", "--port", "19080"],
-      runCommand: async () => ({
-        stdout: [
-          " 4321     1 1048576   0.0 node /usr/local/bin/corepack pnpm openclaw gateway --port 19080",
-          " 4322  4321  262144  12.5 openclaw-gateway",
-          " 4323  4322   32768   1.5 node helper.js",
-        ].join("\n"),
-        stderr: "",
-      }),
-    });
+    const sample = await samplePosixSnapshot(
+      [
+        " 4321     1 1048576   0.0 node /usr/local/bin/corepack pnpm openclaw gateway --port 19080",
+        " 4322  4321  262144  12.5 openclaw-gateway",
+        " 4323  4322   32768   1.5 node helper.js",
+      ].join("\n"),
+      { commandLineNeedles: ["gateway", "--port", "19080"], platform: "darwin" },
+    );
 
     expect(sample).toEqual({
       aggregateRssMiB: 288,
@@ -2214,18 +2002,14 @@ describe("kitchen-sink RPC process sampling", () => {
   });
 
   it("falls back to the largest POSIX child when the gateway command line is unavailable", async () => {
-    const sample = await sampleProcess(4321, {
-      platform: "linux",
-      posixCommandLineNeedles: ["gateway", "--port", "19080"],
-      runCommand: async () => ({
-        stdout: [
-          " 4321     1 1048576   0.0 node /usr/local/bin/corepack pnpm openclaw gateway --port 19080",
-          " 4322  4321  262144  12.5 node",
-          " 4323  4322   32768   1.5 node helper.js",
-        ].join("\n"),
-        stderr: "",
-      }),
-    });
+    const sample = await samplePosixSnapshot(
+      [
+        " 4321     1 1048576   0.0 node /usr/local/bin/corepack pnpm openclaw gateway --port 19080",
+        " 4322  4321  262144  12.5 node",
+        " 4323  4322   32768   1.5 node helper.js",
+      ].join("\n"),
+      { commandLineNeedles: ["gateway", "--port", "19080"] },
+    );
 
     expect(sample).toEqual({
       aggregateRssMiB: 288,
@@ -2236,14 +2020,10 @@ describe("kitchen-sink RPC process sampling", () => {
   });
 
   it("does not accept a POSIX launcher sample when the gateway child is missing", async () => {
-    const sample = await sampleProcess(4321, {
-      platform: "darwin",
-      posixCommandLineNeedles: ["gateway", "--port", "19080"],
-      runCommand: async () => ({
-        stdout: " 4321     1   16384   0.0 node /usr/local/bin/corepack pnpm openclaw status\n",
-        stderr: "",
-      }),
-    });
+    const sample = await samplePosixSnapshot(
+      " 4321     1   16384   0.0 node /usr/local/bin/corepack pnpm openclaw status\n",
+      { commandLineNeedles: ["gateway", "--port", "19080"], platform: "darwin" },
+    );
 
     expect(sample).toBeNull();
   });
@@ -2322,159 +2102,6 @@ describe("kitchen-sink RPC process sampling", () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
-  it("rejects oversized HTTP probe responses before reading declared large bodies", async () => {
-    let canceled = false;
-    const response = new Response(
-      new ReadableStream({
-        cancel() {
-          canceled = true;
-        },
-      }),
-      {
-        headers: {
-          "content-length": "1025",
-        },
-      },
-    );
-
-    await expect(readBoundedResponseText(response, 1024)).rejects.toMatchObject({
-      code: "ETOOBIG",
-      message: "fetch response body exceeded 1024 bytes",
-    });
-    expect(canceled).toBe(true);
-  });
-
-  it("bounds HTTP probe response bodies without a readable stream", async () => {
-    const response = {
-      headers: new Headers(),
-      text: vi.fn(async () => "x".repeat(1025)),
-    };
-
-    await expect(readBoundedResponseText(response, 1024)).rejects.toMatchObject({
-      code: "ETOOBIG",
-      message: "fetch response body exceeded 1024 bytes",
-    });
-    expect(response.text).toHaveBeenCalledTimes(1);
-  });
-
-  it("rejects declared large HTTP probe responses without a readable stream", async () => {
-    const response = {
-      headers: new Headers({
-        "content-length": "1025",
-      }),
-      text: vi.fn(async () => "not read"),
-    };
-
-    await expect(readBoundedResponseText(response, 1024)).rejects.toMatchObject({
-      code: "ETOOBIG",
-      message: "fetch response body exceeded 1024 bytes",
-    });
-    expect(response.text).not.toHaveBeenCalled();
-  });
-
-  it("rejects unsafe decimal HTTP content lengths before reading", async () => {
-    const response = {
-      headers: new Headers({
-        "content-length": "9007199254740992",
-      }),
-      text: vi.fn(async () => "not read"),
-    };
-
-    await expect(readBoundedResponseText(response, 1024)).rejects.toMatchObject({
-      code: "ETOOBIG",
-      message: "fetch response body exceeded 1024 bytes",
-    });
-    expect(response.text).not.toHaveBeenCalled();
-  });
-
-  it("streams HTTP probe responses with non-decimal content-length values", async () => {
-    let readStarted = false;
-    let canceled = false;
-    const response = {
-      headers: new Headers({
-        "content-length": "1e3",
-      }),
-      body: {
-        getReader() {
-          return {
-            async read() {
-              readStarted = true;
-              return { done: false, value: new Uint8Array(1025) };
-            },
-            async cancel() {
-              canceled = true;
-            },
-          };
-        },
-      },
-      text: vi.fn(async () => "not read"),
-    };
-
-    await expect(readBoundedResponseText(response, 1024)).rejects.toMatchObject({
-      code: "ETOOBIG",
-      message: "fetch response body exceeded 1024 bytes",
-    });
-    expect(readStarted).toBe(true);
-    expect(canceled).toBe(true);
-    expect(response.text).not.toHaveBeenCalled();
-  });
-
-  it("reads bounded response streams", async () => {
-    await expect(readBoundedResponseText(new Response('{"status":"live"}'), 1024)).resolves.toBe(
-      '{"status":"live"}',
-    );
-  });
-
-  it("releases HTTP probe response stream readers after bounded reads", async () => {
-    const releaseLock = vi.fn();
-    const response = {
-      headers: new Headers(),
-      body: {
-        getReader() {
-          return {
-            read: vi
-              .fn()
-              .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode("ok") })
-              .mockResolvedValueOnce({ done: true }),
-            releaseLock,
-          };
-        },
-      },
-      text: vi.fn(async () => "not read"),
-    };
-
-    await expect(readBoundedResponseText(response, 1024)).resolves.toBe("ok");
-
-    expect(releaseLock).toHaveBeenCalledOnce();
-    expect(response.text).not.toHaveBeenCalled();
-  });
-
-  it("cancels stalled HTTP probe response streams when the timeout wins", async () => {
-    let canceled = false;
-    const timeoutError = Object.assign(new Error("fetch probe timed out"), {
-      code: "ETIMEDOUT",
-    });
-    const response = new Response(
-      new ReadableStream({
-        pull() {
-          return new Promise(() => {});
-        },
-        cancel() {
-          canceled = true;
-        },
-      }),
-      { headers: new Headers() },
-    );
-
-    await expect(
-      readBoundedResponseText(response, 1024, Promise.reject(timeoutError)),
-    ).rejects.toMatchObject({
-      code: "ETIMEDOUT",
-      message: "fetch probe timed out",
-    });
-    expect(canceled).toBe(true);
-  });
-
   it("cancels stalled HTTP probe response streams when the external signal fires", async () => {
     let readStarted = false;
     let canceled = false;
@@ -2511,11 +2138,16 @@ describe("kitchen-sink RPC process sampling", () => {
 
   it("times out stalled HTTP probe response bodies", async () => {
     vi.useFakeTimers();
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: () => new Promise(() => {}),
-    });
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          pull() {
+            return new Promise(() => {});
+          },
+        }),
+        { status: 200 },
+      ),
+    );
 
     const result = fetchJson("http://127.0.0.1:19680/readyz", {
       attempts: 1,


### PR DESCRIPTION
## What Problem This Solves

The kitchen-sink RPC E2E walk had accumulated private copies of shared bounded-response and log-tail logic, parallel process-signal and POSIX snapshot paths, and repeated test setup. That made release-critical gateway coverage harder to maintain and allowed shared safety fixes to drift.

## Why This Change Was Made

The walk now uses the canonical bounded-response and text-tail owners, shares one process-tree signal path while preserving the command/gateway ESRCH distinction, shares one POSIX snapshot path, and table-drives repeated Windows/POSIX test setup. Test-only exports and duplicate tests already owned by the shared helper suites were removed; the plain-Node entrypoint remains dependency-free.

Root cause: the walk predated later shared E2E helpers, while command and gateway lifecycle hardening landed in parallel local paths.

Architectural owner: `scripts/e2e/kitchen-sink-rpc-walk.mjs`, with shared response/file mechanics delegated to `scripts/lib/bounded-response.mjs` and `scripts/e2e/lib/text-file-utils.mjs`.

Canonical fix/removals: one response reader, one file-tail reader, one process-tree signal implementation, one POSIX snapshot loader; dead `main`, TTS extraction, response-reader, and tail-file exports removed with declaration sync.

Production LOC: +122/-256, net -134. Total LOC: +345/-847, net -502.

## User Impact

No user-visible behavior changes. Maintainers get a smaller, single-owner kitchen-sink RPC release gate while every command, request, response, authorization error, ordering constraint, diagnostic, resource ceiling, and CLI behavior remains covered.

## Evidence

- Final-head Blacksmith Testbox lease `tbx_01kz30k2yrfx993sxjxnkey3ax`: 105/105 kitchen-sink tests and 7/7 shared bounded-response tests passed; the full changed-scope gate also passed, including format, declaration contracts, script/test tsgo, type-aware script lint, Docker E2E boundaries, and HTTP/2 guard: https://github.com/openclaw/openclaw/actions/runs/30786492362
- Final-head autoreview: clean, no accepted/actionable findings; overall correctness 0.98.
- Local `git diff --check`, Node syntax check, targeted `oxfmt`, and targeted type-aware `oxlint` passed.
