### PR TITLE
refactor: deduplicate Codex doctor fixtures

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -47,6 +47,10 @@ const CODEX_PLUGIN_REPAIR_CHANGES = [
   "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
   "Added codex to plugins.allow because configured agent routes use Codex runtime.",
 ];
+const CODEX_COMPACTION_REPAIR_CHANGES = [
+  "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
+  "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
+];
 
 type CodexRouteWarningOptions = Omit<
   Parameters<typeof collectCodexRouteWarningsUnderTest>[0],
@@ -70,6 +74,112 @@ function maybeRepairCodexRoutes(cfg: unknown, options: CodexRouteRepairOptions =
     shouldRepair: true,
     ...options,
   });
+}
+
+type CodexRouteRepairResult = ReturnType<typeof maybeRepairCodexRoutes>;
+type AgentRuntime = ReturnType<typeof resolveAgentHarnessPolicy>["runtime"];
+
+function expectAgentRuntime(
+  config: OpenClawConfig,
+  expected: AgentRuntime,
+  options: { provider?: string; modelId?: string; agentId?: string } = {},
+) {
+  expect(
+    resolveAgentHarnessPolicy({
+      provider: options.provider ?? "openai",
+      modelId: options.modelId ?? "gpt-5.4",
+      agentId: options.agentId,
+      config,
+    }).runtime,
+  ).toBe(expected);
+}
+
+function expectCodexPluginEnabled(result: CodexRouteRepairResult) {
+  expect(result.warnings).toStrictEqual([]);
+  expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
+  expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+}
+
+function expectCodexPluginDisabled(result: CodexRouteRepairResult) {
+  expect(result.warnings).toStrictEqual([]);
+  expect(result.changes).toStrictEqual([]);
+  expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+}
+
+function itReenablesCodexPlugin(title: string, cfg: Record<string, unknown>) {
+  it(title, () => {
+    expectCodexPluginEnabled(
+      maybeRepairCodexRoutes({ plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG, ...cfg }),
+    );
+  });
+}
+
+function itKeepsCodexPluginDisabled(title: string, cfg: Record<string, unknown>) {
+  it(title, () => {
+    expectCodexPluginDisabled(
+      maybeRepairCodexRoutes({ plugins: DISABLED_CODEX_PLUGIN_CONFIG, ...cfg }),
+    );
+  });
+}
+
+function itAddsCodexToAllowlist(title: string, withOpenAIEntry = true) {
+  it(title, () => {
+    const result = maybeRepairCodexRoutes({
+      plugins: {
+        allow: ["openai"],
+        ...(withOpenAIEntry ? { entries: { openai: { enabled: true } } } : {}),
+      },
+      agents: { defaults: { model: "gpt-5.5" } },
+    });
+
+    expectCodexPluginEnabled(result);
+    expect(result.cfg.plugins?.allow).toEqual(["openai", "codex"]);
+  });
+}
+
+function itRepairsCodexCompaction(title: string, cfg: Record<string, unknown>) {
+  it(title, () => {
+    const result = maybeRepairCodexRoutes(cfg);
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual(CODEX_COMPACTION_REPAIR_CHANGES);
+    expect(result.cfg.agents?.defaults?.compaction).toEqual({ keepRecentTokens: 10_000 });
+  });
+}
+
+function getSession(store: Record<string, SessionEntry>, key: string): SessionEntry {
+  return expectDefined(store[key], `store.${key} test invariant`);
+}
+
+function legacyRouteWarning(...routes: string[]): string {
+  return [
+    "- Legacy `codex/*` and `openai-codex/*` model refs should be rewritten to `openai/*`.",
+    ...routes,
+    "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
+  ].join("\n");
+}
+
+function disabledCodexPluginWarning(...routes: string[]): string {
+  return [
+    "- Codex runtime is selected, but the Codex plugin is disabled.",
+    ...routes,
+    "- Enable plugins.entries.codex and plugin loading, and remove `codex` from plugins.deny; or set the affected OpenAI models to an OpenClaw runtime policy.",
+  ].join("\n");
+}
+
+function codexCompactionWarning(...details: string[]): string {
+  return [
+    "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+    ...details,
+  ].join("\n");
+}
+
+function losslessCompactionWarning(...routes: string[]): string {
+  return [
+    "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+    ...routes,
+    "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
+  ].join("\n");
 }
 
 describe("collectCodexRouteWarnings", () => {
@@ -96,11 +206,9 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(warnings).toStrictEqual([
-      [
-        "- Legacy `codex/*` and `openai-codex/*` model refs should be rewritten to `openai/*`.",
+      legacyRouteWarning(
         "- agents.defaults.model: openai-codex/gpt-5.5 should become openai/gpt-5.5.",
-        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -163,11 +271,9 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(warnings).toStrictEqual([
-      [
-        "- Legacy `codex/*` and `openai-codex/*` model refs should be rewritten to `openai/*`.",
+      legacyRouteWarning(
         '- agents.defaults.model: openai-codex/gpt-5.5 should become openai/gpt-5.5; current runtime is "codex".',
-        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -180,11 +286,9 @@ describe("collectCodexRouteWarnings", () => {
     );
 
     expect(warnings).toStrictEqual([
-      [
-        "- Legacy `codex/*` and `openai-codex/*` model refs should be rewritten to `openai/*`.",
+      legacyRouteWarning(
         "- agents.defaults.model: openai-codex/gpt-5.5 should become openai/gpt-5.5.",
-        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -210,11 +314,9 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(warnings).toStrictEqual([
-      [
-        "- Legacy `codex/*` and `openai-codex/*` model refs should be rewritten to `openai/*`.",
+      legacyRouteWarning(
         "- agents.list.worker.models.openai-codex/gpt-5.4: openai-codex/gpt-5.4 should become openai/gpt-5.4.",
-        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -281,11 +383,9 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(warnings).toStrictEqual([
-      [
-        "- Codex runtime is selected, but the Codex plugin is disabled.",
+      disabledCodexPluginWarning(
         "- agents.defaults.model.primary: gpt-5.5 resolves to openai/gpt-5.5 with Codex runtime while the Codex plugin is disabled by config.",
-        "- Enable plugins.entries.codex and plugin loading, and remove `codex` from plugins.deny; or set the affected OpenAI models to an OpenClaw runtime policy.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -296,11 +396,9 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(warnings).toStrictEqual([
-      [
-        "- Codex runtime is selected, but the Codex plugin is disabled.",
+      disabledCodexPluginWarning(
         "- agents.defaults.model.primary: openai/gpt-5.6 resolves to openai/gpt-5.6 with Codex runtime while the Codex plugin is disabled by config.",
-        "- Enable plugins.entries.codex and plugin loading, and remove `codex` from plugins.deny; or set the affected OpenAI models to an OpenClaw runtime policy.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -313,11 +411,9 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(warnings).toStrictEqual([
-      [
-        "- Codex runtime is selected, but the Codex plugin is disabled.",
+      disabledCodexPluginWarning(
         "- agents.defaults.model.primary: openai/gpt-5.3-codex-spark resolves to openai/gpt-5.3-codex-spark with Codex runtime while the Codex plugin is disabled by config.",
-        "- Enable plugins.entries.codex and plugin loading, and remove `codex` from plugins.deny; or set the affected OpenAI models to an OpenClaw runtime policy.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -337,11 +433,9 @@ describe("collectCodexRouteWarnings", () => {
         env: { OPENAI_BASE_URL: "https://chatgpt.com/backend-api/codex" },
       }),
     ).toStrictEqual([
-      [
-        "- Codex runtime is selected, but the Codex plugin is disabled.",
+      disabledCodexPluginWarning(
         "- agents.defaults.model.primary: openai/gpt-5.4-nano resolves to openai/gpt-5.4-nano with Codex runtime while the Codex plugin is disabled by config.",
-        "- Enable plugins.entries.codex and plugin loading, and remove `codex` from plugins.deny; or set the affected OpenAI models to an OpenClaw runtime policy.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -356,12 +450,11 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(warnings).toStrictEqual([
-      [
-        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+      codexCompactionWarning(
         "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
         "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
         "- Run `openclaw doctor --fix`: it removes unsupported Codex compaction overrides.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -375,12 +468,11 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(warnings).toStrictEqual([
-      [
-        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+      codexCompactionWarning(
         "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
         "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
         "- Run `openclaw doctor --fix`: it removes unsupported Codex compaction overrides.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -396,17 +488,17 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(warnings).toStrictEqual([
-      [
-        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+      codexCompactionWarning(
         "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
         "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
         "- Run `openclaw doctor --fix`: it removes unsupported Codex compaction overrides.",
-      ].join("\n"),
+      ),
     ]);
   });
 
-  it("repairs Codex-runtime compaction summarizer overrides by removing them", () => {
-    const result = maybeRepairCodexRoutes({
+  itRepairsCodexCompaction(
+    "repairs Codex-runtime compaction summarizer overrides by removing them",
+    {
       agents: {
         defaults: {
           model: "openai/gpt-5.5",
@@ -417,20 +509,12 @@ describe("collectCodexRouteWarnings", () => {
           },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([
-      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
-      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
-    ]);
-    expect(result.cfg.agents?.defaults?.compaction).toEqual({
-      keepRecentTokens: 10_000,
-    });
-  });
-
-  it("repairs compaction overrides for the implicit default OpenAI Codex runtime", () => {
-    const result = maybeRepairCodexRoutes({
+  itRepairsCodexCompaction(
+    "repairs compaction overrides for the implicit default OpenAI Codex runtime",
+    {
       agents: {
         defaults: {
           compaction: {
@@ -440,45 +524,26 @@ describe("collectCodexRouteWarnings", () => {
           },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([
-      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
-      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
-    ]);
-    expect(result.cfg.agents?.defaults?.compaction).toEqual({
-      keepRecentTokens: 10_000,
-    });
-  });
-
-  it("repairs compaction overrides for the Codex app-server runtime alias", () => {
-    const result = maybeRepairCodexRoutes({
-      agents: {
-        defaults: {
-          agentRuntime: { id: "codex-app-server" },
-          model: "anthropic/claude-sonnet-4.6",
-          compaction: {
-            model: "openai/gpt-5.4",
-            provider: "custom-summary",
-            keepRecentTokens: 10_000,
-          },
+  itRepairsCodexCompaction("repairs compaction overrides for the Codex app-server runtime alias", {
+    agents: {
+      defaults: {
+        agentRuntime: { id: "codex-app-server" },
+        model: "anthropic/claude-sonnet-4.6",
+        compaction: {
+          model: "openai/gpt-5.4",
+          provider: "custom-summary",
+          keepRecentTokens: 10_000,
         },
       },
-    });
-
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([
-      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
-      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
-    ]);
-    expect(result.cfg.agents?.defaults?.compaction).toEqual({
-      keepRecentTokens: 10_000,
-    });
+    },
   });
 
-  it("repairs compaction overrides for model-scoped Codex app-server runtime aliases", () => {
-    const result = maybeRepairCodexRoutes({
+  itRepairsCodexCompaction(
+    "repairs compaction overrides for model-scoped Codex app-server runtime aliases",
+    {
       agents: {
         defaults: {
           model: "openai/gpt-5.5",
@@ -492,17 +557,8 @@ describe("collectCodexRouteWarnings", () => {
           },
         },
       },
-    });
-
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([
-      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
-      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
-    ]);
-    expect(result.cfg.agents?.defaults?.compaction).toEqual({
-      keepRecentTokens: 10_000,
-    });
-  });
+    },
+  );
 
   it("migrates legacy Lossless compaction config to the context-engine slot", () => {
     const result = maybeRepairCodexRoutes({
@@ -558,12 +614,10 @@ describe("collectCodexRouteWarnings", () => {
       model: "openai/gpt-5.4-mini",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+      losslessCompactionWarning(
         "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.list.fast.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
-        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -716,14 +770,12 @@ describe("collectCodexRouteWarnings", () => {
       provider: "lossless-claw",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+      losslessCompactionWarning(
         "- agents.list.fast.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.list.fast.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
         "- agents.list.deep.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.list.deep.compaction.model: openai/gpt-5.5 should become plugins.entries.lossless-claw.config.summaryModel.",
-        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -759,12 +811,10 @@ describe("collectCodexRouteWarnings", () => {
       id: "codex",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+      losslessCompactionWarning(
         "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.defaults.compaction.model: openai/gpt-5.4 should become plugins.entries.lossless-claw.config.summaryModel.",
-        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -804,12 +854,10 @@ describe("collectCodexRouteWarnings", () => {
       id: "codex",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+      losslessCompactionWarning(
         "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.list.fast.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
-        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -899,12 +947,10 @@ describe("collectCodexRouteWarnings", () => {
       id: "codex",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+      losslessCompactionWarning(
         "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.defaults.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
-        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -936,12 +982,10 @@ describe("collectCodexRouteWarnings", () => {
       provider: "lossless-claw",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+      losslessCompactionWarning(
         "- agents.list.fast.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.defaults.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
-        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1001,14 +1045,12 @@ describe("collectCodexRouteWarnings", () => {
       id: "codex",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+      losslessCompactionWarning(
         "- agents.list.fast.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.defaults.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
         "- agents.list.deep.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.defaults.compaction.model: openai/gpt-5.4-mini should become plugins.entries.lossless-claw.config.summaryModel.",
-        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1083,11 +1125,7 @@ describe("collectCodexRouteWarnings", () => {
     } as unknown as OpenClawConfig;
 
     expect(collectCodexRouteWarnings(cfg)).toStrictEqual([
-      [
-        "- Legacy `codex/*` and `openai-codex/*` model refs should be rewritten to `openai/*`.",
-        "- hooks.gmail.model: openai-codex/gpt-5.4 should become openai/gpt-5.4.",
-        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
-      ].join("\n"),
+      legacyRouteWarning("- hooks.gmail.model: openai-codex/gpt-5.4 should become openai/gpt-5.4."),
     ]);
   });
 
@@ -1111,12 +1149,10 @@ describe("collectCodexRouteWarnings", () => {
       provider: "lossless-claw",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+      losslessCompactionWarning(
         "- agents.list.codex.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.defaults.compaction.model: openai/gpt-5.4 should become plugins.entries.lossless-claw.config.summaryModel.",
-        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1144,12 +1180,10 @@ describe("collectCodexRouteWarnings", () => {
       provider: "lossless-claw",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+      losslessCompactionWarning(
         "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.defaults.compaction.model: openai/gpt-5.4 should become plugins.entries.lossless-claw.config.summaryModel.",
-        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1171,12 +1205,10 @@ describe("collectCodexRouteWarnings", () => {
       provider: "lossless-claw",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+      losslessCompactionWarning(
         "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.defaults.compaction.model: openai/gpt-5.4 should become plugins.entries.lossless-claw.config.summaryModel.",
-        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1207,12 +1239,10 @@ describe("collectCodexRouteWarnings", () => {
       provider: "custom-summary",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy Lossless compaction config should use the Lossless context-engine slot for Codex.",
+      losslessCompactionWarning(
         "- agents.defaults.compaction.provider: lossless-claw should become plugins.slots.contextEngine: lossless-claw.",
         "- agents.defaults.compaction.model: openai/gpt-5.4 should become plugins.entries.lossless-claw.config.summaryModel.",
-        "- Move the Lossless config manually; doctor will not overwrite an existing non-Lossless context-engine slot or collapse conflicting per-agent summary models.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1246,12 +1276,11 @@ describe("collectCodexRouteWarnings", () => {
       keepRecentTokens: 10_000,
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+      codexCompactionWarning(
         "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
         "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
         "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1272,12 +1301,11 @@ describe("collectCodexRouteWarnings", () => {
       provider: "custom-summary",
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+      codexCompactionWarning(
         "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
         "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
         "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1312,11 +1340,10 @@ describe("collectCodexRouteWarnings", () => {
       keepRecentTokens: 10_000,
     });
     expect(result.warnings).toStrictEqual([
-      [
-        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+      codexCompactionWarning(
         "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
         "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1341,12 +1368,11 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.agents?.list?.[0]?.agentRuntime).toBeUndefined();
     expect(result.changes.join("\n")).not.toContain("Removed agents.defaults.compaction");
     expect(result.warnings).toStrictEqual([
-      [
-        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+      codexCompactionWarning(
         "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
         "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
         "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1364,10 +1390,7 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([
-      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
-      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
-    ]);
+    expect(result.changes).toStrictEqual(CODEX_COMPACTION_REPAIR_CHANGES);
     expect(result.cfg.agents?.defaults?.compaction).toBeUndefined();
     expect(result.cfg.agents?.list?.[0]?.agentRuntime).toEqual({ id: "codex" });
   });
@@ -1385,10 +1408,7 @@ describe("collectCodexRouteWarnings", () => {
       },
     });
 
-    expect(result.changes).toStrictEqual([
-      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
-      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
-    ]);
+    expect(result.changes).toStrictEqual(CODEX_COMPACTION_REPAIR_CHANGES);
     expect(result.cfg.agents?.defaults?.compaction).toBeUndefined();
     expect(result.cfg.agents?.defaults?.models).toBeUndefined();
     expect(result.cfg.agents?.list?.[0]?.agentRuntime).toEqual({ id: "codex" });
@@ -1444,25 +1464,17 @@ describe("collectCodexRouteWarnings", () => {
     } as unknown as OpenClawConfig;
 
     expect(collectCodexRouteWarnings(cfg)).toStrictEqual([
-      [
-        "- Legacy `codex/*` and `openai-codex/*` model refs should be rewritten to `openai/*`.",
-        "- hooks.gmail.model: openai-codex/gpt-5.4 should become openai/gpt-5.4.",
-        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
-      ].join("\n"),
-      [
-        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+      legacyRouteWarning("- hooks.gmail.model: openai-codex/gpt-5.4 should become openai/gpt-5.4."),
+      codexCompactionWarning(
         "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
         "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
         "- Run `openclaw doctor --fix`: it removes unsupported Codex compaction overrides.",
-      ].join("\n"),
+      ),
     ]);
 
     const result = maybeRepairCodexRoutes(cfg);
 
-    expect(result.changes).toStrictEqual([
-      "Removed agents.defaults.compaction.model; Codex runtime uses native server-side compaction.",
-      "Removed agents.defaults.compaction.provider; Codex runtime uses native server-side compaction.",
-    ]);
+    expect(result.changes).toStrictEqual(CODEX_COMPACTION_REPAIR_CHANGES);
     expect(result.cfg.agents?.defaults?.compaction).toBeUndefined();
     expect(result.cfg.agents?.defaults?.agentRuntime).toEqual({ id: "codex" });
     expect(result.cfg.hooks?.gmail?.model).toBe("openai-codex/gpt-5.4");
@@ -1538,16 +1550,14 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(warnings).toStrictEqual([
-      [
-        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+      codexCompactionWarning(
         "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
         "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
-      ].join("\n"),
-      [
-        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+      ),
+      codexCompactionWarning(
         "- agents.list.codex.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
         "- Run `openclaw doctor --fix`: it removes unsupported Codex compaction overrides.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1569,12 +1579,11 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.agents?.defaults?.models).toBeUndefined();
     expect(result.cfg.agents?.defaults?.agentRuntime).toBeUndefined();
     expect(result.warnings).toStrictEqual([
-      [
-        "- Codex runtime uses native server-side compaction and ignores OpenClaw compaction summarizer overrides.",
+      codexCompactionWarning(
         "- agents.defaults.compaction.model: openai/gpt-5.4 is ignored while this agent uses Codex runtime.",
         "- agents.defaults.compaction.provider: custom-summary is ignored while this agent uses Codex runtime.",
         "- Move or remove shared `agents.defaults.compaction.model/provider` settings manually; doctor keeps shared defaults while non-Codex agents can inherit them.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -1607,13 +1616,7 @@ describe("collectCodexRouteWarnings", () => {
       provider: "custom-summary",
     });
     expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.4"]).toBeUndefined();
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "openclaw");
   });
 
   it("repairs configured Codex model refs to canonical OpenAI refs with model-scoped Codex runtime", () => {
@@ -1785,99 +1788,71 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(result.warnings).toStrictEqual([
-      [
-        "- Codex runtime is selected, but the Codex plugin is disabled.",
+      disabledCodexPluginWarning(
         "- agents.defaults.model.primary: gpt-5.5 resolves to openai/gpt-5.5 with Codex runtime while the Codex plugin is disabled by config.",
-        "- Enable plugins.entries.codex and plugin loading, and remove `codex` from plugins.deny; or set the affected OpenAI models to an OpenClaw runtime policy.",
-      ].join("\n"),
+      ),
     ]);
     expect(result.changes).toStrictEqual([]);
     expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
     expect(result.cfg.plugins?.allow).toEqual(["openai"]);
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("codex");
+    expectAgentRuntime(result.cfg, "codex", { modelId: "gpt-5.5" });
   });
 
-  it("keeps Codex disabled when a bare heartbeat model inherits an Anthropic primary", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "keeps Codex disabled when a bare heartbeat model inherits an Anthropic primary",
+    {
       agents: {
         defaults: { model: "anthropic/claude-sonnet-4-6", heartbeat: { model: "gpt-5.5" } },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("re-enables the Codex plugin when a qualified default heartbeat uses Codex runtime", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables the Codex plugin when a qualified default heartbeat uses Codex runtime",
+    {
       agents: {
         defaults: { model: "anthropic/claude-sonnet-4-6", heartbeat: { model: "openai/gpt-5.5" } },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-  });
-
-  it("re-enables the Codex plugin when a default subagent model uses Codex runtime", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables the Codex plugin when a default subagent model uses Codex runtime",
+    {
       agents: {
         defaults: {
           model: "anthropic/claude-sonnet-4-6",
           subagents: { model: { primary: "openai/gpt-5.5" } },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-  });
-
-  it("re-enables the Codex plugin when an agent inherits a default heartbeat model that uses Codex runtime", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables the Codex plugin when an agent inherits a default heartbeat model that uses Codex runtime",
+    {
       agents: {
         defaults: { heartbeat: { model: "openai/gpt-5.5" } },
         list: [{ id: "research", model: "anthropic/claude-sonnet-4-6" }],
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-  });
-
-  it("re-enables the Codex plugin when an agent model alias resolves to OpenAI", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables the Codex plugin when an agent model alias resolves to OpenAI",
+    {
       agents: {
         defaults: {
           model: "xiaomi/mimo-v2-pro-mit",
           models: { "openai/xiaomi/mimo-v2-pro-mit": { alias: "xiaomi/mimo-v2-pro-mit" } },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-  });
-
-  it("keeps the Codex plugin disabled when a bare alias resolves through a non-OpenAI default provider", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "keeps the Codex plugin disabled when a bare alias resolves through a non-OpenAI default provider",
+    {
       agents: {
         defaults: {
           model: "anthropic/claude-sonnet-4-6",
@@ -1885,16 +1860,12 @@ describe("collectCodexRouteWarnings", () => {
           subagents: { model: "opus" },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("keeps the Codex plugin disabled when a bare alias inherits a default provider from the primary alias", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "keeps the Codex plugin disabled when a bare alias inherits a default provider from the primary alias",
+    {
       agents: {
         defaults: {
           model: "sonnet",
@@ -1905,32 +1876,24 @@ describe("collectCodexRouteWarnings", () => {
           subagents: { model: "opus" },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("keeps the Codex plugin disabled when an auth-profiled bare alias resolves outside OpenAI", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "keeps the Codex plugin disabled when an auth-profiled bare alias resolves outside OpenAI",
+    {
       agents: {
         defaults: {
           model: "fast@work",
           models: { "anthropic/claude-sonnet-4-6": { alias: "fast" } },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("re-enables the Codex plugin when a per-agent-only bare alias falls back to OpenAI", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables the Codex plugin when a per-agent-only bare alias falls back to OpenAI",
+    {
       agents: {
         list: [
           {
@@ -1940,16 +1903,12 @@ describe("collectCodexRouteWarnings", () => {
           },
         ],
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-  });
-
-  it("re-enables the Codex plugin when a listed-agent bare primary ignores per-agent provider metadata", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables the Codex plugin when a listed-agent bare primary ignores per-agent provider metadata",
+    {
       agents: {
         list: [
           {
@@ -1961,27 +1920,19 @@ describe("collectCodexRouteWarnings", () => {
           },
         ],
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-  });
-
-  it("re-enables the Codex plugin when defaults inherit the implicit OpenAI model", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables the Codex plugin when defaults inherit the implicit OpenAI model",
+    {
       agents: {
         defaults: {
           models: { "anthropic/claude-sonnet-4-6": { alias: "sonnet" } },
         },
       },
-    });
-
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-  });
+    },
+  );
 
   it("keeps Codex disabled when no agent routes are configured", () => {
     const result = maybeRepairCodexRoutes({
@@ -1991,15 +1942,13 @@ describe("collectCodexRouteWarnings", () => {
       },
     });
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+    expectCodexPluginDisabled(result);
     expect(result.cfg.plugins?.allow).toEqual(["brave"]);
   });
 
-  it("re-enables the Codex plugin when defaults configure only non-Codex fallbacks", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables the Codex plugin when defaults configure only non-Codex fallbacks",
+    {
       agents: {
         defaults: {
           model: {
@@ -2007,16 +1956,12 @@ describe("collectCodexRouteWarnings", () => {
           },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-  });
-
-  it("keeps Codex disabled when implicit defaults resolve to a configured provider", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "keeps Codex disabled when implicit defaults resolve to a configured provider",
+    {
       models: {
         providers: {
           anthropic: {
@@ -2027,32 +1972,21 @@ describe("collectCodexRouteWarnings", () => {
       agents: {
         defaults: {},
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("keeps Codex disabled for unused OpenAI model-map metadata", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
-      agents: {
-        defaults: {
-          model: "anthropic/claude-sonnet-4-6",
-          models: { "openai/gpt-5.5": { alias: "gpt" } },
-        },
+  itKeepsCodexPluginDisabled("keeps Codex disabled for unused OpenAI model-map metadata", {
+    agents: {
+      defaults: {
+        model: "anthropic/claude-sonnet-4-6",
+        models: { "openai/gpt-5.5": { alias: "gpt" } },
       },
-    });
-
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+    },
   });
 
-  it("re-enables Codex for model-map runtime policies even when the primary is non-Codex", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables Codex for model-map runtime policies even when the primary is non-Codex",
+    {
       agents: {
         defaults: {
           model: "anthropic/claude-sonnet-4-6",
@@ -2061,16 +1995,12 @@ describe("collectCodexRouteWarnings", () => {
           },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-  });
-
-  it("re-enables Codex for default model-map runtime policies inherited by listed agents", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables Codex for default model-map runtime policies inherited by listed agents",
+    {
       agents: {
         defaults: {
           models: {
@@ -2079,27 +2009,16 @@ describe("collectCodexRouteWarnings", () => {
         },
         list: [{ id: "worker", model: "anthropic/claude-sonnet-4-6" }],
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  itKeepsCodexPluginDisabled("keeps Codex disabled when openrouter:auto resolves outside OpenAI", {
+    agents: { defaults: { model: "openrouter:auto" } },
   });
 
-  it("keeps Codex disabled when openrouter:auto resolves outside OpenAI", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
-      agents: { defaults: { model: "openrouter:auto" } },
-    });
-
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("keeps Codex disabled when a bare alias inherits an OpenRouter compat primary provider", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "keeps Codex disabled when a bare alias inherits an OpenRouter compat primary provider",
+    {
       agents: {
         defaults: {
           model: "openrouter:auto",
@@ -2107,90 +2026,67 @@ describe("collectCodexRouteWarnings", () => {
           subagents: { model: "sonnet" },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("keeps Codex disabled when an alias resolves to an OpenRouter compat model", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "keeps Codex disabled when an alias resolves to an OpenRouter compat model",
+    {
       agents: {
         defaults: {
           model: "router-auto",
           models: { "openrouter:auto": { alias: "router-auto" } },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("keeps Codex disabled when a bare channel model inherits an Anthropic primary", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "keeps Codex disabled when a bare channel model inherits an Anthropic primary",
+    {
       agents: { defaults: { model: "anthropic/claude-sonnet-4-6" } },
       channels: {
         modelByChannel: { telegram: { default: "gpt-5.5" } },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("re-enables the Codex plugin when a qualified channel model uses Codex runtime", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables the Codex plugin when a qualified channel model uses Codex runtime",
+    {
       agents: { defaults: { model: "anthropic/claude-sonnet-4-6" } },
       channels: {
         modelByChannel: { telegram: { default: "openai/gpt-5.5" } },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-  });
-
-  it("checks channel model runtime policy for every configured agent", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
-      agents: {
-        defaults: {
-          model: "anthropic/claude-sonnet-4-6",
+  itReenablesCodexPlugin("checks channel model runtime policy for every configured agent", {
+    agents: {
+      defaults: {
+        model: "anthropic/claude-sonnet-4-6",
+        models: {
+          "openai/gpt-5.5": { agentRuntime: { id: "openclaw" } },
+        },
+      },
+      list: [
+        { id: "main" },
+        {
+          id: "worker",
           models: {
-            "openai/gpt-5.5": { agentRuntime: { id: "openclaw" } },
+            "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
           },
         },
-        list: [
-          { id: "main" },
-          {
-            id: "worker",
-            models: {
-              "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
-            },
-          },
-        ],
-      },
-      channels: {
-        modelByChannel: { telegram: { default: "openai/gpt-5.5" } },
-      },
-    });
-
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+      ],
+    },
+    channels: {
+      modelByChannel: { telegram: { default: "openai/gpt-5.5" } },
+    },
   });
 
-  it("uses normalized runtime agent ids when checking model runtime policy", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "uses normalized runtime agent ids when checking model runtime policy",
+    {
       agents: {
         list: [
           {
@@ -2202,12 +2098,8 @@ describe("collectCodexRouteWarnings", () => {
           },
         ],
       },
-    });
-
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
+    },
+  );
 
   it("keeps an empty allowlist unchanged when explicit opt-out blocks repair", () => {
     const result = maybeRepairCodexRoutes({
@@ -2224,58 +2116,13 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.plugins?.allow).toEqual([]);
   });
 
-  it("adds Codex to a non-empty plugin allowlist when OpenAI routes require Codex runtime", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: {
-        allow: ["openai"],
-        entries: { openai: { enabled: true } },
-      },
-      agents: { defaults: { model: "gpt-5.5" } },
-    });
+  itAddsCodexToAllowlist(
+    "adds Codex to a non-empty plugin allowlist when OpenAI routes require Codex runtime",
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([
-      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
-      "Added codex to plugins.allow because configured agent routes use Codex runtime.",
-    ]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-    expect(result.cfg.plugins?.allow).toEqual(["openai", "codex"]);
-  });
+  itAddsCodexToAllowlist("treats plugin allowlists as restrictive for the Codex harness");
 
-  it("treats plugin allowlists as restrictive for the Codex harness", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: {
-        allow: ["openai"],
-        entries: { openai: { enabled: true } },
-      },
-      agents: { defaults: { model: "gpt-5.5" } },
-    });
-
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([
-      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
-      "Added codex to plugins.allow because configured agent routes use Codex runtime.",
-    ]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-    expect(result.cfg.plugins?.allow).toEqual(["openai", "codex"]);
-  });
-
-  it("adds Codex to plugin allowlists when re-enabling Codex", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: {
-        allow: ["openai"],
-      },
-      agents: { defaults: { model: "gpt-5.5" } },
-    });
-
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([
-      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
-      "Added codex to plugins.allow because configured agent routes use Codex runtime.",
-    ]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-    expect(result.cfg.plugins?.allow).toEqual(["openai", "codex"]);
-  });
+  itAddsCodexToAllowlist("adds Codex to plugin allowlists when re-enabling Codex", false);
 
   it("keeps the Codex plugin disabled when OpenAI routes explicitly use the OpenClaw runtime", () => {
     const result = maybeRepairCodexRoutes({
@@ -2288,21 +2135,13 @@ describe("collectCodexRouteWarnings", () => {
       agents: { defaults: { model: "gpt-5.5" } },
     });
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectCodexPluginDisabled(result);
+    expectAgentRuntime(result.cfg, "openclaw", { modelId: "gpt-5.5" });
   });
 
-  it("keeps the Codex plugin disabled when an auth-profiled OpenAI route explicitly uses the OpenClaw runtime", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "keeps the Codex plugin disabled when an auth-profiled OpenAI route explicitly uses the OpenClaw runtime",
+    {
       agents: {
         defaults: {
           model: "openai/gpt-5.5@work",
@@ -2311,16 +2150,12 @@ describe("collectCodexRouteWarnings", () => {
           },
         },
       },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("keeps the Codex plugin disabled when a bare model resolves to a configured provider", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "keeps the Codex plugin disabled when a bare model resolves to a configured provider",
+    {
       models: {
         providers: {
           "qwen-dashscope": {
@@ -2329,16 +2164,12 @@ describe("collectCodexRouteWarnings", () => {
         },
       },
       agents: { defaults: { model: "qwen-max" } },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("keeps the Codex plugin disabled when a bare model case-insensitively resolves to a configured provider", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: DISABLED_CODEX_PLUGIN_CONFIG,
+  itKeepsCodexPluginDisabled(
+    "keeps the Codex plugin disabled when a bare model case-insensitively resolves to a configured provider",
+    {
       models: {
         providers: {
           "qwen-dashscope": {
@@ -2347,16 +2178,12 @@ describe("collectCodexRouteWarnings", () => {
         },
       },
       agents: { defaults: { model: "qwen-max" } },
-    });
+    },
+  );
 
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-  });
-
-  it("re-enables the Codex plugin when a provider-prefixed catalog model does not claim a bare model", () => {
-    const result = maybeRepairCodexRoutes({
-      plugins: REPAIRABLE_CODEX_PLUGIN_CONFIG,
+  itReenablesCodexPlugin(
+    "re-enables the Codex plugin when a provider-prefixed catalog model does not claim a bare model",
+    {
       models: {
         providers: {
           "qwen-dashscope": {
@@ -2365,12 +2192,8 @@ describe("collectCodexRouteWarnings", () => {
         },
       },
       agents: { defaults: { model: "qwen-max" } },
-    });
-
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.changes).toStrictEqual(CODEX_PLUGIN_REPAIR_CHANGES);
-    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
-  });
+    },
+  );
 
   it("repairs live multi-agent Codex upgrade configs and enables Codex through allowlists", () => {
     const result = maybeRepairCodexRoutes({
@@ -2433,13 +2256,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime).toEqual({
       id: "codex",
     });
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("codex");
+    expectAgentRuntime(result.cfg, "codex", { modelId: "gpt-5.5" });
   });
 
   it("preserves explicit listed-agent canonical refs when default legacy model repair adds Codex policy", () => {
@@ -2470,21 +2287,8 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.agents?.list?.[1]?.models?.["openai/gpt-5.5"]?.agentRuntime).toEqual({
       id: "openclaw",
     });
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("codex");
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        agentId: "worker",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "codex", { modelId: "gpt-5.5" });
+    expectAgentRuntime(result.cfg, "openclaw", { modelId: "gpt-5.5", agentId: "worker" });
   });
 
   it("preserves inherited default legacy runtime pins for listed-agent legacy refs", () => {
@@ -2499,14 +2303,7 @@ describe("collectCodexRouteWarnings", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai-codex",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(cfg, "openclaw", { provider: "openai-codex", agentId: "worker" });
 
     const result = maybeRepairCodexRoutes(cfg);
 
@@ -2519,14 +2316,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.changes.join("\n")).not.toContain(
       'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "codex"',
     );
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "openclaw", { agentId: "worker" });
   });
 
   it("preserves listed-agent legacy model-map runtime pins while repairing listed-agent refs", () => {
@@ -2544,14 +2334,7 @@ describe("collectCodexRouteWarnings", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai-codex",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(cfg, "openclaw", { provider: "openai-codex", agentId: "worker" });
 
     const result = maybeRepairCodexRoutes(cfg);
 
@@ -2563,14 +2346,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.changes.join("\n")).not.toContain(
       'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "codex"',
     );
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "openclaw", { agentId: "worker" });
   });
 
   it("preserves inherited default wildcard runtime pins for listed-agent legacy refs", () => {
@@ -2585,14 +2361,7 @@ describe("collectCodexRouteWarnings", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai-codex",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(cfg, "openclaw", { provider: "openai-codex", agentId: "worker" });
 
     const result = maybeRepairCodexRoutes(cfg);
 
@@ -2605,14 +2374,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.changes.join("\n")).not.toContain(
       'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "codex"',
     );
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "openclaw", { agentId: "worker" });
   });
 
   it("preserves provider-level legacy runtime pins while repairing default legacy refs", () => {
@@ -2626,13 +2388,7 @@ describe("collectCodexRouteWarnings", () => {
       plugins: DISABLED_CODEX_PLUGIN_CONFIG,
     } as unknown as OpenClawConfig;
 
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai-codex",
-        modelId: "gpt-5.4",
-        config: cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(cfg, "openclaw", { provider: "openai-codex" });
 
     const result = maybeRepairCodexRoutes(cfg);
 
@@ -2643,13 +2399,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.changes.join("\n")).toContain(
       'Set agents.defaults.models.openai/gpt-5.4.agentRuntime.id to "openclaw"',
     );
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "openclaw");
   });
 
   it("preserves legacy provider catalog runtime pins while repairing default legacy refs", () => {
@@ -2664,13 +2414,7 @@ describe("collectCodexRouteWarnings", () => {
       agents: { defaults: { model: "openai-codex/gpt-5.4" } },
     } as unknown as OpenClawConfig;
 
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai-codex",
-        modelId: "gpt-5.4",
-        config: cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(cfg, "openclaw", { provider: "openai-codex" });
 
     const result = maybeRepairCodexRoutes(cfg);
 
@@ -2681,13 +2425,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.changes.join("\n")).toContain(
       'Set agents.defaults.models.openai/gpt-5.4.agentRuntime.id to "openclaw"',
     );
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "openclaw");
   });
 
   it("preserves legacy provider catalog runtime pins while repairing listed-agent legacy refs", () => {
@@ -2704,14 +2442,7 @@ describe("collectCodexRouteWarnings", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai-codex",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(cfg, "openclaw", { provider: "openai-codex", agentId: "worker" });
 
     const result = maybeRepairCodexRoutes(cfg);
 
@@ -2722,14 +2453,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.changes.join("\n")).toContain(
       'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "openclaw"',
     );
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "openclaw", { agentId: "worker" });
   });
 
   it("shields listed canonical refs when provider-level legacy default pins migrate", () => {
@@ -2748,22 +2472,8 @@ describe("collectCodexRouteWarnings", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai-codex",
-        modelId: "gpt-5.4",
-        agentId: "main",
-        config: cfg,
-      }).runtime,
-    ).toBe("openclaw");
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        agentId: "regular",
-        config: cfg,
-      }).runtime,
-    ).toBe("codex");
+    expectAgentRuntime(cfg, "openclaw", { provider: "openai-codex", agentId: "main" });
+    expectAgentRuntime(cfg, "codex", { agentId: "regular" });
 
     const result = maybeRepairCodexRoutes(cfg);
 
@@ -2779,22 +2489,8 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.changes.join("\n")).toContain(
       'Set agents.list.regular.models.openai/gpt-5.4.agentRuntime.id to "codex"',
     );
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        agentId: "main",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        agentId: "regular",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("codex");
+    expectAgentRuntime(result.cfg, "openclaw", { agentId: "main" });
+    expectAgentRuntime(result.cfg, "codex", { agentId: "regular" });
   });
 
   it("preserves provider-level legacy runtime pins while repairing listed-agent legacy refs", () => {
@@ -2809,14 +2505,7 @@ describe("collectCodexRouteWarnings", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai-codex",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(cfg, "openclaw", { provider: "openai-codex", agentId: "worker" });
 
     const result = maybeRepairCodexRoutes(cfg);
 
@@ -2827,14 +2516,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.changes.join("\n")).toContain(
       'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "openclaw"',
     );
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "openclaw", { agentId: "worker" });
   });
 
   it("does not apply pre-existing canonical default runtime pins to listed-agent legacy refs", () => {
@@ -2849,14 +2531,7 @@ describe("collectCodexRouteWarnings", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai-codex",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: cfg,
-      }).runtime,
-    ).toBe("auto");
+    expectAgentRuntime(cfg, "auto", { provider: "openai-codex", agentId: "worker" });
 
     const result = maybeRepairCodexRoutes(cfg);
 
@@ -2870,14 +2545,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.changes.join("\n")).toContain(
       'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "codex"',
     );
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        agentId: "worker",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("codex");
+    expectAgentRuntime(result.cfg, "codex", { agentId: "worker" });
   });
 
   it("preserves explicit model-scoped runtime pins when repairing legacy model map keys", () => {
@@ -2897,13 +2565,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.changes.join("\n")).not.toContain(
       'Set agents.defaults.models.openai/gpt-5.5.agentRuntime.id to "codex"',
     );
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "openclaw", { modelId: "gpt-5.5" });
   });
 
   it("overwrites non-concrete model-scoped runtime pins when preserving Codex route intent", () => {
@@ -2927,13 +2589,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime).toEqual({
       id: "codex",
     });
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.5",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("codex");
+    expectAgentRuntime(result.cfg, "codex", { modelId: "gpt-5.5" });
   });
 
   it("leaves path-scoped agent refs unchanged when repair would broaden another canonical agent slot", () => {
@@ -2958,20 +2614,12 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.agents?.defaults?.model).toEqual({ primary: "openai/gpt-5.4" });
     expect(result.cfg.agents?.defaults?.heartbeat?.model).toBe("openai-codex/gpt-5.4");
     expect(result.cfg.agents?.defaults?.models).toBeUndefined();
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "openclaw");
     expect(result.changes).toStrictEqual([]);
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy `codex/*` and `openai-codex/*` model refs should be rewritten to `openai/*`.",
+      legacyRouteWarning(
         "- agents.defaults.heartbeat.model: openai-codex/gpt-5.4 should become openai/gpt-5.4.",
-        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
-      ].join("\n"),
+      ),
     ]);
   });
 
@@ -3013,20 +2661,10 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.agents?.defaults?.model).toBe("openai/gpt-5.4");
     expect(result.cfg.agents?.defaults?.models).toBeUndefined();
     expect(result.cfg.hooks?.gmail?.model).toBe("openai-codex/gpt-5.4");
-    expect(
-      resolveAgentHarnessPolicy({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        config: result.cfg,
-      }).runtime,
-    ).toBe("openclaw");
+    expectAgentRuntime(result.cfg, "openclaw");
     expect(result.changes).toStrictEqual([]);
     expect(result.warnings).toStrictEqual([
-      [
-        "- Legacy `codex/*` and `openai-codex/*` model refs should be rewritten to `openai/*`.",
-        "- hooks.gmail.model: openai-codex/gpt-5.4 should become openai/gpt-5.4.",
-        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
-      ].join("\n"),
+      legacyRouteWarning("- hooks.gmail.model: openai-codex/gpt-5.4 should become openai/gpt-5.4."),
     ]);
   });
 
@@ -3062,31 +2700,21 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
-    expect(expectDefined(store.main, "store.main test invariant").updatedAt).toBe(123);
-    expect(expectDefined(store.main, "store.main test invariant").modelProvider).toBe("openai");
-    expect(expectDefined(store.main, "store.main test invariant").model).toBe("gpt-5.5");
-    expect(expectDefined(store.main, "store.main test invariant").providerOverride).toBe("openai");
-    expect(expectDefined(store.main, "store.main test invariant").modelOverride).toBe("gpt-5.4");
-    expect(expectDefined(store.main, "store.main test invariant").modelOverrideSource).toBe("auto");
-    expect(
-      expectDefined(store.main, "store.main test invariant").modelOverrideRouteResolution,
-    ).toBe("resolved");
-    expect(expectDefined(store.main, "store.main test invariant").authProfileOverride).toBe(
-      "openai:chatgpt-default",
-    );
-    expect(expectDefined(store.main, "store.main test invariant").authProfileOverrideSource).toBe(
-      "auto",
-    );
-    expect(
-      expectDefined(store.main, "store.main test invariant").authProfileOverrideCompactionCount,
-    ).toBe(2);
-    expect(expectDefined(store.main, "store.main test invariant").agentHarnessId).toBeUndefined();
-    expect(expectDefined(store.main, "store.main test invariant").agentRuntimeOverride).toBe(
-      "codex",
-    );
-    expect(expectDefined(store.main, "store.main test invariant").fallbackNotice).toBeUndefined();
-    expect(expectDefined(store.other, "store.other test invariant").updatedAt).toBe(2);
-    expect(expectDefined(store.other, "store.other test invariant").agentHarnessId).toBe("codex");
+    expect(getSession(store, "main").updatedAt).toBe(123);
+    expect(getSession(store, "main").modelProvider).toBe("openai");
+    expect(getSession(store, "main").model).toBe("gpt-5.5");
+    expect(getSession(store, "main").providerOverride).toBe("openai");
+    expect(getSession(store, "main").modelOverride).toBe("gpt-5.4");
+    expect(getSession(store, "main").modelOverrideSource).toBe("auto");
+    expect(getSession(store, "main").modelOverrideRouteResolution).toBe("resolved");
+    expect(getSession(store, "main").authProfileOverride).toBe("openai:chatgpt-default");
+    expect(getSession(store, "main").authProfileOverrideSource).toBe("auto");
+    expect(getSession(store, "main").authProfileOverrideCompactionCount).toBe(2);
+    expect(getSession(store, "main").agentHarnessId).toBeUndefined();
+    expect(getSession(store, "main").agentRuntimeOverride).toBe("codex");
+    expect(getSession(store, "main").fallbackNotice).toBeUndefined();
+    expect(getSession(store, "other").updatedAt).toBe(2);
+    expect(getSession(store, "other").agentHarnessId).toBe("codex");
   });
 
   it("rewrites only exactly mapped auth pins on otherwise canonical sessions", () => {
@@ -3397,9 +3025,7 @@ describe("collectCodexRouteWarnings", () => {
       modelProvider: "openai",
       model: "gpt-5.5",
     });
-    expect(
-      expectDefined(store.ordinary, "store.ordinary test invariant").agentHarnessId,
-    ).toBeUndefined();
+    expect(getSession(store, "ordinary").agentHarnessId).toBeUndefined();
   });
 
   it("preserves explicit OpenClaw runtime pins while repairing legacy session routes", () => {
@@ -3423,15 +3049,13 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
-    expect(expectDefined(store.main, "store.main test invariant").modelProvider).toBe("openai");
-    expect(expectDefined(store.main, "store.main test invariant").model).toBe("gpt-5.5");
-    expect(expectDefined(store.main, "store.main test invariant").providerOverride).toBe("openai");
-    expect(expectDefined(store.main, "store.main test invariant").modelOverride).toBe("gpt-5.4");
-    expect(expectDefined(store.main, "store.main test invariant").agentHarnessId).toBe("pi");
-    expect(expectDefined(store.main, "store.main test invariant").agentRuntimeOverride).toBe("pi");
-    expect(expectDefined(store.main, "store.main test invariant").authProfileOverride).toBe(
-      "openai-codex:default",
-    );
+    expect(getSession(store, "main").modelProvider).toBe("openai");
+    expect(getSession(store, "main").model).toBe("gpt-5.5");
+    expect(getSession(store, "main").providerOverride).toBe("openai");
+    expect(getSession(store, "main").modelOverride).toBe("gpt-5.4");
+    expect(getSession(store, "main").agentHarnessId).toBe("pi");
+    expect(getSession(store, "main").agentRuntimeOverride).toBe("pi");
+    expect(getSession(store, "main").authProfileOverride).toBe("openai-codex:default");
   });
 
   it("preserves Codex runtime intent alongside explicit OpenClaw harness pins", () => {
@@ -3452,12 +3076,10 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
-    expect(expectDefined(store.main, "store.main test invariant").modelProvider).toBe("openai");
-    expect(expectDefined(store.main, "store.main test invariant").model).toBe("gpt-5.5");
-    expect(expectDefined(store.main, "store.main test invariant").agentHarnessId).toBe("pi");
-    expect(expectDefined(store.main, "store.main test invariant").agentRuntimeOverride).toBe(
-      "codex",
-    );
+    expect(getSession(store, "main").modelProvider).toBe("openai");
+    expect(getSession(store, "main").model).toBe("gpt-5.5");
+    expect(getSession(store, "main").agentHarnessId).toBe("pi");
+    expect(getSession(store, "main").agentRuntimeOverride).toBe("codex");
   });
 
   it("installs Codex runtime intent for a session-only legacy route", () => {
@@ -3478,19 +3100,13 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
-    expect(expectDefined(store.main, "store.main test invariant").updatedAt).toBe(123);
-    expect(expectDefined(store.main, "store.main test invariant").providerOverride).toBe("openai");
-    expect(expectDefined(store.main, "store.main test invariant").modelOverride).toBe("gpt-5.5");
-    expect(expectDefined(store.main, "store.main test invariant").authProfileOverride).toBe(
-      "openai-codex:default",
-    );
-    expect(expectDefined(store.main, "store.main test invariant").authProfileOverrideSource).toBe(
-      "auto",
-    );
-    expect(expectDefined(store.main, "store.main test invariant").agentHarnessId).toBeUndefined();
-    expect(expectDefined(store.main, "store.main test invariant").agentRuntimeOverride).toBe(
-      "codex",
-    );
+    expect(getSession(store, "main").updatedAt).toBe(123);
+    expect(getSession(store, "main").providerOverride).toBe("openai");
+    expect(getSession(store, "main").modelOverride).toBe("gpt-5.5");
+    expect(getSession(store, "main").authProfileOverride).toBe("openai-codex:default");
+    expect(getSession(store, "main").authProfileOverrideSource).toBe("auto");
+    expect(getSession(store, "main").agentHarnessId).toBeUndefined();
+    expect(getSession(store, "main").agentRuntimeOverride).toBe("codex");
   });
 
   it("repairs Telegram direct session routes while preserving canonical OpenAI auth pins", () => {
@@ -3577,25 +3193,17 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(result).toEqual({ changed: true, sessionKeys: ["main"] });
-    expect(expectDefined(store.main, "store.main test invariant").updatedAt).toBe(123);
-    expect(expectDefined(store.main, "store.main test invariant").providerOverride).toBe("openai");
-    expect(expectDefined(store.main, "store.main test invariant").modelOverride).toBe("gpt-5.5");
-    expect(expectDefined(store.main, "store.main test invariant").modelOverrideSource).toBe("auto");
-    expect(
-      expectDefined(store.main, "store.main test invariant").modelOverrideRouteResolution,
-    ).toBe("resolved");
-    expect(expectDefined(store.main, "store.main test invariant").authProfileOverride).toBe(
-      "openai:chatgpt-default",
-    );
-    expect(expectDefined(store.main, "store.main test invariant").authProfileOverrideSource).toBe(
-      "auto",
-    );
-    expect(expectDefined(store.main, "store.main test invariant").modelProvider).toBeUndefined();
-    expect(expectDefined(store.main, "store.main test invariant").model).toBeUndefined();
-    expect(expectDefined(store.main, "store.main test invariant").contextTokens).toBeUndefined();
-    expect(
-      expectDefined(store.main, "store.main test invariant").contextBudgetStatus,
-    ).toBeUndefined();
+    expect(getSession(store, "main").updatedAt).toBe(123);
+    expect(getSession(store, "main").providerOverride).toBe("openai");
+    expect(getSession(store, "main").modelOverride).toBe("gpt-5.5");
+    expect(getSession(store, "main").modelOverrideSource).toBe("auto");
+    expect(getSession(store, "main").modelOverrideRouteResolution).toBe("resolved");
+    expect(getSession(store, "main").authProfileOverride).toBe("openai:chatgpt-default");
+    expect(getSession(store, "main").authProfileOverrideSource).toBe("auto");
+    expect(getSession(store, "main").modelProvider).toBeUndefined();
+    expect(getSession(store, "main").model).toBeUndefined();
+    expect(getSession(store, "main").contextTokens).toBeUndefined();
+    expect(getSession(store, "main").contextBudgetStatus).toBeUndefined();
   });
 
   it("preserves legacy providerless overrides with Codex auth pins", () => {
@@ -3615,9 +3223,9 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(result).toEqual({ changed: false, sessionKeys: [] });
-    expect(expectDefined(store.main, "store.main test invariant").updatedAt).toBe(1);
-    expect(expectDefined(store.main, "store.main test invariant").providerOverride).toBeUndefined();
-    expect(expectDefined(store.main, "store.main test invariant").modelOverride).toBe("gpt-5.5");
+    expect(getSession(store, "main").updatedAt).toBe(1);
+    expect(getSession(store, "main").providerOverride).toBeUndefined();
+    expect(getSession(store, "main").modelOverride).toBe("gpt-5.5");
   });
 
   it("preserves canonical OpenAI sessions that are explicitly pinned to OpenClaw", () => {
@@ -3641,14 +3249,10 @@ describe("collectCodexRouteWarnings", () => {
     });
 
     expect(result).toEqual({ changed: false, sessionKeys: [] });
-    expect(expectDefined(store.main, "store.main test invariant").updatedAt).toBe(1);
-    expect(expectDefined(store.main, "store.main test invariant").agentHarnessId).toBe("openclaw");
-    expect(expectDefined(store.main, "store.main test invariant").agentRuntimeOverride).toBe(
-      "openclaw",
-    );
-    expect(expectDefined(store.main, "store.main test invariant").authProfileOverride).toBe(
-      "openai:work",
-    );
+    expect(getSession(store, "main").updatedAt).toBe(1);
+    expect(getSession(store, "main").agentHarnessId).toBe("openclaw");
+    expect(getSession(store, "main").agentRuntimeOverride).toBe("openclaw");
+    expect(getSession(store, "main").authProfileOverride).toBe("openai:work");
   });
 
   it("repairs legacy routes without probing OAuth readiness", () => {
@@ -3764,13 +3368,7 @@ describe("collectCodexRouteWarnings", () => {
       });
       expect(result.cfg.agents?.defaults?.models?.["openai-codex/gpt-5.4"]).toBeUndefined();
       expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
-      expect(
-        resolveAgentHarnessPolicy({
-          provider: "openai",
-          modelId: "gpt-5.4",
-          config: result.cfg,
-        }).runtime,
-      ).toBe("openclaw");
+      expectAgentRuntime(result.cfg, "openclaw");
     });
   }
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The Codex doctor route suite repeated the same runtime-policy, plugin-state, warning, compaction, and session expectations across many cases. That made an already large owner test harder to extend and review without adding behavior coverage.

## Why This Change Was Made

The doctor test owner now has canonical, test-local helpers for the repeated contracts while each of the 129 case titles, inputs, order, and expected outcomes stays intact. This removes 402 net test lines; production code and behavior are unchanged.

Root cause: equivalent fixture policy was encoded inline at every call site instead of at the test-owner boundary. The canonical fix removes those duplicate inline blocks; no test path, compatibility path, or production path was removed.

## User Impact

No user-visible behavior changes. Maintainers can add and audit Codex route migration cases with less duplicated fixture code.

## Evidence

- `src/commands/doctor/shared/codex-route-warnings.test.ts`: 129/129 focused tests passed on Blacksmith Testbox after the final rebase ([run](https://github.com/openclaw/openclaw/actions/runs/30785867631)).
- Core-test typecheck passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/30785559066)).
- Targeted core oxlint: 0 warnings, 0 errors; targeted `oxfmt --check`: clean (Testbox `tbx_01kz2zday9dajd4kx6xsa0qr94`).
- `git diff --check`: clean. Registered test-title/order comparison against `origin/main`: identical.
- Structured autoreview: no findings; patch correct with 0.99 confidence.
- `pnpm check:changed` reached the expected `coreTests` lane, then stopped on an unrelated current max-lines baseline cleanup for `extensions/policy/src/cli.test.ts` before diff-specific type/lint work ([run](https://github.com/openclaw/openclaw/actions/runs/30785391704)); the affected type/lint/format commands were run separately above.
- LOC: +441/-843 in one test file (net -402). Production LOC delta: 0.
- Owner/sibling coverage read: `src/commands/doctor/shared/codex-route-warnings.ts`, route model/agent/config/runtime/compaction/session owners, `src/commands/doctor/shared/preview-warnings.ts`, and `src/commands/doctor/repair-sequencing.ts`.
- Upstream Codex contract checked at `ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff`: built-in OpenAI provider identity and backend selection ([provider identity](https://github.com/openai/codex/blob/ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff/codex-rs/model-provider-info/src/lib.rs#L35-L38), [URL/auth routing](https://github.com/openai/codex/blob/ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff/codex-rs/model-provider-info/src/lib.rs#L244-L280), [provider registration](https://github.com/openai/codex/blob/ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff/codex-rs/model-provider-info/src/lib.rs#L332-L367)), auth/backend modes ([protocol](https://github.com/openai/codex/blob/ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff/codex-rs/protocol/src/auth.rs#L6-L55), [stored-auth mapping](https://github.com/openai/codex/blob/ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff/codex-rs/login/src/auth/manager.rs#L418-L459)), and default provider selection ([config](https://github.com/openai/codex/blob/ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff/codex-rs/core/src/config/mod.rs#L3650-L3672)).
