### PR TITLE
test(channels): consolidate remaining channel scaffolding

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -114,9 +114,9 @@ function createTestMeetVoiceProvider(
     handleBargeIn?: RealtimeVoiceBridge["handleBargeIn"];
     sendUserMessage?: RealtimeVoiceBridge["sendUserMessage"];
     triggerGreeting?: RealtimeVoiceBridge["triggerGreeting"];
-    onCreateBridge?: (request: TestMeetVoiceBridgeRequest) => void;
   } = {},
 ) {
+  let request: TestMeetVoiceBridgeRequest | undefined;
   const bridge = {
     ...(options.supportsToolResultContinuation
       ? { supportsToolResultContinuation: options.supportsToolResultContinuation }
@@ -139,20 +139,30 @@ function createTestMeetVoiceProvider(
     autoSelectOrder: 1,
     resolveConfig: ({ rawConfig }) => rawConfig,
     isConfigured: () => true,
-    createBridge: (request) => {
-      options.onCreateBridge?.(request);
+    createBridge: (nextRequest) => {
+      request = nextRequest;
       return bridge;
     },
   };
-  return { bridge, provider, sendAudio: bridge.sendAudio };
+  return {
+    bridge,
+    provider,
+    sendAudio: bridge.sendAudio,
+    requireRequest: () => {
+      if (!request) {
+        throw new Error("Expected realtime bridge callbacks");
+      }
+      return request;
+    },
+  };
 }
 
 function createTestMeetTranscriptionProvider(
   options: {
-    onCreateSession?: (request: TestMeetTranscriptionRequest) => void;
     createSession?: RealtimeTranscriptionProviderPlugin["createSession"];
   } = {},
 ) {
+  let request: TestMeetTranscriptionRequest | undefined;
   const sttSession = {
     connect: vi.fn(async () => {}),
     sendAudio: vi.fn(),
@@ -168,12 +178,22 @@ function createTestMeetTranscriptionProvider(
     isConfigured: () => true,
     createSession:
       options.createSession ??
-      ((request) => {
-        options.onCreateSession?.(request);
+      ((nextRequest) => {
+        request = nextRequest;
         return sttSession;
       }),
   };
-  return { provider, sttSession, sendAudio: sttSession.sendAudio };
+  return {
+    provider,
+    sttSession,
+    sendAudio: sttSession.sendAudio,
+    requireRequest: () => {
+      if (!request) {
+        throw new Error("Expected transcription session callbacks");
+      }
+      return request;
+    },
+  };
 }
 
 function createGoogleMeetTestEngineBindings(params: {
@@ -657,43 +677,75 @@ type TwilioSetupCredentials = {
   fromNumber: string;
 };
 
+type SetupFullConfig = NonNullable<GoogleMeetSetupOptions["fullConfig"]>;
+type SetupPluginEntries = NonNullable<NonNullable<SetupFullConfig["plugins"]>["entries"]>;
+type TwilioVoiceCallEntry = SetupPluginEntries[string];
+
+async function runTwilioSetupStatus(params: {
+  env?: TwilioSetupCredentials;
+  googleMeetConfig?: NonNullable<Parameters<typeof setup>[0]>;
+  includeVoiceCallInAllowlist?: boolean;
+  voiceCallEntry?: TwilioVoiceCallEntry | null;
+  request?: Record<string, unknown>;
+}) {
+  const env = params.env ?? {
+    accountSid: "AC123",
+    authToken: "secret",
+    fromNumber: "+15550001234",
+  };
+  vi.stubEnv("TWILIO_ACCOUNT_SID", env.accountSid);
+  vi.stubEnv("TWILIO_AUTH_TOKEN", env.authToken);
+  vi.stubEnv("TWILIO_FROM_NUMBER", env.fromNumber);
+  const voiceCallEntry =
+    params.voiceCallEntry === undefined
+      ? {
+          enabled: true,
+          config: {
+            provider: "twilio",
+            publicUrl: "https://voice.example.com/voice/webhook",
+          },
+        }
+      : params.voiceCallEntry;
+  const { tools } = setup(params.googleMeetConfig ?? { defaultTransport: "chrome" }, {
+    fullConfig: {
+      plugins: {
+        allow: [
+          "google-meet",
+          ...(params.includeVoiceCallInAllowlist === false ? [] : ["voice-call"]),
+        ],
+        entries: voiceCallEntry ? { "voice-call": voiceCallEntry } : {},
+      },
+    },
+  });
+  return await getMeetTool({ tools }).execute("id", {
+    action: "setup_status",
+    ...params.request,
+  });
+}
+
 async function getTwilioVoiceCallCredentialsCheck(params: {
   env: TwilioSetupCredentials;
   configured?: Partial<TwilioSetupCredentials>;
 }): Promise<Record<string, unknown>> {
-  vi.stubEnv("TWILIO_ACCOUNT_SID", params.env.accountSid);
-  vi.stubEnv("TWILIO_AUTH_TOKEN", params.env.authToken);
-  vi.stubEnv("TWILIO_FROM_NUMBER", params.env.fromNumber);
-  const { tools } = setup(
-    {
+  const result = await runTwilioSetupStatus({
+    env: params.env,
+    googleMeetConfig: {
       defaultTransport: "chrome-node",
       chromeNode: { node: "parallels-macos" },
     },
-    {
-      fullConfig: {
-        plugins: {
-          allow: ["google-meet", "voice-call"],
-          entries: {
-            "voice-call": {
-              enabled: true,
-              config: {
-                provider: "twilio",
-                publicUrl: "https://voice.example.com/voice/webhook",
-                fromNumber: params.configured?.fromNumber,
-                twilio: {
-                  accountSid: params.configured?.accountSid,
-                  authToken: params.configured?.authToken,
-                },
-              },
-            },
-          },
+    voiceCallEntry: {
+      enabled: true,
+      config: {
+        provider: "twilio",
+        publicUrl: "https://voice.example.com/voice/webhook",
+        fromNumber: params.configured?.fromNumber,
+        twilio: {
+          accountSid: params.configured?.accountSid,
+          authToken: params.configured?.authToken,
         },
       },
     },
-  );
-  const tool = getMeetTool({ tools });
-
-  const result = await tool.execute("id", { action: "setup_status" });
+  });
   return requireSetupCheck(result.details.checks, "twilio-voice-call-credentials");
 }
 
@@ -2672,34 +2724,12 @@ describe("google-meet plugin", () => {
   });
 
   it("reports Twilio delegation readiness when voice-call is enabled", async () => {
-    vi.stubEnv("TWILIO_ACCOUNT_SID", "AC123");
-    vi.stubEnv("TWILIO_AUTH_TOKEN", "secret");
-    vi.stubEnv("TWILIO_FROM_NUMBER", "+15550001234");
-    const { tools } = setup(
-      {
+    const result = await runTwilioSetupStatus({
+      googleMeetConfig: {
         defaultTransport: "chrome-node",
         chromeNode: { node: "parallels-macos" },
       },
-      {
-        fullConfig: {
-          plugins: {
-            allow: ["google-meet", "voice-call"],
-            entries: {
-              "voice-call": {
-                enabled: true,
-                config: {
-                  provider: "twilio",
-                  publicUrl: "https://voice.example.com/voice/webhook",
-                },
-              },
-            },
-          },
-        },
-      },
-    );
-    const tool = getMeetTool({ tools });
-
-    const result = await tool.execute("id", { action: "setup_status" });
+    });
 
     expect(result.details.ok).toBe(true);
     expect(requireSetupCheck(result.details.checks, "twilio-voice-call-plugin").ok).toBe(true);
@@ -2766,25 +2796,12 @@ describe("google-meet plugin", () => {
   });
 
   it("reports missing voice-call wiring for explicit Twilio transport", async () => {
-    vi.stubEnv("TWILIO_ACCOUNT_SID", "");
-    vi.stubEnv("TWILIO_AUTH_TOKEN", "");
-    vi.stubEnv("TWILIO_FROM_NUMBER", "");
-    const { tools } = setup(
-      { defaultTransport: "chrome" },
-      {
-        fullConfig: {
-          plugins: {
-            allow: ["google-meet"],
-            entries: {
-              "voice-call": { enabled: false },
-            },
-          },
-        },
-      },
-    );
-    const tool = getMeetTool({ tools });
-
-    const result = await tool.execute("id", { action: "setup_status", transport: "twilio" });
+    const result = await runTwilioSetupStatus({
+      env: { accountSid: "", authToken: "", fromNumber: "" },
+      includeVoiceCallInAllowlist: false,
+      voiceCallEntry: { enabled: false },
+      request: { transport: "twilio" },
+    });
 
     expect(result.details.ok).toBe(false);
     expect(requireSetupCheck(result.details.checks, "twilio-voice-call-plugin").ok).toBe(false);
@@ -2794,54 +2811,17 @@ describe("google-meet plugin", () => {
   });
 
   it("reports missing voice-call plugin entry for explicit Twilio transport", async () => {
-    vi.stubEnv("TWILIO_ACCOUNT_SID", "AC123");
-    vi.stubEnv("TWILIO_AUTH_TOKEN", "secret");
-    vi.stubEnv("TWILIO_FROM_NUMBER", "+15550001234");
-    const { tools } = setup(
-      { defaultTransport: "chrome" },
-      {
-        fullConfig: {
-          plugins: {
-            allow: ["google-meet", "voice-call"],
-            entries: {},
-          },
-        },
-      },
-    );
-    const tool = getMeetTool({ tools });
-
-    const result = await tool.execute("id", { action: "setup_status", transport: "twilio" });
+    const result = await runTwilioSetupStatus({
+      voiceCallEntry: null,
+      request: { transport: "twilio" },
+    });
 
     expect(result.details.ok).toBe(false);
     expect(requireSetupCheck(result.details.checks, "twilio-voice-call-plugin").ok).toBe(false);
   });
 
   it("reports missing Twilio dial plan for explicit Twilio setup", async () => {
-    vi.stubEnv("TWILIO_ACCOUNT_SID", "AC123");
-    vi.stubEnv("TWILIO_AUTH_TOKEN", "secret");
-    vi.stubEnv("TWILIO_FROM_NUMBER", "+15550001234");
-    const { tools } = setup(
-      { defaultTransport: "chrome" },
-      {
-        fullConfig: {
-          plugins: {
-            allow: ["google-meet", "voice-call"],
-            entries: {
-              "voice-call": {
-                enabled: true,
-                config: {
-                  provider: "twilio",
-                  publicUrl: "https://voice.example.com/voice/webhook",
-                },
-              },
-            },
-          },
-        },
-      },
-    );
-    const tool = getMeetTool({ tools });
-
-    const result = await tool.execute("id", { action: "setup_status", transport: "twilio" });
+    const result = await runTwilioSetupStatus({ request: { transport: "twilio" } });
 
     expect(result.details.ok).toBe(false);
     const check = requireSetupCheck(result.details.checks, "twilio-dial-plan");
@@ -2850,34 +2830,8 @@ describe("google-meet plugin", () => {
   });
 
   it("accepts request-provided Twilio dial-in details during setup", async () => {
-    vi.stubEnv("TWILIO_ACCOUNT_SID", "AC123");
-    vi.stubEnv("TWILIO_AUTH_TOKEN", "secret");
-    vi.stubEnv("TWILIO_FROM_NUMBER", "+15550001234");
-    const { tools } = setup(
-      { defaultTransport: "chrome" },
-      {
-        fullConfig: {
-          plugins: {
-            allow: ["google-meet", "voice-call"],
-            entries: {
-              "voice-call": {
-                enabled: true,
-                config: {
-                  provider: "twilio",
-                  publicUrl: "https://voice.example.com/voice/webhook",
-                },
-              },
-            },
-          },
-        },
-      },
-    );
-    const tool = getMeetTool({ tools });
-
-    const result = await tool.execute("id", {
-      action: "setup_status",
-      transport: "twilio",
-      dialInNumber: "+15551234567",
+    const result = await runTwilioSetupStatus({
+      request: { transport: "twilio", dialInNumber: "+15551234567" },
     });
 
     expect(result.details.ok).toBe(true);
@@ -2893,31 +2847,13 @@ describe("google-meet plugin", () => {
   ])(
     "reports local voice-call publicUrl %s as unusable for Twilio transport",
     async (publicUrl) => {
-      vi.stubEnv("TWILIO_ACCOUNT_SID", "AC123");
-      vi.stubEnv("TWILIO_AUTH_TOKEN", "secret");
-      vi.stubEnv("TWILIO_FROM_NUMBER", "+15550001234");
-      const { tools } = setup(
-        { defaultTransport: "twilio" },
-        {
-          fullConfig: {
-            plugins: {
-              allow: ["google-meet", "voice-call"],
-              entries: {
-                "voice-call": {
-                  enabled: true,
-                  config: {
-                    provider: "twilio",
-                    publicUrl,
-                  },
-                },
-              },
-            },
-          },
+      const result = await runTwilioSetupStatus({
+        googleMeetConfig: { defaultTransport: "twilio" },
+        voiceCallEntry: {
+          enabled: true,
+          config: { provider: "twilio", publicUrl },
         },
-      );
-      const tool = getMeetTool({ tools });
-
-      const result = await tool.execute("id", { action: "setup_status" });
+      });
 
       expect(result.details.ok).toBe(false);
       expect(requireSetupCheck(result.details.checks, "twilio-voice-call-webhook").ok).toBe(false);
@@ -3194,9 +3130,27 @@ describe("google-meet plugin", () => {
     return callGatewayFromCli;
   }
 
+  async function withLocalChromeMeetSession<T>(
+    options: Parameters<typeof mockLocalMeetBrowserRequestWithTabState>[0],
+    run: (context: {
+      callGatewayFromCli: ReturnType<typeof mockLocalMeetBrowserRequestWithTabState>;
+      methods: ReturnType<typeof setup>["methods"];
+      joined: { session: { id: string; chrome?: Record<string, unknown> } };
+    }) => Promise<T>,
+  ): Promise<T> {
+    return await withPlatform("darwin", async () => {
+      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState(options);
+      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
+      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
+        url: MEET_URL,
+      })) as { session: { id: string; chrome?: Record<string, unknown> } };
+      return await run({ callGatewayFromCli, methods, joined });
+    });
+  }
+
   it("reads and snapshots the bounded transcript from the exact tracked tab", async () => {
-    await withPlatform("darwin", async () => {
-      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState({
+    await withLocalChromeMeetSession(
+      {
         transcript: {
           droppedLines: 2,
           lines: [
@@ -3204,82 +3158,68 @@ describe("google-meet plugin", () => {
             { at: "2026-07-12T06:00:01.000Z", speaker: "Bob", text: "fourth line" },
           ],
         },
-      });
-      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
-      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
-        url: MEET_URL,
-      })) as { session: { id: string } };
+      },
+      async ({ callGatewayFromCli, methods, joined }) => {
+        const beforeRead = callGatewayFromCli.mock.calls.length;
+        const transcript = (await invokeGoogleMeetGatewayMethodForTest(
+          methods,
+          "googlemeet.transcript",
+          { sessionId: joined.session.id, sinceIndex: 3 },
+        )) as {
+          droppedLines: number;
+          startIndex: number;
+          nextIndex: number;
+          lines: Array<{ text: string }>;
+        };
+        expect(transcript).toMatchObject({ droppedLines: 2, startIndex: 3, nextIndex: 4 });
+        expect(transcript.lines.map((line) => line.text)).toEqual(["fourth line"]);
+        const readCalls = callGatewayFromCli.mock.calls.slice(beforeRead);
+        expect(readCalls).toHaveLength(1);
+        expect(requireRecord(readCalls[0]?.[2], "transcript request")).toMatchObject({
+          method: "POST",
+          path: "/act",
+          body: { targetId: "local-meet-tab" },
+        });
 
-      const beforeRead = callGatewayFromCli.mock.calls.length;
-      const transcript = (await invokeGoogleMeetGatewayMethodForTest(
-        methods,
-        "googlemeet.transcript",
-        { sessionId: joined.session.id, sinceIndex: 3 },
-      )) as {
-        droppedLines: number;
-        startIndex: number;
-        nextIndex: number;
-        lines: Array<{ text: string }>;
-      };
-      expect(transcript).toMatchObject({ droppedLines: 2, startIndex: 3, nextIndex: 4 });
-      expect(transcript.lines.map((line) => line.text)).toEqual(["fourth line"]);
-      const readCalls = callGatewayFromCli.mock.calls.slice(beforeRead);
-      expect(readCalls).toHaveLength(1);
-      expect(requireRecord(readCalls[0]?.[2], "transcript request")).toMatchObject({
-        method: "POST",
-        path: "/act",
-        body: { targetId: "local-meet-tab" },
-      });
-
-      await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
-        sessionId: joined.session.id,
-      });
-      const afterLeave = (await invokeGoogleMeetGatewayMethodForTest(
-        methods,
-        "googlemeet.transcript",
-        { sessionId: joined.session.id },
-      )) as { lines: Array<{ text: string }> };
-      expect(afterLeave.lines.map((line) => line.text)).toEqual(["third line", "fourth line"]);
-
-      await expect(
-        invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
+        await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
           sessionId: joined.session.id,
-          sinceIndex: 1.5,
-        }),
-      ).rejects.toThrow("sinceIndex must be a non-negative safe integer");
-    });
+        });
+        const afterLeave = (await invokeGoogleMeetGatewayMethodForTest(
+          methods,
+          "googlemeet.transcript",
+          { sessionId: joined.session.id },
+        )) as { lines: Array<{ text: string }> };
+        expect(afterLeave.lines.map((line) => line.text)).toEqual(["third line", "fourth line"]);
+
+        await expect(
+          invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
+            sessionId: joined.session.id,
+            sinceIndex: 1.5,
+          }),
+        ).rejects.toThrow("sinceIndex must be a non-negative safe integer");
+      },
+    );
   });
 
   it("refuses to read a tracked tab after it navigates away from the meeting", async () => {
-    await withPlatform("darwin", async () => {
-      mockLocalMeetBrowserRequestWithTabState({
+    await withLocalChromeMeetSession(
+      {
         tabUrlAfterJoin: "https://meet.google.com/lookup/unrelated",
         transcript: { lines: [{ text: "must not leak" }] },
-      });
-      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
-      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
-        url: MEET_URL,
-      })) as { session: { id: string } };
-
-      await expect(
-        invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
-          sessionId: joined.session.id,
-        }),
-      ).rejects.toThrow("tracked Meet tab no longer shows this session's meeting URL");
-    });
+      },
+      async ({ methods, joined }) => {
+        await expect(
+          invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
+            sessionId: joined.session.id,
+          }),
+        ).rejects.toThrow("tracked Meet tab no longer shows this session's meeting URL");
+      },
+    );
   });
 
   it("keeps the cursor monotonic when the Meet page transcript epoch resets", async () => {
-    await withPlatform("darwin", async () => {
-      const transcript = { epoch: "page-1", lines: [{ text: "before reload" }] };
-      mockLocalMeetBrowserRequestWithTabState({
-        transcript,
-      });
-      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
-      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
-        url: MEET_URL,
-      })) as { session: { id: string } };
-
+    const transcript = { epoch: "page-1", lines: [{ text: "before reload" }] };
+    await withLocalChromeMeetSession({ transcript }, async ({ methods, joined }) => {
       const first = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
         sessionId: joined.session.id,
       })) as { nextIndex: number; lines: Array<{ text: string }> };
@@ -3303,18 +3243,18 @@ describe("google-meet plugin", () => {
   });
 
   it("does not let a late active read replace the finalized leave snapshot", async () => {
-    await withPlatform("darwin", async () => {
-      let releaseRead: (() => void) | undefined;
-      let markReadStarted: (() => void) | undefined;
-      const readGate = new Promise<void>((resolve) => {
-        releaseRead = resolve;
-      });
-      const readStarted = new Promise<void>((resolve) => {
-        markReadStarted = resolve;
-      });
-      let activeReads = 0;
-      let gateNonFinalTranscriptReads = false;
-      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState({
+    let releaseRead: (() => void) | undefined;
+    let markReadStarted: (() => void) | undefined;
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
+    let activeReads = 0;
+    let gateNonFinalTranscriptReads = false;
+    await withLocalChromeMeetSession(
+      {
         transcript: { lines: [{ text: "partial" }] },
         finalTranscript: { lines: [{ text: "partial" }, { text: "complete caption" }] },
         nonFinalTranscriptGate: readGate,
@@ -3323,81 +3263,81 @@ describe("google-meet plugin", () => {
           activeReads += 1;
           markReadStarted?.();
         },
-      });
-      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
-      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
-        url: MEET_URL,
-      })) as { session: { id: string } };
-
-      gateNonFinalTranscriptReads = true;
-      const lateRead = invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
-        sessionId: joined.session.id,
-      });
-      await readStarted;
-      const secondRead = invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
-        sessionId: joined.session.id,
-      });
-      await new Promise((resolve) => {
-        setTimeout(resolve, 0);
-      });
-      expect(activeReads).toBe(1);
-      const leaving = invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
-        sessionId: joined.session.id,
-      });
-      const repeatedLeave = invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
-        sessionId: joined.session.id,
-      });
-      releaseRead?.();
-      await Promise.allSettled([lateRead, secondRead, leaving, repeatedLeave]);
-      const finalCaptures = callGatewayFromCli.mock.calls.filter((call) => {
-        const request = call[2] as { body?: { fn?: string } };
-        const script = String(request.body?.fn);
-        return script.includes("const expectedSessionId =") && script.includes("if (true &&");
-      });
-      expect(finalCaptures).toHaveLength(1);
-      const result = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
-        sessionId: joined.session.id,
-      })) as { lines: Array<{ text: string }> };
-      expect(result.lines.map((line) => line.text)).toEqual(["partial", "complete caption"]);
-    });
+      },
+      async ({ callGatewayFromCli, methods, joined }) => {
+        gateNonFinalTranscriptReads = true;
+        const lateRead = invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
+          sessionId: joined.session.id,
+        });
+        await readStarted;
+        const secondRead = invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
+          sessionId: joined.session.id,
+        });
+        await new Promise((resolve) => {
+          setTimeout(resolve, 0);
+        });
+        expect(activeReads).toBe(1);
+        const leaving = invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+          sessionId: joined.session.id,
+        });
+        const repeatedLeave = invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+          sessionId: joined.session.id,
+        });
+        releaseRead?.();
+        await Promise.allSettled([lateRead, secondRead, leaving, repeatedLeave]);
+        const finalCaptures = callGatewayFromCli.mock.calls.filter((call) => {
+          const request = call[2] as { body?: { fn?: string } };
+          const script = String(request.body?.fn);
+          return script.includes("const expectedSessionId =") && script.includes("if (true &&");
+        });
+        expect(finalCaptures).toHaveLength(1);
+        const result = (await invokeGoogleMeetGatewayMethodForTest(
+          methods,
+          "googlemeet.transcript",
+          { sessionId: joined.session.id },
+        )) as { lines: Array<{ text: string }> };
+        expect(result.lines.map((line) => line.text)).toEqual(["partial", "complete caption"]);
+      },
+    );
   });
 
   it("retains only the four most recently ended transcripts", async () => {
-    await withPlatform("darwin", async () => {
-      mockLocalMeetBrowserRequestWithTabState({
+    await withLocalChromeMeetSession(
+      {
         transcript: { lines: [{ text: "retained line" }] },
-      });
-      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
-      const sessionIds: string[] = [];
-      for (let index = 0; index < 5; index += 1) {
-        const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
-          url: MEET_URL,
-        })) as { session: { id: string } };
-        sessionIds.push(joined.session.id);
+      },
+      async ({ methods, joined }) => {
+        const sessionIds = [joined.session.id];
         await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
           sessionId: joined.session.id,
         });
-      }
+        for (let index = 1; index < 5; index += 1) {
+          const nextJoin = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
+            url: MEET_URL,
+          })) as { session: { id: string } };
+          sessionIds.push(nextJoin.session.id);
+          await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+            sessionId: nextJoin.session.id,
+          });
+        }
 
-      const oldest = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
-        sessionId: sessionIds[0],
-      })) as { evicted?: boolean; lines: unknown[] };
-      const next = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
-        sessionId: sessionIds[1],
-      })) as { evicted?: boolean; lines: unknown[] };
-      expect(oldest).toMatchObject({ evicted: true, lines: [] });
-      expect(next.evicted).toBeUndefined();
-      expect(next.lines).toHaveLength(1);
-    });
+        const oldest = (await invokeGoogleMeetGatewayMethodForTest(
+          methods,
+          "googlemeet.transcript",
+          { sessionId: sessionIds[0] },
+        )) as { evicted?: boolean; lines: unknown[] };
+        const next = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.transcript", {
+          sessionId: sessionIds[1],
+        })) as { evicted?: boolean; lines: unknown[] };
+        expect(oldest).toMatchObject({ evicted: true, lines: [] });
+        expect(next.evicted).toBeUndefined();
+        expect(next.lines).toHaveLength(1);
+      },
+    );
   });
 
   it("leaves the Meet call in the browser when a chrome session leaves", async () => {
-    await withPlatform("darwin", async () => {
-      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState();
-      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
-      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
-        url: MEET_URL,
-      })) as { session: { id: string; chrome?: { browserTab?: unknown } } };
+    await withLocalChromeMeetSession(undefined, async ({ callGatewayFromCli, methods, joined }) => {
       expect(joined.session.chrome?.browserTab).toEqual({
         targetId: "local-meet-tab",
         openedByPlugin: true,
@@ -3428,148 +3368,143 @@ describe("google-meet plugin", () => {
   });
 
   it("still ends the chrome session when its Meet tab is already closed on leave", async () => {
-    await withPlatform("darwin", async () => {
-      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState({
-        tabClosesAfterJoin: true,
-      });
-      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
-      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
-        url: MEET_URL,
-      })) as { session: { id: string } };
+    await withLocalChromeMeetSession(
+      { tabClosesAfterJoin: true },
+      async ({ callGatewayFromCli, methods, joined }) => {
+        const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+          sessionId: joined.session.id,
+        })) as {
+          found: boolean;
+          browserLeft?: boolean;
+          session: { state: string; notes: string[] };
+        };
 
-      const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
-        sessionId: joined.session.id,
-      })) as { found: boolean; browserLeft?: boolean; session: { state: string; notes: string[] } };
-
-      expect(left.found).toBe(true);
-      expect(left.session.state).toBe("ended");
-      expect(left.browserLeft).toBe(true);
-      expect(left.session.notes).toContain("Meet tab is already closed.");
-      expect(
-        callGatewayFromCli.mock.calls.some(
-          (call) => (call[2] as { method?: string }).method === "DELETE",
-        ),
-      ).toBe(false);
-    });
+        expect(left.found).toBe(true);
+        expect(left.session.state).toBe("ended");
+        expect(left.browserLeft).toBe(true);
+        expect(left.session.notes).toContain("Meet tab is already closed.");
+        expect(
+          callGatewayFromCli.mock.calls.some(
+            (call) => (call[2] as { method?: string }).method === "DELETE",
+          ),
+        ).toBe(false);
+      },
+    );
   });
 
   it("confirms host leave and keeps the reused Meet tab open", async () => {
-    await withPlatform("darwin", async () => {
-      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState({
+    await withLocalChromeMeetSession(
+      {
         reused: true,
         leaveConfirmationRequired: true,
-      });
-      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
-      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
-        url: MEET_URL,
-      })) as { session: { id: string; chrome?: Record<string, unknown> } };
-      expect(joined.session.chrome?.browserTab).toEqual({
-        targetId: "local-meet-tab",
-        openedByPlugin: false,
-      });
+      },
+      async ({ callGatewayFromCli, methods, joined }) => {
+        expect(joined.session.chrome?.browserTab).toEqual({
+          targetId: "local-meet-tab",
+          openedByPlugin: false,
+        });
 
-      const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
-        sessionId: joined.session.id,
-      })) as { found: boolean; browserLeft?: boolean; session: { state: string; notes: string[] } };
+        const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+          sessionId: joined.session.id,
+        })) as {
+          found: boolean;
+          browserLeft?: boolean;
+          session: { state: string; notes: string[] };
+        };
 
-      expect(left.found).toBe(true);
-      expect(left.session.state).toBe("ended");
-      expect(left.browserLeft).toBe(true);
-      expect(left.session.notes).toContain(
-        "Clicked Meet's Leave call button; kept the reused browser tab open.",
-      );
-      const leaveActCall = callGatewayFromCli.mock.calls.find((call) =>
-        String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
-      );
-      expect(
-        requireRecord(requireRecord(leaveActCall?.[2], "leave act request").body, "leave act body")
-          .targetId,
-      ).toBe("local-meet-tab");
-      const leaveSteps = callGatewayFromCli.mock.calls.filter((call) =>
-        String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
-      );
-      expect(leaveSteps).toHaveLength(3);
-    });
+        expect(left.found).toBe(true);
+        expect(left.session.state).toBe("ended");
+        expect(left.browserLeft).toBe(true);
+        expect(left.session.notes).toContain(
+          "Clicked Meet's Leave call button; kept the reused browser tab open.",
+        );
+        const leaveActCall = callGatewayFromCli.mock.calls.find((call) =>
+          String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
+        );
+        expect(
+          requireRecord(
+            requireRecord(leaveActCall?.[2], "leave act request").body,
+            "leave act body",
+          ).targetId,
+        ).toBe("local-meet-tab");
+        const leaveSteps = callGatewayFromCli.mock.calls.filter((call) =>
+          String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
+        );
+        expect(leaveSteps).toHaveLength(3);
+      },
+    );
   });
 
   it("reports browserLeft false when the reused tab's Leave call click fails", async () => {
-    await withPlatform("darwin", async () => {
-      mockLocalMeetBrowserRequestWithTabState({
-        reused: true,
-        leaveClicked: false,
-      });
-      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
-      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
-        url: MEET_URL,
-      })) as { session: { id: string } };
+    await withLocalChromeMeetSession(
+      { reused: true, leaveClicked: false },
+      async ({ methods, joined }) => {
+        const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+          sessionId: joined.session.id,
+        })) as {
+          found: boolean;
+          browserLeft?: boolean;
+          session: { state: string; notes: string[] };
+        };
 
-      const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
-        sessionId: joined.session.id,
-      })) as { found: boolean; browserLeft?: boolean; session: { state: string; notes: string[] } };
-
-      expect(left.found).toBe(true);
-      expect(left.session.state).toBe("ended");
-      expect(left.browserLeft).toBe(false);
-      expect(left.session.notes).toContain(
-        "Could not find Meet's Leave call button in the reused browser tab; leave it manually.",
-      );
-    });
+        expect(left.found).toBe(true);
+        expect(left.session.state).toBe("ended");
+        expect(left.browserLeft).toBe(false);
+        expect(left.session.notes).toContain(
+          "Could not find Meet's Leave call button in the reused browser tab; leave it manually.",
+        );
+      },
+    );
   });
 
   it("does not touch a reused tab after it moves to another meeting", async () => {
-    await withPlatform("darwin", async () => {
-      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState({
+    await withLocalChromeMeetSession(
+      {
         reused: true,
         tabUrlAfterJoin: "https://meet.google.com/xyz-abcd-efg?hl=en",
-      });
-      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
-      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
-        url: MEET_URL,
-      })) as { session: { id: string } };
+      },
+      async ({ callGatewayFromCli, methods, joined }) => {
+        const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+          sessionId: joined.session.id,
+        })) as { browserLeft?: boolean; session: { notes: string[] } };
 
-      const left = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
-        sessionId: joined.session.id,
-      })) as { browserLeft?: boolean; session: { notes: string[] } };
-
-      expect(left.browserLeft).toBe(true);
-      expect(left.session.notes).toContain(
-        "Meet tab moved away from this session; left its current page untouched.",
-      );
-      expect(
-        callGatewayFromCli.mock.calls.some((call) =>
-          String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
-        ),
-      ).toBe(true);
-      expect(
-        callGatewayFromCli.mock.calls.some(
-          (call) => (call[2] as { method?: string }).method === "DELETE",
-        ),
-      ).toBe(false);
-    });
+        expect(left.browserLeft).toBe(true);
+        expect(left.session.notes).toContain(
+          "Meet tab moved away from this session; left its current page untouched.",
+        );
+        expect(
+          callGatewayFromCli.mock.calls.some((call) =>
+            String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
+          ),
+        ).toBe(true);
+        expect(
+          callGatewayFromCli.mock.calls.some(
+            (call) => (call[2] as { method?: string }).method === "DELETE",
+          ),
+        ).toBe(false);
+      },
+    );
   });
 
   it("does not leave the browser twice when an ended session is retried", async () => {
-    await withPlatform("darwin", async () => {
-      const callGatewayFromCli = mockLocalMeetBrowserRequestWithTabState({ reused: true });
-      const { methods } = setup({ defaultMode: "transcribe", defaultTransport: "chrome" });
-      const joined = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.join", {
-        url: MEET_URL,
-      })) as { session: { id: string } };
+    await withLocalChromeMeetSession(
+      { reused: true },
+      async ({ callGatewayFromCli, methods, joined }) => {
+        const first = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+          sessionId: joined.session.id,
+        })) as { browserLeft?: boolean };
+        const second = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
+          sessionId: joined.session.id,
+        })) as { browserLeft?: boolean };
 
-      const first = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
-        sessionId: joined.session.id,
-      })) as { browserLeft?: boolean };
-      const second = (await invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.leave", {
-        sessionId: joined.session.id,
-      })) as { browserLeft?: boolean };
-
-      expect(first.browserLeft).toBe(true);
-      expect(second.browserLeft).toBe(true);
-      const leaveCalls = callGatewayFromCli.mock.calls.filter((call) =>
-        String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
-      );
-      expect(leaveCalls).toHaveLength(2);
-    });
+        expect(first.browserLeft).toBe(true);
+        expect(second.browserLeft).toBe(true);
+        const leaveCalls = callGatewayFromCli.mock.calls.filter((call) =>
+          String((call[2] as { body?: { fn?: string } }).body?.fn).includes("leaveAction"),
+        );
+        expect(leaveCalls).toHaveLength(2);
+      },
+    );
   });
 
   it("meet leave script clicks the enabled Leave call button", async () => {
@@ -6365,12 +6300,7 @@ describe("google-meet plugin", () => {
 
   it("uses realtime transcription plus regular TTS in Chrome agent mode", async () => {
     vi.useFakeTimers();
-    let callbacks: Parameters<RealtimeTranscriptionProviderPlugin["createSession"]>[0] | undefined;
-    const { provider, sendAudio } = createTestMeetTranscriptionProvider({
-      onCreateSession: (request) => {
-        callbacks = request;
-      },
-    });
+    const { provider, requireRequest, sendAudio } = createTestMeetTranscriptionProvider();
     const inputStdout = new PassThrough();
     const outputStdinWrites: Buffer[] = [];
     const outputStdin = new Writable({
@@ -6421,12 +6351,13 @@ describe("google-meet plugin", () => {
       providers: [provider],
       spawn: spawnMock,
     });
+    const callbacks = requireRequest();
 
     expect(noopLogger.info).toHaveBeenCalledWith(
       "[google-meet] agent audio bridge starting: transcriptionProvider=openai transcriptionModel=gpt-4o-transcribe tts=telephony audioFormat=pcm16-24khz",
     );
     inputStdout.write(Buffer.from([1, 0, 2, 0, 3, 0, 4, 0]));
-    callbacks?.onTranscript?.("Please summarize the launch.");
+    callbacks.onTranscript?.("Please summarize the launch.");
     await vi.advanceTimersByTimeAsync(TEST_TALKBACK_DEBOUNCE_MS);
 
     expect(sendAudio).toHaveBeenCalledTimes(1);
@@ -6470,12 +6401,7 @@ describe("google-meet plugin", () => {
 
   it("closes output and turn lifecycle when agent audio delivery fails", async () => {
     vi.useFakeTimers();
-    let callbacks: Parameters<RealtimeTranscriptionProviderPlugin["createSession"]>[0] | undefined;
-    const { provider } = createTestMeetTranscriptionProvider({
-      onCreateSession: (request) => {
-        callbacks = request;
-      },
-    });
+    const { provider, requireRequest } = createTestMeetTranscriptionProvider();
     const { transport, writeOutput } = createTestMeetRealtimeAudioTransport();
     writeOutput.mockRejectedValueOnce(new Error("audio sink failed"));
     const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
@@ -6506,8 +6432,9 @@ describe("google-meet plugin", () => {
       providers: [provider],
       consultAgent: async () => ({ text: "Answer from the agent." }),
     });
+    const callbacks = requireRequest();
 
-    callbacks?.onTranscript?.("Question from the meeting.");
+    callbacks.onTranscript?.("Question from the meeting.");
     await vi.advanceTimersByTimeAsync(TEST_TALKBACK_DEBOUNCE_MS);
     await vi.waitFor(() => {
       expect(logger.warn).toHaveBeenCalledWith("[google-meet] agent TTS failed: audio sink failed");
@@ -6654,15 +6581,11 @@ describe("google-meet plugin", () => {
   });
 
   it("pipes Chrome command-pair audio through the realtime provider", async () => {
-    let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
-    const { bridge, provider, sendAudio } = createTestMeetVoiceProvider({
+    const { bridge, provider, requireRequest, sendAudio } = createTestMeetVoiceProvider({
       defaultModel: "gpt-realtime-2",
       supportsToolResultContinuation: true,
       handleBargeIn: vi.fn(),
       triggerGreeting: vi.fn(),
-      onCreateBridge: (request) => {
-        callbacks = request;
-      },
     });
     const inputStdout = new PassThrough();
     const outputStdinWrites: Buffer[] = [];
@@ -6719,32 +6642,33 @@ describe("google-meet plugin", () => {
       providers: [provider],
       spawn: spawnMock,
     });
+    const callbacks = requireRequest();
 
     expect(noopLogger.info).toHaveBeenCalledWith(
       "[google-meet] realtime voice bridge starting: strategy=bidi provider=openai model=gpt-realtime audioFormat=pcm16-24khz",
     );
-    expect(callbacks?.cfg).toBe(fullConfig);
+    expect(callbacks.cfg).toBe(fullConfig);
     inputStdout.write(Buffer.from([1, 2, 3]));
-    callbacks?.onAudio(Buffer.from([4, 5]));
+    callbacks.onAudio(Buffer.from([4, 5]));
     await vi.waitFor(() => {
       expect(outputStdinWrites).toEqual([Buffer.from([4, 5])]);
     });
-    callbacks?.onMark?.("mark-1");
-    callbacks?.onClearAudio();
+    callbacks.onMark?.("mark-1");
+    callbacks.onClearAudio();
     await vi.waitFor(() => {
       expect(outputProcess.kill).toHaveBeenCalledWith("SIGKILL");
     });
-    callbacks?.onReady?.();
-    callbacks?.onTranscript?.("assistant", "How can I help you?", true);
-    callbacks?.onTranscript?.("user", "Please summarize the launch.", true);
-    callbacks?.onEvent?.({ direction: "client", type: "response.create" });
-    callbacks?.onEvent?.({
+    callbacks.onReady?.();
+    callbacks.onTranscript?.("assistant", "How can I help you?", true);
+    callbacks.onTranscript?.("user", "Please summarize the launch.", true);
+    callbacks.onEvent?.({ direction: "client", type: "response.create" });
+    callbacks.onEvent?.({
       direction: "server",
       type: "response.done",
       detail: "status=completed",
     });
-    callbacks?.onAudio(Buffer.from([6, 7]));
-    callbacks?.onToolCall?.({
+    callbacks.onAudio(Buffer.from([6, 7]));
+    callbacks.onToolCall?.({
       itemId: "item-1",
       callId: "tool-call-1",
       name: "openclaw_agent_consult",
@@ -6800,9 +6724,6 @@ describe("google-meet plugin", () => {
     expect(health.recentRealtimeEvents?.[1]?.direction).toBe("server");
     expect(health.recentRealtimeEvents?.[1]?.type).toBe("response.done");
     expect(health.recentRealtimeEvents?.[1]?.detail).toBe("status=completed");
-    if (!callbacks) {
-      throw new Error("Expected realtime bridge callbacks");
-    }
     expect(callbacks.audioFormat).toStrictEqual({
       encoding: "pcm16",
       sampleRateHz: 24000,
@@ -6908,15 +6829,11 @@ describe("google-meet plugin", () => {
   it("defaults Chrome command-pair realtime to agent-driven talk-back", async () => {
     vi.useFakeTimers();
     try {
-      let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
       const sendUserMessage = vi.fn();
-      const { provider } = createTestMeetVoiceProvider({
+      const { provider, requireRequest } = createTestMeetVoiceProvider({
         defaultModel: "gpt-realtime-2",
         sendUserMessage,
         triggerGreeting: vi.fn(),
-        onCreateBridge: (request) => {
-          callbacks = request;
-        },
       });
       const inputStdout = new PassThrough();
       const outputProcess = testBridgeProcess({
@@ -6958,10 +6875,8 @@ describe("google-meet plugin", () => {
         providers: [provider],
         spawn: spawnMock,
       });
+      const callbacks = requireRequest();
 
-      if (!callbacks) {
-        throw new Error("Expected realtime bridge callbacks");
-      }
       expect(callbacks.autoRespondToAudio).toBe(false);
       expect(callbacks.tools).toStrictEqual([]);
       callbacks.onTranscript?.(
@@ -6978,8 +6893,8 @@ describe("google-meet plugin", () => {
       expect(runtime.agent.runEmbeddedAgent).not.toHaveBeenCalled();
 
       callbacks.onTranscript?.("user", "yes yes yes yes", true);
-      callbacks?.onTranscript?.("user", "Are we still on track?", true);
-      callbacks?.onTranscript?.("user", "Please include launch blockers.", true);
+      callbacks.onTranscript?.("user", "Are we still on track?", true);
+      callbacks.onTranscript?.("user", "Please include launch blockers.", true);
 
       await vi.advanceTimersByTimeAsync(TEST_TALKBACK_DEBOUNCE_MS);
       await vi.waitFor(() => {
@@ -7013,13 +6928,9 @@ describe("google-meet plugin", () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(1_000);
-      let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
-      const { bridge, provider } = createTestMeetVoiceProvider({
+      const { bridge, provider, requireRequest } = createTestMeetVoiceProvider({
         sendUserMessage: vi.fn(),
         triggerGreeting: vi.fn(),
-        onCreateBridge: (request) => {
-          callbacks = request;
-        },
       });
       const audioTransport = createTestMeetRealtimeAudioTransport();
       const config = resolveGoogleMeetConfig({
@@ -7040,9 +6951,7 @@ describe("google-meet plugin", () => {
         providers: [provider],
         transport: audioTransport.transport,
       });
-      if (!callbacks) {
-        throw new Error("Expected realtime bridge callbacks");
-      }
+      const callbacks = requireRequest();
 
       callbacks.onAudio(Buffer.alloc(48_000));
       vi.setSystemTime(1_100);
@@ -7066,16 +6975,8 @@ describe("google-meet plugin", () => {
   });
 
   it("uses a local barge-in input command to clear active Chrome playback", async () => {
-    let callbacks:
-      | {
-          onAudio: (audio: Buffer) => void;
-        }
-      | undefined;
-    const { bridge, provider, sendAudio } = createTestMeetVoiceProvider({
+    const { bridge, provider, requireRequest, sendAudio } = createTestMeetVoiceProvider({
       handleBargeIn: vi.fn(),
-      onCreateBridge: (request) => {
-        callbacks = request;
-      },
     });
     const inputStdout = new PassThrough();
     const bargeInStdout = new PassThrough();
@@ -7122,8 +7023,9 @@ describe("google-meet plugin", () => {
       providers: [provider],
       spawn: spawnMock,
     });
+    const callbacks = requireRequest();
 
-    callbacks?.onAudio(Buffer.alloc(48_000));
+    callbacks.onAudio(Buffer.alloc(48_000));
     inputStdout.write(Buffer.from([1, 2, 3, 4]));
     bargeInStdout.write(Buffer.from([0xff, 0x7f, 0xff, 0x7f]));
 
@@ -7146,13 +7048,9 @@ describe("google-meet plugin", () => {
   });
 
   it("pipes paired-node command-pair audio through the realtime provider", async () => {
-    let callbacks: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
-    const { bridge, provider, sendAudio } = createTestMeetVoiceProvider({
+    const { bridge, provider, requireRequest, sendAudio } = createTestMeetVoiceProvider({
       supportsToolResultContinuation: true,
       triggerGreeting: vi.fn(),
-      onCreateBridge: (request) => {
-        callbacks = request;
-      },
     });
     let pullCount = 0;
     let idlePullStarted = false;
@@ -7204,27 +7102,28 @@ describe("google-meet plugin", () => {
       logger: noopLogger,
       providers: [provider],
     });
+    const callbacks = requireRequest();
 
     expect(noopLogger.info).toHaveBeenCalledWith(
       "[google-meet] realtime voice bridge starting: strategy=bidi provider=openai model=gpt-realtime audioFormat=pcm16-24khz",
     );
-    expect(callbacks?.cfg).toBe(fullConfig);
-    callbacks?.onAudio(Buffer.from([1, 2, 3]));
+    expect(callbacks.cfg).toBe(fullConfig);
+    callbacks.onAudio(Buffer.from([1, 2, 3]));
     await vi.waitFor(() => {
       const pushCall = runtime.nodes.invoke.mock.calls
         .map(([call]) => call)
         .find((call) => isRecord(call.params) && call.params.action === "pushAudio");
       expect(pushCall).toBeDefined();
     });
-    callbacks?.onClearAudio();
-    callbacks?.onReady?.();
-    callbacks?.onTranscript?.("assistant", "How can I help from the node?", true);
-    callbacks?.onEvent?.({
+    callbacks.onClearAudio();
+    callbacks.onReady?.();
+    callbacks.onTranscript?.("assistant", "How can I help from the node?", true);
+    callbacks.onEvent?.({
       direction: "server",
       type: "response.done",
       detail: "status=completed",
     });
-    callbacks?.onToolCall?.({
+    callbacks.onToolCall?.({
       itemId: "item-1",
       callId: "tool-call-1",
       name: "openclaw_agent_consult",
@@ -7278,9 +7177,6 @@ describe("google-meet plugin", () => {
     expect(bridge.triggerGreeting).not.toHaveBeenCalled();
     handle.speak("Say exactly: hello from the node.");
     expect(bridge.triggerGreeting).toHaveBeenLastCalledWith("Say exactly: hello from the node.");
-    if (!callbacks) {
-      throw new Error("Expected node realtime callbacks");
-    }
     expect(callbacks.audioFormat).toStrictEqual({
       encoding: "pcm16",
       sampleRateHz: 24000,

--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -677,9 +677,15 @@ type TwilioSetupCredentials = {
   fromNumber: string;
 };
 
-type SetupFullConfig = NonNullable<GoogleMeetSetupOptions["fullConfig"]>;
-type SetupPluginEntries = NonNullable<NonNullable<SetupFullConfig["plugins"]>["entries"]>;
-type TwilioVoiceCallEntry = SetupPluginEntries[string];
+type TwilioVoiceCallEntry = {
+  enabled: boolean;
+  config?: {
+    provider?: string;
+    publicUrl?: string;
+    fromNumber?: string;
+    twilio?: { accountSid?: string; authToken?: string };
+  };
+};
 
 async function runTwilioSetupStatus(params: {
   env?: TwilioSetupCredentials;

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -220,6 +220,52 @@ function getTelegramCallbackHandlerForTests() {
   return getOnHandler("callback_query") as (ctx: Record<string, unknown>) => Promise<void>;
 }
 
+function createTelegramPluginCallbackHandler(params: {
+  handler: TelegramInteractiveHandlerRegistration["handler"];
+  namespace?: string;
+  pluginId?: string;
+  config?: NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+}) {
+  registerPluginInteractiveHandler(params.pluginId ?? "codex-plugin", {
+    channel: "telegram",
+    namespace: params.namespace ?? "codexapp",
+    handler: params.handler,
+  });
+  createTelegramBot({
+    token: "tok",
+    config: params.config ?? {
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    },
+  });
+  return getTelegramCallbackHandlerForTests();
+}
+
+function createReplyPhotoMessage(text: string) {
+  return {
+    chat: { id: 7, type: "private" },
+    text,
+    date: 1_736_380_800,
+    reply_to_message: {
+      message_id: 9001,
+      photo: [{ file_id: "reply-photo-1" }],
+      from: { first_name: "Ada" },
+    },
+  };
+}
+
+async function dispatchTelegramReaction(params: {
+  updateId: number;
+  channelConfig: TelegramChannelConfig;
+  reaction?: Record<string, unknown>;
+}) {
+  mockTelegramConfig(params.channelConfig);
+  createTelegramBot({ token: "tok" });
+  const handler = getOnHandler("message_reaction") as (
+    ctx: Record<string, unknown>,
+  ) => Promise<void>;
+  await handler(createTelegramReactionContext(params));
+}
+
 const getEmptyTelegramFile = async () => ({
   download: async () => new Uint8Array(),
 });
@@ -3700,16 +3746,7 @@ describe("createTelegramBot", () => {
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
 
       await handler({
-        message: {
-          chat: { id: 7, type: "private" },
-          text: "what is in this image?",
-          date: 1736380800,
-          reply_to_message: {
-            message_id: 9001,
-            photo: [{ file_id: "reply-photo-1" }],
-            from: { first_name: "Ada" },
-          },
-        },
+        message: createReplyPhotoMessage("what is in this image?"),
         me: { username: "openclaw_bot" },
         getFile: async () => ({}),
       });
@@ -3766,16 +3803,7 @@ describe("createTelegramBot", () => {
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
 
       await handler({
-        message: {
-          chat: { id: 7, type: "private" },
-          text: "continue without the old image",
-          date: 1736380800,
-          reply_to_message: {
-            message_id: 9001,
-            photo: [{ file_id: "reply-photo-1" }],
-            from: { first_name: "Ada" },
-          },
-        },
+        message: createReplyPhotoMessage("continue without the old image"),
         me: { username: "openclaw_bot" },
         getFile: async () => ({}),
       });
@@ -3802,16 +3830,7 @@ describe("createTelegramBot", () => {
 
     const { result } = await runWithTelegramUpdateProcessingFrame(() =>
       handler({
-        message: {
-          chat: { id: 7, type: "private" },
-          text: "continue after polling restart",
-          date: 1736380800,
-          reply_to_message: {
-            message_id: 9001,
-            photo: [{ file_id: "reply-photo-1" }],
-            from: { first_name: "Ada" },
-          },
-        },
+        message: createReplyPhotoMessage("continue after polling restart"),
         me: { username: "openclaw_bot" },
         getFile: async () => ({}),
       }),
@@ -3838,19 +3857,7 @@ describe("createTelegramBot", () => {
       mediaAbortSignal: mediaAbort.signal,
     });
     const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-    const update = {
-      update_id: 98081,
-      message: {
-        chat: { id: 7, type: "private" },
-        text: "keep the old image",
-        date: 1736380800,
-        reply_to_message: {
-          message_id: 9001,
-          photo: [{ file_id: "reply-photo-1" }],
-          from: { first_name: "Ada" },
-        },
-      },
-    };
+    const update = { update_id: 98081, message: createReplyPhotoMessage("keep the old image") };
 
     const { result } = await runWithTelegramUpdateProcessingFrame(() =>
       withTelegramSpooledReplayUpdate(update, () =>
@@ -4822,9 +4829,7 @@ describe("createTelegramBot", () => {
   });
 
   it("routes plugin-owned callback namespaces before synthetic command fallback", async () => {
-    registerPluginInteractiveHandler("codex-plugin", {
-      channel: "telegram",
-      namespace: "codexapp",
+    const callbackHandler = createTelegramPluginCallbackHandler({
       handler: (async ({ respond, callback }: TelegramInteractiveHandlerContext) => {
         await respond.editMessage({
           text: `Handled ${callback.payload}`,
@@ -4833,21 +4838,8 @@ describe("createTelegramBot", () => {
       }) as never,
     });
 
-    createTelegramBot({
-      token: "tok",
-      config: {
-        channels: {
-          telegram: {
-            dmPolicy: "open",
-            allowFrom: ["*"],
-          },
-        },
-      },
-    });
-    const callbackHandler = getTelegramCallbackHandlerForTests();
-
-    await callbackHandler({
-      callbackQuery: makeCallbackQuery({
+    await callbackHandler(
+      createTelegramCallbackContext({
         id: "cbq-codex-1",
         data: "codexapp:resume:thread-1",
         message: {
@@ -4856,9 +4848,7 @@ describe("createTelegramBot", () => {
           text: "Select a thread",
         },
       }),
-      me: { username: "openclaw_bot" },
-      getFile: getEmptyTelegramFile,
-    });
+    );
 
     expect(editMessageTextSpy).toHaveBeenCalledWith(1234, 11, "Handled resume:thread-1", {
       business_connection_id: "biz-1",
@@ -4867,30 +4857,15 @@ describe("createTelegramBot", () => {
   });
 
   it("deletes plugin-owned callback messages through the bot API", async () => {
-    registerPluginInteractiveHandler("codex-plugin", {
-      channel: "telegram",
-      namespace: "codexapp",
+    const callbackHandler = createTelegramPluginCallbackHandler({
       handler: (async ({ respond }: TelegramInteractiveHandlerContext) => {
         await respond.deleteMessage();
         return { handled: true };
       }) as never,
     });
 
-    createTelegramBot({
-      token: "tok",
-      config: {
-        channels: {
-          telegram: {
-            dmPolicy: "open",
-            allowFrom: ["*"],
-          },
-        },
-      },
-    });
-    const callbackHandler = getTelegramCallbackHandlerForTests();
-
-    await callbackHandler({
-      callbackQuery: makeCallbackQuery({
+    await callbackHandler(
+      createTelegramCallbackContext({
         id: "cbq-codex-delete",
         data: "codexapp:delete:thread-1",
         message: {
@@ -4898,39 +4873,22 @@ describe("createTelegramBot", () => {
           text: "Select a thread",
         },
       }),
-      me: { username: "openclaw_bot" },
-      getFile: getEmptyTelegramFile,
-    });
+    );
 
     expect(deleteMessageSpy).toHaveBeenCalledWith(1234, 11);
     expect(replySpy).not.toHaveBeenCalled();
   });
 
   it("routes plugin-owned callback replies with Telegram topic params", async () => {
-    registerPluginInteractiveHandler("codex-plugin", {
-      channel: "telegram",
-      namespace: "codexapp",
+    const callbackHandler = createTelegramPluginCallbackHandler({
       handler: (async ({ respond }: TelegramInteractiveHandlerContext) => {
         await respond.reply({ text: "Handled in topic" });
         return { handled: true };
       }) as never,
     });
 
-    createTelegramBot({
-      token: "tok",
-      config: {
-        channels: {
-          telegram: {
-            dmPolicy: "open",
-            allowFrom: ["*"],
-          },
-        },
-      },
-    });
-    const callbackHandler = getTelegramCallbackHandlerForTests();
-
-    await callbackHandler({
-      callbackQuery: makeCallbackQuery({
+    await callbackHandler(
+      createTelegramCallbackContext({
         id: "cbq-codex-topic-reply",
         data: "codexapp:reply:thread-1",
         message: {
@@ -4942,9 +4900,7 @@ describe("createTelegramBot", () => {
           text: "Select a thread",
         },
       }),
-      me: { username: "openclaw_bot" },
-      getFile: getEmptyTelegramFile,
-    });
+    );
 
     expect(sendMessageSpy).toHaveBeenCalledWith(-100987654321, "Handled in topic", {
       business_connection_id: "biz-topic-1",
@@ -4952,8 +4908,8 @@ describe("createTelegramBot", () => {
     });
 
     sendMessageSpy.mockClear();
-    await callbackHandler({
-      callbackQuery: makeCallbackQuery({
+    await callbackHandler(
+      createTelegramCallbackContext({
         id: "cbq-codex-general-reply",
         data: "codexapp:reply:thread-1",
         message: {
@@ -4964,9 +4920,7 @@ describe("createTelegramBot", () => {
           text: "Select a thread",
         },
       }),
-      me: { username: "openclaw_bot" },
-      getFile: getEmptyTelegramFile,
-    });
+    );
 
     expect(sendMessageSpy).toHaveBeenCalledWith(-100987654322, "Handled in topic", undefined);
     expect(replySpy).not.toHaveBeenCalled();
@@ -4974,29 +4928,16 @@ describe("createTelegramBot", () => {
 
   it("submits plugin-owned callback text through the Telegram inbound path", async () => {
     const replyDone = waitForReplyCalls(1);
-    registerPluginInteractiveHandler("smart-replies-plugin", {
-      channel: "telegram",
-      namespace: "openclaw-smart-replies",
-      handler: async () => ({ handled: true, submitText: "Fix a broken tool" }),
-    } satisfies TelegramInteractiveHandlerRegistration);
     setTelegramPluginStateRuntimeForTests();
 
     try {
-      createTelegramBot({
-        token: "tok",
-        config: {
-          channels: {
-            telegram: {
-              dmPolicy: "open",
-              allowFrom: ["*"],
-            },
-          },
-        },
+      const callbackHandler = createTelegramPluginCallbackHandler({
+        pluginId: "smart-replies-plugin",
+        namespace: "openclaw-smart-replies",
+        handler: async () => ({ handled: true, submitText: "Fix a broken tool" }),
       });
-      const callbackHandler = getTelegramCallbackHandlerForTests();
-
-      await callbackHandler({
-        callbackQuery: makeCallbackQuery({
+      await callbackHandler(
+        createTelegramCallbackContext({
           id: "cbq-smart-reply-submit",
           data: "openclaw-smart-replies:v1:Rm14IGEgYnJva2VuIHRvb2w",
           message: {
@@ -5005,9 +4946,7 @@ describe("createTelegramBot", () => {
             text: "What should I help you sharpen next?",
           },
         }),
-        me: { username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-      });
+      );
       await replyDone;
     } finally {
       clearTelegramRuntime();
@@ -5025,29 +4964,16 @@ describe("createTelegramBot", () => {
 
   it("does not submit plugin-owned callback text when the handler declines the callback", async () => {
     const handler = vi.fn(async () => ({ handled: false, submitText: "Ignore this" }));
-    registerPluginInteractiveHandler("smart-replies-plugin", {
-      channel: "telegram",
-      namespace: "openclaw-smart-replies",
-      handler,
-    } satisfies TelegramInteractiveHandlerRegistration);
     setTelegramPluginStateRuntimeForTests();
 
     try {
-      createTelegramBot({
-        token: "tok",
-        config: {
-          channels: {
-            telegram: {
-              dmPolicy: "open",
-              allowFrom: ["*"],
-            },
-          },
-        },
+      const callbackHandler = createTelegramPluginCallbackHandler({
+        pluginId: "smart-replies-plugin",
+        namespace: "openclaw-smart-replies",
+        handler,
       });
-      const callbackHandler = getTelegramCallbackHandlerForTests();
-
-      await callbackHandler({
-        callbackQuery: makeCallbackQuery({
+      await callbackHandler(
+        createTelegramCallbackContext({
           id: "cbq-smart-reply-declined-submit",
           data: "openclaw-smart-replies:v1:SWdub3JlIHRoaXM",
           message: {
@@ -5056,9 +4982,7 @@ describe("createTelegramBot", () => {
             text: "Pick a direction",
           },
         }),
-        me: { username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-      });
+      );
     } finally {
       clearTelegramRuntime();
     }
@@ -5082,16 +5006,12 @@ describe("createTelegramBot", () => {
       });
       return { handled: true, submitText: "Do not submit this" };
     });
-    registerPluginInteractiveHandler("smart-replies-plugin", {
-      channel: "telegram",
-      namespace: "openclaw-smart-replies",
-      handler,
-    } satisfies TelegramInteractiveHandlerRegistration);
     setTelegramPluginStateRuntimeForTests();
-
     try {
-      createTelegramBot({
-        token: "tok",
+      const callbackHandler = createTelegramPluginCallbackHandler({
+        pluginId: "smart-replies-plugin",
+        namespace: "openclaw-smart-replies",
+        handler,
         config: {
           channels: {
             telegram: {
@@ -5102,21 +5022,15 @@ describe("createTelegramBot", () => {
           },
         },
       });
-      const callbackHandler = getTelegramCallbackHandlerForTests();
-
-      const callbackContext = {
-        callbackQuery: makeCallbackQuery({
-          id: "cbq-smart-reply-policy-skip",
-          data: "openclaw-smart-replies:v1:RG8gbm90IHN1Ym1pdCB0aGlz",
-          message: {
-            chat: { id: 9, type: "private" },
-            message_id: 11,
-            text: "Pick a direction",
-          },
-        }),
-        me: { username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-      };
+      const callbackContext = createTelegramCallbackContext({
+        id: "cbq-smart-reply-policy-skip",
+        data: "openclaw-smart-replies:v1:RG8gbm90IHN1Ym1pdCB0aGlz",
+        message: {
+          chat: { id: 9, type: "private" },
+          message_id: 11,
+          text: "Pick a direction",
+        },
+      });
 
       await expect(callbackHandler(callbackContext)).resolves.toBeUndefined();
       await expect(callbackHandler(callbackContext)).resolves.toBeUndefined();
@@ -5131,16 +5045,12 @@ describe("createTelegramBot", () => {
 
   it("submits plugin-owned callback text in mention-required group topics", async () => {
     const replyDone = waitForReplyCalls(1);
-    registerPluginInteractiveHandler("smart-replies-plugin", {
-      channel: "telegram",
-      namespace: "openclaw-smart-replies",
-      handler: async () => ({ handled: true, submitText: "Investigate topic callback" }),
-    } satisfies TelegramInteractiveHandlerRegistration);
     setTelegramPluginStateRuntimeForTests();
-
     try {
-      createTelegramBot({
-        token: "tok",
+      const callbackHandler = createTelegramPluginCallbackHandler({
+        pluginId: "smart-replies-plugin",
+        namespace: "openclaw-smart-replies",
+        handler: async () => ({ handled: true, submitText: "Investigate topic callback" }),
         config: {
           channels: {
             telegram: {
@@ -5153,10 +5063,8 @@ describe("createTelegramBot", () => {
           },
         },
       });
-      const callbackHandler = getTelegramCallbackHandlerForTests();
-
-      await callbackHandler({
-        callbackQuery: makeCallbackQuery({
+      await callbackHandler(
+        createTelegramCallbackContext({
           id: "cbq-smart-reply-topic-submit",
           data: "openclaw-smart-replies:v1:SW52ZXN0aWdhdGUgdG9waWMgY2FsbGJhY2s",
           message: {
@@ -5167,9 +5075,7 @@ describe("createTelegramBot", () => {
             text: "What should I help you sharpen next?",
           },
         }),
-        me: { username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
-      });
+      );
       await replyDone;
     } finally {
       clearTelegramRuntime();
@@ -5197,26 +5103,14 @@ describe("createTelegramBot", () => {
       }
       return undefined;
     });
-    registerPluginInteractiveHandler("smart-replies-plugin", {
-      channel: "telegram",
-      namespace: "openclaw-smart-replies",
-      handler: async () => ({ handled: true, submitText: "Make Alice funnier" }),
-    } satisfies TelegramInteractiveHandlerRegistration);
     setTelegramPluginStateRuntimeForTests();
 
     try {
-      createTelegramBot({
-        token: "tok",
-        config: {
-          channels: {
-            telegram: {
-              dmPolicy: "open",
-              allowFrom: ["*"],
-            },
-          },
-        },
+      const callbackHandler = createTelegramPluginCallbackHandler({
+        pluginId: "smart-replies-plugin",
+        namespace: "openclaw-smart-replies",
+        handler: async () => ({ handled: true, submitText: "Make Alice funnier" }),
       });
-      const callbackHandler = getTelegramCallbackHandlerForTests();
       const callbackQuery = makeCallbackQuery({
         id: "cbq-smart-reply-submit-retry",
         data: "openclaw-smart-replies:v1:TWFrZSBBbGljZSBmdW5uaWVy",
@@ -5267,29 +5161,17 @@ describe("createTelegramBot", () => {
       return undefined;
     });
     const handler = vi.fn(async () => ({ handled: true, submitText: "Try this later" }));
-    registerPluginInteractiveHandler("smart-replies-plugin", {
-      channel: "telegram",
-      namespace: "openclaw-smart-replies",
-      handler,
-    } satisfies TelegramInteractiveHandlerRegistration);
     setTelegramPluginStateRuntimeForTests();
 
     try {
-      createTelegramBot({
-        token: "tok",
-        config: {
-          channels: {
-            telegram: {
-              dmPolicy: "open",
-              allowFrom: ["*"],
-            },
-          },
-        },
+      const callbackHandler = createTelegramPluginCallbackHandler({
+        pluginId: "smart-replies-plugin",
+        namespace: "openclaw-smart-replies",
+        handler,
       });
-      const callbackHandler = getTelegramCallbackHandlerForTests();
       const createCallbackUpdate = (updateId: number) => ({
         update_id: updateId,
-        callbackQuery: makeCallbackQuery({
+        ...createTelegramCallbackContext({
           id: "cbq-smart-reply-submit-fail",
           data: "openclaw-smart-replies:v1:VHJ5IHRoaXMgbGF0ZXI",
           message: {
@@ -5298,8 +5180,6 @@ describe("createTelegramBot", () => {
             text: "Pick a direction",
           },
         }),
-        me: { username: "openclaw_bot" },
-        getFile: getEmptyTelegramFile,
       });
 
       await expect(callbackHandler(createCallbackUpdate(401))).rejects.toThrow(
@@ -5338,11 +5218,6 @@ describe("createTelegramBot", () => {
       observedAuth = auth;
       return { handled: true };
     });
-    registerPluginInteractiveHandler("codex-plugin", {
-      channel: "telegram",
-      namespace: "codexapp",
-      handler: handler as never,
-    });
 
     const config = {
       commands: {
@@ -5361,8 +5236,10 @@ describe("createTelegramBot", () => {
     } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
     loadConfig.mockReturnValue(config);
 
-    createTelegramBot({ token: "tok", config });
-    const callbackHandler = getTelegramCallbackHandlerForTests();
+    const callbackHandler = createTelegramPluginCallbackHandler({
+      handler: handler as never,
+      config,
+    });
 
     await callbackHandler(
       createTelegramCallbackContext({
@@ -5387,11 +5264,6 @@ describe("createTelegramBot", () => {
       observedAuth = auth;
       return { handled: true };
     });
-    registerPluginInteractiveHandler("codex-plugin", {
-      channel: "telegram",
-      namespace: "codexapp",
-      handler: handler as never,
-    });
 
     const config = {
       accessGroups: {
@@ -5410,11 +5282,13 @@ describe("createTelegramBot", () => {
     } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
     loadConfig.mockReturnValue(config);
 
-    createTelegramBot({ token: "tok", config });
-    const callbackHandler = getTelegramCallbackHandlerForTests();
+    const callbackHandler = createTelegramPluginCallbackHandler({
+      handler: handler as never,
+      config,
+    });
 
-    await callbackHandler({
-      callbackQuery: makeCallbackQuery({
+    await callbackHandler(
+      createTelegramCallbackContext({
         id: "cbq-plugin-access-group-auth",
         data: "codexapp:resume:thread-1",
         from: { id: 123456789, first_name: "Ada", username: "ada" },
@@ -5424,9 +5298,7 @@ describe("createTelegramBot", () => {
           text: "Select a thread",
         },
       }),
-      me: { username: "openclaw_bot" },
-      getFile: getEmptyTelegramFile,
-    });
+    );
 
     expect(handler).toHaveBeenCalledOnce();
     expect(observedAuth?.isAuthorizedSender).toBe(true);
@@ -5444,27 +5316,12 @@ describe("createTelegramBot", () => {
         return { handled: true };
       },
     );
-    registerPluginInteractiveHandler("codex-plugin", {
-      channel: "telegram",
-      namespace: "codexapp",
+    const callbackHandler = createTelegramPluginCallbackHandler({
       handler: handler as never,
     });
 
-    createTelegramBot({
-      token: "tok",
-      config: {
-        channels: {
-          telegram: {
-            dmPolicy: "open",
-            allowFrom: ["*"],
-          },
-        },
-      },
-    });
-    const callbackHandler = getTelegramCallbackHandlerForTests();
-
-    await callbackHandler({
-      callbackQuery: makeCallbackQuery({
+    await callbackHandler(
+      createTelegramCallbackContext({
         id: "cbq-codex-general",
         data: "codexapp:resume:thread-1",
         message: {
@@ -5473,9 +5330,7 @@ describe("createTelegramBot", () => {
           text: "Select a thread",
         },
       }),
-      me: { username: "openclaw_bot" },
-      getFile: getEmptyTelegramFile,
-    });
+    );
 
     expect(getChatSpy).toHaveBeenCalledWith(-100123456789);
     expect(handler).toHaveBeenCalledOnce();
@@ -5644,22 +5499,11 @@ describe("createTelegramBot", () => {
   });
 
   it("enqueues system event for reaction", async () => {
-    mockTelegramConfig({ dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 500 },
-      messageReaction: {
-        chat: { id: 1234, type: "private" },
-        message_id: 42,
+    await dispatchTelegramReaction({
+      updateId: 500,
+      channelConfig: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" },
+      reaction: {
         user: { id: 9, first_name: "Ada", username: "ada_bot" },
-        date: 1736380800,
-        old_reaction: [],
-        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
       },
     });
 
@@ -5822,14 +5666,7 @@ describe("createTelegramBot", () => {
         wasSentByBot.mockReturnValue(sentByBot);
       }
 
-      mockTelegramConfig(channelConfig);
-
-      createTelegramBot({ token: "tok" });
-      const handler = getOnHandler("message_reaction") as (
-        ctx: Record<string, unknown>,
-      ) => Promise<void>;
-
-      await handler(createTelegramReactionContext({ updateId, reaction }));
+      await dispatchTelegramReaction({ updateId, channelConfig, reaction });
 
       expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(expectedEnqueueCalls);
       if (expectedEvent) {
@@ -5840,20 +5677,10 @@ describe("createTelegramBot", () => {
   );
 
   it("enqueues one event per added emoji reaction", async () => {
-    mockTelegramConfig({ dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 505 },
-      messageReaction: {
-        chat: { id: 1234, type: "private" },
-        message_id: 42,
-        user: { id: 9, first_name: "Ada" },
-        date: 1736380800,
+    await dispatchTelegramReaction({
+      updateId: 505,
+      channelConfig: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" },
+      reaction: {
         old_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
         new_reaction: [
           { type: "emoji", emoji: THUMBS_UP_EMOJI },
@@ -5871,23 +5698,15 @@ describe("createTelegramBot", () => {
   });
 
   it("routes forum group reactions to the general topic (thread id not available on reactions)", async () => {
-    mockTelegramConfig({ dmPolicy: "open", reactionNotifications: "all" });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
     // MessageReactionUpdated does not include message_thread_id in the Bot API,
     // so forum reactions always route to the general topic (1).
-    await handler({
-      update: { update_id: 505 },
-      messageReaction: {
+    await dispatchTelegramReaction({
+      updateId: 505,
+      channelConfig: { dmPolicy: "open", reactionNotifications: "all" },
+      reaction: {
         chat: { id: 5678, type: "supergroup", is_forum: true },
         message_id: 100,
         user: { id: 10, first_name: "Bob", username: "bob_user" },
-        date: 1736380800,
-        old_reaction: [],
         new_reaction: [{ type: "emoji", emoji: FIRE_EMOJI }],
       },
     });
@@ -5901,22 +5720,14 @@ describe("createTelegramBot", () => {
   });
 
   it("uses correct session key for forum group reactions in general topic", async () => {
-    mockTelegramConfig({ dmPolicy: "open", reactionNotifications: "all" });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 506 },
-      messageReaction: {
+    await dispatchTelegramReaction({
+      updateId: 506,
+      channelConfig: { dmPolicy: "open", reactionNotifications: "all" },
+      reaction: {
         chat: { id: 5678, type: "supergroup", is_forum: true },
         message_id: 101,
         // No message_thread_id - should default to general topic (1)
         user: { id: 10, first_name: "Bob" },
-        date: 1736380800,
-        old_reaction: [],
         new_reaction: [{ type: "emoji", emoji: EYES_EMOJI }],
       },
     });
@@ -5928,21 +5739,13 @@ describe("createTelegramBot", () => {
   });
 
   it("uses correct session key for regular group reactions without topic", async () => {
-    mockTelegramConfig({ dmPolicy: "open", reactionNotifications: "all" });
-
-    createTelegramBot({ token: "tok" });
-    const handler = getOnHandler("message_reaction") as (
-      ctx: Record<string, unknown>,
-    ) => Promise<void>;
-
-    await handler({
-      update: { update_id: 507 },
-      messageReaction: {
+    await dispatchTelegramReaction({
+      updateId: 507,
+      channelConfig: { dmPolicy: "open", reactionNotifications: "all" },
+      reaction: {
         chat: { id: 9999, type: "group" },
         message_id: 200,
         user: { id: 11, first_name: "Charlie" },
-        date: 1736380800,
-        old_reaction: [],
         new_reaction: [{ type: "emoji", emoji: HEART_EMOJI }],
       },
     });

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -229,7 +229,7 @@ function createTelegramPluginCallbackHandler(params: {
   registerPluginInteractiveHandler(params.pluginId ?? "codex-plugin", {
     channel: "telegram",
     namespace: params.namespace ?? "codexapp",
-    handler: params.handler,
+    handler: params.handler as never,
   });
   createTelegramBot({
     token: "tok",

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -571,58 +571,45 @@ describe("web auto-reply connection", () => {
     },
   );
 
-  it("retries inbox attach when auth state is still stabilizing", async () => {
+  it.each([
+    ["retries inbox attach when auth state is still stabilizing", true, 3],
+    ["stops retrying inbox attach when auth stays unstable past max attempts", false, 2],
+  ] as const)("%s", async (_name, recovers, maxAttempts) => {
     const sleep = vi.fn(async () => {});
     const listenerFactory = vi.fn(async () => {
-      if (listenerFactory.mock.calls.length === 1) {
-        throw new WhatsAppAuthUnstableError(
-          "WhatsApp auth state is still stabilizing; retrying inbox attach.",
-        );
+      if (recovers && listenerFactory.mock.calls.length > 1) {
+        return createMockWebListener();
       }
-      return createMockWebListener();
+      throw new WhatsAppAuthUnstableError(
+        "WhatsApp auth state is still stabilizing; retrying inbox attach.",
+      );
     });
     const { runtime, controller, run } = startWebAutoReplyMonitor({
       monitorWebChannelFn: monitorWebChannel as never,
       listenerFactory,
       sleep,
-      reconnect: { initialMs: 5, maxMs: 5, maxAttempts: 3, factor: 1.1 },
+      reconnect: { initialMs: 5, maxMs: 5, maxAttempts, factor: 1.1 },
     });
 
-    await vi.waitFor(
-      () => {
-        expect(listenerFactory).toHaveBeenCalledTimes(2);
-      },
-      { timeout: 250, interval: 2 },
-    );
-
-    controller.abort();
-    await run;
-
-    expect(typeof mockCallArg(sleep, 0, 0)).toBe("number");
-    expect(mockCallArg(sleep, 0, 1)).toBeInstanceOf(AbortSignal);
-    expectErrorContaining(runtime.error, "inbox attach");
-  });
-
-  it("stops retrying inbox attach when auth stays unstable past max attempts", async () => {
-    const sleep = vi.fn(async () => {});
-    const listenerFactory = vi.fn(async () => {
-      throw new WhatsAppAuthUnstableError(
-        "WhatsApp auth state is still stabilizing; retrying inbox attach.",
-      );
-    });
-    const { runtime, run } = startWebAutoReplyMonitor({
-      monitorWebChannelFn: monitorWebChannel as never,
-      listenerFactory,
-      sleep,
-      reconnect: { initialMs: 5, maxMs: 5, maxAttempts: 2, factor: 1.1 },
-    });
-
+    if (recovers) {
+      await vi.waitFor(() => expect(listenerFactory).toHaveBeenCalledTimes(2), {
+        timeout: 250,
+        interval: 2,
+      });
+      controller.abort();
+    }
     await run;
 
     expect(listenerFactory).toHaveBeenCalledTimes(2);
-    expect(sleep).toHaveBeenCalledTimes(1);
-    expectErrorContaining(runtime.error, "Retry 1/2");
-    expectErrorContaining(runtime.error, "Stopping web monitoring");
+    if (recovers) {
+      expect(typeof mockCallArg(sleep, 0, 0)).toBe("number");
+      expect(mockCallArg(sleep, 0, 1)).toBeInstanceOf(AbortSignal);
+      expectErrorContaining(runtime.error, "inbox attach");
+    } else {
+      expect(sleep).toHaveBeenCalledTimes(1);
+      expectErrorContaining(runtime.error, "Retry 1/2");
+      expectErrorContaining(runtime.error, "Stopping web monitoring");
+    }
   });
 
   type WatchdogCaseContext = {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -906,45 +906,33 @@ describe("whatsapp inbound dispatch", () => {
     expect(ctx.To).toBe("+2000");
   });
 
-  it("passes groupSystemPrompt into GroupSystemPrompt for group chats", async () => {
+  it.each([
+    [
+      "passes groupSystemPrompt into GroupSystemPrompt for group chats",
+      true,
+      "Specific group prompt",
+    ],
+    [
+      "passes groupSystemPrompt into GroupSystemPrompt for direct chats",
+      false,
+      "Specific direct prompt",
+    ],
+    ["omits GroupSystemPrompt when groupSystemPrompt is not provided", true, undefined],
+  ] as const)("%s", async (_name, isGroup, groupSystemPrompt) => {
+    const kind = isGroup ? "group" : "direct";
+    const conversationId = isGroup ? "123@g.us" : "+1555";
     const ctx = await buildWhatsAppInboundContext({
       combinedBody: "hi",
-      groupSystemPrompt: "Specific group prompt",
+      ...(groupSystemPrompt === undefined ? {} : { groupSystemPrompt }),
       msg: makeMsg({
-        admission: groupAdmission("123@g.us"),
-        group: { participants: [] },
+        admission: isGroup ? groupAdmission(conversationId) : directAdmission(conversationId),
+        ...(isGroup ? { group: { participants: [] } } : {}),
       }),
-      route: makeRoute({ sessionKey: "agent:main:whatsapp:group:123@g.us" }),
-      sender: { e164: "+15550002222" },
+      route: makeRoute({ sessionKey: `agent:main:whatsapp:${kind}:${conversationId}` }),
+      sender: { e164: isGroup ? "+15550002222" : conversationId },
     });
 
-    expect(ctx.GroupSystemPrompt).toBe("Specific group prompt");
-  });
-
-  it("passes groupSystemPrompt into GroupSystemPrompt for direct chats", async () => {
-    const ctx = await buildWhatsAppInboundContext({
-      combinedBody: "hi",
-      groupSystemPrompt: "Specific direct prompt",
-      msg: makeMsg({ admission: directAdmission("+1555") }),
-      route: makeRoute({ sessionKey: "agent:main:whatsapp:direct:+1555" }),
-      sender: { e164: "+1555" },
-    });
-
-    expect(ctx.GroupSystemPrompt).toBe("Specific direct prompt");
-  });
-
-  it("omits GroupSystemPrompt when groupSystemPrompt is not provided", async () => {
-    const ctx = await buildWhatsAppInboundContext({
-      combinedBody: "hi",
-      msg: makeMsg({
-        admission: groupAdmission("123@g.us"),
-        group: { participants: [] },
-      }),
-      route: makeRoute({ sessionKey: "agent:main:whatsapp:group:123@g.us" }),
-      sender: { e164: "+15550002222" },
-    });
-
-    expect(ctx.GroupSystemPrompt).toBeUndefined();
+    expect(ctx.GroupSystemPrompt).toBe(groupSystemPrompt);
   });
 
   it("preserves reply threading policy in the inbound context", async () => {

--- a/extensions/whatsapp/src/monitor-inbox.reply-context.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.reply-context.test.ts
@@ -249,27 +249,16 @@ describe("web monitor inbox reply context", () => {
     await listener.close();
   });
 
-  it("captures reply context from wrapped quoted messages", async () => {
+  it.each([
+    ["captures reply context from wrapped quoted messages", "viewOnceMessageV2Extension"],
+    ["captures reply context from botInvokeMessage wrapped quoted messages", "botInvokeMessage"],
+    [
+      "captures reply context from groupMentionedMessage wrapped quoted messages",
+      "groupMentionedMessage",
+    ],
+  ])("%s", async (_name, wrapper) => {
     await expectQuotedReplyContext({
-      viewOnceMessageV2Extension: {
-        message: { conversation: "original" },
-      },
-    });
-  });
-
-  it("captures reply context from botInvokeMessage wrapped quoted messages", async () => {
-    await expectQuotedReplyContext({
-      botInvokeMessage: {
-        message: { conversation: "original" },
-      },
-    });
-  });
-
-  it("captures reply context from groupMentionedMessage wrapped quoted messages", async () => {
-    await expectQuotedReplyContext({
-      groupMentionedMessage: {
-        message: { conversation: "original" },
-      },
+      [wrapper]: { message: { conversation: "original" } },
     });
   });
 });

--- a/extensions/whatsapp/src/monitor-inbox.socket-lifecycle.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.socket-lifecycle.test.ts
@@ -33,6 +33,61 @@ function createAcceptedSendMessageMock() {
   }));
 }
 
+type SuccessorIdentity = {
+  jid: string | null;
+  lid: string | null;
+  e164?: string;
+};
+
+async function primeCapturedReplyWithSuccessor(params: {
+  upsertId: string;
+  acceptedMessageId: string;
+  identity: SuccessorIdentity;
+}) {
+  const onMessage = vi.fn(async () => undefined);
+  const socketRef = createSocketRef();
+  let shouldRetryDisconnect = true;
+  const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+    socketRef,
+    shouldRetryDisconnect: () => shouldRetryDisconnect,
+    disconnectRetryPolicy: fastReconnectPolicy(1),
+  });
+
+  sock.ev.emit(
+    "messages.upsert",
+    buildNotifyMessageUpsert({
+      id: nextMessageId(params.upsertId),
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    }),
+  );
+  await waitForMessageCalls(onMessage, 1);
+  const inbound = inboundMessage(onMessage);
+
+  // Model the health monitor replacing controller A while its captured reply remains live.
+  socketRef.current = null;
+  shouldRetryDisconnect = false;
+  const successorSock = {
+    sendMessage: vi.fn(async () => ({ key: { id: params.acceptedMessageId } })),
+  };
+  controllerContexts.set(DEFAULT_ACCOUNT_ID, {
+    getActiveListener: () => null,
+    getCurrentSock: () => successorSock as never,
+    getSelfIdentity: () => params.identity,
+  } as never);
+
+  return {
+    inbound,
+    successorSock,
+    close: async () => {
+      controllerContexts.delete(DEFAULT_ACCOUNT_ID);
+      await listener.close();
+    },
+  };
+}
+
 describe("web monitor inbox socket lifecycle", () => {
   installStreamsInboundMessageHooks();
 
@@ -562,193 +617,65 @@ describe("web monitor inbox socket lifecycle", () => {
     await listener.close();
   });
 
-  // VE-513: when the gateway's channel-health-monitor tears down controller A
-  // mid-run (shutdown nulls A.socketRef and aborts A.disconnectRetries), then a
-  // fresh controller B registers for the same accountId, an in-flight inbound's
-  // captured reply closure must route through B's socket via the registry instead
-  // of throwing RECONNECT_IN_PROGRESS. Before the registry fallback was added,
-  // sendTrackedMessage only knew its own controller's socketRef and the captured
-  // reply was permanently broken.
-
   it("socket session routes captured replies through a matching successor", async () => {
-    const onMessage = vi.fn(async () => undefined);
-    const socketRefA = createSocketRef();
-
-    let aShouldRetryDisconnect = true;
-    const { listener: listenerA, sock: sockA } = await startInboxMonitor(
-      onMessage as InboxOnMessage,
-      {
-        socketRef: socketRefA,
-        shouldRetryDisconnect: () => aShouldRetryDisconnect,
-        disconnectRetryPolicy: fastReconnectPolicy(1),
-      },
-    );
-
-    sockA.ev.emit(
-      "messages.upsert",
-      buildNotifyMessageUpsert({
-        id: nextMessageId("outbound-successor"),
-        remoteJid: "999@s.whatsapp.net",
-        text: "ping",
-        timestamp: 1_700_000_000,
-        pushName: "Tester",
-      }),
-    );
-    await waitForMessageCalls(onMessage, 1);
-    const inbound = inboundMessage(onMessage);
-
-    // === Simulate health-monitor-driven shutdown of controller A ===
-    socketRefA.current = null;
-    aShouldRetryDisconnect = false;
-
-    // The mock harness socket exposes user.id = "123@s.whatsapp.net"; the
-    // successor must report an overlapping identity for the handoff to succeed.
-    const sockB = {
-      sendMessage: vi.fn(async () => ({ key: { id: "post-restart-msg-id" } })),
-    };
-    const handleB = {
-      getActiveListener: () => null,
-      getCurrentSock: () => sockB as never,
-      getSelfIdentity: () => ({ jid: "123@s.whatsapp.net", lid: null }),
-    } as never;
-    controllerContexts.set(DEFAULT_ACCOUNT_ID, handleB);
+    const { inbound, successorSock, close } = await primeCapturedReplyWithSuccessor({
+      upsertId: "outbound-successor",
+      acceptedMessageId: "post-restart-msg-id",
+      identity: { jid: "123@s.whatsapp.net", lid: null },
+    });
 
     try {
       await inbound.reply("pong");
       await inbound.sendMedia({ text: "media after restart" });
 
-      // Captured A reply routed through B via the runtime context.
-      expect(sockB.sendMessage).toHaveBeenCalledTimes(2);
-      expect(sockB.sendMessage).toHaveBeenNthCalledWith(1, "999@s.whatsapp.net", {
+      expect(successorSock.sendMessage).toHaveBeenCalledTimes(2);
+      expect(successorSock.sendMessage).toHaveBeenNthCalledWith(1, "999@s.whatsapp.net", {
         text: "pong",
       });
-      expect(sockB.sendMessage).toHaveBeenNthCalledWith(2, "999@s.whatsapp.net", {
+      expect(successorSock.sendMessage).toHaveBeenNthCalledWith(2, "999@s.whatsapp.net", {
         text: "media after restart",
       });
     } finally {
-      controllerContexts.delete(DEFAULT_ACCOUNT_ID);
-      await listenerA.close();
+      await close();
     }
   });
 
-  // VE-513 PN/LID normalization: Baileys sockets may expose self identity in
-  // different forms across reconnects (PN JID `<n>@s.whatsapp.net` vs LID
-  // `<x>@lid`). The fallback must recognize the same account when one side
-  // reports only PN and the other only LID, because the captured reply
-  // shouldn't be dropped just because the identity form rotated.
-
+  // Reconnects may rotate the self identity from a phone JID to a LID; the
+  // matching e164 must keep the captured reply usable across that rotation.
   it("socket session accepts a successor with equivalent LID and phone identity", async () => {
-    const onMessage = vi.fn(async () => undefined);
-    const socketRefA = createSocketRef();
-
-    let aShouldRetryDisconnect = true;
-    const { listener: listenerA, sock: sockA } = await startInboxMonitor(
-      onMessage as InboxOnMessage,
-      {
-        socketRef: socketRefA,
-        shouldRetryDisconnect: () => aShouldRetryDisconnect,
-        disconnectRetryPolicy: fastReconnectPolicy(1),
-      },
-    );
-
-    sockA.ev.emit(
-      "messages.upsert",
-      buildNotifyMessageUpsert({
-        id: nextMessageId("outbound-successor-lid"),
-        remoteJid: "999@s.whatsapp.net",
-        text: "ping",
-        timestamp: 1_700_000_000,
-        pushName: "Tester",
-      }),
-    );
-    await waitForMessageCalls(onMessage, 1);
-    const inbound = inboundMessage(onMessage);
-
-    socketRefA.current = null;
-    aShouldRetryDisconnect = false;
-
-    // The mock harness socket has user.id="123@s.whatsapp.net" (PN JID, no
-    // lid). The successor reports only the LID form. Both resolve to the same
-    // synthetic e164 via resolveComparableIdentity, so identitiesOverlap
-    // accepts the fallback. (resolveComparableIdentity preserves an explicit
-    // e164 on the input over deriving from the JID via authDir lookup.)
-    const sharedE164 = "+123";
-    const sockB = {
-      sendMessage: vi.fn(async () => ({ key: { id: "post-restart-lid-msg-id" } })),
-    };
-    const handleB = {
-      getActiveListener: () => null,
-      getCurrentSock: () => sockB as never,
-      getSelfIdentity: () => ({ jid: null, lid: "12300:1@lid", e164: sharedE164 }),
-    } as never;
-    controllerContexts.set(DEFAULT_ACCOUNT_ID, handleB);
+    const { inbound, successorSock, close } = await primeCapturedReplyWithSuccessor({
+      upsertId: "outbound-successor-lid",
+      acceptedMessageId: "post-restart-lid-msg-id",
+      identity: { jid: null, lid: "12300:1@lid", e164: "+123" },
+    });
 
     try {
       await inbound.reply("pong");
-      expect(sockB.sendMessage).toHaveBeenCalledTimes(1);
-      expect(sockB.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", { text: "pong" });
+      expect(successorSock.sendMessage).toHaveBeenCalledTimes(1);
+      expect(successorSock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
+        text: "pong",
+      });
     } finally {
-      controllerContexts.delete(DEFAULT_ACCOUNT_ID);
-      await listenerA.close();
+      await close();
     }
   });
 
-  // VE-513 session-safety guard: if the registered successor controller has been
-  // re-linked to a different WhatsApp identity (different self JID), the
-  // captured reply must fail closed rather than route through the wrong number.
-
+  // A re-linked successor can belong to another account, so mismatched self
+  // identity must fail closed instead of sending the captured reply there.
   it("socket session refuses a successor with a mismatched self identity", async () => {
-    const onMessage = vi.fn(async () => undefined);
-    const socketRefA = createSocketRef();
-
-    let aShouldRetryDisconnect = true;
-    const { listener: listenerA, sock: sockA } = await startInboxMonitor(
-      onMessage as InboxOnMessage,
-      {
-        socketRef: socketRefA,
-        shouldRetryDisconnect: () => aShouldRetryDisconnect,
-        disconnectRetryPolicy: fastReconnectPolicy(1),
-      },
-    );
-
-    sockA.ev.emit(
-      "messages.upsert",
-      buildNotifyMessageUpsert({
-        id: nextMessageId("outbound-successor-mismatch"),
-        remoteJid: "999@s.whatsapp.net",
-        text: "ping",
-        timestamp: 1_700_000_000,
-        pushName: "Tester",
-      }),
-    );
-    await waitForMessageCalls(onMessage, 1);
-    const inbound = inboundMessage(onMessage);
-
-    // A's shutdown sequence.
-    socketRefA.current = null;
-    aShouldRetryDisconnect = false;
-
-    // === Successor is registered but with a DIFFERENT self identity (relink/repair) ===
-    const sockB = {
-      sendMessage: vi.fn(async () => ({ key: { id: "should-not-be-called" } })),
-    };
-    const handleBMismatch = {
-      getActiveListener: () => null,
-      getCurrentSock: () => sockB as never,
-      getSelfIdentity: () => ({ jid: "456@s.whatsapp.net", lid: null }),
-    } as never;
-    controllerContexts.set(DEFAULT_ACCOUNT_ID, handleBMismatch);
+    const { inbound, successorSock, close } = await primeCapturedReplyWithSuccessor({
+      upsertId: "outbound-successor-mismatch",
+      acceptedMessageId: "should-not-be-called",
+      identity: { jid: "456@s.whatsapp.net", lid: null },
+    });
 
     try {
       await expect(inbound.reply("pong")).rejects.toThrow(
         "no active socket - reconnection in progress",
       );
-
-      // The mismatched successor's socket was never used.
-      expect(sockB.sendMessage).not.toHaveBeenCalled();
+      expect(successorSock.sendMessage).not.toHaveBeenCalled();
     } finally {
-      controllerContexts.delete(DEFAULT_ACCOUNT_ID);
-      await listenerA.close();
+      await close();
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The remaining Telegram, Google Meet, and WhatsApp channel tests repeated large callback, media, setup, transcript, realtime, successor-controller, and retry fixtures. That duplication obscured the assertions that actually distinguish each behavior and made fixture changes expensive.

## Why This Change Was Made

This follows the test-only consolidation shape from #117826, #117854, and #117910: narrow local factories own byte-equivalent setup, mechanically isomorphic cases use named tables, and async lifecycle cases remain explicit when their ordering or ownership differs.

| Previous repeated shape | Consolidated shape | Divergence deliberately preserved |
| --- | --- | --- |
| Telegram plugin callback registration, open-DM bot setup, and callback envelopes | `createTelegramPluginCallbackHandler` plus the existing callback-context factory | Edit, delete, topic reply, submitted-text, authorization, retry, and policy outcomes retain their own named cases and assertions |
| Telegram replied-photo messages and reaction dispatch | `createReplyPhotoMessage` and `dispatchTelegramReaction` | Timeout, classic polling abort, spooled abort, multi-emoji delta, forum routing, and ordinary-group routing remain distinct |
| Google Meet Twilio environment/plugin/config setup | `runTwilioSetupStatus` | Environment vs configured credentials, missing allowlist/entry, dial plan, request dial-in, and webhook URL checks remain distinct |
| Google Meet local Chrome setup/join/session lifecycle | `withLocalChromeMeetSession` | Owned/reused/closed/moved tabs, transcript epoch/finalization/concurrency/eviction, and repeated leave assertions remain distinct |
| Google Meet realtime callback capture | Provider factories retain and require their created request | Local child-process bridge, direct realtime engine, and node transport scaffolding remain explicit |
| WhatsApp successor controller A/B setup | `primeCapturedReplyWithSuccessor` | Matching identity, PN/LID rotation, and mismatched fail-closed outcomes remain distinct |
| WhatsApp quoted wrappers and GroupSystemPrompt variants | Named `it.each` rows | All generated case names and per-row expectations are preserved |
| WhatsApp auth-stabilization retry setup | Two named table rows | Recovery/abort and retry-exhaustion lifecycle assertions remain branch-specific |

The batch estimate of 650–1,000 removable test lines was optimistic on current `main`: several cited reaction/platform cases were already table-driven by the precedent PRs, and the remaining async cases protect meaningfully different ownership and ordering. This stops at 404 net lines removed rather than hiding those differences behind a test DSL.

## User Impact

None. This is test-only scaffolding cleanup: no production, configuration, protocol, SDK, schema, documentation, or changelog files changed.

## Evidence

- Static preservation against immutable pre-edit base `128361397aa745e8b24176fada82553cc3b12239`: Telegram 94/94 test declarations and 463/463 assertions; Google Meet 146/146 declarations and 762/762 assertions; WhatsApp table conversions preserve 3 successor, 3 quoted-wrapper, 3 GroupSystemPrompt, and 2 auth-stabilization cases with their original titles.
- Canonical `oxfmt` over all 6 touched files — passed.
- Canonical `oxlint --config .oxlintrc.json` over all 6 touched files — passed.
- `git diff --check` — passed before and after rebases.
- Codex autoreview (`gpt-5.6-sol`, high) — clean on the full bundle and the CI typing repair, no accepted/actionable findings, both at 0.99 confidence; TruffleHog bundle scans clean.
- First-head CI found two test-helper typing errors: a nested type derived from a generic `Record<string, unknown>` and a channel-specific callback passed through an erased process-global registry. Both were repaired at their test-helper boundaries; no behavior or assertions changed.
- Final exact-head CI: run `30786728791` on `6fd9ff981c059430b7db57ef2b78682412c072f4` passed with no failed or pending checks.
- Focused verbose Vitest baseline/final attempts were blocked before Vitest spawn by this fleet host's I/O/runner environment. Blacksmith was not installed, managed AWS lacked broker authentication, and `node scripts/check-changed.mjs` reported no ready provider. Hosted exact-head CI supplies the executable test/type/check proof.
- LOC: production +0/-0; tests +698/-1,102, net -404.
