### PR TITLE
fix(matrix): preserve indented code without triggering mentions

### DIFF
--- a/extensions/matrix/src/actions.account-propagation.test.ts
+++ b/extensions/matrix/src/actions.account-propagation.test.ts
@@ -76,6 +76,55 @@ describe("matrixMessageActions account propagation", () => {
     expect(call.options).toMatchObject({ mediaLocalRoots: undefined });
   });
 
+  it.each([
+    { action: "send" as const, expectedAction: "sendMessage", message: "    @room" },
+    {
+      action: "send" as const,
+      expectedAction: "sendMessage",
+      message: "    @alice:example.org",
+    },
+    { action: "edit" as const, expectedAction: "editMessage", message: "    @room" },
+    {
+      action: "edit" as const,
+      expectedAction: "editMessage",
+      message: "    @alice:example.org",
+    },
+  ])(
+    "preserves leading Markdown indentation for $action with $message",
+    async ({ action, expectedAction, message }) => {
+      await matrixMessageActions.handleAction?.(
+        createContext({
+          action,
+          accountId: "ops",
+          params:
+            action === "send"
+              ? { to: "room:!room:example", message }
+              : { roomId: "!room:example", messageId: "$original", message },
+        }),
+      );
+
+      expect(matrixActionCall().input).toMatchObject({
+        action: expectedAction,
+        accountId: "ops",
+        content: message,
+      });
+    },
+  );
+
+  it.each(["send", "edit"] as const)("rejects a missing %s message", async (action) => {
+    await expect(
+      matrixMessageActions.handleAction?.(
+        createContext({
+          action,
+          params:
+            action === "send"
+              ? { to: "room:!room:example" }
+              : { roomId: "!room:example", messageId: "$original" },
+        }),
+      ),
+    ).rejects.toThrow("message required");
+  });
+
   it("forwards accountId for permissions actions", async () => {
     await matrixMessageActions.handleAction?.(
       createContext({

--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -203,6 +203,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
       const content = readStringParam(params, "message", {
         required: !mediaUrl,
         allowEmpty: true,
+        trim: false,
       });
       const replyTo = readStringParam(params, "replyTo");
       const threadId = readStringParam(params, "threadId");
@@ -272,7 +273,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
 
     if (action === "edit") {
       const messageId = readStringParam(params, "messageId", { required: true });
-      const content = readStringParam(params, "message", { required: true });
+      const content = readStringParam(params, "message", { required: true, trim: false });
       return await dispatch({
         action: "editMessage",
         roomId: resolveRoomId(),

--- a/extensions/matrix/src/matrix/actions/messages.test.ts
+++ b/extensions/matrix/src/matrix/actions/messages.test.ts
@@ -228,6 +228,25 @@ describe("matrix message actions", () => {
     }
   });
 
+  it("preserves leading Markdown indentation while trimming trailing edit whitespace", async () => {
+    const editSpy = vi.spyOn(sendModule, "editMessageMatrix").mockResolvedValue("evt-edit");
+
+    try {
+      await editMatrixMessage("!room:example.org", "$original", "    @room  \t\n", {
+        cfg: MATRIX_ACTION_TEST_CFG,
+      });
+
+      expect(editSpy).toHaveBeenCalledWith("!room:example.org", "$original", "    @room", {
+        cfg: MATRIX_ACTION_TEST_CFG,
+        accountId: undefined,
+        client: undefined,
+        timeoutMs: undefined,
+      });
+    } finally {
+      editSpy.mockRestore();
+    }
+  });
+
   it("rejects whitespace-only Matrix edits", async () => {
     await expect(
       editMatrixMessage("!room:example.org", "$original", "   \n  ", {

--- a/extensions/matrix/src/matrix/actions/messages.test.ts
+++ b/extensions/matrix/src/matrix/actions/messages.test.ts
@@ -205,18 +205,19 @@ describe("matrix message actions", () => {
     }
   });
 
-  it("forwards timeoutMs to the shared Matrix edit helper", async () => {
+  it("preserves Markdown indentation and forwards timeoutMs to the Matrix edit helper", async () => {
     const editSpy = vi.spyOn(sendModule, "editMessageMatrix").mockResolvedValue("evt-edit");
 
     try {
       const cfg = {} as never;
-      const result = await editMatrixMessage("!room:example.org", "$original", "hello", {
+      const markdown = "    @room";
+      const result = await editMatrixMessage("!room:example.org", "$original", markdown, {
         cfg,
         timeoutMs: 12_345,
       });
 
       expect(result).toEqual({ eventId: "evt-edit" });
-      expect(editSpy).toHaveBeenCalledWith("!room:example.org", "$original", "hello", {
+      expect(editSpy).toHaveBeenCalledWith("!room:example.org", "$original", markdown, {
         cfg,
         accountId: undefined,
         client: undefined,
@@ -225,6 +226,14 @@ describe("matrix message actions", () => {
     } finally {
       editSpy.mockRestore();
     }
+  });
+
+  it("rejects whitespace-only Matrix edits", async () => {
+    await expect(
+      editMatrixMessage("!room:example.org", "$original", "   \n  ", {
+        cfg: MATRIX_ACTION_TEST_CFG,
+      }),
+    ).rejects.toThrow("Matrix edit requires content");
   });
 
   it("routes edits through the shared Matrix edit helper so mentions are preserved", async () => {

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -111,7 +111,7 @@ export async function editMatrixMessage(
   if (!content.trim()) {
     throw new Error("Matrix edit requires content");
   }
-  const eventId = await editMessageMatrix(roomId, messageId, content, {
+  const eventId = await editMessageMatrix(roomId, messageId, content.trimEnd(), {
     cfg: opts.cfg,
     accountId: opts.accountId ?? undefined,
     client: opts.client,

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -108,11 +108,10 @@ export async function editMatrixMessage(
   if (!opts.cfg) {
     throw new Error("Matrix message actions require a resolved runtime config.");
   }
-  const trimmed = content.trim();
-  if (!trimmed) {
+  if (!content.trim()) {
     throw new Error("Matrix edit requires content");
   }
-  const eventId = await editMessageMatrix(roomId, messageId, trimmed, {
+  const eventId = await editMessageMatrix(roomId, messageId, content, {
     cfg: opts.cfg,
     accountId: opts.accountId ?? undefined,
     client: opts.client,

--- a/extensions/matrix/src/matrix/draft-stream.test.ts
+++ b/extensions/matrix/src/matrix/draft-stream.test.ts
@@ -13,8 +13,11 @@ const sendModuleMocks = vi.hoisted(() => {
   const chunkMarkdownTextWithModeMock = vi.fn((text: string) => (text ? [text] : []));
   const convertMarkdownTablesMock = vi.fn((text: string) => text);
   const prepareMatrixSingleText = vi.fn(
-    (text: string, opts: { cfg?: unknown; accountId?: string } = {}) => {
-      const trimmedText = text.trim();
+    (
+      text: string,
+      opts: { cfg?: unknown; accountId?: string; preserveWhitespace?: boolean } = {},
+    ) => {
+      const trimmedText = opts.preserveWhitespace ? text : text.trim();
       const convertedText = convertMarkdownTablesMock(trimmedText);
       const singleEventLimit = Math.min(
         resolveTextChunkLimitMock(opts.cfg ?? {}, "matrix", opts.accountId),
@@ -46,6 +49,7 @@ const sendModuleMocks = vi.hoisted(() => {
       const prepared = prepareMatrixSingleText(text, {
         cfg: opts.cfg,
         accountId: opts.accountId,
+        preserveWhitespace: true,
       });
       if (!prepared.trimmedText) {
         throw new Error("Matrix single-message send requires text");
@@ -242,6 +246,31 @@ describe("createMatrixDraftStream", () => {
     await stream.flush();
 
     expect(stream.content()).toBe("prepared:raw table");
+  });
+
+  it("preserves indented code through draft sends, edits, and final comparisons", async () => {
+    const stream = createMatrixDraftStream({
+      roomId: "!room:test",
+      client,
+      cfg: {} as import("../types.js").CoreConfig,
+    });
+    const firstMarkdown = "    @room";
+
+    stream.update(`${firstMarkdown}  `);
+    await stream.flush();
+
+    expect(sentContentAt(0).body).toBe(firstMarkdown);
+    expect(stream.content()).toBe(firstMarkdown);
+    expect(stream.matchesPreparedText(`${firstMarkdown}  `)).toBe(true);
+    expect(stream.matchesPreparedText("@room")).toBe(false);
+
+    vi.advanceTimersByTime(1000);
+    const editedMarkdown = "    @alice:example.org";
+    stream.update(editedMarkdown);
+    await stream.flush();
+
+    expect(sendModuleMocks.editMessageMatrix.mock.lastCall?.[2]).toBe(editedMarkdown);
+    expect(stream.content()).toBe(editedMarkdown);
   });
 
   it("sends quiet preview notices when quiet mode is enabled", async () => {

--- a/extensions/matrix/src/matrix/draft-stream.ts
+++ b/extensions/matrix/src/matrix/draft-stream.ts
@@ -79,10 +79,14 @@ export function createMatrixDraftStream(params: {
 
   const sendOrEdit = async (text: string): Promise<boolean> => {
     const trimmed = text.trimEnd();
-    if (!trimmed) {
+    if (!trimmed.trim()) {
       return false;
     }
-    const preparedText = prepareMatrixSingleText(trimmed, { cfg, accountId });
+    const preparedText = prepareMatrixSingleText(trimmed, {
+      cfg,
+      accountId,
+      preserveWhitespace: true,
+    });
     if (!preparedText.fitsInSingleEvent) {
       finalizeInPlaceBlocked = true;
       if (!currentEventId) {
@@ -220,9 +224,10 @@ export function createMatrixDraftStream(params: {
     eventId: () => currentEventId,
     content: () => lastSentContent || undefined,
     matchesPreparedText: (text: string) =>
-      prepareMatrixSingleText(text, {
+      prepareMatrixSingleText(text.trimEnd(), {
         cfg,
         accountId,
+        preserveWhitespace: true,
       }).trimmedText === lastSentText,
     mustDeliverFinalNormally: () => sendFailed || finalizeInPlaceBlocked,
   };

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -451,7 +451,11 @@ describe("deliverMatrixReplies", () => {
     });
 
     expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
-    expect(sendCall(0)[1]).toBe(text.trim());
+    expect(sendCall(0)[1]).toBe(text);
+    expect(chunkMatrixTextMock).toHaveBeenCalledWith(
+      text,
+      expect.objectContaining({ preserveWhitespace: true }),
+    );
   });
 
   it("delivers Matrix media without a reasoning-only caption", async () => {
@@ -507,6 +511,7 @@ describe("deliverMatrixReplies", () => {
       cfg: explicitCfg,
       accountId: "ops",
       tableMode: "code",
+      preserveWhitespace: true,
     });
     expect(sendCall(0)[0]).toBe("room:4");
     expect(sendCall(0)[1]).toBe("hello");

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -182,13 +182,13 @@ export async function deliverMatrixReplies(params: {
           cfg: params.cfg,
           accountId: params.accountId,
           tableMode,
+          preserveWhitespace: true,
         });
         for (const chunk of chunks) {
-          const trimmed = chunk.trim();
-          if (!trimmed) {
+          if (!chunk.trim()) {
             continue;
           }
-          await sendMessageMatrix(params.roomId, trimmed, {
+          await sendMessageMatrix(params.roomId, chunk, {
             client: params.client,
             cfg: params.cfg,
             replyToId: replyToIdForReply,

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -875,6 +875,29 @@ describe("sendMessageMatrix mentions", () => {
     expect(sentContent(sendMessage)["m.mentions"]).toEqual({});
   });
 
+  it.each([
+    { mention: "@room", mediaUrl: undefined },
+    { mention: "@alice:example.org", mediaUrl: undefined },
+    { mention: "@room", mediaUrl: "file:///tmp/photo.png" },
+  ])(
+    "keeps indented $mention inert in messages and media captions",
+    async ({ mention, mediaUrl }) => {
+      const { client, sendMessage } = makeClient();
+      const markdown = `    ${mention}`;
+
+      await sendMessageMatrix("room:!room:example", markdown, {
+        client,
+        cfg: {} as never,
+        ...(mediaUrl ? { mediaUrl } : {}),
+      });
+
+      const content = sentContent(sendMessage);
+      expect(content.body).toBe(markdown);
+      expect(content.formatted_body).toBe(`<pre><code>${mention}\n</code></pre>`);
+      expect(content["m.mentions"]).toEqual({});
+    },
+  );
+
   it("emits m.mentions and matrix.to anchors for qualified user mentions", async () => {
     const { client, sendMessage } = makeClient();
 
@@ -1136,6 +1159,37 @@ describe("sendSingleTextMessageMatrix", () => {
         cfg: {} as never,
       }),
     ).rejects.toThrow("Matrix single-message text exceeds limit");
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it.each(["@room", "@alice:example.org"])(
+    "keeps indented %s inert in single-event messages",
+    async (mention) => {
+      const { client, sendMessage } = makeClient();
+      const markdown = `    ${mention}`;
+
+      await sendSingleTextMessageMatrix("room:!room:example", markdown, {
+        client,
+        cfg: {} as never,
+      });
+
+      const content = sentContent(sendMessage);
+      expect(content.body).toBe(markdown);
+      expect(content.formatted_body).toBe(`<pre><code>${mention}\n</code></pre>`);
+      expect(content["m.mentions"]).toEqual({});
+    },
+  );
+
+  it("rejects whitespace-only single-event messages", async () => {
+    const { client, sendMessage } = makeClient();
+
+    await expect(
+      sendSingleTextMessageMatrix("room:!room:example", "   \n  ", {
+        client,
+        cfg: {} as never,
+      }),
+    ).rejects.toThrow("Matrix single-message send requires text");
 
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -194,8 +194,8 @@ export async function sendMessageMatrix(
   message: string | undefined,
   opts: MatrixSendOpts,
 ): Promise<MatrixSendResult> {
-  const trimmedMessage = message?.trim() ?? "";
-  if (!trimmedMessage && !opts.mediaUrl) {
+  const messageText = message?.trimEnd() ?? "";
+  if (!messageText.trim() && !opts.mediaUrl) {
     throw new Error("Matrix send requires text or media");
   }
   const durableIdentity = resolveMatrixDurableDeliveryIdentity({
@@ -229,9 +229,10 @@ export async function sendMessageMatrix(
         : null;
       let plannedEvents: MatrixPreparedEvent[] | undefined = storedPlan?.events;
       if (!plannedEvents) {
-        const { chunks, tableMode } = chunkMatrixText(trimmedMessage, {
+        const { chunks, tableMode } = chunkMatrixText(messageText, {
           cfg,
           accountId: opts.accountId,
+          preserveWhitespace: true,
         });
         const relation = threadId
           ? buildThreadRelation(threadId, opts.replyToId)
@@ -524,11 +525,12 @@ export async function sendSingleTextMessageMatrix(
     eventTextLength,
     fitsInSingleEvent,
     tableMode,
-  } = prepareMatrixSingleText(text, {
+  } = prepareMatrixSingleText(text.trimEnd(), {
     cfg: opts.cfg,
     accountId: opts.accountId,
+    preserveWhitespace: true,
   });
-  if (!trimmedText) {
+  if (!trimmedText.trim()) {
     throw new Error("Matrix single-message send requires text");
   }
   if (!fitsInSingleEvent) {

--- a/extensions/matrix/src/tool-actions.test.ts
+++ b/extensions/matrix/src/tool-actions.test.ts
@@ -373,6 +373,31 @@ describe("handleMatrixAction pollVote", () => {
     });
   });
 
+  it.each(["sendMessage", "editMessage"] as const)(
+    "preserves indented Markdown when handling %s",
+    async (action) => {
+      const cfg = { channels: { matrix: { actions: { messages: true } } } } as CoreConfig;
+      const markdown = "    @room";
+
+      await handleMatrixAction(
+        {
+          action,
+          to: "room:!room:example",
+          roomId: "!room:example",
+          messageId: "$original",
+          content: markdown,
+        },
+        cfg,
+      );
+
+      const providerCall =
+        action === "sendMessage"
+          ? mocks.sendMatrixMessage.mock.lastCall?.[1]
+          : mocks.editMatrixMessage.mock.lastCall?.[2];
+      expect(providerCall).toBe(markdown);
+    },
+  );
+
   it("returns the authorized room and thread with message reads", async () => {
     const cfg = { channels: { matrix: { actions: { messages: true } } } } as CoreConfig;
     const result = await handleMatrixAction(

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -273,6 +273,7 @@ export async function handleMatrixAction(
         const content = readStringParam(params, "content", {
           required: !mediaUrl,
           allowEmpty: true,
+          trim: false,
         });
         const replyToId =
           readStringParam(params, "replyToId") ?? readStringParam(params, "replyTo");
@@ -297,7 +298,7 @@ export async function handleMatrixAction(
       case "editMessage": {
         const roomId = readRoomId(params);
         const messageId = readStringParam(params, "messageId", { required: true });
-        const content = readStringParam(params, "content", { required: true });
+        const content = readStringParam(params, "content", { required: true, trim: false });
         const result = await withReadTarget(roomId, async (target) => {
           return await editMatrixMessage(target.roomId, messageId, content, {
             ...clientOpts,


### PR DESCRIPTION
## What Problem This Solves

Matrix stripped leading Markdown indentation across normal sends, edits, media captions, replies, streaming drafts, and the actual Gateway message-action adapter. Indented @room or user examples could become real room-wide/user notifications instead of safe code blocks.

## Canonical Owner-Boundary Repair

All six Matrix-owned producer and transport boundaries now preserve significant leading whitespace through the existing preserveWhitespace contract: public channel actions, tool actions, message actions, normal sending, monitored replies, and streaming drafts. Existing blank-message rejection and legacy trailing-whitespace normalization remain unchanged.

## User Impact

Indented Matrix text remains an HTML pre/code block with empty mention metadata, preventing unintended room-wide or user notifications across actual Gateway sends, edits, replies, and streaming.

## Exact-Head Real Matrix / Gateway Proof

The exact published commit f5ff631b7be74d7f0e0fb39c57e55ae4a7c22a80 passed a remote disposable Tuwunel homeserver with a real Gateway, the actual registered Matrix plugin, genuine Gateway message.action send/edit calls, and direct Matrix event inspection. Both room and user targets were tested; user identities are redacted:

- Room send: pre/code containing @room; Matrix mentions object empty.
- Room edit: pre/code containing the user mention; Matrix mentions object empty.
- User send: pre/code containing the user mention; Matrix mentions object empty.
- User edit: pre/code containing @room; Matrix mentions object empty.
- Disposable real-homeserver scenario: 1/1 passing.
- Real workspaces and real user homeservers were not touched.

## Regression Evidence

- Initial owner regressions reproduced the failure; real Gateway proof uncovered four additional channel-adapter send/edit regressions that were repaired in the same canonical Matrix neighborhood.
- Complete focused Matrix adapter, tool-action, send, edit, reply, and draft coverage: 178/178 passing.
- Actual installed markdown-it parser source and current Matrix client-server mention/edit specification directly inspected.
- Fresh final independent structured high-reasoning owner review: clean, confidence 0.99.
- Existing whitespace-only rejection and edit trailing trimEnd compatibility explicitly preserved.
- No auth, end-to-end encryption, public SDK, configuration, or persistence changes.
- AI-assisted implementation and independently verified source review.
