### PR TITLE
fix(cli): close standalone memory managers after commands

### DIFF
--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -31,6 +31,7 @@ import {
   resolveActiveMemoryBackendConfig,
 } from "./memory-runtime.js";
 import { resetStandaloneMemoryRegistrySlot } from "./memory-runtime.test-support.js";
+import { hasMemoryRuntime } from "./memory-state.js";
 
 function createRuntime() {
   return {
@@ -93,6 +94,73 @@ describe("memory runtime handles", () => {
     expect(resolveActiveMemoryBackendConfig({ cfg: memoryConfig, agentId: "main" })).toEqual({
       backend: "builtin",
     });
+  });
+
+  it("tracks standalone managers without activating config-only lookups and rearms reused handles", async () => {
+    const { registry, runtime } = createRegistry();
+    mocks.loadPluginRegistryHandle.mockReturnValue(registry);
+
+    expect(hasMemoryRuntime()).toBe(false);
+    expect(resolveActiveMemoryBackendConfig({ cfg: memoryConfig, agentId: "main" })).toEqual({
+      backend: "builtin",
+    });
+    expect(hasMemoryRuntime()).toBe(false);
+
+    await getActiveMemorySearchManager({ cfg: memoryConfig, agentId: "main" });
+    expect(hasMemoryRuntime()).toBe(true);
+
+    await closeActiveMemorySearchManagers();
+    expect(hasMemoryRuntime()).toBe(false);
+
+    await getActiveMemorySearchManager({ cfg: memoryConfig, agentId: "main" });
+    expect(hasMemoryRuntime()).toBe(true);
+    expect(mocks.loadPluginRegistryHandle).toHaveBeenCalledTimes(1);
+
+    await closeActiveMemorySearchManagers();
+    expect(runtime.closeAllMemorySearchManagers).toHaveBeenCalledTimes(2);
+    expect(hasMemoryRuntime()).toBe(false);
+  });
+
+  it("retains standalone ownership across workspace replacement and per-agent cleanup", async () => {
+    const main = createRegistry();
+    const research = createRegistry();
+    mocks.loadPluginRegistryHandle
+      .mockReturnValueOnce(main.registry)
+      .mockReturnValueOnce(research.registry);
+
+    await getActiveMemorySearchManager({ cfg: memoryConfig, agentId: "main" });
+    await getActiveMemorySearchManager({ cfg: memoryConfig, agentId: "research" });
+    expect(hasMemoryRuntime()).toBe(true);
+
+    await closeActiveMemorySearchManager({ cfg: memoryConfig, agentId: "main" });
+    expect(hasMemoryRuntime()).toBe(true);
+
+    await closeActiveMemorySearchManagers();
+    expect(main.runtime.closeAllMemorySearchManagers).toHaveBeenCalledTimes(1);
+    expect(research.runtime.closeAllMemorySearchManagers).toHaveBeenCalledTimes(1);
+    expect(hasMemoryRuntime()).toBe(false);
+  });
+
+  it("retains standalone cleanup ownership when manager acquisition or teardown fails", async () => {
+    const { registry, runtime } = createRegistry();
+    mocks.loadPluginRegistryHandle.mockReturnValue(registry);
+    runtime.getMemorySearchManager.mockRejectedValueOnce(
+      new Error("manager initialization failed"),
+    );
+
+    await expect(
+      getActiveMemorySearchManager({ cfg: memoryConfig, agentId: "main" }),
+    ).rejects.toThrow("manager initialization failed");
+    expect(hasMemoryRuntime()).toBe(true);
+
+    runtime.closeAllMemorySearchManagers.mockRejectedValueOnce(
+      new Error("manager teardown failed"),
+    );
+    await expect(closeActiveMemorySearchManagers()).rejects.toThrow("manager teardown failed");
+    expect(hasMemoryRuntime()).toBe(true);
+
+    await closeActiveMemorySearchManagers();
+    expect(hasMemoryRuntime()).toBe(false);
   });
 
   it("keys the single slot by the requesting agent workspace", () => {

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -4,7 +4,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveUserPath } from "../utils.js";
 import { normalizePluginsConfig } from "./config-state.js";
 import { loadPluginRegistryHandle, resolvePluginRegistryLoadCacheKey } from "./loader.js";
-import { getMemoryRuntime, resolveMemoryCapabilityRegistration } from "./memory-state.js";
+import {
+  getMemoryRuntime,
+  resolveMemoryCapabilityRegistration,
+  setStandaloneMemoryManagerActive,
+} from "./memory-state.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
 
@@ -121,6 +125,9 @@ export async function getActiveMemorySearchManager(params: {
   if (!owner) {
     return { manager: null, error: "memory plugin unavailable" };
   }
+  if (owner.registry) {
+    setStandaloneMemoryManagerActive(true);
+  }
   return await withMemoryRuntimeOwner(
     owner,
     async (runtime) => await runtime.getMemorySearchManager(params),
@@ -146,6 +153,7 @@ export async function closeActiveMemorySearchManagers(cfg?: OpenClawConfig): Pro
     ),
   );
   standaloneMemoryRegistrySlot?.retiredRuntimes.clear();
+  setStandaloneMemoryManagerActive(false);
 }
 
 /** Closes the plugin-backed memory search manager for one agent. */
@@ -164,6 +172,7 @@ export async function closeActiveMemorySearchManager(params: {
 
 function resetStandaloneMemoryRegistrySlot(): void {
   standaloneMemoryRegistrySlot = undefined;
+  setStandaloneMemoryManagerActive(false);
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -266,8 +266,15 @@ export function getMemoryRuntime(): MemoryPluginRuntime | undefined {
   return getMemoryCapability()?.capability.runtime;
 }
 
+let standaloneMemoryManagerActive = false;
+
+// Standalone managers are intentionally absent from the active plugin registry.
+export function setStandaloneMemoryManagerActive(active: boolean): void {
+  standaloneMemoryManagerActive = active;
+}
+
 export function hasMemoryRuntime(): boolean {
-  return getMemoryRuntime() !== undefined;
+  return standaloneMemoryManagerActive || getMemoryRuntime() !== undefined;
 }
 
 function cloneMemoryPublicArtifact(


### PR DESCRIPTION
## What Problem This Solves

Standalone memory-backed commands such as `openclaw wiki get ... --json` printed their correct result but never exited because standalone memory managers retained active filesystem watchers.

## Why This Change Was Made

The memory-runtime owner records the authoritative standalone-manager activity fact in the existing lightweight runtime-presence owner. The unchanged CLI finalizer can then close both current and retired standalone managers without importing heavy memory code for ordinary help/status commands.

## User Impact

Memory-backed CLI commands terminate naturally after returning their result. Commands that never initialize memory retain their intentional fast startup behavior.

## Real Packaged CLI / SQLite / Watcher Proof

Exact committed memory-state/runtime candidate files were rebuilt on an isolated Testbox and run through the actual packaged operator CLI, real configured memory-core, real per-agent SQLite, and its default live filesystem watcher:

```text
$ node openclaw.mjs wiki --help
natural exit: 0

$ node openclaw.mjs wiki get memory/missing.md --corpus memory --json
result: null
natural exit: 0, 9139 ms, forced termination: false

$ node openclaw.mjs wiki get memory/empty.md --corpus memory --json
result: {corpus:"memory",path:"memory/empty.md",content:"",fromLine:1,lineCount:200}
natural exit: 0, 4035 ms, forced termination: false

$ node openclaw.mjs wiki get memory/broken.md --corpus memory --json
error: path must be a regular file
natural exit: 1, 4134 ms

real per-agent SQLite database: 528384 bytes
real default filesystem watcher: enabled
```

Before the fix, the same genuine successful commands emitted complete JSON but remained alive until a supervisor killed the leaking process. Testbox run: https://github.com/openclaw/openclaw/actions/runs/30787071524

## Regression Evidence

- Red-first owner regressions: three failed before repair.
- memory-runtime suite 11/11; memory-state suite 18/18; unchanged CLI exit/startup suite 199/199.
- Partial initialization, current+retired manager replacement, failed close/retry, cache rearm, and config-only cold startup remain covered.
- Git history proves standalone registry ownership (`6c9b38862d2`) bypassed the intentional lightweight startup guard (`a5cb9ec674b`).
- Independent structured Sol/high review clean, confidence 0.91.
- Production +16 lines including formatter import expansion; no CLI production, SQLite schema, auth, config, or public SDK changes.
- AI-assisted implementation and independently verified source review.
