### PR TITLE
fix(media): honor configured CLI audio language

### DIFF
--- a/src/media-understanding/runner.cli-audio.test.ts
+++ b/src/media-understanding/runner.cli-audio.test.ts
@@ -196,6 +196,38 @@ describe("media-understanding CLI audio entry", () => {
   });
 
   it.each([
+    { source: "model entry", entryLanguage: "de", configLanguage: "fr", expected: "de" },
+    {
+      source: "capability default",
+      entryLanguage: undefined,
+      configLanguage: "fr",
+      expected: "fr",
+    },
+  ])("applies the configured $source language to CLI templating", async (testCase) => {
+    await withAudioFixture("openclaw-cli-language", async ({ ctx, media, cache }) => {
+      await runCliEntry({
+        capability: "audio",
+        entry: {
+          type: "cli",
+          command: "mock-transcriber",
+          args: ["--language", "{{Language}}", "--file", "{{MediaPath}}"],
+          language: testCase.entryLanguage,
+        },
+        cfg: {
+          tools: { media: { audio: { language: testCase.configLanguage } } },
+        } as OpenClawConfig,
+        ctx,
+        attachment: requireFirstAttachment(media),
+        cache,
+        config: { language: testCase.configLanguage } as never,
+      });
+    });
+
+    const [, args] = requireFirstRunExecCall();
+    expect(args).toEqual(["--language", testCase.expected, "--file", expect.any(String)]);
+  });
+
+  it.each([
     { name: "one attachment", count: 1, leadingEmpty: false },
     { name: "many attachments after an empty slot", count: 2, leadingEmpty: true },
   ])(

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -1020,6 +1020,7 @@ export async function runCliEntry(params: {
     throw new Error(`CLI entry missing command for ${capability}`);
   }
   const requestOverrides = resolveMediaRequestOverrides(params.config);
+  const language = requestOverrides.language ?? entry.language ?? params.config?.language;
   const { maxBytes, maxChars, timeoutMs, prompt } = resolveEntryRunOptions({
     capability,
     entry,
@@ -1061,7 +1062,7 @@ export async function runCliEntry(params: {
       OutputDir: outputDir,
       OutputBase: outputBase,
       Prompt: requestOverrides.prompt ?? prompt,
-      ...(requestOverrides.language ? { Language: requestOverrides.language } : {}),
+      ...(capability === "audio" && language ? { Language: language } : {}),
       MaxChars: maxChars,
     };
     for (const key of [


### PR DESCRIPTION
## What Problem This Solves

Configured audio language hints on CLI-backed media model entries were validated and documented, but only one-shot request overrides reached the `{{Language}}` command template. Model-entry and `tools.media.audio.language` defaults were silently ignored.

The batch also re-audited `nodeHost.browserProxy.enabled` and `allowProfiles`. Those controls are already enforced at both command advertisement and invocation time, so this PR does not add a duplicate browser reader.

## Why This Change Was Made

The CLI runner now uses the same language precedence as provider-backed audio: request override, then model entry, then capability default. The fix stays at the CLI template-construction owner and does not broaden language behavior to image or video entries.

The remaining overbroad media schema combinations (image transport fields, non-audio provider options, and provider-only fields on CLI entries) need a compatibility/doctor migration decision rather than speculative runtime behavior, so they are intentionally left unchanged.

## User Impact

Operators can use `language` on an audio CLI model entry or under `tools.media.audio`; `{{Language}}` now expands to that configured value. Existing per-request overrides keep highest precedence.

## Evidence

- `node scripts/run-vitest.mjs src/media-understanding/runner.cli-audio.test.ts` — passed before rebase.
- The same focused rerun was queued behind another checkout's local heavy-test lock after rebase; hosted PR CI is the final exact-head proof.
- `/Users/steipete/Projects/openclaw/node_modules/.bin/oxfmt src/media-understanding/runner.entries.ts src/media-understanding/runner.cli-audio.test.ts` — passed.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings.
- `node scripts/check-changed.mjs` selected remote CI but could not acquire a ready Crabbox provider; hosted PR CI covers the changed-surface gates.
