### PR TITLE
macOS: surface realtime Talk settings

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -23843,6 +23843,17 @@
       ]
     },
     {
+      "id": "native.apple.55154d93c122c1ac",
+      "source": "Choose the realtime provider, model, voice, and transport in the Control UI.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-named-argument",
+          "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.e4b13f49bb435884",
       "source": "Choose where the Gateway runs and how this Mac app reaches it.",
       "surface": "apple",
@@ -36503,6 +36514,10 @@
         {
           "kind": "ui-call",
           "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift"
+        },
+        {
+          "kind": "ui-call",
+          "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift"
         }
       ]
     },
@@ -45631,6 +45646,17 @@
       ]
     },
     {
+      "id": "native.apple.c7d73b77de59d303",
+      "source": "Talk configuration",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-named-argument",
+          "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.1da1f8b0f2cf232d",
       "source": "Talk failed: %@",
       "surface": "apple",
@@ -48912,6 +48938,17 @@
         {
           "kind": "ui-named-argument",
           "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.2ece20cb05d073cd",
+      "source": "Voice & Talk Settings…",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-call",
+          "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift"
         }
       ]
     },

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -131,6 +131,11 @@ struct MenuContent: View {
             if self.showVoiceWakeMicPicker {
                 self.voiceWakeMicMenu
             }
+            Button {
+                self.open(tab: .voiceWake)
+            } label: {
+                Label("Voice & Talk Settings…", systemImage: "slider.horizontal.3")
+            }
             Divider()
             Button {
                 AppNavigationActions.openDashboard()

--- a/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
@@ -1,6 +1,7 @@
 import AppKit
 import AVFoundation
 import Observation
+import OpenClawKit
 import Speech
 import SwabbleKit
 import SwiftUI
@@ -183,6 +184,19 @@ struct VoiceWakeSettings: View {
                             binding: self.$state.voicePushToTalkEnabled)
 
                         self.realtimeRelayToggle
+
+                        SettingsCardRow(
+                            title: "Talk configuration",
+                            subtitle: "Choose the realtime provider, model, voice, and transport in the Control UI.")
+                        {
+                            Button("Open in Dashboard") {
+                                Task {
+                                    await DashboardManager.shared.show(
+                                        atPath: DashboardRouteMap.talkSettingsPath)
+                                }
+                            }
+                            .buttonStyle(.link)
+                        }
 
                         if self.state.voicePushToTalkEnabled, self.state.talkEnabled {
                             SettingsCardRow(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DashboardRouteMap.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DashboardRouteMap.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum DashboardRouteMap {
     public static let channelsSettingsPath = "/settings/channels"
+    public static let talkSettingsPath = "/settings/talk"
     public static let skillsPagePath = "/skills"
     public static let cronJobsPagePath = "/cron"
     public static let sessionsPagePath = "/sessions"

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DashboardRouteMapTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DashboardRouteMapTests.swift
@@ -5,13 +5,14 @@ import Testing
 struct DashboardRouteMapTests {
     @Test func `route constants match Control UI paths`() {
         #expect(DashboardRouteMap.channelsSettingsPath == "/settings/channels")
+        #expect(DashboardRouteMap.talkSettingsPath == "/settings/talk")
         #expect(DashboardRouteMap.skillsPagePath == "/skills")
         #expect(DashboardRouteMap.cronJobsPagePath == "/cron")
         #expect(DashboardRouteMap.sessionsPagePath == "/sessions")
         #expect(DashboardRouteMap.devicesSettingsPath == "/settings/devices")
     }
 
-    @Test(arguments: ["/settings/channels", "/skills", "/cron"])
+    @Test(arguments: ["/settings/channels", "/settings/talk", "/skills", "/cron"])
     func `same-app path validation accepts rooted paths`(_ path: String) {
         #expect(DashboardRouteMap.isValidSameAppPath(path))
     }

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -268,8 +268,10 @@ to waitlist-enabled Platform access.
 
 ## macOS UI
 
-- Menu bar toggle: **Talk**
-- Config tab: **Talk Mode** group (voice id + interrupt toggle)
+- Menu bar: **Voice & Talk Settings…** opens the native **Voice & Talk** settings page.
+- Native settings: **Use realtime Gateway relay** is a local, default-off opt-in for this Mac.
+- **Open in Dashboard** hands provider, model, voice, and transport setup to Control UI **Settings → Talk** under **Connections**.
+- Menu bar: **Talk Mode** starts or stops the current Talk session.
 - Overlay: the orb renders the universal talk waveform (shared with iOS, watchOS, and Android). Listening follows the live mic level, Speaking follows the actual TTS playback envelope, Thinking breathes softly. Click the orb to pause/resume, double-click to stop speaking, click X to exit Talk mode.
 
 ## Android UI

--- a/ui/src/pages/config/talk-page.ts
+++ b/ui/src/pages/config/talk-page.ts
@@ -8,7 +8,11 @@ import { property, state } from "lit/decorators.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
-import { isTalkGptLiveModel, resolveTalkRealtimeSelection } from "./talk-schema.ts";
+import {
+  isTalkGptLiveModel,
+  resolveTalkRealtimeSelection,
+  talkProviderRejectsTransport,
+} from "./talk-schema.ts";
 import {
   renderTalk,
   selectedTalkProviderOption,
@@ -196,11 +200,16 @@ class TalkSettingsPage extends OpenClawLightDomElement {
     const runtimeConfig = this.context.runtimeConfig;
     if (model !== null) {
       runtimeConfig.patchForm(["talk", "realtime", "model"], model);
-      // GPT-Live is WebRTC-only; a configured relay or provider-websocket
-      // transport would make the just-picked model fail at session create, so
-      // clearing it lets the default client-owned WebRTC path apply.
-      const transport = this.liveSelection().transport;
-      if (isTalkGptLiveModel(model) && transport && transport !== "webrtc") {
+      const selection = this.liveSelection();
+      const transport = selection.transport;
+      const provider = selectedTalkProviderOption(this.catalog, selection);
+      // Preserve configured transports unless the selected provider positively
+      // advertises that it cannot serve them.
+      if (
+        isTalkGptLiveModel(model) &&
+        transport &&
+        talkProviderRejectsTransport(provider?.transports, transport)
+      ) {
         runtimeConfig.removeFormValue(["talk", "realtime", "transport"]);
       }
       return;
@@ -247,11 +256,10 @@ class TalkSettingsPage extends OpenClawLightDomElement {
   }
 
   /**
-   * Model, voice, and transport picks are provider-coupled (an xAI session
-   * cannot use a gpt-live model, marin, or webrtc), so a provider switch
-   * clears the top-level overrides instead of carrying them across. Each
-   * provider's own `talk.realtime.providers.<id>` entry survives untouched and
-   * supplies that provider's fallback values.
+   * Model and voice picks are provider-coupled, so a provider switch clears
+   * those top-level overrides. Transport survives when the target provider
+   * advertises it; an unavailable catalog is not evidence of incompatibility.
+   * Each provider's own entry survives and supplies its fallback values.
    */
   private changeProvider(providerId: string | null) {
     if (this.mutationDisabled) {
@@ -268,20 +276,25 @@ class TalkSettingsPage extends OpenClawLightDomElement {
       runtimeConfig.removeFormValue(["talk", "realtime", "provider"]);
       return;
     }
-    runtimeConfig.removeFormValue(["talk", "realtime", "transport"]);
-    runtimeConfig.patchForm(["talk", "realtime", "provider"], providerId);
-    // A relay-only provider (no client-owned transport) needs the transport
-    // written explicitly: an unset transport routes to talk.client.create,
-    // which such a provider cannot serve.
+    const configuredTransport = this.liveSelection().transport;
     const option =
       this.catalog.kind === "ready"
         ? this.catalog.providers.find((provider) => provider.id === providerId)
         : undefined;
+    if (
+      configuredTransport &&
+      talkProviderRejectsTransport(option?.transports, configuredTransport)
+    ) {
+      runtimeConfig.removeFormValue(["talk", "realtime", "transport"]);
+    }
+    runtimeConfig.patchForm(["talk", "realtime", "provider"], providerId);
+    // A relay-only provider (no client-owned transport) needs the transport
+    // written explicitly when the current selection cannot carry across.
     const relayOnly =
       option !== undefined &&
       option.transports.length > 0 &&
-      !option.transports.some((transport) => TALK_CLIENT_OWNED_TRANSPORTS.has(transport));
-    if (relayOnly) {
+      !option.transports.some((candidate) => TALK_CLIENT_OWNED_TRANSPORTS.has(candidate));
+    if (relayOnly && configuredTransport !== "gateway-relay") {
       runtimeConfig.patchForm(["talk", "realtime", "transport"], "gateway-relay");
     }
   }

--- a/ui/src/pages/config/talk-page.ts
+++ b/ui/src/pages/config/talk-page.ts
@@ -14,6 +14,7 @@ import {
   talkProviderRejectsTransport,
 } from "./talk-schema.ts";
 import {
+  effectiveTalkValues,
   renderTalk,
   selectedTalkProviderOption,
   talkProviderConfigKeys,
@@ -57,6 +58,10 @@ function toProviderOption(
 
 /** Transports whose sessions are client-owned (`talk.client.create`). */
 const TALK_CLIENT_OWNED_TRANSPORTS = new Set(["webrtc", "provider-websocket"]);
+
+function gptLiveRejectsTransport(model: string | null, transport: string): boolean {
+  return isTalkGptLiveModel(model) && transport === "provider-websocket";
+}
 
 class TalkSettingsPage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
@@ -203,14 +208,21 @@ class TalkSettingsPage extends OpenClawLightDomElement {
       const selection = this.liveSelection();
       const transport = selection.transport;
       const provider = selectedTalkProviderOption(this.catalog, selection);
+      const rejectsTransport =
+        transport !== null &&
+        (gptLiveRejectsTransport(model, transport) ||
+          talkProviderRejectsTransport(provider?.transports, transport));
       // Preserve configured transports unless the selected provider positively
       // advertises that it cannot serve them.
-      if (
-        isTalkGptLiveModel(model) &&
-        transport &&
-        talkProviderRejectsTransport(provider?.transports, transport)
-      ) {
+      if (isTalkGptLiveModel(model) && rejectsTransport) {
         runtimeConfig.removeFormValue(["talk", "realtime", "transport"]);
+      } else if (
+        provider?.id === "openai" &&
+        isTalkGptLiveModel(model) &&
+        transport === "gateway-relay" &&
+        selection.consultRouting === "force-agent-consult"
+      ) {
+        runtimeConfig.removeFormValue(["talk", "realtime", "consultRouting"]);
       }
       return;
     }
@@ -266,6 +278,7 @@ class TalkSettingsPage extends OpenClawLightDomElement {
       return;
     }
     const runtimeConfig = this.context.runtimeConfig;
+    const selection = this.liveSelection();
     for (const key of ["model", "speakerVoice", "speakerVoiceId"]) {
       runtimeConfig.removeFormValue(["talk", "realtime", key]);
     }
@@ -276,15 +289,21 @@ class TalkSettingsPage extends OpenClawLightDomElement {
       runtimeConfig.removeFormValue(["talk", "realtime", "provider"]);
       return;
     }
-    const configuredTransport = this.liveSelection().transport;
+    const configuredTransport = selection.transport;
     const option =
       this.catalog.kind === "ready"
         ? this.catalog.providers.find((provider) => provider.id === providerId)
         : undefined;
-    if (
-      configuredTransport &&
-      talkProviderRejectsTransport(option?.transports, configuredTransport)
-    ) {
+    const targetModel =
+      effectiveTalkValues(
+        { ...selection, provider: providerId, model: null, speakerVoice: null },
+        option,
+      ).model ?? option?.defaultModel;
+    const rejectsTransport =
+      configuredTransport !== null &&
+      (gptLiveRejectsTransport(targetModel ?? null, configuredTransport) ||
+        talkProviderRejectsTransport(option?.transports, configuredTransport));
+    if (rejectsTransport) {
       runtimeConfig.removeFormValue(["talk", "realtime", "transport"]);
     }
     runtimeConfig.patchForm(["talk", "realtime", "provider"], providerId);
@@ -294,8 +313,18 @@ class TalkSettingsPage extends OpenClawLightDomElement {
       option !== undefined &&
       option.transports.length > 0 &&
       !option.transports.some((candidate) => TALK_CLIENT_OWNED_TRANSPORTS.has(candidate));
+    let resultingTransport = rejectsTransport ? null : configuredTransport;
     if (relayOnly && configuredTransport !== "gateway-relay") {
       runtimeConfig.patchForm(["talk", "realtime", "transport"], "gateway-relay");
+      resultingTransport = "gateway-relay";
+    }
+    if (
+      option?.id === "openai" &&
+      isTalkGptLiveModel(targetModel ?? null) &&
+      resultingTransport === "gateway-relay" &&
+      selection.consultRouting === "force-agent-consult"
+    ) {
+      runtimeConfig.removeFormValue(["talk", "realtime", "consultRouting"]);
     }
   }
 

--- a/ui/src/pages/config/talk-schema.ts
+++ b/ui/src/pages/config/talk-schema.ts
@@ -57,10 +57,20 @@ export function resolveTalkRealtimeSelection(
 }
 
 /**
- * Mirrors the server-side gpt-live prefix contract
- * (extensions/openai/realtime-quicksilver.ts); the UI only uses it to decide
- * whether to show the ChatGPT sign-in hint, never to gate a session.
+ * Mirrors the server-side gpt-live family contract
+ * (extensions/openai/realtime-quicksilver.ts); the UI uses it for the ChatGPT
+ * sign-in hint and to avoid retaining a transport the selected provider
+ * positively rejects. It never gates a session.
  */
 export function isTalkGptLiveModel(model: string | null): boolean {
-  return model !== null && model.toLowerCase().startsWith("gpt-live");
+  const normalized = model?.trim().toLowerCase();
+  return normalized === "gpt-live" || normalized?.startsWith("gpt-live-") === true;
+}
+
+/** An empty or unavailable transport catalog is not evidence of incompatibility. */
+export function talkProviderRejectsTransport(
+  transports: readonly string[] | undefined,
+  transport: string,
+): boolean {
+  return transports !== undefined && transports.length > 0 && !transports.includes(transport);
 }

--- a/ui/src/pages/config/talk-schema.ts
+++ b/ui/src/pages/config/talk-schema.ts
@@ -19,6 +19,8 @@ export type TalkRealtimeSelection = {
   speakerVoice: string | null;
   /** Raw configured `talk.realtime.transport`. */
   transport: string | null;
+  /** Normalized configured `talk.realtime.consultRouting`. */
+  consultRouting: string | null;
   /** Per-provider fallback values keyed by the raw config map key. */
   providerEntries: Record<string, TalkProviderEntryValues>;
 };
@@ -52,6 +54,7 @@ export function resolveTalkRealtimeSelection(
     speakerVoice:
       readTrimmedString(realtime?.speakerVoice) ?? readTrimmedString(realtime?.speakerVoiceId),
     transport: readTrimmedString(realtime?.transport),
+    consultRouting: readTrimmedString(realtime?.consultRouting)?.toLowerCase() ?? null,
     providerEntries,
   };
 }

--- a/ui/src/pages/config/talk.test.ts
+++ b/ui/src/pages/config/talk.test.ts
@@ -7,7 +7,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import "./talk-page.ts";
-import { isTalkGptLiveModel } from "./talk-schema.ts";
+import { isTalkGptLiveModel, resolveTalkRealtimeSelection } from "./talk-schema.ts";
 import { renderTalk } from "./talk.ts";
 
 type TalkSettingsPageTestElement = HTMLElement & {
@@ -21,7 +21,11 @@ type TalkSettingsPageTestElement = HTMLElement & {
 type TalkMutationHarnessOptions = {
   activeProvider?: string | null;
   aliases?: string[];
+  consultRouting?: string | null;
+  defaultModel?: string;
+  openAIProviderModel?: string;
   provider?: string | null;
+  transport?: string | null;
   transports?: string[];
   unavailable?: boolean;
 };
@@ -45,7 +49,7 @@ function createTalkMutationHarness(options: TalkMutationHarnessOptions = {}) {
                 models: ["gpt-live-1-boulder-alpha"],
                 voices: ["marin"],
                 transports: options.transports ?? ["gateway-relay"],
-                defaultModel: "gpt-live-1-boulder-alpha",
+                defaultModel: options.defaultModel ?? "gpt-live-1-boulder-alpha",
               },
               {
                 id: "xai",
@@ -78,7 +82,11 @@ function createTalkMutationHarness(options: TalkMutationHarnessOptions = {}) {
       realtime: {
         provider: options.provider === undefined ? "openai" : options.provider,
         model: "gpt-realtime-2.1",
-        transport: "gateway-relay",
+        transport: options.transport === undefined ? "gateway-relay" : options.transport,
+        consultRouting: options.consultRouting,
+        providers: options.openAIProviderModel
+          ? { openai: { model: options.openAIProviderModel } }
+          : undefined,
       },
     },
   };
@@ -150,6 +158,21 @@ describe("isTalkGptLiveModel", () => {
   );
 });
 
+describe("resolveTalkRealtimeSelection", () => {
+  it.each([
+    [" force-agent-consult ", "force-agent-consult"],
+    [" Provider-Direct ", "provider-direct"],
+    [" ", null],
+    [null, null],
+  ])("normalizes consult routing: %s", (consultRouting, expected) => {
+    expect(
+      resolveTalkRealtimeSelection({
+        talk: { realtime: { consultRouting } },
+      }).consultRouting,
+    ).toBe(expected);
+  });
+});
+
 describe("renderTalk", () => {
   it("locks every curated picker when config mutation is unavailable", () => {
     const container = document.createElement("div");
@@ -160,6 +183,7 @@ describe("renderTalk", () => {
           model: "gpt-live",
           speakerVoice: "marin",
           transport: "webrtc",
+          consultRouting: null,
           providerEntries: {},
         },
         catalog: {
@@ -210,6 +234,7 @@ describe("renderTalk", () => {
           model: "gpt-live",
           speakerVoice: null,
           transport: "webrtc",
+          consultRouting: null,
           providerEntries: {},
         },
         catalog: {
@@ -263,6 +288,7 @@ describe("renderTalk", () => {
           model,
           speakerVoice: null,
           transport: "gateway-relay",
+          consultRouting: null,
           providerEntries: {},
         },
         catalog: {
@@ -296,6 +322,42 @@ describe("renderTalk", () => {
 });
 
 describe("TalkSettingsPage realtime transport mutation", () => {
+  it("removes forced consult routing when OpenAI GPT-Live keeps gateway relay", async () => {
+    const removeFormValue = await selectModel("gpt-live-1-boulder-alpha", {
+      consultRouting: " Force-Agent-Consult ",
+      transports: ["gateway-relay"],
+    });
+
+    expect(removeFormValue).toHaveBeenCalledTimes(1);
+    expect(removeFormValue).toHaveBeenCalledWith(["talk", "realtime", "consultRouting"]);
+    expect(removeFormValue).not.toHaveBeenCalledWith(["talk", "realtime", "transport"]);
+  });
+
+  it.each([
+    [
+      "provider-direct routing",
+      "gpt-live-1-boulder-alpha",
+      "provider-direct",
+      "openai",
+      "gateway-relay",
+    ],
+    ["another model", "gpt-realtime", "force-agent-consult", "openai", "gateway-relay"],
+    ["another provider", "gpt-live-1-boulder-alpha", "force-agent-consult", "xai", "gateway-relay"],
+    ["another transport", "gpt-live-1-boulder-alpha", "force-agent-consult", "openai", "webrtc"],
+  ] as const)(
+    "preserves consult routing for %s",
+    async (_label, model, consultRouting, provider, transport) => {
+      const removeFormValue = await selectModel(model, {
+        consultRouting,
+        provider,
+        transport,
+        transports: ["gateway-relay", "webrtc"],
+      });
+
+      expect(removeFormValue).not.toHaveBeenCalledWith(["talk", "realtime", "consultRouting"]);
+    },
+  );
+
   it("preserves transport when switching to a provider that advertises it", async () => {
     const removeFormValue = await selectProvider("openai", {
       provider: "xai",
@@ -304,6 +366,35 @@ describe("TalkSettingsPage realtime transport mutation", () => {
 
     expect(removeFormValue).not.toHaveBeenCalledWith(["talk", "realtime", "transport"]);
   });
+
+  it("removes provider websocket when switching to a GPT-Live provider", async () => {
+    const removeFormValue = await selectProvider("openai", {
+      provider: "xai",
+      transport: "provider-websocket",
+      transports: ["provider-websocket", "webrtc"],
+    });
+
+    expect(removeFormValue).toHaveBeenCalledWith(["talk", "realtime", "transport"]);
+  });
+
+  it.each([
+    ["catalog default", "gpt-live-1-boulder-alpha", undefined],
+    ["provider fallback", "gpt-realtime-2.1", "gpt-live-1-boulder-alpha"],
+  ])(
+    "removes forced consult when a provider switch activates a GPT-Live %s",
+    async (_label, defaultModel, openAIProviderModel) => {
+      const removeFormValue = await selectProvider("openai", {
+        consultRouting: "force-agent-consult",
+        defaultModel,
+        openAIProviderModel,
+        provider: "xai",
+        transports: ["gateway-relay", "webrtc"],
+      });
+
+      expect(removeFormValue).toHaveBeenCalledWith(["talk", "realtime", "consultRouting"]);
+      expect(removeFormValue).not.toHaveBeenCalledWith(["talk", "realtime", "transport"]);
+    },
+  );
 
   it("removes transport when switching to a provider that positively rejects it", async () => {
     const removeFormValue = await selectProvider("openai", {
@@ -324,6 +415,15 @@ describe("TalkSettingsPage realtime transport mutation", () => {
     expect(
       await selectModel("gpt-live-1-boulder-alpha", { transports: [] }),
     ).not.toHaveBeenCalled();
+  });
+
+  it("removes provider websocket from a selected GPT-Live model", async () => {
+    expect(
+      await selectModel("gpt-live-1-boulder-alpha", {
+        transport: "provider-websocket",
+        transports: ["provider-websocket", "webrtc"],
+      }),
+    ).toHaveBeenCalledWith(["talk", "realtime", "transport"]);
   });
 
   it("preserves a transport advertised by the explicit provider", async () => {

--- a/ui/src/pages/config/talk.test.ts
+++ b/ui/src/pages/config/talk.test.ts
@@ -1,8 +1,154 @@
 /* @vitest-environment jsdom */
 
+import type { TalkCatalogResult } from "@openclaw/gateway-protocol";
 import { html, render } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { t } from "../../i18n/index.ts";
+import "./talk-page.ts";
+import { isTalkGptLiveModel } from "./talk-schema.ts";
 import { renderTalk } from "./talk.ts";
+
+type TalkSettingsPageTestElement = HTMLElement & {
+  context: ApplicationContext;
+  configObject: Record<string, unknown>;
+  updateComplete: Promise<boolean>;
+  changeModel: (model: string | null) => void;
+  changeProvider: (providerId: string | null) => void;
+};
+
+type TalkMutationHarnessOptions = {
+  activeProvider?: string | null;
+  aliases?: string[];
+  provider?: string | null;
+  transports?: string[];
+  unavailable?: boolean;
+};
+
+function createTalkMutationHarness(options: TalkMutationHarnessOptions = {}) {
+  const request = options.unavailable
+    ? vi.fn(async () => {
+        throw new Error("talk.catalog unavailable");
+      })
+    : vi.fn(async () => {
+        return {
+          realtime: {
+            ready: true,
+            activeProvider: options.activeProvider ?? "openai",
+            providers: [
+              {
+                id: "openai",
+                label: "OpenAI",
+                configured: true,
+                aliases: options.aliases ?? [],
+                models: ["gpt-live-1-boulder-alpha"],
+                voices: ["marin"],
+                transports: options.transports ?? ["gateway-relay"],
+                defaultModel: "gpt-live-1-boulder-alpha",
+              },
+              {
+                id: "xai",
+                label: "xAI",
+                configured: true,
+                aliases: [],
+                models: ["grok-voice"],
+                voices: ["ara"],
+                transports: ["gateway-relay"],
+                defaultModel: "grok-voice",
+              },
+            ],
+          },
+        } as TalkCatalogResult;
+      });
+  const snapshot: ApplicationGatewaySnapshot = {
+    client: { request } as unknown as GatewayBrowserClient,
+    phase: "connected",
+    offlineStable: false,
+    canvasPluginSurfaceUrl: null,
+    hello: null,
+    assistantAgentId: "main",
+    sessionKey: "main",
+    lastError: null,
+    lastErrorCode: null,
+  };
+  const subscribe = () => () => undefined;
+  const configForm = {
+    talk: {
+      realtime: {
+        provider: options.provider === undefined ? "openai" : options.provider,
+        model: "gpt-realtime-2.1",
+        transport: "gateway-relay",
+      },
+    },
+  };
+  const runtimeConfig = {
+    state: {
+      configForm,
+      configSnapshot: { hash: "hash" },
+      configLoading: false,
+      configSaving: false,
+      configApplying: false,
+    },
+    patchForm: vi.fn(),
+    removeFormValue: vi.fn(),
+    subscribe,
+  };
+  const context = {
+    gateway: { snapshot, subscribe },
+    runtimeConfig,
+  } as unknown as ApplicationContext;
+  const page = document.createElement("openclaw-talk-settings") as TalkSettingsPageTestElement;
+  page.context = context;
+  page.configObject = configForm;
+  document.body.append(page);
+  return { page, request, runtimeConfig };
+}
+
+async function selectModel(model: string, options: TalkMutationHarnessOptions = {}) {
+  const harness = createTalkMutationHarness(options);
+  await vi.waitFor(() => expect(harness.request).toHaveBeenCalledWith("talk.catalog", {}));
+  await harness.page.updateComplete;
+  harness.page.changeModel(model);
+  expect(harness.runtimeConfig.patchForm).toHaveBeenCalledWith(
+    ["talk", "realtime", "model"],
+    model,
+  );
+  return harness.runtimeConfig.removeFormValue;
+}
+
+async function selectProvider(providerId: string, options: TalkMutationHarnessOptions = {}) {
+  const harness = createTalkMutationHarness(options);
+  await vi.waitFor(() => expect(harness.request).toHaveBeenCalledWith("talk.catalog", {}));
+  await harness.page.updateComplete;
+  harness.page.changeProvider(providerId);
+  expect(harness.runtimeConfig.patchForm).toHaveBeenCalledWith(
+    ["talk", "realtime", "provider"],
+    providerId,
+  );
+  return harness.runtimeConfig.removeFormValue;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("isTalkGptLiveModel", () => {
+  it.each(["gpt-live", "gpt-live-1-codex", " GPT-Live-1-Boulder-Alpha "])(
+    "accepts the GPT-Live family: %s",
+    (model) => {
+      expect(isTalkGptLiveModel(model)).toBe(true);
+    },
+  );
+
+  it.each([null, "", "gpt-liveish", "gpt-lively", "gpt-realtime"])(
+    "rejects GPT-Live lookalikes: %s",
+    (model) => {
+      expect(isTalkGptLiveModel(model)).toBe(false);
+    },
+  );
+});
 
 describe("renderTalk", () => {
   it("locks every curated picker when config mutation is unavailable", () => {
@@ -103,4 +249,119 @@ describe("renderTalk", () => {
     }
     expect(onModelChange).toHaveBeenCalledWith("gpt-realtime");
   });
+
+  it.each([
+    ["gpt-liveish", false],
+    ["gpt-lively", false],
+    ["gpt-live-1-codex", true],
+  ] as const)("renders the GPT-Live hint only for the exact family: %s", (model, showsHint) => {
+    const container = document.createElement("div");
+    render(
+      renderTalk({
+        selection: {
+          provider: "openai",
+          model,
+          speakerVoice: null,
+          transport: "gateway-relay",
+          providerEntries: {},
+        },
+        catalog: {
+          kind: "ready",
+          ready: true,
+          activeProvider: "openai",
+          providers: [
+            {
+              id: "openai",
+              label: "OpenAI",
+              configured: true,
+              aliases: [],
+              models: [model],
+              voices: [],
+              transports: ["gateway-relay"],
+              defaultModel: model,
+            },
+          ],
+        },
+        configBusy: false,
+        onProviderChange: vi.fn(),
+        onModelChange: vi.fn(),
+        onVoiceChange: vi.fn(),
+        editor: html``,
+      }),
+      container,
+    );
+
+    expect(container.textContent?.includes(t("talkPage.gptLive.hint"))).toBe(showsHint);
+  });
+});
+
+describe("TalkSettingsPage realtime transport mutation", () => {
+  it("preserves transport when switching to a provider that advertises it", async () => {
+    const removeFormValue = await selectProvider("openai", {
+      provider: "xai",
+      transports: ["gateway-relay", "webrtc"],
+    });
+
+    expect(removeFormValue).not.toHaveBeenCalledWith(["talk", "realtime", "transport"]);
+  });
+
+  it("removes transport when switching to a provider that positively rejects it", async () => {
+    const removeFormValue = await selectProvider("openai", {
+      provider: "xai",
+      transports: ["webrtc"],
+    });
+
+    expect(removeFormValue).toHaveBeenCalledWith(["talk", "realtime", "transport"]);
+  });
+
+  it("preserves transport when the catalog is unavailable", async () => {
+    expect(
+      await selectModel("gpt-live-1-boulder-alpha", { unavailable: true }),
+    ).not.toHaveBeenCalled();
+  });
+
+  it("preserves transport when the provider advertises no transport capabilities", async () => {
+    expect(
+      await selectModel("gpt-live-1-boulder-alpha", { transports: [] }),
+    ).not.toHaveBeenCalled();
+  });
+
+  it("preserves a transport advertised by the explicit provider", async () => {
+    expect(
+      await selectModel("gpt-live-1-boulder-alpha", { transports: ["gateway-relay"] }),
+    ).not.toHaveBeenCalled();
+  });
+
+  it("resolves an explicit provider alias before preserving transport", async () => {
+    expect(
+      await selectModel("gpt-live-1-boulder-alpha", {
+        aliases: ["openai-preview"],
+        provider: "openai-preview",
+        transports: ["gateway-relay"],
+      }),
+    ).not.toHaveBeenCalled();
+  });
+
+  it("uses the auto-selected provider before preserving transport", async () => {
+    expect(
+      await selectModel("gpt-live-1-boulder-alpha", {
+        activeProvider: "openai",
+        provider: null,
+        transports: ["gateway-relay"],
+      }),
+    ).not.toHaveBeenCalled();
+  });
+
+  it("removes transport only when the resolved provider positively excludes it", async () => {
+    expect(
+      await selectModel("gpt-live-1-boulder-alpha", { transports: ["webrtc"] }),
+    ).toHaveBeenCalledOnce();
+  });
+
+  it.each(["gpt-liveish", "gpt-lively"])(
+    "preserves transport for GPT-Live lookalikes: %s",
+    async (model) => {
+      expect(await selectModel(model, { transports: ["webrtc"] })).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/ui/src/pages/config/talk.ts
+++ b/ui/src/pages/config/talk.ts
@@ -110,7 +110,7 @@ export function talkProviderConfigKeys(
 }
 
 /** Effective model/voice: top-level override, else the provider entry value. */
-function effectiveTalkValues(
+export function effectiveTalkValues(
   selection: TalkRealtimeSelection,
   option: TalkRealtimeProviderOption | undefined,
 ): { model: string | null; speakerVoice: string | null } {


### PR DESCRIPTION
## What Problem This Solves

macOS operators need a direct handoff from Voice & Talk settings to the existing Control UI Talk configuration. The Control UI must preserve configured realtime transport whenever the target provider positively advertises it, while removing forced transcript consultation when OpenAI GPT-Live remains on Gateway relay.

This layer adds the native handoff, clears transport only when the resolved target provider positively advertises a non-empty incompatible list, preserves the GPT-Live-specific `provider-websocket` exclusion, and removes only `talk.realtime.consultRouting: force-agent-consult` for the exact OpenAI GPT-Live plus `gateway-relay` selection.

## Scope And Ownership

- link macOS Voice & Talk settings to Control UI Settings -> Talk;
- keep the local realtime relay opt-in default-off;
- preserve supported realtime transport through provider switches, aliases, automatic provider selection, and model changes;
- reject `provider-websocket` specifically for GPT-Live even when OpenAI advertises it for other realtime models;
- normalize the existing `consultRouting` selection fact and remove only the incompatible forced-routing value; and
- keep native i18n source-only.

Exactly ten paths are changed: native source inventory, two macOS settings/menu surfaces, the shared Dashboard route plus its test, Talk docs, and four Control UI Talk files.

## Exact Artifact

- Exact base and landed prerequisite #128204: `000db97c8252da49ae39b9382525552e75c687a7`
- Feature commit: `c2c37ecc3c782f745dddb81551b28955b940f01c`
- Head commit and direct parent: `9d657637f9d1142c687f0b3ac4f139be7aa2f83c` over `c2c37ecc3c782f745dddb81551b28955b940f01c`
- Tree: `291bb125e77ae74cdc25134d0be756f09b209170`
- Feature patch ID: `80dab669add59d66afd1dcc3efd37e31177bc540`
- GPT-Live routing patch ID: `d5d87b664f3fd53e2bf5bd02289d679875e2fc58`
- Aggregate layer patch ID: `ba2efd6e7a082c500fa537dd3f648047e6a0bbf7`
- Binary diff SHA-256: `3f6a4cd218e9a3d9a68790ac176a9f1f44466cb000e663a005cf094ec2c74ced`
- Both commit signatures verified; Zhilong Zheng co-author credit is preserved.

Old contributor head `b32096ae95fbf2ca21d620b6a7892d164aa39c86` was mechanically restacked onto landed C. Exact-head review then repaired provider-switch forced-routing ownership and the GPT-Live-specific `provider-websocket` exclusion in the existing routing commit.

## Scope And LOC

- Production: `+98/-23`
- Tests: `+364/-2`
- Docs: `+4/-2`
- Native source inventory: `+37/-0`
- Raw total: `+503/-27`

No locale JSON or Apple `.xcstrings` files are changed.

## Evidence

- Exact-head focused Talk UI tests: `36/36`.
- Exact-head `pnpm tsgo:test:ui`: passed.
- Exact-head shared Dashboard route tests: `7/7`.
- Exact-head macOS menu smoke tests: `9/9`.
- SwiftFormat, SwiftLint, Oxfmt, `git diff --check`, changed-gate classification, signatures, ancestry, and final exact-head autoreview: passed.
- Native source verification on the restacked layer: `4,237` entries, `changed=false`; no locale JSON or `.xcstrings` churn.
- Provider-switch coverage proves compatible transport preservation, positive incompatibility clearing, forced-consult removal when a provider switch activates OpenAI GPT-Live on retained `gateway-relay`, and GPT-Live `provider-websocket` removal in both model and provider mutation paths.
- The two `provider-websocket` regressions failed before the owner fix and pass afterward; provider-wide transport advertisement no longer overrides the model-specific GPT-Live constraint.

## Visual And Native Proof

Exact-head Control UI proof was produced through the existing Playwright/mock-Gateway harness:

![Exact-head Talk settings showing OpenAI GPT-Live on Gateway relay](https://github.com/user-attachments/assets/d088f013-e174-4680-b651-2f4c65eb039a)

- Screenshot head: `9d657637f9d1142c687f0b3ac4f139be7aa2f83c`
- Screenshot SHA-256: `aa846166f37894c3e0c1caec13ecac057849eb8863fe00b79f6ad33a04640226`
- The view shows Settings -> Talk, OpenAI Realtime Voice, `gpt-live-1-boulder-alpha`, and the GPT-Live readiness hint.

The macOS release product built successfully on the immediately preceding restacked head. The final follow-up changes only Control UI transport mutation and tests, so hosted exact-head CI remains the final build gate.

The screenshot is mock-Gateway UI evidence, not physical live-audio proof. No discoverable native app window was available, so no exact-head native Voice & Talk -> Dashboard click-through screenshot or physical microphone/speaker outcome is claimed.

## Codex Boundary

Personally checked `openai/codex@e1831db7c31ec3ec3a88f29e95cc336858038bad`:

- `codex-rs/core/src/realtime_conversation.rs:100-101` defines the default realtime model and frameless GPT-Live model.
- `codex-rs/codex-api/src/endpoint/realtime_websocket/protocol_v2.rs:29-47` maps output audio and output text/audio-transcript events.
- `codex-rs/app-server/tests/suite/v2/realtime_conversation.rs:1721-1725` verifies `/v1/live` creation with `gpt-live-1-boulder-alpha`.

This settings layer changes no Codex transport, authentication, realtime event, cancellation, or PCM behavior.

## Remaining Gates

- Hosted exact-head CI and repository landing gates remain.
- Maintainer accepts the mock-Gateway screenshot as the bounded UI proof for this settings layer.
- No physical-device audio proof or exact-head native click-through screenshot is claimed.

## Release Note

macOS: surface Voice & Talk setup, preserve supported realtime transports, and clear incompatible forced GPT-Live consultation. Thanks @zhilong1115.
