### PR TITLE
fix(usage): honor configured session.store in usage-cost discovery

### DIFF
--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -489,6 +489,81 @@ describe("gateway usage helpers", () => {
     );
   });
 
+  it("loadCostUsageSummaryCached does not serve the previous store after session.store changes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+
+    // The summary is config-dependent now, so a reload that repoints session.store inside
+    // the TTL must not be answered from the entry built against the previous store.
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config: {} as OpenClawConfig,
+    });
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config: { session: { store: "/configured/my-store.json" } } as OpenClawConfig,
+    });
+
+    expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledTimes(2);
+  });
+
+  it("loadCostUsageSummaryCached re-reads when a non-default agent is swapped under one store", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+
+    // Same default and same roster size, different non-default agent: the all-agent path
+    // enumerates the ids, so a length-only key would serve the previous roster's totals.
+    const store = "/configured/my-store.json";
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config: {
+        agents: { entries: { main: { default: true }, beta: {} } },
+        session: { store },
+      } as unknown as OpenClawConfig,
+    });
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config: {
+        agents: { entries: { main: { default: true }, gamma: {} } },
+        session: { store },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledTimes(2);
+  });
+
+  it("loadCostUsageSummaryCached re-reads when the ownership roster changes under one store", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+
+    // With a configured store, who claims a shared artifact depends on the default agent
+    // and on whether the roster holds more than one agent, so the store path alone is not
+    // a complete key.
+    const store = "/configured/my-store.json";
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config: {
+        agents: { entries: { main: { default: true } } },
+        session: { store },
+      } as unknown as OpenClawConfig,
+    });
+    await testApi.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config: {
+        agents: { entries: { main: { default: true }, beta: {} } },
+        session: { store },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps refreshing cost summaries fresh for the TTL window", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-05T00:00:00.000Z"));

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -770,6 +770,7 @@ async function discoverAllSessionsForUsage(params: {
       const agentId = normalizeAgentId(agent.id);
       const sessions = await discoverAllSessions({
         agentId,
+        config: params.config,
         startMs: params.startMs,
         endMs: params.endMs,
         includeFirstUserMessage: false,
@@ -1078,7 +1079,19 @@ async function loadCostUsageSummaryCached(params: {
     ? undefined
     : normalizeAgentId(params.agentId ?? resolveDefaultAgentId(params.config));
   const dayBucketKey = usageDayBucketCacheKey(params.dayBucket);
-  const cacheKey = `${allAgents ? "all" : `agent:${agentId}`}:${params.startMs}-${params.endMs}:${dayBucketKey}`;
+  // With a configured store the summary depends on the store path and on the ownership
+  // inputs that decide who claims a shared artifact -- the default agent for globally
+  // scoped keys, and the roster itself, since the all-agent path enumerates those ids. A
+  // roster length alone would collide when one non-default agent replaces another. Only a
+  // configured store adds a segment, so the default-store key keeps its existing shape.
+  const store = params.config.session?.store;
+  const storeKey = store
+    ? `:${store}:${resolveDefaultAgentId(params.config)}:${listAgentIds(params.config)
+        .map((id) => normalizeAgentId(id))
+        .toSorted()
+        .join(",")}`
+    : "";
+  const cacheKey = `${allAgents ? "all" : `agent:${agentId}`}:${params.startMs}-${params.endMs}:${dayBucketKey}${storeKey}`;
   const now = Date.now();
   const cached = costUsageCache.get(cacheKey);
   if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {

--- a/src/infra/session-cost-usage-aggregation.ts
+++ b/src/infra/session-cost-usage-aggregation.ts
@@ -575,7 +575,6 @@ export async function refreshCostUsageCacheForAgent(params: {
   agentDir?: string;
   databasePath?: string;
   maxFiles?: number;
-  sessionsDir?: string;
   sessionFiles?: string[];
   startMs?: number;
 }): Promise<UsageCostRefreshResult> {
@@ -590,10 +589,9 @@ export async function refreshCostUsageCacheForAgent(params: {
     const rows = readSessionCostUsageRollupRows(params.agentId, databasePath);
     const rawValues = new Map(rows.map((row) => [row.key, row.valueJson]));
     const rollups = readUsageCostRollups(params.agentId, pricingFingerprint, databasePath, rows);
-    const discoveredFiles = await listUsageCountedTranscriptStats(
-      params.agentId,
-      params.sessionsDir ? { sessionsDir: params.sessionsDir } : undefined,
-    );
+    const discoveredFiles = await listUsageCountedTranscriptStats(params.agentId, {
+      config: params.config,
+    });
     const requestedFiles: UsageCostTranscriptFile[] = [];
     for (const requested of params.sessionFiles ?? []) {
       const resolved = await resolveUsageCostTranscriptFile(requested);

--- a/src/infra/session-cost-usage-cache-runtime.ts
+++ b/src/infra/session-cost-usage-cache-runtime.ts
@@ -1,4 +1,3 @@
-import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
@@ -43,7 +42,6 @@ type UsageCostRefreshState = {
   fullRefreshRequested: boolean;
   pendingSessionFiles: Set<string>;
   running: boolean;
-  sessionsDir: string;
   busyRetryDelayMs: number;
   timer?: ReturnType<typeof setTimeout>;
 };
@@ -72,7 +70,7 @@ export async function loadCostUsageSummary(params: {
   });
   const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config, agentDir);
   const rollups = readUsageCostRollups(params.agentId, pricingFingerprint, databasePath);
-  const files = await listUsageCountedTranscriptStats(params.agentId);
+  const files = await listUsageCountedTranscriptStats(params.agentId, { config: params.config });
   return buildCostUsageSummaryFromRollups({
     rollups,
     files,
@@ -99,7 +97,7 @@ export async function loadCostUsageSummaryFromCache(params: {
   const databasePath = resolveUsageCostCacheDatabasePath(params.agentId);
   const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config, agentDir);
   let rollups = readUsageCostRollups(params.agentId, pricingFingerprint, databasePath);
-  let files = await listUsageCountedTranscriptStats(params.agentId);
+  let files = await listUsageCountedTranscriptStats(params.agentId, { config: params.config });
   const staleFiles = getUsageCostStaleRollupFiles({ rollups, files });
   if (params.requestRefresh !== false && staleFiles.length > 0) {
     const cachedFiles = countUsableUsageCostRollups({ rollups, files });
@@ -111,7 +109,7 @@ export async function loadCostUsageSummaryFromCache(params: {
         startMs: params.startMs,
       });
       rollups = readUsageCostRollups(params.agentId, pricingFingerprint, databasePath);
-      files = await listUsageCountedTranscriptStats(params.agentId);
+      files = await listUsageCountedTranscriptStats(params.agentId, { config: params.config });
       if (result === "refreshed" && getUsageCostStaleRollupFiles({ rollups, files }).length > 0) {
         requestCostUsageCacheRefresh({ config: params.config, agentId: params.agentId });
       }
@@ -224,7 +222,6 @@ function requestCostUsageCacheRefresh(params: {
     fullRefreshRequested: false,
     pendingSessionFiles: new Set(),
     running: false,
-    sessionsDir: resolveSessionTranscriptsDirForAgent(params.agentId),
     busyRetryDelayMs: USAGE_COST_REFRESH_RETRY_MIN_MS,
   };
   mergeUsageCostRefreshRequest(state, params);
@@ -289,7 +286,6 @@ async function runQueuedUsageCostRefresh(
         config: state.config,
         agentId: state.agentId,
         databasePath: state.databasePath,
-        sessionsDir: state.sessionsDir,
         sessionFiles: fullRefreshRequested ? undefined : sessionFiles,
       });
       if (result === "busy") {

--- a/src/infra/session-cost-usage-collection.ts
+++ b/src/infra/session-cost-usage-collection.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { listAgentIds } from "../agents/agent-scope.js";
 import {
   materializeSessionArchiveForRead,
   SESSION_ARCHIVE_ZSTD_SUFFIX,
@@ -21,6 +22,7 @@ import {
   resolveDefaultSessionStorePath,
   resolveSessionFilePath,
   resolveSessionTranscriptsDirForAgent,
+  resolveStorePath,
 } from "../config/sessions/paths.js";
 import {
   listSessionTranscriptInstances,
@@ -28,15 +30,23 @@ import {
   loadTranscriptEventsSync,
   readTranscriptStatsSync,
 } from "../config/sessions/session-accessor.js";
-import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import {
+  resolveSqliteTargetFromSessionStorePath,
+  resolveUnsuffixedSqliteTargetFromSessionStorePath,
+} from "../config/sessions/session-sqlite-target.js";
 import { streamSessionTranscriptLines } from "../config/sessions/transcript-stream.js";
 import { selectVisibleTranscriptEvents } from "../config/sessions/transcript-visible-events.js";
 import type { SessionEntry } from "../config/sessions/types.js";
-import { parseAgentSessionKey } from "../routing/session-key.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveSessionStoreAgentId } from "../gateway/session-store-key.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 
 export const USAGE_COST_TRANSCRIPT_STAT_CONCURRENCY = 32;
+
+/** Config is the only input that decides which session store usage discovery scans. */
+type UsageCostDiscoveryScope = { minMtimeMs?: number; config?: OpenClawConfig };
 
 export type UsageCostTranscriptFile = {
   filePath: string;
@@ -50,20 +60,73 @@ export type UsageCostTranscriptFile = {
   maxSeq?: number;
 };
 
+// Discovery must enumerate the operator's configured store: a custom store
+// filename resolves to a different SQLite database than the default one, so
+// rebuilding the default path here hides every session the writer recorded.
 function resolveUsageCostSessionStorePath(params: {
   agentId: string;
-  sessionsDir?: string;
+  config?: OpenClawConfig;
 }): string {
-  return params.sessionsDir
-    ? path.join(params.sessionsDir, "sessions.json")
+  const store = params.config?.session?.store;
+  return store
+    ? resolveStorePath(store, { agentId: params.agentId })
     : resolveDefaultSessionStorePath(params.agentId);
+}
+
+/**
+ * A configured store is shared when it expands to the same target for every agent, and
+ * artifacts under it that carry no agent of their own -- legacy `<sessionId>.jsonl` files,
+ * globally scoped keys -- must then be claimed by exactly one scan, or the all-agent
+ * rollup counts them once per agent. `{agentId}` expansion is what makes a store
+ * per-agent, and the two halves of discovery key off different parts of it: the SQLite
+ * target follows the whole path, while legacy files only follow its directory. A store
+ * like `<dir>/{agentId}.json` has per-agent databases but one shared directory.
+ */
+function resolveSharedStoreConfig(
+  config: OpenClawConfig | undefined,
+  part: "path" | "directory",
+): OpenClawConfig | undefined {
+  const store = config?.session?.store;
+  if (typeof store !== "string" || !store.trim()) {
+    return undefined;
+  }
+  const scoped = part === "directory" ? path.dirname(store) : store;
+  return scoped.includes("{agentId}") ? undefined : config;
+}
+
+/**
+ * A legacy `<sessionId>.jsonl` name carries no agent, so ownership has to come from the
+ * directory holding it. A canonical store path names its owner (`agents/<id>/sessions/...`)
+ * and that is authoritative; a shared locator's owner is only the configured default, which
+ * names no one in particular. With no derivable owner and more than one agent, these files
+ * are unattributable: charging the default agent would report one agent's spend under
+ * another, which is worse than the omission it replaces -- they are not discovered at all
+ * today. A sole configured agent still claims them, since that directory cannot be ambiguous.
+ */
+function ownsLegacyStoreDirectory(
+  config: OpenClawConfig,
+  agentId: string,
+  storePath: string,
+): boolean {
+  // Resolve from the path alone: the agentId-aware form echoes the requesting agent back
+  // for a custom store, which would make every agent look like the owner.
+  const owner = resolveUnsuffixedSqliteTargetFromSessionStorePath(storePath).agentId;
+  return owner
+    ? normalizeAgentId(owner) === normalizeAgentId(agentId)
+    : listAgentIds(config).length <= 1;
 }
 
 async function listUsageCountedTranscriptFileStats(
   agentId: string,
-  params?: { minMtimeMs?: number; sessionsDir?: string },
+  params?: UsageCostDiscoveryScope,
 ): Promise<UsageCostTranscriptFile[]> {
-  const sessionsDir = params?.sessionsDir ?? resolveSessionTranscriptsDirForAgent(agentId);
+  // Legacy JSONL transcripts sit beside the store file; SQLite needs the store itself.
+  const storePath = resolveUsageCostSessionStorePath({ agentId, ...params });
+  const sharedStoreConfig = resolveSharedStoreConfig(params?.config, "directory");
+  if (sharedStoreConfig && !ownsLegacyStoreDirectory(sharedStoreConfig, agentId, storePath)) {
+    return [];
+  }
+  const sessionsDir = path.dirname(storePath);
   let entries: fs.Dirent[];
   try {
     entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
@@ -133,16 +196,42 @@ async function listUsageCountedTranscriptFileStats(
 
 function listUsageCountedSqliteTranscriptStats(
   agentId: string,
-  params?: { minMtimeMs?: number; sessionsDir?: string },
+  params?: UsageCostDiscoveryScope,
 ): UsageCostTranscriptFile[] {
-  const storePath = resolveUsageCostSessionStorePath({
-    agentId,
-    ...(params?.sessionsDir ? { sessionsDir: params.sessionsDir } : {}),
-  });
+  const storePath = resolveUsageCostSessionStorePath({ agentId, ...params });
+  const requestedAgentId = normalizeAgentId(agentId);
+  const sqliteTarget = resolveSqliteTargetFromSessionStorePath(storePath, { agentId });
+  // A fixed store can name one agent's own database, e.g. agents/<id>/sessions/sessions.json.
+  // Reading it as any other agent is not merely empty: the scope resolver rejects the
+  // mismatch, and one throw would abort the whole all-agent usage fan-out.
+  if (
+    sqliteTarget.shared !== true &&
+    sqliteTarget.agentId &&
+    normalizeAgentId(sqliteTarget.agentId) !== requestedAgentId
+  ) {
+    return [];
+  }
+  // Only an exact .sqlite locator under a fixed store is one database for every agent.
+  // Any other store resolves to a per-agent database, where each row is ours by
+  // construction and an ownership filter would silently drop transcripts.
+  const fixedStoreConfig = resolveSharedStoreConfig(params?.config, "path");
+  const sharedStoreConfig =
+    fixedStoreConfig && sqliteTarget.shared === true ? fixedStoreConfig : undefined;
   const files: UsageCostTranscriptFile[] = [];
   // This scan reads transcript identity/timestamps only; clone:false avoids
   // cloning every current entry before the history projection and SQL rollups.
   for (const instance of listSessionTranscriptInstances({ agentId, storePath, clone: false })) {
+    // The marker below stamps the caller's agent, so in a shared store every agent
+    // would claim the same transcript and the all-agent rollup would re-count it.
+    // Globally scoped keys have no agent of their own; the store-key owner rule
+    // hands them to the default agent so exactly one scan picks them up.
+    if (
+      sharedStoreConfig &&
+      normalizeAgentId(resolveSessionStoreAgentId(sharedStoreConfig, instance.sessionKey)) !==
+        requestedAgentId
+    ) {
+      continue;
+    }
     const marker = { agentId, sessionId: instance.sessionId, storePath };
     const mtimeMs = instance.updatedAtMs;
     if (params?.minMtimeMs !== undefined && mtimeMs < params.minMtimeMs) {
@@ -177,7 +266,7 @@ function formatCanonicalUsageCostSqliteMarker(marker: SqliteSessionFileMarker): 
 
 export async function listUsageCountedTranscriptStats(
   agentId: string,
-  params?: { minMtimeMs?: number; sessionsDir?: string },
+  params?: UsageCostDiscoveryScope,
 ): Promise<UsageCostTranscriptFile[]> {
   const fileBacked = await listUsageCountedTranscriptFileStats(agentId, params);
   const sqliteBacked = listUsageCountedSqliteTranscriptStats(agentId, params);

--- a/src/infra/session-cost-usage-collection.ts
+++ b/src/infra/session-cost-usage-collection.ts
@@ -110,10 +110,36 @@ function ownsLegacyStoreDirectory(
 ): boolean {
   // Resolve from the path alone: the agentId-aware form echoes the requesting agent back
   // for a custom store, which would make every agent look like the owner.
-  const owner = resolveUnsuffixedSqliteTargetFromSessionStorePath(storePath).agentId;
-  return owner
-    ? normalizeAgentId(owner) === normalizeAgentId(agentId)
-    : listAgentIds(config).length <= 1;
+  const owner = resolveCanonicalStoreDirectoryOwner(storePath);
+  const requested = normalizeAgentId(agentId);
+  if (owner) {
+    return normalizeAgentId(owner) === requested;
+  }
+  // The sole-agent case has to check *which* agent is asking. Discovery fans out over
+  // the gateway roster, which admits agents this list does not (disk-resident ones), and
+  // a per-agent request may name any id at all; answering "yes" on roster size alone
+  // hands the same directory to every caller and double counts it.
+  const roster = listAgentIds(config).map((id) => normalizeAgentId(id));
+  return roster.length === 1 && roster[0] === requested;
+}
+
+/**
+ * The agent named by a canonical `agents/<id>/sessions/` directory, if any.
+ *
+ * The store's own basename is not part of that question: `my-store.json` sitting in
+ * `agents/main/sessions/` is still main's directory, and its legacy transcripts are still
+ * main's. `resolveUnsuffixedSqliteTargetFromSessionStorePath` only derives an owner for the
+ * exact `sessions.json` basename, so ask it a second time about the canonical name in the
+ * same directory rather than restating its path rule here.
+ */
+function resolveCanonicalStoreDirectoryOwner(storePath: string): string | undefined {
+  const direct = resolveUnsuffixedSqliteTargetFromSessionStorePath(storePath).agentId;
+  if (direct) {
+    return direct;
+  }
+  return resolveUnsuffixedSqliteTargetFromSessionStorePath(
+    path.join(path.dirname(storePath), "sessions.json"),
+  ).agentId;
 }
 
 async function listUsageCountedTranscriptFileStats(

--- a/src/infra/session-cost-usage-refresh.test.ts
+++ b/src/infra/session-cost-usage-refresh.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { testing as testApi } from "./session-cost-usage.test-support.js";
 
 describe("session cost usage refresh backoff", () => {
@@ -65,5 +66,32 @@ describe("session cost usage refresh backoff", () => {
     expect(refresh).toHaveBeenCalledTimes(12);
     await vi.advanceTimersByTimeAsync(1);
     expect(refresh).toHaveBeenCalledTimes(13);
+  });
+
+  it("queues a refresh with no scan target of its own, so late config decides the store", async () => {
+    // The queued state used to snapshot a scan directory when it was created and
+    // never refresh it, so a request that arrived before config pinned the default
+    // store for every later run against that agent. Nothing but the merged config
+    // may reach the runner.
+    const calls: Array<Record<string, unknown>> = [];
+    vi.spyOn(testApi.usageCostRefreshRuntime, "refreshCostUsageCacheForAgent").mockImplementation(
+      async (params) => {
+        calls.push({ ...params });
+        return "refreshed";
+      },
+    );
+
+    testApi.requestCostUsageCacheRefresh({ agentId: "merge-test" });
+    testApi.requestCostUsageCacheRefresh({
+      agentId: "merge-test",
+      config: { session: { store: "/configured/my-store.json" } } as OpenClawConfig,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).not.toHaveProperty("sessionsDir");
+    expect((calls[0]?.config as { session?: { store?: string } })?.session?.store).toBe(
+      "/configured/my-store.json",
+    );
   });
 });

--- a/src/infra/session-cost-usage-reporting.ts
+++ b/src/infra/session-cost-usage-reporting.ts
@@ -55,12 +55,14 @@ const USAGE_COST_DIRECT_REFRESH_RETRY_MS = 25;
  */
 export async function discoverAllSessions(params: {
   agentId: string;
+  config?: OpenClawConfig;
   startMs?: number;
   endMs?: number;
   includeFirstUserMessage?: boolean;
 }): Promise<DiscoveredSession[]> {
   const files = await listUsageCountedTranscriptStats(params.agentId, {
     minMtimeMs: params.startMs,
+    config: params.config,
   });
 
   const discovered = new Map<string, DiscoveredSession>();

--- a/src/infra/session-cost-usage.configured-store.test.ts
+++ b/src/infra/session-cost-usage.configured-store.test.ts
@@ -1,0 +1,509 @@
+// Covers usage-cost discovery honoring a configured session.store.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import {
+  persistSessionTranscriptTurn,
+  upsertSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { discoverAllSessions, loadCostUsageSummaryFromCache } from "./session-cost-usage.js";
+
+describe("usage cost discovery with a configured session store", () => {
+  const suiteRootTracker = createSuiteTempRootTracker({
+    prefix: "openclaw-configured-store-usage-",
+  });
+
+  beforeAll(async () => {
+    await suiteRootTracker.setup();
+  });
+
+  afterAll(async () => {
+    await suiteRootTracker.cleanup();
+  });
+
+  const writeUsageTurn = async (params: {
+    agentId: string;
+    sessionId: string;
+    storePath?: string;
+    timestampMs: number;
+    usage?: { totalTokens: number; cost: number };
+  }): Promise<void> => {
+    const totalTokens = params.usage?.totalTokens ?? 18;
+    const cost = params.usage?.cost ?? 0.018;
+    const sessionKey = `agent:${params.agentId}:${params.agentId}`;
+    const scope = params.storePath ? { sessionKey, storePath: params.storePath } : { sessionKey };
+    await upsertSessionEntry(scope, {
+      sessionId: params.sessionId,
+      updatedAt: params.timestampMs,
+    });
+    await persistSessionTranscriptTurn(
+      {
+        agentId: params.agentId,
+        sessionId: params.sessionId,
+        sessionKey,
+        ...(params.storePath ? { storePath: params.storePath } : {}),
+      },
+      {
+        messages: [
+          { message: { role: "user", content: "usage prompt", timestamp: params.timestampMs } },
+          {
+            message: {
+              role: "assistant",
+              content: "usage answer",
+              model: "gpt-5.4",
+              provider: "openai",
+              timestamp: params.timestampMs + 1000,
+              usage: {
+                input: Math.floor(totalTokens / 2),
+                output: totalTokens - Math.floor(totalTokens / 2),
+                totalTokens,
+                cost: { total: cost },
+              },
+            },
+          },
+        ],
+        touchSessionEntry: false,
+      },
+    );
+  };
+
+  it("aggregates sessions written to a store with a custom filename", async () => {
+    const root = await suiteRootTracker.make("custom-store");
+    const agentId = "main";
+    const sessionId = "custom-store-session";
+    // A custom basename is what makes the SQLite target diverge: the store
+    // resolves to <basename>.sqlite instead of the default agent database.
+    const store = path.join(root, "custom", "my-store.json");
+    const config = { session: { store } } as OpenClawConfig;
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      const storePath = resolveStorePath(store, { agentId });
+      expect(storePath).toBe(store);
+      await writeUsageTurn({ agentId, sessionId, storePath, timestampMs: now });
+
+      const summary = await loadCostUsageSummaryFromCache({
+        agentId,
+        config,
+        startMs: now - 3_600_000,
+        endMs: now + 3_600_000,
+        refreshMode: "sync-when-empty",
+      });
+      expect(summary.totals.totalTokens).toBe(18);
+      expect(summary.totals.totalCost).toBeCloseTo(0.018, 8);
+
+      const discovered = await discoverAllSessions({ agentId, config });
+      expect(discovered.map((session) => session.sessionId)).toEqual([sessionId]);
+    });
+  });
+
+  it("attributes sessions per agent when the configured store is a shared SQLite locator", async () => {
+    const root = await suiteRootTracker.make("shared-store");
+    // An exact .sqlite locator is a shared store: every agent's rows live in one
+    // file, partitioned by scoped session key.
+    const store = path.join(root, "shared", "team.sqlite");
+    const config = { session: { store } } as OpenClawConfig;
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      for (const [agentId, sessionId, tokens, cost] of [
+        ["alpha", "alpha-session", 18, 0.018],
+        ["beta", "beta-session", 40, 0.04],
+      ] as const) {
+        await writeUsageTurn({
+          agentId,
+          sessionId,
+          storePath: resolveStorePath(store, { agentId }),
+          timestampMs: now,
+          usage: { totalTokens: tokens, cost },
+        });
+      }
+
+      for (const [agentId, sessionId, tokens, cost] of [
+        ["alpha", "alpha-session", 18, 0.018],
+        ["beta", "beta-session", 40, 0.04],
+      ] as const) {
+        const discovered = await discoverAllSessions({ agentId, config });
+        expect(discovered.map((session) => session.sessionId)).toEqual([sessionId]);
+
+        const summary = await loadCostUsageSummaryFromCache({
+          agentId,
+          config,
+          startMs: now - 3_600_000,
+          endMs: now + 3_600_000,
+          refreshMode: "sync-when-empty",
+        });
+        expect(summary.totals.totalTokens).toBe(tokens);
+        expect(summary.totals.totalCost).toBeCloseTo(cost, 8);
+      }
+    });
+  });
+
+  it("counts a globally scoped shared-store session once, under the default agent", async () => {
+    const root = await suiteRootTracker.make("global-scope");
+    const store = path.join(root, "shared", "team.sqlite");
+    // A "global" session key has no agent of its own, so without an owner rule
+    // every agent would claim it and the all-agent rollup would re-count it.
+    const config = {
+      agents: { entries: { alpha: { default: true }, beta: {} } },
+      session: { scope: "global", store },
+    } as unknown as OpenClawConfig;
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      const storePath = resolveStorePath(store, { agentId: "alpha" });
+      await upsertSessionEntry(
+        { agentId: "alpha", sessionKey: "global", storePath },
+        { sessionId: "global-session", updatedAt: now },
+      );
+      await persistSessionTranscriptTurn(
+        { agentId: "alpha", sessionId: "global-session", sessionKey: "global", storePath },
+        {
+          messages: [
+            { message: { role: "user", content: "usage prompt", timestamp: now } },
+            {
+              message: {
+                role: "assistant",
+                content: "usage answer",
+                model: "gpt-5.4",
+                provider: "openai",
+                timestamp: now + 1000,
+                usage: { input: 9, output: 9, totalTokens: 18, cost: { total: 0.018 } },
+              },
+            },
+          ],
+          touchSessionEntry: false,
+        },
+      );
+
+      const totals: number[] = [];
+      for (const agentId of ["alpha", "beta"]) {
+        const summary = await loadCostUsageSummaryFromCache({
+          agentId,
+          config,
+          startMs: now - 3_600_000,
+          endMs: now + 3_600_000,
+          refreshMode: "sync-when-empty",
+        });
+        totals.push(summary.totals.totalTokens);
+      }
+      // Default agent claims it; the other sees nothing, so the sum is not doubled.
+      expect(totals).toEqual([18, 0]);
+    });
+  });
+
+  it("treats an {agentId}-templated store as per-agent, not shared", async () => {
+    const root = await suiteRootTracker.make("templated-store");
+    // The template expands to a custom .sqlite filename per agent, so each agent's
+    // own globally scoped session must stay visible to it.
+    const store = path.join(root, "stores", "{agentId}", "agent.sqlite");
+    const config = {
+      agents: { entries: { alpha: { default: true }, beta: {} } },
+      session: { scope: "global", store },
+    } as unknown as OpenClawConfig;
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      for (const [agentId, tokens, cost] of [
+        ["alpha", 18, 0.018],
+        ["beta", 40, 0.04],
+      ] as const) {
+        const storePath = resolveStorePath(store, { agentId });
+        await fs.mkdir(path.dirname(storePath), { recursive: true });
+        await upsertSessionEntry(
+          { agentId, sessionKey: "global", storePath },
+          { sessionId: `${agentId}-global`, updatedAt: now },
+        );
+        await persistSessionTranscriptTurn(
+          { agentId, sessionId: `${agentId}-global`, sessionKey: "global", storePath },
+          {
+            messages: [
+              { message: { role: "user", content: "usage prompt", timestamp: now } },
+              {
+                message: {
+                  role: "assistant",
+                  content: "usage answer",
+                  model: "gpt-5.4",
+                  provider: "openai",
+                  timestamp: now + 1000,
+                  usage: {
+                    input: tokens / 2,
+                    output: tokens / 2,
+                    totalTokens: tokens,
+                    cost: { total: cost },
+                  },
+                },
+              },
+            ],
+            touchSessionEntry: false,
+          },
+        );
+      }
+
+      const totals: number[] = [];
+      for (const agentId of ["alpha", "beta"]) {
+        const summary = await loadCostUsageSummaryFromCache({
+          agentId,
+          config,
+          startMs: now - 3_600_000,
+          endMs: now + 3_600_000,
+          refreshMode: "sync-when-empty",
+        });
+        totals.push(summary.totals.totalTokens);
+      }
+      expect(totals).toEqual([18, 40]);
+    });
+  });
+
+  it("charges no agent for a legacy transcript in a directory several agents share", async () => {
+    const root = await suiteRootTracker.make("shared-legacy-jsonl");
+    const store = path.join(root, "shared", "team-store.json");
+    const config = {
+      agents: { entries: { alpha: { default: true }, beta: {} } },
+      session: { store },
+    } as unknown as OpenClawConfig;
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      // A pre-migration JSONL transcript: its filename carries no agent id, and more than
+      // one agent shares this directory, so no owner is recoverable and no agent may be
+      // charged for it. On main it is discovered by nobody either.
+      await fs.mkdir(path.dirname(store), { recursive: true });
+      await fs.writeFile(
+        path.join(path.dirname(store), "legacy-session.jsonl"),
+        [
+          JSON.stringify({ type: "session", version: 1, id: "legacy-session" }),
+          JSON.stringify({
+            type: "message",
+            timestamp: new Date(now).toISOString(),
+            message: {
+              role: "assistant",
+              model: "gpt-5.4",
+              provider: "openai",
+              usage: { input: 50, output: 50, totalTokens: 100, cost: { total: 0.1 } },
+            },
+          }),
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const totals: number[] = [];
+      for (const agentId of ["alpha", "beta"]) {
+        const summary = await loadCostUsageSummaryFromCache({
+          agentId,
+          config,
+          startMs: now - 3_600_000,
+          endMs: now + 3_600_000,
+          refreshMode: "sync-when-empty",
+        });
+        totals.push(summary.totals.totalTokens);
+      }
+      expect(totals).toEqual([0, 0]);
+    });
+  });
+
+  it("still counts a legacy transcript when one agent owns the store directory", async () => {
+    const root = await suiteRootTracker.make("sole-agent-legacy-jsonl");
+    const store = path.join(root, "solo", "my-store.json");
+    // One configured agent: the directory cannot be ambiguous, so omitting its legacy
+    // transcripts would lose usage rather than protect anyone from being mischarged.
+    const config = {
+      agents: { entries: { main: { default: true } } },
+      session: { store },
+    } as unknown as OpenClawConfig;
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      await fs.mkdir(path.dirname(store), { recursive: true });
+      await fs.writeFile(
+        path.join(path.dirname(store), "solo-session.jsonl"),
+        [
+          JSON.stringify({ type: "session", version: 1, id: "solo-session" }),
+          JSON.stringify({
+            type: "message",
+            timestamp: new Date(now).toISOString(),
+            message: {
+              role: "assistant",
+              model: "gpt-5.4",
+              provider: "openai",
+              usage: { input: 50, output: 50, totalTokens: 100, cost: { total: 0.1 } },
+            },
+          }),
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const summary = await loadCostUsageSummaryFromCache({
+        agentId: "main",
+        config,
+        startMs: now - 3_600_000,
+        endMs: now + 3_600_000,
+        refreshMode: "sync-when-empty",
+      });
+      expect(summary.totals.totalTokens).toBe(100);
+    });
+  });
+
+  it("counts legacy transcripts for the agent a canonical store path names", async () => {
+    const root = await suiteRootTracker.make("owned-legacy-jsonl");
+    const stateDir = path.join(root, "state");
+    // `agents/<id>/sessions/sessions.json` names its owner in the path, which is
+    // authoritative even with several agents configured -- skipping it would silently
+    // undercount that agent's history.
+    const store = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const config = {
+      agents: { entries: { main: { default: true }, beta: {} } },
+      session: { store },
+    } as unknown as OpenClawConfig;
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      await fs.mkdir(path.dirname(store), { recursive: true });
+      await fs.writeFile(
+        path.join(path.dirname(store), "owned-session.jsonl"),
+        [
+          JSON.stringify({ type: "session", version: 1, id: "owned-session" }),
+          JSON.stringify({
+            type: "message",
+            timestamp: new Date(now).toISOString(),
+            message: {
+              role: "assistant",
+              model: "gpt-5.4",
+              provider: "openai",
+              usage: { input: 50, output: 50, totalTokens: 100, cost: { total: 0.1 } },
+            },
+          }),
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const totals: number[] = [];
+      for (const agentId of ["main", "beta"]) {
+        const summary = await loadCostUsageSummaryFromCache({
+          agentId,
+          config,
+          startMs: now - 3_600_000,
+          endMs: now + 3_600_000,
+          refreshMode: "sync-when-empty",
+        });
+        totals.push(summary.totals.totalTokens);
+      }
+      expect(totals).toEqual([100, 0]);
+    });
+  });
+
+  it("charges no agent when only the store filename is templated, so the directory is shared", async () => {
+    const root = await suiteRootTracker.make("filename-template");
+    // `<dir>/{agentId}.json` gives each agent its own database but one shared
+    // directory, so the legacy files in it still need a single owner.
+    const store = path.join(root, "srv", "{agentId}.json");
+    const config = {
+      agents: { entries: { alpha: { default: true }, beta: {} } },
+      session: { store },
+    } as unknown as OpenClawConfig;
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      await fs.mkdir(path.join(root, "srv"), { recursive: true });
+      await fs.writeFile(
+        path.join(root, "srv", "legacy-session.jsonl"),
+        [
+          JSON.stringify({ type: "session", version: 1, id: "legacy-session" }),
+          JSON.stringify({
+            type: "message",
+            timestamp: new Date(now).toISOString(),
+            message: {
+              role: "assistant",
+              model: "gpt-5.4",
+              provider: "openai",
+              usage: { input: 50, output: 50, totalTokens: 100, cost: { total: 0.1 } },
+            },
+          }),
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const totals: number[] = [];
+      for (const agentId of ["alpha", "beta"]) {
+        const summary = await loadCostUsageSummaryFromCache({
+          agentId,
+          config,
+          startMs: now - 3_600_000,
+          endMs: now + 3_600_000,
+          refreshMode: "sync-when-empty",
+        });
+        totals.push(summary.totals.totalTokens);
+      }
+      expect(totals).toEqual([0, 0]);
+    });
+  });
+
+  it("returns nothing instead of throwing when a fixed store names another agent's database", async () => {
+    const root = await suiteRootTracker.make("canonical-store");
+    const stateDir = path.join(root, "state");
+    // A fixed store pointing at one agent's own canonical store. Reading it as any
+    // other agent is rejected by the scope resolver, and one throw would abort the
+    // all-agent usage fan-out.
+    const store = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const config = {
+      agents: { entries: { main: { default: true }, beta: {} } },
+      session: { store },
+    } as unknown as OpenClawConfig;
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      await fs.mkdir(path.dirname(store), { recursive: true });
+      await writeUsageTurn({
+        agentId: "main",
+        sessionId: "main-session",
+        storePath: store,
+        timestampMs: now,
+      });
+
+      const totals: number[] = [];
+      for (const agentId of ["main", "beta"]) {
+        const summary = await loadCostUsageSummaryFromCache({
+          agentId,
+          config,
+          startMs: now - 3_600_000,
+          endMs: now + 3_600_000,
+          refreshMode: "sync-when-empty",
+        });
+        totals.push(summary.totals.totalTokens);
+      }
+      expect(totals).toEqual([18, 0]);
+      await expect(discoverAllSessions({ agentId: "beta", config })).resolves.toEqual([]);
+    });
+  });
+
+  it("keeps scanning the default store when session.store is unset", async () => {
+    const root = await suiteRootTracker.make("default-store");
+    const agentId = "main";
+    const sessionId = "default-store-session";
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      await writeUsageTurn({ agentId, sessionId, timestampMs: now });
+
+      const summary = await loadCostUsageSummaryFromCache({
+        agentId,
+        config: {} as OpenClawConfig,
+        startMs: now - 3_600_000,
+        endMs: now + 3_600_000,
+        refreshMode: "sync-when-empty",
+      });
+      expect(summary.totals.totalTokens).toBe(18);
+
+      const discovered = await discoverAllSessions({ agentId, config: {} as OpenClawConfig });
+      expect(discovered.map((session) => session.sessionId)).toEqual([sessionId]);
+    });
+  });
+});

--- a/src/infra/session-cost-usage.configured-store.test.ts
+++ b/src/infra/session-cost-usage.configured-store.test.ts
@@ -399,6 +399,101 @@ describe("usage cost discovery with a configured session store", () => {
     });
   });
 
+  it("counts legacy transcripts for the owner even when the store filename is custom", async () => {
+    const root = await suiteRootTracker.make("canonical-dir-custom-filename");
+    const stateDir = path.join(root, "state");
+    // The basename is not what names the owner: `my-store.json` in `agents/main/sessions/`
+    // is still main's directory. Deriving ownership from `sessions.json` alone dropped
+    // these files for every agent, main included.
+    const store = path.join(stateDir, "agents", "main", "sessions", "my-store.json");
+    const config = {
+      agents: { entries: { main: { default: true }, beta: {} } },
+      session: { store },
+    } as unknown as OpenClawConfig;
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      await fs.mkdir(path.dirname(store), { recursive: true });
+      await fs.writeFile(
+        path.join(path.dirname(store), "custom-named-session.jsonl"),
+        [
+          JSON.stringify({ type: "session", version: 1, id: "custom-named-session" }),
+          JSON.stringify({
+            type: "message",
+            timestamp: new Date(now).toISOString(),
+            message: {
+              role: "assistant",
+              model: "gpt-5.4",
+              provider: "openai",
+              usage: { input: 50, output: 50, totalTokens: 100, cost: { total: 0.1 } },
+            },
+          }),
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const totals: number[] = [];
+      for (const agentId of ["main", "beta"]) {
+        const summary = await loadCostUsageSummaryFromCache({
+          agentId,
+          config,
+          startMs: now - 3_600_000,
+          endMs: now + 3_600_000,
+          refreshMode: "sync-when-empty",
+        });
+        totals.push(summary.totals.totalTokens);
+      }
+      expect(totals).toEqual([100, 0]);
+    });
+  });
+
+  it("gives a shared directory to the sole configured agent, not to whoever asks", async () => {
+    const root = await suiteRootTracker.make("sole-agent-other-caller");
+    const store = path.join(root, "shared", "team-store.json");
+    // Discovery fans out over the gateway roster, which admits agents this config does
+    // not, and a per-agent request may name any id. Answering on roster size alone let
+    // every caller claim the same directory and counted it once per caller.
+    const config = { session: { store } } as unknown as OpenClawConfig;
+    const now = Date.now();
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      await fs.mkdir(path.dirname(store), { recursive: true });
+      await fs.writeFile(
+        path.join(path.dirname(store), "unclaimed-session.jsonl"),
+        [
+          JSON.stringify({ type: "session", version: 1, id: "unclaimed-session" }),
+          JSON.stringify({
+            type: "message",
+            timestamp: new Date(now).toISOString(),
+            message: {
+              role: "assistant",
+              model: "gpt-5.4",
+              provider: "openai",
+              usage: { input: 50, output: 50, totalTokens: 100, cost: { total: 0.1 } },
+            },
+          }),
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const totals: number[] = [];
+      for (const agentId of ["main", "beta"]) {
+        const summary = await loadCostUsageSummaryFromCache({
+          agentId,
+          config,
+          startMs: now - 3_600_000,
+          endMs: now + 3_600_000,
+          refreshMode: "sync-when-empty",
+        });
+        totals.push(summary.totals.totalTokens);
+      }
+      // 100 once, not once per caller.
+      expect(totals).toEqual([100, 0]);
+    });
+  });
+
   it("charges no agent when only the store filename is templated, so the directory is shared", async () => {
     const root = await suiteRootTracker.make("filename-template");
     // `<dir>/{agentId}.json` gives each agent its own database but one shared

--- a/src/infra/session-cost-usage.test-support.ts
+++ b/src/infra/session-cost-usage.test-support.ts
@@ -1,7 +1,9 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import "./session-cost-usage.js";
 
 type UsageCostRefreshParams = {
   agentId?: string;
+  config?: OpenClawConfig;
   sessionFiles?: string[];
 };
 


### PR DESCRIPTION
Closes #118437

## What Problem This Solves

Fixes an issue where operators who set `session.store` see their aggregate usage and cost totals report zero while the sessions those numbers should cover sit on disk with the usage recorded in them.

The fix is in the aggregate loader (`loadCostUsageSummaryFromCache` / `loadCostUsageSummary`) that `/usage`, `/cost` and the gateway usage summary each call for their totals. That loader is what the proof below drives, and what the tests cover; the three callers' own wiring and rendering are unchanged and were not driven end to end.

The linked issue asks for two things together. In its own words ([#118437](https://github.com/openclaw/openclaw/issues/118437)):

> So honoring `session.store` is not separable from deciding who owns a transcript in a shared store — a fix that does only the first replaces an under-report with a wrong number. Anything resolving this should cover both, and should keep `{agentId}`-templated stores out of the shared case, since those give each agent its own database and directory.

That is measured, not asserted: with discovery alone, two agents owning 18 and 40 tokens in one shared locator are each reported as 58 (capture below).

Per-session reads are not affected: they carry an explicit `sqlite:<agent>:<session>:<store>` marker instead of rediscovering the store. This PR does not claim to change them.

`Closes #118437` is scoped to what that issue reports and reproduces: its repro prints `aggregate totalTokens: 0` / `discoverAllSessions: 0 session(s)`, and the capture below re-runs that same script and prints 18 / 1. The session-list family-history gap named further down is a different surface that the issue neither reports nor reproduces; it is recorded as a follow-up rather than folded in.

## Why This Change Was Made

Usage-cost transcript discovery never read `cfg.session.store`. `resolveUsageCostSessionStorePath` rebuilt a default path — `join(sessionsDir, "sessions.json")` — and the only thing that produced that `sessionsDir`, the queued cache refresh, pinned it to `resolveSessionTranscriptsDirForAgent(agentId)`, a helper that takes no config argument. The summary and session-discovery entry points passed no store at all.

The writer does read the config: `persistSessionTranscriptTurn` resolves `resolveStorePath(cfg.session?.store, { agentId })`. And `resolveSqliteTargetFromSessionStorePath` branches on the store **basename** — when it is not `sessions.json`, the target becomes `<basename>.sqlite`. So rebuilding `sessions.json` from a directory did not merely pick the wrong directory: for a custom store filename it resolved to a **different SQLite database than the writer had used**.

### The fix

Config becomes the single input that decides which store discovery scans, resolved in one place. SQLite discovery uses the exact store path; legacy JSONL discovery uses its `dirname`, which is the legacy-directory contract `resolveSessionFilePathOptions` already defines for a configured store.

The gateway's 30-second cost-summary memo became config-dependent with this change, so with a configured store its key carries the configured `session.store` value **as written in config** — not its resolved path, so a fixed store and a `{agentId}` template that happen to expand to the same path stay distinct keys — plus the default agent and the roster ids themselves — the all-agent path enumerates those ids, so a roster *length* would collide when one non-default agent replaces another. Without that, a reload changing any of them would have been answered from the previous result until the entry expired.

`UsageCostRefreshState.sessionsDir` is deleted rather than kept in sync. It snapshotted the default directory when the refresh was queued, and `mergeUsageCostRefreshRequest` refreshed `config` and `agentId` but never the scan target — so a state created before config arrived kept a stale target forever. Removing the field closes that by deletion instead of adding a second path to synchronize.

### The ownership rule

Who claims an artifact that carries no agent of its own, by store shape:

| store shape | SQLite rows | legacy `<sessionId>.jsonl` beside the store |
| --- | --- | --- |
| default (no `session.store`) | per-agent database, unchanged | per-agent directory, unchanged |
| `{agentId}` anywhere in the path | per-agent — not shared, each agent reads its own database | per-agent directory |
| `{agentId}` only in the filename | per-agent databases | **shared directory, no derivable owner → charged to no agent** |
| fixed path under `agents/<id>/sessions/` (any basename) | owner named by the path; non-owners get an empty result | **owner named by the path, that agent only** |
| fixed path elsewhere, one configured agent | that agent | **that agent, and only when it is the agent asking** |
| fixed path elsewhere, several agents | agent-keyed rows go to their agent; `global`/`unknown` keys go to the default agent via `resolveSessionStoreAgentId` | **no derivable owner → charged to no agent** |

The two rows that read differently are the point: a SQLite `global` key is a store-key the owner rule already maps to the default agent, while a legacy filename carries nothing at all, so there is no rule to apply and charging anyone would be a guess.

A store that expands to the same path for every agent is shared — for an exact `.sqlite` locator, one database holding every agent's rows. **Before this change** the scan stamped the caller's agent onto whatever it found; **after it**, rows are dispatched by the agent their own store key names, and only a key with no agent of its own (`global`, `unknown`) falls back to the default agent through `resolveSessionStoreAgentId`. The table above is the post-change rule. Measured on a two-agent shared locator where alpha owned 18 tokens and beta owned 40, discovery-only reports **58 for each of them** — a defect this PR would introduce, not a pre-existing gap it declines to fix. That is the issue's second acceptance requirement.

Required cases: a shared `.sqlite` locator with agent-keyed rows, and globally scoped keys, which have no agent of their own. Defensive coverage: both `{agentId}` template shapes. The invariant is **never more than once**, not *always attributed*. An artifact with no agent of its own is claimed by at most one scan: a globally scoped session key has a store-key owner rule (`resolveSessionStoreAgentId` maps `global` and `unknown` to the default agent) and is attributed exactly once; a legacy `<sessionId>.jsonl` in an ambiguous shared directory has no such rule and is attributed to **no one** rather than guessed at. Both outcomes satisfy the invariant; only the second is a deliberate omission, and it is the `[0, 0]` row in the table above. Concretely, for one such artifact: the owning agent's total includes it once, every other agent's total excludes it, and summing across agents gives its tokens once rather than once per agent.

One deliberate behavior change falls out of this: when a fixed store names an agent's own database, agents that do not own it now get an empty discovery result. That path previously could not be reached at all, and reading it as a non-owner is refused by the scope resolver — returning empty keeps the all-agent fan-out alive instead of letting one agent's rejection abort the whole sweep.

`{agentId}` expansion is what makes a store per-agent, and the two halves of discovery key off different parts of it — the SQLite target follows the whole path, legacy files only its directory. Both directions were measured: a templated `.sqlite` store still reports `shared: true` for each expanded path, so keying on that flag alone hid every non-default agent's own globally scoped sessions; and `<dir>/{agentId}.json` gives per-agent databases but one shared directory, where the legacy files still need a single owner.

### Production LOC

**+150 / −26** production across **five** files (`usage.ts`, `session-cost-usage-{aggregation,cache-runtime,collection,reporting}.ts`) plus a two-line test-support helper; +709 test. The growth is an **ownership boundary**: nothing in usage discovery previously decided which agent owns a transcript, because every scan assumed a per-agent store. The −26 is the deleted `sessionsDir` parameter chain and refresh-state field.

### Non-scope

This PR only changes usage-cost discovery. `resolveSessionTranscriptsDirForAgent` keeps its behavior, because `src/commands/doctor-state-integrity.ts` computes the default directory alongside the configured `storeDir` precisely to compare the two. Its other call sites — `agents.commands.delete.ts`, `onboard-helpers.ts`, `setup.ts`, `agent-create.ts` — also keep theirs; agent lifecycle is a different invariant and each site needs its own gate.

The usage-cost cache database stays agent-keyed. Rollup keys are built from the resolved SQLite target, so rows written against a previous store carry a different key; the same refresh that drops them via `deleteSessionCostUsageRollupsExcept` also rescans and rebuilds rows for the live file set, so the operator sees recomputed numbers rather than a persistent zero. Both the empty-cache path and the populated-cache upgrade are measured — see the capture below. No re-keying or migration is part of this change.

### Known boundaries

**Legacy transcripts, and who owns the directory holding them.** A legacy `<sessionId>.jsonl` name carries no agent, so ownership has to come from the directory. A canonical store path names its owner — `agents/<id>/sessions/…` — and that is authoritative, so those transcripts are still counted, for that agent only. The store's *basename* is not part of that question: `my-store.json` sitting in `agents/main/sessions/` is still main's directory. Nothing that `main` counts today stops being counted: for a configured store, current `main` discovers **none** of these legacy files, so every row in the table is either the same as `main` or strictly more. Where no owner is derivable and several agents share the directory, **no agent is charged**: attributing them to the default agent would report one agent's spend under another, worse than the omission it replaces since `main` does not discover them at all. A sole configured agent still claims them — but only when it is the agent asking. Discovery fans out over `listGatewayAgentsBasic`, which admits agents `listAgentIds(config)` does not, so answering on roster size alone handed the same directory to every caller.

```
canonical store agents/main/sessions/sessions.json, agents main + beta:
  agent=main  totalTokens=100        (owner named by the path)
  agent=beta  totalTokens=0

<dir>/{agentId}.json, two agents, one legacy transcript each:
  agent=alpha discovered=[]
  agent=beta  discovered=[]          (same as main)

one configured agent owning its store directory:
  agent=main  totalTokens=100
```

The alternative of letting every agent scan the directory was measured too: each transcript is then counted once per agent in the all-agent total. Exact attribution would need a per-file store-entry lookup inside a scan whose own comment says it avoids materializing rows, on the file-era path retired by [#113233](https://github.com/openclaw/openclaw/pull/113233).

**A fixed store naming one agent's own database.** `session.store` can point at `agents/<id>/sessions/sessions.json`. Reading that as a different agent is rejected by the scope resolver, and honoring the configured store without a guard turned that rejection into a thrown error that would abort the all-agent usage fan-out. Agents that do not own the named database now get an empty list; that is the same result they had before this PR, reached without the throw.

**What the legacy directory scan can pick up.** It enumerates only names `isUsageCountedSessionTranscriptFileName` accepts, and any file whose session id already appears in the SQLite set is dropped before the lists are merged, so a migrated session is not counted twice. What remains is genuinely un-migrated JSONL sitting beside the configured store — which is what the ownership rule above assigns.

**Multi-store family history — named follow-up.** The `sessions.usage` family loader expands a family's `includedSessionIds` and calls `resolveExistingUsageSessionFile({ sessionId, agentId })` with no store path, so a rotated transcript living in a configured store falls back to the default directory and drops out of family totals. That loop is untouched here. It is strictly better than today either way: on `main` discovery returns nothing for a configured store, so the family total is zero; after this PR the current session counts and only rotated history is missed. Threading a store target through that loader is a different owner seam, so it is named as follow-up work rather than widened into this PR.

## User Impact

Aggregate usage discovery uses the configured store. The result is established at `loadCostUsageSummaryFromCache` and `loadCostUsageSummary`. Of the two files that call them for totals, this PR touches only `src/gateway/server-methods/usage.ts`, in the two hunks visible in the diff: one line passing `config` into discovery, and the memo cache key. No presentation logic changes anywhere, and no caller was driven end to end. Operators on the default store see no change; that path has a regression test here.

The claim is limited to those **aggregate totals**. The per-session list view (`sessionsUsage`) resolves each session separately, and its family-history expansion still falls back to the default directory — the named follow-up above. This PR does not claim to fix that surface, and nothing here makes it worse.

**Changing `session.store` re-points the totals rather than merging two stores.** Rollup keys are derived from the resolved SQLite target, so after a switch the aggregate reports what the new store holds; turns recorded against the previous store are no longer counted, exactly as they are not counted today when discovery reads only the default path. This is behavior, not a migration gap: the measured upgrade path below shows the total recomputed (40 -> 18) rather than left stale or stuck at zero.

No config surface is added or changed and no migration is required. Two different caches are in play and only one changes shape: the gateway's 30-second in-memory summary **memo** gains a store segment in its key (described above), while the persistent **rollup** rows keep their existing key form — they are derived from the resolved SQLite target, as they already were, so pointing at a different store simply produces different keys and the refresh rebuilds them. Nothing rewrites or migrates existing rollup rows.

## Evidence

HEAD `91bb0679dad09bc617f1b60ce5847a29b7b6239b`, base `upstream/main` `b4faa5aa5eee35705e4b98736acfe83dea2aecdb`. Both captures below were taken at that head; the before run is the same harness with this patch's five production files checked out at that upstream commit, so it measures current `main` rather than a pinned historical base. Only those five files move: the harness runs under no test runner and imports production modules directly, so the head-side test files present on disk cannot reach it.

### Real behavior proof

Behavior addressed: with `session.store` configured, aggregate usage and cost totals omit every session, because usage discovery reconstructs the default store path instead of using the configured one — and for a custom store filename that resolves to a different SQLite database than the writer used.

Real environment tested: Linux 6.8, Node v24.18.0, real OpenClaw source. The harness itself runs under no test runner and with no build or mocks — the Vitest suites below are a separate lane. An operator `openclaw.json` on disk is the only input: the writer and the readers each resolve the store themselves through `getRuntimeConfig()`; neither is handed a path. Transcript storage is the real SQLite backend.

Exact steps or command run after this patch: a `tsx` script, not committed to this repo. Every number it prints is also asserted by a committed test — `src/infra/session-cost-usage.configured-store.test.ts` case 1 for 18 tokens / $0.018, cases 2-3 for the shared-locator split, the two ownership cases for `[100, 0]` — so the measurements are reproducible with `node scripts/run-vitest.mjs src/infra/session-cost-usage.configured-store.test.ts` without the script. The script itself is 40 lines and does exactly this:

1. `mkdtemp` a root; write `<root>/openclaw.json` containing `{"session":{"store":"<root>/custom/my-store.json"}}`
2. set `OPENCLAW_STATE_DIR=<root>/state` and `OPENCLAW_CONFIG_PATH=<root>/openclaw.json`, then import the runtime
3. `upsertSessionEntry({ sessionKey })` and `persistSessionTranscriptTurn({ agentId, sessionId, sessionKey }, …)` with one assistant message carrying `usage: { input: 7, output: 11, totalTokens: 18, cost: { total: 0.018 } }` — **no `storePath` argument**, so the writer resolves it from config
4. print where `resolveSqliteTargetFromSessionStorePath` puts the configured and the default store, and whether each exists
5. `loadCostUsageSummaryFromCache({ agentId, config, startMs, endMs, refreshMode: "sync-when-empty" })` and `discoverAllSessions({ agentId, config })`

Before evidence (production files checked out at `upstream/main` `b4faa5aa5ee`):

```
=== operator config ===
config file          : /tmp/usage-store-proof-gIpJfN/openclaw.json
session.store        : /tmp/usage-store-proof-gIpJfN/custom/my-store.json

=== where the transcript actually is ===
writer store path    : /tmp/usage-store-proof-gIpJfN/custom/my-store.json
writer SQLite target : /tmp/usage-store-proof-gIpJfN/custom/my-store.sqlite  (exists: true)
default store path   : /tmp/usage-store-proof-gIpJfN/state/agents/main/sessions/sessions.json
default SQLite target: /tmp/usage-store-proof-gIpJfN/state/agents/main/agent/openclaw-agent.sqlite  (exists: true)

=== what the operator is shown (/usage, /cost, gateway usage) ===
aggregate totalTokens: 0   (expected 18)
aggregate totalCost  : 0   (expected 0.018)
cacheStatus          : fresh
discoverAllSessions  : 0 session(s) 

VERDICT: OMITTED — transcript written to the configured store but absent from the aggregate
```

Evidence after fix:

```
=== operator config ===
config file          : /tmp/usage-store-proof-PW2nRc/openclaw.json
session.store        : /tmp/usage-store-proof-PW2nRc/custom/my-store.json

=== where the transcript actually is ===
writer store path    : /tmp/usage-store-proof-PW2nRc/custom/my-store.json
writer SQLite target : /tmp/usage-store-proof-PW2nRc/custom/my-store.sqlite  (exists: true)
default store path   : /tmp/usage-store-proof-PW2nRc/state/agents/main/sessions/sessions.json
default SQLite target: /tmp/usage-store-proof-PW2nRc/state/agents/main/agent/openclaw-agent.sqlite  (exists: true)

=== what the operator is shown (/usage, /cost, gateway usage) ===
aggregate totalTokens: 18   (expected 18)
aggregate totalCost  : 0.018   (expected 0.018)
cacheStatus          : fresh
discoverAllSessions  : 1 session(s) configured-store-session

VERDICT: REPORTED — configured store is enumerated
```

(`cacheStatus: fresh` appears in both captures — it reports that the cache is not mid-refresh, not that the numbers are right, which is exactly why the pre-fix zero is silent.)

Observed result after fix: the run that recorded 18 tokens / $0.018 into `custom/my-store.sqlite` now reports them and lists the session; before the patch both were empty while that database sat on disk holding the data. The two `exists: true` lines show why — `my-store.sqlite` and `openclaw-agent.sqlite` are different files, and discovery was reading the second.

Shared-store measurement, one exact `.sqlite` locator, two agents, one turn each. Discovery without the ownership rule:

```
agent=alpha  discovered=[beta-session, alpha-session]  totalTokens=58  totalCost=0.058
agent=beta   discovered=[beta-session, alpha-session]  totalTokens=58  totalCost=0.058
```

As shipped:

```
agent=alpha  discovered=[alpha-session]  totalTokens=18  totalCost=0.018
agent=beta   discovered=[beta-session]   totalTokens=40  totalCost=0.04
```

A `{agentId}`-templated `.sqlite` store, where each agent has its own database and each legitimately holds a `global` key — treating the expansion as shared would have hidden beta's own session:

```
agent=alpha  totalTokens=18
agent=beta   totalTokens=40
```

Ownership of a shared legacy directory, measured against the real discovery path. Each case runs in its own process because `getRuntimeConfig()` caches:

```
=== case A — no configured roster, a second agent still claims the directory ===
  discovery fan-out   : [main]
  ownership roster    : [main]
  agent=main   discovered=[legacy-session] totalTokens=100
  agent=beta   discovered=[] totalTokens=0
  sum across agents = 100   (100 = counted once, 200 = duplicated)

=== case B — custom filename under agents/<id>/sessions, two configured agents ===
  discovery fan-out   : [main, beta]
  ownership roster    : [main, beta]
  agent=main   discovered=[legacy-session] totalTokens=100
  agent=beta   discovered=[] totalTokens=0
  sum across agents = 100   (100 = main still claims its own directory, 0 = dropped for everyone)
```

Without the owner check these measure **200** (case A: every caller claims the directory) and **0** (case B: the owner named by the path is lost with its transcripts) — both regressions this PR would otherwise introduce, since current `main` does not discover these files for a configured store at all.

Upgrade path, measured: a cache populated from the **default** store, then the operator sets `session.store` and records a turn there.

```
1. default store, cache populated : totalTokens=40 (expect 40)
   rollup rows                    : 1
2. after configuring session.store: totalTokens=18 (expect 18)
   cacheStatus                    : fresh
   rollup rows                    : 1
   keys                           : sqlite:main:new-custom-session:<tmp>/custom/my-store.sqlite
```

The operator sees recomputed numbers, not a stale total or a persistent zero, and the old-store row is dropped rather than double counted.

What was not tested: the four named surfaces are not driven end to end. The proof drives `loadCostUsageSummaryFromCache`, which is the function each of them calls for its totals; there is no CLI invocation, gateway socket round-trip, or status-line render in the capture. Per-session reads (`loadSessionCostSummary`, `loadSessionUsageTimeSeries`, `loadSessionLogs`) are outside the claim and untested here. No `~`-prefixed store value was exercised; `resolveStorePath` handles it and this patch calls that helper rather than reimplementing it.

Proof limitations or environment constraints: one turn per session, one process. `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` point at a temp tree, so no real operator state is touched; that is the only environment substitution. Timestamps use the real clock deliberately — `refreshCostUsageCacheForAgent` filters discovered files by `mtimeMs >= startMs`, so a fixed future date would mask the result for reasons unrelated to this defect.

### Tests

`node scripts/run-vitest.mjs src/infra/session-cost-usage*` → 5 files / 79 passed.
`node scripts/run-vitest.mjs src/gateway/server-methods/usage*` → 5 files / 88 passed. That set includes the suite #118918 rewrote after this branch was opened; it passes unmodified on this rebased head, which is the coexistence check for that PR.
Typecheck and lint ran through `pnpm check:changed`; the build was not run, as no build output, packaging, or module boundary changes.

`src/infra/session-cost-usage.configured-store.test.ts` adds twelve cases:

- custom store filename → aggregate reports 18 tokens / $0.018 and one discovered session
- exact shared `.sqlite` locator, two agents → each sees only its own session and totals
- exact shared `.sqlite` locator, globally scoped session → `[18, 0]` across the two agents, not `[18, 18]`
- `{agentId}`-templated `.sqlite` store, globally scoped sessions → `[18, 40]`, each agent reading its own database
- fixed shared store directory holding a legacy `.jsonl` transcript → `[100, 0]`
- `<dir>/{agentId}.json`, per-agent databases but a shared directory → still `[0, 0]`
- fixed store naming another agent's own database → that agent gets `[]` instead of the scope resolver throwing
- sole configured agent owning its store directory → its legacy transcript is still counted (100 tokens)
- canonical store path naming its owner, two agents → `[100, 0]`, counted for the named owner only
- custom store filename under `agents/<id>/sessions/`, two agents → `[100, 0]`; the basename does not decide ownership
- shared directory with no configured roster → `[100, 0]`; claimed once, not once per caller
- no `session.store` → the default store is still scanned (regression guard)

`src/gateway/server-methods/usage.test.ts` adds three memo-invalidation cases, since the summary memo became config-dependent here: the previous store is not served after `session.store` changes, and the memo re-reads when a non-default agent is swapped or the ownership roster changes under one unchanged store path.

And in `src/infra/session-cost-usage-refresh.test.ts`, one case for the deleted snapshot: a refresh queued before config arrives must reach the runner carrying only the merged config and no scan target of its own. It fails on base with `expected { config: … } to not have property "sessionsDir"`.

Each was checked against base: case 1 fails `expected 18, received 0` without the discovery change; cases 2 and 3 fail without the ownership rule; case 7 passes either way, so the regression guard is not just re-asserting the fix.

A new file rather than an append to `src/infra/session-cost-usage.test.ts`, which is 3209 lines and carries a grandfathered `oxlint-disable max-lines` TODO.
