### PR TITLE
test(node-host): reuse approvals database fixture

### DIFF
--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -19,6 +19,7 @@ import {
   getRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "../config/runtime-snapshot.js";
+import { deleteExecApprovalsConfigRow } from "../infra/exec-approvals-sqlite.js";
 import { testing as execApprovalsStoreTesting } from "../infra/exec-approvals-store.test-support.js";
 import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
 import {
@@ -30,8 +31,10 @@ import {
 import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
 import type { ExecHostResponse } from "../infra/exec-host.js";
 import { formatExecCommand } from "../infra/system-run-command.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { buildSystemRunApprovalPlan } from "./invoke-system-run-plan.js";
 import { handleSystemRunInvoke } from "./invoke-system-run.js";
@@ -58,6 +61,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   const sharedRuntimeBins = new Set<string>();
 
   beforeAll(() => {
+    closeOpenClawStateDatabaseForTest();
     sharedFixtureRoot = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-node-host-fixtures-")),
     );
@@ -68,6 +72,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   afterAll(() => {
+    closeOpenClawStateDatabaseForTest();
     if (sharedFixtureRoot) {
       fs.rmSync(sharedFixtureRoot, { recursive: true, force: true });
     }
@@ -82,14 +87,13 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   beforeEach(() => {
     previousOpenClawHome = process.env.OPENCLAW_HOME;
     process.env.OPENCLAW_HOME = sharedOpenClawHome;
-    closeOpenClawStateDatabaseForTest();
-    fs.rmSync(resolveOpenClawStateSqlitePath(), { force: true });
     execApprovalsStoreTesting.reset();
+    // Cases isolate the canonical policy row, not shared-state schema bootstrap.
+    deleteExecApprovalsConfigRow(openOpenClawStateDatabase().db);
     clearRuntimeConfigSnapshot();
   });
 
   afterEach(() => {
-    closeOpenClawStateDatabaseForTest();
     execApprovalsStoreTesting.reset();
     clearRuntimeConfigSnapshot();
     if (previousOpenClawHome === undefined) {


### PR DESCRIPTION
## What Problem This Solves

`invoke-system-run.test.ts` deleted and recreated the entire shared SQLite database before each of 81 cases. Every case repeated schema creation, migrations, integrity/index checks, and connection setup even though this suite only needs approvals-policy isolation.

## Why This Change Was Made

Keep one real shared database for the suite and delete only the canonical `exec_approvals_config` row before each case. The production database, Kysely row helper, approval store, runtime snapshot, and all assertions remain real.

No production code, schema version, sharding, worker, or concurrency changes.

## Performance

Paired same-head benchmark:

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| wall time | 11.36s | 5.15s | 54.7% |
| Vitest | 6.87s | 719ms | 89.5% |
| test bodies | 6.47s | 314ms | 95.1% |
| peak RSS | 1.065GB | 0.930GB | 12.6% |

## Proof

- rebased focused suite: 81/81 passed
- sibling owner/caller proof: 167 passed with one platform skip across plan, allowlist, exec policy, SQLite store, and invoke caller suites
- targeted oxfmt, oxlint, and `git diff --check`: clean
- exact local autoreview: clean, patch correct 0.99

Blacksmith Testbox was unavailable because this host lacks its CLI. Direct AWS lease `cbx_7cd90c39f1b3`, run `run_716305fd45b1`, never left sync on the raw unhydrated box and was stopped; the documented trusted focused local proof used an already-ready dependency tree.
