### PR TITLE
test(tasks): reuse registry state fixture

### DIFF
--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -2,7 +2,7 @@
 import { statSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import {
   executeSqliteQuerySync,
@@ -20,8 +20,11 @@ import {
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import { captureEnv } from "../test-utils/env.js";
-import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+  withOpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import {
@@ -56,8 +59,6 @@ import {
   resetTaskFlowRegistryForTests,
   resetTaskRegistryForTests,
 } from "./task-runtime.test-helpers.js";
-
-const ORIGINAL_ENV = captureEnv(["OPENCLAW_STATE_DIR"]);
 
 function createTaskRecord(params: Parameters<typeof createTaskRecordOrNull>[0]): TaskRecord {
   const task = createTaskRecordOrNull(params);
@@ -132,9 +133,22 @@ function createUnsafeTaskOwnerIndex(database: DatabaseSync): void {
 }
 
 describe("task-registry store runtime", () => {
+  let testState: OpenClawTestState;
+
+  beforeAll(async () => {
+    testState = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-task-store-suite-",
+    });
+  });
+
+  afterAll(async () => {
+    await testState.cleanup();
+  });
+
   afterEach(() => {
-    ORIGINAL_ENV.restore();
-    resetTaskRegistryForTests();
+    testState.applyEnv();
+    resetTaskRegistryForTests({ persist: false });
     resetTaskFlowRegistryForTests({ persist: false });
     loggingState.rawConsole = null;
     setLoggerOverride(null);


### PR DESCRIPTION
## What Problem This Solves

`task-registry.store.test.ts` reset the registry with default persistence after every one of 43 cases. Even pure custom/mock-store cases switched back to the default SQLite store, opened and validated the full shared-state schema, wrote an empty snapshot, and closed it.

## Why This Change Was Made

Give the file one isolated shared-state fixture and make generic cleanup non-persisting. Explicit SQLite persistence, reload, corruption, requester-origin, pruning, permissions, and failure-atomicity cases remain unchanged and still use the real store.

No production code, schema version, sharding, worker, or concurrency changes.

## Performance

Paired same-head, same AWS lease:

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| wall | 17.58s | 11.50s | 34.6% |
| test bodies | 11.39s | 5.23s | 54.1% |
| peak RSS | 1,235,780 KiB | 1,112,068 KiB | 10.0% |

A repeat isolation run passed in 11.39s. The rebased current-main focused run passed 43/43 in 15.07s wall; that contended local sample is correctness proof, not comparative timing.

## Proof

- focused suite: 43/43 passed on paired remote runs, repeat isolation run, and rebased current head
- all explicit persistence/reload/corruption/prune/permission/failure assertions retained
- targeted oxfmt, oxlint, and `git diff --check`: clean
- core test tsgo: clean
- exact local autoreview: clean, patch correct 0.99

Blacksmith Testbox was unavailable because this host lacks its CLI. Direct AWS lease `cbx_7410b57ba8fb` supplied paired proof: baseline `run_dbb297ef5956`, final `run_103132686af6`, repeat `run_be65a60ff38d`, and static/type proof `run_e79cc7fb680b` / `run_7b16db54761b`. Normal hydration hit the existing missing-TypeScript postinstall failure twice; the proof used `pnpm install --ignore-scripts`, after which normal pnpm self-reconciled successfully. The lease was released.
