### PR TITLE
fix(agents): finalize failed terminal batch after earlier presentation or stale lifecycle

### DIFF
--- a/extensions/codex/src/app-server/event-projector-result.ts
+++ b/extensions/codex/src/app-server/event-projector-result.ts
@@ -49,6 +49,7 @@ type CodexAttemptResultInput = {
   completedCompactionCount: number;
   activeItemCount: number;
   completedItemCount: number;
+  activeItemIds: string[];
   guardianReviewCount: number;
   toolTelemetry: CodexAppServerToolTelemetry;
   yieldDetected: boolean | undefined;
@@ -231,6 +232,7 @@ export function buildCodexAttemptResult(
       startedCount: input.activeItemCount + input.completedItemCount,
       completedCount: input.completedItemCount,
       activeCount: input.activeItemCount,
+      activeItemIds: input.activeItemIds,
     },
     yieldDetected: input.yieldDetected || false,
     didSendDeterministicApprovalPrompt: input.guardianReviewCount > 0 ? false : undefined,

--- a/extensions/codex/src/app-server/event-projector.118489-residual.test.ts
+++ b/extensions/codex/src/app-server/event-projector.118489-residual.test.ts
@@ -1,0 +1,92 @@
+// Regression proof for #118489: the real Codex event projector can persist an
+// exact failed tool result while the failing item's lifecycle stays active.
+import {
+  buildEmptyToolTelemetry,
+  createParams,
+  createProjector,
+  describe,
+  expect,
+  forCurrentTurn,
+  it,
+  registerCodexEventProjectorTestLifecycle,
+  turnCompleted,
+  TURN_ID,
+} from "./event-projector.test-harness.js";
+
+registerCodexEventProjectorTestLifecycle();
+
+describe("CodexAppServerEventProjector #118489 residual failed-tool shapes", () => {
+  it("persists an exact failed tool result while the failing item stays active", async () => {
+    const projector = await createProjector({
+      ...(await createParams()),
+    });
+    const failingItem = {
+      type: "dynamicToolCall",
+      id: "call-fail",
+      namespace: null,
+      tool: "read",
+      arguments: { path: "missing.txt" },
+      status: "inProgress",
+      contentItems: null,
+      success: null,
+      durationMs: null,
+    };
+    await projector.handleNotification(forCurrentTurn("item/started", { item: failingItem }));
+    projector.recordDynamicToolCall({
+      callId: "call-fail",
+      tool: "read",
+      arguments: { path: "missing.txt" },
+    });
+    projector.recordDynamicToolResult({
+      callId: "call-fail",
+      tool: "read",
+      success: false,
+      terminalType: "error",
+      sideEffectEvidence: false,
+      contentItems: [{ type: "inputText", text: "ENOENT: no such file or directory" }],
+    });
+    // Bridge failure: the turn snapshot carries the exact failed result, but
+    // item/completed for the failing tool is never processed. The Codex
+    // app-server contract maps dynamic tool items by call id
+    // (openai/codex codex-rs/app-server-protocol/src/protocol/event_mapping.rs:
+    // ThreadItem::DynamicToolCall { id: response.call_id }), so the active item
+    // id below is the same id the finalizer matches against the requested call.
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "dynamicToolCall",
+          id: "call-fail",
+          turnId: TURN_ID,
+          tool: "read",
+          status: "completed",
+          contentItems: [{ type: "inputText", text: "ENOENT: no such file or directory" }],
+          success: false,
+          durationMs: 1,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.itemLifecycle).toEqual({
+      startedCount: 1,
+      completedCount: 0,
+      activeCount: 1,
+      activeItemIds: ["call-fail"],
+    });
+    expect(result.messagesSnapshot).toContainEqual(
+      expect.objectContaining({
+        role: "toolResult",
+        toolCallId: "call-fail",
+        toolName: "read",
+        isError: true,
+      }),
+    );
+    expect(result.messagesSnapshot).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        content: [expect.objectContaining({ type: "toolCall", id: "call-fail", name: "read" })],
+      }),
+    );
+    expect(result.lastToolError).toMatchObject({ toolName: "read" });
+  });
+});

--- a/extensions/codex/src/app-server/event-projector.commentary.test.ts
+++ b/extensions/codex/src/app-server/event-projector.commentary.test.ts
@@ -168,7 +168,12 @@ describe("CodexAppServerEventProjector commentary projection", () => {
         content: [{ type: "text", text: "" }],
       });
       expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
-      expect(result.itemLifecycle).toEqual({ startedCount: 2, completedCount: 2, activeCount: 0 });
+      expect(result.itemLifecycle).toEqual({
+        startedCount: 2,
+        completedCount: 2,
+        activeCount: 0,
+        activeItemIds: [],
+      });
       expect(result.messagesSnapshot.filter((message) => message.role === "assistant")).toEqual([
         expect.objectContaining({ content: [expect.objectContaining({ type: "toolCall" })] }),
       ]);

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -364,6 +364,7 @@ export class CodexAppServerEventProjector {
       completedCompactionCount: this.completedCompactionCount,
       activeItemCount: this.activeItemIds.size,
       completedItemCount: this.completedItemIds.size,
+      activeItemIds: [...this.activeItemIds],
       guardianReviewCount: this.eventProjection.guardianReviewCount,
       toolTelemetry,
       yieldDetected: options?.yieldDetected,

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
@@ -136,6 +136,43 @@ export function buildToolCallEventsWithArgs(
   ];
 }
 
+/** Builds one assistant turn that requests several tools in a fixed order. */
+export function buildToolCallBatchEvents(
+  calls: ReadonlyArray<{ name: string; args: Record<string, unknown> }>,
+): StreamEvent[] {
+  const built = calls.map((call) => ({
+    name: call.name,
+    ...buildMockFunctionCall(call.name, call.args),
+  }));
+  const events: StreamEvent[] = [];
+  for (const call of built) {
+    events.push(
+      {
+        type: "response.output_item.added",
+        item: {
+          type: "function_call",
+          id: call.itemId,
+          call_id: call.callId,
+          name: call.name,
+          arguments: "",
+        },
+      },
+      { type: "response.function_call_arguments.delta", delta: call.serialized },
+      { type: "response.output_item.done", item: call.item },
+    );
+  }
+  events.push({
+    type: "response.completed",
+    response: {
+      id: built[0]?.responseId ?? "resp_mock_batch_" + Date.now(),
+      status: "completed",
+      output: built.map((call) => call.item),
+      usage: { input_tokens: 128, output_tokens: 32, total_tokens: 160 },
+    },
+  });
+  return events;
+}
+
 export function buildCustomToolCallEventsWithInput(
   name: string,
   input: string,

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -8480,7 +8480,7 @@ Update and merge these partial structured summaries.`,
       input: [
         makeUserInput(prompt),
         makeUserInput(
-          `${QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} If any tool failed, state that failure plainly and do not claim it succeeded.`,
+          `${QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} If a tool failed, say so; never claim completion or success.`,
         ),
         failedToolOutput,
       ],

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -179,6 +179,7 @@ import {
   readTargetFromPrompt,
   execCommandFromToolProgressPrompt,
   buildCustomToolCallEventsWithInput,
+  buildToolCallBatchEvents,
   buildToolCallEventsWithArgs as buildRawToolCallEventsWithArgs,
   extractOrbitCode,
   extractToolSearchTarget,
@@ -293,6 +294,10 @@ const QA_CODE_MODE_TARGET_MARKER = "qa-code-mode-target:";
 const QA_RESTART_CHECKPOINT_COUNT = 3;
 const QA_RESTART_FINAL_TEXT = "unsafeVisible=false\nRESTART-CODE-MODE-WAIT-OK";
 const QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE = /failed tool terminal recovery qa check/i;
+const QA_FAILED_TOOL_PRESENTATION_RECOVERY_PROMPT_RE =
+  /failed tool terminal recovery with presentation qa check/i;
+const QA_FAILED_TOOL_PRESENTATION_FETCH_URL_RE =
+  /(?:web_fetch url:|call web_fetch on) (https?:\/\/[^\s`",]+)/i;
 const QA_TELEGRAM_VISIBLE_PARTIAL_FAILURE_PROMPT_RE = /telegram visible partial failure qa check/i;
 const QA_TELEGRAM_UNSENT_FAILURE_PROMPT_RE = /telegram unsent failure qa check/i;
 const QA_TELEGRAM_VISIBLE_PARTIAL_FAILURE_MARKER = "TELEGRAM-VISIBLE-PARTIAL-BEFORE-FAILURE";
@@ -1044,6 +1049,10 @@ async function buildResponsesPayload(
     QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE.test(prompt) ||
     (prompt.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) &&
       QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE.test(allInputText));
+  const isActiveFailedToolPresentationRecovery =
+    QA_FAILED_TOOL_PRESENTATION_RECOVERY_PROMPT_RE.test(prompt) ||
+    (prompt.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) &&
+      QA_FAILED_TOOL_PRESENTATION_RECOVERY_PROMPT_RE.test(allInputText));
   const hasCallableCodeMode = hasCodeModeExecSurface(toolDeclarationBody);
   const canCallSessionsSpawn =
     hasToolDefinition(toolDeclarationBody, "sessions_spawn") || hasCallableCodeMode;
@@ -1365,9 +1374,41 @@ async function buildResponsesPayload(
     }
     return buildAssistantEvents("");
   }
+  // #118489: the terminal presentation flag from a later successful tool must
+  // not suppress the failure-honest finalization for an exactly persisted
+  // failed batch. The failing read is planned first, the presentation-producing
+  // web_fetch second, so the tracked presentation belongs to the later outcome.
+  if (isActiveFailedToolPresentationRecovery) {
+    if (allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE)) {
+      if (
+        !allInputText.includes("If a tool failed, say so; never claim completion or success.") &&
+        !allInputText.includes("state that failure plainly and do not claim it succeeded")
+      ) {
+        return buildAssistantEvents("FAILED-TOOL-HONESTY-INSTRUCTION-MISSING");
+      }
+      const marker =
+        exactMarkerDirective ?? exactReplyDirective ?? "QA-FAILED-TOOL-PRESENTATION-FINALIZED-OK";
+      return buildAssistantEvents("The requested file could not be read: ENOENT. " + marker);
+    }
+    if (!hasCompletedToolOutput) {
+      const fetchUrl =
+        QA_FAILED_TOOL_PRESENTATION_FETCH_URL_RE.exec(prompt)?.[1] ?? "https://example.com";
+      return buildToolCallBatchEvents([
+        { name: "read", args: { path: "qa-failed-terminal-missing-file.txt" } },
+        { name: "web_fetch", args: { url: fetchUrl } },
+      ]);
+    }
+    // After the tools have output, end the turn with no assistant message so
+    // the runtime's terminal assistant stays the toolUse batch (the residual
+    // shape); a replay or plain text would mask the finalization decision.
+    return buildAssistantEvents("");
+  }
   if (isActiveFailedToolTerminalRecovery) {
     if (allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE)) {
-      if (!allInputText.includes("state that failure plainly and do not claim it succeeded")) {
+      if (
+        !allInputText.includes("If a tool failed, say so; never claim completion or success.") &&
+        !allInputText.includes("state that failure plainly and do not claim it succeeded")
+      ) {
         return buildAssistantEvents("FAILED-TOOL-HONESTY-INSTRUCTION-MISSING");
       }
       const marker = exactMarkerDirective ?? exactReplyDirective ?? "QA-FAILED-TOOL-FINALIZED-OK";

--- a/qa/scenarios/channels/qa-channel-failed-tool-presentation-terminal-finalization.yaml
+++ b/qa/scenarios/channels/qa-channel-failed-tool-presentation-terminal-finalization.yaml
@@ -1,0 +1,126 @@
+title: QA channel final reply after a failed tool with a later terminal presentation
+
+scenario:
+  id: qa-channel-failed-tool-presentation-terminal-finalization
+  surface: channel
+  coverage:
+    primary: [agent-runtime.failure-recovery-empty-response-recovery]
+    secondary: [channels.qa-channel-final-reply, agent-runtime.failure-recovery-retry-policy]
+  regressionRefs:
+    - openclaw/openclaw#118489
+  runtimePairLane: core
+  gatewayConfigPatch:
+    tools:
+      web:
+        fetch:
+          # The presentation probe fetches the local mock server; private
+          # loopback must be allowed for this isolated QA scenario.
+          ssrfPolicy:
+            dangerouslyAllowPrivateNetwork: true
+  objective: Verify a failed terminal batch still receives one failure-honest finalization when a later tool outcome recorded a terminal presentation.
+  successCriteria:
+    - The failing read and the presentation-producing web_fetch are dispatched exactly once.
+    - The later web_fetch terminal presentation does not suppress the failure-honest finalization.
+    - The failed tool never replays and qa-channel delivers exactly one visible reply.
+  codeRefs:
+    - src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
+  execution:
+    kind: flow
+    suiteIsolation: isolated
+    isolationReason: Verifies one exact tool batch with a terminal presentation and isolated qa-channel delivery.
+    channel: qa-channel
+    retryCount: 0
+    summary: Prove a failed read followed by a successful web_fetch presentation still yields one failure-honest reply.
+    config:
+      requiredProviderMode: mock-openai
+      channelId: qa-failed-terminal-presentation
+      promptSnippet: Failed tool terminal recovery with presentation QA check
+      retryNeedle: The previous assistant turn completed its tool calls but did not produce a user-visible answer.
+      failureHonestyNeedle: If a tool failed, say so; never claim completion or success.
+      expectedMarker: QA-FAILED-TOOL-PRESENTATION-FINALIZED-OK
+
+flow:
+  steps:
+    - name: finalizes a failed batch despite a later terminal presentation
+      actions:
+        - if:
+            expr: "(env.gateway.runtimeEnv?.OPENCLAW_QA_FORCE_RUNTIME ?? 'openclaw') !== 'codex'"
+            then:
+              - call: qaImport
+                args:
+                  - ./errors.js
+                saveAs: qaErrors
+              - throw:
+                  expr: "new qaErrors.QaSuiteScenarioSkipError(`known-harness-gap openclaw-runtime: presentation residual requires the Codex app-server dynamic tool bridge (${config.promptSnippet})`)"
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: failed-terminal presentation proof requires mock-openai
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - call: reset
+        - set: requestCursorBefore
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - set: sessionKey
+          value:
+            expr: "`agent:qa:qa-channel:group:group:${config.channelId}`"
+        - sendInbound:
+            conversation:
+              id:
+                ref: config.channelId
+              kind: group
+            senderId: qa-driver
+            senderName: QA Driver
+            text:
+              expr: "`@openclaw Failed tool terminal recovery with presentation QA check: read the missing workspace file, then call web_fetch on ${env.mock.baseUrl}/debug/request-cursor, then respond with exact marker: \\`QA-FAILED-TOOL-PRESENTATION-FINALIZED-OK\\`.`"
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: config.channelId
+              kind: group
+            sinceIndex:
+              ref: outboundStartIndex
+            textIncludes:
+              ref: config.expectedMarker
+            timeoutMs: 60000
+          saveAs: reply
+        - set: allRequests
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`))"
+        - set: scenarioRequests
+          value:
+            expr: "allRequests.filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
+        - set: readPlans
+          value:
+            expr: "scenarioRequests.filter((request) => request.plannedToolName === 'read')"
+        - assert:
+            expr: "readPlans.length === 1"
+            message:
+              expr: "`expected one read plan, got ${JSON.stringify(scenarioRequests.map((request) => request.plannedToolName))}`"
+        - call: readSessionTranscriptSummary
+          saveAs: transcript
+          args:
+            - ref: env
+            - ref: sessionKey
+        - assert:
+            expr: "transcript.assistantToolCallCounts.read === 1 && transcript.completedToolCallCounts.read === 1 && !transcript.successfulToolCallCounts.read && transcript.successfulToolCallCounts.web_fetch === 1"
+            message:
+              expr: "`expected one failed read and one successful web_fetch, got ${JSON.stringify(transcript)}`"
+        - set: deliveries
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.channelId)"
+        - assert:
+            expr: "deliveries.length === 1 && reply.text.trim() === config.expectedMarker"
+            message:
+              expr: "`expected exactly one failure-honest reply, got ${JSON.stringify(deliveries)}`"
+      detailsExpr: "`${reply.text}; read-calls=${String(transcript.assistantToolCallCounts.read)} fetch-success=${String(transcript.successfulToolCallCounts.web_fetch)}`"

--- a/qa/scenarios/channels/qa-channel-failed-tool-terminal-finalization.yaml
+++ b/qa/scenarios/channels/qa-channel-failed-tool-terminal-finalization.yaml
@@ -34,7 +34,7 @@ scenario:
       channelId: qa-failed-terminal
       promptSnippet: Failed tool terminal recovery QA check
       retryNeedle: The previous assistant turn completed its tool calls but did not produce a user-visible answer.
-      failureHonestyNeedle: state that failure plainly and do not claim it succeeded
+      failureHonestyNeedle: If a tool failed, say so; never claim completion or success.
       expectedMarker: QA-FAILED-TOOL-FINALIZED-OK
       expectedReply: "The requested file could not be read: ENOENT. QA-FAILED-TOOL-FINALIZED-OK"
 

--- a/qa/scenarios/scheduling/cron-failed-tool-terminal-finalization.yaml
+++ b/qa/scenarios/scheduling/cron-failed-tool-terminal-finalization.yaml
@@ -34,7 +34,7 @@ scenario:
       channelId: qa-failed-cron
       promptSnippet: Failed tool terminal recovery QA check
       retryNeedle: The previous assistant turn completed its tool calls but did not produce a user-visible answer.
-      failureHonestyNeedle: state that failure plainly and do not claim it succeeded
+      failureHonestyNeedle: If a tool failed, say so; never claim completion or success.
       expectedMarker: CRON-FAILED-TOOL-FINALIZED-OK
       expectedReply: "The requested file could not be read: ENOENT. CRON-FAILED-TOOL-FINALIZED-OK"
 

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -161,7 +161,12 @@ function createSubscriptionMock(): SubscriptionMock {
     getAssistantTurnCount: () => 0,
     getCompactionCount: () => 0,
     getLastCompactionTokensAfter: () => undefined,
-    getItemLifecycle: () => ({ startedCount: 0, completedCount: 0, activeCount: 0 }),
+    getItemLifecycle: () => ({
+      startedCount: 0,
+      completedCount: 0,
+      activeCount: 0,
+      activeItemIds: [],
+    }),
     isCompacting: () => false,
     isCompactionInFlight: () => false,
   };

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -240,15 +240,44 @@ export function resolveSettledToolBatchEvidence(attempt: IncompleteTurnAttempt) 
         : [];
     }),
   );
-  const allToolsProvenSettled =
-    attempt.itemLifecycle.startedCount > 0 &&
-    attempt.itemLifecycle.completedCount === attempt.itemLifecycle.startedCount &&
-    attempt.itemLifecycle.activeCount === 0 &&
+  const allRequestedToolsHavePersistedResults =
     requestedToolCalls.length > 0 &&
     requestedToolCalls.every(
       ({ id, name }) =>
         id !== null && name !== null && settledToolResults.get(id)?.toolName === name,
     );
+  const hasPersistedTerminalFailure =
+    allRequestedToolsHavePersistedResults &&
+    requestedToolCalls.some(
+      ({ id }) => id !== null && settledToolResults.get(id)?.isError === true,
+    );
+  // Exact persisted results are durable settlement evidence even when a bridge
+  // error raced the lifecycle decrement. Only override the aggregate count when
+  // the producer recorded that every still-active item belongs to this batch.
+  const activeItemIds = attempt.itemLifecycle.activeItemIds;
+  const everyActiveItemBelongsToSettledBatch =
+    Array.isArray(activeItemIds) &&
+    activeItemIds.length === attempt.itemLifecycle.activeCount &&
+    activeItemIds.every((itemId) =>
+      requestedToolCalls.some(
+        ({ id }) =>
+          id !== null &&
+          (itemId === id ||
+            itemId === `tool:${id}` ||
+            itemId === `command:${id}` ||
+            itemId === `patch:${id}`) &&
+          settledToolResults.get(id) !== undefined,
+      ),
+    );
+  const lifecycleIsSettled =
+    (attempt.itemLifecycle.startedCount > 0 &&
+      attempt.itemLifecycle.completedCount === attempt.itemLifecycle.startedCount &&
+      attempt.itemLifecycle.activeCount === 0) ||
+    (hasPersistedTerminalFailure &&
+      everyActiveItemBelongsToSettledBatch &&
+      !hasAsyncActivity(attempt.toolMetas) &&
+      !hasAcceptedSessionSpawn(attempt.acceptedSessionSpawns));
+  const allToolsProvenSettled = allRequestedToolsHavePersistedResults && lifecycleIsSettled;
   const failedToolNames = new Set(
     requestedToolCalls.flatMap(({ id, name }) =>
       id !== null && name !== null && settledToolResults.get(id)?.isError === true ? [name] : [],
@@ -266,7 +295,13 @@ export function resolveSettledToolBatchEvidence(attempt: IncompleteTurnAttempt) 
       );
       return metadata?.terminate === true && metadata.isError !== true;
     });
-  return { assistant, allToolsProvenSettled, failedToolNames, intentionalTermination };
+  return {
+    assistant,
+    allToolsProvenSettled,
+    failedToolNames,
+    intentionalTermination,
+    hasPersistedTerminalFailure,
+  };
 }
 
 /** Builds one fresh continuation after settled tools ended without a visible final answer. */
@@ -283,8 +318,13 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
   attempt: IncompleteTurnAttempt;
 }): string | null {
   const { attempt } = params;
-  const { assistant, allToolsProvenSettled, failedToolNames, intentionalTermination } =
-    resolveSettledToolBatchEvidence(attempt);
+  const {
+    assistant,
+    allToolsProvenSettled,
+    failedToolNames,
+    intentionalTermination,
+    hasPersistedTerminalFailure,
+  } = resolveSettledToolBatchEvidence(attempt);
   const terminal = attempt.terminal;
   const idlePromptTimeout =
     terminal.kind === "timeout" &&
@@ -315,7 +355,7 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
   );
   if (
     params.payloadCount !== 0 ||
-    params.hasTerminalToolPresentation ||
+    (params.hasTerminalToolPresentation && !hasPersistedTerminalFailure) ||
     params.aborted ||
     ((params.timedOut || terminal.kind === "timeout") && !idlePromptTimeout) ||
     (terminal.kind === "failed" && !attempt.settledTurnFinalizationContext) ||

--- a/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
@@ -605,4 +605,122 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
     expect(instruction).toBeNull();
   });
+
+  function makeFailedReadAttempt(overrides: Partial<EmbeddedRunAttemptResult> = {}) {
+    const toolUseAssistant = makeLastAssistant({
+      stopReason: "toolUse",
+      content: [{ type: "toolCall", id: "tool_1", name: "read", arguments: {} }],
+    });
+    return makeAttemptResult({
+      assistantTexts: [],
+      toolMetas: [{ toolName: "read", isError: true }],
+      itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+      messagesSnapshot: [
+        toolUseAssistant,
+        { role: "toolResult", toolCallId: "tool_1", toolName: "read", isError: true },
+      ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+      lastAssistant: toolUseAssistant,
+      currentAttemptAssistant: toolUseAssistant,
+      lastToolError: { toolName: "read", error: "ENOENT" },
+      ...overrides,
+    });
+  }
+
+  it.each([
+    {
+      label: "an earlier successful tool presentation",
+      attemptOverrides: {},
+      extraParams: { hasTerminalToolPresentation: true },
+    },
+    {
+      label: "a stale lifecycle activeCount after the exact result persisted",
+      attemptOverrides: {
+        itemLifecycle: {
+          startedCount: 1,
+          completedCount: 0,
+          activeCount: 1,
+          activeItemIds: ["tool_1"],
+        },
+      },
+      extraParams: {},
+    },
+  ])(
+    "finalizes an exact current failed terminal batch despite $label (#118489)",
+    ({ attemptOverrides, extraParams }) => {
+      const instruction = resolveSettledToolTerminalContinuationInstruction(
+        makeSettledContinuationParams(makeFailedReadAttempt(attemptOverrides), extraParams),
+      );
+      expect(instruction).toContain(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
+      expect(instruction).toContain("If a tool failed, say so; never claim completion or success.");
+    },
+  );
+
+  it.each([
+    {
+      label: "an async tool is still active",
+      attemptOverrides: {
+        itemLifecycle: {
+          startedCount: 1,
+          completedCount: 0,
+          activeCount: 1,
+          activeItemIds: ["tool_1"],
+        },
+        toolMetas: [{ toolName: "read", isError: true, asyncStarted: true }],
+      },
+    },
+    {
+      label: "an accepted child session still owns the response",
+      attemptOverrides: {
+        itemLifecycle: {
+          startedCount: 1,
+          completedCount: 0,
+          activeCount: 1,
+          activeItemIds: ["tool_1"],
+        },
+        acceptedSessionSpawns: [
+          { runId: "run-child", childSessionKey: "agent:main:subagent:child" },
+        ],
+      },
+    },
+    {
+      label: "an unrelated active item remains",
+      attemptOverrides: {
+        itemLifecycle: {
+          startedCount: 1,
+          completedCount: 0,
+          activeCount: 1,
+          activeItemIds: ["tool_unrelated"],
+        },
+      },
+    },
+  ])("does not override stale lifecycle proof when $label (#118489)", ({ attemptOverrides }) => {
+    const instruction = resolveSettledToolTerminalContinuationInstruction(
+      makeSettledContinuationParams(makeFailedReadAttempt(attemptOverrides)),
+    );
+    expect(instruction).toBeNull();
+  });
+
+  it("still suppresses continuation when the presentation belongs to a successful batch (#118489)", () => {
+    const toolUseAssistant = makeLastAssistant({
+      stopReason: "toolUse",
+      content: [{ type: "toolCall", id: "tool_ok", name: "read", arguments: {} }],
+    });
+    const instruction = resolveSettledToolTerminalContinuationInstruction(
+      makeSettledContinuationParams(
+        makeAttemptResult({
+          assistantTexts: [],
+          toolMetas: [{ toolName: "read" }],
+          itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+          messagesSnapshot: [
+            toolUseAssistant,
+            { role: "toolResult", toolCallId: "tool_ok", toolName: "read", isError: false },
+          ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
+          lastAssistant: toolUseAssistant,
+          currentAttemptAssistant: toolUseAssistant,
+        }),
+        { hasTerminalToolPresentation: true },
+      ),
+    );
+    expect(instruction).toBeNull();
+  });
 });

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -238,4 +238,58 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
     expect(result.attempt).toBe(attempt);
     expect(result.prepared.payloadsWithToolMedia?.[0]).toMatchObject({ isError: true });
   });
+
+  it("finalizes an exact failed batch once when an earlier presentation was recorded (#118489)", async () => {
+    const attempt = settledFailedAttempt();
+    const finalAssistant = buildEmbeddedRunnerAssistant({
+      content: [{ type: "text", text: "CANARY_RECOVERED: the exec tool failed as expected." }],
+    });
+    backendMocks.runSettledFinalization.mockResolvedValueOnce({
+      outcome: "answered",
+      result: {
+        assistant: finalAssistant,
+        usage: finalAssistant.usage,
+        diagnosticTrace: { traceId: "trace-118489", spanId: "span-118489" },
+      },
+    });
+    const input = finalizationInput(attempt);
+    input.finalization.hasTerminalToolPresentation = true;
+
+    const result = await prepareTerminalWithSettledTurnFinalization(input);
+
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledOnce();
+    expect(result.finalizationOutcome).toBe("answered");
+    expect(result.prepared.payloadsWithToolMedia).toEqual([
+      expect.objectContaining({ text: "CANARY_RECOVERED: the exec tool failed as expected." }),
+    ]);
+  });
+
+  it("finalizes an exact failed batch once with a stale lifecycle activeCount (#118489)", async () => {
+    const attempt = settledFailedAttempt();
+    attempt.itemLifecycle = {
+      startedCount: 2,
+      completedCount: 1,
+      activeCount: 1,
+      activeItemIds: ["tool-exec"],
+    };
+    const finalAssistant = buildEmbeddedRunnerAssistant({
+      content: [{ type: "text", text: "CANARY_RECOVERED: bridge failure explained." }],
+    });
+    backendMocks.runSettledFinalization.mockResolvedValueOnce({
+      outcome: "answered",
+      result: {
+        assistant: finalAssistant,
+        usage: finalAssistant.usage,
+        diagnosticTrace: { traceId: "trace-118489", spanId: "span-118489" },
+      },
+    });
+
+    const result = await prepareTerminalWithSettledTurnFinalization(finalizationInput(attempt));
+
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledOnce();
+    expect(result.finalizationOutcome).toBe("answered");
+    expect(result.prepared.payloadsWithToolMedia).toEqual([
+      expect.objectContaining({ text: "CANARY_RECOVERED: bridge failure explained." }),
+    ]);
+  });
 });

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -364,6 +364,12 @@ export type EmbeddedRunAttemptResult = {
     startedCount: number;
     completedCount: number;
     activeCount: number;
+    /**
+     * Producer-owned identity of the still-active items. Absent for older
+     * harnesses; the finalizer fails closed on a nonzero activeCount when the
+     * producer did not record which items remain active.
+     */
+    activeItemIds?: string[];
   };
   setTerminalLifecycleMeta?: (meta: {
     replayInvalid?: boolean;

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -709,6 +709,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       startedCount: state.itemStartedCount,
       completedCount: state.itemCompletedCount,
       activeCount: state.itemActiveIds.size,
+      activeItemIds: [...state.itemActiveIds],
     }),
     waitForCompactionRetry: () => {
       // Reject after unsubscribe so callers treat it as cancellation, not success

--- a/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
@@ -199,7 +199,7 @@ describe("diagnostics-otel gateway runtime", () => {
       expect(finalizations).toHaveLength(1);
       expect(finalizations[0]?.body?.tools ?? []).toHaveLength(0);
       expect(finalizations[0]?.allInputText).toContain(
-        "state that failure plainly and do not claim it succeeded",
+        "If a tool failed, say so; never claim completion or success.",
       );
       const finalizationInput = finalizations[0]?.body?.input ?? [];
       const failedExecCalls = finalizationInput.filter(


### PR DESCRIPTION
Closes #118489

## What Problem This Solves

Fixes an issue where channel users and required isolated cron runs could still end without a final assistant payload after a failed terminal tool. The merged #118344 repair only covered fully settled terminal batches; two residual states kept suppressing the tools-disabled finalizer:

1. An earlier successful tool had already set the terminal tool presentation, so the guard rejected finalization even though the current batch's exact failed result was persisted.
2. A Code Mode bridge failure persisted the exact failed `toolResult` while `itemLifecycle.activeCount` was still stale at `1`.

## Why This Change Was Made

Split exact result proof from lifecycle proof in `resolveSettledToolTerminalContinuationInstruction()` (now in `src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts` after main's #122209/#123114 runner refactors). A batch whose every terminal call has an exact persisted result by call ID and tool owner, with at least one failed result, no async tool activity, and no accepted child session, is durably settled even when the aggregate presentation flag or `activeCount` is stale. The terminal-presentation guard now only suppresses finalization when the current batch has no persisted failure, so an earlier successful presentation cannot settle a later failure. All existing fail-closed checks (abort, timeout, prompt error, client tools, yield, approval, delivery, async, child session, exact owner correlation) are preserved.

## User Impact

Users of Telegram/channel and isolated cron runs now receive an honest failure explanation instead of a silent no-reply fallback or `cron isolated run completed without a final assistant payload` after a failed terminal tool.

## Evidence

Regression matrix reproduced before the fix and passing after:

- Unit matrix (`src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts`): earlier successful tool presentation + current failed batch finalizes; stale `activeCount: 1` + exact persisted failed result finalizes; stale lifecycle proof does not override an active async tool, an accepted child session, or an unrelated active item; presentation alone still suppresses a successful batch.
- Owner-level flow (`src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts`, real `prepareTerminalWithSettledTurnFinalization` chain with mocked backend): prior-presentation failed batch finalizes exactly once; stale `activeCount: 1` failed batch finalizes exactly once with the failure-honest prompt and no replay.
- Real event-projection premise proof (`extensions/codex/src/app-server/event-projector.118489-residual.test.ts`): scripting the Codex app-server protocol boundary (item/started for a failing dynamic tool, exact failed toolResult persisted in the turn snapshot, no item/completed) makes the real `CodexAppServerEventProjector` produce `itemLifecycle {startedCount: 1, completedCount: 0, activeCount: 1, activeItemIds: ["call-fail"]}` with the exact failed result and matching `lastToolError` - the stale-lifecycle premise of #118489 reproduced through the production projection pipeline.
- Mock-gateway delivery proof (`extensions/qa-lab/src/providers/mock-openai/server.test.ts`): the presentation-residual branch plans a failing `read` and a presentation-producing `web_fetch` in one batch, requires the failure-honesty needle, and delivers exactly one final reply with no replay.

Local validation on this head: focused suites 37 + 4 + 24 + 2 + 1 tests passed; `tsgo:core`, `tsgo:extensions`, `tsgo:core:test`, `tsgo:extensions:test` passed; oxfmt and `git diff --check` clean. oxlint reports only four pre-existing `no-redundant-type-constituents` findings that reproduce on pristine main with the stale local install (main-side dependency drift, not this PR).

## Observable mock-gateway delivery proof (after-fix, ephemeral gateway)

Ran the repository's real QA harness with explicit scenario selection (real gateway child + qa-channel bus + mock-openai provider): `qa run --provider-mode mock-openai --scenario qa-channel-failed-tool-terminal-finalization` and `--scenario cron-failed-tool-terminal-finalization`, plus the runtime-pair suite for the residual scenario. Redacted verdict JSONs and the codex-cell transcript are committed under `qa/evidence/118489/`.

- `qa-channel-failed-tool-terminal-finalization` (#118274 channel path): **pass** - details `The requested file could not be read: ENOENT. QA-FAILED-TOOL-FINALIZED-OK; calls=1 failed=1 finalizations=1` (exactly one failed call, one failure-honest tools-disabled finalization, exactly one qa-channel reply, no replay).
- `cron-failed-tool-terminal-finalization` (#118274 required isolated cron path): **pass** - details `The requested file could not be read: ENOENT. CRON-FAILED-TOOL-FINALIZED-OK; calls=1 failed=1 finalizations=1`.
- Verdict artifacts: `qa/evidence/118489/channel-118274-qa-evidence.json` and `qa/evidence/118489/cron-118274-qa-evidence.json` (`openclaw.qa.evidence-summary` schema v2, `result.status: pass`).

#118489-specific change and coverage:

- The stale-lifecycle bypass is scoped to the failed batch's own items: the Codex projector (`extensions/codex/src/app-server/event-projector-result.ts`, fed by `event-projector.ts`) and the embedded subscription (`src/agents/embedded-agent-subscribe.ts`) record the still-active item ids (`activeItemIds`) at the producer, and the finalizer only overrides a nonzero `activeCount` when every still-active item belongs to a requested terminal call with an exact persisted result (`tool:`/`command:`/`patch:` id forms included). A remaining active item for unrelated work keeps the lifecycle fail-closed, and attempts whose producer did not record the fact fail closed as before (the field is optional in the attempt type).
- The mock-openai provider has a unit-tested presentation-residual branch (failing `read` followed by a presentation-producing `web_fetch` in the same batch), and the runtime-paired gateway scenario `qa/scenarios/channels/qa-channel-failed-tool-presentation-terminal-finalization.yaml` covers it end-to-end.

## Exact residual delivery proof through the real Codex CLI

The presentation-residual scenario passes end-to-end through the real Codex runtime: `qa suite --runtime-pair openclaw,codex --runtime-pair-lane core --scenario qa-channel-failed-tool-presentation-terminal-finalization` (real `@openai/codex` app-server CLI + mock-openai model endpoint + qa-channel).

- openclaw cell: skipped as `known-harness-gap` (the openclaw harness cannot produce the presentation residual; flow `skip` action).
- codex cell: **pass** - the mock planned the failing `read` (real ENOENT) and the presentation-producing `web_fetch` (real HTTP 200) in one batch, the turn then completed with no assistant message so the terminal assistant stayed the toolUse batch, and the shared finalizer issued the failure-honest continuation; exactly one reply `QA-FAILED-TOOL-PRESENTATION-FINALIZED-OK` was delivered with no tool replay (`toolCalls=2`, read failed once, web_fetch succeeded once, final text = the marker).
- Runtime parity: pass (`known harness gap in openclaw runtime; paired runtime passed`).

New QA infra in this PR: a `skip` flow action (with unit tests) so a runtime cell can declare a known harness gap with `known-harness-gap` details, and the mock provider ends post-tool turns with no assistant message to preserve the residual terminal shape.

## Note on the Code Mode ordering premise

"Code Mode" in this repository is the in-repo QuickJS tool bridge (`src/agents/code-mode.ts`, `src/agents/code-mode-bridge.ts`), not the external OpenAI Codex runtime. The changed finalizer is provider-agnostic and makes no external protocol claim: it treats exact persisted current-batch results as settlement evidence only when the lifecycle aggregate is stale and no async or child-session activity exists. The tool-result transcript and the item lifecycle events are separate in-repo producers, which is why the exact result can be persisted ahead of the decrement. The Codex app-server dynamic-tool item contract was inspected directly in the sibling `openai/codex` checkout at commit `8e3b5d3e` (`codex-rs/app-server-protocol/src/protocol/event_mapping.rs` `ThreadItem::DynamicToolCall { id: response.call_id }`; `codex-rs/app-server/src/bespoke_event_handling.rs` ItemCompleted forwarding), excerpted in `qa/evidence/118489/codex-contract.md`.

cc @steipete

## Rebase and PR size (head 71df6bdd)

- Rebased onto current main (was 2548 commits behind); main's runner refactors moved the finalizer to `run/incomplete-turn-recovery.ts` and deleted the old `run/incomplete-turn.ts`/test file, so the fix and its tests were ported onto the new structure instead of resurrecting deleted files.
- Total diff: 23 files, +1170/-7. Production is +139/-5, split between the finalizer (+41), the two `activeItemIds` producers (+10), and QA harness seams (mock provider branch, tool-batch events, `skip` flow action; +88). Everything else is regression tests and redacted evidence.
- `qa/evidence/118489/parity6-qa-evidence.json` keeps only the #118489 scenario entry (82 lines); the other 27 scenarios in that suite run are omitted as noise.
- History is three clean commits (fix, tests, evidence) instead of the previous 15-commit stack, all on the refactored main layout.

Current red CI lanes are main-side, not this PR: #120536 tracks the `checks-node-compact-large-1/2` context-usage regression from #120497 (fix PR #120550 is open), and the remaining red lanes are pre-existing timeouts/flakes.
