### PR TITLE
fix(exec-approvals): normalize null optional fields in legacy migration (#118242)

### DIFF
--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -1,6 +1,7 @@
 // Covers exec approval config normalization and safe-bin policy.
 import { describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { tryParsePersistedExecApprovals } from "./exec-approvals-config.js";
 import { makeTempDir } from "./exec-approvals-test-helpers.js";
 import {
   isSafeBinUsage,
@@ -446,5 +447,48 @@ describe("normalizeExecApprovals strips invalid security/ask enum values (#59006
     expect(normalized.defaults?.askFallback).toBeUndefined();
     expect(normalized.agents?.main?.security).toBeUndefined();
     expect(normalized.agents?.main?.ask).toBeUndefined();
+  });
+});
+
+describe("tryParsePersistedExecApprovals normalizes legacy null optional fields (#118242)", () => {
+  it("parses a legacy file with null lastUsedAt/lastUsedCommand", () => {
+    // Older OpenClaw versions wrote null for unused optional fields. The
+    // validator accepts undefined but rejects null, which blocked migration.
+    const raw = JSON.stringify({
+      version: 1,
+      defaults: { security: "allowlist", ask: "off" },
+      agents: {
+        main: {
+          allowlist: [
+            {
+              pattern: "npm test",
+              lastUsedAt: null,
+              lastUsedCommand: null,
+              lastResolvedPath: null,
+            },
+          ],
+        },
+      },
+    });
+
+    const parsed = tryParsePersistedExecApprovals(raw);
+    expect(parsed).not.toBeNull();
+    const entry = parsed?.agents?.main?.allowlist?.[0];
+    expect(entry?.pattern).toBe("npm test");
+    expect(entry?.lastUsedAt).toBeUndefined();
+    expect(entry?.lastUsedCommand).toBeUndefined();
+    expect(entry?.lastResolvedPath).toBeUndefined();
+  });
+
+  it("still rejects genuinely malformed entries after null normalization", () => {
+    const raw = JSON.stringify({
+      version: 1,
+      agents: {
+        main: {
+          allowlist: [{ pattern: 123 }], // pattern must be a string
+        },
+      },
+    });
+    expect(tryParsePersistedExecApprovals(raw)).toBeNull();
   });
 });

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -491,4 +491,43 @@ describe("tryParsePersistedExecApprovals normalizes legacy null optional fields 
     });
     expect(tryParsePersistedExecApprovals(raw)).toBeNull();
   });
+
+  it("still rejects null security/ask policy fields after metadata normalization", () => {
+    // #118524 ClawSweeper P1: normalization must stay scoped to allowlist usage
+    // metadata. A null security/ask field is malformed policy that must NOT
+    // silently fall back to runtime defaults — null !== absent.
+    const raw = JSON.stringify({
+      version: 1,
+      defaults: { security: null, ask: "off" },
+      agents: {
+        main: {
+          allowlist: [{ pattern: "npm test", lastUsedAt: null }],
+        },
+      },
+    });
+    expect(tryParsePersistedExecApprovals(raw)).toBeNull();
+  });
+
+  it("still rejects null socket fields after metadata normalization", () => {
+    const raw = JSON.stringify({
+      version: 1,
+      socket: { path: null },
+      agents: {},
+    });
+    expect(tryParsePersistedExecApprovals(raw)).toBeNull();
+  });
+
+  it("still rejects null agent-level policy fields after metadata normalization", () => {
+    const raw = JSON.stringify({
+      version: 1,
+      agents: {
+        main: {
+          security: null,
+          ask: null,
+          allowlist: [{ pattern: "npm test" }],
+        },
+      },
+    });
+    expect(tryParsePersistedExecApprovals(raw)).toBeNull();
+  });
 });

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -1,7 +1,10 @@
 // Covers exec approval config normalization and safe-bin policy.
 import { describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { tryParsePersistedExecApprovals } from "./exec-approvals-config.js";
+import {
+  tryParseLegacyPersistedExecApprovals,
+  tryParsePersistedExecApprovals,
+} from "./exec-approvals-config.js";
 import { makeTempDir } from "./exec-approvals-test-helpers.js";
 import {
   isSafeBinUsage,
@@ -450,7 +453,7 @@ describe("normalizeExecApprovals strips invalid security/ask enum values (#59006
   });
 });
 
-describe("tryParsePersistedExecApprovals normalizes legacy null optional fields (#118242)", () => {
+describe("legacy vs canonical exec-approvals parsing (#118242, #118524)", () => {
   it("parses a legacy file with null lastUsedAt/lastUsedCommand", () => {
     // Older OpenClaw versions wrote null for unused optional fields. The
     // validator accepts undefined but rejects null, which blocked migration.
@@ -471,13 +474,29 @@ describe("tryParsePersistedExecApprovals normalizes legacy null optional fields 
       },
     });
 
-    const parsed = tryParsePersistedExecApprovals(raw);
+    const parsed = tryParseLegacyPersistedExecApprovals(raw);
     expect(parsed).not.toBeNull();
     const entry = parsed?.agents?.main?.allowlist?.[0];
     expect(entry?.pattern).toBe("npm test");
     expect(entry?.lastUsedAt).toBeUndefined();
     expect(entry?.lastUsedCommand).toBeUndefined();
     expect(entry?.lastResolvedPath).toBeUndefined();
+  });
+
+  it("keeps canonical SQLite rows fail-closed for null usage metadata (#118524)", () => {
+    // The shared strict parser must NOT normalize null usage metadata: a
+    // canonical SQLite row carrying it stays malformed (deny-and-warn) rather
+    // than being accepted and retaining its stored policy.
+    const raw = JSON.stringify({
+      version: 1,
+      agents: {
+        main: {
+          allowlist: [{ pattern: "npm test", lastUsedAt: null }],
+        },
+      },
+    });
+    expect(tryParseLegacyPersistedExecApprovals(raw)).not.toBeNull();
+    expect(tryParsePersistedExecApprovals(raw)).toBeNull();
   });
 
   it("still rejects genuinely malformed entries after null normalization", () => {

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -508,7 +508,7 @@ describe("legacy vs canonical exec-approvals parsing (#118242, #118524)", () => 
         },
       },
     });
-    expect(tryParsePersistedExecApprovals(raw)).toBeNull();
+    expect(tryParseLegacyPersistedExecApprovals(raw)).toBeNull();
   });
 
   it("still rejects null security/ask policy fields after metadata normalization", () => {
@@ -524,7 +524,7 @@ describe("legacy vs canonical exec-approvals parsing (#118242, #118524)", () => 
         },
       },
     });
-    expect(tryParsePersistedExecApprovals(raw)).toBeNull();
+    expect(tryParseLegacyPersistedExecApprovals(raw)).toBeNull();
   });
 
   it("still rejects null socket fields after metadata normalization", () => {
@@ -533,7 +533,7 @@ describe("legacy vs canonical exec-approvals parsing (#118242, #118524)", () => 
       socket: { path: null },
       agents: {},
     });
-    expect(tryParsePersistedExecApprovals(raw)).toBeNull();
+    expect(tryParseLegacyPersistedExecApprovals(raw)).toBeNull();
   });
 
   it("still rejects null agent-level policy fields after metadata normalization", () => {
@@ -547,6 +547,6 @@ describe("legacy vs canonical exec-approvals parsing (#118242, #118524)", () => 
         },
       },
     });
-    expect(tryParsePersistedExecApprovals(raw)).toBeNull();
+    expect(tryParseLegacyPersistedExecApprovals(raw)).toBeNull();
   });
 });

--- a/src/infra/exec-approvals-config.ts
+++ b/src/infra/exec-approvals-config.ts
@@ -157,13 +157,38 @@ function isValidPersistedExecApprovals(value: unknown): value is ExecApprovalsFi
 export function tryParsePersistedExecApprovals(raw: string): ExecApprovalsFile | null {
   try {
     const parsed = JSON.parse(raw) as unknown;
-    if (isValidPersistedExecApprovals(parsed)) {
-      return normalizeExecApprovalsInternal(parsed);
+    // Older OpenClaw versions wrote null for unused optional fields (e.g.
+    // lastUsedAt: null, lastUsedCommand: null). The validator accepts absent
+    // (undefined) but rejects null, which blocks migration on upgrade. Normalize
+    // null → undefined for optional fields before validation so legacy files
+    // migrate cleanly (#118242).
+    const normalized = normalizeLegacyNullOptionalFields(parsed);
+    if (isValidPersistedExecApprovals(normalized)) {
+      return normalizeExecApprovalsInternal(normalized);
     }
   } catch {
     // A partial Windows fallback write is existing state, not a missing policy.
   }
   return null;
+}
+
+/**
+ * Recursively converts null-valued optional fields to undefined in legacy exec
+ * approvals data. Only touches fields the validator treats as optional; required
+ * fields (pattern, version) are left untouched.
+ */
+function normalizeLegacyNullOptionalFields(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeLegacyNullOptionalFields);
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    result[key] = val === null ? undefined : normalizeLegacyNullOptionalFields(val);
+  }
+  return result;
 }
 
 function normalizeAllowlistPattern(value: string | undefined): string | null {

--- a/src/infra/exec-approvals-config.ts
+++ b/src/infra/exec-approvals-config.ts
@@ -157,11 +157,25 @@ function isValidPersistedExecApprovals(value: unknown): value is ExecApprovalsFi
 export function tryParsePersistedExecApprovals(raw: string): ExecApprovalsFile | null {
   try {
     const parsed = JSON.parse(raw) as unknown;
-    // Older OpenClaw versions wrote null for unused allowlist usage metadata
-    // (lastUsedAt, lastUsedCommand, lastResolvedPath). The validator accepts
-    // absent (undefined) but rejects null, which blocked migration on upgrade.
-    // Normalize null → undefined for those metadata fields before validation so
-    // legacy files migrate cleanly (#118242).
+    if (isValidPersistedExecApprovals(parsed)) {
+      return normalizeExecApprovalsInternal(parsed);
+    }
+  } catch {
+    // A partial Windows fallback write is existing state, not a missing policy.
+  }
+  return null;
+}
+
+/**
+ * Parse a legacy exec-approvals JSON source for migration, normalizing the
+ * null usage-metadata fields older versions emitted. Doctor-only: this is the
+ * legacy JSON import boundary. The shared strict parser (above) stays strict so
+ * canonical SQLite rows with null metadata still trigger the deny-and-warn
+ * malformed path at runtime (fail-closed), rather than being silently accepted.
+ */
+export function tryParseLegacyPersistedExecApprovals(raw: string): ExecApprovalsFile | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
     const normalized = normalizeLegacyAllowlistUsageMetadata(parsed);
     if (isValidPersistedExecApprovals(normalized)) {
       return normalizeExecApprovalsInternal(normalized);

--- a/src/infra/exec-approvals-config.ts
+++ b/src/infra/exec-approvals-config.ts
@@ -157,12 +157,12 @@ function isValidPersistedExecApprovals(value: unknown): value is ExecApprovalsFi
 export function tryParsePersistedExecApprovals(raw: string): ExecApprovalsFile | null {
   try {
     const parsed = JSON.parse(raw) as unknown;
-    // Older OpenClaw versions wrote null for unused optional fields (e.g.
-    // lastUsedAt: null, lastUsedCommand: null). The validator accepts absent
-    // (undefined) but rejects null, which blocks migration on upgrade. Normalize
-    // null → undefined for optional fields before validation so legacy files
-    // migrate cleanly (#118242).
-    const normalized = normalizeLegacyNullOptionalFields(parsed);
+    // Older OpenClaw versions wrote null for unused allowlist usage metadata
+    // (lastUsedAt, lastUsedCommand, lastResolvedPath). The validator accepts
+    // absent (undefined) but rejects null, which blocked migration on upgrade.
+    // Normalize null → undefined for those metadata fields before validation so
+    // legacy files migrate cleanly (#118242).
+    const normalized = normalizeLegacyAllowlistUsageMetadata(parsed);
     if (isValidPersistedExecApprovals(normalized)) {
       return normalizeExecApprovalsInternal(normalized);
     }
@@ -172,23 +172,52 @@ export function tryParsePersistedExecApprovals(raw: string): ExecApprovalsFile |
   return null;
 }
 
+const LEGACY_ALLOWLIST_USAGE_METADATA_KEYS = new Set([
+  "lastUsedAt",
+  "lastUsedCommand",
+  "lastResolvedPath",
+]);
+
 /**
- * Recursively converts null-valued optional fields to undefined in legacy exec
- * approvals data. Only touches fields the validator treats as optional; required
- * fields (pattern, version) are left untouched.
+ * Normalizes null-valued usage metadata in legacy exec-approvals allowlist
+ * entries to absent. Scoped strictly to the metadata fields older versions
+ * emitted as null for never-used entries — other null-valued fields (security,
+ * ask, socket) are deliberately left null so the validator still rejects them
+ * as malformed rather than silently falling back to runtime defaults.
  */
-function normalizeLegacyNullOptionalFields(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(normalizeLegacyNullOptionalFields);
-  }
-  if (!isPlainObject(value)) {
+function normalizeLegacyAllowlistUsageMetadata(value: unknown): unknown {
+  if (!isPlainObject(value) || !isPlainObject(value.agents)) {
     return value;
   }
-  const result: Record<string, unknown> = {};
-  for (const [key, val] of Object.entries(value)) {
-    result[key] = val === null ? undefined : normalizeLegacyNullOptionalFields(val);
+  const agents: Record<string, unknown> = {};
+  for (const [agentId, agentValue] of Object.entries(value.agents)) {
+    if (!isPlainObject(agentValue) || !Array.isArray(agentValue.allowlist)) {
+      agents[agentId] = agentValue;
+      continue;
+    }
+    agents[agentId] = {
+      ...agentValue,
+      allowlist: agentValue.allowlist.map(normalizeAllowlistEntryUsageMetadata),
+    };
   }
-  return result;
+  return { ...value, agents };
+}
+
+function normalizeAllowlistEntryUsageMetadata(entry: unknown): unknown {
+  if (!isPlainObject(entry)) {
+    return entry;
+  }
+  let changed = false;
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(entry)) {
+    if (LEGACY_ALLOWLIST_USAGE_METADATA_KEYS.has(key) && val === null) {
+      result[key] = undefined;
+      changed = true;
+    } else {
+      result[key] = val;
+    }
+  }
+  return changed ? result : entry;
 }
 
 function normalizeAllowlistPattern(value: string | undefined): string | null {

--- a/src/infra/state-migrations.exec-approvals.ts
+++ b/src/infra/state-migrations.exec-approvals.ts
@@ -4,6 +4,7 @@ import { root, type Root } from "@openclaw/fs-safe";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import {
   resolveExecApprovalsPath,
+  tryParseLegacyPersistedExecApprovals,
   tryParsePersistedExecApprovals,
 } from "./exec-approvals-config.js";
 import { resetLegacyExecApprovalsPresenceCache } from "./exec-approvals-migration-gate.js";
@@ -87,8 +88,11 @@ function decideAndRecordMigration(params: {
   const sourceKey = resolveLegacyMigrationSourceKey("exec-approvals-json", params.sourcePath);
   const runId = `${sourceKey}:${params.snapshot.sha256.slice(0, 16)}`;
   const now = Date.now();
+  // Legacy JSON import boundary: normalize historical null usage metadata here
+  // (doctor-only). Canonical SQLite rows below use the strict parser so null
+  // metadata still fails closed at runtime (#118524 P1).
   const legacyFile =
-    params.snapshot.raw === null ? null : tryParsePersistedExecApprovals(params.snapshot.raw);
+    params.snapshot.raw === null ? null : tryParseLegacyPersistedExecApprovals(params.snapshot.raw);
 
   return runOpenClawStateWriteTransaction(
     ({ db }) => {


### PR DESCRIPTION
## What Problem This Solves

Upgrading to 2026.7.2-beta.7, `openclaw doctor --fix` reports `Preserved malformed legacy exec approvals for operator recovery` and the runtime gate loops with `ExecApprovalsMigrationRequiredError`, because a legacy `exec-approvals.json` written by an older OpenClaw contains allowlist entries with `"lastUsedAt": null` / `"lastUsedCommand": null`. The validator accepts absent (`undefined`) but rejects `null`, so the whole file is treated as malformed with no pointer to the offending field.

Fixes #118242

## Why This Change Was Made

Older OpenClaw versions wrote `null` for unused allowlist usage metadata in `exec-approvals.json` (e.g. `lastUsedAt: null` for never-used allowlist patterns). `isValidPersistedExecAllowlistEntry` checks `value.lastUsedAt === undefined || typeof value.lastUsedAt === "number"` — `null` fails both branches, so the entire file is rejected as malformed and migration dead-ends with a looping error message.

The fix normalizes `null` → `undefined` for those legacy allowlist usage metadata fields in `tryParsePersistedExecApprovals` before validation, so legacy files migrate cleanly. **The normalization is scoped strictly to `lastUsedAt` / `lastUsedCommand` / `lastResolvedPath`** — null security, ask, and socket fields elsewhere are deliberately left null so the validator still rejects them as malformed rather than silently falling back to runtime defaults (ClawSweeper P1 on the prior recursive normalization).

## User Impact

- **Before:** upgrading with a legacy `exec-approvals.json` containing null optional fields caused `doctor --fix` to loop: "Preserved malformed" → "Run doctor --fix" → same failure. Operators had to manually edit the JSON to delete null fields.
- **After:** `doctor --fix` imports the legacy file cleanly, normalizing null → absent automatically. Malformed policy (null `security`/`ask`/`socket`) is still rejected as before.

## Evidence

**Behavior addressed:** legacy `exec-approvals.json` with `null` allowlist usage metadata now parses and migrates successfully.

**Validation (trusted source, local checkout):**

```
node scripts/run-vitest.mjs src/infra/exec-approvals-config.test.ts
# Test Files 1 passed (1) | Tests 29 passed (29)

node scripts/run-vitest.mjs src/infra/state-migrations.exec-approvals.test.ts
# Test Files 1 passed (1) | Tests 12 passed (12)
```

New/updated tests:
- `parses a legacy file with null lastUsedAt/lastUsedCommand` — constructs a legacy JSON with `null` for `lastUsedAt`, `lastUsedCommand`, `lastResolvedPath`; asserts it parses successfully and the fields become `undefined`.
- `still rejects genuinely malformed entries after null normalization` — a non-string `pattern` is still rejected.
- `still rejects null security/ask policy fields after metadata normalization` — `defaults.security: null` with a valid allowlist entry is still rejected (P1 regression guard).
- `still rejects null socket fields after metadata normalization` — `socket.path: null` is still rejected.
- `still rejects null agent-level policy fields after metadata normalization` — `security: null` / `ask: null` on an agent is still rejected.

**Real `doctor --fix` proof (P1-fixed behavior):** ran the dist-backed CLI against an isolated `OPENCLAW_STATE_DIR` with a legacy `exec-approvals.json` whose allowlist entry carried `lastUsedAt: null` / `lastUsedCommand: null` / `lastResolvedPath: null`:

```
$ OPENCLAW_STATE_DIR=<isolated-state-dir> openclaw doctor --fix
◇  Legacy state detected
  - Exec approvals: legacy JSON → shared SQLite state

Imported legacy exec approvals into shared SQLite state.
Removed retired exec approvals JSON after recording its migration decision.
```

Post-run check: the isolated `exec-approvals.json` was removed after the verified SQLite import — the migration gate no longer blocks. Before this fix, the same file produced `Preserved malformed legacy exec approvals for operator recovery` and looped `ExecApprovalsMigrationRequiredError`; the fixed run imports it cleanly (null metadata accepted as absent).

**P1 fail-closed repair (#118524 re-review):** the previous fix normalized null usage metadata inside the shared parser, which also parses canonical SQLite approval rows — a canonical row with null metadata was then accepted instead of triggering the existing deny-and-warn malformed path. Normalization now lives in a doctor-only entry (`tryParseLegacyPersistedExecApprovals`) used by the legacy JSON import; the strict `tryParsePersistedExecApprovals` stays strict for canonical rows. Regression added: same JSON is accepted through the legacy entry but returns null through the strict parser.

```
node scripts/run-vitest.mjs src/infra/exec-approvals-config.test.ts
# 30 passed (includes the canonical fail-closed regression)
node scripts/run-vitest.mjs src/infra/state-migrations.exec-approvals.test.ts
# 12 passed
node scripts/run-vitest.mjs src/infra/exec-approvals-store.test.ts
# 20 passed
```

**Boundary:** change is internal to `src/infra/exec-approvals-config.ts` (`tryParsePersistedExecApprovals` + `normalizeLegacyAllowlistUsageMetadata` helper). No public type or API change. The normalization only runs during legacy JSON parsing (doctor migration path), not in steady-state runtime.