### PR TITLE
refactor(ui): consolidate Workboard view test setup

### DIFF
--- a/ui/src/pages/workboard/view.test.ts
+++ b/ui/src/pages/workboard/view.test.ts
@@ -46,6 +46,19 @@ function renderInto(container: HTMLElement, props: WorkboardRenderProps) {
   render(renderWorkboard(props), container);
 }
 
+function createWorkboardView(
+  overrides: Partial<WorkboardRenderProps> = {},
+  host: WorkboardRenderProps["host"] = {},
+) {
+  const state = getWorkboardState(host);
+  state.loaded = true;
+  const container = document.createElement("div");
+  const props = createWorkboardRenderProps(host, overrides);
+  const renderView = (next: Partial<WorkboardRenderProps> = {}) =>
+    renderInto(container, { ...props, ...next });
+  return { host, state, container, renderView };
+}
+
 function buttonByLabel(container: Element, label: string): HTMLButtonElement | null {
   return (
     Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
@@ -202,7 +215,7 @@ describe("nextWorkboardCardPosition", () => {
 
 describe("renderWorkboard", () => {
   it("shows a card dashboard only for linked cards while the plugin is active", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.detailCardId = "card-1";
     state.cards = [
       createWorkboardCard({
@@ -211,17 +224,14 @@ describe("renderWorkboard", () => {
         position: 1,
       }),
     ];
-    const container = document.createElement("div");
-    const props = createWorkboardRenderProps(host);
-
-    renderInto(container, props);
+    renderView();
     expect(container.querySelector("openclaw-workboard-card-dashboard")).toBeNull();
 
     state.cards = [{ ...state.cards[0]!, sessionKey: "agent:main:dashboard-aware" }];
-    renderInto(container, props);
+    renderView();
     expect(container.querySelector("openclaw-workboard-card-dashboard")).not.toBeNull();
 
-    renderInto(container, { ...props, pluginEnabled: false });
+    renderView({ pluginEnabled: false });
     expect(container.querySelector("openclaw-workboard-card-dashboard")).toBeNull();
   });
 
@@ -281,86 +291,72 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps manual recovery refresh visible while data is loading", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.loading = true;
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(buttonByText(container, "Refreshing")?.disabled).toBe(true);
   });
 
   it("renders lifecycle refresh errors without replacing generic errors", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.lifecycleTaskRefreshError = "Task refresh unavailable";
-    const container = document.createElement("div");
-    const props = createWorkboardRenderProps(host);
-
-    renderInto(container, props);
+    renderView();
     expect(container.querySelector(".callout.danger")?.textContent).toBe(
       "Task refresh unavailable",
     );
 
     state.error = "Write denied";
-    renderInto(container, props);
+    renderView();
     expect(container.querySelector(".callout.danger")?.textContent).toBe("Write denied");
   });
 
   it("keeps dispatch available during refresh and disables it during writes", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.loading = true;
-    const container = document.createElement("div");
-    const props = createWorkboardRenderProps(host);
-
-    render(renderWorkboard(props), container);
+    renderView();
 
     const dispatchButton = buttonByText(container, "Dispatch ready work");
     expect(dispatchButton?.disabled).toBe(false);
 
     state.draftSaving = true;
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(buttonByText(container, "Dispatch ready work")?.disabled).toBe(true);
 
     state.loading = false;
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(buttonByText(container, "Refresh")?.disabled).toBe(true);
 
     state.draftSaving = false;
     state.dispatching = true;
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(buttonByText(container, "Dispatch ready work")?.disabled).toBe(true);
 
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(buttonByText(container, "Refresh")?.disabled).toBe(true);
   });
 
   it("disables card-write controls while dispatch is running", () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const sessionKey = "agent:main:workboard-dispatch";
-    const request = vi.fn(async () => ({ card: state.cards[0] }));
-    state.loaded = true;
-    state.dispatching = true;
-    state.detailCardId = "card-1";
-    state.cards = [
-      createWorkboardCard({
-        title: "Dispatch-safe card",
-        sessionKey,
-      }),
-    ];
-    const container = document.createElement("div");
-    const props = createWorkboardRenderProps(host, {
+    const card = createWorkboardCard({
+      title: "Dispatch-safe card",
+      sessionKey,
+    });
+    const request = vi.fn(async () => ({ card }));
+    const { state, container, renderView } = createWorkboardView({
       client: { request } as unknown as GatewayBrowserClient,
       sessions: [
         { key: sessionKey, kind: "direct", status: "running", hasActiveRun: true, updatedAt: 2 },
       ],
     });
-
-    render(renderWorkboard(props), container);
+    state.dispatching = true;
+    state.detailCardId = "card-1";
+    state.cards = [card];
+    renderView();
 
     expect(buttonByText(container, "New card")?.disabled).toBe(true);
     expect(buttonByLabel(container, "Edit card")?.disabled).toBe(true);
@@ -386,7 +382,7 @@ describe("renderWorkboard", () => {
     state.draftOpen = true;
     state.editingCardId = "card-1";
     state.draftTitle = "Dispatch-safe card";
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(
       container.querySelector<HTMLButtonElement>(".workboard-draft .btn.primary")?.disabled,
@@ -394,7 +390,17 @@ describe("renderWorkboard", () => {
   });
 
   it("renders stable card action slots and top updated timestamps", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({
+      sessions: [
+        {
+          key: "agent:main:dashboard:1",
+          kind: "direct",
+          updatedAt: Date.now(),
+          status: "running",
+          hasActiveRun: true,
+        },
+      ],
+    });
     state.cards = [
       {
         id: "ready",
@@ -419,24 +425,7 @@ describe("renderWorkboard", () => {
         sessionKey: "agent:main:dashboard:1",
       },
     ];
-    const container = document.createElement("div");
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          sessions: [
-            {
-              key: "agent:main:dashboard:1",
-              kind: "direct",
-              updatedAt: Date.now(),
-              status: "running",
-              hasActiveRun: true,
-            },
-          ],
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     const cards = [...container.querySelectorAll(".workboard-card")];
     expect(cards).toHaveLength(2);
@@ -470,7 +459,7 @@ describe("renderWorkboard", () => {
   });
 
   it("renders date and time in detail drawer timestamps", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.detailCardId = "card-1";
     state.cards = [
       {
@@ -490,9 +479,7 @@ describe("renderWorkboard", () => {
         },
       },
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     const detailText = container.querySelector(".workboard-detail")?.textContent ?? "";
     expect(detailText).toContain("Updated");
@@ -500,13 +487,11 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps the last updated timestamp stable next to density controls while refreshing", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.loading = true;
     state.lastRefreshAt = new Date("2026-06-03T18:47:00Z").getTime();
     state.lastRefreshStartedAt = Date.now();
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     const layoutControls = container.querySelector(".workboard-layout-controls");
     expect(layoutControls?.querySelector(".workboard-layout-toggle")).toBeTruthy();
@@ -518,7 +503,18 @@ describe("renderWorkboard", () => {
 
   it("renders board columns and preloaded cards", () => {
     const now = Date.now();
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({
+      sessions: [
+        {
+          key: "agent:main:dashboard:1",
+          kind: "direct",
+          displayName: "Dashboard session",
+          updatedAt: now,
+          hasActiveRun: true,
+          status: "running",
+        },
+      ],
+    });
     state.cards = [
       {
         id: "card-1",
@@ -534,25 +530,7 @@ describe("renderWorkboard", () => {
         sessionKey: "agent:main:dashboard:1",
       },
     ];
-    const container = document.createElement("div");
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          sessions: [
-            {
-              key: "agent:main:dashboard:1",
-              kind: "direct",
-              displayName: "Dashboard session",
-              updatedAt: now,
-              hasActiveRun: true,
-              status: "running",
-            },
-          ],
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     expect(container.textContent).toContain("Todo");
     expect(container.textContent).toContain("Wire dashboard tab");
@@ -564,19 +542,14 @@ describe("renderWorkboard", () => {
   });
 
   it("distinguishes the dragged card from its available drop columns", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({ canWrite: true });
     state.cards = [
       createWorkboardCard({
         title: "Drag feedback",
       }),
     ];
     state.draggedCardId = "card-1";
-    const container = document.createElement("div");
-    const props = createWorkboardRenderProps(host, {
-      canWrite: true,
-    });
-
-    renderInto(container, props);
+    renderView();
 
     expect(container.querySelector(".workboard-card")?.classList).toContain(
       "workboard-card--dragging",
@@ -584,27 +557,22 @@ describe("renderWorkboard", () => {
     expect(container.querySelectorAll(".workboard-column--drop")).toHaveLength(9);
 
     state.draggedCardId = null;
-    renderInto(container, props);
+    renderView();
 
     expect(container.querySelector(".workboard-card--dragging")).toBeNull();
     expect(container.querySelector(".workboard-column--drop")).toBeNull();
   });
 
   it("moves the resolved active card when a drop has no transfer payload", async () => {
-    const { host, state } = createLoadedWorkboardState();
     const card = createWorkboardCard({ title: "Fallback drag move" });
     const moved = { ...card, status: "running" as const, position: 1000 };
+    const request = vi.fn(async () => ({ card: moved }));
+    const { state, container, renderView } = createWorkboardView({
+      client: { request } as unknown as GatewayBrowserClient,
+    });
     state.cards = [card];
     state.draggedCardId = card.id;
-    const request = vi.fn(async () => ({ card: moved }));
-    const container = document.createElement("div");
-
-    renderInto(
-      container,
-      createWorkboardRenderProps(host, {
-        client: { request } as unknown as GatewayBrowserClient,
-      }),
-    );
+    renderView();
 
     container
       .querySelector(".workboard-column--running")
@@ -621,25 +589,14 @@ describe("renderWorkboard", () => {
   });
 
   it("hides cached card mutation controls until a lifecycle teardown reload succeeds", async () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { host, state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Stale cached card",
       }),
     ];
     stopWorkboardLifecycleRefresh(host);
-    const props = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-    };
-    const container = document.createElement("div");
-
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(buttonByLabel(container, "Edit card")).toBeNull();
     expect(buttonByLabel(container, "Archive card")).toBeNull();
@@ -647,14 +604,14 @@ describe("renderWorkboard", () => {
     expect(container.querySelector(".workboard-card")?.getAttribute("draggable")).toBe("false");
 
     state.mutationReadiness = "ready";
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(buttonByLabel(container, "Edit card")).not.toBeNull();
     expect(buttonByText(container, "New card")).not.toBeNull();
   });
 
   it("keeps a stale edit draft disabled until it is cancelled", async () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { host, state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Canonical title",
@@ -664,20 +621,9 @@ describe("renderWorkboard", () => {
     state.editingCardId = "card-1";
     state.draftTitle = "Unsaved edit";
     stopWorkboardLifecycleRefresh(host);
-    const props = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-    };
-    const container = document.createElement("div");
-
-    render(renderWorkboard(props), container);
+    renderView();
     state.mutationReadiness = "stale_edit_draft";
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(
       container.querySelector<HTMLButtonElement>(".workboard-modal__actions .primary")?.disabled,
@@ -694,7 +640,7 @@ describe("renderWorkboard", () => {
   });
 
   it("renders health counts and dense card metadata", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Blocked worker",
@@ -733,9 +679,7 @@ describe("renderWorkboard", () => {
         },
       }),
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.querySelector(".workboard-health")?.textContent).toContain("1blocked");
     expect(container.textContent).toContain("1 attempts");
@@ -746,7 +690,7 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps bounded diagnostic badges UTF-16 safe", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         id: "card-boundary",
@@ -767,9 +711,7 @@ describe("renderWorkboard", () => {
         },
       }),
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.querySelector(".workboard-card__badge--warning")?.textContent?.trim()).toBe(
       `${"x".repeat(62)}…`,
@@ -779,7 +721,7 @@ describe("renderWorkboard", () => {
   it("renders sub-minute heartbeat ages with the duration count interpolation", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-13T12:00:00Z"));
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Active worker",
@@ -794,18 +736,8 @@ describe("renderWorkboard", () => {
         },
       }),
     ];
-    const container = document.createElement("div");
-
     try {
-      renderInto(container, {
-        host,
-        client: null,
-        connected: true,
-        pluginEnabled: true,
-        agentsList: null,
-        sessions: [],
-        onOpenSession: () => undefined,
-      });
+      renderView();
 
       expect(container.textContent).toContain("heartbeat 42s");
     } finally {
@@ -814,7 +746,7 @@ describe("renderWorkboard", () => {
   });
 
   it("highlights cards matching a clicked health badge", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Blocked worker",
@@ -831,15 +763,12 @@ describe("renderWorkboard", () => {
         updatedAt: 1,
       },
     ];
-    const container = document.createElement("div");
-    const renderBoard = () => render(renderWorkboard(createWorkboardRenderProps(host)), container);
-
-    renderBoard();
+    renderView();
 
     container
       .querySelector<HTMLButtonElement>(".workboard-health__item--blocked")
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    renderBoard();
+    renderView();
 
     const cards = [...container.querySelectorAll<HTMLElement>(".workboard-card")];
     expect(state.activeHealthHighlight).toBe("blocked");
@@ -861,14 +790,14 @@ describe("renderWorkboard", () => {
     container
       .querySelector<HTMLButtonElement>(".workboard-health__item--blocked")
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    renderBoard();
+    renderView();
 
     expect(state.activeHealthHighlight).toBeNull();
     expect(container.querySelector(".workboard-card--health-highlight")).toBeNull();
   });
 
   it("filters cards with the view preset selector", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.viewPreset = "ready";
     state.cards = [
       createWorkboardCard({
@@ -882,9 +811,7 @@ describe("renderWorkboard", () => {
         status: "blocked",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.textContent).toContain("Ready card");
     expect(container.textContent).not.toContain("Blocked card");
@@ -902,7 +829,7 @@ describe("renderWorkboard", () => {
   });
 
   it("shows an empty state and disables zero-result view presets", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.viewPreset = "running";
     state.cards = [
       createWorkboardCard({
@@ -911,9 +838,7 @@ describe("renderWorkboard", () => {
         status: "ready",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.querySelector(".workboard-column")).toBeNull();
     expect(container.querySelector(".workboard-board")).toBeNull();
@@ -929,7 +854,7 @@ describe("renderWorkboard", () => {
   });
 
   it("shows the empty state when non-view filters match no cards", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.viewPreset = "all";
     state.priorityFilter = "urgent";
     state.cards = [
@@ -939,9 +864,7 @@ describe("renderWorkboard", () => {
         status: "ready",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.querySelector(".workboard-column")).toBeNull();
     expect(container.querySelector(".workboard-empty-state")?.textContent).toContain(
@@ -950,22 +873,15 @@ describe("renderWorkboard", () => {
   });
 
   it("uses the same Web Awesome select control for Workboard toolbar filters", () => {
-    const { host } = createLoadedWorkboardState();
-    const container = document.createElement("div");
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          agentsList: {
-            defaultId: "main",
-            mainKey: "agent:main:main",
-            scope: "test",
-            agents: [{ id: "main", name: "Main" }],
-          },
-        }),
-      ),
-      container,
-    );
+    const { container, renderView } = createWorkboardView({
+      agentsList: {
+        defaultId: "main",
+        mainKey: "agent:main:main",
+        scope: "test",
+        agents: [{ id: "main", name: "Main" }],
+      },
+    });
+    renderView();
 
     const toolbarFilters = container.querySelector(".workboard-toolbar__filters");
     expect(toolbarFilters?.querySelectorAll(".workboard-select--toolbar")).toHaveLength(2);
@@ -987,7 +903,16 @@ describe("renderWorkboard", () => {
   });
 
   it("filters cards to the global agent scope and hides the secondary agent filter", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({
+      agentsList: {
+        defaultId: "main",
+        mainKey: "agent:main:main",
+        scope: "test",
+        agents: [{ id: "main" }, { id: "writer" }, { id: "ops" }],
+      },
+      scopeAgentId: "writer",
+      showAgentFilter: false,
+    });
     state.viewPreset = "all";
     state.cards = [
       createWorkboardCard({
@@ -1008,23 +933,7 @@ describe("renderWorkboard", () => {
         agentId: "ops",
       },
     ];
-    const container = document.createElement("div");
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          agentsList: {
-            defaultId: "main",
-            mainKey: "agent:main:main",
-            scope: "test",
-            agents: [{ id: "main" }, { id: "writer" }, { id: "ops" }],
-          },
-          scopeAgentId: "writer",
-          showAgentFilter: false,
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     expect(container.textContent).toContain("Writer card");
     expect(container.textContent).not.toContain("Ops card");
@@ -1032,10 +941,8 @@ describe("renderWorkboard", () => {
   });
 
   it("uses labelled controls for Workboard filters", () => {
-    const { host } = createLoadedWorkboardState();
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    const { container, renderView } = createWorkboardView();
+    renderView();
 
     const selects = [
       ...container.querySelectorAll<HTMLElement & { value: string }>(
@@ -1057,25 +964,15 @@ describe("renderWorkboard", () => {
   });
 
   it("can hide empty columns while keeping populated columns visible", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({
+      onRequestUpdate: () => undefined,
+    });
     state.cards = [
       createWorkboardCard({
         title: "Keep visible",
       }),
     ];
-    const container = document.createElement("div");
-    const props = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-      onRequestUpdate: () => undefined,
-    } satisfies WorkboardRenderProps;
-
-    render(renderWorkboard(props), container);
+    renderView();
     expect(container.querySelectorAll(".workboard-column")).toHaveLength(9);
 
     const toggle = container.querySelector<HTMLInputElement>(
@@ -1084,7 +981,7 @@ describe("renderWorkboard", () => {
     expect(toggle).toBeInstanceOf(HTMLInputElement);
     toggle!.checked = true;
     toggle!.dispatchEvent(new Event("change", { bubbles: true }));
-    render(renderWorkboard(props), container);
+    renderView();
 
     const columnHeadings = Array.from(
       container.querySelectorAll<HTMLElement>(".workboard-column__header h2"),
@@ -1097,7 +994,7 @@ describe("renderWorkboard", () => {
   });
 
   it("does not render Invalid Date for Date-invalid card timestamps", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       {
         id: "card-1",
@@ -1111,19 +1008,27 @@ describe("renderWorkboard", () => {
         events: [{ id: "event-1", kind: "edited", at: 8_640_000_000_000_001 }],
       },
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.textContent).toContain("Bad timestamp card");
     expect(container.textContent).not.toContain("Invalid Date");
   });
 
   it("opens card details from the card surface without hijacking action buttons", () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const onOpenSession = vi.fn();
-    state.loaded = true;
+    const { state, container, renderView } = createWorkboardView({
+      sessions: [
+        {
+          key: "agent:main:dashboard:1",
+          kind: "direct",
+          displayName: "Dashboard session",
+          updatedAt: 2,
+          hasActiveRun: true,
+          status: "running",
+        },
+      ],
+      onOpenSession,
+    });
     state.cards = [
       createWorkboardCard({
         title: "Inspect a running task",
@@ -1131,47 +1036,11 @@ describe("renderWorkboard", () => {
         sessionKey: "agent:main:dashboard:1",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          sessions: [
-            {
-              key: "agent:main:dashboard:1",
-              kind: "direct",
-              displayName: "Dashboard session",
-              updatedAt: 2,
-              hasActiveRun: true,
-              status: "running",
-            },
-          ],
-          onOpenSession,
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     const card = container.querySelector<HTMLElement>(".workboard-card");
     card?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          sessions: [
-            {
-              key: "agent:main:dashboard:1",
-              kind: "direct",
-              displayName: "Dashboard session",
-              updatedAt: 2,
-              hasActiveRun: true,
-              status: "running",
-            },
-          ],
-          onOpenSession,
-        }),
-      ),
-      container,
-    );
+    renderView();
     expect(container.querySelector(".workboard-detail")?.textContent).toContain(
       "Inspect a running task",
     );
@@ -1185,10 +1054,22 @@ describe("renderWorkboard", () => {
   });
 
   it("mirrors compact card actions in the detail drawer", () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const sessionKey = "agent:main:detail-parity";
-    state.loaded = true;
+    const onOpenSession = vi.fn();
+    const { state, container, renderView } = createWorkboardView({
+      client: { request: vi.fn() } as unknown as GatewayBrowserClient,
+      sessions: [
+        {
+          key: sessionKey,
+          kind: "direct",
+          displayName: "Detail parity session",
+          updatedAt: 2,
+          hasActiveRun: true,
+          status: "running",
+        },
+      ],
+      onOpenSession,
+    });
     state.detailCardId = "card-1";
     state.cards = [
       createWorkboardCard({
@@ -1197,28 +1078,7 @@ describe("renderWorkboard", () => {
         sessionKey,
       }),
     ];
-    const container = document.createElement("div");
-    const onOpenSession = vi.fn();
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          client: { request: vi.fn() } as unknown as GatewayBrowserClient,
-          sessions: [
-            {
-              key: sessionKey,
-              kind: "direct",
-              displayName: "Detail parity session",
-              updatedAt: 2,
-              hasActiveRun: true,
-              status: "running",
-            },
-          ],
-          onOpenSession,
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     const actions = container.querySelector<HTMLElement>(".workboard-detail__actions");
     expect(actions).not.toBeNull();
@@ -1421,15 +1281,13 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps cards compact and puts model-specific execution actions in details", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Start this later",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     const startButtons = [
       ...container.querySelectorAll<HTMLButtonElement>(".workboard-card__start"),
@@ -1443,7 +1301,7 @@ describe("renderWorkboard", () => {
     container
       .querySelector<HTMLButtonElement>('button[aria-label="View details"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     const detailStartButtons = [
       ...container.querySelectorAll<HTMLButtonElement>(".workboard-detail .workboard-card__start"),
@@ -1458,7 +1316,9 @@ describe("renderWorkboard", () => {
   });
 
   it("shows unfinished parent dependencies without blocking stale local starts", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({
+      onRequestUpdate: () => undefined,
+    });
     state.cards = [
       createWorkboardCard({
         id: "parent-1",
@@ -1478,19 +1338,7 @@ describe("renderWorkboard", () => {
         },
       },
     ];
-    const container = document.createElement("div");
-    const props = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-      onRequestUpdate: () => undefined,
-    } satisfies WorkboardRenderProps;
-
-    render(renderWorkboard(props), container);
+    renderView();
 
     const childCard = [...container.querySelectorAll<HTMLElement>(".workboard-card")].find((card) =>
       card.textContent?.includes("Ship game shell"),
@@ -1503,7 +1351,7 @@ describe("renderWorkboard", () => {
     childCard
       ?.querySelector<HTMLButtonElement>('button[aria-label="View details"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(renderWorkboard(props), container);
+    renderView();
 
     const detail = container.querySelector(".workboard-detail");
     expect(detail?.textContent).toContain("Dependencies");
@@ -1526,22 +1374,13 @@ describe("renderWorkboard", () => {
   });
 
   it("hides autonomous model override actions for non-admin operators", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({ canModelOverride: false });
     state.cards = [
       createWorkboardCard({
         title: "Start with default model",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          canModelOverride: false,
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     const startButtons = [
       ...container.querySelectorAll<HTMLButtonElement>(".workboard-card__start"),
@@ -1554,14 +1393,7 @@ describe("renderWorkboard", () => {
     container
       .querySelector<HTMLButtonElement>('button[aria-label="View details"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          canModelOverride: false,
-        }),
-      ),
-      container,
-    );
+    renderView();
     const detailStartButtons = [
       ...container.querySelectorAll<HTMLButtonElement>(".workboard-detail .workboard-card__start"),
     ];
@@ -1573,7 +1405,7 @@ describe("renderWorkboard", () => {
   });
 
   it("renders linked Gateway task status on cards", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Review task result",
@@ -1592,9 +1424,7 @@ describe("renderWorkboard", () => {
       runId: "run-1",
       terminalSummary: "Ready for operator review.",
     });
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.textContent).toContain("task linked");
     expect(container.textContent).toContain("Task complete");
@@ -1602,7 +1432,19 @@ describe("renderWorkboard", () => {
   });
 
   it("uses terminal session lifecycle when cached task status is stale", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({
+      sessions: [
+        {
+          key: "agent:main:subagent:workboard-default-card-1",
+          kind: "direct",
+          displayName: "Finished session",
+          updatedAt: 2,
+          hasActiveRun: false,
+          status: "done",
+        },
+      ],
+      onRequestUpdate: () => undefined,
+    });
     state.cards = [
       createWorkboardCard({
         title: "Finished despite stale task",
@@ -1621,28 +1463,7 @@ describe("renderWorkboard", () => {
       runId: "run-1",
       progressSummary: "Still running according to stale cache.",
     });
-    const container = document.createElement("div");
-    const props = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [
-        {
-          key: "agent:main:subagent:workboard-default-card-1",
-          kind: "direct",
-          displayName: "Finished session",
-          updatedAt: 2,
-          hasActiveRun: false,
-          status: "done",
-        },
-      ],
-      onOpenSession: () => undefined,
-      onRequestUpdate: () => undefined,
-    } satisfies WorkboardRenderProps;
-
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(container.textContent).toContain("Done");
     expect(container.textContent).toContain("Finished session");
@@ -1652,7 +1473,7 @@ describe("renderWorkboard", () => {
     container
       .querySelector<HTMLButtonElement>('button[aria-label="View details"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(container.querySelector(".workboard-detail")?.textContent).toContain("Finished session");
     expect(container.querySelector(".workboard-detail")?.textContent).not.toContain(
@@ -1661,7 +1482,9 @@ describe("renderWorkboard", () => {
   });
 
   it("shows stop controls without start controls for active task-only cards", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({
+      onRequestUpdate: () => undefined,
+    });
     state.cards = [
       createWorkboardCard({
         title: "Task only run",
@@ -1676,19 +1499,7 @@ describe("renderWorkboard", () => {
       title: "Task only run",
       progressSummary: "Worker is active.",
     });
-    const container = document.createElement("div");
-    const props = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-      onRequestUpdate: () => undefined,
-    };
-
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(container.textContent).toContain("Task running");
     expect(container.querySelector('button[aria-label="Stop thread"]')).not.toBeNull();
@@ -1698,7 +1509,7 @@ describe("renderWorkboard", () => {
     container
       .querySelector<HTMLButtonElement>('button[aria-label="View details"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(container.querySelector(".workboard-detail")?.textContent).toContain(
       "Worker is active.",
@@ -1707,7 +1518,7 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps unresolved task-linked cards from exposing duplicate starts", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Historical task link",
@@ -1715,16 +1526,14 @@ describe("renderWorkboard", () => {
         taskId: "task-older-than-poll-page",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.querySelector('button[aria-label="Stop thread"]')).not.toBeNull();
     expect(container.querySelectorAll<HTMLButtonElement>(".workboard-card__start")).toHaveLength(0);
   });
 
   it("does not expose live controls for terminal cards with unresolved task links", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Completed historical task",
@@ -1732,9 +1541,7 @@ describe("renderWorkboard", () => {
         taskId: "task-older-than-poll-page",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.querySelector(".workboard-live")).toBeNull();
     expect(container.querySelector('button[aria-label="Stop thread"]')).toBeNull();
@@ -1742,7 +1549,7 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps newly started unresolved runs from exposing duplicate starts", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Newly started run",
@@ -1751,16 +1558,14 @@ describe("renderWorkboard", () => {
         runId: "run-1",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.querySelector('button[aria-label="Stop thread"]')).not.toBeNull();
     expect(container.querySelectorAll<HTMLButtonElement>(".workboard-card__start")).toHaveLength(0);
   });
 
   it("allows starts for authoritatively missing historical task links", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Historical task link",
@@ -1769,31 +1574,20 @@ describe("renderWorkboard", () => {
       }),
     ];
     state.missingTaskIds = new Set(["task-pruned-from-ledger"]);
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.querySelector('button[aria-label="Stop thread"]')).toBeNull();
     expect(container.querySelectorAll<HTMLButtonElement>(".workboard-card__start")).toHaveLength(1);
   });
 
   it("hides write controls for read-only operators", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({ canWrite: false });
     state.cards = [
       createWorkboardCard({
         title: "Inspect only",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          canWrite: false,
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     expect(buttonByLabel(container, "Edit card")).toBeNull();
     expect(buttonByLabel(container, "Delete card")).toBeNull();
@@ -1807,7 +1601,7 @@ describe("renderWorkboard", () => {
   });
 
   it("moves a card from the compact status control", async () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Keyboard move",
@@ -1816,19 +1610,7 @@ describe("renderWorkboard", () => {
     const request = vi.fn(async () => ({
       card: { ...state.cards[0], status: "blocked", position: 1000, updatedAt: 2 },
     }));
-    const props = {
-      host,
-      client: { request } as unknown as GatewayBrowserClient,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-      onRequestUpdate: () => undefined,
-    };
-    const container = document.createElement("div");
-
-    render(renderWorkboard(props), container);
+    renderView({ client: { request } as unknown as GatewayBrowserClient });
     const moveSelect = container.querySelector<HTMLSelectElement>(".workboard-card__move-select");
     expect(moveSelect?.value).toBe("todo");
     expect(moveSelect?.tagName).toBe("SELECT");
@@ -1839,7 +1621,7 @@ describe("renderWorkboard", () => {
     moveSelect!.dispatchEvent(new Event("change", { bubbles: true }));
     await Promise.resolve();
     await Promise.resolve();
-    render(renderWorkboard(props), container);
+    renderView({ client: { request } as unknown as GatewayBrowserClient });
 
     expect(request).toHaveBeenCalledWith("workboard.cards.move", {
       id: "card-1",
@@ -1854,7 +1636,7 @@ describe("renderWorkboard", () => {
   });
 
   it("appends a status move after archived cards on its own board only", async () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     const movingCard = createWorkboardCard({
       title: "Move within Operations",
       metadata: { automation: { boardId: "ops" } },
@@ -1879,14 +1661,7 @@ describe("renderWorkboard", () => {
     ];
     const moved = { ...movingCard, status: "running" as const, position: 4000 };
     const request = vi.fn(async () => ({ card: moved }));
-    const container = document.createElement("div");
-
-    renderInto(
-      container,
-      createWorkboardRenderProps(host, {
-        client: { request } as unknown as GatewayBrowserClient,
-      }),
-    );
+    renderView({ client: { request } as unknown as GatewayBrowserClient });
     const moveSelect = container.querySelector<HTMLSelectElement>(".workboard-card__move-select");
     expect(moveSelect).not.toBeNull();
     moveSelect!.value = "running";
@@ -1903,7 +1678,7 @@ describe("renderWorkboard", () => {
   });
 
   it("moves a focused status control with keyboard arrows", async () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Keyboard arrow move",
@@ -1912,19 +1687,7 @@ describe("renderWorkboard", () => {
     const request = vi.fn(async () => ({
       card: { ...state.cards[0], status: "scheduled", position: 1000, updatedAt: 2 },
     }));
-    const props = {
-      host,
-      client: { request } as unknown as GatewayBrowserClient,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-      onRequestUpdate: () => undefined,
-    };
-    const container = document.createElement("div");
-
-    render(renderWorkboard(props), container);
+    renderView({ client: { request } as unknown as GatewayBrowserClient });
     const moveSelect = container.querySelector<HTMLSelectElement>(".workboard-card__move-select");
     const dispatched = moveSelect!.dispatchEvent(
       new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, cancelable: true }),
@@ -1942,7 +1705,7 @@ describe("renderWorkboard", () => {
   });
 
   it("does not queue status-control moves while a card is busy", async () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.busyCardIds.add("card-1");
     state.cards = [
       createWorkboardCard({
@@ -1950,19 +1713,7 @@ describe("renderWorkboard", () => {
       }),
     ];
     const request = vi.fn();
-    const props = {
-      host,
-      client: { request } as unknown as GatewayBrowserClient,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-      onRequestUpdate: () => undefined,
-    };
-    const container = document.createElement("div");
-
-    render(renderWorkboard(props), container);
+    renderView({ client: { request } as unknown as GatewayBrowserClient });
     const moveSelect = container.querySelector<HTMLSelectElement>(".workboard-card__move-select");
     expect(moveSelect?.disabled).toBe(true);
 
@@ -1979,7 +1730,7 @@ describe("renderWorkboard", () => {
   });
 
   it("offers start controls when a linked session no longer exists", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Restart this",
@@ -1987,25 +1738,20 @@ describe("renderWorkboard", () => {
         sessionKey: "agent:main:missing:1",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.textContent).toContain("Thread missing");
     expect(container.querySelectorAll<HTMLButtonElement>(".workboard-card__start")).toHaveLength(1);
   });
 
   it("opens a modal for new cards", () => {
-    const host = {};
-    getWorkboardState(host).loaded = true;
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    const { container, renderView } = createWorkboardView();
+    renderView();
 
     container
       .querySelector<HTMLButtonElement>(".workboard-toolbar__actions .btn.primary")
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.querySelector("openclaw-modal-dialog")?.textContent).toContain("New card");
     expect(container.querySelector('[aria-label="Card templates"]')?.textContent).toContain(
@@ -2058,10 +1804,7 @@ describe("renderWorkboard", () => {
       expectedAgentId: "",
     },
   ])("initializes new cards from $name", ({ scopeAgentId, agentFilter, expectedAgentId }) => {
-    const { host, state } = createLoadedWorkboardState();
-    state.agentFilter = agentFilter;
-    const container = document.createElement("div");
-    const props = createWorkboardRenderProps(host, {
+    const { state, container, renderView } = createWorkboardView({
       agentsList: {
         defaultId: "main",
         mainKey: "agent:main:main",
@@ -2075,12 +1818,12 @@ describe("renderWorkboard", () => {
       },
       scopeAgentId,
     });
-
-    render(renderWorkboard(props), container);
+    state.agentFilter = agentFilter;
+    renderView();
     container
       .querySelector<HTMLButtonElement>(".workboard-toolbar__actions .btn.primary")
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(state.draftOpen).toBe(true);
     expect(state.draftAgentId).toBe(expectedAgentId);
@@ -2127,23 +1870,20 @@ describe("renderWorkboard", () => {
   ])(
     "keeps $name while its roster has not loaded",
     ({ scopeAgentId, defaultAgentId, agentFilter, expectedAgentId }) => {
-      const { host, state } = createLoadedWorkboardState();
-      state.agentFilter = agentFilter ?? "all";
-      if (agentFilter) {
-        state.cards = [createWorkboardCard({ agentId: agentFilter })];
-      }
-      const container = document.createElement("div");
-      const props = createWorkboardRenderProps(host, {
+      const { state, container, renderView } = createWorkboardView({
         agentsList: null,
         defaultAgentId,
         scopeAgentId,
       });
-
-      render(renderWorkboard(props), container);
+      state.agentFilter = agentFilter ?? "all";
+      if (agentFilter) {
+        state.cards = [createWorkboardCard({ agentId: agentFilter })];
+      }
+      renderView();
       container
         .querySelector<HTMLButtonElement>(".workboard-toolbar__actions .btn.primary")
         ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      render(renderWorkboard(props), container);
+      renderView();
 
       expect(state.draftOpen).toBe(true);
       expect(state.draftAgentId).toBe(expectedAgentId);
@@ -2156,25 +1896,15 @@ describe("renderWorkboard", () => {
   );
 
   it("applies card templates in the create modal", () => {
-    const { host, state } = createLoadedWorkboardState();
-    state.draftOpen = true;
-    const container = document.createElement("div");
-    const props = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
+    const { state, container, renderView } = createWorkboardView({
       onRequestUpdate: () => undefined,
-    };
-
-    render(renderWorkboard(props), container);
+    });
+    state.draftOpen = true;
+    renderView();
     [...container.querySelectorAll<HTMLButtonElement>(".workboard-template-strip .btn")]
       .find((button) => button.textContent?.includes("Release"))
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(state.draftTemplateId).toBe("release");
     expect(container.querySelector<HTMLInputElement>(".workboard-draft__title")?.value).toBe(
@@ -2186,7 +1916,9 @@ describe("renderWorkboard", () => {
   });
 
   it("renders card event history", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({
+      onRequestUpdate: () => undefined,
+    });
     state.cards = [
       {
         id: "card-1",
@@ -2208,26 +1940,14 @@ describe("renderWorkboard", () => {
         ],
       },
     ];
-    const container = document.createElement("div");
-    const props = {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-      onRequestUpdate: () => undefined,
-    };
-
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(container.querySelector(".workboard-events")?.textContent).toContain("Moved to Review");
 
     container
       .querySelector<HTMLButtonElement>('button[aria-label="View details"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(renderWorkboard(props), container);
+    renderView();
 
     expect(container.querySelector(".workboard-detail")?.textContent).toContain("Moved to Done");
     expect(container.querySelector(".workboard-detail")?.textContent).not.toContain(
@@ -2236,7 +1956,7 @@ describe("renderWorkboard", () => {
   });
 
   it("renders card metadata badges and hides archived cards", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.cards = [
       createWorkboardCard({
         title: "Metadata rich",
@@ -2281,9 +2001,7 @@ describe("renderWorkboard", () => {
         metadata: { archivedAt: 7 },
       },
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.textContent).toContain("Plugin");
     expect(container.textContent).toContain("1 failed");
@@ -2295,14 +2013,14 @@ describe("renderWorkboard", () => {
     container
       .querySelector<HTMLButtonElement>(".workboard-archive-toggle")
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
     expect(container.textContent).toContain("Archived task");
     expect(container.querySelector<HTMLButtonElement>(".workboard-archive-toggle")).not.toBeNull();
 
     container
       .querySelector<HTMLButtonElement>('button[aria-label="View details"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
     expect(container.querySelector(".workboard-detail")?.textContent).toContain("1 attempts");
     expect(container.querySelector(".workboard-detail")?.textContent).toContain("1 links");
     expect(container.querySelector(".workboard-detail")?.textContent).not.toContain("pnpm test 1");
@@ -2325,10 +2043,8 @@ describe("renderWorkboard", () => {
   });
 
   it("filters cards by persisted boards and keeps empty archived boards selectable", () => {
-    const host = {};
-    const state = getWorkboardState(host);
     const onBoardFilterChange = vi.fn();
-    state.loaded = true;
+    const { state, container, renderView } = createWorkboardView({ onBoardFilterChange });
     state.boards = [
       { id: "default", total: 1, active: 1, archived: 0, byStatus: { todo: 1 } },
       {
@@ -2366,19 +2082,14 @@ describe("renderWorkboard", () => {
         metadata: { automation: { boardId: "ops" } },
       },
     ];
-    const container = document.createElement("div");
-    const props = createWorkboardRenderProps(host, {
-      onBoardFilterChange,
-    });
-
-    renderInto(container, props);
+    renderView();
     const boardFilter = container.querySelector(".workboard-select--toolbar-board");
     expect(boardFilter?.textContent).toContain("Default board");
     expect(boardFilter?.textContent).toContain("Operations (ops)");
     expect(boardFilter?.textContent).toContain("Old work (archive)");
 
     changeWorkboardSelect(boardFilter, "ops");
-    renderInto(container, props);
+    renderView();
 
     expect(onBoardFilterChange).toHaveBeenCalledWith("ops");
     expect(container.textContent).not.toContain("Default work");
@@ -2386,7 +2097,7 @@ describe("renderWorkboard", () => {
   });
 
   it("shows the board switcher at two boards with icon, color, and fallback glyphs", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.boards = [
       { id: "default", total: 0, active: 0, archived: 0, byStatus: {} },
       {
@@ -2400,17 +2111,7 @@ describe("renderWorkboard", () => {
         byStatus: {},
       },
     ];
-    const container = document.createElement("div");
-
-    renderInto(container, {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-    });
+    renderView();
 
     const boardFilter = container.querySelector(".workboard-select--toolbar-board");
     expect(boardFilter).not.toBeNull();
@@ -2424,7 +2125,7 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps a deleted routed board filtered instead of exposing every board", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.boardFilter = "deleted";
     state.boards = [{ id: "default", total: 1, active: 1, archived: 0, byStatus: { todo: 1 } }];
     state.cards = [
@@ -2433,24 +2134,23 @@ describe("renderWorkboard", () => {
         title: "Default board work",
       }),
     ];
-    const container = document.createElement("div");
-
-    renderInto(container, {
-      host,
-      client: null,
-      connected: true,
-      pluginEnabled: true,
-      agentsList: null,
-      sessions: [],
-      onOpenSession: () => undefined,
-    });
+    renderView();
 
     expect(container.textContent).not.toContain("Default board work");
     expect(container.querySelector(".workboard-empty-state")).not.toBeNull();
   });
 
   it("filters cards by linked agent", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const agentsList = {
+      defaultId: "main",
+      mainKey: "agent:main:main",
+      scope: "test",
+      agents: [
+        { id: "main", name: "Main" },
+        { id: "ops", name: "Ops" },
+      ],
+    };
+    const { state, container, renderView } = createWorkboardView({ agentsList });
     state.cards = [
       {
         id: "card-1",
@@ -2486,24 +2186,7 @@ describe("renderWorkboard", () => {
         updatedAt: 1,
       },
     ];
-    const container = document.createElement("div");
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          agentsList: {
-            defaultId: "main",
-            mainKey: "agent:main:main",
-            scope: "test",
-            agents: [
-              { id: "main", name: "Main" },
-              { id: "ops", name: "Ops" },
-            ],
-          },
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     const agentFilter = container.querySelector<
       HTMLElement & { options: Array<{ label: string }>; value: string }
@@ -2517,22 +2200,7 @@ describe("renderWorkboard", () => {
     ]);
 
     selectWorkboardAgent(agentFilter, "ops");
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          agentsList: {
-            defaultId: "main",
-            mainKey: "agent:main:main",
-            scope: "test",
-            agents: [
-              { id: "main", name: "Main" },
-              { id: "ops", name: "Ops" },
-            ],
-          },
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     expect(container.textContent).not.toContain("Main work");
     expect(container.textContent).toContain("Ops work");
@@ -2545,22 +2213,7 @@ describe("renderWorkboard", () => {
       container.querySelector(".workboard-agent-select--toolbar"),
       "workboard-dispatcher",
     );
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          agentsList: {
-            defaultId: "main",
-            mainKey: "agent:main:main",
-            scope: "test",
-            agents: [
-              { id: "main", name: "Main" },
-              { id: "ops", name: "Ops" },
-            ],
-          },
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     expect(container.textContent).not.toContain("Ops work");
     expect(container.textContent).toContain("Dispatcher work");
@@ -2571,7 +2224,18 @@ describe("renderWorkboard", () => {
   });
 
   it("limits assignment choices to configured agents and preserves an unknown current assignee", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({
+      agentsList: {
+        defaultId: "main",
+        mainKey: "agent:main:main",
+        scope: "test",
+        agents: [
+          { id: "main", name: "Main" },
+          { id: "main", name: "Main duplicate" },
+          { id: "ops", name: "Ops" },
+        ],
+      },
+    });
     state.draftOpen = true;
     state.draftTitle = "Assign me";
     state.draftAgentId = "workboard-dispatcher";
@@ -2588,25 +2252,7 @@ describe("renderWorkboard", () => {
         updatedAt: 1,
       },
     ];
-    const container = document.createElement("div");
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          agentsList: {
-            defaultId: "main",
-            mainKey: "agent:main:main",
-            scope: "test",
-            agents: [
-              { id: "main", name: "Main" },
-              { id: "main", name: "Main duplicate" },
-              { id: "ops", name: "Ops" },
-            ],
-          },
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     const draft = container.querySelector<HTMLElement>(".workboard-draft");
     const agentSelect = draft?.querySelector<HTMLElement & { options: Array<{ label: string }> }>(
@@ -2621,12 +2267,10 @@ describe("renderWorkboard", () => {
   });
 
   it("renders the card modal with a single scrollable body and stable footer actions", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.draftOpen = true;
     state.draftTitle = "New task";
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     const draft = container.querySelector(".workboard-draft");
     const body = draft?.querySelector(".workboard-draft__body");
@@ -2639,12 +2283,10 @@ describe("renderWorkboard", () => {
   });
 
   it("delegates modal select positioning and dismissal to Web Awesome", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.draftOpen = true;
     state.draftTitle = "New task";
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     const selects = container.querySelectorAll(".workboard-draft wa-select");
     expect(selects.length).toBeGreaterThan(0);
@@ -2652,7 +2294,14 @@ describe("renderWorkboard", () => {
   });
 
   it("preflights model-specific starts for ACP runtime agents", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({
+      agentsList: {
+        defaultId: "main",
+        mainKey: "agent:main:main",
+        scope: "test",
+        agents: [{ id: "main", name: "Main", agentRuntime: { id: "codex", source: "agent" } }],
+      },
+    });
     state.detailCardId = "card-1";
     state.cards = [
       {
@@ -2667,21 +2316,7 @@ describe("renderWorkboard", () => {
         updatedAt: 1,
       },
     ];
-    const container = document.createElement("div");
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          agentsList: {
-            defaultId: "main",
-            mainKey: "agent:main:main",
-            scope: "test",
-            agents: [{ id: "main", name: "Main", agentRuntime: { id: "codex", source: "agent" } }],
-          },
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     const engineButtons = [
       ...container.querySelectorAll<HTMLButtonElement>(
@@ -2694,7 +2329,7 @@ describe("renderWorkboard", () => {
   });
 
   it("does not render details for archived selected cards", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView();
     state.detailCardId = "card-1";
     state.cards = [
       createWorkboardCard({
@@ -2702,29 +2337,24 @@ describe("renderWorkboard", () => {
         metadata: { archivedAt: 2 },
       }),
     ];
-    const container = document.createElement("div");
-
-    render(renderWorkboard(createWorkboardRenderProps(host)), container);
+    renderView();
 
     expect(container.querySelector(".workboard-detail")).toBeNull();
     expect(container.querySelectorAll<HTMLButtonElement>(".workboard-card__start")).toHaveLength(0);
   });
 
   it("keeps visible archived cards inspectable and restorable without move or drag controls", () => {
-    const { host, state } = createLoadedWorkboardState();
     const archivedCard = createWorkboardCard({
       title: "Archived historical task",
       metadata: { archivedAt: 10 },
     });
-    state.cards = [archivedCard];
-    state.showArchived = true;
     const request = vi.fn();
-    const props = createWorkboardRenderProps(host, {
+    const { state, container, renderView } = createWorkboardView({
       client: { request } as unknown as GatewayBrowserClient,
     });
-    const container = document.createElement("div");
-
-    renderInto(container, props);
+    state.cards = [archivedCard];
+    state.showArchived = true;
+    renderView();
 
     const article = container.querySelector<HTMLElement>(".workboard-card--archived");
     expect(article).not.toBeNull();
@@ -2744,7 +2374,7 @@ describe("renderWorkboard", () => {
 
     state.draggedCardId = null;
     state.detailCardId = archivedCard.id;
-    renderInto(container, props);
+    renderView();
 
     const drawer = container.querySelector<HTMLElement>(".workboard-detail");
     expect(drawer?.textContent).toContain(archivedCard.title);
@@ -2774,25 +2404,22 @@ describe("renderWorkboard", () => {
           },
         }),
       ];
-      const container = document.createElement("div");
-
-      render(
-        renderWorkboard(
-          createWorkboardRenderProps(host, {
-            sessions: [
-              {
-                key: "agent:main:dashboard:1",
-                kind: "direct",
-                displayName: "Dashboard session",
-                updatedAt: 1,
-                hasActiveRun: false,
-                status: "running",
-              },
-            ],
-          }),
-        ),
-        container,
+      const { container, renderView } = createWorkboardView(
+        {
+          sessions: [
+            {
+              key: "agent:main:dashboard:1",
+              kind: "direct",
+              displayName: "Dashboard session",
+              updatedAt: 1,
+              hasActiveRun: false,
+              status: "running",
+            },
+          ],
+        },
+        host,
       );
+      renderView();
 
       expect(container.textContent).toContain("Stale");
       expect(container.textContent).toContain("No recent thread activity");
@@ -2805,7 +2432,17 @@ describe("renderWorkboard", () => {
   });
 
   it("keeps live controls for legacy running session rows", () => {
-    const { host, state } = createLoadedWorkboardState();
+    const { state, container, renderView } = createWorkboardView({
+      sessions: [
+        {
+          key: "agent:main:dashboard:1",
+          kind: "direct",
+          displayName: "Dashboard session",
+          updatedAt: 1,
+          status: "running",
+        },
+      ],
+    });
     state.cards = [
       createWorkboardCard({
         title: "Stop legacy run",
@@ -2813,24 +2450,7 @@ describe("renderWorkboard", () => {
         sessionKey: "agent:main:dashboard:1",
       }),
     ];
-    const container = document.createElement("div");
-
-    render(
-      renderWorkboard(
-        createWorkboardRenderProps(host, {
-          sessions: [
-            {
-              key: "agent:main:dashboard:1",
-              kind: "direct",
-              displayName: "Dashboard session",
-              updatedAt: 1,
-              status: "running",
-            },
-          ],
-        }),
-      ),
-      container,
-    );
+    renderView();
 
     expect(container.querySelector(".workboard-live")?.textContent).toContain("live");
     expect(container.querySelector('button[aria-label="Stop thread"]')).not.toBeNull();
@@ -2848,7 +2468,6 @@ describe("renderWorkboard", () => {
       topLevelSessionKey: "agent:main:top-level-linked-session",
     },
   ])("preserves $scenario when editing a Workboard card", async (testCase) => {
-    const { host, state } = createLoadedWorkboardState();
     const card = createWorkboardCard({
       title: "Keep my linked session",
       ...(testCase.topLevelSessionKey ? { sessionKey: testCase.topLevelSessionKey } : {}),
@@ -2856,12 +2475,10 @@ describe("renderWorkboard", () => {
         sessionKey: "agent:main:execution-linked-session",
       }),
     });
-    state.cards = [card];
-    state.detailCardId = card.id;
     const request = vi.fn(async () => ({
       card: { ...card, title: "Renamed without unlinking", updatedAt: 2 },
     }));
-    const props = createWorkboardRenderProps(host, {
+    const { state, container, renderView } = createWorkboardView({
       client: { request } as unknown as GatewayBrowserClient,
       onRequestUpdate: () => undefined,
       sessions: [
@@ -2874,13 +2491,14 @@ describe("renderWorkboard", () => {
         },
       ],
     });
-    const container = document.createElement("div");
+    state.cards = [card];
+    state.detailCardId = card.id;
 
-    renderInto(container, props);
+    renderView();
     const editButton = buttonByLabel(container, "Edit card");
     expect(editButton).not.toBeNull();
     editButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    renderInto(container, props);
+    renderView();
 
     expect(state.draftSessionKey).toBe(testCase.sessionKey);
     expect(
@@ -2907,7 +2525,7 @@ describe("renderWorkboard", () => {
       }),
     });
     expect(state.cards[0]?.execution?.sessionKey).toBe("agent:main:execution-linked-session");
-    renderInto(container, props);
+    renderView();
     expect(container.querySelector("openclaw-workboard-card-dashboard")).not.toBeNull();
   });
 


### PR DESCRIPTION
## What Problem This Solves

The Workboard view test suite repeated the same loaded state, render properties, container, and rerender setup across dozens of cases. That repetition made the suite harder to scan and maintain.

## Why This Change Was Made

Adds one local Workboard view harness and uses it throughout the existing test cases. Test declarations, matcher order, DOM teardown, lifecycle cleanup, production behavior, and browser/E2E coverage are unchanged.

## User Impact

No user-visible impact. This is a test-only cleanup: +326/-708 lines (net -382), with zero production-line changes.

## Evidence

- Structural audit against current `origin/main`: 81/81 declaration entries in identical order (79 tests + 2 describes); 354/354 matcher calls in identical order.
- DOM lifecycle counts unchanged: 6 body appends, 6 `render(nothing, container)`, 6 container removals, and 2 lifecycle-refresh stops.
- Blacksmith Testbox `tbx_01kz3308xqtzxbwzvngaqrxpc9`: `pnpm test ui/src/pages/workboard/view.test.ts` passed 97/97 tests ([run 30788488946](https://github.com/openclaw/openclaw/actions/runs/30788488946)).
- Same Testbox lease: `pnpm check:changed` passed, including formatting, core-test typecheck, and lint with 0 warnings/errors.
- Fresh `gpt-5.6-sol` xhigh autoreview: 0 findings, patch correct (0.99 confidence).
- Exact target path had no changes between the audited base `e04caa6aee38` and current `origin/main` at commit time.
