### PR TITLE
test(doctor): avoid plugin discovery for core SecretRef fixture

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -17,6 +17,16 @@ import {
 import { runDoctorLintChecks } from "./doctor-lint-flow.js";
 import type { HealthCheck, HealthFinding } from "./health-checks.js";
 
+// This suite's SecretRef migration assertion uses a core model credential. Registry owner suites
+// cover plugin-derived targets, so avoid scanning every bundled plugin for this core-only fixture.
+vi.mock("../secrets/target-registry-data.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../secrets/target-registry-data.js")>();
+  return {
+    ...actual,
+    getSecretTargetRegistry: actual.getCoreSecretTargetRegistry,
+  };
+});
+
 const mocks = vi.hoisted(() => ({
   isDefaultInstallIdentity: vi.fn(() => true),
   maybeRunConfiguredPluginInstallReleaseStep: vi.fn(),


### PR DESCRIPTION
## What Problem This Solves

The Doctor health-contribution suite spent most of its runtime scanning and loading every bundled plugin to verify one core model-credential SecretRef migration.

## Why This Change Was Made

Use the static core secret-target registry in this suite. The exercised models.providers.*.apiKey target is core-owned; installed, bundled, and channel-derived target discovery remains covered by the target-registry owner suites.

## User Impact

No user-visible behavior changes. The Doctor test file runs substantially faster while retaining all assertions and leaving production code unchanged.

## Evidence

- Same-head focused benchmark, 101/101 tests: 36.46s to 10.72s wall time (70.6% faster); Vitest 31.53s to 5.74s; test bodies 26.14s to 0.474s.
- Peak RSS: 1.708 GB to 0.825 GB (51.7% lower).
- Registry and migration sibling proof: 162/162 tests passed across target-registry, installed-origin snapshot, runtime coverage, and Doctor legacy migration suites.
- Formatting, targeted Oxlint, git diff check, and autoreview are clean.
- Production LOC delta: 0.
