### PR TITLE
fix(ci): prevent contributor-fork artifact checks from timing out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1067,7 +1067,7 @@ jobs:
     # check-lint/check-dependencies; tsdown parallelizes across the extra
     # cores for roughly the same billed core-minutes.
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-32vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
-    timeout-minutes: 20
+    timeout-minutes: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 35 || 20 }}
     outputs:
       channels-result: ${{ steps.built_artifact_checks.outputs['channels-result'] }}
       core-support-boundary-result: ${{ steps.built_artifact_checks.outputs['core-support-boundary-result'] }}

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2979,6 +2979,9 @@ describe("ci workflow guards", () => {
 
     expect(source).toContain("createNodeTestShardBundles");
     expect(workflow.jobs["build-artifacts"]["runs-on"]).toContain("blacksmith-32vcpu-ubuntu-2404");
+    expect(workflow.jobs["build-artifacts"]["timeout-minutes"]).toBe(
+      "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 35 || 20 }}",
+    );
     expect(buildArtifactsTestbox.jobs["build-artifacts"]["runs-on"]).toBe(
       "blacksmith-16vcpu-ubuntu-2404",
     );


### PR DESCRIPTION
Related: #117992

## What Problem This Solves
Contributor pull requests from forks fail the required CI gate when artifact validation exceeds its 20-minute budget on lower-capacity GitHub-hosted runners.

## Why This Change Was Made
Give only cross-repository pull-request build-artifacts jobs 35 minutes while preserving the existing 20-minute limit for same-repository PRs, pushes, and manual runs. Add an assertion to the existing workflow-policy guard; runners, permissions, secrets, caches, and concurrency are unchanged.

## User Impact
External contributors can land otherwise healthy fixes without deterministic artifact-validation timeouts; trusted maintainer and main-branch CI behavior is unchanged.

## Evidence
- Original contributor PR #117992 exceeded the existing 20-minute artifact-job limit twice despite a successful distribution build.
- Trusted remote Testbox: workflow guard 97/97 passed.
- Parsed event truth table: fork PR 35; same-repository PR, push, and workflow_dispatch 20.
- Targeted formatting/lint and independent high-depth review passed.
- AI-assisted.