### PR TITLE
test(gateway): settle reply dispatchers after failed chat sends

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -16,6 +16,7 @@ import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { CHAT_SEND_SESSION_KEY_MAX_LENGTH } from "../../../packages/gateway-protocol/src/schema.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import { getTotalPendingReplies } from "../../auto-reply/reply/dispatcher-registry.js";
 import { markInboundContextLabel } from "../../auto-reply/reply/inbound-context-marker.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import {
@@ -222,14 +223,18 @@ vi.mock("../../auto-reply/dispatch.js", async () => {
   const { createReplyDispatcher } = await vi.importActual<
     typeof import("../../auto-reply/reply/reply-dispatcher.js")
   >("../../auto-reply/reply/reply-dispatcher.js");
+  const { withReplyDispatcher } = await vi.importActual<
+    typeof import("../../auto-reply/dispatch-dispatcher.js")
+  >("../../auto-reply/dispatch-dispatcher.js");
   return {
     dispatchInboundMessage: dispatchInboundMessageMock,
     dispatchInboundMessageWithProjectedDispatcher: vi.fn(
       async (params: ProjectedDispatchParams) => {
         const { dispatcherOptions, ...dispatchParams } = params;
-        return await dispatchInboundMessageMock({
-          ...dispatchParams,
-          dispatcher: createReplyDispatcher(dispatcherOptions),
+        const dispatcher = createReplyDispatcher(dispatcherOptions);
+        return await withReplyDispatcher({
+          dispatcher,
+          run: () => dispatchInboundMessageMock({ ...dispatchParams, dispatcher }),
         });
       },
     ),
@@ -5894,6 +5899,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(typeof message?.timestamp).toBe("number");
     const persistedUser = readPersistedUserMessages()[0];
     expect(persistedUser?.content).toBe("quick command");
+    expect(getTotalPendingReplies()).toBe(0);
   });
 
   it("emits a user transcript update when chat.send fails before an agent run starts", async () => {
@@ -5918,6 +5924,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       const persistedUser = readPersistedUserMessages()[0];
       expect(persistedUser?.content).toBe("hello from failed dispatch");
     });
+    expect(getTotalPendingReplies()).toBe(0);
   });
 
   it("emits a user transcript update when a slash-prefixed turn fails before command delivery", async () => {


### PR DESCRIPTION
## What Problem This Solves

Non-isolated Gateway test workers intermittently reported pending reply blockers after an earlier chat dispatch had failed, causing unrelated continuation and suspend tests to fail even though production behavior was correct.

## Root Cause

The chat directive fixture constructed a real reply dispatcher, which immediately registers one pending reservation in the process-global active dispatcher registry. Its mocked dispatch path called the fake dispatch implementation directly. If the fake threw, the fixture bypassed production dispatcher settlement, permanently leaking that reservation into later test files sharing the same worker.

## Canonical Repair

Use the existing production withReplyDispatcher lifecycle owner inside the test fixture. Its existing try/finally settles the dispatcher on success and failure, preserves the original thrown error, and removes the authoritative global pending reservation. Existing success and failure tests explicitly assert that the real global pending-reply count returns to zero.

## Regression Evidence

- Before fix: real failure-path regression expected zero global pending replies and observed one; corresponding success path passed.
- After fix: both success and failure regressions pass.
- Ordered non-isolated same-worker execution of the changed chat directive suite followed by the affected Gateway agent suite: 426/426 tests passing.
- Independent source/history/owner review clean.
- Production changes: zero; one test fixture changed (+10/-3).
- No timeout changes, retries, worker isolation changes, global resets, production guards, or weakened assertions.
- AI-assisted implementation and independently verified source review.
