### PR TITLE
test(android): consolidate connection TLS fixtures

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app.node
 import ai.openclaw.app.LocationMode
 import ai.openclaw.app.SecurePrefs
 import ai.openclaw.app.gateway.GatewayEndpoint
+import ai.openclaw.app.gateway.GatewayTlsParams
 import ai.openclaw.app.gateway.isLocalCleartextGatewayHost
 import ai.openclaw.app.gateway.isLoopbackGatewayHost
 import ai.openclaw.app.protocol.OpenClawCallLogCommand
@@ -26,268 +27,62 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class ConnectionManagerTest {
   @Test
-  fun resolveTlsParamsForEndpoint_prefersStoredPinOverAdvertisedFingerprint() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
+  fun resolveTlsParamsForEndpoint_prefersStoredPinOverAdvertisedFingerprint() =
+    assertTls(
+      resolveDiscoveredTls(
         host = "10.0.0.2",
-        port = 18789,
-        tlsEnabled = true,
-        tlsFingerprintSha256 = "attacker",
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
         storedFingerprint = "legit",
-        manualTlsEnabled = false,
-      )
-
-    assertEquals("legit", params?.expectedFingerprint)
-    assertEquals(false, params?.allowTOFU)
-  }
+        tlsEnabled = true,
+        advertisedFingerprint = "attacker",
+      ),
+      expectedFingerprint = "legit",
+    )
 
   @Test
-  fun resolveTlsParamsForEndpoint_doesNotTrustAdvertisedFingerprintWhenNoStoredPin() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
+  fun resolveTlsParamsForEndpoint_doesNotTrustAdvertisedFingerprintWhenNoStoredPin() =
+    assertTls(
+      resolveDiscoveredTls(
         host = "10.0.0.2",
-        port = 18789,
         tlsEnabled = true,
-        tlsFingerprintSha256 = "attacker",
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertNull(params?.expectedFingerprint)
-    assertEquals(false, params?.allowTOFU)
-  }
+        advertisedFingerprint = "attacker",
+      ),
+    )
 
   @Test
   fun resolveTlsParamsForEndpoint_manualRespectsManualTlsToggle() {
-    val endpoint = GatewayEndpoint.manual(host = "127.0.0.1", port = 443)
-
-    val off =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-    assertNull(off)
-
-    val on =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = true,
-      )
-    assertNull(on?.expectedFingerprint)
-    assertEquals(false, on?.allowTOFU)
+    assertNull(resolveManualTls(host = "127.0.0.1", port = 443))
+    assertTls(resolveManualTls(host = "127.0.0.1", port = 443, manualTlsEnabled = true))
   }
 
   @Test
-  fun resolveTlsParamsForEndpoint_manualNonLoopbackForcesTlsWhenToggleIsOff() {
-    val endpoint = GatewayEndpoint.manual(host = "example.com", port = 443)
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertEquals(true, params?.required)
-    assertNull(params?.expectedFingerprint)
-    assertEquals(false, params?.allowTOFU)
-  }
+  fun resolveTlsParamsForEndpoint_manualNonLoopbackForcesTlsWhenToggleIsOff() = assertTlsRequired(resolveManualTls(host = "example.com", port = 443))
 
   @Test
-  fun resolveTlsParamsForEndpoint_manualPrivateLanRespectsManualTlsToggle() {
-    val endpoint = GatewayEndpoint.manual(host = "192.168.1.20", port = 18789)
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertNull(params)
-  }
+  fun resolveTlsParamsForEndpoint_manualPrivateLanRespectsManualTlsToggle() = assertNull(resolveManualTls("192.168.1.20"))
 
   @Test
-  fun resolveTlsParamsForEndpoint_manualMdnsRespectsManualTlsToggle() {
-    val endpoint = GatewayEndpoint.manual(host = "gateway.local", port = 18789)
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertNull(params)
-  }
+  fun resolveTlsParamsForEndpoint_manualMdnsRespectsManualTlsToggle() = assertNull(resolveManualTls("gateway.local"))
 
   @Test
-  fun resolveTlsParamsForEndpoint_manualPrivateLanCleartextCanOverrideStoredPin() {
-    val endpoint = GatewayEndpoint.manual(host = "192.168.1.20", port = 18789)
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = "pinned",
-        manualTlsEnabled = false,
-      )
-
-    assertNull(params)
-  }
+  fun resolveTlsParamsForEndpoint_manualPrivateLanCleartextCanOverrideStoredPin() = assertNull(resolveManualTls(host = "192.168.1.20", storedFingerprint = "pinned"))
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryTailnetWithoutHintsStillRequiresTls() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
-        host = "100.64.0.9",
-        port = 18789,
-        tlsEnabled = false,
-        tlsFingerprintSha256 = null,
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertEquals(true, params?.required)
-    assertNull(params?.expectedFingerprint)
-    assertEquals(false, params?.allowTOFU)
-  }
+  fun resolveTlsParamsForEndpoint_discoveryTailnetWithoutHintsStillRequiresTls() = assertDiscoveredHostRequiresTls("100.64.0.9")
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryPrivateLanWithoutHintsStillRequiresTls() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
-        host = "192.168.1.20",
-        port = 18789,
-        tlsEnabled = false,
-        tlsFingerprintSha256 = null,
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertEquals(true, params?.required)
-    assertNull(params?.expectedFingerprint)
-    assertEquals(false, params?.allowTOFU)
-  }
+  fun resolveTlsParamsForEndpoint_discoveryPrivateLanWithoutHintsStillRequiresTls() = assertDiscoveredHostRequiresTls("192.168.1.20")
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryMdnsWithoutHintsStillRequiresTls() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
-        host = "gateway.local",
-        port = 18789,
-        tlsEnabled = false,
-        tlsFingerprintSha256 = null,
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertEquals(true, params?.required)
-    assertNull(params?.expectedFingerprint)
-    assertEquals(false, params?.allowTOFU)
-  }
+  fun resolveTlsParamsForEndpoint_discoveryMdnsWithoutHintsStillRequiresTls() = assertDiscoveredHostRequiresTls("gateway.local")
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryLoopbackWithoutHintsCanStayCleartext() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
-        host = "127.0.0.1",
-        port = 18789,
-        tlsEnabled = false,
-        tlsFingerprintSha256 = null,
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertNull(params)
-  }
+  fun resolveTlsParamsForEndpoint_discoveryLoopbackWithoutHintsCanStayCleartext() = assertDiscoveredHostCanStayCleartext("127.0.0.1")
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryLocalhostWithoutHintsCanStayCleartext() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
-        host = "localhost",
-        port = 18789,
-        tlsEnabled = false,
-        tlsFingerprintSha256 = null,
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertNull(params)
-  }
+  fun resolveTlsParamsForEndpoint_discoveryLocalhostWithoutHintsCanStayCleartext() = assertDiscoveredHostCanStayCleartext("localhost")
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryAndroidEmulatorWithoutHintsCanStayCleartext() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
-        host = "10.0.2.2",
-        port = 18789,
-        tlsEnabled = false,
-        tlsFingerprintSha256 = null,
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertNull(params)
-  }
+  fun resolveTlsParamsForEndpoint_discoveryAndroidEmulatorWithoutHintsCanStayCleartext() = assertDiscoveredHostCanStayCleartext("10.0.2.2")
 
   @Test
   fun isLoopbackGatewayHost_onlyTreatsEmulatorBridgeAsLocalWhenAllowed() {
@@ -311,120 +106,19 @@ class ConnectionManagerTest {
   }
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryIpv6LoopbackWithoutHintsCanStayCleartext() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
-        host = "::1",
-        port = 18789,
-        tlsEnabled = false,
-        tlsFingerprintSha256 = null,
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertNull(params)
-  }
+  fun resolveTlsParamsForEndpoint_discoveryIpv6LoopbackWithoutHintsCanStayCleartext() = assertDiscoveredHostCanStayCleartext("::1")
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryMappedIpv4LoopbackWithoutHintsCanStayCleartext() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
-        host = "::ffff:127.0.0.1",
-        port = 18789,
-        tlsEnabled = false,
-        tlsFingerprintSha256 = null,
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertNull(params)
-  }
+  fun resolveTlsParamsForEndpoint_discoveryMappedIpv4LoopbackWithoutHintsCanStayCleartext() = assertDiscoveredHostCanStayCleartext("::ffff:127.0.0.1")
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryNonLoopbackIpv6WithoutHintsRequiresTls() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
-        host = "2001:db8::1",
-        port = 18789,
-        tlsEnabled = false,
-        tlsFingerprintSha256 = null,
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertEquals(true, params?.required)
-    assertNull(params?.expectedFingerprint)
-    assertEquals(false, params?.allowTOFU)
-  }
+  fun resolveTlsParamsForEndpoint_discoveryNonLoopbackIpv6WithoutHintsRequiresTls() = assertDiscoveredHostRequiresTls("2001:db8::1")
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryUnspecifiedIpv4WithoutHintsRequiresTls() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
-        host = "0.0.0.0",
-        port = 18789,
-        tlsEnabled = false,
-        tlsFingerprintSha256 = null,
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertEquals(true, params?.required)
-    assertNull(params?.expectedFingerprint)
-    assertEquals(false, params?.allowTOFU)
-  }
+  fun resolveTlsParamsForEndpoint_discoveryUnspecifiedIpv4WithoutHintsRequiresTls() = assertDiscoveredHostRequiresTls("0.0.0.0")
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryUnspecifiedIpv6WithoutHintsRequiresTls() {
-    val endpoint =
-      GatewayEndpoint(
-        stableId = "_openclaw-gw._tcp.|local.|Test",
-        name = "Test",
-        host = "::",
-        port = 18789,
-        tlsEnabled = false,
-        tlsFingerprintSha256 = null,
-      )
-
-    val params =
-      ConnectionManager.resolveTlsParamsForEndpoint(
-        endpoint,
-        storedFingerprint = null,
-        manualTlsEnabled = false,
-      )
-
-    assertEquals(true, params?.required)
-    assertNull(params?.expectedFingerprint)
-    assertEquals(false, params?.allowTOFU)
-  }
+  fun resolveTlsParamsForEndpoint_discoveryUnspecifiedIpv6WithoutHintsRequiresTls() = assertDiscoveredHostRequiresTls("::")
 
   @Test
   fun buildOperatorConnectOptions_requestsNativeClientOperatorScopes() {
@@ -649,6 +343,54 @@ class ConnectionManagerTest {
 
     assertEquals(permissionSnapshot.gatewayPermissions(), options.permissions)
   }
+
+  private fun resolveDiscoveredTls(
+    host: String,
+    storedFingerprint: String? = null,
+    tlsEnabled: Boolean = false,
+    advertisedFingerprint: String? = null,
+  ): GatewayTlsParams? =
+    ConnectionManager.resolveTlsParamsForEndpoint(
+      GatewayEndpoint(
+        stableId = "_openclaw-gw._tcp.|local.|Test",
+        name = "Test",
+        host = host,
+        port = 18789,
+        tlsEnabled = tlsEnabled,
+        tlsFingerprintSha256 = advertisedFingerprint,
+      ),
+      storedFingerprint = storedFingerprint,
+      manualTlsEnabled = false,
+    )
+
+  private fun resolveManualTls(
+    host: String,
+    port: Int = 18789,
+    storedFingerprint: String? = null,
+    manualTlsEnabled: Boolean = false,
+  ): GatewayTlsParams? =
+    ConnectionManager.resolveTlsParamsForEndpoint(
+      GatewayEndpoint.manual(host = host, port = port),
+      storedFingerprint = storedFingerprint,
+      manualTlsEnabled = manualTlsEnabled,
+    )
+
+  private fun assertTls(
+    params: GatewayTlsParams?,
+    expectedFingerprint: String? = null,
+  ) {
+    assertEquals(expectedFingerprint, params?.expectedFingerprint)
+    assertEquals(false, params?.allowTOFU)
+  }
+
+  private fun assertTlsRequired(params: GatewayTlsParams?) {
+    assertEquals(true, params?.required)
+    assertTls(params)
+  }
+
+  private fun assertDiscoveredHostRequiresTls(host: String) = assertTlsRequired(resolveDiscoveredTls(host))
+
+  private fun assertDiscoveredHostCanStayCleartext(host: String) = assertNull(resolveDiscoveredTls(host))
 
   private fun newManager(
     cameraEnabled: Boolean = false,


### PR DESCRIPTION
## Summary
- consolidate repeated Android connection TLS endpoint setup and assertion scaffolding into focused test helpers
- preserve all 36 tests and their order, including pin, TXT, manual discovery, emulator, IPv4/IPv6, mDNS, Tailnet, scope, capability, command, permission, flavor, and build coverage
- test-only cleanup: 80 additions, 338 deletions, net -258; production and dependency delta 0

## Validation
- [Exact-head hosted Android CI](https://github.com/openclaw/openclaw/actions/runs/30789469502) on `0c5a9f1591f3a59f245c727859dc3fcc69152fbe`: all selected jobs passed
  - [android-test-play](https://github.com/openclaw/openclaw/actions/runs/30789469502/job/91609929425)
  - [android-test-third-party](https://github.com/openclaw/openclaw/actions/runs/30789469502/job/91609929431)
  - [android-test-wear](https://github.com/openclaw/openclaw/actions/runs/30789469502/job/91609929444)
  - [android-build-play](https://github.com/openclaw/openclaw/actions/runs/30789469502/job/91609929393)
  - [android-build-wear](https://github.com/openclaw/openclaw/actions/runs/30789469502/job/91609929456)
  - [android-ktlint](https://github.com/openclaw/openclaw/actions/runs/30789469502/job/91609929490)
- Blacksmith Testbox `tbx_01kz339545kc6h35vpxs5asysn`: `:app:ktlintCheck`
- Blacksmith Testbox: exact `ConnectionManagerTest` on `testPlayDebugUnitTest`
- Blacksmith Testbox: exact `ConnectionManagerTest` on `testThirdPartyDebugUnitTest`
- [Testbox hydration run](https://github.com/openclaw/openclaw/actions/runs/30788716035)
- fresh autoreview: `gpt-5.6-sol`, xhigh, clean at 0.99 correctness

Source head: `0c5a9f1591f3a59f245c727859dc3fcc69152fbe`