### PR TITLE
docs(release): clarify Codex OAuth validation prerequisites

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -866,6 +866,7 @@ jobs:
               add_profile_suite live-codex-harness-gpt56-sol-docker "stable full"
               add_profile_suite live-codex-harness-gpt56-terra-docker "stable full"
               add_profile_suite live-codex-harness-gpt56-luna-docker "stable full"
+              add_profile_suite live-codex-harness-gpt56-oauth-smoke-docker "stable full"
               add_profile_suite live-codex-harness-gpt56-docker "stable full"
               add_profile_suite live-subagent-announce-docker "stable full"
 
@@ -3798,6 +3799,13 @@ jobs:
             timeout_minutes: 40
             profile_env_only: false
             profiles: stable full
+          - suite_id: live-codex-harness-gpt56-oauth-smoke-docker
+            suite_group: live-codex-harness-gpt56-docker
+            label: Docker live Codex GPT-5.6 ChatGPT OAuth smoke
+            command: OPENCLAW_LIVE_CODEX_HARNESS_TARGETS=openai/gpt-5.6-sol=ultra,openai/gpt-5.6-terra=ultra,openai/gpt-5.6-luna=max OPENCLAW_LIVE_CODEX_HARNESS_IMAGE_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_MCP_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_SUBAGENT_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_GUARDIAN_PROBE=0 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-codex-harness-docker.sh
+            timeout_minutes: 40
+            profile_env_only: false
+            profiles: stable full
           - suite_id: live-subagent-announce-docker
             label: Docker live subagent announce
             command: OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 20m bash .release-harness/scripts/test-live-subagent-announce-docker.sh
@@ -3965,6 +3973,15 @@ jobs:
                 echo "OPENCLAW_LIVE_CLI_BACKEND_AUTH=api-key" >> "$GITHUB_ENV"
               fi
               echo "OPENCLAW_LIVE_CLI_BACKEND_DEBUG=1" >> "$GITHUB_ENV"
+              echo "OPENCLAW_CLI_BACKEND_LOG_OUTPUT=1" >> "$GITHUB_ENV"
+              echo "OPENCLAW_TEST_CONSOLE=1" >> "$GITHUB_ENV"
+              ;;
+            live-codex-harness-gpt56-oauth-smoke-docker)
+              # This smoke exercises every GPT-5.6 model through the managed Codex
+              # ChatGPT route. API-key lanes cannot detect version requirements
+              # enforced by chatgpt.com for individual models.
+              echo "OPENCLAW_LIVE_CODEX_HARNESS_AUTH=codex-auth" >> "$GITHUB_ENV"
+              echo "OPENCLAW_LIVE_CODEX_HARNESS_DEBUG=1" >> "$GITHUB_ENV"
               echo "OPENCLAW_CLI_BACKEND_LOG_OUTPUT=1" >> "$GITHUB_ENV"
               echo "OPENCLAW_TEST_CONSOLE=1" >> "$GITHUB_ENV"
               ;;

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -3640,10 +3640,8 @@ jobs:
               echo "OPENCLAW_TEST_CONSOLE=1" >> "$GITHUB_ENV"
               ;;
             live-codex-harness*-docker)
-              # TODO(2026-10-01): Repair or remove stale staged Codex auth, then choose the canonical CI auth path.
-              # Keep CI on the API-key path. The staged Codex auth secret
-              # is currently stale, but the wrapper still supports codex-auth for
-              # local maintainer reruns without changing Peter's flow.
+              # Keep the full harness on API-key auth; the focused GPT-5.6 OAuth
+              # cohort below owns ChatGPT-route coverage without duplicating all probes.
               echo "OPENCLAW_LIVE_CODEX_HARNESS_AUTH=api-key" >> "$GITHUB_ENV"
               echo "OPENCLAW_LIVE_CODEX_HARNESS_DEBUG=1" >> "$GITHUB_ENV"
               echo "OPENCLAW_CLI_BACKEND_LOG_OUTPUT=1" >> "$GITHUB_ENV"
@@ -3802,8 +3800,8 @@ jobs:
           - suite_id: live-codex-harness-gpt56-oauth-smoke-docker
             suite_group: live-codex-harness-gpt56-docker
             label: Docker live Codex GPT-5.6 ChatGPT OAuth smoke
-            command: OPENCLAW_LIVE_CODEX_HARNESS_TARGETS=openai/gpt-5.6-sol=ultra,openai/gpt-5.6-terra=ultra,openai/gpt-5.6-luna=max OPENCLAW_LIVE_CODEX_HARNESS_IMAGE_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_MCP_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_SUBAGENT_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_GUARDIAN_PROBE=0 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-codex-harness-docker.sh
-            timeout_minutes: 40
+            command: OPENCLAW_LIVE_CODEX_HARNESS_TARGETS=openai/gpt-5.6-sol=ultra,openai/gpt-5.6-terra=ultra,openai/gpt-5.6-luna=max OPENCLAW_LIVE_CODEX_HARNESS_IMAGE_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_MCP_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_SUBAGENT_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_GUARDIAN_PROBE=0 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 120m bash .release-harness/scripts/test-live-codex-harness-docker.sh
+            timeout_minutes: 125
             profile_env_only: false
             profiles: stable full
           - suite_id: live-subagent-announce-docker

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -866,7 +866,6 @@ jobs:
               add_profile_suite live-codex-harness-gpt56-sol-docker "stable full"
               add_profile_suite live-codex-harness-gpt56-terra-docker "stable full"
               add_profile_suite live-codex-harness-gpt56-luna-docker "stable full"
-              add_profile_suite live-codex-harness-gpt56-oauth-smoke-docker "stable full"
               add_profile_suite live-codex-harness-gpt56-docker "stable full"
               add_profile_suite live-subagent-announce-docker "stable full"
 
@@ -3640,8 +3639,8 @@ jobs:
               echo "OPENCLAW_TEST_CONSOLE=1" >> "$GITHUB_ENV"
               ;;
             live-codex-harness*-docker)
-              # Keep the full harness on API-key auth; the focused GPT-5.6 OAuth
-              # cohort below owns ChatGPT-route coverage without duplicating all probes.
+              # Keep release CI on API-key auth until the staged ChatGPT account has
+              # durable quota and a full OAuth cohort is proven on current tooling.
               echo "OPENCLAW_LIVE_CODEX_HARNESS_AUTH=api-key" >> "$GITHUB_ENV"
               echo "OPENCLAW_LIVE_CODEX_HARNESS_DEBUG=1" >> "$GITHUB_ENV"
               echo "OPENCLAW_CLI_BACKEND_LOG_OUTPUT=1" >> "$GITHUB_ENV"
@@ -3795,13 +3794,6 @@ jobs:
             label: Docker live Codex GPT-5.6 Luna Max
             command: OPENCLAW_LIVE_CODEX_HARNESS_TARGETS=openai/gpt-5.6-luna=max OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-codex-harness-docker.sh
             timeout_minutes: 40
-            profile_env_only: false
-            profiles: stable full
-          - suite_id: live-codex-harness-gpt56-oauth-smoke-docker
-            suite_group: live-codex-harness-gpt56-docker
-            label: Docker live Codex GPT-5.6 ChatGPT OAuth smoke
-            command: OPENCLAW_LIVE_CODEX_HARNESS_TARGETS=openai/gpt-5.6-sol=ultra,openai/gpt-5.6-terra=ultra,openai/gpt-5.6-luna=max OPENCLAW_LIVE_CODEX_HARNESS_IMAGE_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_MCP_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_SUBAGENT_PROBE=0 OPENCLAW_LIVE_CODEX_HARNESS_GUARDIAN_PROBE=0 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 120m bash .release-harness/scripts/test-live-codex-harness-docker.sh
-            timeout_minutes: 125
             profile_env_only: false
             profiles: stable full
           - suite_id: live-subagent-announce-docker
@@ -3971,15 +3963,6 @@ jobs:
                 echo "OPENCLAW_LIVE_CLI_BACKEND_AUTH=api-key" >> "$GITHUB_ENV"
               fi
               echo "OPENCLAW_LIVE_CLI_BACKEND_DEBUG=1" >> "$GITHUB_ENV"
-              echo "OPENCLAW_CLI_BACKEND_LOG_OUTPUT=1" >> "$GITHUB_ENV"
-              echo "OPENCLAW_TEST_CONSOLE=1" >> "$GITHUB_ENV"
-              ;;
-            live-codex-harness-gpt56-oauth-smoke-docker)
-              # This smoke exercises every GPT-5.6 model through the managed Codex
-              # ChatGPT route. API-key lanes cannot detect version requirements
-              # enforced by chatgpt.com for individual models.
-              echo "OPENCLAW_LIVE_CODEX_HARNESS_AUTH=codex-auth" >> "$GITHUB_ENV"
-              echo "OPENCLAW_LIVE_CODEX_HARNESS_DEBUG=1" >> "$GITHUB_ENV"
               echo "OPENCLAW_CLI_BACKEND_LOG_OUTPUT=1" >> "$GITHUB_ENV"
               echo "OPENCLAW_TEST_CONSOLE=1" >> "$GITHUB_ENV"
               ;;

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3566,6 +3566,24 @@ describe("package artifact reuse", () => {
       candidate.name?.startsWith("Run ${{ matrix.label }}"),
     );
     expect(runCodexSuite?.if).toContain("steps.codex_compat.outputs.run_lane != 'false'");
+    const configureCodexSuite = workflowStep(providerSuites, "Configure suite-specific env");
+    expect(configureCodexSuite.run).toMatch(
+      /live-codex-harness-gpt56-oauth-smoke-docker\)[\s\S]*?OPENCLAW_LIVE_CODEX_HARNESS_AUTH=codex-auth/u,
+    );
+    const oauthSmoke = workflowMatrixEntry(
+      LIVE_E2E_WORKFLOW,
+      "validate_live_docker_provider_suites",
+      "live-codex-harness-gpt56-oauth-smoke-docker",
+    );
+    expectTextToIncludeAll(oauthSmoke.command, [
+      "openai/gpt-5.6-sol=ultra",
+      "openai/gpt-5.6-terra=ultra",
+      "openai/gpt-5.6-luna=max",
+      "OPENCLAW_LIVE_CODEX_HARNESS_IMAGE_PROBE=0",
+      "OPENCLAW_LIVE_CODEX_HARNESS_MCP_PROBE=0",
+      "OPENCLAW_LIVE_CODEX_HARNESS_SUBAGENT_PROBE=0",
+      "OPENCLAW_LIVE_CODEX_HARNESS_GUARDIAN_PROBE=0",
+    ]);
     for (const [model, thinking] of [
       ["sol", "ultra"],
       ["terra", "ultra"],
@@ -3582,6 +3600,7 @@ describe("package artifact reuse", () => {
       "live-codex-harness-gpt56-sol-docker",
       "live-codex-harness-gpt56-terra-docker",
       "live-codex-harness-gpt56-luna-docker",
+      "live-codex-harness-gpt56-oauth-smoke-docker",
       "live-codex-harness-gpt56-docker",
     ]) {
       expect(workflow).toContain(`add_profile_suite ${suiteId} "stable full"`);

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3583,7 +3583,9 @@ describe("package artifact reuse", () => {
       "OPENCLAW_LIVE_CODEX_HARNESS_MCP_PROBE=0",
       "OPENCLAW_LIVE_CODEX_HARNESS_SUBAGENT_PROBE=0",
       "OPENCLAW_LIVE_CODEX_HARNESS_GUARDIAN_PROBE=0",
+      "timeout --foreground --kill-after=30s 120m",
     ]);
+    expect(oauthSmoke.timeout_minutes).toBe(125);
     for (const [model, thinking] of [
       ["sol", "ultra"],
       ["terra", "ultra"],

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3566,26 +3566,6 @@ describe("package artifact reuse", () => {
       candidate.name?.startsWith("Run ${{ matrix.label }}"),
     );
     expect(runCodexSuite?.if).toContain("steps.codex_compat.outputs.run_lane != 'false'");
-    const configureCodexSuite = workflowStep(providerSuites, "Configure suite-specific env");
-    expect(configureCodexSuite.run).toMatch(
-      /live-codex-harness-gpt56-oauth-smoke-docker\)[\s\S]*?OPENCLAW_LIVE_CODEX_HARNESS_AUTH=codex-auth/u,
-    );
-    const oauthSmoke = workflowMatrixEntry(
-      LIVE_E2E_WORKFLOW,
-      "validate_live_docker_provider_suites",
-      "live-codex-harness-gpt56-oauth-smoke-docker",
-    );
-    expectTextToIncludeAll(oauthSmoke.command, [
-      "openai/gpt-5.6-sol=ultra",
-      "openai/gpt-5.6-terra=ultra",
-      "openai/gpt-5.6-luna=max",
-      "OPENCLAW_LIVE_CODEX_HARNESS_IMAGE_PROBE=0",
-      "OPENCLAW_LIVE_CODEX_HARNESS_MCP_PROBE=0",
-      "OPENCLAW_LIVE_CODEX_HARNESS_SUBAGENT_PROBE=0",
-      "OPENCLAW_LIVE_CODEX_HARNESS_GUARDIAN_PROBE=0",
-      "timeout --foreground --kill-after=30s 120m",
-    ]);
-    expect(oauthSmoke.timeout_minutes).toBe(125);
     for (const [model, thinking] of [
       ["sol", "ultra"],
       ["terra", "ultra"],
@@ -3602,7 +3582,6 @@ describe("package artifact reuse", () => {
       "live-codex-harness-gpt56-sol-docker",
       "live-codex-harness-gpt56-terra-docker",
       "live-codex-harness-gpt56-luna-docker",
-      "live-codex-harness-gpt56-oauth-smoke-docker",
       "live-codex-harness-gpt56-docker",
     ]) {
       expect(workflow).toContain(`add_profile_suite ${suiteId} "stable full"`);


### PR DESCRIPTION
## Summary

- clarify that GPT-5.6 Codex release lanes remain API-key backed
- document that OAuth-backed release validation must use a current staged credential with durable quota before it becomes blocking
- defer the proposed OAuth cohort until a non-publishing exact-head run completes Sol, Terra, and Luna

## Why the OAuth gate is deferred

The rotated ChatGPT credential was accepted in no-publish run 32440095597 far enough to start a Codex thread and turn, but the service rejected execution because its usage quota is exhausted until August 25. That proves current authentication, not a reliable blocking release gate.

The safe exact-head result therefore leaves the existing API-key release lanes unchanged and corrects only stale workflow guidance. OAuth coverage can return once a durable staged credential completes the full three-target cohort.

## Validation

- focused release-workflow test passed
- branch autoreview clean
- direct pinned Codex source contract inspected for managed ChatGPT auth, versioned user agent, and client-version model query behavior

Production/runtime delta: 0. Workflow-comment delta only.
