### PR TITLE
fix(plugins): agent prompt no longer silently loses a plugin's injected context block

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -112,6 +112,14 @@ instead of continuing without a policy decision.
 logged and shutdown continues so plugin cleanup cannot consume the Gateway
 process watchdog.
 
+`before_prompt_build` uses a 15-second default per handler and fails open, but
+the discard is never silent. When a handler throws, exceeds its budget, or the
+whole dispatch is skipped because a handler started a nested prompt build,
+OpenClaw prepends a one-line `[context-lost]` marker naming the plugin and the
+reason to the prompt it was going to contribute to. Plugins inject the agent's
+work queue through this hook, so a prompt that lost a contribution has to say so
+rather than look complete. Surviving handlers' contributions are unaffected.
+
 Outbound modifying hooks `message_sending` and `reply_payload_sending` use a
 15-second default per handler. If one times out, OpenClaw logs the plugin error
 and continues with the latest payload so the serialized delivery lane can

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -13,6 +13,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { registerContextEngineForOwner } from "../../context-engine/registry.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import type { CliBackendPlugin } from "../../plugins/cli-backend.types.js";
+import { buildPromptBuildDropMarker } from "../../plugins/hook-prompt-build-drop-marker.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import {
   clearMemoryPluginState,
@@ -1911,7 +1912,7 @@ describe("prepareCliRunContext", () => {
     expect(promptContext?.senderId).toBe("user-789");
   });
 
-  it("preserves the base prompt when prompt-build hooks fail", async () => {
+  it("marks the prompt but preserves the base ask when prompt-build hooks fail", async () => {
     const hookRunner = {
       hasHooks: vi.fn((hookName: string) => hookName === "before_prompt_build"),
       runBeforePromptBuild: vi.fn(async () => {
@@ -1922,7 +1923,10 @@ describe("prepareCliRunContext", () => {
 
     const context = await fixture.prepare({});
 
-    expect(context.params.prompt).toBe("latest ask");
+    // The lost contribution is named in-prompt; the raw error text is not.
+    expect(context.params.prompt).toBe(
+      `${buildPromptBuildDropMarker({ reason: "failed" })}\n\nlatest ask`,
+    );
     expect(context.systemPrompt).toContain("You are a personal assistant running inside OpenClaw.");
     expect(context.systemPrompt).toContain("Current model identity: test-cli/test-model.");
     expect(context.systemPrompt).not.toContain("hook exploded");

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts
@@ -36,6 +36,7 @@ vi.mock("../../music-generation-task-status.js", () => musicGenerationTaskStatus
 vi.mock("../../video-generation-task-status.js", () => videoGenerationTaskStatusMocks);
 vi.mock("../../../plugins/host-hook-state.js", () => hostHookStateMocks);
 
+import { buildPromptBuildDropMarker } from "../../../plugins/hook-prompt-build-drop-marker.js";
 import { resolvePromptSubmissionSkipReason } from "./attempt-prompt-skip.js";
 import {
   forgetPromptBuildDrainCacheForRun,
@@ -285,6 +286,33 @@ describe("resolvePromptBuildHookResult drain cache", () => {
     expect(result.toolsAllow).toEqual([]);
     expect(runBeforePromptBuild).toHaveBeenCalledOnce();
     forgetPromptBuildDrainCacheForRun("tools-allow-run");
+  });
+
+  it("marks the prompt when the whole prompt-build dispatch throws", async () => {
+    hostHookStateMocks.drainPluginNextTurnInjectionContext.mockReset();
+    hostHookStateMocks.drainPluginNextTurnInjectionContext.mockResolvedValue({
+      queuedInjections: [],
+      prependContext: "queued injection",
+    });
+
+    const result = await resolvePromptBuildHookResult({
+      config: {},
+      prompt: "what is ready?",
+      messages: [],
+      hookCtx: { runId: "dispatch-throw-run", sessionKey: "agent:main:main" },
+      hookRunner: {
+        hasHooks: vi.fn((hookName: string) => hookName === "before_prompt_build"),
+        runBeforePromptBuild: vi.fn(async () => {
+          throw new Error("dispatch exploded");
+        }),
+      },
+    });
+
+    // Surviving contributions still land; the marker stands in for the lost one.
+    expect(result.prependContext).toBe(
+      `queued injection\n\n${buildPromptBuildDropMarker({ reason: "failed" })}`,
+    );
+    forgetPromptBuildDrainCacheForRun("dispatch-throw-run");
   });
 
   it("does not drain global injections or heartbeat contributions for commitment-only runs", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -8,6 +8,7 @@ import type {
   ContextEngineRuntimeContext,
   ContextEngineSessionTarget,
 } from "../../../context-engine/types.js";
+import { buildPromptBuildDropMarker } from "../../../plugins/hook-prompt-build-drop-marker.js";
 import { drainPluginNextTurnInjectionContext } from "../../../plugins/host-hook-state.js";
 import { buildPluginAgentTurnPrepareContext } from "../../../plugins/host-hooks.js";
 import type {
@@ -171,9 +172,11 @@ export async function resolvePromptBuildHookResult(params: {
           },
           params.hookCtx,
         )
-        .catch((hookErr: unknown) => {
+        .catch((hookErr: unknown): PluginHookBeforePromptBuildResult => {
           log.warn(`before_prompt_build hook failed: ${String(hookErr)}`);
-          return undefined;
+          // A dispatch-level throw loses every contribution; surface it in the
+          // prompt so the agent does not read a silently incomplete context.
+          return { prependContext: buildPromptBuildDropMarker({ reason: "failed" }) };
         })
     : undefined;
   return {

--- a/src/agents/harness/prompt-compaction-hook-helpers.test.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildPromptBuildDropMarker } from "../../plugins/hook-prompt-build-drop-marker.js";
 import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
@@ -138,5 +139,36 @@ describe("resolveAgentHarnessBeforePromptBuildResult", () => {
     expect(heartbeatHandler).not.toHaveBeenCalled();
     expect(promptHandler).toHaveBeenCalledTimes(1);
     expect(result.prompt).toBe("turn policy\n\ndue commitment");
+  });
+
+  // Harness runtimes assemble the prompt here rather than through the embedded
+  // runner, so the drop marker has to survive this seam too. Driven through the
+  // real hook runner so the fail-open discard is the one being observed.
+  it("marks the harness prompt when a prompt-build handler throws", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_prompt_build",
+          handler: () => {
+            throw new Error("hook exploded");
+          },
+          pluginId: "beads",
+        },
+      ]),
+    );
+
+    const result = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "what is ready?",
+      developerInstructions: "base instructions",
+      messages: [],
+      ctx: { trigger: "heartbeat", agentId: "agent-1", sessionKey: "session-1" },
+    });
+
+    const marker = buildPromptBuildDropMarker({ reason: "failed", pluginId: "beads" });
+    expect(result.prompt).toBe(`${marker}\n\nwhat is ready?`);
+    expect(result.promptInputRange).toEqual({
+      start: marker.length + 2,
+      end: marker.length + 2 + "what is ready?".length,
+    });
   });
 });

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -5,6 +5,7 @@
  * compaction while keeping hook failures non-fatal.
  */
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { buildPromptBuildDropMarker } from "../../plugins/hook-prompt-build-drop-marker.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { PluginHookBeforePromptBuildResult } from "../../plugins/types.js";
 import { joinPresentTextSegments } from "../../shared/text/join-segments.js";
@@ -75,10 +76,14 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
       : undefined;
 
   const promptBuildResult = hookRunner?.hasHooks("before_prompt_build")
-    ? await hookRunner.runBeforePromptBuild(promptEvent, hookCtx).catch((error: unknown) => {
-        log.warn(`before_prompt_build hook failed: ${String(error)}`);
-        return undefined;
-      })
+    ? await hookRunner
+        .runBeforePromptBuild(promptEvent, hookCtx)
+        .catch((error: unknown): PluginHookBeforePromptBuildResult => {
+          log.warn(`before_prompt_build hook failed: ${String(error)}`);
+          // Mirrors the embedded runner: a dispatch-level throw loses every
+          // contribution, so the prompt must say so rather than look complete.
+          return { prependContext: buildPromptBuildDropMarker({ reason: "failed" }) };
+        })
     : undefined;
   const systemPrompt = resolvePromptBuildSystemPrompt({
     developerInstructions: params.developerInstructions,

--- a/src/plugins/hook-prompt-build-drop-marker.ts
+++ b/src/plugins/hook-prompt-build-drop-marker.ts
@@ -1,0 +1,35 @@
+/**
+ * In-prompt markers for dropped `before_prompt_build` contributions.
+ *
+ * The runtime is fail-open around prompt-build hooks: a re-entrant dispatch, a
+ * throwing handler, and a handler that exceeds its timeout all end with the
+ * contribution discarded. Logging alone leaves the assembled prompt looking
+ * complete, so the agent reasons over a context whose injected work queue is
+ * silently absent. The marker replaces the lost contribution in the prompt so
+ * the loss is a visible fact rather than an inference.
+ */
+
+/** Closed set of reasons a prompt-build contribution can be discarded. */
+export type PromptBuildDropReason = "reentrant" | "failed" | "timed-out";
+
+const PROMPT_BUILD_DROP_REASON_TEXT: Record<PromptBuildDropReason, string> = {
+  reentrant: "re-entrant dispatch",
+  failed: "handler failed",
+  "timed-out": "handler timed out",
+};
+
+/**
+ * Terse failure signal, not a report: one line naming the lost source and why.
+ * `pluginId` is omitted for `reentrant`, which skips every handler at once and
+ * therefore has no single owner to name.
+ */
+export function buildPromptBuildDropMarker(params: {
+  reason: PromptBuildDropReason;
+  pluginId?: string;
+}): string {
+  const source = params.pluginId ? ` from plugin "${params.pluginId}"` : "";
+  return (
+    `[context-lost] before_prompt_build contribution${source} was dropped ` +
+    `(${PROMPT_BUILD_DROP_REASON_TEXT[params.reason]}); this prompt is missing it.`
+  );
+}

--- a/src/plugins/hooks.model-override-wiring.test.ts
+++ b/src/plugins/hooks.model-override-wiring.test.ts
@@ -6,6 +6,7 @@
  * 2. before_prompt_build receives session messages and prepends prompt context
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildPromptBuildDropMarker } from "./hook-prompt-build-drop-marker.js";
 import { createHookRunner } from "./hooks.js";
 import { addTestHook, TEST_PLUGIN_AGENT_CTX } from "./hooks.test-fixtures.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
@@ -159,7 +160,7 @@ describe("model override pipeline wiring", () => {
       });
     });
 
-    it("skips timed-out handlers and continues", async () => {
+    it("marks a timed-out handler and continues with the surviving contribution", async () => {
       vi.useFakeTimers();
       try {
         addBeforePromptBuildHook(
@@ -186,7 +187,14 @@ describe("model override pipeline wiring", () => {
         );
         await vi.advanceTimersByTimeAsync(5);
 
-        await expect(resultPromise).resolves.toEqual({ prependContext: "fast" });
+        // The timeout is still fail-open, but the discarded contribution is now
+        // named in the prompt instead of only in the log.
+        await expect(resultPromise).resolves.toMatchObject({
+          prependContext: `${buildPromptBuildDropMarker({
+            reason: "timed-out",
+            pluginId: "slow-plugin",
+          })}\n\nfast`,
+        });
         expect(logger.error).toHaveBeenCalledWith(
           "[hooks] before_prompt_build handler from slow-plugin failed: timed out after 5ms",
         );

--- a/src/plugins/hooks.prompt-build-drop-marker.test.ts
+++ b/src/plugins/hooks.prompt-build-drop-marker.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Test: a dropped before_prompt_build contribution is visible in the prompt.
+ *
+ * The runner is fail-open around prompt-build hooks: a throwing handler and a
+ * re-entrant dispatch both end with the contribution discarded and only a log
+ * line written. Plugins use this hook to inject the agent's work queue, so a
+ * silent discard leaves a prompt that still looks complete while the queue is
+ * gone. These tests assert the loss reaches the prompt itself.
+ *
+ * The timeout path shares this seam; it is covered where the prompt-build
+ * timeout budget is already exercised, in hooks.model-override-wiring.test.ts.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { buildPromptBuildDropMarker } from "./hook-prompt-build-drop-marker.js";
+import { createHookRunner } from "./hooks.js";
+import { createMockPluginRegistry, TEST_PLUGIN_AGENT_CTX } from "./hooks.test-fixtures.js";
+
+const promptEvent = { prompt: "outer", messages: [] };
+
+describe("before_prompt_build drop markers", () => {
+  it("marks a throwing handler and keeps the surviving handler's contribution", async () => {
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const runner = createHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_prompt_build",
+          handler: () => {
+            throw new Error("hook exploded");
+          },
+          pluginId: "beads",
+          priority: 10,
+        },
+        {
+          hookName: "before_prompt_build",
+          handler: () => ({ prependContext: "healthy block" }),
+          pluginId: "healthy",
+          priority: 1,
+        },
+      ]),
+      { logger },
+    );
+
+    const result = await runner.runBeforePromptBuild(promptEvent, TEST_PLUGIN_AGENT_CTX);
+
+    expect(result?.prependContext).toBe(
+      `${buildPromptBuildDropMarker({ reason: "failed", pluginId: "beads" })}\n\nhealthy block`,
+    );
+    // The marker is additive: logging still records the failure for operators.
+    expect(logger.error).toHaveBeenCalledWith(
+      "[hooks] before_prompt_build handler from beads failed: hook exploded",
+    );
+  });
+
+  it("marks a re-entrant dispatch once for the whole skipped hook list", async () => {
+    let nested: Awaited<ReturnType<typeof runner.runBeforePromptBuild>>;
+    const runner = createHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_prompt_build",
+          handler: async () => {
+            nested = await runner.runBeforePromptBuild(
+              { prompt: "nested", messages: [] },
+              TEST_PLUGIN_AGENT_CTX,
+            );
+            return { prependContext: "outer block" };
+          },
+          pluginId: "beads",
+        },
+        {
+          hookName: "before_prompt_build",
+          handler: () => ({ prependContext: "second block" }),
+          pluginId: "second",
+        },
+      ]),
+    );
+
+    const outer = await runner.runBeforePromptBuild(promptEvent, TEST_PLUGIN_AGENT_CTX);
+
+    // Named per-plugin markers would be wrong here: the guard skipped both
+    // handlers at once, so the nested prompt gets one dispatch-level line.
+    expect(nested?.prependContext).toBe(buildPromptBuildDropMarker({ reason: "reentrant" }));
+    expect(outer?.prependContext).toBe("outer block\n\nsecond block");
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -25,6 +25,7 @@ import {
   isHookDecision,
 } from "./hook-decision-types.js";
 import { cloneHookIsolationValue, HookIsolationError } from "./hook-isolation.js";
+import { buildPromptBuildDropMarker } from "./hook-prompt-build-drop-marker.js";
 import type { GlobalHookRunnerRegistry, HookRunnerRegistry } from "./hook-registry.types.js";
 import type {
   PluginHookAfterCompactionEvent,
@@ -198,6 +199,11 @@ const DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, 
   skill_proposal_evaluate: 120_000,
 };
 
+// Distinguishes a budget overrun from a handler throw so callers that surface
+// drops to the model (see buildPromptBuildDropMarker) can name the right reason
+// instead of matching on the timeout message text.
+class HookTimeoutError extends Error {}
+
 function deepFreezeHookValue<T>(value: T, seen = new WeakSet<object>()): T {
   if ((typeof value !== "object" && typeof value !== "function") || value === null) {
     return value;
@@ -224,6 +230,15 @@ type ModifyingHookPolicy<K extends PluginHookName, TResult> = {
   shouldStop?: (result: TResult) => boolean;
   terminalLabel?: string;
   onTerminal?: (params: { hookName: K; pluginId: string; result: TResult }) => void;
+  /**
+   * Substitute result merged in place of a handler whose contribution was
+   * dropped, so a fail-open discard leaves a recorded fact instead of a hole
+   * that downstream consumers cannot distinguish from "nothing to contribute".
+   */
+  dropReplacementResult?: (params: {
+    pluginId: string;
+    reason: "failed" | "timed-out";
+  }) => TResult | undefined;
 };
 
 type PluginTargetedInboundClaimOutcome =
@@ -651,7 +666,7 @@ export function createHookRunner(
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
-        reject(new Error(`timed out after ${timeoutMs}ms`));
+        reject(new HookTimeoutError(`timed out after ${timeoutMs}ms`));
       }, timeoutMs);
       if (optionsResult.unref) {
         timer.unref?.();
@@ -779,7 +794,18 @@ export function createHookRunner(
         if (err instanceof HookIsolationError) {
           throw err;
         }
+        // handleHookError rethrows for fail-closed hooks, so the replacement is
+        // only reached on the fail-open path where the drop would be silent.
         handleHookError({ hookName, pluginId: hook.pluginId, error: err });
+        const replacement = policy.dropReplacementResult?.({
+          pluginId: hook.pluginId,
+          reason: err instanceof HookTimeoutError ? "timed-out" : "failed",
+        });
+        if (replacement !== undefined) {
+          result = policy.mergeResults
+            ? policy.mergeResults(result, replacement, hook)
+            : replacement;
+        }
       }
     }
 
@@ -951,7 +977,10 @@ export function createHookRunner(
     ctx: PluginHookAgentContext,
   ): Promise<PluginHookBeforePromptBuildResult | undefined> {
     if (beforePromptBuildDispatch.getStore()?.active) {
-      return undefined;
+      // Reaching here means a handler is mid-flight, so at least one handler is
+      // registered and every one of them is being skipped. No single plugin owns
+      // the loss, so the nested prompt gets one dispatch-level marker.
+      return { prependContext: buildPromptBuildDropMarker({ reason: "reentrant" }) };
     }
     const token = { active: true };
     return await beforePromptBuildDispatch.run(token, async () => {
@@ -960,7 +989,14 @@ export function createHookRunner(
           "before_prompt_build",
           event,
           ctx,
-          { mergeResults: mergeBeforePromptBuild },
+          {
+            mergeResults: mergeBeforePromptBuild,
+            // Prompt-build hooks are the agent's injected work queue. A dropped
+            // contribution must be visible in the prompt, not log-only.
+            dropReplacementResult: ({ pluginId, reason }) => ({
+              prependContext: buildPromptBuildDropMarker({ reason, pluginId }),
+            }),
+          },
         );
       } finally {
         token.active = false;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where an agent turn could lose an entire plugin-injected context block — most visibly the ready-work queue a task-tracking plugin contributes — and the assembled prompt still looked complete, so the agent had no way to tell the difference between "there is no work queued" and "the work queue never arrived."

`before_prompt_build` is the hook plugins use to inject that context. The runtime is fail-open around it in three places, and every one of them discarded the contribution with nothing in the prompt to show it:

1. **Re-entrancy guard.** `runBeforePromptBuild` returned `undefined` when a handler had started a nested prompt build, skipping *every* handler — and emitting no log line at all. Completely silent.
2. **Handler throw.** `runModifyingHook` caught the throw, logged one line, dropped that handler's contribution. The dispatch-level `.catch()` sites in the embedded runner (`attempt.prompt-helpers.ts`) and the harness prompt helper (`prompt-compaction-hook-helpers.ts`) did the same for a whole-dispatch failure.
3. **Timeout.** The 15s modifying-hook budget discarded the contribution.

Paths 2 and 3 were log-only, which does not reach the party that needs the fact. Path 1 was invisible everywhere.

**Observed in production.** On 2026-08-03 05:38 UTC an OpenClaw agent heartbeat turn received no `<plans_and_tasks>` context block at all — not the normal block, not the plugin's own degraded variant — while the plugin's issue store showed open, ready work. The heartbeat's own instructions assert that the turn "already includes" that block. It did not, and nothing in the prompt said so. This is the failure mode above, observed from inside the affected turn.

Per this repo's severity order, silent failure outranks a crash: an action path that ends with no visible outcome and no recorded reason is the worst bug class here. A dropped prompt-context contribution is exactly that.

## Why This Change Was Made

A dropped contribution now leaves a one-line `[context-lost]` marker in the `prependContext` slot it would have occupied, naming the plugin and the reason (`handler failed` / `handler timed out`). The re-entrant case gets a single dispatch-level marker with no plugin named, because the guard skips every handler at once and no single plugin owns the loss.

Policy is deliberately unchanged. The re-entrancy guard still guards, the timeout still expires, surviving handlers' contributions still land unmodified, and operator log lines are untouched — the marker is additive. Only the *visibility* of the discard changes, which is the whole defect.

Design notes for reviewers:

- The marker rides the existing `PluginHookBeforePromptBuildResult` merge path, so it needs no new field on the result type and no new plumbing through prompt assembly. It reaches the model through the same seam a real contribution does.
- `prependContext` is the slot rather than `appendContext` because it is the canonical injection position used by queued injections, `agent_turn_prepare`, heartbeat contributions, and the task-tracking plugin whose loss prompted this. The marker stands in for the lost contribution where that contribution would have been.
- `HookTimeoutError` distinguishes a budget overrun from a handler throw, so the reason is read from a type rather than matched out of the timeout error's message text.
- `ModifyingHookPolicy.dropReplacementResult` is the generic seam in `runModifyingHook`; only `before_prompt_build` opts in. It is reached only on the fail-open path, since `handleHookError` rethrows for fail-closed hooks.
- The marker is one bounded line (~120 chars), well inside the model-context budget rules, and appears only on failure.

**Named follow-up (sibling surfaces, intentionally not in this PR).** `agent_turn_prepare` and `heartbeat_prompt_contribution` inject prompt context through the same `runModifyingHook` machinery and are likewise log-only when a handler throws (`runHeartbeatPromptContribution` at `src/plugins/hooks.ts:1674`, plus `.catch()`-and-warn sites in both prompt helpers). They violate the same invariant and the `dropReplacementResult` seam added here generalizes to them, but the tracked issue scopes this change to `before_prompt_build`; extending it needs the marker text parameterized by hook name. Happy to fold that in here if maintainers prefer one change over two.

## User Impact

Operators and agents can now see, in the prompt itself, when a plugin's prompt-build contribution was lost and why. An agent that would previously have silently reasoned over a missing work queue now reads a line telling it the context is incomplete, so it can say so or re-derive the missing state instead of confidently acting on a partial picture. Plugin authors get the same signal when debugging a hook that intermittently throws or overruns its budget.

No configuration change, no new config surface, and no behavior change on the success path.

## Evidence

Production LOC delta `+87` (35 of which are the new single-purpose marker module, most of it the doc comment explaining the invariant); tests `+156`.

**Test coverage, one per drop path:**

| Drop path | Test |
| --- | --- |
| Re-entrancy guard (path 1) | `src/plugins/hooks.prompt-build-drop-marker.test.ts` — nested dispatch gets one dispatch-level marker; outer result unaffected |
| Handler throw (path 2) | same file — marker names the plugin, surviving handler's contribution preserved, operator log still emitted |
| Timeout (path 3) | `src/plugins/hooks.model-override-wiring.test.ts` — extended the existing prompt-build timeout case rather than adding a near-duplicate |
| Dispatch-level `.catch()`, embedded runner | `src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts` — marker lands alongside surviving queued-injection context |
| Dispatch-level `.catch()`, harness runtime | `src/agents/harness/prompt-compaction-hook-helpers.test.ts` — driven through the **real** hook runner, not a stub, so the observed discard is the production fail-open path; also asserts `promptInputRange` still points at the user's ask |

Two pre-existing tests asserted the silent drop and were updated, not weakened — `cli-runner/prepare.test.ts` ("preserves the base prompt when prompt-build hooks fail") now also asserts the marker is present and that the raw error text is still not leaked into the prompt; the timeout case above now asserts the marker as well as the continuation.

**Validation gates, run from the topic worktree:**

```
pnpm tsgo:core                  # clean
pnpm tsgo:core:test             # clean
pnpm config:schema:check        # [base-config-schema] ok
pnpm plugin-sdk:api:check       # OK docs/.generated/plugin-sdk-api-baseline.sha256 (no drift)
node scripts/run-oxlint.mjs <9 touched files>   # clean
./node_modules/.bin/oxfmt --check <9 touched files>  # All matched files use the correct format
git diff --check                # clean
```

**Focused vitest** (`node scripts/run-vitest.mjs`), covering the changed seams plus every suite in the repo that exercises `before_prompt_build`:

```
hooks.prompt-build-drop-marker, hooks.prompt-build-reentrancy,
hooks.model-override-wiring, hooks.phase-hooks,
plugins/contracts/{boundary-invariants,shape.contract},
agents/harness/prompt-compaction-hook-helpers,
embedded-agent-runner/run/{attempt.prompt-helpers,runtime-context-prompt,
  attempt.spawn-workspace.context-engine},
cli-runner/prepare
  -> 3 shards, all passed (17 + 104 + 11 tests)

extensions: codex/run-attempt, codex/run-attempt.context-engine,
  copilot/attempt, active-memory, memory-core
  -> 4 shards, all passed (200 + 152 + 23 + 143 tests)
```

Every failure encountered during the run was an existing test that had codified the silent drop; both are listed above with what they now assert. No test was skipped, loosened, or given a broader mock to pass.

**Known proof gap:** no live-gateway reproduction of the original 05:38 UTC heartbeat. That failure is load- and timing-dependent, so the proof here is boundary-level: the harness test drives the real hook runner through the real fail-open discard rather than stubbing it.

Related: the tracked issue for this work is `openclaw-beads-201`.
