### PR TITLE
refactor(cron): centralize failure alert test fixtures

### DIFF
--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -1,45 +1,76 @@
 // Cron failure alert tests cover notification behavior for failed scheduled jobs.
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { CronService } from "./service.js";
+import { setupCronServiceSuite } from "./service.test-harness.js";
+import type { CronJobCreate } from "./types.js";
 
 type CronServiceParams = ConstructorParameters<typeof CronService>[0];
+type RunIsolatedAgentJob = NonNullable<CronServiceParams["runIsolatedAgentJob"]>;
+type IsolatedAgentRunResult = Awaited<ReturnType<RunIsolatedAgentJob>>;
+type FailureAlertConfig = NonNullable<CronServiceParams["cronConfig"]>["failureAlert"];
 
-const noopLogger = {
-  debug: vi.fn(),
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
-};
+const { logger: noopLogger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-failure-alert-",
+  baseTimeIso: "2026-01-01T00:00:00.000Z",
+});
 
-async function makeStorePath() {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-failure-alert-"));
+function createTelegramDelivery(): NonNullable<CronJobCreate["delivery"]> {
+  return { mode: "announce", channel: "telegram", to: "19098680" };
+}
+
+function createFailureAlertJob(
+  name: string,
+  overrides: Partial<CronJobCreate> = {},
+): CronJobCreate {
   return {
-    storePath: path.join(dir, "cron", "jobs.json"),
-    cleanup: async () => {
-      await fs.rm(dir, { recursive: true, force: true });
-    },
+    name,
+    enabled: true,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "run report" },
+    ...overrides,
   };
 }
 
-function createFailureAlertCron(params: {
-  storePath: string;
-  cronConfig?: CronServiceParams["cronConfig"];
-  runIsolatedAgentJob: NonNullable<CronServiceParams["runIsolatedAgentJob"]>;
-  sendCronFailureAlert: NonNullable<CronServiceParams["sendCronFailureAlert"]>;
-}) {
-  return new CronService({
-    storePath: params.storePath,
+async function withFailureAlertCron(
+  params: {
+    failureAlert: FailureAlertConfig;
+    runResult?: IsolatedAgentRunResult;
+  },
+  run: (context: {
+    cron: CronService;
+    sendCronFailureAlert: ReturnType<typeof vi.fn>;
+    addJob: (name: string, overrides?: Partial<CronJobCreate>) => ReturnType<CronService["add"]>;
+  }) => Promise<void>,
+): Promise<void> {
+  const store = await makeStorePath();
+  const sendCronFailureAlert = vi.fn(async () => undefined);
+  const runResult = params.runResult ?? {
+    status: "error",
+    error: "temporary upstream error",
+  };
+  const cron = new CronService({
+    storePath: store.storePath,
     cronEnabled: true,
-    cronConfig: params.cronConfig,
+    cronConfig: { failureAlert: params.failureAlert },
     log: noopLogger,
     enqueueSystemEvent: vi.fn(),
     requestHeartbeat: vi.fn(),
-    runIsolatedAgentJob: params.runIsolatedAgentJob,
-    sendCronFailureAlert: params.sendCronFailureAlert,
+    runIsolatedAgentJob: vi.fn(async () => runResult),
+    sendCronFailureAlert,
   });
+
+  await cron.start();
+  try {
+    await run({
+      cron,
+      sendCronFailureAlert,
+      addJob: async (name, overrides) => await cron.add(createFailureAlertJob(name, overrides)),
+    });
+  } finally {
+    cron.stop();
+  }
 }
 
 function alertCallArg(
@@ -79,234 +110,127 @@ function expectAlertTextContaining(
 }
 
 describe("CronService failure alerts", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-    noopLogger.debug.mockClear();
-    noopLogger.info.mockClear();
-    noopLogger.warn.mockClear();
-    noopLogger.error.mockClear();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   it("alerts after configured consecutive failures and honors cooldown", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "error" as const,
-      error: "wrong model id",
-    }));
-
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
-        failureAlert: {
-          enabled: true,
-          after: 2,
-          cooldownMs: 60_000,
-        },
+    await withFailureAlertCron(
+      {
+        failureAlert: { enabled: true, after: 2, cooldownMs: 60_000 },
+        runResult: { status: "error", error: "wrong model id" },
       },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("daily report", {
+          delivery: { mode: "announce", channel: "telegram", to: "19098680" },
+        });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "daily report",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "run report" },
-      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
-    });
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).not.toHaveBeenCalled();
 
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).not.toHaveBeenCalled();
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+        const firstAlert = expectAlertFields(sendCronFailureAlert, {
+          channel: "telegram",
+          to: "19098680",
+        });
+        expect((firstAlert.job as { id?: string } | undefined)?.id).toBe(job.id);
+        expectAlertTextContaining(sendCronFailureAlert, 'Automation "daily report" failed 2 times');
 
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
-    const firstAlert = expectAlertFields(sendCronFailureAlert, {
-      channel: "telegram",
-      to: "19098680",
-    });
-    expect((firstAlert.job as { id?: string } | undefined)?.id).toBe(job.id);
-    expectAlertTextContaining(sendCronFailureAlert, 'Automation "daily report" failed 2 times');
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
 
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
-
-    vi.advanceTimersByTime(60_000);
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(2);
-    expectAlertTextContaining(sendCronFailureAlert, 'Automation "daily report" failed 4 times');
-
-    cron.stop();
-    await store.cleanup();
+        vi.advanceTimersByTime(60_000);
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(2);
+        expectAlertTextContaining(sendCronFailureAlert, 'Automation "daily report" failed 4 times');
+      },
+    );
   });
 
   it("supports per-job failure alert override when global alerts are disabled", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "error" as const,
-      error: "timeout",
-    }));
-
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
-        failureAlert: {
-          enabled: false,
-        },
+    await withFailureAlertCron(
+      {
+        failureAlert: { enabled: false },
+        runResult: { status: "error", error: "timeout" },
       },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("job with override", {
+          failureAlert: {
+            after: 1,
+            channel: "telegram",
+            to: "12345",
+            cooldownMs: 1,
+          },
+        });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "job with override",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "run report" },
-      failureAlert: {
-        after: 1,
-        channel: "telegram",
-        to: "12345",
-        cooldownMs: 1,
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+        expectAlertFields(sendCronFailureAlert, {
+          channel: "telegram",
+          to: "12345",
+        });
       },
-    });
-
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
-    expectAlertFields(sendCronFailureAlert, {
-      channel: "telegram",
-      to: "12345",
-    });
-
-    cron.stop();
-    await store.cleanup();
+    );
   });
 
   it("respects per-job failureAlert=false and suppresses alerts", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "error" as const,
-      error: "auth error",
-    }));
-
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
-        failureAlert: {
-          enabled: true,
-          after: 1,
-        },
+    await withFailureAlertCron(
+      {
+        failureAlert: { enabled: true, after: 1 },
+        runResult: { status: "error", error: "auth error" },
       },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("disabled alert job", { failureAlert: false });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "disabled alert job",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "run report" },
-      failureAlert: false,
-    });
-
-    await cron.run(job.id, "force");
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).not.toHaveBeenCalled();
-
-    cron.stop();
-    await store.cleanup();
+        await cron.run(job.id, "force");
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).not.toHaveBeenCalled();
+      },
+    );
   });
 
   it("preserves includeSkipped through failure alert updates", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "skipped" as const,
-      error: "requests-in-flight",
-    }));
-
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
-        failureAlert: {
-          enabled: true,
-          after: 1,
-        },
+    await withFailureAlertCron(
+      {
+        failureAlert: { enabled: true, after: 1 },
+        runResult: { status: "skipped", error: "requests-in-flight" },
       },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("updated skipped alert job", {
+          failureAlert: {
+            after: 1,
+            channel: "telegram",
+            to: "12345",
+          },
+        });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "updated skipped alert job",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "run report" },
-      failureAlert: {
-        after: 1,
-        channel: "telegram",
-        to: "12345",
+        const updated = await cron.update(job.id, {
+          failureAlert: {
+            includeSkipped: true,
+          },
+        });
+        const updatedFailureAlert = updated?.failureAlert;
+        if (!updatedFailureAlert) {
+          throw new Error("expected updated failure alert config");
+        }
+        expect(updatedFailureAlert.after).toBe(1);
+        expect(updatedFailureAlert.channel).toBe("telegram");
+        expect(updatedFailureAlert.to).toBe("12345");
+        expect(updatedFailureAlert.includeSkipped).toBe(true);
+
+        await cron.run(job.id, "force");
+        expectAlertFields(sendCronFailureAlert, {
+          channel: "telegram",
+          to: "12345",
+        });
+        expectAlertTextContaining(
+          sendCronFailureAlert,
+          'Automation "updated skipped alert job" skipped 1 times',
+        );
       },
-    });
-
-    const updated = await cron.update(job.id, {
-      failureAlert: {
-        includeSkipped: true,
-      },
-    });
-    const updatedFailureAlert = updated?.failureAlert;
-    if (!updatedFailureAlert) {
-      throw new Error("expected updated failure alert config");
-    }
-    expect(updatedFailureAlert.after).toBe(1);
-    expect(updatedFailureAlert.channel).toBe("telegram");
-    expect(updatedFailureAlert.to).toBe("12345");
-    expect(updatedFailureAlert.includeSkipped).toBe(true);
-
-    await cron.run(job.id, "force");
-    expectAlertFields(sendCronFailureAlert, {
-      channel: "telegram",
-      to: "12345",
-    });
-    expectAlertTextContaining(
-      sendCronFailureAlert,
-      'Automation "updated skipped alert job" skipped 1 times',
     );
-
-    cron.stop();
-    await store.cleanup();
   });
 
   it("threads failure alert mode/accountId and skips best-effort jobs", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "error" as const,
-      error: "temporary upstream error",
-    }));
-
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
+    await withFailureAlertCron(
+      {
         failureAlert: {
           enabled: true,
           after: 1,
@@ -314,48 +238,31 @@ describe("CronService failure alerts", () => {
           accountId: "global-account",
         },
       },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const normalJob = await addJob("normal alert job", {
+          delivery: { mode: "announce", channel: "telegram", to: "19098680" },
+        });
+        const bestEffortJob = await addJob("best effort alert job", {
+          delivery: {
+            mode: "announce",
+            channel: "telegram",
+            to: "19098680",
+            bestEffort: true,
+          },
+        });
 
-    await cron.start();
-    const normalJob = await cron.add({
-      name: "normal alert job",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "run report" },
-      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
-    });
-    const bestEffortJob = await cron.add({
-      name: "best effort alert job",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "run report" },
-      delivery: {
-        mode: "announce",
-        channel: "telegram",
-        to: "19098680",
-        bestEffort: true,
+        await cron.run(normalJob.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+        expectAlertFields(sendCronFailureAlert, {
+          mode: "webhook",
+          accountId: "global-account",
+          to: undefined,
+        });
+
+        await cron.run(bestEffortJob.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
       },
-    });
-
-    await cron.run(normalJob.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
-    expectAlertFields(sendCronFailureAlert, {
-      mode: "webhook",
-      accountId: "global-account",
-      to: undefined,
-    });
-
-    await cron.run(bestEffortJob.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
-
-    cron.stop();
-    await store.cleanup();
+    );
   });
 
   it.each([
@@ -537,45 +444,26 @@ describe("CronService failure alerts", () => {
       },
     },
   ])("$name", async ({ globalAlert, jobAlert, expected }) => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: { failureAlert: globalAlert },
-      runIsolatedAgentJob: vi.fn(async () => ({
-        status: "error" as const,
-        error: "temporary upstream error",
-      })),
-      sendCronFailureAlert,
+    await withFailureAlertCron({ failureAlert: globalAlert }, async (context) => {
+      const { cron, sendCronFailureAlert, addJob } = context;
+      const job = await addJob("globally routed failure alert", {
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:19098680",
+        },
+        ...(jobAlert ? { failureAlert: jobAlert } : {}),
+      });
+
+      await cron.run(job.id, "force");
+
+      expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+      expectAlertFields(sendCronFailureAlert, expected);
+      expectAlertTextContaining(
+        sendCronFailureAlert,
+        'Automation "globally routed failure alert" failed 1 times',
+      );
     });
-
-    await cron.start();
-    const job = await cron.add({
-      name: "globally routed failure alert",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "run report" },
-      delivery: {
-        mode: "announce",
-        channel: "telegram",
-        to: "telegram:19098680",
-      },
-      ...(jobAlert ? { failureAlert: jobAlert } : {}),
-    });
-
-    await cron.run(job.id, "force");
-
-    expect(sendCronFailureAlert).toHaveBeenCalledOnce();
-    expectAlertFields(sendCronFailureAlert, expected);
-    expectAlertTextContaining(
-      sendCronFailureAlert,
-      'Automation "globally routed failure alert" failed 1 times',
-    );
-
-    cron.stop();
-    await store.cleanup();
   });
 
   it.each([
@@ -600,11 +488,8 @@ describe("CronService failure alerts", () => {
       },
     },
   ])("does not duplicate an explicitly owned $name", async ({ failureDestination }) => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
+    await withFailureAlertCron(
+      {
         failureAlert: {
           enabled: true,
           after: 1,
@@ -612,39 +497,22 @@ describe("CronService failure alerts", () => {
           to: "https://alerts.example.test/global-failures",
         },
       },
-      runIsolatedAgentJob: vi.fn(async () => ({
-        status: "error" as const,
-        error: "temporary upstream error",
-      })),
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("explicitly routed failure destination", {
+          delivery: { mode: "none", failureDestination },
+        });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "explicitly routed failure destination",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "run report" },
-      delivery: { mode: "none", failureDestination },
-    });
+        expect(job.delivery?.failureDestination).toBeDefined();
+        await cron.run(job.id, "force");
 
-    expect(job.delivery?.failureDestination).toBeDefined();
-    await cron.run(job.id, "force");
-
-    expect(sendCronFailureAlert).not.toHaveBeenCalled();
-
-    cron.stop();
-    await store.cleanup();
+        expect(sendCronFailureAlert).not.toHaveBeenCalled();
+      },
+    );
   });
 
   it("preserves explicit job alerts alongside an owned failure destination", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
+    await withFailureAlertCron(
+      {
         failureAlert: {
           enabled: true,
           after: 1,
@@ -652,56 +520,39 @@ describe("CronService failure alerts", () => {
           to: "https://alerts.example.test/global-failures",
         },
       },
-      runIsolatedAgentJob: vi.fn(async () => ({
-        status: "error" as const,
-        error: "temporary upstream error",
-      })),
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("explicit job alert with a failure destination", {
+          delivery: {
+            mode: "none",
+            failureDestination: { channel: "slack", to: "#alerts" },
+          },
+          failureAlert: {
+            after: 1,
+            mode: "announce",
+            channel: "telegram",
+            to: "telegram:19098680",
+          },
+        });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "explicit job alert with a failure destination",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "run report" },
-      delivery: {
-        mode: "none",
-        failureDestination: { channel: "slack", to: "#alerts" },
+        await cron.run(job.id, "force");
+
+        expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+        expectAlertFields(sendCronFailureAlert, {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:19098680",
+        });
+        expectAlertTextContaining(
+          sendCronFailureAlert,
+          'Automation "explicit job alert with a failure destination" failed 1 times',
+        );
       },
-      failureAlert: {
-        after: 1,
-        mode: "announce",
-        channel: "telegram",
-        to: "telegram:19098680",
-      },
-    });
-
-    await cron.run(job.id, "force");
-
-    expect(sendCronFailureAlert).toHaveBeenCalledOnce();
-    expectAlertFields(sendCronFailureAlert, {
-      mode: "announce",
-      channel: "telegram",
-      to: "telegram:19098680",
-    });
-    expectAlertTextContaining(
-      sendCronFailureAlert,
-      'Automation "explicit job alert with a failure destination" failed 1 times',
     );
-
-    cron.stop();
-    await store.cleanup();
   });
 
   it("preserves global skipped alerts alongside an owned failure destination", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
+    await withFailureAlertCron(
+      {
         failureAlert: {
           enabled: true,
           after: 1,
@@ -710,379 +561,238 @@ describe("CronService failure alerts", () => {
           channel: "telegram",
           to: "telegram:19098680",
         },
+        runResult: { status: "skipped", error: "requests-in-flight" },
       },
-      runIsolatedAgentJob: vi.fn(async () => ({
-        status: "skipped" as const,
-        error: "requests-in-flight",
-      })),
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("skipped job with a failure destination", {
+          delivery: {
+            mode: "none",
+            failureDestination: { channel: "slack", to: "#alerts" },
+          },
+        });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "skipped job with a failure destination",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "run report" },
-      delivery: {
-        mode: "none",
-        failureDestination: { channel: "slack", to: "#alerts" },
+        await cron.run(job.id, "force");
+
+        expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+        expectAlertFields(sendCronFailureAlert, {
+          mode: "announce",
+          channel: "telegram",
+          to: "telegram:19098680",
+        });
+        expectAlertTextContaining(
+          sendCronFailureAlert,
+          'Automation "skipped job with a failure destination" skipped 1 times',
+        );
       },
-    });
-
-    await cron.run(job.id, "force");
-
-    expect(sendCronFailureAlert).toHaveBeenCalledOnce();
-    expectAlertFields(sendCronFailureAlert, {
-      mode: "announce",
-      channel: "telegram",
-      to: "telegram:19098680",
-    });
-    expectAlertTextContaining(
-      sendCronFailureAlert,
-      'Automation "skipped job with a failure destination" skipped 1 times',
     );
-
-    cron.stop();
-    await store.cleanup();
   });
 
   it("alerts for repeated skipped runs only when opted in", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "skipped" as const,
-      error: "disabled",
-    }));
-
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
+    await withFailureAlertCron(
+      {
         failureAlert: {
           enabled: true,
           after: 2,
           cooldownMs: 60_000,
           includeSkipped: true,
         },
+        runResult: { status: "skipped", error: "disabled" },
       },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("gateway restart", {
+          payload: { kind: "agentTurn", message: "restart gateway if needed" },
+          delivery: createTelegramDelivery(),
+        });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "gateway restart",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "restart gateway if needed" },
-      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
-    });
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).not.toHaveBeenCalled();
 
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).not.toHaveBeenCalled();
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+        expectAlertFields(sendCronFailureAlert, {
+          channel: "telegram",
+          to: "19098680",
+        });
+        const alertText = alertCallArg(sendCronFailureAlert).text;
+        expect(typeof alertText).toBe("string");
+        if (typeof alertText !== "string") {
+          throw new Error("expected failure alert text");
+        }
+        expect(alertText).toMatch(
+          /Automation "gateway restart" skipped 2 times\nSkip reason: disabled/,
+        );
 
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
-    expectAlertFields(sendCronFailureAlert, {
-      channel: "telegram",
-      to: "19098680",
-    });
-    const alertText = alertCallArg(sendCronFailureAlert).text;
-    expect(typeof alertText).toBe("string");
-    if (typeof alertText !== "string") {
-      throw new Error("expected failure alert text");
-    }
-    expect(alertText).toMatch(
-      /Automation "gateway restart" skipped 2 times\nSkip reason: disabled/,
+        const skippedJob = cron.getJob(job.id);
+        expect(skippedJob?.state.consecutiveSkipped).toBe(2);
+        expect(skippedJob?.state.consecutiveErrors).toBe(0);
+      },
     );
-
-    const skippedJob = cron.getJob(job.id);
-    expect(skippedJob?.state.consecutiveSkipped).toBe(2);
-    expect(skippedJob?.state.consecutiveErrors).toBe(0);
-
-    cron.stop();
-    await store.cleanup();
   });
 
   it("surfaces classified causes before raw errors in failure alerts", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "error" as const,
-      error: "cron: job execution timed out",
-    }));
-
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
-        failureAlert: {
-          enabled: true,
-          after: 1,
-        },
+    await withFailureAlertCron(
+      {
+        failureAlert: { enabled: true, after: 1 },
+        runResult: { status: "error", error: "cron: job execution timed out" },
       },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("timeout cause alert", {
+          payload: { kind: "agentTurn", message: "ping" },
+          delivery: createTelegramDelivery(),
+        });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "timeout cause alert",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "ping" },
-      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
-    });
-
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
-    const alertText = alertCallArg(sendCronFailureAlert).text;
-    expect(alertText).toBe(
-      'Automation "timeout cause alert" failed 1 times\n' +
-        "Cause: timeout\n" +
-        "Last error: cron: job execution timed out",
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+        const alertText = alertCallArg(sendCronFailureAlert).text;
+        expect(alertText).toBe(
+          'Automation "timeout cause alert" failed 1 times\n' +
+            "Cause: timeout\n" +
+            "Last error: cron: job execution timed out",
+        );
+      },
     );
-
-    cron.stop();
-    await store.cleanup();
   });
 
   it("uses provider context when surfacing failure alert causes", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "error" as const,
-      error: "403 Key limit exceeded (monthly limit)",
-      provider: "openrouter",
-    }));
-
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
-        failureAlert: {
-          enabled: true,
-          after: 1,
+    await withFailureAlertCron(
+      {
+        failureAlert: { enabled: true, after: 1 },
+        runResult: {
+          status: "error",
+          error: "403 Key limit exceeded (monthly limit)",
+          provider: "openrouter",
         },
       },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("provider limit alert", {
+          payload: { kind: "agentTurn", message: "ping" },
+          delivery: createTelegramDelivery(),
+        });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "provider limit alert",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "ping" },
-      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
-    });
-
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
-    const alertText = alertCallArg(sendCronFailureAlert).text;
-    expect(alertText).toBe(
-      'Automation "provider limit alert" failed 1 times\n' +
-        "Cause: billing\n" +
-        "Last error: 403 Key limit exceeded (monthly limit)",
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+        const alertText = alertCallArg(sendCronFailureAlert).text;
+        expect(alertText).toBe(
+          'Automation "provider limit alert" failed 1 times\n' +
+            "Cause: billing\n" +
+            "Last error: 403 Key limit exceeded (monthly limit)",
+        );
+      },
     );
-
-    cron.stop();
-    await store.cleanup();
   });
 
   it("does not reclassify permanent local script errors in failure alerts", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "error" as const,
-      error: "cron script failed after a tool side effect: request timed out",
-      errorClassification: { kind: "permanent" as const },
-    }));
-
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
-        failureAlert: {
-          enabled: true,
-          after: 1,
+    await withFailureAlertCron(
+      {
+        failureAlert: { enabled: true, after: 1 },
+        runResult: {
+          status: "error",
+          error: "cron script failed after a tool side effect: request timed out",
+          errorClassification: { kind: "permanent" },
         },
       },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("permanent script alert", {
+          payload: { kind: "agentTurn", message: "ping" },
+          delivery: createTelegramDelivery(),
+        });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "permanent script alert",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "ping" },
-      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
-    });
-
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
-    expect(alertCallArg(sendCronFailureAlert).text).toBe(
-      'Automation "permanent script alert" failed 1 times\n' +
-        "Last error: cron script failed after a tool side effect: request timed out",
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+        expect(alertCallArg(sendCronFailureAlert).text).toBe(
+          'Automation "permanent script alert" failed 1 times\n' +
+            "Last error: cron script failed after a tool side effect: request timed out",
+        );
+      },
     );
-
-    cron.stop();
-    await store.cleanup();
   });
 
   it("keeps skipped alert text unchanged when the skip reason looks classifiable", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "skipped" as const,
-      error: "cron: job execution timed out",
-    }));
-
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
-        failureAlert: {
-          enabled: true,
-          after: 1,
-          includeSkipped: true,
-        },
+    await withFailureAlertCron(
+      {
+        failureAlert: { enabled: true, after: 1, includeSkipped: true },
+        runResult: { status: "skipped", error: "cron: job execution timed out" },
       },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("skipped timeout", {
+          payload: { kind: "agentTurn", message: "ping" },
+          delivery: createTelegramDelivery(),
+        });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "skipped timeout",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "ping" },
-      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
-    });
-
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
-    const alertText = alertCallArg(sendCronFailureAlert).text;
-    expect(alertText).toBe(
-      'Automation "skipped timeout" skipped 1 times\nSkip reason: cron: job execution timed out',
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+        const alertText = alertCallArg(sendCronFailureAlert).text;
+        expect(alertText).toBe(
+          'Automation "skipped timeout" skipped 1 times\nSkip reason: cron: job execution timed out',
+        );
+      },
     );
-
-    cron.stop();
-    await store.cleanup();
   });
 
   it("tracks skipped runs without alerting or affecting error backoff when includeSkipped is off", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "skipped" as const,
-      error: "requests-in-flight",
-    }));
-
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: {
-        failureAlert: {
-          enabled: true,
-          after: 1,
-        },
+    await withFailureAlertCron(
+      {
+        failureAlert: { enabled: true, after: 1 },
+        runResult: { status: "skipped", error: "requests-in-flight" },
       },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("busy heartbeat", { delivery: createTelegramDelivery() });
 
-    await cron.start();
-    const job = await cron.add({
-      name: "busy heartbeat",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "run report" },
-      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
-    });
+        await cron.run(job.id, "force");
+        await cron.run(job.id, "force");
 
-    await cron.run(job.id, "force");
-    await cron.run(job.id, "force");
-
-    expect(sendCronFailureAlert).not.toHaveBeenCalled();
-    const skippedJob = cron.getJob(job.id);
-    expect(skippedJob?.state.consecutiveSkipped).toBe(2);
-    expect(skippedJob?.state.consecutiveErrors).toBe(0);
-
-    cron.stop();
-    await store.cleanup();
+        expect(sendCronFailureAlert).not.toHaveBeenCalled();
+        const skippedJob = cron.getJob(job.id);
+        expect(skippedJob?.state.consecutiveSkipped).toBe(2);
+        expect(skippedJob?.state.consecutiveErrors).toBe(0);
+      },
+    );
   });
 
   it("truncates failure alert error text on UTF-16 code-point boundary", async () => {
-    const store = await makeStorePath();
-    const sendCronFailureAlert = vi.fn(async () => undefined);
     // 209 code units: emoji (surrogate pair) at positions 199-200 straddles the 200-unit boundary
     const longError = `${"x".repeat(199)}🎉trailing`;
-    const runIsolatedAgentJob = vi.fn(async () => ({
-      status: "error" as const,
-      error: longError,
-    }));
+    await withFailureAlertCron(
+      {
+        failureAlert: { enabled: true, after: 1 },
+        runResult: { status: "error", error: longError },
+      },
+      async ({ cron, sendCronFailureAlert, addJob }) => {
+        const job = await addJob("utf16 boundary job", {
+          payload: { kind: "agentTurn", message: "ping" },
+          delivery: createTelegramDelivery(),
+        });
 
-    const cron = createFailureAlertCron({
-      storePath: store.storePath,
-      cronConfig: { failureAlert: { enabled: true, after: 1 } },
-      runIsolatedAgentJob,
-      sendCronFailureAlert,
-    });
+        await cron.run(job.id, "force");
+        expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+        const alertText = alertCallArg(sendCronFailureAlert).text;
+        expect(typeof alertText).toBe("string");
+        if (typeof alertText !== "string") {
+          throw new Error("expected failure alert text");
+        }
 
-    await cron.start();
-    const job = await cron.add({
-      name: "utf16 boundary job",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "ping" },
-      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
-    });
+        // Verify no dangling surrogates in the truncated error text.
+        // Must check every character including the last: a dangling high surrogate
+        // at the final position would be missed by stopping at length-1.
+        for (let i = 0; i < alertText.length; i++) {
+          const cu = alertText.charCodeAt(i);
+          if (cu >= 0xd800 && cu <= 0xdbff) {
+            expect(
+              alertText.charCodeAt(i + 1) >= 0xdc00 && alertText.charCodeAt(i + 1) <= 0xdfff,
+            ).toBe(true);
+          }
+          if (cu >= 0xdc00 && cu <= 0xdfff) {
+            expect(
+              i > 0 &&
+                alertText.charCodeAt(i - 1) >= 0xd800 &&
+                alertText.charCodeAt(i - 1) <= 0xdbff,
+            ).toBe(true);
+          }
+        }
 
-    await cron.run(job.id, "force");
-    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
-    const alertText = alertCallArg(sendCronFailureAlert).text;
-    expect(typeof alertText).toBe("string");
-    if (typeof alertText !== "string") {
-      throw new Error("expected failure alert text");
-    }
-
-    // Verify no dangling surrogates in the truncated error text.
-    // Must check every character including the last: a dangling high surrogate
-    // at the final position would be missed by stopping at length-1.
-    for (let i = 0; i < alertText.length; i++) {
-      const cu = alertText.charCodeAt(i);
-      if (cu >= 0xd800 && cu <= 0xdbff) {
-        expect(alertText.charCodeAt(i + 1) >= 0xdc00 && alertText.charCodeAt(i + 1) <= 0xdfff).toBe(
-          true,
-        );
-      }
-      if (cu >= 0xdc00 && cu <= 0xdfff) {
-        expect(
-          i > 0 && alertText.charCodeAt(i - 1) >= 0xd800 && alertText.charCodeAt(i - 1) <= 0xdbff,
-        ).toBe(true);
-      }
-    }
-
-    // Verify the emoji was excluded (truncated at the safe boundary before it)
-    expect(alertText).not.toContain("🎉");
-
-    cron.stop();
-    await store.cleanup();
+        // Verify the emoji was excluded (truncated at the safe boundary before it)
+        expect(alertText).not.toContain("🎉");
+      },
+    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The cron failure-alert suite repeated temporary-store creation, service construction, start/stop cleanup, mock outcomes, and the same recurring agent-turn job shape across every scenario. That boilerplate obscured the policy assertions for thresholds, cooldowns, routing precedence, skip handling, cause classification, and text truncation.

## Why This Change Was Made

The suite now reuses the existing cron service harness for isolated stores, fake timers, logger reset, and cleanup. One typed failure-alert lifecycle fixture owns service startup and guaranteed shutdown, while a canonical job builder keeps each case focused on only the job fields that differ.

All 27 named cases remain in their original order with their alert counts, routing fields, exact text, counter, update, and UTF-16 assertions unchanged. Production code is untouched.

## User Impact

No runtime behavior changes. The failure-alert regression suite is smaller and future policy cases can declare their scenario without duplicating scheduler lifecycle code.

## Evidence

- Exact branch head: `ab0574d194ad48e7633377c655c1a0b2295d4204`.
- `node scripts/run-vitest.mjs src/cron/service.failure-alert.test.ts`: 27/27 passed on the exact rebased head.
- Blacksmith Testbox `tbx_01kz343ns6dp39cz0ybjqpcw9t`: `node scripts/check-changed.mjs -- src/cron/service.failure-alert.test.ts` passed, including core-test typecheck, lint, formatting, dead-code, boundary, dependency, and ratchet checks ([run](https://github.com/openclaw/openclaw/actions/runs/30789503625)).
- Fresh xhigh committed-branch autoreview: no accepted/actionable findings; patch correct with 0.99 confidence (thread `019fc64b-a7f2-7390-8266-d4a2ab995c81`).
- Stable patch id before and after the final rebase: `c75dd0c8d5158953a1fed79e5f32cbbc581c7a93`.
- Current-main gate: `src/cron/service.failure-alert.test.ts` remained at reserved blob `efc04502814b73572f53efaf688c842558215690` before the final rebase.
- Production LOC: 0. Test LOC: +423/-713 (-290 net), reducing the suite from 1,088 to 798 lines.

Real-behavior proof is not applicable because this change only consolidates test fixture ownership and does not alter production behavior.
