### PR TITLE
test(system-agent): reuse CLI backend fixture

### DIFF
--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -16,6 +16,7 @@ import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
 import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
 import {
   createSystemAgentVerifiedInferenceTestFixture,
+  installSystemAgentClaudeCliBackendTestFixture,
   installSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
@@ -62,6 +63,7 @@ vi.mock("../config/config.js", async (importOriginal) => ({
 }));
 
 const tempDirs: string[] = [];
+let restoreCliBackendFixture: (() => void) | undefined;
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 
 function useTempStateDir(): string {
@@ -109,36 +111,12 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  // Core tests install a contract-level selectable backend instead of loading
-  // a plugin's generated setup artifact from dist/.
-  cliBackendsTesting.setDepsForTest({
-    resolveRuntimeCliBackends: () => [
-      {
-        id: "claude-cli",
-        pluginId: "anthropic",
-        modelProvider: "anthropic",
-        bundleMcp: true,
-        bundleMcpMode: "claude-config-file",
-        config: { command: "claude" },
-        normalizeConfig: (config, context) => ({
-          ...config,
-          args: [
-            ...(config.args ?? []),
-            "--test-exec-policy",
-            JSON.stringify(context?.config?.tools?.exec ?? null),
-          ],
-        }),
-        nativeToolMode: "selectable",
-        toolAvailabilityEnforcement: "execution-args",
-        sideQuestionToolMode: "disabled",
-        resolveExecutionArgs: (context) => context.baseArgs,
-      },
-    ],
-  });
+  restoreCliBackendFixture = installSystemAgentClaudeCliBackendTestFixture();
 });
 
 afterEach(() => {
-  cliBackendsTesting.resetDepsForTest();
+  restoreCliBackendFixture?.();
+  restoreCliBackendFixture = undefined;
   vi.unstubAllEnvs();
   pluginMetadataSnapshot?.rebindForCurrentEnv();
   vi.clearAllMocks();

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -27,6 +27,7 @@ import {
 import { verifyConfigAfterSystemAgentWrite } from "./post-write-verification.js";
 import {
   createSystemAgentVerifiedInferenceTestFixture,
+  installSystemAgentClaudeCliBackendTestFixture,
   installSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
@@ -3147,6 +3148,18 @@ describe("SystemAgentChatEngine", () => {
 });
 
 describe("OpenClaw agent loop backends", () => {
+  let restoreCliBackendFixture: (() => void) | undefined;
+
+  beforeAll(() => {
+    // These cases own chat routing and CLI session continuity. Anthropic setup tests own loading
+    // the generated backend artifact, so keep this integration on the same contract-level fixture.
+    restoreCliBackendFixture = installSystemAgentClaudeCliBackendTestFixture();
+  });
+
+  afterAll(() => {
+    restoreCliBackendFixture?.();
+  });
+
   it("runs a configured claude-cli model through the CLI loop with the ring-zero MCP tool", async () => {
     useTempStateDir();
     const config = {

--- a/src/system-agent/system-agent.test-helpers.ts
+++ b/src/system-agent/system-agent.test-helpers.ts
@@ -1,6 +1,7 @@
 import { expect } from "vitest";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveCliBackendConfig } from "../agents/cli-backends.js";
+import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 // OpenClaw test helpers build runtime environments for rescue tests.
 import {
   fingerprintAuthProfileOwnerShape,
@@ -36,6 +37,35 @@ export type SystemAgentPluginMetadataTestSnapshot = {
   rebindForCurrentEnv: () => void;
   restore: () => void;
 };
+
+/** Install the contract-level selectable CLI backend used by core system-agent tests. */
+export function installSystemAgentClaudeCliBackendTestFixture(): () => void {
+  cliBackendsTesting.setDepsForTest({
+    resolveRuntimeCliBackends: () => [
+      {
+        id: "claude-cli",
+        pluginId: "anthropic",
+        modelProvider: "anthropic",
+        bundleMcp: true,
+        bundleMcpMode: "claude-config-file",
+        config: { command: "claude" },
+        normalizeConfig: (config, context) => ({
+          ...config,
+          args: [
+            ...(config.args ?? []),
+            "--test-exec-policy",
+            JSON.stringify(context?.config?.tools?.exec ?? null),
+          ],
+        }),
+        nativeToolMode: "selectable",
+        toolAvailabilityEnforcement: "execution-args",
+        sideQuestionToolMode: "disabled",
+        resolveExecutionArgs: (context) => context.baseArgs,
+      },
+    ],
+  });
+  return () => cliBackendsTesting.resetDepsForTest();
+}
 
 /** Install the process-stable plugin metadata snapshot that the real Gateway owns. */
 export function installSystemAgentPluginMetadataTestSnapshot(


### PR DESCRIPTION
## What Problem This Solves

The system-agent chat suite spent most of one CLI-routing test loading the Anthropic plugin's generated setup artifact even though the test mocks CLI execution and owns only chat routing, tool restriction, and native-session continuity.

## Why This Change Was Made

Move the existing contract-level selectable Claude CLI backend fixture into the shared system-agent test helper and reuse it from both agent-turn and chat tests. Anthropic plugin tests remain the owner of the real generated backend descriptor, normalization, and execution-argument contract.

## User Impact

No user-visible behavior changes. The same assertions run with substantially less CPU, memory, and wall time; production code is unchanged.

## Evidence

- Exact main CI run 30789242864, job 91609378936: chat-engine.test.ts took 25.988s; the configured Claude CLI case alone took 15.478s.
- Exact-head PR CI run 30790194583: chat-engine.test.ts fell to 11.038s, a 14.950s (57.5%) reduction on the real compact large-8 runner. The current combined main+PR test step completed its four sequential groups in 284.03s versus the 299.82s baseline.
- Same-head focused benchmark: that case fell from 14.443s to 40ms. The full 92-test file fell from 41.83s to 20.01s wall time (52.2% faster), with Vitest duration 37.13s to 15.30s and peak RSS 1.807 GB to 1.153 GB.
- Core sibling proof: 119/119 tests passed across chat-engine, agent-turn, and CLI backend owner suites.
- Anthropic owner proof: 96/96 tests passed across index and CLI shared-contract suites.
- Oxfmt, git diff --check, and Codex autoreview passed with no findings.
- Production LOC delta: 0.
