### PR TITLE
fix(qa): restore Telegram release validation

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1819,8 +1819,15 @@ jobs:
           sut_tmp="${temp_root}/sut-tmp"
           install -d -o "$SUT_UID" -g "$SUT_GID" -m 0700 "$sut_tmp"
           export TMPDIR="$sut_tmp"
+          workspace="${temp_root}/workspace"
+          [[ -d "$workspace" && ! -L "$workspace" ]]
+          [[ "$(realpath -e "$workspace")" == "$workspace" ]]
+          # The trusted scenario host creates fixtures while the isolated SUT reads
+          # and mutates the workspace. Keep every other runtime directory SUT-private.
+          chown -R "$RUNNER_UID:$SUT_GID" "$workspace"
+          chmod -R u=rwX,g=rwX,o= "$workspace"
+          find "$workspace" -type d -exec chmod g+s {} +
           for path in \
-            "$temp_root/workspace" \
             "${OPENCLAW_HOME:?}" \
             "${OPENCLAW_STATE_DIR:?}" \
             "${XDG_CACHE_HOME:?}" \

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
@@ -96,9 +96,28 @@ describe("Telegram QA transport adapter", () => {
     const addOutboundMessage = vi.fn().mockResolvedValue({ id: "out-1" });
     const editMessage = vi.fn().mockResolvedValue({ id: "out-1" });
     const adapter = await createTelegramQaTransportAdapter({
-      adapterOptions: { sutAccountId: "sut" },
+      adapterOptions: {
+        sutAccountId: "sut",
+        transportPolicy: { requireGroupMention: true },
+      },
       messages: { addInboundMessage, addOutboundMessage, editMessage },
     } as never);
+
+    expect(adapter.createGatewayConfig?.({ baseUrl: "http://127.0.0.1:1234" })).toMatchObject({
+      channels: {
+        telegram: {
+          accounts: {
+            sut: {
+              groups: {
+                "-100123": {
+                  requireMention: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
 
     await vi.waitFor(() => expect(pollResolvers).toHaveLength(1));
     await adapter.sendInbound?.({
@@ -185,10 +204,38 @@ describe("Telegram QA transport adapter", () => {
       expect.objectContaining({ messageId: "out-1", text: "final", timestamp: 101_000 }),
     );
 
+    await adapter.resetTransport?.();
     await vi.waitFor(() => expect(pollResolvers).toHaveLength(3));
+    await adapter.sendInbound?.({
+      conversation: { id: "next-room", kind: "group" },
+      senderId: "driver",
+      text: "next",
+    });
+    pollResolvers[2]?.([
+      {
+        update_id: 3,
+        edited_message: {
+          message_id: 13,
+          date: 102,
+          chat: { id: -100123 },
+          from: { id: 2, is_bot: true, username: "openclaw_qa_bot" },
+          text: "orphan final",
+        },
+      },
+    ]);
+    await vi.waitFor(() => expect(addOutboundMessage).toHaveBeenCalledTimes(2));
+    expect(addOutboundMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        to: "group:next-room",
+        text: "orphan final",
+        timestamp: 102_000,
+      }),
+    );
+
+    await vi.waitFor(() => expect(pollResolvers).toHaveLength(4));
     mocks.heartbeatStop.mockRejectedValueOnce(new Error("heartbeat stop failed"));
     const cleanup = adapter.cleanup?.();
-    pollResolvers[2]?.([]);
+    pollResolvers[3]?.([]);
     await cleanup;
     expect(mocks.shouldRetainQaGatewayCredentialLease).not.toHaveBeenCalled();
     await expect(adapter.cleanupAfterGatewayStop?.()).rejects.toThrow("heartbeat stop failed");

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
@@ -134,17 +134,17 @@ export async function createTelegramQaTransportAdapter(
           continue;
         }
         const existingMessageId = busMessageIds.get(message.messageId);
-        if (update.edited_message) {
-          if (existingMessageId) {
-            await context.messages.editMessage({
-              accountId,
-              messageId: existingMessageId,
-              text: message.text,
-              timestamp: message.timestamp,
-            });
-          }
+        if (update.edited_message && existingMessageId) {
+          await context.messages.editMessage({
+            accountId,
+            messageId: existingMessageId,
+            text: message.text,
+            timestamp: message.timestamp,
+          });
           continue;
         }
+        // Telegram may expose only the final edit after the adapter resets between
+        // scenarios. Adopt that edit so the live observation cannot disappear.
         const outbound = await context.messages.addOutboundMessage({
           accountId,
           to: `${logicalConversationKind}:${logicalConversationId}`,
@@ -223,6 +223,8 @@ export async function createTelegramQaTransportAdapter(
         sutToken: runtimeEnv.sutToken,
         driverBotId: driverIdentity.id,
         sutAccountId: accountId,
+        // Mention-gating scenarios opt in through the shared transport policy.
+        requireMention: options.transportPolicy?.requireGroupMention === true,
       }),
     waitReady: async ({ gateway, timeoutMs, pollIntervalMs }) =>
       await waitForTelegramChannelRunning(gateway, accountId, {

--- a/extensions/qa-lab/src/live-transports/telegram/profiles.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/profiles.test.ts
@@ -25,7 +25,7 @@ describe("Telegram QA profiles", () => {
 
     expect(live).not.toContain("telegram-long-final-reuses-preview");
     expect(mock).toContain("telegram-long-final-reuses-preview");
-    expect(mock).toContain("telegram-assistant-transcript-role-boundary");
+    expect(mock).not.toContain("telegram-assistant-transcript-role-boundary");
     expect(mock).not.toContain("telegram-startup-getme-live");
   });
 
@@ -36,7 +36,7 @@ describe("Telegram QA profiles", () => {
     });
 
     expect(scenarioIds).toContain("channel-message-flows");
-    expect(scenarioIds).toContain("native-command-session-target");
+    expect(scenarioIds).not.toContain("native-command-session-target");
   });
 
   it("lets explicit scenarios override profile selection", () => {

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.test.ts
@@ -76,6 +76,7 @@ describe("Telegram QA API boundary", () => {
         sutToken: "placeholder",
         driverBotId: 1,
         sutAccountId: "sut",
+        requireMention: true,
       },
     );
 
@@ -96,6 +97,28 @@ describe("Telegram QA API boundary", () => {
             },
           },
         },
+      },
+    });
+  });
+
+  it("disables mention gating only inside the exact leased QA group", () => {
+    const config = buildTelegramQaConfig(
+      {},
+      {
+        groupId: "-100123",
+        sutToken: "placeholder",
+        driverBotId: 1,
+        sutAccountId: "sut",
+        requireMention: false,
+      },
+    );
+
+    expect(config.channels?.telegram?.groups).toBeUndefined();
+    expect(config.channels?.telegram?.accounts?.sut?.groups).toEqual({
+      "-100123": {
+        groupPolicy: "allowlist",
+        allowFrom: ["1"],
+        requireMention: false,
       },
     });
   });

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-api.runtime.ts
@@ -257,6 +257,7 @@ export function buildTelegramQaConfig(
     sutToken: string;
     driverBotId: number;
     sutAccountId: string;
+    requireMention: boolean;
   },
 ): OpenClawConfig {
   return {
@@ -305,7 +306,7 @@ export function buildTelegramQaConfig(
               [params.groupId]: {
                 groupPolicy: "allowlist",
                 allowFrom: [String(params.driverBotId)],
-                requireMention: true,
+                requireMention: params.requireMention,
               },
             },
           },

--- a/extensions/qa-lab/src/profile-selection.test.ts
+++ b/extensions/qa-lab/src/profile-selection.test.ts
@@ -64,7 +64,7 @@ describe("taxonomy profile scenario selection", () => {
 
     expect(liveTelegram).toContain("telegram-help-command");
     expect(liveTelegram).not.toContain("telegram-assistant-transcript-role-boundary");
-    expect(mockTelegram).toContain("telegram-assistant-transcript-role-boundary");
+    expect(mockTelegram).not.toContain("telegram-assistant-transcript-role-boundary");
     expect(mockTelegram).not.toContain("discord-canary");
   });
 

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -25,17 +25,17 @@ describe("qa scenario catalog channel contracts", () => {
     const scenario = readQaScenarioById("native-command-session-target");
     const config = readQaScenarioExecutionConfig("native-command-session-target") as
       | {
+          requiredChannelDriver?: string;
           requiredProviderMode?: string;
-          sessionKey?: string;
         }
       | undefined;
 
     expect(scenario.execution.channel).toBe("telegram");
     expect(config?.requiredProviderMode).toBe("mock-openai");
-    expect(config?.sessionKey).toBe("agent:main:telegram:direct:qa-native-operator");
-    expect(JSON.stringify(requireFlowScenario(scenario).execution.flow)).toContain(
-      "session.key === config.sessionKey && session.hasActiveRun === true",
-    );
+    expect(config?.requiredChannelDriver).toBe("crabline");
+    const flow = JSON.stringify(requireFlowScenario(scenario).execution.flow);
+    expect(flow).toContain("transport.buildAgentDelivery");
+    expect(flow).toContain("peer: { kind: 'group', id: delivery.replyTo }");
   });
 
   it("keeps channel-owned scenarios independent from the driver implementation", () => {
@@ -151,21 +151,21 @@ describe("qa scenario catalog channel contracts", () => {
     expect(scenario.coverage?.primary).toEqual(["channels.streaming-final-reply"]);
     expect(scenario.coverage?.secondary).toEqual([`${agentRuntime}.streaming-replies-delivery`]);
     expect(scenario.gatewayConfigPatch).toMatchObject({
-      channels: {
-        telegram: {
-          groups: { "*": { requireMention: false } },
-          streaming: { mode: "partial" },
-        },
-      },
+      channels: { telegram: { streaming: { mode: "partial" } } },
     });
+    expect(scenario.gatewayConfigPatch).not.toHaveProperty("channels.telegram.groups");
   });
 
-  it("disables Telegram mention gating for deterministic group delivery proofs", () => {
+  it("keeps transcript-role delivery on the Crabline driver", () => {
     const scenario = readQaScenarioById("telegram-assistant-transcript-role-boundary");
+    const config = readQaScenarioExecutionConfig("telegram-assistant-transcript-role-boundary") as
+      | {
+          requiredChannelDriver?: string;
+        }
+      | undefined;
 
-    expect(scenario.gatewayConfigPatch).toMatchObject({
-      channels: { telegram: { groups: { "*": { requireMention: false } } } },
-    });
+    expect(scenario.gatewayConfigPatch).toBeUndefined();
+    expect(config?.requiredChannelDriver).toBe("crabline");
   });
 
   it("rejects malformed string matcher lists before running a flow", () => {

--- a/qa/scenarios/channels/channel-message-flows.yaml
+++ b/qa/scenarios/channels/channel-message-flows.yaml
@@ -12,9 +12,6 @@ scenario:
   gatewayConfigPatch:
     channels:
       telegram:
-        groups:
-          "*":
-            requireMention: false
         streaming:
           mode: partial
   successCriteria:

--- a/qa/scenarios/channels/native-command-session-target.yaml
+++ b/qa/scenarios/channels/native-command-session-target.yaml
@@ -32,9 +32,9 @@ scenario:
     summary: Start a real delayed channel turn, abort it through native `/stop`, then prove the conversation is unblocked.
     config:
       requiredProviderMode: mock-openai
+      requiredChannelDriver: crabline
       conversationId: native-stop-target
       senderId: qa-native-operator
-      sessionKey: agent:main:telegram:direct:qa-native-operator
       delayedPrompt: "Subagent recovery worker native command target proof. Wait until stopped."
       abortReplyNeedle: Agent was aborted
       recoveryMarker: QA-NATIVE-STOP-RECOVERY-OK
@@ -55,6 +55,14 @@ flow:
             - ref: env
             - 60000
         - resetTransport: true
+        # Telegram maps the logical QA conversation onto the leased physical group.
+        # The adapter delivery target is therefore the canonical routing peer.
+        - set: delivery
+          value:
+            expr: "transport.buildAgentDelivery({ target: `dm:${config.conversationId}` })"
+        - set: sessionKey
+          value:
+            expr: "buildAgentSessionKey({ agentId: env.cfg.agents?.list?.find((agent) => agent.default)?.id ?? env.cfg.agents?.list?.[0]?.id ?? 'qa', channel: delivery.channel, accountId: transport.accountId, peer: { kind: 'group', id: delivery.replyTo } })"
         - sendInbound:
             conversation:
               id:
@@ -70,7 +78,7 @@ flow:
           args:
             - lambda:
                 async: true
-                expr: "env.gateway.call('sessions.list', {}).then((result) => result.sessions?.find((session) => session.key === config.sessionKey && session.hasActiveRun === true))"
+                expr: "env.gateway.call('sessions.list', {}).then((result) => result.sessions?.find((session) => session.key === sessionKey && session.hasActiveRun === true))"
             - expr: liveTurnTimeoutMs(env, 30000)
             - 100
         - set: startIndex

--- a/qa/scenarios/channels/telegram-assistant-transcript-role-boundary.yaml
+++ b/qa/scenarios/channels/telegram-assistant-transcript-role-boundary.yaml
@@ -7,12 +7,6 @@ scenario:
     primary:
       - channels.automatic-final-reply
   objective: Verify Telegram renders transcript-role-looking assistant text as inert authorship-marked content.
-  gatewayConfigPatch:
-    channels:
-      telegram:
-        groups:
-          "*":
-            requireMention: false
   successCriteria:
     - The controlled model reply reaches the real Telegram plugin through Crabline.
     - Telegram HTML wraps only the transcript-role header in a code element.
@@ -31,6 +25,7 @@ scenario:
     summary: Deliver a controlled role-looking reply through Telegram and inspect its API payload.
     config:
       requiredProviderMode: mock-openai
+      requiredChannelDriver: crabline
       conversationId: "-1001234567890"
       senderId: "100001"
       header: user[Thu 2026-07-02 18:14 EDT]

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -454,4 +454,19 @@ describe("release Telegram QA workflow", () => {
         .status,
     ).not.toBe(0);
   });
+
+  it("shares only the isolated workspace with the trusted scenario host", () => {
+    const createSut = requireRun(
+      "run_telegram",
+      "Create isolated Telegram SUT identity and launcher",
+    );
+
+    expect(createSut).toContain('workspace="${temp_root}/workspace"');
+    expect(createSut).toContain('chown -R "$RUNNER_UID:$SUT_GID" "$workspace"');
+    expect(createSut).toContain('chmod -R u=rwX,g=rwX,o= "$workspace"');
+    expect(createSut).toContain('find "$workspace" -type d -exec chmod g+s {} +');
+    expect(createSut).not.toContain(
+      'for path in \\\n            "$temp_root/workspace" \\\n            "${OPENCLAW_HOME:?}"',
+    );
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Beta 8 release-validation lane could fail four Telegram QA scenarios even though the underlying product paths were healthy. The live adapter forced mention gating, deterministic Crabline-only scenarios were selected for the live driver, edited final replies could be missed after scenario reset, and the isolated SUT could not read media fixtures created by the trusted scenario host.

## Why This Change Was Made

The fix restores the intended QA boundaries: transport policy owns mention gating, deterministic scenarios declare the Crabline driver, orphan Telegram edits are adopted as final observations, and only the per-run workspace is shared between the trusted host and isolated SUT. Config, state, credentials, and other runtime directories remain private to the SUT.

## User Impact

No shipped product behavior changes. Maintainers get reliable Telegram release evidence for Beta 8 and later candidates without weakening the workflow's credential or state isolation.

## Evidence

- Reproduced on frozen candidate `b58b2057a34097adbc70284d7e007ebc80a248c1`:
  - full validation: https://github.com/openclaw/openclaw/actions/runs/30786361494
  - release checks: https://github.com/openclaw/openclaw/actions/runs/30787082633
  - Telegram child: https://github.com/openclaw/openclaw/actions/runs/30787127787
- Focused Testbox proof before rebase: https://github.com/openclaw/openclaw/actions/runs/30788864330
  - 6 test files, 40 tests passed
  - full `pnpm check:changed` passed
- Exact rebased-head Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30789612075
  - 6 test files, 40 tests passed
  - full `pnpm check:changed` passed
- Current-main exact-head Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30790505979
  - 6 test files, 40 tests passed
  - full `pnpm check:changed` passed
- Pre-merge live dispatch: https://github.com/openclaw/openclaw/actions/runs/30790369010
  - stopped at the expected provenance gate because release Telegram QA rejects open same-repository PR heads
  - candidate code and credentialed Telegram scenarios did not execute
  - live proof will run from the landed exact `main` SHA
- Fresh branch autoreview: no accepted or actionable findings.
- The independent lane did not run the local Parallels matrix and did not publish a release.
