### PR TITLE
test: avoid plugin scans in doctor preflight tests

### DIFF
--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -1,6 +1,7 @@
 // Doctor config preflight tests cover state migration preflight behavior before config repair.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigSnapshotReadMeasure } from "../config/io.js";
+import type { LegacyConfigIssue } from "../config/types.js";
 import {
   listActiveDegradedPlugins,
   setActiveDegradedPlugins,
@@ -153,6 +154,7 @@ const readConfigFileSnapshot = vi.hoisted(() =>
     issues: [] as Array<{ path: string; message: string }>,
   })),
 );
+const findDoctorLegacyConfigIssues = vi.hoisted(() => vi.fn((): LegacyConfigIssue[] => []));
 const note = vi.hoisted(() => vi.fn());
 
 vi.mock("./doctor-state-migrations.js", () => ({
@@ -196,6 +198,10 @@ vi.mock("../config/io.js", () => ({
   recoverConfigFromLastKnownGood: vi.fn(),
 }));
 
+vi.mock("./doctor/shared/legacy-config-issues.js", () => ({
+  findDoctorLegacyConfigIssues,
+}));
+
 vi.mock("../../packages/terminal-core/src/note.js", () => ({ note }));
 
 const { runDoctorConfigPreflight } = await import("./doctor-config-preflight.js");
@@ -203,6 +209,8 @@ const { runDoctorConfigPreflight } = await import("./doctor-config-preflight.js"
 describe("runDoctorConfigPreflight state migration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    findDoctorLegacyConfigIssues.mockReset();
+    findDoctorLegacyConfigIssues.mockReturnValue([]);
     setActiveDegradedPlugins([]);
     needsStartupMigrationCheckpoint.mockReturnValue(false);
     runPostCorePluginConvergence.mockResolvedValue(makeStartupConvergenceResult());
@@ -1046,6 +1054,9 @@ describe("runDoctorConfigPreflight state migration", () => {
   });
 
   it("runs config-independent state migration for invalid config", async () => {
+    findDoctorLegacyConfigIssues.mockReturnValueOnce([
+      { path: "cron.store", message: "cron.store is legacy." },
+    ]);
     readConfigFileSnapshot.mockResolvedValueOnce({
       exists: true,
       valid: false,


### PR DESCRIPTION
## Summary

- keep the Doctor state-migration suite focused on preflight orchestration by fixtureing legacy-issue discovery
- preserve the ownerless plugin-verification regression and all 29 assertions
- seed the one invalid-config case that intentionally depends on a `cron.store` legacy issue

The previous fixture's `plugins.entries.discord` triggered a real bundled registry scan and source transformation of Discord's Doctor contract before reaching the mocked convergence result. Real legacy-rule discovery remains covered by the dedicated preflight, channel legacy-config, and Doctor-contract registry suites.

## Performance

Exact CI evidence: [run 30789242864](https://github.com/openclaw/openclaw/actions/runs/30789242864), `checks-node-compact-small-8`.

- CI hotspot: `doctor-config-preflight.state-migration.test.ts` 38.315s; ownerless case 38.266s
- same AWS lease baseline median: 66.47s
- same AWS lease after median: 1.66s
- reduction: 64.81s / 97.5% on the paired benchmark

No shard, config, worker, or concurrency changes.

## Proof

- focused state-migration suite: 29/29 passed
- real preflight + payload/convergence + channel/plugin legacy registry siblings: 102/102 passed
- remote `check-changed`: formatting, core-test types, lint, boundaries, dead-code, and guards passed
- autoreview clean, no accepted/actionable findings

Production LOC delta: 0.
