### PR TITLE
chore: speed up CLI test fixtures

### DIFF
--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -3,10 +3,30 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import JSON5 from "json5";
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { runConfigSet } from "./config-cli.js";
+
+// Config mutation owns these assertions; plugin discovery suites own registry breadth.
+// Keep the two real schemas this suite exercises, but build their metadata only once.
+vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>();
+  let snapshot: ReturnType<typeof actual.loadPluginMetadataSnapshot> | undefined;
+  return {
+    ...actual,
+    resolvePluginMetadataSnapshot: (
+      params: Parameters<typeof actual.resolvePluginMetadataSnapshot>[0],
+    ) => {
+      snapshot ??= actual.loadPluginMetadataSnapshot({
+        ...params,
+        pluginIds: ["discord", "openclaw-mem0"],
+        pluginIdScope: undefined,
+      });
+      return snapshot;
+    },
+  };
+});
 
 function createTestRuntime() {
   const logs: string[] = [];
@@ -113,30 +133,6 @@ async function withExecDryRunConfigHarness(
 }
 
 describe("config cli integration", () => {
-  beforeAll(async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-cli-warmup-"));
-    const configPath = path.join(tempDir, "openclaw.json");
-    const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH", "OPENCLAW_TEST_FAST"]);
-    try {
-      fs.writeFileSync(configPath, `${JSON.stringify({ gateway: { port: 18789 } }, null, 2)}\n`);
-      setTestEnvValue("OPENCLAW_TEST_FAST", "1");
-      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-      clearConfigCache();
-      clearRuntimeConfigSnapshot();
-      await runConfigSet({
-        path: "gateway.port",
-        value: "18790",
-        cliOptions: {},
-        runtime: createTestRuntime().runtime,
-      });
-    } finally {
-      envSnapshot.restore();
-      clearConfigCache();
-      clearRuntimeConfigSnapshot();
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
   it("accepts plugin hook conversation-access policy via config set", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-cli-plugin-hooks-"));
     const configPath = path.join(tempDir, "openclaw.json");

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as mcpRuntime from "../agents/agent-bundle-mcp-runtime.js";
 import * as mcpHttpFetch from "../agents/mcp-http-fetch.js";
 import { withTempHome } from "../config/home-env.test-harness.js";
 import { createDeferred } from "../shared/deferred.js";
@@ -336,42 +337,53 @@ describe("mcp cli", () => {
     },
   );
 
-  it(
-    "bounds initialize with a five-second probe timeout when no flag is supplied",
-    { timeout: 8_000 },
-    async () => {
-      await withTempHome("openclaw-cli-mcp-home-", async (home) => {
-        const workspaceDir = await createWorkspace();
-        const serverPath = path.join(workspaceDir, "probe-server.mjs");
-        const configPath = path.join(home, ".openclaw", "openclaw.json");
-        await writeProbeMcpServer(serverPath);
-        vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
-
-        const startedAt = performance.now();
-        await expect(
-          runMcpCommand([
-            "mcp",
-            "add",
-            "hung-default",
-            "--command",
-            process.execPath,
-            "--arg",
-            serverPath,
-            "--env",
-            "MCP_MODE=hang-start",
-          ]),
-        ).rejects.toThrow("__exit__:1");
-        const elapsedMs = performance.now() - startedAt;
-
-        expect(elapsedMs).toBeGreaterThanOrEqual(4_500);
-        expect(elapsedMs).toBeLessThan(6_500);
-        expect(lastErrorLine()).toContain(
-          'MCP server "hung-default" timed out: did not complete initialize within 5s',
-        );
-        await expect(fs.readFile(configPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  it("passes a five-second default initialize timeout to the probe runtime", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async (home) => {
+      const workspaceDir = await createWorkspace();
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      let probeTimeoutMs: unknown;
+      vi.spyOn(mcpRuntime, "createSessionMcpRuntime").mockImplementation((params) => {
+        probeTimeoutMs = params.cfg?.mcp?.servers?.["hung-default"]?.connectionTimeoutMs;
+        return {
+          sessionId: params.sessionId,
+          workspaceDir: params.workspaceDir,
+          configFingerprint: "cli-probe-test",
+          createdAt: 0,
+          lastUsedAt: 0,
+          getCatalog: async () => ({
+            version: 1,
+            generatedAt: Date.now(),
+            servers: {},
+            tools: [],
+            diagnostics: [
+              {
+                serverName: "hung-default",
+                safeServerName: "hung-default",
+                launchSummary: process.execPath,
+                message:
+                  'MCP server "hung-default" timed out: did not complete initialize within 5s',
+              },
+            ],
+          }),
+          peekCatalog: () => null,
+          markUsed: () => {},
+          callTool: async () => ({ content: [] }),
+          dispose: async () => {},
+        };
       });
-    },
-  );
+
+      await expect(
+        runMcpCommand(["mcp", "add", "hung-default", "--command", process.execPath]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(probeTimeoutMs).toBe(5_000);
+      expect(lastErrorLine()).toContain(
+        'MCP server "hung-default" timed out: did not complete initialize within 5s',
+      );
+      await expect(fs.readFile(configPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
 
   it("labels listed MCP servers as OpenClaw-managed", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -4,11 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as mcpRuntime from "../agents/agent-bundle-mcp-runtime.js";
 import * as mcpHttpFetch from "../agents/mcp-http-fetch.js";
 import { withTempHome } from "../config/home-env.test-harness.js";
 import { createDeferred } from "../shared/deferred.js";
 import { registerMcpCli } from "./mcp-cli.js";
+
+type CreateSessionMcpRuntime =
+  typeof import("../agents/agent-bundle-mcp-runtime.js").createSessionMcpRuntime;
 
 const mocks = vi.hoisted(() => {
   const runtime = {
@@ -27,6 +29,7 @@ const mocks = vi.hoisted(() => {
     clearMcpOAuthCredentials: vi.fn(),
     readMcpOAuthCredentialsStatus: vi.fn(),
     runMcpOAuthLogin: vi.fn(),
+    createSessionMcpRuntimeOverride: undefined as CreateSessionMcpRuntime | undefined,
   };
 });
 
@@ -51,6 +54,15 @@ vi.mock("../agents/mcp-oauth.js", () => ({
   readMcpOAuthCredentialsStatus: mocks.readMcpOAuthCredentialsStatus,
   runMcpOAuthLogin: mocks.runMcpOAuthLogin,
 }));
+
+vi.mock("../agents/agent-bundle-mcp-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/agent-bundle-mcp-runtime.js")>();
+  return {
+    ...actual,
+    createSessionMcpRuntime: (params: Parameters<CreateSessionMcpRuntime>[0]) =>
+      mocks.createSessionMcpRuntimeOverride?.(params) ?? actual.createSessionMcpRuntime(params),
+  };
+});
 
 const tempDirs: string[] = [];
 
@@ -146,6 +158,7 @@ describe("mcp cli", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.createSessionMcpRuntimeOverride = undefined;
     readMcpOAuthCredentialsStatus.mockResolvedValue({
       hasTokens: false,
       requiresAuthorization: false,
@@ -343,7 +356,7 @@ describe("mcp cli", () => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");
       vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
       let probeTimeoutMs: unknown;
-      vi.spyOn(mcpRuntime, "createSessionMcpRuntime").mockImplementation((params) => {
+      mocks.createSessionMcpRuntimeOverride = (params) => {
         probeTimeoutMs = params.cfg?.mcp?.servers?.["hung-default"]?.connectionTimeoutMs;
         return {
           sessionId: params.sessionId,
@@ -371,7 +384,7 @@ describe("mcp cli", () => {
           callTool: async () => ({ content: [] }),
           dispose: async () => {},
         };
-      });
+      };
 
       await expect(
         runMcpCommand(["mcp", "add", "hung-default", "--command", process.execPath]),


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's CLI test shard spends substantial time rebuilding the full plugin metadata graph for config mutation tests and waiting five real seconds to assert the MCP probe default.

## Why This Change Was Made

The config integration fixture now loads the two real plugin schemas it exercises once, while keeping all five real-file, schema, SecretRef, and exec-provider cases. The MCP suite now asserts the five-second default at the runtime boundary; its separate real hung-child case still proves cancellation, cleanup, error reporting, and that failed probes are not saved.

This is test-only. It does not change production behavior, sharding, concurrency, or test counts.

## User Impact

No user-visible behavior changes. Maintainers get a meaningfully faster CLI test shard without losing the process and persistence coverage that guards shipped behavior.

## Evidence

- Config integration: 29.83s before, 4.86s after locally; 5/5 tests retained and passing.
- MCP CLI: 17.38s before, 12.63s after locally; 30/30 tests retained and passing.
- Combined focused proof: 35/35 passing after rebase onto current main.
- Formatter, targeted oxlint, and git diff checks pass.
- Structured Codex autoreview: clean, no accepted or actionable findings.
- The hosted changed gate was unavailable: Blacksmith doctor failed, and the trusted AWS fallback hydration failed because its postinstall could not resolve TypeScript. Direct core-test typecheck reports only two existing errors outside this diff; neither changed file reports an error.
