### PR TITLE
test(agents): reuse worktree state database fixture

### DIFF
--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -7,10 +7,13 @@ import { promisify } from "node:util";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
+  deleteRegistryWorktree,
+  finalizeWorktreeRemovalRows,
   getRegistryWorktree,
   getRegistryWorktreeProvisionedChunk,
   getRegistryWorktreeProvisionedPaths,
   getRegistryWorktreeProvisionedState,
+  listRegistryWorktrees,
 } from "./registry.js";
 import {
   IDLE_GC_MS,
@@ -70,6 +73,7 @@ describe("ManagedWorktreeService", () => {
   let templateRoot: string;
   let templateRepo: string;
   let gitTemplate: string;
+  let stateDir: string;
   let root: string;
   let repo: string;
   let env: NodeJS.ProcessEnv;
@@ -80,6 +84,7 @@ describe("ManagedWorktreeService", () => {
     const tempRoot = await fs.realpath(os.tmpdir());
     templateRoot = await fs.mkdtemp(path.join(tempRoot, "openclaw-managed-worktrees-template-"));
     gitTemplate = path.join(templateRoot, "git-template");
+    stateDir = path.join(templateRoot, "state");
     // Keep the hooks directory expected by hook-safety coverage without copying
     // the host's sample hooks into every per-test repository.
     await fs.mkdir(path.join(gitTemplate, "hooks"), { recursive: true });
@@ -87,6 +92,7 @@ describe("ManagedWorktreeService", () => {
   });
 
   afterAll(async () => {
+    closeOpenClawStateDatabaseForTest();
     await fs.rm(templateRoot, { recursive: true, force: true });
   });
 
@@ -99,13 +105,17 @@ describe("ManagedWorktreeService", () => {
       recursive: true,
     });
     repo = await fs.realpath(repo);
-    env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "openclaw-state") };
+    env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     now = 1_700_000_000_000;
     service = new ManagedWorktreeService({ env, now: () => now });
   });
 
   afterEach(async () => {
-    closeOpenClawStateDatabaseForTest();
+    for (const record of listRegistryWorktrees(env)) {
+      finalizeWorktreeRemovalRows(env, record.id);
+      deleteRegistryWorktree(env, record.id);
+    }
+    await fs.rm(path.join(stateDir, "worktrees"), { recursive: true, force: true });
     await fs.rm(root, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary

- reuse one suite-scoped OpenClaw state database for the managed-worktree service tests
- retain a fresh reflinked Git repository and filesystem root for every case
- explicitly clear worktree registry rows, run leases, provisioned chunks, and the managed worktree directory after each case

## Root cause

Production keeps the shared state database open for the process lifetime, but this suite created a new `OPENCLAW_STATE_DIR` and physically reopened the full state database for nearly every one of its 48 cases. Each cold open repeated database validation, pragmas, and schema setup before the test could exercise the worktree behavior it owned.

The Git fixture was already suite-templated and reflinked. Reusing the process-owned SQLite fixture is therefore the owner-aligned simplification: Git repositories remain isolated per case, while shared state now follows the production lifecycle.

## Coverage and isolation

- all 48 managed-worktree service tests remain unchanged
- each case still receives a distinct source repository, worktree common directory, remotes, branches, and filesystem root
- teardown clears every worktree record and its lease/provisioned rows, then removes the shared managed-worktree directory
- the state database closes once before suite teardown removes the shared state directory

## Performance

Paired focused runs on the same ready dependency install at base `4b3d0b37be5eb07608b315ecb35453d0df39ec0c`:

- before: 28.36s Vitest / 31.01s wrapper, 48 passed
- after: 18.00s Vitest / 21.27s wrapper, 48 passed
- improvement: 36.5% (10.36s Vitest)

In the profiled compact-large-7 environment, this file was the agents-support critical tail at 92.43s. The focused reduction clears the lane's updated 10s execution target without changing sharding or concurrency.

## Proof

- managed-worktree service: 48/48
- service plus provisioned, run-lease, naming, and removal siblings: 77 passed, 1 skipped
- targeted formatting, Oxlint, and `git diff --check`: clean
- autoreview against current `origin/main`: clean

Core test typechecking reaches two pre-existing errors outside this change in `packages/terminal-core/src/ansi.ts` and `ui/src/app-session-route-paths.ts`; it reports no changed-file errors.
