### PR TITLE
test(state): reuse canonical database template

### DIFF
--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { pathToFileURL } from "node:url";
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { buildApprovalResolutionRef } from "../infra/approval-resolution-ref.js";
 import {
@@ -52,6 +52,7 @@ type StateDbTestDatabase = Pick<
 >;
 
 const stateDbTempDirs: string[] = [];
+let canonicalStateDatabaseTemplatePath: string | undefined;
 
 function createTempStateDir(): string {
   return makeTempDir(stateDbTempDirs, "openclaw-state-db-");
@@ -418,9 +419,13 @@ function createLegacyAuditStateDatabase(stateDir: string): string {
 }
 
 function createCanonicalAuditStateDatabase(stateDir: string): string {
-  const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
-  const databasePath = database.path;
-  closeOpenClawStateDatabaseForTest();
+  if (!canonicalStateDatabaseTemplatePath) {
+    throw new Error("canonical state database template was not initialized");
+  }
+  // These cases own post-initialization schema drift; fresh creation and migrations stay real below.
+  const databasePath = resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: stateDir });
+  fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+  fs.copyFileSync(canonicalStateDatabaseTemplatePath, databasePath);
   return databasePath;
 }
 
@@ -1027,6 +1032,14 @@ function runConcurrentSchemaProbe(params: {
   }
   return JSON.parse(resultLine) as string[];
 }
+
+beforeAll(() => {
+  const stateDir = createTempStateDir();
+  canonicalStateDatabaseTemplatePath = openOpenClawStateDatabase({
+    env: { OPENCLAW_STATE_DIR: stateDir },
+  }).path;
+  closeOpenClawStateDatabaseForTest();
+});
 
 afterAll(() => {
   cleanupTempDirs(stateDbTempDirs);


### PR DESCRIPTION
## What Problem This Solves

Fourteen current-schema drift and read-only tests rebuilt the complete shared SQLite schema even though their assertions begin after canonical initialization.

## Why This Change Was Made

Create one canonical state database in beforeAll, close it cleanly, and copy it into each selected test state directory. Fresh initialization, every migration, WAL and hot-journal behavior, concurrent schema creation, integrity checks, and subprocess path ownership continue to use real independently created databases.

## User Impact

No user-visible behavior changes. All state-database assertions remain, while repeated fixture-only DDL work and memory use are reduced; production code is unchanged.

## Evidence

- Exact main CI run 30789242864, job 91609378936: openclaw-state-db.test.ts took 29.429s.
- Exact-head PR CI run 30792035994: the file fell to 28.187s, a 1.242s (4.2%) reduction on the warm compact large-8 runner.
- Same-head focused benchmark: Vitest duration 29.11s to 23.10s (20.6% faster); wall time 33.91s to 27.97s; peak RSS 2.381 GB to 2.102 GB.
- Full owner proof: 108 passed with one existing platform skip, including fresh creation, migrations, WAL, rollback-journal, concurrency, integrity, and subprocess cases.
- Sibling proof: 28/28 legacy-backfill, schema-migration-required, corruption-recovery, and permissions tests passed.
- Oxfmt, git diff --check, and Codex autoreview passed with no findings.
- Production LOC delta: 0.
