### PR TITLE
fix(gateway): send Content-Length on MCP App sandbox HEAD responses

### DIFF
--- a/src/gateway/mcp-app-sandbox-http.test.ts
+++ b/src/gateway/mcp-app-sandbox-http.test.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
 import { describe, expect, it } from "vitest";
 import { buildMcpAppSandboxPath } from "../agents/mcp-app-sandbox.js";
 import { createSandboxHostHttpServer } from "./mcp-app-sandbox-http.js";
@@ -10,6 +11,25 @@ function request(url: string, method: "GET" | "HEAD" | "POST" = "GET") {
   server.emit("request", { url, method } as IncomingMessage, res);
   server.removeAllListeners();
   return { res, end, setHeader };
+}
+
+async function withSandboxHost(run: (origin: string) => Promise<void>): Promise<void> {
+  const server = createSandboxHostHttpServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  try {
+    await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
 }
 
 describe("MCP App sandbox HTTP origin", () => {
@@ -80,4 +100,50 @@ describe("MCP App sandbox HTTP origin", () => {
       expect.stringContaining("connect-src https://xn--bcher-kva.example"),
     );
   });
+
+  it.each([
+    {
+      label: "sandbox HTML",
+      path: buildMcpAppSandboxPath(),
+      statusCode: 200,
+    },
+    {
+      label: "missing path",
+      path: "/missing",
+      statusCode: 404,
+    },
+    {
+      label: "malformed policy",
+      path: `${buildMcpAppSandboxPath()}?csp=not-json`,
+      statusCode: 400,
+    },
+  ])(
+    "keeps GET and HEAD representation metadata aligned for $label",
+    async ({ path, statusCode }) => {
+      await withSandboxHost(async (origin) => {
+        const get = await fetch(`${origin}${path}`);
+        const head = await fetch(`${origin}${path}`, { method: "HEAD" });
+        const getBody = await get.text();
+
+        expect(get.status).toBe(statusCode);
+        expect(head.status).toBe(statusCode);
+        expect(getBody).not.toBe("");
+        expect(await head.text()).toBe("");
+        expect(get.headers.get("content-length")).toBe(String(Buffer.byteLength(getBody)));
+        for (const header of [
+          "content-type",
+          "content-length",
+          "cache-control",
+          "content-security-policy",
+          "permissions-policy",
+          "cross-origin-resource-policy",
+          "origin-agent-cluster",
+          "referrer-policy",
+          "x-content-type-options",
+        ]) {
+          expect(head.headers.get(header), header).toBe(get.headers.get(header));
+        }
+      });
+    },
+  );
 });

--- a/src/gateway/mcp-app-sandbox-http.ts
+++ b/src/gateway/mcp-app-sandbox-http.ts
@@ -12,6 +12,7 @@ import {
   decodeSandboxHostCsp,
   SANDBOX_HOST_PATH,
 } from "../agents/sandbox-host.js";
+import { respondPlainText } from "./control-ui-http-utils.js";
 
 const MCP_APP_PERMISSIONS_POLICY = "camera=(), microphone=(), geolocation=(), clipboard-write=()";
 
@@ -20,13 +21,11 @@ function handleMcpAppSandboxHttpRequest(req: IncomingMessage, res: ServerRespons
   try {
     url = new URL(req.url ?? "/", "http://localhost");
   } catch {
-    res.statusCode = 400;
-    res.end("Bad Request");
+    respondPlainText(res, 400, "Bad Request");
     return;
   }
   if (url.pathname !== SANDBOX_HOST_PATH || (req.method !== "GET" && req.method !== "HEAD")) {
-    res.statusCode = 404;
-    res.end("Not Found");
+    respondPlainText(res, 404, "Not Found");
     return;
   }
 
@@ -34,9 +33,7 @@ function handleMcpAppSandboxHttpRequest(req: IncomingMessage, res: ServerRespons
   try {
     csp = decodeSandboxHostCsp(url.searchParams.get("csp"));
   } catch {
-    res.statusCode = 400;
-    res.setHeader("Content-Type", "text/plain; charset=utf-8");
-    res.end("invalid MCP App sandbox policy");
+    respondPlainText(res, 400, "invalid MCP App sandbox policy");
     return;
   }
 
@@ -49,7 +46,10 @@ function handleMcpAppSandboxHttpRequest(req: IncomingMessage, res: ServerRespons
   res.setHeader("Origin-Agent-Cluster", "?1");
   res.setHeader("Referrer-Policy", "no-referrer");
   res.setHeader("X-Content-Type-Options", "nosniff");
-  res.end(req.method === "HEAD" ? undefined : buildSandboxHostProxyHtml(csp));
+  const html = buildSandboxHostProxyHtml(csp);
+  // Keep GET and HEAD representation metadata aligned while suppressing the HEAD body.
+  res.setHeader("Content-Length", String(Buffer.byteLength(html)));
+  res.end(req.method === "HEAD" ? undefined : html);
 }
 
 /** Dedicated listener: this origin must never serve Control UI or authenticated Gateway data. */


### PR DESCRIPTION
## Summary

Preserve byte-accurate representation metadata for `GET` and `HEAD` responses from the dedicated MCP App sandbox origin.

The rewritten change:

- reuses the shared plain-text responder for deterministic 400 and 404 metadata;
- materializes the sandbox HTML once;
- sets its byte-accurate `Content-Length` for both methods;
- suppresses only the `HEAD` response body.

## What Problem This Solves

The sandbox handler accepted `HEAD`, but its successful response called `res.end()` without the HTML body. Node therefore had no bytes from which to derive `Content-Length`. The same problem existed on the route's plain-text 400 and 404 responses.

Current-main loopback reproduction:

| Response | GET `Content-Length` | HEAD `Content-Length` |
| --- | ---: | ---: |
| sandbox HTML (200) | 4469 | missing |
| missing path (404) | 9 | missing |
| malformed policy (400) | 30 | missing |

This is a metadata parity defect, not a claim that RFC 9110 universally requires `Content-Length` on every HEAD response. When supplied on HEAD, the value must match the corresponding GET representation size.

## Root Cause

The route relied on Node's implicit length calculation from `res.end(body)`. That calculation worked for GET, but the handler intentionally passed no body for HEAD. Error branches duplicated response construction and had the same omission.

Provenance: the route and HEAD branch originated in `f3971bbd56e` / #69039. The current PR author is @zenglingbiao.

## Why This Change Was Made

The route owns the representation, so it is the correct place to record its byte length. Reusing `respondPlainText()` also removes duplicate error-response policy and fixes 400/404 through the existing canonical helper.

Alternatives rejected:

- Set the header only in a HEAD branch: leaves GET and HEAD on separate metadata paths.
- Depend on Node to synthesize it: impossible when the handler supplies no HEAD body.
- Add range, compression, standalone, config, or protocol behavior: unrelated to this defect.

## User Impact

Clients probing the sandbox origin with HEAD receive the same representation metadata as GET while still receiving no body. GET response bytes and sandbox security headers remain unchanged.

## Evidence

- Current-main real loopback regression: all three cases above reproduced missing HEAD lengths.
- Focused Vitest: `src/gateway/mcp-app-sandbox-http.test.ts` passes 6/6; repeated local runs stayed green.
- Max-P1 autoreview: clean, no actionable findings, confidence 0.97.
- Local ClawSweeper on exact commit `613b01fbaac027d1f18b10ffd3d40857197e7305`: `nothing_found`, high confidence.
- Secretless direct AWS Crabbox on exact PR head: 6/6 passed, lease `cbx_843c23648b61`, run `run_1a97b1290420`.
- Production LOC: +8/-8 (net 0). Tests: +66/-0.

Punchcard-Session: coral-summit-orchard-93
