### PR TITLE
improve: speed up storage migration tests

### DIFF
--- a/src/infra/state-migrations.mcp-oauth.test.ts
+++ b/src/infra/state-migrations.mcp-oauth.test.ts
@@ -459,8 +459,24 @@ describe("legacy MCP OAuth Doctor migration", () => {
     const sourcePath = await writeLegacy({ stateDir });
     await fsp.writeFile(`${sourcePath}.lock`, "not a verifiable lock owner");
 
-    const result = await migrate(stateDir, env);
+    const retryDelays: number[] = [];
+    const setTimeoutActual = globalThis.setTimeout;
+    // fs-safe owns backoff timing; this migration test still exercises every failed acquisition.
+    const fastSetTimeout = (...params: Parameters<typeof setTimeout>) => {
+      const [callback, delay, ...args] = params;
+      retryDelays.push(Number(delay ?? 0));
+      return setTimeoutActual(callback, 0, ...args);
+    };
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(fastSetTimeout);
 
+    let result: Awaited<ReturnType<typeof migrate>>;
+    try {
+      result = await migrate(stateDir, env);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+
+    expect(retryDelays).toHaveLength(20);
     expect(result.changes).toEqual([]);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("Failed locking legacy MCP OAuth store");

--- a/src/infra/state-migrations.mcp-oauth.test.ts
+++ b/src/infra/state-migrations.mcp-oauth.test.ts
@@ -464,7 +464,7 @@ describe("legacy MCP OAuth Doctor migration", () => {
     // fs-safe owns backoff timing; this migration test still exercises every failed acquisition.
     const fastSetTimeout = (...params: Parameters<typeof setTimeout>) => {
       const [callback, delay, ...args] = params;
-      retryDelays.push(Number(delay ?? 0));
+      retryDelays.push(delay ?? 0);
       return setTimeoutActual(callback, 0, ...args);
     };
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(fastSetTimeout);

--- a/src/infra/state-migrations.orphan-keys.test.ts
+++ b/src/infra/state-migrations.orphan-keys.test.ts
@@ -4,8 +4,10 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
-import { migrateOrphanedSessionKeys } from "./state-migrations.js";
-import { resolveSessionStoreOwnership } from "./state-migrations.session-store.js";
+import {
+  migrateOrphanedSessionKeys,
+  resolveSessionStoreOwnership,
+} from "./state-migrations.session-store.js";
 
 const listPluginDoctorSessionStoreAgentIdsMock = vi.hoisted(() => vi.fn((): string[] => []));
 
@@ -16,6 +18,17 @@ vi.mock("../plugins/doctor-contract-registry.js", async (importOriginal) => {
     listPluginDoctorSessionStoreAgentIds: listPluginDoctorSessionStoreAgentIdsMock,
   };
 });
+
+vi.mock(
+  "../channels/plugins/bundled.js",
+  () =>
+    ({
+      listBundledChannelLegacySessionSurfaces: () => [],
+    }) satisfies Pick<
+      typeof import("../channels/plugins/bundled.js"),
+      "listBundledChannelLegacySessionSurfaces"
+    >,
+);
 
 function writeStore(storePath: string, store: Record<string, unknown>): void {
   fs.mkdirSync(path.dirname(storePath), { recursive: true });


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's storage migration test shard spends several seconds on a real lock retry schedule and loads bundled channel setup metadata in generic orphan-key tests. Those costs make CI slower without exercising the contracts those tests own.

## Why This Change Was Made

The ambiguous MCP OAuth lock case still performs and asserts all 20 failed acquisition attempts, but runs the dependency-owned delays at zero milliseconds. The orphan-key suite now imports its session-store owner directly and supplies an empty typed legacy-channel surface; real channel migration wiring remains covered by its owner suites.

## User Impact

There is no user-visible runtime change. Maintainers get faster storage migration test feedback with the same test and assertion coverage.

## Evidence

- Paired three-run median, same host and commit: Vitest 17.14s -> 6.21s (63.8% faster); wall 19.84s -> 9.78s (50.7% faster); max RSS 745 MB -> 308 MB (58.7% lower).
- Changed suites: 60/60 tests passed before and after.
- Owner/sibling proof: 203/203 tests passed across the lock policy, broad state migration, Doctor migration, WhatsApp setup, and bundled-channel shape suites.
- Formatting, targeted oxlint, git diff checks, and autoreview are clean.
- The local changed gate passed its guards and dead-code scan; core-test typecheck was blocked by unrelated current-main build-state errors in terminal-core and the generated session URL contract. Full PR CI is the authoritative typecheck proof.
