### PR TITLE
test(node-host): isolate linux plugin discovery

### DIFF
--- a/src/node-host/linux-node-plugin.integration.test.ts
+++ b/src/node-host/linux-node-plugin.integration.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -25,10 +26,31 @@ function resetPluginState(): void {
   resetNodeHostPluginRegistry();
 }
 
+const tempBundledRoots: string[] = [];
+
+function createLinuxNodeBundledRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-linux-node-plugin-"));
+  try {
+    fs.symlinkSync(
+      path.resolve("extensions/linux-node"),
+      path.join(root, "linux-node"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+  } catch (error) {
+    fs.rmSync(root, { force: true, recursive: true });
+    throw error;
+  }
+  tempBundledRoots.push(root);
+  return root;
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
   resetPluginState();
+  for (const root of tempBundledRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
 });
 
 describe("linux-node node-host integration", () => {
@@ -38,6 +60,7 @@ describe("linux-node node-host integration", () => {
     if (!platformDescriptor) {
       throw new Error("process.platform descriptor unavailable");
     }
+    const bundledRoot = createLinuxNodeBundledRoot();
     Object.defineProperty(process, "platform", { ...platformDescriptor, value: "linux" });
 
     const fakeBinDir = path.resolve(".artifacts", "linux-node-test-bin");
@@ -49,7 +72,7 @@ describe("linux-node node-host integration", () => {
       return originalAccessSync(candidate, mode);
     });
     vi.stubEnv("PATH", `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`);
-    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", path.resolve("extensions"));
+    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", bundledRoot);
     vi.stubEnv("OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR", "1");
     vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", undefined);
 


### PR DESCRIPTION
## What Problem This Solves

The Linux node-host integration scanned every bundled plugin under extensions even though it enables and asserts only the real linux-node plugin.

## Why This Change Was Made

Create a temporary bundled root containing one symlink/junction to the real extensions/linux-node package, then point the existing trusted test override at that root. Plugin discovery, manifest loading, runtime registration, command/capability filtering, node-host manifest generation, and gateway pairing reconciliation remain real; unrelated plugin inventory is excluded.

## User Impact

No user-visible behavior changes. The full integration assertion runs faster and with less memory while retaining the real bundled plugin source and production loader; production code is unchanged.

## Evidence

- Exact main CI run 30789242864, job 91609378936: linux-node-plugin.integration.test.ts took 11.849s.
- Exact-head PR CI run 30792784876: the file fell to 2.938s, an 8.911s (75.2%) reduction on the real compact large-8 runner.
- Same-head focused benchmark: Vitest duration 12.93s to 8.51s; wall time 17.77s to 13.33s; peak RSS 1.227 GB to 0.973 GB.
- Focused integration proof: 1/1 passed through real discovery, registration, node-host preparation, and gateway reconciliation.
- Sibling proof: 29/29 node-host and linux-node plugin owner tests passed.
- Oxfmt, git diff --check, and Codex autoreview passed with no findings.
- Production LOC delta: 0.
