### PR TITLE
refactor(ui): deduplicate config array test fixtures

### DIFF
--- a/ui/src/components/config-form-array-integrity.browser.test.ts
+++ b/ui/src/components/config-form-array-integrity.browser.test.ts
@@ -14,182 +14,119 @@ function expectElement<T extends Element>(element: T | null | undefined, label: 
   return element;
 }
 
+type RenderArrayFixtureOptions = Omit<
+  Parameters<typeof renderArray>[0],
+  "disabled" | "hints" | "unsupported"
+>;
+
+function renderArrayFixture(container: HTMLElement, options: RenderArrayFixtureOptions): void {
+  render(
+    renderArray({ hints: {}, unsupported: new Set(), disabled: false, ...options }, renderNode),
+    container,
+  );
+}
+
+function findAddButton(container: Element): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
+    (button) => button.textContent?.trim() === "Add",
+  );
+}
+
 describe("config form array integrity", () => {
   it("applies safe whole-array composition candidates atomically", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            items: { type: "string" },
-            allOf: [{ const: ["a", "b"] }],
-          },
-          value: undefined,
-          path: ["values"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          isRequired: true,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
-    expectElement(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "whole-array composition add",
-    ).click();
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        items: { type: "string" },
+        allOf: [{ const: ["a", "b"] }],
+      },
+      value: undefined,
+      path: ["values"],
+      isRequired: true,
+      onPatch,
+    });
+    expectElement(findAddButton(container), "whole-array composition add").click();
     expect(onPatch).toHaveBeenCalledWith(["values"], ["a", "b"]);
 
     onPatch.mockClear();
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            items: { type: "string" },
-            enum: [[], ["a", "b"]],
-          },
-          value: [],
-          path: ["values"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          isRequired: true,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
-    expectElement(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "valid constrained array extension",
-    ).click();
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        items: { type: "string" },
+        enum: [[], ["a", "b"]],
+      },
+      value: [],
+      path: ["values"],
+      isRequired: true,
+      onPatch,
+    });
+    expectElement(findAddButton(container), "valid constrained array extension").click();
     expect(onPatch).toHaveBeenCalledWith(["values"], ["a", "b"]);
 
     onPatch.mockClear();
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            items: { type: "string", default: "item" },
-            default: ["a", "b"],
-          },
-          value: [],
-          path: ["values"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          isRequired: true,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
-    expectElement(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "explicit empty array add",
-    ).click();
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        items: { type: "string", default: "item" },
+        default: ["a", "b"],
+      },
+      value: [],
+      path: ["values"],
+      isRequired: true,
+      onPatch,
+    });
+    expectElement(findAddButton(container), "explicit empty array add").click();
     expect(onPatch).toHaveBeenCalledWith(["values"], ["item"]);
 
     onPatch.mockClear();
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            items: { type: "string" },
-            const: ["a", "b"],
-          },
-          value: [],
-          path: ["values"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          isRequired: true,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
-    expectElement(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "explicit invalid constrained array add",
-    ).click();
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        items: { type: "string" },
+        const: ["a", "b"],
+      },
+      value: [],
+      path: ["values"],
+      isRequired: true,
+      onPatch,
+    });
+    expectElement(findAddButton(container), "explicit invalid constrained array add").click();
     expect(onPatch).toHaveBeenCalledWith(["values"], ["a", "b"]);
 
     onPatch.mockClear();
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            items: { type: "string" },
-            const: [],
-            maxItems: 0,
-          },
-          value: undefined,
-          path: ["values"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          isRequired: true,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
-    const emptyConstAdd = expectElement(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "empty const array add",
-    );
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        items: { type: "string" },
+        const: [],
+        maxItems: 0,
+      },
+      value: undefined,
+      path: ["values"],
+      isRequired: true,
+      onPatch,
+    });
+    const emptyConstAdd = expectElement(findAddButton(container), "empty const array add");
     expect(emptyConstAdd.disabled).toBe(false);
     emptyConstAdd.click();
     expect(onPatch).toHaveBeenCalledWith(["values"], []);
 
     onPatch.mockClear();
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            items: { type: "string" },
-            maxItems: 0,
-          },
-          value: undefined,
-          path: ["values"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          isRequired: true,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        items: { type: "string" },
+        maxItems: 0,
+      },
+      value: undefined,
+      path: ["values"],
+      isRequired: true,
+      onPatch,
+    });
     const requiredEmptyAdd = expectElement(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
+      findAddButton(container),
       "required empty-only array add",
     );
     expect(requiredEmptyAdd.disabled).toBe(false);
@@ -202,21 +139,12 @@ describe("config form array integrity", () => {
     const container = document.createElement("div");
     document.body.append(container);
     const renderSchema = (schema: JsonSchema) => {
-      render(
-        renderArray(
-          {
-            schema,
-            value: undefined,
-            path: ["codes"],
-            hints: {},
-            unsupported: new Set(),
-            disabled: false,
-            onPatch,
-          },
-          renderNode,
-        ),
-        container,
-      );
+      renderArrayFixture(container, {
+        schema,
+        value: undefined,
+        path: ["codes"],
+        onPatch,
+      });
     };
 
     renderSchema({
@@ -224,12 +152,7 @@ describe("config form array integrity", () => {
       minItems: 101,
       items: { type: "string" },
     });
-    const largeMinimumAdd = expectElement(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "large minimum array add",
-    );
+    const largeMinimumAdd = expectElement(findAddButton(container), "large minimum array add");
     expect(largeMinimumAdd.disabled).toBe(false);
     largeMinimumAdd.click();
     expect(onPatch).toHaveBeenCalledWith(["codes"], [""]);
@@ -246,12 +169,7 @@ describe("config form array integrity", () => {
       "unique array draft",
     );
     await draftHost.updateComplete;
-    expectElement(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "unique array add",
-    ).click();
+    expectElement(findAddButton(container), "unique array add").click();
     await draftHost.updateComplete;
     const draftValue = expectElement(
       draftHost.querySelector<HTMLInputElement>("[data-collection-draft-value]"),
@@ -260,46 +178,27 @@ describe("config form array integrity", () => {
     draftValue.value = "first";
     draftValue.dispatchEvent(new Event("input", { bubbles: true }));
     await draftHost.updateComplete;
-    expectElement(
-      Array.from(draftHost.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "unique array draft commit",
-    ).click();
+    expectElement(findAddButton(draftHost), "unique array draft commit").click();
     expect(onPatch).toHaveBeenCalledWith(["codes"], ["first"]);
 
     onPatch.mockClear();
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            minItems: 2,
-            uniqueItems: true,
-            items: { type: "string" },
-          },
-          value: ["first"],
-          path: ["codes"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        minItems: 2,
+        uniqueItems: true,
+        items: { type: "string" },
+      },
+      value: ["first"],
+      path: ["codes"],
+      onPatch,
+    });
     const duplicateDraft = expectElement(
       container.querySelector<ConfigFormCollectionDraft>("openclaw-config-form-collection-draft"),
       "duplicate array draft",
     );
     await duplicateDraft.updateComplete;
-    expectElement(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "duplicate array add",
-    ).click();
+    expectElement(findAddButton(container), "duplicate array add").click();
     await duplicateDraft.updateComplete;
     const duplicateValue = expectElement(
       duplicateDraft.querySelector<HTMLInputElement>("[data-collection-draft-value]"),
@@ -308,47 +207,28 @@ describe("config form array integrity", () => {
     duplicateValue.value = "first";
     duplicateValue.dispatchEvent(new Event("input", { bubbles: true }));
     await duplicateDraft.updateComplete;
-    expectElement(
-      Array.from(duplicateDraft.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "duplicate array draft commit",
-    ).click();
+    expectElement(findAddButton(duplicateDraft), "duplicate array draft commit").click();
     await duplicateDraft.updateComplete;
     expect(duplicateValue.getAttribute("aria-invalid")).toBe("true");
     expect(onPatch).not.toHaveBeenCalled();
 
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            minItems: 2,
-            items: { type: "string" },
-            allOf: [{ items: { type: "string", pattern: "^[0-9]+$" } }],
-          },
-          value: undefined,
-          path: ["codes"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        minItems: 2,
+        items: { type: "string" },
+        allOf: [{ items: { type: "string", pattern: "^[0-9]+$" } }],
+      },
+      value: undefined,
+      path: ["codes"],
+      onPatch,
+    });
     const composedDraft = expectElement(
       container.querySelector<ConfigFormCollectionDraft>("openclaw-config-form-collection-draft"),
       "composed item draft",
     );
     await composedDraft.updateComplete;
-    expectElement(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "composed item add",
-    ).click();
+    expectElement(findAddButton(container), "composed item add").click();
     await composedDraft.updateComplete;
     const composedValue = expectElement(
       composedDraft.querySelector<HTMLInputElement>("[data-collection-draft-value]"),
@@ -358,9 +238,7 @@ describe("config form array integrity", () => {
     composedValue.dispatchEvent(new Event("input", { bubbles: true }));
     await composedDraft.updateComplete;
     const composedCommit = expectElement(
-      Array.from(composedDraft.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
+      findAddButton(composedDraft),
       "composed item draft commit",
     );
     composedCommit.click();
@@ -379,25 +257,16 @@ describe("config form array integrity", () => {
   it("rejects existing array edits that violate uniqueItems", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            uniqueItems: true,
-            items: { type: "string" },
-          },
-          value: ["alpha", "beta"],
-          path: ["codes"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        uniqueItems: true,
+        items: { type: "string" },
+      },
+      value: ["alpha", "beta"],
+      path: ["codes"],
+      onPatch,
+    });
     const inputs = Array.from(container.querySelectorAll<HTMLInputElement>(".cfg-array input"));
     expect(inputs).toHaveLength(2);
     const second = expectElement(inputs[1], "second unique array item");
@@ -416,25 +285,16 @@ describe("config form array integrity", () => {
   it("restores boolean rows when uniqueItems rejects a toggle", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            uniqueItems: true,
-            items: { type: "boolean" },
-          },
-          value: [false, true],
-          path: ["flags"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        uniqueItems: true,
+        items: { type: "boolean" },
+      },
+      value: [false, true],
+      path: ["flags"],
+      onPatch,
+    });
     const switches = Array.from(
       container.querySelectorAll<HTMLElement & { checked: boolean }>("wa-switch.settings-toggle"),
     );
@@ -459,21 +319,12 @@ describe("config form array integrity", () => {
       items: { type: "string" },
     };
     const renderValue = (value: string[]) => {
-      render(
-        renderArray(
-          {
-            schema,
-            value,
-            path: ["codes"],
-            hints: {},
-            unsupported: new Set(),
-            disabled: false,
-            onPatch,
-          },
-          renderNode,
-        ),
-        container,
-      );
+      renderArrayFixture(container, {
+        schema,
+        value,
+        path: ["codes"],
+        onPatch,
+      });
     };
 
     renderValue(["alpha", "alpha", "beta", "beta"]);
@@ -505,25 +356,16 @@ describe("config form array integrity", () => {
   it("validates the resulting tuple before removing an item", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            items: [{ type: "string" }, { type: "number" }],
-            additionalItems: false,
-          },
-          value: ["identifier", 3],
-          path: ["tuple"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        items: [{ type: "string" }, { type: "number" }],
+        additionalItems: false,
+      },
+      value: ["identifier", 3],
+      path: ["tuple"],
+      onPatch,
+    });
 
     const removeButtons = Array.from(
       container.querySelectorAll<HTMLButtonElement>("button[aria-label='Remove item']"),
@@ -531,9 +373,7 @@ describe("config form array integrity", () => {
     expect(removeButtons).toHaveLength(2);
     expect(removeButtons[0]?.disabled).toBe(true);
     expect(removeButtons[1]?.disabled).toBe(false);
-    const addButton = Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-      (button) => button.textContent?.trim() === "Add",
-    );
+    const addButton = findAddButton(container);
     expect(addButton?.disabled).toBe(true);
     removeButtons[1]?.click();
     expect(onPatch).toHaveBeenCalledWith(["tuple"], ["identifier"]);
@@ -548,21 +388,12 @@ describe("config form array integrity", () => {
       items: { type: "string" },
     };
     const renderValue = (value: string[]) => {
-      render(
-        renderArray(
-          {
-            schema,
-            value,
-            path: ["codes"],
-            hints: {},
-            unsupported: new Set(),
-            disabled: false,
-            onPatch,
-          },
-          renderNode,
-        ),
-        container,
-      );
+      renderArrayFixture(container, {
+        schema,
+        value,
+        path: ["codes"],
+        onPatch,
+      });
     };
 
     renderValue(["one", "two", "three", "four"]);
@@ -586,27 +417,18 @@ describe("config form array integrity", () => {
   it("restores JSON rows when a collection constraint rejects the edit", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            uniqueItems: true,
-            items: {
-              anyOf: [{ type: "object" }, { type: "array" }],
-            },
-          },
-          value: [{ id: "first" }, { id: "second" }],
-          path: ["entries"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          onPatch,
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        uniqueItems: true,
+        items: {
+          anyOf: [{ type: "object" }, { type: "array" }],
         },
-        renderNode,
-      ),
-      container,
-    );
+      },
+      value: [{ id: "first" }, { id: "second" }],
+      path: ["entries"],
+      onPatch,
+    });
 
     const textareas = Array.from(container.querySelectorAll<HTMLTextAreaElement>("textarea"));
     expect(textareas).toHaveLength(2);
@@ -630,24 +452,15 @@ describe("config form array integrity", () => {
     };
     let currentValue: unknown[] = [{ id: "first" }, { id: "second" }];
     const renderValue = () => {
-      render(
-        renderArray(
-          {
-            schema,
-            value: currentValue,
-            path: ["entries"],
-            hints: {},
-            unsupported: new Set(),
-            disabled: false,
-            onPatch: (_path, nextValue) => {
-              currentValue = nextValue as unknown[];
-              renderValue();
-            },
-          },
-          renderNode,
-        ),
-        container,
-      );
+      renderArrayFixture(container, {
+        schema,
+        value: currentValue,
+        path: ["entries"],
+        onPatch: (_path, nextValue) => {
+          currentValue = nextValue as unknown[];
+          renderValue();
+        },
+      });
     };
 
     renderValue();
@@ -672,27 +485,18 @@ describe("config form array integrity", () => {
     const scalarContainer = document.createElement("div");
     let scalarValue: unknown[] = ["same", "same"];
     const renderScalarValue = () => {
-      render(
-        renderArray(
-          {
-            schema: {
-              type: "array",
-              items: { type: "string", minLength: 2 },
-            },
-            value: scalarValue,
-            path: ["values"],
-            hints: {},
-            unsupported: new Set(),
-            disabled: false,
-            onPatch: (_path, nextValue) => {
-              scalarValue = nextValue as unknown[];
-              renderScalarValue();
-            },
-          },
-          renderNode,
-        ),
-        scalarContainer,
-      );
+      renderArrayFixture(scalarContainer, {
+        schema: {
+          type: "array",
+          items: { type: "string", minLength: 2 },
+        },
+        value: scalarValue,
+        path: ["values"],
+        onPatch: (_path, nextValue) => {
+          scalarValue = nextValue as unknown[];
+          renderScalarValue();
+        },
+      });
     };
     renderScalarValue();
     const scalarInput = expectElement(
@@ -717,24 +521,15 @@ describe("config form array integrity", () => {
     const jsonContainer = document.createElement("div");
     let jsonValue: unknown[] = [true, true];
     const renderJsonValue = () => {
-      render(
-        renderArray(
-          {
-            schema: { type: "array", items: {} },
-            value: jsonValue,
-            path: ["values"],
-            hints: {},
-            unsupported: new Set(),
-            disabled: false,
-            onPatch: (_path, nextValue) => {
-              jsonValue = nextValue as unknown[];
-              renderJsonValue();
-            },
-          },
-          renderNode,
-        ),
-        jsonContainer,
-      );
+      renderArrayFixture(jsonContainer, {
+        schema: { type: "array", items: {} },
+        value: jsonValue,
+        path: ["values"],
+        onPatch: (_path, nextValue) => {
+          jsonValue = nextValue as unknown[];
+          renderJsonValue();
+        },
+      });
     };
     renderJsonValue();
     const jsonDraft = expectElement(
@@ -761,35 +556,21 @@ describe("config form array integrity", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");
     document.body.append(container);
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            uniqueItems: true,
-            items: { type: ["string", "null"] },
-          },
-          value: [""],
-          path: ["values"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        uniqueItems: true,
+        items: { type: ["string", "null"] },
+      },
+      value: [""],
+      path: ["values"],
+      onPatch,
+    });
     const draftHost = expectElement(
       container.querySelector<ConfigFormCollectionDraft>("openclaw-config-form-collection-draft"),
       "nullable scalar collection draft",
     );
-    expectElement(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "nullable scalar array add",
-    ).click();
+    expectElement(findAddButton(container), "nullable scalar array add").click();
     await draftHost.updateComplete;
     const nullToggle = expectElement(
       draftHost.querySelector<HTMLInputElement>("[data-collection-draft-null]"),
@@ -801,12 +582,7 @@ describe("config form array integrity", () => {
     expect(
       draftHost.querySelector<HTMLInputElement>("[data-collection-draft-value]")?.disabled,
     ).toBe(true);
-    expectElement(
-      Array.from(draftHost.querySelectorAll<HTMLButtonElement>("button")).find(
-        (button) => button.textContent?.trim() === "Add",
-      ),
-      "nullable scalar null commit",
-    ).click();
+    expectElement(findAddButton(draftHost), "nullable scalar null commit").click();
     expect(onPatch).toHaveBeenCalledWith(["values"], ["", null]);
     container.remove();
   });
@@ -814,28 +590,19 @@ describe("config form array integrity", () => {
   it("propagates rejected edits through nested constrained arrays", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            uniqueItems: true,
-            items: {
-              type: "array",
-              items: { type: "string" },
-            },
-          },
-          value: [["alpha"], ["beta"]],
-          path: ["groups"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          onPatch,
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        uniqueItems: true,
+        items: {
+          type: "array",
+          items: { type: "string" },
         },
-        renderNode,
-      ),
-      container,
-    );
+      },
+      value: [["alpha"], ["beta"]],
+      path: ["groups"],
+      onPatch,
+    });
 
     const inputs = Array.from(container.querySelectorAll<HTMLInputElement>("input"));
     expect(inputs).toHaveLength(2);
@@ -861,24 +628,15 @@ describe("config form array integrity", () => {
     };
     let currentValue: unknown[] = [{ name: "same" }, { name: "same" }];
     const renderValue = () => {
-      render(
-        renderArray(
-          {
-            schema,
-            value: currentValue,
-            path: ["entries"],
-            hints: {},
-            unsupported: new Set(),
-            disabled: false,
-            onPatch: (_path, nextValue) => {
-              currentValue = nextValue as unknown[];
-              renderValue();
-            },
-          },
-          renderNode,
-        ),
-        container,
-      );
+      renderArrayFixture(container, {
+        schema,
+        value: currentValue,
+        path: ["entries"],
+        onPatch: (_path, nextValue) => {
+          currentValue = nextValue as unknown[];
+          renderValue();
+        },
+      });
     };
 
     renderValue();
@@ -908,24 +666,15 @@ describe("config form array integrity", () => {
   it("renders open tuple tail items as unconstrained JSON values", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");
-    render(
-      renderArray(
-        {
-          schema: {
-            type: "array",
-            items: [{ type: "string" }],
-          },
-          value: ["head", { enabled: true }],
-          path: ["tuple"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        items: [{ type: "string" }],
+      },
+      value: ["head", { enabled: true }],
+      path: ["tuple"],
+      onPatch,
+    });
 
     const tail = expectElement(
       container.querySelector<HTMLTextAreaElement>("textarea"),
@@ -936,9 +685,7 @@ describe("config form array integrity", () => {
     tail.dispatchEvent(new Event("change", { bubbles: true }));
     expect(onPatch).toHaveBeenCalledWith(["tuple"], ["head", { enabled: false }]);
 
-    const addButton = Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
-      (button) => button.textContent?.trim() === "Add",
-    );
+    const addButton = findAddButton(container);
     expect(addButton?.disabled).toBe(false);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The config-form array integrity browser suite repeated the same low-level Lit render setup and Add-button lookup across 22 scenarios. That duplication made the coverage harder to scan and made fixture-default drift more likely during maintenance.

This is a maintainer-directed, test-only cleanup; it does not change shipped Control UI behavior.

## Why This Change Was Made

This change introduces two file-local helpers for the shared array-render fixture defaults and Add-button lookup. Each scenario keeps its schema, value, path, callbacks, interaction sequence, and assertions; no production, E2E, docs, or config surface changes.

## User Impact

No user-visible impact. Developers get a smaller, clearer browser test while retaining the same 14 integrity scenarios.

## Evidence

- Blacksmith Testbox focused browser proof: [run 30792490022](https://github.com/openclaw/openclaw/actions/runs/30792490022), 1 file and 14/14 tests passed.
- Reused Testbox changed gate passed formatting, guards, dead-code, Control UI i18n, core-test typecheck, and changed-file lint.
- AST before/after audit preserved 1 describe, 14 tests, 15 declarations, all 66 matcher calls in kind/order, 2 async tests, 15 containers, 22 render call-site option/target tuples, and 17 first-match Add searches.
- `git diff --check` passed.
- Codex autoreview with `gpt-5.6-sol` at `xhigh` returned no findings (`patch is correct`, confidence 0.99).

AI-assisted: yes. I understand the change and verified the preserved test contract above. A redacted agent transcript was intentionally omitted.
