### PR TITLE
fix(litellm): image edits fail when model traffic routes through a LiteLLM proxy

### DIFF
--- a/extensions/litellm/image-generation-provider.test.ts
+++ b/extensions/litellm/image-generation-provider.test.ts
@@ -31,6 +31,15 @@ function mockGeneratedPngResponse() {
   });
 }
 
+function mockEditedPngResponse() {
+  postMultipartRequestMock.mockResolvedValue({
+    response: jsonResponse({
+      data: [{ b64_json: Buffer.from("png-bytes").toString("base64") }],
+    }),
+    release: vi.fn(async () => {}),
+  });
+}
+
 function mockObjectArg(mock: unknown, index = -1): Record<string, unknown> {
   const calls = (mock as { mock?: { calls?: Array<Array<unknown>> } }).mock?.calls ?? [];
   const call = index < 0 ? calls.at(index) : calls[index];
@@ -147,8 +156,8 @@ describe("litellm image generation provider", () => {
     });
   });
 
-  it("routes to the edit endpoint when input images are provided", async () => {
-    mockGeneratedPngResponse();
+  it("routes to the edit endpoint as multipart when input images are provided", async () => {
+    mockEditedPngResponse();
 
     const provider = buildLitellmImageGenerationProvider();
     await provider.generateImage({
@@ -164,9 +173,40 @@ describe("litellm image generation provider", () => {
       ],
     });
 
-    expect(mockObjectArg(postJsonRequestMock).url).toBe("http://localhost:4000/images/edits");
-    const call = postJsonRequestMock.mock.calls[0]?.[0] as { body: { images: unknown[] } };
-    expect(call.body.images).toHaveLength(1);
+    // Edits must be multipart, never JSON: LiteLLM's /images/edits maps onto
+    // `aimage_edit(image=...)` and rejects a JSON body outright.
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
+    expect(mockObjectArg(postMultipartRequestMock).url).toBe("http://localhost:4000/images/edits");
+
+    const form = mockObjectArg(postMultipartRequestMock).body as FormData;
+    expect(form.get("model")).toBe("gpt-image-2");
+    expect(form.get("prompt")).toBe("refine the hero");
+    // A single reference uses the singular `image` part name.
+    expect(form.getAll("image")).toHaveLength(1);
+    expect(form.getAll("image[]")).toHaveLength(0);
+    expect(form.get("image")).toBeInstanceOf(Blob);
+  });
+
+  it("sends multiple reference images as repeated image[] parts", async () => {
+    mockEditedPngResponse();
+
+    const provider = buildLitellmImageGenerationProvider();
+    await provider.generateImage({
+      provider: "litellm",
+      model: "gpt-image-2",
+      prompt: "merge these",
+      cfg: {},
+      inputImages: [
+        { buffer: Buffer.from("first"), mimeType: "image/png" },
+        { buffer: Buffer.from("second"), mimeType: "image/jpeg" },
+      ],
+    });
+
+    const form = mockObjectArg(postMultipartRequestMock).body as FormData;
+    // Both names are accepted by OpenAI-compatible edit endpoints, but only one
+    // may be present per request — sending both is an error.
+    expect(form.getAll("image[]")).toHaveLength(2);
+    expect(form.getAll("image")).toHaveLength(0);
   });
 
   it("throws a clear error when the API key is missing", async () => {

--- a/extensions/litellm/image-generation-provider.ts
+++ b/extensions/litellm/image-generation-provider.ts
@@ -3,9 +3,8 @@ import { isIP } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   createOpenAiCompatibleImageGenerationProvider,
+  imageSourceUploadFileName,
   type ImageGenerationProvider,
-  type ImageGenerationSourceImage,
-  toImageDataUrl,
 } from "openclaw/plugin-sdk/image-generation";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { LITELLM_BASE_URL } from "./onboard.js";
@@ -39,10 +38,6 @@ function resolveLitellmProviderConfig(
 
 function resolveConfiguredLitellmBaseUrl(cfg: OpenClawConfig | undefined): string {
   return normalizeOptionalString(resolveLitellmProviderConfig(cfg)?.baseUrl) ?? LITELLM_BASE_URL;
-}
-
-function imageToDataUrl(image: ImageGenerationSourceImage): string {
-  return toImageDataUrl({ buffer: image.buffer, mimeType: image.mimeType });
 }
 
 // LiteLLM's default proxy is loopback. Auto-enable private-network access only
@@ -124,18 +119,28 @@ export function buildLitellmImageGenerationProvider(): ImageGenerationProvider {
         size: req.size ?? DEFAULT_SIZE,
       },
     }),
-    buildEditRequest: ({ req, inputImages, model, count }) => ({
-      kind: "json",
-      body: {
-        model,
-        prompt: req.prompt,
-        n: count,
-        size: req.size ?? DEFAULT_SIZE,
-        images: inputImages.map((image) => ({
-          image_url: imageToDataUrl(image),
-        })),
-      },
-    }),
+    // LiteLLM's /v1/images/edits is multipart (OpenAI's edits schema): the
+    // reference image must be an uploaded file part, not a JSON field — a JSON
+    // body fails before the request reaches the provider.
+    buildEditRequest: ({ req, inputImages, model, count }) => {
+      const form = new FormData();
+      form.set("model", model);
+      form.set("prompt", req.prompt);
+      form.set("n", String(count));
+      form.set("size", req.size ?? DEFAULT_SIZE);
+      // OpenAI-compatible edits take repeated `image[]` parts when more than one
+      // reference is supplied, and a single `image` part otherwise.
+      const partName = inputImages.length > 1 ? "image[]" : "image";
+      for (const [index, image] of inputImages.entries()) {
+        const mimeType = normalizeOptionalString(image.mimeType) ?? "image/png";
+        form.append(
+          partName,
+          new Blob([new Uint8Array(image.buffer)], { type: mimeType }),
+          imageSourceUploadFileName({ image, index }),
+        );
+      }
+      return { kind: "multipart", form };
+    },
     missingApiKeyError: "LiteLLM API key missing",
     failureLabels: {
       generate: "LiteLLM image generation failed",


### PR DESCRIPTION
Closes #118561

## What Problem This Solves

Fixes an issue where users running OpenClaw against a LiteLLM proxy would have **every image edit fail**, while plain text-to-image generation kept working. Any `image_generate` call carrying reference images — "edit this photo", "combine these two" — returned an error instead of an image.

Affected setups route model traffic through a LiteLLM proxy and use the bundled `litellm` image provider. That provider is often the *only* usable one there: the `google` provider ends up authenticating with the proxy's virtual key rather than a real Google key, and the `openai` image provider hardcodes its private-network decision in `shouldAllowPrivateImageEndpoint()` (localhost or `browser.ssrfPolicy` only), so it SSRF-blocks a private LiteLLM host and never consults `models.providers.openai.request.allowPrivateNetwork`. With the only working provider unable to edit, image editing is effectively unavailable on those deployments.

## Why This Change Was Made

`buildEditRequest` in the `litellm` image provider sent edits as a JSON body containing `images: [{ image_url }]`. LiteLLM's `POST /v1/images/edits` is a **multipart** endpoint following OpenAI's edits schema, where the reference image is an uploaded file part named `image` (or `image[]`) — so the request failed inside LiteLLM before it ever reached the upstream model.

The fix returns `{ kind: "multipart", form }`, which `createOpenAiCompatibleImageGenerationProvider` already routes to `postMultipartRequest` — the same shape the built-in `openai` and `deepinfra` providers already use. A single reference uses the `image` part name and multiple references use repeated `image[]` parts; LiteLLM accepts either as `List[UploadFile]` and merges them, erroring only when both appear in one request.

Scope is deliberately narrow: **only the edit path changes.** Plain generation still posts JSON and is untouched, no shared transport code is modified, and no other provider is affected. The now-unused `imageToDataUrl` helper and its imports are removed.

## User Impact

On LiteLLM-proxied deployments, image **editing** works: single-reference edits (e.g. restyling a supplied photo) and multi-image merges both return real images. Previously these always failed while generation succeeded, which made the failure look intermittent or model-related rather than transport-related.

No configuration change is required, and there is no behaviour change for anyone not using the `litellm` image provider.

## Evidence

### 1. Reproduced at the wire level, without OpenClaw

Every JSON variant fails against `ghcr.io/berriai/litellm:main-v1.82.3-stable`; only multipart succeeds. Tested with a real 512×512 PNG — a 1×1 PNG returns the same "invalid image" error as a genuinely undelivered payload and will mislead you.

| Request body | Result |
|---|---|
| `images: [{image_url: "data:image/png;base64,…"}]` *(current behaviour)* | **HTTP 500** `aimage_edit() missing 1 required positional argument: 'image'` |
| `image: "data:image/png;base64,…"` | HTTP 400 `Invalid image file or mode for image 1` |
| `image: ["data:image/png;base64,…"]` | HTTP 400 `Invalid image file or mode for image 1` |
| `image: ["<bare base64>"]` | HTTP 400 `Invalid image file or mode for image 1` |
| **multipart, file part named `image`** | **200 — image returned** |

```bash
# fails (current behaviour)
curl -X POST "$LITELLM/v1/images/edits" -H "Authorization: Bearer $KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"<model>","prompt":"x","n":1,"images":[{"image_url":"data:image/png;base64,..."}]}'

# succeeds
curl -X POST "$LITELLM/v1/images/edits" -H "Authorization: Bearer $KEY" \
  -F model=<model> -F prompt=x -F n=1 -F "image=@real.png;type=image/png"
```

Worth flagging for reviewers: switching the JSON field to singular `image` clears the 500 and reaches the provider, so the error *changes* and looks like progress — but the bytes still never arrive as a usable file. Only multipart actually works.

### 2. After-fix behaviour on a live deployment (redacted logs)

LiteLLM proxy access log, same endpoint, before and after this change:

```
# BEFORE — current main's JSON body, rejected inside LiteLLM
POST /v1/images/edits  ->  500   litellm.InternalServerError - aimage_edit()
                                 missing 1 required positional argument: 'image'

# BEFORE — singular `image` as a JSON field (the tempting "fix"), reaches the
# provider but the bytes never arrive as a usable file
POST /v1/images/edits  ->  400   Invalid image file or mode for image 1

# AFTER — this PR's multipart body
POST /v1/images/edits  ->  200 OK
```

The corresponding OpenClaw agent run, ten seconds later, completing successfully with the image returned to the user:

```
[agent] run image_generate:<run-id>:ok ended with stopReason=stop
```

versus the pre-fix failure it replaces:

```
image-generation candidate failed: litellm/<model>: LiteLLM image edit failed (HTTP 500)
[agent] run image_generate:<run-id>:error ended with stopReason=stop
```

Exercised on two deployments (one containerised, one running OpenClaw directly on the host), covering plain generation, single-reference edits, and multi-image merges. Generation succeeded throughout — only edits changed from failing to working, which matches the diagnosis that this is purely an edit-path transport problem.

### 3. Dependency contract — LiteLLM's accepted multipart field names

ClawSweeper flagged that it could not retrieve LiteLLM's source to confirm the multipart field
contract (DNS blocked in its sandbox), so here it is read directly from the running proxy —
`litellm==1.82.3`, image `ghcr.io/berriai/litellm:main-v1.82.3-stable`,
`litellm/proxy/image_endpoints/endpoints.py`:

```python
# POST /v1/images/edits
    image:       Optional[List[UploadFile]] = File(None),
    image_array: Optional[List[UploadFile]] = File(None, alias="image[]"),
    mask:        Optional[List[UploadFile]] = File(None),
    mask_array:  Optional[List[UploadFile]] = File(None, alias="mask[]"),
    ...
    if image is not None and image_array is not None:
        raise HTTPException(
            status_code=422, detail="Cannot specify both 'image' and 'image[]'"
```

Three things this settles:

1. Both `image` and `image[]` are accepted, each as `List[UploadFile]`, and are merged into the
   same list downstream — so either name works for any number of references.
2. The **only** field-name error is sending both in one request. This PR sends `image` for a
   single reference and `image[]` for multiple, never both, so it cannot hit that path.
3. The endpoint is multipart by construction (`File(...)`), which is why no JSON body shape can
   satisfy it — matching the wire results in §1.

LiteLLM's own docstring for this endpoint uses `image[]`:

```bash
curl -X POST "http://localhost:4000/v1/images/edits" \
  -H "Authorization: Bearer sk-..." \
  -F "model=gpt-image-1" -F "image[]=@soap.png" \
  -F 'prompt=Create a studio ghibli image of this'
```

### 4. Tests — and proof they fail without the fix

`pnpm test:extension litellm` on this branch, Node v24.18.1 / vitest v4.1.10:

```
 Test Files  3 passed (3)
      Tests  15 passed (15)
```

Reverting **only** `extensions/litellm/image-generation-provider.ts` to `main` while keeping the tests:

```
     × routes to the edit endpoint as multipart when input images are provided
     × sends multiple reference images as repeated image[] parts
 Test Files  1 failed | 2 passed (3)
      Tests  2 failed | 13 passed (15)
```

Exactly the two new tests fail, so they are regression coverage rather than a description of current behaviour.

Note the existing test `routes to the edit endpoint when input images are provided` asserted the buggy shape (`postJsonRequestMock`, `body.images`), so it is rewritten to assert a multipart request and that `postJsonRequest` is *not* called. Calling that out explicitly, since changing an existing test to pass deserves scrutiny.

### Scope of local validation

Ran the prescribed fast lane for extension changes (`pnpm test:extension litellm`) with commit hooks enabled. Did not run the full `pnpm build && pnpm check && pnpm test` locally — no shared plugin/channel surface or broader runtime behaviour is touched, so per CONTRIBUTING the wider lanes did not apply; CI covers them. The `autoreview` skill referenced in CONTRIBUTING was not available in my environment.

Branch is rebased onto current `main`.
