### PR TITLE
refactor(gateway): consolidate worker environment test fixtures

### DIFF
--- a/src/gateway/worker-environments/service.test.ts
+++ b/src/gateway/worker-environments/service.test.ts
@@ -72,6 +72,10 @@ const LIVE_EVENT = {
 };
 
 type WorkerLifecycleLease = Parameters<WorkerProvider["inspect"]>[0];
+type TranscriptRequest = Parameters<WorkerEnvironmentService["commitTranscript"]>[1];
+type TranscriptOverrides = Partial<Pick<TranscriptRequest, "baseLeafId" | "runEpoch" | "seq">>;
+type LiveEventRequest = Parameters<WorkerEnvironmentService["pushLiveEvent"]>[1];
+type LiveOpts = Partial<Pick<LiveEventRequest, "lastAckedSeq" | "runEpoch" | "runId" | "seq">>;
 
 describe("worker environment service", () => {
   let root: string;
@@ -299,6 +303,91 @@ describe("worker environment service", () => {
     };
   }
 
+  function transcriptRequest(
+    identity: WorkerConnectionIdentity,
+    text: string,
+    overrides: TranscriptOverrides = {},
+  ): TranscriptRequest {
+    return {
+      runEpoch: identity.ownerEpoch,
+      seq: 1,
+      baseLeafId: null,
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text }],
+          timestamp: 1,
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  function liveEventRequest(
+    identity: WorkerConnectionIdentity,
+    event: LiveEventRequest["event"],
+    overrides: LiveOpts = {},
+  ): LiveEventRequest {
+    return {
+      runEpoch: identity.ownerEpoch,
+      lastAckedSeq: 0,
+      seq: 1,
+      runId: identity.runId ?? "run-missing",
+      event,
+      ...overrides,
+    };
+  }
+
+  function assistantEvent(identity: WorkerConnectionIdentity, text: string, extra: LiveOpts = {}) {
+    return liveEventRequest(identity, { kind: "assistant", payload: { text, delta: text } }, extra);
+  }
+
+  function terminalEvent(identity: WorkerConnectionIdentity, overrides: LiveOpts = {}) {
+    return liveEventRequest(
+      identity,
+      { kind: "lifecycle", payload: { phase: "end", endedAt: 2 } },
+      overrides,
+    );
+  }
+
+  function successfulTranscriptCommit(entryId: string, beforeCommit?: () => Promise<unknown>) {
+    return vi.fn(async () => {
+      await beforeCommit?.();
+      return { ok: true as const, result: { entryIds: [entryId], newLeafId: entryId } };
+    });
+  }
+
+  function sequencedLiveEvents(ackedSeq = (seq: number) => seq) {
+    const apply = vi.fn(({ request }: { request: LiveEventRequest }) => ({
+      ok: true as const,
+      result: { ackedSeq: ackedSeq(request.seq) },
+    }));
+    return { apply, liveEvents: createLiveEvents({ apply }) };
+  }
+
+  function placementBinding(identity: WorkerConnectionIdentity) {
+    return {
+      sessionId: identity.sessionId ?? "session-missing",
+      environmentId: identity.environmentId,
+      ownerEpoch: identity.ownerEpoch,
+      runId: identity.runId ?? "run-missing",
+    };
+  }
+
+  function placementHarness(
+    environmentId: string,
+    sessionId: string,
+    serviceOptions: Parameters<typeof createService>[1] = {},
+  ) {
+    const identity = seedAttachedIdentity(environmentId, sessionId);
+    const placementStore = {
+      validateWorkerTurn: vi.fn(() => true),
+      updateAckCursors: vi.fn(),
+    };
+    const workerService = createService(createProvider(), { ...serviceOptions, placementStore });
+    return { identity, placementStore, workerService };
+  }
+
   it("persists intent and an immutable profile snapshot before provisioning", async () => {
     const operationIds: string[] = [];
     const provider = createProvider({
@@ -404,23 +493,9 @@ describe("worker environment service", () => {
     const environmentId = "worker-transcript-fence";
     const sessionId = "session-transcript-fence";
     const identity = seedAttachedIdentity(environmentId, sessionId);
-    const applyTranscriptCommit = vi.fn(async () => ({
-      ok: true as const,
-      result: { entryIds: ["entry-1"], newLeafId: "entry-1" },
-    }));
+    const applyTranscriptCommit = successfulTranscriptCommit("entry-1");
     const workerService = createService(createProvider(), { applyTranscriptCommit });
-    const request = {
-      runEpoch: identity.ownerEpoch,
-      seq: 1,
-      baseLeafId: null,
-      messages: [
-        {
-          role: "user" as const,
-          content: [{ type: "text" as const, text: "hello" }],
-          timestamp: 1,
-        },
-      ],
-    };
+    const request = transcriptRequest(identity, "hello");
 
     await expect(workerService.commitTranscript(identity, request)).resolves.toMatchObject({
       ok: true,
@@ -446,12 +521,7 @@ describe("worker environment service", () => {
   it("admits only a gateway-preclaimed worker placement and fences later requests", async () => {
     const environmentId = "worker-placement-fence";
     const sessionId = "session-placement-fence";
-    const identity = seedAttachedIdentity(environmentId, sessionId);
-    const placementStore = {
-      validateWorkerTurn: vi.fn(() => true),
-      updateAckCursors: vi.fn(),
-    };
-    const workerService = createService(createProvider(), { placementStore });
+    const { identity, placementStore, workerService } = placementHarness(environmentId, sessionId);
     const admission = {
       environmentId,
       credential: [CREDENTIAL, environmentId, sessionId].join("-"),
@@ -502,81 +572,35 @@ describe("worker environment service", () => {
     placementStore.validateWorkerTurn.mockReturnValue(false);
     expect(workerService.validateWorkerConnection(identity)).toBe("placement-mismatch");
     await expect(
-      workerService.commitTranscript(identity, {
-        runEpoch: identity.ownerEpoch,
-        seq: 1,
-        baseLeafId: null,
-        messages: [
-          {
-            role: "user",
-            content: [{ type: "text", text: "fenced" }],
-            timestamp: 1,
-          },
-        ],
-      }),
+      workerService.commitTranscript(identity, transcriptRequest(identity, "fenced")),
     ).resolves.toEqual({ ok: false, closeReason: "placement-mismatch" });
   });
 
   it("persists worker transcript and terminal live ACK cursors", async () => {
-    const identity = seedAttachedIdentity("worker-placement-ack", "session-placement-ack");
-    const placementStore = {
-      validateWorkerTurn: vi.fn(() => true),
-      updateAckCursors: vi.fn(),
-    };
-    const applyTranscriptCommit = vi.fn(async () => ({
-      ok: true as const,
-      result: { entryIds: ["entry-placement"], newLeafId: "entry-placement" },
-    }));
-    const liveEvents = createLiveEvents({
-      apply: vi.fn(
-        ({
-          request,
-        }: Parameters<NonNullable<WorkerEnvironmentServiceOptions["liveEvents"]>["apply"]>[0]) => ({
-          ok: true as const,
-          result: { ackedSeq: request.seq },
-        }),
-      ),
-    });
-    const workerService = createService(createProvider(), {
-      applyTranscriptCommit,
-      liveEvents,
-      placementStore,
-    });
-    const binding = {
-      sessionId: identity.sessionId ?? "session-missing",
-      environmentId: identity.environmentId,
-      ownerEpoch: identity.ownerEpoch,
-      runId: identity.runId ?? "run-missing",
-    };
+    const applyTranscriptCommit = successfulTranscriptCommit("entry-placement");
+    const { liveEvents } = sequencedLiveEvents();
+    const { identity, placementStore, workerService } = placementHarness(
+      "worker-placement-ack",
+      "session-placement-ack",
+      {
+        applyTranscriptCommit,
+        liveEvents,
+      },
+    );
+    const binding = placementBinding(identity);
 
     await expect(
-      workerService.commitTranscript(identity, {
-        runEpoch: identity.ownerEpoch,
-        seq: 7,
-        baseLeafId: null,
-        messages: [
-          {
-            role: "user",
-            content: [{ type: "text", text: "commit" }],
-            timestamp: 1,
-          },
-        ],
-      }),
+      workerService.commitTranscript(identity, transcriptRequest(identity, "commit", { seq: 7 })),
     ).resolves.toMatchObject({ ok: true });
     expect(placementStore.updateAckCursors).toHaveBeenCalledWith({
       ...binding,
       transcriptSeq: 7,
     });
 
-    await expect(
-      workerService.pushLiveEvent(identity, {
-        runEpoch: identity.ownerEpoch,
-        lastAckedSeq: 0,
-        seq: 1,
-        runId: binding.runId,
-        event: { kind: "lifecycle", payload: { phase: "end", endedAt: 2 } },
-      }),
-    ).resolves.toEqual({ ok: true, result: { ackedSeq: 1 } });
+    await expect(workerService.pushLiveEvent(identity, terminalEvent(identity))).resolves.toEqual({
+      ok: true,
+      result: { ackedSeq: 1 },
+    });
     expect(placementStore.updateAckCursors).toHaveBeenLastCalledWith({
       ...binding,
       liveSeq: 1,
@@ -585,39 +609,24 @@ describe("worker environment service", () => {
   });
 
   it("does not ACK a transcript commit after its worker claim is fenced", async () => {
-    const identity = seedAttachedIdentity("worker-placement-race", "session-placement-race");
-    const placementStore = {
-      validateWorkerTurn: vi.fn(() => true),
-      updateAckCursors: vi.fn(),
-    };
     let finishCommit: (() => void) | undefined;
     const commitBlocked = new Promise<void>((resolve) => {
       finishCommit = resolve;
     });
-    const applyTranscriptCommit = vi.fn(async () => {
-      await commitBlocked;
-      return {
-        ok: true as const,
-        result: { entryIds: ["entry-placement-race"], newLeafId: "entry-placement-race" },
-      };
-    });
-    const workerService = createService(createProvider(), {
-      applyTranscriptCommit,
-      placementStore,
-    });
+    const applyTranscriptCommit = successfulTranscriptCommit(
+      "entry-placement-race",
+      () => commitBlocked,
+    );
+    const { identity, placementStore, workerService } = placementHarness(
+      "worker-placement-race",
+      "session-placement-race",
+      { applyTranscriptCommit },
+    );
 
-    const commit = workerService.commitTranscript(identity, {
-      runEpoch: identity.ownerEpoch,
-      seq: 1,
-      baseLeafId: null,
-      messages: [
-        {
-          role: "user",
-          content: [{ type: "text", text: "commit before claim fence" }],
-          timestamp: 1,
-        },
-      ],
-    });
+    const commit = workerService.commitTranscript(
+      identity,
+      transcriptRequest(identity, "commit before claim fence"),
+    );
     await waitForFast(() => expect(applyTranscriptCommit).toHaveBeenCalledOnce());
     placementStore.validateWorkerTurn.mockReturnValue(false);
     finishCommit?.();
@@ -628,41 +637,26 @@ describe("worker environment service", () => {
   });
 
   it("advances the transcript cursor when a stale-base commit consumes its sequence", async () => {
-    const identity = seedAttachedIdentity("worker-placement-stale", "session-placement-stale");
-    const placementStore = {
-      validateWorkerTurn: vi.fn(() => true),
-      updateAckCursors: vi.fn(),
-    };
     const applyTranscriptCommit = vi
       .fn<NonNullable<WorkerEnvironmentServiceOptions["applyTranscriptCommit"]>>()
       .mockResolvedValueOnce({ ok: false, reason: "stale-base-leaf" })
       .mockResolvedValueOnce({ ok: false, reason: "invalid-batch" });
-    const workerService = createService(createProvider(), {
-      applyTranscriptCommit,
-      placementStore,
-    });
-    const request = {
-      runEpoch: identity.ownerEpoch,
+    const { identity, placementStore, workerService } = placementHarness(
+      "worker-placement-stale",
+      "session-placement-stale",
+      { applyTranscriptCommit },
+    );
+    const request = transcriptRequest(identity, "stale commit", {
       seq: 11,
       baseLeafId: "stale-leaf",
-      messages: [
-        {
-          role: "user" as const,
-          content: [{ type: "text" as const, text: "stale commit" }],
-          timestamp: 1,
-        },
-      ],
-    };
+    });
 
     await expect(workerService.commitTranscript(identity, request)).resolves.toEqual({
       ok: false,
       reason: "stale-base-leaf",
     });
     expect(placementStore.updateAckCursors).toHaveBeenCalledWith({
-      sessionId: identity.sessionId,
-      environmentId: identity.environmentId,
-      ownerEpoch: identity.ownerEpoch,
-      runId: identity.runId,
+      ...placementBinding(identity),
       transcriptSeq: 11,
     });
 
@@ -673,134 +667,61 @@ describe("worker environment service", () => {
   });
 
   it("fences after a buffered terminal event becomes acknowledged by a gap fill", async () => {
-    const identity = seedAttachedIdentity("worker-placement-gap", "session-placement-gap");
-    const placementStore = {
-      validateWorkerTurn: vi.fn(() => true),
-      updateAckCursors: vi.fn(),
-    };
-    const applyTranscriptCommit = vi.fn(async () => ({
-      ok: true as const,
-      result: { entryIds: ["entry-after-terminal-gap"], newLeafId: "entry-after-terminal-gap" },
-    }));
-    const liveApply = vi.fn(
-      ({
-        request,
-      }: Parameters<NonNullable<WorkerEnvironmentServiceOptions["liveEvents"]>["apply"]>[0]) => ({
-        ok: true as const,
-        result: { ackedSeq: request.seq === 1 ? 2 : 0 },
-      }),
+    const applyTranscriptCommit = successfulTranscriptCommit("entry-after-terminal-gap");
+    const { apply: liveApply, liveEvents } = sequencedLiveEvents((seq) => (seq === 1 ? 2 : 0));
+    const { identity, placementStore, workerService } = placementHarness(
+      "worker-placement-gap",
+      "session-placement-gap",
+      {
+        applyTranscriptCommit,
+        liveEvents,
+      },
     );
-    const workerService = createService(createProvider(), {
-      applyTranscriptCommit,
-      liveEvents: createLiveEvents({ apply: liveApply }),
-      placementStore,
-    });
 
     await expect(
-      workerService.pushLiveEvent(identity, {
-        runEpoch: identity.ownerEpoch,
-        lastAckedSeq: 0,
-        seq: 2,
-        runId: identity.runId ?? "run-missing",
-        event: { kind: "lifecycle", payload: { phase: "end", endedAt: 2 } },
-      }),
+      workerService.pushLiveEvent(identity, terminalEvent(identity, { seq: 2 })),
     ).resolves.toEqual({ ok: true, result: { ackedSeq: 0 } });
     expect(placementStore.updateAckCursors).toHaveBeenCalledWith({
-      sessionId: identity.sessionId,
-      environmentId: identity.environmentId,
-      ownerEpoch: identity.ownerEpoch,
-      runId: identity.runId,
+      ...placementBinding(identity),
       liveSeq: 0,
       workspaceResultPending: true,
     });
 
     await expect(
-      workerService.pushLiveEvent(identity, {
-        runEpoch: identity.ownerEpoch,
-        lastAckedSeq: 0,
-        seq: 1,
-        runId: identity.runId ?? "run-missing",
-        event: { kind: "assistant", payload: { text: "fills gap", delta: "fills gap" } },
-      }),
+      workerService.pushLiveEvent(identity, assistantEvent(identity, "fills gap")),
     ).resolves.toEqual({ ok: true, result: { ackedSeq: 2 } });
     await expect(
-      workerService.commitTranscript(identity, {
-        runEpoch: identity.ownerEpoch,
-        seq: 1,
-        baseLeafId: null,
-        messages: [
-          {
-            role: "user",
-            content: [{ type: "text", text: "late transcript" }],
-            timestamp: 1,
-          },
-        ],
-      }),
+      workerService.commitTranscript(identity, transcriptRequest(identity, "late transcript")),
     ).resolves.toEqual({ ok: false, closeReason: "placement-mismatch" });
     await expect(
-      workerService.pushLiveEvent(identity, {
-        runEpoch: identity.ownerEpoch,
-        lastAckedSeq: 2,
-        seq: 3,
-        runId: identity.runId ?? "run-missing",
-        event: { kind: "assistant", payload: { text: "late", delta: "late" } },
-      }),
+      workerService.pushLiveEvent(
+        identity,
+        assistantEvent(identity, "late", { lastAckedSeq: 2, seq: 3 }),
+      ),
     ).resolves.toEqual({ ok: false, closeReason: "placement-mismatch" });
     expect(applyTranscriptCommit).not.toHaveBeenCalled();
     expect(liveApply).toHaveBeenCalledTimes(2);
   });
 
   it("applies a terminal ACK only after its transcript commit finishes", async () => {
-    const identity = seedAttachedIdentity("worker-placement-order", "session-placement-order");
-    const placementStore = {
-      validateWorkerTurn: vi.fn(() => true),
-      updateAckCursors: vi.fn(),
-    };
     let finishCommit: (() => void) | undefined;
     const commitBlocked = new Promise<void>((resolve) => {
       finishCommit = resolve;
     });
-    const applyTranscriptCommit = vi.fn(async () => {
-      await commitBlocked;
-      return {
-        ok: true as const,
-        result: { entryIds: ["entry-order"], newLeafId: "entry-order" },
-      };
-    });
-    const workerService = createService(createProvider(), {
-      applyTranscriptCommit,
-      liveEvents: createLiveEvents({
-        apply: vi.fn(
-          ({
-            request,
-          }: Parameters<
-            NonNullable<WorkerEnvironmentServiceOptions["liveEvents"]>["apply"]
-          >[0]) => ({ ok: true as const, result: { ackedSeq: request.seq } }),
-        ),
-      }),
-      placementStore,
-    });
+    const applyTranscriptCommit = successfulTranscriptCommit("entry-order", () => commitBlocked);
+    const { liveEvents } = sequencedLiveEvents();
+    const { identity, placementStore, workerService } = placementHarness(
+      "worker-placement-order",
+      "session-placement-order",
+      { applyTranscriptCommit, liveEvents },
+    );
 
-    const commit = workerService.commitTranscript(identity, {
-      runEpoch: identity.ownerEpoch,
-      seq: 1,
-      baseLeafId: null,
-      messages: [
-        {
-          role: "user",
-          content: [{ type: "text", text: "commit before terminal" }],
-          timestamp: 1,
-        },
-      ],
-    });
+    const commit = workerService.commitTranscript(
+      identity,
+      transcriptRequest(identity, "commit before terminal"),
+    );
     await waitForFast(() => expect(applyTranscriptCommit).toHaveBeenCalledOnce());
-    const terminal = workerService.pushLiveEvent(identity, {
-      runEpoch: identity.ownerEpoch,
-      lastAckedSeq: 0,
-      seq: 1,
-      runId: identity.runId ?? "run-missing",
-      event: { kind: "lifecycle", payload: { phase: "end", endedAt: 2 } },
-    });
+    const terminal = workerService.pushLiveEvent(identity, terminalEvent(identity));
     await Promise.resolve();
     expect(placementStore.updateAckCursors).not.toHaveBeenCalled();
 
@@ -810,19 +731,13 @@ describe("worker environment service", () => {
     expect(placementStore.updateAckCursors.mock.calls).toEqual([
       [
         {
-          sessionId: identity.sessionId,
-          environmentId: identity.environmentId,
-          ownerEpoch: identity.ownerEpoch,
-          runId: identity.runId,
+          ...placementBinding(identity),
           transcriptSeq: 1,
         },
       ],
       [
         {
-          sessionId: identity.sessionId,
-          environmentId: identity.environmentId,
-          ownerEpoch: identity.ownerEpoch,
-          runId: identity.runId,
+          ...placementBinding(identity),
           liveSeq: 1,
           workspaceResultPending: true,
         },
@@ -831,23 +746,8 @@ describe("worker environment service", () => {
   });
 
   it("fences post-terminal mutations while preserving sequenced replays", async () => {
-    const identity = seedAttachedIdentity("worker-terminal-fence", "session-terminal-fence");
-    const placementStore = {
-      validateWorkerTurn: vi.fn(() => true),
-      updateAckCursors: vi.fn(),
-    };
-    const applyTranscriptCommit = vi.fn(async () => ({
-      ok: true as const,
-      result: { entryIds: ["entry-terminal"], newLeafId: "entry-terminal" },
-    }));
-    const liveApply = vi.fn(
-      ({
-        request,
-      }: Parameters<NonNullable<WorkerEnvironmentServiceOptions["liveEvents"]>["apply"]>[0]) => ({
-        ok: true as const,
-        result: { ackedSeq: request.seq },
-      }),
-    );
+    const applyTranscriptCommit = successfulTranscriptCommit("entry-terminal");
+    const { apply: liveApply, liveEvents } = sequencedLiveEvents();
     const executeInference = vi.fn<WorkerEnvironmentServiceOptions["executeInference"]>(
       async () => ({
         type: "error",
@@ -855,31 +755,13 @@ describe("worker environment service", () => {
         message: "Provider request failed",
       }),
     );
-    const workerService = createService(createProvider(), {
-      applyTranscriptCommit,
-      executeInference,
-      liveEvents: createLiveEvents({ apply: liveApply }),
-      placementStore,
-    });
-    const transcript = {
-      runEpoch: identity.ownerEpoch,
-      seq: 1,
-      baseLeafId: null,
-      messages: [
-        {
-          role: "user" as const,
-          content: [{ type: "text" as const, text: "terminal fence" }],
-          timestamp: 1,
-        },
-      ],
-    };
-    const terminal = {
-      runEpoch: identity.ownerEpoch,
-      lastAckedSeq: 0,
-      seq: 1,
-      runId: identity.runId ?? "run-missing",
-      event: { kind: "lifecycle" as const, payload: { phase: "end" as const, endedAt: 2 } },
-    };
+    const { identity, workerService } = placementHarness(
+      "worker-terminal-fence",
+      "session-terminal-fence",
+      { applyTranscriptCommit, executeInference, liveEvents },
+    );
+    const transcript = transcriptRequest(identity, "terminal fence");
+    const terminal = terminalEvent(identity);
 
     await expect(workerService.commitTranscript(identity, transcript)).resolves.toMatchObject({
       ok: true,
@@ -902,11 +784,7 @@ describe("worker environment service", () => {
       result: { ackedSeq: 1 },
     });
     await expect(
-      workerService.pushLiveEvent(identity, {
-        ...terminal,
-        seq: 2,
-        event: { kind: "assistant", payload: { text: "late", delta: "late" } },
-      }),
+      workerService.pushLiveEvent(identity, assistantEvent(identity, "late", { seq: 2 })),
     ).resolves.toEqual({ ok: false, closeReason: "placement-mismatch" });
     expect(liveApply).toHaveBeenCalledTimes(2);
 
@@ -938,55 +816,21 @@ describe("worker environment service", () => {
   });
 
   it("does not treat a terminal event on an already ACKed sequence as authoritative", async () => {
-    const identity = seedAttachedIdentity("worker-terminal-reuse", "session-terminal-reuse");
-    const applyTranscriptCommit = vi.fn(async () => ({
-      ok: true as const,
-      result: { entryIds: ["entry-after-reuse"], newLeafId: "entry-after-reuse" },
-    }));
-    const workerService = createService(createProvider(), {
-      applyTranscriptCommit,
-      liveEvents: createLiveEvents({
-        apply: vi.fn(
-          ({
-            request,
-          }: Parameters<
-            NonNullable<WorkerEnvironmentServiceOptions["liveEvents"]>["apply"]
-          >[0]) => ({ ok: true as const, result: { ackedSeq: request.seq } }),
-        ),
-      }),
-      placementStore: {
-        validateWorkerTurn: vi.fn(() => true),
-        updateAckCursors: vi.fn(),
-      },
-    });
-    const event = {
-      runEpoch: identity.ownerEpoch,
-      lastAckedSeq: 0,
-      seq: 1,
-      runId: identity.runId ?? "run-missing",
-      event: { kind: "assistant" as const, payload: { text: "first", delta: "first" } },
-    };
+    const applyTranscriptCommit = successfulTranscriptCommit("entry-after-reuse");
+    const { liveEvents } = sequencedLiveEvents();
+    const { identity, workerService } = placementHarness(
+      "worker-terminal-reuse",
+      "session-terminal-reuse",
+      { applyTranscriptCommit, liveEvents },
+    );
+    const event = assistantEvent(identity, "first");
 
     await expect(workerService.pushLiveEvent(identity, event)).resolves.toMatchObject({ ok: true });
     await expect(
-      workerService.pushLiveEvent(identity, {
-        ...event,
-        event: { kind: "lifecycle", payload: { phase: "end", endedAt: 2 } },
-      }),
+      workerService.pushLiveEvent(identity, terminalEvent(identity)),
     ).resolves.toMatchObject({ ok: true });
     await expect(
-      workerService.commitTranscript(identity, {
-        runEpoch: identity.ownerEpoch,
-        seq: 1,
-        baseLeafId: null,
-        messages: [
-          {
-            role: "user",
-            content: [{ type: "text", text: "still mutable" }],
-            timestamp: 1,
-          },
-        ],
-      }),
+      workerService.commitTranscript(identity, transcriptRequest(identity, "still mutable")),
     ).resolves.toMatchObject({ ok: true });
     expect(applyTranscriptCommit).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
## What Problem This Solves

The worker-environment service suite repeated placement, transcript, and live-event fixture construction across closely related cases. That repetition made the already-large test owner harder to audit and increased the chance that sibling invariant tests would drift.

## Why This Change Was Made

Consolidates the repeated test-only setup behind typed request, event, placement, ACK-binding, and success-callback factories. All test titles, ordering, identifiers, epochs, credentials, sequences, payloads, race ordering, cursor expectations, fencing behavior, and cleanup remain unchanged. Production code is untouched.

## User Impact

No user-visible behavior changes. The gateway test owner is 156 lines smaller and its placement/transcript/live-event cases now share canonical fixture construction.

## Evidence

- LOC: +181/-337 in one test file (net -156); production delta 0.
- Test declaration count remains 60 and ordered declaration SHA-256 remains `32db6a11e9945bc953b1827cab8c4046bbf0190a29f2a65a8af7d498d3a0a833`.
- Baseline Blacksmith Testbox: 65/65 passed ([run 30792717452](https://github.com/openclaw/openclaw/actions/runs/30792717452)).
- Post-change focused local proof: 65/65 passed.
- Post-change Blacksmith Testbox: 65/65 passed ([run 30794137856](https://github.com/openclaw/openclaw/actions/runs/30794137856)).
- Changed gate: format, guards, core-test tsgo, and lint passed ([run 30793731690](https://github.com/openclaw/openclaw/actions/runs/30793731690)).
- Fresh Codex `gpt-5.6-sol` xhigh autoreview: no accepted/actionable findings; correctness 0.99.
- `git diff --check` passed.
