### PR TITLE
fix(ui): compact queued exec approval commands without splitting surrogate pairs

### DIFF
--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -156,6 +156,25 @@ describe("openclaw-exec-approval", () => {
     expect(queue.map((entry) => entry.id)).toEqual(["approval-oldest", "approval-newer"]);
   });
 
+  it("compacts queued commands without splitting a surrogate pair", async () => {
+    const queue = [
+      createExecRequest({ id: "approval-active", createdAtMs: 1 }),
+      createExecRequest({
+        id: "approval-queued",
+        createdAtMs: 2,
+        // The emoji straddles code unit 61, so a hard slice(0, 61) would
+        // leave a dangling high surrogate in front of the ellipsis.
+        request: { command: `${"a".repeat(60)}🙂 --with-extra-arguments` },
+      }),
+    ];
+    await renderApproval(queue);
+    await getRenderedModalDialog(container);
+
+    expect(container.querySelector(".exec-approval-list__command")?.textContent).toBe(
+      `${"a".repeat(60)}…`,
+    );
+  });
+
   it("handles modal approval keyboard shortcuts", async () => {
     const { onDecision } = await renderApproval(createExecRequest());
     const { modal } = await getRenderedModalDialog(container);

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -1,4 +1,5 @@
 // Control UI modal queues approvals that are not currently inline in chat.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing, type PropertyValues } from "lit";
 import { property, query, state } from "lit/decorators.js";
 import { modalApprovalQueue } from "../app/approval-presentation.ts";
@@ -27,7 +28,7 @@ type ExecApprovalProps = {
 
 function compactCommand(command: string): string {
   const singleLine = command.replace(/\s+/g, " ").trim();
-  return singleLine.length > 64 ? `${singleLine.slice(0, 61)}…` : singleLine;
+  return singleLine.length > 64 ? `${truncateUtf16Safe(singleLine, 61)}…` : singleLine;
 }
 
 function renderApprovalQueueList(params: {


### PR DESCRIPTION
## Summary

The exec approval modal's queue list compacts long commands with `singleLine.slice(0, 61)`, which can cut a UTF-16 surrogate pair in half — the rendered queue label then ends in a lone surrogate that shows up as tofu (`�`).

## What Problem This Solves

`compactCommand` (`ui/src/components/exec-approval.ts:30`) collapses whitespace, then hard-truncates at 61 UTF-16 code units and appends an ellipsis:

```ts
return singleLine.length > 64 ? `${singleLine.slice(0, 61)}…` : singleLine;
```

- The text is `request.command` from an exec approval request — agent-generated shell commands that routinely contain emoji or CJK characters (2-unit surrogate pairs / wide code points).
- When a surrogate pair straddles code unit 61, `slice(0, 61)` keeps only the high surrogate. The lone half renders as `�` in the approval queue entry — exactly where the operator is deciding whether to authorize a command.
- The queue label is also used in the entry's `aria-label`, so screen readers announce the replacement character too.

**代码证据**: rendering the real `openclaw-exec-approval` element with a queued command of 60 ASCII chars + `🙂` + arguments (85 code units) yields the label `"aaaa…\ud83d…"` — a dangling high surrogate directly before the ellipsis.

## Root Cause

Introduced by 430147fc899 ("feat(ui): approval UX overhaul — inline cards, fair queue, shortcuts, badges (#110989)", 2026-07-19): the compacting helper treats UTF-16 code units as display characters. The violated invariant: a truncated display string must never end inside a surrogate pair. The repo already has the correct primitive for exactly this — `truncateUtf16Safe` from `@openclaw/normalization-core/utf16-slice`, already used by other Control UI surfaces (`app/custom-theme.ts`, `app/user-identity.ts`, `components/sidebar-build-chip-format.ts`, `components/browser/browser-annotation.ts`).

## Why This Fix

- Swap `singleLine.slice(0, 61)` for `truncateUtf16Safe(singleLine, 61)`, keeping the same 61/64 thresholds and the manually appended ellipsis (matches the existing `${truncateUtf16Safe(branch, N)}…` idiom in `sidebar-build-chip-format.ts`).
- `truncateUtf16Safe` backs the cut off by one code unit when it would land between surrogate halves, so the pair is either fully kept or fully dropped — never split.
- Alternative considered: `Array.from(singleLine).slice(0, 61).join("")` (code-point slicing) — rejected because it changes the truncation budget semantics and diverges from the established UI helper; `truncateUtf16Safe` is the codebase-standard fix for this defect class.

## User Impact

- Queued exec approval entries whose commands contain emoji/CJK at the truncation boundary now render a clean label ending in `…` instead of `�…`.
- No change for commands that are short or purely BMP text at the boundary (the helper is a no-op when the cut is already safe).

## Evidence

- **Before**: standalone jsdom render of the real `openclaw-exec-approval` element on `main` — queued command `aaaa…🙂 --with-extra-arguments` (emoji straddling code unit 61) renders the queue label `"aaaa…\ud83d…"` → lone surrogate → FAIL.
- **After**: same render on this branch — label is `"aaaa…"` (pair dropped whole at the boundary, ellipsis appended) → PASS.

## Real Behavior Proof

### Before (on main)

```bash
$ node --import tsx proof.mjs
queued command (85 UTF-16 code units): "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa🙂 --with-extra-arguments"
rendered compact label: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\ud83d…"
FAIL: compacted queue label contains a lone UTF-16 surrogate (renders as tofu)
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
queued command (85 UTF-16 code units): "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa🙂 --with-extra-arguments"
rendered compact label: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…"
PASS: compacted queue label is surrogate-safe
```

(Real `openclaw-exec-approval` custom element rendered under jsdom with the production i18n locale; the label is read from the rendered `.exec-approval-list__command` DOM node, and the check scans the string for unpaired UTF-16 surrogates.)

## Tests and Validation

- `node scripts/check.mjs` passed
- `npx vitest run ui/src/components/exec-approval.test.ts` passed (16 tests, incl. new regression test `compacts queued commands without splitting a surrogate pair` asserting the rendered queue label equals `"aaaa…"` when the emoji straddles the cut)
