### PR TITLE
test(tui): reuse real gateway PTY fixture

### DIFF
--- a/src/tui/tui-pty-local-test-support.test.ts
+++ b/src/tui/tui-pty-local-test-support.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { createDeferred } from "../test-utils/deferred.js";
+import { cleanupStartedFixture, createFreshSession } from "./tui-pty-local-test-support.js";
+import type { PtyRun } from "./tui-pty-test-support.js";
+
+const SUBMISSION_SETTLE_MS = 150;
+const SESSION_ROLLOVER_BUSY_MESSAGE = "abort the current run before /new";
+
+describe("local TUI PTY fixture support", () => {
+  it("owns late fixture startup without swallowing cleanup failures", async () => {
+    await expect(cleanupStartedFixture(Promise.reject(new Error("setup failed")))).resolves.toBe(
+      undefined,
+    );
+
+    const cleanupError = new Error("cleanup failed");
+    const fixture = {
+      cleanup: async () => {
+        throw cleanupError;
+      },
+    };
+    await expect(cleanupStartedFixture(Promise.resolve(fixture))).rejects.toBe(cleanupError);
+  });
+
+  it("does not replay a session rollover when an old busy notice is redrawn", async () => {
+    const newSessionPrefix = "new session: agent:main:tui-";
+    const acceptedSession = createDeferred();
+    const writes: string[] = [];
+    let output = "";
+    let acceptanceTimer: ReturnType<typeof setTimeout> | undefined;
+    const run = {
+      output: () => output,
+      visibleOutput: () => output.replace(/\s+/gu, " "),
+      write: async (data: string) => {
+        writes.push(data);
+        if (writes.length === 1) {
+          output += `${SESSION_ROLLOVER_BUSY_MESSAGE}\n`;
+          acceptanceTimer = setTimeout(() => {
+            output += `${newSessionPrefix}accepted\nlocal ready | idle\n`;
+            acceptedSession.resolve();
+          }, SUBMISSION_SETTLE_MS + 50);
+          return;
+        }
+        output += `${newSessionPrefix}duplicate\nlocal ready | idle\n`;
+      },
+      waitForOutput: async () => output,
+      waitForExit: async () => ({ exitCode: 0, signal: 0 }),
+      forceKill: async () => {},
+      dispose: async () => {},
+    } satisfies PtyRun;
+
+    try {
+      await createFreshSession(run, newSessionPrefix);
+      await acceptedSession.promise;
+      expect(writes).toEqual(["/new\r"]);
+    } finally {
+      if (acceptanceTimer) {
+        clearTimeout(acceptanceTimer);
+      }
+    }
+  });
+});

--- a/src/tui/tui-pty-local-test-support.ts
+++ b/src/tui/tui-pty-local-test-support.ts
@@ -1,0 +1,56 @@
+import { waitFor, type PtyRun } from "./tui-pty-test-support.js";
+
+const STARTUP_TIMEOUT_MS = 60_000;
+const OUTPUT_TIMEOUT_MS = 120_000;
+
+export async function waitForOutputAfter(
+  run: PtyRun,
+  needle: string,
+  offset: number,
+  timeoutMs = OUTPUT_TIMEOUT_MS,
+) {
+  await waitFor({
+    timeoutMs,
+    read: () => (run.visibleOutput().slice(offset).includes(needle) ? true : null),
+    onTimeout: () =>
+      new Error(
+        `timed out waiting for ${JSON.stringify(needle)} after offset ${offset}\n${run.output()}`,
+      ),
+  });
+}
+
+export function lastOutputIndexAfter(run: PtyRun, needle: string, offset: number): number {
+  const relativeIndex = run.visibleOutput().slice(offset).lastIndexOf(needle);
+  return relativeIndex < 0 ? -1 : offset + relativeIndex;
+}
+
+export async function createFreshSession(run: PtyRun, newSessionPrefix: string) {
+  const outputOffset = run.visibleOutput().length;
+  await run.write("/new\r", { delay: false });
+  await waitFor({
+    timeoutMs: STARTUP_TIMEOUT_MS,
+    read: () => (run.visibleOutput().includes(newSessionPrefix, outputOffset) ? true : null),
+    onTimeout: () =>
+      new Error(`timed out creating a fresh session after one submission\n${run.output()}`),
+  });
+  const newSessionOffset = run.visibleOutput().lastIndexOf(newSessionPrefix);
+  // Wait for the accepted session's own idle redraw; older PTY frames can
+  // replay busy messages and must never cause a second session creation.
+  await waitForOutputAfter(run, "| idle", newSessionOffset);
+}
+
+export async function cleanupStartedFixture(
+  startup: Promise<{ cleanup: () => Promise<void> }> | undefined,
+): Promise<void> {
+  if (!startup) {
+    return;
+  }
+  let fixture: { cleanup: () => Promise<void> };
+  try {
+    fixture = await startup;
+  } catch {
+    // The setup hook already reports startup failures. Teardown only owns cleanup.
+    return;
+  }
+  await fixture.cleanup();
+}

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -45,15 +45,18 @@ type MockModelRequest = {
 type GatewayScenario = MockModelBehavior & {
   agentId: string;
   modelId: string;
+  routeMarker: string;
   toolsProfile: "minimal" | "coding";
 };
 
 const SHARED_GATEWAY_AGENT_ID = "tui-pty-gateway";
+const SHARED_GATEWAY_MODEL_ID = "tui-pty-gateway";
 
 const GATEWAY_SCENARIOS = {
   validation: {
     agentId: "tui-pty-validation",
     modelId: "tui-pty-validation",
+    routeMarker: "trigger malformed edit calls",
     toolsProfile: "coding",
     replyText: "FIRST_RUN_ACTIVE",
     holdFirstResponse: false,
@@ -63,6 +66,7 @@ const GATEWAY_SCENARIOS = {
   crossClient: {
     agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-cross-client",
+    routeMarker: "seed cross-client session",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
     holdFirstResponse: false,
@@ -71,6 +75,7 @@ const GATEWAY_SCENARIOS = {
   followup: {
     agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-followup",
+    routeMarker: "slow first turn",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
     holdFirstResponse: true,
@@ -79,6 +84,7 @@ const GATEWAY_SCENARIOS = {
   emptyReply: {
     agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-empty-reply",
+    routeMarker: "non-deliverable first turn",
     toolsProfile: "minimal",
     replyText: "[[reply_to_current]]",
     holdFirstResponse: false,
@@ -87,6 +93,7 @@ const GATEWAY_SCENARIOS = {
   cancel: {
     agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-cancel",
+    routeMarker: "slow turn to abort",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
     holdFirstResponse: true,
@@ -95,6 +102,7 @@ const GATEWAY_SCENARIOS = {
   collect: {
     agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-collect",
+    routeMarker: "slow collect parent",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
     holdFirstResponse: true,
@@ -103,6 +111,7 @@ const GATEWAY_SCENARIOS = {
   reconnect: {
     agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-reconnect",
+    routeMarker: "send preserved draft after restart",
     toolsProfile: "minimal",
     replyText: "RECONNECTED_RUN_COMPLETE",
   },
@@ -280,6 +289,10 @@ async function readJsonRequest(req: IncomingMessage): Promise<Record<string, unk
 
 async function startRoutedMockModelServer(
   behaviors: Readonly<Record<string, MockModelBehavior>>,
+  opts: {
+    advertisedModelIds?: string[];
+    resolveBehaviorId?: (body: Record<string, unknown>, modelId: string) => string;
+  } = {},
 ): Promise<MockModelServer> {
   const requests: MockModelRequest[] = [];
   const requestsByModel = new Map<string, MockModelRequest[]>();
@@ -297,7 +310,10 @@ async function startRoutedMockModelServer(
       }
       if (req.method === "GET" && url.pathname === "/v1/models") {
         writeJson(res, 200, {
-          data: Object.keys(behaviors).map((id) => ({ id, object: "model" })),
+          data: (opts.advertisedModelIds ?? Object.keys(behaviors)).map((id) => ({
+            id,
+            object: "model",
+          })),
         });
         return;
       }
@@ -305,14 +321,15 @@ async function startRoutedMockModelServer(
         const body = await readJsonRequest(req);
         if (url.pathname === "/v1/responses" || url.pathname === "/responses") {
           const modelId = typeof body.model === "string" ? body.model : "";
-          const behavior = behaviors[modelId];
+          const behaviorId = opts.resolveBehaviorId?.(body, modelId) ?? modelId;
+          const behavior = behaviors[behaviorId];
           if (!behavior) {
-            writeJson(res, 400, { error: `unknown mock model: ${modelId || "missing"}` });
+            writeJson(res, 400, { error: `unknown mock behavior: ${behaviorId || "missing"}` });
             return;
           }
-          const modelRequests = requestsByModel.get(modelId) ?? [];
-          if (!requestsByModel.has(modelId)) {
-            requestsByModel.set(modelId, modelRequests);
+          const modelRequests = requestsByModel.get(behaviorId) ?? [];
+          if (!requestsByModel.has(behaviorId)) {
+            requestsByModel.set(behaviorId, modelRequests);
           }
           const requestIndex = modelRequests.length;
           const request = { method: req.method, path: url.pathname, body };
@@ -327,7 +344,7 @@ async function startRoutedMockModelServer(
             requestIndex === 0
               ? behavior.replyText
               : (behavior.followupReplyText ?? behavior.replyText),
-            requestIndex === 0 ? firstResponseGates.get(modelId)?.promise : undefined,
+            requestIndex === 0 ? firstResponseGates.get(behaviorId)?.promise : undefined,
           );
           return;
         }
@@ -597,8 +614,7 @@ function buildGatewayModeConfig(params: { tempDir: string; providerBaseUrl: stri
     ...new Map(scenarios.map((scenario) => [scenario.agentId, scenario])).values(),
   ];
   const defaultScenario = GATEWAY_SCENARIOS.validation;
-  const defaultModelRef = `tui-pty-mock/${defaultScenario.modelId}`;
-  const modelRefs = scenarios.map((scenario) => `tui-pty-mock/${scenario.modelId}`);
+  const defaultModelRef = `tui-pty-mock/${SHARED_GATEWAY_MODEL_ID}`;
   const base = buildLocalModeConfig({
     workspaceDir: path.join(params.tempDir, defaultScenario.agentId),
     providerBaseUrl: params.providerBaseUrl,
@@ -609,9 +625,7 @@ function buildGatewayModeConfig(params: { tempDir: string; providerBaseUrl: stri
       defaults: {
         workspace: path.join(params.tempDir, defaultScenario.agentId),
         model: { primary: defaultModelRef },
-        models: Object.fromEntries(
-          modelRefs.map((modelRef) => [modelRef, { agentRuntime: { id: "openclaw" } }]),
-        ),
+        models: { [defaultModelRef]: { agentRuntime: { id: "openclaw" } } },
         skills: [],
         skipBootstrap: true,
       },
@@ -622,7 +636,7 @@ function buildGatewayModeConfig(params: { tempDir: string; providerBaseUrl: stri
             ...(index === 0 ? { default: true } : {}),
             workspace: path.join(params.tempDir, scenario.agentId),
             skills: [],
-            model: { primary: `tui-pty-mock/${scenario.modelId}` },
+            model: { primary: defaultModelRef },
             tools: { profile: scenario.toolsProfile },
           },
         ]),
@@ -631,10 +645,7 @@ function buildGatewayModeConfig(params: { tempDir: string; providerBaseUrl: stri
     models: {
       mode: "replace",
       providers: {
-        "tui-pty-mock": buildMockModelProvider(
-          params.providerBaseUrl,
-          scenarios.map((scenario) => scenario.modelId),
-        ),
+        "tui-pty-mock": buildMockModelProvider(params.providerBaseUrl, [SHARED_GATEWAY_MODEL_ID]),
       },
     },
     messages: {
@@ -643,6 +654,14 @@ function buildGatewayModeConfig(params: { tempDir: string; providerBaseUrl: stri
       },
     },
   } satisfies OpenClawConfig;
+}
+
+function resolveGatewayBehaviorId(body: Record<string, unknown>): string {
+  const serialized = JSON.stringify(body);
+  const match = Object.values(GATEWAY_SCENARIOS).find((scenario) =>
+    serialized.includes(scenario.routeMarker),
+  );
+  return match?.modelId ?? "";
 }
 
 async function startSharedGatewayFixture(): Promise<SharedGatewayFixture> {
@@ -670,6 +689,10 @@ async function startSharedGatewayFixture(): Promise<SharedGatewayFixture> {
           },
         ]),
       ),
+      {
+        advertisedModelIds: [SHARED_GATEWAY_MODEL_ID],
+        resolveBehaviorId: (body) => resolveGatewayBehaviorId(body),
+      },
     );
     gateway = await createOpenClawTestInstance({
       name: "tui-pty-shared-gateway",
@@ -800,7 +823,7 @@ async function startGatewayModeTui(
   await shared.controlClient.patchSession({
     key: sessionKey,
     agentId: scenario.agentId,
-    model: `tui-pty-mock/${scenario.modelId}`,
+    model: `tui-pty-mock/${SHARED_GATEWAY_MODEL_ID}`,
   });
   const run = shared.run;
   const outputOffset = run.visibleOutput().length;

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -14,6 +14,12 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { connectGatewayClient } from "../gateway/test-helpers.e2e.js";
 import { createDeferred } from "../test-utils/deferred.js";
 import { GatewayChatClient } from "./gateway-chat.js";
+import {
+  cleanupStartedFixture,
+  createFreshSession,
+  lastOutputIndexAfter,
+  waitForOutputAfter,
+} from "./tui-pty-local-test-support.js";
 import { sleep, startPty, waitFor, type PtyRun } from "./tui-pty-test-support.js";
 
 type MockModelServer = {
@@ -42,6 +48,8 @@ type GatewayScenario = MockModelBehavior & {
   toolsProfile: "minimal" | "coding";
 };
 
+const SHARED_GATEWAY_AGENT_ID = "tui-pty-gateway";
+
 const GATEWAY_SCENARIOS = {
   validation: {
     agentId: "tui-pty-validation",
@@ -52,16 +60,8 @@ const GATEWAY_SCENARIOS = {
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
     invalidEditLoop: true,
   },
-  newSession: {
-    agentId: "tui-pty-new-session",
-    modelId: "tui-pty-new-session",
-    toolsProfile: "minimal",
-    replyText: "FIRST_RUN_ACTIVE",
-    holdFirstResponse: false,
-    followupReplyText: "FOLLOWUP_RUN_COMPLETE",
-  },
   crossClient: {
-    agentId: "tui-pty-cross-client",
+    agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-cross-client",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
@@ -69,23 +69,15 @@ const GATEWAY_SCENARIOS = {
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
   },
   followup: {
-    agentId: "tui-pty-followup",
+    agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-followup",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
     holdFirstResponse: true,
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
   },
-  reset: {
-    agentId: "tui-pty-reset",
-    modelId: "tui-pty-reset",
-    toolsProfile: "minimal",
-    replyText: "FIRST_RUN_ACTIVE",
-    holdFirstResponse: true,
-    followupReplyText: "FOLLOWUP_RUN_COMPLETE",
-  },
   emptyReply: {
-    agentId: "tui-pty-empty-reply",
+    agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-empty-reply",
     toolsProfile: "minimal",
     replyText: "[[reply_to_current]]",
@@ -93,7 +85,7 @@ const GATEWAY_SCENARIOS = {
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
   },
   cancel: {
-    agentId: "tui-pty-cancel",
+    agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-cancel",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
@@ -101,7 +93,7 @@ const GATEWAY_SCENARIOS = {
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
   },
   collect: {
-    agentId: "tui-pty-collect",
+    agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-collect",
     toolsProfile: "minimal",
     replyText: "FIRST_RUN_ACTIVE",
@@ -109,16 +101,10 @@ const GATEWAY_SCENARIOS = {
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
   },
   reconnect: {
-    agentId: "tui-pty-reconnect",
+    agentId: SHARED_GATEWAY_AGENT_ID,
     modelId: "tui-pty-reconnect",
     toolsProfile: "minimal",
     replyText: "RECONNECTED_RUN_COMPLETE",
-  },
-  ctrlD: {
-    agentId: "tui-pty-ctrl-d",
-    modelId: "tui-pty-ctrl-d",
-    toolsProfile: "minimal",
-    replyText: "CTRL_D_FORWARD_DELETE_COMPLETE",
   },
 } as const satisfies Record<string, GatewayScenario>;
 
@@ -129,7 +115,6 @@ const LOCAL_OUTPUT_TIMEOUT_MS = 120_000;
 const LOCAL_EXIT_TIMEOUT_MS = 4_000;
 const LOCAL_TEST_TIMEOUT_MS = 150_000;
 const SUBMISSION_SETTLE_MS = 150;
-const SESSION_ROLLOVER_BUSY_MESSAGE = "abort the current run before /new";
 
 function isRetryableGatewayUnavailable(error: unknown): error is Error & {
   retryAfterMs?: number;
@@ -161,32 +146,6 @@ function createIdempotentCleanup(cleanup: () => Promise<void>) {
 }
 
 type CleanupRegistrar = (cleanup: () => Promise<void>) => void;
-
-async function waitForOutputAfter(run: PtyRun, needle: string, offset: number) {
-  await waitFor({
-    timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
-    read: () => (run.visibleOutput().slice(offset).includes(needle) ? true : null),
-    onTimeout: () =>
-      new Error(
-        `timed out waiting for ${JSON.stringify(needle)} after offset ${offset}\n${run.output()}`,
-      ),
-  });
-}
-
-async function createFreshSession(run: PtyRun, newSessionPrefix: string) {
-  const outputOffset = run.visibleOutput().length;
-  await run.write("/new\r", { delay: false });
-  await waitFor({
-    timeoutMs: LOCAL_STARTUP_TIMEOUT_MS,
-    read: () => (run.visibleOutput().includes(newSessionPrefix, outputOffset) ? true : null),
-    onTimeout: () =>
-      new Error(`timed out creating a fresh session after one submission\n${run.output()}`),
-  });
-  const newSessionOffset = run.visibleOutput().lastIndexOf(newSessionPrefix);
-  // Wait for the accepted session's own idle redraw; older PTY frames can
-  // replay busy messages and must never cause a second session creation.
-  await waitForOutputAfter(run, "| idle", newSessionOffset);
-}
 
 async function readRequestBody(req: IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
@@ -623,6 +582,7 @@ type SharedGatewayFixture = {
   gateway: OpenClawTestInstance;
   controlClient: GatewayChatClient;
   mockModel: MockModelServer;
+  run: PtyRun;
   cleanup: () => Promise<void>;
 };
 
@@ -631,6 +591,11 @@ let gatewaySessionSequence = 0;
 
 function buildGatewayModeConfig(params: { tempDir: string; providerBaseUrl: string }) {
   const scenarios: GatewayScenario[] = Object.values(GATEWAY_SCENARIOS);
+  // One minimal agent keeps provider/runtime initialization warm; unique
+  // sessions and per-session models retain each scenario's state boundary.
+  const agentScenarios = [
+    ...new Map(scenarios.map((scenario) => [scenario.agentId, scenario])).values(),
+  ];
   const defaultScenario = GATEWAY_SCENARIOS.validation;
   const defaultModelRef = `tui-pty-mock/${defaultScenario.modelId}`;
   const modelRefs = scenarios.map((scenario) => `tui-pty-mock/${scenario.modelId}`);
@@ -651,7 +616,7 @@ function buildGatewayModeConfig(params: { tempDir: string; providerBaseUrl: stri
         skipBootstrap: true,
       },
       entries: Object.fromEntries(
-        scenarios.map((scenario, index) => [
+        agentScenarios.map((scenario, index) => [
           scenario.agentId,
           {
             ...(index === 0 ? { default: true } : {}),
@@ -685,10 +650,13 @@ async function startSharedGatewayFixture(): Promise<SharedGatewayFixture> {
   let mockModel: MockModelServer | undefined;
   let gateway: OpenClawTestInstance | undefined;
   let controlClient: GatewayChatClient | undefined;
+  let run: PtyRun | undefined;
   try {
     const scenarios: GatewayScenario[] = Object.values(GATEWAY_SCENARIOS);
     await Promise.all(
-      scenarios.map((scenario) => mkdir(path.join(tempDir, scenario.agentId), { recursive: true })),
+      [...new Set(scenarios.map((scenario) => scenario.agentId))].map((agentId) =>
+        mkdir(path.join(tempDir, agentId), { recursive: true }),
+      ),
     );
     mockModel = await startRoutedMockModelServer(
       Object.fromEntries(
@@ -730,18 +698,56 @@ async function startSharedGatewayFixture(): Promise<SharedGatewayFixture> {
       onTimeout: () => new Error("shared Gateway control client did not connect"),
     });
 
+    const initialScenario = GATEWAY_SCENARIOS.validation;
+    const initialSessionKey = `agent:${initialScenario.agentId}:tui-pty-shared`;
+    await controlClient.createSession({
+      key: initialSessionKey,
+      agentId: initialScenario.agentId,
+    });
+    run = startPty(
+      process.execPath,
+      buildTuiProcessArgs([
+        "tui",
+        "--url",
+        gateway.url,
+        "--token",
+        gateway.gatewayToken,
+        "--session",
+        initialSessionKey,
+      ]),
+      {
+        cwd: process.cwd(),
+        env: {
+          ...gateway.env,
+          OPENCLAW_THEME: "dark",
+          NO_COLOR: undefined,
+        },
+        exitTimeoutMs: LOCAL_EXIT_TIMEOUT_MS,
+        outputTimeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+      },
+    );
+    await run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
+
     const fixtureGateway = gateway;
     const fixtureMockModel = mockModel;
     const fixtureControlClient = controlClient;
+    const fixtureRun = run;
     const cleanup = createIdempotentCleanup(async () => {
-      await fixtureControlClient.stop();
       try {
-        await fixtureGateway.cleanup();
+        await fixtureRun.dispose();
       } finally {
         try {
-          await fixtureMockModel.stop();
+          await fixtureControlClient.stop();
         } finally {
-          await rm(tempDir, { recursive: true, force: true });
+          try {
+            await fixtureGateway.cleanup();
+          } finally {
+            try {
+              await fixtureMockModel.stop();
+            } finally {
+              await rm(tempDir, { recursive: true, force: true });
+            }
+          }
         }
       }
     });
@@ -749,17 +755,25 @@ async function startSharedGatewayFixture(): Promise<SharedGatewayFixture> {
       gateway: fixtureGateway,
       controlClient: fixtureControlClient,
       mockModel: fixtureMockModel,
+      run: fixtureRun,
       cleanup,
     };
   } catch (error) {
-    await controlClient?.stop();
     try {
-      await gateway?.cleanup();
+      await run?.dispose();
     } finally {
       try {
-        await mockModel?.stop();
+        await controlClient?.stop();
       } finally {
-        await rm(tempDir, { recursive: true, force: true });
+        try {
+          await gateway?.cleanup();
+        } finally {
+          try {
+            await mockModel?.stop();
+          } finally {
+            await rm(tempDir, { recursive: true, force: true });
+          }
+        }
       }
     }
     throw error;
@@ -773,22 +787,6 @@ async function requireSharedGatewayFixture(): Promise<SharedGatewayFixture> {
   return await sharedGatewayFixtureStartup;
 }
 
-async function cleanupSharedGatewayFixture(
-  startup: Promise<Pick<SharedGatewayFixture, "cleanup">> | undefined,
-): Promise<void> {
-  if (!startup) {
-    return;
-  }
-  let fixture: Pick<SharedGatewayFixture, "cleanup">;
-  try {
-    fixture = await startup;
-  } catch {
-    // The setup hook already reports startup failures. Teardown only owns cleanup.
-    return;
-  }
-  await fixture.cleanup();
-}
-
 async function startGatewayModeTui(
   scenarioId: GatewayScenarioId,
   registerCleanup: CleanupRegistrar,
@@ -798,31 +796,19 @@ async function startGatewayModeTui(
   const requestOffset = shared.mockModel.requests(scenario.modelId).length;
   const sessionKey = `agent:${scenario.agentId}:tui-pty-${++gatewaySessionSequence}`;
   const sessionKeys = new Set([sessionKey]);
-  const run = startPty(
-    process.execPath,
-    buildTuiProcessArgs([
-      "tui",
-      "--url",
-      shared.gateway.url,
-      "--token",
-      shared.gateway.gatewayToken,
-      "--session",
-      sessionKey,
-    ]),
-    {
-      cwd: process.cwd(),
-      env: {
-        ...shared.gateway.env,
-        OPENCLAW_THEME: "dark",
-        NO_COLOR: undefined,
-      },
-      exitTimeoutMs: LOCAL_EXIT_TIMEOUT_MS,
-      outputTimeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
-    },
-  );
+  await shared.controlClient.createSession({ key: sessionKey, agentId: scenario.agentId });
+  await shared.controlClient.patchSession({
+    key: sessionKey,
+    agentId: scenario.agentId,
+    model: `tui-pty-mock/${scenario.modelId}`,
+  });
+  const run = shared.run;
+  const outputOffset = run.visibleOutput().length;
+  // Session adoption is the per-case isolation boundary for the shared PTY.
+  await run.write(`/session ${sessionKey}\r`, { delay: false });
+  await waitForOutputAfter(run, `session ${sessionKey.split(":").at(-1)}`, outputOffset);
   const cleanup = createIdempotentCleanup(async () => {
     shared.mockModel.releaseFirstResponse(scenario.modelId);
-    await run.dispose();
     for (const key of sessionKeys) {
       await shared.controlClient.abortChat({ sessionKey: key });
     }
@@ -838,70 +824,26 @@ async function startGatewayModeTui(
     },
     agentId: scenario.agentId,
     sessionKey,
+    outputOffset,
+    waitForOutput: async (needle: string, timeoutMs = LOCAL_OUTPUT_TIMEOUT_MS) =>
+      await waitForOutputAfter(run, needle, outputOffset, timeoutMs),
+    visibleOutput: () => run.visibleOutput().slice(outputOffset),
+    lastOutputIndex: (needle: string) => lastOutputIndexAfter(run, needle, outputOffset),
     trackSessionKey: (key: string) => sessionKeys.add(key),
     cleanup,
   };
 }
 
-// Gateway cases share one real server but keep isolated PTYs, models, and sessions.
-// Keep them serial so constrained release runners avoid host contention.
+// Gateway cases share one real server and PTY but keep isolated models and sessions.
+// Per-case abort cleanup and serial order prevent active-run or queue state leaks.
 describe("TUI PTY real backends", () => {
-  it("owns late fixture startup without swallowing cleanup failures", async () => {
-    await expect(
-      cleanupSharedGatewayFixture(Promise.reject(new Error("setup failed"))),
-    ).resolves.toBe(undefined);
-
-    const cleanupError = new Error("cleanup failed");
-    const fixture = {
-      cleanup: async () => {
-        throw cleanupError;
-      },
-    };
-    await expect(cleanupSharedGatewayFixture(Promise.resolve(fixture))).rejects.toBe(cleanupError);
-  });
-
-  it("does not replay a session rollover when an old busy notice is redrawn", async () => {
-    const newSessionPrefix = "new session: agent:main:tui-";
-    const acceptedSession = createDeferred();
-    const writes: string[] = [];
-    let output = "";
-    let acceptanceTimer: ReturnType<typeof setTimeout> | undefined;
-    const run = {
-      output: () => output,
-      visibleOutput: () => output.replace(/\s+/gu, " "),
-      write: async (data: string) => {
-        writes.push(data);
-        if (writes.length === 1) {
-          output += `${SESSION_ROLLOVER_BUSY_MESSAGE}\n`;
-          acceptanceTimer = setTimeout(() => {
-            output += `${newSessionPrefix}accepted\nlocal ready | idle\n`;
-            acceptedSession.resolve();
-          }, SUBMISSION_SETTLE_MS + 50);
-          return;
-        }
-        output += `${newSessionPrefix}duplicate\nlocal ready | idle\n`;
-      },
-      waitForOutput: async () => output,
-      waitForExit: async () => ({ exitCode: 0, signal: 0 }),
-      forceKill: async () => {},
-      dispose: async () => {},
-    } satisfies PtyRun;
-
-    try {
-      await createFreshSession(run, newSessionPrefix);
-      await acceptedSession.promise;
-      expect(writes).toEqual(["/new\r"]);
-    } finally {
-      if (acceptanceTimer) {
-        clearTimeout(acceptanceTimer);
-      }
-    }
-  });
-
   it(
-    "drives the real local backend with a mocked model endpoint",
+    "drives and steers the real local backend with a mocked model endpoint",
     async ({ onTestFinished }) => {
-      const fixture = await startLocalModeTui(onTestFinished);
+      const fixture = await startLocalModeTui(onTestFinished, {
+        holdFirstResponse: true,
+        followupReplyText: "LOCAL_STEER_COMPLETE",
+      });
       try {
         await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
         for (const command of ["/status", "/compact", "/commands", "/context"]) {
@@ -914,10 +856,10 @@ describe("TUI PTY real backends", () => {
         await fixture.run.waitForOutput("Usage: /btw [side question]");
         expect(fixture.mockModel.requests()).toHaveLength(0);
 
-        await fixture.run.write("send the local PTY smoke response\r");
+        await fixture.run.write("slow local parent\r");
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
-          read: () => (fixture.mockModel.requests().length > 0 ? true : null),
+          read: () => (fixture.mockModel.requests().length === 1 ? true : null),
           onTimeout: () =>
             new Error(
               `mock model server did not receive a request\nrequests=${JSON.stringify(
@@ -930,52 +872,6 @@ describe("TUI PTY real backends", () => {
         const request = fixture.mockModel.requests()[0];
         expect(request?.path).toBe("/v1/responses");
         expect(request?.body.model).toBe("gpt-5.5");
-        await fixture.run.waitForOutput("LOCAL_PTY_RESPONSE");
-
-        const responseOffset = fixture.run.visibleOutput().lastIndexOf("LOCAL_PTY_RESPONSE");
-        await waitForOutputAfter(fixture.run, "| idle", responseOffset);
-        await createFreshSession(fixture.run, "new session: agent:main:tui-");
-        const secondResponseStart = fixture.run.visibleOutput().length;
-        await fixture.run.write("send after local new\r");
-        await waitFor({
-          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
-          read: () => (fixture.mockModel.requests().length === 2 ? true : null),
-          onTimeout: () =>
-            new Error(`post-/new prompt did not reach the model\n${fixture.run.output()}`),
-        });
-        expect(JSON.stringify(fixture.mockModel.requests()[1]?.body)).toContain(
-          "send after local new",
-        );
-        await waitForOutputAfter(fixture.run, "LOCAL_PTY_RESPONSE", secondResponseStart);
-        const secondResponseOffset = fixture.run.visibleOutput().lastIndexOf("LOCAL_PTY_RESPONSE");
-        await waitForOutputAfter(fixture.run, "| idle", secondResponseOffset);
-
-        await fixture.run.write("/exit\r", { delay: false });
-        const exit = await fixture.run.waitForExit();
-        expect(exit.exitCode).toBe(0);
-      } finally {
-        await fixture.cleanup();
-      }
-    },
-    LOCAL_TEST_TIMEOUT_MS,
-  );
-
-  it(
-    "steers an active real local session in the same turn",
-    async ({ onTestFinished }) => {
-      const fixture = await startLocalModeTui(onTestFinished, {
-        holdFirstResponse: true,
-        followupReplyText: "LOCAL_STEER_COMPLETE",
-      });
-      try {
-        await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
-        await fixture.run.write("slow local parent\r");
-        await waitFor({
-          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
-          read: () => (fixture.mockModel.requests().length === 1 ? true : null),
-          onTimeout: () =>
-            new Error(`first prompt did not reach the model\n${fixture.run.output()}`),
-        });
 
         const steerOffset = fixture.run.visibleOutput().length;
         await fixture.run.write("steer the active local turn\r");
@@ -1012,6 +908,25 @@ describe("TUI PTY real backends", () => {
             }),
           );
         }
+
+        const steerResponseOffset = fixture.run.visibleOutput().lastIndexOf("LOCAL_STEER_COMPLETE");
+        await waitForOutputAfter(fixture.run, "| idle", steerResponseOffset);
+        await createFreshSession(fixture.run, "new session: agent:main:tui-");
+        const freshResponseStart = fixture.run.visibleOutput().length;
+        await fixture.run.write("send after local new\r");
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (fixture.mockModel.requests().length === 3 ? true : null),
+          onTimeout: () =>
+            new Error(`post-/new prompt did not reach the model\n${fixture.run.output()}`),
+        });
+        const freshRequest = JSON.stringify(fixture.mockModel.requests()[2]?.body);
+        expect(freshRequest).toContain("send after local new");
+        expect(freshRequest).not.toContain("slow local parent");
+        expect(freshRequest).not.toContain("steer the active local turn");
+        await waitForOutputAfter(fixture.run, "LOCAL_STEER_COMPLETE", freshResponseStart);
+        const freshResponseOffset = fixture.run.visibleOutput().lastIndexOf("LOCAL_STEER_COMPLETE");
+        await waitForOutputAfter(fixture.run, "| idle", freshResponseOffset);
 
         await fixture.run.write("/exit\r", { delay: false });
         expect((await fixture.run.waitForExit()).exitCode).toBe(0);
@@ -1056,10 +971,9 @@ describe("TUI PTY real backends", () => {
             });
             await eventProbe.subscribeSessionEvents();
           }
-          await fixture.run.waitForOutput(
-            mode === "gateway" ? "gateway connected" : "local ready",
-            LOCAL_STARTUP_TIMEOUT_MS,
-          );
+          if (fixture.kind === "local") {
+            await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
+          }
           await fixture.run.write("trigger malformed edit calls\r");
           await waitFor({
             timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
@@ -1093,16 +1007,24 @@ describe("TUI PTY real backends", () => {
             });
           }
           await fixture.run.write("\u001b", { delay: false });
-          await fixture.run.waitForOutput(
-            "run aborted: edit tool validation failed:",
-            LOCAL_OUTPUT_TIMEOUT_MS,
-          );
+          if (fixture.kind === "gateway") {
+            await fixture.waitForOutput("run aborted: edit tool validation failed:");
+          } else {
+            await fixture.run.waitForOutput(
+              "run aborted: edit tool validation failed:",
+              LOCAL_OUTPUT_TIMEOUT_MS,
+            );
+          }
 
           expect(fixture.mockModel.requests().length).toBeGreaterThanOrEqual(2);
-          expect(fixture.run.visibleOutput()).not.toContain("Received arguments");
+          const caseOutput =
+            fixture.kind === "gateway" ? fixture.visibleOutput() : fixture.run.visibleOutput();
+          expect(caseOutput).not.toContain("Received arguments");
 
-          await fixture.run.write("/exit\r", { delay: false });
-          expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+          if (fixture.kind === "local") {
+            await fixture.run.write("/exit\r", { delay: false });
+            expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+          }
         } finally {
           await eventProbe?.stop();
           await fixture.cleanup();
@@ -1111,8 +1033,6 @@ describe("TUI PTY real backends", () => {
       LOCAL_TEST_TIMEOUT_MS,
     );
   }
-
-  registerValidationLoopTest("local");
 
   // Register every Gateway case inside the nested suite so targeted runs retain
   // the fixture's separate startup timeout.
@@ -1124,67 +1044,18 @@ describe("TUI PTY real backends", () => {
   }
 
   registerGatewayTest(
-    "forwards Ctrl+D-edited terminal input through the real Gateway",
-    async ({ onTestFinished }) => {
-      const fixture = await startGatewayModeTui("ctrlD", onTestFinished);
-      try {
-        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
-        await fixture.run.write("keepXword", { delay: false });
-        await fixture.run.write("\u001b[D".repeat(5), { delay: false });
-        await fixture.run.write("\u0004", { delay: false });
-        await fixture.run.write("\r", { delay: false });
-
-        await waitFor({
-          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
-          read: () => (fixture.mockModel.requests().length === 1 ? true : null),
-          onTimeout: () =>
-            new Error(
-              `Ctrl+D-edited terminal input did not reach the real Gateway\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
-            ),
-        });
-        const request = JSON.stringify(fixture.mockModel.requests()[0]?.body);
-        expect(request).toContain("keepword");
-        expect(request).not.toContain("keepXword");
-        await fixture.run.waitForOutput("CTRL_D_FORWARD_DELETE_COMPLETE");
-
-        await fixture.run.write("/exit\r", { delay: false });
-        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
-      } finally {
-        await fixture.cleanup();
-      }
-    },
-    LOCAL_TEST_TIMEOUT_MS,
-  );
-
-  registerGatewayTest(
-    "exits the real Gateway terminal when Ctrl+D is pressed with empty input",
-    async ({ onTestFinished }) => {
-      const fixture = await startGatewayModeTui("ctrlD", onTestFinished);
-      try {
-        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
-        await fixture.run.write("\u0004", { delay: false });
-        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
-      } finally {
-        await fixture.cleanup();
-      }
-    },
-    LOCAL_TEST_TIMEOUT_MS,
-  );
-
-  registerGatewayTest(
     "preserves a disconnected draft across a real Gateway restart",
     async ({ onTestFinished }) => {
       const fixture = await startGatewayModeTui("reconnect", onTestFinished);
       let gatewayStopped = false;
       try {
-        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
         const disconnectOffset = fixture.run.visibleOutput().length;
         await fixture.gateway.stopGateway();
         gatewayStopped = true;
         await waitForOutputAfter(fixture.run, "gateway disconnected", disconnectOffset);
 
         await fixture.run.write("send preserved draft after restart\r");
-        await fixture.run.waitForOutput("not connected to gateway — message not sent");
+        await fixture.waitForOutput("not connected to gateway — message not sent");
         expect(fixture.mockModel.requests()).toHaveLength(0);
 
         const reconnectOffset = fixture.run.visibleOutput().length;
@@ -1208,10 +1079,7 @@ describe("TUI PTY real backends", () => {
         expect(JSON.stringify(fixture.mockModel.requests()[0]?.body)).toContain(
           "send preserved draft after restart",
         );
-        await fixture.run.waitForOutput("RECONNECTED_RUN_COMPLETE");
-
-        await fixture.run.write("/exit\r", { delay: false });
-        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+        await fixture.waitForOutput("RECONNECTED_RUN_COMPLETE");
       } finally {
         if (gatewayStopped) {
           await fixture.gateway.startGateway();
@@ -1228,10 +1096,9 @@ describe("TUI PTY real backends", () => {
       const fixture = await startGatewayModeTui("crossClient", onTestFinished);
       let externalClient: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
       try {
-        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
         await fixture.run.write("seed cross-client session\r");
-        await fixture.run.waitForOutput("FIRST_RUN_ACTIVE", LOCAL_OUTPUT_TIMEOUT_MS);
-        const firstReplyOffset = fixture.run.visibleOutput().lastIndexOf("FIRST_RUN_ACTIVE");
+        await fixture.waitForOutput("FIRST_RUN_ACTIVE");
+        const firstReplyOffset = fixture.lastOutputIndex("FIRST_RUN_ACTIVE");
         await waitForOutputAfter(fixture.run, "| idle", firstReplyOffset);
         const connectedExternalClient = await connectGatewayClient({
           url: fixture.gateway.url,
@@ -1252,9 +1119,9 @@ describe("TUI PTY real backends", () => {
             }),
         );
 
-        await fixture.run.waitForOutput(marker, LOCAL_OUTPUT_TIMEOUT_MS);
-        await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE", LOCAL_OUTPUT_TIMEOUT_MS);
-        const followupOffset = fixture.run.visibleOutput().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
+        await fixture.waitForOutput(marker);
+        await fixture.waitForOutput("FOLLOWUP_RUN_COMPLETE");
+        const followupOffset = fixture.lastOutputIndex("FOLLOWUP_RUN_COMPLETE");
         await waitForOutputAfter(fixture.run, "| idle", followupOffset);
         console.info(
           "[behavior-evidence] tui-real-gateway-cross-client",
@@ -1262,13 +1129,11 @@ describe("TUI PTY real backends", () => {
             transport: "real Gateway WebSocket",
             terminal: "real PTY",
             externalMessage: marker,
-            externalMessageRendered: fixture.run.visibleOutput().includes(marker),
-            followupRendered: fixture.run.visibleOutput().includes("FOLLOWUP_RUN_COMPLETE"),
+            externalMessageRendered: fixture.visibleOutput().includes(marker),
+            followupRendered: fixture.visibleOutput().includes("FOLLOWUP_RUN_COMPLETE"),
             returnedToIdle: fixture.run.visibleOutput().slice(followupOffset).includes("| idle"),
           }),
         );
-        await fixture.run.write("/exit\r", { delay: false });
-        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
       } finally {
         try {
           await externalClient?.stopAndWait({ timeoutMs: 1_000 });
@@ -1281,97 +1146,10 @@ describe("TUI PTY real backends", () => {
   );
 
   registerGatewayTest(
-    "creates and adopts a fresh session through the real Gateway backend",
-    async ({ onTestFinished }) => {
-      const fixture = await startGatewayModeTui("newSession", onTestFinished);
-      try {
-        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
-        await fixture.run.write("seed gateway session\r");
-        await fixture.run.waitForOutput("FIRST_RUN_ACTIVE");
-
-        const responseOffset = fixture.run.visibleOutput().lastIndexOf("FIRST_RUN_ACTIVE");
-        await waitForOutputAfter(fixture.run, "| idle", responseOffset);
-        const newSessionPrefix = `new session: agent:${fixture.agentId}:tui-`;
-        await createFreshSession(fixture.run, newSessionPrefix);
-        const newSessionKey = fixture.run
-          .visibleOutput()
-          .match(new RegExp(`new session: (agent:${fixture.agentId}:tui-[a-z0-9-]+)`))?.[1];
-        expect(newSessionKey).toBeDefined();
-        if (newSessionKey) {
-          fixture.trackSessionKey(newSessionKey);
-        }
-        await fixture.run.write("send after gateway new\r");
-        await waitFor({
-          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
-          read: () => (fixture.mockModel.requests().length === 2 ? true : null),
-          onTimeout: () =>
-            new Error(
-              `post-/new Gateway prompt did not reach the model\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
-            ),
-        });
-        const freshRequest = JSON.stringify(fixture.mockModel.requests()[1]?.body);
-        expect(freshRequest).toContain("send after gateway new");
-        expect(freshRequest).not.toContain("seed gateway session");
-
-        await fixture.run.write("/exit\r", { delay: false });
-        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
-      } finally {
-        await fixture.cleanup();
-      }
-    },
-    LOCAL_TEST_TIMEOUT_MS,
-  );
-
-  registerGatewayTest(
-    "preserves a running session when /reset is typed against the real Gateway",
-    async ({ onTestFinished }) => {
-      const fixture = await startGatewayModeTui("reset", onTestFinished);
-      try {
-        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
-        await fixture.run.write("keep the active Gateway turn\r");
-        await waitFor({
-          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
-          read: () => (fixture.mockModel.requests().length === 1 ? true : null),
-          onTimeout: () =>
-            new Error(`active Gateway turn did not reach the model\n${fixture.run.output()}`),
-        });
-
-        await fixture.run.write("/reset\r", { delay: false });
-        await fixture.run.waitForOutput("abort the current run before /reset", 5_000);
-        expect(fixture.mockModel.requests()).toHaveLength(1);
-
-        fixture.mockModel.releaseFirstResponse();
-        await fixture.run.waitForOutput("FIRST_RUN_ACTIVE");
-
-        await fixture.run.write("continue the preserved Gateway session\r");
-        await waitFor({
-          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
-          read: () => (fixture.mockModel.requests().length === 2 ? true : null),
-          onTimeout: () =>
-            new Error(
-              `preserved Gateway session did not accept its next turn\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
-            ),
-        });
-        const preservedRequest = JSON.stringify(fixture.mockModel.requests()[1]?.body);
-        expect(preservedRequest).toContain("keep the active Gateway turn");
-        expect(preservedRequest).toContain("continue the preserved Gateway session");
-        await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE");
-
-        await fixture.run.write("/exit\r", { delay: false });
-        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
-      } finally {
-        await fixture.cleanup();
-      }
-    },
-    LOCAL_TEST_TIMEOUT_MS,
-  );
-
-  registerGatewayTest(
     "forwards an active-run prompt through the real Gateway followup queue",
     async ({ onTestFinished }) => {
       const fixture = await startGatewayModeTui("followup", onTestFinished);
       try {
-        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
         await fixture.run.write("slow first turn\r");
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
@@ -1398,8 +1176,8 @@ describe("TUI PTY real backends", () => {
               )}\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
             ),
         });
-        await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE");
-        const completedOffset = fixture.run.visibleOutput().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
+        await fixture.waitForOutput("FOLLOWUP_RUN_COMPLETE");
+        const completedOffset = fixture.lastOutputIndex("FOLLOWUP_RUN_COMPLETE");
 
         await fixture.run.write("turn after queued followup\r");
         await waitFor({
@@ -1417,14 +1195,14 @@ describe("TUI PTY real backends", () => {
         expect(JSON.stringify(fixture.mockModel.requests()[2]?.body)).toContain(
           "turn after queued followup",
         );
-        await waitForOutputAfter(fixture.run, "FOLLOWUP_RUN_COMPLETE", completedOffset);
-        const finalResponseOffset = fixture.run
-          .visibleOutput()
-          .lastIndexOf("FOLLOWUP_RUN_COMPLETE");
+        const nextResponseOffset = completedOffset + "FOLLOWUP_RUN_COMPLETE".length;
+        await waitForOutputAfter(fixture.run, "FOLLOWUP_RUN_COMPLETE", nextResponseOffset);
+        const finalResponseOffset = lastOutputIndexAfter(
+          fixture.run,
+          "FOLLOWUP_RUN_COMPLETE",
+          nextResponseOffset,
+        );
         await waitForOutputAfter(fixture.run, "| idle", finalResponseOffset);
-
-        await fixture.run.write("/exit\r", { delay: false });
-        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
       } finally {
         await fixture.cleanup();
       }
@@ -1437,7 +1215,6 @@ describe("TUI PTY real backends", () => {
     async ({ onTestFinished }) => {
       const fixture = await startGatewayModeTui("emptyReply", onTestFinished);
       try {
-        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
         await fixture.run.write("non-deliverable first turn\r");
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
@@ -1449,7 +1226,7 @@ describe("TUI PTY real backends", () => {
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
           read: () =>
-            fixture.run.visibleOutput().includes("did not produce a visible reply") ? true : null,
+            fixture.visibleOutput().includes("did not produce a visible reply") ? true : null,
           onTimeout: () =>
             new Error(
               `empty-reply fallback was not rendered\nrequests=${JSON.stringify(
@@ -1460,7 +1237,7 @@ describe("TUI PTY real backends", () => {
             ),
         });
         expect(fixture.mockModel.requests()).toHaveLength(1);
-        expect(fixture.run.visibleOutput()).not.toContain("[[reply_to_current]]");
+        expect(fixture.visibleOutput()).not.toContain("[[reply_to_current]]");
 
         await fixture.run.write("turn after empty reply\r");
         await waitFor({
@@ -1471,10 +1248,7 @@ describe("TUI PTY real backends", () => {
               `TUI stayed blocked after empty-reply fallback\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
             ),
         });
-        await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE");
-
-        await fixture.run.write("/exit\r", { delay: false });
-        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+        await fixture.waitForOutput("FOLLOWUP_RUN_COMPLETE");
       } finally {
         await fixture.cleanup();
       }
@@ -1487,7 +1261,6 @@ describe("TUI PTY real backends", () => {
     async ({ onTestFinished }) => {
       const fixture = await startGatewayModeTui("cancel", onTestFinished);
       try {
-        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
         await fixture.run.write("slow turn to abort\r");
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
@@ -1500,16 +1273,15 @@ describe("TUI PTY real backends", () => {
         await waitForOutputAfter(fixture.run, "must never reach model", followupOffset);
         await sleep(SUBMISSION_SETTLE_MS);
         await fixture.run.write("\u001b", { delay: false });
-        await fixture.run.waitForOutput("aborted");
+        await fixture.waitForOutput("aborted");
         fixture.mockModel.releaseFirstResponse();
         // Abort has cleared the queue; keep only a short window for a stray provider request.
         await sleep(250);
 
         expect(fixture.mockModel.requests()).toHaveLength(1);
-        expect(fixture.run.visibleOutput()).not.toContain("FOLLOWUP_RUN_COMPLETE");
-
-        await fixture.run.write("/exit\r", { delay: false });
-        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+        expect(fixture.run.visibleOutput().slice(followupOffset)).not.toContain(
+          "FOLLOWUP_RUN_COMPLETE",
+        );
       } finally {
         await fixture.cleanup();
       }
@@ -1532,14 +1304,13 @@ describe("TUI PTY real backends", () => {
           queueClientConnected = true;
         };
         queueClient.start();
-        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
         await waitFor({
           timeoutMs: LOCAL_STARTUP_TIMEOUT_MS,
           read: () => (queueClientConnected ? true : null),
           onTimeout: () => new Error("TUI Gateway client did not connect"),
         });
         await fixture.run.write("/queue collect debounce:250ms\r", { delay: false });
-        await fixture.run.waitForOutput("Queue mode set to collect.");
+        await fixture.waitForOutput("Queue mode set to collect.");
         await fixture.run.write("slow collect parent\r");
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
@@ -1570,8 +1341,8 @@ describe("TUI PTY real backends", () => {
               `collected prompt did not reach the model\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
             ),
         });
-        await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE");
-        const completedOffset = fixture.run.visibleOutput().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
+        await fixture.waitForOutput("FOLLOWUP_RUN_COMPLETE");
+        const completedOffset = fixture.lastOutputIndex("FOLLOWUP_RUN_COMPLETE");
         await waitForOutputAfter(fixture.run, "| idle", completedOffset);
 
         const requests = fixture.mockModel.requests();
@@ -1586,9 +1357,6 @@ describe("TUI PTY real backends", () => {
         const collectedBody = JSON.stringify(fixture.mockModel.requests()[1]?.body);
         expect(collectedBody).toContain("collect prompt alpha");
         expect(collectedBody).toContain("collect prompt beta");
-
-        await fixture.run.write("/exit\r", { delay: false });
-        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
       } finally {
         await queueClient.stop();
         await fixture.cleanup();
@@ -1607,7 +1375,7 @@ describe("TUI PTY real backends", () => {
     afterAll(async () => {
       const startup = sharedGatewayFixtureStartup;
       sharedGatewayFixtureStartup = undefined;
-      await cleanupSharedGatewayFixture(startup);
+      await cleanupStartedFixture(startup);
     }, LOCAL_TEST_TIMEOUT_MS);
 
     for (const register of gatewayTestRegistrations) {


### PR DESCRIPTION
## What Problem This Solves

The built-artifact check was dominated by the serial TUI PTY lane. In main run 30789242864, channels and core-support completed in about 30 seconds and gateway-watch reported 14.24 seconds, while TUI PTY held the step for about 359 seconds.

The real Gateway and mock model server were already shared, but each retained Gateway scenario still launched a new TUI process and cold-initialized a dedicated agent. This change keeps the suite serial and reuses one real Gateway PTY across the unique full-stack scenarios. Every case still gets a fresh session, an explicit per-session model, request/output offsets, and abort cleanup. Repeated output markers are scoped to the session-switch boundary so an earlier case cannot satisfy a later assertion.

The real-local smoke and steering contracts now run in one isolated local PTY. Backend-free helper regressions move to a fast owner test.

Redundant real-Gateway cases were removed only where dedicated owners retain the behavior:

- Ctrl+D editing and empty-editor exit: `src/tui/tui-pty-harness.e2e.test.ts` plus `src/tui/components/custom-editor.test.ts`.
- Blocked `/reset` during an active run: `src/tui/tui-pty-harness.e2e.test.ts` plus `src/tui/tui-command-handlers.test.ts`.
- Gateway `/new`: the real-local smoke retains fresh-context proof, while the fake PTY and command-handler suites own create/adopt/serialization behavior.
- Local validation-loop duplication: the retained real-Gateway case adds the unique `session.tool` projection proof; embedded-backend and event-handler suites own local mechanics.

No production code, test sharding, worker count, or concurrency changed. The test patch is net 115 lines smaller.

## Evidence

Exact main baseline:

- Run: https://github.com/openclaw/openclaw/actions/runs/30789242864
- Job: https://github.com/openclaw/openclaw/actions/runs/30789242864/job/91609378440
- `Run built artifact checks`: about 359 seconds, owned by TUI PTY.
- Original real-local case time: about 302 seconds.

After, using the built CLI path:

```sh
OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 \
OPENCLAW_TUI_PTY_USE_BUILT_CLI=1 \
node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.tui-pty.config.ts \
  --reporter=verbose
```

- Full TUI PTY shard: 3/3 files, 61/61 tests, 139.01 seconds.
- Retained real-local file: 8/8 tests, 91.00 seconds.
- Measured TUI lane saving: about 220 seconds.

Coverage-owner proof:

- Moved helper regressions: 2/2 passed in 631ms.
- Targeted Ctrl+D, `/new`, and `/reset` owners: 15/15 passed.
- Real external-client behavior evidence remained present in the full-shard run.
- `git diff --check` and oxfmt passed.
- Autoreview initially found stale shared-output matching; the finding was accepted and fixed. Final P1 review was clean.

`check-changed` was attempted through Crabbox/Daytona but provider hydration failed before repository checks because `/var/cache/crabbox` was not writable. The owned lease was cleaned up; focused and sibling proof above completed locally.
