### PR TITLE
fix: clarify bootstrap setup versus prompt injection

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -91,7 +91,7 @@ Skips creation of selected optional workspace files while still writing required
 Controls when workspace bootstrap files are injected into the system prompt. Default: `"always"`.
 
 - `"continuation-skip"`: safe continuation turns (after a completed assistant response) skip workspace bootstrap re-injection, reducing prompt size. Heartbeat runs and post-compaction retries still rebuild context.
-- `"never"`: disable workspace bootstrap and context-file injection on every turn. Use this only for agents that fully own their prompt lifecycle (custom context engines, native runtimes that build their own context, or specialized bootstrap-free workflows). Heartbeat and compaction-recovery turns also skip injection.
+- `"never"`: disable OpenClaw-managed workspace bootstrap and context-file injection on every turn. Native harnesses may still load their own project documents (for example, `AGENTS.md`) according to their SDK rules. Use this only for agents that fully own their prompt lifecycle (custom context engines, native runtimes that build their own context, or specialized bootstrap-free workflows). Heartbeat and compaction-recovery turns also skip OpenClaw-managed injection.
 
 ```json5
 {

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -64,7 +64,7 @@ Optional default skill allowlist for agents that do not set
 
 ### `agents.defaults.skipBootstrap`
 
-Disables automatic creation of workspace bootstrap files (`AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, `BOOTSTRAP.md`).
+Disables automatic creation of workspace bootstrap files (`AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, `BOOTSTRAP.md`). This only affects setup; to disable injecting existing workspace bootstrap and context files into agent prompts, use `agents.defaults.contextInjection: "never"`.
 
 ```json5
 {

--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -11,6 +11,7 @@ import {
   registerMemoryCapability,
 } from "openclaw/plugin-sdk/memory-host-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
   buildCodexOpenClawPromptContext,
   buildCodexWatchedSessionsContext,
@@ -27,6 +28,8 @@ afterEach(() => {
   vi.restoreAllMocks();
   clearMemoryPluginState();
 });
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("Codex app-server attempt context", () => {
   it("treats missing mirrored session history as empty without hook warning", async () => {
@@ -148,7 +151,7 @@ describe("Codex app-server attempt context", () => {
   });
 
   it("does not load OpenClaw-managed workspace context when injection is never", async () => {
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-context-injection-never-"));
+    const workspaceDir = tempDirs.make("codex-context-injection-never-");
     await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "must not reach the prompt");
 
     const context = await buildCodexWorkspaceBootstrapContext({

--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -11,7 +11,6 @@ import {
   registerMemoryCapability,
 } from "openclaw/plugin-sdk/memory-host-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
   buildCodexOpenClawPromptContext,
   buildCodexWatchedSessionsContext,
@@ -28,8 +27,6 @@ afterEach(() => {
   vi.restoreAllMocks();
   clearMemoryPluginState();
 });
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("Codex app-server attempt context", () => {
   it("treats missing mirrored session history as empty without hook warning", async () => {
@@ -151,28 +148,32 @@ describe("Codex app-server attempt context", () => {
   });
 
   it("does not load OpenClaw-managed workspace context when injection is never", async () => {
-    const workspaceDir = tempDirs.make("codex-context-injection-never-");
-    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "must not reach the prompt");
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-context-injection-never-"));
+    try {
+      await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "must not reach the prompt");
 
-    const context = await buildCodexWorkspaceBootstrapContext({
-      params: {
-        sessionId: "session-1",
-        sessionKey: "agent:main:session-1",
-        agentId: "main",
-        config: {
-          agents: {
-            defaults: { workspace: workspaceDir, contextInjection: "never" },
+      const context = await buildCodexWorkspaceBootstrapContext({
+        params: {
+          sessionId: "session-1",
+          sessionKey: "agent:main:session-1",
+          agentId: "main",
+          config: {
+            agents: {
+              defaults: { workspace: workspaceDir, contextInjection: "never" },
+            },
           },
-        },
-      } as EmbeddedRunAttemptParams,
-      resolvedWorkspace: workspaceDir,
-      effectiveWorkspace: workspaceDir,
-      sessionKey: "agent:main:session-1",
-      sessionAgentId: "main",
-      memoryToolNames: [],
-    });
+        } as EmbeddedRunAttemptParams,
+        resolvedWorkspace: workspaceDir,
+        effectiveWorkspace: workspaceDir,
+        sessionKey: "agent:main:session-1",
+        sessionAgentId: "main",
+        memoryToolNames: [],
+      });
 
-    expect(context).toEqual({ bootstrapFiles: [], contextFiles: [] });
+      expect(context).toEqual({ bootstrapFiles: [], contextFiles: [] });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   it("passes agent context to Codex memory collaboration guidance", async () => {

--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -147,6 +147,31 @@ describe("Codex app-server attempt context", () => {
     expect(context.memoryToolRouted).toBe(false);
   });
 
+  it("does not load OpenClaw-managed workspace context when injection is never", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-context-injection-never-"));
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "must not reach the prompt");
+
+    const context = await buildCodexWorkspaceBootstrapContext({
+      params: {
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        agentId: "main",
+        config: {
+          agents: {
+            defaults: { workspace: workspaceDir, contextInjection: "never" },
+          },
+        },
+      } as EmbeddedRunAttemptParams,
+      resolvedWorkspace: workspaceDir,
+      effectiveWorkspace: workspaceDir,
+      sessionKey: "agent:main:session-1",
+      sessionAgentId: "main",
+      memoryToolNames: [],
+    });
+
+    expect(context).toEqual({ bootstrapFiles: [], contextFiles: [] });
+  });
+
   it("passes agent context to Codex memory collaboration guidance", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-agent-memory-"));
     let observedContext:

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -8,6 +8,7 @@ import {
   buildBootstrapContextForFiles,
   buildWatchedSessionsHarnessContext,
   embeddedAgentLog,
+  resolveContextInjectionMode,
   resolveBootstrapFilesForRun,
   type AgentMessage,
   type ContextEngineProjection,
@@ -176,6 +177,14 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
   sandboxed?: boolean;
 }): Promise<CodexWorkspaceBootstrapContext> {
   try {
+    if (
+      resolveContextInjectionMode(
+        params.params.config,
+        params.params.agentId ?? params.sessionAgentId,
+      ) === "never"
+    ) {
+      return { bootstrapFiles: [], contextFiles: [] };
+    }
     const memoryToolsAvailable =
       params.memoryToolNames.length > 0 &&
       canRouteCodexWorkspaceMemoryThroughTools({

--- a/extensions/copilot/src/workspace-bootstrap.test.ts
+++ b/extensions/copilot/src/workspace-bootstrap.test.ts
@@ -55,6 +55,19 @@ describe("resolveCopilotWorkspaceBootstrapContext", () => {
     expect(result.instructions).toContain("Soul voice goes here.");
   });
 
+  it("does not load OpenClaw-managed workspace context when injection is never", async () => {
+    await writeFile(path.join(workspaceDir, "SOUL.md"), "must not reach the prompt");
+    const result = await resolveCopilotWorkspaceBootstrapContext({
+      attempt: makeAttempt({
+        workspaceDir,
+        config: { agents: { defaults: { contextInjection: "never" } } },
+      }),
+      effectiveWorkspaceDir: workspaceDir,
+    });
+
+    expect(result).toEqual({ bootstrapFiles: [], contextFiles: [] });
+  });
+
   it("orders persona context and renders the SOUL hint through the workspace boundary", async () => {
     await writeFile(path.join(workspaceDir, "USER.md"), "USER body");
     await writeFile(path.join(workspaceDir, "SOUL.md"), "SOUL body");

--- a/extensions/copilot/src/workspace-bootstrap.ts
+++ b/extensions/copilot/src/workspace-bootstrap.ts
@@ -5,6 +5,7 @@ import type {
   EmbeddedContextFile,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
+  resolveContextInjectionMode,
   resolveBootstrapContextForRun,
   resolveUserPath,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
@@ -82,6 +83,9 @@ export async function resolveCopilotWorkspaceBootstrapContext(params: {
   const { attempt } = params;
   const workspaceDir = readResolvedWorkspacePath(attempt.workspaceDir);
   if (!workspaceDir) {
+    return { bootstrapFiles: [], contextFiles: [] };
+  }
+  if (resolveContextInjectionMode(attempt.config, attempt.agentId) === "never") {
     return { bootstrapFiles: [], contextFiles: [] };
   }
   try {

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -272,7 +272,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: normalized Gateway public origin resolver for plugin-generated links.
       // -2: retire the dead progress-draft render reader; it counted twice via
       // channel-outbound and channel-message's wildcard re-export of it.
-      4306,
+      // +1: context-injection mode resolver for bundled agent harnesses.
+      4307,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -341,7 +342,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: normalized Gateway public origin resolver for plugin-generated links.
       // -2: retire the dead progress-draft render reader; it counted twice via
       // channel-outbound and channel-message's wildcard re-export of it.
-      2570,
+      // +1: context-injection mode resolver for bundled agent harnesses.
+      2571,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1739,6 +1739,35 @@ describe("prepareCliRunContext", () => {
     }
   });
 
+  it("does not inject workspace context when contextInjection is never", async () => {
+    const { dir } = fixture.session;
+    const resolveBootstrapContextForRun = vi.fn(async () => ({
+      bootstrapFiles: [
+        { name: "AGENTS.md" as const, path: path.join(dir, "AGENTS.md"), content: "bootstrap" },
+      ],
+      contextFiles: [{ path: path.join(dir, "AGENTS.md"), content: "bootstrap" }],
+    }));
+    setCliRunnerPrepareTestDeps({
+      resolveBootstrapContextForRun,
+    });
+
+    const context = await fixture.prepare({
+      agentId: "main",
+      config: {
+        agents: {
+          defaults: {
+            contextInjection: "never",
+            workspace: dir,
+          },
+        },
+      },
+    });
+
+    expect(resolveBootstrapContextForRun).not.toHaveBeenCalled();
+    expect(context.systemPrompt).not.toContain("bootstrap");
+    expect(context.systemPromptReport.injectedWorkspaceFiles).toEqual([]);
+  });
+
   it("applies prompt-build hook context to Claude-style CLI preparation", async () => {
     const { dir } = fixture.session;
     fixture.appendTranscript({

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -73,6 +73,7 @@ import {
 import {
   makeBootstrapWarn as makeBootstrapWarnImpl,
   resolveBootstrapContextForRun as resolveBootstrapContextForRunImpl,
+  resolveContextInjectionMode,
 } from "../bootstrap-files.js";
 import { isHeartbeatLifecycleRunKind } from "../bootstrap-mode.js";
 import { isPrimaryBootstrapRun, resolveWorkspaceBootstrapRouting } from "../bootstrap-routing.js";
@@ -865,23 +866,25 @@ export async function prepareCliRunContext(
     : undefined;
 
   const sessionLabel = params.sessionKey ?? params.sessionId;
-  const { bootstrapFiles, contextFiles: resolvedContextFiles } = isSideQuestion
-    ? { bootstrapFiles: [], contextFiles: [] }
-    : await prepareDeps.resolveBootstrapContextForRun({
-        workspaceDir,
-        config: params.config,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-        chatType: runtimeChatType,
-        agentId: sessionAgentId,
-        contextMode: params.bootstrapContextMode,
-        runKind: params.bootstrapContextRunKind,
-        warn: prepareDeps.makeBootstrapWarn({
-          sessionLabel,
+  const contextInjectionMode = resolveContextInjectionMode(params.config, sessionAgentId);
+  const { bootstrapFiles, contextFiles: resolvedContextFiles } =
+    isSideQuestion || contextInjectionMode === "never"
+      ? { bootstrapFiles: [], contextFiles: [] }
+      : await prepareDeps.resolveBootstrapContextForRun({
           workspaceDir,
-          warn: (message) => cliBackendLog.warn(message),
-        }),
-      });
+          config: params.config,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          chatType: runtimeChatType,
+          agentId: sessionAgentId,
+          contextMode: params.bootstrapContextMode,
+          runKind: params.bootstrapContextRunKind,
+          warn: prepareDeps.makeBootstrapWarn({
+            sessionLabel,
+            workspaceDir,
+            warn: (message) => cliBackendLog.warn(message),
+          }),
+        });
   // Mirror the embedded runner's bootstrap routing for backends that transport
   // OpenClaw's system prompt. Only a declared native-tool backend can complete
   // the file-based ritual; other backends receive limited guidance.

--- a/src/config/schema.help.models.ts
+++ b/src/config/schema.help.models.ts
@@ -162,7 +162,7 @@ export const MODEL_FIELD_HELP: Record<string, string> = {
   "agents.defaults.skipOptionalBootstrapFiles":
     "Optional bootstrap files that should not be created in agent workspaces. Valid values: SOUL.md, USER.md, IDENTITY.md (HEARTBEAT.md is accepted but a no-op).",
   "agents.defaults.contextInjection":
-    'Controls when workspace bootstrap files are injected into the system prompt: "always" (default), "continuation-skip" for safe continuation turns after a completed assistant response, or "never" to disable workspace bootstrap and context-file injection on every turn.',
+    'Controls when OpenClaw-managed workspace bootstrap files are injected into the system prompt: "always" (default), "continuation-skip" for safe continuation turns after a completed assistant response, or "never" to disable OpenClaw-managed workspace bootstrap and context-file injection on every turn. Native harness loaders may still apply their own project-document rules.',
   "agents.defaults.bootstrapMaxChars":
     "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
   "agents.defaults.bootstrapTotalMaxChars":

--- a/src/config/schema.help.models.ts
+++ b/src/config/schema.help.models.ts
@@ -157,10 +157,12 @@ export const MODEL_FIELD_HELP: Record<string, string> = {
   "auth.order": "Ordered auth profile IDs per provider (used for automatic failover).",
   "agents.defaults.workspace":
     "Default workspace path exposed to agent runtime tools for filesystem context and repo-aware behavior. Set this explicitly when running from wrappers so path resolution stays deterministic.",
+  "agents.defaults.skipBootstrap":
+    'Controls whether setup creates the default workspace bootstrap files. Set true to skip creation; it does not suppress bootstrap-file injection into agent prompts. Use agents.defaults.contextInjection: "never" when you need no workspace bootstrap or context-file injection.',
   "agents.defaults.skipOptionalBootstrapFiles":
     "Optional bootstrap files that should not be created in agent workspaces. Valid values: SOUL.md, USER.md, IDENTITY.md (HEARTBEAT.md is accepted but a no-op).",
   "agents.defaults.contextInjection":
-    'Controls when workspace bootstrap files are injected into the system prompt: "always" (default) or "continuation-skip" for safe continuation turns after a completed assistant response.',
+    'Controls when workspace bootstrap files are injected into the system prompt: "always" (default), "continuation-skip" for safe continuation turns after a completed assistant response, or "never" to disable workspace bootstrap and context-file injection on every turn.',
   "agents.defaults.bootstrapMaxChars":
     "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
   "agents.defaults.bootstrapTotalMaxChars":

--- a/src/config/schema.help.quality.test-fixtures.ts
+++ b/src/config/schema.help.quality.test-fixtures.ts
@@ -372,6 +372,7 @@ export const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "logging.consoleStyle": ['"pretty"', '"json"'],
   "update.channel": ['"stable"', '"extended-stable"', '"beta"', '"dev"'],
   "agents.defaults.compaction.mode": ['"default"', '"safeguard"'],
+  "agents.defaults.contextInjection": ['"always"', '"continuation-skip"', '"never"'],
   "agents.defaults.compaction.thinkingLevel": [
     '"off"',
     '"minimal"',
@@ -447,6 +448,8 @@ export const CHANNELS_AGENTS_TARGET_KEYS = [
   "memory.search.query.maxResults",
   "memory.search.query.minScore",
   "agents.defaults.workspace",
+  "agents.defaults.skipBootstrap",
+  "agents.defaults.contextInjection",
   "agents.entries.*.tools.alsoAllow",
   "agents.entries.*.tools.byProvider",
   "agents.entries.*.tools.message.crossContext.allowAcrossProviders",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -432,6 +432,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.entries.*.subagents.delegationMode": "Sub-agent Delegation Mode",
   "agents.defaults.workspace": "Workspace",
   "agents.defaults.repoRoot": "Repo Root",
+  "agents.defaults.skipBootstrap": "Skip Bootstrap",
   "agents.defaults.skipOptionalBootstrapFiles": "Skipped Optional Bootstrap Files",
   "agents.defaults.contextInjection": "Context Injection",
   "agents.defaults.bootstrapMaxChars": "Bootstrap Max Chars",

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -441,6 +441,7 @@ export {
 } from "../agents/sandbox/fs-paths.js";
 export {
   buildBootstrapContextForFiles,
+  resolveContextInjectionMode,
   resolveBootstrapContextForRun,
   resolveBootstrapFilesForRun,
 } from "../agents/bootstrap-files.js";


### PR DESCRIPTION
Closes #75184

## What Problem This Solves

Fixes an issue where users who set `agents.defaults.skipBootstrap: true` could reasonably expect workspace bootstrap files to stop affecting agent prompts, while the configuration help did not explain that this setting only controls file creation or point to the existing prompt-injection control.

## Why This Change Was Made

Clarify the existing configuration boundary in schema help and gateway documentation: `skipBootstrap` controls workspace file creation, while `contextInjection: "never"` controls prompt-time workspace and context-file injection. The configuration shape remains unchanged, and CLI-run preparation now honors the existing prompt-injection control.

## User Impact

Operators can now choose the correct setting for bootstrap-file creation versus prompt injection without relying on trial and error.

## Evidence

- Exact-head production-path CLI preparation proof on `1e20508b1822867ed73a77700f5db86ec699d447`: `node --import tsx --input-type=module -` invoked `prepareCliRunContext` with the repository test CLI backend and a temporary workspace containing `AGENTS.md`; the bootstrap resolver was not mocked.

  Redacted inspectable output:

  ```text
  {"mode":"always","injectedWorkspaceFiles":[{"name":"AGENTS.md","missing":false,"injectedChars":32,"truncated":false}],"promptContainsBootstrapText":true}
  {"mode":"never","injectedWorkspaceFiles":[],"promptContainsBootstrapText":false}
  ```

  The `always` control confirms the real workspace file is discoverable and injected, while `never` suppresses both the file list and its prompt content.
- Exact-head CLI config-schema proof: `pnpm openclaw config schema --json` returned exit 0 and exposed `skipBootstrap` as file-creation-only plus `contextInjection` values `always`, `continuation-skip`, and `never`, including the per-agent override.
- Supporting checks on the same head: focused regression test passed (`Test Files 1 passed`, `Tests 1 passed | 104 skipped (105)`); targeted `oxfmt --check` passed for 11 changed source files; `git diff --check` passed.
- Proof boundary: the production-path harness proves CLI preparation with a temporary workspace and repository test backend, and the schema CLI proves the exported configuration contract. It does not claim behavior for external providers, private credentials, or devices.
- Exact PR head: `1e20508b1822867ed73a77700f5db86ec699d447`.
AI-assisted: Codex.