### PR TITLE
test(system-agent): reuse approval CLI fixture

### DIFF
--- a/src/system-agent/approval-intent.test.ts
+++ b/src/system-agent/approval-intent.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./approval-intent.js";
 import {
   createSystemAgentVerifiedInferenceTestFixture,
+  installSystemAgentClaudeCliBackendTestFixture,
   installSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
@@ -44,9 +45,11 @@ async function createVerifiedInference(
 }
 
 let sharedVerifiedInference: SystemAgentVerifiedInferenceBinding | undefined;
+let restoreCliBackendFixture: (() => void) | undefined;
 let cliPluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 
 beforeAll(async () => {
+  restoreCliBackendFixture = installSystemAgentClaudeCliBackendTestFixture();
   const defaultSnapshot = installSystemAgentPluginMetadataTestSnapshot(
     verifiedInferenceConfig(DEFAULT_MODEL),
   );
@@ -61,6 +64,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+  restoreCliBackendFixture?.();
   cliPluginMetadataSnapshot?.restore();
 });
 


### PR DESCRIPTION
## What Problem This Solves

The approval-intent suite spent almost all of its runtime loading the Anthropic plugin setup artifact for one mocked CLI approval case.

## Why This Change Was Made

Install the shared contract-level Claude CLI backend fixture already used by the system-agent chat and agent-turn suites, then restore default resolution after the file. The test still exercises real configured-route selection, owner fingerprinting, verified binding, exact-text approval behavior, and drift rejection; Anthropic owner suites retain real generated-backend coverage.

## User Impact

No user-visible behavior changes. The same assertions run substantially faster and with less memory; production code is unchanged.

## Evidence

- Exact main CI run 30793809495, job 91623522072: approval-intent.test.ts took 21.624s; the CLI case alone took 21.151s.
- Same-head focused benchmark: Vitest duration 23.10s to 3.68s; wall time 27.71s to 8.20s; peak RSS 1.654 GB to 0.795 GB.
- Focused proof: 11/11 approval-intent tests passed.
- Core sibling proof: 130/130 chat-engine, agent-turn, and CLI backend tests passed.
- Anthropic owner proof: 96/96 index and CLI shared-contract tests passed.
- Oxfmt, git diff --check, and Codex autoreview passed with no findings.
- Production LOC delta: 0.
