### PR TITLE
fix: keep command tests independent of ambient Gateway tokens

### DIFF
--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -153,6 +153,7 @@ import { EXTERNAL_SERVICE_REPAIR_NOTE } from "./doctor-service-repair-policy.js"
 
 const originalStdinIsTTY = process.stdin.isTTY;
 const originalPlatform = process.platform;
+const originalGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
 const originalUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
 const originalParentSupportsConfigWrite =
   process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE;
@@ -433,6 +434,7 @@ function setupGatewayTokenRepairScenario() {
 describe("maybeRepairGatewayServiceConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
     fsMocks.realpath.mockImplementation(async (value: string) => value);
     mocks.resolveGatewayPort.mockReturnValue(18789);
     mocks.isDefaultInstallIdentity.mockReturnValue(true);
@@ -457,6 +459,11 @@ describe("maybeRepairGatewayServiceConfig", () => {
       configurable: true,
     });
     mockProcessPlatform(originalPlatform);
+    if (originalGatewayToken === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    } else {
+      process.env.OPENCLAW_GATEWAY_TOKEN = originalGatewayToken;
+    }
     if (originalUpdateInProgress === undefined) {
       delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
     } else {

--- a/src/commands/gateway-auth-token.test.ts
+++ b/src/commands/gateway-auth-token.test.ts
@@ -94,7 +94,7 @@ describe("gatewayAuthTokenCommand", () => {
       hadUnresolvedTargets: false,
     });
 
-    await expect(gatewayAuthTokenCommand(runtime, { interactive: true })).rejects.toThrow(
+    await expect(gatewayAuthTokenCommand(runtime, { env: {}, interactive: true })).rejects.toThrow(
       "openclaw doctor --generate-gateway-token",
     );
 


### PR DESCRIPTION
Closes #118574

## What Problem This Solves

Fixes an issue where command-suite validation would fail on credential-hydrated runners when `OPENCLAW_GATEWAY_TOKEN` was present in the ambient environment. Correct production auth resolution changed six unrelated doctor staging assertions and made a missing-token CLI test resolve instead of reject.

## Why This Change Was Made

The test boundary now owns the state it depends on. The missing-token CLI case injects an empty environment explicitly, while the doctor Gateway-service suite clears and restores the Gateway token around each test; cases that intentionally exercise the token still set it through the tracked environment helper. Runtime token precedence and service-repair behavior are unchanged.

## User Impact

There is no runtime behavior change. Maintainers and CI receive deterministic command-suite results regardless of Gateway credentials available on the runner.

This PR is AI-assisted with Codex. I reviewed the implementation and understand the changes.

## Evidence

- Pre-fix focused repro: `OPENCLAW_GATEWAY_TOKEN=ambient-test-token node scripts/run-vitest.mjs src/commands/gateway-auth-token.test.ts src/commands/doctor-gateway-services.test.ts` failed 6 of 80 assertions in the doctor suite while the auth-token suite exposed the same ambient-state dependency.
- Post-fix focused repro: the same command passed 80/80 assertions.
- Stress: the focused forced-token command passed 20 consecutive runs, 1,600/1,600 assertions.
- Path-scoped changed gate: Blacksmith Testbox `tbx_01kz395mx0a1px4c5zrg2q5b3c` passed typecheck, lint, formatting, environment/max-lines ratchets, dependency pins, architecture boundaries, and dead-export checks. Run: https://github.com/openclaw/openclaw/actions/runs/30794620596
- Broad forced-token proof: Blacksmith Testbox `tbx_01kz39hznhe52w80fxetk7cs0c` passed commands-light 463/463 and full commands 3,717 passed with 3 intentional skips (3,720 total). Run: https://github.com/openclaw/openclaw/actions/runs/30795029764
- Exact-head hosted CI: attempt 2 passed every selected job at `f3b5718ae80534c0be874113ba8fe705e82abb41`. Run: https://github.com/openclaw/openclaw/actions/runs/30796088862
- Fresh branch autoreview: clean, no accepted/actionable findings.
- Production LOC delta: 0. Test delta: +8/-1 across two files.

The Testbox wrapper returned exit 0 for both successful remote commands. Their backing Actions run may show cancellation after external lease cleanup because Blacksmith owns the delegated session lifecycle.
