### PR TITLE
chore: speed up Gateway session test fixtures

### DIFF
--- a/src/gateway/server-methods/sessions-abort.test.ts
+++ b/src/gateway/server-methods/sessions-abort.test.ts
@@ -13,11 +13,11 @@ import { testState } from "../test-helpers.js";
 import {
   directSessionReq,
   getGatewayConfigModule,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "../test/server-sessions.test-helpers.js";
 import { createActiveRun, createChatAbortContext } from "./chat.abort.test-helpers.js";
 
-setupGatewaySessionsTestHarness();
+setupGatewaySessionsHandlerTestHarness();
 
 function requireStateDir(): string {
   const stateDir = process.env.OPENCLAW_STATE_DIR;

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -15,12 +15,12 @@ import {
   getGatewayConfigModule,
   directSessionReq,
   seedLinearSessionTranscript,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "../test/server-sessions.test-helpers.js";
 import { agentsHandlers } from "./agents.js";
 import type { GatewayRequestContext } from "./types.js";
 
-setupGatewaySessionsTestHarness();
+setupGatewaySessionsHandlerTestHarness();
 
 const UNKNOWN_AGENT_ID = "ghost";
 const UNKNOWN_SESSION_KEY = `agent:${UNKNOWN_AGENT_ID}:zzz`;

--- a/src/gateway/server.sessions.agent-model-catalog.test.ts
+++ b/src/gateway/server.sessions.agent-model-catalog.test.ts
@@ -5,10 +5,10 @@ import { writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
   sessionStoreEntry,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSelectedGlobalSessionStore } = setupGatewaySessionsTestHarness();
+const { createSelectedGlobalSessionStore } = setupGatewaySessionsHandlerTestHarness();
 
 const mainModel = { id: "main-only", name: "Main Model", provider: "main-provider" };
 const workModel = { id: "work-only", name: "Work Model", provider: "work-provider" };

--- a/src/gateway/server.sessions.delete-board.test.ts
+++ b/src/gateway/server.sessions.delete-board.test.ts
@@ -7,11 +7,11 @@ import { testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
   sessionStoreEntry,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
   writeSingleLineSession,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();

--- a/src/gateway/server.sessions.list-connection-reuse.test.ts
+++ b/src/gateway/server.sessions.list-connection-reuse.test.ts
@@ -9,10 +9,10 @@ import { writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
   sessionStoreEntry,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 const LIST_PARAMS = {
   agentId: "main",

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -15,10 +15,10 @@ import {
   directSessionReq,
   seedSessionTranscript,
   sessionStoreEntry,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 const LIST_PARAMS = {
   agentId: "main",

--- a/src/gateway/server.sessions.patch-expected-identity.test.ts
+++ b/src/gateway/server.sessions.patch-expected-identity.test.ts
@@ -6,10 +6,10 @@ import { embeddedRunMock, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
   sessionStoreEntry,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();

--- a/src/gateway/server.sessions.placement-projection.test.ts
+++ b/src/gateway/server.sessions.placement-projection.test.ts
@@ -3,12 +3,12 @@ import type { GatewaySessionRow } from "./session-utils.types.js";
 import { writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 import type { WorkerSessionPlacementReader } from "./worker-environments/placement-projector.js";
 import type { WorkerSessionPlacementRecord } from "./worker-environments/placement-store.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 function activePlacementRecord(): WorkerSessionPlacementRecord {
   return {

--- a/src/gateway/server.sessions.plugin-ownership.test.ts
+++ b/src/gateway/server.sessions.plugin-ownership.test.ts
@@ -9,10 +9,10 @@ import { writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
   sessionStoreEntry,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 test.each([
   {

--- a/src/gateway/server.sessions.process-cleanup.test.ts
+++ b/src/gateway/server.sessions.process-cleanup.test.ts
@@ -15,10 +15,10 @@ import { writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
   sessionStoreEntry,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsHandlerTestHarness();
 
 afterEach(() => {
   resetProcessRegistryForTests();

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -19,7 +19,7 @@ import { runExclusiveSessionLifecycle } from "../sessions/session-lifecycle-admi
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { embeddedRunMock, testState, writeSessionStore } from "./test-helpers.js";
 import {
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
   bootstrapCacheMocks,
   subagentLifecycleHookMocks,
   subagentLifecycleHookState,
@@ -37,7 +37,7 @@ import {
   sessionHookMocks,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsHandlerTestHarness();
 
 type ResetAcpState = {
   backend?: string;

--- a/src/gateway/server.sessions.reset-concurrency.test.ts
+++ b/src/gateway/server.sessions.reset-concurrency.test.ts
@@ -8,12 +8,12 @@ import { writeSessionStore } from "./test-helpers.js";
 import {
   sessionLifecycleHookMocks,
   sessionStoreEntry,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
   subagentLifecycleHookMocks,
   threadBindingMocks,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();

--- a/src/gateway/server.sessions.reset-hooks.succession.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.succession.test.ts
@@ -8,10 +8,10 @@ import {
   directSessionReq,
   seedSessionTranscript,
   sessionLifecycleHookMocks,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 type HookEvent = {
   sessionKey?: string;

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -9,7 +9,7 @@ import type { InternalSessionEntry } from "../config/sessions/types.js";
 import { beginSessionWorkAdmission } from "../sessions/session-lifecycle-admission.js";
 import { embeddedRunMock, testState, writeSessionStore } from "./test-helpers.js";
 import {
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
   bootstrapCacheMocks,
   sessionHookMocks,
   beforeResetHookMocks,
@@ -23,7 +23,7 @@ import {
   seedSessionTranscript,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsHandlerTestHarness();
 
 type HookEventRecord = Record<string, unknown> & {
   context?: Record<string, unknown> & {

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -12,12 +12,12 @@ import { listSessionStateEventsSince } from "../sessions/session-state-events.js
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
 import {
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
   sessionStoreEntry,
   directSessionReq,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 type ResetSessionEntry = {
   sessionId?: string;

--- a/src/gateway/server.sessions.thinking-e2e.test.ts
+++ b/src/gateway/server.sessions.thinking-e2e.test.ts
@@ -12,13 +12,13 @@ import { expect, test, vi } from "vitest";
 import { formatThinkingLevels } from "../auto-reply/thinking.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
 import {
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
   getGatewayConfigModule,
   getSessionsHandlers,
   sessionStoreEntry,
 } from "./test/server-sessions.test-helpers.js";
 
-const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
 
 /**
  * Simulates the consumer-side resolution from session-controls.ts and

--- a/src/gateway/server.sessions.worker-placement-lifecycle.test.ts
+++ b/src/gateway/server.sessions.worker-placement-lifecycle.test.ts
@@ -6,12 +6,12 @@ import { embeddedRunMock, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
   sessionStoreEntry,
-  setupGatewaySessionsTestHarness,
+  setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 import type { WorkerSessionPlacementReader } from "./worker-environments/placement-projector.js";
 import type { WorkerSessionPlacementRecord } from "./worker-environments/placement-store.js";
 
-const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsTestHarness();
+const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsHandlerTestHarness();
 let uninstallResetGuard: (() => void) | undefined;
 
 afterEach(() => {

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -5,27 +5,17 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { expectDefined } from "@openclaw/normalization-core";
 import type { AssistantMessage, UserMessage } from "openclaw/plugin-sdk/llm";
 import { afterAll, beforeAll, beforeEach, expect, vi } from "vitest";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
-import {
-  loadTranscriptEvents,
-  persistSessionTranscriptTurn,
-} from "../../config/sessions/session-accessor.js";
 import type { InternalHookEvent } from "../../hooks/internal-hooks.js";
 import { resetSystemEventsForTest } from "../../infra/system-events.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import type { GatewayRequestContext } from "../server-methods/types.js";
-import { startGatewayServerHarness, type GatewayServerHarness } from "../server.e2e-ws-harness.js";
-import {
-  connectOk,
-  embeddedRunMock,
-  installGatewayTestHooks,
-  agentDiscoveryMock,
-  testState,
-  writeSessionStore,
-} from "../test-helpers.js";
+import type { GatewayServerHarness } from "../server.e2e-ws-harness.js";
+import { embeddedRunMock, agentDiscoveryMock, testState } from "../test-helpers.runtime-state.js";
+import type { connectOk } from "../test-helpers.server.js";
+import { installGatewayTestHooks, writeSessionStore } from "../test-helpers.server.js";
 import { sessionHandlerTestSurface } from "./server-sessions-handlers.test-support.js";
 
 export const getSessionManagerModule = createLazyRuntimeModule(
@@ -34,6 +24,14 @@ export const getSessionManagerModule = createLazyRuntimeModule(
 
 export const getGatewayConfigModule = createLazyRuntimeModule(
   () => import("../../config/config.js"),
+);
+
+const getSessionAccessorModule = createLazyRuntimeModule(
+  () => import("../../config/sessions/session-accessor.js"),
+);
+
+const getGatewayServerHarnessModule = createLazyRuntimeModule(
+  () => import("../server.e2e-ws-harness.js"),
 );
 
 export async function getSessionsHandlers() {
@@ -54,6 +52,7 @@ export async function seedSessionTranscript(params: {
   sessionKey: string;
   storePath: string;
 }): Promise<void> {
+  const { persistSessionTranscriptTurn } = await getSessionAccessorModule();
   await persistSessionTranscriptTurn(
     {
       agentId: params.agentId,
@@ -101,6 +100,7 @@ export async function loadSeededTranscriptEvents(params: {
   sessionKey: string;
   storePath: string;
 }): Promise<unknown[]> {
+  const { loadTranscriptEvents } = await getSessionAccessorModule();
   return await loadTranscriptEvents({
     agentId: params.agentId,
     sessionId: params.sessionId,
@@ -310,7 +310,18 @@ vi.mock("../../agents/agent-bundle-mcp-tools.js", () => ({
   retireSessionMcpRuntime: bundleMcpRuntimeMocks.retireSessionMcpRuntime,
 }));
 
+export function setupGatewaySessionsHandlerTestHarness() {
+  const { getHarness, openClient, ...handlerFixture } = createGatewaySessionsTestHarness(false);
+  void getHarness;
+  void openClient;
+  return handlerFixture;
+}
+
 export function setupGatewaySessionsTestHarness() {
+  return createGatewaySessionsTestHarness(true);
+}
+
+function createGatewaySessionsTestHarness(startServer: boolean) {
   installGatewayTestHooks({ scope: "suite" });
 
   let harness: GatewayServerHarness | undefined;
@@ -318,7 +329,10 @@ export function setupGatewaySessionsTestHarness() {
   let sessionStoreCaseSeq = 0;
 
   beforeAll(async () => {
-    harness = await startGatewayServerHarness();
+    if (startServer) {
+      const { startGatewayServerHarness } = await getGatewayServerHarnessModule();
+      harness = await startGatewayServerHarness();
+    }
     sharedSessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-"));
   });
 
@@ -680,10 +694,11 @@ export async function directSessionReq<TPayload = unknown>(
   let result:
     | { ok: boolean; payload?: TPayload; error?: { code?: string; message?: string } }
     | undefined;
-  await expectDefined(
-    sessionsHandlers[method],
-    "sessions handlers entry at method",
-  )({
+  const handler = sessionsHandlers[method];
+  if (!handler) {
+    throw new Error(`missing sessions handler for ${method}`);
+  }
+  await handler({
     req: {} as never,
     params,
     respond: (ok, payload, error) => {


### PR DESCRIPTION
## What Problem This Solves

The Gateway agent/chat test group starts a real WebSocket server and loads its transport graph in session test files that call handlers directly and never use the server. This redundant fixture work keeps a critical CI shard above its target runtime.

## Why This Change Was Made

The shared sessions fixture now has explicit handler-only and server-backed entry points. Seventeen direct-handler files use the lightweight entry point; all ten suites with real client or WebSocket assertions keep the existing eager server lifecycle. Server transport and transcript-owner modules are loaded only when their fixture functions need them.

This is test-only. It changes no production behavior, test sharding, concurrency, assertions, or state-isolation policy.

## User Impact

No user-visible behavior changes. Maintainers get a faster Gateway test shard while retaining every direct handler and real transport assertion.

## Evidence

- Exact `agentic-control-plane-agent-chat` group: 159.83s baseline, 140.50-140.71s after on the same host, saving 19.1-19.3s.
- Exact group retained 31/31 files and 491/491 tests.
- The three consumers outside that group passed 21/21 after rebasing onto current main.
- All ten server-backed fixture consumers remain on the default eager server path; 17 handler-only consumers use the new typed entry point.
- Targeted oxfmt, oxlint, and git diff checks pass.
- Structured Codex autoreview: clean, no accepted or actionable findings.
- Blacksmith Testbox was unavailable on this host because the `blacksmith` CLI is not installed, so exact-head PR CI is the hosted broad proof.
