### PR TITLE
fix(agents): preserve successful sessions_yield handoffs

### DIFF
--- a/src/agents/agent-tools.abort.ts
+++ b/src/agents/agent-tools.abort.ts
@@ -20,10 +20,27 @@ function throwAbortError(): never {
  * Tool settlements pass through untouched to preserve tool error semantics,
  * including non-Error rejections.
  */
-function raceWithAbortSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+function raceWithAbortSignal<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+  yieldRunSignal?: AbortSignal,
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const onAbort = () => {
       signal.removeEventListener("abort", onAbort);
+      const reason = yieldRunSignal?.reason as
+        | { code?: unknown; turnHandoff?: unknown }
+        | undefined;
+      // Only the initiating tool may finish its run owner's deliberate handoff;
+      // caller-authored aborts and concurrent sibling tools must still cancel.
+      if (
+        yieldRunSignal?.aborted &&
+        signal.reason === reason &&
+        reason?.code === "sessions_yield" &&
+        reason.turnHandoff === true
+      ) {
+        return;
+      }
       reject(createAbortError("Aborted"));
     };
     signal.addEventListener("abort", onAbort, { once: true });
@@ -67,6 +84,7 @@ export function wrapToolWithAbortSignal(
       return await raceWithAbortSignal(
         execute(toolCallId, params, combinedSignal, onUpdate),
         combinedSignal,
+        tool.name === "sessions_yield" ? abortSignal : undefined,
       );
     },
   };

--- a/src/agents/agent-tools.runtime.test.ts
+++ b/src/agents/agent-tools.runtime.test.ts
@@ -14,6 +14,7 @@ import {
   getToolTerminalPresentation,
   setToolTerminalPresentation,
 } from "./tool-terminal-presentation.js";
+import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
 
 type ExecuteMock = ReturnType<typeof vi.fn>;
 
@@ -82,6 +83,157 @@ describe("wrapToolWithAbortSignal", () => {
     });
     rejectTool(new Error("tool observed the abort"));
     await flushMicrotasks();
+  });
+
+  it("preserves the successful result when sessions_yield intentionally aborts its own run", async () => {
+    const runAbort = new AbortController();
+    const handoffReason = { code: "sessions_yield", turnHandoff: true } as const;
+    const beforeYield = vi.fn();
+    const wrapped = wrapToolWithAbortSignal(
+      createSessionsYieldTool({
+        sessionId: "requester",
+        onBeforeYield: beforeYield,
+        onYield: () => {
+          runAbort.abort(handoffReason);
+        },
+      }),
+      runAbort.signal,
+    );
+
+    await expect(wrapped.execute("call-yield", {})).resolves.toMatchObject({
+      details: { status: "yielded", message: "Turn yielded." },
+    });
+    expect(beforeYield).toHaveBeenCalledOnce();
+    expect(runAbort.signal.reason).toBe(handoffReason);
+  });
+
+  it("still aborts a concurrent sibling when sessions_yield hands off the run", async () => {
+    const runAbort = new AbortController();
+    const handoffReason = { code: "sessions_yield", turnHandoff: true } as const;
+    const sibling = wrapToolWithAbortSignal(
+      asAgentTool({ name: "wedged", execute: vi.fn(() => new Promise<never>(() => {})) }),
+      runAbort.signal,
+    );
+    const siblingAborted = expect(sibling.execute("call-sibling", {})).rejects.toMatchObject({
+      name: "AbortError",
+      message: "Aborted",
+    });
+    const yieldTool = wrapToolWithAbortSignal(
+      createSessionsYieldTool({
+        sessionId: "requester",
+        onYield: () => {
+          runAbort.abort(handoffReason);
+        },
+      }),
+      runAbort.signal,
+    );
+
+    await expect(yieldTool.execute("call-yield", {})).resolves.toMatchObject({
+      details: { status: "yielded" },
+    });
+    await siblingAborted;
+  });
+
+  it("preserves the handoff when distinct run and per-call signals both yield", async () => {
+    const runAbort = new AbortController();
+    const callAbort = new AbortController();
+    const handoffReason = { code: "sessions_yield", turnHandoff: true } as const;
+    const wrapped = wrapToolWithAbortSignal(
+      createSessionsYieldTool({
+        sessionId: "requester",
+        onYield: () => {
+          runAbort.abort(handoffReason);
+          callAbort.abort(handoffReason);
+        },
+      }),
+      runAbort.signal,
+    );
+
+    await expect(wrapped.execute("call-yield", {}, callAbort.signal)).resolves.toMatchObject({
+      details: { status: "yielded" },
+    });
+    expect(runAbort.signal.reason).toBe(handoffReason);
+    expect(callAbort.signal.reason).toBe(handoffReason);
+  });
+
+  it.each([
+    { name: "ordinary caller cancellation", reason: new Error("operator cancelled") },
+    {
+      name: "a caller-authored lookalike handoff",
+      reason: { code: "sessions_yield", turnHandoff: true },
+    },
+  ])("rejects sessions_yield for $name without an owner-authored handoff", async ({ reason }) => {
+    const runAbort = new AbortController();
+    const callAbort = new AbortController();
+    const execute = vi.fn(() => new Promise<never>(() => {}));
+    const wrapped = wrapToolWithAbortSignal(
+      asAgentTool({ name: "sessions_yield", execute }),
+      runAbort.signal,
+    );
+
+    const executePromise = wrapped.execute("call-yield", {}, callAbort.signal);
+    callAbort.abort(reason);
+
+    await expect(executePromise).rejects.toMatchObject({
+      name: "AbortError",
+      message: "Aborted",
+    });
+    expect(runAbort.signal.aborted).toBe(false);
+  });
+
+  it.each([
+    { name: "ordinary cancellation", reason: new Error("operator cancelled") },
+    { name: "a missing handoff flag", reason: { code: "sessions_yield" } },
+    { name: "a disabled handoff flag", reason: { code: "sessions_yield", turnHandoff: false } },
+    { name: "a different handoff owner", reason: { code: "different", turnHandoff: true } },
+  ])("rejects sessions_yield when its run owner aborts with $name", async ({ reason }) => {
+    const runAbort = new AbortController();
+    const execute = vi.fn(async () => {
+      runAbort.abort(reason);
+      return textResult("late");
+    });
+    const wrapped = wrapToolWithAbortSignal(
+      asAgentTool({ name: "sessions_yield", execute }),
+      runAbort.signal,
+    );
+
+    await expect(wrapped.execute("call-yield", {})).rejects.toMatchObject({
+      name: "AbortError",
+      message: "Aborted",
+    });
+  });
+
+  it("does not start sessions_yield when the run was already handed off", async () => {
+    const runAbort = new AbortController();
+    runAbort.abort({ code: "sessions_yield", turnHandoff: true });
+    const onYield = vi.fn();
+    const wrapped = wrapToolWithAbortSignal(
+      createSessionsYieldTool({ sessionId: "requester", onYield }),
+      runAbort.signal,
+    );
+
+    await expect(wrapped.execute("call-yield", {})).rejects.toMatchObject({
+      name: "AbortError",
+      message: "Aborted",
+    });
+    expect(onYield).not.toHaveBeenCalled();
+  });
+
+  it("preserves an actual sessions_yield failure after its owner starts the handoff", async () => {
+    const runAbort = new AbortController();
+    const yieldError = new Error("yield bookkeeping failed");
+    const wrapped = wrapToolWithAbortSignal(
+      createSessionsYieldTool({
+        sessionId: "requester",
+        onYield: () => {
+          runAbort.abort({ code: "sessions_yield", turnHandoff: true });
+          throw yieldError;
+        },
+      }),
+      runAbort.signal,
+    );
+
+    await expect(wrapped.execute("call-yield", {})).rejects.toBe(yieldError);
   });
 
   it("rejects with AbortError when the per-call signal aborts through the combined signal", async () => {

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -3131,8 +3131,222 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
   });
 
-  it("directly delivers settle synthesis even when a direct-message requester turn is active", async () => {
-    const callGateway = createGatewayMock();
+  const requesterSettleSourceTarget = {
+    tool: "message",
+    provider: "discord",
+    accountId: "acct-1",
+    to: "dm:U123",
+    text: "the consolidated answer",
+  } as const;
+  const deliveredRequesterFinal = { delivered: true, path: "direct" } as const;
+  const missingRequesterFinal = {
+    delivered: false,
+    path: "direct",
+    reason: "visible_reply_missing",
+  } as const;
+
+  it.each([
+    {
+      name: "preserves an ordinary non-yielded direct settle turn",
+      response: {},
+      requireVisibleReply: false,
+      expected: deliveredRequesterFinal,
+    },
+    {
+      name: "preserves an intentional silent non-yielded settle turn",
+      response: { result: { payloads: [{ text: "NO_REPLY" }] } },
+      requireVisibleReply: false,
+      expected: deliveredRequesterFinal,
+    },
+    {
+      name: "accepts a yielded requester's visible final answer",
+      response: { result: { payloads: [{ text: "The consolidated answer." }] } },
+      requireVisibleReply: true,
+      expected: deliveredRequesterFinal,
+    },
+    {
+      name: "rejects a yielded turn without a result",
+      response: {},
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a yielded turn with no response payloads",
+      response: { result: { payloads: [] } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a yielded turn that emits only an error",
+      response: { result: { payloads: [{ text: "tool failed", isError: true }] } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a yielded turn that emits only private reasoning",
+      response: { result: { payloads: [{ text: "thinking", isReasoning: true }] } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects pre-tool commentary instead of a final answer",
+      response: { result: { payloads: [{ text: "working on it", isCommentary: true }] } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects an explicitly hidden assistant payload",
+      response: { result: { payloads: [{ text: "not user visible", visible: false }] } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a yielded turn that emits only the silent reply token",
+      response: { result: { payloads: [{ text: "NO_REPLY" }] } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a visible final whose external delivery was suppressed",
+      response: {
+        result: {
+          payloads: [{ text: "never delivered" }],
+          deliveryStatus: { status: "suppressed", succeeded: true, resultCount: 0 },
+        },
+      },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a messaging-tool flag without a committed source receipt",
+      response: { result: { payloads: [], didSendViaMessagingTool: true } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects messaging aggregates without a source-matched receipt",
+      response: {
+        result: {
+          payloads: [],
+          didSendViaMessagingTool: true,
+          messagingToolSentTexts: ["sent somewhere else"],
+        },
+      },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects an accepted subagent spawn without a final reply",
+      response: {
+        result: {
+          payloads: [],
+          acceptedSessionSpawns: [{ runId: "run-child", childSessionKey: "agent:main:child" }],
+        },
+      },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a cron side effect without a final reply",
+      response: { result: { payloads: [], successfulCronAdds: 1 } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a source-matched messaging progress update",
+      response: {
+        result: {
+          payloads: [],
+          didSendViaMessagingTool: true,
+          messagingToolSentTargets: [{ ...requesterSettleSourceTarget, sourceReplyFinal: false }],
+        },
+      },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a final message sent to another recipient",
+      response: {
+        result: {
+          payloads: [],
+          didSendViaMessagingTool: true,
+          messagingToolSentTargets: [
+            { ...requesterSettleSourceTarget, to: "dm:OTHER", sourceReplyFinal: true },
+          ],
+        },
+      },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "does not let an off-target final upgrade source progress",
+      response: {
+        result: {
+          payloads: [],
+          didSendViaMessagingTool: true,
+          messagingToolSentTargets: [
+            { ...requesterSettleSourceTarget, sourceReplyFinal: false },
+            { ...requesterSettleSourceTarget, to: "dm:OTHER", sourceReplyFinal: true },
+          ],
+        },
+      },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "accepts an explicit source-matched final messaging delivery",
+      response: {
+        result: {
+          payloads: [{ text: "NO_REPLY" }],
+          didSendViaMessagingTool: true,
+          messagingToolSentTargets: [{ ...requesterSettleSourceTarget, sourceReplyFinal: true }],
+        },
+      },
+      requireVisibleReply: true,
+      expected: deliveredRequesterFinal,
+    },
+    {
+      name: "accepts an automatic source-matched final without legacy intent markers",
+      response: {
+        result: {
+          payloads: [{ text: "NO_REPLY" }],
+          didSendViaMessagingTool: true,
+          messagingToolSentTargets: [requesterSettleSourceTarget],
+        },
+      },
+      requireVisibleReply: true,
+      expected: deliveredRequesterFinal,
+    },
+    {
+      name: "accepts a source final after source progress in the same turn",
+      response: {
+        result: {
+          payloads: [],
+          didSendViaMessagingTool: true,
+          messagingToolSentTargets: [
+            { ...requesterSettleSourceTarget, sourceReplyFinal: false },
+            { ...requesterSettleSourceTarget, sourceReplyFinal: true },
+          ],
+        },
+      },
+      requireVisibleReply: true,
+      expected: deliveredRequesterFinal,
+    },
+    {
+      name: "accepts a committed source final when automatic delivery was suppressed",
+      response: {
+        result: {
+          payloads: [{ text: "NO_REPLY" }],
+          deliveryStatus: { status: "suppressed", succeeded: true, resultCount: 0 },
+          didSendViaMessagingTool: true,
+          messagingToolSentTargets: [{ ...requesterSettleSourceTarget, sourceReplyFinal: true }],
+        },
+      },
+      requireVisibleReply: true,
+      expected: deliveredRequesterFinal,
+    },
+  ])("$name", async ({ response, requireVisibleReply, expected }) => {
+    const callGateway = createGatewayMock(response);
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
     const origin = {
       channel: "discord",
@@ -3160,11 +3374,12 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       requesterIsSubagent: false,
       expectsCompletionMessage: false,
       requireDirectDelivery: true,
+      ...(requireVisibleReply ? { requireVisibleReply: true } : {}),
       directIdempotencyKey: "announce-requester-settle-direct",
       sourceTool: "subagent_announce",
     });
 
-    expectDeliveryPath(result, "direct");
+    expect(result).toMatchObject(expected);
     expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
     const agentParams = expectGatewayAgentParams(callGateway, {
       deliver: true,

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -3195,6 +3195,24 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expected: missingRequesterFinal,
     },
     {
+      name: "rejects a compaction notice instead of a final answer",
+      response: { result: { payloads: [{ text: "compacting", isCompactionNotice: true }] } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a provider-fallback notice instead of a final answer",
+      response: { result: { payloads: [{ text: "switching providers", isFallbackNotice: true }] } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a transient status notice instead of a final answer",
+      response: { result: { payloads: [{ text: "still working", isStatusNotice: true }] } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
       name: "rejects an explicitly hidden assistant payload",
       response: { result: { payloads: [{ text: "not user visible", visible: false }] } },
       requireVisibleReply: true,

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -42,6 +42,7 @@ import {
   hasMessagingToolDeliveryEvidence,
   hasPayloadOutcomeSendEvidence,
   hasUnaccountedMessagingToolAggregateEvidence,
+  resolveExplicitFinalSourceReplyDeliveryEvidence,
 } from "./embedded-agent-runner/delivery-evidence.js";
 import {
   hasIntentionalSilentAgentPayload,
@@ -796,7 +797,43 @@ function hasMessagingToolDeliveryToSource(
     messagingToolSourceReplyPayloads?: unknown;
   },
   deliveryTarget: Parameters<typeof sourceDeliveryTargetsMatch>[1],
+  options?: { requireFinalReply?: boolean },
 ): boolean {
+  const targets = Array.isArray(result.messagingToolSentTargets)
+    ? result.messagingToolSentTargets
+    : [];
+  const sourceTargets = targets.filter((target) => {
+    if (
+      !target ||
+      typeof target !== "object" ||
+      Array.isArray(target) ||
+      !deliveryTarget.channel ||
+      !deliveryTarget.to
+    ) {
+      return false;
+    }
+    const record = target as Parameters<typeof sourceDeliveryTargetsMatch>[0];
+    // Older source receipts omit `to`; explicit off-target sends must never satisfy it.
+    const sourceTarget =
+      typeof record.to === "string" && record.to.trim()
+        ? record
+        : { ...record, to: deliveryTarget.to };
+    return sourceDeliveryTargetsMatch(sourceTarget, deliveryTarget);
+  });
+  if (options?.requireFinalReply) {
+    const hasCommittedSourceDelivery =
+      hasCommittedSourceReplyDeliveryEvidence(result) ||
+      (hasMessagingToolDeliveryEvidence(result) && sourceTargets.length > 0);
+    // Only current-source final markers count; another target's final cannot
+    // turn a source progress update into the owed requester reply.
+    return (
+      hasCommittedSourceDelivery &&
+      resolveExplicitFinalSourceReplyDeliveryEvidence({
+        messagingToolSentTargets: sourceTargets,
+        messagingToolSourceReplyPayloads: result.messagingToolSourceReplyPayloads,
+      }) !== false
+    );
+  }
   if (
     hasCommittedSourceReplyDeliveryEvidence(result) ||
     hasUnaccountedMessagingToolAggregateEvidence({ ...result, didSendViaMessagingTool: false })
@@ -804,28 +841,11 @@ function hasMessagingToolDeliveryToSource(
     return true;
   }
 
-  const targets = Array.isArray(result.messagingToolSentTargets)
-    ? result.messagingToolSentTargets
-    : [];
   if (targets.length === 0 || !deliveryTarget.channel || !deliveryTarget.to) {
     return hasMessagingToolDeliveryEvidence(result);
   }
 
-  return (
-    hasMessagingToolDeliveryEvidence(result) &&
-    targets.some((target) => {
-      if (!target || typeof target !== "object" || Array.isArray(target)) {
-        return false;
-      }
-      const record = target as Parameters<typeof sourceDeliveryTargetsMatch>[0];
-      // Older current-source receipts omit `to`; explicit off-target sends must never satisfy it.
-      const sourceTarget =
-        typeof record.to === "string" && record.to.trim()
-          ? record
-          : { ...record, to: deliveryTarget.to };
-      return sourceDeliveryTargetsMatch(sourceTarget, deliveryTarget);
-    })
-  );
+  return hasMessagingToolDeliveryEvidence(result) && sourceTargets.length > 0;
 }
 
 async function sendSubagentAnnounceDirectly(params: {
@@ -834,6 +854,7 @@ async function sendSubagentAnnounceDirectly(params: {
   triggerMessage: string;
   internalEvents?: AgentInternalEvent[];
   expectsCompletionMessage: boolean;
+  requireVisibleReply?: boolean;
   bestEffortDeliver?: boolean;
   directIdempotencyKey: string;
   completionDirectOrigin?: DeliveryContext;
@@ -1199,11 +1220,26 @@ async function sendSubagentAnnounceDirectly(params: {
     }
     const hasVisibleCompletionReply = Boolean(
       directAnnounceResult &&
-      (hasMessagingToolDelivery ||
-        hasVisibleAgentPayload(directAnnounceResult, {
-          ...completionPayloadVisibility,
-          includeSilentReplyPayloads: false,
-        })),
+      ((params.requireVisibleReply
+        ? hasMessagingToolDeliveryToSource(directAnnounceResult, deliveryTarget, {
+            requireFinalReply: true,
+          })
+        : hasMessagingToolDelivery) ||
+        (hasVisibleAgentPayload(
+          params.requireVisibleReply
+            ? {
+                payloads: Array.isArray(directAnnounceResult.payloads)
+                  ? directAnnounceResult.payloads.filter((payload) => {
+                      const flags = payload as { isCommentary?: unknown; visible?: unknown };
+                      return flags?.isCommentary !== true && flags?.visible !== false;
+                    })
+                  : [],
+              }
+            : directAnnounceResult,
+          { ...completionPayloadVisibility, includeSilentReplyPayloads: false },
+        ) &&
+          (!params.requireVisibleReply ||
+            directAnnounceResult.deliveryStatus?.status !== "suppressed"))),
     );
     const hasCompletionSideEffect = Boolean(
       directAnnounceResult && hasCommittedOutboundDeliveryEvidence(directAnnounceResult),
@@ -1211,12 +1247,13 @@ async function sendSubagentAnnounceDirectly(params: {
     const acceptsIntentionalSilentCompletion =
       hasIntentionalSilentCompletionReply && !isSubagentCompletion;
     if (
-      params.expectsCompletionMessage &&
-      !shouldDeliverAgentFinal &&
-      !requiresMessageToolDelivery &&
       !hasVisibleCompletionReply &&
-      !hasCompletionSideEffect &&
-      !acceptsIntentionalSilentCompletion
+      (params.requireVisibleReply ||
+        (params.expectsCompletionMessage &&
+          !shouldDeliverAgentFinal &&
+          !requiresMessageToolDelivery &&
+          !hasCompletionSideEffect &&
+          !acceptsIntentionalSilentCompletion))
     ) {
       return {
         delivered: false,
@@ -1279,6 +1316,7 @@ export async function deliverSubagentAnnouncement(params: {
   requesterIsSubagent: boolean;
   expectsCompletionMessage: boolean;
   requireDirectDelivery?: boolean;
+  requireVisibleReply?: boolean;
   bestEffortDeliver?: boolean;
   directIdempotencyKey: string;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
@@ -1432,6 +1470,7 @@ export async function deliverSubagentAnnouncement(params: {
         isSourceSessionEffectsAllowed: params.isSourceSessionEffectsAllowed,
         requesterIsSubagent: params.requesterIsSubagent,
         expectsCompletionMessage: params.expectsCompletionMessage,
+        requireVisibleReply: params.requireVisibleReply,
         onDeliveryResult: params.onDeliveryResult,
         signal: params.signal,
         bestEffortDeliver: params.bestEffortDeliver,

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1230,8 +1230,14 @@ async function sendSubagentAnnounceDirectly(params: {
             ? {
                 payloads: Array.isArray(directAnnounceResult.payloads)
                   ? directAnnounceResult.payloads.filter((payload) => {
-                      const flags = payload as { isCommentary?: unknown; visible?: unknown };
-                      return flags?.isCommentary !== true && flags?.visible !== false;
+                      const flags = payload as Record<string, unknown>;
+                      return (
+                        flags?.isCommentary !== true &&
+                        flags?.isCompactionNotice !== true &&
+                        flags?.isFallbackNotice !== true &&
+                        flags?.isStatusNotice !== true &&
+                        flags?.visible !== false
+                      );
                     })
                   : [],
               }

--- a/src/agents/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.test.ts
@@ -188,11 +188,13 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     expect(call.requesterIsSubagent).toBe(false);
     expect(call.expectsCompletionMessage).toBe(false);
     expect(call.requireDirectDelivery).toBe(true);
+    expect(call.requireVisibleReply).toBeUndefined();
     expect(call.directIdempotencyKey).toBe(`announce:requester-settle:${REQUESTER}:run-a,run-b`);
     const message = String(call.triggerMessage);
     expect(message).toContain("settled");
     expect(message).toContain("social findings");
     expect(message).toContain("network findings");
+    expect(message).toContain("NO_REPLY");
     expect(registryRuntimeMock.hasDescendantRunAwaitingSettle).toHaveBeenCalledWith(
       REQUESTER,
       "run-b",
@@ -425,6 +427,10 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(true);
     expect(deliverSpy).toHaveBeenCalledOnce();
+    expect(deliveredCallArg().requireVisibleReply).toBe(true);
+    const message = String(deliveredCallArg().triggerMessage);
+    expect(message).not.toContain("NO_REPLY");
+    expect(message).toContain("original user request still requires your visible final answer");
     expect(deliveredCallArg().directIdempotencyKey).toBe(
       `announce:requester-settle:${REQUESTER}:run-b:yield-1`,
     );
@@ -452,6 +458,10 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(true);
     expect(deliverSpy).toHaveBeenCalledOnce();
+    expect(deliveredCallArg().requireVisibleReply).toBe(true);
+    const message = String(deliveredCallArg().triggerMessage);
+    expect(message).not.toContain("NO_REPLY");
+    expect(message).toContain("original user request still requires your visible final answer");
     expect(deliveredCallArg().directIdempotencyKey).toBe(
       `announce:requester-settle:${REQUESTER}:run-b:yield-1`,
     );
@@ -538,6 +548,55 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       const keys = deliverSpy.mock.calls.map(([arg]) => arg.directIdempotencyKey);
       expect(keys[0]).toBe(`announce:requester-settle:${REQUESTER}:run-a,run-b`);
       expect(keys[1]).toBe(`announce:requester-settle:${REQUESTER}:run-a,run-b:retry-1`);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retains a yielded wake after a silent final and retries its visible reply", async () => {
+    const child = makeSettledChild({
+      runId: "run-b",
+      delivery: { status: "delivered" },
+      requesterSettleWake: {
+        status: "pending",
+        attemptCount: 0,
+        batchRunIds: ["run-b"],
+        requesterYieldBatch: true,
+        rearmGeneration: 1,
+      },
+    });
+    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
+    deliverSpy.mockResolvedValueOnce({
+      delivered: false,
+      path: "direct",
+      reason: "visible_reply_missing",
+    });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      await expect(
+        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
+      ).resolves.toBe(false);
+      expect(completeBatchSpy).not.toHaveBeenCalled();
+      expect(child.requesterSettleWake).toMatchObject({
+        status: "pending",
+        attemptCount: 1,
+        nextAttemptAt: 30_000,
+        requesterYieldBatch: true,
+        rearmGeneration: 1,
+        lastError: "visible_reply_missing",
+      });
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(
+        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
+      ).resolves.toBe(true);
+      expect(deliverSpy.mock.calls.map(([arg]) => arg.directIdempotencyKey)).toEqual([
+        `announce:requester-settle:${REQUESTER}:run-b:yield-1`,
+        `announce:requester-settle:${REQUESTER}:run-b:yield-1:retry-1`,
+      ]);
+      expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1);
     } finally {
       vi.useRealTimers();
     }

--- a/src/agents/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.ts
@@ -59,12 +59,17 @@ const REQUESTER_SETTLE_WAKE_MAX_AMBIGUOUS_REPLAYS = 3;
 const REQUESTER_SETTLE_WAKE_RETRY_DELAYS_MS = [30_000, 120_000] as const;
 const activeRequesterSettleWakeBatches = new Set<string>();
 
-function buildRequesterSettleWakeMessage(params: { findings?: string }): string {
+function buildRequesterSettleWakeMessage(params: {
+  findings?: string;
+  requireVisibleReply: boolean;
+}): string {
   return [
     "[Subagent Context] Every subagent spawned from this session has now settled — none are still running or awaiting completion delivery.",
     "[Subagent Context] Do not keep waiting or call sessions_yield again for this batch; no further completion events will arrive.",
     "[Subagent Context] Review the completion results and send your consolidated final answer to the user now.",
-    `[Subagent Context] Reply ONLY: ${SILENT_REPLY_TOKEN} only if you already delivered the consolidated final answer for this batch.`,
+    params.requireVisibleReply
+      ? "[Subagent Context] Child completion delivery is internal; the original user request still requires your visible final answer."
+      : `[Subagent Context] Reply ONLY: ${SILENT_REPLY_TOKEN} only if you already delivered the consolidated final answer for this batch.`,
     "",
     params.findings ??
       "(each child result was announced individually in earlier completion events)",
@@ -317,7 +322,10 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
       }),
     ),
   );
-  const wakeMessage = buildRequesterSettleWakeMessage({ findings });
+  const wakeMessage = buildRequesterSettleWakeMessage({
+    findings,
+    requireVisibleReply: requesterYieldedAfterDelivery,
+  });
   const requesterSessionOrigin = normalizeDeliveryContext(params.requesterOrigin);
   const directOrigin = resolveAnnounceOrigin(requesterEntry, requesterSessionOrigin);
   const wakeKeyBase = [
@@ -400,6 +408,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
         requesterIsSubagent: false,
         expectsCompletionMessage: false,
         requireDirectDelivery: true,
+        ...(requesterYieldedAfterDelivery ? { requireVisibleReply: true } : {}),
         directIdempotencyKey: buildAnnounceIdempotencyKey(
           attemptIndex === 0 ? wakeKeyBase : `${wakeKeyBase}:retry-${attemptIndex}`,
         ),


### PR DESCRIPTION
## Root cause and canonical owner repairs
- The run-owner yield handoff aborted its own initiating sessions_yield result before the actual tool could settle.
- Durable yielded-requester settlement then incorrectly treated silent, suppressed, off-target, progress-only, or notice-only output as successful final delivery.
- Restrict the intentional owner-abort exception to the actual initiating yield, require a verified original-recipient final for durably yielded batches, and retain existing ordinary cancellation and intentional non-yield silence.
- Preserve current main metadata ownership, per-call cancellation, recipient/account/thread isolation, durable retries, legacy source-message receipts, and compaction/fallback/status-notice classification.

## Exact-head authenticated live Gateway proof
Actual ephemeral Gateway and QA channel using authenticated real OpenAI GPT-5.4, immutable PR head ad580527dbb5781ad2ccc10c3085ae9b1d2220a5:

{"scenario":"subagent-handoff","provider":"openai/gpt-5.4","providerMode":"live-frontier","result":"pass","suite":{"total":1,"passed":1,"failed":0},"parent":{"sessionsSpawn":"accepted","sessionsYield":{"isError":false,"status":"yielded"},"visibleRequestedFinalSequences":[26,35],"allRequestedLabelsPresent":true},"child":{"status":"succeeded","deliveryStatus":"delivered"},"remainingSubagentObligations":0,"builtInRetryUsed":true}

The real original requester produced the requested three-label visible final at transcript sequence 26 after successful child delivery, and again at sequence 35. The canonical QA harness used its single built-in retry even though the original requester had already produced the valid sequence-26 answer; later redundant requester-settle bookkeeping turns also emitted silent replies. The precise public-history observation or timing cause has not been established, and the retry did not spawn a second child. Redundant wake handling and observer timing remain separate follow-ups; the real user-visible final was recorded.

## Verification
- Full private QA build succeeded; all 149 plugin-SDK subpaths and Control UI build gates passed.
- Nine focused owner and sibling files: 289 tests passed across six shards.
- Separate deterministic red-to-green coverage proves owner yield cancellation, silent/suppressed/off-target/progress/notice final rejection, legitimate source final delivery, and durable requester retries.
- Whole rebased six-file change received independent structured gpt-5.6-sol/high review: clean, confidence 0.98.
- Production LOC: 104 added / 32 removed = net +72 across the three shared ownership repairs; tests add 444 lines.
- Exact-head required openclaw/ci-gate: SUCCESS.